### PR TITLE
Tenant discovery login (kapacitor setup / login --discover)

### DIFF
--- a/src/kapacitor/Auth/AuthModels.cs
+++ b/src/kapacitor/Auth/AuthModels.cs
@@ -91,3 +91,24 @@ public record RefreshTokenRequest {
     [JsonPropertyName("access_token")]
     public required string AccessToken { get; init; }
 }
+
+// Auth proxy: GET /config
+public sealed record ProxyConfigResponse {
+    [JsonPropertyName("github_client_id")] public string GitHubClientId { get; init; } = "";
+}
+
+// Auth proxy: POST /discover-tenants response item
+public sealed record DiscoveredTenant {
+    [JsonPropertyName("org_id")]    public long   OrgId    { get; init; }
+    [JsonPropertyName("org_login")] public string OrgLogin { get; init; } = "";
+    [JsonPropertyName("origin")]    public string Origin   { get; init; } = "";
+}
+
+public enum DiscoveryError {
+    None,
+    ProxyUnreachable,
+    TokenRejected,
+    UpstreamError
+}
+
+public sealed record DiscoveryResult(DiscoveredTenant[] Tenants, DiscoveryError Error);

--- a/src/kapacitor/Auth/AuthProxyClient.cs
+++ b/src/kapacitor/Auth/AuthProxyClient.cs
@@ -1,27 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.Text.Json.Serialization;
 
 namespace kapacitor.Auth;
-
-public sealed record ProxyConfigResponse {
-    [JsonPropertyName("github_client_id")] public string GitHubClientId { get; init; } = "";
-}
-
-public sealed record DiscoveredTenant {
-    [JsonPropertyName("org_id")]    public long   OrgId    { get; init; }
-    [JsonPropertyName("org_login")] public string OrgLogin { get; init; } = "";
-    [JsonPropertyName("origin")]    public string Origin   { get; init; } = "";
-}
-
-public enum DiscoveryError {
-    None,
-    ProxyUnreachable,
-    TokenRejected,
-    GitHubError
-}
-
-public sealed record DiscoveryResult(DiscoveredTenant[] Tenants, DiscoveryError Error);
 
 public class AuthProxyClient(HttpClient http) {
     public async Task<string?> GetGitHubClientIdAsync(string proxyUrl) {
@@ -30,7 +10,7 @@ public class AuthProxyClient(HttpClient http) {
             if (!response.IsSuccessStatusCode) return null;
             var body = await response.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.ProxyConfigResponse);
             return body?.GitHubClientId;
-        } catch (Exception e) when (e is HttpRequestException or TaskCanceledException or OperationCanceledException) {
+        } catch (Exception e) when (e is HttpRequestException or OperationCanceledException) {
             return null;
         }
     }
@@ -44,9 +24,9 @@ public class AuthProxyClient(HttpClient http) {
             return response.StatusCode switch {
                 HttpStatusCode.OK                                       => new(await ReadTenants(response), DiscoveryError.None),
                 HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => new([], DiscoveryError.TokenRejected),
-                _                                                       => new([], DiscoveryError.GitHubError)
+                _                                                       => new([], DiscoveryError.UpstreamError)
             };
-        } catch (Exception e) when (e is HttpRequestException or TaskCanceledException or OperationCanceledException) {
+        } catch (Exception e) when (e is HttpRequestException or OperationCanceledException) {
             return new([], DiscoveryError.ProxyUnreachable);
         }
     }

--- a/src/kapacitor/Auth/AuthProxyClient.cs
+++ b/src/kapacitor/Auth/AuthProxyClient.cs
@@ -3,7 +3,12 @@ using System.Net.Http.Json;
 
 namespace kapacitor.Auth;
 
-public class AuthProxyClient(HttpClient http) {
+public interface IAuthProxyClient {
+    Task<string?>         GetGitHubClientIdAsync(string proxyUrl);
+    Task<DiscoveryResult> DiscoverTenantsAsync(string proxyUrl, string githubAccessToken);
+}
+
+public class AuthProxyClient(HttpClient http) : IAuthProxyClient {
     public async Task<string?> GetGitHubClientIdAsync(string proxyUrl) {
         try {
             var response = await http.GetAsync($"{proxyUrl}/config");

--- a/src/kapacitor/Auth/AuthProxyClient.cs
+++ b/src/kapacitor/Auth/AuthProxyClient.cs
@@ -11,7 +11,7 @@ public interface IAuthProxyClient {
 public class AuthProxyClient(HttpClient http) : IAuthProxyClient {
     public async Task<string?> GetGitHubClientIdAsync(string proxyUrl) {
         try {
-            var response = await http.GetAsync($"{proxyUrl}/config");
+            using var response = await http.GetAsync($"{proxyUrl}/config");
             if (!response.IsSuccessStatusCode) return null;
             var body = await response.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.ProxyConfigResponse);
             return body?.GitHubClientId;
@@ -24,7 +24,7 @@ public class AuthProxyClient(HttpClient http) : IAuthProxyClient {
         try {
             using var request = new HttpRequestMessage(HttpMethod.Post, $"{proxyUrl}/discover-tenants");
             request.Headers.Authorization = new("Bearer", githubAccessToken);
-            var response = await http.SendAsync(request);
+            using var response = await http.SendAsync(request);
 
             return response.StatusCode switch {
                 HttpStatusCode.OK                                       => new(await ReadTenants(response), DiscoveryError.None),

--- a/src/kapacitor/Auth/AuthProxyClient.cs
+++ b/src/kapacitor/Auth/AuthProxyClient.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace kapacitor.Auth;
+
+public sealed record ProxyConfigResponse {
+    [JsonPropertyName("github_client_id")] public string GitHubClientId { get; init; } = "";
+}
+
+public sealed record DiscoveredTenant {
+    [JsonPropertyName("org_id")]    public long   OrgId    { get; init; }
+    [JsonPropertyName("org_login")] public string OrgLogin { get; init; } = "";
+    [JsonPropertyName("origin")]    public string Origin   { get; init; } = "";
+}
+
+public enum DiscoveryError {
+    None,
+    ProxyUnreachable,
+    TokenRejected,
+    GitHubError
+}
+
+public sealed record DiscoveryResult(DiscoveredTenant[] Tenants, DiscoveryError Error);
+
+public class AuthProxyClient(HttpClient http) {
+    public async Task<string?> GetGitHubClientIdAsync(string proxyUrl) {
+        try {
+            var response = await http.GetAsync($"{proxyUrl}/config");
+            if (!response.IsSuccessStatusCode) return null;
+            var body = await response.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.ProxyConfigResponse);
+            return body?.GitHubClientId;
+        } catch (Exception e) when (e is HttpRequestException or TaskCanceledException or OperationCanceledException) {
+            return null;
+        }
+    }
+
+    public async Task<DiscoveryResult> DiscoverTenantsAsync(string proxyUrl, string githubAccessToken) {
+        try {
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{proxyUrl}/discover-tenants");
+            request.Headers.Authorization = new("Bearer", githubAccessToken);
+            var response = await http.SendAsync(request);
+
+            return response.StatusCode switch {
+                HttpStatusCode.OK                                       => new(await ReadTenants(response), DiscoveryError.None),
+                HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => new([], DiscoveryError.TokenRejected),
+                _                                                       => new([], DiscoveryError.GitHubError)
+            };
+        } catch (Exception e) when (e is HttpRequestException or TaskCanceledException or OperationCanceledException) {
+            return new([], DiscoveryError.ProxyUnreachable);
+        }
+    }
+
+    static async Task<DiscoveredTenant[]> ReadTenants(HttpResponseMessage response) =>
+        await response.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.DiscoveredTenantArray) ?? [];
+}

--- a/src/kapacitor/Auth/AuthProxyEndpoint.cs
+++ b/src/kapacitor/Auth/AuthProxyEndpoint.cs
@@ -1,7 +1,7 @@
 namespace kapacitor.Auth;
 
 public static class AuthProxyEndpoint {
-    public const string DefaultUrl = "https://auth.kurrent.example";
+    public const string DefaultUrl = "https://auth.kapacitor.ai";
 
     // KAPACITOR_AUTH_PROXY_URL is an internal dev/test override; not documented for end users.
     public static string Url =>

--- a/src/kapacitor/Auth/AuthProxyEndpoint.cs
+++ b/src/kapacitor/Auth/AuthProxyEndpoint.cs
@@ -1,0 +1,8 @@
+namespace kapacitor.Auth;
+
+public static class AuthProxyEndpoint {
+    public const string DefaultUrl = "https://auth.kurrent.example";
+
+    public static string Url =>
+        (Environment.GetEnvironmentVariable("KAPACITOR_AUTH_PROXY_URL") ?? DefaultUrl).TrimEnd('/');
+}

--- a/src/kapacitor/Auth/AuthProxyEndpoint.cs
+++ b/src/kapacitor/Auth/AuthProxyEndpoint.cs
@@ -3,6 +3,7 @@ namespace kapacitor.Auth;
 public static class AuthProxyEndpoint {
     public const string DefaultUrl = "https://auth.kurrent.example";
 
+    // KAPACITOR_AUTH_PROXY_URL is an internal dev/test override; not documented for end users.
     public static string Url =>
         (Environment.GetEnvironmentVariable("KAPACITOR_AUTH_PROXY_URL") ?? DefaultUrl).TrimEnd('/');
 }

--- a/src/kapacitor/Auth/OAuthLoginFlow.cs
+++ b/src/kapacitor/Auth/OAuthLoginFlow.cs
@@ -167,13 +167,17 @@ public static class OAuthLoginFlow {
     /// is responsible for user-facing output. Returns 0 on success, 1 on failure.
     /// </summary>
     public static async Task<int> ExchangeAndSaveAsync(string serverUrl, string githubAccessToken, string provider, string profile) {
+        using var http = new HttpClient();
+        return await ExchangeAndSaveAsync(http, serverUrl, githubAccessToken, provider, profile);
+    }
+
+    public static async Task<int> ExchangeAndSaveAsync(
+            HttpClient http, string serverUrl, string githubAccessToken, string provider, string profile) {
         if (provider is not AuthProvider.GitHubApp and not AuthProvider.Auth0) {
             Console.Error.WriteLine($"Error: unknown auth provider '{provider}'");
 
             return 1;
         }
-
-        using var http = new HttpClient();
 
         var exchangeResponse = await http.PostAsJsonAsync(
             $"{serverUrl}/auth/token",

--- a/src/kapacitor/Auth/OAuthLoginFlow.cs
+++ b/src/kapacitor/Auth/OAuthLoginFlow.cs
@@ -161,6 +161,44 @@ public static class OAuthLoginFlow {
         return 0;
     }
 
+    /// <summary>
+    /// Exchanges a GitHub access token for a Capacitor JWT and saves it to the named profile.
+    /// Unlike the single-argument overload, this does NOT print "Logged in as …" — the caller
+    /// is responsible for user-facing output. Returns 0 on success, 1 on failure.
+    /// </summary>
+    public static async Task<int> ExchangeAndSaveAsync(string serverUrl, string githubAccessToken, string provider, string profile) {
+        if (provider is not AuthProvider.GitHubApp and not AuthProvider.Auth0) {
+            Console.Error.WriteLine($"Error: unknown auth provider '{provider}'");
+
+            return 1;
+        }
+
+        using var http = new HttpClient();
+
+        var exchangeResponse = await http.PostAsJsonAsync(
+            $"{serverUrl}/auth/token",
+            new TokenExchangeRequest { GithubAccessToken = githubAccessToken },
+            KapacitorJsonContext.Default.TokenExchangeRequest
+        );
+
+        if (!exchangeResponse.IsSuccessStatusCode) {
+            Console.Error.WriteLine($"Error exchanging token for profile '{profile}': {await exchangeResponse.Content.ReadAsStringAsync()}");
+
+            return 1;
+        }
+
+        var exchange = (await exchangeResponse.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.TokenExchangeResponse))!;
+
+        await TokenStore.SaveAsync(profile, new StoredTokens {
+            AccessToken    = exchange.AccessToken,
+            ExpiresAt      = DateTimeOffset.UtcNow.AddSeconds(exchange.ExpiresIn),
+            GitHubUsername = exchange.Username,
+            Provider       = provider
+        });
+
+        return 0;
+    }
+
     static async Task<int> HandleGitHubLogin(string serverUrl, AuthDiscoveryResponse config) {
         var accessToken = await RunDeviceFlowAsync(config.GithubClientId!);
         if (accessToken is null) return 1;

--- a/src/kapacitor/Auth/OAuthLoginFlow.cs
+++ b/src/kapacitor/Auth/OAuthLoginFlow.cs
@@ -8,6 +8,12 @@ using System.Text.Json;
 
 namespace kapacitor.Auth;
 
+public static class AuthProvider {
+    public const string GitHubApp = "GitHubApp";
+    public const string Auth0     = "Auth0";
+    public const string None      = "None";
+}
+
 public static class OAuthLoginFlow {
     public static async Task<int> LoginWithDiscoveryAsync(string serverUrl) {
         // ReSharper disable once ShortLivedHttpClient
@@ -32,10 +38,10 @@ public static class OAuthLoginFlow {
         var config = (await configResponse.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.AuthDiscoveryResponse))!;
 
         return config.Provider switch {
-            "None"      => HandleNoneLogin(),
-            "GitHubApp" => await HandleGitHubLogin(serverUrl, config),
-            "Auth0"     => await HandleAuth0Login(config),
-            _           => HandleUnknownProvider(config.Provider)
+            AuthProvider.None      => HandleNoneLogin(),
+            AuthProvider.GitHubApp => await HandleGitHubLogin(serverUrl, config),
+            AuthProvider.Auth0     => await HandleAuth0Login(config),
+            _                      => HandleUnknownProvider(config.Provider)
         };
     }
 
@@ -51,6 +57,12 @@ public static class OAuthLoginFlow {
         return 1;
     }
 
+    /// <summary>
+    /// Runs GitHub Device Flow interactively. Prints the user code and verification URL to
+    /// <see cref="Console.Out"/>, opens the system browser to the verification URL, and polls
+    /// GitHub for the access token. Intended for CLI use — not suitable for headless callers.
+    /// </summary>
+    /// <returns>The GitHub access token on success, or <c>null</c> on failure.</returns>
     public static async Task<string?> RunDeviceFlowAsync(string clientId) {
         using var http = new HttpClient();
         http.DefaultRequestHeaders.Accept.Add(new("application/json"));
@@ -115,6 +127,12 @@ public static class OAuthLoginFlow {
     }
 
     public static async Task<int> ExchangeAndSaveAsync(string serverUrl, string githubAccessToken, string provider) {
+        if (provider is not AuthProvider.GitHubApp and not AuthProvider.Auth0) {
+            Console.Error.WriteLine($"Error: unknown auth provider '{provider}'");
+
+            return 1;
+        }
+
         using var http = new HttpClient();
 
         var exchangeResponse = await http.PostAsJsonAsync(
@@ -233,7 +251,7 @@ public static class OAuthLoginFlow {
                 RefreshToken   = json.RefreshToken,
                 ExpiresAt      = DateTimeOffset.UtcNow.AddSeconds(json.ExpiresIn),
                 GitHubUsername = username,
-                Provider       = "Auth0",
+                Provider       = AuthProvider.Auth0,
                 Auth0Domain    = auth0Domain,
                 ClientId       = clientId
             }

--- a/src/kapacitor/Auth/OAuthLoginFlow.cs
+++ b/src/kapacitor/Auth/OAuthLoginFlow.cs
@@ -51,26 +51,22 @@ public static class OAuthLoginFlow {
         return 1;
     }
 
-    static async Task<int> HandleGitHubLogin(string serverUrl, AuthDiscoveryResponse config) {
-        var clientId = config.GithubClientId!;
-
+    public static async Task<string?> RunDeviceFlowAsync(string clientId) {
         using var http = new HttpClient();
         http.DefaultRequestHeaders.Accept.Add(new("application/json"));
 
         var deviceResponse = await http.PostAsync(
             "https://github.com/login/device/code",
-            new FormUrlEncodedContent(
-                new Dictionary<string, string> {
-                    ["client_id"] = clientId,
-                    ["scope"]     = "read:user read:org"
-                }
-            )
+            new FormUrlEncodedContent(new Dictionary<string, string> {
+                ["client_id"] = clientId,
+                ["scope"]     = "read:user read:org"
+            })
         );
 
         if (!deviceResponse.IsSuccessStatusCode) {
             Console.Error.WriteLine($"Error requesting device code: {await deviceResponse.Content.ReadAsStringAsync()}");
 
-            return 1;
+            return null;
         }
 
         var device   = (await deviceResponse.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.GitHubDeviceCodeResponse))!;
@@ -81,79 +77,77 @@ public static class OAuthLoginFlow {
         await Console.Out.WriteLineAsync($"  at: {device.VerificationUri}");
         await Console.Out.WriteLineAsync();
 
-        try { Process.Start(new ProcessStartInfo(device.VerificationUri) { UseShellExecute = true }); } catch {
+        try {
+            Process.Start(new ProcessStartInfo(device.VerificationUri) { UseShellExecute = true });
+        } catch {
             /* Browser open is best-effort */
         }
 
         Console.Write("Waiting for authorization...");
 
-        string? accessToken = null;
-
-        while (accessToken is null) {
+        while (true) {
             await Task.Delay(TimeSpan.FromSeconds(interval));
 
             var tokenResponse = await http.PostAsync(
                 "https://github.com/login/oauth/access_token",
-                new FormUrlEncodedContent(
-                    new Dictionary<string, string> {
-                        ["client_id"]   = clientId,
-                        ["device_code"] = device.DeviceCode,
-                        ["grant_type"]  = "urn:ietf:params:oauth:grant-type:device_code"
-                    }
-                )
+                new FormUrlEncodedContent(new Dictionary<string, string> {
+                    ["client_id"]   = clientId,
+                    ["device_code"] = device.DeviceCode,
+                    ["grant_type"]  = "urn:ietf:params:oauth:grant-type:device_code"
+                })
             );
 
             var tokenResult = (await tokenResponse.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.GitHubTokenResponse))!;
 
             if (tokenResult.AccessToken is not null) {
-                accessToken = tokenResult.AccessToken;
-            } else if (tokenResult.Error is not null) {
-                switch (tokenResult.Error) {
-                    case "authorization_pending":
-                        Console.Write(".");
+                await Console.Out.WriteLineAsync(" done!");
 
-                        continue;
-                    case "slow_down":
-                        interval += 5;
-
-                        continue;
-                    default:
-                        Console.Error.WriteLine($"\nError: {tokenResult.Error}");
-
-                        return 1;
-                }
+                return tokenResult.AccessToken;
             }
-        }
 
-        await Console.Out.WriteLineAsync(" done!");
+            if (tokenResult.Error is "authorization_pending") { Console.Write("."); continue; }
+            if (tokenResult.Error is "slow_down")             { interval += 5; continue; }
+
+            Console.Error.WriteLine($"\nError: {tokenResult.Error}");
+
+            return null;
+        }
+    }
+
+    public static async Task<int> ExchangeAndSaveAsync(string serverUrl, string githubAccessToken, string provider) {
+        using var http = new HttpClient();
 
         var exchangeResponse = await http.PostAsJsonAsync(
             $"{serverUrl}/auth/token",
-            new() { GithubAccessToken = accessToken },
+            new TokenExchangeRequest { GithubAccessToken = githubAccessToken },
             KapacitorJsonContext.Default.TokenExchangeRequest
         );
 
         if (!exchangeResponse.IsSuccessStatusCode) {
-            var errorBody = await exchangeResponse.Content.ReadAsStringAsync();
-            Console.Error.WriteLine($"Error exchanging token: {errorBody}");
+            Console.Error.WriteLine($"Error exchanging token: {await exchangeResponse.Content.ReadAsStringAsync()}");
 
             return 1;
         }
 
         var exchange = (await exchangeResponse.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.TokenExchangeResponse))!;
 
-        await TokenStore.SaveAsync(
-            new() {
-                AccessToken    = exchange.AccessToken,
-                ExpiresAt      = DateTimeOffset.UtcNow.AddSeconds(exchange.ExpiresIn),
-                GitHubUsername = exchange.Username,
-                Provider       = config.Provider
-            }
-        );
+        await TokenStore.SaveAsync(new StoredTokens {
+            AccessToken    = exchange.AccessToken,
+            ExpiresAt      = DateTimeOffset.UtcNow.AddSeconds(exchange.ExpiresIn),
+            GitHubUsername = exchange.Username,
+            Provider       = provider
+        });
 
         await Console.Out.WriteLineAsync($"Logged in as {exchange.Username}");
 
         return 0;
+    }
+
+    static async Task<int> HandleGitHubLogin(string serverUrl, AuthDiscoveryResponse config) {
+        var accessToken = await RunDeviceFlowAsync(config.GithubClientId!);
+        if (accessToken is null) return 1;
+
+        return await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider);
     }
 
     static async Task<int> HandleAuth0Login(AuthDiscoveryResponse config) {

--- a/src/kapacitor/Auth/TenantDiscovery.cs
+++ b/src/kapacitor/Auth/TenantDiscovery.cs
@@ -1,0 +1,64 @@
+using kapacitor.Config;
+using Profile = kapacitor.Config.Profile;
+
+namespace kapacitor.Auth;
+
+public sealed record DiscoveryOutcome(
+    DiscoveredTenant[] Tenants,
+    DiscoveredTenant?  Picked,
+    string?            ErrorMessage
+);
+
+public interface ITenantPicker {
+    DiscoveredTenant? Pick(DiscoveredTenant[] tenants);
+}
+
+public class TenantDiscovery(IAuthProxyClient proxy, ITenantPicker picker) {
+    public async Task<DiscoveryOutcome> RunAsync(string proxyUrl, string githubAccessToken) {
+        var result = await proxy.DiscoverTenantsAsync(proxyUrl, githubAccessToken);
+
+        if (result.Error != DiscoveryError.None) {
+            return new([], null, result.Error switch {
+                DiscoveryError.ProxyUnreachable => "The Kurrent auth service is unreachable.",
+                DiscoveryError.TokenRejected    => "GitHub rejected the authentication token. Please sign in again.",
+                DiscoveryError.UpstreamError    => "Kurrent auth service could not reach GitHub. Try again later.",
+                _                               => "Tenant discovery failed."
+            });
+        }
+
+        if (result.Tenants.Length == 0) {
+            return new([], null,
+                "No Capacitor tenants are linked to your GitHub orgs. Ask your admin to install the Kurrent GitHub App on your org, or re-run with --server-url <url> for a self-hosted server.");
+        }
+
+        var picked = result.Tenants.Length == 1
+            ? result.Tenants[0]
+            : picker.Pick(result.Tenants);
+
+        if (picked is null) {
+            return new(result.Tenants, null, "No tenant selected.");
+        }
+
+        return new(result.Tenants, picked, null);
+    }
+
+    public static ProfileConfig MergeProfiles(
+            ProfileConfig      existing,
+            DiscoveredTenant[] discovered,
+            DiscoveredTenant   active) {
+        var profiles = new Dictionary<string, Profile>(existing.Profiles);
+        var template = existing.Profiles.GetValueOrDefault("default") ?? new Profile();
+
+        foreach (var t in discovered) {
+            var name = t.OrgLogin;
+            profiles[name] = (profiles.GetValueOrDefault(name) ?? template) with {
+                ServerUrl = t.Origin
+            };
+        }
+
+        return existing with {
+            Profiles      = profiles,
+            ActiveProfile = active.OrgLogin
+        };
+    }
+}

--- a/src/kapacitor/Auth/TenantDiscovery.cs
+++ b/src/kapacitor/Auth/TenantDiscovery.cs
@@ -47,7 +47,9 @@ public class TenantDiscovery(IAuthProxyClient proxy, ITenantPicker picker) {
             DiscoveredTenant[] discovered,
             DiscoveredTenant   active) {
         var profiles = new Dictionary<string, Profile>(existing.Profiles);
-        var template = existing.Profiles.GetValueOrDefault("default") ?? new Profile();
+        var template = existing.Profiles.GetValueOrDefault(existing.ActiveProfile)
+                    ?? existing.Profiles.GetValueOrDefault("default")
+                    ?? new Profile();
 
         foreach (var t in discovered) {
             var name = t.OrgLogin;

--- a/src/kapacitor/Auth/TenantDiscovery.cs
+++ b/src/kapacitor/Auth/TenantDiscovery.cs
@@ -54,7 +54,7 @@ public class TenantDiscovery(IAuthProxyClient proxy, ITenantPicker picker) {
         foreach (var t in discovered) {
             var name = t.OrgLogin;
             profiles[name] = (profiles.GetValueOrDefault(name) ?? template) with {
-                ServerUrl = t.Origin
+                ServerUrl = AppConfig.NormalizeUrl(t.Origin)
             };
         }
 

--- a/src/kapacitor/Auth/TenantDiscovery.cs
+++ b/src/kapacitor/Auth/TenantDiscovery.cs
@@ -21,7 +21,7 @@ public class TenantDiscovery(IAuthProxyClient proxy, ITenantPicker picker) {
             return new([], null, result.Error switch {
                 DiscoveryError.ProxyUnreachable => "The Kurrent auth service is unreachable.",
                 DiscoveryError.TokenRejected    => "GitHub rejected the authentication token. Please sign in again.",
-                DiscoveryError.UpstreamError    => "Kurrent auth service could not reach GitHub. Try again later.",
+                DiscoveryError.UpstreamError    => "Kurrent auth service returned an error. Try again later.",
                 _                               => "Tenant discovery failed."
             });
         }
@@ -46,8 +46,9 @@ public class TenantDiscovery(IAuthProxyClient proxy, ITenantPicker picker) {
             ProfileConfig      existing,
             DiscoveredTenant[] discovered,
             DiscoveredTenant   active) {
-        var profiles = new Dictionary<string, Profile>(existing.Profiles);
-        var template = existing.Profiles.GetValueOrDefault(existing.ActiveProfile)
+        var profiles      = new Dictionary<string, Profile>(existing.Profiles);
+        var activeProfile = string.IsNullOrWhiteSpace(existing.ActiveProfile) ? "default" : existing.ActiveProfile;
+        var template = existing.Profiles.GetValueOrDefault(activeProfile)
                     ?? existing.Profiles.GetValueOrDefault("default")
                     ?? new Profile();
 

--- a/src/kapacitor/Auth/TokenStore.cs
+++ b/src/kapacitor/Auth/TokenStore.cs
@@ -84,9 +84,9 @@ public static class TokenStore {
         await SaveAsync(profile, tokens);
     }
 
-    public static void Delete() {
+    public static async Task DeleteAsync() {
         if (File.Exists(LegacyTokenPath)) File.Delete(LegacyTokenPath);
-        var profile = ResolveActiveProfileAsync().GetAwaiter().GetResult();
+        var profile = await ResolveActiveProfileAsync();
         Delete(profile);
     }
 

--- a/src/kapacitor/Auth/TokenStore.cs
+++ b/src/kapacitor/Auth/TokenStore.cs
@@ -33,7 +33,25 @@ public record StoredTokens {
 public static class TokenStore {
     static string LegacyTokenPath => PathHelpers.ConfigPath("tokens.json");
     static string TokenDir         => PathHelpers.ConfigPath("tokens");
-    static string ProfileTokenPath(string profile) => Path.Combine(TokenDir, $"{profile}.json");
+
+    static void ValidateProfileName(string profile) {
+        if (string.IsNullOrWhiteSpace(profile)) {
+            throw new ArgumentException("Profile name must not be empty.", nameof(profile));
+        }
+        if (profile == "." || profile == "..") {
+            throw new ArgumentException("Profile name is invalid.", nameof(profile));
+        }
+        if (profile.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0 ||
+            profile.Contains(Path.DirectorySeparatorChar) ||
+            profile.Contains(Path.AltDirectorySeparatorChar)) {
+            throw new ArgumentException("Profile name contains invalid filename characters.", nameof(profile));
+        }
+    }
+
+    static string ProfileTokenPath(string profile) {
+        ValidateProfileName(profile);
+        return Path.Combine(TokenDir, $"{profile}.json");
+    }
 
     // ── Profile-aware overloads ──────────────────────────────────────────────
 
@@ -85,12 +103,16 @@ public static class TokenStore {
     }
 
     public static Task DeleteAsync() {
-        if (File.Exists(LegacyTokenPath)) File.Delete(LegacyTokenPath);
+        if (File.Exists(LegacyTokenPath)) {
+            try { File.Delete(LegacyTokenPath); } catch { /* best-effort */ }
+        }
 
         if (Directory.Exists(TokenDir)) {
-            foreach (var file in Directory.EnumerateFiles(TokenDir, "*.json")) {
-                try { File.Delete(file); } catch { /* best-effort */ }
-            }
+            try {
+                foreach (var file in Directory.EnumerateFiles(TokenDir, "*.json")) {
+                    try { File.Delete(file); } catch { /* best-effort */ }
+                }
+            } catch { /* best-effort */ }
         }
 
         return Task.CompletedTask;

--- a/src/kapacitor/Auth/TokenStore.cs
+++ b/src/kapacitor/Auth/TokenStore.cs
@@ -31,34 +31,68 @@ public record StoredTokens {
 }
 
 public static class TokenStore {
-    static readonly string TokenPath = PathHelpers.ConfigPath("tokens.json");
+    static string LegacyTokenPath => PathHelpers.ConfigPath("tokens.json");
+    static string TokenDir         => PathHelpers.ConfigPath("tokens");
+    static string ProfileTokenPath(string profile) => Path.Combine(TokenDir, $"{profile}.json");
 
-    public static async Task<StoredTokens?> LoadAsync() {
-        if (!File.Exists(TokenPath)) {
-            return null;
+    // ── Profile-aware overloads ──────────────────────────────────────────────
+
+    public static async Task<StoredTokens?> LoadAsync(string profile) {
+        var path = ProfileTokenPath(profile);
+        if (!File.Exists(path)) return null;
+        var json = await File.ReadAllTextAsync(path);
+        return JsonSerializer.Deserialize(json, KapacitorJsonContext.Default.StoredTokens);
+    }
+
+    public static async Task SaveAsync(string profile, StoredTokens tokens) {
+        Directory.CreateDirectory(TokenDir);
+        var path     = ProfileTokenPath(profile);
+        var tempPath = $"{path}.tmp";
+        await File.WriteAllTextAsync(tempPath, JsonSerializer.Serialize(tokens, KapacitorJsonContext.Default.StoredTokens));
+        File.Move(tempPath, path, overwrite: true);
+
+        if (!OperatingSystem.IsWindows()) {
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
         }
 
-        var json = await File.ReadAllTextAsync(TokenPath);
+        // Migration: remove the pre-upgrade single-file token if it still exists
+        if (File.Exists(LegacyTokenPath)) {
+            try { File.Delete(LegacyTokenPath); } catch { /* best-effort */ }
+        }
+    }
 
+    public static void Delete(string profile) {
+        var path = ProfileTokenPath(profile);
+        if (File.Exists(path)) File.Delete(path);
+    }
+
+    // ── Legacy (profile-resolving) overloads ────────────────────────────────
+
+    public static async Task<StoredTokens?> LoadAsync() {
+        var profile    = await ResolveActiveProfileAsync();
+        var perProfile = await LoadAsync(profile);
+        if (perProfile is not null) return perProfile;
+
+        // Fall back to legacy single-file layout for pre-upgrade installs
+        if (!File.Exists(LegacyTokenPath)) return null;
+        var json = await File.ReadAllTextAsync(LegacyTokenPath);
         return JsonSerializer.Deserialize(json, KapacitorJsonContext.Default.StoredTokens);
     }
 
     public static async Task SaveAsync(StoredTokens tokens) {
-        var dir = Path.GetDirectoryName(TokenPath)!;
-        Directory.CreateDirectory(dir);
-        var tempPath = $"{TokenPath}.tmp";
-        await File.WriteAllTextAsync(tempPath, JsonSerializer.Serialize(tokens, KapacitorJsonContext.Default.StoredTokens));
-        File.Move(tempPath, TokenPath, overwrite: true);
-
-        if (!OperatingSystem.IsWindows()) {
-            File.SetUnixFileMode(TokenPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
-        }
+        var profile = await ResolveActiveProfileAsync();
+        await SaveAsync(profile, tokens);
     }
 
     public static void Delete() {
-        if (File.Exists(TokenPath)) {
-            File.Delete(TokenPath);
-        }
+        if (File.Exists(LegacyTokenPath)) File.Delete(LegacyTokenPath);
+        var profile = ResolveActiveProfileAsync().GetAwaiter().GetResult();
+        Delete(profile);
+    }
+
+    static async Task<string> ResolveActiveProfileAsync() {
+        var cfg = await AppConfig.LoadProfileConfig();
+        return string.IsNullOrEmpty(cfg.ActiveProfile) ? "default" : cfg.ActiveProfile;
     }
 
     public static async Task<StoredTokens?> GetValidTokensAsync() {

--- a/src/kapacitor/Auth/TokenStore.cs
+++ b/src/kapacitor/Auth/TokenStore.cs
@@ -84,10 +84,16 @@ public static class TokenStore {
         await SaveAsync(profile, tokens);
     }
 
-    public static async Task DeleteAsync() {
+    public static Task DeleteAsync() {
         if (File.Exists(LegacyTokenPath)) File.Delete(LegacyTokenPath);
-        var profile = await ResolveActiveProfileAsync();
-        Delete(profile);
+
+        if (Directory.Exists(TokenDir)) {
+            foreach (var file in Directory.EnumerateFiles(TokenDir, "*.json")) {
+                try { File.Delete(file); } catch { /* best-effort */ }
+            }
+        }
+
+        return Task.CompletedTask;
     }
 
     static async Task<string> ResolveActiveProfileAsync() {

--- a/src/kapacitor/Commands/SetupCommand.cs
+++ b/src/kapacitor/Commands/SetupCommand.cs
@@ -31,42 +31,62 @@ public static class SetupCommand {
             }
         }
 
-        // Step 1: Server URL
+        // Step 1: Server
         AnsiConsole.Write(new Rule("[yellow]Step 1/5 — Server[/]").LeftJustified());
         string serverUrl;
+        string? preAuthToken = null;
+        string  provider;
 
         if (serverUrlArg is not null) {
-            serverUrl = serverUrlArg;
+            serverUrl = AppConfig.NormalizeUrl(serverUrlArg);
             await Console.Out.WriteLineAsync($"  Server URL: {serverUrl}");
+
+            try {
+                provider = await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync("Checking server…",
+                    async _ => await HttpClientExtensions.DiscoverProviderAsync(serverUrl));
+                AnsiConsole.MarkupLine($"  [green]✓[/] Reachable · auth provider: [cyan]{Markup.Escape(provider)}[/]");
+            } catch (Exception ex) {
+                AnsiConsole.MarkupLine($"  [red]✗[/] Cannot reach server: {Markup.Escape(ex.Message)}");
+                return 1;
+            }
         } else if (noPrompt) {
             await Console.Error.WriteLineAsync("  --server-url is required with --no-prompt");
-
             return 1;
         } else {
-            serverUrl = AnsiConsole.Prompt(
-                new TextPrompt<string>("Capacitor server URL:")
-                    .Validate(u => !string.IsNullOrWhiteSpace(u)
-                        ? ValidationResult.Success()
-                        : ValidationResult.Error("[red]URL cannot be empty[/]")));
-        }
+            // Discovery path
+            AnsiConsole.MarkupLine($"  Proxy: [dim]{Markup.Escape(AuthProxyEndpoint.Url)}[/]");
 
-        // Normalize: strip trailing slashes to avoid double-slash URLs
-        serverUrl = AppConfig.NormalizeUrl(serverUrl);
+            using var http    = new HttpClient();
+            var proxyClient   = new AuthProxyClient(http);
 
-        // Validate server reachability
-        string provider;
+            var clientId = await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync("Contacting auth service…",
+                async _ => await proxyClient.GetGitHubClientIdAsync(AuthProxyEndpoint.Url));
+            if (clientId is null) {
+                AnsiConsole.MarkupLine("  [red]✗[/] Cannot reach the Kurrent auth service. Retry later, or pass --server-url <url>.");
+                return 1;
+            }
 
-        try {
-            provider = await AnsiConsole.Status()
-                .Spinner(Spinner.Known.Dots)
-                .StartAsync("Checking server…", async _ =>
-                    await HttpClientExtensions.DiscoverProviderAsync(serverUrl));
+            var ghToken = await OAuthLoginFlow.RunDeviceFlowAsync(clientId);
+            if (ghToken is null) return 1;
 
-            AnsiConsole.MarkupLine($"  [green]✓[/] Reachable · auth provider: [cyan]{Markup.Escape(provider)}[/]");
-        } catch (Exception ex) {
-            AnsiConsole.MarkupLine($"  [red]✗[/] Cannot reach server: {Markup.Escape(ex.Message)}");
+            var discovery = new TenantDiscovery(proxyClient, new SpectreTenantPicker());
+            var outcome   = await discovery.RunAsync(AuthProxyEndpoint.Url, ghToken);
 
-            return 1;
+            if (outcome.ErrorMessage is not null) {
+                AnsiConsole.MarkupLine($"  [red]✗[/] {Markup.Escape(outcome.ErrorMessage)}");
+                return 1;
+            }
+
+            serverUrl    = outcome.Picked!.Origin;
+            preAuthToken = ghToken;
+            provider     = AuthProvider.GitHubApp;
+
+            // Create/update a profile per discovered tenant; the picked one becomes active
+            var profileCfg = await AppConfig.LoadProfileConfig();
+            profileCfg     = TenantDiscovery.MergeProfiles(profileCfg, outcome.Tenants, outcome.Picked);
+            await AppConfig.SaveProfileConfig(profileCfg);
+
+            AnsiConsole.MarkupLine($"  [green]✓[/] Discovered {outcome.Tenants.Length} tenant(s). Active: [cyan]{Markup.Escape(outcome.Picked.OrgLogin)}[/]");
         }
 
         await Console.Out.WriteLineAsync();
@@ -74,8 +94,14 @@ public static class SetupCommand {
         // Step 2: Login
         AnsiConsole.Write(new Rule("[yellow]Step 2/5 — Login[/]").LeftJustified());
 
-        if (provider == "None") {
+        if (provider == AuthProvider.None) {
             await Console.Out.WriteLineAsync("  Auth provider is None — no login required.");
+        } else if (preAuthToken is not null) {
+            var exchangeResult = await OAuthLoginFlow.ExchangeAndSaveAsync(serverUrl, preAuthToken, provider);
+            if (exchangeResult != 0) {
+                await Console.Error.WriteLineAsync("  Token exchange failed.");
+                return 1;
+            }
         } else {
             var loginResult = await OAuthLoginFlow.LoginWithDiscoveryAsync(serverUrl);
 
@@ -195,16 +221,17 @@ public static class SetupCommand {
 
         // Save config
         var profileConfig  = await AppConfig.LoadProfileConfig();
-        var defaultProfile = profileConfig.Profiles.GetValueOrDefault("default") ?? new Profile();
+        var activeName     = profileConfig.ActiveProfile;
+        var defaultProfile = profileConfig.Profiles.GetValueOrDefault(activeName) ?? new Profile();
 
         defaultProfile = defaultProfile with {
-            ServerUrl = serverUrl,
+            ServerUrl         = serverUrl,
             DefaultVisibility = defaultVisibility,
-            Daemon = (defaultProfile.Daemon ?? new DaemonSettings()) with { Name = daemonName }
+            Daemon            = (defaultProfile.Daemon ?? new DaemonSettings()) with { Name = daemonName }
         };
 
         var profiles = new Dictionary<string, Profile>(profileConfig.Profiles) {
-            ["default"] = defaultProfile
+            [activeName] = defaultProfile
         };
         profileConfig = profileConfig with { Profiles = profiles };
         await AppConfig.SaveProfileConfig(profileConfig);

--- a/src/kapacitor/Commands/SetupCommand.cs
+++ b/src/kapacitor/Commands/SetupCommand.cs
@@ -258,7 +258,7 @@ public static class SetupCommand {
 
         AnsiConsole.MarkupLine($"  [green]✓[/] Discovered {outcome.Tenants.Length} tenant(s). Active: [cyan]{Markup.Escape(outcome.Picked!.OrgLogin)}[/]");
 
-        return (outcome.Picked.Origin, ghToken, AuthProvider.GitHubApp);
+        return (AppConfig.NormalizeUrl(outcome.Picked.Origin), ghToken, AuthProvider.GitHubApp);
     }
 
     internal static string? ResolvePluginPath() {

--- a/src/kapacitor/Commands/SetupCommand.cs
+++ b/src/kapacitor/Commands/SetupCommand.cs
@@ -16,7 +16,7 @@ public static class SetupCommand {
 
         // Check if already configured
         var existingProfile = await AppConfig.LoadProfileConfig();
-        var existing        = existingProfile.Profiles.GetValueOrDefault("default");
+        var existing        = existingProfile.Profiles.GetValueOrDefault(existingProfile.ActiveProfile);
         var existingTokens  = await TokenStore.LoadAsync();
 
         if (existing?.ServerUrl is not null && existingTokens is not null && !noPrompt) {
@@ -53,40 +53,9 @@ public static class SetupCommand {
             await Console.Error.WriteLineAsync("  --server-url is required with --no-prompt");
             return 1;
         } else {
-            // Discovery path
-            AnsiConsole.MarkupLine($"  Proxy: [dim]{Markup.Escape(AuthProxyEndpoint.Url)}[/]");
-
-            using var http    = new HttpClient();
-            var proxyClient   = new AuthProxyClient(http);
-
-            var clientId = await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync("Contacting auth service…",
-                async _ => await proxyClient.GetGitHubClientIdAsync(AuthProxyEndpoint.Url));
-            if (clientId is null) {
-                AnsiConsole.MarkupLine("  [red]✗[/] Cannot reach the Kurrent auth service. Retry later, or pass --server-url <url>.");
-                return 1;
-            }
-
-            var ghToken = await OAuthLoginFlow.RunDeviceFlowAsync(clientId);
-            if (ghToken is null) return 1;
-
-            var discovery = new TenantDiscovery(proxyClient, new SpectreTenantPicker());
-            var outcome   = await discovery.RunAsync(AuthProxyEndpoint.Url, ghToken);
-
-            if (outcome.ErrorMessage is not null) {
-                AnsiConsole.MarkupLine($"  [red]✗[/] {Markup.Escape(outcome.ErrorMessage)}");
-                return 1;
-            }
-
-            serverUrl    = outcome.Picked!.Origin;
-            preAuthToken = ghToken;
-            provider     = AuthProvider.GitHubApp;
-
-            // Create/update a profile per discovered tenant; the picked one becomes active
-            var profileCfg = await AppConfig.LoadProfileConfig();
-            profileCfg     = TenantDiscovery.MergeProfiles(profileCfg, outcome.Tenants, outcome.Picked);
-            await AppConfig.SaveProfileConfig(profileCfg);
-
-            AnsiConsole.MarkupLine($"  [green]✓[/] Discovered {outcome.Tenants.Length} tenant(s). Active: [cyan]{Markup.Escape(outcome.Picked.OrgLogin)}[/]");
+            var discovered = await RunDiscoveryAsync();
+            if (discovered is null) return 1;
+            (serverUrl, preAuthToken, provider) = discovered.Value;
         }
 
         await Console.Out.WriteLineAsync();
@@ -102,6 +71,9 @@ public static class SetupCommand {
                 await Console.Error.WriteLineAsync("  Token exchange failed.");
                 return 1;
             }
+            // Keep formatting consistent with the non-discovery branch
+            var tokens = await TokenStore.LoadAsync();
+            AnsiConsole.MarkupLine($"  [green]✓[/] Logged in as [cyan]{Markup.Escape(tokens?.GitHubUsername ?? "?")}[/]");
         } else {
             var loginResult = await OAuthLoginFlow.LoginWithDiscoveryAsync(serverUrl);
 
@@ -254,6 +226,39 @@ public static class SetupCommand {
         AnsiConsole.MarkupLine("\n[dim]Optional:[/] start the agent daemon with [cyan]kapacitor agent start -d[/]");
 
         return 0;
+    }
+
+    static async Task<(string ServerUrl, string PreAuthToken, string Provider)?> RunDiscoveryAsync() {
+        AnsiConsole.MarkupLine($"  Proxy: [dim]{Markup.Escape(AuthProxyEndpoint.Url)}[/]");
+
+        using var http  = new HttpClient();
+        var proxyClient = new AuthProxyClient(http);
+
+        var clientId = await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync("Contacting auth service…",
+            async _ => await proxyClient.GetGitHubClientIdAsync(AuthProxyEndpoint.Url));
+        if (clientId is null) {
+            AnsiConsole.MarkupLine("  [red]✗[/] Cannot reach the Kurrent auth service. Retry later, or pass --server-url <url>.");
+            return null;
+        }
+
+        var ghToken = await OAuthLoginFlow.RunDeviceFlowAsync(clientId);
+        if (ghToken is null) return null;
+
+        var discovery = new TenantDiscovery(proxyClient, new SpectreTenantPicker());
+        var outcome   = await discovery.RunAsync(AuthProxyEndpoint.Url, ghToken);
+
+        if (outcome.ErrorMessage is not null) {
+            AnsiConsole.MarkupLine($"  [red]✗[/] {Markup.Escape(outcome.ErrorMessage)}");
+            return null;
+        }
+
+        var profileCfg = await AppConfig.LoadProfileConfig();
+        profileCfg     = TenantDiscovery.MergeProfiles(profileCfg, outcome.Tenants, outcome.Picked!);
+        await AppConfig.SaveProfileConfig(profileCfg);
+
+        AnsiConsole.MarkupLine($"  [green]✓[/] Discovered {outcome.Tenants.Length} tenant(s). Active: [cyan]{Markup.Escape(outcome.Picked!.OrgLogin)}[/]");
+
+        return (outcome.Picked.Origin, ghToken, AuthProvider.GitHubApp);
     }
 
     internal static string? ResolvePluginPath() {

--- a/src/kapacitor/Commands/SetupCommand.cs
+++ b/src/kapacitor/Commands/SetupCommand.cs
@@ -16,7 +16,8 @@ public static class SetupCommand {
 
         // Check if already configured
         var existingProfile = await AppConfig.LoadProfileConfig();
-        var existing        = existingProfile.Profiles.GetValueOrDefault(existingProfile.ActiveProfile);
+        var activeProfile   = string.IsNullOrWhiteSpace(existingProfile.ActiveProfile) ? "default" : existingProfile.ActiveProfile;
+        var existing        = existingProfile.Profiles.GetValueOrDefault(activeProfile);
         var existingTokens  = await TokenStore.LoadAsync();
 
         if (existing?.ServerUrl is not null && existingTokens is not null && !noPrompt) {

--- a/src/kapacitor/Commands/SpectreTenantPicker.cs
+++ b/src/kapacitor/Commands/SpectreTenantPicker.cs
@@ -1,0 +1,15 @@
+using kapacitor.Auth;
+using Spectre.Console;
+
+namespace kapacitor.Commands;
+
+public class SpectreTenantPicker : ITenantPicker {
+    public DiscoveredTenant? Pick(DiscoveredTenant[] tenants) {
+        var prompt = new SelectionPrompt<DiscoveredTenant>()
+            .Title("Which Capacitor tenant would you like to use as default?")
+            .UseConverter(t => $"{t.OrgLogin} · {t.Origin}")
+            .AddChoices(tenants);
+
+        return AnsiConsole.Prompt(prompt);
+    }
+}

--- a/src/kapacitor/Models.cs
+++ b/src/kapacitor/Models.cs
@@ -435,6 +435,8 @@ record RepoEntry {
 [JsonSerializable(typeof(Auth.GitHubTokenResponse))]
 [JsonSerializable(typeof(Auth.Auth0TokenResponse))]
 [JsonSerializable(typeof(Auth.Auth0IdTokenClaims))]
+[JsonSerializable(typeof(Auth.ProxyConfigResponse))]
+[JsonSerializable(typeof(Auth.DiscoveredTenant[]))]
 [JsonSerializable(typeof(LaunchAgentCommand))]
 [JsonSerializable(typeof(SendInputCommand))]
 [JsonSerializable(typeof(ResizeTerminalCommand))]

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -816,16 +816,19 @@ async Task<int> HandleDiscoverLoginAsync() {
     cfg = TenantDiscovery.MergeProfiles(cfg, outcome.Tenants, outcome.Picked!);
     await AppConfig.SaveProfileConfig(cfg);
 
-    // Exchange tokens for every discovered tenant so switching profiles works immediately
-    foreach (var tenant in outcome.Tenants) {
-        var exchangeExit = await OAuthLoginFlow.ExchangeAndSaveAsync(
-            tenant.Origin, ghToken, AuthProvider.GitHubApp, tenant.OrgLogin);
+    // Discovery flows only via the shared GitHub App proxy, so every discovered tenant
+    // uses the GitHubApp provider. If DiscoveredTenant ever gains a Provider field, read it here.
 
-        if (exchangeExit != 0) {
+    // Exchange tokens for every discovered tenant so switching profiles works immediately
+    var exchanges = outcome.Tenants.Select(async tenant => {
+        var exit = await OAuthLoginFlow.ExchangeAndSaveAsync(
+            tenant.Origin, ghToken, AuthProvider.GitHubApp, tenant.OrgLogin);
+        if (exit != 0) {
             await Console.Error.WriteLineAsync(
                 $"Warning: token exchange failed for {tenant.OrgLogin}. Run 'kapacitor login' after switching to that profile.");
         }
-    }
+    });
+    await Task.WhenAll(exchanges);
 
     await Console.Out.WriteLineAsync($"Logged in. Active profile: {outcome.Picked!.OrgLogin}.");
 

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -170,7 +170,7 @@ switch (command) {
         return await OAuthLoginFlow.LoginWithDiscoveryAsync(baseUrl!);
     }
     case "logout": {
-        TokenStore.Delete();
+        await TokenStore.DeleteAsync();
         await Console.Out.WriteLineAsync("Logged out.");
 
         return 0;

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -822,8 +822,9 @@ async Task<int> HandleDiscoverLoginAsync() {
     // Exchange tokens for every discovered tenant so switching profiles works immediately.
     // One HttpClient shared across all per-tenant exchanges to avoid socket/port exhaustion.
     var exchanges = outcome.Tenants.Select(async tenant => {
+        var origin = AppConfig.NormalizeUrl(tenant.Origin);
         var exit = await OAuthLoginFlow.ExchangeAndSaveAsync(
-            http, tenant.Origin, ghToken, AuthProvider.GitHubApp, tenant.OrgLogin);
+            http, origin, ghToken, AuthProvider.GitHubApp, tenant.OrgLogin);
         if (exit != 0) {
             await Console.Error.WriteLineAsync(
                 $"Warning: token exchange failed for {tenant.OrgLogin}. Run 'kapacitor login' after switching to that profile.");

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -819,10 +819,11 @@ async Task<int> HandleDiscoverLoginAsync() {
     // Discovery flows only via the shared GitHub App proxy, so every discovered tenant
     // uses the GitHubApp provider. If DiscoveredTenant ever gains a Provider field, read it here.
 
-    // Exchange tokens for every discovered tenant so switching profiles works immediately
+    // Exchange tokens for every discovered tenant so switching profiles works immediately.
+    // One HttpClient shared across all per-tenant exchanges to avoid socket/port exhaustion.
     var exchanges = outcome.Tenants.Select(async tenant => {
         var exit = await OAuthLoginFlow.ExchangeAndSaveAsync(
-            tenant.Origin, ghToken, AuthProvider.GitHubApp, tenant.OrgLogin);
+            http, tenant.Origin, ghToken, AuthProvider.GitHubApp, tenant.OrgLogin);
         if (exit != 0) {
             await Console.Error.WriteLineAsync(
                 $"Warning: token exchange failed for {tenant.OrgLogin}. Run 'kapacitor login' after switching to that profile.");

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -53,7 +53,7 @@ if (args.Skip(1).Any(a => a is "--help" or "-h")) {
 }
 
 // Commands that don't need a server URL
-string[] offlineCommands = ["--help", "-h", "help", "--version", "-v", "logout", "cleanup", "config", "agent", "setup", "status", "update", "plugin", "profile", "use", "repos"];
+string[] offlineCommands = ["--help", "-h", "help", "--version", "-v", "logout", "cleanup", "config", "agent", "setup", "status", "update", "plugin", "profile", "use", "repos", "login"];
 
 if (baseUrl is null && !offlineCommands.Contains(command)) {
     Console.Error.WriteLine("No server configured. Run `kapacitor setup` or set KAPACITOR_URL.");
@@ -167,7 +167,17 @@ switch (command) {
         return await WhatsDoneCommand.HandleGenerateWhatsDone(baseUrl!, wdSessionId);
     }
     case "login": {
-        return await OAuthLoginFlow.LoginWithDiscoveryAsync(baseUrl!);
+        if (args.Contains("--discover")) {
+            return await HandleDiscoverLoginAsync();
+        }
+
+        if (baseUrl is null) {
+            Console.Error.WriteLine("No server configured. Run `kapacitor setup`, set KAPACITOR_URL, or use `kapacitor login --discover`.");
+
+            return 1;
+        }
+
+        return await OAuthLoginFlow.LoginWithDiscoveryAsync(baseUrl);
     }
     case "logout": {
         await TokenStore.DeleteAsync();
@@ -775,6 +785,51 @@ void NormalizeGuidField(JsonNode node, string fieldName) {
     if (value is not null && value.Contains('-')) {
         node[fieldName] = value.Replace("-", "");
     }
+}
+
+async Task<int> HandleDiscoverLoginAsync() {
+    using var http  = new HttpClient();
+    var proxyClient = new AuthProxyClient(http);
+
+    var clientId = await proxyClient.GetGitHubClientIdAsync(AuthProxyEndpoint.Url);
+
+    if (clientId is null) {
+        await Console.Error.WriteLineAsync("Cannot reach the Kurrent auth service.");
+
+        return 1;
+    }
+
+    var ghToken = await OAuthLoginFlow.RunDeviceFlowAsync(clientId);
+    if (ghToken is null) return 1;
+
+    var discovery = new TenantDiscovery(proxyClient, new SpectreTenantPicker());
+    var outcome   = await discovery.RunAsync(AuthProxyEndpoint.Url, ghToken);
+
+    if (outcome.ErrorMessage is not null) {
+        await Console.Error.WriteLineAsync(outcome.ErrorMessage);
+
+        return 1;
+    }
+
+    // Merge discovered tenants as profiles; the picked one becomes active
+    var cfg = await AppConfig.LoadProfileConfig();
+    cfg = TenantDiscovery.MergeProfiles(cfg, outcome.Tenants, outcome.Picked!);
+    await AppConfig.SaveProfileConfig(cfg);
+
+    // Exchange tokens for every discovered tenant so switching profiles works immediately
+    foreach (var tenant in outcome.Tenants) {
+        var exchangeExit = await OAuthLoginFlow.ExchangeAndSaveAsync(
+            tenant.Origin, ghToken, AuthProvider.GitHubApp, tenant.OrgLogin);
+
+        if (exchangeExit != 0) {
+            await Console.Error.WriteLineAsync(
+                $"Warning: token exchange failed for {tenant.OrgLogin}. Run 'kapacitor login' after switching to that profile.");
+        }
+    }
+
+    await Console.Out.WriteLineAsync($"Logged in. Active profile: {outcome.Picked!.OrgLogin}.");
+
+    return 0;
 }
 
 async Task PrintUsage() {

--- a/src/kapacitor/Resources/help-login.txt
+++ b/src/kapacitor/Resources/help-login.txt
@@ -1,6 +1,12 @@
 kapacitor login — Authenticate via OAuth
 
-Usage: kapacitor login
+Usage: kapacitor login [--discover]
 
 Opens a browser for OAuth authentication. The auth method (GitHub Device
 Flow or Auth0 PKCE) is auto-discovered from the server configuration.
+
+Options:
+  --discover    Run tenant discovery across all your GitHub org memberships.
+                Exchanges tokens for each discovered Capacitor tenant and saves
+                them as named profiles, then sets the picked tenant as the
+                active profile. No existing profile configuration is required.

--- a/test/kapacitor.Tests.Unit/AuthProxyClientTests.cs
+++ b/test/kapacitor.Tests.Unit/AuthProxyClientTests.cs
@@ -82,7 +82,7 @@ public class AuthProxyClientTests {
     }
 
     [Test]
-    public async Task DiscoverTenantsAsync_returns_GitHubError_on_502() {
+    public async Task DiscoverTenantsAsync_returns_UpstreamError_on_502() {
         using var server = WireMockServer.Start();
         server.Given(Request.Create().WithPath("/discover-tenants").UsingPost())
               .RespondWith(Response.Create().WithStatusCode(502));
@@ -92,7 +92,7 @@ public class AuthProxyClientTests {
 
         var result = await client.DiscoverTenantsAsync(server.Urls[0], "gh-token");
 
-        await Assert.That(result.Error).IsEqualTo(DiscoveryError.GitHubError);
+        await Assert.That(result.Error).IsEqualTo(DiscoveryError.UpstreamError);
     }
 
     [Test]

--- a/test/kapacitor.Tests.Unit/AuthProxyClientTests.cs
+++ b/test/kapacitor.Tests.Unit/AuthProxyClientTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using kapacitor.Auth;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace kapacitor.Tests.Unit;
+
+public class AuthProxyClientTests {
+    [Test]
+    public async Task GetGitHubClientIdAsync_returns_id_on_200() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/config").UsingGet())
+              .RespondWith(Response.Create().WithStatusCode(200)
+                  .WithBody("""{"github_client_id":"Iv1.abc"}""")
+                  .WithHeader("Content-Type", "application/json"));
+
+        using var http = new HttpClient();
+        var client = new AuthProxyClient(http);
+
+        var id = await client.GetGitHubClientIdAsync(server.Urls[0]);
+
+        await Assert.That(id).IsEqualTo("Iv1.abc");
+    }
+
+    [Test]
+    public async Task GetGitHubClientIdAsync_returns_null_on_proxy_unreachable() {
+        using var http = new HttpClient { Timeout = TimeSpan.FromMilliseconds(200) };
+        var client = new AuthProxyClient(http);
+
+        var id = await client.GetGitHubClientIdAsync("http://127.0.0.1:1");
+
+        await Assert.That(id).IsNull();
+    }
+
+    [Test]
+    public async Task DiscoverTenantsAsync_returns_tenants_on_200() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/discover-tenants").UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(200)
+                  .WithBody("""[{"org_id":100,"org_login":"acme","origin":"https://a.example"}]""")
+                  .WithHeader("Content-Type", "application/json"));
+
+        using var http = new HttpClient();
+        var client = new AuthProxyClient(http);
+
+        var result = await client.DiscoverTenantsAsync(server.Urls[0], "gh-token");
+
+        await Assert.That(result.Error).IsEqualTo(DiscoveryError.None);
+        await Assert.That(result.Tenants.Length).IsEqualTo(1);
+        await Assert.That(result.Tenants[0].OrgLogin).IsEqualTo("acme");
+        await Assert.That(result.Tenants[0].OrgId).IsEqualTo(100L);
+        await Assert.That(result.Tenants[0].Origin).IsEqualTo("https://a.example");
+    }
+
+    [Test]
+    public async Task DiscoverTenantsAsync_returns_TokenRejected_on_401() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/discover-tenants").UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(401));
+
+        using var http = new HttpClient();
+        var client = new AuthProxyClient(http);
+
+        var result = await client.DiscoverTenantsAsync(server.Urls[0], "gh-token");
+
+        await Assert.That(result.Error).IsEqualTo(DiscoveryError.TokenRejected);
+    }
+
+    [Test]
+    public async Task DiscoverTenantsAsync_returns_TokenRejected_on_403() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/discover-tenants").UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(403));
+
+        using var http = new HttpClient();
+        var client = new AuthProxyClient(http);
+
+        var result = await client.DiscoverTenantsAsync(server.Urls[0], "gh-token");
+
+        await Assert.That(result.Error).IsEqualTo(DiscoveryError.TokenRejected);
+    }
+
+    [Test]
+    public async Task DiscoverTenantsAsync_returns_GitHubError_on_502() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/discover-tenants").UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(502));
+
+        using var http = new HttpClient();
+        var client = new AuthProxyClient(http);
+
+        var result = await client.DiscoverTenantsAsync(server.Urls[0], "gh-token");
+
+        await Assert.That(result.Error).IsEqualTo(DiscoveryError.GitHubError);
+    }
+
+    [Test]
+    public async Task DiscoverTenantsAsync_returns_ProxyUnreachable_on_connection_refused() {
+        using var http = new HttpClient { Timeout = TimeSpan.FromMilliseconds(200) };
+        var client = new AuthProxyClient(http);
+
+        var result = await client.DiscoverTenantsAsync("http://127.0.0.1:1", "gh-token");
+
+        await Assert.That(result.Error).IsEqualTo(DiscoveryError.ProxyUnreachable);
+    }
+}

--- a/test/kapacitor.Tests.Unit/AuthProxyEndpointTests.cs
+++ b/test/kapacitor.Tests.Unit/AuthProxyEndpointTests.cs
@@ -7,7 +7,11 @@ public class AuthProxyEndpointTests {
     [NotInParallel(nameof(AuthProxyEndpointTests))]
     public async Task Returns_default_when_env_var_is_unset() {
         Environment.SetEnvironmentVariable("KAPACITOR_AUTH_PROXY_URL", null);
-        await Assert.That(AuthProxyEndpoint.Url).IsEqualTo(AuthProxyEndpoint.DefaultUrl);
+        try {
+            await Assert.That(AuthProxyEndpoint.Url).IsEqualTo(AuthProxyEndpoint.DefaultUrl);
+        } finally {
+            Environment.SetEnvironmentVariable("KAPACITOR_AUTH_PROXY_URL", null);
+        }
     }
 
     [Test]

--- a/test/kapacitor.Tests.Unit/AuthProxyEndpointTests.cs
+++ b/test/kapacitor.Tests.Unit/AuthProxyEndpointTests.cs
@@ -1,0 +1,23 @@
+using kapacitor.Auth;
+
+namespace kapacitor.Tests.Unit;
+
+public class AuthProxyEndpointTests {
+    [Test]
+    [NotInParallel(nameof(AuthProxyEndpointTests))]
+    public async Task Returns_default_when_env_var_is_unset() {
+        Environment.SetEnvironmentVariable("KAPACITOR_AUTH_PROXY_URL", null);
+        await Assert.That(AuthProxyEndpoint.Url).IsEqualTo(AuthProxyEndpoint.DefaultUrl);
+    }
+
+    [Test]
+    [NotInParallel(nameof(AuthProxyEndpointTests))]
+    public async Task Uses_env_var_when_set() {
+        Environment.SetEnvironmentVariable("KAPACITOR_AUTH_PROXY_URL", "https://local-proxy.test/");
+        try {
+            await Assert.That(AuthProxyEndpoint.Url).IsEqualTo("https://local-proxy.test");
+        } finally {
+            Environment.SetEnvironmentVariable("KAPACITOR_AUTH_PROXY_URL", null);
+        }
+    }
+}

--- a/test/kapacitor.Tests.Unit/LoginDiscoverTests.cs
+++ b/test/kapacitor.Tests.Unit/LoginDiscoverTests.cs
@@ -1,0 +1,102 @@
+using kapacitor.Auth;
+
+namespace kapacitor.Tests.Unit;
+
+/// <summary>
+/// Tests for OAuthLoginFlow.ExchangeAndSaveAsync(string, string, string, string) —
+/// the named-profile overload used by `kapacitor login --discover`.
+///
+/// Uses the shared KAPACITOR_CONFIG_DIR temp directory set by RepoPathStoreGlobalSetup
+/// so token files land in an isolated directory, not ~/.config/kapacitor.
+///
+/// Shares the TokenStoreProfileTests NotInParallel key so both classes serialize
+/// access to the shared tokens directory and don't race each other.
+/// </summary>
+[NotInParallel(nameof(TokenStoreProfileTests))]
+public class LoginDiscoverTests {
+    static string TokensDir => PathHelpers.ConfigPath("tokens");
+
+    [Before(Test)]
+    public void Cleanup() {
+        try {
+            if (Directory.Exists(TokensDir)) Directory.Delete(TokensDir, recursive: true);
+        } catch {
+            // Best-effort: if deletion fails, individual tests create isolated profile files
+        }
+    }
+
+    [Test]
+    public async Task Exchange_writes_token_to_named_profile() {
+        using var tenant = WireMock.Server.WireMockServer.Start();
+        tenant.Given(WireMock.RequestBuilders.Request.Create().WithPath("/auth/token").UsingPost())
+              .RespondWith(WireMock.ResponseBuilders.Response.Create().WithStatusCode(200)
+                  .WithBody("""{"access_token":"capacitor-jwt","expires_in":3600,"username":"alice"}""")
+                  .WithHeader("Content-Type", "application/json"));
+
+        var exit = await OAuthLoginFlow.ExchangeAndSaveAsync(tenant.Urls[0], "gh-token", AuthProvider.GitHubApp, "acme");
+
+        await Assert.That(exit).IsEqualTo(0);
+        var stored = await TokenStore.LoadAsync("acme");
+        await Assert.That(stored).IsNotNull();
+        await Assert.That(stored!.AccessToken).IsEqualTo("capacitor-jwt");
+    }
+
+    [Test]
+    public async Task Exchange_sets_correct_username_and_provider() {
+        using var tenant = WireMock.Server.WireMockServer.Start();
+        tenant.Given(WireMock.RequestBuilders.Request.Create().WithPath("/auth/token").UsingPost())
+              .RespondWith(WireMock.ResponseBuilders.Response.Create().WithStatusCode(200)
+                  .WithBody("""{"access_token":"tok","expires_in":7200,"username":"bob"}""")
+                  .WithHeader("Content-Type", "application/json"));
+
+        await OAuthLoginFlow.ExchangeAndSaveAsync(tenant.Urls[0], "gh-token", AuthProvider.GitHubApp, "contoso");
+
+        var stored = await TokenStore.LoadAsync("contoso");
+        await Assert.That(stored).IsNotNull();
+        await Assert.That(stored!.GitHubUsername).IsEqualTo("bob");
+        await Assert.That(stored.Provider).IsEqualTo(AuthProvider.GitHubApp);
+    }
+
+    [Test]
+    public async Task Exchange_rejects_unknown_provider() {
+        using var tenant = WireMock.Server.WireMockServer.Start();
+        var exit = await OAuthLoginFlow.ExchangeAndSaveAsync(tenant.Urls[0], "gh-token", "NonsenseProvider", "acme");
+        await Assert.That(exit).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Exchange_returns_one_on_server_error() {
+        using var tenant = WireMock.Server.WireMockServer.Start();
+        tenant.Given(WireMock.RequestBuilders.Request.Create().WithPath("/auth/token").UsingPost())
+              .RespondWith(WireMock.ResponseBuilders.Response.Create().WithStatusCode(401)
+                  .WithBody("Unauthorized"));
+
+        var exit = await OAuthLoginFlow.ExchangeAndSaveAsync(tenant.Urls[0], "bad-token", AuthProvider.GitHubApp, "acme");
+        await Assert.That(exit).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Exchange_writes_independent_tokens_for_multiple_profiles() {
+        using var acmeTenant    = WireMock.Server.WireMockServer.Start();
+        using var contosoTenant = WireMock.Server.WireMockServer.Start();
+
+        acmeTenant.Given(WireMock.RequestBuilders.Request.Create().WithPath("/auth/token").UsingPost())
+                  .RespondWith(WireMock.ResponseBuilders.Response.Create().WithStatusCode(200)
+                      .WithBody("""{"access_token":"acme-jwt","expires_in":3600,"username":"alice"}""")
+                      .WithHeader("Content-Type", "application/json"));
+
+        contosoTenant.Given(WireMock.RequestBuilders.Request.Create().WithPath("/auth/token").UsingPost())
+                     .RespondWith(WireMock.ResponseBuilders.Response.Create().WithStatusCode(200)
+                         .WithBody("""{"access_token":"contoso-jwt","expires_in":3600,"username":"bob"}""")
+                         .WithHeader("Content-Type", "application/json"));
+
+        await OAuthLoginFlow.ExchangeAndSaveAsync(acmeTenant.Urls[0],    "gh-token", AuthProvider.GitHubApp, "acme");
+        await OAuthLoginFlow.ExchangeAndSaveAsync(contosoTenant.Urls[0], "gh-token", AuthProvider.GitHubApp, "contoso");
+
+        var acme    = await TokenStore.LoadAsync("acme");
+        var contoso = await TokenStore.LoadAsync("contoso");
+
+        await Assert.That(acme!.AccessToken).IsEqualTo("acme-jwt");
+        await Assert.That(contoso!.AccessToken).IsEqualTo("contoso-jwt");
+    }
+}

--- a/test/kapacitor.Tests.Unit/LoginDiscoverTests.cs
+++ b/test/kapacitor.Tests.Unit/LoginDiscoverTests.cs
@@ -49,8 +49,9 @@ public class LoginDiscoverTests {
                   .WithBody("""{"access_token":"tok","expires_in":7200,"username":"bob"}""")
                   .WithHeader("Content-Type", "application/json"));
 
-        await OAuthLoginFlow.ExchangeAndSaveAsync(tenant.Urls[0], "gh-token", AuthProvider.GitHubApp, "contoso");
+        var exit = await OAuthLoginFlow.ExchangeAndSaveAsync(tenant.Urls[0], "gh-token", AuthProvider.GitHubApp, "contoso");
 
+        await Assert.That(exit).IsEqualTo(0);
         var stored = await TokenStore.LoadAsync("contoso");
         await Assert.That(stored).IsNotNull();
         await Assert.That(stored!.GitHubUsername).IsEqualTo("bob");
@@ -59,8 +60,8 @@ public class LoginDiscoverTests {
 
     [Test]
     public async Task Exchange_rejects_unknown_provider() {
-        using var tenant = WireMock.Server.WireMockServer.Start();
-        var exit = await OAuthLoginFlow.ExchangeAndSaveAsync(tenant.Urls[0], "gh-token", "NonsenseProvider", "acme");
+        var exit = await OAuthLoginFlow.ExchangeAndSaveAsync(
+            "http://localhost:1", "gh-token", "NonsenseProvider", "acme");
         await Assert.That(exit).IsEqualTo(1);
     }
 

--- a/test/kapacitor.Tests.Unit/SetupCommandTests.cs
+++ b/test/kapacitor.Tests.Unit/SetupCommandTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using kapacitor.Commands;
+using kapacitor.Config;
 
 namespace kapacitor.Tests.Unit;
 
@@ -112,6 +113,24 @@ public class SetupCommandTests {
 
         await Assert.That(root["enabledPlugins"]?["kapacitor@kapacitor"]?.GetValue<bool>() ?? false)
             .IsTrue();
+    }
+
+    [Test]
+    public async Task Setup_save_profile_config_round_trips_active_profile() {
+        // Smoke-check that the discovery-path SetupCommand can save and reload the active
+        // profile after MergeProfiles has set it to a non-"default" name. The full discovery
+        // flow is end-to-end-tested by the integration suite.
+        var cfg = new ProfileConfig {
+            ActiveProfile = "acme",
+            Profiles = new Dictionary<string, Profile> {
+                ["acme"] = new() { ServerUrl = "https://a.example", DefaultVisibility = "org_public" }
+            }
+        };
+        await AppConfig.SaveProfileConfig(cfg);
+
+        var reloaded = await AppConfig.LoadProfileConfig();
+        await Assert.That(reloaded.ActiveProfile).IsEqualTo("acme");
+        await Assert.That(reloaded.Profiles["acme"].ServerUrl).IsEqualTo("https://a.example");
     }
 
     sealed class TempDir : IDisposable {

--- a/test/kapacitor.Tests.Unit/TenantDiscoveryTests.cs
+++ b/test/kapacitor.Tests.Unit/TenantDiscoveryTests.cs
@@ -137,6 +137,28 @@ public class TenantDiscoveryTests {
     }
 
     [Test]
+    public async Task MergeProfiles_inherits_from_active_profile_when_not_default() {
+        var existing = new ProfileConfig {
+            ActiveProfile = "acme",
+            Profiles = new Dictionary<string, Profile> {
+                ["acme"]    = new() { ServerUrl = "https://a.example", DefaultVisibility = "private" },
+                ["default"] = new() { DefaultVisibility = "org_public" }
+            }
+        };
+        DiscoveredTenant[] discovered = [
+            new() { OrgId = 1, OrgLogin = "acme",   Origin = "https://a.example" },
+            new() { OrgId = 2, OrgLogin = "newly",  Origin = "https://n.example" }
+        ];
+
+        var merged = TenantDiscovery.MergeProfiles(existing, discovered, discovered[1]);
+
+        // newly-discovered "newly" profile should inherit settings from active "acme", NOT from "default"
+        await Assert.That(merged.Profiles["newly"].DefaultVisibility).IsEqualTo("private");
+        await Assert.That(merged.Profiles["newly"].ServerUrl).IsEqualTo("https://n.example");
+        await Assert.That(merged.ActiveProfile).IsEqualTo("newly");
+    }
+
+    [Test]
     public async Task MergeProfiles_preserves_existing_profile_settings() {
         var existing = new ProfileConfig {
             Profiles = new Dictionary<string, Profile> {

--- a/test/kapacitor.Tests.Unit/TenantDiscoveryTests.cs
+++ b/test/kapacitor.Tests.Unit/TenantDiscoveryTests.cs
@@ -83,6 +83,39 @@ public class TenantDiscoveryTests {
     }
 
     [Test]
+    public async Task RunAsync_returns_upstream_error_message() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.UpstreamError)));
+
+        var discovery = new TenantDiscovery(proxy, Substitute.For<ITenantPicker>());
+        var outcome = await discovery.RunAsync("https://proxy", "gh");
+
+        await Assert.That(outcome.ErrorMessage!).Contains("could not reach GitHub");
+    }
+
+    [Test]
+    public async Task RunAsync_returns_no_tenant_selected_when_picker_returns_null() {
+        DiscoveredTenant[] list = [
+            new() { OrgId = 1, OrgLogin = "acme",    Origin = "https://a.example" },
+            new() { OrgId = 2, OrgLogin = "contoso", Origin = "https://b.example" }
+        ];
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult(list, DiscoveryError.None)));
+
+        var picker = Substitute.For<ITenantPicker>();
+        picker.Pick(list).Returns((DiscoveredTenant?)null);
+
+        var discovery = new TenantDiscovery(proxy, picker);
+        var outcome = await discovery.RunAsync("https://proxy", "gh");
+
+        await Assert.That(outcome.Picked).IsNull();
+        await Assert.That(outcome.ErrorMessage).IsEqualTo("No tenant selected.");
+        await Assert.That(outcome.Tenants.Length).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task MergeProfiles_creates_profile_per_tenant_and_sets_active() {
         var existing = new ProfileConfig {
             ActiveProfile = "default",

--- a/test/kapacitor.Tests.Unit/TenantDiscoveryTests.cs
+++ b/test/kapacitor.Tests.Unit/TenantDiscoveryTests.cs
@@ -91,7 +91,7 @@ public class TenantDiscoveryTests {
         var discovery = new TenantDiscovery(proxy, Substitute.For<ITenantPicker>());
         var outcome = await discovery.RunAsync("https://proxy", "gh");
 
-        await Assert.That(outcome.ErrorMessage!).Contains("could not reach GitHub");
+        await Assert.That(outcome.ErrorMessage!).Contains("returned an error");
     }
 
     [Test]

--- a/test/kapacitor.Tests.Unit/TenantDiscoveryTests.cs
+++ b/test/kapacitor.Tests.Unit/TenantDiscoveryTests.cs
@@ -1,0 +1,122 @@
+using kapacitor.Auth;
+using kapacitor.Config;
+using NSubstitute;
+using Profile = kapacitor.Config.Profile;
+using DiscoveryResult = kapacitor.Auth.DiscoveryResult;
+
+namespace kapacitor.Tests.Unit;
+
+public class TenantDiscoveryTests {
+    [Test]
+    public async Task RunAsync_auto_picks_single_tenant() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult(
+                 [new DiscoveredTenant { OrgId = 1, OrgLogin = "solo", Origin = "https://solo.example" }],
+                 DiscoveryError.None)));
+
+        var picker    = Substitute.For<ITenantPicker>();
+        var discovery = new TenantDiscovery(proxy, picker);
+
+        var outcome = await discovery.RunAsync("https://proxy", "gh");
+
+        await Assert.That(outcome.Picked).IsNotNull();
+        await Assert.That(outcome.Picked!.OrgLogin).IsEqualTo("solo");
+        picker.DidNotReceive().Pick(Arg.Any<DiscoveredTenant[]>());
+    }
+
+    [Test]
+    public async Task RunAsync_delegates_to_picker_when_multiple_tenants() {
+        DiscoveredTenant[] list = [
+            new() { OrgId = 1, OrgLogin = "acme",    Origin = "https://a.example" },
+            new() { OrgId = 2, OrgLogin = "contoso", Origin = "https://b.example" }
+        ];
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult(list, DiscoveryError.None)));
+
+        var picker = Substitute.For<ITenantPicker>();
+        picker.Pick(list).Returns(list[1]);
+
+        var discovery = new TenantDiscovery(proxy, picker);
+        var outcome = await discovery.RunAsync("https://proxy", "gh");
+
+        await Assert.That(outcome.Picked!.OrgLogin).IsEqualTo("contoso");
+    }
+
+    [Test]
+    public async Task RunAsync_returns_empty_tenant_error_message() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
+
+        var discovery = new TenantDiscovery(proxy, Substitute.For<ITenantPicker>());
+
+        var outcome = await discovery.RunAsync("https://proxy", "gh");
+
+        await Assert.That(outcome.Picked).IsNull();
+        await Assert.That(outcome.ErrorMessage!).Contains("No Capacitor tenants");
+    }
+
+    [Test]
+    public async Task RunAsync_returns_proxy_unreachable_error() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.ProxyUnreachable)));
+
+        var discovery = new TenantDiscovery(proxy, Substitute.For<ITenantPicker>());
+        var outcome = await discovery.RunAsync("https://proxy", "gh");
+
+        await Assert.That(outcome.ErrorMessage!).Contains("unreachable");
+    }
+
+    [Test]
+    public async Task RunAsync_returns_token_rejected_error() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.TokenRejected)));
+
+        var discovery = new TenantDiscovery(proxy, Substitute.For<ITenantPicker>());
+        var outcome = await discovery.RunAsync("https://proxy", "gh");
+
+        await Assert.That(outcome.ErrorMessage!).Contains("GitHub rejected");
+    }
+
+    [Test]
+    public async Task MergeProfiles_creates_profile_per_tenant_and_sets_active() {
+        var existing = new ProfileConfig {
+            ActiveProfile = "default",
+            Profiles = new Dictionary<string, Profile> {
+                ["default"] = new() { DefaultVisibility = "org_public" }
+            }
+        };
+        DiscoveredTenant[] discovered = [
+            new() { OrgId = 1, OrgLogin = "acme",    Origin = "https://a.example" },
+            new() { OrgId = 2, OrgLogin = "contoso", Origin = "https://b.example" }
+        ];
+
+        var merged = TenantDiscovery.MergeProfiles(existing, discovered, discovered[0]);
+
+        await Assert.That(merged.ActiveProfile).IsEqualTo("acme");
+        await Assert.That(merged.Profiles["acme"].ServerUrl).IsEqualTo("https://a.example");
+        await Assert.That(merged.Profiles["contoso"].ServerUrl).IsEqualTo("https://b.example");
+        await Assert.That(merged.Profiles["acme"].DefaultVisibility).IsEqualTo("org_public");
+    }
+
+    [Test]
+    public async Task MergeProfiles_preserves_existing_profile_settings() {
+        var existing = new ProfileConfig {
+            Profiles = new Dictionary<string, Profile> {
+                ["acme"] = new() { ServerUrl = "https://old", DefaultVisibility = "private" }
+            }
+        };
+        DiscoveredTenant[] discovered = [
+            new() { OrgId = 1, OrgLogin = "acme", Origin = "https://new.example" }
+        ];
+
+        var merged = TenantDiscovery.MergeProfiles(existing, discovered, discovered[0]);
+
+        await Assert.That(merged.Profiles["acme"].ServerUrl).IsEqualTo("https://new.example");
+        await Assert.That(merged.Profiles["acme"].DefaultVisibility).IsEqualTo("private");
+    }
+}

--- a/test/kapacitor.Tests.Unit/TokenStoreProfileTests.cs
+++ b/test/kapacitor.Tests.Unit/TokenStoreProfileTests.cs
@@ -96,6 +96,17 @@ public class TokenStoreProfileTests {
         await Assert.That((await TokenStore.LoadAsync("contoso"))!.GitHubUsername).IsEqualTo("bob");
     }
 
+    [Test]
+    [NotInParallel(nameof(TokenStoreProfileTests))]
+    public async Task SaveAsync_with_invalid_profile_name_throws() {
+        await Assert.That(async () => await TokenStore.SaveAsync("../evil", MakeTokens("x")))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => await TokenStore.SaveAsync("", MakeTokens("x")))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => await TokenStore.SaveAsync("has/slash", MakeTokens("x")))
+            .Throws<ArgumentException>();
+    }
+
     static StoredTokens MakeTokens(string username) => new() {
         AccessToken    = "t",
         ExpiresAt      = DateTimeOffset.UtcNow.AddHours(1),

--- a/test/kapacitor.Tests.Unit/TokenStoreProfileTests.cs
+++ b/test/kapacitor.Tests.Unit/TokenStoreProfileTests.cs
@@ -74,6 +74,18 @@ public class TokenStoreProfileTests {
 
     [Test]
     [NotInParallel(nameof(TokenStoreProfileTests))]
+    public async Task DeleteAsync_removes_all_profile_tokens() {
+        await TokenStore.SaveAsync("acme",    MakeTokens("alice"));
+        await TokenStore.SaveAsync("contoso", MakeTokens("bob"));
+
+        await TokenStore.DeleteAsync();
+
+        await Assert.That(await TokenStore.LoadAsync("acme")).IsNull();
+        await Assert.That(await TokenStore.LoadAsync("contoso")).IsNull();
+    }
+
+    [Test]
+    [NotInParallel(nameof(TokenStoreProfileTests))]
     public async Task Delete_with_profile_removes_only_that_profile() {
         await TokenStore.SaveAsync("acme",    MakeTokens("alice"));
         await TokenStore.SaveAsync("contoso", MakeTokens("bob"));

--- a/test/kapacitor.Tests.Unit/TokenStoreProfileTests.cs
+++ b/test/kapacitor.Tests.Unit/TokenStoreProfileTests.cs
@@ -1,0 +1,93 @@
+using kapacitor.Auth;
+using TUnit;
+
+namespace kapacitor.Tests.Unit;
+
+/// <summary>
+/// Tests for per-profile TokenStore methods.
+///
+/// PathHelpers.ConfigDir is static readonly — captured once at class-load time from
+/// KAPACITOR_CONFIG_DIR. RepoPathStoreGlobalSetup.[Before(Assembly)] sets that env var
+/// to a shared temp dir before PathHelpers is first touched, so all path-based tests
+/// in this process share that same base dir.
+///
+/// Each test cleans up token files it might leave behind via [Before(Test)].
+/// [NotInParallel] on the class ensures tests don't race on the shared token dir.
+/// </summary>
+[NotInParallel(nameof(TokenStoreProfileTests))]
+public class TokenStoreProfileTests {
+    // Paths resolved through PathHelpers — same base dir as RepoPathStoreTests
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+    static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
+
+    [Before(Test)]
+    public void Cleanup() {
+        if (File.Exists(LegacyPath)) File.Delete(LegacyPath);
+        if (Directory.Exists(TokensDir)) Directory.Delete(TokensDir, recursive: true);
+    }
+
+    [Test]
+    public async Task SaveAsync_with_profile_writes_to_per_profile_path() {
+        await TokenStore.SaveAsync("acme", MakeTokens("alice"));
+
+        var expected = Path.Combine(TokensDir, "acme.json");
+        await Assert.That(File.Exists(expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task LoadAsync_with_profile_reads_per_profile_file() {
+        await TokenStore.SaveAsync("acme", MakeTokens("alice"));
+        var loaded = await TokenStore.LoadAsync("acme");
+
+        await Assert.That(loaded).IsNotNull();
+        await Assert.That(loaded!.GitHubUsername).IsEqualTo("alice");
+    }
+
+    [Test]
+    public async Task LoadAsync_with_unknown_profile_returns_null() {
+        var loaded = await TokenStore.LoadAsync("nonexistent");
+
+        await Assert.That(loaded).IsNull();
+    }
+
+    [Test]
+    public async Task Legacy_tokens_json_is_migrated_on_first_profile_save() {
+        // Write a legacy tokens.json in the config base dir
+        Directory.CreateDirectory(Path.GetDirectoryName(LegacyPath)!);
+        await File.WriteAllTextAsync(LegacyPath,
+            System.Text.Json.JsonSerializer.Serialize(MakeTokens("legacy"), KapacitorJsonContext.Default.StoredTokens));
+
+        await TokenStore.SaveAsync("acme", MakeTokens("alice"));
+
+        await Assert.That(File.Exists(LegacyPath)).IsFalse();
+        await Assert.That(File.Exists(Path.Combine(TokensDir, "acme.json"))).IsTrue();
+    }
+
+    [Test]
+    public async Task Per_profile_files_are_independent() {
+        await TokenStore.SaveAsync("acme", MakeTokens("alice"));
+        await TokenStore.SaveAsync("contoso", MakeTokens("bob"));
+
+        await Assert.That((await TokenStore.LoadAsync("acme"))!.GitHubUsername).IsEqualTo("alice");
+        await Assert.That((await TokenStore.LoadAsync("contoso"))!.GitHubUsername).IsEqualTo("bob");
+    }
+
+    static StoredTokens MakeTokens(string username) => new() {
+        AccessToken    = "t",
+        ExpiresAt      = DateTimeOffset.UtcNow.AddHours(1),
+        GitHubUsername = username,
+        Provider       = AuthProvider.GitHubApp
+    };
+
+    // Inline copy matching SetupCommandTests.cs / ProfileCommandTests.cs
+    sealed class TempDir : IDisposable {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            "kapacitor-test-" + Guid.NewGuid().ToString("N")[..8]
+        );
+        public TempDir() => Directory.CreateDirectory(Path);
+        public void Dispose() {
+            try { Directory.Delete(Path, true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/test/kapacitor.Tests.Unit/TokenStoreProfileTests.cs
+++ b/test/kapacitor.Tests.Unit/TokenStoreProfileTests.cs
@@ -72,22 +72,22 @@ public class TokenStoreProfileTests {
         await Assert.That((await TokenStore.LoadAsync("contoso"))!.GitHubUsername).IsEqualTo("bob");
     }
 
+    [Test]
+    [NotInParallel(nameof(TokenStoreProfileTests))]
+    public async Task Delete_with_profile_removes_only_that_profile() {
+        await TokenStore.SaveAsync("acme",    MakeTokens("alice"));
+        await TokenStore.SaveAsync("contoso", MakeTokens("bob"));
+
+        TokenStore.Delete("acme");
+
+        await Assert.That(await TokenStore.LoadAsync("acme")).IsNull();
+        await Assert.That((await TokenStore.LoadAsync("contoso"))!.GitHubUsername).IsEqualTo("bob");
+    }
+
     static StoredTokens MakeTokens(string username) => new() {
         AccessToken    = "t",
         ExpiresAt      = DateTimeOffset.UtcNow.AddHours(1),
         GitHubUsername = username,
         Provider       = AuthProvider.GitHubApp
     };
-
-    // Inline copy matching SetupCommandTests.cs / ProfileCommandTests.cs
-    sealed class TempDir : IDisposable {
-        public string Path { get; } = System.IO.Path.Combine(
-            System.IO.Path.GetTempPath(),
-            "kapacitor-test-" + Guid.NewGuid().ToString("N")[..8]
-        );
-        public TempDir() => Directory.CreateDirectory(Path);
-        public void Dispose() {
-            try { Directory.Delete(Path, true); } catch { /* best effort */ }
-        }
-    }
 }

--- a/test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj
+++ b/test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj
@@ -12,5 +12,6 @@
     <ItemGroup>
         <PackageReference Include="TUnit" Version="1.18.37" />
         <PackageReference Include="WireMock.Net" Version="1.7.0" />
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Lets the CLI onboard a user without an explicit server URL in GitHubApp mode. The flow:

1. `kapacitor setup` (no `--server-url`) fetches the shared GitHub App client_id from the auth proxy, runs GitHub Device Flow, and asks the proxy which tenants the user can reach.
2. One profile is created per discovered tenant; the user picks which is active (auto-selected if only one). The same GitHub access token is reused for each tenant's `/auth/token` exchange.
3. `kapacitor login --discover` re-runs the same flow and pre-warms tokens for every discovered tenant (parallelized), so later `kapacitor use <org>` switches instantly.
4. Self-hosted users still pass `--server-url <url>`.

Also in this PR:

- `TokenStore` migrated to per-profile layout (`tokens/<profile>.json`), with transparent legacy fallback and one-time migration from the old single-file `tokens.json`.
- `OAuthLoginFlow.HandleGitHubLogin` refactored into two composable helpers (`RunDeviceFlowAsync` + `ExchangeAndSaveAsync`) so discovery can reuse the Device Flow without the tenant token exchange.
- `AuthProvider` constants class replaces the scattered `"GitHubApp"` / `"Auth0"` / `"None"` string literals.
- `IAuthProxyClient` interface extracted so `TenantDiscovery` can be unit-tested with NSubstitute.
- `help-login.txt` documents `--discover`.

## Depends on

- The proxy half of this feature lives in `kurrent-io/Kurrent.Capacitor` → branch `worktree-unified-waddling-ember`. That PR ships the two new proxy endpoints (`/config`, `/discover-tenants`). Merge order doesn't matter (both are additive; old CLIs continue to work unchanged).

## Test Plan

- [x] Unit tests: 336/336 passing (including new `AuthProxyEndpointTests`, `AuthProxyClientTests`, `TokenStoreProfileTests`, `TenantDiscoveryTests`, `LoginDiscoverTests`).
- [x] Release build clean (only pre-existing warnings in `HistoryCommand.cs`).
- [ ] Manual smoke test: `KAPACITOR_AUTH_PROXY_URL=... kapacitor setup` against a dev proxy + tenant.
- [ ] Legacy token file migration path on an existing install.

Co-change: see `kurrent-io/Kurrent.Capacitor` → `worktree-unified-waddling-ember` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)