### PR TITLE
docs: add help text for profile and use commands

### DIFF
--- a/src/kapacitor/Resources/help-profile.txt
+++ b/src/kapacitor/Resources/help-profile.txt
@@ -1,0 +1,21 @@
+kapacitor profile — Manage server profiles
+
+Usage: kapacitor profile <subcommand> [options]
+
+Subcommands:
+  add <name> --server-url <url> [--remote <pattern>]...
+                            Add a new profile
+  list                      Show all profiles
+  remove <name>             Remove a profile
+  show [name]               Show profile details (defaults to active)
+
+Options for 'add':
+  --server-url <url>        Server URL (required)
+  --remote <pattern>        Git remote pattern for auto-matching (repeatable)
+
+Examples:
+  kapacitor profile add work --server-url https://cap.example.com
+  kapacitor profile add oss --server-url https://cap.oss.dev --remote github.com/myorg
+  kapacitor profile list
+  kapacitor profile show work
+  kapacitor profile remove work

--- a/src/kapacitor/Resources/help-usage.txt
+++ b/src/kapacitor/Resources/help-usage.txt
@@ -9,6 +9,13 @@ Getting Started:
   logout                           Remove stored credentials
   whoami                           Show current authenticated user
 
+Profiles:
+  profile add <name> --server-url <url>  Add a server profile
+  profile list                     Show all profiles
+  profile remove <name>            Remove a profile
+  profile show [name]              Show profile details
+  use <profile> [--global] [--save]  Switch active profile
+
 Configuration:
   config show                      Print current configuration
   config set <key> <value>         Update a config value

--- a/src/kapacitor/Resources/help-use.txt
+++ b/src/kapacitor/Resources/help-use.txt
@@ -2,14 +2,15 @@ kapacitor use — Switch active profile
 
 Usage: kapacitor use <profile-name> [options]
 
-Switches the active profile globally or binds it to the current repository.
-Without --global, binds the profile to the current repo path.
+Switches the active profile globally or binds it to a directory.
+Without --global, binds the profile to the git repo root, or the current
+directory if not inside a git repository.
 
 Options:
   --global                  Set as the global active profile
-  --save                    Write .kapacitor.json to the repo root (for team sharing)
+  --save                    Write .kapacitor.json to the bind directory (for team sharing)
 
 Examples:
-  kapacitor use work                  Bind 'work' profile to current repo
+  kapacitor use work                  Bind 'work' profile to current repo/directory
   kapacitor use work --global         Set 'work' as the global default
   kapacitor use oss --save            Bind and write .kapacitor.json

--- a/src/kapacitor/Resources/help-use.txt
+++ b/src/kapacitor/Resources/help-use.txt
@@ -1,0 +1,15 @@
+kapacitor use — Switch active profile
+
+Usage: kapacitor use <profile-name> [options]
+
+Switches the active profile globally or binds it to the current repository.
+Without --global, binds the profile to the current repo path.
+
+Options:
+  --global                  Set as the global active profile
+  --save                    Write .kapacitor.json to the repo root (for team sharing)
+
+Examples:
+  kapacitor use work                  Bind 'work' profile to current repo
+  kapacitor use work --global         Set 'work' as the global default
+  kapacitor use oss --save            Bind and write .kapacitor.json


### PR DESCRIPTION
## Summary
- Add `help-profile.txt` and `help-use.txt` embedded resource files so `kapacitor profile --help` and `kapacitor use --help` work
- Add a **Profiles** section to the main `--help` output listing all profile/use subcommands

## Test plan
- [ ] `kapacitor --help` shows the new Profiles section
- [ ] `kapacitor profile --help` prints subcommand help with examples
- [ ] `kapacitor use --help` prints usage with `--global` and `--save` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)