### PR TITLE
[AI-75] Watcher: send vendor arg to SendTranscriptBatch

### DIFF
--- a/src/kapacitor/Commands/WatchCommand.cs
+++ b/src/kapacitor/Commands/WatchCommand.cs
@@ -423,6 +423,9 @@ static partial class WatchCommand {
                 : null;
 
             try {
+                // Arg count must match `CapacitorHub.SendTranscriptBatch` exactly —
+                // SignalR's protocol layer does a strict arity match and does NOT
+                // auto-supply defaults for missing args (PR #576 / v0.4.0 incident).
                 await hubConnection.InvokeAsync(
                     "SendTranscriptBatch",
                     sessionId,
@@ -430,6 +433,7 @@ static partial class WatchCommand {
                     newLines.ToArray(),
                     newLineNumbers.ToArray(),
                     repoJson,
+                    "claude",
                     ct
                 );
 


### PR DESCRIPTION
## Summary

- Watcher's `InvokeAsync("SendTranscriptBatch", ...)` was missing the 6th positional `vendor` arg the server requires after [#576](https://github.com/kurrent-io/Kurrent.Capacitor/pull/576). SignalR's protocol layer rejects every batch with `InvalidDataException: Invocation provides 5 argument(s) but target expects 6.`, so users on the upgraded server see sessions with no transcript content — only the synchronous permission-request hook rows surface.
- Adds the missing positional `"claude"` so v0.4.1 watchers match the server signature.

## Why a backwards-compat fix wasn't chosen

[#576](https://github.com/kurrent-io/Kurrent.Capacitor/pull/576) assumed SignalR fills in default-valued parameters when a client invokes with fewer args. It doesn't — `JsonHubProtocol.BindArguments` does a strict arity match against `MethodInfo.GetParameters().Length`. The "right" backwards-compat shape would have been to put `vendor` inside the existing `repositoryJson` blob (rename to `metadataJson`), but that's a deeper change. Existing v0.4.0 installs will keep failing until they auto-update (`kapacitor update` runs every 24h).

## Test plan

- [ ] Build CLI in Release: `dotnet publish src/kapacitor/kapacitor.csproj -c Release` (already verified locally — AOT clean).
- [ ] Companion server PR adds `SendTranscriptBatchWireTests` exercising the exact wire shape via real SignalR `HubConnection`. Both arms (current 6-arg shape succeeds, legacy 5-arg shape rejected with arity error) pass.
- [ ] After merging both: tag CLI v0.4.1, bump submodule on server, redeploy staging. Confirm `~/.config/kapacitor/logs/<sessionId>.log` no longer shows the "SendTranscriptBatch failed" retry loop and the dashboard shows full transcripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)