### PR TITLE
[DEV-1651] Daemon: route hosted-agent permission flow over SignalR

### DIFF
--- a/src/kapacitor/Commands/PermissionRequestCommand.cs
+++ b/src/kapacitor/Commands/PermissionRequestCommand.cs
@@ -56,11 +56,35 @@ static class PermissionRequestCommand {
         // Cloudflare's HTTP-request timeout (~120s) that severs the equivalent route
         // on the server. Older daemon builds don't set this env var, so we fall back
         // to the original /hooks/permission-request HTTPS path.
-        var daemonUrl = Environment.GetEnvironmentVariable("KAPACITOR_DAEMON_URL");
+        //
+        // Validate the daemon URL is loopback before posting — the env var carries no
+        // auth, so an accidentally / maliciously set non-loopback value would leak the
+        // hook payload (tool name, raw tool input) to an arbitrary endpoint.
+        if (TryGetLoopbackDaemonUrl(out var daemonUrl)) {
+            return await PostAsync(daemonUrl + "/permission-request", payload, authenticated: false);
+        }
 
-        return daemonUrl is { Length: > 0 } d
-            ? await PostAsync(d + "/permission-request", payload, authenticated: false)
-            : await PostAsync(baseUrl + "/hooks/permission-request", payload, authenticated: true);
+        return await PostAsync(baseUrl + "/hooks/permission-request", payload, authenticated: true);
+    }
+
+    static bool TryGetLoopbackDaemonUrl(out string daemonUrl) {
+        daemonUrl = "";
+        var raw = Environment.GetEnvironmentVariable("KAPACITOR_DAEMON_URL");
+        if (string.IsNullOrEmpty(raw)) return false;
+
+        if (!Uri.TryCreate(raw, UriKind.Absolute, out var uri) || !uri.IsLoopback) {
+            Console.Error.WriteLine($"[kapacitor] Ignoring non-loopback KAPACITOR_DAEMON_URL: {raw}");
+            return false;
+        }
+
+        if (uri.Scheme != Uri.UriSchemeHttp) {
+            Console.Error.WriteLine($"[kapacitor] Ignoring non-http KAPACITOR_DAEMON_URL scheme: {uri.Scheme}");
+            return false;
+        }
+
+        // Trim trailing slash so the appended "/permission-request" produces a clean URL.
+        daemonUrl = raw.TrimEnd('/');
+        return true;
     }
 
     static async Task<int> PostAsync(string url, JsonObject payload, bool authenticated) {

--- a/src/kapacitor/Commands/PermissionRequestCommand.cs
+++ b/src/kapacitor/Commands/PermissionRequestCommand.cs
@@ -44,9 +44,6 @@ static class PermissionRequestCommand {
         var toolInput   = node["tool_input"];
         var suggestions = node["permission_suggestions"];
 
-        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync();
-        client.Timeout = TimeSpan.FromHours(10) + TimeSpan.FromMinutes(1);
-
         var payload = new JsonObject {
             ["session_id"]             = sessionId,
             ["tool_name"]              = toolName,
@@ -54,10 +51,32 @@ static class PermissionRequestCommand {
             ["permission_suggestions"] = suggestions?.DeepClone()
         };
 
+        // Prefer the daemon's local SignalR bridge when present — that path runs the
+        // long-poll over the daemon's persistent SignalR connection, bypassing
+        // Cloudflare's HTTP-request timeout (~120s) that severs the equivalent route
+        // on the server. Older daemon builds don't set this env var, so we fall back
+        // to the original /hooks/permission-request HTTPS path.
+        var daemonUrl = Environment.GetEnvironmentVariable("KAPACITOR_DAEMON_URL");
+
+        return daemonUrl is { Length: > 0 } d
+            ? await PostAsync(d + "/permission-request", payload, authenticated: false)
+            : await PostAsync(baseUrl + "/hooks/permission-request", payload, authenticated: true);
+    }
+
+    static async Task<int> PostAsync(string url, JsonObject payload, bool authenticated) {
+        using var client = authenticated
+            ? await HttpClientExtensions.CreateAuthenticatedClientAsync()
+            : new HttpClient();
+
+        // The server-side long-poll waits up to 10 hours for the user to decide; the
+        // daemon-side bridge inherits that bound transparently. Add a minute of slack
+        // so the HTTP client doesn't tear down a still-pending request first.
+        client.Timeout = TimeSpan.FromHours(10) + TimeSpan.FromMinutes(1);
+
         using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
 
         try {
-            using var response = await client.PostAsync($"{baseUrl}/hooks/permission-request", content);
+            using var response = await client.PostAsync(url, content);
 
             if (!response.IsSuccessStatusCode) {
                 Console.Error.WriteLine($"[kapacitor] permission-request failed: HTTP {(int)response.StatusCode}");

--- a/src/kapacitor/Daemon/DaemonRunner.cs
+++ b/src/kapacitor/Daemon/DaemonRunner.cs
@@ -159,7 +159,11 @@ public static partial class DaemonRunner {
         _ = host.Services.GetRequiredService<EvalRunner>();
 
         try {
-            await host.WaitForShutdownAsync(lifetime.ApplicationStopping);
+            // Wait without passing the lifetime token: WaitForShutdownAsync(token) treats
+            // token cancellation as a fault, so a normal Ctrl+C / lifetime.StopApplication()
+            // would surface as OperationCanceledException. The no-arg overload listens
+            // internally for ApplicationStopping and returns cleanly.
+            await host.WaitForShutdownAsync();
         } finally {
             await orchestrator.DisposeAsync();
             await connection.DisposeAsync();

--- a/src/kapacitor/Daemon/DaemonRunner.cs
+++ b/src/kapacitor/Daemon/DaemonRunner.cs
@@ -111,6 +111,13 @@ public static partial class DaemonRunner {
         builder.Services.AddSingleton(config);
         builder.Services.AddSingleton<ServerConnection>();
 
+        // Local HTTP bridge that fronts the server's permission flow. Registered as a
+        // singleton so AgentOrchestrator can read its bound URL at agent-spawn time, AND
+        // as a hosted service so its IHostedService lifecycle starts the listener before
+        // any agent is spawned.
+        builder.Services.AddSingleton<LocalPermissionBridge>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<LocalPermissionBridge>());
+
         if (OperatingSystem.IsWindows()) {
             builder.Services.AddSingleton<IPtyProcessFactory, Pty.Windows.WinPtyProcessFactory>();
         } else {

--- a/src/kapacitor/Daemon/DaemonRunner.cs
+++ b/src/kapacitor/Daemon/DaemonRunner.cs
@@ -139,6 +139,13 @@ public static partial class DaemonRunner {
 
         var lifetime   = host.Services.GetRequiredService<IHostApplicationLifetime>();
         var connection = host.Services.GetRequiredService<ServerConnection>();
+
+        // Start hosted services (LocalPermissionBridge in particular) BEFORE the SignalR
+        // connection comes up. Otherwise an early LaunchAgent message can arrive while
+        // BaseUrl is still null and the spawned Claude falls back to the HTTPS path —
+        // exactly what this bridge is meant to avoid.
+        await host.StartAsync(lifetime.ApplicationStopping);
+
         await connection.ConnectAsync(lifetime.ApplicationStopping);
 
         var worktreeManager = host.Services.GetRequiredService<WorktreeManager>();
@@ -152,10 +159,11 @@ public static partial class DaemonRunner {
         _ = host.Services.GetRequiredService<EvalRunner>();
 
         try {
-            await host.RunAsync();
+            await host.WaitForShutdownAsync(lifetime.ApplicationStopping);
         } finally {
             await orchestrator.DisposeAsync();
             await connection.DisposeAsync();
+            await host.StopAsync();
         }
 
         return 0;

--- a/src/kapacitor/Daemon/Services/AgentOrchestrator.cs
+++ b/src/kapacitor/Daemon/Services/AgentOrchestrator.cs
@@ -63,6 +63,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     readonly RepoMatcher                                 _repoMatcher;
     readonly IPtyProcessFactory                          _ptyFactory;
     readonly IHttpClientFactory                          _httpClientFactory;
+    readonly LocalPermissionBridge                       _permissionBridge;
     readonly ILogger<AgentOrchestrator>                  _logger;
     readonly PeriodicTimer                               _heartbeatTimer  = new(TimeSpan.FromSeconds(30));
     readonly PeriodicTimer                               _daemonHeartbeat = new(TimeSpan.FromMinutes(1));
@@ -75,6 +76,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             RepoMatcher                repoMatcher,
             IPtyProcessFactory         ptyFactory,
             IHttpClientFactory         httpClientFactory,
+            LocalPermissionBridge      permissionBridge,
             ILogger<AgentOrchestrator> logger
         ) {
         _config            = config;
@@ -83,6 +85,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _repoMatcher       = repoMatcher;
         _ptyFactory        = ptyFactory;
         _httpClientFactory = httpClientFactory;
+        _permissionBridge  = permissionBridge;
         _logger            = logger;
 
         // Wire up server commands
@@ -292,6 +295,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             if (!string.IsNullOrEmpty(_config.ServerUrl)) {
                 env["KAPACITOR_URL"] = _config.ServerUrl;
+            }
+
+            // Tell the spawned Claude's permission-request hook where to find this
+            // daemon's local SignalR bridge. Bypasses Cloudflare's HTTP timeout on
+            // the server's /hooks/permission-request long-poll. CLI falls back to
+            // KAPACITOR_URL if this var is absent (e.g. older CLI builds).
+            if (_permissionBridge.BaseUrl is { } bridgeUrl) {
+                env["KAPACITOR_DAEMON_URL"] = bridgeUrl;
             }
 
             if (isReview && cmd.Review is { } reviewEnv) {

--- a/src/kapacitor/Daemon/Services/LocalPermissionBridge.cs
+++ b/src/kapacitor/Daemon/Services/LocalPermissionBridge.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace kapacitor.Daemon.Services;
+
+/// <summary>
+/// Localhost-only HTTP bridge that fronts the server's permission flow for spawned
+/// Claude processes. The daemon's local Claude permission hook posts here instead of
+/// going through the server's <c>/hooks/permission-request</c> route — that route runs
+/// through Cloudflare which severs the long-poll at ~120s; the bridge invokes the
+/// server's SignalR <c>RequestPermission</c> hub method over the daemon's persistent
+/// connection, where no HTTP-request timeout applies.
+///
+/// Bound to <c>127.0.0.1</c> on a random ephemeral port. The orchestrator publishes
+/// <see cref="BaseUrl"/> via the <c>KAPACITOR_DAEMON_URL</c> env var on every spawned
+/// agent so the CLI <c>permission-request</c> command can detect and use it.
+/// </summary>
+internal sealed partial class LocalPermissionBridge(
+        ServerConnection                server,
+        ILogger<LocalPermissionBridge>  logger
+    ) : IHostedService, IAsyncDisposable {
+    HttpListener?            _listener;
+    Task?                    _acceptLoop;
+    CancellationTokenSource? _cts;
+
+    public string? BaseUrl { get; private set; }
+
+    public Task StartAsync(CancellationToken cancellationToken) {
+        var port = ReserveFreeLoopbackPort();
+
+        _listener = new HttpListener();
+        _listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+        _listener.Start();
+
+        BaseUrl = $"http://127.0.0.1:{port}";
+        _cts    = new CancellationTokenSource();
+
+        _acceptLoop = Task.Run(() => AcceptLoopAsync(_cts.Token), _cts.Token);
+        LogBridgeStarted(logger, BaseUrl);
+
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken) {
+        if (_cts is not null) await _cts.CancelAsync();
+        _listener?.Stop();
+
+        if (_acceptLoop is not null) {
+            try {
+                await _acceptLoop.WaitAsync(TimeSpan.FromSeconds(2), cancellationToken);
+            } catch { /* shutting down */ }
+        }
+    }
+
+    public async ValueTask DisposeAsync() {
+        await StopAsync(CancellationToken.None);
+        _listener?.Close();
+        _cts?.Dispose();
+    }
+
+    static int ReserveFreeLoopbackPort() {
+        // HttpListener doesn't accept port 0 in its prefix; reserve a free ephemeral
+        // port via TcpListener and immediately release. There's a TOCTOU window before
+        // HttpListener.Start binds the same port, but on a single-user developer machine
+        // the race is benign — port collisions are vanishingly rare.
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        try { return ((IPEndPoint)probe.LocalEndpoint).Port; }
+        finally { probe.Stop(); }
+    }
+
+    async Task AcceptLoopAsync(CancellationToken ct) {
+        while (!ct.IsCancellationRequested && _listener!.IsListening) {
+            HttpListenerContext context;
+            try {
+                context = await _listener.GetContextAsync();
+            } catch (ObjectDisposedException) {
+                break;
+            } catch (HttpListenerException) {
+                break;
+            }
+
+            // Fire-and-forget — each request is independent and the SignalR
+            // round-trip blocks until the user decides (potentially hours).
+            _ = Task.Run(() => HandleAsync(context, ct), ct);
+        }
+    }
+
+    async Task HandleAsync(HttpListenerContext context, CancellationToken ct) {
+        try {
+            if (context.Request.Url?.AbsolutePath != "/permission-request" || context.Request.HttpMethod != "POST") {
+                context.Response.StatusCode = 404;
+                context.Response.Close();
+                return;
+            }
+
+            using var reader = new StreamReader(context.Request.InputStream, Encoding.UTF8);
+            var       body   = await reader.ReadToEndAsync(ct);
+            var       node   = JsonNode.Parse(body);
+
+            if (node is null) {
+                context.Response.StatusCode = 400;
+                context.Response.Close();
+                return;
+            }
+
+            // Match the wire shape Claude's PermissionRequest hook posts: session_id is the
+            // canonical (dashless) form, tool_name + tool_input + permission_suggestions are
+            // pass-through.
+            var sessionId = node["session_id"]?.GetValue<string>()?.Replace("-", "");
+
+            if (sessionId is null) {
+                context.Response.StatusCode = 400;
+                context.Response.Close();
+                return;
+            }
+
+            var toolName    = node["tool_name"]?.GetValue<string>();
+            var toolInput   = ExtractElement(node, "tool_input");
+            var suggestions = ExtractElement(node, "permission_suggestions");
+
+            // Use a CTS chained on the request's lifetime so a closed/aborted local connection
+            // (Claude exit, daemon shutdown) cancels the SignalR call promptly.
+            using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            PermissionDecision decision;
+
+            try {
+                decision = await server.RequestPermissionAsync(sessionId, toolName, toolInput, suggestions, requestCts.Token);
+            } catch (Exception ex) {
+                LogRequestPermissionFailed(logger, ex, sessionId);
+                decision = new PermissionDecision("deny", null, null);
+            }
+
+            var responseJson = BuildHookResponseJson(decision);
+            var bytes        = Encoding.UTF8.GetBytes(responseJson);
+
+            context.Response.ContentType   = "application/json";
+            context.Response.StatusCode    = 200;
+            context.Response.ContentLength64 = bytes.LongLength;
+            await context.Response.OutputStream.WriteAsync(bytes, ct);
+            context.Response.Close();
+        } catch (Exception ex) {
+            LogBridgeHandlerError(logger, ex);
+
+            try {
+                context.Response.StatusCode = 500;
+                context.Response.Close();
+            } catch { /* response already closed */ }
+        }
+    }
+
+    static JsonElement? ExtractElement(JsonNode root, string property) {
+        var child = root[property];
+        if (child is null) return null;
+
+        // JsonNode → JsonElement via raw JSON is the AOT-safe path; child.GetValue<JsonElement>()
+        // is finicky on JsonObject children.
+        return JsonDocument.Parse(child.ToJsonString()).RootElement.Clone();
+    }
+
+    static string BuildHookResponseJson(PermissionDecision decision) {
+        // Mirrors the server-side BuildHookResponse. Claude expects camelCase keys here
+        // (hookSpecificOutput, hookEventName, applyPermissions, updatedInput) — these are
+        // outside the server's snake_case JSON convention because Claude defines them.
+        var decisionNode = new JsonObject { ["behavior"] = decision.Behavior };
+
+        if (decision.ApplyPermissions is { } ap) decisionNode["applyPermissions"] = JsonNode.Parse(ap.GetRawText());
+        if (decision.UpdatedInput is { } ui)     decisionNode["updatedInput"]     = JsonNode.Parse(ui.GetRawText());
+
+        var payload = new JsonObject {
+            ["hookSpecificOutput"] = new JsonObject {
+                ["hookEventName"] = "PermissionRequest",
+                ["decision"]      = decisionNode
+            }
+        };
+
+        return payload.ToJsonString();
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Local permission bridge listening on {BaseUrl}")]
+    static partial void LogBridgeStarted(ILogger logger, string baseUrl);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "RequestPermission via SignalR failed for session {SessionId}; falling back to deny")]
+    static partial void LogRequestPermissionFailed(ILogger logger, Exception exception, string sessionId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Permission bridge handler error")]
+    static partial void LogBridgeHandlerError(ILogger logger, Exception exception);
+}

--- a/src/kapacitor/Daemon/Services/LocalPermissionBridge.cs
+++ b/src/kapacitor/Daemon/Services/LocalPermissionBridge.cs
@@ -24,24 +24,50 @@ internal sealed partial class LocalPermissionBridge(
         ServerConnection                server,
         ILogger<LocalPermissionBridge>  logger
     ) : IHostedService, IAsyncDisposable {
+    const int    MaxBindAttempts = 8;
+    const string PathPrefix      = "/permission-request";
+
     HttpListener?            _listener;
     Task?                    _acceptLoop;
     CancellationTokenSource? _cts;
+    string?                  _token;
 
+    /// <summary>
+    /// Full URL the spawned CLI hook command should POST to. Includes the random per-run
+    /// token as a path segment so unrelated local processes can't pose as a Claude hook
+    /// even if they discover the ephemeral port.
+    /// </summary>
     public string? BaseUrl { get; private set; }
 
     public Task StartAsync(CancellationToken cancellationToken) {
-        var port = ReserveFreeLoopbackPort();
+        // The TcpListener-based port probe has a TOCTOU window before HttpListener.Start
+        // binds the same port. Retry up to MaxBindAttempts on AddressAlreadyInUse so a
+        // single rare race doesn't crash daemon startup.
+        for (var attempt = 1; attempt <= MaxBindAttempts; attempt++) {
+            var port  = ReserveFreeLoopbackPort();
+            var token = Guid.NewGuid().ToString("N");
 
-        _listener = new HttpListener();
-        _listener.Prefixes.Add($"http://127.0.0.1:{port}/");
-        _listener.Start();
+            var listener = new HttpListener();
+            listener.Prefixes.Add($"http://127.0.0.1:{port}/{token}/");
 
-        BaseUrl = $"http://127.0.0.1:{port}";
-        _cts    = new CancellationTokenSource();
+            try {
+                listener.Start();
+                _listener = listener;
+                _token    = token;
+                BaseUrl   = $"http://127.0.0.1:{port}/{token}";
+                break;
+            } catch (HttpListenerException ex) when (attempt < MaxBindAttempts) {
+                LogBindRetry(logger, attempt, port, ex.Message);
+                listener.Close();
+            }
+        }
 
+        if (_listener is null)
+            throw new InvalidOperationException($"Failed to bind LocalPermissionBridge after {MaxBindAttempts} attempts");
+
+        _cts        = new CancellationTokenSource();
         _acceptLoop = Task.Run(() => AcceptLoopAsync(_cts.Token), _cts.Token);
-        LogBridgeStarted(logger, BaseUrl);
+        LogBridgeStarted(logger, BaseUrl!);
 
         return Task.CompletedTask;
     }
@@ -93,7 +119,13 @@ internal sealed partial class LocalPermissionBridge(
 
     async Task HandleAsync(HttpListenerContext context, CancellationToken ct) {
         try {
-            if (context.Request.Url?.AbsolutePath != "/permission-request" || context.Request.HttpMethod != "POST") {
+            // Require token + endpoint match. Token check first (constant-time-ish via string
+            // equality is fine — discovery vector is the env var, not timing). The HttpListener
+            // prefix already filters to /{token}/, but check explicitly so a misconfigured
+            // listener prefix can't quietly admit anything.
+            var path = context.Request.Url?.AbsolutePath;
+
+            if (path != $"/{_token}{PathPrefix}" || context.Request.HttpMethod != "POST") {
                 context.Response.StatusCode = 404;
                 context.Response.Close();
                 return;
@@ -124,13 +156,16 @@ internal sealed partial class LocalPermissionBridge(
             var toolInput   = ExtractElement(node, "tool_input");
             var suggestions = ExtractElement(node, "permission_suggestions");
 
-            // Use a CTS chained on the request's lifetime so a closed/aborted local connection
-            // (Claude exit, daemon shutdown) cancels the SignalR call promptly.
-            using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            // The HttpListener API doesn't expose a per-request "client disconnected" token,
+            // so the SignalR call is bound to the daemon-shutdown token only. If Claude exits
+            // mid-wait, the server hub call stays open until the user decides or the session
+            // ends — wasteful but bounded by the ServerConnection's connection lifetime.
+            // Switching to Kestrel + HttpContext.RequestAborted would give us per-request
+            // cancellation; out of scope for this PR.
             PermissionDecision decision;
 
             try {
-                decision = await server.RequestPermissionAsync(sessionId, toolName, toolInput, suggestions, requestCts.Token);
+                decision = await server.RequestPermissionAsync(sessionId, toolName, toolInput, suggestions, ct);
             } catch (Exception ex) {
                 LogRequestPermissionFailed(logger, ex, sessionId);
                 decision = new PermissionDecision("deny", null, null);
@@ -159,8 +194,10 @@ internal sealed partial class LocalPermissionBridge(
         if (child is null) return null;
 
         // JsonNode → JsonElement via raw JSON is the AOT-safe path; child.GetValue<JsonElement>()
-        // is finicky on JsonObject children.
-        return JsonDocument.Parse(child.ToJsonString()).RootElement.Clone();
+        // is finicky on JsonObject children. Dispose the document — Clone() copies the buffer
+        // so the returned element stays valid.
+        using var doc = JsonDocument.Parse(child.ToJsonString());
+        return doc.RootElement.Clone();
     }
 
     static string BuildHookResponseJson(PermissionDecision decision) {
@@ -184,6 +221,9 @@ internal sealed partial class LocalPermissionBridge(
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Local permission bridge listening on {BaseUrl}")]
     static partial void LogBridgeStarted(ILogger logger, string baseUrl);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Local permission bridge bind attempt {Attempt} on port {Port} failed: {Reason} — retrying")]
+    static partial void LogBindRetry(ILogger logger, int attempt, int port, string reason);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "RequestPermission via SignalR failed for session {SessionId}; falling back to deny")]
     static partial void LogRequestPermissionFailed(ILogger logger, Exception exception, string sessionId);

--- a/src/kapacitor/Daemon/Services/LocalPermissionBridge.cs
+++ b/src/kapacitor/Daemon/Services/LocalPermissionBridge.cs
@@ -41,8 +41,9 @@ internal sealed partial class LocalPermissionBridge(
 
     public Task StartAsync(CancellationToken cancellationToken) {
         // The TcpListener-based port probe has a TOCTOU window before HttpListener.Start
-        // binds the same port. Retry up to MaxBindAttempts on AddressAlreadyInUse so a
-        // single rare race doesn't crash daemon startup.
+        // binds the same port. Retry up to MaxBindAttempts on TRANSIENT bind failures so a
+        // single rare race doesn't crash daemon startup. Non-transient errors (URLACL on
+        // Windows, permission issues) bubble up immediately so they aren't masked.
         for (var attempt = 1; attempt <= MaxBindAttempts; attempt++) {
             var port  = ReserveFreeLoopbackPort();
             var token = Guid.NewGuid().ToString("N");
@@ -56,7 +57,7 @@ internal sealed partial class LocalPermissionBridge(
                 _token    = token;
                 BaseUrl   = $"http://127.0.0.1:{port}/{token}";
                 break;
-            } catch (HttpListenerException ex) when (attempt < MaxBindAttempts) {
+            } catch (HttpListenerException ex) when (attempt < MaxBindAttempts && IsAddressInUse(ex)) {
                 LogBindRetry(logger, attempt, port, ex.Message);
                 listener.Close();
             }
@@ -71,6 +72,15 @@ internal sealed partial class LocalPermissionBridge(
 
         return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// Detects "address already in use" across platforms. HttpListenerException's ErrorCode
+    /// is the underlying socket/Win32 error: 10048 = WSAEADDRINUSE (Windows), 48 = EADDRINUSE
+    /// (macOS), 98 = EADDRINUSE (Linux). Anything else (URLACL denial code 5, etc.) is not
+    /// transient and shouldn't be retried.
+    /// </summary>
+    static bool IsAddressInUse(HttpListenerException ex) =>
+        ex.ErrorCode is 10048 or 48 or 98;
 
     public async Task StopAsync(CancellationToken cancellationToken) {
         if (_cts is not null) await _cts.CancelAsync();
@@ -133,7 +143,18 @@ internal sealed partial class LocalPermissionBridge(
 
             using var reader = new StreamReader(context.Request.InputStream, Encoding.UTF8);
             var       body   = await reader.ReadToEndAsync(ct);
-            var       node   = JsonNode.Parse(body);
+
+            JsonNode? node;
+            try {
+                node = JsonNode.Parse(body);
+            } catch (JsonException) {
+                // Malformed JSON from the local hook caller — that's a 400 (caller error),
+                // not a 500 (daemon failure). Without this branch the outer Exception catch
+                // would mislabel client-side parse errors as server faults.
+                context.Response.StatusCode = 400;
+                context.Response.Close();
+                return;
+            }
 
             if (node is null) {
                 context.Response.StatusCode = 400;

--- a/src/kapacitor/Daemon/Services/ServerConnection.cs
+++ b/src/kapacitor/Daemon/Services/ServerConnection.cs
@@ -221,6 +221,31 @@ internal partial class ServerConnection : IAsyncDisposable {
     public Task LaunchFailedAsync(string agentId, string reason)
         => _hub.InvokeAsync("LaunchFailed", new LaunchFailed(agentId, reason), cancellationToken: _ct);
 
+    /// <summary>
+    /// Forwards a hosted-agent permission request to the server's <c>RequestPermission</c>
+    /// hub method and returns the user's decision. Runs over the persistent SignalR
+    /// connection so the long-poll isn't subject to the Cloudflare HTTP-request timeout
+    /// that severs the equivalent <c>/hooks/permission-request</c> route at ~120s.
+    /// The provided <paramref name="ct"/> should be the local hook caller's lifetime
+    /// (the daemon's HTTP listener tracks the incoming request); cancellation propagates
+    /// to the server which translates it into a synthesised "deny" decision.
+    /// </summary>
+    public Task<PermissionDecision> RequestPermissionAsync(
+            string            sessionId,
+            string?           toolName,
+            JsonElement?      toolInput,
+            JsonElement?      suggestions,
+            CancellationToken ct
+        ) =>
+        _hub.InvokeAsync<PermissionDecision>(
+            "RequestPermission",
+            sessionId,
+            toolName,
+            toolInput,
+            suggestions,
+            cancellationToken: ct
+        );
+
     public Task SendTerminalOutputAsync(string agentId, string base64Data)
         => _hub.SendAsync("SendTerminalOutput", new TerminalOutput(agentId, base64Data), cancellationToken: _ct);
 

--- a/src/kapacitor/Daemon/Services/ServerConnection.cs
+++ b/src/kapacitor/Daemon/Services/ServerConnection.cs
@@ -226,9 +226,10 @@ internal partial class ServerConnection : IAsyncDisposable {
     /// hub method and returns the user's decision. Runs over the persistent SignalR
     /// connection so the long-poll isn't subject to the Cloudflare HTTP-request timeout
     /// that severs the equivalent <c>/hooks/permission-request</c> route at ~120s.
-    /// The provided <paramref name="ct"/> should be the local hook caller's lifetime
-    /// (the daemon's HTTP listener tracks the incoming request); cancellation propagates
-    /// to the server which translates it into a synthesised "deny" decision.
+    /// The provided <paramref name="ct"/> typically tracks daemon shutdown — HttpListener
+    /// in the bridge doesn't surface a per-request "client disconnected" signal, so a
+    /// Claude process exiting mid-wait won't cancel this call. Switching the bridge to
+    /// Kestrel + <c>HttpContext.RequestAborted</c> would give us per-request cancellation.
     /// </summary>
     public Task<PermissionDecision> RequestPermissionAsync(
             string            sessionId,

--- a/src/kapacitor/Models.cs
+++ b/src/kapacitor/Models.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
@@ -468,12 +469,26 @@ record RepoEntry {
 [JsonSerializable(typeof(AgentRunStarted))]
 [JsonSerializable(typeof(AgentRunStopped))]
 [JsonSerializable(typeof(AgentRunHeartbeat))]
+[JsonSerializable(typeof(PermissionDecision))]
 [JsonSerializable(typeof(int))]
 [JsonSerializable(typeof(string))]
 [JsonSerializable(typeof(string[]))]
 [JsonSerializable(typeof(RepoEntry[]))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 partial class KapacitorJsonContext : JsonSerializerContext;
+
+/// <summary>
+/// Decision returned by the server's <c>RequestPermission</c> SignalR hub method.
+/// Mirrors <c>PermissionResponseEntry</c> on the server side. ApplyPermissions /
+/// UpdatedInput are typed as <see cref="JsonElement"/> so the daemon can relay
+/// them verbatim into Claude's hook decision payload without the server having
+/// to know about the hook wire shape.
+/// </summary>
+public readonly record struct PermissionDecision(
+        string       Behavior,
+        JsonElement? ApplyPermissions,
+        JsonElement? UpdatedInput
+    );
 
 /// <summary>Commands sent from the server to daemon clients via SignalR.</summary>
 public readonly record struct LaunchAgentCommand(


### PR DESCRIPTION
## Summary

Pair with the server PR `kurrent-io/Kurrent.Capacitor#558`. Together they move the hosted-agent permission long-poll off HTTP (where Cloudflare cuts it at ~120s) onto the daemon's persistent SignalR connection.

- New \`LocalPermissionBridge\` IHostedService — an \`HttpListener\` bound to \`127.0.0.1\` on a random ephemeral port. \`POST /permission-request\` reads Claude's hook payload, calls \`ServerConnection.RequestPermissionAsync\`, wraps the decision into Claude's hook-response shape (mirrors the server's \`BuildHookResponse\`), returns it.
- New \`ServerConnection.RequestPermissionAsync\` — invokes the server's \`RequestPermission\` hub method over the existing \`_hub\` connection.
- \`PermissionDecision\` record struct in \`Models.cs\`, added to \`KapacitorJsonContext\` source-gen for AOT.
- \`AgentOrchestrator\` injects \`LocalPermissionBridge\` and adds \`KAPACITOR_DAEMON_URL=http://127.0.0.1:<port>\` to every spawned Claude's env.
- \`PermissionRequestCommand.HandleRenderedAgent\` prefers the daemon URL when set; falls back to the existing HTTPS \`/hooks/permission-request\` path when absent (older daemons / direct integrations).

## Test plan

- [x] \`dotnet build\` clean
- [x] \`dotnet publish -c Release\` (AOT) clean — no IL2026/IL3050 from new code
- [ ] Pair-deploy with server PR #558; redeploy daemon locally; launch a hosted agent that triggers a permission. Wait >5min before clicking Allow; Claude should proceed with the chosen behaviour.
- [ ] No \`Permission request cancelled for session\` line on the server during a successful long wait.
- [ ] Cancel path: kill the daemon mid-request — server's SignalR connection-aborted token cancels the in-flight \`tcs.Task.WaitAsync\`.

## Related

- Server PR: kurrent-io/Kurrent.Capacitor#558
- Stopgap PR: kurrent-io/Kurrent.Capacitor#557 (cancel-state cleanup; independent, can land in any order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)