### PR TITLE
[DEV-1659] Restore executable bit on platform binaries before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,18 @@ jobs:
           for dir in npm-artifacts/npm-kapacitor-*/; do
             pkg_name=$(basename "$dir" | sed 's/^npm-//')
             cp "npm/$pkg_name/package.json" "$dir/package.json"
+
+            # actions/upload-artifact + download-artifact round-trips through ZIP,
+            # which drops the executable bit. The platform packages have no `bin`
+            # field in package.json (the wrapper resolves the binary path
+            # manually), so npm won't restore +x at install time either. Set it
+            # explicitly here so the published tarball ships an executable file.
+            if [[ "$pkg_name" == *win-x64* ]]; then
+              chmod +x "$dir/bin/kapacitor.exe"
+            else
+              chmod +x "$dir/bin/kapacitor"
+            fi
+
             cd "$dir"
             npm version "$VERSION" --no-git-tag-version --allow-same-version
             npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,10 +167,18 @@ jobs:
             # field in package.json (the wrapper resolves the binary path
             # manually), so npm won't restore +x at install time either. Set it
             # explicitly here so the published tarball ships an executable file.
-            if [[ "$pkg_name" == *win-x64* ]]; then
+            #
+            # Each platform package only has one of these (kapacitor or
+            # kapacitor.exe), set per the build matrix' `binary-name`. Pick by
+            # file existence instead of pkg_name pattern so adding new RIDs
+            # doesn't silently regress this step.
+            if [ -f "$dir/bin/kapacitor.exe" ]; then
               chmod +x "$dir/bin/kapacitor.exe"
-            else
+            elif [ -f "$dir/bin/kapacitor" ]; then
               chmod +x "$dir/bin/kapacitor"
+            else
+              echo "::error::No kapacitor binary found in $dir/bin (contents: $(ls "$dir/bin" 2>&1))"
+              exit 1
             fi
 
             cd "$dir"


### PR DESCRIPTION
## Summary

GitHub Actions' upload-artifact + download-artifact cycle round-trips through ZIP, which drops the Unix executable bit. The platform packages (`@kurrent/kapacitor-darwin-arm64` etc.) have no `bin` field in `package.json` — the wrapper resolves the binary path manually — so npm doesn't restore +x at install time either.

Result: `npm install -g @kurrent/kapacitor` lands a `-rw-r--r--` binary on disk. The `kapacitor.js` wrapper has an `accessSync(X_OK)` + `chmodSync(0o755)` fallback that heals it on next CLI invocation, but that's not enough in practice:

- A daemon started before the update keeps the old mmap'd binary alive (Unix lets a deleted/replaced inode keep running). A user who reinstalls but doesn't restart the daemon process keeps running stale code, no errors, no signal.
- This caused [DEV-1659](https://linear.app/kurrent/issue/DEV-1659) — a daemon running a pre-DEV-1632 binary silently dropped \`FindRepoForRemote\` SignalR probes, so the Review-PR dialog showed \"No connected daemon has a checkout of <repo>\" even though the daemon was connected and had the repo locally.

Fix: chmod +x in the publish-npm step so the published tarball ships an executable binary, matching what `dotnet publish` produces.

## Test plan

- [ ] Cut a pre-release tag, watch the publish workflow
- [ ] `npm install -g @kurrent/kapacitor@<pre>` and verify `ls -la $(npm root -g)/@kurrent/kapacitor-darwin-arm64/bin/kapacitor` shows `-rwxr-xr-x`
- [ ] `kapacitor --version` runs without the wrapper having to chmod first

🤖 Generated with [Claude Code](https://claude.com/claude-code)