### PR TITLE
chore: add InternalsVisibleTo entries for split server test projects

### DIFF
--- a/src/Kapacitor.Core/Kapacitor.Core.csproj
+++ b/src/Kapacitor.Core/Kapacitor.Core.csproj
@@ -21,6 +21,13 @@
         <!-- Used when referenced as a submodule from the server repo -->
         <InternalsVisibleTo Include="Kurrent.Capacitor.TestHelpers" />
         <InternalsVisibleTo Include="Kurrent.Capacitor.Tests" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Agents" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Auth" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Chat" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Evals" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Ingest" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Notify" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Read" />
         <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.UI" />
     </ItemGroup>
 </Project>

--- a/src/Kapacitor.Daemon/Kapacitor.Daemon.csproj
+++ b/src/Kapacitor.Daemon/Kapacitor.Daemon.csproj
@@ -23,6 +23,13 @@
         <!-- Used when referenced as a submodule from the server repo -->
         <InternalsVisibleTo Include="Kurrent.Capacitor.TestHelpers" />
         <InternalsVisibleTo Include="Kurrent.Capacitor.Tests" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Agents" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Auth" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Chat" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Evals" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Ingest" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Notify" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Read" />
         <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.UI" />
     </ItemGroup>
     <ItemGroup>

--- a/src/kapacitor/kapacitor.csproj
+++ b/src/kapacitor/kapacitor.csproj
@@ -18,6 +18,13 @@
         <!-- Used when referenced as a submodule from the server repo -->
         <InternalsVisibleTo Include="Kurrent.Capacitor.TestHelpers" />
         <InternalsVisibleTo Include="Kurrent.Capacitor.Tests" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Agents" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Auth" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Chat" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Evals" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Ingest" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Notify" />
+        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Read" />
         <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.UI" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
## Summary
- The Capacitor server's `Kurrent.Capacitor.Tests` project is being split into 7 capability-focused projects (Auth, Ingest, Chat, Agents, Evals, Read, Notify).
- Each new project name needs an `InternalsVisibleTo` entry on `Kapacitor.Core`, `Kapacitor.Daemon`, and `kapacitor` so server tests can keep accessing internal helpers like `SessionImporter` and `HistoryCommand`.

## Test plan
- [ ] No code changes — only csproj `InternalsVisibleTo` additions; existing CLI builds and tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)