### PR TITLE
[DEV-1477] SecretRedactor: cover all AWS unique-ID prefixes

### DIFF
--- a/src/kapacitor/SecretRedactor.cs
+++ b/src/kapacitor/SecretRedactor.cs
@@ -59,7 +59,7 @@ static partial class SecretRedactor {
 
     static string RedactSecrets(string text) {
         text = PemBlockRegex.Replace(text, "[REDACTED]");
-        text = AwsAccessKeyRegex.Replace(text, "[REDACTED]");
+        text = AwsUniqueIdRegex.Replace(text, "[REDACTED]");
         text = VendorTokenRegex.Replace(text, "[REDACTED]");
         text = JsonKeySecretRegex.Replace(text, "$1[REDACTED]$3");
         text = EnvVarSecretRegex.Replace(text, "$1[REDACTED]");
@@ -75,11 +75,13 @@ static partial class SecretRedactor {
 
     static readonly Regex PemBlockRegex = PemBlockRx();
 
-    // AWS access key IDs: AKIA followed by 16 uppercase alphanumeric chars
-    [GeneratedRegex(@"AKIA[0-9A-Z]{16}", RegexOptions.None)]
-    private static partial Regex AwsAccessKeyRx();
+    // AWS unique ID prefixes (access keys, session tokens, IAM principals).
+    // See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-prefixes
+    // Each prefix is 4 uppercase letters followed by 16 uppercase alphanumeric chars.
+    [GeneratedRegex(@"(?:AKIA|ASIA|AROA|AIDA|AIPA|AGPA|ANPA|ANVA|ASCA|APKA|ABIA|ACCA)[0-9A-Z]{16}", RegexOptions.None)]
+    private static partial Regex AwsUniqueIdRx();
 
-    static readonly Regex AwsAccessKeyRegex = AwsAccessKeyRx();
+    static readonly Regex AwsUniqueIdRegex = AwsUniqueIdRx();
 
     // Known vendor token prefixes followed by token characters
     // Each prefix is specific enough to avoid false positives

--- a/src/kapacitor/SecretRedactor.cs
+++ b/src/kapacitor/SecretRedactor.cs
@@ -77,8 +77,10 @@ static partial class SecretRedactor {
 
     // AWS unique ID prefixes (access keys, session tokens, IAM principals).
     // See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-prefixes
-    // Each prefix is 4 uppercase letters followed by 16 uppercase alphanumeric chars.
-    [GeneratedRegex(@"(?:AKIA|ASIA|AROA|AIDA|AIPA|AGPA|ANPA|ANVA|ASCA|APKA|ABIA|ACCA)[0-9A-Z]{16}", RegexOptions.None)]
+    // Access keys (AKIA/ASIA) are 20 chars total; IAM principal unique IDs are typically 21 chars
+    // but not strictly length-bounded, so match {16,128} with a non-alnum lookahead to avoid
+    // leaving a trailing character adjacent to [REDACTED].
+    [GeneratedRegex(@"(?:AKIA|ASIA|AROA|AIDA|AIPA|AGPA|ANPA|ANVA|ASCA|APKA|ABIA|ACCA)[0-9A-Z]{16,128}(?![0-9A-Z])", RegexOptions.None)]
     private static partial Regex AwsUniqueIdRx();
 
     static readonly Regex AwsUniqueIdRegex = AwsUniqueIdRx();

--- a/test/kapacitor.Tests.Unit/SecretRedactorTests.cs
+++ b/test/kapacitor.Tests.Unit/SecretRedactorTests.cs
@@ -96,8 +96,10 @@ public class SecretRedactorTests {
 
         var result = SecretRedactor.RedactLine(line);
 
+        // Assert full redaction with adjacent-character locked down — a partial leak like
+        // "[REDACTED]5" (21-char ID redacted as 20) would still pass DoesNotContain(id).
+        await Assert.That(result).Contains("id is [REDACTED] here");
         await Assert.That(result).DoesNotContain(id);
-        await Assert.That(result).Contains("[REDACTED]");
     }
 
     [Test]

--- a/test/kapacitor.Tests.Unit/SecretRedactorTests.cs
+++ b/test/kapacitor.Tests.Unit/SecretRedactorTests.cs
@@ -84,6 +84,38 @@ public class SecretRedactorTests {
     }
 
     [Test]
+    [Arguments("ASIASUOU4HYNTGJIZ23T", "STS temporary access key")]
+    [Arguments("AROASUOU4HYN3THVQBHO5", "IAM role unique ID")]
+    [Arguments("AIDAJQABLZS4A3QDU576Q", "IAM user unique ID")]
+    [Arguments("AIPAIFHHFHABCDEF12345", "EC2 instance profile ID")]
+    [Arguments("AGPAI23HXD2XYZ123ABCD", "IAM group ID")]
+    public async Task RedactsLine_AwsUniqueId_InToolResult(string id, string _description) {
+        var line = $$$"""
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"id is {{{id}}} here","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain(id);
+        await Assert.That(result).Contains("[REDACTED]");
+    }
+
+    [Test]
+    public async Task RedactsLine_SecretAccessKey_InTruncatedToolOutput() {
+        // Reproduces a real leak: a shell script prints only the first N chars of a JSON
+        // credentials blob, so the SecretAccessKey value has no closing quote.
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"First 100 chars: {\n    \"AccessKeyId\": \"ASIASUOU4HYNTGJIZ23T\",\n    \"SecretAccessKey\": \"0X+FPiUxddhI7babryQv4l5JQ37Smuy","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("0X+FPiUxddhI7babryQv4l5JQ37Smuy");
+        await Assert.That(result).DoesNotContain("ASIASUOU4HYNTGJIZ23T");
+        await Assert.That(result).Contains("[REDACTED]");
+    }
+
+    [Test]
     public async Task RedactsLine_JsonKeySecret_InToolResult() {
         var line = """
             {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"{ \"client_secret\": \"a8f3b2c91d4e7f0123456789abcdef01\" }","is_error":false}]}}


### PR DESCRIPTION
## Summary
- Replaces the `AKIA`-only AWS access key regex in `SecretRedactor` with `AwsUniqueIdRegex`, matching all AWS unique-ID prefixes (`AKIA`, `ASIA`, `AROA`, `AIDA`, `AIPA`, `AGPA`, `ANPA`, `ANVA`, `ASCA`, `APKA`, `ABIA`, `ACCA`).
- Closes a real leak observed in a transcript where `aws sts assume-role` output (`AccessKeyId: ASIA…`, `UserId: AROA…:debug`) was relayed unredacted because only `AKIA` was covered.
- Adds parameterised tests for the new prefixes and a regression test reproducing the truncated-output shape (JSON string cut mid-value by a shell `First 100 chars:` pattern).

## Not in scope
- Redaction is still gated on lines containing a `tool_result` block (`SecretRedactor.cs:35-46`), so assistant text and `tool_use` inputs remain unscanned. Left for a separate discussion.
- 40-char secret access keys without a preceding key name are still only caught when labelled (`"SecretAccessKey"`, `AWS_SECRET_ACCESS_KEY=…`).

## Test plan
- [x] `dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj` — 227/227 pass
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — clean, no IL3050/IL2026 warnings

Closes DEV-1477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)