### PR TITLE
[DEV-1491] Eval: stabilise judge invocations against context overflow

### DIFF
--- a/src/kapacitor/ClaudeCliRunner.cs
+++ b/src/kapacitor/ClaudeCliRunner.cs
@@ -69,20 +69,41 @@ static class ClaudeCliRunner {
             string?           jsonSchema     = null,
             CancellationToken ct             = default
         ) {
-        // Run from a stable isolated directory to avoid loading project-specific plugins/config
-        // that might interfere with the headless title generation session.
-        // Uses a fixed path so Claude treats all invocations as the same "project" and doesn't
-        // scatter transcripts across many per-invocation directories under ~/.claude/projects.
-        var stableDir = PathHelpers.ConfigPath("claude-cwd");
+        // Fresh empty working dir per invocation: keeps Claude's CLAUDE.md
+        // auto-discovery from picking anything up, and isolates every run
+        // from user project state. Deleted in the `finally` so we don't
+        // leak one directory per eval question under the OS tmp root.
+        //
+        // A previous implementation reused a single stable dir under
+        // ~/.config/kapacitor/claude-cwd. That kept all transcripts under
+        // one ~/.claude/projects/ slug but still allowed ambient context
+        // (hooks, plugin sync, auto-memory) to accumulate — and when an
+        // ancestor directory happened to contain a CLAUDE.md, it would
+        // load into the judge's prompt and push it over the 200K token
+        // auto-compact threshold (DEV-1463 eval failures).
+        var workingDir = Path.Combine(Path.GetTempPath(), $"kapacitor-claude-{Guid.NewGuid():N}");
+        var createdWorkingDir = false;
 
         try {
-            Directory.CreateDirectory(stableDir);
+            Directory.CreateDirectory(workingDir);
+            createdWorkingDir = true;
         } catch (Exception ex) {
             log($"Failed to create isolated working directory: {ex.Message}");
-            stableDir = Path.GetTempPath();
+            workingDir = Path.GetTempPath();
         }
 
-        return await RunCoreAsync(prompt, timeout, log, stableDir, model, maxTurns, promptViaStdin, jsonSchema, ct);
+        try {
+            return await RunCoreAsync(prompt, timeout, log, workingDir, model, maxTurns, promptViaStdin, jsonSchema, ct);
+        } finally {
+            if (createdWorkingDir) {
+                try {
+                    Directory.Delete(workingDir, recursive: true);
+                } catch {
+                    // Best-effort cleanup; don't fail the caller because a
+                    // transcript file is still being flushed by claude.
+                }
+            }
+        }
     }
 
     static async Task<ClaudeCliResult?> RunCoreAsync(
@@ -139,6 +160,13 @@ static class ClaudeCliRunner {
         psi.ArgumentList.Add("--strict-mcp-config");
         psi.ArgumentList.Add("--disallowedTools");
         psi.ArgumentList.Add("LSP");
+        // Skills load ~200 entries into the system prompt and the
+        // `using-superpowers` skill auto-invokes `Skill` on every session.
+        // Both are pure overhead for a headless judge: they inflate the
+        // prompt (contributing to the 200K-token auto-compact that
+        // destroys verdicts) and burn turns on skill dispatch that never
+        // produces a StructuredOutput reply.
+        psi.ArgumentList.Add("--disable-slash-commands");
 
         if (!string.IsNullOrEmpty(jsonSchema)) {
             // --json-schema makes the CLI enforce a structured reply via an

--- a/src/kapacitor/Eval/EvalService.cs
+++ b/src/kapacitor/Eval/EvalService.cs
@@ -44,6 +44,35 @@ internal static class EvalService {
     const int JudgeMaxTurns = 3;
 
     /// <summary>
+    /// Resolves a caller-supplied model alias to the variant we actually
+    /// want to dispatch to for a judge call. Today: force the 1M-context
+    /// Sonnet variant for any plain <c>sonnet</c> request, because the
+    /// embedded compacted trace routinely exceeds the 200K window of the
+    /// default Sonnet (see DEV-1474 audit — real traces hit ~278K input
+    /// tokens, triggering the CLI's auto-compact and destroying verdicts).
+    ///
+    /// <para>
+    /// Temporary workaround pending DEV-1485 / DEV-1486, which will give
+    /// judges session-scoped tool access and drop the embedded trace
+    /// entirely. Once those ship, default-Sonnet is enough and this
+    /// remap can go away.
+    /// </para>
+    ///
+    /// <para>
+    /// Only the two short aliases the dashboard and CLI ship today
+    /// (<c>sonnet</c>, <c>claude-sonnet-4-6</c>) are rewritten — every
+    /// other alias or explicit full model ID passes through unchanged,
+    /// so a caller who knows what they're doing can still opt out by
+    /// naming the model exactly.
+    /// </para>
+    /// </summary>
+    public static string JudgeModelFor(string model) => model switch {
+        "sonnet"            => "sonnet[1m]",
+        "claude-sonnet-4-6" => "claude-sonnet-4-6[1m]",
+        _                   => model
+    };
+
+    /// <summary>
     /// Output of <see cref="PrepareAsync"/> — the shared state threaded
     /// through every <see cref="RunQuestionAsync"/> and finally consumed by
     /// <see cref="FinalizeAsync"/>. All fields are non-null on success.
@@ -249,7 +278,7 @@ internal static class EvalService {
             prompt,
             TimeSpan.FromMinutes(5),
             msg => { diagnostics.Add(msg); observer.OnInfo($"  {msg}"); },
-            model: model,
+            model: JudgeModelFor(model),
             maxTurns: JudgeMaxTurns,
             // Prompts embed the full compacted trace and can be hundreds
             // of KB — well past Windows' 32K argv limit. Stream via stdin.
@@ -665,7 +694,7 @@ internal static class EvalService {
                 prompt,
                 TimeSpan.FromMinutes(5),
                 msg => observer.OnInfo($"  {msg}"),
-                model:          model,
+                model:          JudgeModelFor(model),
                 maxTurns:       JudgeMaxTurns,
                 // Prompt embeds full compacted trace + verdicts; likely >32K on Windows.
                 promptViaStdin: true,


### PR DESCRIPTION
## Summary

- Real compacted traces (~1.1 MB / ~278K tokens) blow past default Sonnet's 200K context, auto-compact mid-call, and the `--json-schema` Stop hook forces a hallucinated second `StructuredOutput` before `--max-turns` trips. Every judge call fails `error_max_turns`.
- Fix the three compounding factors: the stable cwd that inherited CLAUDE.md/plugin/auto-memory context, the skills system injecting ~200 skill entries, and default Sonnet being too small.
- Forces `sonnet` → `sonnet[1m]` for judge invocations only (title generation keeps `haiku`) via a `JudgeModelFor` helper that's flagged in its docstring as temporary pending DEV-1485/DEV-1486.

Linear: [DEV-1491](https://linear.app/kurrent/issue/DEV-1491/eval-stabilise-judge-invocations-against-context-overflow)

## Follow-up

- Default judge model dispatched from the Kurrent.Capacitor server should move to `sonnet[1m]` so the CLI remap becomes redundant. Separate repo, separate PR.

## Test plan

- [x] 245/245 unit tests pass (`dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj`)
- [x] Release publish clean — zero `IL3050`/`IL2026` warnings
- [x] Locally-built binary installed and exercised against the daemon: small sessions complete without compaction; large sessions (~1.1 MB trace) complete on `sonnet[1m]` where they previously always failed
- [ ] Transcripts under `/tmp/kapacitor-claude-*/` removed on successful exit (verify in final daemon run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)