### PR TITLE
[DEV-1463] PR 2/3: Per-question SignalR eval dispatch (daemon side)

### DIFF
--- a/src/kapacitor/Daemon/DaemonRunner.cs
+++ b/src/kapacitor/Daemon/DaemonRunner.cs
@@ -137,9 +137,10 @@ public static partial class DaemonRunner {
         await worktreeManager.CleanupOrphanedAsync();
 
         var orchestrator = host.Services.GetRequiredService<AgentOrchestrator>();
-        // Instantiate EvalRunner so it subscribes to OnRunEval on the
-        // ServerConnection. It's stateless beyond the subscription, so no
-        // disposal dance is needed.
+        // Instantiate EvalRunner so it wires the per-phase eval handlers
+        // (PrepareEval / RunQuestion / FinalizeEval / CancelEval) on the
+        // ServerConnection. It's stateless beyond the handler assignment —
+        // cached context lives in EvalContextCache — so no disposal dance.
         _ = host.Services.GetRequiredService<EvalRunner>();
 
         try {

--- a/src/kapacitor/Daemon/DaemonRunner.cs
+++ b/src/kapacitor/Daemon/DaemonRunner.cs
@@ -121,6 +121,7 @@ public static partial class DaemonRunner {
 
         builder.Services.AddHttpClient("Attachments", client => client.BaseAddress = new Uri(config.ServerUrl));
         builder.Services.AddSingleton<AgentOrchestrator>();
+        builder.Services.AddSingleton<EvalContextCache>();
         builder.Services.AddSingleton<EvalRunner>();
 
         var host   = builder.Build();

--- a/src/kapacitor/Daemon/Services/AgentOrchestrator.cs
+++ b/src/kapacitor/Daemon/Services/AgentOrchestrator.cs
@@ -50,7 +50,7 @@ public class TerminalOutputBuffer {
     }
 }
 
-public partial class AgentOrchestrator : IAsyncDisposable {
+internal partial class AgentOrchestrator : IAsyncDisposable {
     readonly ConcurrentDictionary<string, AgentInstance> _agents = new();
     readonly DaemonConfig                                _config;
     readonly ServerConnection                            _server;

--- a/src/kapacitor/Daemon/Services/EvalContextCache.cs
+++ b/src/kapacitor/Daemon/Services/EvalContextCache.cs
@@ -7,29 +7,58 @@ namespace kapacitor.Daemon.Services;
 /// In-memory, per-evalRunId cache of prepared <see cref="EvalService.EvalContext"/> +
 /// accumulated verdicts. Populated by <c>PrepareEval</c>, read by each
 /// <c>RunQuestion</c>, evicted by <c>FinalizeEval</c> or <c>CancelEval</c>.
-/// A hard TTL guards against daemons holding a context indefinitely if
-/// the server crashes between Prepare and Finalize.
+///
+/// <para>Entries use sliding expiration keyed off last access so a long eval
+/// (13 questions × up to 5 min each) can't exceed the window between phase
+/// calls — only truly idle contexts expire. A background timer sweeps
+/// abandoned entries so a server crash between Prepare and Finalize doesn't
+/// leak <c>TraceJson</c> until process restart.</para>
 /// </summary>
-internal sealed class EvalContextCache {
-    sealed record Entry(EvalService.EvalContext Context, DateTimeOffset CreatedAt);
+internal sealed class EvalContextCache : IDisposable {
+    sealed record Entry(EvalService.EvalContext Context, DateTimeOffset LastAccessed);
 
     readonly ConcurrentDictionary<string, Entry> _entries = new();
+    readonly Timer                               _sweepTimer;
 
-    static readonly TimeSpan MaxAge = TimeSpan.FromMinutes(15);
+    // Sliding expiration — an entry is evicted when MaxIdle elapses since
+    // its last Get(). Per-question calls refresh the timestamp, so only
+    // abandoned entries (server crashed mid-run) expire.
+    static readonly TimeSpan MaxIdle       = TimeSpan.FromMinutes(30);
+    static readonly TimeSpan SweepInterval = TimeSpan.FromMinutes(5);
+
+    public EvalContextCache() {
+        _sweepTimer = new Timer(_ => Sweep(), null, SweepInterval, SweepInterval);
+    }
 
     public void Put(string evalRunId, EvalService.EvalContext ctx) =>
         _entries[evalRunId] = new Entry(ctx, DateTimeOffset.UtcNow);
 
     public EvalService.EvalContext? Get(string evalRunId) {
         if (!_entries.TryGetValue(evalRunId, out var entry)) return null;
-        if (DateTimeOffset.UtcNow - entry.CreatedAt > MaxAge) {
-            _entries.TryRemove(evalRunId, out _);
+        var now = DateTimeOffset.UtcNow;
+        if (now - entry.LastAccessed > MaxIdle) {
+            _entries.TryRemove(new KeyValuePair<string, Entry>(evalRunId, entry));
             return null;
         }
+        // Refresh last-access so sequential per-question dispatches don't
+        // age out a still-active run. Race-safe via TryUpdate — concurrent
+        // Get or Remove just loses the refresh, which is benign.
+        _entries.TryUpdate(evalRunId, entry with { LastAccessed = now }, entry);
         return entry.Context;
     }
 
     public void Remove(string evalRunId) => _entries.TryRemove(evalRunId, out _);
 
     public int Count => _entries.Count;
+
+    void Sweep() {
+        var now = DateTimeOffset.UtcNow;
+        foreach (var kvp in _entries) {
+            if (now - kvp.Value.LastAccessed > MaxIdle) {
+                _entries.TryRemove(kvp);
+            }
+        }
+    }
+
+    public void Dispose() => _sweepTimer.Dispose();
 }

--- a/src/kapacitor/Daemon/Services/EvalContextCache.cs
+++ b/src/kapacitor/Daemon/Services/EvalContextCache.cs
@@ -1,0 +1,35 @@
+using System.Collections.Concurrent;
+using kapacitor.Eval;
+
+namespace kapacitor.Daemon.Services;
+
+/// <summary>
+/// In-memory, per-evalRunId cache of prepared <see cref="EvalService.EvalContext"/> +
+/// accumulated verdicts. Populated by <c>PrepareEval</c>, read by each
+/// <c>RunQuestion</c>, evicted by <c>FinalizeEval</c> or <c>CancelEval</c>.
+/// A hard TTL guards against daemons holding a context indefinitely if
+/// the server crashes between Prepare and Finalize.
+/// </summary>
+internal sealed class EvalContextCache {
+    sealed record Entry(EvalService.EvalContext Context, DateTimeOffset CreatedAt);
+
+    readonly ConcurrentDictionary<string, Entry> _entries = new();
+
+    static readonly TimeSpan MaxAge = TimeSpan.FromMinutes(15);
+
+    public void Put(string evalRunId, EvalService.EvalContext ctx) =>
+        _entries[evalRunId] = new Entry(ctx, DateTimeOffset.UtcNow);
+
+    public EvalService.EvalContext? Get(string evalRunId) {
+        if (!_entries.TryGetValue(evalRunId, out var entry)) return null;
+        if (DateTimeOffset.UtcNow - entry.CreatedAt > MaxAge) {
+            _entries.TryRemove(evalRunId, out _);
+            return null;
+        }
+        return entry.Context;
+    }
+
+    public void Remove(string evalRunId) => _entries.TryRemove(evalRunId, out _);
+
+    public int Count => _entries.Count;
+}

--- a/src/kapacitor/Daemon/Services/EvalRunner.cs
+++ b/src/kapacitor/Daemon/Services/EvalRunner.cs
@@ -5,75 +5,126 @@ using Microsoft.Extensions.Logging;
 namespace kapacitor.Daemon.Services;
 
 /// <summary>
-/// DEV-1440 milestone 2 — handles <see cref="RunEvalCommand"/> dispatched
-/// from the dashboard via SignalR. The daemon pulls an authenticated
-/// HTTP client, runs <see cref="EvalService"/> with a
-/// <see cref="DaemonEvalObserver"/> that relays progress back over the
-/// SignalR connection, and completes asynchronously — the SignalR
-/// <c>RunEval</c> hub invocation fires-and-forgets; progress comes back
-/// through <c>EvalStarted</c> / <c>EvalQuestionCompleted</c> / etc.
+/// Per-phase handlers for the DEV-1463 PR 2 eval dispatch protocol.
+/// Replaces the pre-PR-2 single-shot <c>RunEvalCommand</c> handler.
+/// Holds no state between calls except via <see cref="EvalContextCache"/>.
+///
+/// <para>Each handler translates a SignalR client-result invocation into
+/// a call to <see cref="EvalService"/> and packages the outcome as a
+/// typed result DTO. The server's orchestrator (see
+/// <c>EvalRunOrchestrator</c>) threads the phases together.</para>
 /// </summary>
-public sealed class EvalRunner {
+internal sealed class EvalRunner {
     readonly ServerConnection    _connection;
+    readonly EvalContextCache    _cache;
     readonly ILogger<EvalRunner> _logger;
     readonly string              _baseUrl;
     readonly CancellationToken   _shutdownToken;
 
     public EvalRunner(
             ServerConnection         connection,
+            EvalContextCache         cache,
             DaemonConfig             config,
             IHostApplicationLifetime lifetime,
             ILogger<EvalRunner>      logger
         ) {
         _connection    = connection;
+        _cache         = cache;
         _logger        = logger;
         _baseUrl       = config.ServerUrl.TrimEnd('/');
         _shutdownToken = lifetime.ApplicationStopping;
 
-        _connection.OnRunEval += HandleRunEvalAsync;
+        _connection.PrepareEvalHandler  = HandlePrepareAsync;
+        _connection.RunQuestionHandler  = HandleRunQuestionAsync;
+        _connection.FinalizeEvalHandler = HandleFinalizeAsync;
+        _connection.CancelEvalHandler   = HandleCancelAsync;
     }
 
-    async Task HandleRunEvalAsync(RunEvalCommand cmd) {
-        _logger.LogInformation(
-            "Dispatched eval {RunId} for session {Sid} (model {Model}, chain={Chain})",
-            cmd.EvalRunId, cmd.SessionId, cmd.Model, cmd.Chain
-        );
+    async Task<PrepareResult> HandlePrepareAsync(PrepareEvalCommand cmd) {
+        // SignalR 10.0.5's On<T1, TResult> overloads don't surface a
+        // per-call CancellationToken, so cancellation here is bounded
+        // only by the daemon's shutdown token. Server-side phase timeouts
+        // take effect via InvokeAsync<T>'s own timeout unwinding (the
+        // daemon's response is simply discarded if the server moved on).
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+        var observer = new DaemonEvalObserver(_connection, cmd.EvalRunId, cmd.SessionId, _logger);
 
-        // Fire-and-forget so the SignalR hub invocation doesn't block; the
-        // eval's own observer callbacks fan progress back to the server.
-        // Daemon shutdown cancels the token so in-flight evals get a clean
-        // OnFailed("cancelled") rather than dying mid-judge. Any unhandled
-        // exception from the run is caught and translated to an EvalFailed
-        // event so the dashboard learns about it either way.
-        _ = Task.Run(async () => {
-            try {
-                using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
-                var observer = new DaemonEvalObserver(_connection, cmd.EvalRunId, cmd.SessionId, _logger);
+        try {
+            var ctx = await EvalService.PrepareAsync(
+                _baseUrl, httpClient, cmd.SessionId, cmd.Questions,
+                cmd.Chain, cmd.ThresholdBytes, observer, _shutdownToken, cmd.Model, cmd.EvalRunId
+            );
+            if (ctx is null) return new PrepareResult(false, "context load failed", null, 0, 0, 0, 0, 0);
 
-                await EvalService.RunAsync(
-                    _baseUrl,
-                    httpClient,
-                    cmd.SessionId,
-                    cmd.Model,
-                    cmd.Chain,
-                    cmd.ThresholdBytes,
-                    observer,
-                    ct: _shutdownToken,
-                    // Use the dispatched run id so all progress events and
-                    // the persisted aggregate share the same correlation id
-                    // the dashboard already knows about.
-                    evalRunId: cmd.EvalRunId
-                );
-            } catch (Exception ex) {
-                _logger.LogError(ex, "Unhandled exception running eval {RunId} on session {Sid}", cmd.EvalRunId, cmd.SessionId);
+            _cache.Put(cmd.EvalRunId, ctx);
+            return new PrepareResult(
+                true, null,
+                ctx.SessionId,
+                ctx.ContextResult.Trace.Count,
+                ctx.TraceJson.Length,
+                ctx.ContextResult.Compaction.ToolResultsTotal,
+                ctx.ContextResult.Compaction.ToolResultsTruncated,
+                ctx.ContextResult.Compaction.BytesSaved
+            );
+        } catch (Exception ex) {
+            _logger.LogError(ex, "PrepareEval failed for {RunId}", cmd.EvalRunId);
+            return new PrepareResult(false, $"{ex.GetType().Name}: {ex.Message}", null, 0, 0, 0, 0, 0);
+        }
+    }
 
-                try {
-                    await _connection.EvalFailedAsync(cmd.EvalRunId, cmd.SessionId, $"daemon error: {ex.GetType().Name}");
-                } catch (Exception relayEx) {
-                    _logger.LogError(relayEx, "Failed to relay EvalFailed for eval {RunId}", cmd.EvalRunId);
-                }
-            }
-        });
+    async Task<QuestionResult> HandleRunQuestionAsync(RunQuestionCommand cmd) {
+        var ctx = _cache.Get(cmd.EvalRunId);
+        if (ctx is null) return new QuestionResult(false, null, "context not cached (prepare missing or expired)", 0, 0);
+
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+        var observer = new DaemonEvalObserver(_connection, cmd.EvalRunId, ctx.SessionId, _logger);
+
+        try {
+            // Model is carried on the cached EvalContext (set during Prepare) —
+            // the per-question wire format doesn't repeat it.
+            var verdict = await EvalService.RunQuestionAsync(
+                ctx, httpClient, _baseUrl, cmd.Question, ctx.Model,
+                cmd.Index, cmd.Total, observer, _shutdownToken
+            );
+            if (verdict is null) return new QuestionResult(false, null, "verdict null", 0, 0);
+
+            // Token counts are emitted by EvalService via the observer;
+            // daemon no longer owns that accounting. Report 0 here unless
+            // we surface them on the verdict type directly (future change).
+            return new QuestionResult(true, verdict, null, 0, 0);
+        } catch (Exception ex) {
+            _logger.LogError(ex, "RunQuestion failed for {RunId}/{QuestionId}", cmd.EvalRunId, cmd.Question.Id);
+            return new QuestionResult(false, null, $"{ex.GetType().Name}: {ex.Message}", 0, 0);
+        }
+    }
+
+    async Task<FinalizeResult> HandleFinalizeAsync(FinalizeEvalCommand cmd) {
+        var ctx = _cache.Get(cmd.EvalRunId);
+        if (ctx is null) return new FinalizeResult(false, "context not cached", null);
+
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+        var observer = new DaemonEvalObserver(_connection, cmd.EvalRunId, ctx.SessionId, _logger);
+
+        try {
+            // FinalizeAsync signature was updated in Task 6.5 — the taxonomy is
+            // carried on ctx.Questions, not passed separately.
+            var aggregate = await EvalService.FinalizeAsync(
+                ctx, httpClient, _baseUrl, cmd.Verdicts, cmd.Model,
+                observer, _shutdownToken
+            );
+
+            _cache.Remove(cmd.EvalRunId);
+            return new FinalizeResult(aggregate is not null, aggregate is null ? "finalize failed" : null, aggregate);
+        } catch (Exception ex) {
+            _logger.LogError(ex, "FinalizeEval failed for {RunId}", cmd.EvalRunId);
+            return new FinalizeResult(false, $"{ex.GetType().Name}: {ex.Message}", null);
+        }
+    }
+
+    Task HandleCancelAsync(CancelEvalCommand cmd) {
+        _cache.Remove(cmd.EvalRunId);
+        _logger.LogInformation("Cancelled eval {RunId}", cmd.EvalRunId);
+        return Task.CompletedTask;
     }
 }
 

--- a/src/kapacitor/Daemon/Services/EvalRunner.cs
+++ b/src/kapacitor/Daemon/Services/EvalRunner.cs
@@ -46,7 +46,7 @@ internal sealed class EvalRunner {
         // only by the daemon's shutdown token. Server-side phase timeouts
         // take effect via InvokeAsync<T>'s own timeout unwinding (the
         // daemon's response is simply discarded if the server moved on).
-        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync(_baseUrl);
         var observer = new DaemonEvalObserver(_connection, cmd.EvalRunId, cmd.SessionId, _logger);
 
         try {
@@ -76,7 +76,7 @@ internal sealed class EvalRunner {
         var ctx = _cache.Get(cmd.EvalRunId);
         if (ctx is null) return new QuestionResult(false, null, "context not cached (prepare missing or expired)", 0, 0);
 
-        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync(_baseUrl);
         var observer = new DaemonEvalObserver(_connection, cmd.EvalRunId, ctx.SessionId, _logger);
 
         try {
@@ -102,7 +102,7 @@ internal sealed class EvalRunner {
         var ctx = _cache.Get(cmd.EvalRunId);
         if (ctx is null) return new FinalizeResult(false, "context not cached", null);
 
-        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync(_baseUrl);
         var observer = new DaemonEvalObserver(_connection, cmd.EvalRunId, ctx.SessionId, _logger);
 
         try {
@@ -112,12 +112,13 @@ internal sealed class EvalRunner {
                 ctx, httpClient, _baseUrl, cmd.Verdicts, cmd.Model,
                 observer, _shutdownToken
             );
-
-            _cache.Remove(cmd.EvalRunId);
             return new FinalizeResult(aggregate is not null, aggregate is null ? "finalize failed" : null, aggregate);
         } catch (Exception ex) {
             _logger.LogError(ex, "FinalizeEval failed for {RunId}", cmd.EvalRunId);
             return new FinalizeResult(false, $"{ex.GetType().Name}: {ex.Message}", null);
+        } finally {
+            // Always evict — a finalize throw must not leak the cached context.
+            _cache.Remove(cmd.EvalRunId);
         }
     }
 

--- a/src/kapacitor/Daemon/Services/ServerConnection.cs
+++ b/src/kapacitor/Daemon/Services/ServerConnection.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace kapacitor.Daemon.Services;
 
-public partial class ServerConnection : IAsyncDisposable {
+internal partial class ServerConnection : IAsyncDisposable {
     readonly HubConnection             _hub;
     readonly DaemonConfig              _config;
     readonly ILogger<ServerConnection> _logger;
@@ -22,7 +22,20 @@ public partial class ServerConnection : IAsyncDisposable {
     public event Func<SendInputCommand, Task>?      OnSendInput;
     public event Func<string, string, Task>?        OnSendSpecialKey; // agentId, key
     public event Func<ResizeTerminalCommand, Task>? OnResizeTerminal;
-    public event Func<RunEvalCommand, Task>?        OnRunEval;
+
+    // Per-phase eval handlers (DEV-1463 PR 2). These use SignalR's
+    // client-result invocation — the server calls
+    // HubConnection.InvokeAsync<T> which expects exactly one handler
+    // returning the typed result, so we use settable properties rather
+    // than multicast events. The SignalR 10.0.5 On<T1, TResult> overloads
+    // don't expose a CancellationToken to the handler (verified against
+    // Microsoft.AspNetCore.SignalR.Client reflection), so per-call
+    // cancellation has to be driven by the daemon's own shutdown token —
+    // the handler implementations link their work to _shutdownToken.
+    public Func<PrepareEvalCommand,  Task<PrepareResult>>?  PrepareEvalHandler  { get; set; }
+    public Func<RunQuestionCommand,  Task<QuestionResult>>? RunQuestionHandler  { get; set; }
+    public Func<FinalizeEvalCommand, Task<FinalizeResult>>? FinalizeEvalHandler { get; set; }
+    public Func<CancelEvalCommand,   Task>?                 CancelEvalHandler   { get; set; }
 
     public ServerConnection(DaemonConfig config, ILogger<ServerConnection> logger) {
         _config = config;
@@ -52,7 +65,22 @@ public partial class ServerConnection : IAsyncDisposable {
         _hub.On<SendInputCommand>("SendInput", cmd => OnSendInput?.Invoke(cmd)                             ?? Task.CompletedTask);
         _hub.On<string, string>("SendSpecialKey", (agentId, key) => OnSendSpecialKey?.Invoke(agentId, key) ?? Task.CompletedTask);
         _hub.On<ResizeTerminalCommand>("ResizeTerminal", cmd => OnResizeTerminal?.Invoke(cmd) ?? Task.CompletedTask);
-        _hub.On<RunEvalCommand>("RunEval", cmd => OnRunEval?.Invoke(cmd) ?? Task.CompletedTask);
+
+        // Client-result invocations for per-phase eval dispatch.
+        _hub.On<PrepareEvalCommand, PrepareResult>("PrepareEval",
+            cmd => PrepareEvalHandler?.Invoke(cmd)
+                ?? Task.FromResult(new PrepareResult(false, "no handler", null, 0, 0, 0, 0, 0)));
+
+        _hub.On<RunQuestionCommand, QuestionResult>("RunQuestion",
+            cmd => RunQuestionHandler?.Invoke(cmd)
+                ?? Task.FromResult(new QuestionResult(false, null, "no handler", 0, 0)));
+
+        _hub.On<FinalizeEvalCommand, FinalizeResult>("FinalizeEval",
+            cmd => FinalizeEvalHandler?.Invoke(cmd)
+                ?? Task.FromResult(new FinalizeResult(false, "no handler", null)));
+
+        _hub.On<CancelEvalCommand>("CancelEval",
+            cmd => CancelEvalHandler?.Invoke(cmd) ?? Task.CompletedTask);
 
         _hub.Reconnected += OnReconnected;
         _hub.Closed      += OnClosed;

--- a/src/kapacitor/Eval/EvalService.cs
+++ b/src/kapacitor/Eval/EvalService.cs
@@ -55,7 +55,8 @@ internal static class EvalService {
         string                                       TraceJson,
         EvalContextResult                            ContextResult,
         IReadOnlyDictionary<string, List<JudgeFact>> KnownFactsByCategory,
-        string                                       PromptTemplate
+        string                                       PromptTemplate,
+        IReadOnlyList<EvalQuestionDto>               Questions
     );
 
     /// <summary>
@@ -108,7 +109,7 @@ internal static class EvalService {
                 if (verdict is not null) verdicts.Add(verdict);
             }
 
-            return await FinalizeAsync(ctx, httpClient, baseUrl, verdicts, model, questions, observer, ct);
+            return await FinalizeAsync(ctx, httpClient, baseUrl, verdicts, model, observer, ct);
         } catch (OperationCanceledException) {
             // Honour the contract that observers always see OnFinished or
             // OnFailed — cancellation isn't an exception path consumers
@@ -212,7 +213,8 @@ internal static class EvalService {
             TraceJson:            traceJson,
             ContextResult:        context,
             KnownFactsByCategory: knownFactsByCategory,
-            PromptTemplate:       promptTemplate
+            PromptTemplate:       promptTemplate,
+            Questions:            questions
         );
     }
 
@@ -296,7 +298,6 @@ internal static class EvalService {
             string                             baseUrl,
             IReadOnlyList<EvalQuestionVerdict> verdicts,
             string                             model,
-            IReadOnlyList<EvalQuestionDto>     questions,
             IEvalObserver                      observer,
             CancellationToken                  ct
         ) {
@@ -307,7 +308,7 @@ internal static class EvalService {
         }
 
         // 4. Aggregate per-category + overall scores.
-        var aggregate = Aggregate(verdicts, ctx.EvalRunId, model, questions);
+        var aggregate = Aggregate(verdicts, ctx.EvalRunId, model, ctx.Questions);
 
         // 5. Synthesise a retrospective from the per-question verdicts. Non-fatal:
         //    the verdicts are the persistence contract, a failed synthesis

--- a/src/kapacitor/Eval/EvalService.cs
+++ b/src/kapacitor/Eval/EvalService.cs
@@ -56,7 +56,8 @@ internal static class EvalService {
         EvalContextResult                            ContextResult,
         IReadOnlyDictionary<string, List<JudgeFact>> KnownFactsByCategory,
         string                                       PromptTemplate,
-        IReadOnlyList<EvalQuestionDto>               Questions
+        IReadOnlyList<EvalQuestionDto>               Questions,
+        string                                       Model
     );
 
     /// <summary>
@@ -214,7 +215,8 @@ internal static class EvalService {
             ContextResult:        context,
             KnownFactsByCategory: knownFactsByCategory,
             PromptTemplate:       promptTemplate,
-            Questions:            questions
+            Questions:            questions,
+            Model:                model
         );
     }
 

--- a/src/kapacitor/Models.cs
+++ b/src/kapacitor/Models.cs
@@ -425,7 +425,6 @@ record RepoEntry {
 [JsonSerializable(typeof(LaunchAgentCommand))]
 [JsonSerializable(typeof(SendInputCommand))]
 [JsonSerializable(typeof(ResizeTerminalCommand))]
-[JsonSerializable(typeof(RunEvalCommand))]
 [JsonSerializable(typeof(PrepareEvalCommand))]
 [JsonSerializable(typeof(RunQuestionCommand))]
 [JsonSerializable(typeof(FinalizeEvalCommand))]
@@ -513,17 +512,6 @@ public readonly record struct LaunchFailed(
 public readonly record struct TerminalOutput(
         string AgentId,
         string Base64Data
-    );
-
-// ── Eval dispatch (DEV-1440) ──────────────────────────────────────────────
-
-/// <summary>Sent by the server when the dashboard triggers an eval; received by the daemon over SignalR.</summary>
-public readonly record struct RunEvalCommand(
-        string EvalRunId,
-        string SessionId,
-        string Model,
-        bool   Chain,
-        int?   ThresholdBytes
     );
 
 // ── Per-question eval dispatch (DEV-1463 PR 2) ────────────────────────────

--- a/src/kapacitor/Models.cs
+++ b/src/kapacitor/Models.cs
@@ -426,6 +426,13 @@ record RepoEntry {
 [JsonSerializable(typeof(SendInputCommand))]
 [JsonSerializable(typeof(ResizeTerminalCommand))]
 [JsonSerializable(typeof(RunEvalCommand))]
+[JsonSerializable(typeof(PrepareEvalCommand))]
+[JsonSerializable(typeof(RunQuestionCommand))]
+[JsonSerializable(typeof(FinalizeEvalCommand))]
+[JsonSerializable(typeof(CancelEvalCommand))]
+[JsonSerializable(typeof(PrepareResult))]
+[JsonSerializable(typeof(QuestionResult))]
+[JsonSerializable(typeof(FinalizeResult))]
 [JsonSerializable(typeof(EvalStarted))]
 [JsonSerializable(typeof(EvalQuestionStarted))]
 [JsonSerializable(typeof(EvalQuestionCompleted))]
@@ -517,6 +524,69 @@ public readonly record struct RunEvalCommand(
         string Model,
         bool   Chain,
         int?   ThresholdBytes
+    );
+
+// ── Per-question eval dispatch (DEV-1463 PR 2) ────────────────────────────
+// Plain PascalCase records — no [JsonPropertyName] attrs — so they round-trip
+// via SignalR's default JSON protocol with the matching server-side records.
+// Inner DTOs (EvalQuestionDto, EvalQuestionVerdict) carry their own snake_case
+// [JsonPropertyName] attrs which agree on both ends (see server's
+// EvalQuestionMetadata.Question and SessionMetadataEvents.EvalQuestionVerdict).
+
+/// <summary>Server → daemon: prepare an eval run. Daemon fetches + caches context, returns counts.</summary>
+internal readonly record struct PrepareEvalCommand(
+        string                         EvalRunId,
+        string                         SessionId,
+        string                         Model,
+        bool                           Chain,
+        int?                           ThresholdBytes,
+        IReadOnlyList<EvalQuestionDto> Questions
+    );
+
+/// <summary>Server → daemon: run a single judge question against the cached context.</summary>
+internal readonly record struct RunQuestionCommand(
+        string          EvalRunId,
+        EvalQuestionDto Question,
+        int             Index,
+        int             Total
+    );
+
+/// <summary>Server → daemon: aggregate verdicts, run retrospective, persist final result.</summary>
+internal readonly record struct FinalizeEvalCommand(
+        string                             EvalRunId,
+        IReadOnlyList<EvalQuestionVerdict> Verdicts,
+        string                             Model
+    );
+
+/// <summary>Server → daemon: discard any cached context for this run (e.g. dashboard aborted).</summary>
+internal readonly record struct CancelEvalCommand(string EvalRunId);
+
+/// <summary>Daemon → server: prepare-phase result.</summary>
+internal readonly record struct PrepareResult(
+        bool    Success,
+        string? Error,
+        string? CanonicalSessionId,
+        int     TraceEntries,
+        int     TraceChars,
+        int     ToolResultsTotal,
+        int     ToolResultsTruncated,
+        long    BytesSaved
+    );
+
+/// <summary>Daemon → server: per-question judge result.</summary>
+internal readonly record struct QuestionResult(
+        bool                 Success,
+        EvalQuestionVerdict? Verdict,
+        string?              Error,
+        long                 InputTokens,
+        long                 OutputTokens
+    );
+
+/// <summary>Daemon → server: finalize-phase result including the aggregate to persist.</summary>
+internal readonly record struct FinalizeResult(
+        bool                         Success,
+        string?                      Error,
+        SessionEvalCompletedPayload? Aggregate
     );
 
 /// <summary>Daemon → server: eval has fetched context and is about to run the first judge.</summary>


### PR DESCRIPTION
## Summary

Part 2 of 3 for DEV-1463 (server-owned eval question taxonomy).

Replaces the single-shot `RunEvalCommand` protocol with a per-phase dispatch: `PrepareEvalCommand` → `RunQuestionCommand` × N → `FinalizeEvalCommand`, plus `CancelEvalCommand`. Still runs all 13 questions by default — no UI-facing change (that lands in PR 3).

Daemon side: swaps the `OnRunEval` event for four settable handler properties on `ServerConnection`, using SignalR client-result invocation. New `EvalContextCache` holds the prepared context per `evalRunId` between `Prepare` and `Finalize` calls (15-min TTL as a crash-safety backstop). `EvalRunner` is rewritten as stateless per-phase handlers.

## Cross-repo merge order ⚠️

This is **protocol-changing**. Must merge **before** the corresponding server PR (which deletes `RunEvalCommand` from the server). Between the two PRs landing, a production daemon running the old CLI against the new server would get unhandled `PrepareEval` / `RunQuestion` / `FinalizeEval` invocations. Coordinate the rollout.

Correct sequence:
1. Merge this CLI PR → CLI `main` tip = new daemon code
2. Bump submodule pointer on server `main` in a separate commit
3. Rebase + merge the server PR

## Known deviation from plan

The plan's `HubConnection.On<T1, CancellationToken, TResult>` three-generic-arg registration form **doesn't exist** in `Microsoft.AspNetCore.SignalR.Client 10.0.5` — no `On` overload at any arity exposes a per-call `CancellationToken` to the handler. Handlers are therefore registered as `On<T1, TResult>(name, Func<T1, Task<TResult>>)` and rely on `IHostApplicationLifetime.ApplicationStopping` for shutdown cancellation. Server-side per-phase timeouts still unwind independently via `InvokeAsync`'s own cancellation; the daemon may keep a dropped handler running until shutdown, with the 15-min `EvalContextCache` TTL as the cleanup backstop.

## Other notable choices

- `EvalContext` gains two fields (`Model`, `Questions`) so the daemon's stateless per-phase handlers can read them out of the cached context without the server re-shipping them per call.
- `FinalizeAsync` signature drops the `questions` parameter (now reads `ctx.Questions`).
- `QuestionResult.InputTokens` / `OutputTokens` are reported as 0 for now — accounting is owned by `EvalService`'s observer, not the return value. Tech debt for later.

## Test plan

- [x] Unit tests green: 233/233 pass
- [x] AOT publish clean (zero IL2xxx/IL3xxx warnings)
- [ ] Manual smoke (cross-repo): start server on this CLI's daemon, dispatch an eval, verify daemon log shows `PrepareEval` → `RunQuestion` × 13 → `FinalizeEval` and the dashboard renders identically to pre-PR-2

Spec: `docs/superpowers/specs/2026-04-19-eval-question-selection-design.md` (in server repo).
Plan: `docs/superpowers/plans/2026-04-19-eval-question-selection-pr2.md` (in server repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)