### PR TITLE
Persist daemon repo paths for agent launch dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,19 @@ kapacitor agent status             # check if daemon is running
 kapacitor agent stop               # stop the background daemon
 ```
 
+### Repository paths
+
+Manage known repo paths for the agent launch dialog. Repos are automatically added when agents are launched, but you can also manage the list manually:
+
+```bash
+kapacitor repos                    # list known repos (sorted by last used)
+kapacitor repos add .              # add current directory
+kapacitor repos add ~/dev/project  # add a specific path
+kapacitor repos remove ~/dev/old   # remove a path
+```
+
+Known repos are persisted to `~/.config/kapacitor/repos.json` and reported to the server when the daemon connects, so the launch dialog always shows previously-used repos even after restarts.
+
 ### Profiles
 
 Profiles let you work with multiple Capacitor servers — for example, a company server for work repos and a separate one for open-source projects. Each profile stores its own server URL, visibility settings, and daemon configuration.

--- a/src/kapacitor/Config/RepoPathStore.cs
+++ b/src/kapacitor/Config/RepoPathStore.cs
@@ -6,6 +6,8 @@ namespace kapacitor.Config;
 static class RepoPathStore {
     static readonly string StorePath = PathHelpers.ConfigPath("repos.json");
 
+    static readonly SemaphoreSlim Lock = new(1, 1);
+
     static readonly StringComparison PathComparison =
         RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
             ? StringComparison.Ordinal
@@ -28,33 +30,47 @@ static class RepoPathStore {
 
     public static async Task AddAsync(string path) {
         var normalized = NormalizePath(path);
-        var entries    = (await LoadAsync()).ToList();
-        var existing   = entries.FindIndex(e => string.Equals(e.Path, normalized, PathComparison));
 
-        if (existing >= 0) {
-            entries[existing] = entries[existing] with { LastUsed = DateTimeOffset.UtcNow };
-        } else {
-            entries.Add(new RepoEntry { Path = normalized, LastUsed = DateTimeOffset.UtcNow });
+        await Lock.WaitAsync();
+
+        try {
+            var entries  = (await LoadAsync()).ToList();
+            var existing = entries.FindIndex(e => string.Equals(e.Path, normalized, PathComparison));
+
+            if (existing >= 0) {
+                entries[existing] = entries[existing] with { LastUsed = DateTimeOffset.UtcNow };
+            } else {
+                entries.Add(new RepoEntry { Path = normalized, LastUsed = DateTimeOffset.UtcNow });
+            }
+
+            await SaveAsync(entries);
+        } finally {
+            Lock.Release();
         }
-
-        await SaveAsync(entries);
     }
 
     public static async Task<bool> RemoveAsync(string path) {
         var normalized = NormalizePath(path);
-        var entries    = (await LoadAsync()).ToList();
-        var removed    = entries.RemoveAll(e => string.Equals(e.Path, normalized, PathComparison));
 
-        if (removed == 0) return false;
+        await Lock.WaitAsync();
 
-        await SaveAsync(entries);
-        return true;
+        try {
+            var entries = (await LoadAsync()).ToList();
+            var removed = entries.RemoveAll(e => string.Equals(e.Path, normalized, PathComparison));
+
+            if (removed == 0) return false;
+
+            await SaveAsync(entries);
+            return true;
+        } finally {
+            Lock.Release();
+        }
     }
 
     static async Task SaveAsync(List<RepoEntry> entries) {
         var dir = Path.GetDirectoryName(StorePath)!;
         Directory.CreateDirectory(dir);
-        var tempPath = $"{StorePath}.tmp";
+        var tempPath = Path.Combine(dir, $"repos.{Environment.ProcessId}.tmp");
         var sorted   = entries.OrderByDescending(e => e.LastUsed).ToArray();
         await File.WriteAllTextAsync(tempPath, JsonSerializer.Serialize(sorted, KapacitorJsonContext.Default.RepoEntryArray));
         File.Move(tempPath, StorePath, overwrite: true);

--- a/src/kapacitor/Resources/help-usage.txt
+++ b/src/kapacitor/Resources/help-usage.txt
@@ -24,6 +24,9 @@ Agent Daemon:
   agent start [-d]                 Start agent daemon (foreground, or -d for background)
   agent stop                       Stop background agent daemon
   agent status                     Show agent daemon status
+  repos                            List known repos (sorted by last used)
+  repos add <path>                 Add a repo path (supports "." for cwd)
+  repos remove <path>              Remove a repo path
 
 Session:
   errors [--chain] [id]            List tool call errors for a session


### PR DESCRIPTION
## Summary

- Add `RepoPathStore` that persists known repo paths to `~/.config/kapacitor/repos.json` with `last_used` timestamps
- Add `kapacitor repos` CLI command (list/add/remove) for manual management — supports `kapacitor repos add .`
- Daemon merges persisted repos with configured `AllowedRepoPaths` on connect (separation: config stays security whitelist, persisted store is for UI)
- Auto-add repo on successful agent launch + live UI update via `DaemonUpdateRepoPaths` hub method
- 19 unit tests for `RepoPathStore`

Server-side counterpart: kurrent-io/Kurrent.Capacitor PR (adds `DaemonUpdateRepoPaths` hub method)

## Test plan

- [x] `kapacitor repos` shows empty state
- [x] `kapacitor repos add .` adds current directory
- [x] `kapacitor repos` lists with "just now" timestamp
- [x] `kapacitor repos remove .` removes and confirms
- [x] Daemon restart picks up persisted repos on connect
- [x] AOT publish clean — no IL3050/IL2026 warnings
- [x] 19 unit tests pass (load, add, remove, dedup, normalization, sorting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)