### PR TITLE
cli: more actionable auth error messages

### DIFF
--- a/src/Kapacitor.Core/Auth/AuthModels.cs
+++ b/src/Kapacitor.Core/Auth/AuthModels.cs
@@ -41,6 +41,12 @@ public record TokenExchangeResponse {
     public string Username { get; init; } = "";
 }
 
+// POST /auth/token error body (any failing status)
+public record AuthErrorResponse {
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+}
+
 // GitHub Device Flow: POST https://github.com/login/device/code
 public record GitHubDeviceCodeResponse {
     [JsonPropertyName("device_code")]

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -146,7 +146,7 @@ public static class OAuthLoginFlow {
         );
 
         if (!exchangeResponse.IsSuccessStatusCode) {
-            Console.Error.WriteLine($"Error exchanging token: {await exchangeResponse.Content.ReadAsStringAsync()}");
+            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(), profile: null);
 
             return 1;
         }
@@ -190,7 +190,7 @@ public static class OAuthLoginFlow {
         );
 
         if (!exchangeResponse.IsSuccessStatusCode) {
-            Console.Error.WriteLine($"Error exchanging token for profile '{profile}': {await exchangeResponse.Content.ReadAsStringAsync()}");
+            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(), profile);
 
             return 1;
         }
@@ -205,6 +205,54 @@ public static class OAuthLoginFlow {
         });
 
         return 0;
+    }
+
+    /// <summary>
+    /// Prints the server's <c>/auth/token</c> error to stderr. When the server reports that
+    /// the Capacitor GitHub App isn't installed on the user's org, appends a troubleshooting
+    /// checklist — the most common cause is the device-flow consent being completed under a
+    /// different GitHub account than the one with org membership.
+    /// </summary>
+    static void WriteExchangeError(string body, string? profile) {
+        var prefix = profile is null
+            ? "Error exchanging token"
+            : $"Error exchanging token for profile '{profile}'";
+
+        var serverMessage = TryParseInstallationMessage(body);
+
+        if (serverMessage is null) {
+            Console.Error.WriteLine($"{prefix}: {body}");
+
+            return;
+        }
+
+        Console.Error.WriteLine($"{prefix}: {serverMessage}");
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("This usually means the Capacitor GitHub App isn't visible to your GitHub user.");
+        Console.Error.WriteLine("Common fixes:");
+        Console.Error.WriteLine("  1. Authorize as the right GitHub account. The device-flow page authorizes");
+        Console.Error.WriteLine("     whoever is signed in to your browser — sign in to https://github.com as");
+        Console.Error.WriteLine("     your org user, then re-run `kapacitor setup ...`.");
+        Console.Error.WriteLine("  2. If your org enforces SAML SSO, authorize SSO for the App at");
+        Console.Error.WriteLine("     https://github.com/settings/apps/authorizations.");
+        Console.Error.WriteLine("  3. Revoke a stale prior authorization at the same URL and retry.");
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("If the App was never installed on your org, an org admin must install it.");
+    }
+
+    internal static string? TryParseInstallationMessage(string body) {
+        if (string.IsNullOrWhiteSpace(body)) return null;
+
+        try {
+            var parsed = JsonSerializer.Deserialize(body, KapacitorJsonContext.Default.AuthErrorResponse);
+            var msg    = parsed?.Error;
+
+            return msg is not null && msg.Contains("not installed", StringComparison.OrdinalIgnoreCase)
+                ? msg
+                : null;
+        } catch (JsonException) {
+            return null;
+        }
     }
 
     static async Task<int> HandleGitHubLogin(string serverUrl, AuthDiscoveryResponse config) {

--- a/src/Kapacitor.Core/Models.cs
+++ b/src/Kapacitor.Core/Models.cs
@@ -439,6 +439,7 @@ record RepoEntry {
 [JsonSerializable(typeof(Auth.AuthDiscoveryResponse))]
 [JsonSerializable(typeof(Auth.TokenExchangeRequest))]
 [JsonSerializable(typeof(Auth.TokenExchangeResponse))]
+[JsonSerializable(typeof(Auth.AuthErrorResponse))]
 [JsonSerializable(typeof(Auth.RefreshTokenRequest))]
 [JsonSerializable(typeof(Auth.GitHubDeviceCodeResponse))]
 [JsonSerializable(typeof(Auth.GitHubTokenResponse))]

--- a/src/kapacitor/Commands/StatusCommand.cs
+++ b/src/kapacitor/Commands/StatusCommand.cs
@@ -39,7 +39,7 @@ public static class StatusCommand {
             var rawTokens = await TokenStore.LoadAsync();
 
             await Console.Out.WriteLineAsync(rawTokens is not null
-                ? $"{rawTokens.GitHubUsername} ({rawTokens.Provider}) ✗ token expired"
+                ? $"{rawTokens.GitHubUsername} ({rawTokens.Provider}) ✗ token expired (run: kapacitor login)"
                 : "not authenticated (run: kapacitor login)");
         }
 

--- a/test/kapacitor.Tests.Unit/LoginDiscoverTests.cs
+++ b/test/kapacitor.Tests.Unit/LoginDiscoverTests.cs
@@ -77,6 +77,25 @@ public class LoginDiscoverTests {
     }
 
     [Test]
+    public async Task Installation_message_extracted_from_not_installed_error() {
+        var msg = OAuthLoginFlow.TryParseInstallationMessage(
+            """{"error":"The Kurrent Capacitor GitHub App is not installed on your organization."}""");
+
+        await Assert.That(msg).IsEqualTo("The Kurrent Capacitor GitHub App is not installed on your organization.");
+    }
+
+    [Test]
+    public async Task Installation_message_null_for_unrelated_error() {
+        await Assert.That(OAuthLoginFlow.TryParseInstallationMessage("""{"error":"invalid_token"}""")).IsNull();
+    }
+
+    [Test]
+    public async Task Installation_message_null_for_non_json_body() {
+        await Assert.That(OAuthLoginFlow.TryParseInstallationMessage("Unauthorized")).IsNull();
+        await Assert.That(OAuthLoginFlow.TryParseInstallationMessage("")).IsNull();
+    }
+
+    [Test]
     public async Task Exchange_writes_independent_tokens_for_multiple_profiles() {
         using var acmeTenant    = WireMock.Server.WireMockServer.Start();
         using var contosoTenant = WireMock.Server.WireMockServer.Start();


### PR DESCRIPTION
## Summary

Two small UX improvements to auth-related CLI errors. Both came out of a recent support investigation where a user (Stephen) hit the "App not installed on your organization" error during `kapacitor setup` on staging, and a separate user (Sérgio) had `kapacitor status` say "✗ token expired" with no remediation hint.

- **`OAuthLoginFlow.WriteExchangeError`** — when `POST /auth/token` returns the "Kurrent Capacitor GitHub App is not installed on your organization" body, the CLI used to dump the raw JSON. It now prints a numbered checklist for the realistic causes: wrong GitHub account authorized in the browser, SAML SSO not authorized for the App, stale prior authorization. Unknown errors still fall through to the raw body so unexpected failures aren't hidden. Adds an `AuthErrorResponse` record registered in the source-gen JSON context (AOT-safe).
- **`StatusCommand`** — the "✗ token expired" line now appends `(run: kapacitor login)` so a user past the 30-day refresh window has an obvious next step.

## Test plan

- [x] `dotnet build src/kapacitor/kapacitor.csproj` — clean
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — no IL3050 / IL2026
- [x] `dotnet run --project test/kapacitor.Tests.Unit/...` — 436/436 pass (3 new parser tests in `LoginDiscoverTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)