### PR TITLE
[AI-73] CLI: kapacitor history --codex imports Codex rollouts

### DIFF
--- a/docs/superpowers/specs/2026-05-07-ai-73-codex-history-import-design.md
+++ b/docs/superpowers/specs/2026-05-07-ai-73-codex-history-import-design.md
@@ -1,0 +1,127 @@
+# AI-73 — Codex historical session import (`kapacitor history --codex`)
+
+## Problem
+
+Server PR #576 added `CodexNormalizer` and a `vendor` discriminator on `TranscriptBatch`. The CLI side has no path that walks `~/.codex/sessions/` and POSTs the rollouts with `vendor: "codex"`, so users can't backfill their Codex history. This spec closes that gap.
+
+## Scope
+
+Extend `kapacitor history` with a `--codex` flag that mirrors the existing (default) Claude mode but targets the Codex rollout layout. Reuse the existing classify → plan → import → titles/summaries pipeline; the only vendor-specific pieces are discovery, metadata extraction, the title context extractor, and the new `vendor` field on outgoing transcript batches.
+
+In scope:
+
+- `--codex` flag — switches the discovery + metadata stage to the Codex rollout layout.
+- `--since YYYY-MM-DD` — filters by date (cheap directory pruning for Codex; falls back to per-file metadata for Claude).
+- `Vendor` field on `TranscriptBatch` (CLI-side mirror of the server record).
+- Codex-shaped session-start hook payload (cwd, model from `model_provider`, repo from `git` block, `started_at` from session_meta `timestamp`).
+- Codex-shaped title context extractor (first user `input_text` + first assistant `message.content[].text`).
+- Windows path resolution via `%USERPROFILE%\.codex\sessions\...` (same `Environment.SpecialFolder.UserProfile` mechanism `ClaudePaths` uses).
+
+Out of scope (per ticket):
+
+- Live SignalR streaming / hooks — AI-70.
+- Daemon-spawned hosted Codex agents — AI-68 / AI-72.
+- Subagent transcript walk — Codex has no analog.
+- Continuation chains — Codex rollouts have no on-disk slug; every rollout is a single-element chain (the existing `BuildImportChains` already handles slug-less sessions as length-1 chains, so no special-case needed).
+
+## Discovery
+
+Codex layout (per machine inspection):
+
+```
+~/.codex/sessions/YYYY/MM/DD/rollout-<ISO-ts>-<uuid>.jsonl
+```
+
+`<uuid>` is the session id and is also present in the first JSONL line's `payload.id`. The CLI extracts it from the filename (cheap, no I/O) and validates against the metadata at metadata-extraction time.
+
+`--since YYYY-MM-DD` is applied at the directory level: enumerate the year/month/day directories sorted lexicographically (which equals chronological for ISO-shaped names) and skip anything strictly less than the cutoff. For Claude mode, `--since` is best-effort: applied after metadata extraction by comparing `meta.FirstTimestamp ?? File.GetLastWriteTimeUtc(path)`.
+
+## Codex session_meta shape (real example, abbreviated)
+
+```json
+{
+  "timestamp": "2026-05-07T15:51:46.684Z",
+  "type": "session_meta",
+  "payload": {
+    "id": "019e0322-05fc-7570-be65-75719c3ea861",
+    "timestamp": "2026-05-07T15:50:21.989Z",
+    "cwd": "/Users/alexey/dev/temp/Kurrent.Capacitor",
+    "originator": "codex-tui",
+    "cli_version": "0.128.0",
+    "source": "cli",
+    "model_provider": "openai",
+    "git": {
+      "commit_hash": "...",
+      "branch": "main",
+      "repository_url": "https://github.com/owner/repo"
+    }
+  }
+}
+```
+
+Mapping to the session-start hook:
+
+| Hook field            | Source                                                    |
+| --------------------- | --------------------------------------------------------- |
+| `session_id`          | UUID from filename (validated against `payload.id`)       |
+| `transcript_path`     | full rollout path                                         |
+| `cwd`                 | `payload.cwd`                                             |
+| `started_at`          | `payload.timestamp` (the inner one — when codex started)  |
+| `model`               | `payload.model_provider` (provider name, no model name in session_meta — fine; the server's CodexNormalizer pulls the actual model from `event_msg`/response-item lines) |
+| `source`              | `"Startup"` (matches Claude mode literal)                 |
+| `hook_event_name`     | `"session_start"`                                         |
+| `repository.remote_url` / `branch` | `payload.git.repository_url` / `payload.git.branch` (when present) — git owner/repo derived via existing `GitUrlParser.ParseRemoteUrl` |
+| `vendor` (batch)      | `"codex"` on every `TranscriptBatch` POST                 |
+
+`previous_session_id` is omitted (no chain detection for Codex).
+
+## Wire change: `TranscriptBatch.Vendor`
+
+Add an optional `vendor` field to `src/Kapacitor.Core/Models.cs`:
+
+```csharp
+record TranscriptBatch {
+    [JsonPropertyName("session_id")]   public required string  SessionId   { get; init; }
+    [JsonPropertyName("agent_id")]     public string?          AgentId     { get; init; }
+    [JsonPropertyName("lines")]        public required string[] Lines      { get; init; }
+    [JsonPropertyName("line_numbers")] public int[]?           LineNumbers { get; init; }
+    [JsonPropertyName("repository")]   public RepositoryPayload? Repository { get; init; }
+    [JsonPropertyName("vendor")]       public string?          Vendor      { get; init; }
+}
+```
+
+Defaults to null → omitted by the serializer → server treats as `"claude"` (its existing default). Watcher path is unchanged (it goes via SignalR, not HTTP — already passes `"claude"` as a positional arg).
+
+## Code surface
+
+- `src/Kapacitor.Core/CodexPaths.cs` (new) — `Sessions` directory + `--since` directory walk.
+- `src/Kapacitor.Core/Models.cs` — add `Vendor` field to `TranscriptBatch`.
+- `src/kapacitor/Commands/HistoryCommand.cs`:
+  - `HandleHistory(...)` gains `bool codex` and `DateOnly? since`.
+  - `DiscoverCodexRollouts(string sessionsDir, DateOnly? since)` (sibling to `DiscoverTranscripts`) — returns `(SessionId, FilePath, EncodedCwd)` tuples like the Claude path. `EncodedCwd` is synthesised from the session_meta cwd by mirroring Claude's `/`→`-` encoding so `DecodeCwdFromDirName` round-trips.
+  - `ExtractCodexSessionMetadata(filePath)` — pulls cwd, model_provider, first timestamp, git block from the first `session_meta` line.
+  - Vendor threads through `ImportSingleSessionAsync` (only impacts the session-start hook and the batch POSTs).
+- `src/kapacitor/Commands/SessionImporter.cs`:
+  - `ImportSessionAsync(..., string vendor)` — passes vendor into batch posts, skips subagent walk when `vendor == "codex"`.
+  - `SendTranscriptBatches(..., string vendor)` and `PostTranscriptBatch(..., string vendor)` — vendor lands on the JSON payload.
+- `src/kapacitor/Commands/TitleGenerator.cs`:
+  - `ExtractCodexTitleContext(filePath)` — first `response_item` with `role:"user"` containing `input_text`, skipping `<environment_context>` blocks; first `response_item` with `role:"assistant"` containing `output_text`. Same return shape and 200-line scan budget.
+- `src/kapacitor/Program.cs` — parse `--codex` and `--since`, route to `HandleHistory`.
+- `src/Kapacitor.Core/Resources/help-history.txt` — document new flags.
+
+## Tests
+
+`test/kapacitor.Tests.Unit/`:
+
+- `CodexPathsTests` — fixture tree of `YYYY/MM/DD/rollout-*.jsonl`, asserts `--since` cutoff prunes correctly.
+- `HistoryCommandTests` (extend) — `ExtractCodexSessionMetadata` parses cwd/model_provider/git from a fixture line; missing-git tolerated.
+- `TitleGeneratorTests` — `ExtractCodexTitleContext` returns first user input_text + first assistant output_text; tolerates missing assistant; truncates user at 500 chars (matching Claude path).
+- `TranscriptBatch` JSON shape — when `Vendor` is null the field is absent; when `"codex"` it serializes as `"vendor":"codex"`.
+- Existing `HistoryCommandTests` and `SessionImporterScanTests` keep passing (no shape changes to Claude transcripts).
+
+## Verification
+
+- `dotnet build src/kapacitor/kapacitor.csproj` — no warnings.
+- `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — no IL3050/IL2026 (we're adding a property and a literal vendor string; no new reflection or dynamic JSON paths).
+- `dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj` — all green.
+- Manual smoke (post-merge, against staging): `kapacitor history --codex --since 2026-05-01` imports the user's recent rollouts and they render in the dashboard with chat / events / trace.

--- a/docs/superpowers/specs/2026-05-07-ai-73-codex-history-import-design.md
+++ b/docs/superpowers/specs/2026-05-07-ai-73-codex-history-import-design.md
@@ -98,7 +98,7 @@ Defaults to null → omitted by the serializer → server treats as `"claude"` (
 - `src/Kapacitor.Core/Models.cs` — add `Vendor` field to `TranscriptBatch`.
 - `src/kapacitor/Commands/HistoryCommand.cs`:
   - `HandleHistory(...)` gains `bool codex` and `DateOnly? since`.
-  - `DiscoverCodexRollouts(string sessionsDir, DateOnly? since)` (sibling to `DiscoverTranscripts`) — returns `(SessionId, FilePath, EncodedCwd)` tuples like the Claude path. `EncodedCwd` is synthesised from the session_meta cwd by mirroring Claude's `/`→`-` encoding so `DecodeCwdFromDirName` round-trips.
+  - `DiscoverCodexRollouts(string sessionsDir, DateOnly? since)` (sibling to `DiscoverTranscripts`) — returns `(SessionId, FilePath, EncodedCwd)` tuples like the Claude path. `EncodedCwd` is left empty for Codex: the day folder name isn't a Claude-style hyphen-encoded path, and an empty string makes `DecodeCwdFromDirName` return null so callers skip cwd-dependent work cleanly when `session_meta` parsing fails.
   - `ExtractCodexSessionMetadata(filePath)` — pulls cwd, model_provider, first timestamp, git block from the first `session_meta` line.
   - Vendor threads through `ImportSingleSessionAsync` (only impacts the session-start hook and the batch POSTs).
 - `src/kapacitor/Commands/SessionImporter.cs`:

--- a/src/Kapacitor.Core/CodexCliRunner.cs
+++ b/src/Kapacitor.Core/CodexCliRunner.cs
@@ -1,0 +1,192 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace kapacitor;
+
+/// <summary>
+/// Headless invocation of the <c>codex exec</c> CLI for title generation and
+/// what's-done summaries on Codex-vendor sessions.
+/// </summary>
+/// <remarks>
+/// Mirrors <see cref="ClaudeCliRunner"/>'s contract — same return record, same
+/// timeout / cancellation semantics — but the wire is much simpler: <c>codex
+/// exec</c> writes a single text response to <c>--output-last-message &lt;file&gt;</c>
+/// which we read back as <see cref="ClaudeCliResult.Result"/>. Token usage and
+/// cost are not currently parsed (would require <c>--json</c> event-stream
+/// processing); they default to zero.
+/// </remarks>
+static class CodexCliRunner {
+    public static async Task<ClaudeCliResult?> RunAsync(
+            string            prompt,
+            TimeSpan          timeout,
+            Action<string>    log,
+            string            model         = "gpt-5.3-codex",
+            string            reasoning     = "low",
+            CancellationToken ct            = default
+        ) {
+        // Fresh empty working dir per invocation: --skip-git-repo-check is
+        // passed below so codex won't refuse to run, but a stable per-session
+        // dir keeps any incidental writes (cache, temp probes) isolated and
+        // sweepable.
+        var workingDir        = Path.Combine(Path.GetTempPath(), $"kapacitor-codex-{Guid.NewGuid():N}");
+        var lastMessageFile   = Path.Combine(workingDir, "last-message.txt");
+        var createdWorkingDir = false;
+
+        try {
+            Directory.CreateDirectory(workingDir);
+            createdWorkingDir = true;
+        } catch (Exception ex) {
+            log($"Failed to create isolated working directory: {ex.Message}");
+            workingDir      = Path.GetTempPath();
+            lastMessageFile = Path.Combine(workingDir, $"kapacitor-codex-last-{Guid.NewGuid():N}.txt");
+        }
+
+        try {
+            return await RunCoreAsync(prompt, timeout, log, workingDir, lastMessageFile, model, reasoning, ct);
+        } finally {
+            if (createdWorkingDir) {
+                try { Directory.Delete(workingDir, recursive: true); } catch {
+                    /* best effort */
+                }
+            } else {
+                try { File.Delete(lastMessageFile); } catch {
+                    /* best effort */
+                }
+            }
+        }
+    }
+
+    static async Task<ClaudeCliResult?> RunCoreAsync(
+            string            prompt,
+            TimeSpan          timeout,
+            Action<string>    log,
+            string            workingDir,
+            string            lastMessageFile,
+            string            model,
+            string            reasoning,
+            CancellationToken ct
+        ) {
+        var psi = new ProcessStartInfo {
+            FileName               = "codex",
+            WorkingDirectory       = workingDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            RedirectStandardInput  = true,
+            UseShellExecute        = false,
+            CreateNoWindow         = true,
+            Environment = {
+                // Symmetric with the Claude path — block any nested kapacitor hook
+                // forwarding so a headless codex invocation can't re-trigger import.
+                ["KAPACITOR_SKIP"] = "1"
+            }
+        };
+
+        psi.ArgumentList.Add("exec");
+        psi.ArgumentList.Add("--ephemeral");
+        psi.ArgumentList.Add("--ignore-user-config");
+        psi.ArgumentList.Add("--ignore-rules");
+        psi.ArgumentList.Add("--skip-git-repo-check");
+        psi.ArgumentList.Add("--sandbox");
+        psi.ArgumentList.Add("read-only");
+        psi.ArgumentList.Add("--color");
+        psi.ArgumentList.Add("never");
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add($"model_reasoning_effort=\"{reasoning}\"");
+        psi.ArgumentList.Add("-m");
+        psi.ArgumentList.Add(model);
+        psi.ArgumentList.Add("--output-last-message");
+        psi.ArgumentList.Add(lastMessageFile);
+        // Read prompt from stdin via the literal "-" placeholder so titles longer
+        // than the OS argv limit (and embedded special characters like "$" or
+        // backticks) don't need escaping.
+        psi.ArgumentList.Add("-");
+
+        using var process = Process.Start(psi);
+
+        if (process is null) {
+            log("Failed to start codex process");
+
+            return null;
+        }
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts  = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+
+        try {
+            await process.StandardInput.WriteAsync(prompt.AsMemory(), linkedCts.Token);
+            await process.StandardInput.FlushAsync(linkedCts.Token);
+            process.StandardInput.Close();
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            try { process.Kill(entireProcessTree: true); } catch {
+                /* ignore */
+            }
+
+            throw;
+        } catch (Exception ex) {
+            log($"Failed to stream prompt to codex stdin: {ex.Message}");
+            try { process.Kill(entireProcessTree: true); } catch {
+                /* ignore */
+            }
+
+            return null;
+        }
+
+        try {
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(linkedCts.Token);
+            var stderrTask = process.StandardError.ReadToEndAsync(linkedCts.Token);
+
+            await process.WaitForExitAsync(linkedCts.Token);
+            await stdoutTask;
+            var stderr = await stderrTask;
+
+            if (process.ExitCode != 0) {
+                var stderrPreview = stderr.Length > 200 ? stderr[..200] : stderr;
+                log($"Codex exited with code {process.ExitCode}, stderr: {stderrPreview}");
+
+                return null;
+            }
+
+            if (!File.Exists(lastMessageFile)) {
+                log("Codex exited 0 but last-message file is missing");
+
+                return null;
+            }
+
+            var resultText = (await File.ReadAllTextAsync(lastMessageFile, Encoding.UTF8, linkedCts.Token)).Trim();
+
+            if (string.IsNullOrWhiteSpace(resultText)) {
+                log("Codex produced an empty last message");
+
+                return null;
+            }
+
+            // Token usage / cost are not parsed: would require --json event-stream
+            // processing. Title and what's-done payloads tolerate zeros (they're
+            // surfaced for diagnostics, not billing).
+            return new ClaudeCliResult(
+                Result: resultText,
+                Model: model,
+                InputTokens: 0,
+                OutputTokens: 0,
+                CacheReadTokens: 0,
+                CacheWriteTokens: 0,
+                CostUsd: null,
+                NumTurns: 1
+            );
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            try { process.Kill(entireProcessTree: true); } catch {
+                /* ignore */
+            }
+
+            throw;
+        } catch (OperationCanceledException) {
+            log($"Codex process timed out ({timeout.TotalSeconds:0}s), killing");
+
+            try { process.Kill(entireProcessTree: true); } catch {
+                /* ignore */
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Kapacitor.Core/CodexPaths.cs
+++ b/src/Kapacitor.Core/CodexPaths.cs
@@ -1,0 +1,83 @@
+namespace kapacitor;
+
+static class CodexPaths {
+    static readonly string Home = Path.Combine(PathHelpers.HomeDirectory, ".codex");
+
+    public static string Sessions { get; } = Path.Combine(Home, "sessions");
+
+    /// <summary>
+    /// Walk <c>~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl</c>, optionally pruning
+    /// directories below <paramref name="since"/>. Returns one entry per rollout
+    /// with the session id parsed from the filename suffix
+    /// (<c>rollout-&lt;ISO-ts&gt;-&lt;uuid&gt;.jsonl</c>) and a synthesised
+    /// EncodedCwd matching Claude's <c>/</c>→<c>-</c> encoding so callers that
+    /// share the Claude path's plumbing (<see cref="kapacitor.Commands.SessionImporter.DecodeCwdFromDirName"/>)
+    /// keep working without a special case.
+    /// </summary>
+    /// <param name="sessionsDir">Override of the <c>~/.codex/sessions</c> root, primarily for tests.</param>
+    /// <param name="since">Inclusive lower bound — files in date directories before this are skipped.</param>
+    public static List<(string SessionId, string FilePath, string EncodedCwd)> Discover(string? sessionsDir = null, DateOnly? since = null) {
+        var root    = sessionsDir ?? Sessions;
+        var results = new List<(string, string, string)>();
+
+        if (!Directory.Exists(root)) return results;
+
+        foreach (var year in EnumerateNumericDirs(root, since?.Year)) {
+            foreach (var month in EnumerateNumericDirs(year.Path, MonthBound(since, year.Value))) {
+                foreach (var day in EnumerateNumericDirs(month.Path, DayBound(since, year.Value, month.Value))) {
+                    foreach (var jsonl in Directory.GetFiles(day.Path, "rollout-*.jsonl")) {
+                        var sid = ExtractSessionIdFromFileName(jsonl);
+
+                        if (sid is null) continue;
+
+                        // Codex rollouts have no project-hashed parent dir, so synthesise an EncodedCwd
+                        // from the day path. The session_meta line is the source of truth for cwd —
+                        // this fallback only matters if metadata extraction fails.
+                        var encoded = Path.GetFileName(day.Path);
+                        results.Add((sid, jsonl, encoded));
+                    }
+                }
+            }
+        }
+
+        return results;
+    }
+
+    static IEnumerable<(string Path, int Value)> EnumerateNumericDirs(string parent, int? minInclusive) {
+        if (!Directory.Exists(parent)) yield break;
+
+        foreach (var dir in Directory.GetDirectories(parent)) {
+            var name = Path.GetFileName(dir);
+
+            if (!int.TryParse(name, out var value)) continue;
+            if (minInclusive is { } min && value < min) continue;
+
+            yield return (dir, value);
+        }
+    }
+
+    static int? MonthBound(DateOnly? since, int year) =>
+        since is { } s && s.Year == year ? s.Month : null;
+
+    static int? DayBound(DateOnly? since, int year, int month) =>
+        since is { } s && s.Year == year && s.Month == month ? s.Day : null;
+
+    /// <summary>
+    /// Parse the trailing UUID from <c>rollout-&lt;ISO-ts&gt;-&lt;uuid&gt;.jsonl</c>.
+    /// The UUID is normalized to dashless form so it round-trips with the rest of
+    /// the CLI's NormalizeGuidField behaviour.
+    /// </summary>
+    public static string? ExtractSessionIdFromFileName(string filePath) {
+        var name = Path.GetFileNameWithoutExtension(filePath);
+
+        // rollout-2026-05-07T17-50-21-019e0322-05fc-7570-be65-75719c3ea861
+        // Last 5 dash-separated chunks form the UUID.
+        var parts = name.Split('-');
+
+        if (parts.Length < 5) return null;
+
+        var uuid = string.Join('-', parts[^5..]);
+
+        return Guid.TryParse(uuid, out var guid) ? guid.ToString("N") : null;
+    }
+}

--- a/src/Kapacitor.Core/CodexPaths.cs
+++ b/src/Kapacitor.Core/CodexPaths.cs
@@ -9,10 +9,12 @@ static class CodexPaths {
     /// Walk <c>~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl</c>, optionally pruning
     /// directories below <paramref name="since"/>. Returns one entry per rollout
     /// with the session id parsed from the filename suffix
-    /// (<c>rollout-&lt;ISO-ts&gt;-&lt;uuid&gt;.jsonl</c>) and a synthesised
-    /// EncodedCwd matching Claude's <c>/</c>→<c>-</c> encoding so callers that
-    /// share the Claude path's plumbing (<see cref="kapacitor.Commands.SessionImporter.DecodeCwdFromDirName"/>)
-    /// keep working without a special case.
+    /// (<c>rollout-&lt;ISO-ts&gt;-&lt;uuid&gt;.jsonl</c>) and an always-empty
+    /// EncodedCwd — the day folder name (e.g. <c>"07"</c>) is NOT a Claude-style
+    /// hyphen-encoded absolute path, so feeding it to
+    /// <see cref="kapacitor.Commands.SessionImporter.DecodeCwdFromDirName"/> would
+    /// produce a misleading relative cwd if <c>session_meta</c> parsing fails.
+    /// Empty makes the decoder return null and callers degrade to "no cwd" cleanly.
     /// </summary>
     /// <param name="sessionsDir">Override of the <c>~/.codex/sessions</c> root, primarily for tests.</param>
     /// <param name="since">Inclusive lower bound — files in date directories before this are skipped.</param>

--- a/src/Kapacitor.Core/CodexPaths.cs
+++ b/src/Kapacitor.Core/CodexPaths.cs
@@ -30,11 +30,14 @@ static class CodexPaths {
 
                         if (sid is null) continue;
 
-                        // Codex rollouts have no project-hashed parent dir, so synthesise an EncodedCwd
-                        // from the day path. The session_meta line is the source of truth for cwd —
-                        // this fallback only matters if metadata extraction fails.
-                        var encoded = Path.GetFileName(day.Path);
-                        results.Add((sid, jsonl, encoded));
+                        // EncodedCwd is left empty: Codex rollouts have no project-hashed parent
+                        // dir, and the day name (e.g. "07") is NOT a Claude-style hyphen-encoded
+                        // absolute path. Returning a non-empty value would cause
+                        // SessionImporter.DecodeCwdFromDirName to feed a relative-looking string
+                        // into RepositoryDetection.DetectRepositoryAsync if session_meta parsing
+                        // fails — empty makes the decoder return null so the caller skips the
+                        // probe entirely.
+                        results.Add((sid, jsonl, ""));
                     }
                 }
             }

--- a/src/Kapacitor.Core/Models.cs
+++ b/src/Kapacitor.Core/Models.cs
@@ -19,6 +19,14 @@ record TranscriptBatch {
 
     [JsonPropertyName("repository")]
     public RepositoryPayload? Repository { get; init; }
+
+    // Routes the server's INormalizerSelector to CodexNormalizer when "codex".
+    // Null/absent → server treats the batch as Claude (default). Omitted on the
+    // wire when null so older servers (pre-#576) keep deserialising the batch
+    // unchanged — the server-side record had no vendor field before that PR.
+    [JsonPropertyName("vendor")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Vendor { get; init; }
 }
 
 record ErrorEntry(

--- a/src/Kapacitor.Core/Resources/help-generate-whats-done.txt
+++ b/src/Kapacitor.Core/Resources/help-generate-whats-done.txt
@@ -1,6 +1,9 @@
 kapacitor generate-whats-done — Generate what's-done summary
 
-Usage: kapacitor generate-whats-done <sessionId>
+Usage: kapacitor generate-whats-done <sessionId> [--codex]
 
 Arguments:
   sessionId               Session ID (required)
+
+Options:
+  --codex                 Use codex exec (instead of claude -p) to generate the summary

--- a/src/Kapacitor.Core/Resources/help-history.txt
+++ b/src/Kapacitor.Core/Resources/help-history.txt
@@ -3,6 +3,9 @@ kapacitor history — Import local transcript history to server
 Usage: kapacitor history [options]
 
 Options:
+  --codex                 Import Codex rollouts from ~/.codex/sessions instead of Claude
+  --since YYYY-MM-DD      Only import sessions started on or after this date
   --cwd <path>            Filter by working directory
   --session <id>          Import a specific session only
   --min-lines <n>         Skip sessions shorter than n lines (default: 10)
+  --generate-summaries    Also generate per-session what's-done summaries

--- a/src/Kapacitor.Core/Resources/help-history.txt
+++ b/src/Kapacitor.Core/Resources/help-history.txt
@@ -7,5 +7,5 @@ Options:
   --since YYYY-MM-DD      Only import sessions started on or after this date
   --cwd <path>            Filter by working directory
   --session <id>          Import a specific session only
-  --min-lines <n>         Skip sessions shorter than n lines (default: 10)
+  --min-lines <n>         Skip sessions shorter than n lines (default: 15)
   --generate-summaries    Also generate per-session what's-done summaries

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -126,6 +126,10 @@ static class HistoryCommand {
         public required SessionMetadata      Meta       { get; init; }
         public required ClassificationStatus Status     { get; init; }
 
+        /// <summary>"claude" (default) or "codex" — picks the matching metadata extractor,
+        /// title extractor, session-start hook shape, and TranscriptBatch.Vendor tag.</summary>
+        public string Vendor { get; init; } = "claude";
+
         /// <summary>Only populated when Status == Partial.</summary>
         public int ResumeFromLine { get; init; }
 
@@ -172,21 +176,42 @@ static class HistoryCommand {
             bool RequestedSummaries
         );
 
-    public static async Task<int> HandleHistory(string baseUrl, string? filterCwd, string? filterSession = null, int minLines = 15, bool generateSummaries = false) {
+    public static async Task<int> HandleHistory(
+            string     baseUrl,
+            string?    filterCwd,
+            string?    filterSession    = null,
+            int        minLines         = 15,
+            bool       generateSummaries = false,
+            bool       codex            = false,
+            DateOnly?  since            = null
+        ) {
         using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
         var       display    = HistoryDisplay.Create();
+        var       vendor     = codex ? "codex" : "claude";
 
         // --- Discover ---
         display.BeginPhase("Discovering");
-        var projectsDir = ClaudePaths.Projects;
+        List<(string SessionId, string FilePath, string EncodedCwd)> transcriptFiles;
 
-        if (!Directory.Exists(projectsDir)) {
-            display.Line("No Claude Code projects directory found.");
+        if (codex) {
+            if (!Directory.Exists(CodexPaths.Sessions)) {
+                display.Line("No Codex sessions directory found.");
 
-            return 0;
+                return 0;
+            }
+
+            transcriptFiles = CodexPaths.Discover(since: since);
+        } else {
+            var projectsDir = ClaudePaths.Projects;
+
+            if (!Directory.Exists(projectsDir)) {
+                display.Line("No Claude Code projects directory found.");
+
+                return 0;
+            }
+
+            transcriptFiles = DiscoverTranscripts(projectsDir);
         }
-
-        var transcriptFiles = DiscoverTranscripts(projectsDir);
 
         if (transcriptFiles.Count == 0) {
             display.Line("No transcript files found.");
@@ -210,7 +235,7 @@ static class HistoryCommand {
 
             transcriptFiles = [
                 .. transcriptFiles.Where(t => {
-                        var cwd = ExtractCwdFromTranscript(t.FilePath);
+                        var cwd = ExtractCwdFromTranscript(t.FilePath, codex);
 
                         return cwd?.TrimEnd('/').Equals(normalizedFilter, StringComparison.Ordinal) == true;
                     }
@@ -219,7 +244,7 @@ static class HistoryCommand {
         }
 
         var projectCount = transcriptFiles.Select(t => t.EncodedCwd).Distinct().Count();
-        display.Line($"Found {transcriptFiles.Count} session{(transcriptFiles.Count == 1 ? "" : "s")} in {projectCount} project{(projectCount == 1 ? "" : "s")}");
+        display.Line($"Found {transcriptFiles.Count} {vendor} session{(transcriptFiles.Count == 1 ? "" : "s")} in {projectCount} project{(projectCount == 1 ? "" : "s")}");
 
         // --- Classify (parallel probes) ---
         var                         excludedRepos = (await AppConfig.Load())?.ExcludedRepos;
@@ -241,6 +266,7 @@ static class HistoryCommand {
                             minLines,
                             excludedRepos,
                             CancellationToken.None,
+                            vendor,
                             onProbed: () => bar.Increment(1)
                         );
                         tmp.AddRange(results);
@@ -249,7 +275,25 @@ static class HistoryCommand {
             classifications = tmp;
         } else {
             display.Line($"Probing {transcriptFiles.Count} sessions...");
-            classifications = await ClassifyAsync(httpClient, baseUrl, transcriptFiles, minLines, excludedRepos, CancellationToken.None);
+            classifications = await ClassifyAsync(httpClient, baseUrl, transcriptFiles, minLines, excludedRepos, CancellationToken.None, vendor);
+        }
+
+        // --- --since filter (Claude path only — Codex pruned at discovery) ---
+        if (since is { } sinceCutoff && !codex) {
+            var cutoff = sinceCutoff.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+            classifications = [
+                .. classifications.Where(c => {
+                        var ts = c.Meta.FirstTimestamp?.UtcDateTime;
+
+                        if (ts is null) {
+                            try { ts = File.GetLastWriteTimeUtc(c.FilePath); } catch { return true; }
+                        }
+
+                        return ts >= cutoff;
+                    }
+                )
+            ];
         }
 
         // --- Resolve excluded-repo prompts (TTY only; non-TTY auto-skips) ---
@@ -348,7 +392,7 @@ static class HistoryCommand {
                 );
             },
             OnTitleTaskReady = t => {
-                var (sid, fp, _) = t;
+                var (sid, fp, _, vnd) = t;
                 Interlocked.Increment(ref titleTaskCount);
 
                 backgroundTasks.Add(
@@ -356,7 +400,7 @@ static class HistoryCommand {
                             await concurrencyLimit.WaitAsync();
 
                             try {
-                                var result = await GenerateTitleForImportAsync(httpClient, baseUrl, sid, fp);
+                                var result = await GenerateTitleForImportAsync(httpClient, baseUrl, sid, fp, vnd);
 
                                 switch (result) {
                                     case TitleResult.Generated: Interlocked.Increment(ref titlesGenerated); break;
@@ -377,13 +421,14 @@ static class HistoryCommand {
 
                 Interlocked.Increment(ref summaryTaskCount);
                 var sid = t.SessionId;
+                var vnd = t.Vendor;
 
                 backgroundTasks.Add(
                     Task.Run(async () => {
                             await concurrencyLimit.WaitAsync();
 
                             try {
-                                var rc = await WhatsDoneCommand.GenerateForSessionAsync(baseUrl, sid, _ => { });
+                                var rc = await WhatsDoneCommand.GenerateForSessionAsync(baseUrl, sid, _ => { }, vnd);
 
                                 if (rc == 0) Interlocked.Increment(ref summariesGenerated);
                                 else {
@@ -733,7 +778,7 @@ static class HistoryCommand {
         return null;
     }
 
-    static string? ExtractCwdFromTranscript(string filePath) {
+    static string? ExtractCwdFromTranscript(string filePath, bool codex = false) {
         try {
             using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var reader = new StreamReader(stream);
@@ -750,9 +795,110 @@ static class HistoryCommand {
                 try {
                     var doc = JsonDocument.Parse(line);
 
-                    if (doc.RootElement.Str("cwd") is { } cwd) {
+                    // Codex stores cwd inside a session_meta envelope; Claude stores it
+                    // at the JSONL root.
+                    var cwd = codex
+                        ? doc.RootElement.Obj("payload")?.Str("cwd")
+                        : doc.RootElement.Str("cwd");
+
+                    if (cwd is { }) {
                         return cwd;
                     }
+                } catch (JsonException) { }
+            }
+        } catch {
+            // Best effort
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Codex-shape variant of <see cref="ExtractSessionMetadata"/>. Reads the first
+    /// <c>session_meta</c> line and pulls cwd, model_provider (mapped to
+    /// <see cref="SessionMetadata.Model"/>), and the inner timestamp (when codex
+    /// started, not when the envelope was written). Codex rollouts have no slug,
+    /// so <see cref="SessionMetadata.Slug"/> stays null.
+    /// </summary>
+    internal static SessionMetadata ExtractCodexSessionMetadata(string filePath) {
+        var meta = new SessionMetadata();
+
+        try {
+            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream);
+
+            // Codex always emits session_meta as the first non-empty line — but read up
+            // to 5 lines for resilience against future preludes.
+            var linesChecked = 0;
+
+            while (reader.ReadLine() is { } line && linesChecked < 5) {
+                linesChecked++;
+
+                if (string.IsNullOrWhiteSpace(line)) continue;
+
+                try {
+                    using var doc  = JsonDocument.Parse(line);
+                    var       root = doc.RootElement;
+
+                    if (root.Str("type") != "session_meta") continue;
+
+                    var payload = root.Obj("payload");
+
+                    if (payload is null) continue;
+
+                    meta.Cwd       = payload.Value.Str("cwd");
+                    meta.Model     = payload.Value.Str("model_provider");
+                    meta.SessionId = payload.Value.Str("id");
+
+                    if (payload.Value.Str("timestamp") is { } tsStr
+                     && DateTimeOffset.TryParse(tsStr, out var ts)) {
+                        meta.FirstTimestamp = ts;
+                    }
+
+                    break;
+                } catch (JsonException) { }
+            }
+        } catch {
+            // Best effort
+        }
+
+        return meta;
+    }
+
+    internal sealed record CodexGitInfo(string? RemoteUrl, string? Branch, string? CommitHash);
+
+    /// <summary>
+    /// Extract the optional <c>git</c> block from the first <c>session_meta</c> line
+    /// of a Codex rollout (commit_hash, branch, repository_url). Returns null when
+    /// there's no git block — codex omits it for sessions started outside a repo.
+    /// </summary>
+    internal static CodexGitInfo? ExtractCodexGitInfo(string filePath) {
+        try {
+            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream);
+
+            var linesChecked = 0;
+
+            while (reader.ReadLine() is { } line && linesChecked < 5) {
+                linesChecked++;
+
+                if (string.IsNullOrWhiteSpace(line)) continue;
+
+                try {
+                    using var doc  = JsonDocument.Parse(line);
+                    var       root = doc.RootElement;
+
+                    if (root.Str("type") != "session_meta") continue;
+
+                    var git = root.Obj("payload")?.Obj("git");
+
+                    if (git is null) return null;
+
+                    return new CodexGitInfo(
+                        RemoteUrl: git.Value.Str("repository_url"),
+                        Branch: git.Value.Str("branch"),
+                        CommitHash: git.Value.Str("commit_hash")
+                    );
                 } catch (JsonException) { }
             }
         } catch {
@@ -825,15 +971,17 @@ static class HistoryCommand {
     static string NormalizeGuid(string value) =>
         Guid.TryParse(value, out var guid) ? guid.ToString("N") : value;
 
-    static async Task<TitleResult> GenerateTitleForImportAsync(HttpClient httpClient, string baseUrl, string sessionId, string filePath) {
+    static async Task<TitleResult> GenerateTitleForImportAsync(HttpClient httpClient, string baseUrl, string sessionId, string filePath, string vendor) {
         try {
-            var (userText, assistantText) = TitleGenerator.ExtractTitleContext(filePath);
+            var (userText, assistantText) = vendor == "codex"
+                ? TitleGenerator.ExtractCodexTitleContext(filePath)
+                : TitleGenerator.ExtractTitleContext(filePath);
 
             if (userText is null) {
                 return TitleResult.Skipped;
             }
 
-            var result = await TitleGenerator.GenerateAsync(userText, assistantText, _ => { });
+            var result = await TitleGenerator.GenerateAsync(userText, assistantText, _ => { }, vendor);
 
             if (result is null) {
                 return TitleResult.Skipped;
@@ -884,7 +1032,7 @@ static class HistoryCommand {
         // slot, classification, outcome (Loaded|Resumed), linesSent
 
         /// <summary>Fired when a successfully-imported session is ready for title generation.</summary>
-        public required Action<(string SessionId, string FilePath, string? PreviousSessionId)> OnTitleTaskReady { get; init; }
+        public required Action<(string SessionId, string FilePath, string? PreviousSessionId, string Vendor)> OnTitleTaskReady { get; init; }
 
         /// <summary>
         /// Fired when a session's session-end hook returned, signalling that the
@@ -892,7 +1040,7 @@ static class HistoryCommand {
         /// Renamed from the previous `OnSessionEnded` to disambiguate from the
         /// slot-aware lifecycle event above.
         /// </summary>
-        public required Action<(string SessionId, bool GenerateWhatsDone)> OnBackgroundWorkReady { get; init; }
+        public required Action<(string SessionId, bool GenerateWhatsDone, string Vendor)> OnBackgroundWorkReady { get; init; }
     }
 
     /// <summary>
@@ -996,7 +1144,8 @@ static class HistoryCommand {
                     session.FilePath,
                     agentId: null,
                     startLine: session.ResumeFromLine,
-                    progress: perSessionProgress
+                    progress: perSessionProgress,
+                    vendor: session.Vendor
                 );
 
                 return (SessionImportOutcome.Resumed, linesSent);
@@ -1028,19 +1177,36 @@ static class HistoryCommand {
         if (meta.FirstTimestamp is not null) startHook["started_at"]                = meta.FirstTimestamp.Value.ToString("O");
         if (session.PreviousSessionId is not null) startHook["previous_session_id"] = session.PreviousSessionId;
         if (meta.Slug is not null) startHook["slug"]                                = meta.Slug;
+        if (session.Vendor != "claude") startHook["vendor"]                         = session.Vendor;
+
+        // Codex sessions carry a `git` block on session_meta — prefer it over a fresh
+        // RepositoryDetection probe (which reads the live git config and might disagree
+        // with what was true when the rollout was recorded). Detection still runs as a
+        // fallback for fields the rollout omits (user_name / user_email).
+        var codexRepo = session.Vendor == "codex" ? ExtractCodexGitInfo(session.FilePath) : null;
 
         if (cwd is not null) {
             var repo = await RepositoryDetection.DetectRepositoryAsync(cwd);
 
-            if (repo is not null) {
-                var repoNode                                           = new System.Text.Json.Nodes.JsonObject();
-                if (repo.UserName is not null) repoNode["user_name"]   = repo.UserName;
-                if (repo.UserEmail is not null) repoNode["user_email"] = repo.UserEmail;
-                if (repo.RemoteUrl is not null) repoNode["remote_url"] = repo.RemoteUrl;
-                if (repo.Owner is not null) repoNode["owner"]          = repo.Owner;
-                if (repo.RepoName is not null) repoNode["repo_name"]   = repo.RepoName;
-                if (repo.Branch is not null) repoNode["branch"]        = repo.Branch;
-                startHook["repository"] = repoNode;
+            if (repo is not null || codexRepo is not null) {
+                var repoNode = new System.Text.Json.Nodes.JsonObject();
+
+                if (repo?.UserName is not null) repoNode["user_name"]   = repo.UserName;
+                if (repo?.UserEmail is not null) repoNode["user_email"] = repo.UserEmail;
+
+                var remoteUrl = codexRepo?.RemoteUrl ?? repo?.RemoteUrl;
+                if (remoteUrl is not null) repoNode["remote_url"] = remoteUrl;
+
+                var (codexOwner, codexRepoName) = GitUrlParser.ParseRemoteUrl(codexRepo?.RemoteUrl);
+                var owner    = codexOwner    ?? repo?.Owner;
+                var repoName = codexRepoName ?? repo?.RepoName;
+                var branch   = codexRepo?.Branch ?? repo?.Branch;
+
+                if (owner is not null) repoNode["owner"]        = owner;
+                if (repoName is not null) repoNode["repo_name"] = repoName;
+                if (branch is not null) repoNode["branch"]      = branch;
+
+                if (repoNode.Count > 0) startHook["repository"] = repoNode;
             }
         }
 
@@ -1069,7 +1235,8 @@ static class HistoryCommand {
                 session.SessionId,
                 meta,
                 session.EncodedCwd,
-                perSessionProgress
+                perSessionProgress,
+                session.Vendor
             );
         } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
             throw;
@@ -1109,8 +1276,8 @@ static class HistoryCommand {
             /* best effort */
         }
 
-        events.OnTitleTaskReady((session.SessionId, session.FilePath, session.PreviousSessionId));
-        events.OnBackgroundWorkReady((session.SessionId, generateWhatsDone));
+        events.OnTitleTaskReady((session.SessionId, session.FilePath, session.PreviousSessionId, session.Vendor));
+        events.OnBackgroundWorkReady((session.SessionId, generateWhatsDone, session.Vendor));
 
         return (SessionImportOutcome.Loaded, importResult.LinesSent);
     }
@@ -1131,13 +1298,14 @@ static class HistoryCommand {
             int                                                          minLines,
             string[]?                                                    excludedRepos,
             CancellationToken                                            ct,
+            string                                                       vendor   = "claude",
             Action?                                                      onProbed = null
         ) {
         using var probeGate = new SemaphoreSlim(8);
         var       tasks     = new List<Task<SessionClassification>>(transcripts.Count);
 
         foreach (var (sessionId, filePath, encodedCwd) in transcripts) {
-            tasks.Add(ClassifyOneAsync(httpClient, baseUrl, sessionId, filePath, encodedCwd, minLines, excludedRepos, probeGate, onProbed, ct));
+            tasks.Add(ClassifyOneAsync(httpClient, baseUrl, sessionId, filePath, encodedCwd, minLines, excludedRepos, probeGate, vendor, onProbed, ct));
         }
 
         var results = await Task.WhenAll(tasks);
@@ -1154,11 +1322,12 @@ static class HistoryCommand {
             int               minLines,
             string[]?         excludedRepos,
             SemaphoreSlim     probeGate,
+            string            vendor,
             Action?           onProbed,
             CancellationToken ct
         ) {
         try {
-            return await ClassifyOneCoreAsync(httpClient, baseUrl, sessionId, filePath, encodedCwd, minLines, excludedRepos, probeGate, ct);
+            return await ClassifyOneCoreAsync(httpClient, baseUrl, sessionId, filePath, encodedCwd, minLines, excludedRepos, probeGate, vendor, ct);
         } finally {
             onProbed?.Invoke();
         }
@@ -1173,18 +1342,22 @@ static class HistoryCommand {
             int               minLines,
             string[]?         excludedRepos,
             SemaphoreSlim     probeGate,
+            string            vendor,
             CancellationToken ct
         ) {
-        var meta = ExtractSessionMetadata(filePath);
+        var isCodex = vendor == "codex";
+        var meta    = isCodex ? ExtractCodexSessionMetadata(filePath) : ExtractSessionMetadata(filePath);
 
         // Short-circuit: kapacitor's own sub-sessions (title / what's-done) never get imported.
-        if (TitleGenerator.IsKapacitorSubSession(filePath)) {
+        // Codex rollouts have no analog, so the check is Claude-only.
+        if (!isCodex && TitleGenerator.IsKapacitorSubSession(filePath)) {
             return new() {
                 SessionId  = sessionId,
                 FilePath   = filePath,
                 EncodedCwd = encodedCwd,
                 Meta       = meta,
                 Status     = ClassificationStatus.InternalSubSession,
+                Vendor     = vendor,
             };
         }
 
@@ -1257,6 +1430,7 @@ static class HistoryCommand {
                         Meta       = meta,
                         Status     = ClassificationStatus.TooShort,
                         TotalLines = observedLines,
+                        Vendor     = vendor,
                     };
                 }
 
@@ -1301,6 +1475,7 @@ static class HistoryCommand {
             ResumeFromLine   = resumeFromLine,
             ProbeErrorReason = probeErrorReason,
             ExcludedRepoKey  = excludedRepoKey,
+            Vendor           = vendor,
         };
     }
 

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -1361,6 +1361,24 @@ static class HistoryCommand {
             };
         }
 
+        // Codex rollouts carry the session id in two places — the trailing UUID in the
+        // filename (which the rest of the pipeline trusts as the canonical id used for
+        // probe URLs and hook payloads) and `session_meta.payload.id`. Validate they
+        // agree so a renamed/copied file can't import under the wrong server session.
+        if (isCodex && meta.SessionId is { } innerId
+         && Guid.TryParse(innerId, out var innerGuid)
+         && innerGuid.ToString("N") != sessionId) {
+            return new() {
+                SessionId        = sessionId,
+                FilePath         = filePath,
+                EncodedCwd       = encodedCwd,
+                Meta             = meta,
+                Status           = ClassificationStatus.ProbeError,
+                Vendor           = vendor,
+                ProbeErrorReason = "codex session id mismatch (filename vs session_meta.payload.id)",
+            };
+        }
+
         // Probe the server BEFORE scanning the file. On re-runs the probe returns
         // 204 (AlreadyLoaded) quickly and we never need to read the transcript.
         ClassificationStatus status;

--- a/src/kapacitor/Commands/SessionImporter.cs
+++ b/src/kapacitor/Commands/SessionImporter.cs
@@ -14,6 +14,13 @@ static class SessionImporter {
     /// events interleaved at the position where each agent first appears in
     /// <c>progress</c> / <c>agent_progress</c> entries.
     /// </summary>
+    /// <param name="vendor">
+    /// "claude" (default) or "codex". Stamped on every <see cref="TranscriptBatch"/>
+    /// so the server's <c>INormalizerSelector</c> picks the matching normalizer.
+    /// Codex rollouts have no <c>subagents/</c> sibling directory and no
+    /// agent-progress markers, so the agent walk is short-circuited when
+    /// <paramref name="vendor"/> is <c>"codex"</c>.
+    /// </param>
     internal static async Task<ImportResult> ImportSessionAsync(
             HttpClient                 httpClient,
             string                     baseUrl,
@@ -21,16 +28,23 @@ static class SessionImporter {
             string                     sessionId,
             SessionMetadata            metadata,
             string?                    encodedCwd,
-            IProgress<ImportProgress>? progress = null
+            IProgress<ImportProgress>? progress = null,
+            string                     vendor   = "claude"
         ) {
         if (!File.Exists(transcriptPath))
             return new(sessionId, [], 0);
 
         var cwd = metadata.Cwd ?? (encodedCwd is not null ? DecodeCwdFromDirName(encodedCwd) : null) ?? "";
 
-        // Discover all agent transcripts on disk
-        var agentTranscripts = DiscoverAgentTranscripts(transcriptPath);
-        var agentMap         = new Dictionary<string, string>(StringComparer.Ordinal); // agentId → path
+        // Codex rollouts don't ship a subagents/ sibling directory and don't carry
+        // agent-progress markers in-band, so the entire agent walk is skipped — we
+        // stream the rollout straight through the batch loop with vendor="codex".
+        var isCodex = vendor == "codex";
+
+        var agentTranscripts = isCodex
+            ? []
+            : DiscoverAgentTranscripts(transcriptPath);
+        var agentMap = new Dictionary<string, string>(StringComparer.Ordinal); // agentId → path
 
         foreach (var (agentId, agentPath) in agentTranscripts) {
             agentMap[agentId] = agentPath;
@@ -40,7 +54,17 @@ static class SessionImporter {
         // referenced — via agent_progress, an async_launched tool_result, or a
         // foreground toolUseResult.agentId (for interleave position) — plus the real
         // subagent_type from the parent Task-tool invocation (for canonical fidelity).
-        var (agentFirstLine, agentTypes) = ScanAgentLifecycle(transcriptPath);
+        Dictionary<string, int>     agentFirstLine;
+        Dictionary<string, string?> agentTypes;
+
+        if (isCodex) {
+            agentFirstLine = new Dictionary<string, int>(StringComparer.Ordinal);
+            agentTypes     = new Dictionary<string, string?>(StringComparer.Ordinal);
+        } else {
+            var scan = ScanAgentLifecycle(transcriptPath);
+            agentFirstLine = scan.FirstLineByAgent;
+            agentTypes     = scan.AgentTypeByAgent;
+        }
 
         // Track which agents were sent inline
         var sentAgents = new HashSet<string>(StringComparer.Ordinal);
@@ -65,7 +89,7 @@ static class SessionImporter {
                 if (firstLine == lineIndex && !sentAgents.Contains(agentId) && agentMap.TryGetValue(agentId, out var agentPath)) {
                     // Flush the current batch before inserting agent lifecycle
                     if (batchLines.Count > 0) {
-                        await PostTranscriptBatch(httpClient, baseUrl, sessionId, agentId: null, batchLines, batchLineNumbers);
+                        await PostTranscriptBatch(httpClient, baseUrl, sessionId, agentId: null, batchLines, batchLineNumbers, vendor);
                         var flushed = batchLines.Count;
                         totalSent += flushed;
                         progress?.Report(new BatchFlushed(AgentId: null, flushed));
@@ -89,7 +113,7 @@ static class SessionImporter {
             lineIndex++;
 
             if (batchLines.Count >= batchSize) {
-                await PostTranscriptBatch(httpClient, baseUrl, sessionId, agentId: null, batchLines, batchLineNumbers);
+                await PostTranscriptBatch(httpClient, baseUrl, sessionId, agentId: null, batchLines, batchLineNumbers, vendor);
                 var flushed = batchLines.Count;
                 totalSent += flushed;
                 progress?.Report(new BatchFlushed(AgentId: null, flushed));
@@ -100,7 +124,7 @@ static class SessionImporter {
 
         // Flush remaining main transcript lines
         if (batchLines.Count > 0) {
-            await PostTranscriptBatch(httpClient, baseUrl, sessionId, agentId: null, batchLines, batchLineNumbers);
+            await PostTranscriptBatch(httpClient, baseUrl, sessionId, agentId: null, batchLines, batchLineNumbers, vendor);
             var flushed = batchLines.Count;
             totalSent += flushed;
             progress?.Report(new BatchFlushed(AgentId: null, flushed));
@@ -431,6 +455,10 @@ static class SessionImporter {
     /// <summary>
     /// Send transcript lines in batches of 100 for a given file (main or agent).
     /// </summary>
+    /// <param name="vendor">
+    /// "claude" (default) or "codex" — stamped on the outgoing
+    /// <see cref="TranscriptBatch"/> so the server picks the matching normalizer.
+    /// </param>
     internal static async Task<int> SendTranscriptBatches(
             HttpClient                 httpClient,
             string                     baseUrl,
@@ -438,7 +466,8 @@ static class SessionImporter {
             string                     filePath,
             string?                    agentId,
             int                        startLine,
-            IProgress<ImportProgress>? progress = null
+            IProgress<ImportProgress>? progress = null,
+            string                     vendor   = "claude"
         ) {
         if (!File.Exists(filePath)) return 0;
 
@@ -467,7 +496,7 @@ static class SessionImporter {
             lineIndex++;
 
             if (batchLines.Count >= batchSize) {
-                await PostTranscriptBatch(httpClient, baseUrl, sessionId, agentId, batchLines, batchLineNumbers);
+                await PostTranscriptBatch(httpClient, baseUrl, sessionId, agentId, batchLines, batchLineNumbers, vendor);
                 var flushed = batchLines.Count;
                 totalSent += flushed;
                 progress?.Report(new BatchFlushed(agentId, flushed));
@@ -477,7 +506,7 @@ static class SessionImporter {
         }
 
         if (batchLines.Count > 0) {
-            await PostTranscriptBatch(httpClient, baseUrl, sessionId, agentId, batchLines, batchLineNumbers);
+            await PostTranscriptBatch(httpClient, baseUrl, sessionId, agentId, batchLines, batchLineNumbers, vendor);
             var flushed = batchLines.Count;
             totalSent += flushed;
             progress?.Report(new BatchFlushed(agentId, flushed));
@@ -492,13 +521,17 @@ static class SessionImporter {
             string       sessionId,
             string?      agentId,
             List<string> lines,
-            List<int>    lineNumbers
+            List<int>    lineNumbers,
+            string       vendor
         ) {
         var batch = new TranscriptBatch {
             SessionId   = sessionId,
             AgentId     = agentId,
             Lines       = [.. lines],
-            LineNumbers = [.. lineNumbers]
+            LineNumbers = [.. lineNumbers],
+            // Default vendor "claude" stays absent on the wire to match older servers; the
+            // explicit "codex" tag is what flips the server to CodexNormalizer.
+            Vendor = vendor == "claude" ? null : vendor
         };
 
         var       json    = JsonSerializer.Serialize(batch, KapacitorJsonContext.Default.TranscriptBatch);

--- a/src/kapacitor/Commands/TitleGenerator.cs
+++ b/src/kapacitor/Commands/TitleGenerator.cs
@@ -50,12 +50,27 @@ static partial class TitleGenerator {
     }
 
     /// <summary>
-    /// Generates a title by calling Claude CLI. Returns the cleaned title string, or null on failure
-    /// (including when the model produced a refusal rather than a title).
+    /// Generates a title by calling the headless CLI for the matching vendor —
+    /// <c>claude -p</c> for Claude sessions, <c>codex exec</c> for Codex sessions.
+    /// Returns the cleaned title string, or null on failure (including when the
+    /// model produced a refusal rather than a title).
     /// </summary>
-    internal static async Task<ClaudeCliResult?> GenerateAsync(string userText, string? assistantText, Action<string> log) {
+    internal static async Task<ClaudeCliResult?> GenerateAsync(
+            string         userText,
+            string?        assistantText,
+            Action<string> log,
+            string         vendor = "claude"
+        ) {
         var prompt = BuildPrompt(userText, assistantText);
-        var result = await ClaudeCliRunner.RunAsync(prompt, TimeSpan.FromSeconds(15), log);
+
+        // Codex sessions go through `codex exec` so a user with only Codex
+        // installed can still backfill — and so the title model matches the
+        // vendor that produced the work being summarised. Codex's --output-
+        // last-message gives us a single text response with no token usage,
+        // mirroring ClaudeCliResult's shape with zeros for the metric fields.
+        var result = vendor == "codex"
+            ? await CodexCliRunner.RunAsync(prompt, TimeSpan.FromSeconds(30), log)
+            : await ClaudeCliRunner.RunAsync(prompt, TimeSpan.FromSeconds(15), log);
 
         if (result is null) {
             return null;
@@ -180,6 +195,78 @@ static partial class TitleGenerator {
         }
 
         return (userText, assistantText);
+    }
+
+    /// <summary>
+    /// Codex-shape variant of <see cref="ExtractTitleContext"/>. Reads the rollout looking for
+    /// the first user-authored <c>response_item</c> (skipping the synthetic
+    /// <c>&lt;environment_context&gt;</c> block) and the first assistant <c>response_item</c>
+    /// with an <c>output_text</c> block.
+    /// </summary>
+    internal static (string? UserText, string? AssistantText) ExtractCodexTitleContext(string filePath) {
+        string? userText      = null;
+        string? assistantText = null;
+
+        try {
+            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream);
+
+            var linesChecked = 0;
+
+            while (reader.ReadLine() is { } line && linesChecked < 200) {
+                linesChecked++;
+
+                if (string.IsNullOrWhiteSpace(line)) continue;
+
+                try {
+                    using var doc  = JsonDocument.Parse(line);
+                    var       root = doc.RootElement;
+
+                    // Codex wraps every event under a top-level "type" + "payload" envelope.
+                    if (root.Str("type") != "response_item") continue;
+
+                    var payload = root.Obj("payload");
+
+                    if (payload?.Str("type") != "message") continue;
+
+                    var role = payload.Value.Str("role");
+
+                    if (userText is null && role == "user") {
+                        var text = ExtractCodexBlockText(payload.Value, "input_text");
+
+                        // Skip the env context block — it's injected by codex on every session
+                        // and would produce a useless title.
+                        if (text is not null && !text.StartsWith("<environment_context>", StringComparison.Ordinal)) {
+                            userText = text;
+                        }
+                    } else if (assistantText is null && role == "assistant") {
+                        var text = ExtractCodexBlockText(payload.Value, "output_text");
+
+                        if (text is not null) {
+                            assistantText = text.Length > 300 ? text[..300] : text;
+                        }
+                    }
+
+                    if (userText is not null && assistantText is not null) break;
+                } catch (JsonException) { }
+            }
+        } catch {
+            // Best effort
+        }
+
+        return (userText, assistantText);
+    }
+
+    static string? ExtractCodexBlockText(JsonElement payload, string blockType) {
+        if (payload.Arr("content") is not { } content) return null;
+
+        foreach (var block in content.EnumerateArray()) {
+            if (block.Str("type") == blockType && block.Str("text") is { } text && !string.IsNullOrEmpty(text)) {
+                return text;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/kapacitor/Commands/TitleGenerator.cs
+++ b/src/kapacitor/Commands/TitleGenerator.cs
@@ -234,9 +234,11 @@ static partial class TitleGenerator {
                     if (userText is null && role == "user") {
                         var text = ExtractCodexBlockText(payload.Value, "input_text");
 
-                        // Skip the env context block — it's injected by codex on every session
-                        // and would produce a useless title.
-                        if (text is not null && !text.StartsWith("<environment_context>", StringComparison.Ordinal)) {
+                        // Skip codex-injected wrappers that surface as role:"user" messages
+                        // before (or interleaved with) real user prompts. Without these
+                        // skips, titles get generated from the repo's AGENTS.md content or
+                        // an interrupt notice instead of the actual work request.
+                        if (text is not null && !IsCodexInjectedUserPrelude(text)) {
                             userText = text;
                         }
                     } else if (assistantText is null && role == "assistant") {
@@ -256,6 +258,23 @@ static partial class TitleGenerator {
 
         return (userText, assistantText);
     }
+
+    /// <summary>
+    /// Detects role:"user" payload bodies that codex synthesises around the real
+    /// conversation — none of which represent a user prompt and all of which would
+    /// otherwise dominate the title context window. Observed on real rollouts:
+    /// <list type="bullet">
+    ///   <item><c>&lt;environment_context&gt;...</c> — every session gets one.</item>
+    ///   <item><c># AGENTS.md instructions for &lt;path&gt;...</c> — repo context auto-injected
+    ///   when an AGENTS.md is found anywhere up the cwd tree.</item>
+    ///   <item><c>&lt;turn_aborted&gt;...</c> — emitted when the user interrupts a turn,
+    ///   which can land before a follow-up prompt in the same session.</item>
+    /// </list>
+    /// </summary>
+    static bool IsCodexInjectedUserPrelude(string text) =>
+        text.StartsWith("<environment_context>",     StringComparison.Ordinal)
+     || text.StartsWith("# AGENTS.md instructions",  StringComparison.Ordinal)
+     || text.StartsWith("<turn_aborted>",            StringComparison.Ordinal);
 
     static string? ExtractCodexBlockText(JsonElement payload, string blockType) {
         if (payload.Arr("content") is not { } content) return null;

--- a/src/kapacitor/Commands/WhatsDoneCommand.cs
+++ b/src/kapacitor/Commands/WhatsDoneCommand.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace kapacitor.Commands;
 
 static class WhatsDoneCommand {
-    public static async Task<int> HandleGenerateWhatsDone(string baseUrl, string sessionId) {
+    public static async Task<int> HandleGenerateWhatsDone(string baseUrl, string sessionId, string vendor = "claude") {
         // Redirect output to log file (same pattern as WatchCommand)
         var logDir = PathHelpers.ConfigPath("logs");
         Directory.CreateDirectory(logDir);
@@ -14,7 +14,7 @@ static class WhatsDoneCommand {
         Console.SetError(logWriter);
 
         try {
-            return await GenerateForSessionAsync(baseUrl, sessionId, Log);
+            return await GenerateForSessionAsync(baseUrl, sessionId, Log, vendor);
         } finally {
             await logWriter.DisposeAsync();
         }
@@ -24,7 +24,8 @@ static class WhatsDoneCommand {
     /// Core what's-done generation logic, callable without Console redirection.
     /// Uses the provided <paramref name="log"/> callback for diagnostics.
     /// </summary>
-    public static async Task<int> GenerateForSessionAsync(string baseUrl, string sessionId, Action<string> log) {
+    /// <param name="vendor">"claude" (default) or "codex" — picks the headless CLI runner.</param>
+    public static async Task<int> GenerateForSessionAsync(string baseUrl, string sessionId, Action<string> log, string vendor = "claude") {
         log($"Generating what's-done summary for session {sessionId}");
 
         using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
@@ -63,16 +64,20 @@ static class WhatsDoneCommand {
             return 1;
         }
 
-        // 2. Call claude -p to generate the summary
-        log("Calling claude to generate summary...");
+        // 2. Call the headless CLI for the matching vendor to generate the summary.
+        // Codex-vendor sessions go through `codex exec` so the summary model
+        // matches the one that actually produced the work.
+        log($"Calling {vendor} to generate summary...");
         log($"Recap text: {recapText.Length} chars");
 
         var prompt = EmbeddedResources.Load("prompt-whats-done.txt") + recapText;
 
-        var result = await ClaudeCliRunner.RunAsync(prompt, TimeSpan.FromSeconds(90), log);
+        var result = vendor == "codex"
+            ? await CodexCliRunner.RunAsync(prompt, TimeSpan.FromSeconds(90), log)
+            : await ClaudeCliRunner.RunAsync(prompt, TimeSpan.FromSeconds(90), log);
 
         if (result is null) {
-            log("Claude returned empty or failed");
+            log($"{vendor} returned empty or failed");
 
             return 1;
         }

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -170,13 +170,14 @@ switch (command) {
         );
     }
     case "generate-whats-done" when args.Length < 2:
-        Console.Error.WriteLine("Usage: kapacitor generate-whats-done <sessionId>");
+        Console.Error.WriteLine("Usage: kapacitor generate-whats-done <sessionId> [--codex]");
 
         return 1;
     case "generate-whats-done": {
         var wdSessionId = args[1].Replace("-", "");
+        var wdVendor    = args.Contains("--codex") ? "codex" : "claude";
 
-        return await WhatsDoneCommand.HandleGenerateWhatsDone(baseUrl!, wdSessionId);
+        return await WhatsDoneCommand.HandleGenerateWhatsDone(baseUrl!, wdSessionId, wdVendor);
     }
     case "login": {
         if (args.Contains("--discover")) {
@@ -377,10 +378,12 @@ switch (command) {
         return 0;
     }
     case "history": {
-        string? filterCwd     = null;
-        string? filterSession = null;
-        var     minLines      = 15;
-        var     cwdArgIdx     = Array.IndexOf(args, "--cwd");
+        string?   filterCwd     = null;
+        string?   filterSession = null;
+        var       minLines      = 15;
+        DateOnly? since         = null;
+        var       codex         = args.Contains("--codex");
+        var       cwdArgIdx     = Array.IndexOf(args, "--cwd");
 
         if (cwdArgIdx >= 0 && cwdArgIdx + 1 < args.Length) {
             filterCwd = args[cwdArgIdx + 1];
@@ -398,9 +401,21 @@ switch (command) {
             minLines = parsed;
         }
 
+        var sinceIdx = Array.IndexOf(args, "--since");
+
+        if (sinceIdx >= 0 && sinceIdx + 1 < args.Length) {
+            if (!DateOnly.TryParseExact(args[sinceIdx + 1], "yyyy-MM-dd", out var parsedSince)) {
+                Console.Error.WriteLine("--since must be YYYY-MM-DD");
+
+                return 1;
+            }
+
+            since = parsedSince;
+        }
+
         var generateSummaries = args.Contains("--generate-summaries");
 
-        return await HistoryCommand.HandleHistory(baseUrl!, filterCwd, filterSession, minLines, generateSummaries);
+        return await HistoryCommand.HandleHistory(baseUrl!, filterCwd, filterSession, minLines, generateSummaries, codex, since);
     }
     case "watch" when args.Length < 3:
         Console.Error.WriteLine("Usage: kapacitor watch <sessionId> <transcriptPath> [--agent-id <agentId>] [--cwd <cwd>] [--skip-title] [--parent-pid <pid>]");

--- a/test/kapacitor.Tests.Unit/CodexHistoryTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexHistoryTests.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using kapacitor;
+using kapacitor.Commands;
+
+namespace kapacitor.Tests.Unit;
+
+public class CodexHistoryTests {
+    [Test]
+    public async Task ExtractCodexSessionMetadata_pulls_cwd_model_provider_and_first_timestamp() {
+        var path = Path.GetTempFileName();
+
+        try {
+            await File.WriteAllLinesAsync(path, [
+                """{"timestamp":"2026-05-07T15:51:46.684Z","type":"session_meta","payload":{"id":"019e0322-05fc-7570-be65-75719c3ea861","timestamp":"2026-05-07T15:50:21.989Z","cwd":"/Users/alexey/dev/temp/Kurrent.Capacitor","originator":"codex-tui","cli_version":"0.128.0","model_provider":"openai","git":{"commit_hash":"abc","branch":"main","repository_url":"https://github.com/owner/repo"}}}""",
+                """{"timestamp":"2026-05-07T15:51:46.686Z","type":"event_msg","payload":{"type":"task_started"}}""",
+            ]);
+
+            var meta = HistoryCommand.ExtractCodexSessionMetadata(path);
+
+            await Assert.That(meta.Cwd).IsEqualTo("/Users/alexey/dev/temp/Kurrent.Capacitor");
+            await Assert.That(meta.Model).IsEqualTo("openai");
+            await Assert.That(meta.SessionId).IsEqualTo("019e0322-05fc-7570-be65-75719c3ea861");
+            await Assert.That(meta.FirstTimestamp).IsNotNull();
+            await Assert.That(meta.FirstTimestamp!.Value).IsEqualTo(DateTimeOffset.Parse("2026-05-07T15:50:21.989Z"));
+            await Assert.That(meta.Slug).IsNull();
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task ExtractCodexSessionMetadata_returns_empty_when_first_line_is_not_session_meta() {
+        var path = Path.GetTempFileName();
+
+        try {
+            await File.WriteAllLinesAsync(path, [
+                """{"type":"event_msg","payload":{"type":"task_started"}}""",
+            ]);
+
+            var meta = HistoryCommand.ExtractCodexSessionMetadata(path);
+
+            await Assert.That(meta.Cwd).IsNull();
+            await Assert.That(meta.Model).IsNull();
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task ExtractCodexGitInfo_returns_git_block_when_present() {
+        var path = Path.GetTempFileName();
+
+        try {
+            await File.WriteAllLinesAsync(path, [
+                """{"type":"session_meta","payload":{"id":"x","cwd":"/x","git":{"commit_hash":"deadbeef","branch":"main","repository_url":"https://github.com/owner/repo"}}}""",
+            ]);
+
+            var git = HistoryCommand.ExtractCodexGitInfo(path);
+
+            await Assert.That(git).IsNotNull();
+            await Assert.That(git!.RemoteUrl).IsEqualTo("https://github.com/owner/repo");
+            await Assert.That(git.Branch).IsEqualTo("main");
+            await Assert.That(git.CommitHash).IsEqualTo("deadbeef");
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task ExtractCodexGitInfo_returns_null_when_no_git_block() {
+        var path = Path.GetTempFileName();
+
+        try {
+            await File.WriteAllLinesAsync(path, [
+                """{"type":"session_meta","payload":{"id":"x","cwd":"/x"}}""",
+            ]);
+
+            var git = HistoryCommand.ExtractCodexGitInfo(path);
+
+            await Assert.That(git).IsNull();
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task ExtractCodexTitleContext_skips_environment_context_and_returns_first_real_user_text() {
+        var path = Path.GetTempFileName();
+
+        try {
+            await File.WriteAllLinesAsync(path, [
+                """{"type":"session_meta","payload":{"id":"x","cwd":"/x"}}""",
+                """{"type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"<permissions instructions>..."}]}}""",
+                """{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>foo</environment_context>"}]}}""",
+                """{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"review combined work in PR 573"}]}}""",
+                """{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I will inspect both PRs as one change set."}]}}""",
+            ]);
+
+            var (userText, assistantText) = TitleGenerator.ExtractCodexTitleContext(path);
+
+            await Assert.That(userText).IsEqualTo("review combined work in PR 573");
+            await Assert.That(assistantText).IsEqualTo("I will inspect both PRs as one change set.");
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task ExtractCodexTitleContext_returns_null_user_when_only_environment_context_present() {
+        var path = Path.GetTempFileName();
+
+        try {
+            await File.WriteAllLinesAsync(path, [
+                """{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>only</environment_context>"}]}}""",
+            ]);
+
+            var (userText, assistantText) = TitleGenerator.ExtractCodexTitleContext(path);
+
+            await Assert.That(userText).IsNull();
+            await Assert.That(assistantText).IsNull();
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    // Wire-shape: vendor field is omitted when null and serialized as "vendor":"codex" otherwise.
+    // The server's INormalizerSelector keys off this exact field — see Kurrent.Capacitor#576.
+
+    [Test]
+    public async Task TranscriptBatch_omits_vendor_field_when_null() {
+        var batch = new TranscriptBatch {
+            SessionId = "abc",
+            Lines     = ["{}"],
+            Vendor    = null,
+        };
+
+        var json = JsonSerializer.Serialize(batch, KapacitorJsonContext.Default.TranscriptBatch);
+
+        await Assert.That(json.Contains("\"vendor\"")).IsFalse();
+    }
+
+    [Test]
+    public async Task TranscriptBatch_serializes_vendor_when_set() {
+        var batch = new TranscriptBatch {
+            SessionId = "abc",
+            Lines     = ["{}"],
+            Vendor    = "codex",
+        };
+
+        var json = JsonSerializer.Serialize(batch, KapacitorJsonContext.Default.TranscriptBatch);
+
+        await Assert.That(json.Contains("\"vendor\":\"codex\"")).IsTrue();
+    }
+}

--- a/test/kapacitor.Tests.Unit/CodexHistoryTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexHistoryTests.cs
@@ -1,6 +1,9 @@
 using System.Text.Json;
 using kapacitor;
 using kapacitor.Commands;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
 
 namespace kapacitor.Tests.Unit;
 
@@ -137,6 +140,88 @@ public class CodexHistoryTests {
         var json = JsonSerializer.Serialize(batch, KapacitorJsonContext.Default.TranscriptBatch);
 
         await Assert.That(json.Contains("\"vendor\"")).IsFalse();
+    }
+
+    [Test]
+    public async Task ClassifyAsync_returns_ProbeError_when_codex_filename_uuid_disagrees_with_session_meta_id() {
+        using var server = WireMockServer.Start();
+        // Stub /last-line in case the short-circuit ever regresses — the test should
+        // fail loudly rather than time out on a real network call.
+        server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404));
+
+        var dir = Directory.CreateTempSubdirectory("codex-id-mismatch").FullName;
+
+        try {
+            var path = Path.Combine(dir, "rollout.jsonl");
+            // Filename-derived sessionId we'll pass in: 019e0322...c3ea861 (dashless).
+            // Inner payload.id is a different UUID — the validator must catch this.
+            await File.WriteAllLinesAsync(path, [
+                """{"type":"session_meta","payload":{"id":"00000000-0000-0000-0000-000000000001","cwd":"/x"}}""",
+            ]);
+
+            var transcripts = new List<(string SessionId, string FilePath, string EncodedCwd)> {
+                ("019e032205fc7570be6575719c3ea861", path, "")
+            };
+
+            using var client = new HttpClient();
+
+            var result = await HistoryCommand.ClassifyAsync(
+                client,
+                server.Url!,
+                transcripts,
+                minLines: 0,
+                excludedRepos: null,
+                CancellationToken.None,
+                vendor: "codex"
+            );
+
+            await Assert.That(result.Count).IsEqualTo(1);
+            await Assert.That(result[0].Status).IsEqualTo(HistoryCommand.ClassificationStatus.ProbeError);
+            await Assert.That(result[0].ProbeErrorReason).IsNotNull();
+            await Assert.That(result[0].ProbeErrorReason!).Contains("session id mismatch");
+        } finally {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Test]
+    public async Task ClassifyAsync_accepts_codex_session_when_filename_and_session_meta_id_match() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404));
+
+        var dir = Directory.CreateTempSubdirectory("codex-id-match").FullName;
+
+        try {
+            var path = Path.Combine(dir, "rollout.jsonl");
+            // Filename uuid (dashless) and session_meta payload.id (dashed) refer to
+            // the same GUID — validator must let this through to the server probe.
+            await File.WriteAllLinesAsync(path, [
+                """{"type":"session_meta","payload":{"id":"019e0322-05fc-7570-be65-75719c3ea861","cwd":"/x"}}""",
+            ]);
+
+            var transcripts = new List<(string SessionId, string FilePath, string EncodedCwd)> {
+                ("019e032205fc7570be6575719c3ea861", path, "")
+            };
+
+            using var client = new HttpClient();
+
+            var result = await HistoryCommand.ClassifyAsync(
+                client,
+                server.Url!,
+                transcripts,
+                minLines: 0,
+                excludedRepos: null,
+                CancellationToken.None,
+                vendor: "codex"
+            );
+
+            await Assert.That(result.Count).IsEqualTo(1);
+            await Assert.That(result[0].Status).IsEqualTo(HistoryCommand.ClassificationStatus.New);
+        } finally {
+            Directory.Delete(dir, true);
+        }
     }
 
     [Test]

--- a/test/kapacitor.Tests.Unit/CodexHistoryTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexHistoryTests.cs
@@ -109,6 +109,47 @@ public class CodexHistoryTests {
     }
 
     [Test]
+    public async Task ExtractCodexTitleContext_skips_AGENTS_md_repo_context_prelude() {
+        var path = Path.GetTempFileName();
+
+        try {
+            // Reproduces the shape Codex emits when AGENTS.md auto-injection fires —
+            // a role:"user" message whose input_text starts with the literal AGENTS.md
+            // header. Picking this as the title context produces a title for the repo
+            // overview, not the actual work request that follows.
+            await File.WriteAllLinesAsync(path, [
+                """{"type":"session_meta","payload":{"id":"x","cwd":"/x"}}""",
+                """{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"# AGENTS.md instructions for /Users/alexey/dev/eventuous/eventuous\n\n<INSTRUCTIONS>\n# Eventuous - AI Agent Context\n..."}]}}""",
+                """{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Review this PR https://github.com/Eventuous/eventuous/pull/502"}]}}""",
+            ]);
+
+            var (userText, _) = TitleGenerator.ExtractCodexTitleContext(path);
+
+            await Assert.That(userText).IsEqualTo("Review this PR https://github.com/Eventuous/eventuous/pull/502");
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task ExtractCodexTitleContext_skips_turn_aborted_prelude() {
+        var path = Path.GetTempFileName();
+
+        try {
+            await File.WriteAllLinesAsync(path, [
+                """{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<turn_aborted>\nThe user interrupted the previous turn..."}]}}""",
+                """{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"skip the tests. CI ran fine"}]}}""",
+            ]);
+
+            var (userText, _) = TitleGenerator.ExtractCodexTitleContext(path);
+
+            await Assert.That(userText).IsEqualTo("skip the tests. CI ran fine");
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
     public async Task ExtractCodexTitleContext_returns_null_user_when_only_environment_context_present() {
         var path = Path.GetTempFileName();
 

--- a/test/kapacitor.Tests.Unit/CodexPathsTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexPathsTests.cs
@@ -41,7 +41,9 @@ public class CodexPathsTests {
             var result = CodexPaths.Discover(root, since: new DateOnly(2026, 5, 1));
 
             await Assert.That(result.Count).IsEqualTo(2);
-            await Assert.That(result.Any(r => r.FilePath.Contains("/03/03/"))).IsFalse();
+            // Normalise to forward slashes so the assertion works regardless of platform
+            // path separator (Windows would otherwise produce \03\03\ here).
+            await Assert.That(result.Any(r => r.FilePath.Replace('\\', '/').Contains("/03/03/"))).IsFalse();
         } finally {
             Directory.Delete(root, true);
         }

--- a/test/kapacitor.Tests.Unit/CodexPathsTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexPathsTests.cs
@@ -63,6 +63,25 @@ public class CodexPathsTests {
     }
 
     [Test]
+    public async Task Discover_leaves_EncodedCwd_empty_so_decode_returns_null() {
+        var root = TempRoot();
+
+        try {
+            CreateRollout(root, "2026/05/07", "rollout-2026-05-07T17-50-21-019e0322-05fc-7570-be65-75719c3ea861");
+
+            var result = CodexPaths.Discover(root);
+
+            await Assert.That(result.Count).IsEqualTo(1);
+            // The day folder name ("07") would be a misleading non-empty cwd encoding.
+            // Empty makes SessionImporter.DecodeCwdFromDirName return null so callers
+            // skip repo detection on metadata-extraction failure.
+            await Assert.That(result[0].EncodedCwd).IsEqualTo("");
+        } finally {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Test]
     public async Task ExtractSessionIdFromFileName_returns_null_for_non_rollout_pattern() {
         var sid = CodexPaths.ExtractSessionIdFromFileName("/tmp/random.jsonl");
         await Assert.That(sid).IsNull();

--- a/test/kapacitor.Tests.Unit/CodexPathsTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexPathsTests.cs
@@ -1,0 +1,90 @@
+using kapacitor;
+
+namespace kapacitor.Tests.Unit;
+
+public class CodexPathsTests {
+    [Test]
+    public async Task Discover_returns_empty_when_root_missing() {
+        var result = CodexPaths.Discover(Path.Combine(Path.GetTempPath(), $"codex-missing-{Guid.NewGuid():N}"));
+        await Assert.That(result).IsEmpty();
+    }
+
+    [Test]
+    public async Task Discover_finds_rollouts_across_date_dirs() {
+        var root = TempRoot();
+
+        try {
+            CreateRollout(root, "2026/03/03", "rollout-2026-03-03T12-58-16-019cb390-2ea9-7541-b633-464c3536a262");
+            CreateRollout(root, "2026/05/07", "rollout-2026-05-07T17-50-21-019e0322-05fc-7570-be65-75719c3ea861");
+
+            var result = CodexPaths.Discover(root);
+
+            await Assert.That(result.Count).IsEqualTo(2);
+
+            var ids = result.Select(r => r.SessionId).OrderBy(s => s, StringComparer.Ordinal).ToList();
+            await Assert.That(ids[0]).IsEqualTo("019cb3902ea97541b633464c3536a262");
+            await Assert.That(ids[1]).IsEqualTo("019e032205fc7570be6575719c3ea861");
+        } finally {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Test]
+    public async Task Discover_with_since_prunes_earlier_directories() {
+        var root = TempRoot();
+
+        try {
+            CreateRollout(root, "2026/03/03", "rollout-2026-03-03T12-58-16-019cb390-2ea9-7541-b633-464c3536a262");
+            CreateRollout(root, "2026/05/01", "rollout-2026-05-01T01-00-00-019d0000-0000-7000-8000-000000000001");
+            CreateRollout(root, "2026/05/07", "rollout-2026-05-07T17-50-21-019e0322-05fc-7570-be65-75719c3ea861");
+
+            var result = CodexPaths.Discover(root, since: new DateOnly(2026, 5, 1));
+
+            await Assert.That(result.Count).IsEqualTo(2);
+            await Assert.That(result.Any(r => r.FilePath.Contains("/03/03/"))).IsFalse();
+        } finally {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Test]
+    public async Task Discover_with_since_keeps_same_day() {
+        var root = TempRoot();
+
+        try {
+            CreateRollout(root, "2026/05/07", "rollout-2026-05-07T17-50-21-019e0322-05fc-7570-be65-75719c3ea861");
+
+            var result = CodexPaths.Discover(root, since: new DateOnly(2026, 5, 7));
+
+            await Assert.That(result.Count).IsEqualTo(1);
+        } finally {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Test]
+    public async Task ExtractSessionIdFromFileName_returns_null_for_non_rollout_pattern() {
+        var sid = CodexPaths.ExtractSessionIdFromFileName("/tmp/random.jsonl");
+        await Assert.That(sid).IsNull();
+    }
+
+    [Test]
+    public async Task ExtractSessionIdFromFileName_normalizes_to_dashless_guid() {
+        var sid = CodexPaths.ExtractSessionIdFromFileName(
+            "/tmp/rollout-2026-05-07T17-50-21-019e0322-05fc-7570-be65-75719c3ea861.jsonl"
+        );
+        await Assert.That(sid).IsEqualTo("019e032205fc7570be6575719c3ea861");
+    }
+
+    static string TempRoot() {
+        var p = Path.Combine(Path.GetTempPath(), $"codex-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(p);
+        return p;
+    }
+
+    static void CreateRollout(string root, string subPath, string fileNameStem) {
+        var dir = Path.Combine(root, subPath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, fileNameStem + ".jsonl"), "{}");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `kapacitor history --codex` to walk `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` and import Codex rollouts to the server with `vendor:"codex"` on every `TranscriptBatch`. Closes the gap left by [Kurrent.Capacitor#576](https://github.com/kurrent-io/Kurrent.Capacitor/pull/576), which shipped the server-side `CodexNormalizer` + vendor selector but had no matching client.
- Adds `--since YYYY-MM-DD` (cheap directory-level pruning for Codex, metadata-based filter for Claude) and a CLI-side `Vendor` field on `TranscriptBatch` (omitted on the wire when null so older servers keep deserialising unchanged).
- Routes headless **title generation** and **what's-done summaries** through `codex exec` for Codex-vendor sessions so users with only Codex installed can backfill, and so the summarising model matches the one that produced the work. New `CodexCliRunner` mirrors the `ClaudeCliRunner` contract via `--output-last-message`.

## Closes

- AI-73

## Out of scope

- Live SignalR streaming for Codex — AI-70.
- Daemon-spawned hosted Codex agents — AI-68 (macOS/Linux) and AI-72 (Windows).
- Codex subagent walk / continuation chains — Codex rollouts have no analog on disk.

## Test plan

- [x] `dotnet build src/kapacitor/kapacitor.csproj` — clean, 0 warnings.
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — no IL3050/IL2026 AOT warnings.
- [x] `dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj` — 418/418 pass (incl. 14 new tests across `CodexPathsTests` and `CodexHistoryTests`).
- [ ] Manual smoke against staging: `kapacitor history --codex --since 2026-05-01` imports recent rollouts; sessions render in the unified dashboard (Chat / Events / Trace / Details), `ContextCompacted` shows up where applicable, reasoning events render as opaque thinking markers, token totals on the imported session match `total_token_usage` from the source's last `token_count`.
- [ ] Windows path resolution (`%USERPROFILE%\.codex\sessions\...`) — covered by the same `Environment.SpecialFolder.UserProfile` mechanism `ClaudePaths` already uses; sanity-check on a Windows host before merge.

## Notes for reviewers

- Spec lives at `docs/superpowers/specs/2026-05-07-ai-73-codex-history-import-design.md`.
- `TranscriptBatch.Vendor` uses `JsonIgnoreCondition.WhenWritingNull` so pre-#576 servers keep working unchanged — the `vendor` field only appears on the wire when explicitly `"codex"`.
- `CodexCliRunner` doesn't parse token usage / cost (would need `--json` event-stream processing). Title and what's-done payloads tolerate the zeros — those fields are diagnostic, not billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)