### PR TITLE
[DEV-1485] Session-scoped MCP tools: summary, search, tool-result fetch

### DIFF
--- a/src/kapacitor/Commands/McpJudgeServer.cs
+++ b/src/kapacitor/Commands/McpJudgeServer.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -109,10 +110,18 @@ static class McpJudgeServer {
             var encoded = Uri.EscapeDataString(sessionId);
 
             using var httpResponse = toolName switch {
-                "get_session_recap"  => await client.GetAsync($"{apiRoot}/api/sessions/{encoded}/recap?chain=true"),
-                "get_session_errors" => await client.GetAsync($"{apiRoot}/api/sessions/{encoded}/errors?chain=true"),
-                "get_transcript"     => await client.GetAsync(BuildTranscriptUrl(apiRoot, sessionId, arguments)),
-                _                    => throw new ArgumentException($"Unknown tool: {toolName}")
+                "get_session_recap"   => await client.GetAsync($"{apiRoot}/api/sessions/{encoded}/recap?chain=true"),
+                "get_session_errors"  => await client.GetAsync($"{apiRoot}/api/sessions/{encoded}/errors?chain=true"),
+                "get_transcript"      => await client.GetAsync(BuildTranscriptUrl(apiRoot, sessionId, arguments)),
+                "get_session_summary" => await client.GetAsync($"{apiRoot}/api/sessions/{encoded}/eval-summary"),
+                "search_session"      => await client.PostAsync(
+                    $"{apiRoot}/api/sessions/{encoded}/search",
+                    JsonContent.Create(BuildSearchBody(arguments), McpJsonContext.Default.SessionSearchQuery)
+                ),
+                "get_tool_result"     => await client.GetAsync(
+                    $"{apiRoot}/api/sessions/{encoded}/tool-results/{Uri.EscapeDataString(GetRequiredString(arguments, "call_id"))}"
+                ),
+                _                     => throw new ArgumentException($"Unknown tool: {toolName}")
             };
 
             var body = await httpResponse.Content.ReadAsStringAsync();
@@ -194,8 +203,65 @@ static class McpJudgeServer {
                 },
                 ["session_id"]
             )
+        ),
+        new(
+            "get_session_summary",
+            "Get a structured orientation digest for the session: title, turn count, plan text, files touched (path + change type + event count), "
+          + "test runs with pass/fail, error flag, and which tool results were truncated in the compacted trace (pair call_ids with get_tool_result). "
+          + "START HERE when you need a quick overview before deciding which MCP tool to call next.",
+            new(
+                "object",
+                new() { ["session_id"] = new("string", "Session ID (must match the judge's bound session)") },
+                ["session_id"]
+            )
+        ),
+        new(
+            "search_session",
+            "Full-text search scoped to one session. Returns ranked excerpts with speaker (user/assistant/tool), timestamp, and a highlighted snippet. "
+          + "Use for targeted lookups ('where did the agent run rm', 'what error mentioned permission') rather than paging the full trace. "
+          + "limit defaults to 20, capped at 50.",
+            new(
+                "object",
+                new() {
+                    ["session_id"] = new("string", "Session ID (must match the judge's bound session)"),
+                    ["query"]      = new("string", "Free-text FTS5 query"),
+                    ["limit"]      = new("integer", "Max number of ranked excerpts to return (default 20, max 50)")
+                },
+                ["session_id", "query"]
+            )
+        ),
+        new(
+            "get_tool_result",
+            "Fetch the untruncated body of a single tool result by its call_id. Use when get_session_summary reported the result was truncated "
+          + "(see the truncated_tool_results field) and the finding depends on what the tool actually produced — e.g. full dotnet test output, "
+          + "full git diff, full search hit list. 1 MB hard cap on response size.",
+            new(
+                "object",
+                new() {
+                    ["session_id"] = new("string", "Session ID (must match the judge's bound session)"),
+                    ["call_id"]    = new("string", "call_id from a tool_invocation/tool_result pair (e.g. toolu_01abc...)")
+                },
+                ["session_id", "call_id"]
+            )
         )
     ];
+
+    static SessionSearchQuery BuildSearchBody(JsonObject? arguments) {
+        var query = GetRequiredString(arguments, "query");
+        var limit = arguments?["limit"]?.GetValue<int>();
+
+        return new(query, limit);
+    }
+
+    static string GetRequiredString(JsonObject? arguments, string name) {
+        var value = arguments?[name]?.GetValue<string>();
+
+        if (string.IsNullOrWhiteSpace(value)) {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return value;
+    }
 
     static string BuildTranscriptUrl(string baseUrl, string sessionId, JsonObject? arguments) {
         var url         = $"{baseUrl}/api/review/sessions/{Uri.EscapeDataString(sessionId)}/transcript";

--- a/src/kapacitor/Commands/McpJudgeServer.cs
+++ b/src/kapacitor/Commands/McpJudgeServer.cs
@@ -248,7 +248,18 @@ static class McpJudgeServer {
 
     static SessionSearchQuery BuildSearchBody(JsonObject? arguments) {
         var query = GetRequiredString(arguments, "query");
-        var limit = arguments?["limit"]?.GetValue<int>();
+
+        int? limit = null;
+
+        if (arguments?["limit"] is { } limitNode) {
+            try {
+                limit = limitNode.GetValue<int>();
+            } catch (InvalidOperationException) {
+                throw new ArgumentException("limit must be an integer");
+            } catch (FormatException) {
+                throw new ArgumentException("limit must be an integer");
+            }
+        }
 
         return new(query, limit);
     }

--- a/src/kapacitor/Commands/McpReviewServer.cs
+++ b/src/kapacitor/Commands/McpReviewServer.cs
@@ -284,6 +284,8 @@ record McpError(int Code, string Message);
 
 record SearchQuery(string Query);
 
+record SessionSearchQuery(string Query, int? Limit = null);
+
 [JsonSourceGenerationOptions(
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase
@@ -293,4 +295,5 @@ record SearchQuery(string Query);
 [JsonSerializable(typeof(McpToolCallResult))]
 [JsonSerializable(typeof(McpError))]
 [JsonSerializable(typeof(SearchQuery))]
+[JsonSerializable(typeof(SessionSearchQuery))]
 partial class McpJsonContext : JsonSerializerContext;

--- a/src/kapacitor/Eval/EvalService.cs
+++ b/src/kapacitor/Eval/EvalService.cs
@@ -745,7 +745,10 @@ internal static class EvalService {
         var allowedTools = new[] {
             "mcp__kapacitor-review__get_session_recap",
             "mcp__kapacitor-review__get_session_errors",
-            "mcp__kapacitor-review__get_transcript"
+            "mcp__kapacitor-review__get_transcript",
+            "mcp__kapacitor-review__get_session_summary",
+            "mcp__kapacitor-review__search_session",
+            "mcp__kapacitor-review__get_tool_result"
         };
 
         try {

--- a/src/kapacitor/Resources/prompt-eval-retrospective.txt
+++ b/src/kapacitor/Resources/prompt-eval-retrospective.txt
@@ -15,11 +15,14 @@ You MUST ground every point in the verdicts below OR in evidence pulled via the 
 
 Use these MCP tools to pull session details on demand — the trace is NOT embedded in this prompt:
 
-- `get_session_recap(session_id)` — START HERE. Short narrative of user inputs, assistant replies, and tool invocations. Cheapest way to orient yourself.
-- `get_session_errors(session_id)` — explicit errors, tool failures, non-zero exits. Use when grounding issues.
-- `get_transcript(session_id, skip, take, file_path?)` — paginated raw events. Use for targeted drill-downs; prefer recap and errors first.
+- `get_session_summary(session_id)` — START HERE. Title, turn count, plan text, files touched (with change types), test runs with pass/fail, error flag, and the list of tool results whose bodies were truncated (their `call_id`s pair with `get_tool_result`).
+- `get_session_recap(session_id)` — short narrative if you need it.
+- `search_session(session_id, query, limit?)` — targeted full-text lookup for a phrase. Default limit 20, cap 50.
+- `get_session_errors(session_id)` — explicit errors, tool failures, non-zero exits.
+- `get_transcript(session_id, skip, take, file_path?)` — paginated raw events. Use for drill-downs after summary + search have narrowed the target.
+- `get_tool_result(session_id, call_id)` — full untruncated body of a specific tool result. Only call when `truncated_tool_results` lists a relevant call_id and the finding depends on what the tool actually produced.
 
-Budget: at most 6 tool calls. Prefer recap + errors + one targeted transcript slice over paging the full trace. Only call `get_transcript` when recap/errors leave a specific question unanswered.
+Budget: at most 6 tool calls. Prefer summary → search → targeted fetch over paging the full trace. Don't call `get_transcript` unless summary + search + recap left a specific question unanswered.
 
 # Task
 Produce a structured retrospective that calls out what went well, what went poorly, and concrete CLAUDE.md-style suggestions the user can apply to their next session in this project. Reference the known patterns where relevant.

--- a/test/kapacitor.Tests.Unit/McpJudgeServerTests.cs
+++ b/test/kapacitor.Tests.Unit/McpJudgeServerTests.cs
@@ -221,4 +221,74 @@ public class McpJudgeServerTests : IDisposable {
         await Assert.That(content.GetProperty("content")[0].GetProperty("text").GetString())
             .Contains("session_id");
     }
+
+    [Test]
+    public async Task get_session_summary_forwards_session_id() {
+        _server.Given(Request.Create()
+                .WithPath("/api/sessions/abc-123/eval-summary")
+                .UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithBody("""{"session_id":"abc-123","title":"t","turn_count":5}"""));
+
+        using var http = new HttpClient();
+        var result = await McpJudgeServer.HandleToolCallForTests(
+            toolName: "get_session_summary",
+            arguments: new JsonObject { ["session_id"] = "abc-123" },
+            client: http,
+            baseUrl: _server.Url!,
+            expectedSessionId: "abc-123"
+        );
+
+        using var doc = JsonDocument.Parse(result);
+        var text = doc.RootElement.GetProperty("result").GetProperty("content")[0].GetProperty("text").GetString();
+        await Assert.That(text).Contains("\"turn_count\":5");
+    }
+
+    [Test]
+    public async Task search_session_posts_query_body() {
+        _server.Given(Request.Create()
+                .WithPath("/api/sessions/abc-123/search")
+                .UsingPost()
+                .WithBody(b => b.Contains("\"query\"")))
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithBody("""{"session_id":"abc-123","query":"rm","total_candidates":0,"results":[]}"""));
+
+        using var http = new HttpClient();
+        var result = await McpJudgeServer.HandleToolCallForTests(
+            toolName: "search_session",
+            arguments: new JsonObject { ["session_id"] = "abc-123", ["query"] = "rm" },
+            client: http,
+            baseUrl: _server.Url!,
+            expectedSessionId: "abc-123"
+        );
+
+        using var doc = JsonDocument.Parse(result);
+        var text = doc.RootElement.GetProperty("result").GetProperty("content")[0].GetProperty("text").GetString();
+        await Assert.That(text).Contains("\"results\"");
+    }
+
+    [Test]
+    public async Task get_tool_result_forwards_call_id_in_path() {
+        _server.Given(Request.Create()
+                .WithPath("/api/sessions/abc-123/tool-results/toolu_xyz")
+                .UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithBody("""{"call_id":"toolu_xyz","output":"untruncated-body"}"""));
+
+        using var http = new HttpClient();
+        var result = await McpJudgeServer.HandleToolCallForTests(
+            toolName: "get_tool_result",
+            arguments: new JsonObject { ["session_id"] = "abc-123", ["call_id"] = "toolu_xyz" },
+            client: http,
+            baseUrl: _server.Url!,
+            expectedSessionId: "abc-123"
+        );
+
+        using var doc = JsonDocument.Parse(result);
+        var text = doc.RootElement.GetProperty("result").GetProperty("content")[0].GetProperty("text").GetString();
+        await Assert.That(text).Contains("untruncated-body");
+    }
 }


### PR DESCRIPTION
## Summary

- Three new MCP tools on `kapacitor mcp judge`: `get_session_summary` (structured orientation digest), `search_session` (session-scoped FTS), `get_tool_result` (untruncated body fetch for a specific tool result by call_id).
- Retrospective prompt updated to guide the judge through the expanded tool set (summary → recap → search → errors → transcript → tool_result), budget capped at 6 tool calls.
- `EvalService.allowedTools` whitelist extended to include the three new MCP tool names, so the retrospective judge can actually call them.
- MCP config body for `search_session` uses a source-gen-registered `SessionSearchQuery` record (AOT-safe) rather than the plan's anonymous-object form. Mirrors the existing `SearchQuery` pattern used by `McpReviewServer`.

Server-side companion PR: kurrent-io/Kurrent.Capacitor (same branch name, coming once this merges).

Linear: [DEV-1485](https://linear.app/kurrent/issue/DEV-1485) (parent DEV-1474; follows DEV-1484; blocks DEV-1486).

## Test plan

- [x] 14 tests in `McpJudgeServerTests` pass (8 existing + 3 new + 3 unrelated; 258 full suite total)
- [x] `dotnet publish -c Release` clean — no IL3050/IL2026 AOT warnings
- [x] `SessionSearchQuery` registered on `McpJsonContext` source-gen context
- [x] Quality-review fixes applied: non-integer `limit` surfaces as clean `ArgumentException` (200-with-error-payload), not 500

## Out of scope

- Server-side endpoints (`/eval-summary`, `/search`, `/tool-results/{callId}`) and FTS rename — these are the server-repo PR, merged separately.
- Per-question opt-in to tools — [DEV-1486](https://linear.app/kurrent/issue/DEV-1486), blocked on server-repo merge landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)