### PR TITLE
Auto-install Claude Code plugin during setup

### DIFF
--- a/src/kapacitor/Commands/SetupCommand.cs
+++ b/src/kapacitor/Commands/SetupCommand.cs
@@ -250,7 +250,15 @@ public static class SetupCommand {
 
         if (exeDir is null) return null;
 
-        // Try: <exe_dir>/../../kapacitor/plugin  (npm layout)
+        // Try: <exe_dir>/../../../../plugin  (npm optional-deps layout)
+        // Binary is at <wrapper>/node_modules/@kurrent/<platform-pkg>/bin/kapacitor
+        // Plugin is at <wrapper>/plugin
+        var optDepsPluginPath = Path.GetFullPath(Path.Combine(exeDir, "..", "..", "..", "..", "plugin"));
+
+        if (Directory.Exists(optDepsPluginPath))
+            return optDepsPluginPath;
+
+        // Try: <exe_dir>/../../kapacitor/plugin  (npm flat layout)
         var npmPluginPath = Path.GetFullPath(Path.Combine(exeDir, "..", "..", "kapacitor", "plugin"));
 
         if (Directory.Exists(npmPluginPath))


### PR DESCRIPTION
## Summary
- Adds Step 4 to `kapacitor setup` that automatically registers the Kapacitor plugin in Claude Code's `settings.json`
- Offers user-wide, project-only, or skip options
- Fixes plugin path resolution for npm optional-dependencies layout where the AOT binary is 4 levels deep from the wrapper package root

## Test plan
- [x] Unit tests pass (85/85)
- [ ] Run `npm install -g @kurrent/kapacitor` and `kapacitor setup` — verify Step 4 prompt appears and plugin is written to `~/.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)