### PR TITLE
[AI-566] Daemon round-trip Ping replaces fire-and-forget heartbeat

### DIFF
--- a/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
@@ -75,7 +75,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     readonly LocalPermissionBridge                       _permissionBridge;
     readonly ILogger<AgentOrchestrator>                  _logger;
     readonly PeriodicTimer                               _heartbeatTimer  = new(TimeSpan.FromSeconds(30));
-    readonly PeriodicTimer                               _daemonHeartbeat = new(TimeSpan.FromMinutes(1));
+    // AI-79: heartbeat tightened from 60 s SendAsync to 15 s round-trip Ping.
+    // Server's default ClientTimeoutInterval is 30 s, and the staging incident
+    // showed daemons holding a displaced slot for nearly a minute before
+    // anyone noticed; 15 s puts us comfortably under both.
+    readonly PeriodicTimer                               _daemonHeartbeat = new(TimeSpan.FromSeconds(15));
+    static readonly TimeSpan                             _pingDeadline    = TimeSpan.FromSeconds(10);
     readonly CancellationTokenSource                     _shutdownCts     = new();
 
     public AgentOrchestrator(
@@ -813,12 +818,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     }
 
     async Task RunDaemonHeartbeatLoopAsync(CancellationToken ct) {
+        var loop = new DaemonHeartbeatLoop(_server, _pingDeadline, _logger);
+
         while (await _daemonHeartbeat.WaitForNextTickAsync(ct)) {
-            try {
-                await _server.SendHeartbeatAsync();
-            } catch (Exception ex) {
-                LogHeartbeatFailed(ex);
-            }
+            await loop.TickAsync(ct);
         }
     }
 
@@ -1238,9 +1241,6 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to spawn what's-done generator for session {SessionId}")]
     partial void LogWhatsDoneSpawnFailed(Exception? ex, string sessionId);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Daemon heartbeat failed")]
-    partial void LogHeartbeatFailed(Exception ex);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to persist repo path for agent {AgentId}")]
     partial void LogRepoPathPersistFailed(Exception ex, string agentId);

--- a/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
@@ -821,7 +821,17 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         var loop = new DaemonHeartbeatLoop(_server, _pingDeadline, _logger);
 
         while (await _daemonHeartbeat.WaitForNextTickAsync(ct)) {
-            await loop.TickAsync(ct);
+            // Defence in depth: TickAsync is intentionally total, but we
+            // run as an unobserved background Task — guarding here keeps
+            // the loop alive even if a future change accidentally lets an
+            // exception escape the tick.
+            try {
+                await loop.TickAsync(ct);
+            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                return;
+            } catch (Exception ex) {
+                _logger.LogWarning(ex, "Heartbeat tick faulted — continuing loop");
+            }
         }
     }
 

--- a/src/Kapacitor.Daemon/Services/DaemonHeartbeatLoop.cs
+++ b/src/Kapacitor.Daemon/Services/DaemonHeartbeatLoop.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging;
+
+namespace kapacitor.Daemon.Services;
+
+/// <summary>
+/// Daemon-driven liveness probe — replaces the pre-AI-79 fire-and-forget
+/// <c>SendHeartbeatAsync</c>. The server-side <c>DaemonPing</c> hub method
+/// returns <c>true</c> if the calling connection is still the registered
+/// daemon for its <c>(owner, name)</c> slot, and <c>false</c> if it isn't —
+/// either because the daemon never called <c>DaemonConnect</c> on this
+/// connection, or because a subsequent <c>DaemonConnect</c> displaced this
+/// connection's registry entry. The displacement case is the staging
+/// incident: the orchestrator's view of the daemon is bound to the new
+/// conn id while the daemon's WebSocket transport keeps believing the old
+/// one is fine. A round-trip ping surfaces that mismatch within one tick
+/// instead of waiting for the WebSocket to teach the daemon.
+/// </summary>
+internal interface IDaemonHeartbeatPort {
+    Task<bool> PingAsync(CancellationToken ct);
+    Task       ReRegisterAsync();
+    Task       ForceReconnectAsync();
+}
+
+internal sealed class DaemonHeartbeatLoop(IDaemonHeartbeatPort port, TimeSpan pingDeadline, ILogger logger) {
+    public async Task TickAsync(CancellationToken ct) {
+        try {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(pingDeadline);
+
+            var alive = await port.PingAsync(cts.Token);
+
+            if (!alive) {
+                logger.LogWarning("Heartbeat: server does not recognise this connection — re-registering daemon");
+                await port.ReRegisterAsync();
+            }
+        } catch (OperationCanceledException) when (!ct.IsCancellationRequested) {
+            // Per-tick deadline fired before the server answered. The
+            // WebSocket is hung; force WithAutomaticReconnect by stopping
+            // the hub and letting OnClosed → ConnectWithRetryAsync rebuild
+            // it under a fresh conn id.
+            logger.LogWarning("Heartbeat: ping exceeded deadline — forcing reconnect");
+            await port.ForceReconnectAsync();
+        } catch (OperationCanceledException) {
+            // Outer cancellation (process shutting down) — let the loop exit.
+        } catch (Exception ex) {
+            logger.LogWarning(ex, "Heartbeat: ping threw — forcing reconnect");
+            await port.ForceReconnectAsync();
+        }
+    }
+}

--- a/src/Kapacitor.Daemon/Services/DaemonHeartbeatLoop.cs
+++ b/src/Kapacitor.Daemon/Services/DaemonHeartbeatLoop.cs
@@ -22,6 +22,16 @@ internal interface IDaemonHeartbeatPort {
 }
 
 internal sealed class DaemonHeartbeatLoop(IDaemonHeartbeatPort port, TimeSpan pingDeadline, ILogger logger) {
+    /// <summary>
+    /// Total — never throws (modulo outer cancellation, which is expected at
+    /// shutdown). The loop in <c>AgentOrchestrator.RunDaemonHeartbeatLoopAsync</c>
+    /// runs as an unobserved background Task; if a tick faulted, the loop
+    /// would die silently and the daemon would stop probing for liveness
+    /// forever. Recovery actions (<see cref="IDaemonHeartbeatPort.ReRegisterAsync"/>,
+    /// <see cref="IDaemonHeartbeatPort.ForceReconnectAsync"/>) are individually
+    /// guarded since both ultimately call into SignalR (<c>InvokeAsync</c> /
+    /// <c>StopAsync</c>) and can throw on transient transport state.
+    /// </summary>
     public async Task TickAsync(CancellationToken ct) {
         try {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -31,7 +41,7 @@ internal sealed class DaemonHeartbeatLoop(IDaemonHeartbeatPort port, TimeSpan pi
 
             if (!alive) {
                 logger.LogWarning("Heartbeat: server does not recognise this connection — re-registering daemon");
-                await port.ReRegisterAsync();
+                await SafeReRegisterAsync();
             }
         } catch (OperationCanceledException) when (!ct.IsCancellationRequested) {
             // Per-tick deadline fired before the server answered. The
@@ -39,12 +49,34 @@ internal sealed class DaemonHeartbeatLoop(IDaemonHeartbeatPort port, TimeSpan pi
             // the hub and letting OnClosed → ConnectWithRetryAsync rebuild
             // it under a fresh conn id.
             logger.LogWarning("Heartbeat: ping exceeded deadline — forcing reconnect");
-            await port.ForceReconnectAsync();
+            await SafeForceReconnectAsync();
         } catch (OperationCanceledException) {
             // Outer cancellation (process shutting down) — let the loop exit.
         } catch (Exception ex) {
             logger.LogWarning(ex, "Heartbeat: ping threw — forcing reconnect");
+            await SafeForceReconnectAsync();
+        }
+    }
+
+    async Task SafeReRegisterAsync() {
+        try {
+            await port.ReRegisterAsync();
+        } catch (Exception ex) {
+            // Re-register itself failed. Escalate to a full reconnect — if
+            // SignalR's InvokeAsync rejected, the transport is likely in
+            // bad shape too. Both calls are guarded so the tick is total.
+            logger.LogWarning(ex, "Heartbeat: re-register failed — escalating to forced reconnect");
+            await SafeForceReconnectAsync();
+        }
+    }
+
+    async Task SafeForceReconnectAsync() {
+        try {
             await port.ForceReconnectAsync();
+        } catch (Exception ex) {
+            // Last line of defence. Log and let the next tick retry; with
+            // no rethrow the unobserved heartbeat Task stays alive.
+            logger.LogWarning(ex, "Heartbeat: force reconnect failed — will retry next tick");
         }
     }
 }

--- a/src/Kapacitor.Daemon/Services/ServerConnection.cs
+++ b/src/Kapacitor.Daemon/Services/ServerConnection.cs
@@ -203,11 +203,8 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
 
     public event Action? OnReconnectedCallback;
 
-    public Task SendHeartbeatAsync()
-        => _hub.SendAsync("DaemonHeartbeat", cancellationToken: _ct);
-
     /// <summary>
-    /// Round-trip liveness probe (AI-79). Calls <c>DaemonPing</c> on the server
+    /// Round-trip liveness probe (AI-566). Calls <c>DaemonPing</c> on the server
     /// and returns whether this connection is still the registered daemon for
     /// its <c>(owner, name)</c> slot. <c>false</c> means the slot was displaced
     /// — usually by an auto-reconnect Register from a different conn id —

--- a/src/Kapacitor.Daemon/Services/ServerConnection.cs
+++ b/src/Kapacitor.Daemon/Services/ServerConnection.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace kapacitor.Daemon.Services;
 
-internal partial class ServerConnection : IAsyncDisposable {
+internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort {
     readonly HubConnection             _hub;
     readonly DaemonConfig              _config;
     readonly ILogger<ServerConnection> _logger;
@@ -205,6 +205,35 @@ internal partial class ServerConnection : IAsyncDisposable {
 
     public Task SendHeartbeatAsync()
         => _hub.SendAsync("DaemonHeartbeat", cancellationToken: _ct);
+
+    /// <summary>
+    /// Round-trip liveness probe (AI-79). Calls <c>DaemonPing</c> on the server
+    /// and returns whether this connection is still the registered daemon for
+    /// its <c>(owner, name)</c> slot. <c>false</c> means the slot was displaced
+    /// — usually by an auto-reconnect Register from a different conn id —
+    /// and the daemon should re-register so the orchestrator's view is
+    /// repaired. <c>virtual</c> so unit tests can override without spinning
+    /// up a real SignalR client.
+    /// </summary>
+    public virtual Task<bool> PingAsync(CancellationToken ct)
+        => _hub.InvokeAsync<bool>("DaemonPing", cancellationToken: ct);
+
+    /// <summary>
+    /// Re-runs <c>DaemonConnect</c> on the existing hub connection. Used by
+    /// the heartbeat loop when the server reports it doesn't recognise this
+    /// connection as a daemon (slot displaced or never registered).
+    /// </summary>
+    public virtual Task ReRegisterAsync() => RegisterDaemon();
+
+    /// <summary>
+    /// Stops the underlying hub. <see cref="OnClosed"/> fires and calls
+    /// <see cref="ConnectWithRetryAsync"/>, which establishes a fresh
+    /// transport and a new server-side conn id, then re-registers via
+    /// <see cref="RegisterDaemon"/>. Used when the heartbeat ping times out
+    /// or throws — the WebSocket is hung and only a fresh connection
+    /// recovers it.
+    /// </summary>
+    public virtual Task ForceReconnectAsync() => _hub.StopAsync(_ct);
 
     public async Task UpdateRepoPathsAsync() {
         try {

--- a/test/kapacitor.Tests.Unit/DaemonHeartbeatLoopTests.cs
+++ b/test/kapacitor.Tests.Unit/DaemonHeartbeatLoopTests.cs
@@ -1,0 +1,125 @@
+using kapacitor.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace kapacitor.Tests.Unit;
+
+/// <summary>
+/// Unit tests for the daemon-side heartbeat tick. The loop runs every ~15 s
+/// and must, in three distinct cases:
+///
+/// <list type="bullet">
+/// <item>healthy — server returns true; do nothing.</item>
+/// <item>slot displaced — server returns false; re-register so the
+/// orchestrator-visible registry tracks the live conn id.</item>
+/// <item>connection hung — ping throws or times out; force a SignalR
+/// reconnect by stopping the hub so <c>WithAutomaticReconnect</c> kicks in.
+/// This is the failure mode that wedged staging: the server timed the
+/// daemon out, but the daemon's WebSocket transport never noticed.</item>
+/// </list>
+///
+/// The loop is exercised through a fake <see cref="IDaemonHeartbeatPort"/>
+/// so we don't need a real SignalR HubConnection.
+/// </summary>
+public class DaemonHeartbeatLoopTests {
+    sealed class FakePort : IDaemonHeartbeatPort {
+        public Func<CancellationToken, Task<bool>>? PingHandler { get; set; }
+        public int                                  ReRegisterCalls;
+        public int                                  ForceReconnectCalls;
+
+        public Task<bool> PingAsync(CancellationToken ct)
+            => PingHandler is null ? Task.FromResult(true) : PingHandler(ct);
+
+        public Task ReRegisterAsync() {
+            ReRegisterCalls++;
+
+            return Task.CompletedTask;
+        }
+
+        public Task ForceReconnectAsync() {
+            ForceReconnectCalls++;
+
+            return Task.CompletedTask;
+        }
+    }
+
+    static DaemonHeartbeatLoop CreateLoop(FakePort port, TimeSpan? deadline = null)
+        => new(port, deadline ?? TimeSpan.FromSeconds(10), NullLogger.Instance);
+
+    [Test]
+    public async Task Tick_ServerSaysHealthy_DoesNothing() {
+        var port = new FakePort { PingHandler = _ => Task.FromResult(true) };
+        var loop = CreateLoop(port);
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.ReRegisterCalls).IsEqualTo(0);
+        await Assert.That(port.ForceReconnectCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Tick_ServerSaysFalse_ReRegistersWithoutForcingReconnect() {
+        var port = new FakePort { PingHandler = _ => Task.FromResult(false) };
+        var loop = CreateLoop(port);
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.ReRegisterCalls).IsEqualTo(1);
+        await Assert.That(port.ForceReconnectCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Tick_PingThrows_ForcesReconnect() {
+        var port = new FakePort {
+            PingHandler = _ => Task.FromException<bool>(new InvalidOperationException("hub closed"))
+        };
+        var loop = CreateLoop(port);
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.ReRegisterCalls).IsEqualTo(0);
+        await Assert.That(port.ForceReconnectCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Tick_PingExceedsDeadline_ForcesReconnect() {
+        // The ping never returns. The loop's per-tick deadline must fire so
+        // the daemon doesn't sit on a hung WebSocket forever.
+        var port = new FakePort {
+            PingHandler = ct => {
+                var tcs = new TaskCompletionSource<bool>();
+                ct.Register(() => tcs.TrySetCanceled(ct));
+
+                return tcs.Task;
+            }
+        };
+        var loop = CreateLoop(port, deadline: TimeSpan.FromMilliseconds(50));
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.ReRegisterCalls).IsEqualTo(0);
+        await Assert.That(port.ForceReconnectCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Tick_OuterCancellation_DoesNotForceReconnect() {
+        // Outer cancellation = process shutdown. The loop must not interpret
+        // that as a stuck connection and try to reconnect during teardown.
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var port = new FakePort {
+            PingHandler = ct => {
+                var tcs = new TaskCompletionSource<bool>();
+                ct.Register(() => tcs.TrySetCanceled(ct));
+
+                return tcs.Task;
+            }
+        };
+        var loop = CreateLoop(port);
+
+        await loop.TickAsync(cts.Token);
+
+        await Assert.That(port.ReRegisterCalls).IsEqualTo(0);
+        await Assert.That(port.ForceReconnectCalls).IsEqualTo(0);
+    }
+}

--- a/test/kapacitor.Tests.Unit/DaemonHeartbeatLoopTests.cs
+++ b/test/kapacitor.Tests.Unit/DaemonHeartbeatLoopTests.cs
@@ -22,7 +22,9 @@ namespace kapacitor.Tests.Unit;
 /// </summary>
 public class DaemonHeartbeatLoopTests {
     sealed class FakePort : IDaemonHeartbeatPort {
-        public Func<CancellationToken, Task<bool>>? PingHandler { get; set; }
+        public Func<CancellationToken, Task<bool>>? PingHandler              { get; set; }
+        public Func<Task>?                          ReRegisterHandler        { get; set; }
+        public Func<Task>?                          ForceReconnectHandler    { get; set; }
         public int                                  ReRegisterCalls;
         public int                                  ForceReconnectCalls;
 
@@ -32,13 +34,13 @@ public class DaemonHeartbeatLoopTests {
         public Task ReRegisterAsync() {
             ReRegisterCalls++;
 
-            return Task.CompletedTask;
+            return ReRegisterHandler is null ? Task.CompletedTask : ReRegisterHandler();
         }
 
         public Task ForceReconnectAsync() {
             ForceReconnectCalls++;
 
-            return Task.CompletedTask;
+            return ForceReconnectHandler is null ? Task.CompletedTask : ForceReconnectHandler();
         }
     }
 
@@ -97,6 +99,44 @@ public class DaemonHeartbeatLoopTests {
         await loop.TickAsync(CancellationToken.None);
 
         await Assert.That(port.ReRegisterCalls).IsEqualTo(0);
+        await Assert.That(port.ForceReconnectCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Tick_ForceReconnectThrows_DoesNotRethrow() {
+        // Qodo finding: ForceReconnectAsync ultimately calls _hub.StopAsync,
+        // which can throw (invalid state, transient SignalR cancellation).
+        // The heartbeat loop runs as an unobserved background Task — if
+        // TickAsync rethrows, the loop dies and the daemon stops probing
+        // for liveness forever. TickAsync must be total.
+        var port = new FakePort {
+            PingHandler           = _ => Task.FromException<bool>(new InvalidOperationException("hub closed")),
+            ForceReconnectHandler = () => Task.FromException(new InvalidOperationException("StopAsync from invalid state"))
+        };
+        var loop = CreateLoop(port);
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.ForceReconnectCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Tick_ReRegisterAndForceReconnectBothThrow_DoesNotRethrow() {
+        // Same reliability concern as Tick_ForceReconnectThrows: the
+        // displaced-slot recovery path is also a SignalR call that can
+        // throw transiently. ReRegister throwing escalates to the outer
+        // catch, which calls ForceReconnect; if BOTH fail the tick still
+        // must not fault the unobserved loop.
+        var port = new FakePort {
+            PingHandler           = _ => Task.FromResult(false),
+            ReRegisterHandler     = () => Task.FromException(new InvalidOperationException("InvokeAsync during reconnect")),
+            ForceReconnectHandler = () => Task.FromException(new InvalidOperationException("StopAsync from invalid state"))
+        };
+        var loop = CreateLoop(port);
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.ReRegisterCalls).IsEqualTo(1);
         await Assert.That(port.ForceReconnectCalls).IsEqualTo(1);
     }
 


### PR DESCRIPTION
Pairs with the server-side `DaemonPing` hub method + `EvalRunOrchestrator` fast-fail on slot replacement (server PR https://github.com/kurrent-io/Kurrent.Capacitor pending).

## Why

The current `DaemonHeartbeat` is fire-and-forget `SendAsync`, so when `DaemonRegistry.Register` silently displaces this connection's `(owner, name)` slot (the staging incident — an auto-reconnect that lands a new conn id), the daemon never notices. It keeps pumping heartbeats the server drops, while the orchestrator's in-flight `IClientProxy.InvokeAsync` hangs on the dead conn id for the full 3 / 12 min per-question timeout. See AI-566 for the full root cause.

## Change

- `DaemonHeartbeatLoop` (small testable class behind `IDaemonHeartbeatPort`) replaces the SendAsync heartbeat:
  - tick interval **15 s** (was 60 s) — under the server's default 30 s `ClientTimeoutInterval`
  - per-tick **10 s ping deadline** so a hung WebSocket can't park the loop
  - Ping returns `false` → `ReRegisterAsync` (slot was displaced; re-run `DaemonConnect` so the new conn id takes the slot)
  - Ping throws / times out → `ForceReconnectAsync` (transport hung; `_hub.StopAsync` triggers `OnClosed → ConnectWithRetryAsync` which builds a fresh conn and re-registers)
  - outer cancel → exit cleanly (no reconnect storm at process shutdown)
- `ServerConnection` exposes `PingAsync`, `ReRegisterAsync`, `ForceReconnectAsync` (virtual so the unit test double overrides without needing a real SignalR client) and implements `IDaemonHeartbeatPort` directly.
- `AgentOrchestrator.RunDaemonHeartbeatLoopAsync` delegates each tick to the new loop.

## Tests

`DaemonHeartbeatLoopTests` (5 cases):

- healthy → no side effects
- server says false → ReRegister, no reconnect
- ping throws → force reconnect
- ping exceeds deadline → force reconnect
- outer cancellation (shutdown) → no force reconnect

`dotnet run --project test/kapacitor.Tests.Unit … 428/428 pass`. AOT publish clean for both `kapacitor` and `Kapacitor.Daemon` (no IL3050 / IL2026).

## Test plan

- [x] Unit tests cover the four loop branches + shutdown
- [x] AOT publish clean
- [ ] Smoke: run daemon against staging, simulate a `Register` displacement (or just trigger an eval that previously stuck) and confirm UI advances within ~1 s instead of waiting out the per-question timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)