### PR TITLE
[DEV-1466] Relay per-question eval progress (started + failed)

### DIFF
--- a/src/kapacitor/Daemon/Services/EvalRunner.cs
+++ b/src/kapacitor/Daemon/Services/EvalRunner.cs
@@ -78,13 +78,20 @@ public sealed class EvalRunner {
 }
 
 /// <summary>
-/// <see cref="IEvalObserver"/> implementation that pushes the shaped
-/// callbacks — <see cref="OnStarted"/>, <see cref="OnQuestionCompleted"/>,
-/// <see cref="OnFinished"/>, <see cref="OnFailed"/> — over the daemon's
-/// SignalR connection so the dashboard can render live progress. Info /
-/// per-question-start / per-question-failure / fact-retained callbacks
-/// just log locally; they're not interesting enough to justify SignalR
-/// chatter for every judge.
+/// <see cref="IEvalObserver"/> implementation that pushes every per-run
+/// and per-question transition — <see cref="OnStarted"/>,
+/// <see cref="OnQuestionStarted"/>, <see cref="OnQuestionCompleted"/>,
+/// <see cref="OnQuestionFailed"/>, <see cref="OnFinished"/>,
+/// <see cref="OnFailed"/> — over the daemon's SignalR connection so the
+/// dashboard can render live progress. Per-question start + fail are
+/// relayed (not just completed) because the dashboard advances the
+/// "running" marker off `QuestionStarted` and the ✗ marker off
+/// `QuestionFailed`; without them, a judge that returned an unparseable
+/// verdict (or timed out) leaves the UI stuck on the previous question
+/// until the whole 13-judge loop finally ends. <see cref="OnInfo"/>,
+/// <see cref="OnContextFetched"/>, and <see cref="OnFactRetained"/> are
+/// debug-log-only — the dashboard has no rendering for them and the
+/// SignalR chatter would be pure overhead.
 /// </summary>
 sealed class DaemonEvalObserver(
         ServerConnection connection,

--- a/src/kapacitor/Daemon/Services/EvalRunner.cs
+++ b/src/kapacitor/Daemon/Services/EvalRunner.cs
@@ -110,8 +110,10 @@ sealed class DaemonEvalObserver(
     public void OnContextFetched(int traceEntries, int traceChars, int toolResultsTotal, int toolResultsTruncated, long bytesSaved) =>
         logger.LogDebug("Eval {Run} context fetched: {Entries} entries, {Chars} chars", evalRunId, traceEntries, traceChars);
 
-    public void OnQuestionStarted(int index, int total, string category, string questionId) =>
+    public void OnQuestionStarted(int index, int total, string category, string questionId) {
         logger.LogDebug("[eval {Run}] [{Index}/{Total}] {Category}/{Question} started", evalRunId, index, total, category, questionId);
+        Relay(() => connection.EvalQuestionStartedAsync(evalRunId, sessionId, index, total, category, questionId), "EvalQuestionStarted");
+    }
 
     public void OnQuestionCompleted(int index, int total, EvalQuestionVerdict verdict, long inputTokens, long outputTokens) {
         logger.LogInformation(
@@ -121,8 +123,10 @@ sealed class DaemonEvalObserver(
         Relay(() => connection.EvalQuestionCompletedAsync(evalRunId, sessionId, index, total, verdict.Category, verdict.QuestionId, verdict.Score, verdict.Verdict), "EvalQuestionCompleted");
     }
 
-    public void OnQuestionFailed(int index, int total, string category, string questionId, string reason) =>
+    public void OnQuestionFailed(int index, int total, string category, string questionId, string reason) {
         logger.LogWarning("[eval {Run}] [{Index}/{Total}] {Category}/{Question} failed: {Reason}", evalRunId, index, total, category, questionId, reason);
+        Relay(() => connection.EvalQuestionFailedAsync(evalRunId, sessionId, index, total, category, questionId, reason), "EvalQuestionFailed");
+    }
 
     public void OnFactRetained(string category, string fact) =>
         logger.LogDebug("[eval {Run}] retained fact for {Category}: {Fact}", evalRunId, category, fact);

--- a/src/kapacitor/Daemon/Services/ServerConnection.cs
+++ b/src/kapacitor/Daemon/Services/ServerConnection.cs
@@ -184,8 +184,14 @@ public partial class ServerConnection : IAsyncDisposable {
     public Task EvalStartedAsync(string evalRunId, string sessionId, string judgeModel, int totalQuestions)
         => _hub.SendAsync("EvalStarted", new EvalStarted(evalRunId, sessionId, judgeModel, totalQuestions), cancellationToken: _ct);
 
+    public Task EvalQuestionStartedAsync(string evalRunId, string sessionId, int index, int total, string category, string questionId)
+        => _hub.SendAsync("EvalQuestionStarted", new EvalQuestionStarted(evalRunId, sessionId, index, total, category, questionId), cancellationToken: _ct);
+
     public Task EvalQuestionCompletedAsync(string evalRunId, string sessionId, int index, int total, string category, string questionId, int score, string verdict)
         => _hub.SendAsync("EvalQuestionCompleted", new EvalQuestionCompleted(evalRunId, sessionId, index, total, category, questionId, score, verdict), cancellationToken: _ct);
+
+    public Task EvalQuestionFailedAsync(string evalRunId, string sessionId, int index, int total, string category, string questionId, string reason)
+        => _hub.SendAsync("EvalQuestionFailed", new EvalQuestionFailed(evalRunId, sessionId, index, total, category, questionId, reason), cancellationToken: _ct);
 
     public Task EvalFinishedAsync(string evalRunId, string sessionId, int overallScore, string summary)
         => _hub.SendAsync("EvalFinished", new EvalFinished(evalRunId, sessionId, overallScore, summary), cancellationToken: _ct);

--- a/src/kapacitor/Eval/IEvalObserver.cs
+++ b/src/kapacitor/Eval/IEvalObserver.cs
@@ -2,11 +2,16 @@ namespace kapacitor.Eval;
 
 /// <summary>
 /// Progress surface for an eval run. The CLI implementation writes each
-/// callback to stderr; a daemon implementation (DEV-1440 milestone 2) will
-/// push the shaped callbacks (<see cref="OnStarted"/>,
-/// <see cref="OnQuestionCompleted"/>, <see cref="OnFinished"/>,
-/// <see cref="OnFailed"/>) over SignalR so the dashboard can render live
-/// progress while judges run on the user's machine.
+/// callback to stderr; the daemon implementation (DEV-1440 milestone 2)
+/// pushes every per-run and per-question transition
+/// (<see cref="OnStarted"/>, <see cref="OnQuestionStarted"/>,
+/// <see cref="OnQuestionCompleted"/>, <see cref="OnQuestionFailed"/>,
+/// <see cref="OnFinished"/>, <see cref="OnFailed"/>) over SignalR so the
+/// dashboard can render live progress — including failed judges —
+/// while they run on the user's machine.
+/// <see cref="OnInfo"/>, <see cref="OnContextFetched"/>, and
+/// <see cref="OnFactRetained"/> are daemon-local (debug logs only) since
+/// the dashboard has no rendering for them.
 ///
 /// <para>
 /// Callbacks are fired from the running eval task but must not perform

--- a/src/kapacitor/Models.cs
+++ b/src/kapacitor/Models.cs
@@ -382,7 +382,9 @@ record RepoEntry {
 [JsonSerializable(typeof(ResizeTerminalCommand))]
 [JsonSerializable(typeof(RunEvalCommand))]
 [JsonSerializable(typeof(EvalStarted))]
+[JsonSerializable(typeof(EvalQuestionStarted))]
 [JsonSerializable(typeof(EvalQuestionCompleted))]
+[JsonSerializable(typeof(EvalQuestionFailed))]
 [JsonSerializable(typeof(EvalFinished))]
 [JsonSerializable(typeof(EvalFailed))]
 [JsonSerializable(typeof(DaemonConnect))]
@@ -477,6 +479,16 @@ public readonly record struct EvalStarted(
         int    TotalQuestions
     );
 
+/// <summary>Daemon → server: a judge question started running. Emitted before each claude invocation so the dashboard can show which question is currently in flight even when earlier ones failed.</summary>
+public readonly record struct EvalQuestionStarted(
+        string EvalRunId,
+        string SessionId,
+        int    Index,
+        int    Total,
+        string Category,
+        string QuestionId
+    );
+
 /// <summary>Daemon → server: a judge question completed with a verdict.</summary>
 public readonly record struct EvalQuestionCompleted(
         string EvalRunId,
@@ -487,6 +499,17 @@ public readonly record struct EvalQuestionCompleted(
         string QuestionId,
         int    Score,
         string Verdict
+    );
+
+/// <summary>Daemon → server: a judge question failed (claude returned no/unparseable result, timed out, or emitted an out-of-range score). The overall eval continues to the next question.</summary>
+public readonly record struct EvalQuestionFailed(
+        string EvalRunId,
+        string SessionId,
+        int    Index,
+        int    Total,
+        string Category,
+        string QuestionId,
+        string Reason
     );
 
 /// <summary>Daemon → server: eval run finished end-to-end and aggregate has been persisted.</summary>


### PR DESCRIPTION
## Summary

- Add `EvalQuestionStarted` and `EvalQuestionFailed` record structs + source-gen JSON registration
- `ServerConnection` gains `EvalQuestionStartedAsync` / `EvalQuestionFailedAsync` send methods
- `DaemonEvalObserver` now relays both callbacks over SignalR in addition to the local log

## Why

The existing observer only relayed `OnQuestionCompleted`. A judge that returned unparseable JSON, a score outside 1..5, or timed out at 5min would silently fall into `OnQuestionFailed` (local log only) and the next question would start silently too because `OnQuestionStarted` also only logged. If Q1 hit any of those paths, the dashboard sat on the Q1 spinner for ~65 minutes — until the full 13-judge loop finished and `EvalFailed("all judge invocations failed")` finally fired. Paired with a confusing "Evaluating…" UI that never progressed, this rendered the UI-driven eval effectively unusable when any judge misbehaved.

Relaying both per-question transitions lets the dashboard be strictly event-driven: the UI advances the running marker when the daemon says a question started, and marks a row ✗ with the reason when one fails, regardless of whether the previous one completed.

## Paired server PR

Server-side wiring (hub methods, `AgentStoreDataService` events, `SessionEvaluationTab` handlers, + two unrelated follow-ups on the same ticket) is in [kurrent-io/Kurrent.Capacitor#alexeyzimarev/dev-1466-follow-up-eval-issues](https://github.com/kurrent-io/Kurrent.Capacitor/pull/new/alexeyzimarev/dev-1466-follow-up-eval-issues). Merge this PR first so the server's submodule bump pulls it in.

## Test plan

- [ ] \`dotnet publish src/kapacitor/kapacitor.csproj -c Release\` — no IL3050 / IL2026 warnings (verified locally)
- [ ] Trigger an eval from the dashboard against a session whose trace causes one or more judges to fail (e.g. verdict JSON malformed) — the UI should mark those rows ✗ with the failure reason and continue advancing through the remaining 12 questions instead of locking up

🤖 Generated with [Claude Code](https://claude.com/claude-code)