### PR TITLE
DEV-1595 CLI: history import UX fixes

### DIFF
--- a/docs/superpowers/plans/2026-04-25-dev-1595-history-import-ux-fixes.md
+++ b/docs/superpowers/plans/2026-04-25-dev-1595-history-import-ux-fixes.md
@@ -1,0 +1,1207 @@
+# DEV-1595 History Import UX Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three UX regressions in `kapacitor history`: probing bar stuck at 0%, false `Partial` classifications when no new lines beyond server's last imported line, and per-session "Loading" lines scrolling instead of staying live.
+
+**Architecture:** All changes are in `src/kapacitor/Commands/HistoryCommand.cs`. Issue 1 adds an optional `Action? onProbed` callback to `ClassifyAsync`. Issue 2 extends `CountLinesUpTo`'s read in `ClassifyOneAsync` to detect "no new lines beyond server's last line" and reclassify Partial → AlreadyLoaded. Issue 3 replaces `Parallel.ForEachAsync` with a `Channel`-based 4-worker fan-out, threads a `slot` index through `ChainWorkerEvents`, and rewires the TTY Importing-phase wrapper to render four live `ProgressTask` "slot rows" in place of the scrolling per-session log.
+
+**Tech Stack:** .NET 10, NativeAOT (`PublishAot=true`, `TrimMode=full`), TUnit test framework, WireMock.Net for HTTP mocking, Spectre.Console (already a dependency), `System.Threading.Channels` (BCL).
+
+**Spec:** `docs/superpowers/specs/2026-04-25-dev-1595-history-import-ux-fixes-design.md`
+
+---
+
+## File map
+
+- **Modify:** `src/kapacitor/Commands/HistoryCommand.cs` — all production changes.
+- **Modify:** `test/kapacitor.Tests.Unit/HistoryClassifyTests.cs` — add tests for probe-callback and Partial → AlreadyLoaded reclassification.
+- **Modify:** `test/kapacitor.Tests.Unit/HistoryImportChainsTests.cs` — update existing tests for new `ChainWorkerEvents` shape.
+
+No new files. No changes to `SessionImporter`, `ImportProgress`, `TitleGenerator`, `WhatsDoneCommand`, or `Program.cs`.
+
+---
+
+## Task 1: Probe progress callback (Issue 1)
+
+**Files:**
+- Modify: `src/kapacitor/Commands/HistoryCommand.cs:992-1010` (`ClassifyAsync` signature + body)
+- Modify: `src/kapacitor/Commands/HistoryCommand.cs:1012-1132` (`ClassifyOneAsync` — invoke callback on completion)
+- Modify: `src/kapacitor/Commands/HistoryCommand.cs:219-232` (TTY wrapper passes callback)
+- Test: `test/kapacitor.Tests.Unit/HistoryClassifyTests.cs` (add new test)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this method to `test/kapacitor.Tests.Unit/HistoryClassifyTests.cs` just before the closing `}` of the class:
+
+```csharp
+[Test]
+public async Task ClassifyAsync_invokes_onProbed_callback_once_per_transcript() {
+    _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+        .RespondWith(Response.Create().WithStatusCode(404));
+
+    var paths = new List<(string SessionId, string FilePath, string EncodedCwd)>();
+    for (var i = 0; i < 5; i++) {
+        var path = await WriteTranscript(_tempDir, $"cb-{i}", lines: 50);
+        paths.Add(($"cb-{i}", path, "-tmp-proj"));
+    }
+
+    var probedCount = 0;
+    using var client = new HttpClient();
+
+    var result = await HistoryCommand.ClassifyAsync(
+        client,
+        _server.Url!,
+        paths,
+        minLines: 15,
+        excludedRepos: null,
+        CancellationToken.None,
+        onProbed: () => Interlocked.Increment(ref probedCount)
+    );
+
+    await Assert.That(result.Count).IsEqualTo(5);
+    await Assert.That(probedCount).IsEqualTo(5);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/HistoryClassifyTests/ClassifyAsync_invokes_onProbed_callback_once_per_transcript"
+```
+
+Expected: build error — `ClassifyAsync` does not accept `onProbed` parameter.
+
+- [ ] **Step 3: Add `onProbed` parameter to `ClassifyAsync`**
+
+In `src/kapacitor/Commands/HistoryCommand.cs`, find the existing `ClassifyAsync` declaration (search for `internal static async Task<List<SessionClassification>> ClassifyAsync(`) and update the signature and body:
+
+```csharp
+internal static async Task<List<SessionClassification>> ClassifyAsync(
+        HttpClient                                                   httpClient,
+        string                                                       baseUrl,
+        List<(string SessionId, string FilePath, string EncodedCwd)> transcripts,
+        int                                                          minLines,
+        string[]?                                                    excludedRepos,
+        CancellationToken                                            ct,
+        Action?                                                      onProbed = null
+    ) {
+    using var probeGate = new SemaphoreSlim(8);
+    var       tasks     = new List<Task<SessionClassification>>(transcripts.Count);
+
+    foreach (var (sessionId, filePath, encodedCwd) in transcripts) {
+        tasks.Add(ClassifyOneAsync(httpClient, baseUrl, sessionId, filePath, encodedCwd, minLines, excludedRepos, probeGate, onProbed, ct));
+    }
+
+    var results = await Task.WhenAll(tasks);
+
+    return [.. results];
+}
+```
+
+- [ ] **Step 4: Add `onProbed` parameter to `ClassifyOneAsync` and invoke it**
+
+In `src/kapacitor/Commands/HistoryCommand.cs`, find `ClassifyOneAsync` (search for `static async Task<SessionClassification> ClassifyOneAsync(`). Update its signature to add the `Action? onProbed` parameter just before `CancellationToken ct`, and wrap the entire body in a `try { … } finally { onProbed?.Invoke(); }`. The simplest way: rename the existing body method to `ClassifyOneCoreAsync` and add a thin wrapper.
+
+Replace the entire `ClassifyOneAsync` method with:
+
+```csharp
+static async Task<SessionClassification> ClassifyOneAsync(
+        HttpClient        httpClient,
+        string            baseUrl,
+        string            sessionId,
+        string            filePath,
+        string            encodedCwd,
+        int               minLines,
+        string[]?         excludedRepos,
+        SemaphoreSlim     probeGate,
+        Action?           onProbed,
+        CancellationToken ct
+    ) {
+    try {
+        return await ClassifyOneCoreAsync(httpClient, baseUrl, sessionId, filePath, encodedCwd, minLines, excludedRepos, probeGate, ct);
+    } finally {
+        onProbed?.Invoke();
+    }
+}
+
+static async Task<SessionClassification> ClassifyOneCoreAsync(
+        HttpClient        httpClient,
+        string            baseUrl,
+        string            sessionId,
+        string            filePath,
+        string            encodedCwd,
+        int               minLines,
+        string[]?         excludedRepos,
+        SemaphoreSlim     probeGate,
+        CancellationToken ct
+    ) {
+    // <existing body of ClassifyOneAsync — copy it verbatim>
+}
+```
+
+Copy the entire existing `ClassifyOneAsync` body (from `var meta = ExtractSessionMetadata(filePath);` through the final `return new SessionClassification { … };`) into the new `ClassifyOneCoreAsync` method. The wrapper above guarantees `onProbed` fires exactly once per transcript regardless of exceptions inside the core.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/HistoryClassifyTests/ClassifyAsync_invokes_onProbed_callback_once_per_transcript"
+```
+
+Expected: PASS. Also re-run the full HistoryClassifyTests class to ensure no regressions:
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/HistoryClassifyTests/*"
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Wire callback into `HandleHistory` TTY wrapper**
+
+In `src/kapacitor/Commands/HistoryCommand.cs`, find the TTY branch of the Probing block (around line 219-232). Replace:
+
+```csharp
+        if (display.Tty) {
+            var tmp = new List<SessionClassification>();
+
+            await AnsiConsole.Progress()
+                .AutoClear(true)
+                .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
+                .StartAsync(async ctx => {
+                        var bar     = ctx.AddTask("[yellow]Probing[/]", maxValue: transcriptFiles.Count);
+                        var results = await ClassifyAsync(httpClient, baseUrl, transcriptFiles, minLines, excludedRepos, CancellationToken.None);
+                        bar.Value = bar.MaxValue;
+                        tmp.AddRange(results);
+                    }
+                );
+            classifications = tmp;
+        } else {
+```
+
+with:
+
+```csharp
+        if (display.Tty) {
+            var tmp = new List<SessionClassification>();
+
+            await AnsiConsole.Progress()
+                .AutoClear(true)
+                .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
+                .StartAsync(async ctx => {
+                        var bar     = ctx.AddTask("[yellow]Probing[/]", maxValue: transcriptFiles.Count);
+                        var results = await ClassifyAsync(
+                            httpClient,
+                            baseUrl,
+                            transcriptFiles,
+                            minLines,
+                            excludedRepos,
+                            CancellationToken.None,
+                            onProbed: () => bar.Increment(1)
+                        );
+                        tmp.AddRange(results);
+                    }
+                );
+            classifications = tmp;
+        } else {
+```
+
+The `bar.Value = bar.MaxValue` line is removed because the bar reaches max via the per-probe increments.
+
+- [ ] **Step 7: Build**
+
+```bash
+dotnet build src/kapacitor/kapacitor.csproj
+```
+
+Expected: build succeeds with no warnings.
+
+- [ ] **Step 8: AOT publish gate**
+
+```bash
+dotnet publish src/kapacitor/kapacitor.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
+```
+
+Expected: no output (no IL3050/IL2026 warnings).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/kapacitor/Commands/HistoryCommand.cs test/kapacitor.Tests.Unit/HistoryClassifyTests.cs
+git commit -m "$(cat <<'EOF'
+[DEV-1595] history: live probing progress
+
+Add an optional onProbed callback to ClassifyAsync that fires once per
+transcript when its probe completes. The HandleHistory TTY wrapper
+passes bar.Increment(1) so the Probing bar advances smoothly instead
+of jumping from 0% to 100% at the end.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Reclassify Partial-with-no-new-lines as AlreadyLoaded (Issue 2)
+
+**Files:**
+- Modify: `src/kapacitor/Commands/HistoryCommand.cs` — `ClassifyOneCoreAsync` body
+- Test: `test/kapacitor.Tests.Unit/HistoryClassifyTests.cs` (add three tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these methods to `test/kapacitor.Tests.Unit/HistoryClassifyTests.cs` before the closing `}` of the class:
+
+```csharp
+[Test]
+public async Task ClassifyAsync_reclassifies_Partial_to_AlreadyLoaded_when_no_new_lines() {
+    // Server says last_line_number = 49 (50 lines stored: indices 0..49).
+    // Local transcript is exactly 50 lines (indices 0..49). resumeFromLine
+    // would be 50 — but there are no lines past index 49, so this is a
+    // false Partial that should be reclassified as AlreadyLoaded.
+    _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+        .RespondWith(
+            Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"last_line_number": 49}""")
+        );
+
+    var path = await WriteTranscript(_tempDir, "noNewLines", lines: 50);
+
+    var transcripts = new List<(string SessionId, string FilePath, string EncodedCwd)> {
+        ("noNewLines", path, "-tmp-proj")
+    };
+
+    using var client = new HttpClient();
+
+    var result = await HistoryCommand.ClassifyAsync(
+        client, _server.Url!, transcripts,
+        minLines: 15, excludedRepos: null, CancellationToken.None
+    );
+
+    await Assert.That(result[0].Status).IsEqualTo(HistoryCommand.ClassificationStatus.AlreadyLoaded);
+    await Assert.That(result[0].ResumeFromLine).IsEqualTo(0);
+}
+
+[Test]
+public async Task ClassifyAsync_keeps_Partial_when_local_transcript_has_new_lines() {
+    // Server says last_line_number = 49. Local transcript is 60 lines —
+    // there are 10 new lines past index 49, so Partial is correct.
+    _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+        .RespondWith(
+            Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"last_line_number": 49}""")
+        );
+
+    var path = await WriteTranscript(_tempDir, "hasNewLines", lines: 60);
+
+    var transcripts = new List<(string SessionId, string FilePath, string EncodedCwd)> {
+        ("hasNewLines", path, "-tmp-proj")
+    };
+
+    using var client = new HttpClient();
+
+    var result = await HistoryCommand.ClassifyAsync(
+        client, _server.Url!, transcripts,
+        minLines: 15, excludedRepos: null, CancellationToken.None
+    );
+
+    await Assert.That(result[0].Status).IsEqualTo(HistoryCommand.ClassificationStatus.Partial);
+    await Assert.That(result[0].ResumeFromLine).IsEqualTo(50);
+}
+
+[Test]
+public async Task ClassifyAsync_does_not_set_ExcludedRepoKey_when_reclassified_to_AlreadyLoaded() {
+    // A "Partial" probe in an excluded repo, but the local transcript has
+    // no new lines. We must NOT prompt the user to "include this excluded
+    // repo" for work that does not exist — ExcludedRepoKey must be null.
+    _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+        .RespondWith(
+            Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"last_line_number": 49}""")
+        );
+
+    // The repo detection in ClassifyOneCoreAsync uses RepositoryDetection
+    // against meta.Cwd, which falls back to DecodeCwdFromDirName(EncodedCwd).
+    // We bypass repo detection by leaving cwd unset — the excluded check
+    // never fires when cwd is null. So we need a different angle: rely on
+    // the order of operations in the spec — reclassification happens BEFORE
+    // the excluded-repo check, so even with a real excluded repo the flag
+    // should not be set. We simulate by writing a transcript whose path's
+    // EncodedCwd would NOT match the excluded list, but mark "anything" as
+    // excluded; the assertion is that ExcludedRepoKey is null because the
+    // session is no longer New|Partial when the excluded check runs.
+    var path = await WriteTranscript(_tempDir, "excludedNoNew", lines: 50);
+
+    var transcripts = new List<(string SessionId, string FilePath, string EncodedCwd)> {
+        ("excludedNoNew", path, "-tmp-proj")
+    };
+
+    using var client = new HttpClient();
+
+    // We pass an excluded list that would match EVERY repo if reached; the
+    // contract says it must not be reached for AlreadyLoaded.
+    var result = await HistoryCommand.ClassifyAsync(
+        client, _server.Url!, transcripts,
+        minLines: 15,
+        excludedRepos: new[] { "any/repo" },
+        CancellationToken.None
+    );
+
+    await Assert.That(result[0].Status).IsEqualTo(HistoryCommand.ClassificationStatus.AlreadyLoaded);
+    await Assert.That(result[0].ExcludedRepoKey).IsNull();
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/HistoryClassifyTests/ClassifyAsync_reclassifies_Partial_to_AlreadyLoaded_when_no_new_lines"
+```
+
+Expected: FAIL — current code returns `Partial` with `ResumeFromLine = 50`.
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/HistoryClassifyTests/ClassifyAsync_does_not_set_ExcludedRepoKey_when_reclassified_to_AlreadyLoaded"
+```
+
+Expected: FAIL.
+
+(`ClassifyAsync_keeps_Partial_when_local_transcript_has_new_lines` should already pass — it documents existing behavior.)
+
+- [ ] **Step 3: Update `ClassifyOneCoreAsync` to reclassify**
+
+In `src/kapacitor/Commands/HistoryCommand.cs`, find the existing TooShort block in `ClassifyOneCoreAsync`:
+
+```csharp
+        // Apply the TooShort filter only for sessions that would otherwise be imported.
+        // This avoids scanning the whole transcript when AlreadyLoaded / ProbeError.
+        if (minLines > 0 && (status == ClassificationStatus.New || status == ClassificationStatus.Partial)) {
+            var observedLines = CountLinesUpTo(filePath, minLines);
+
+            if (observedLines < minLines) {
+                return new SessionClassification {
+                    SessionId  = sessionId,
+                    FilePath   = filePath,
+                    EncodedCwd = encodedCwd,
+                    Meta       = meta,
+                    Status     = ClassificationStatus.TooShort,
+                    TotalLines = observedLines,
+                };
+            }
+        }
+```
+
+Replace it with:
+
+```csharp
+        // Read enough of the local transcript to satisfy two checks at once:
+        //   1. TooShort — fewer lines than minLines.
+        //   2. False Partial — server says last_line_number = N but the local
+        //      transcript has no lines past index N (resumeFromLine would be
+        //      N+1 with nothing to send).
+        // CountLinesUpTo early-exits at the threshold, so the read cost is
+        // bounded by Math.Max(minLines, resumeFromLine + 1) lines.
+        if (status is ClassificationStatus.New or ClassificationStatus.Partial) {
+            var threshold = Math.Max(
+                minLines,
+                status == ClassificationStatus.Partial ? resumeFromLine + 1 : 0
+            );
+
+            if (threshold > 0) {
+                var observedLines = CountLinesUpTo(filePath, threshold);
+
+                if (minLines > 0 && observedLines < minLines) {
+                    return new SessionClassification {
+                        SessionId  = sessionId,
+                        FilePath   = filePath,
+                        EncodedCwd = encodedCwd,
+                        Meta       = meta,
+                        Status     = ClassificationStatus.TooShort,
+                        TotalLines = observedLines,
+                    };
+                }
+
+                // Server has lines >= the local transcript — nothing to resume.
+                if (status == ClassificationStatus.Partial && observedLines <= resumeFromLine) {
+                    status         = ClassificationStatus.AlreadyLoaded;
+                    resumeFromLine = 0;
+                }
+            }
+        }
+```
+
+The reclassification is placed *before* the excluded-repo block (which still follows immediately below), so a session that becomes `AlreadyLoaded` here will not be flagged with `ExcludedRepoKey`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/HistoryClassifyTests/*"
+```
+
+Expected: all tests pass, including the three new ones.
+
+- [ ] **Step 5: AOT publish gate**
+
+```bash
+dotnet publish src/kapacitor/kapacitor.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/kapacitor/Commands/HistoryCommand.cs test/kapacitor.Tests.Unit/HistoryClassifyTests.cs
+git commit -m "$(cat <<'EOF'
+[DEV-1595] history: reclassify Partial as AlreadyLoaded when no new lines
+
+When the server probe returns 200 with last_line_number = N, the local
+transcript may have no lines past index N. The previous classifier
+marked these as Partial and the import phase then sent zero lines per
+session — wasted work and a misleading plan grid that under-reported
+"Already loaded".
+
+Extend the bounded line read in ClassifyOneCoreAsync to cover both
+TooShort and "no new lines" detection in one pass, with early exit at
+Math.Max(minLines, resumeFromLine + 1). Reclassification happens before
+the excluded-repo flag so a falsely-Partial excluded session no longer
+prompts the user.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Channel-based 4-worker dispatch with slot-aware events (Issue 3 — plumbing)
+
+**Files:**
+- Modify: `src/kapacitor/Commands/HistoryCommand.cs` — `ChainWorkerEvents` record (lines ~775-781), `ImportChainsAsync` (lines ~788-835), `ImportSingleSessionAsync` (lines ~839-981).
+- Modify: `test/kapacitor.Tests.Unit/HistoryImportChainsTests.cs` — update existing event-shape usages.
+- Modify: `src/kapacitor/Commands/HistoryCommand.cs:312-373` and lines ~390-400 — `HandleHistory` event-construction sites must adopt the new shape (legacy log behavior preserved in this task; visual change comes in Task 4).
+
+This task is a behavior-preserving refactor: tests and end-user output are identical when complete. It enables Task 4 to render slot rows.
+
+- [ ] **Step 1: Update `ChainWorkerEvents` record**
+
+In `src/kapacitor/Commands/HistoryCommand.cs`, replace the `ChainWorkerEvents` record (currently at line ~775) with:
+
+```csharp
+internal sealed record ChainWorkerEvents {
+    /// <summary>Fired before a worker begins importing a session on its slot.</summary>
+    public required Action<int, SessionClassification> OnSessionStarted { get; init; }
+
+    /// <summary>Fired when the worker begins streaming a subagent's transcript inline.</summary>
+    public required Action<int, string, string> OnSubagentStarted { get; init; }   // slot, sessionId, agentId
+
+    /// <summary>Fired after a subagent's transcript has been fully streamed.</summary>
+    public required Action<int, string, string, int> OnSubagentFinished { get; init; }  // slot, sessionId, agentId, lines
+
+    /// <summary>Fired when a session import fails on a worker slot.</summary>
+    public required Action<int, string, string> OnSessionErrored { get; init; }   // slot, sessionId, reason
+
+    /// <summary>
+    /// Fired after a session import completes (loaded or resumed). The slot is
+    /// available for the next session as soon as this returns.
+    /// </summary>
+    public required Action<int, SessionClassification, SessionImportOutcome, int> OnSessionEnded { get; init; }
+    // slot, classification, outcome (Loaded|Resumed), linesSent
+
+    /// <summary>Fired when a successfully-imported session is ready for title generation.</summary>
+    public required Action<(string SessionId, string FilePath, string? PreviousSessionId)> OnTitleTaskReady { get; init; }
+
+    /// <summary>
+    /// Fired when a session's session-end hook returned, signalling that the
+    /// background phase may enqueue title / what's-done work for it.
+    /// Renamed from the previous `OnSessionEnded` to disambiguate from the
+    /// slot-aware lifecycle event above.
+    /// </summary>
+    public required Action<(string SessionId, bool GenerateWhatsDone)> OnBackgroundWorkReady { get; init; }
+}
+```
+
+Also promote the existing `enum SessionImportOutcome` from `private` to `internal` so it can be referenced by callers and tests. Find:
+
+```csharp
+    enum SessionImportOutcome { Loaded, Resumed, Errored }
+```
+
+Replace with:
+
+```csharp
+    internal enum SessionImportOutcome { Loaded, Resumed, Errored }
+```
+
+- [ ] **Step 2: Rewrite `ImportChainsAsync` with channel-based 4-worker fan-out**
+
+Find `ImportChainsAsync` (around line 788) and replace its body:
+
+```csharp
+internal static async Task<ImportChainsResult> ImportChainsAsync(
+        HttpClient                        httpClient,
+        string                            baseUrl,
+        List<List<SessionClassification>> chains,
+        ChainWorkerEvents                 events,
+        CancellationToken                 ct
+    ) {
+    var loaded  = 0;
+    var resumed = 0;
+    var errored = 0;
+
+    var queue = System.Threading.Channels.Channel.CreateUnbounded<List<SessionClassification>>(
+        new System.Threading.Channels.UnboundedChannelOptions {
+            SingleReader = false,
+            SingleWriter = true,
+        }
+    );
+
+    foreach (var chain in chains) await queue.Writer.WriteAsync(chain, ct);
+    queue.Writer.Complete();
+
+    const int workerCount = 4;
+    var workers = new Task[workerCount];
+
+    for (var i = 0; i < workerCount; i++) {
+        var slot = i; // capture
+        workers[i] = Task.Run(async () => {
+            while (await queue.Reader.WaitToReadAsync(ct)) {
+                while (queue.Reader.TryRead(out var chain)) {
+                    foreach (var session in chain) {
+                        events.OnSessionStarted(slot, session);
+
+                        SessionImportOutcome r;
+                        var linesSent = 0;
+                        try {
+                            (r, linesSent) = await ImportSingleSessionAsync(httpClient, baseUrl, session, slot, events, ct);
+                        } catch (Exception ex) {
+                            events.OnSessionErrored(slot, session.SessionId, ex.Message);
+                            r = SessionImportOutcome.Errored;
+                        }
+
+                        switch (r) {
+                            case SessionImportOutcome.Loaded:  Interlocked.Increment(ref loaded);  break;
+                            case SessionImportOutcome.Resumed: Interlocked.Increment(ref resumed); break;
+                            case SessionImportOutcome.Errored: Interlocked.Increment(ref errored); break;
+                        }
+
+                        if (r != SessionImportOutcome.Errored) {
+                            events.OnSessionEnded(slot, session, r, linesSent);
+                        }
+                    }
+                }
+            }
+        }, ct);
+    }
+
+    await Task.WhenAll(workers);
+
+    return new ImportChainsResult(loaded, resumed, errored);
+}
+```
+
+The signature of `ImportSingleSessionAsync` now takes a `slot` and returns a tuple `(outcome, linesSent)` — Step 3 updates it.
+
+- [ ] **Step 3: Update `ImportSingleSessionAsync`**
+
+Replace the entire `ImportSingleSessionAsync` method. The new signature returns `(SessionImportOutcome, int linesSent)` and threads `slot` through to events:
+
+```csharp
+static async Task<(SessionImportOutcome Outcome, int LinesSent)> ImportSingleSessionAsync(
+        HttpClient            httpClient,
+        string                baseUrl,
+        SessionClassification session,
+        int                   slot,
+        ChainWorkerEvents     events,
+        CancellationToken     ct
+    ) {
+    IProgress<ImportProgress> perSessionProgress = new CallbackProgress(ev => {
+            switch (ev) {
+                case SubagentStarted ss:  events.OnSubagentStarted(slot, session.SessionId, ss.AgentId); break;
+                case SubagentFinished sf: events.OnSubagentFinished(slot, session.SessionId, sf.AgentId, sf.LinesSent); break;
+            }
+        }
+    );
+
+    if (session.Status == ClassificationStatus.Partial) {
+        try {
+            var linesSent = await SessionImporter.SendTranscriptBatches(
+                httpClient,
+                baseUrl,
+                session.SessionId,
+                session.FilePath,
+                agentId: null,
+                startLine: session.ResumeFromLine,
+                progress: perSessionProgress
+            );
+
+            return (SessionImportOutcome.Resumed, linesSent);
+        } catch (HttpRequestException ex) {
+            events.OnSessionErrored(slot, session.SessionId, $"server unreachable: {ex.Message}");
+
+            return (SessionImportOutcome.Errored, 0);
+        } catch (Exception ex) {
+            events.OnSessionErrored(slot, session.SessionId, ex.Message);
+
+            return (SessionImportOutcome.Errored, 0);
+        }
+    }
+
+    // status == New: session-start → import → session-end → enqueue background tasks
+    var meta = session.Meta;
+    var cwd  = meta.Cwd ?? SessionImporter.DecodeCwdFromDirName(session.EncodedCwd);
+
+    var startHook = new System.Text.Json.Nodes.JsonObject {
+        ["session_id"]      = session.SessionId,
+        ["transcript_path"] = session.FilePath,
+        ["cwd"]             = cwd ?? "",
+        ["source"]          = "Startup",
+        ["hook_event_name"] = "session_start",
+        ["model"]           = meta.Model,
+    };
+    if (meta.FirstTimestamp is not null) startHook["started_at"]                = meta.FirstTimestamp.Value.ToString("O");
+    if (session.PreviousSessionId is not null) startHook["previous_session_id"] = session.PreviousSessionId;
+    if (meta.Slug is not null) startHook["slug"]                                = meta.Slug;
+
+    if (cwd is not null) {
+        var repo = await RepositoryDetection.DetectRepositoryAsync(cwd);
+
+        if (repo is not null) {
+            var repoNode                                           = new System.Text.Json.Nodes.JsonObject();
+            if (repo.UserName is not null) repoNode["user_name"]   = repo.UserName;
+            if (repo.UserEmail is not null) repoNode["user_email"] = repo.UserEmail;
+            if (repo.RemoteUrl is not null) repoNode["remote_url"] = repo.RemoteUrl;
+            if (repo.Owner is not null) repoNode["owner"]          = repo.Owner;
+            if (repo.RepoName is not null) repoNode["repo_name"]   = repo.RepoName;
+            if (repo.Branch is not null) repoNode["branch"]        = repo.Branch;
+            startHook["repository"] = repoNode;
+        }
+    }
+
+    try {
+        using var startContent = new StringContent(startHook.ToJsonString(), System.Text.Encoding.UTF8, "application/json");
+        using var startResp    = await httpClient.PostWithRetryAsync($"{baseUrl}/hooks/session-start", startContent, ct: ct);
+
+        if (!startResp.IsSuccessStatusCode) {
+            events.OnSessionErrored(slot, session.SessionId, $"session-start failed: HTTP {(int)startResp.StatusCode}");
+
+            return (SessionImportOutcome.Errored, 0);
+        }
+    } catch (HttpRequestException ex) {
+        events.OnSessionErrored(slot, session.SessionId, $"server unreachable: {ex.Message}");
+
+        return (SessionImportOutcome.Errored, 0);
+    }
+
+    ImportResult importResult;
+
+    try {
+        importResult = await SessionImporter.ImportSessionAsync(
+            httpClient,
+            baseUrl,
+            session.FilePath,
+            session.SessionId,
+            meta,
+            session.EncodedCwd,
+            perSessionProgress
+        );
+    } catch (Exception ex) {
+        events.OnSessionErrored(slot, session.SessionId, ex.Message);
+
+        return (SessionImportOutcome.Errored, 0);
+    }
+
+    var lastTs = ExtractLastTimestamp(session.FilePath);
+
+    var endHook = new System.Text.Json.Nodes.JsonObject {
+        ["session_id"]      = session.SessionId,
+        ["transcript_path"] = session.FilePath,
+        ["cwd"]             = cwd ?? "",
+        ["reason"]          = "Other",
+        ["hook_event_name"] = "session_end",
+    };
+    if (lastTs is not null) endHook["ended_at"] = lastTs.Value.ToString("O");
+
+    var generateWhatsDone = false;
+
+    try {
+        using var endContent = new StringContent(endHook.ToJsonString(), System.Text.Encoding.UTF8, "application/json");
+        using var endResp    = await httpClient.PostWithRetryAsync($"{baseUrl}/hooks/session-end", endContent, ct: ct);
+
+        if (endResp.IsSuccessStatusCode) {
+            try {
+                var body = await endResp.Content.ReadAsStringAsync(ct);
+                var node = System.Text.Json.Nodes.JsonNode.Parse(body);
+                generateWhatsDone = node?["generate_whats_done"]?.GetValue<bool>() == true;
+            } catch {
+                /* best effort */
+            }
+        }
+    } catch {
+        /* best effort */
+    }
+
+    events.OnTitleTaskReady((session.SessionId, session.FilePath, session.PreviousSessionId));
+    events.OnBackgroundWorkReady((session.SessionId, generateWhatsDone));
+
+    return (SessionImportOutcome.Loaded, importResult.LinesSent);
+}
+```
+
+Three notable behavior preservations:
+- `OnTitleTaskReady` and `OnBackgroundWorkReady` (renamed) fire only on the success path of New imports, exactly as before.
+- The Partial path's `events.OnLineCompleted(...)` is gone — its UI role moves to `OnSessionEnded(slot, session, Resumed, linesSent)` invoked by `ImportChainsAsync`. The TTY/non-TTY wrappers translate.
+- The New path's `events.OnLineCompleted(...)` likewise moves to `OnSessionEnded`.
+
+- [ ] **Step 4: Update `HandleHistory` event constructions**
+
+In `src/kapacitor/Commands/HistoryCommand.cs`, find the `var events = new ChainWorkerEvents { … }` block (around line 312). Replace it entirely:
+
+```csharp
+var events = new ChainWorkerEvents {
+    OnSessionStarted = (_, _) => { },     // overridden by display wrappers below
+    OnSubagentStarted = (_, _, _) => { }, // overridden by display wrappers below
+    OnSubagentFinished = (_, sid, aid, lines) => display.Line(
+        $"  ↳ imported subagent {aid} ({lines} lines)",
+        $"  [dim]↳[/] imported subagent [cyan]{Markup.Escape(aid)}[/] ({lines} lines)"
+    ),
+    OnSessionErrored = (_, sid, reason) => display.Line(
+        $"Skipping {sid} [{reason}]",
+        $"[red]✗[/] Skipping [cyan]{Markup.Escape(sid)}[/] [{Markup.Escape(reason)}]"
+    ),
+    OnSessionEnded = (_, c, outcome, lines) => {
+        var verb = outcome == SessionImportOutcome.Resumed
+            ? $"resuming from line {c.ResumeFromLine}"
+            : "new";
+        display.Line(
+            $"Loading {c.SessionId}... {lines} lines [{verb}]",
+            $"[green]✓[/] Loading [cyan]{Markup.Escape(c.SessionId)}[/]... {lines} lines [{verb}]"
+        );
+    },
+    OnTitleTaskReady = t => {
+        var (sid, fp, _) = t;
+        Interlocked.Increment(ref titleTaskCount);
+
+        backgroundTasks.Add(
+            Task.Run(async () => {
+                    await concurrencyLimit.WaitAsync();
+
+                    try {
+                        var result = await GenerateTitleForImportAsync(httpClient, baseUrl, sid, fp);
+
+                        switch (result) {
+                            case TitleResult.Generated: Interlocked.Increment(ref titlesGenerated); break;
+                            case TitleResult.Skipped:   Interlocked.Increment(ref titlesSkipped); break;
+                            case TitleResult.Failed:
+                                Interlocked.Increment(ref titlesFailed);
+                                titleFailures.Add((sid, "generation error"));
+
+                                break;
+                        }
+                    } finally { concurrencyLimit.Release(); }
+                }
+            )
+        );
+    },
+    OnBackgroundWorkReady = t => {
+        if (!t.GenerateWhatsDone || !generateSummaries) return;
+
+        Interlocked.Increment(ref summaryTaskCount);
+        var sid = t.SessionId;
+
+        backgroundTasks.Add(
+            Task.Run(async () => {
+                    await concurrencyLimit.WaitAsync();
+
+                    try {
+                        var rc = await WhatsDoneCommand.GenerateForSessionAsync(baseUrl, sid, _ => { });
+
+                        if (rc == 0) Interlocked.Increment(ref summariesGenerated);
+                        else {
+                            Interlocked.Increment(ref summariesFailed);
+                            summaryFailures.Add((sid, $"exit {rc}"));
+                        }
+                    } catch (Exception ex) {
+                        Interlocked.Increment(ref summariesFailed);
+                        summaryFailures.Add((sid, ex.Message));
+                    } finally { concurrencyLimit.Release(); }
+                }
+            )
+        );
+    },
+};
+```
+
+This preserves the exact pre-Task-3 console output (errors, subagent lines, the per-session "Loading … N lines [new|resuming…]" line) but routes them through the new event shape. Task 4 will replace the TTY portion of these handlers with slot-row updates.
+
+- [ ] **Step 5: Update the TTY Importing-phase wrapper to drop the now-redundant `OnLineCompleted` plumbing**
+
+Find the existing TTY block inside the `if (chains.Count > 0)` branch (around line 380):
+
+```csharp
+        if (display.Tty) {
+            var r = default(ImportChainsResult);
+
+            await AnsiConsole.Progress()
+                .AutoClear(false)
+                .HideCompleted(false)
+                .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
+                .StartAsync(async ctx => {
+                        var bar = ctx.AddTask("[green]Importing[/]", maxValue: chains.Sum(c => c.Count));
+
+                        var wrappedEvents = events with {
+                            OnLineCompleted = s => {
+                                events.OnLineCompleted(s);
+                                bar.Increment(1);
+                            },
+                        };
+                        r = await ImportChainsAsync(httpClient, baseUrl, chains, wrappedEvents, CancellationToken.None);
+                    }
+                );
+            importResult = r!;
+        } else {
+            importResult = await ImportChainsAsync(httpClient, baseUrl, chains, events, CancellationToken.None);
+        }
+```
+
+Replace with (Task 4 will completely rewrite the TTY branch — for now just rewire the bar increment to `OnSessionEnded`):
+
+```csharp
+        if (display.Tty) {
+            var r = default(ImportChainsResult);
+
+            await AnsiConsole.Progress()
+                .AutoClear(false)
+                .HideCompleted(false)
+                .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
+                .StartAsync(async ctx => {
+                        var bar = ctx.AddTask("[green]Importing[/]", maxValue: chains.Sum(c => c.Count));
+
+                        var wrappedEvents = events with {
+                            OnSessionEnded = (slot, c, outcome, lines) => {
+                                events.OnSessionEnded(slot, c, outcome, lines);
+                                bar.Increment(1);
+                            },
+                            // Errored sessions also count toward the bar so it reaches 100%.
+                            OnSessionErrored = (slot, sid, reason) => {
+                                events.OnSessionErrored(slot, sid, reason);
+                                bar.Increment(1);
+                            },
+                        };
+                        r = await ImportChainsAsync(httpClient, baseUrl, chains, wrappedEvents, CancellationToken.None);
+                    }
+                );
+            importResult = r!;
+        } else {
+            importResult = await ImportChainsAsync(httpClient, baseUrl, chains, events, CancellationToken.None);
+        }
+```
+
+- [ ] **Step 6: Update existing `HistoryImportChainsTests` test fixtures**
+
+In `test/kapacitor.Tests.Unit/HistoryImportChainsTests.cs`, find every `new HistoryCommand.ChainWorkerEvents { … }` literal and update its shape. There are several tests — update them all by pattern.
+
+For example, the first one at line 76-82:
+
+```csharp
+        var events = new HistoryCommand.ChainWorkerEvents {
+            OnLineCompleted    = s => completedLines.Add(s),
+            OnSubagentFinished = (_, _, _) => { },
+            OnSessionErrored   = (_, _) => { },
+            OnTitleTaskReady   = _ => { },
+            OnSessionEnded     = _ => { },
+        };
+```
+
+becomes:
+
+```csharp
+        var events = new HistoryCommand.ChainWorkerEvents {
+            OnSessionStarted      = (_, _) => { },
+            OnSubagentStarted     = (_, _, _) => { },
+            OnSubagentFinished    = (_, _, _, _) => { },
+            OnSessionErrored      = (_, _, _) => { },
+            OnSessionEnded        = (_, c, _, _) => completedLines.Add($"Loading {c.SessionId}..."),
+            OnTitleTaskReady      = _ => { },
+            OnBackgroundWorkReady = _ => { },
+        };
+```
+
+The migration rule for each test: anywhere the test was capturing `OnLineCompleted` strings, capture the equivalent in `OnSessionEnded` using the classification. If the test was checking `OnSessionEnded` for background-work tracking, rename to `OnBackgroundWorkReady`. Stub the new `OnSessionStarted` and `OnSubagentStarted` as no-ops. Update arity of `OnSubagentFinished` from `(_, _, _)` to `(_, _, _, _)` and `OnSessionErrored` from `(_, _)` to `(_, _, _)`.
+
+Search for every occurrence of `ChainWorkerEvents` in the test project and apply the migration:
+
+```bash
+grep -rn "ChainWorkerEvents" test/kapacitor.Tests.Unit/
+```
+
+- [ ] **Step 7: Run all unit tests to verify no regressions**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: AOT publish gate**
+
+```bash
+dotnet publish src/kapacitor/kapacitor.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
+```
+
+Expected: no output. `System.Threading.Channels` and `Channel.CreateUnbounded` are AOT-safe.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/kapacitor/Commands/HistoryCommand.cs test/kapacitor.Tests.Unit/HistoryImportChainsTests.cs
+git commit -m "$(cat <<'EOF'
+[DEV-1595] history: slot-aware ChainWorkerEvents + channel dispatch
+
+Replace Parallel.ForEachAsync with a 4-worker channel-based fan-out so
+each chain runs on a stable, identifiable slot (0..3). Thread the slot
+index through ChainWorkerEvents so future UI layers can render four
+live worker rows instead of scrolling per-session log lines.
+
+Behavior is preserved in this refactor: the TTY wrapper still emits
+the same per-session output it did before. Task 4 rewires the TTY
+output to render the four slot rows.
+
+Renames the background-work trigger callback OnSessionEnded →
+OnBackgroundWorkReady so OnSessionEnded can carry slot lifecycle
+semantics.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Render four worker-slot rows in the TTY Importing phase (Issue 3 — UI)
+
+**Files:**
+- Modify: `src/kapacitor/Commands/HistoryCommand.cs` — `HandleHistory` Importing-phase TTY block (around line 380), `events` construction (around line 312).
+
+This task is the visual change. No test changes — the unit tests cover dispatch and counts; the slot rendering is verified by manual smoke.
+
+The base `events` object built in Task 3 already encodes the correct non-TTY behavior (per-session log lines, scrolling). This task only rewrites the TTY branch: it overrides the slot-aware events to render four live `ProgressTask` rows.
+
+- [ ] **Step 1: Rewrite the TTY Importing-phase block to render slot rows**
+
+Find the TTY block from Task 3 Step 5 (the `if (display.Tty) { … }` inside `if (chains.Count > 0)`). Replace it with:
+
+```csharp
+        if (display.Tty) {
+            var r = default(ImportChainsResult);
+            const int slotCount = 4;
+
+            await AnsiConsole.Progress()
+                .AutoClear(false)
+                .HideCompleted(false)
+                .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
+                .StartAsync(async ctx => {
+                        var bar = ctx.AddTask("[green]Importing[/]", maxValue: chains.Sum(c => c.Count));
+
+                        // Four description-only progress tasks rendered as live "slot rows"
+                        // beneath the main bar. IsIndeterminate=true draws a stripe
+                        // animation while a worker is processing; setting it to false
+                        // and Description="idle" parks the slot.
+                        var slots = new ProgressTask[slotCount];
+                        for (var i = 0; i < slotCount; i++) {
+                            slots[i] = ctx.AddTask($"  Slot {i + 1} — idle", maxValue: 1);
+                            slots[i].IsIndeterminate = false;
+                        }
+
+                        // currentSession[slot] holds the SessionId currently rendered on
+                        // the slot row, used to revert the description after a subagent
+                        // finishes (revert from "↳ subagent X" to "Loading <parent>").
+                        var currentVerb = new string[slotCount];
+                        var currentSid  = new string[slotCount];
+
+                        void SetSlot(int slot, string markup) {
+                            slots[slot].Description    = markup;
+                            slots[slot].IsIndeterminate = true;
+                        }
+
+                        void IdleSlot(int slot) {
+                            slots[slot].Description    = $"  Slot {slot + 1} — idle";
+                            slots[slot].IsIndeterminate = false;
+                            currentSid[slot]            = "";
+                            currentVerb[slot]           = "";
+                        }
+
+                        var wrappedEvents = events with {
+                            OnSessionStarted = (slot, c) => {
+                                var verb = c.Status == ClassificationStatus.Partial
+                                    ? $"resuming from line {c.ResumeFromLine}"
+                                    : "new";
+                                currentSid[slot]  = c.SessionId;
+                                currentVerb[slot] = verb;
+                                SetSlot(slot, $"  [bold]Slot {slot + 1}[/] — Loading [cyan]{Markup.Escape(c.SessionId)}[/] ({verb})");
+                            },
+                            OnSubagentStarted = (slot, sid, aid) => {
+                                SetSlot(slot, $"  [bold]Slot {slot + 1}[/] — [dim]↳[/] subagent [cyan]{Markup.Escape(aid)}[/] (parent {Markup.Escape(sid)})");
+                            },
+                            OnSubagentFinished = (slot, sid, aid, lines) => {
+                                // Revert to the parent session's "Loading" description.
+                                if (!string.IsNullOrEmpty(currentSid[slot])) {
+                                    SetSlot(slot,
+                                        $"  [bold]Slot {slot + 1}[/] — Loading [cyan]{Markup.Escape(currentSid[slot])}[/] ({currentVerb[slot]})");
+                                }
+                                // Also fire the base handler so non-TTY callers (and any
+                                // other observers) still see the "↳ imported subagent" line.
+                                events.OnSubagentFinished(slot, sid, aid, lines);
+                            },
+                            OnSessionEnded = (slot, c, outcome, lines) => {
+                                // Description stays on the just-finished session until
+                                // the next OnSessionStarted swaps it. We only flip the
+                                // stripe off here so a slot that drains (queue empty)
+                                // looks calm.
+                                bar.Increment(1);
+                                slots[slot].IsIndeterminate = false;
+                                // Suppress the legacy per-session log line in TTY mode
+                                // by NOT calling the base handler. Errors and subagents
+                                // already render via slot updates / scrollback below.
+                            },
+                            OnSessionErrored = (slot, sid, reason) => {
+                                bar.Increment(1);
+                                IdleSlot(slot);
+                                // Errors print to scrollback above the live region —
+                                // Spectre.Console.Progress flushes prior writes.
+                                AnsiConsole.MarkupLine($"[red]✗[/] Skipping [cyan]{Markup.Escape(sid)}[/] [{Markup.Escape(reason)}]");
+                            },
+                        };
+
+                        r = await ImportChainsAsync(httpClient, baseUrl, chains, wrappedEvents, CancellationToken.None);
+
+                        // After the await, all workers have drained; mark every slot idle.
+                        for (var i = 0; i < slotCount; i++) IdleSlot(i);
+                    }
+                );
+            importResult = r!;
+        } else {
+            importResult = await ImportChainsAsync(httpClient, baseUrl, chains, events, CancellationToken.None);
+        }
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build src/kapacitor/kapacitor.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Run all unit tests**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: AOT publish gate**
+
+```bash
+dotnet publish src/kapacitor/kapacitor.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Manual smoke test**
+
+Run the AOT-published binary against the developer's own `~/.claude/projects` (the screenshots' 2261-session sample is representative). The binary path after publish is:
+
+```
+src/kapacitor/bin/Release/net10.0/<rid>/publish/kapacitor
+```
+
+(re-sign on macOS per CLAUDE.md if you copied it elsewhere). Invoke:
+
+```bash
+src/kapacitor/bin/Release/net10.0/osx-arm64/publish/kapacitor history
+```
+
+Verify:
+- Probing bar advances smoothly from 0% to 100%.
+- Plan grid's "Already loaded" count is greater than zero (was always 0 in the regression).
+- Importing phase shows: one main `Importing` bar + four "Slot N — Loading <id> (…)" rows updating in place. No `✓ Loading …` lines scroll.
+- Errors (if any) scroll above the live region as `✗ Skipping …`.
+- After the import phase, all slots show "idle" briefly before the Done grid prints.
+
+Pipe-friendly path (smoke):
+
+```bash
+src/kapacitor/bin/Release/net10.0/osx-arm64/publish/kapacitor history > /tmp/history.txt
+head -40 /tmp/history.txt
+```
+
+Verify the file contains the legacy scrolling lines (`Loading <id>... N lines […]`, `↳ imported subagent …`, `Skipping …`) — the non-TTY path is unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/kapacitor/Commands/HistoryCommand.cs
+git commit -m "$(cat <<'EOF'
+[DEV-1595] history: render four live worker-slot rows in TTY
+
+The Importing phase now shows one main progress bar plus four
+"Slot N — Loading <id> (…)" rows that update in place as workers pick
+up the next chain. Subagent activity is rendered on the same slot
+row while in flight and reverts to the parent session line on finish.
+Errors continue to scroll into scrollback above the live region.
+
+Non-TTY output is unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Final verification
+
+**Files:** none.
+
+- [ ] **Step 1: Run all unit and integration tests**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj
+dotnet run --project test/kapacitor.Tests.Integration/kapacitor.Tests.Integration.csproj
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Final AOT publish gate**
+
+```bash
+dotnet publish src/kapacitor/kapacitor.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Confirm git log**
+
+```bash
+git log --oneline -5
+```
+
+Expected: four DEV-1595 commits on top of the spec commit, each addressing one of: probe progress, reclassification, slot-aware events, slot rendering.
+
+---
+
+## Risks & open questions
+
+- **Slot animation under non-iTerm terminals.** Spectre stripe rendering may degrade gracefully on Windows Terminal / Conhost; acceptable, slot rows still legible.
+- **Channel single-writer flag.** `SingleWriter = true` is correct because all chains are written before the workers start reading. If a future change writes chains incrementally, flip the flag.
+- **Errored sessions and the main bar.** Task 3 Step 5's wrapper increments `bar` on both `OnSessionEnded` and `OnSessionErrored` so the bar always reaches 100%. Without the errored increment, a single failed session would leave the bar stuck below max.

--- a/docs/superpowers/specs/2026-04-25-dev-1595-history-import-ux-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-25-dev-1595-history-import-ux-fixes-design.md
@@ -1,0 +1,322 @@
+# DEV-1595 — History import UX fixes
+
+## Background
+
+The DEV-1579 history import rewrite (`HistoryCommand.cs`, commit `7936ef8`)
+parallelised the import path and replaced the previous live "footer"
+display with per-session log lines. Three regressions surfaced in real
+runs (Linear DEV-1595, screenshots in the issue):
+
+1. **Probing stuck at 0%.** The "Probing N sessions" progress bar sits at
+   zero through the entire `ClassifyAsync` await, then jumps to 100%.
+   The bar value is set after the await — there is no per-task increment.
+
+2. **"Already loaded: 0" but resuming many sessions with 0 new lines.**
+   A 200 OK from the `/api/sessions/{id}/last-line` probe is always
+   classified as `Partial`, even when the local transcript has no lines
+   beyond `last_line_number`. The plan grid under-reports
+   `AlreadyLoaded`; the import phase then sends zero lines per such
+   session, which is wasted work and misleading output.
+
+3. **"Loading" lines scroll instead of staying live.** Each completed
+   session prints a `✓ Loading <id>… N lines` line via
+   `AnsiConsole.MarkupLine`. With 4 parallel workers and hundreds of
+   sessions, the screen scrolls continuously. The previous
+   single-line footer pattern (DEV-1573) was lost when the importer
+   was parallelised.
+
+This spec addresses all three issues. They are independent fixes in
+the same file but warrant a single change because they share test
+fixtures and ship together.
+
+## Goals
+
+- Probing bar advances smoothly from 0% to 100% as probes complete.
+- Plan grid `AlreadyLoaded` accounts for sessions whose local
+  transcript has no lines beyond the server's last-imported line.
+- Importing phase shows up to 4 live worker slots that update in place
+  instead of scrolling per-session log lines. Subagent activity is
+  visible while it is happening.
+
+## Non-goals
+
+- No change to `MaxDegreeOfParallelism` (stays at 4).
+- No change to the non-TTY pipe-friendly output (still scrolls).
+- No change to the probe HTTP contract or the `last-line` endpoint.
+- No change to background title/summary phase rendering.
+
+## Design
+
+### Issue 1 — Probing progress
+
+`ClassifyAsync` gains an optional probe-completion callback:
+
+```csharp
+internal static Task<List<SessionClassification>> ClassifyAsync(
+    HttpClient httpClient,
+    string baseUrl,
+    List<(string SessionId, string FilePath, string EncodedCwd)> transcripts,
+    int minLines,
+    string[]? excludedRepos,
+    CancellationToken ct,
+    Action? onProbed = null);
+```
+
+Each `ClassifyOneAsync` invokes `onProbed?.Invoke()` exactly once after
+its work finishes (probe + optional line count + excluded-repo check),
+in a `try { … } finally { onProbed?.Invoke(); }` so the bar still
+advances when a probe throws.
+
+The TTY wrapper at `HistoryCommand.cs:222-231` passes
+`() => bar.Increment(1)`; the non-TTY caller passes `null`. The
+post-await `bar.Value = bar.MaxValue` line goes away — by the time the
+await returns, every probe has already incremented.
+
+Spectre's `ProgressTask` mutations are safe from arbitrary threads
+under the active `Progress` context; we are not introducing any new
+synchronisation requirement that the existing footer pattern did not
+already meet.
+
+### Issue 2 — Plan classification correctness
+
+`ClassifyOneAsync` currently calls `CountLinesUpTo(filePath, minLines)`
+only on `New | Partial` to apply the `TooShort` filter. We extend that
+read to also cover the "no new lines beyond last imported" case:
+
+```csharp
+if (status is ClassificationStatus.New or ClassificationStatus.Partial) {
+    var threshold = Math.Max(
+        minLines,
+        status == ClassificationStatus.Partial ? resumeFromLine + 1 : 0);
+    var observedLines = CountLinesUpTo(filePath, threshold);
+
+    if (minLines > 0 && observedLines < minLines) {
+        // existing TooShort branch — return immediately
+    }
+
+    if (status == ClassificationStatus.Partial && observedLines <= resumeFromLine) {
+        status = ClassificationStatus.AlreadyLoaded;
+        resumeFromLine = 0;
+    }
+}
+```
+
+Order matters: the `TooShort` check still wins because a transcript
+below `minLines` should be skipped regardless of what the server
+thinks. The reclassification to `AlreadyLoaded` happens *before* the
+excluded-repo flagging block, so reclassified sessions do not pull
+the user into a "include excluded repo?" prompt for work that does
+not exist.
+
+`CountLinesUpTo` already early-exits at the threshold, so the read
+cost is bounded by `Math.Max(minLines, resumeFromLine + 1)` lines per
+session — usually a few KB.
+
+`AlreadyLoaded` carries no `ResumeFromLine` semantics, so we clear it
+back to `0` for tidiness; nothing reads it for that status, but the
+record's invariant ("ResumeFromLine only meaningful when Partial")
+stays clean.
+
+### Issue 3 — Loading display
+
+The `Importing` phase replaces its single bar + scrolling per-session
+log lines with **one progress bar plus four live "slot" rows**, all
+rendered inside a single `AnsiConsole.Progress(...).StartAsync(...)`.
+
+**Rendering**
+
+```
+─ Importing 401 sessions ──────────────────────────────
+Importing  ████████████░░░░░░░░░  60%
+  Slot 1   Loading e71eb384… (resuming from line 34)
+  Slot 2   Loading 3fe3d96e… (new)
+            ↳ subagent aedf7cc3… (35 lines)
+  Slot 3   Loading c280f03c… (resuming from line 16)
+  Slot 4   idle
+```
+
+Implementation: alongside the main `bar`, the wrapper adds four
+description-only `ProgressTask`s. Each slot task is created with
+`IsIndeterminate = true` while the worker is processing a session
+(stripe animation under `ProgressBarColumn`) and toggled to
+`IsIndeterminate = false` with `Description = "idle"` when the
+worker has nothing to do. The same `Progress` context renders the
+main `Importing` bar and the four slot rows together, so the whole
+phase is one cohesive live region.
+
+**Worker dispatch**
+
+`Parallel.ForEachAsync` does not expose a worker index. To put each
+session on a stable slot row, we replace the current parallel loop
+with a hand-rolled four-worker fan-out:
+
+```csharp
+var queue = Channel.CreateUnbounded<List<SessionClassification>>(
+    new UnboundedChannelOptions { SingleReader = false, SingleWriter = true });
+foreach (var chain in chains) await queue.Writer.WriteAsync(chain, ct);
+queue.Writer.Complete();
+
+var workers = Enumerable.Range(0, 4).Select(slot => Task.Run(async () => {
+    while (await queue.Reader.WaitToReadAsync(ct)) {
+        while (queue.Reader.TryRead(out var chain)) {
+            foreach (var session in chain) {
+                events.OnSessionStarted(slot, session);
+                // existing per-session import logic …
+                events.OnSessionEnded(slot, session, outcome);
+            }
+        }
+    }
+})).ToArray();
+
+await Task.WhenAll(workers);
+```
+
+The `MaxDegreeOfParallelism = 4` guarantee is preserved (four
+workers, no more, no fewer for the duration of the phase). Cancellation
+flows through `ct` as before.
+
+**Events**
+
+`ChainWorkerEvents` shape:
+
+```csharp
+internal sealed record ChainWorkerEvents {
+    // Slot-aware lifecycle (new):
+    public required Action<int, SessionClassification> OnSessionStarted { get; init; }
+    public required Action<int, string, string> OnSubagentStarted { get; init; }      // slot, agentId, sessionId
+    public required Action<int, string, string, int> OnSubagentFinished { get; init; }// slot, sessionId, agentId, lines
+    public required Action<int, SessionClassification, SessionImportOutcome, int> OnSessionEnded { get; init; }
+    // Errors (replaces old OnSessionErrored streaming line):
+    public required Action<int, string, string> OnSessionErrored { get; init; }       // slot, sessionId, reason
+
+    // Background phase (renamed from the previous `OnSessionEnded` — that name
+    // now belongs to the slot-aware lifecycle event above):
+    public required Action<(string SessionId, string FilePath, string? PreviousSessionId)> OnTitleTaskReady { get; init; }
+    public required Action<(string SessionId, bool GenerateWhatsDone)> OnBackgroundWorkReady { get; init; }
+}
+```
+
+The rename of the background-trigger callback (`OnSessionEnded` →
+`OnBackgroundWorkReady`) disambiguates the two roles the old field
+had: signalling slot completion vs. enqueueing background title /
+summary work. `HandleHistory` is the only caller; one rename.
+
+The TTY wrapper:
+
+- `OnSessionStarted(slot, c)` → `slots[slot].Description = "Loading <short> (<verb>)"`
+  where verb is `new` or `resuming from line N`.
+- `OnSubagentStarted(slot, agentId, sid)` → swap description to `"  ↳ subagent <short> …"`
+  on the same slot row (it is the same worker doing the work — no
+  extra row is needed).
+- `OnSubagentFinished` → revert description back to the parent
+  session's `Loading …` line.
+- `OnSessionEnded` → increment `bar.Increment(1)`. Description stays
+  on the last completed session until `OnSessionStarted` swaps it,
+  giving the user a brief glance at what just finished.
+- `OnSessionErrored(slot, sid, reason)` → write a single
+  `AnsiConsole.MarkupLine($"[red]✗[/] Skipping {sid} [{reason}]")` *outside*
+  the slot rows so errors persist in scrollback, then revert the slot
+  description as if `OnSessionEnded`. Errors are rare and worth
+  keeping; we accept a minor scroll for them.
+- When a worker drains the channel, its slot description becomes
+  `"idle"` and `IsIndeterminate = false` so the stripe animation
+  stops.
+
+The non-TTY wrapper keeps the existing `Console.WriteLine`
+implementation: `OnSessionStarted` is a no-op, `OnSessionEnded`
+prints the same `Loading <id>… N lines [new|resuming from line X]`
+line, `OnSubagentFinished` prints the existing `↳ imported subagent`
+line, `OnSessionErrored` prints `Skipping <id> […]`. Pipe-friendly
+output is preserved.
+
+**Concurrency notes**
+
+- Slot description writes happen from worker threads inside an active
+  `Progress` context. `ProgressTask` mutations under `Progress` are
+  thread-safe — same guarantee the existing footer used.
+- `bar.Increment(1)` is called once per `OnSessionEnded`; no double
+  counting because the wrapper only runs in the TTY branch.
+
+## Testing
+
+### Unit-level
+
+- `ClassifyAsync` with a probe callback: assert callback invoked
+  exactly `transcripts.Count` times across mixed `New / Partial /
+  AlreadyLoaded / TooShort / ProbeError / InternalSubSession` cases.
+  Use the existing `WireMock.Net` setup.
+- `ClassifyOneAsync` reclassification: server returns 200 with
+  `last_line_number = 27` against a local transcript with exactly 28
+  lines → status is `AlreadyLoaded`. Same probe against a 29-line
+  transcript → `Partial` with `ResumeFromLine = 28`.
+- `ClassifyOneAsync` excluded-repo interaction: a server-200/28-line
+  fixture in an excluded repo classifies as `AlreadyLoaded` and does
+  *not* set `ExcludedRepoKey`.
+
+### Integration-level
+
+- A real `Progress` context with a `TestConsole` (Spectre's testing
+  helper): drive `ImportChainsAsync` with a synthetic chain set and
+  capture the rendered output. Assertions:
+  - Four slot rows exist while imports are in flight.
+  - No `✓ Loading …` lines appear in the captured output (only
+    `Importing` bar plus slot rows plus error lines).
+  - Per-error rendering: a forced `OnSessionErrored` produces an
+    `✗ Skipping …` line in scrollback.
+- Non-TTY path: redirect stdout, verify the legacy
+  `Loading <id>… N lines […]` and `↳ imported subagent …` lines are
+  still emitted line by line.
+
+### Manual smoke
+
+- Run `kapacitor history` on the developer's own
+  `~/.claude/projects` (the screenshot's 2261 sessions / 401 imports
+  is a representative sample) and visually confirm:
+  - Probing bar advances smoothly.
+  - Plan grid no longer reports many "Resumable" entries that import
+    zero lines (the "Already loaded" count should jump to roughly the
+    previous "Resumable, 0 lines" tally).
+  - Slot rows update in place; no per-session scroll except for
+    errors.
+- Pipe to a file (`kapacitor history > out.txt`) and verify legacy
+  output still works.
+
+## AOT considerations
+
+`System.Threading.Channels` is AOT-safe and already in use elsewhere
+in the project. Spectre.Console's `Progress` API is AOT-safe under
+the existing trim flags (no reflection-based formatting). No new
+analyzer warnings are expected, but `dotnet publish -c Release` must
+be re-run to confirm no IL3050 / IL2026 surfaces — per
+`CLAUDE.md`, AOT warnings only show on publish.
+
+## Rollout
+
+Single PR titled `DEV-1595 CLI: history import UX fixes`. Three
+commits, one per issue, in the order:
+
+1. Probe progress callback (Issue 1).
+2. Reclassify Partial-with-no-new-lines as AlreadyLoaded (Issue 2).
+3. Worker-slot live display (Issue 3).
+
+Each commit ships its tests. The third commit touches the most code
+and merges last so the first two can be cherry-picked if needed.
+
+## Risks
+
+- **Worker-slot rendering correctness across terminals.** Spectre's
+  `Progress` with multiple `IsIndeterminate` tasks renders well in
+  iTerm2 and Apple Terminal. Windows Terminal / Conhost have known
+  oddities with stripe animations. Acceptable: stripe animations
+  fall back to a static block; legibility is preserved.
+- **Channel-based dispatch vs. `Parallel.ForEachAsync` at scale.**
+  The existing parallel loop uses internal pacing optimisations.
+  Four hand-rolled workers reading from an unbounded channel will
+  start all four immediately and idle as the queue drains; this is
+  what we want for live display, and the per-chain overhead is
+  negligible relative to HTTP I/O.
+- **`OnSessionEnded` description latency.** A worker that finishes a
+  session and then waits for the channel will leave its slot
+  description on the just-finished session for a tick. That is a
+  feature, not a bug — it gives the user time to see the last
+  completed work.

--- a/docs/superpowers/specs/2026-04-25-dev-1595-history-import-ux-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-25-dev-1595-history-import-ux-fixes-design.md
@@ -183,7 +183,7 @@ flows through `ct` as before.
 internal sealed record ChainWorkerEvents {
     // Slot-aware lifecycle (new):
     public required Action<int, SessionClassification> OnSessionStarted { get; init; }
-    public required Action<int, string, string> OnSubagentStarted { get; init; }      // slot, agentId, sessionId
+    public required Action<int, string, string> OnSubagentStarted { get; init; }      // slot, sessionId, agentId
     public required Action<int, string, string, int> OnSubagentFinished { get; init; }// slot, sessionId, agentId, lines
     public required Action<int, SessionClassification, SessionImportOutcome, int> OnSessionEnded { get; init; }
     // Errors (replaces old OnSessionErrored streaming line):

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -300,7 +300,7 @@ static class HistoryCommand {
         var chains = BuildImportChains(classifications);
 
         // --- Import ---
-        // ConcurrentBag rather than List: OnTitleTaskReady / OnSessionEnded
+        // ConcurrentBag rather than List: OnTitleTaskReady / OnBackgroundWorkReady
         // callbacks fire from parallel chain-worker threads, so a plain List's
         // Add would race. No ordering guarantees needed — we only enumerate at
         // the end via Task.WhenAll.
@@ -317,8 +317,8 @@ static class HistoryCommand {
         var       summaryFailures    = new System.Collections.Concurrent.ConcurrentBag<(string SessionId, string Reason)>();
 
         var events = new ChainWorkerEvents {
-            OnSessionStarted = (_, _) => { },     // overridden by display wrappers below
-            OnSubagentStarted = (_, _, _) => { }, // overridden by display wrappers below
+            OnSessionStarted = (_, _) => { },     // Task 4 will override for TTY slot rendering
+            OnSubagentStarted = (_, _, _) => { }, // Task 4 will override for TTY slot rendering
             OnSubagentFinished = (_, sid, aid, lines) => display.Line(
                 $"  ↳ imported subagent {aid} ({lines} lines)",
                 $"  [dim]↳[/] imported subagent [cyan]{Markup.Escape(aid)}[/] ({lines} lines)"

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -317,8 +317,8 @@ static class HistoryCommand {
         var       summaryFailures    = new System.Collections.Concurrent.ConcurrentBag<(string SessionId, string Reason)>();
 
         var events = new ChainWorkerEvents {
-            OnSessionStarted = (_, _) => { },     // Task 4 will override for TTY slot rendering
-            OnSubagentStarted = (_, _, _) => { }, // Task 4 will override for TTY slot rendering
+            OnSessionStarted = (_, _) => { },     // non-TTY: session start is silent; TTY overrides below
+            OnSubagentStarted = (_, _, _) => { }, // non-TTY: subagent start is silent; TTY overrides below
             OnSubagentFinished = (_, sid, aid, lines) => display.Line(
                 $"  ↳ imported subagent {aid} ({lines} lines)",
                 $"  [dim]↳[/] imported subagent [cyan]{Markup.Escape(aid)}[/] ({lines} lines)"
@@ -445,15 +445,14 @@ static class HistoryCommand {
                                 OnSubagentStarted = (slot, sid, aid) => {
                                     SetSlot(slot, $"  [bold]Slot {slot + 1}[/] — [dim]↳[/] subagent [cyan]{Markup.Escape(aid)}[/] (parent {Markup.Escape(sid)})");
                                 },
-                                OnSubagentFinished = (slot, sid, aid, lines) => {
+                                OnSubagentFinished = (slot, _, _, _) => {
                                     // Revert to the parent session's "Loading" description.
+                                    // No scrollback line in TTY mode — subagent activity was
+                                    // already visible on the slot row while it ran.
                                     if (!string.IsNullOrEmpty(currentSid[slot])) {
                                         SetSlot(slot,
                                             $"  [bold]Slot {slot + 1}[/] — Loading [cyan]{Markup.Escape(currentSid[slot])}[/] ({currentVerb[slot]})");
                                     }
-                                    // Also fire the base handler so non-TTY callers (and any
-                                    // other observers) still see the "↳ imported subagent" line.
-                                    events.OnSubagentFinished(slot, sid, aid, lines);
                                 },
                                 OnSessionEnded = (slot, c, outcome, lines) => {
                                     // Description stays on the just-finished session until
@@ -463,8 +462,8 @@ static class HistoryCommand {
                                     bar.Increment(1);
                                     slots[slot].IsIndeterminate = false;
                                     // Suppress the legacy per-session log line in TTY mode
-                                    // by NOT calling the base handler. Errors and subagents
-                                    // already render via slot updates / scrollback below.
+                                    // by NOT calling the base handler. Slot rows showed the
+                                    // session while it ran; errors render via scrollback below.
                                 },
                                 OnSessionErrored = (slot, sid, reason) => {
                                     bar.Increment(1);

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -224,8 +224,15 @@ static class HistoryCommand {
                 .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
                 .StartAsync(async ctx => {
                         var bar     = ctx.AddTask("[yellow]Probing[/]", maxValue: transcriptFiles.Count);
-                        var results = await ClassifyAsync(httpClient, baseUrl, transcriptFiles, minLines, excludedRepos, CancellationToken.None);
-                        bar.Value = bar.MaxValue;
+                        var results = await ClassifyAsync(
+                            httpClient,
+                            baseUrl,
+                            transcriptFiles,
+                            minLines,
+                            excludedRepos,
+                            CancellationToken.None,
+                            onProbed: () => bar.Increment(1)
+                        );
                         tmp.AddRange(results);
                     }
                 );
@@ -995,13 +1002,14 @@ static class HistoryCommand {
             List<(string SessionId, string FilePath, string EncodedCwd)> transcripts,
             int                                                          minLines,
             string[]?                                                    excludedRepos,
-            CancellationToken                                            ct
+            CancellationToken                                            ct,
+            Action?                                                      onProbed = null
         ) {
         using var probeGate = new SemaphoreSlim(8);
         var       tasks     = new List<Task<SessionClassification>>(transcripts.Count);
 
         foreach (var (sessionId, filePath, encodedCwd) in transcripts) {
-            tasks.Add(ClassifyOneAsync(httpClient, baseUrl, sessionId, filePath, encodedCwd, minLines, excludedRepos, probeGate, ct));
+            tasks.Add(ClassifyOneAsync(httpClient, baseUrl, sessionId, filePath, encodedCwd, minLines, excludedRepos, probeGate, onProbed, ct));
         }
 
         var results = await Task.WhenAll(tasks);
@@ -1010,6 +1018,25 @@ static class HistoryCommand {
     }
 
     static async Task<SessionClassification> ClassifyOneAsync(
+            HttpClient        httpClient,
+            string            baseUrl,
+            string            sessionId,
+            string            filePath,
+            string            encodedCwd,
+            int               minLines,
+            string[]?         excludedRepos,
+            SemaphoreSlim     probeGate,
+            Action?           onProbed,
+            CancellationToken ct
+        ) {
+        try {
+            return await ClassifyOneCoreAsync(httpClient, baseUrl, sessionId, filePath, encodedCwd, minLines, excludedRepos, probeGate, ct);
+        } finally {
+            onProbed?.Invoke();
+        }
+    }
+
+    static async Task<SessionClassification> ClassifyOneCoreAsync(
             HttpClient        httpClient,
             string            baseUrl,
             string            sessionId,

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -1105,20 +1105,38 @@ static class HistoryCommand {
             probeGate.Release();
         }
 
-        // Apply the TooShort filter only for sessions that would otherwise be imported.
-        // This avoids scanning the whole transcript when AlreadyLoaded / ProbeError.
-        if (minLines > 0 && (status == ClassificationStatus.New || status == ClassificationStatus.Partial)) {
-            var observedLines = CountLinesUpTo(filePath, minLines);
+        // Read enough of the local transcript to satisfy two checks at once:
+        //   1. TooShort — fewer lines than minLines.
+        //   2. False Partial — server says last_line_number = N but the local
+        //      transcript has no lines past index N (resumeFromLine would be
+        //      N+1 with nothing to send).
+        // CountLinesUpTo early-exits at the threshold, so the read cost is
+        // bounded by Math.Max(minLines, resumeFromLine + 1) lines.
+        if (status is ClassificationStatus.New or ClassificationStatus.Partial) {
+            var threshold = Math.Max(
+                minLines,
+                status == ClassificationStatus.Partial ? resumeFromLine + 1 : 0
+            );
 
-            if (observedLines < minLines) {
-                return new SessionClassification {
-                    SessionId  = sessionId,
-                    FilePath   = filePath,
-                    EncodedCwd = encodedCwd,
-                    Meta       = meta,
-                    Status     = ClassificationStatus.TooShort,
-                    TotalLines = observedLines,
-                };
+            if (threshold > 0) {
+                var observedLines = CountLinesUpTo(filePath, threshold);
+
+                if (minLines > 0 && observedLines < minLines) {
+                    return new SessionClassification {
+                        SessionId  = sessionId,
+                        FilePath   = filePath,
+                        EncodedCwd = encodedCwd,
+                        Meta       = meta,
+                        Status     = ClassificationStatus.TooShort,
+                        TotalLines = observedLines,
+                    };
+                }
+
+                // Server has lines >= the local transcript — nothing to resume.
+                if (status == ClassificationStatus.Partial && observedLines <= resumeFromLine) {
+                    status         = ClassificationStatus.AlreadyLoaded;
+                    resumeFromLine = 0;
+                }
             }
         }
 

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -396,6 +396,7 @@ static class HistoryCommand {
 
             if (display.Tty) {
                 var r = default(ImportChainsResult);
+                const int slotCount = 4;
 
                 await AnsiConsole.Progress()
                     .AutoClear(false)
@@ -404,18 +405,80 @@ static class HistoryCommand {
                     .StartAsync(async ctx => {
                             var bar = ctx.AddTask("[green]Importing[/]", maxValue: chains.Sum(c => c.Count));
 
+                            // Four description-only progress tasks rendered as live "slot rows"
+                            // beneath the main bar. IsIndeterminate=true draws a stripe
+                            // animation while a worker is processing; setting it to false
+                            // and Description="idle" parks the slot.
+                            var slots = new ProgressTask[slotCount];
+                            for (var i = 0; i < slotCount; i++) {
+                                slots[i] = ctx.AddTask($"  Slot {i + 1} — idle", maxValue: 1);
+                                slots[i].IsIndeterminate = false;
+                            }
+
+                            // currentSession[slot] holds the SessionId currently rendered on
+                            // the slot row, used to revert the description after a subagent
+                            // finishes (revert from "↳ subagent X" to "Loading <parent>").
+                            var currentVerb = new string[slotCount];
+                            var currentSid  = new string[slotCount];
+
+                            void SetSlot(int slot, string markup) {
+                                slots[slot].Description    = markup;
+                                slots[slot].IsIndeterminate = true;
+                            }
+
+                            void IdleSlot(int slot) {
+                                slots[slot].Description    = $"  Slot {slot + 1} — idle";
+                                slots[slot].IsIndeterminate = false;
+                                currentSid[slot]            = "";
+                                currentVerb[slot]           = "";
+                            }
+
                             var wrappedEvents = events with {
-                                OnSessionEnded = (slot, c, outcome, lines) => {
-                                    events.OnSessionEnded(slot, c, outcome, lines);
-                                    bar.Increment(1);
+                                OnSessionStarted = (slot, c) => {
+                                    var verb = c.Status == ClassificationStatus.Partial
+                                        ? $"resuming from line {c.ResumeFromLine}"
+                                        : "new";
+                                    currentSid[slot]  = c.SessionId;
+                                    currentVerb[slot] = verb;
+                                    SetSlot(slot, $"  [bold]Slot {slot + 1}[/] — Loading [cyan]{Markup.Escape(c.SessionId)}[/] ({verb})");
                                 },
-                                // Errored sessions also count toward the bar so it reaches 100%.
-                                OnSessionErrored = (slot, sid, reason) => {
-                                    events.OnSessionErrored(slot, sid, reason);
+                                OnSubagentStarted = (slot, sid, aid) => {
+                                    SetSlot(slot, $"  [bold]Slot {slot + 1}[/] — [dim]↳[/] subagent [cyan]{Markup.Escape(aid)}[/] (parent {Markup.Escape(sid)})");
+                                },
+                                OnSubagentFinished = (slot, sid, aid, lines) => {
+                                    // Revert to the parent session's "Loading" description.
+                                    if (!string.IsNullOrEmpty(currentSid[slot])) {
+                                        SetSlot(slot,
+                                            $"  [bold]Slot {slot + 1}[/] — Loading [cyan]{Markup.Escape(currentSid[slot])}[/] ({currentVerb[slot]})");
+                                    }
+                                    // Also fire the base handler so non-TTY callers (and any
+                                    // other observers) still see the "↳ imported subagent" line.
+                                    events.OnSubagentFinished(slot, sid, aid, lines);
+                                },
+                                OnSessionEnded = (slot, c, outcome, lines) => {
+                                    // Description stays on the just-finished session until
+                                    // the next OnSessionStarted swaps it. We only flip the
+                                    // stripe off here so a slot that drains (queue empty)
+                                    // looks calm.
                                     bar.Increment(1);
+                                    slots[slot].IsIndeterminate = false;
+                                    // Suppress the legacy per-session log line in TTY mode
+                                    // by NOT calling the base handler. Errors and subagents
+                                    // already render via slot updates / scrollback below.
+                                },
+                                OnSessionErrored = (slot, sid, reason) => {
+                                    bar.Increment(1);
+                                    IdleSlot(slot);
+                                    // Errors print to scrollback above the live region —
+                                    // Spectre.Console.Progress flushes prior writes.
+                                    AnsiConsole.MarkupLine($"[red]✗[/] Skipping [cyan]{Markup.Escape(sid)}[/] [{Markup.Escape(reason)}]");
                                 },
                             };
+
                             r = await ImportChainsAsync(httpClient, baseUrl, chains, wrappedEvents, CancellationToken.None);
+
+                            // After the await, all workers have drained; mark every slot idle.
+                            for (var i = 0; i < slotCount; i++) IdleSlot(i);
                         }
                     );
                 importResult = r!;

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -317,15 +317,25 @@ static class HistoryCommand {
         var       summaryFailures    = new System.Collections.Concurrent.ConcurrentBag<(string SessionId, string Reason)>();
 
         var events = new ChainWorkerEvents {
-            OnLineCompleted = s => display.Line(s, $"[green]✓[/] {Markup.Escape(s)}"),
-            OnSubagentFinished = (_, aid, lines) => display.Line(
+            OnSessionStarted = (_, _) => { },     // overridden by display wrappers below
+            OnSubagentStarted = (_, _, _) => { }, // overridden by display wrappers below
+            OnSubagentFinished = (_, sid, aid, lines) => display.Line(
                 $"  ↳ imported subagent {aid} ({lines} lines)",
                 $"  [dim]↳[/] imported subagent [cyan]{Markup.Escape(aid)}[/] ({lines} lines)"
             ),
-            OnSessionErrored = (sid, reason) => display.Line(
+            OnSessionErrored = (_, sid, reason) => display.Line(
                 $"Skipping {sid} [{reason}]",
                 $"[red]✗[/] Skipping [cyan]{Markup.Escape(sid)}[/] [{Markup.Escape(reason)}]"
             ),
+            OnSessionEnded = (_, c, outcome, lines) => {
+                var verb = outcome == SessionImportOutcome.Resumed
+                    ? $"resuming from line {c.ResumeFromLine}"
+                    : "new";
+                display.Line(
+                    $"Loading {c.SessionId}... {lines} lines [{verb}]",
+                    $"[green]✓[/] Loading [cyan]{Markup.Escape(c.SessionId)}[/]... {lines} lines [{verb}]"
+                );
+            },
             OnTitleTaskReady = t => {
                 var (sid, fp, _) = t;
                 Interlocked.Increment(ref titleTaskCount);
@@ -351,7 +361,7 @@ static class HistoryCommand {
                     )
                 );
             },
-            OnSessionEnded = t => {
+            OnBackgroundWorkReady = t => {
                 if (!t.GenerateWhatsDone || !generateSummaries) return;
 
                 Interlocked.Increment(ref summaryTaskCount);
@@ -395,8 +405,13 @@ static class HistoryCommand {
                             var bar = ctx.AddTask("[green]Importing[/]", maxValue: chains.Sum(c => c.Count));
 
                             var wrappedEvents = events with {
-                                OnLineCompleted = s => {
-                                    events.OnLineCompleted(s);
+                                OnSessionEnded = (slot, c, outcome, lines) => {
+                                    events.OnSessionEnded(slot, c, outcome, lines);
+                                    bar.Increment(1);
+                                },
+                                // Errored sessions also count toward the bar so it reaches 100%.
+                                OnSessionErrored = (slot, sid, reason) => {
+                                    events.OnSessionErrored(slot, sid, reason);
                                     bar.Increment(1);
                                 },
                             };
@@ -780,11 +795,35 @@ static class HistoryCommand {
     internal sealed record ImportChainsResult(int Loaded, int Resumed, int Errored);
 
     internal sealed record ChainWorkerEvents {
-        public required Action<string>                                                         OnLineCompleted    { get; init; }
-        public required Action<string, string, int>                                            OnSubagentFinished { get; init; }
-        public required Action<string, string>                                                 OnSessionErrored   { get; init; }
-        public required Action<(string SessionId, string FilePath, string? PreviousSessionId)> OnTitleTaskReady   { get; init; }
-        public required Action<(string SessionId, bool GenerateWhatsDone)>                     OnSessionEnded     { get; init; }
+        /// <summary>Fired before a worker begins importing a session on its slot.</summary>
+        public required Action<int, SessionClassification> OnSessionStarted { get; init; }
+
+        /// <summary>Fired when the worker begins streaming a subagent's transcript inline.</summary>
+        public required Action<int, string, string> OnSubagentStarted { get; init; }   // slot, sessionId, agentId
+
+        /// <summary>Fired after a subagent's transcript has been fully streamed.</summary>
+        public required Action<int, string, string, int> OnSubagentFinished { get; init; }  // slot, sessionId, agentId, lines
+
+        /// <summary>Fired when a session import fails on a worker slot.</summary>
+        public required Action<int, string, string> OnSessionErrored { get; init; }   // slot, sessionId, reason
+
+        /// <summary>
+        /// Fired after a session import completes (loaded or resumed). The slot is
+        /// available for the next session as soon as this returns.
+        /// </summary>
+        public required Action<int, SessionClassification, SessionImportOutcome, int> OnSessionEnded { get; init; }
+        // slot, classification, outcome (Loaded|Resumed), linesSent
+
+        /// <summary>Fired when a successfully-imported session is ready for title generation.</summary>
+        public required Action<(string SessionId, string FilePath, string? PreviousSessionId)> OnTitleTaskReady { get; init; }
+
+        /// <summary>
+        /// Fired when a session's session-end hook returned, signalling that the
+        /// background phase may enqueue title / what's-done work for it.
+        /// Renamed from the previous `OnSessionEnded` to disambiguate from the
+        /// slot-aware lifecycle event above.
+        /// </summary>
+        public required Action<(string SessionId, bool GenerateWhatsDone)> OnBackgroundWorkReady { get; init; }
     }
 
     /// <summary>
@@ -803,56 +842,70 @@ static class HistoryCommand {
         var resumed = 0;
         var errored = 0;
 
-        // Parallel.ForEachAsync caps outstanding tasks at MaxDegreeOfParallelism,
-        // which matters when we have thousands of singleton chains. A hand-rolled
-        // chains.Select(Task.Run) would queue one Task per chain, all blocked on
-        // a semaphore — significant overhead at scale.
-        var options = new ParallelOptions {
-            MaxDegreeOfParallelism = 4,
-            CancellationToken      = ct,
-        };
-
-        await Parallel.ForEachAsync(
-            chains,
-            options,
-            async (chain, token) => {
-                foreach (var session in chain) {
-                    // Belt-and-suspenders: ImportSingleSessionAsync already catches
-                    // expected failures; a bare catch here guarantees one rogue
-                    // session can't fault the worker and abort the iteration.
-                    SessionImportOutcome r;
-
-                    try {
-                        r = await ImportSingleSessionAsync(httpClient, baseUrl, session, events, token);
-                    } catch (Exception ex) {
-                        events.OnSessionErrored(session.SessionId, ex.Message);
-                        r = SessionImportOutcome.Errored;
-                    }
-
-                    switch (r) {
-                        case SessionImportOutcome.Loaded:  Interlocked.Increment(ref loaded); break;
-                        case SessionImportOutcome.Resumed: Interlocked.Increment(ref resumed); break;
-                        case SessionImportOutcome.Errored: Interlocked.Increment(ref errored); break;
-                    }
-                }
+        var queue = System.Threading.Channels.Channel.CreateUnbounded<List<SessionClassification>>(
+            new System.Threading.Channels.UnboundedChannelOptions {
+                SingleReader = false,
+                SingleWriter = true,
             }
         );
+
+        foreach (var chain in chains) await queue.Writer.WriteAsync(chain, ct);
+        queue.Writer.Complete();
+
+        const int workerCount = 4;
+        var workers = new Task[workerCount];
+
+        for (var i = 0; i < workerCount; i++) {
+            var slot = i; // capture
+            workers[i] = Task.Run(async () => {
+                while (await queue.Reader.WaitToReadAsync(ct)) {
+                    while (queue.Reader.TryRead(out var chain)) {
+                        foreach (var session in chain) {
+                            events.OnSessionStarted(slot, session);
+
+                            SessionImportOutcome r;
+                            var linesSent = 0;
+                            try {
+                                (r, linesSent) = await ImportSingleSessionAsync(httpClient, baseUrl, session, slot, events, ct);
+                            } catch (Exception ex) {
+                                events.OnSessionErrored(slot, session.SessionId, ex.Message);
+                                r = SessionImportOutcome.Errored;
+                            }
+
+                            switch (r) {
+                                case SessionImportOutcome.Loaded:  Interlocked.Increment(ref loaded);  break;
+                                case SessionImportOutcome.Resumed: Interlocked.Increment(ref resumed); break;
+                                case SessionImportOutcome.Errored: Interlocked.Increment(ref errored); break;
+                            }
+
+                            if (r != SessionImportOutcome.Errored) {
+                                events.OnSessionEnded(slot, session, r, linesSent);
+                            }
+                        }
+                    }
+                }
+            }, ct);
+        }
+
+        await Task.WhenAll(workers);
 
         return new ImportChainsResult(loaded, resumed, errored);
     }
 
-    enum SessionImportOutcome { Loaded, Resumed, Errored }
+    internal enum SessionImportOutcome { Loaded, Resumed, Errored }
 
-    static async Task<SessionImportOutcome> ImportSingleSessionAsync(
+    static async Task<(SessionImportOutcome Outcome, int LinesSent)> ImportSingleSessionAsync(
             HttpClient            httpClient,
             string                baseUrl,
             SessionClassification session,
+            int                   slot,
             ChainWorkerEvents     events,
             CancellationToken     ct
         ) {
         IProgress<ImportProgress> perSessionProgress = new CallbackProgress(ev => {
-                if (ev is SubagentFinished sf) {
-                    events.OnSubagentFinished(session.SessionId, sf.AgentId, sf.LinesSent);
+                switch (ev) {
+                    case SubagentStarted ss:  events.OnSubagentStarted(slot, session.SessionId, ss.AgentId); break;
+                    case SubagentFinished sf: events.OnSubagentFinished(slot, session.SessionId, sf.AgentId, sf.LinesSent); break;
                 }
             }
         );
@@ -868,17 +921,16 @@ static class HistoryCommand {
                     startLine: session.ResumeFromLine,
                     progress: perSessionProgress
                 );
-                events.OnLineCompleted($"Loading {session.SessionId}... {linesSent} lines [resuming from line {session.ResumeFromLine}]");
 
-                return SessionImportOutcome.Resumed;
+                return (SessionImportOutcome.Resumed, linesSent);
             } catch (HttpRequestException ex) {
-                events.OnSessionErrored(session.SessionId, $"server unreachable: {ex.Message}");
+                events.OnSessionErrored(slot, session.SessionId, $"server unreachable: {ex.Message}");
 
-                return SessionImportOutcome.Errored;
+                return (SessionImportOutcome.Errored, 0);
             } catch (Exception ex) {
-                events.OnSessionErrored(session.SessionId, ex.Message);
+                events.OnSessionErrored(slot, session.SessionId, ex.Message);
 
-                return SessionImportOutcome.Errored;
+                return (SessionImportOutcome.Errored, 0);
             }
         }
 
@@ -918,14 +970,14 @@ static class HistoryCommand {
             using var startResp    = await httpClient.PostWithRetryAsync($"{baseUrl}/hooks/session-start", startContent, ct: ct);
 
             if (!startResp.IsSuccessStatusCode) {
-                events.OnSessionErrored(session.SessionId, $"session-start failed: HTTP {(int)startResp.StatusCode}");
+                events.OnSessionErrored(slot, session.SessionId, $"session-start failed: HTTP {(int)startResp.StatusCode}");
 
-                return SessionImportOutcome.Errored;
+                return (SessionImportOutcome.Errored, 0);
             }
         } catch (HttpRequestException ex) {
-            events.OnSessionErrored(session.SessionId, $"server unreachable: {ex.Message}");
+            events.OnSessionErrored(slot, session.SessionId, $"server unreachable: {ex.Message}");
 
-            return SessionImportOutcome.Errored;
+            return (SessionImportOutcome.Errored, 0);
         }
 
         ImportResult importResult;
@@ -941,15 +993,10 @@ static class HistoryCommand {
                 perSessionProgress
             );
         } catch (Exception ex) {
-            // Catches file-IO, JSON parsing, and anything else ImportSessionAsync can throw.
-            // Sending session-end on a half-imported session would be misleading; let the
-            // errored count reflect reality and move on to the next session in the chain.
-            events.OnSessionErrored(session.SessionId, ex.Message);
+            events.OnSessionErrored(slot, session.SessionId, ex.Message);
 
-            return SessionImportOutcome.Errored;
+            return (SessionImportOutcome.Errored, 0);
         }
-
-        events.OnLineCompleted($"Loading {session.SessionId}... {importResult.LinesSent} lines [new]");
 
         var lastTs = ExtractLastTimestamp(session.FilePath);
 
@@ -982,9 +1029,9 @@ static class HistoryCommand {
         }
 
         events.OnTitleTaskReady((session.SessionId, session.FilePath, session.PreviousSessionId));
-        events.OnSessionEnded((session.SessionId, generateWhatsDone));
+        events.OnBackgroundWorkReady((session.SessionId, generateWhatsDone));
 
-        return SessionImportOutcome.Loaded;
+        return (SessionImportOutcome.Loaded, importResult.LinesSent);
     }
 
     sealed class CallbackProgress(Action<ImportProgress> onReport) : IProgress<ImportProgress> {

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -7,6 +7,14 @@ using kapacitor.Config;
 namespace kapacitor.Commands;
 
 static class HistoryCommand {
+    /// <summary>
+    /// Maximum parallel worker count for the Importing phase. Both the
+    /// channel-based dispatcher in ImportChainsAsync and the TTY slot-row
+    /// renderer in HandleHistory size themselves to this value, so they
+    /// MUST stay in lockstep.
+    /// </summary>
+    const int ImportWorkerCount = 4;
+
     readonly struct HistoryDisplay {
         public bool Tty { get; init; }
 
@@ -396,7 +404,7 @@ static class HistoryCommand {
 
             if (display.Tty) {
                 var r = default(ImportChainsResult);
-                const int slotCount = 4;
+                const int slotCount = ImportWorkerCount;
 
                 await AnsiConsole.Progress()
                     .AutoClear(false)
@@ -914,7 +922,7 @@ static class HistoryCommand {
         foreach (var chain in chains) await queue.Writer.WriteAsync(chain, ct);
         queue.Writer.Complete();
 
-        const int workerCount = 4;
+        const int workerCount = ImportWorkerCount;
         var workers = new Task[workerCount];
 
         for (var i = 0; i < workerCount; i++) {
@@ -923,12 +931,15 @@ static class HistoryCommand {
                 while (await queue.Reader.WaitToReadAsync(ct)) {
                     while (queue.Reader.TryRead(out var chain)) {
                         foreach (var session in chain) {
+                            ct.ThrowIfCancellationRequested();
                             events.OnSessionStarted(slot, session);
 
                             SessionImportOutcome r;
                             var linesSent = 0;
                             try {
                                 (r, linesSent) = await ImportSingleSessionAsync(httpClient, baseUrl, session, slot, events, ct);
+                            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                                throw;
                             } catch (Exception ex) {
                                 events.OnSessionErrored(slot, session.SessionId, ex.Message);
                                 r = SessionImportOutcome.Errored;
@@ -989,6 +1000,8 @@ static class HistoryCommand {
                 events.OnSessionErrored(slot, session.SessionId, $"server unreachable: {ex.Message}");
 
                 return (SessionImportOutcome.Errored, 0);
+            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                throw;
             } catch (Exception ex) {
                 events.OnSessionErrored(slot, session.SessionId, ex.Message);
 
@@ -1054,6 +1067,8 @@ static class HistoryCommand {
                 session.EncodedCwd,
                 perSessionProgress
             );
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            throw;
         } catch (Exception ex) {
             events.OnSessionErrored(slot, session.SessionId, ex.Message);
 

--- a/test/kapacitor.Tests.Unit/HistoryClassifyTests.cs
+++ b/test/kapacitor.Tests.Unit/HistoryClassifyTests.cs
@@ -337,9 +337,17 @@ public class HistoryClassifyTests : IDisposable {
 
     [Test]
     public async Task ClassifyAsync_does_not_set_ExcludedRepoKey_when_reclassified_to_AlreadyLoaded() {
-        // A "Partial" probe in an excluded repo, but the local transcript has
-        // no new lines. We must NOT prompt the user to "include this excluded
-        // repo" for work that does not exist — ExcludedRepoKey must be null.
+        // A "Partial" probe in an excluded repo, but the local transcript has no new
+        // lines. We must NOT prompt the user to "include this excluded repo" for work
+        // that does not exist — ExcludedRepoKey must be null.
+        //
+        // This fixture uses a real git-initialised temp directory whose remote matches
+        // the excluded list, so DetectRepositoryAsync returns a repo key of "any/repo".
+        // With that setup, the only way ExcludedRepoKey can remain null is if
+        // reclassification (Partial → AlreadyLoaded) has already moved status out of
+        // New|Partial before the excluded-repo block runs. If a future refactor swaps
+        // those two blocks, DetectRepositoryAsync will resolve "any/repo" and
+        // ExcludedRepoKey will be set — causing this test to fail.
         _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
             .RespondWith(
                 Response.Create()
@@ -348,26 +356,31 @@ public class HistoryClassifyTests : IDisposable {
                     .WithBody("""{"last_line_number": 49}""")
             );
 
-        // The repo detection in ClassifyOneCoreAsync uses RepositoryDetection
-        // against meta.Cwd, which falls back to DecodeCwdFromDirName(EncodedCwd).
-        // We bypass repo detection by leaving cwd unset — the excluded check
-        // never fires when cwd is null. So we need a different angle: rely on
-        // the order of operations in the spec — reclassification happens BEFORE
-        // the excluded-repo check, so even with a real excluded repo the flag
-        // should not be set. We simulate by writing a transcript whose path's
-        // EncodedCwd would NOT match the excluded list, but mark "anything" as
-        // excluded; the assertion is that ExcludedRepoKey is null because the
-        // session is no longer New|Partial when the excluded check runs.
-        var path = await WriteTranscript(_tempDir, "excludedNoNew", lines: 50);
+        // Create a real git repo under _tempDir so DetectRepositoryAsync can resolve it.
+        var repoDir = Path.Combine(_tempDir, "kapacitor-reclass-excl");
+        Directory.CreateDirectory(repoDir);
+        await RunGitAsync("init", repoDir);
+        await RunGitAsync("remote add origin https://github.com/any/repo.git", repoDir);
+
+        // Write a 50-line transcript whose cwd points at the repo above.
+        // ExtractSessionMetadata reads "cwd" from the JSONL lines, so
+        // DetectRepositoryAsync will be called with repoDir.
+        var transcriptPath = Path.Combine(_tempDir, "excludedNoNew.jsonl");
+
+        await File.WriteAllLinesAsync(
+            transcriptPath,
+            Enumerable.Range(0, 50)
+                .Select(i =>
+                    $$$"""{"type":"user","timestamp":"2026-03-15T10:00:00Z","cwd":"{{{repoDir.Replace("\\", "\\\\")}}}","message":{"content":"line-{{{i}}}"}}"""
+                )
+        );
 
         var transcripts = new List<(string SessionId, string FilePath, string EncodedCwd)> {
-            ("excludedNoNew", path, "-tmp-proj")
+            ("excludedNoNew", transcriptPath, repoDir.Replace('/', '-'))
         };
 
         using var client = new HttpClient();
 
-        // We pass an excluded list that would match EVERY repo if reached; the
-        // contract says it must not be reached for AlreadyLoaded.
         var result = await HistoryCommand.ClassifyAsync(
             client, _server.Url!, transcripts,
             minLines: 15,
@@ -375,6 +388,10 @@ public class HistoryClassifyTests : IDisposable {
             CancellationToken.None
         );
 
+        // last_line_number=49 with exactly 50 local lines means no new lines to send,
+        // so the session is reclassified from Partial to AlreadyLoaded.
+        // The excluded-repo block only fires for New|Partial, so ExcludedRepoKey must
+        // be null even though the repo key matches the excluded list.
         await Assert.That(result[0].Status).IsEqualTo(HistoryCommand.ClassificationStatus.AlreadyLoaded);
         await Assert.That(result[0].ExcludedRepoKey).IsNull();
     }

--- a/test/kapacitor.Tests.Unit/HistoryClassifyTests.cs
+++ b/test/kapacitor.Tests.Unit/HistoryClassifyTests.cs
@@ -247,6 +247,34 @@ public class HistoryClassifyTests : IDisposable {
         await Assert.That(result[0].ExcludedRepoKey).IsEqualTo("acme/secret");
     }
 
+    [Test]
+    public async Task ClassifyAsync_invokes_onProbed_callback_once_per_transcript() {
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404));
+
+        var paths = new List<(string SessionId, string FilePath, string EncodedCwd)>();
+        for (var i = 0; i < 5; i++) {
+            var path = await WriteTranscript(_tempDir, $"cb-{i}", lines: 50);
+            paths.Add(($"cb-{i}", path, "-tmp-proj"));
+        }
+
+        var probedCount = 0;
+        using var client = new HttpClient();
+
+        var result = await HistoryCommand.ClassifyAsync(
+            client,
+            _server.Url!,
+            paths,
+            minLines: 15,
+            excludedRepos: null,
+            CancellationToken.None,
+            onProbed: () => Interlocked.Increment(ref probedCount)
+        );
+
+        await Assert.That(result.Count).IsEqualTo(5);
+        await Assert.That(probedCount).IsEqualTo(5);
+    }
+
     static async Task RunGitAsync(string arguments, string workingDir) {
         var psi = new System.Diagnostics.ProcessStartInfo("git", arguments) {
             WorkingDirectory       = workingDir,

--- a/test/kapacitor.Tests.Unit/HistoryClassifyTests.cs
+++ b/test/kapacitor.Tests.Unit/HistoryClassifyTests.cs
@@ -275,6 +275,110 @@ public class HistoryClassifyTests : IDisposable {
         await Assert.That(probedCount).IsEqualTo(5);
     }
 
+    [Test]
+    public async Task ClassifyAsync_reclassifies_Partial_to_AlreadyLoaded_when_no_new_lines() {
+        // Server says last_line_number = 49 (50 lines stored: indices 0..49).
+        // Local transcript is exactly 50 lines (indices 0..49). resumeFromLine
+        // would be 50 — but there are no lines past index 49, so this is a
+        // false Partial that should be reclassified as AlreadyLoaded.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody("""{"last_line_number": 49}""")
+            );
+
+        var path = await WriteTranscript(_tempDir, "noNewLines", lines: 50);
+
+        var transcripts = new List<(string SessionId, string FilePath, string EncodedCwd)> {
+            ("noNewLines", path, "-tmp-proj")
+        };
+
+        using var client = new HttpClient();
+
+        var result = await HistoryCommand.ClassifyAsync(
+            client, _server.Url!, transcripts,
+            minLines: 15, excludedRepos: null, CancellationToken.None
+        );
+
+        await Assert.That(result[0].Status).IsEqualTo(HistoryCommand.ClassificationStatus.AlreadyLoaded);
+        await Assert.That(result[0].ResumeFromLine).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ClassifyAsync_keeps_Partial_when_local_transcript_has_new_lines() {
+        // Server says last_line_number = 49. Local transcript is 60 lines —
+        // there are 10 new lines past index 49, so Partial is correct.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody("""{"last_line_number": 49}""")
+            );
+
+        var path = await WriteTranscript(_tempDir, "hasNewLines", lines: 60);
+
+        var transcripts = new List<(string SessionId, string FilePath, string EncodedCwd)> {
+            ("hasNewLines", path, "-tmp-proj")
+        };
+
+        using var client = new HttpClient();
+
+        var result = await HistoryCommand.ClassifyAsync(
+            client, _server.Url!, transcripts,
+            minLines: 15, excludedRepos: null, CancellationToken.None
+        );
+
+        await Assert.That(result[0].Status).IsEqualTo(HistoryCommand.ClassificationStatus.Partial);
+        await Assert.That(result[0].ResumeFromLine).IsEqualTo(50);
+    }
+
+    [Test]
+    public async Task ClassifyAsync_does_not_set_ExcludedRepoKey_when_reclassified_to_AlreadyLoaded() {
+        // A "Partial" probe in an excluded repo, but the local transcript has
+        // no new lines. We must NOT prompt the user to "include this excluded
+        // repo" for work that does not exist — ExcludedRepoKey must be null.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody("""{"last_line_number": 49}""")
+            );
+
+        // The repo detection in ClassifyOneCoreAsync uses RepositoryDetection
+        // against meta.Cwd, which falls back to DecodeCwdFromDirName(EncodedCwd).
+        // We bypass repo detection by leaving cwd unset — the excluded check
+        // never fires when cwd is null. So we need a different angle: rely on
+        // the order of operations in the spec — reclassification happens BEFORE
+        // the excluded-repo check, so even with a real excluded repo the flag
+        // should not be set. We simulate by writing a transcript whose path's
+        // EncodedCwd would NOT match the excluded list, but mark "anything" as
+        // excluded; the assertion is that ExcludedRepoKey is null because the
+        // session is no longer New|Partial when the excluded check runs.
+        var path = await WriteTranscript(_tempDir, "excludedNoNew", lines: 50);
+
+        var transcripts = new List<(string SessionId, string FilePath, string EncodedCwd)> {
+            ("excludedNoNew", path, "-tmp-proj")
+        };
+
+        using var client = new HttpClient();
+
+        // We pass an excluded list that would match EVERY repo if reached; the
+        // contract says it must not be reached for AlreadyLoaded.
+        var result = await HistoryCommand.ClassifyAsync(
+            client, _server.Url!, transcripts,
+            minLines: 15,
+            excludedRepos: new[] { "any/repo" },
+            CancellationToken.None
+        );
+
+        await Assert.That(result[0].Status).IsEqualTo(HistoryCommand.ClassificationStatus.AlreadyLoaded);
+        await Assert.That(result[0].ExcludedRepoKey).IsNull();
+    }
+
     static async Task RunGitAsync(string arguments, string workingDir) {
         var psi = new System.Diagnostics.ProcessStartInfo("git", arguments) {
             WorkingDirectory       = workingDir,

--- a/test/kapacitor.Tests.Unit/HistoryImportChainsTests.cs
+++ b/test/kapacitor.Tests.Unit/HistoryImportChainsTests.cs
@@ -74,11 +74,13 @@ public class HistoryImportChainsTests : IDisposable {
 
         var completedLines = new System.Collections.Concurrent.ConcurrentBag<string>();
         var events = new HistoryCommand.ChainWorkerEvents {
-            OnLineCompleted    = s => completedLines.Add(s),
-            OnSubagentFinished = (_, _, _) => { },
-            OnSessionErrored   = (_, _) => { },
-            OnTitleTaskReady   = _ => { },
-            OnSessionEnded     = _ => { },
+            OnSessionStarted      = (_, _) => { },
+            OnSubagentStarted     = (_, _, _) => { },
+            OnSubagentFinished    = (_, _, _, _) => { },
+            OnSessionErrored      = (_, _, _) => { },
+            OnSessionEnded        = (_, c, _, _) => completedLines.Add($"Loading {c.SessionId}..."),
+            OnTitleTaskReady      = _ => { },
+            OnBackgroundWorkReady = _ => { },
         };
 
         using var client = new HttpClient();
@@ -101,11 +103,13 @@ public class HistoryImportChainsTests : IDisposable {
 
         var order = new System.Collections.Concurrent.ConcurrentQueue<string>();
         var events = new HistoryCommand.ChainWorkerEvents {
-            OnLineCompleted    = s => order.Enqueue(s),
-            OnSubagentFinished = (_, _, _) => { },
-            OnSessionErrored   = (_, _) => { },
-            OnTitleTaskReady   = _ => { },
-            OnSessionEnded     = _ => { },
+            OnSessionStarted      = (_, _) => { },
+            OnSubagentStarted     = (_, _, _) => { },
+            OnSubagentFinished    = (_, _, _, _) => { },
+            OnSessionErrored      = (_, _, _) => { },
+            OnSessionEnded        = (_, c, _, _) => order.Enqueue($"Loading {c.SessionId}..."),
+            OnTitleTaskReady      = _ => { },
+            OnBackgroundWorkReady = _ => { },
         };
 
         using var client = new HttpClient();
@@ -143,11 +147,13 @@ public class HistoryImportChainsTests : IDisposable {
             .ToList();
 
         var events = new HistoryCommand.ChainWorkerEvents {
-            OnLineCompleted    = _ => { },
-            OnSubagentFinished = (_, _, _) => { },
-            OnSessionErrored   = (_, _) => { },
-            OnTitleTaskReady   = _ => { },
-            OnSessionEnded     = _ => { },
+            OnSessionStarted      = (_, _) => { },
+            OnSubagentStarted     = (_, _, _) => { },
+            OnSubagentFinished    = (_, _, _, _) => { },
+            OnSessionErrored      = (_, _, _) => { },
+            OnSessionEnded        = (_, _, _, _) => { },
+            OnTitleTaskReady      = _ => { },
+            OnBackgroundWorkReady = _ => { },
         };
 
         using var client = new HttpClient();


### PR DESCRIPTION
## Summary

Three regressions in the DEV-1579 history import (Linear DEV-1595):

- **Probing bar stuck at 0%.** `ClassifyAsync` returned only after every probe finished, so the bar jumped 0→100%. Now each probe fires an `onProbed` callback and the TTY wrapper increments the bar per probe.
- **"Already loaded: 0" but resuming with 0 new lines.** When the server's `last_line_number = N` matched the local transcript exactly, the classifier still marked `Partial` and the import phase sent 0 lines per session. Bounded line read (`Math.Max(minLines, resumeFromLine + 1)`) now reclassifies these to `AlreadyLoaded` before the excluded-repo prompt, so the plan grid is honest.
- **"Loading" lines scroll instead of staying live.** Replaced `Parallel.ForEachAsync` with a `Channel`-based 4-worker fan-out that threads a stable `slot` index through `ChainWorkerEvents`. The TTY Importing phase now renders one main bar plus four live "Slot N" rows that update in place. Subagents temporarily replace the slot's parent line; errors keep scrolling above the live region.

Non-TTY pipe-friendly output is unchanged.

## Test plan

- [x] 342/342 unit tests pass
- [x] 4/4 integration tests pass
- [x] AOT publish (`dotnet publish -c Release`) clean — no IL3050/IL2026
- [ ] Manual smoke: run `kapacitor history` against `~/.claude/projects` and confirm:
  - Probing bar advances smoothly from 0% to 100%
  - Plan grid's "Already loaded" count is non-zero (was 0 in the regression)
  - Importing phase shows one main bar + four "Slot N — Loading <id> (…)" rows updating in place; no `✓ Loading …` lines scroll
  - Errors still scroll as `✗ Skipping …` above the live region
- [ ] Pipe smoke: `kapacitor history > /tmp/history.txt` and verify the legacy scrolling lines (`Loading <id>... N lines […]`, `↳ imported subagent …`) still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)