### PR TITLE
[DEV-1664] Watch: self-terminate when parent claude dies

### DIFF
--- a/src/kapacitor/Commands/WatchCommand.cs
+++ b/src/kapacitor/Commands/WatchCommand.cs
@@ -14,7 +14,8 @@ static partial class WatchCommand {
             string  transcriptPath,
             string? agentId,
             string? cwd,
-            bool    skipTitle = false
+            bool    skipTitle = false,
+            int?    parentPid = null
         ) {
         // Redirect all output to a log file so we don't hold parent's pipe FDs open
         var logDir = PathHelpers.ConfigPath("logs");
@@ -33,6 +34,27 @@ static partial class WatchCommand {
             cts.Cancel();
         };
         PosixSignalRegistration.Create(PosixSignal.SIGTERM, _ => cts.Cancel());
+
+        // Watch the spawning claude process. If it dies without firing session-end
+        // (crash, force-kill, IDE-detach), self-terminate within ~5s instead of orphaning.
+        if (parentPid is { } ppid && ProcessHelpers.IsProcessAlive(ppid)) {
+            Log($"Monitoring parent pid {ppid}");
+            _ = Task.Run(async () => {
+                while (!cts.Token.IsCancellationRequested) {
+                    try {
+                        await Task.Delay(TimeSpan.FromSeconds(5), cts.Token);
+                    } catch (OperationCanceledException) {
+                        return;
+                    }
+
+                    if (!ProcessHelpers.IsProcessAlive(ppid)) {
+                        Log($"Parent pid {ppid} exited; shutting down watcher");
+                        cts.Cancel();
+                        return;
+                    }
+                }
+            }, cts.Token);
+        }
 
         var state = new WatchState();
 

--- a/src/kapacitor/ProcessHelpers.cs
+++ b/src/kapacitor/ProcessHelpers.cs
@@ -1,0 +1,113 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace kapacitor;
+
+static partial class ProcessHelpers {
+    // POSIX errno values used by IsProcessAliveUnix.
+    // kill(pid, 0) returns 0 if the process exists and we can signal it,
+    // -1 with errno = EPERM (1) if it exists but we can't signal it,
+    // -1 with errno = ESRCH (3) if no such process.
+    const int EPERM = 1;
+
+    [LibraryImport("libc", EntryPoint = "getppid")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial int getppid_native();
+
+    [LibraryImport("libc", EntryPoint = "kill", SetLastError = true)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial int kill_native(int pid, int sig);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial nint OpenProcess(uint dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, uint dwProcessId);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseHandle(nint hObject);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial uint WaitForSingleObject(nint hHandle, uint dwMilliseconds);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial nint GetCurrentProcess();
+
+    [LibraryImport("ntdll.dll")]
+    private static partial int NtQueryInformationProcess(
+        nint                          processHandle,
+        int                           processInformationClass,
+        ref ProcessBasicInformation   processInformation,
+        int                           processInformationLength,
+        out int                       returnLength
+    );
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct ProcessBasicInformation {
+        public  nint  ExitStatus;
+        public  nint  PebBaseAddress;
+        public  nint  AffinityMask;
+        public  nint  BasePriority;
+        public  nuint UniqueProcessId;
+        public  nuint InheritedFromUniqueProcessId;
+    }
+
+    const uint SYNCHRONIZE   = 0x00100000;
+    const uint WAIT_TIMEOUT  = 258;
+
+    /// <summary>
+    /// Returns the parent process id of the current process, or <c>null</c> on failure.
+    /// </summary>
+    public static int? GetParentPid() {
+        try {
+            return OperatingSystem.IsWindows() ? GetParentPidWindows() : getppid_native();
+        } catch {
+            return null;
+        }
+    }
+
+    static int? GetParentPidWindows() {
+        var handle = GetCurrentProcess();
+        var pbi    = default(ProcessBasicInformation);
+        var status = NtQueryInformationProcess(handle, 0, ref pbi, Unsafe.SizeOf<ProcessBasicInformation>(), out _);
+
+        return status == 0 ? (int)pbi.InheritedFromUniqueProcessId : null;
+    }
+
+    /// <summary>
+    /// Returns true if a process with the given id exists at the moment of the call.
+    /// PID reuse is theoretically possible but unlikely within a 5-second polling window.
+    /// </summary>
+    public static bool IsProcessAlive(int pid) {
+        if (pid <= 1) {
+            return false;
+        }
+
+        return OperatingSystem.IsWindows() ? IsProcessAliveWindows(pid) : IsProcessAliveUnix(pid);
+    }
+
+    static bool IsProcessAliveUnix(int pid) {
+        var rc = kill_native(pid, 0);
+
+        if (rc == 0) {
+            return true;
+        }
+
+        // Distinguish "no such process" (dead) from "permission denied" (alive but not signallable).
+        return Marshal.GetLastPInvokeError() == EPERM;
+    }
+
+    static bool IsProcessAliveWindows(int pid) {
+        var handle = OpenProcess(SYNCHRONIZE, false, (uint)pid);
+
+        if (handle == 0) {
+            return false;
+        }
+
+        try {
+            // WAIT_OBJECT_0 (0) = signalled => process has exited.
+            // WAIT_TIMEOUT       => still running.
+            return WaitForSingleObject(handle, 0) == WAIT_TIMEOUT;
+        } finally {
+            CloseHandle(handle);
+        }
+    }
+}

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -403,7 +403,7 @@ switch (command) {
         return await HistoryCommand.HandleHistory(baseUrl!, filterCwd, filterSession, minLines, generateSummaries);
     }
     case "watch" when args.Length < 3:
-        Console.Error.WriteLine("Usage: kapacitor watch <sessionId> <transcriptPath> [--agent-id <agentId>] [--cwd <cwd>] [--skip-title]");
+        Console.Error.WriteLine("Usage: kapacitor watch <sessionId> <transcriptPath> [--agent-id <agentId>] [--cwd <cwd>] [--skip-title] [--parent-pid <pid>]");
 
         return 1;
     case "watch": {
@@ -425,7 +425,14 @@ switch (command) {
 
         var watchSkipTitle = Array.IndexOf(args, "--skip-title") >= 0;
 
-        return await WatchCommand.RunWatch(baseUrl!, watchSessionId, watchPath, watchAgentId, watchCwd, watchSkipTitle);
+        int? parentPid    = null;
+        var  parentPidIdx = Array.IndexOf(args, "--parent-pid");
+
+        if (parentPidIdx >= 0 && parentPidIdx + 1 < args.Length && int.TryParse(args[parentPidIdx + 1], out var ppid)) {
+            parentPid = ppid;
+        }
+
+        return await WatchCommand.RunWatch(baseUrl!, watchSessionId, watchPath, watchAgentId, watchCwd, watchSkipTitle, parentPid);
     }
     case "permission-request":
         return await PermissionRequestCommand.Handle(baseUrl!);

--- a/src/kapacitor/WatcherManager.cs
+++ b/src/kapacitor/WatcherManager.cs
@@ -42,6 +42,12 @@ static class WatcherManager {
                 arguments += " --skip-title";
             }
 
+            // Pass the spawning hook's parent PID (claude) so the watcher can self-terminate
+            // if claude dies without firing session-end. Best-effort — skip if lookup fails.
+            if (ProcessHelpers.GetParentPid() is { } parentPid && parentPid > 1) {
+                arguments += $" --parent-pid {parentPid}";
+            }
+
             var psi = new ProcessStartInfo(kapacitorPath, arguments) {
                 RedirectStandardOutput = true,
                 RedirectStandardInput  = true,

--- a/test/kapacitor.Tests.Unit/ProcessHelpersTests.cs
+++ b/test/kapacitor.Tests.Unit/ProcessHelpersTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace kapacitor.Tests.Unit;
 
@@ -25,14 +26,15 @@ public class ProcessHelpersTests {
     [Test]
     public async Task IsProcessAlive_transitions_to_false_after_child_exits() {
         // Spawn a short-lived child process, capture its pid, wait for exit, then assert dead.
-        using var process = new Process {
-            StartInfo = new ProcessStartInfo("/bin/sh", "-c \"exit 0\"") {
-                RedirectStandardOutput = true,
-                RedirectStandardError  = true,
-                UseShellExecute        = false
-            }
-        };
+        var psi = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? new ProcessStartInfo("cmd.exe", "/c exit 0")
+            : new ProcessStartInfo("/bin/sh", "-c \"exit 0\"");
 
+        psi.RedirectStandardOutput = true;
+        psi.RedirectStandardError  = true;
+        psi.UseShellExecute        = false;
+
+        using var process = new Process { StartInfo = psi };
         process.Start();
         var pid = process.Id;
 

--- a/test/kapacitor.Tests.Unit/ProcessHelpersTests.cs
+++ b/test/kapacitor.Tests.Unit/ProcessHelpersTests.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+
+namespace kapacitor.Tests.Unit;
+
+public class ProcessHelpersTests {
+    [Test]
+    public async Task IsProcessAlive_returns_true_for_current_process() {
+        var alive = ProcessHelpers.IsProcessAlive(Environment.ProcessId);
+
+        await Assert.That(alive).IsTrue();
+    }
+
+    [Test]
+    public async Task IsProcessAlive_returns_false_for_pid_zero_or_one() {
+        // pid 0 is invalid; pid 1 is init/launchd which we treat as "no parent" by convention.
+        await Assert.That(ProcessHelpers.IsProcessAlive(0)).IsFalse();
+        await Assert.That(ProcessHelpers.IsProcessAlive(1)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsProcessAlive_returns_false_for_negative_pid() {
+        await Assert.That(ProcessHelpers.IsProcessAlive(-1)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsProcessAlive_transitions_to_false_after_child_exits() {
+        // Spawn a short-lived child process, capture its pid, wait for exit, then assert dead.
+        using var process = new Process {
+            StartInfo = new ProcessStartInfo("/bin/sh", "-c \"exit 0\"") {
+                RedirectStandardOutput = true,
+                RedirectStandardError  = true,
+                UseShellExecute        = false
+            }
+        };
+
+        process.Start();
+        var pid = process.Id;
+
+        await Assert.That(ProcessHelpers.IsProcessAlive(pid)).IsTrue();
+
+        await process.WaitForExitAsync();
+
+        // Reap any zombie state so kill(pid, 0) reports ESRCH.
+        // On Unix, the OS clears the process table entry when the parent waits.
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+
+        while (DateTime.UtcNow < deadline && ProcessHelpers.IsProcessAlive(pid)) {
+            await Task.Delay(50);
+        }
+
+        await Assert.That(ProcessHelpers.IsProcessAlive(pid)).IsFalse();
+    }
+
+    [Test]
+    public async Task GetParentPid_returns_a_live_process() {
+        var ppid = ProcessHelpers.GetParentPid();
+
+        await Assert.That(ppid).IsNotNull();
+        await Assert.That(ProcessHelpers.IsProcessAlive(ppid!.Value)).IsTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds cross-platform parent-pid monitoring to `kapacitor watch` so it shuts down within ~5s if the spawning claude process crashes, is force-killed, or an IDE detaches the ACP agent without firing `session-end`.
- Previously these watchers reparented to init and reconnected to SignalR forever — encountered 25 orphans across two machines / 7 days, oldest 7 days old.
- Issue: [DEV-1664](https://linear.app/kurrent/issue/DEV-1664/watcher-should-self-terminate-when-parent-claude-process-dies).

## Approach

PPID polling alone won't work: `WatcherManager.SpawnWatcher` exits immediately after `Process.Start`, so the watcher reparents to init within ms (which is why every observed orphan had `PPID=1`). Instead, capture claude's PID at hook time (the spawning hook's PPID) and pass it to the watcher via `--parent-pid`, then poll liveness from inside the watcher.

- `ProcessHelpers` — cross-platform helpers, all `[LibraryImport]` for AOT:
  - Unix: libc `getppid()` / `kill(pid, 0)` (distinguishes ESRCH vs EPERM).
  - Windows: `NtQueryInformationProcess` + `OpenProcess(SYNCHRONIZE)` / `WaitForSingleObject(0)`.
- `WatcherManager.SpawnWatcher` appends `--parent-pid <pid>` when `GetParentPid()` returns a valid pid (>1).
- `WatchCommand.RunWatch` parses the flag and starts a 5s liveness poller that cancels `cts` on parent death; the existing graceful drain + `WatcherDrainComplete` path still runs.

## Test plan

- [x] `dotnet build src/kapacitor/kapacitor.csproj` — clean.
- [x] `dotnet run --project test/kapacitor.Tests.Unit/...` — **387/387 pass** (382 existing + 5 new in `ProcessHelpersTests`).
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — no IL3050/IL2026 warnings.
- [ ] Manual smoke: kill a parent claude process and confirm the watcher logs `Parent pid <n> exited; shutting down watcher` within ~10s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)