### PR TITLE
[DEV-1463] PR 3/3: kapacitor eval question selection flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ kapacitor eval <sessionId>                      # default: sonnet judge
 kapacitor eval --model opus <sessionId>         # stronger judge
 kapacitor eval --chain <sessionId>              # include the full continuation chain
 kapacitor eval --threshold 5000 <sessionId>     # keep more of each tool output before truncation
+kapacitor eval --questions safety <sessionId>   # run only the 4 safety judges
+kapacitor eval --skip efficiency <sessionId>    # run everything except efficiency
+kapacitor eval --list-questions                 # print the question taxonomy
 ```
 
 Output is a per-category + overall score (1-5, with `pass`/`warn`/`fail` verdicts), with a specific finding and supporting evidence per question. The aggregate is also persisted back to the session's stream as a `SessionEvalCompleted` event, so past evaluations can be queried from the dashboard or used to track quality trends across sessions.

--- a/src/kapacitor/Commands/EvalCommand.cs
+++ b/src/kapacitor/Commands/EvalCommand.cs
@@ -67,10 +67,14 @@ static class EvalCommand {
         return 0;
     }
 
-    static IReadOnlyList<string>? Parse(string? csv) {
-        if (string.IsNullOrEmpty(csv)) return null;
-        var parts = csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        return parts.Length == 0 ? null : parts;
+    // Distinguishes "flag absent" (null) from "flag present, empty value"
+    // (empty array). An explicit --questions "" or --questions "," flows
+    // into Resolve() as zero tokens, which produces an empty selection —
+    // HandleEval then exits 2 with "selection resolved to zero questions"
+    // rather than silently running the full catalog.
+    internal static IReadOnlyList<string>? Parse(string? csv) {
+        if (csv is null) return null;
+        return csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
     }
 
     static void Render(SessionEvalCompletedPayload agg, string sessionId) {

--- a/src/kapacitor/Commands/EvalCommand.cs
+++ b/src/kapacitor/Commands/EvalCommand.cs
@@ -9,18 +9,68 @@ namespace kapacitor.Commands;
 /// the daemon (DEV-1440 milestone 2) can reuse it.
 /// </summary>
 static class EvalCommand {
-    public static async Task<int> HandleEval(string baseUrl, string sessionId, string model, bool chain, int? thresholdBytes) {
-        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+    public static async Task<int> HandleEval(
+            string  baseUrl,
+            string  sessionId,
+            string  model,
+            bool    chain,
+            int?    thresholdBytes,
+            string? questionsCsv,
+            string? skipCsv
+        ) {
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
 
+        // Fetch taxonomy once up-front so --list and --questions/--skip share
+        // the same source of truth; the server controls it (PR 1), not the CLI.
         var observer = new ConsoleEvalObserver(sessionId);
-        var result   = await EvalService.RunAsync(baseUrl, httpClient, sessionId, model, chain, thresholdBytes, observer);
-
-        if (result is null) {
+        var catalog  = await EvalQuestionCatalogClient.FetchAsync(baseUrl, httpClient, observer, CancellationToken.None);
+        if (catalog is null || catalog.Length == 0) {
+            // FetchAsync emitted OnFailed with a reason already.
             return 1;
         }
 
+        var include = Parse(questionsCsv);
+        var skip    = Parse(skipCsv);
+        var (questions, error) = EvalQuestionSelection.Resolve(catalog, include, skip);
+        if (error is not null) {
+            await Console.Error.WriteLineAsync($"eval: {error}");
+            return 2;
+        }
+        if (questions!.Count == 0) {
+            await Console.Error.WriteLineAsync("eval: selection resolved to zero questions");
+            return 2;
+        }
+
+        var result = await EvalService.RunAsync(
+            baseUrl, httpClient, sessionId, model, chain, thresholdBytes,
+            observer, questions: questions
+        );
+
+        if (result is null) return 1;
+
         Render(result, sessionId);
         return 0;
+    }
+
+    public static async Task<int> HandleListQuestions(string baseUrl) {
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+        var observer = new ConsoleEvalObserver(sessionId: "");
+        var catalog  = await EvalQuestionCatalogClient.FetchAsync(baseUrl, httpClient, observer, CancellationToken.None);
+        if (catalog is null) return 1;
+
+        foreach (var group in catalog.GroupBy(q => q.Category)) {
+            Console.WriteLine(group.Key);
+            foreach (var q in group) {
+                Console.WriteLine($"  {q.Id,-26}  {q.Text}");
+            }
+        }
+        return 0;
+    }
+
+    static IReadOnlyList<string>? Parse(string? csv) {
+        if (string.IsNullOrEmpty(csv)) return null;
+        var parts = csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return parts.Length == 0 ? null : parts;
     }
 
     static void Render(SessionEvalCompletedPayload agg, string sessionId) {

--- a/src/kapacitor/Eval/EvalQuestionSelection.cs
+++ b/src/kapacitor/Eval/EvalQuestionSelection.cs
@@ -24,7 +24,15 @@ internal static class EvalQuestionSelection {
         }
 
         var categories    = catalog.Select(q => q.Category).Distinct(StringComparer.Ordinal).ToHashSet(StringComparer.Ordinal);
-        var questionsById = catalog.ToDictionary(q => q.Id, StringComparer.Ordinal);
+        // Defensive TryAdd rather than ToDictionary: the server-side catalog
+        // has unique IDs by construction, but a misbehaving server response
+        // should surface a controlled error instead of crashing the CLI.
+        var questionsById = new Dictionary<string, EvalQuestionDto>(StringComparer.Ordinal);
+        foreach (var q in catalog) {
+            if (!questionsById.TryAdd(q.Id, q)) {
+                return (null, $"eval question catalog contains duplicate id '{q.Id}'");
+            }
+        }
 
         var resolved = new HashSet<string>(StringComparer.Ordinal);
         var tokens   = include ?? skip!;

--- a/src/kapacitor/Eval/EvalQuestionSelection.cs
+++ b/src/kapacitor/Eval/EvalQuestionSelection.cs
@@ -1,0 +1,49 @@
+namespace kapacitor.Eval;
+
+/// <summary>
+/// Resolves <c>--questions</c>/<c>--skip</c> flag values against a fetched
+/// taxonomy. Pure function so tests can exercise it without network.
+///
+/// <para>Return value is a tuple rather than an exception-based API because
+/// flag validation errors flow to stderr + exit code 2, not to a crash.
+/// Both flags set at once is an error (mutually exclusive). Null for both
+/// returns the full catalog.</para>
+/// </summary>
+internal static class EvalQuestionSelection {
+    public static (IReadOnlyList<EvalQuestionDto>? Questions, string? Error) Resolve(
+            IReadOnlyList<EvalQuestionDto> catalog,
+            IReadOnlyList<string>?         include,
+            IReadOnlyList<string>?         skip
+        ) {
+        if (include is not null && skip is not null) {
+            return (null, "--questions and --skip are mutually exclusive");
+        }
+
+        if (include is null && skip is null) {
+            return (catalog, null);
+        }
+
+        var categories    = catalog.Select(q => q.Category).Distinct(StringComparer.Ordinal).ToHashSet(StringComparer.Ordinal);
+        var questionsById = catalog.ToDictionary(q => q.Id, StringComparer.Ordinal);
+
+        var resolved = new HashSet<string>(StringComparer.Ordinal);
+        var tokens   = include ?? skip!;
+        foreach (var token in tokens) {
+            if (categories.Contains(token)) {
+                foreach (var q in catalog) {
+                    if (q.Category == token) resolved.Add(q.Id);
+                }
+            } else if (questionsById.ContainsKey(token)) {
+                resolved.Add(token);
+            } else {
+                return (null, $"unknown question or category '{token}'. Run `kapacitor eval --list-questions` to see available tokens.");
+            }
+        }
+
+        var result = include is not null
+            ? catalog.Where(q => resolved.Contains(q.Id)).ToList()
+            : catalog.Where(q => !resolved.Contains(q.Id)).ToList();
+
+        return (result, null);
+    }
+}

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -118,10 +118,17 @@ switch (command) {
         return await ValidatePlanCommand.Handle(baseUrl!, vpSessionId);
     }
     case "eval": {
-        var evalSessionId = ResolveSessionId(args, valueFlags: ["--model", "--threshold"]);
+        // --list-questions is a standalone sub-action; short-circuit.
+        if (args.Contains("--list-questions")) {
+            return await EvalCommand.HandleListQuestions(baseUrl!);
+        }
+
+        var evalSessionId = ResolveSessionId(args, valueFlags: ["--model", "--threshold", "--questions", "--skip"]);
 
         if (evalSessionId is null) {
-            Console.Error.WriteLine("Usage: kapacitor eval [--model sonnet] [--chain] [--threshold N] [sessionId]");
+            Console.Error.WriteLine("Usage: kapacitor eval [--model sonnet] [--chain] [--threshold N]");
+            Console.Error.WriteLine("                     [--questions <csv> | --skip <csv>] [sessionId]");
+            Console.Error.WriteLine("       kapacitor eval --list-questions");
             Console.Error.WriteLine("  No session ID provided and KAPACITOR_SESSION_ID not set.");
 
             return 1;
@@ -132,8 +139,13 @@ switch (command) {
         var evalThreshold = GetArg(args, "--threshold") is { } ts && int.TryParse(ts, out var parsed)
             ? parsed
             : (int?)null;
+        var evalQuestions = GetArg(args, "--questions");
+        var evalSkip      = GetArg(args, "--skip");
 
-        return await EvalCommand.HandleEval(baseUrl!, evalSessionId, evalModel, evalChain, evalThreshold);
+        return await EvalCommand.HandleEval(
+            baseUrl!, evalSessionId, evalModel, evalChain, evalThreshold,
+            evalQuestions, evalSkip
+        );
     }
     case "generate-whats-done" when args.Length < 2:
         Console.Error.WriteLine("Usage: kapacitor generate-whats-done <sessionId>");

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -142,6 +142,16 @@ switch (command) {
         var evalQuestions = GetArg(args, "--questions");
         var evalSkip      = GetArg(args, "--skip");
 
+        // Guard against the user dropping the flag value — otherwise GetArg
+        // silently returns the next token ("--skip", "--chain", …) and the
+        // resolver later reports a confusing "unknown token" error.
+        foreach (var (flag, value) in new[] { ("--questions", evalQuestions), ("--skip", evalSkip) }) {
+            if (value is not null && value.StartsWith("--")) {
+                Console.Error.WriteLine($"eval: {flag} requires a value (got '{value}')");
+                return 2;
+            }
+        }
+
         return await EvalCommand.HandleEval(
             baseUrl!, evalSessionId, evalModel, evalChain, evalThreshold,
             evalQuestions, evalSkip

--- a/src/kapacitor/Resources/help-eval.txt
+++ b/src/kapacitor/Resources/help-eval.txt
@@ -1,4 +1,5 @@
 Usage: kapacitor eval <sessionId> [options]
+       kapacitor eval --list-questions
 
 Runs an LLM-as-judge evaluation over a stored session. 13 questions across 4
 categories (safety, plan adherence, quality, efficiency) are asked of Claude
@@ -12,6 +13,13 @@ Options:
   --chain             Evaluate the full continuation chain, not just this session.
   --threshold <n>     Override the server's compaction threshold (bytes per tool
                       result, default server-side: 2000). Capped at 200_000.
+  --questions <csv>   Run only the listed questions. Accepts category names
+                      (safety, plan_adherence, quality, efficiency) and
+                      individual question IDs (e.g. tests_written). Mutually
+                      exclusive with --skip.
+  --skip <csv>        Run everything except the listed questions/categories.
+                      Mutually exclusive with --questions.
+  --list-questions    Print the question taxonomy (grouped by category) and exit.
   --help, -h          Show this help.
 
 Notes:
@@ -21,3 +29,8 @@ Notes:
     The full compacted trace is embedded in the prompt.
   - If the session ID is omitted, the currently-recorded session (as set by
     the session-start hook in KAPACITOR_SESSION_ID) is used.
+
+Examples:
+  kapacitor eval --questions safety                # 4 safety judges only
+  kapacitor eval --questions safety,tests_written  # 4 safety + tests_written = 5
+  kapacitor eval --skip efficiency                 # 10 judges (skip the 3 efficiency ones)

--- a/test/kapacitor.Tests.Unit/EvalCommandParseTests.cs
+++ b/test/kapacitor.Tests.Unit/EvalCommandParseTests.cs
@@ -1,0 +1,35 @@
+using kapacitor.Commands;
+
+namespace kapacitor.Tests.Unit;
+
+// Covers Qodo PR #23 finding #1: distinguishing "flag absent" (null) from
+// "flag present, empty value" (empty array). The latter must NOT silently
+// fall through to the full-catalog resolver path.
+public class EvalCommandParseTests {
+    [Test]
+    public async Task Null_csv_returns_null_flag_absent() {
+        await Assert.That(EvalCommand.Parse(null)).IsNull();
+    }
+
+    [Test]
+    public async Task Empty_csv_returns_empty_array_flag_present_no_tokens() {
+        var parsed = EvalCommand.Parse("");
+        await Assert.That(parsed).IsNotNull();
+        await Assert.That(parsed!.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Commas_only_csv_returns_empty_array() {
+        var parsed = EvalCommand.Parse(",,, , ,");
+        await Assert.That(parsed).IsNotNull();
+        await Assert.That(parsed!.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Whitespace_around_tokens_is_trimmed() {
+        var parsed = EvalCommand.Parse("  safety  ,  tests_written  ");
+        await Assert.That(parsed!.Count).IsEqualTo(2);
+        await Assert.That(parsed[0]).IsEqualTo("safety");
+        await Assert.That(parsed[1]).IsEqualTo("tests_written");
+    }
+}

--- a/test/kapacitor.Tests.Unit/EvalQuestionSelectionTests.cs
+++ b/test/kapacitor.Tests.Unit/EvalQuestionSelectionTests.cs
@@ -58,4 +58,32 @@ public class EvalQuestionSelectionTests {
         await Assert.That(resolved).IsNull();
         await Assert.That(error!).Contains("notarealthing");
     }
+
+    // Qodo PR #23 finding #1 — an explicitly-empty --questions must not
+    // silently fall back to the full catalog; Resolve sees an empty token
+    // list and returns an empty selection, which HandleEval treats as a
+    // zero-question user error.
+    [Test]
+    public async Task Empty_include_returns_empty_selection_not_full_catalog() {
+        var (resolved, error) = EvalQuestionSelection.Resolve(Catalog, include: [], skip: null);
+        await Assert.That(error).IsNull();
+        await Assert.That(resolved!.Count).IsEqualTo(0);
+    }
+
+    // Qodo PR #23 finding #3 — a misbehaving server returning a catalog
+    // with duplicate IDs must produce a controlled error, not an
+    // uncaught ToDictionary ArgumentException.
+    [Test]
+    public async Task Duplicate_catalog_id_returns_error_instead_of_throwing() {
+        IReadOnlyList<EvalQuestionDto> dupCatalog = [
+            new() { Category = "safety", Id = "same_id", Text = "t", Prompt = "p" },
+            new() { Category = "safety", Id = "same_id", Text = "t", Prompt = "p" }
+        ];
+
+        var (resolved, error) = EvalQuestionSelection.Resolve(dupCatalog, include: ["safety"], skip: null);
+
+        await Assert.That(resolved).IsNull();
+        await Assert.That(error!).Contains("duplicate");
+        await Assert.That(error!).Contains("same_id");
+    }
 }

--- a/test/kapacitor.Tests.Unit/EvalQuestionSelectionTests.cs
+++ b/test/kapacitor.Tests.Unit/EvalQuestionSelectionTests.cs
@@ -1,0 +1,61 @@
+using kapacitor;
+using kapacitor.Eval;
+
+namespace kapacitor.Tests.Unit;
+
+public class EvalQuestionSelectionTests {
+    static readonly IReadOnlyList<EvalQuestionDto> Catalog = [
+        new() { Category = "safety",     Id = "sensitive_files",         Text = "t", Prompt = "p" },
+        new() { Category = "safety",     Id = "destructive_commands",    Text = "t", Prompt = "p" },
+        new() { Category = "safety",     Id = "security_vulnerabilities",Text = "t", Prompt = "p" },
+        new() { Category = "safety",     Id = "permission_bypass",       Text = "t", Prompt = "p" },
+        new() { Category = "quality",    Id = "tests_written",           Text = "t", Prompt = "p" },
+        new() { Category = "efficiency", Id = "redundant_calls",         Text = "t", Prompt = "p" }
+    ];
+
+    [Test]
+    public async Task Null_include_null_skip_returns_full_catalog() {
+        var (resolved, error) = EvalQuestionSelection.Resolve(Catalog, include: null, skip: null);
+        await Assert.That(error).IsNull();
+        await Assert.That(resolved!.Count).IsEqualTo(Catalog.Count);
+    }
+
+    [Test]
+    public async Task Include_category_expands() {
+        var (resolved, error) = EvalQuestionSelection.Resolve(Catalog, include: ["safety"], skip: null);
+        await Assert.That(error).IsNull();
+        await Assert.That(resolved!.Count).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task Include_mixed_category_and_id_deduplicates() {
+        var (resolved, error) = EvalQuestionSelection.Resolve(Catalog,
+            include: ["safety", "tests_written"], skip: null);
+        await Assert.That(error).IsNull();
+        await Assert.That(resolved!.Count).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task Skip_category_removes_from_full_catalog() {
+        var (resolved, error) = EvalQuestionSelection.Resolve(Catalog, include: null, skip: ["safety"]);
+        await Assert.That(error).IsNull();
+        await Assert.That(resolved!.All(q => q.Category != "safety")).IsTrue();
+        await Assert.That(resolved!.Count).IsEqualTo(Catalog.Count - 4);
+    }
+
+    [Test]
+    public async Task Include_and_skip_both_set_is_mutually_exclusive() {
+        var (resolved, error) = EvalQuestionSelection.Resolve(Catalog,
+            include: ["safety"], skip: ["tests_written"]);
+        await Assert.That(resolved).IsNull();
+        await Assert.That(error!).Contains("mutually exclusive");
+    }
+
+    [Test]
+    public async Task Unknown_token_returns_error() {
+        var (resolved, error) = EvalQuestionSelection.Resolve(Catalog,
+            include: ["notarealthing"], skip: null);
+        await Assert.That(resolved).IsNull();
+        await Assert.That(error!).Contains("notarealthing");
+    }
+}


### PR DESCRIPTION
## Summary

Final phase of DEV-1463. Adds CLI-side per-question selection to `kapacitor eval`:

- `--questions <csv>` — include list, mix of category names (`safety`, `plan_adherence`, `quality`, `efficiency`) and individual question IDs (`tests_written`, etc.)
- `--skip <csv>` — subtractive form, mutually exclusive with `--questions`
- `--list-questions` — prints the catalog grouped by category and exits

Pure resolver (`src/kapacitor/Eval/EvalQuestionSelection.cs`) with 6 unit tests covering full catalog / empty / category expansion / mixed-token dedup / mutual exclusion / unknown token. Help text and README updated.

## Examples

```bash
kapacitor eval --questions safety              # 4 safety judges only
kapacitor eval --questions safety,tests_written  # 4 safety + tests_written = 5
kapacitor eval --skip efficiency               # 10 judges (skip the 3 efficiency)
kapacitor eval --list-questions                # print taxonomy, exit 0
```

Exit codes: `0` success, `1` infrastructure (catalog fetch failed, eval failed), `2` user input error (bad token, mutual exclusion, zero resolution).

## Cross-repo merge order

Independent of the server PR. The daemon wire protocol is unchanged from PR 2 — `PrepareEvalCommand.Questions` already accepts a subset. CLI's direct-eval path hits the existing `GET /api/eval/questions` endpoint (added in PR 1) for the catalog, resolves locally, and passes the resolved subset into the existing `EvalService.RunAsync(..., questions: ...)` argument.

Merge either PR first; submodule bump on server main afterward is optional (no wire change).

## Test plan

- [x] Unit tests green: 239/239 pass (233 baseline + 6 new)
- [x] AOT publish clean (zero IL2xxx/IL3xxx warnings)
- [ ] Local smoke: `kapacitor eval --list-questions` prints grouped taxonomy; `--questions safety` runs 4 judges; `--skip efficiency` runs 10; `--questions X --skip Y` exits 2 with mutual-exclusion error; `--questions bogus` exits 2 with token in the message

Spec: `docs/superpowers/specs/2026-04-19-eval-question-selection-design.md` (in server repo).
Plan: `docs/superpowers/plans/2026-04-19-eval-question-selection-pr3.md` (in server repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)