### PR TITLE
[DEV-1592] Daemon sends LiveAgentIds on DaemonConnect

### DIFF
--- a/src/kapacitor/Daemon/Services/AgentOrchestrator.cs
+++ b/src/kapacitor/Daemon/Services/AgentOrchestrator.cs
@@ -84,7 +84,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _server.OnSendSpecialKey      += HandleSendSpecialKey;
         _server.OnResizeTerminal      += HandleResizeTerminal;
         _server.OnReconnectedCallback += ReRegisterAgents;
-        _server.GetLiveAgentIds       =  () => _agents.Keys.ToArray();
+        _server.GetLiveAgentIds       =  () => _agents
+            .Where(kvp => kvp.Value.Status is "Starting" or "Running")
+            .Select(kvp => kvp.Key)
+            .ToArray();
 
         // Start heartbeat loops
         _ = RunHeartbeatLoopAsync(_shutdownCts.Token);

--- a/src/kapacitor/Daemon/Services/AgentOrchestrator.cs
+++ b/src/kapacitor/Daemon/Services/AgentOrchestrator.cs
@@ -84,6 +84,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _server.OnSendSpecialKey      += HandleSendSpecialKey;
         _server.OnResizeTerminal      += HandleResizeTerminal;
         _server.OnReconnectedCallback += ReRegisterAgents;
+        _server.GetLiveAgentIds       =  () => _agents.Keys.ToArray();
 
         // Start heartbeat loops
         _ = RunHeartbeatLoopAsync(_shutdownCts.Token);

--- a/src/kapacitor/Daemon/Services/ServerConnection.cs
+++ b/src/kapacitor/Daemon/Services/ServerConnection.cs
@@ -37,6 +37,15 @@ internal partial class ServerConnection : IAsyncDisposable {
     public Func<FinalizeEvalCommand, Task<FinalizeResult>>? FinalizeEvalHandler { get; set; }
     public Func<CancelEvalCommand,   Task>?                 CancelEvalHandler   { get; set; }
 
+    /// <summary>
+    /// Callback invoked at <see cref="RegisterDaemon"/> time to snapshot the
+    /// agent IDs currently hosted by this daemon. The server uses this to
+    /// reconcile its registry against the daemon's view. Set by
+    /// <see cref="AgentOrchestrator"/> at startup; defaults to an empty
+    /// array so tests don't need to wire the callback.
+    /// </summary>
+    public Func<string[]>? GetLiveAgentIds { get; set; }
+
     public ServerConnection(DaemonConfig config, ILogger<ServerConnection> logger) {
         _config = config;
         _logger = logger;
@@ -137,13 +146,13 @@ internal partial class ServerConnection : IAsyncDisposable {
     }
 
     async Task RegisterDaemon() {
-        var platform = $"{RuntimeInformation.OSDescription} {RuntimeInformation.OSArchitecture}";
-
+        var platform  = $"{RuntimeInformation.OSDescription} {RuntimeInformation.OSArchitecture}";
         var repoPaths = await MergeRepoPathsAsync();
+        var liveIds   = GetLiveAgentIds?.Invoke() ?? [];
 
         await _hub.InvokeAsync(
             "DaemonConnect",
-            new DaemonConnect(_config.Name, platform, repoPaths, _config.MaxConcurrentAgents),
+            new DaemonConnect(_config.Name, platform, repoPaths, _config.MaxConcurrentAgents, liveIds),
             cancellationToken: _ct
         );
     }

--- a/src/kapacitor/Daemon/Services/ServerConnection.cs
+++ b/src/kapacitor/Daemon/Services/ServerConnection.cs
@@ -41,8 +41,8 @@ internal partial class ServerConnection : IAsyncDisposable {
     /// Callback invoked at <see cref="RegisterDaemon"/> time to snapshot the
     /// agent IDs currently hosted by this daemon. The server uses this to
     /// reconcile its registry against the daemon's view. Set by
-    /// <see cref="AgentOrchestrator"/> at startup; defaults to an empty
-    /// array so tests don't need to wire the callback.
+    /// <see cref="AgentOrchestrator"/> at startup; when null, an empty array
+    /// is sent (tests don't need to wire the callback).
     /// </summary>
     public Func<string[]>? GetLiveAgentIds { get; set; }
 
@@ -148,7 +148,7 @@ internal partial class ServerConnection : IAsyncDisposable {
     async Task RegisterDaemon() {
         var platform  = $"{RuntimeInformation.OSDescription} {RuntimeInformation.OSArchitecture}";
         var repoPaths = await MergeRepoPathsAsync();
-        var liveIds   = GetLiveAgentIds?.Invoke() ?? [];
+        var liveIds   = GetLiveAgentIds?.Invoke() ?? Array.Empty<string>();
 
         await _hub.InvokeAsync(
             "DaemonConnect",

--- a/src/kapacitor/Models.cs
+++ b/src/kapacitor/Models.cs
@@ -498,7 +498,8 @@ public readonly record struct DaemonConnect(
         string   Name,
         string   Platform,
         string[] RepoPaths,
-        int      MaxAgents
+        int      MaxAgents,
+        string[] LiveAgentIds
     );
 
 public readonly record struct AgentRegistered(


### PR DESCRIPTION
## Summary

- Adds `LiveAgentIds` to the `DaemonConnect` record so the daemon can tell the server which agents it's currently hosting.
- Orchestrator wires a callback that snapshots `_agents.Keys` at (re)connect time.

## Context

Companion to kurrent-io/Kurrent.Capacitor DEV-1592. The server uses this list to reconcile its registry: any agents it thought the daemon owned, but which aren't in the list, get flipped to `Failed` (daemon crashed/killed/restarted).

## Test plan

- [ ] `dotnet build src/kapacitor/kapacitor.csproj` — no warnings
- [ ] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — no AOT warnings (IL3050/IL2026)
- [ ] Hub-level integration test on the server side (DaemonReconcileTests) validates the protocol end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)