### PR TITLE
[AI-78] Refuse foreground `kapacitor agent start` when another daemon is alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,10 @@ The agent daemon connects to the Capacitor server and runs Claude Code agents in
 kapacitor agent start              # start in foreground
 kapacitor agent start -d           # start in background (daemonize)
 kapacitor agent status             # check if daemon is running
-kapacitor agent stop               # stop the background daemon
+kapacitor agent stop               # stop the daemon (foreground or background)
 ```
+
+`agent start` refuses to launch a second daemon when one is already alive, regardless of mode. Run `kapacitor agent stop` to terminate the existing one first. Two concurrent daemons under the same identity used to silently take down each other's hosted agents on the server.
 
 ### Repository paths
 

--- a/src/Kapacitor.Core/Resources/help-agent.txt
+++ b/src/Kapacitor.Core/Resources/help-agent.txt
@@ -4,7 +4,7 @@ Usage: kapacitor agent <subcommand>
 
 Subcommands:
   start [-d]              Start the agent daemon (foreground, or -d for background)
-  stop                    Stop the background agent daemon
+  stop                    Stop the agent daemon (foreground or background)
   status                  Show agent daemon status
   logs                    Show recent daemon log output
 
@@ -14,3 +14,9 @@ Options for start:
   --max-agents <n>        Max concurrent agents (default: 5)
   --log-file <path>       Log to file instead of console
   -d, --detach            Run in background (logs to file automatically)
+
+Notes:
+  start refuses to launch if another kapacitor-daemon is already running
+  (whether started in foreground or background mode). Use `kapacitor agent stop`
+  to terminate the existing one first. Multiple concurrent daemons under the
+  same identity were taking down each other's hosted agents on the server.

--- a/src/Kapacitor.Core/Resources/help-usage.txt
+++ b/src/Kapacitor.Core/Resources/help-usage.txt
@@ -21,8 +21,8 @@ Configuration:
   config set <key> <value>         Update a config value
 
 Agent Daemon:
-  agent start [-d]                 Start agent daemon (foreground, or -d for background)
-  agent stop                       Stop background agent daemon
+  agent start [-d]                 Start agent daemon (foreground, or -d for background; refuses if one is already running)
+  agent stop                       Stop the agent daemon (foreground or background)
   agent status                     Show agent daemon status
   repos                            List known repos (sorted by last used)
   repos add <path>                 Add a repo path (supports "." for cwd)

--- a/src/kapacitor/Commands/AgentCommands.cs
+++ b/src/kapacitor/Commands/AgentCommands.cs
@@ -3,8 +3,9 @@ using System.Diagnostics;
 namespace kapacitor.Commands;
 
 public static class AgentCommands {
-    static readonly string PidPath = PathHelpers.ConfigPath("agent.pid");
-    static readonly string LogPath = PathHelpers.ConfigPath("agent.log");
+    static readonly string PidPath  = PathHelpers.ConfigPath("agent.pid");
+    static readonly string LogPath  = PathHelpers.ConfigPath("agent.log");
+    static readonly string LockPath = PathHelpers.ConfigPath("agent.start.lock");
 
     public static async Task<int> HandleAsync(string[] args) {
         if (args.Length < 2) {
@@ -31,20 +32,64 @@ public static class AgentCommands {
         return detached ? StartDetached(args) : await StartForegroundAsync(args);
     }
 
+    /// <summary>
+    /// Open <c>agent.start.lock</c> with <c>FileShare.None</c>, giving the
+    /// caller exclusive access for as long as the returned stream is held.
+    /// Returns null if another process already holds the lock — i.e. another
+    /// <c>kapacitor agent start</c> is mid-flight (its check + spawn +
+    /// WritePidFile window) or a foreground daemon is currently running.
+    ///
+    /// This is the OS-level barrier the PID-file guard alone can't provide:
+    /// without it, two starts launched concurrently can both observe an
+    /// absent / stale PID file and both spawn a daemon before either writes.
+    /// On POSIX .NET maps <c>FileShare.None</c> to <c>flock(LOCK_EX)</c>;
+    /// on Windows it's a native sharing-mode constraint. Both are
+    /// per-open-handle, so closing the stream releases the lock — including
+    /// when the parent process is SIGKILL'd.
+    /// </summary>
+    static FileStream? TryAcquireStartLock() {
+        try {
+            Directory.CreateDirectory(Path.GetDirectoryName(LockPath)!);
+
+            return new FileStream(LockPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
+        } catch (IOException) {
+            return null;
+        }
+    }
+
     static async Task<int> StartForegroundAsync(string[] args) {
-        // Refuse to start when an existing kapacitor-daemon is alive — even in
-        // foreground mode. Without this guard, a second `kapacitor agent start`
-        // (run by mistake, by an automation, by a parallel terminal) would
-        // happily connect to the server and call DaemonConnect with an empty
-        // live_agents list, which used to mass-fail every hosted agent owned
-        // by the original daemon (AI-78). The detached path has had this
-        // guard since day one; foreground was the only hole.
-        if (ReadPidFile() is { } existing && IsOurDaemon(existing.Pid, existing.StartTicks)) {
-            await Console.Error.WriteLineAsync($"Agent daemon already running (PID {existing.Pid}). Use `kapacitor agent stop` first.");
+        // Take the exclusive start lock BEFORE the PID-file stale-check —
+        // otherwise two concurrent `kapacitor agent start` invocations can
+        // both observe no live daemon, both spawn, and only one's PID ends
+        // up in the file. We hold this lock for the foreground daemon's
+        // entire lifetime so any further start (foreground or detached)
+        // refuses immediately rather than racing through.
+        var startLock = TryAcquireStartLock();
+
+        if (startLock is null) {
+            await Console.Error.WriteLineAsync("Another `kapacitor agent start` is already in progress or holds the daemon lock. Run `kapacitor agent stop` first or wait for the other start to complete.");
 
             return 1;
         }
 
+        try {
+            // Defence in depth: the lock prevents a concurrent start from
+            // racing past us, but a stale PID file from a prior cleanly-exited
+            // daemon (or one whose parent was SIGKILL'd) can still be lying
+            // around. IsOurDaemon's StartTime check rejects recycled PIDs.
+            if (ReadPidFile() is { } existing && IsOurDaemon(existing.Pid, existing.StartTicks)) {
+                await Console.Error.WriteLineAsync($"Agent daemon already running (PID {existing.Pid}). Use `kapacitor agent stop` first.");
+
+                return 1;
+            }
+
+            return await SpawnForegroundAsync(args);
+        } finally {
+            startLock.Dispose();
+        }
+    }
+
+    static async Task<int> SpawnForegroundAsync(string[] args) {
         var daemonPath = ResolveDaemonBinary();
 
         if (daemonPath is null) {
@@ -101,6 +146,21 @@ public static class AgentCommands {
     }
 
     static int StartDetached(string[] args) {
+        // Hold the start lock just for the check + spawn + WritePidFile
+        // window. We can't keep it past method return because the parent
+        // process is about to exit, leaving the daemon detached. Once the
+        // PID file is written, subsequent starts will see it via the
+        // existing stale-check path.
+        var startLock = TryAcquireStartLock();
+
+        if (startLock is null) {
+            Console.Error.WriteLine("Another `kapacitor agent start` is already in progress or holds the daemon lock. Run `kapacitor agent stop` first or wait for the other start to complete.");
+
+            return 1;
+        }
+
+        using var _ = startLock;
+
         if (ReadPidFile() is { } existing && IsOurDaemon(existing.Pid, existing.StartTicks)) {
             Console.Error.WriteLine($"Agent daemon already running (PID {existing.Pid}). Use `kapacitor agent stop` first.");
 

--- a/src/kapacitor/Commands/AgentCommands.cs
+++ b/src/kapacitor/Commands/AgentCommands.cs
@@ -83,7 +83,20 @@ public static class AgentCommands {
 
             return process.ExitCode;
         } finally {
-            try { File.Delete(PidPath); } catch { /* best-effort */ }
+            // Only delete the PID file if it still points at us. A concurrent
+            // legitimate `kapacitor agent start` that ran after our daemon
+            // exited (passing the guard because IsOurDaemon returned false on
+            // our exiting PID) would have rewritten the file to its own PID;
+            // an unconditional delete here would orphan that daemon's PID
+            // file and re-open the duplicate-daemon hole this guard is meant
+            // to close.
+            try {
+                if (ReadPidFile() is { } current && current.Pid == process.Id) {
+                    File.Delete(PidPath);
+                }
+            } catch {
+                /* best-effort */
+            }
         }
     }
 

--- a/src/kapacitor/Commands/AgentCommands.cs
+++ b/src/kapacitor/Commands/AgentCommands.cs
@@ -32,6 +32,19 @@ public static class AgentCommands {
     }
 
     static async Task<int> StartForegroundAsync(string[] args) {
+        // Refuse to start when an existing kapacitor-daemon is alive — even in
+        // foreground mode. Without this guard, a second `kapacitor agent start`
+        // (run by mistake, by an automation, by a parallel terminal) would
+        // happily connect to the server and call DaemonConnect with an empty
+        // live_agents list, which used to mass-fail every hosted agent owned
+        // by the original daemon (AI-78). The detached path has had this
+        // guard since day one; foreground was the only hole.
+        if (ReadPidFile() is { } existing && IsOurDaemon(existing.Pid, existing.StartTicks)) {
+            await Console.Error.WriteLineAsync($"Agent daemon already running (PID {existing.Pid}). Use `kapacitor agent stop` first.");
+
+            return 1;
+        }
+
         var daemonPath = ResolveDaemonBinary();
 
         if (daemonPath is null) {
@@ -58,9 +71,20 @@ public static class AgentCommands {
             return 1;
         }
 
-        await process.WaitForExitAsync();
+        // Write the PID file so the guard above (and `kapacitor agent stop` /
+        // `agent status`) sees the foreground daemon too. Best-effort cleanup
+        // on exit; if the parent dies hard, IsOurDaemon's StartTime check
+        // handles the recycled-PID case so a stale file doesn't lock anyone
+        // out.
+        WritePidFile(process);
 
-        return process.ExitCode;
+        try {
+            await process.WaitForExitAsync();
+
+            return process.ExitCode;
+        } finally {
+            try { File.Delete(PidPath); } catch { /* best-effort */ }
+        }
     }
 
     static int StartDetached(string[] args) {

--- a/src/kapacitor/Commands/StatusCommand.cs
+++ b/src/kapacitor/Commands/StatusCommand.cs
@@ -46,9 +46,16 @@ public static class StatusCommand {
         var pidPath = PathHelpers.ConfigPath("agent.pid");
 
         if (File.Exists(pidPath)) {
-            var pidStr = (await File.ReadAllTextAsync(pidPath)).Trim();
+            // The PID file is one or two lines: PID, optionally followed by
+            // process StartTicks (UTC ticks of Process.StartTime). Parse only
+            // the first non-empty line as the PID — naively passing the whole
+            // contents to int.TryParse fails on the two-line format and
+            // mis-reports a running daemon as "invalid PID file".
+            var firstLine = (await File.ReadAllTextAsync(pidPath))
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault();
 
-            if (int.TryParse(pidStr, out var pid)) {
+            if (int.TryParse(firstLine, out var pid)) {
                 try {
                     System.Diagnostics.Process.GetProcessById(pid);
                     await Console.Out.WriteLineAsync($"running (PID {pid})");


### PR DESCRIPTION
## Summary

- **CLI half of the AI-78 fix.** The detached path (`-d`/`--detach`) has guarded against duplicate launches via the PID file since day one (`StartDetached` line 67 — `Agent daemon already running (PID …). Use \`kapacitor agent stop\` first.`). Foreground was the only hole. A second `kapacitor agent start` — run by mistake, by an automation, or by a parallel terminal — happily spawns a fresh `kapacitor-daemon`. Cold-start fresh daemons call `DaemonConnect` with empty `live_agents` (the orchestrator hasn't been constructed yet, `GetLiveAgentIds` is null, the `?? []` fallback fires), the server silently replaces the active daemon's `(owner, name)` slot via `DaemonRegistry.Register`, then `ReconcileDaemon([])` flips every running hosted agent to Failed. The displaced real daemon keeps its WebSocket open and never notices.
- **The fix**: mirror the detached PID-file check into `StartForegroundAsync`, write the PID file when the foreground daemon launches so subsequent starts in any mode see it, and clean it up on exit. `IsOurDaemon`'s StartTime check already handles the recycled-PID case if the parent dies hard.
- **Help text + README updated** to document the new behaviour, per the project convention of keeping `help-usage.txt` / `help-<cmd>.txt` / README in sync.

Tested locally:

```
$ kapacitor agent --help        # new "Notes:" section visible
$ kapacitor agent start         # exits 1, message: "Agent daemon already running (PID 54115)…"
```

Independent of the server-side belt (kurrent-io/Kurrent.Capacitor PR 590) which tightens `ReconcileDaemon` to ignore empty `live_agents`. Either alone closes the cascade; both together make it double-safe.

See AI-78 for the full investigation, including macOS process-log evidence of 5 distinct `kapacitor-daemon` PIDs today and confirmation the real daemon's HubConnection never reconnected.

## Test plan

- [x] AOT publish clean (no IL3050/IL2026 warnings).
- [x] Smoke test: `kapacitor agent start` with the existing daemon alive exits 1 with the expected message.
- [x] Help text renders the new "Notes:" section correctly.
- [ ] Reviewer: confirm the PID file is properly cleaned up on Ctrl+C in foreground mode (the `try/finally` deletes it; verified manually but worth a second look).

🤖 Generated with [Claude Code](https://claude.com/claude-code)