### PR TITLE
[AI-572] Daemon: classify agent exit by output flow, not wall-clock

### DIFF
--- a/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
@@ -22,11 +22,12 @@ public record AgentInstance(
         WorktreeInfo            Worktree,
         CancellationTokenSource ReadCts
     ) {
-    public string?              SessionId     { get; set; }
-    public string               Status        { get; set; } = "Starting";
-    public DateTime             CreatedAt     { get; }      = DateTime.UtcNow;
-    public DateTime             LastOutputAt  { get; set; } = DateTime.UtcNow;
-    public TerminalOutputBuffer OutputBuffer  { get; }      = new();
+    public string?              SessionId         { get; set; }
+    public string               Status            { get; set; } = "Starting";
+    public DateTime             CreatedAt         { get; }      = DateTime.UtcNow;
+    public DateTime             LastOutputAt      { get; set; } = DateTime.UtcNow;
+    public bool                 HasReceivedOutput { get; set; }
+    public TerminalOutputBuffer OutputBuffer      { get; }      = new();
 
     /// <summary>Temp MCP config path written for hosted PR reviews; deleted on cleanup.</summary>
     public string? McpConfigPath { get; set; }
@@ -425,7 +426,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     async Task ReadAgentOutputAsync(AgentInstance agent) {
         try {
             await foreach (var data in agent.Process.ReadOutputAsync(agent.ReadCts.Token)) {
-                agent.LastOutputAt = DateTime.UtcNow;
+                agent.LastOutputAt      = DateTime.UtcNow;
+                agent.HasReceivedOutput = true;
 
                 if (agent.Status == "Starting") {
                     agent.Status = "Running";
@@ -463,8 +465,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     // "Running" — a one-line error banner triggers that flip too. We
                     // also avoid wall-clock since spawn: a user who types /exit shortly
                     // after starting produces a short-but-real session that must not be
-                    // flagged as a launch failure (AI-572).
-                    if (IsStartupFailure(agent.CreatedAt, agent.LastOutputAt)) {
+                    // flagged as a launch failure (AI-572). HasReceivedOutput guards
+                    // against a no-output process whose CreatedAt/LastOutputAt
+                    // initializers happened to straddle a long pause.
+                    if (IsStartupFailure(agent.CreatedAt, agent.LastOutputAt, agent.HasReceivedOutput)) {
                         var output = ExtractTerminalText(agent.OutputBuffer);
 
                         var reason = !string.IsNullOrWhiteSpace(output)
@@ -796,13 +800,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     static readonly JsonSerializerOptions IndentedJsonOpts   = new() { WriteIndented = true };
 
     /// <summary>
-    /// True when the gap between agent spawn and its last output chunk is too
-    /// short for an interactive session to have happened. A startup failure
-    /// typically prints an error and quits within milliseconds; a real session
-    /// keeps producing output for at least <see cref="MinSessionLifespan"/>.
+    /// True when the agent process exited before establishing a real interactive
+    /// session. We require both that output was actually received (the read loop
+    /// observed at least one chunk) AND that the gap between spawn and the last
+    /// output is at least <see cref="MinSessionLifespan"/>. The
+    /// <paramref name="hasReceivedOutput"/> guard prevents a no-output process
+    /// from being misclassified when the <c>CreatedAt</c> and <c>LastOutputAt</c>
+    /// field initializers happen to straddle a long pause.
     /// </summary>
-    internal static bool IsStartupFailure(DateTime createdAt, DateTime lastOutputAt)
-        => lastOutputAt - createdAt < MinSessionLifespan;
+    internal static bool IsStartupFailure(DateTime createdAt, DateTime lastOutputAt, bool hasReceivedOutput)
+        => !hasReceivedOutput || lastOutputAt - createdAt < MinSessionLifespan;
 
     // Serializes writes to shared JSON config files (~/.claude.json and per-worktree
     // settings.local.json) across concurrent agent launches. Atomic rename prevents

--- a/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Kapacitor.Daemon/Services/AgentOrchestrator.cs
@@ -451,16 +451,20 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 var status = agent.Process.HasExited
                     ? exitCode is null or 0 ? "Completed" : "Failed"
                     : "Failed";
-                var isEarlyExit = DateTime.UtcNow - agent.CreatedAt < EarlyExitWindow;
 
                 if (agent.Status is not "Completed" and not "Failed") {
-                    // If the process died shortly after spawn, treat it as a launch
-                    // failure regardless of exit code. A process that exits within
-                    // EarlyExitWindow never established a session, so even exit code 0
-                    // means something went wrong (e.g., CLI config error, auth issue).
-                    // We use elapsed time rather than status because the first output
-                    // chunk flips status to "Running" before the process exits.
-                    if (isEarlyExit) {
+                    // A startup failure means the process exited before establishing
+                    // a real interactive session (CLI config error, auth issue, immediate
+                    // crash). A real session keeps producing output throughout its
+                    // lifetime, so the gap between CreatedAt and LastOutputAt is the
+                    // discriminator: tiny gap → startup failure; sustained → real session.
+                    //
+                    // We avoid agent.Status because the first output chunk flips it to
+                    // "Running" — a one-line error banner triggers that flip too. We
+                    // also avoid wall-clock since spawn: a user who types /exit shortly
+                    // after starting produces a short-but-real session that must not be
+                    // flagged as a launch failure (AI-572).
+                    if (IsStartupFailure(agent.CreatedAt, agent.LastOutputAt)) {
                         var output = ExtractTerminalText(agent.OutputBuffer);
 
                         var reason = !string.IsNullOrWhiteSpace(output)
@@ -787,9 +791,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         }
     }
 
-    static readonly TimeSpan              StartupTimeout   = TimeSpan.FromSeconds(90);
-    static readonly TimeSpan              EarlyExitWindow  = TimeSpan.FromSeconds(30);
-    static readonly JsonSerializerOptions IndentedJsonOpts = new() { WriteIndented = true };
+    static readonly TimeSpan              StartupTimeout     = TimeSpan.FromSeconds(90);
+    static readonly TimeSpan              MinSessionLifespan = TimeSpan.FromSeconds(2);
+    static readonly JsonSerializerOptions IndentedJsonOpts   = new() { WriteIndented = true };
+
+    /// <summary>
+    /// True when the gap between agent spawn and its last output chunk is too
+    /// short for an interactive session to have happened. A startup failure
+    /// typically prints an error and quits within milliseconds; a real session
+    /// keeps producing output for at least <see cref="MinSessionLifespan"/>.
+    /// </summary>
+    internal static bool IsStartupFailure(DateTime createdAt, DateTime lastOutputAt)
+        => lastOutputAt - createdAt < MinSessionLifespan;
 
     // Serializes writes to shared JSON config files (~/.claude.json and per-worktree
     // settings.local.json) across concurrent agent launches. Atomic rename prevents

--- a/test/kapacitor.Tests.Unit/AgentStartupFailureTests.cs
+++ b/test/kapacitor.Tests.Unit/AgentStartupFailureTests.cs
@@ -1,0 +1,74 @@
+using kapacitor.Daemon.Services;
+
+namespace kapacitor.Tests.Unit;
+
+/// <summary>
+/// Tests <see cref="AgentOrchestrator.IsStartupFailure"/>, the discriminator
+/// between a process that exited before establishing a real session (auth
+/// error, missing config, immediate crash) and a real session that ended.
+///
+/// Regression for AI-572: a user who types <c>/exit</c> shortly after starting
+/// the agent was being mislabeled as "failed during startup" because the prior
+/// implementation used wall-clock time since spawn instead of output flow.
+/// </summary>
+public class AgentStartupFailureTests {
+    static readonly DateTime SpawnedAt = new(2026, 5, 10, 11, 45, 11, DateTimeKind.Utc);
+
+    [Test]
+    public async Task NoOutputEverReceived_IsStartupFailure() {
+        // LastOutputAt defaults to construction time, so it equals CreatedAt
+        // when no output ever arrives. That gap of zero is below the threshold.
+        var result = AgentOrchestrator.IsStartupFailure(SpawnedAt, SpawnedAt);
+
+        await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task ErrorBannerThenImmediateExit_IsStartupFailure() {
+        // Auth error / missing config: Claude prints one banner then quits.
+        // Output flowed for ~200ms — well below the threshold.
+        var result = AgentOrchestrator.IsStartupFailure(
+            SpawnedAt,
+            SpawnedAt.AddMilliseconds(200)
+        );
+
+        await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task UserExitedAfterShortInteractiveSession_IsNotStartupFailure() {
+        // AI-572 scenario: agent ran for ~27 seconds, user typed /exit. The
+        // 30-second wall-clock window misclassified this as a startup failure.
+        // Output flowed throughout, so the spawn → last-output gap is large.
+        var result = AgentOrchestrator.IsStartupFailure(
+            SpawnedAt,
+            SpawnedAt.AddSeconds(27)
+        );
+
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task LongSessionEndedNormally_IsNotStartupFailure() {
+        var result = AgentOrchestrator.IsStartupFailure(
+            SpawnedAt,
+            SpawnedAt.AddMinutes(15)
+        );
+
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task MidSessionCrash_IsNotStartupFailure() {
+        // A non-zero exit after sustained output is a runtime failure, not a
+        // startup failure — the session ran fine, then something crashed.
+        // The orchestrator still marks the agent "Failed" via exit code, but
+        // it does not call LaunchFailedAsync.
+        var result = AgentOrchestrator.IsStartupFailure(
+            SpawnedAt,
+            SpawnedAt.AddSeconds(60)
+        );
+
+        await Assert.That(result).IsFalse();
+    }
+}

--- a/test/kapacitor.Tests.Unit/AgentStartupFailureTests.cs
+++ b/test/kapacitor.Tests.Unit/AgentStartupFailureTests.cs
@@ -16,9 +16,28 @@ public class AgentStartupFailureTests {
 
     [Test]
     public async Task NoOutputEverReceived_IsStartupFailure() {
-        // LastOutputAt defaults to construction time, so it equals CreatedAt
-        // when no output ever arrives. That gap of zero is below the threshold.
-        var result = AgentOrchestrator.IsStartupFailure(SpawnedAt, SpawnedAt);
+        // hasReceivedOutput=false short-circuits to true regardless of timestamps.
+        var result = AgentOrchestrator.IsStartupFailure(
+            SpawnedAt,
+            SpawnedAt,
+            hasReceivedOutput: false
+        );
+
+        await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task NoOutputButLongPauseBetweenInitializers_IsStillStartupFailure() {
+        // AgentInstance initializes CreatedAt and LastOutputAt with two separate
+        // DateTime.UtcNow calls. A GC pause / VM stall between them can make
+        // LastOutputAt - CreatedAt exceed MinSessionLifespan even though the
+        // read loop never observed any output. The hasReceivedOutput guard
+        // makes the timestamps untrusted in that case.
+        var result = AgentOrchestrator.IsStartupFailure(
+            SpawnedAt,
+            SpawnedAt.AddSeconds(10),
+            hasReceivedOutput: false
+        );
 
         await Assert.That(result).IsTrue();
     }
@@ -29,7 +48,8 @@ public class AgentStartupFailureTests {
         // Output flowed for ~200ms — well below the threshold.
         var result = AgentOrchestrator.IsStartupFailure(
             SpawnedAt,
-            SpawnedAt.AddMilliseconds(200)
+            SpawnedAt.AddMilliseconds(200),
+            hasReceivedOutput: true
         );
 
         await Assert.That(result).IsTrue();
@@ -42,7 +62,8 @@ public class AgentStartupFailureTests {
         // Output flowed throughout, so the spawn → last-output gap is large.
         var result = AgentOrchestrator.IsStartupFailure(
             SpawnedAt,
-            SpawnedAt.AddSeconds(27)
+            SpawnedAt.AddSeconds(27),
+            hasReceivedOutput: true
         );
 
         await Assert.That(result).IsFalse();
@@ -52,7 +73,8 @@ public class AgentStartupFailureTests {
     public async Task LongSessionEndedNormally_IsNotStartupFailure() {
         var result = AgentOrchestrator.IsStartupFailure(
             SpawnedAt,
-            SpawnedAt.AddMinutes(15)
+            SpawnedAt.AddMinutes(15),
+            hasReceivedOutput: true
         );
 
         await Assert.That(result).IsFalse();
@@ -66,7 +88,8 @@ public class AgentStartupFailureTests {
         // it does not call LaunchFailedAsync.
         var result = AgentOrchestrator.IsStartupFailure(
             SpawnedAt,
-            SpawnedAt.AddSeconds(60)
+            SpawnedAt.AddSeconds(60),
+            hasReceivedOutput: true
         );
 
         await Assert.That(result).IsFalse();


### PR DESCRIPTION
## Summary

- Hosted agents that exited cleanly (e.g. user typed `/exit`) within 30s of spawn were being logged as "failed during startup" and reported via `LaunchFailedAsync`, which is what surfaces the weird error in the server UI (AI-572).
- The 30s `EarlyExitWindow` wall-clock check is replaced with a sustained-output check: a real session keeps producing output throughout its lifetime, so the gap between `CreatedAt` and `LastOutputAt` is the right discriminator. Startup failures print one banner and exit — gap stays sub-second. Real sessions — gap is large, regardless of total wall-clock duration.
- Extracted the decision into `AgentOrchestrator.IsStartupFailure(createdAt, lastOutputAt)` so it can be unit-tested directly.
- Follow-up [AI-574](https://linear.app/kurrent/issue/AI-574/wire-agent-sessionid-into-the-daemon-for-stronger-lifecycle-signals) tracks wiring the actual `agent.SessionId` into the daemon (currently always null) so the classifier can short-circuit on "real session existed" instead of relying on the output-flow heuristic.

## Test plan

- [x] New `AgentStartupFailureTests` covers: no output, error-banner-then-exit, AI-572's 27s `/exit` scenario, long sessions, mid-session crashes
- [x] Full unit suite passes (438/438)
- [x] AOT publish clean (no IL3050/IL2026 warnings)
- [ ] Manual: spawn a hosted agent, type `/exit` immediately — server UI should show the agent completed cleanly, daemon log should not contain "failed during startup"

🤖 Generated with [Claude Code](https://claude.com/claude-code)