### PR TITLE
[DEV-1685] Fix daemon config resolution after binary split

### DIFF
--- a/src/Kapacitor.Core/Config/AppConfig.cs
+++ b/src/Kapacitor.Core/Config/AppConfig.cs
@@ -45,6 +45,40 @@ public static class AppConfig {
 
     public static string RepoRoot => GetGitRepoRoot() ?? Environment.CurrentDirectory;
 
+    /// <summary>
+    /// Resolve server URL using only the active profile (or KAPACITOR_PROFILE /
+    /// KAPACITOR_URL / --server-url overrides). Skips repo discovery and git
+    /// remote matching — used by the daemon, which is not bound to a working
+    /// directory.
+    /// </summary>
+    public static async Task<string?> ResolveActiveProfile(string[] args) {
+        var idx          = Array.IndexOf(args, "--server-url");
+        var cliServerUrl = (idx >= 0 && idx + 1 < args.Length) ? args[idx + 1] : null;
+        var envUrl       = Environment.GetEnvironmentVariable("KAPACITOR_URL");
+        var envProfile   = Environment.GetEnvironmentVariable("KAPACITOR_PROFILE");
+
+        var config   = await LoadProfileConfig();
+        var resolver = new ProfileResolver(
+            config,
+            cliServerUrl,
+            envUrl,
+            envProfile,
+            repoConfig: null,
+            repoRemoteUrls: [],
+            repoPath: null
+        );
+
+        var resolved = resolver.Resolve();
+        ResolvedProfile   = resolved;
+        ResolvedServerUrl = resolved.ServerUrl;
+
+        if (resolved.Warning is not null) {
+            await Console.Error.WriteLineAsync($"Warning: {resolved.Warning}");
+        }
+
+        return resolved.ServerUrl;
+    }
+
     public static async Task<string?> ResolveServerUrl(string[] args) {
         var idx          = Array.IndexOf(args, "--server-url");
         var cliServerUrl = (idx >= 0 && idx + 1 < args.Length) ? args[idx + 1] : null;

--- a/src/Kapacitor.Core/Config/AppConfig.cs
+++ b/src/Kapacitor.Core/Config/AppConfig.cs
@@ -252,20 +252,39 @@ public static class AppConfig {
         if (!File.Exists(ConfigPath))
             return new() { Profiles = new() { ["default"] = new() } };
 
+        string json;
+
         try {
-            var json   = await File.ReadAllTextAsync(ConfigPath);
-            var result = ConfigMigration.MigrateIfNeeded(json);
-
-            if (result.ShouldPersist) {
-                await SaveProfileConfig(result.Config);
-            }
-
-            return result.Config;
-        } catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException) {
+            json = await File.ReadAllTextAsync(ConfigPath);
+        } catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) {
             await Console.Error.WriteLineAsync($"Warning: could not read config at {ConfigPath}: {ex.Message}");
 
             return new() { Profiles = new() { ["default"] = new() } };
         }
+
+        ConfigMigration.MigrationResult result;
+
+        try {
+            result = ConfigMigration.MigrateIfNeeded(json);
+        } catch (JsonException ex) {
+            await Console.Error.WriteLineAsync($"Warning: invalid config at {ConfigPath}: {ex.Message}");
+
+            return new() { Profiles = new() { ["default"] = new() } };
+        }
+
+        // Persist a v1→v2 migration when possible, but never drop the in-memory
+        // migrated config if the write fails (e.g. read-only volume). Losing the
+        // server URL here previously caused `ServerUrl is required` at daemon
+        // startup despite the on-disk config being intact.
+        if (result.ShouldPersist) {
+            try {
+                await SaveProfileConfig(result.Config);
+            } catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) {
+                await Console.Error.WriteLineAsync($"Warning: could not persist migrated config at {ConfigPath}: {ex.Message}");
+            }
+        }
+
+        return result.Config;
     }
 
     public static async Task SaveProfileConfig(ProfileConfig config) {

--- a/src/Kapacitor.Daemon/DaemonRunner.cs
+++ b/src/Kapacitor.Daemon/DaemonRunner.cs
@@ -14,15 +14,17 @@ public static partial class DaemonRunner {
         string? logFile = null;
         var     config  = new DaemonConfig();
 
-        // Resolve server URL from AppConfig
-        var serverUrl = AppConfig.ResolvedServerUrl;
+        // Resolve server URL + active profile. The CLI does this in its own
+        // Program.cs, but the daemon is a separate process so its statics start
+        // empty. Skips repo discovery (the daemon isn't bound to a working dir);
+        // honors --server-url, KAPACITOR_URL, KAPACITOR_PROFILE.
+        await AppConfig.ResolveActiveProfile(args);
+        config.ServerUrl = AppConfig.ResolvedServerUrl ?? "";
 
         // CLI arg overrides for daemon-specific settings — parse before host builder
         for (var i = 0; i < args.Length - 1; i++) {
             switch (args[i]) {
                 case "--name": config.Name = args[++i]; break;
-                case "--server":
-                case "--server-url": config.ServerUrl = args[++i]; break;
                 case "--log-file": logFile = args[++i]; break;
                 case "--max-agents" when int.TryParse(args[i + 1], out var n) && n >= 1:
                     config.MaxConcurrentAgents = n;
@@ -53,18 +55,17 @@ public static partial class DaemonRunner {
             );
         }
 
-        // If server URL wasn't set by CLI arg, use resolved URL
-        if (string.IsNullOrEmpty(config.ServerUrl) && serverUrl is not null) {
-            config.ServerUrl = serverUrl;
-        }
+        // Daemon settings from the active profile, with env overrides
+        var profileDaemon = AppConfig.ResolvedProfile?.Profile?.Daemon;
 
-        // Env var overrides
-        if (Environment.GetEnvironmentVariable("KAPACITOR_URL") is { } envUrl && string.IsNullOrEmpty(config.ServerUrl)) {
-            config.ServerUrl = envUrl;
-        }
+        if (string.IsNullOrEmpty(config.Name) && !string.IsNullOrEmpty(profileDaemon?.Name))
+            config.Name = profileDaemon.Name;
 
-        if (Environment.GetEnvironmentVariable("KAPACITOR_DAEMON_NAME") is { } name) {
-            config.Name = name;
+        if (config.MaxConcurrentAgents == 5 && profileDaemon is { MaxAgents: var mx and not 5 })
+            config.MaxConcurrentAgents = mx;
+
+        if (Environment.GetEnvironmentVariable("KAPACITOR_DAEMON_NAME") is { } envName) {
+            config.Name = envName;
         }
 
         if (Environment.GetEnvironmentVariable("KAPACITOR_MAX_AGENTS") is { } maxAgents) {
@@ -72,17 +73,6 @@ public static partial class DaemonRunner {
                 config.MaxConcurrentAgents = n;
             else
                 await Console.Error.WriteLineAsync($"Warning: ignoring invalid KAPACITOR_MAX_AGENTS={maxAgents}");
-        }
-
-        // Also load daemon settings from config file
-        var appConfig = await AppConfig.Load();
-
-        if (appConfig?.Daemon is { } daemonSettings) {
-            if (string.IsNullOrEmpty(config.Name) && !string.IsNullOrEmpty(daemonSettings.Name))
-                config.Name = daemonSettings.Name;
-
-            if (config.MaxConcurrentAgents == 5 && daemonSettings.MaxAgents != 5)
-                config.MaxConcurrentAgents = daemonSettings.MaxAgents;
         }
 
         // Fall back to OS username, then machine name, then a static default


### PR DESCRIPTION
## Summary

- The daemon split regressed config loading: in the `kapacitor-daemon` process `AppConfig.ResolvedServerUrl` is never populated, and the `AppConfig.Load()` fallback used the v1 schema and ignored top-level `server_url` anyway. With a v2 profile config, `kapacitor agent start` failed with `ServerUrl is required` while `kapacitor setup` (which uses the v2-aware `LoadProfileConfig`) reported the config as present.
- Add `AppConfig.ResolveActiveProfile(args)` that reuses `ProfileResolver` with no repo data, so it honors `--server-url` / `KAPACITOR_URL` / `KAPACITOR_PROFILE` and otherwise falls through to the active profile, while populating the static `ResolvedServerUrl` / `ResolvedProfile` (needed by `TokenStore.RefreshGitHubAsync`).
- `DaemonRunner.RunAsync` now calls it on entry and reads `Name` / `MaxAgents` defaults from `ResolvedProfile.Profile.Daemon`, replacing the v1-only path. Repo discovery is intentionally skipped — the daemon isn't bound to a working directory.

## Test plan

- [x] `dotnet build` of CLI and daemon: 0 warnings.
- [x] `dotnet publish src/Kapacitor.Daemon/Kapacitor.Daemon.csproj -c Release`: 0 IL2026/IL3050 warnings.
- [x] `dotnet run --project test/kapacitor.Tests.Unit`: 404/404 pass.
- [x] Smoke-tested the published `kapacitor-daemon` against a real v2 `~/.config/kapacitor/config.json`: logs `kapacitor agent 'alexey' starting, connecting to https://staging.kapacitor.ai` and registers on the SignalR hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)