### PR TITLE
[DEV-1665] Fix silent LaunchAgent drop + surface SignalR client errors

### DIFF
--- a/src/kapacitor/Daemon/Services/ServerConnection.cs
+++ b/src/kapacitor/Daemon/Services/ServerConnection.cs
@@ -53,7 +53,7 @@ internal partial class ServerConnection : IAsyncDisposable {
     /// </summary>
     public Func<string[]>? GetLiveAgentIds { get; set; }
 
-    public ServerConnection(DaemonConfig config, ILogger<ServerConnection> logger) {
+    public ServerConnection(DaemonConfig config, ILoggerFactory loggerFactory, ILogger<ServerConnection> logger) {
         _config = config;
         _logger = logger;
 
@@ -69,6 +69,13 @@ internal partial class ServerConnection : IAsyncDisposable {
                 }
             )
             .WithAutomaticReconnect(new RetryPolicy())
+            // Forward SignalR client framework logs (HubConnection, JsonHubProtocol,
+            // …) to the daemon's logger factory. Without this, the HubConnectionBuilder
+            // resolves a NullLoggerFactory internally and protocol-level errors
+            // (e.g. "couldn't bind arguments for invocation 'LaunchAgent'" — exactly
+            // what DEV-1665 was) silently disappear, leaving the daemon looking
+            // healthy while it drops every invocation.
+            .ConfigureLogging(b => b.Services.AddSingleton(loggerFactory))
             .AddJsonProtocol(options => {
                     options.PayloadSerializerOptions.TypeInfoResolverChain.Insert(0, KapacitorJsonContext.Default);
                     options.PayloadSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
@@ -76,11 +83,11 @@ internal partial class ServerConnection : IAsyncDisposable {
             )
             .Build();
 
-        _hub.On<LaunchAgentCommand>("LaunchAgent", cmd => OnLaunchAgent?.Invoke(cmd)                       ?? Task.CompletedTask);
-        _hub.On<string>("StopAgent", agentId => OnStopAgent?.Invoke(agentId)                               ?? Task.CompletedTask);
-        _hub.On<SendInputCommand>("SendInput", cmd => OnSendInput?.Invoke(cmd)                             ?? Task.CompletedTask);
-        _hub.On<string, string>("SendSpecialKey", (agentId, key) => OnSendSpecialKey?.Invoke(agentId, key) ?? Task.CompletedTask);
-        _hub.On<ResizeTerminalCommand>("ResizeTerminal", cmd => OnResizeTerminal?.Invoke(cmd) ?? Task.CompletedTask);
+        _hub.On<LaunchAgentCommand>("LaunchAgent", cmd => SafeInvoke("LaunchAgent", () => OnLaunchAgent?.Invoke(cmd)));
+        _hub.On<string>("StopAgent", agentId => SafeInvoke("StopAgent", () => OnStopAgent?.Invoke(agentId)));
+        _hub.On<SendInputCommand>("SendInput", cmd => SafeInvoke("SendInput", () => OnSendInput?.Invoke(cmd)));
+        _hub.On<string, string>("SendSpecialKey", (agentId, key) => SafeInvoke("SendSpecialKey", () => OnSendSpecialKey?.Invoke(agentId, key)));
+        _hub.On<ResizeTerminalCommand>("ResizeTerminal", cmd => SafeInvoke("ResizeTerminal", () => OnResizeTerminal?.Invoke(cmd)));
 
         // Client-result invocations for per-phase eval dispatch.
         _hub.On<PrepareEvalCommand, PrepareResult>("PrepareEval",
@@ -388,6 +395,27 @@ internal partial class ServerConnection : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to update repo paths on server")]
     partial void LogRepoPathUpdateFailed(Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Hub method '{Method}' handler threw — invocation dropped")]
+    partial void LogHandlerThrew(Exception ex, string method);
+
+    /// <summary>
+    /// Wraps each typed <c>On(...)</c> handler so an exception inside a handler
+    /// is logged with the hub method name instead of bubbling up into SignalR's
+    /// generic dispatch error path. Pairs with the <c>ConfigureLogging</c> wiring
+    /// above, which surfaces the framework's own binding/parsing errors. Together
+    /// they make sure no class of "daemon silently dropped a server invocation"
+    /// is invisible in the logs.
+    /// </summary>
+    async Task SafeInvoke(string method, Func<Task?> handler) {
+        try {
+            var task = handler();
+
+            if (task is not null) await task;
+        } catch (Exception ex) {
+            LogHandlerThrew(ex, method);
+        }
+    }
 
     class RetryPolicy : IRetryPolicy {
         static readonly TimeSpan[] Delays = [

--- a/src/kapacitor/Models.cs
+++ b/src/kapacitor/Models.cs
@@ -474,7 +474,15 @@ record RepoEntry {
 [JsonSerializable(typeof(string))]
 [JsonSerializable(typeof(string[]))]
 [JsonSerializable(typeof(RepoEntry[]))]
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+// UseStringEnumConverter=true matches the server's SignalR JSON protocol, which
+// serialises enums (e.g. LaunchKind) as camelCase strings. Without it the
+// source-gen LaunchKind JsonTypeInfo defaults to numeric and silently drops the
+// invocation — the daemon receives "kind": "review" / "default" and the
+// LaunchAgent handler never fires (DEV-1665).
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy   = JsonKnownNamingPolicy.SnakeCaseLower,
+    UseStringEnumConverter = true
+)]
 partial class KapacitorJsonContext : JsonSerializerContext;
 
 /// <summary>

--- a/test/kapacitor.Tests.Unit/LaunchAgentCommandWireFormatTests.cs
+++ b/test/kapacitor.Tests.Unit/LaunchAgentCommandWireFormatTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using kapacitor;
+
+namespace kapacitor.Tests.Unit;
+
+/// <summary>
+/// Locks in the SignalR JSON wire format for <see cref="LaunchAgentCommand"/>:
+/// the server (Kurrent.Capacitor) configures its SignalR JSON protocol with
+/// <c>JsonStringEnumConverter(JsonNamingPolicy.CamelCase)</c> and snake_case
+/// property names, so <see cref="LaunchKind"/> rides the wire as a camelCase
+/// string. The daemon's <see cref="KapacitorJsonContext"/> must be able to
+/// parse that — historically it couldn't, and the SignalR client silently
+/// dropped every <c>LaunchAgent</c> invocation (DEV-1665).
+/// </summary>
+public class LaunchAgentCommandWireFormatTests {
+    /// <summary>
+    /// Mirrors src/Kurrent.Capacitor/Program.cs SignalR <c>AddJsonProtocol</c>
+    /// configuration. If the server changes its options, update this here too —
+    /// the test is meaningless if it doesn't match production.
+    /// </summary>
+    static readonly JsonSerializerOptions ServerWireOptions = new() {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        Converters           = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    [Test]
+    public async Task DaemonDeserialises_DefaultKind() {
+        var cmd = new LaunchAgentCommand(
+            AgentId:       "abc12345",
+            Prompt:        null,
+            Model:         "opus",
+            Effort:        null,
+            RepoPath:      "/tmp/repo",
+            Tools:         null,
+            AttachmentIds: null
+        );
+
+        var wire   = JsonSerializer.Serialize(cmd, ServerWireOptions);
+        var parsed = JsonSerializer.Deserialize(wire, KapacitorJsonContext.Default.LaunchAgentCommand);
+
+        await Assert.That(parsed.Kind).IsEqualTo(LaunchKind.Default);
+        await Assert.That(parsed.AgentId).IsEqualTo("abc12345");
+    }
+
+    [Test]
+    public async Task DaemonDeserialises_ReviewKind_WithReviewInfo() {
+        var cmd = new LaunchAgentCommand(
+            AgentId:       "def67890",
+            Prompt:        null,
+            Model:         "opus",
+            Effort:        null,
+            RepoPath:      "/tmp/repo",
+            Tools:         null,
+            AttachmentIds: null,
+            Kind:          LaunchKind.Review,
+            Review:        new ReviewLaunchInfo("kurrent-io", "kapacitor", 42)
+        );
+
+        var wire   = JsonSerializer.Serialize(cmd, ServerWireOptions);
+        var parsed = JsonSerializer.Deserialize(wire, KapacitorJsonContext.Default.LaunchAgentCommand);
+
+        await Assert.That(parsed.Kind).IsEqualTo(LaunchKind.Review);
+        await Assert.That(parsed.Review).IsNotNull();
+        await Assert.That(parsed.Review!.Value.Owner).IsEqualTo("kurrent-io");
+        await Assert.That(parsed.Review!.Value.Repo).IsEqualTo("kapacitor");
+        await Assert.That(parsed.Review!.Value.PrNumber).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task ServerWire_EncodesKindAsCamelCaseString() {
+        var cmd = new LaunchAgentCommand(
+            AgentId:       "x",
+            Prompt:        null,
+            Model:         "opus",
+            Effort:        null,
+            RepoPath:      "/r",
+            Tools:         null,
+            AttachmentIds: null,
+            Kind:          LaunchKind.Review
+        );
+
+        var wire = JsonSerializer.Serialize(cmd, ServerWireOptions);
+
+        await Assert.That(wire).Contains("\"kind\":\"review\"");
+    }
+}

--- a/test/kapacitor.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/kapacitor.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -266,6 +266,7 @@ sealed class FakeServerConnection : ServerConnection {
         Func<string, string?, JsonElement?, JsonElement?, CancellationToken, Task<PermissionDecision>>? respond
     ) : base(
         new DaemonConfig { Name = "test", ServerUrl = "http://127.0.0.1:1" },
+        NullLoggerFactory.Instance,
         NullLogger<ServerConnection>.Instance
     ) {
         _respond = respond;


### PR DESCRIPTION
## Summary

Two related fixes for [DEV-1665](https://linear.app/kurrent/issue/DEV-1665).

### 1. `LaunchKind` enum deserialization (the actual bug)

The server's SignalR JSON protocol is configured with `JsonStringEnumConverter(JsonNamingPolicy.CamelCase)`, so it sends `"kind": "review"` / `"kind": "default"` on the wire. The daemon's `KapacitorJsonContext` had `PropertyNamingPolicy = SnakeCaseLower` but **no string-enum converter**, so the source-gen `LaunchKind` `JsonTypeInfo` defaulted to numeric and threw on every payload:

```
JsonException: The JSON value could not be converted to LaunchKind. Path: $.kind
```

SignalR's argument binder swallowed that, dropped the invocation, and the daemon's `OnLaunchAgent` never fired. The UI saw the server-generated `agentId` come back from `RequestLaunchReviewAgentAsync` (fire-and-forget `SendAsync`), navigated to `/agents/{id}`, and waited for an agent that was never going to register. Same failure mode for regular hosted-agent launches — both code paths share `LaunchAgentCommand`. Latent since DEV-1632 (Apr 29).

Fix: `UseStringEnumConverter = true` on the source-gen options. AOT-clean.

### 2. SignalR client diagnostics (so this kind of thing isn't silent again)

The `HubConnectionBuilder` had no `ILoggerFactory` wired in, so the framework's `ErrorBindingArguments` log (and every other SignalR client log) went to `NullLogger` and disappeared. `ServerConnection` now takes `ILoggerFactory` and forwards it via `ConfigureLogging` so framework errors land in the daemon's normal log stream.

On top of that, each typed `On<T>` handler is wrapped in `SafeInvoke(method, ...)` which logs handler-thrown exceptions tagged with the hub method name. That covers the *second* class of "daemon dropped the invocation" — handler exception, not binding failure — which the framework log alone wouldn't make obvious.

### 3. Regression test

`LaunchAgentCommandWireFormatTests` pins the round-trip: serializes `LaunchAgentCommand` with the server's JSON config, deserializes through the daemon's source-gen context, asserts on the parsed values. Catches this category of wire-format drift in CI.

## Test plan

- [x] `dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj` — 385/385 pass
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — no IL2026/IL3050 warnings
- [ ] Manual: restart daemon on rebuilt binary, click "Review this PR", confirm agent registers and a `claude` worktree spawns
- [ ] Manual: provoke a binding failure (e.g. revert just the `Models.cs` change) and confirm an Error log lands in the daemon's log file

🤖 Generated with [Claude Code](https://claude.com/claude-code)