### PR TITLE
[DEV-1663] Tests for hosted-agent permission flow (CLI side)

### DIFF
--- a/src/kapacitor/Commands/PermissionRequestCommand.cs
+++ b/src/kapacitor/Commands/PermissionRequestCommand.cs
@@ -67,7 +67,7 @@ static class PermissionRequestCommand {
         return await PostAsync(baseUrl + "/hooks/permission-request", payload, authenticated: true);
     }
 
-    static bool TryGetLoopbackDaemonUrl(out string daemonUrl) {
+    internal static bool TryGetLoopbackDaemonUrl(out string daemonUrl) {
         daemonUrl = "";
         var raw = Environment.GetEnvironmentVariable("KAPACITOR_DAEMON_URL");
         if (string.IsNullOrEmpty(raw)) return false;

--- a/src/kapacitor/Daemon/Services/ServerConnection.cs
+++ b/src/kapacitor/Daemon/Services/ServerConnection.cs
@@ -231,7 +231,7 @@ internal partial class ServerConnection : IAsyncDisposable {
     /// Claude process exiting mid-wait won't cancel this call. Switching the bridge to
     /// Kestrel + <c>HttpContext.RequestAborted</c> would give us per-request cancellation.
     /// </summary>
-    public Task<PermissionDecision> RequestPermissionAsync(
+    public virtual Task<PermissionDecision> RequestPermissionAsync(
             string            sessionId,
             string?           toolName,
             JsonElement?      toolInput,

--- a/test/kapacitor.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/kapacitor.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -1,4 +1,6 @@
+using System.Net;
 using System.Net.Http.Json;
+using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 using kapacitor.Daemon;
@@ -237,7 +239,7 @@ public class LocalPermissionBridgeTests {
 
             // After stop, the port should accept a fresh bind. If StopAsync didn't release
             // it, this would either throw or hang.
-            var probe = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, port);
+            var probe = new TcpListener(IPAddress.Loopback, port);
             try {
                 probe.Start();
             } finally {

--- a/test/kapacitor.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/kapacitor.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -1,0 +1,278 @@
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using kapacitor.Daemon;
+using kapacitor.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace kapacitor.Tests.Unit;
+
+public class LocalPermissionBridgeTests {
+    static (LocalPermissionBridge bridge, FakeServerConnection server) CreateBridge(
+        Func<string, string?, JsonElement?, JsonElement?, CancellationToken, Task<PermissionDecision>>? respond = null
+    ) {
+        var server = new FakeServerConnection(respond);
+        var bridge = new LocalPermissionBridge(server, NullLogger<LocalPermissionBridge>.Instance);
+
+        return (bridge, server);
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task StartAsync_ExposesLoopbackBaseUrlWithToken() {
+        var (bridge, _) = CreateBridge();
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            await Assert.That(bridge.BaseUrl).IsNotNull();
+            var uri = new Uri(bridge.BaseUrl!);
+
+            await Assert.That(uri.Host).IsEqualTo("127.0.0.1");
+            await Assert.That(uri.Scheme).IsEqualTo("http");
+
+            // Path is "/<32-char hex token>"
+            var token = uri.AbsolutePath.Trim('/');
+            await Assert.That(token.Length).IsEqualTo(32);
+            await Assert.That(token.All(Uri.IsHexDigit)).IsTrue();
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task PostingToWrongTokenReturns404() {
+        var (bridge, _) = CreateBridge();
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            var uri      = new Uri(bridge.BaseUrl!);
+            var bogusUrl = $"http://127.0.0.1:{uri.Port}/{new string('0', 32)}/permission-request";
+
+            using var client   = new HttpClient();
+            using var response = await client.PostAsync(bogusUrl, JsonContent.Create(new { session_id = "abc" }));
+
+            await Assert.That((int)response.StatusCode).IsEqualTo(404);
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task PostingToWrongPathReturns404() {
+        var (bridge, _) = CreateBridge();
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client   = new HttpClient();
+            using var response = await client.PostAsync($"{bridge.BaseUrl}/something-else", JsonContent.Create(new { session_id = "abc" }));
+
+            await Assert.That((int)response.StatusCode).IsEqualTo(404);
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task GetReturns404() {
+        var (bridge, _) = CreateBridge();
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client   = new HttpClient();
+            using var response = await client.GetAsync($"{bridge.BaseUrl}/permission-request");
+
+            await Assert.That((int)response.StatusCode).IsEqualTo(404);
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task MalformedJsonReturns400() {
+        var (bridge, _) = CreateBridge();
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client   = new HttpClient();
+            using var content  = new StringContent("{ this is not json", Encoding.UTF8, "application/json");
+            using var response = await client.PostAsync($"{bridge.BaseUrl}/permission-request", content);
+
+            await Assert.That((int)response.StatusCode).IsEqualTo(400);
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task MissingSessionIdReturns400() {
+        var (bridge, _) = CreateBridge();
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client   = new HttpClient();
+            using var response = await client.PostAsync($"{bridge.BaseUrl}/permission-request", JsonContent.Create(new { tool_name = "Bash" }));
+
+            await Assert.That((int)response.StatusCode).IsEqualTo(400);
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task ValidRequestStripsDashesAndForwardsArgsToServer() {
+        var (bridge, server) = CreateBridge((sid, tool, input, suggestions, _) =>
+            Task.FromResult(new PermissionDecision("allow", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client = new HttpClient();
+            var       payload = new {
+                session_id             = "11111111-2222-3333-4444-555555555555",
+                tool_name              = "Bash",
+                tool_input             = new { command = "ls" },
+                permission_suggestions = new { reason = "ok" }
+            };
+            using var response = await client.PostAsync($"{bridge.BaseUrl}/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)response.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(1);
+
+            var call = server.Calls[0];
+            await Assert.That(call.SessionId).IsEqualTo("11111111222233334444555555555555");
+            await Assert.That(call.ToolName).IsEqualTo("Bash");
+            await Assert.That(call.ToolInput?.GetProperty("command").GetString()).IsEqualTo("ls");
+            await Assert.That(call.Suggestions?.GetProperty("reason").GetString()).IsEqualTo("ok");
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task ResponseShapeMirrorsClaudeHookSchema() {
+        var (bridge, _) = CreateBridge((_, _, _, _, _) =>
+            Task.FromResult(new PermissionDecision("allow", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client   = new HttpClient();
+            using var response = await client.PostAsync($"{bridge.BaseUrl}/permission-request", JsonContent.Create(new { session_id = "abc" }));
+
+            var body = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+
+            var hookOutput = doc.RootElement.GetProperty("hookSpecificOutput");
+            await Assert.That(hookOutput.GetProperty("hookEventName").GetString()).IsEqualTo("PermissionRequest");
+            await Assert.That(hookOutput.GetProperty("decision").GetProperty("behavior").GetString()).IsEqualTo("allow");
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task ApplyPermissionsAndUpdatedInputAreCopiedIntoDecision() {
+        using var apDoc = JsonDocument.Parse("""{"allow":["Bash(ls:*)"]}""");
+        using var uiDoc = JsonDocument.Parse("""{"command":"ls -la"}""");
+
+        var (bridge, _) = CreateBridge((_, _, _, _, _) =>
+            Task.FromResult(new PermissionDecision("allow", apDoc.RootElement.Clone(), uiDoc.RootElement.Clone()))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client   = new HttpClient();
+            using var response = await client.PostAsync($"{bridge.BaseUrl}/permission-request", JsonContent.Create(new { session_id = "abc" }));
+
+            var body = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+
+            var decision = doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("decision");
+            await Assert.That(decision.GetProperty("applyPermissions").GetProperty("allow")[0].GetString()).IsEqualTo("Bash(ls:*)");
+            await Assert.That(decision.GetProperty("updatedInput").GetProperty("command").GetString()).IsEqualTo("ls -la");
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task ServerFailureFallsBackToDeny() {
+        var (bridge, _) = CreateBridge((_, _, _, _, _) =>
+            throw new InvalidOperationException("hub call broke")
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client   = new HttpClient();
+            using var response = await client.PostAsync($"{bridge.BaseUrl}/permission-request", JsonContent.Create(new { session_id = "abc" }));
+
+            await Assert.That((int)response.StatusCode).IsEqualTo(200);
+
+            var body = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+
+            var decision = doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("decision");
+            await Assert.That(decision.GetProperty("behavior").GetString()).IsEqualTo("deny");
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task StopAsyncReleasesPort() {
+        var (bridge, _) = CreateBridge();
+        await bridge.StartAsync(CancellationToken.None);
+
+        var port = new Uri(bridge.BaseUrl!).Port;
+        await bridge.StopAsync(CancellationToken.None);
+
+        // After stop, the port should accept a fresh bind. If StopAsync didn't release
+        // it, this would either throw or hang.
+        var probe = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, port);
+        try {
+            probe.Start();
+        } finally {
+            probe.Stop();
+        }
+
+        await bridge.DisposeAsync();
+    }
+}
+
+/// <summary>
+/// Bypasses ServerConnection's HubConnection plumbing so the bridge can be exercised
+/// without a real server. RequestPermissionAsync is virtual on the base class.
+/// </summary>
+sealed class FakeServerConnection : ServerConnection {
+    readonly Func<string, string?, JsonElement?, JsonElement?, CancellationToken, Task<PermissionDecision>>? _respond;
+
+    public List<Call> Calls { get; } = [];
+
+    public FakeServerConnection(
+        Func<string, string?, JsonElement?, JsonElement?, CancellationToken, Task<PermissionDecision>>? respond
+    ) : base(
+        new DaemonConfig { Name = "test", ServerUrl = "http://127.0.0.1:1" },
+        NullLogger<ServerConnection>.Instance
+    ) {
+        _respond = respond;
+    }
+
+    public override Task<PermissionDecision> RequestPermissionAsync(
+            string            sessionId,
+            string?           toolName,
+            JsonElement?      toolInput,
+            JsonElement?      suggestions,
+            CancellationToken ct
+        ) {
+        Calls.Add(new Call(sessionId, toolName, toolInput, suggestions));
+
+        return _respond is null
+            ? Task.FromResult(new PermissionDecision("allow", null, null))
+            : _respond(sessionId, toolName, toolInput, suggestions, ct);
+    }
+
+    public sealed record Call(string SessionId, string? ToolName, JsonElement? ToolInput, JsonElement? Suggestions);
+}

--- a/test/kapacitor.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/kapacitor.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -17,6 +17,11 @@ public class LocalPermissionBridgeTests {
         return (bridge, server);
     }
 
+    // Short HttpClient timeout so a misbehaving listener fails the test in seconds rather than
+    // stalling the suite on the default ~100s. Bridge replies are loopback and immediate, so
+    // anything past 5s indicates a regression worth surfacing fast.
+    static HttpClient CreateClient() => new() { Timeout = TimeSpan.FromSeconds(5) };
+
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
     public async Task StartAsync_ExposesLoopbackBaseUrlWithToken() {
         var (bridge, _) = CreateBridge();
@@ -47,7 +52,7 @@ public class LocalPermissionBridgeTests {
             var uri      = new Uri(bridge.BaseUrl!);
             var bogusUrl = $"http://127.0.0.1:{uri.Port}/{new string('0', 32)}/permission-request";
 
-            using var client   = new HttpClient();
+            using var client   = CreateClient();
             using var response = await client.PostAsync(bogusUrl, JsonContent.Create(new { session_id = "abc" }));
 
             await Assert.That((int)response.StatusCode).IsEqualTo(404);
@@ -62,7 +67,7 @@ public class LocalPermissionBridgeTests {
         try {
             await bridge.StartAsync(CancellationToken.None);
 
-            using var client   = new HttpClient();
+            using var client   = CreateClient();
             using var response = await client.PostAsync($"{bridge.BaseUrl}/something-else", JsonContent.Create(new { session_id = "abc" }));
 
             await Assert.That((int)response.StatusCode).IsEqualTo(404);
@@ -77,7 +82,7 @@ public class LocalPermissionBridgeTests {
         try {
             await bridge.StartAsync(CancellationToken.None);
 
-            using var client   = new HttpClient();
+            using var client   = CreateClient();
             using var response = await client.GetAsync($"{bridge.BaseUrl}/permission-request");
 
             await Assert.That((int)response.StatusCode).IsEqualTo(404);
@@ -92,7 +97,7 @@ public class LocalPermissionBridgeTests {
         try {
             await bridge.StartAsync(CancellationToken.None);
 
-            using var client   = new HttpClient();
+            using var client   = CreateClient();
             using var content  = new StringContent("{ this is not json", Encoding.UTF8, "application/json");
             using var response = await client.PostAsync($"{bridge.BaseUrl}/permission-request", content);
 
@@ -108,7 +113,7 @@ public class LocalPermissionBridgeTests {
         try {
             await bridge.StartAsync(CancellationToken.None);
 
-            using var client   = new HttpClient();
+            using var client   = CreateClient();
             using var response = await client.PostAsync($"{bridge.BaseUrl}/permission-request", JsonContent.Create(new { tool_name = "Bash" }));
 
             await Assert.That((int)response.StatusCode).IsEqualTo(400);
@@ -126,7 +131,7 @@ public class LocalPermissionBridgeTests {
         try {
             await bridge.StartAsync(CancellationToken.None);
 
-            using var client = new HttpClient();
+            using var client = CreateClient();
             var       payload = new {
                 session_id             = "11111111-2222-3333-4444-555555555555",
                 tool_name              = "Bash",
@@ -157,7 +162,7 @@ public class LocalPermissionBridgeTests {
         try {
             await bridge.StartAsync(CancellationToken.None);
 
-            using var client   = new HttpClient();
+            using var client   = CreateClient();
             using var response = await client.PostAsync($"{bridge.BaseUrl}/permission-request", JsonContent.Create(new { session_id = "abc" }));
 
             var body = await response.Content.ReadAsStringAsync();
@@ -183,7 +188,7 @@ public class LocalPermissionBridgeTests {
         try {
             await bridge.StartAsync(CancellationToken.None);
 
-            using var client   = new HttpClient();
+            using var client   = CreateClient();
             using var response = await client.PostAsync($"{bridge.BaseUrl}/permission-request", JsonContent.Create(new { session_id = "abc" }));
 
             var body = await response.Content.ReadAsStringAsync();
@@ -206,7 +211,7 @@ public class LocalPermissionBridgeTests {
         try {
             await bridge.StartAsync(CancellationToken.None);
 
-            using var client   = new HttpClient();
+            using var client   = CreateClient();
             using var response = await client.PostAsync($"{bridge.BaseUrl}/permission-request", JsonContent.Create(new { session_id = "abc" }));
 
             await Assert.That((int)response.StatusCode).IsEqualTo(200);
@@ -224,21 +229,25 @@ public class LocalPermissionBridgeTests {
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
     public async Task StopAsyncReleasesPort() {
         var (bridge, _) = CreateBridge();
-        await bridge.StartAsync(CancellationToken.None);
-
-        var port = new Uri(bridge.BaseUrl!).Port;
-        await bridge.StopAsync(CancellationToken.None);
-
-        // After stop, the port should accept a fresh bind. If StopAsync didn't release
-        // it, this would either throw or hang.
-        var probe = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, port);
         try {
-            probe.Start();
-        } finally {
-            probe.Stop();
-        }
+            await bridge.StartAsync(CancellationToken.None);
 
-        await bridge.DisposeAsync();
+            var port = new Uri(bridge.BaseUrl!).Port;
+            await bridge.StopAsync(CancellationToken.None);
+
+            // After stop, the port should accept a fresh bind. If StopAsync didn't release
+            // it, this would either throw or hang.
+            var probe = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, port);
+            try {
+                probe.Start();
+            } finally {
+                probe.Stop();
+            }
+        } finally {
+            // Ensure DisposeAsync runs even if the probe.Start() above throws — otherwise the
+            // listener / CTS leak into later tests in the same process.
+            await bridge.DisposeAsync();
+        }
     }
 }
 

--- a/test/kapacitor.Tests.Unit/PermissionRequestCommandTests.cs
+++ b/test/kapacitor.Tests.Unit/PermissionRequestCommandTests.cs
@@ -1,0 +1,92 @@
+using kapacitor.Commands;
+
+namespace kapacitor.Tests.Unit;
+
+public class PermissionRequestCommandTests {
+    const string EnvVar = "KAPACITOR_DAEMON_URL";
+
+    [Test, NotInParallel(nameof(PermissionRequestCommandTests))]
+    public async Task ReturnsFalseWhenEnvVarIsUnset() {
+        using var _ = new EnvVarScope(EnvVar, null);
+
+        var ok = PermissionRequestCommand.TryGetLoopbackDaemonUrl(out var url);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(url).IsEqualTo("");
+    }
+
+    [Test, NotInParallel(nameof(PermissionRequestCommandTests))]
+    public async Task ReturnsFalseWhenEnvVarIsEmpty() {
+        using var _ = new EnvVarScope(EnvVar, "");
+
+        var ok = PermissionRequestCommand.TryGetLoopbackDaemonUrl(out var url);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(url).IsEqualTo("");
+    }
+
+    [Test, NotInParallel(nameof(PermissionRequestCommandTests))]
+    public async Task AcceptsLoopbackHttpAndTrimsTrailingSlash() {
+        using var _ = new EnvVarScope(EnvVar, "http://127.0.0.1:51234/abc/");
+
+        var ok = PermissionRequestCommand.TryGetLoopbackDaemonUrl(out var url);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(url).IsEqualTo("http://127.0.0.1:51234/abc");
+    }
+
+    [Test, NotInParallel(nameof(PermissionRequestCommandTests))]
+    public async Task AcceptsLocalhostHttp() {
+        using var _ = new EnvVarScope(EnvVar, "http://localhost:51234/tok");
+
+        var ok = PermissionRequestCommand.TryGetLoopbackDaemonUrl(out var url);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(url).IsEqualTo("http://localhost:51234/tok");
+    }
+
+    [Test, NotInParallel(nameof(PermissionRequestCommandTests))]
+    public async Task RejectsNonLoopbackHost() {
+        using var _ = new EnvVarScope(EnvVar, "http://example.com:8080/tok");
+
+        var ok = PermissionRequestCommand.TryGetLoopbackDaemonUrl(out var url);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(url).IsEqualTo("");
+    }
+
+    [Test, NotInParallel(nameof(PermissionRequestCommandTests))]
+    public async Task RejectsHttpsLoopback() {
+        // The daemon bridge is plain http on loopback — https implies a different
+        // endpoint and shouldn't be accepted via this env var.
+        using var _ = new EnvVarScope(EnvVar, "https://127.0.0.1:51234/tok");
+
+        var ok = PermissionRequestCommand.TryGetLoopbackDaemonUrl(out var url);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(url).IsEqualTo("");
+    }
+
+    [Test, NotInParallel(nameof(PermissionRequestCommandTests))]
+    public async Task RejectsMalformedUrl() {
+        using var _ = new EnvVarScope(EnvVar, "not-a-url");
+
+        var ok = PermissionRequestCommand.TryGetLoopbackDaemonUrl(out var url);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(url).IsEqualTo("");
+    }
+}
+
+sealed class EnvVarScope : IDisposable {
+    readonly string  _name;
+    readonly string? _previous;
+
+    public EnvVarScope(string name, string? value) {
+        _name     = name;
+        _previous = Environment.GetEnvironmentVariable(name);
+        Environment.SetEnvironmentVariable(name, value);
+    }
+
+    public void Dispose() => Environment.SetEnvironmentVariable(_name, _previous);
+}


### PR DESCRIPTION
## Summary

DEV-1651 introduced the daemon-side `LocalPermissionBridge` that proxies hosted-agent permission requests over SignalR instead of HTTP (working around Cloudflare's 120s long-poll timeout). That PR shipped without dedicated tests — this fills the gap.

- **Two tiny refactors for testability** (no behavioral change):
  - `ServerConnection.RequestPermissionAsync` → `virtual` so a test double can override.
  - `PermissionRequestCommand.TryGetLoopbackDaemonUrl` → `internal` (was `private`).
- **`LocalPermissionBridgeTests`** covers the bridge end-to-end via real HTTP: BaseUrl shape, token-protected routing (404 on wrong token / path / method), JSON validation (400 on malformed / missing `session_id`), dash-stripping + arg forwarding, hook-response shape, `applyPermissions` / `updatedInput` propagation, fallback to `deny` on server failure, and clean port release on stop.
- **`PermissionRequestCommandTests`** covers `TryGetLoopbackDaemonUrl`: accept (loopback http, trim trailing slash, localhost) and reject (unset, empty, non-loopback, https, malformed).
- Both classes use `[NotInParallel]` — env vars are process-global and `HttpListener` cleanup races under TUnit's default parallelism on macOS.

Companion server-side PR: https://github.com/kurrent-io/kapacitor-server (DEV-1663) — covers `RunPermissionFlow` + the new `RequestPermission` hub method's daemon-only ownership gate.

## Test plan
- [x] `dotnet build src/kapacitor/kapacitor.csproj` clean
- [x] `dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj` — 382/382 pass (18 new)
- [x] `dotnet run --project test/kapacitor.Tests.Integration/kapacitor.Tests.Integration.csproj` — 4/4 pass (no regressions)
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — no IL2026/IL3050 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)