### PR TITLE
[DEV-1475] Eval: block auto-loaded LSP/MCP tools and log parse failures

### DIFF
--- a/src/kapacitor/ClaudeCliRunner.cs
+++ b/src/kapacitor/ClaudeCliRunner.cs
@@ -110,6 +110,18 @@ static class ClaudeCliRunner {
         psi.ArgumentList.Add(model);
         psi.ArgumentList.Add("--tools");
         psi.ArgumentList.Add("");
+        // `--tools ""` is not enough for headless single-turn judge runs:
+        //   - MCP servers from the user's global config still load, so we
+        //     need `--strict-mcp-config` (with no `--mcp-config`) to load zero.
+        //   - The built-in `LSP` tool is attached regardless of `--tools`,
+        //     and Claude eagerly probes any file paths it sees in the
+        //     compacted trace, blowing past `--max-turns 1` with
+        //     `stop_reason=tool_use`. `--disallowedTools LSP` blocks it.
+        // Without both flags, real eval traces (which mention file paths)
+        // fail every question with `error_max_turns`.
+        psi.ArgumentList.Add("--strict-mcp-config");
+        psi.ArgumentList.Add("--disallowedTools");
+        psi.ArgumentList.Add("LSP");
 
         using var process = Process.Start(psi);
 

--- a/src/kapacitor/Eval/EvalService.cs
+++ b/src/kapacitor/Eval/EvalService.cs
@@ -154,10 +154,15 @@ internal static class EvalService {
             var patterns = FormatKnownPatterns(knownFactsByCategory.GetValueOrDefault(q.Category, []));
             var prompt   = BuildQuestionPrompt(promptTemplate, context.SessionId, evalRunId, q, traceJson, patterns);
 
+            // Capture ClaudeCliRunner diagnostics (exit code, stdout preview)
+            // so a null result gets reported with *why* it was null — those
+            // lines are the only signal about API errors or max-turn failures,
+            // and daemon observers log OnInfo at Debug level where they vanish.
+            var diagnostics = new List<string>();
             var result = await ClaudeCliRunner.RunAsync(
                 prompt,
                 TimeSpan.FromMinutes(5),
-                msg => observer.OnInfo($"  {msg}"),
+                msg => { diagnostics.Add(msg); observer.OnInfo($"  {msg}"); },
                 model: model,
                 maxTurns: 1,
                 // Prompts embed the full compacted trace and can be hundreds
@@ -167,14 +172,17 @@ internal static class EvalService {
             );
 
             if (result is null) {
-                observer.OnQuestionFailed(i + 1, EvalQuestions.All.Length, q.Category, q.Id, "null claude result");
+                var reason = diagnostics.Count == 0
+                    ? "null claude result"
+                    : $"null claude result; {string.Join(" | ", diagnostics.Select(d => Truncate(d, 300)))}";
+                observer.OnQuestionFailed(i + 1, EvalQuestions.All.Length, q.Category, q.Id, reason);
 
                 continue;
             }
 
             var verdict = ParseVerdict(result.Result, q);
             if (verdict is null) {
-                observer.OnQuestionFailed(i + 1, EvalQuestions.All.Length, q.Category, q.Id, "verdict JSON could not be parsed");
+                observer.OnQuestionFailed(i + 1, EvalQuestions.All.Length, q.Category, q.Id, $"verdict JSON could not be parsed; raw response: {Truncate(result.Result, 500)}");
 
                 continue;
             }
@@ -402,6 +410,9 @@ internal static class EvalService {
         return text.Trim();
     }
 
+    static string Truncate(string text, int max) =>
+        text.Length <= max ? text : text[..max] + $"… ({text.Length - max} more chars)";
+
     // ── Aggregation ────────────────────────────────────────────────────────
 
     public static SessionEvalCompletedPayload Aggregate(List<EvalQuestionVerdict> verdicts, string evalRunId, string model) {
@@ -496,7 +507,7 @@ internal static class EvalService {
 
             var retrospective = ParseRetrospective(result.Result);
             if (retrospective is null) {
-                observer.OnRetrospectiveFailed("retrospective response did not parse as expected JSON shape");
+                observer.OnRetrospectiveFailed($"retrospective response did not parse as expected JSON shape; raw response: {Truncate(result.Result, 500)}");
 
                 return null;
             }

--- a/src/kapacitor/Eval/EvalService.cs
+++ b/src/kapacitor/Eval/EvalService.cs
@@ -410,8 +410,29 @@ internal static class EvalService {
         return text.Trim();
     }
 
-    static string Truncate(string text, int max) =>
-        text.Length <= max ? text : text[..max] + $"… ({text.Length - max} more chars)";
+    /// <summary>
+    /// Prepares untrusted model or subprocess output for embedding in a
+    /// single-line log/observer reason: escapes C0 control chars (so newlines
+    /// can't fake multi-line log entries or inject ANSI/log-structure), then
+    /// truncates to <paramref name="max"/> with a remainder marker. Both steps
+    /// matter — sanitising without truncating lets model output dominate the
+    /// log, truncating without sanitising lets a single \n split the reason
+    /// into what looks like two log entries.
+    /// </summary>
+    internal static string Truncate(string text, int max) {
+        var sb = new StringBuilder(text.Length);
+        foreach (var c in text) {
+            sb.Append(c switch {
+                '\n'             => "\\n",
+                '\r'             => "\\r",
+                '\t'             => "\\t",
+                < ' ' or '\x7f'  => "?",
+                _                => c.ToString()
+            });
+        }
+        var sanitised = sb.ToString();
+        return sanitised.Length <= max ? sanitised : sanitised[..max] + $"… ({sanitised.Length - max} more chars)";
+    }
 
     // ── Aggregation ────────────────────────────────────────────────────────
 

--- a/test/kapacitor.Tests.Unit/EvalServiceTests.cs
+++ b/test/kapacitor.Tests.Unit/EvalServiceTests.cs
@@ -436,4 +436,43 @@ public class EvalServiceTests {
         await Assert.That(prompt).Contains(facts);
         await Assert.That(prompt).Contains(trace);
     }
+
+    // ── Truncate (log-safe sanitisation) ────────────────────────────────────
+
+    [Test]
+    public async Task Truncate_escapes_newlines_tabs_and_carriage_returns() {
+        var s = EvalService.Truncate("line one\nline two\r\nwith\ttab", 500);
+
+        await Assert.That(s).IsEqualTo("line one\\nline two\\r\\nwith\\ttab");
+        await Assert.That(s).DoesNotContain("\n");
+        await Assert.That(s).DoesNotContain("\r");
+        await Assert.That(s).DoesNotContain("\t");
+    }
+
+    [Test]
+    public async Task Truncate_replaces_other_control_chars_with_question_mark() {
+        // BEL (0x07) and NUL (0x00) must not reach logs verbatim — they can
+        // forge terminal escape sequences or truncate log lines on some sinks.
+        var s = EvalService.Truncate("ok\u0007hi\u0000end\u007f", 500);
+
+        await Assert.That(s).IsEqualTo("ok?hi?end?");
+    }
+
+    [Test]
+    public async Task Truncate_shortens_to_max_and_appends_remainder_marker() {
+        var s = EvalService.Truncate(new string('x', 600), 500);
+
+        await Assert.That(s.StartsWith(new string('x', 500))).IsTrue();
+        await Assert.That(s).Contains("… (100 more chars)");
+    }
+
+    [Test]
+    public async Task Truncate_sanitises_before_measuring_length() {
+        // Escaping newlines expands the string (1 char -> 2 chars), so the
+        // truncation budget must apply to the sanitised form, not the raw one.
+        var s = EvalService.Truncate(new string('\n', 300), 500);
+
+        await Assert.That(s.Length).IsEqualTo(500 + "… (100 more chars)".Length);
+        await Assert.That(s).DoesNotContain("\n");
+    }
 }


### PR DESCRIPTION
## Summary

- `--tools ""` is not enough in Claude CLI 2.1.x: user-level MCP servers still load, and the built-in `LSP` tool is attached regardless. Eval judges probe file paths in the compacted trace, hit `stop_reason=tool_use`, and blow past `--max-turns 1` with `error_max_turns` — every question fails with `null claude result` or `verdict JSON could not be parsed`.
- Add `--strict-mcp-config` (loads zero MCP servers) and `--disallowedTools LSP` in `ClaudeCliRunner`.
- Surface parse failures: the raw (truncated) claude response is now included in verdict / retrospective parse-failure reasons, and the "null claude result" path includes the `ClaudeCliRunner` diagnostics (exit code, stdout preview) that were previously only at `Debug` level and invisible in daemon logs.

Linear: DEV-1475. Follow-up exploration for giving judges real tool access tracked in DEV-1474.

## Test plan

- [x] `dotnet build src/kapacitor/kapacitor.csproj -c Release` — clean
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — no IL3050 / IL2026 AOT warnings
- [x] `dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj` — 212/212 pass
- [x] End-to-end: re-ran `kapacitor eval 589e7276c369440fa27da1cbced0bf27 --model sonnet` — questions complete with `tools=[]` in the transcripts instead of `tools=['LSP']` / `tools=['mcp__plugin_playwright_playwright__browser_snapshot']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)