### PR TITLE
[DEV-1676] CLI: emit SessionStart additionalContext from top_clusters

### DIFF
--- a/src/Kapacitor.Core/Config/ProfileConfig.cs
+++ b/src/Kapacitor.Core/Config/ProfileConfig.cs
@@ -23,11 +23,14 @@ public record Profile {
     [JsonPropertyName("daemon")]
     public DaemonSettings? Daemon { get; init; }
 
-    [JsonPropertyName("update_check")]
-    public bool UpdateCheck { get; init; } = true;
-
     [JsonPropertyName("default_visibility")]
     public string DefaultVisibility { get; init; } = "org_public";
+
+    [JsonPropertyName("disable_session_guidelines")]
+    public bool? DisableSessionGuidelines { get; init; }
+
+    [JsonPropertyName("update_check")]
+    public bool UpdateCheck { get; init; } = true;
 
     [JsonPropertyName("excluded_repos")]
     public string[] ExcludedRepos { get; init; } = [];

--- a/src/Kapacitor.Core/Resources/help-config.txt
+++ b/src/Kapacitor.Core/Resources/help-config.txt
@@ -8,8 +8,9 @@ Subcommands:
 
 Config keys:
   server_url              Server URL
-  daemon.name             Daemon name
-  daemon.max_agents       Max concurrent agents
-  update_check            Enable update check (true/false)
-  default_visibility      Default session visibility (private, org_public, public)
-  excluded_repos          Excluded repos, comma-separated (owner/repo,owner/repo)
+  daemon.name                 Daemon name
+  daemon.max_agents           Max concurrent agents
+  default_visibility          Default session visibility (private, org_public, public)
+  disable_session_guidelines  Skip injecting recurring-lessons context at SessionStart (true/false)
+  excluded_repos              Excluded repos, comma-separated (owner/repo,owner/repo)
+  update_check                Enable update check (true/false)

--- a/src/kapacitor/Commands/ConfigCommand.cs
+++ b/src/kapacitor/Commands/ConfigCommand.cs
@@ -36,16 +36,7 @@ public static class ConfigCommand {
         var profileName   = profileConfig.ActiveProfile;
         var profile       = profileConfig.Profiles.GetValueOrDefault(profileName) ?? new Profile();
 
-        profile = key switch {
-            "server_url" => profile with { ServerUrl = value },
-            "daemon.name" => profile with { Daemon = (profile.Daemon ?? new DaemonSettings()) with { Name = value } },
-            "daemon.max_agents" when int.TryParse(value, out var n) => profile with { Daemon = (profile.Daemon ?? new DaemonSettings()) with { MaxAgents = n } },
-            "update_check" when bool.TryParse(value, out var b) => profile with { UpdateCheck = b },
-            "default_visibility" when value is "private" or "org_public" or "public" => profile with { DefaultVisibility = value },
-            "default_visibility" => throw new ArgumentException("Invalid value. Must be: private, org_public, or public"),
-            "excluded_repos" => profile with { ExcludedRepos = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) },
-            _ => throw new ArgumentException($"Unknown config key: {key}")
-        };
+        profile = ApplySet(profile, key, value);
 
         var profiles = new Dictionary<string, Profile>(profileConfig.Profiles) { [profileName] = profile };
         profileConfig = profileConfig with { Profiles = profiles };
@@ -56,16 +47,36 @@ public static class ConfigCommand {
         return 0;
     }
 
+    /// <summary>
+    /// Applies a single <c>key = value</c> update to a <see cref="Profile"/>. Pure function, exposed for testing.
+    /// Throws <see cref="ArgumentException"/> on unknown keys or invalid values.
+    /// </summary>
+    public static Profile ApplySet(Profile profile, string key, string value) =>
+        key switch {
+            "server_url" => profile with { ServerUrl = value },
+            "daemon.name" => profile with { Daemon = (profile.Daemon ?? new DaemonSettings()) with { Name = value } },
+            "daemon.max_agents" when int.TryParse(value, out var n) => profile with { Daemon = (profile.Daemon ?? new DaemonSettings()) with { MaxAgents = n } },
+            "update_check" when bool.TryParse(value, out var b) => profile with { UpdateCheck = b },
+            "update_check" => throw new ArgumentException($"Invalid value for update_check: '{value}'. Must be true or false."),
+            "disable_session_guidelines" when bool.TryParse(value, out var b) => profile with { DisableSessionGuidelines = b },
+            "disable_session_guidelines" => throw new ArgumentException($"Invalid value for disable_session_guidelines: '{value}'. Must be true or false."),
+            "default_visibility" when value is "private" or "org_public" or "public" => profile with { DefaultVisibility = value },
+            "default_visibility" => throw new ArgumentException("Invalid value. Must be: private, org_public, or public"),
+            "excluded_repos" => profile with { ExcludedRepos = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) },
+            _ => throw new ArgumentException($"Unknown config key: {key}")
+        };
+
     static int SetUsage() {
         Console.Error.WriteLine("Usage: kapacitor config set <key> <value>");
         Console.Error.WriteLine();
         Console.Error.WriteLine("Keys:");
-        Console.Error.WriteLine("  server_url         Server URL");
-        Console.Error.WriteLine("  daemon.name        Daemon name");
-        Console.Error.WriteLine("  daemon.max_agents  Max concurrent agents");
-        Console.Error.WriteLine("  update_check       Enable update check (true/false)");
-        Console.Error.WriteLine("  default_visibility   Default session visibility (private, org_public, public)");
-        Console.Error.WriteLine("  excluded_repos       Excluded repos, comma-separated (owner/repo,owner/repo)");
+        Console.Error.WriteLine("  server_url                  Server URL");
+        Console.Error.WriteLine("  daemon.name                 Daemon name");
+        Console.Error.WriteLine("  daemon.max_agents           Max concurrent agents");
+        Console.Error.WriteLine("  update_check                Enable update check (true/false)");
+        Console.Error.WriteLine("  default_visibility          Default session visibility (private, org_public, public)");
+        Console.Error.WriteLine("  disable_session_guidelines  Skip injecting recurring-lessons context at SessionStart (true/false)");
+        Console.Error.WriteLine("  excluded_repos              Excluded repos, comma-separated (owner/repo,owner/repo)");
 
         return 1;
     }

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -705,11 +705,15 @@ switch (command) {
         var transcriptPath = node?["transcript_path"]?.GetValue<string>();
         var sessionCwd     = node?["cwd"]?.GetValue<string>();
 
-        // If CLI didn't inject plan_content, check if server resolved a slug (pending continuation)
-        if (!planContentInjected && sessionId is not null) {
-            try {
-                var responseBody = await response.Content.ReadAsStringAsync();
-                var responseNode = JsonNode.Parse(responseBody);
+        // Parse the server response body once. Two consumers:
+        //   1. slug fallback for plan_content (resume/compact path)
+        //   2. top_clusters → SessionStart additionalContext (DEV-1676)
+        try {
+            var responseBody = await response.Content.ReadAsStringAsync();
+            var responseNode = JsonNode.Parse(responseBody);
+
+            // (1) slug-resolved continuation — inject plan content if server resolved a slug
+            if (!planContentInjected && sessionId is not null) {
                 var resolvedSlug = responseNode?["slug"]?.GetValue<string>();
 
                 if (resolvedSlug is not null) {
@@ -719,9 +723,17 @@ switch (command) {
                         await PostPlanContentAsync(client, baseUrl!, sessionId, planContent);
                     }
                 }
-            } catch {
-                // Best effort — don't fail the hook if plan posting fails
             }
+
+            // (2) DEV-1676 — emit additionalContext from top_clusters unless the user opted out
+            var disabled = AppConfig.ResolvedProfile?.Profile?.DisableSessionGuidelines is true;
+            var emission = SessionGuidelinesEmitter.BuildAdditionalContext(responseNode, disabled);
+
+            if (emission is not null) {
+                Console.WriteLine(emission);
+            }
+        } catch {
+            // Best effort — never fail session start over response parsing
         }
 
         var source = node?["source"]?.GetValue<string>();

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -705,16 +705,24 @@ switch (command) {
         var transcriptPath = node?["transcript_path"]?.GetValue<string>();
         var sessionCwd     = node?["cwd"]?.GetValue<string>();
 
-        // Parse the server response body once. Two consumers:
+        // Parse the server response body once. Two independent consumers:
         //   1. slug fallback for plan_content (resume/compact path)
         //   2. top_clusters → SessionStart additionalContext (DEV-1676)
+        // Each consumer has its own try/catch so a failure in one path
+        // (e.g., PostPlanContentAsync hitting a transient network error)
+        // doesn't suppress the other.
+        JsonNode? responseNode = null;
         try {
             var responseBody = await response.Content.ReadAsStringAsync();
-            var responseNode = JsonNode.Parse(responseBody);
+            responseNode     = JsonNode.Parse(responseBody);
+        } catch {
+            // Best effort — never fail session start over response parsing
+        }
 
-            // (1) slug-resolved continuation — inject plan content if server resolved a slug
-            if (!planContentInjected && sessionId is not null) {
-                var resolvedSlug = responseNode?["slug"]?.GetValue<string>();
+        // (1) slug-resolved continuation — inject plan content if server resolved a slug
+        if (responseNode is not null && !planContentInjected && sessionId is not null) {
+            try {
+                var resolvedSlug = responseNode["slug"]?.GetValue<string>();
 
                 if (resolvedSlug is not null) {
                     var planContent = ReadPlanFile(resolvedSlug);
@@ -723,17 +731,23 @@ switch (command) {
                         await PostPlanContentAsync(client, baseUrl!, sessionId, planContent);
                     }
                 }
+            } catch {
+                // Best effort — slug-fallback failure must not block additionalContext
             }
+        }
 
-            // (2) DEV-1676 — emit additionalContext from top_clusters unless the user opted out
-            var disabled = AppConfig.ResolvedProfile?.Profile?.DisableSessionGuidelines is true;
-            var emission = SessionGuidelinesEmitter.BuildAdditionalContext(responseNode, disabled);
+        // (2) DEV-1676 — emit additionalContext from top_clusters unless the user opted out
+        if (responseNode is not null) {
+            try {
+                var disabled = AppConfig.ResolvedProfile?.Profile?.DisableSessionGuidelines is true;
+                var emission = SessionGuidelinesEmitter.BuildAdditionalContext(responseNode, disabled);
 
-            if (emission is not null) {
-                Console.WriteLine(emission);
+                if (emission is not null) {
+                    Console.WriteLine(emission);
+                }
+            } catch {
+                // Best effort — never fail session start over emission
             }
-        } catch {
-            // Best effort — never fail session start over response parsing
         }
 
         var source = node?["source"]?.GetValue<string>();

--- a/src/kapacitor/SessionGuidelinesEmitter.cs
+++ b/src/kapacitor/SessionGuidelinesEmitter.cs
@@ -1,0 +1,74 @@
+using System.Text.Json.Nodes;
+
+namespace kapacitor;
+
+/// <summary>
+/// Builds the SessionStart <c>additionalContext</c> JSON envelope from the server's
+/// session-start hook response (DEV-1676). The server may attach a
+/// <c>top_clusters</c> array to the response body summarising recurring lessons
+/// from prior sessions in the same repository; the CLI emits that to stdout in
+/// the Claude Code SessionStart hook output format so the model receives it as
+/// additional context.
+/// </summary>
+static class SessionGuidelinesEmitter {
+    /// <summary>
+    /// Returns the JSON envelope to write to stdout, or <c>null</c> if nothing
+    /// should be emitted (no top_clusters, all empty, or user opted out).
+    /// </summary>
+    /// <param name="responseBody">The hook response body returned by the server.</param>
+    /// <param name="disabled">True when the user has set <c>disable_session_guidelines</c> on their active profile.</param>
+    public static string? BuildAdditionalContext(string responseBody, bool disabled) {
+        if (disabled) return null;
+
+        JsonNode? responseNode;
+
+        try {
+            responseNode = JsonNode.Parse(responseBody);
+        } catch {
+            return null;
+        }
+
+        return BuildAdditionalContext(responseNode, disabled);
+    }
+
+    /// <summary>
+    /// Overload taking an already-parsed response node so callers that need
+    /// the parsed tree for other purposes (e.g. slug-fallback plan injection)
+    /// don't have to parse twice.
+    /// </summary>
+    public static string? BuildAdditionalContext(JsonNode? responseNode, bool disabled) {
+        if (disabled) return null;
+
+        var topClusters = responseNode?["top_clusters"]?.AsArray();
+
+        if (topClusters is not { Count: > 0 }) return null;
+
+        var lines = new List<string>(topClusters.Count);
+
+        foreach (var node in topClusters) {
+            string? text = null;
+
+            try {
+                text = node?["text"]?.GetValue<string>();
+            } catch {
+                // Tolerate non-string/missing text entries.
+            }
+
+            if (!string.IsNullOrWhiteSpace(text)) lines.Add($"- {text}");
+        }
+
+        if (lines.Count == 0) return null;
+
+        var ctx = "Recurring lessons from prior sessions in this repo (no action required unless relevant):\n"
+                + string.Join("\n", lines);
+
+        var output = new JsonObject {
+            ["hookSpecificOutput"] = new JsonObject {
+                ["hookEventName"]     = "SessionStart",
+                ["additionalContext"] = ctx
+            }
+        };
+
+        return output.ToJsonString();
+    }
+}

--- a/src/kapacitor/SessionGuidelinesEmitter.cs
+++ b/src/kapacitor/SessionGuidelinesEmitter.cs
@@ -38,10 +38,8 @@ static class SessionGuidelinesEmitter {
     /// </summary>
     public static string? BuildAdditionalContext(JsonNode? responseNode, bool disabled) {
         if (disabled) return null;
-
-        var topClusters = responseNode?["top_clusters"]?.AsArray();
-
-        if (topClusters is not { Count: > 0 }) return null;
+        if (responseNode is not JsonObject obj) return null;
+        if (obj["top_clusters"] is not JsonArray topClusters || topClusters.Count == 0) return null;
 
         var lines = new List<string>(topClusters.Count);
 

--- a/test/kapacitor.Tests.Unit/ConfigCommandTests.cs
+++ b/test/kapacitor.Tests.Unit/ConfigCommandTests.cs
@@ -1,0 +1,49 @@
+using kapacitor.Commands;
+using kapacitor.Config;
+
+namespace kapacitor.Tests.Unit;
+
+public class ConfigCommandTests {
+    [Test]
+    public async Task ApplySet_DisableSessionGuidelines_True_UpdatesProfile() {
+        var profile = new Profile();
+
+        var updated = ConfigCommand.ApplySet(profile, "disable_session_guidelines", "true");
+
+        await Assert.That(updated.DisableSessionGuidelines).IsTrue();
+    }
+
+    [Test]
+    public async Task ApplySet_DisableSessionGuidelines_False_UpdatesProfile() {
+        var profile = new Profile { DisableSessionGuidelines = true };
+
+        var updated = ConfigCommand.ApplySet(profile, "disable_session_guidelines", "false");
+
+        await Assert.That(updated.DisableSessionGuidelines).IsFalse();
+    }
+
+    [Test]
+    public async Task ApplySet_DisableSessionGuidelines_InvalidValue_Throws() {
+        var profile = new Profile();
+
+        await Assert.That(() => ConfigCommand.ApplySet(profile, "disable_session_guidelines", "maybe"))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ApplySet_UnknownKey_Throws() {
+        var profile = new Profile();
+
+        await Assert.That(() => ConfigCommand.ApplySet(profile, "made_up_key", "x"))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ApplySet_UpdateCheck_PreservesExistingBehavior() {
+        var profile = new Profile { UpdateCheck = true };
+
+        var updated = ConfigCommand.ApplySet(profile, "update_check", "false");
+
+        await Assert.That(updated.UpdateCheck).IsFalse();
+    }
+}

--- a/test/kapacitor.Tests.Unit/ConfigMigrationTests.cs
+++ b/test/kapacitor.Tests.Unit/ConfigMigrationTests.cs
@@ -107,4 +107,18 @@ public class ConfigMigrationTests {
         await Assert.That(deserialized.Profiles["contoso"].Remotes).Contains("github.com/contoso/*");
         await Assert.That(deserialized.ProfileBindings["/home/user/contoso-project"]).IsEqualTo("contoso");
     }
+
+    [Test]
+    public async Task ProfileConfig_DisableSessionGuidelines_RoundTripsTrue() {
+        var json   = """{ "disable_session_guidelines": true }""";
+        var config = JsonSerializer.Deserialize(json, ProfileConfigJsonContext.Default.Profile)!;
+        await Assert.That(config.DisableSessionGuidelines).IsTrue();
+    }
+
+    [Test]
+    public async Task ProfileConfig_DisableSessionGuidelines_NullWhenAbsent() {
+        var json   = "{}";
+        var config = JsonSerializer.Deserialize(json, ProfileConfigJsonContext.Default.Profile)!;
+        await Assert.That(config.DisableSessionGuidelines).IsNull();
+    }
 }

--- a/test/kapacitor.Tests.Unit/HookForwardingTests.cs
+++ b/test/kapacitor.Tests.Unit/HookForwardingTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -99,5 +100,125 @@ public class InlineDrainTests : IDisposable {
         } finally {
             Directory.Delete(dir, recursive: true);
         }
+    }
+}
+
+public class SessionStartAdditionalContextTests : IDisposable {
+    readonly WireMockServer _server = WireMockServer.Start();
+
+    public void Dispose() => _server.Stop();
+
+    [Test]
+    public async Task SessionStart_EmitsAdditionalContextJson_WhenServerReturnsTopClusters() {
+        _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody(
+                        """
+                        {
+                          "top_clusters": [
+                            { "category": "safety",          "text": "always close the writer" },
+                            { "category": "maintainability", "text": "prefer JsonNode.Parse for AOT-safe string assignment" }
+                          ]
+                        }
+                        """
+                    )
+            );
+
+        using var client   = new HttpClient();
+        using var content  = new StringContent("{}", Encoding.UTF8, "application/json");
+        var       response = await client.PostAsync($"{_server.Url}/hooks/session-start", content);
+        var       body     = await response.Content.ReadAsStringAsync();
+
+        var emission = SessionGuidelinesEmitter.BuildAdditionalContext(body, disabled: false);
+
+        await Assert.That(emission).IsNotNull();
+        var json = JsonNode.Parse(emission!);
+        await Assert.That(json!["hookSpecificOutput"]!["hookEventName"]!.GetValue<string>()).IsEqualTo("SessionStart");
+        var ctx = json["hookSpecificOutput"]!["additionalContext"]!.GetValue<string>();
+        await Assert.That(ctx).Contains("Recurring lessons");
+        await Assert.That(ctx).Contains("- always close the writer");
+        await Assert.That(ctx).Contains("- prefer JsonNode.Parse for AOT-safe string assignment");
+    }
+
+    [Test]
+    public async Task SessionStart_EmitsNothing_WhenTopClustersAbsent() {
+        _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody("""{ "slug": "some-resumed-session" }""")
+            );
+
+        using var client   = new HttpClient();
+        using var content  = new StringContent("{}", Encoding.UTF8, "application/json");
+        var       response = await client.PostAsync($"{_server.Url}/hooks/session-start", content);
+        var       body     = await response.Content.ReadAsStringAsync();
+
+        var emission = SessionGuidelinesEmitter.BuildAdditionalContext(body, disabled: false);
+
+        await Assert.That(emission).IsNull();
+    }
+
+    [Test]
+    public async Task SessionStart_EmitsNothing_WhenDisableSessionGuidelinesConfigSet() {
+        _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody(
+                        """
+                        {
+                          "top_clusters": [
+                            { "category": "safety", "text": "x" }
+                          ]
+                        }
+                        """
+                    )
+            );
+
+        using var client   = new HttpClient();
+        using var content  = new StringContent("{}", Encoding.UTF8, "application/json");
+        var       response = await client.PostAsync($"{_server.Url}/hooks/session-start", content);
+        var       body     = await response.Content.ReadAsStringAsync();
+
+        // Mirrors how Program.cs reads `AppConfig.ResolvedProfile?.Profile?.DisableSessionGuidelines is true`.
+        var emission = SessionGuidelinesEmitter.BuildAdditionalContext(body, disabled: true);
+
+        await Assert.That(emission).IsNull();
+    }
+
+    [Test]
+    public async Task SessionStart_EmitsNothing_WhenTopClustersEmpty() {
+        var emission = SessionGuidelinesEmitter.BuildAdditionalContext(
+            """{ "top_clusters": [] }""",
+            disabled: false
+        );
+
+        await Assert.That(emission).IsNull();
+    }
+
+    [Test]
+    public async Task SessionStart_SkipsEntries_WithBlankText() {
+        var emission = SessionGuidelinesEmitter.BuildAdditionalContext(
+            """
+            {
+              "top_clusters": [
+                { "category": "safety", "text": "" },
+                { "category": "safety", "text": "real lesson" }
+              ]
+            }
+            """,
+            disabled: false
+        );
+
+        await Assert.That(emission).IsNotNull();
+        var ctx = JsonNode.Parse(emission!)!["hookSpecificOutput"]!["additionalContext"]!.GetValue<string>();
+        await Assert.That(ctx).Contains("- real lesson");
+        await Assert.That(ctx).DoesNotContain("- \n");
     }
 }

--- a/test/kapacitor.Tests.Unit/HookForwardingTests.cs
+++ b/test/kapacitor.Tests.Unit/HookForwardingTests.cs
@@ -203,6 +203,22 @@ public class SessionStartAdditionalContextTests : IDisposable {
     }
 
     [Test]
+    public async Task SessionStart_EmitsNothing_WhenTopClustersIsObject() {
+        var malformed = JsonNode.Parse("""{ "top_clusters": { "category": "x" } }""");
+        var result    = SessionGuidelinesEmitter.BuildAdditionalContext(malformed, disabled: false);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task SessionStart_EmitsNothing_WhenResponseNodeIsArray() {
+        var arrayRoot = JsonNode.Parse("""[ { "top_clusters": [] } ]""");
+        var result    = SessionGuidelinesEmitter.BuildAdditionalContext(arrayRoot, disabled: false);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
     public async Task SessionStart_SkipsEntries_WithBlankText() {
         var emission = SessionGuidelinesEmitter.BuildAdditionalContext(
             """


### PR DESCRIPTION
## Summary
- Adds `disable_session_guidelines` profile config field (`bool?`) for opting out of SessionStart guideline injection.
- Restructures `case "session-start"` in `Program.cs` to parse the `/hooks/session-start` response body once and route it to two consumers: existing slug-fallback (plan_content injection) and new `top_clusters` → `additionalContext` emission.
- New `SessionGuidelinesEmitter` helper builds the Claude Code SessionStart hook JSON envelope (`{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"..."}}`) from the response body, with a single bullet per cluster phrasing prefaced with "Recurring lessons from prior sessions in this repo (no action required unless relevant):".
- Pairs with the server-side change (kapacitor-server PR) that adds the `top_clusters` field to the hook response.

Linear: [DEV-1676](https://linear.app/kurrent/issue/DEV-1676/sessionstart-guideline-injection-from-weighted-clusters)

## Test plan
- [x] `ConfigMigrationTests/ProfileConfig_DisableSessionGuidelines_*` — round-trip + null-when-absent (2/2 pass).
- [x] `SessionStartAdditionalContextTests/*` — emission with clusters, no-emission paths (absent / empty / disabled / blank-text), 5/5 pass.
- [x] Full CLI unit suite: 397/397 pass.
- [x] AOT publish (`dotnet publish src/kapacitor/kapacitor.csproj -c Release`) clean — no IL2026/IL3050.
- [ ] End-to-end smoke against a server with seeded `guideline_facts` rows once both PRs merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)