### PR TITLE
[DEV-1664] Fix flaky IsProcessAlive child-exit test

### DIFF
--- a/test/kapacitor.Tests.Unit/ProcessHelpersTests.cs
+++ b/test/kapacitor.Tests.Unit/ProcessHelpersTests.cs
@@ -28,9 +28,11 @@ public class ProcessHelpersTests {
         // Use a long-running child and Kill() it explicitly: a fast-exit command can be
         // reaped by .NET's SIGCHLD handler before the alive assertion runs on a busy CI
         // scheduler, making `kill(pid, 0)` return ESRCH and the test fail intermittently.
+        // Spawn the binary directly (no shell wrapper) so there's no descendant to orphan
+        // when we kill the tracked pid.
         var psi = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? new ProcessStartInfo("cmd.exe", "/c ping -n 30 127.0.0.1")
-            : new ProcessStartInfo("/bin/sh", "-c \"sleep 30\"");
+            ? new ProcessStartInfo("ping", "-n 30 127.0.0.1")
+            : new ProcessStartInfo("/bin/sleep", "30");
 
         psi.RedirectStandardOutput = true;
         psi.RedirectStandardError  = true;
@@ -42,7 +44,7 @@ public class ProcessHelpersTests {
 
         await Assert.That(ProcessHelpers.IsProcessAlive(pid)).IsTrue();
 
-        process.Kill();
+        process.Kill(entireProcessTree: true);
         await process.WaitForExitAsync();
 
         // After .NET reaps the killed child, kill(pid, 0) returns ESRCH. Poll briefly

--- a/test/kapacitor.Tests.Unit/ProcessHelpersTests.cs
+++ b/test/kapacitor.Tests.Unit/ProcessHelpersTests.cs
@@ -25,10 +25,12 @@ public class ProcessHelpersTests {
 
     [Test]
     public async Task IsProcessAlive_transitions_to_false_after_child_exits() {
-        // Spawn a short-lived child process, capture its pid, wait for exit, then assert dead.
+        // Use a long-running child and Kill() it explicitly: a fast-exit command can be
+        // reaped by .NET's SIGCHLD handler before the alive assertion runs on a busy CI
+        // scheduler, making `kill(pid, 0)` return ESRCH and the test fail intermittently.
         var psi = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? new ProcessStartInfo("cmd.exe", "/c exit 0")
-            : new ProcessStartInfo("/bin/sh", "-c \"exit 0\"");
+            ? new ProcessStartInfo("cmd.exe", "/c ping -n 30 127.0.0.1")
+            : new ProcessStartInfo("/bin/sh", "-c \"sleep 30\"");
 
         psi.RedirectStandardOutput = true;
         psi.RedirectStandardError  = true;
@@ -40,10 +42,11 @@ public class ProcessHelpersTests {
 
         await Assert.That(ProcessHelpers.IsProcessAlive(pid)).IsTrue();
 
+        process.Kill();
         await process.WaitForExitAsync();
 
-        // Reap any zombie state so kill(pid, 0) reports ESRCH.
-        // On Unix, the OS clears the process table entry when the parent waits.
+        // After .NET reaps the killed child, kill(pid, 0) returns ESRCH. Poll briefly
+        // in case the reaper runs slightly later than WaitForExitAsync's completion.
         var deadline = DateTime.UtcNow.AddSeconds(2);
 
         while (DateTime.UtcNow < deadline && ProcessHelpers.IsProcessAlive(pid)) {


### PR DESCRIPTION
## Summary
- Fixes a race in `ProcessHelpersTests.IsProcessAlive_transitions_to_false_after_child_exits` that produced the failure on [run 25248549692](https://github.com/kurrent-io/kapacitor/actions/runs/25248549692/job/74036837572).
- The original test spawned `/bin/sh -c "exit 0"`, which exits in microseconds. With `RedirectStandardOutput=true`, .NET registers the child with its SIGCHLD reaper; on a loaded CI scheduler the kernel delivered SIGCHLD and `waitpid()` cleared the zombie before the test thread reached `Assert.That(IsProcessAlive(pid)).IsTrue()`, so `kill(pid, 0)` returned ESRCH and the assertion fell over.
- Reproduced locally on macOS at ~1% (5/500) under synthetic CPU stress. CI's slower scheduler explains the higher rate.

## Fix
Spawn a long-running child (`sleep 30` / `ping -n 30 127.0.0.1`) and `process.Kill()` it after the alive assertion. The live → dead transition is now driven by the test, not by a race with .NET's reaper. The 2s polling backstop is preserved.

## Test plan
- [x] `dotnet build test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj` — clean
- [x] Full unit suite: 390/390 pass
- [x] 30× stress run of the fixed test under CPU saturation: 0 failures (was 5/500 before fix, ~14ms in CI)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)