### PR TITLE
[AI-194] Codex: use turn_context model name instead of provider

### DIFF
--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -815,23 +815,31 @@ static class HistoryCommand {
 
     /// <summary>
     /// Codex-shape variant of <see cref="ExtractSessionMetadata"/>. Reads the first
-    /// <c>session_meta</c> line and pulls cwd, model_provider (mapped to
-    /// <see cref="SessionMetadata.Model"/>), and the inner timestamp (when codex
-    /// started, not when the envelope was written). Codex rollouts have no slug,
-    /// so <see cref="SessionMetadata.Slug"/> stays null.
+    /// <c>session_meta</c> line and pulls cwd, the inner timestamp (when codex
+    /// started, not when the envelope was written), and the model. Codex rollouts
+    /// have no slug, so <see cref="SessionMetadata.Slug"/> stays null.
+    ///
+    /// Model resolution: <c>turn_context.payload.model</c> (the real model name,
+    /// e.g. <c>gpt-5.5</c>) is preferred when present; falls back to
+    /// <c>session_meta.payload.model_provider</c> (e.g. <c>openai</c>) when the
+    /// rollout never reaches its first turn. The first turn_context typically
+    /// arrives within the first few lines, but we scan generously in case
+    /// future Codex versions interleave more preludes.
     /// </summary>
     internal static SessionMetadata ExtractCodexSessionMetadata(string filePath) {
-        var meta = new SessionMetadata();
+        const int MaxLines = 50;
+
+        var meta             = new SessionMetadata();
+        var sessionMetaFound = false;
+        var turnModelFound   = false;
 
         try {
             using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var reader = new StreamReader(stream);
 
-            // Codex always emits session_meta as the first non-empty line — but read up
-            // to 5 lines for resilience against future preludes.
             var linesChecked = 0;
 
-            while (reader.ReadLine() is { } line && linesChecked < 5) {
+            while (reader.ReadLine() is { } line && linesChecked < MaxLines) {
                 linesChecked++;
 
                 if (string.IsNullOrWhiteSpace(line)) continue;
@@ -840,22 +848,29 @@ static class HistoryCommand {
                     using var doc  = JsonDocument.Parse(line);
                     var       root = doc.RootElement;
 
-                    if (root.Str("type") != "session_meta") continue;
+                    var type = root.Str("type");
 
-                    var payload = root.Obj("payload");
+                    if (!sessionMetaFound && type == "session_meta") {
+                        if (root.Obj("payload") is not { } payload) continue;
 
-                    if (payload is null) continue;
+                        meta.Cwd       = payload.Str("cwd");
+                        meta.Model     = payload.Str("model_provider");
+                        meta.SessionId = payload.Str("id");
 
-                    meta.Cwd       = payload.Value.Str("cwd");
-                    meta.Model     = payload.Value.Str("model_provider");
-                    meta.SessionId = payload.Value.Str("id");
+                        if (payload.Str("timestamp") is { } tsStr
+                         && DateTimeOffset.TryParse(tsStr, out var ts)) {
+                            meta.FirstTimestamp = ts;
+                        }
 
-                    if (payload.Value.Str("timestamp") is { } tsStr
-                     && DateTimeOffset.TryParse(tsStr, out var ts)) {
-                        meta.FirstTimestamp = ts;
+                        sessionMetaFound = true;
+                    } else if (!turnModelFound && type == "turn_context") {
+                        if (root.Obj("payload")?.Str("model") is { Length: > 0 } turnModel) {
+                            meta.Model     = turnModel;
+                            turnModelFound = true;
+                        }
                     }
 
-                    break;
+                    if (sessionMetaFound && turnModelFound) break;
                 } catch (JsonException) { }
             }
         } catch {

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -863,7 +863,11 @@ static class HistoryCommand {
                         }
 
                         sessionMetaFound = true;
-                    } else if (!turnModelFound && type == "turn_context") {
+                    } else if (sessionMetaFound && !turnModelFound && type == "turn_context") {
+                        // Only honor turn_context AFTER session_meta — a turn_context
+                        // that appears before the header (truncated/corrupt rollout) is
+                        // unreliable and would otherwise stamp a model name onto an
+                        // otherwise-empty meta.
                         if (root.Obj("payload")?.Str("model") is { Length: > 0 } turnModel) {
                             meta.Model     = turnModel;
                             turnModelFound = true;

--- a/test/kapacitor.Tests.Unit/CodexHistoryTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexHistoryTests.cs
@@ -13,6 +13,9 @@ public class CodexHistoryTests {
         var path = Path.GetTempFileName();
 
         try {
+            // No turn_context here — the fallback path uses model_provider as
+            // the model name. (When turn_context is present, the real model
+            // overrides this — see ExtractCodexSessionMetadata_prefers_turn_context_model.)
             await File.WriteAllLinesAsync(path, [
                 """{"timestamp":"2026-05-07T15:51:46.684Z","type":"session_meta","payload":{"id":"019e0322-05fc-7570-be65-75719c3ea861","timestamp":"2026-05-07T15:50:21.989Z","cwd":"/Users/alexey/dev/temp/Kurrent.Capacitor","originator":"codex-tui","cli_version":"0.128.0","model_provider":"openai","git":{"commit_hash":"abc","branch":"main","repository_url":"https://github.com/owner/repo"}}}""",
                 """{"timestamp":"2026-05-07T15:51:46.686Z","type":"event_msg","payload":{"type":"task_started"}}""",
@@ -26,6 +29,49 @@ public class CodexHistoryTests {
             await Assert.That(meta.FirstTimestamp).IsNotNull();
             await Assert.That(meta.FirstTimestamp!.Value).IsEqualTo(DateTimeOffset.Parse("2026-05-07T15:50:21.989Z"));
             await Assert.That(meta.Slug).IsNull();
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task ExtractCodexSessionMetadata_prefers_turn_context_model_over_model_provider() {
+        // AI-194 (CLI half): session_meta only carries model_provider ("openai"),
+        // not the actual model. The real model name lives on turn_context.payload.model
+        // (e.g. "gpt-5.5"). Prefer that over the provider so the session card and
+        // details show "gpt-5.5" instead of "openai".
+        var path = Path.GetTempFileName();
+
+        try {
+            await File.WriteAllLinesAsync(path, [
+                """{"timestamp":"2026-05-07T15:51:46.684Z","type":"session_meta","payload":{"id":"019e0322-05fc-7570-be65-75719c3ea861","timestamp":"2026-05-07T15:50:21.989Z","cwd":"/x","model_provider":"openai"}}""",
+                """{"timestamp":"2026-05-07T15:51:46.700Z","type":"event_msg","payload":{"type":"task_started"}}""",
+                """{"timestamp":"2026-05-07T15:51:46.750Z","type":"turn_context","payload":{"turn_id":"abc","cwd":"/x","model":"gpt-5.5"}}""",
+            ]);
+
+            var meta = HistoryCommand.ExtractCodexSessionMetadata(path);
+
+            await Assert.That(meta.Model).IsEqualTo("gpt-5.5");
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task ExtractCodexSessionMetadata_falls_back_to_model_provider_when_no_turn_context() {
+        // Defensive: if a rollout has session_meta but never reaches a turn_context
+        // (e.g. interrupted before the first turn), keep the legacy model_provider
+        // fallback so the model field isn't blank.
+        var path = Path.GetTempFileName();
+
+        try {
+            await File.WriteAllLinesAsync(path, [
+                """{"type":"session_meta","payload":{"id":"x","cwd":"/x","model_provider":"openai"}}""",
+            ]);
+
+            var meta = HistoryCommand.ExtractCodexSessionMetadata(path);
+
+            await Assert.That(meta.Model).IsEqualTo("openai");
         } finally {
             File.Delete(path);
         }

--- a/test/kapacitor.Tests.Unit/CodexHistoryTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexHistoryTests.cs
@@ -14,8 +14,9 @@ public class CodexHistoryTests {
 
         try {
             // No turn_context here — the fallback path uses model_provider as
-            // the model name. (When turn_context is present, the real model
-            // overrides this — see ExtractCodexSessionMetadata_prefers_turn_context_model.)
+            // the model name. When turn_context is present, the real model
+            // overrides this (see
+            // ExtractCodexSessionMetadata_prefers_turn_context_model_over_model_provider).
             await File.WriteAllLinesAsync(path, [
                 """{"timestamp":"2026-05-07T15:51:46.684Z","type":"session_meta","payload":{"id":"019e0322-05fc-7570-be65-75719c3ea861","timestamp":"2026-05-07T15:50:21.989Z","cwd":"/Users/alexey/dev/temp/Kurrent.Capacitor","originator":"codex-tui","cli_version":"0.128.0","model_provider":"openai","git":{"commit_hash":"abc","branch":"main","repository_url":"https://github.com/owner/repo"}}}""",
                 """{"timestamp":"2026-05-07T15:51:46.686Z","type":"event_msg","payload":{"type":"task_started"}}""",
@@ -52,6 +53,30 @@ public class CodexHistoryTests {
             var meta = HistoryCommand.ExtractCodexSessionMetadata(path);
 
             await Assert.That(meta.Model).IsEqualTo("gpt-5.5");
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task ExtractCodexSessionMetadata_ignores_turn_context_before_session_meta() {
+        // Qodo regression (#52): the docstring resolves the model from the first
+        // turn_context AFTER session_meta. If the rollout header is truncated or
+        // corrupt and a turn_context appears without a session_meta, its model
+        // should NOT be picked up — meta.Model stays null so callers treat the
+        // rollout as malformed instead of silently importing it with a model
+        // pulled from an unexpected line.
+        var path = Path.GetTempFileName();
+
+        try {
+            await File.WriteAllLinesAsync(path, [
+                """{"type":"turn_context","payload":{"turn_id":"abc","cwd":"/x","model":"gpt-5.5"}}""",
+                """{"type":"event_msg","payload":{"type":"task_started"}}""",
+            ]);
+
+            var meta = HistoryCommand.ExtractCodexSessionMetadata(path);
+
+            await Assert.That(meta.Model).IsNull();
         } finally {
             File.Delete(path);
         }


### PR DESCRIPTION
## Summary

- Codex's `session_meta.payload` only carries `model_provider` (e.g. `"openai"`); the actual model name (e.g. `"gpt-5.5"`) lives on `turn_context.payload.model`.
- Mapping `model_provider` into `SessionMetadata.Model` meant imported Codex sessions showed `"openai"` instead of the real model on the session card and details.
- `ExtractCodexSessionMetadata` now scans up to 50 lines for the first `turn_context` after `session_meta` and prefers its `payload.model`. Falls back to `model_provider` when no `turn_context` is reached (e.g. interrupted rollouts) so the field is never blank.

Server-side companion: kurrent-io/Kurrent.Capacitor#591 (stamps the per-turn model onto `$usage` so the per-model token rollup includes Codex sessions, and skips the `<environment_context>` preamble for fallback titles).

## Test plan

- [x] New `ExtractCodexSessionMetadata_prefers_turn_context_model_over_model_provider` — confirmed RED before fix, GREEN after
- [x] New `ExtractCodexSessionMetadata_falls_back_to_model_provider_when_no_turn_context` — preserves legacy behavior
- [x] `kapacitor.Tests.Unit` — 425/425 pass
- [x] `dotnet publish -c Release` — no IL3050/IL2026 AOT warnings

Closes [AI-194](https://linear.app/kurrent/issue/AI-194/codex-wrong-session-title-and-no-tokens-in-carddetails) (CLI half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)