### PR TITLE
[DEV-1577] Fix eval judge MCP tool access (+ DEV-1576 budget)

### DIFF
--- a/src/kapacitor/Eval/EvalService.cs
+++ b/src/kapacitor/Eval/EvalService.cs
@@ -47,24 +47,27 @@ internal static class EvalService {
     // DEV-1484: the retrospective judge now pulls session details via MCP
     // tools (recap/errors/transcript) instead of reading them from the
     // embedded trace. Each tool call costs a turn, plus one for the final
-    // StructuredOutput reply and one end-of-turn. 10 gives the prompt's
-    // "at most 6 tool calls" budget room to breathe (6 tool calls + 1
-    // structured-output + headroom for reasoning blocks) without letting
-    // the judge page the transcript indefinitely.
-    const int RetrospectiveMaxTurns = 10;
+    // StructuredOutput reply and one end-of-turn. The prompt's "at most 6
+    // tool calls" budget collides with reasoning-block turns: assistant
+    // tool_use turns and reasoning turns both count, so 6 tool calls can
+    // already burn 8-10 turns before StructuredOutput. DEV-1576 raised
+    // this from 10 → 15 after real runs were hitting error_max_turns
+    // mid-tool-use and producing null results.
+    const int RetrospectiveMaxTurns = 15;
 
-    // 15-min wallclock pairs with RetrospectiveMaxTurns=10: gives the judge
-    // room for up to 6 MCP tool calls plus structured-output + reasoning
-    // headroom even under cold-start claude CLI latency.
+    // 15-min wallclock pairs with RetrospectiveMaxTurns=15: gives the judge
+    // room for the prompt's 6 MCP tool calls plus structured-output and
+    // reasoning headroom even under cold-start claude CLI latency.
     static readonly TimeSpan RetrospectiveTimeout = TimeSpan.FromMinutes(15);
 
     // DEV-1486: tools-enabled per-question judges reuse the retrospective's
-    // MCP tool surface but on a tighter per-question budget. 10 turns /
-    // 10 minutes / $0.50 balances "enough rope to call summary + search +
-    // one or two targeted fetches" against runaway investigation on a
-    // single question.
-    const int    ToolsPerQuestionMaxTurns     = 10;
-    const double ToolsPerQuestionMaxBudgetUsd = 0.50;
+    // MCP tool surface. DEV-1576: original 10 turns / $0.50 was too tight —
+    // judges hit error_max_turns mid-investigation and produced null
+    // verdicts because StructuredOutput never ran. Bumped to 15 turns /
+    // $1.00 to match the retrospective ceiling; the prompt's "at most 6
+    // tool calls" still bounds investigation depth.
+    const int    ToolsPerQuestionMaxTurns     = 15;
+    const double ToolsPerQuestionMaxBudgetUsd = 1.00;
 
     static readonly TimeSpan ToolsPerQuestionTimeout = TimeSpan.FromMinutes(10);
 

--- a/src/kapacitor/Eval/EvalService.cs
+++ b/src/kapacitor/Eval/EvalService.cs
@@ -320,9 +320,11 @@ internal static class EvalService {
 
         if (question.NeedsTools) {
             // DEV-1486 tools-enabled path. Session-scoped MCP tool surface
-            // (same as retrospective) on a per-question budget: 10 turns,
-            // 10-min timeout, $0.50 cap. Prompt omits the compacted trace —
-            // the judge fetches session details on demand.
+            // (same as retrospective) on a per-question budget: 15 turns,
+            // 10-min timeout, $1.00 cap (raised from 10/$0.50 in DEV-1576
+            // after real runs hit error_max_turns mid-tool-use). Prompt
+            // omits the compacted trace — the judge fetches session details
+            // on demand.
             var prompt = BuildToolsQuestionPrompt(
                 ctx.ToolsPromptTemplate, ctx.SessionId, ctx.EvalRunId, question, patterns);
 

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -7,12 +7,6 @@ using kapacitor.Commands;
 using kapacitor.Config;
 using WatchCommand = kapacitor.Commands.WatchCommand;
 
-// Skip all processing when spawned inside a headless claude invocation (e.g., title generation)
-// to prevent infinite hook loops
-if (Environment.GetEnvironmentVariable("KAPACITOR_SKIP") is "1") {
-    return 0;
-}
-
 var baseUrl = await AppConfig.ResolveServerUrl(args);
 
 // Fire-and-forget update check (prints hint to stderr after command finishes)
@@ -40,6 +34,16 @@ if (args.Length < 1) {
 }
 
 var command = args[0];
+
+// Hooks only: short-circuit when spawned inside a headless claude invocation
+// (e.g., title generation, the eval judge) so we don't forward the nested
+// session's hook events back into kapacitor and blow up into a loop. Scoped
+// to hook commands because non-hook commands — notably `kapacitor mcp judge`
+// running as an MCP server child of the eval judge claude process — must
+// actually execute despite inheriting KAPACITOR_SKIP=1 from the parent.
+if (Environment.GetEnvironmentVariable("KAPACITOR_SKIP") is "1" && hookCommands.Contains(command)) {
+    return 0;
+}
 
 if (command is "--help" or "-h" or "help") {
     await PrintUsage();

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -7,16 +7,9 @@ using kapacitor.Commands;
 using kapacitor.Config;
 using WatchCommand = kapacitor.Commands.WatchCommand;
 
-var baseUrl = await AppConfig.ResolveServerUrl(args);
-
-// Fire-and-forget update check (prints hint to stderr after command finishes)
-var   noUpdateCheck   = args.Contains("--no-update-check");
-Task? updateCheckTask = null;
-
-if (!noUpdateCheck) {
-    updateCheckTask = Task.Run(UpdateCommand.PrintUpdateHintIfAvailable);
-}
-
+// Declared before any PrintUsage()/PrintCommandHelp() call because both
+// local functions capture this list to render the hooks section of the
+// help text.
 string[] hookCommands = [
     "session-start",
     "session-end",
@@ -41,8 +34,23 @@ var command = args[0];
 // to hook commands because non-hook commands — notably `kapacitor mcp judge`
 // running as an MCP server child of the eval judge claude process — must
 // actually execute despite inheriting KAPACITOR_SKIP=1 from the parent.
+//
+// Runs before ResolveServerUrl/update-check so a skipped hook does no work:
+// ResolveServerUrl can shell out to `git remote -v` and emit warnings, and
+// the update-check task hits the npm registry — both pure noise inside a
+// nested headless invocation.
 if (Environment.GetEnvironmentVariable("KAPACITOR_SKIP") is "1" && hookCommands.Contains(command)) {
     return 0;
+}
+
+var baseUrl = await AppConfig.ResolveServerUrl(args);
+
+// Fire-and-forget update check (prints hint to stderr after command finishes)
+var   noUpdateCheck   = args.Contains("--no-update-check");
+Task? updateCheckTask = null;
+
+if (!noUpdateCheck) {
+    updateCheckTask = Task.Run(UpdateCommand.PrintUpdateHintIfAvailable);
 }
 
 if (command is "--help" or "-h" or "help") {


### PR DESCRIPTION
## Summary

Two related bugs were keeping the tools-enabled eval judges (DEV-1486 per-question + DEV-1484 retrospective) from working in production. They ship together because DEV-1577 unblocks the tools and DEV-1576 sizes the budget the unblocked tools actually need.

### DEV-1577 — Judge can't access MCP tools

`ClaudeCliRunner` sets `KAPACITOR_SKIP=1` on the spawned `claude` process to prevent infinite hook loops. When `claude` then spawns the `kapacitor mcp judge` MCP server as a child, that env var propagates and `kapacitor mcp judge` early-returns at the top of `Program.cs` with exit 0. `claude` registers zero MCP tools; the judge falls back to built-in `Bash` (auto-denied in headless `-p` mode) and produces verdicts like:

> Unable to retrieve session data … `kapacitor recap` and `kapacitor errors` CLI commands required bash approval that was not granted, and the session-investigation MCP tools listed in the eval prompt (`get_session_summary`, `get_session_errors`, etc.) were not available in this environment.

The retrospective hit the same bug but failed silently — `Retrospective=null` on the payload is non-fatal.

**Fix:** scope the `KAPACITOR_SKIP` guard to hook commands only. Hook-forwarding recursion is the only thing it ever needed to short-circuit; non-hook subprocesses (notably `kapacitor mcp judge` running under the judge `claude`) must execute despite inheriting the env var.

### DEV-1576 — Judge hits `error_max_turns` mid-investigation

Once tools work, the original 10-turn / $0.50 per-question and 10-turn retrospective budgets were too tight: real runs hit `error_max_turns` with `stop_reason=tool_use` after ~11 turns, leaving `StructuredOutput` unpopulated and the verdict null (the schema is required, so transcript fallback is skipped).

**Fix:**
- `RetrospectiveMaxTurns`: 10 → 15
- `ToolsPerQuestionMaxTurns`: 10 → 15
- `ToolsPerQuestionMaxBudgetUsd`: \$0.50 → \$1.00

The prompt's "at most 6 tool calls" still bounds investigation depth.

## Test plan

- [ ] Trigger an eval run with tools-enabled questions (`safety/destructive_commands`, `quality/tests_written`, `quality/broken_tests`, `efficiency/direct_approach`); verify verdicts cite specific tool calls (`get_session_summary`, `search_session`, etc.) instead of "MCP tools not available"
- [ ] Confirm the retrospective produces a non-null `Retrospective` block grounded in tool-fetched evidence
- [ ] Run a vanilla session with `kapacitor session-start` hooks under a Claude session that itself spawned `claude` (e.g. title generation flow) — verify the inner `kapacitor session-start` still short-circuits via `KAPACITOR_SKIP`
- [ ] Spot-check that no per-question judge hits `error_max_turns` after the bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)