### PR TITLE
[AI-62] Daemon ends hosted-agent sessions on stop/exit

### DIFF
--- a/src/Kapacitor.Core/Models.cs
+++ b/src/Kapacitor.Core/Models.cs
@@ -470,6 +470,7 @@ record RepoEntry {
 [JsonSerializable(typeof(AgentRunStopped))]
 [JsonSerializable(typeof(AgentRunHeartbeat))]
 [JsonSerializable(typeof(PermissionDecision))]
+[JsonSerializable(typeof(EndAgentSessionResult))]
 [JsonSerializable(typeof(int))]
 [JsonSerializable(typeof(string))]
 [JsonSerializable(typeof(string[]))]
@@ -742,3 +743,17 @@ record AgentRunStopped(
 record AgentRunHeartbeat(
         string? SessionId
     );
+
+/// <summary>
+/// Returned by the server's <c>EndAgentSession</c> SignalR hub method. Mirrors the
+/// server-side record of the same name. SessionId is surfaced because the daemon
+/// only knows agentId — it can't spawn <c>kapacitor generate-whats-done</c> without
+/// the sessionId, which the server resolves via FindAgentSessionIdAsync.
+/// </summary>
+public record EndAgentSessionResult {
+    [JsonPropertyName("generate_whats_done")]
+    public bool GenerateWhatsDone { get; init; }
+
+    [JsonPropertyName("session_id")]
+    public string? SessionId { get; init; }
+}

--- a/src/Kapacitor.Daemon/DaemonConfig.cs
+++ b/src/Kapacitor.Daemon/DaemonConfig.cs
@@ -14,6 +14,15 @@ public class DaemonConfig {
 
     public string ClaudePath { get; set; } = "claude";
 
+    /// <summary>
+    /// Path to the kapacitor CLI binary. Used by the daemon to spawn auxiliary
+    /// processes (e.g. <c>generate-whats-done</c>) when claude didn't fire its
+    /// own session-end hook. Defaults to "kapacitor" — resolved via PATH, which
+    /// works for npm installs that place both <c>kapacitor</c> and
+    /// <c>kapacitor-daemon</c> in <c>node_modules/.bin</c>.
+    /// </summary>
+    public string KapacitorPath { get; set; } = "kapacitor";
+
     public List<string> Validate() {
         var errors = new List<string>();
 

--- a/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
@@ -493,7 +493,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 // is the one that lands, a user-initiated stop is still recorded as
                 // "agent_stopped" rather than "agent_exited".
                 try {
-                    await _server.EndAgentSessionAsync(agent.Id, agent.PendingEndReason);
+                    var generateWhatsDone = await _server.EndAgentSessionAsync(agent.Id, agent.PendingEndReason);
+
+                    if (generateWhatsDone && agent.SessionId is not null) {
+                        SpawnWhatsDoneGenerator(agent.SessionId);
+                    }
                 } catch (Exception ex) {
                     LogEndSessionFailed(ex, agent.Id);
                 }
@@ -551,9 +555,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             }
 
             // Tell the server to end the session. Idempotent server-side: if claude
-            // did fire session-end during the graceful window, this is a no-op.
+            // did fire session-end during the graceful window, this is a no-op
+            // (returns false and the CLI's session-end handler already spawned the
+            // what's-done generator on its end).
             try {
-                await _server.EndAgentSessionAsync(agentId, agent.PendingEndReason);
+                var generateWhatsDone = await _server.EndAgentSessionAsync(agentId, agent.PendingEndReason);
+
+                if (generateWhatsDone && agent.SessionId is not null) {
+                    SpawnWhatsDoneGenerator(agent.SessionId);
+                }
             } catch (Exception ex) {
                 LogEndSessionFailed(ex, agentId);
             }
@@ -564,6 +574,50 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             await agent.Process.TerminateAsync(TimeSpan.FromSeconds(10));
         } catch (Exception ex) {
             LogStopError(ex, agentId);
+        }
+    }
+
+    /// <summary>
+    /// Spawns <c>kapacitor generate-whats-done {sessionId}</c> as a detached process.
+    /// Used when the daemon-driven session-end path supplants claude's own session-end
+    /// hook — claude normally spawns this generator from its CLI session-end handler,
+    /// but when claude crashed or was killed before firing session-end the daemon has
+    /// to do it instead. Best-effort: failure is logged but doesn't block other
+    /// cleanup, and a missing kapacitor binary just means no what's-done summary.
+    /// </summary>
+    void SpawnWhatsDoneGenerator(string sessionId) {
+        try {
+            var psi = new ProcessStartInfo(_config.KapacitorPath) {
+                RedirectStandardOutput = true,
+                RedirectStandardInput  = true,
+                RedirectStandardError  = true,
+                UseShellExecute        = false,
+                CreateNoWindow         = true,
+                Environment = {
+                    ["KAPACITOR_URL"] = _config.ServerUrl
+                }
+            };
+            psi.ArgumentList.Add("generate-whats-done");
+            psi.ArgumentList.Add(sessionId);
+
+            using var proc = Process.Start(psi);
+
+            if (proc is null) {
+                LogWhatsDoneSpawnFailed(null, sessionId);
+
+                return;
+            }
+
+            // Detach: close redirected streams so we don't hold pipes for the child's
+            // lifetime. The child runs to completion on its own and posts its result
+            // to the server.
+            proc.StandardInput.Close();
+            proc.StandardOutput.Close();
+            proc.StandardError.Close();
+
+            LogWhatsDoneSpawned(sessionId, proc.Id);
+        } catch (Exception ex) {
+            LogWhatsDoneSpawnFailed(ex, sessionId);
         }
     }
 
@@ -1167,6 +1221,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to end session for agent {AgentId} (server may not record SessionEnded)")]
     partial void LogEndSessionFailed(Exception ex, string agentId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Spawned what's-done generator for session {SessionId} (PID {Pid})")]
+    partial void LogWhatsDoneSpawned(string sessionId, int pid);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to spawn what's-done generator for session {SessionId}")]
+    partial void LogWhatsDoneSpawnFailed(Exception? ex, string sessionId);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Daemon heartbeat failed")]
     partial void LogHeartbeatFailed(Exception ex);

--- a/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
@@ -493,10 +493,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 // is the one that lands, a user-initiated stop is still recorded as
                 // "agent_stopped" rather than "agent_exited".
                 try {
-                    var generateWhatsDone = await _server.EndAgentSessionAsync(agent.Id, agent.PendingEndReason);
+                    var result = await _server.EndAgentSessionAsync(agent.Id, agent.PendingEndReason);
 
-                    if (generateWhatsDone && agent.SessionId is not null) {
-                        SpawnWhatsDoneGenerator(agent.SessionId);
+                    // The daemon doesn't track sessionId on its own (only agentId), so
+                    // the server returns it in the result. Spawn what's-done locally
+                    // when the server says yes.
+                    if (result.GenerateWhatsDone && result.SessionId is not null) {
+                        SpawnWhatsDoneGenerator(result.SessionId);
                     }
                 } catch (Exception ex) {
                     LogEndSessionFailed(ex, agent.Id);
@@ -539,8 +542,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // session-end hook (drains transcript, writes SessionEnded + summary,
             // optionally schedules what's-done). Falls through to SIGTERM/SIGKILL
             // below if claude doesn't exit in time.
+            //
+            // Claude CLI requires the slash-command text and the Enter key to arrive
+            // as separate PTY writes (with a small delay between them) — sending them
+            // in a single write makes Claude treat the carriage return as part of the
+            // command buffer instead of a submit. HandleSendInput uses the same split
+            // pattern; matching it here makes the graceful path actually fire.
             try {
-                await agent.Process.WriteAsync("/exit\r");
+                await agent.Process.WriteAsync("/exit");
+                await Task.Delay(50);
+                await agent.Process.WriteAsync("\r");
                 await agent.Process.WaitForExitAsync(GracefulExitWait);
             } catch (Exception ex) {
                 LogGracefulExitFailed(ex, agentId);
@@ -556,13 +567,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             // Tell the server to end the session. Idempotent server-side: if claude
             // did fire session-end during the graceful window, this is a no-op
-            // (returns false and the CLI's session-end handler already spawned the
-            // what's-done generator on its end).
+            // (returns GenerateWhatsDone=false and the CLI's session-end handler
+            // already spawned the what's-done generator on its end).
             try {
-                var generateWhatsDone = await _server.EndAgentSessionAsync(agentId, agent.PendingEndReason);
+                var result = await _server.EndAgentSessionAsync(agentId, agent.PendingEndReason);
 
-                if (generateWhatsDone && agent.SessionId is not null) {
-                    SpawnWhatsDoneGenerator(agent.SessionId);
+                if (result.GenerateWhatsDone && result.SessionId is not null) {
+                    SpawnWhatsDoneGenerator(result.SessionId);
                 }
             } catch (Exception ex) {
                 LogEndSessionFailed(ex, agentId);

--- a/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
@@ -475,6 +475,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
                 LogAgentExited(agent.Id, exitCode);
 
+                // Tell the server to end the AgentSession. Claude doesn't reliably fire
+                // its own session-end hook on SIGTERM/exit, so without this call the
+                // session would stay "active" forever in the read model. Server-side is
+                // idempotent — if claude did fire session-end first, this is a no-op.
+                try {
+                    await _server.EndAgentSessionAsync(agent.Id, "agent_exited");
+                } catch (Exception ex) {
+                    LogEndSessionFailed(ex, agent.Id);
+                }
+
                 // Clean up worktree and unregister from server
                 await CleanupAgentAsync(agent.Id);
             } catch (Exception ex) {
@@ -482,6 +492,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             }
         }
     }
+
+    /// <summary>
+    /// Initial wait after sending /exit to give claude a chance to flush its session-end
+    /// hook (which writes SessionEnded plus the what's-done summary). 15s covers a typical
+    /// session-end POST + watcher drain on a healthy connection.
+    /// </summary>
+    static readonly TimeSpan GracefulExitWait = TimeSpan.FromSeconds(15);
 
     async Task HandleStopAgent(string agentId) {
         if (!_agents.TryGetValue(agentId, out var agent)) {
@@ -497,7 +514,26 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             _            = _server.AgentStatusChangedAsync(agentId, "Completed", agent.SessionId);
             _            = _server.AppendAgentRunEventAsync(agentId, new AgentRunStopped("user", null));
 
-            // Cancel the read loop, then terminate the process.
+            // Try a graceful shutdown first: send /exit so claude can fire its own
+            // session-end hook (drains transcript, writes SessionEnded + summary,
+            // optionally schedules what's-done). Falls through to SIGTERM/SIGKILL
+            // below if claude doesn't exit in time.
+            try {
+                await agent.Process.WriteAsync("/exit\r");
+                await agent.Process.WaitForExitAsync(GracefulExitWait);
+            } catch (Exception ex) {
+                LogGracefulExitFailed(ex, agentId);
+            }
+
+            // Tell the server to end the session. Idempotent server-side: if claude
+            // did fire session-end during the graceful window, this is a no-op.
+            try {
+                await _server.EndAgentSessionAsync(agentId, "agent_stopped");
+            } catch (Exception ex) {
+                LogEndSessionFailed(ex, agentId);
+            }
+
+            // Cancel the read loop, then terminate the process if it didn't exit gracefully.
             // The read loop's finally block will handle CleanupAgentAsync.
             await agent.ReadCts.CancelAsync();
             await agent.Process.TerminateAsync(TimeSpan.FromSeconds(10));
@@ -1097,6 +1133,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Error stopping agent {AgentId}")]
     partial void LogStopError(Exception ex, string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Graceful /exit failed for agent {AgentId}; falling back to SIGTERM")]
+    partial void LogGracefulExitFailed(Exception ex, string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to end session for agent {AgentId} (server may not record SessionEnded)")]
+    partial void LogEndSessionFailed(Exception ex, string agentId);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Daemon heartbeat failed")]
     partial void LogHeartbeatFailed(Exception ex);

--- a/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
@@ -30,6 +30,15 @@ public record AgentInstance(
 
     /// <summary>Temp MCP config path written for hosted PR reviews; deleted on cleanup.</summary>
     public string? McpConfigPath { get; set; }
+
+    /// <summary>
+    /// Reason string sent to the server when ending the AgentSession. Defaults to
+    /// "agent_exited" (claude exited on its own); HandleStopAgent flips it to
+    /// "agent_stopped" so a user-initiated stop is still attributed correctly even
+    /// if HandleStopAgent's own EndAgentSessionAsync call fails and the read-loop's
+    /// finally-block call is the only one that lands.
+    /// </summary>
+    public string PendingEndReason { get; set; } = "agent_exited";
 }
 
 /// <summary>Ring buffer that keeps the last 2 MB of terminal output.</summary>
@@ -479,8 +488,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 // its own session-end hook on SIGTERM/exit, so without this call the
                 // session would stay "active" forever in the read model. Server-side is
                 // idempotent — if claude did fire session-end first, this is a no-op.
+                // Reason is read from agent.PendingEndReason so that if HandleStopAgent's
+                // own call failed (transient SignalR error) and this finally-block call
+                // is the one that lands, a user-initiated stop is still recorded as
+                // "agent_stopped" rather than "agent_exited".
                 try {
-                    await _server.EndAgentSessionAsync(agent.Id, "agent_exited");
+                    await _server.EndAgentSessionAsync(agent.Id, agent.PendingEndReason);
                 } catch (Exception ex) {
                     LogEndSessionFailed(ex, agent.Id);
                 }
@@ -511,8 +524,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // Set status BEFORE cancelling ReadCts so the read loop's finally
             // block sees "Completed" and skips its own status change / event append.
             agent.Status = "Completed";
-            _            = _server.AgentStatusChangedAsync(agentId, "Completed", agent.SessionId);
-            _            = _server.AppendAgentRunEventAsync(agentId, new AgentRunStopped("user", null));
+            // Mark this as a user-initiated stop so the read-loop's finally-block
+            // EndAgentSessionAsync call uses "agent_stopped" if it ends up being
+            // the only successful call (e.g., transient SignalR failure here).
+            agent.PendingEndReason = "agent_stopped";
+            _                      = _server.AgentStatusChangedAsync(agentId, "Completed", agent.SessionId);
+            _                      = _server.AppendAgentRunEventAsync(agentId, new AgentRunStopped("user", null));
 
             // Try a graceful shutdown first: send /exit so claude can fire its own
             // session-end hook (drains transcript, writes SessionEnded + summary,
@@ -525,10 +542,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 LogGracefulExitFailed(ex, agentId);
             }
 
+            // PTY WaitForExitAsync(timeout) returns silently when the timeout elapses,
+            // so a graceful-exit *timeout* doesn't throw. Check HasExited explicitly
+            // so we can tell from logs whether the graceful path is actually working
+            // in production or if claude is consistently being SIGTERMed instead.
+            if (!agent.Process.HasExited) {
+                LogGracefulExitTimedOut(agentId, GracefulExitWait.TotalSeconds);
+            }
+
             // Tell the server to end the session. Idempotent server-side: if claude
             // did fire session-end during the graceful window, this is a no-op.
             try {
-                await _server.EndAgentSessionAsync(agentId, "agent_stopped");
+                await _server.EndAgentSessionAsync(agentId, agent.PendingEndReason);
             } catch (Exception ex) {
                 LogEndSessionFailed(ex, agentId);
             }
@@ -1136,6 +1161,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Graceful /exit failed for agent {AgentId}; falling back to SIGTERM")]
     partial void LogGracefulExitFailed(Exception ex, string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Graceful /exit window of {Seconds}s elapsed for agent {AgentId} without claude exiting; falling back to SIGTERM")]
+    partial void LogGracefulExitTimedOut(string agentId, double seconds);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to end session for agent {AgentId} (server may not record SessionEnded)")]
     partial void LogEndSessionFailed(Exception ex, string agentId);

--- a/src/Kapacitor.Daemon/Services/ServerConnection.cs
+++ b/src/Kapacitor.Daemon/Services/ServerConnection.cs
@@ -235,11 +235,14 @@ internal partial class ServerConnection : IAsyncDisposable {
     /// handler is idempotent — if SessionEnded was already written (e.g. claude did
     /// fire session-end first), this call is a no-op.
     ///
-    /// Returns <c>true</c> when the daemon should spawn the what's-done generator
-    /// (matches the <c>generate_whats_done</c> flag from <c>/hooks/session-end</c>).
+    /// The result carries the resolved <c>SessionId</c> (the daemon only knows
+    /// agentId; the server resolves the link) plus a <c>GenerateWhatsDone</c> flag.
+    /// When the flag is true and SessionId is non-null, the daemon should spawn
+    /// <c>kapacitor generate-whats-done {sessionId}</c> locally — matching the
+    /// behaviour of the CLI session-end handler for the local-claude case.
     /// </summary>
-    public virtual Task<bool> EndAgentSessionAsync(string agentId, string reason)
-        => _hub.InvokeAsync<bool>("EndAgentSession", agentId, reason, cancellationToken: _ct);
+    public virtual Task<EndAgentSessionResult> EndAgentSessionAsync(string agentId, string reason)
+        => _hub.InvokeAsync<EndAgentSessionResult>("EndAgentSession", agentId, reason, cancellationToken: _ct);
 
     /// <summary>
     /// Forwards a hosted-agent permission request to the server's <c>RequestPermission</c>

--- a/src/Kapacitor.Daemon/Services/ServerConnection.cs
+++ b/src/Kapacitor.Daemon/Services/ServerConnection.cs
@@ -234,9 +234,12 @@ internal partial class ServerConnection : IAsyncDisposable {
     /// guaranteed to fire its own <c>session-end</c> hook on SIGTERM. The server-side
     /// handler is idempotent — if SessionEnded was already written (e.g. claude did
     /// fire session-end first), this call is a no-op.
+    ///
+    /// Returns <c>true</c> when the daemon should spawn the what's-done generator
+    /// (matches the <c>generate_whats_done</c> flag from <c>/hooks/session-end</c>).
     /// </summary>
-    public virtual Task EndAgentSessionAsync(string agentId, string reason)
-        => _hub.InvokeAsync("EndAgentSession", agentId, reason, cancellationToken: _ct);
+    public virtual Task<bool> EndAgentSessionAsync(string agentId, string reason)
+        => _hub.InvokeAsync<bool>("EndAgentSession", agentId, reason, cancellationToken: _ct);
 
     /// <summary>
     /// Forwards a hosted-agent permission request to the server's <c>RequestPermission</c>

--- a/src/Kapacitor.Daemon/Services/ServerConnection.cs
+++ b/src/Kapacitor.Daemon/Services/ServerConnection.cs
@@ -229,6 +229,16 @@ internal partial class ServerConnection : IAsyncDisposable {
         => _hub.InvokeAsync("LaunchFailed", new LaunchFailed(agentId, reason), cancellationToken: _ct);
 
     /// <summary>
+    /// Tells the server to end the AgentSession for a daemon-hosted agent. Used when
+    /// the daemon stops or observes a hosted claude exiting, since claude isn't
+    /// guaranteed to fire its own <c>session-end</c> hook on SIGTERM. The server-side
+    /// handler is idempotent — if SessionEnded was already written (e.g. claude did
+    /// fire session-end first), this call is a no-op.
+    /// </summary>
+    public virtual Task EndAgentSessionAsync(string agentId, string reason)
+        => _hub.InvokeAsync("EndAgentSession", agentId, reason, cancellationToken: _ct);
+
+    /// <summary>
     /// Forwards a hosted-agent permission request to the server's <c>RequestPermission</c>
     /// hub method and returns the user's decision. Runs over the persistent SignalR
     /// connection so the long-poll isn't subject to the Cloudflare HTTP-request timeout

--- a/src/kapacitor/Commands/WatchCommand.cs
+++ b/src/kapacitor/Commands/WatchCommand.cs
@@ -209,10 +209,15 @@ static partial class WatchCommand {
             await DrainNewLines(hubConnection, sessionId, transcriptPath, agentId, state, CancellationToken.None);
         }
 
-        // Signal drain complete to server
+        // Signal drain complete to server.
+        // cts.Token is already cancelled by the time we reach here (that's the path
+        // that exits the main loop), so passing it would throw OperationCanceledException
+        // before the call lands. Use a fresh short-lived token so the server actually
+        // hears the drain-complete signal and can release StopAndDrainAsync waiters.
         try {
             if (hubConnection.State == HubConnectionState.Connected) {
-                await hubConnection.InvokeAsync("WatcherDrainComplete", sessionId, agentId, cancellationToken: cts.Token);
+                using var drainCompleteCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                await hubConnection.InvokeAsync("WatcherDrainComplete", sessionId, agentId, cancellationToken: drainCompleteCts.Token);
                 Log("Drain complete signaled to server");
             }
         } catch (Exception ex) {


### PR DESCRIPTION
## Summary

Fixes orphan "active" sessions for hosted agents (AI-62). When the daemon stops a hosted claude (or observes it exiting unexpectedly), nothing was guaranteed to fire claude's `session-end` hook. With no `SessionEnded` event in the stream, the session stayed marked active forever in the read model — and no session summary or what's-done was generated.

Three changes in one PR:

1. **Graceful shutdown attempt before SIGTERM** — `HandleStopAgent` now writes `/exit\r` to the PTY and waits 15s for claude to fire its own `session-end` (which still runs the existing what's-done generation when configured) before falling back to SIGTERM/SIGKILL.

2. **Daemon-driven `EndAgentSession` call** — both `HandleStopAgent` and `ReadAgentOutputAsync`'s `finally` block now call the new `EndAgentSession` hub method (with reasons `agent_stopped` and `agent_exited` respectively). The server-side handler is idempotent: a no-op if claude already fired session-end, otherwise drains the watcher, appends `SessionEnded`, and computes summary stats.

3. **`WatcherDrainComplete` cts bug** — the watcher was passing `cts.Token` (already cancelled when the final-drain block runs) to `InvokeAsync`, so the call threw `OperationCanceledException` synchronously and the server-side `StopAndDrainAsync` always timed out at 10s. Switched to a fresh 5s token.

## Test plan

- [x] CLI unit tests pass (404 ✓)
- [x] AOT publish for `kapacitor` produces no IL3050/IL2026 warnings
- [x] AOT publish for `kapacitor-daemon` produces no IL3050/IL2026 warnings
- [ ] Manual: hosted agent stopped via UI → SessionEnded appears in stream, session shows Ended in dashboard
- [ ] Manual: hosted agent killed externally (`kill -9`) → daemon emits SessionEnded with reason `agent_exited`

## Server-side

This PR depends on a server change in `kurrent-io/Kurrent.Capacitor` that adds the `EndAgentSession` hub method and the `SessionEndReason.AgentStopped` / `AgentExited` enum values. The server PR also bumps this submodule reference. Server-side defaults gracefully when the daemon isn't yet upgraded (no client calls the new method).

🤖 Generated with [Claude Code](https://claude.com/claude-code)