### PR TITLE
[AI-52] GitHub login via localhost callback + PKCE, device flow as headless fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ kapacitor config set excluded_repos "myorg/secret-project,personal/diary"
 ```bash
 kapacitor status         # server health check
 kapacitor whoami         # show current authenticated user
-kapacitor login          # authenticate via OAuth
+kapacitor login          # authenticate via OAuth (browser flow by default)
+kapacitor login --device # force device-code flow (use in SSH / headless envs)
 kapacitor update         # check for CLI updates
 kapacitor logout         # delete stored tokens
 ```

--- a/src/Kapacitor.Core/Auth/AuthModels.cs
+++ b/src/Kapacitor.Core/Auth/AuthModels.cs
@@ -21,6 +21,25 @@ public record AuthDiscoveryResponse {
 
     [JsonPropertyName("token_exchange_url")]
     public string? TokenExchangeUrl { get; init; }
+
+    // Server-mediated GitHub code-exchange endpoint. Required for the localhost
+    // browser flow because GitHub Apps need client_secret on POST /login/oauth/access_token,
+    // and the CLI can't ship a secret. When null, the CLI uses device flow.
+    [JsonPropertyName("github_code_exchange_url")]
+    public string? GithubCodeExchangeUrl { get; init; }
+}
+
+// POST {github_code_exchange_url} — CLI → server. Server adds client_id + client_secret
+// and forwards to https://github.com/login/oauth/access_token.
+public record GitHubCodeExchangeRequest {
+    [JsonPropertyName("code")]
+    public required string Code { get; init; }
+
+    [JsonPropertyName("code_verifier")]
+    public required string CodeVerifier { get; init; }
+
+    [JsonPropertyName("redirect_uri")]
+    public required string RedirectUri { get; init; }
 }
 
 // POST /auth/token request
@@ -100,7 +119,12 @@ public record RefreshTokenRequest {
 
 // Auth proxy: GET /config
 public sealed record ProxyConfigResponse {
-    [JsonPropertyName("github_client_id")] public string GitHubClientId { get; init; } = "";
+    [JsonPropertyName("github_client_id")]         public string  GitHubClientId        { get; init; } = "";
+
+    // Proxy-mediated GitHub code-exchange endpoint. When null, --discover falls back
+    // to device flow because the CLI can't talk to GitHub's token endpoint directly
+    // for a GitHub App without client_secret.
+    [JsonPropertyName("github_code_exchange_url")] public string? GitHubCodeExchangeUrl { get; init; }
 }
 
 // Auth proxy: POST /discover-tenants response item

--- a/src/Kapacitor.Core/Auth/AuthProxyClient.cs
+++ b/src/Kapacitor.Core/Auth/AuthProxyClient.cs
@@ -4,17 +4,16 @@ using System.Net.Http.Json;
 namespace kapacitor.Auth;
 
 public interface IAuthProxyClient {
-    Task<string?>         GetGitHubClientIdAsync(string proxyUrl);
-    Task<DiscoveryResult> DiscoverTenantsAsync(string proxyUrl, string githubAccessToken);
+    Task<ProxyConfigResponse?> GetConfigAsync(string proxyUrl);
+    Task<DiscoveryResult>      DiscoverTenantsAsync(string proxyUrl, string githubAccessToken);
 }
 
 public class AuthProxyClient(HttpClient http) : IAuthProxyClient {
-    public async Task<string?> GetGitHubClientIdAsync(string proxyUrl) {
+    public async Task<ProxyConfigResponse?> GetConfigAsync(string proxyUrl) {
         try {
             using var response = await http.GetAsync($"{proxyUrl}/config");
             if (!response.IsSuccessStatusCode) return null;
-            var body = await response.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.ProxyConfigResponse);
-            return body?.GitHubClientId;
+            return await response.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.ProxyConfigResponse);
         } catch (Exception e) when (e is HttpRequestException or OperationCanceledException) {
             return null;
         }

--- a/src/Kapacitor.Core/Auth/Clipboard.cs
+++ b/src/Kapacitor.Core/Auth/Clipboard.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace kapacitor.Auth;
+
+/// <summary>
+/// Best-effort clipboard writer. Used to make the GitHub device-flow fallback less
+/// painful — the user pastes the user_code into the verification page instead of
+/// retyping it. All failures are swallowed; the caller still prints the code.
+/// </summary>
+public static class Clipboard {
+    public static bool TryCopy(string text) {
+        try {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))     return RunWithStdin("pbcopy", "", text);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return RunWithStdin("clip", "", text);
+
+            // Linux: prefer Wayland, fall back to X11
+            if (RunWithStdin("wl-copy", "", text)) return true;
+            return RunWithStdin("xclip", "-selection clipboard", text);
+        } catch {
+            return false;
+        }
+    }
+
+    static bool RunWithStdin(string fileName, string args, string stdin) {
+        try {
+            var psi = new ProcessStartInfo(fileName, args) {
+                RedirectStandardInput = true,
+                UseShellExecute       = false,
+                CreateNoWindow        = true
+            };
+
+            using var p = Process.Start(psi);
+            if (p is null) return false;
+            p.StandardInput.Write(stdin);
+            p.StandardInput.Close();
+            p.WaitForExit(2000);
+            return p.ExitCode == 0;
+        } catch {
+            return false;
+        }
+    }
+}

--- a/src/Kapacitor.Core/Auth/Clipboard.cs
+++ b/src/Kapacitor.Core/Auth/Clipboard.cs
@@ -34,7 +34,13 @@ public static class Clipboard {
             if (p is null) return false;
             p.StandardInput.Write(stdin);
             p.StandardInput.Close();
-            p.WaitForExit(2000);
+
+            // Bound the wait so a hung helper (e.g. an X server prompting for auth) can't
+            // wedge the login flow; kill on timeout to avoid leaking child processes.
+            if (!p.WaitForExit(2000)) {
+                try { p.Kill(); } catch { /* best-effort */ }
+                return false;
+            }
             return p.ExitCode == 0;
         } catch {
             return false;

--- a/src/Kapacitor.Core/Auth/HeadlessEnvironment.cs
+++ b/src/Kapacitor.Core/Auth/HeadlessEnvironment.cs
@@ -1,0 +1,37 @@
+using System.Runtime.InteropServices;
+
+namespace kapacitor.Auth;
+
+public enum OSPlatformKind { Linux, MacOS, Windows, Other }
+
+/// <summary>
+/// Heuristic check for whether the current process has access to an interactive
+/// desktop browser. Used by <c>OAuthLoginFlow</c> to decide between the localhost
+/// browser flow and the device-code fallback.
+/// </summary>
+public static class HeadlessEnvironment {
+    public static bool IsHeadless() => IsHeadless(CurrentEnv(), CurrentPlatform());
+
+    public static bool IsHeadless(IReadOnlyDictionary<string, string?> env, OSPlatformKind platform) {
+        if (HasValue(env, "SSH_CONNECTION") || HasValue(env, "SSH_CLIENT")) return true;
+
+        return platform == OSPlatformKind.Linux
+            && !HasValue(env, "DISPLAY")
+            && !HasValue(env, "WAYLAND_DISPLAY");
+    }
+
+    static bool HasValue(IReadOnlyDictionary<string, string?> env, string key)
+        => env.TryGetValue(key, out var v) && !string.IsNullOrEmpty(v);
+
+    static IReadOnlyDictionary<string, string?> CurrentEnv() {
+        var keys = new[] { "SSH_CONNECTION", "SSH_CLIENT", "DISPLAY", "WAYLAND_DISPLAY" };
+        return keys.ToDictionary(k => k, Environment.GetEnvironmentVariable);
+    }
+
+    static OSPlatformKind CurrentPlatform() {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))   return OSPlatformKind.Linux;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))     return OSPlatformKind.MacOS;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return OSPlatformKind.Windows;
+        return OSPlatformKind.Other;
+    }
+}

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -210,8 +210,7 @@ public static class OAuthLoginFlow {
                 ["client_id"]     = clientId,
                 ["code"]          = callback.Code,
                 ["redirect_uri"]  = redirectUri,
-                ["code_verifier"] = verifier,
-                ["grant_type"]    = "authorization_code"
+                ["code_verifier"] = verifier
             }));
 
         if (!tokenResponse.IsSuccessStatusCode) {
@@ -411,7 +410,7 @@ public static class OAuthLoginFlow {
         var port        = GetAvailablePort();
         var redirectUri = $"http://localhost:{port}/callback";
 
-        var listener = new HttpListener();
+        using var listener = new HttpListener();
         listener.Prefixes.Add($"http://localhost:{port}/");
         listener.Start();
 
@@ -431,6 +430,12 @@ public static class OAuthLoginFlow {
         var returnedState = context.Request.QueryString["state"];
         if (returnedState != state) {
             Console.Error.WriteLine("Error: state mismatch — possible CSRF. Aborting.");
+            const string errHtml = "<html><body><h2>Authentication failed</h2><p>State mismatch — possible CSRF. Return to the terminal.</p></body></html>";
+            var errBuf = Encoding.UTF8.GetBytes(errHtml);
+            context.Response.ContentType     = "text/html";
+            context.Response.ContentLength64 = errBuf.Length;
+            await context.Response.OutputStream.WriteAsync(errBuf);
+            context.Response.Close();
             listener.Stop();
             return 1;
         }

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -212,8 +212,14 @@ public static class OAuthLoginFlow {
             RedirectUri  = redirectUri
         };
 
-        var tokenResponse = await http.PostAsJsonAsync(
-            codeExchangeUrl, exchangeRequest, KapacitorJsonContext.Default.GitHubCodeExchangeRequest);
+        HttpResponseMessage tokenResponse;
+        try {
+            tokenResponse = await http.PostAsJsonAsync(
+                codeExchangeUrl, exchangeRequest, KapacitorJsonContext.Default.GitHubCodeExchangeRequest);
+        } catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or UriFormatException or InvalidOperationException) {
+            Console.Error.WriteLine($"Could not reach the code-exchange endpoint at {codeExchangeUrl}: {ex.Message}");
+            return null;
+        }
 
         if (!tokenResponse.IsSuccessStatusCode) {
             Console.Error.WriteLine($"Error exchanging code: {await tokenResponse.Content.ReadAsStringAsync()}");
@@ -388,7 +394,7 @@ public static class OAuthLoginFlow {
 
     internal static async Task<string?> AcquireGitHubTokenAsync(string clientId, string? codeExchangeUrl, bool forceDevice) {
         var headless = HeadlessEnvironment.IsHeadless();
-        var choice   = ChooseGitHubFlow(forceDevice, headless, hasExchangeUrl: !string.IsNullOrWhiteSpace(codeExchangeUrl));
+        var choice   = ChooseGitHubFlow(forceDevice, headless, hasExchangeUrl: IsValidExchangeUrl(codeExchangeUrl));
 
         if (choice == GitHubFlow.Browser) {
             try {
@@ -521,6 +527,13 @@ public static class OAuthLoginFlow {
     }
 
     internal readonly record struct CallbackResult(string? Code, string? Error);
+
+    // The server-supplied code-exchange URL must be a fully-qualified http(s) URI before
+    // we trust it. An empty string, whitespace, relative path, or javascript:/file: URL
+    // is treated as "no browser flow available" and the dispatcher falls back to device flow.
+    internal static bool IsValidExchangeUrl(string? url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var parsed)
+        && (parsed.Scheme == Uri.UriSchemeHttp || parsed.Scheme == Uri.UriSchemeHttps);
 
     internal static string BuildGitHubAuthorizeUrl(
             string clientId, string redirectUri, string state, string codeChallenge) =>

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -204,6 +204,7 @@ public static class OAuthLoginFlow {
         }
 
         using var http = new HttpClient();
+        http.DefaultRequestHeaders.Accept.Add(new("application/json"));
 
         var exchangeRequest = new GitHubCodeExchangeRequest {
             Code         = callback.Code,
@@ -219,9 +220,17 @@ public static class OAuthLoginFlow {
             return null;
         }
 
-        var tokenResult = (await tokenResponse.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.GitHubTokenResponse))!;
-        if (tokenResult.AccessToken is null) {
-            Console.Error.WriteLine($"Error: {tokenResult.Error ?? "no access_token in response"}");
+        GitHubTokenResponse? tokenResult;
+        try {
+            tokenResult = await tokenResponse.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.GitHubTokenResponse);
+        } catch (JsonException ex) {
+            var raw = await tokenResponse.Content.ReadAsStringAsync();
+            Console.Error.WriteLine($"Code-exchange response was not valid JSON ({ex.Message}): {raw}");
+            return null;
+        }
+
+        if (tokenResult?.AccessToken is null) {
+            Console.Error.WriteLine($"Error: {tokenResult?.Error ?? "no access_token in response"}");
             return null;
         }
 
@@ -379,7 +388,7 @@ public static class OAuthLoginFlow {
 
     internal static async Task<string?> AcquireGitHubTokenAsync(string clientId, string? codeExchangeUrl, bool forceDevice) {
         var headless = HeadlessEnvironment.IsHeadless();
-        var choice   = ChooseGitHubFlow(forceDevice, headless, hasExchangeUrl: codeExchangeUrl is not null);
+        var choice   = ChooseGitHubFlow(forceDevice, headless, hasExchangeUrl: !string.IsNullOrWhiteSpace(codeExchangeUrl));
 
         if (choice == GitHubFlow.Browser) {
             try {
@@ -424,7 +433,13 @@ public static class OAuthLoginFlow {
             $"&code_challenge={challenge}&code_challenge_method=S256";
 
         await Console.Out.WriteLineAsync("Opening browser for authentication...");
-        Process.Start(new ProcessStartInfo(authUrl) { UseShellExecute = true });
+        await Console.Out.WriteLineAsync($"  If the browser doesn't open, visit: {authUrl}");
+
+        try {
+            Process.Start(new ProcessStartInfo(authUrl) { UseShellExecute = true });
+        } catch {
+            /* Browser open is best-effort — user can still copy the URL */
+        }
 
         var context = await listener.GetContextAsync();
         var code    = context.Request.QueryString["code"];

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -164,11 +164,22 @@ public static class OAuthLoginFlow {
         using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(5));
 
         HttpListenerContext context;
-        try {
-            context = await listener.GetContextAsync().WaitAsync(cts.Token);
-        } catch (OperationCanceledException) {
-            Console.Error.WriteLine("Timed out waiting for authorization. Re-run `kapacitor login` to try again.");
-            return null;
+        while (true) {
+            Task<HttpListenerContext> getContext = listener.GetContextAsync();
+            try {
+                context = await getContext.WaitAsync(cts.Token);
+            } catch (OperationCanceledException) {
+                listener.Stop();
+                _ = getContext.ContinueWith(t => _ = t.Exception, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                Console.Error.WriteLine("Timed out waiting for authorization. Re-run `kapacitor login` to try again.");
+                return null;
+            }
+
+            if (context.Request.Url?.AbsolutePath == "/callback") break;
+
+            // Ignore favicon and other browser-issued requests that aren't our callback.
+            context.Response.StatusCode = 404;
+            context.Response.Close();
         }
 
         var callback = ParseCallback(context.Request.Url?.Query ?? "", state);

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -50,8 +50,8 @@ public static class OAuthLoginFlow {
         };
     }
 
-    internal static GitHubFlow ChooseGitHubFlow(bool forceDevice, bool isHeadless)
-        => forceDevice || isHeadless ? GitHubFlow.Device : GitHubFlow.Browser;
+    internal static GitHubFlow ChooseGitHubFlow(bool forceDevice, bool isHeadless, bool hasExchangeUrl)
+        => forceDevice || isHeadless || !hasExchangeUrl ? GitHubFlow.Device : GitHubFlow.Browser;
 
     static int HandleNoneLogin() {
         Console.Out.WriteLine("Server has no authentication configured — login not required.");
@@ -143,12 +143,14 @@ public static class OAuthLoginFlow {
     /// <summary>
     /// Runs GitHub authorization-code-with-PKCE flow against a localhost loopback
     /// listener. Opens the system browser to GitHub's authorize page; on callback,
-    /// verifies CSRF state and exchanges code+verifier for an access token.
+    /// verifies CSRF state and POSTs the code+verifier to <paramref name="codeExchangeUrl"/>
+    /// on the Capacitor server. The server adds its GitHub App client_secret and forwards
+    /// to GitHub's token endpoint (which GitHub Apps require, even with PKCE).
     /// Returns the token on success, or <c>null</c> on user cancel, state mismatch,
     /// or upstream error. Throws if the loopback port can't be bound — the caller
     /// uses that signal to fall back to device flow.
     /// </summary>
-    public static async Task<string?> RunGitHubBrowserFlowAsync(string clientId, TimeSpan? timeout = null) {
+    public static async Task<string?> RunGitHubBrowserFlowAsync(string clientId, string codeExchangeUrl, TimeSpan? timeout = null) {
         var verifier  = GenerateCodeVerifier();
         var challenge = GenerateCodeChallenge(verifier);
         var state     = GenerateCodeVerifier(); // reuse the random source — same entropy is fine
@@ -202,16 +204,15 @@ public static class OAuthLoginFlow {
         }
 
         using var http = new HttpClient();
-        http.DefaultRequestHeaders.Accept.Add(new("application/json"));
 
-        var tokenResponse = await http.PostAsync(
-            "https://github.com/login/oauth/access_token",
-            new FormUrlEncodedContent(new Dictionary<string, string> {
-                ["client_id"]     = clientId,
-                ["code"]          = callback.Code,
-                ["redirect_uri"]  = redirectUri,
-                ["code_verifier"] = verifier
-            }));
+        var exchangeRequest = new GitHubCodeExchangeRequest {
+            Code         = callback.Code,
+            CodeVerifier = verifier,
+            RedirectUri  = redirectUri
+        };
+
+        var tokenResponse = await http.PostAsJsonAsync(
+            codeExchangeUrl, exchangeRequest, KapacitorJsonContext.Default.GitHubCodeExchangeRequest);
 
         if (!tokenResponse.IsSuccessStatusCode) {
             Console.Error.WriteLine($"Error exchanging code: {await tokenResponse.Content.ReadAsStringAsync()}");
@@ -370,19 +371,19 @@ public static class OAuthLoginFlow {
     }
 
     static async Task<int> HandleGitHubLogin(string serverUrl, AuthDiscoveryResponse config, bool forceDevice) {
-        var accessToken = await AcquireGitHubTokenAsync(config.GithubClientId!, forceDevice);
+        var accessToken = await AcquireGitHubTokenAsync(config.GithubClientId!, config.GithubCodeExchangeUrl, forceDevice);
         if (accessToken is null) return 1;
 
         return await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider);
     }
 
-    internal static async Task<string?> AcquireGitHubTokenAsync(string clientId, bool forceDevice) {
+    internal static async Task<string?> AcquireGitHubTokenAsync(string clientId, string? codeExchangeUrl, bool forceDevice) {
         var headless = HeadlessEnvironment.IsHeadless();
-        var choice   = ChooseGitHubFlow(forceDevice, headless);
+        var choice   = ChooseGitHubFlow(forceDevice, headless, hasExchangeUrl: codeExchangeUrl is not null);
 
         if (choice == GitHubFlow.Browser) {
             try {
-                var token = await RunGitHubBrowserFlowAsync(clientId);
+                var token = await RunGitHubBrowserFlowAsync(clientId, codeExchangeUrl!);
                 if (token is not null) return token;
                 // Browser flow ran but user cancelled / state mismatch — don't silently fall back.
                 return null;

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -407,6 +407,7 @@ public static class OAuthLoginFlow {
     static async Task<int> LoginAsync(string auth0Domain, string clientId, string audience) {
         var verifier    = GenerateCodeVerifier();
         var challenge   = GenerateCodeChallenge(verifier);
+        var state       = GenerateCodeVerifier();
         var port        = GetAvailablePort();
         var redirectUri = $"http://localhost:{port}/callback";
 
@@ -419,6 +420,7 @@ public static class OAuthLoginFlow {
             $"&redirect_uri={Uri.EscapeDataString(redirectUri)}"                    +
             $"&scope={Uri.EscapeDataString("openid profile email offline_access")}" +
             $"&audience={Uri.EscapeDataString(audience)}"                           +
+            $"&state={Uri.EscapeDataString(state)}"                                 +
             $"&code_challenge={challenge}&code_challenge_method=S256";
 
         await Console.Out.WriteLineAsync("Opening browser for authentication...");
@@ -426,6 +428,12 @@ public static class OAuthLoginFlow {
 
         var context = await listener.GetContextAsync();
         var code    = context.Request.QueryString["code"];
+        var returnedState = context.Request.QueryString["state"];
+        if (returnedState != state) {
+            Console.Error.WriteLine("Error: state mismatch — possible CSRF. Aborting.");
+            listener.Stop();
+            return 1;
+        }
 
         const string html = "<html><body><h2>Authentication successful!</h2><p>You can close this window.</p></body></html>";
 

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -14,8 +14,13 @@ public static class AuthProvider {
     public const string None      = "None";
 }
 
+public enum GitHubFlow { Browser, Device }
+
 public static class OAuthLoginFlow {
-    public static async Task<int> LoginWithDiscoveryAsync(string serverUrl) {
+    public static Task<int> LoginWithDiscoveryAsync(string serverUrl)
+        => LoginWithDiscoveryAsync(serverUrl, forceDevice: false);
+
+    public static async Task<int> LoginWithDiscoveryAsync(string serverUrl, bool forceDevice) {
         // ReSharper disable once ShortLivedHttpClient
         using var http = new HttpClient();
 
@@ -39,11 +44,14 @@ public static class OAuthLoginFlow {
 
         return config.Provider switch {
             AuthProvider.None      => HandleNoneLogin(),
-            AuthProvider.GitHubApp => await HandleGitHubLogin(serverUrl, config),
+            AuthProvider.GitHubApp => await HandleGitHubLogin(serverUrl, config, forceDevice),
             AuthProvider.Auth0     => await HandleAuth0Login(config),
             _                      => HandleUnknownProvider(config.Provider)
         };
     }
+
+    internal static GitHubFlow ChooseGitHubFlow(bool forceDevice, bool isHeadless)
+        => forceDevice || isHeadless ? GitHubFlow.Device : GitHubFlow.Browser;
 
     static int HandleNoneLogin() {
         Console.Out.WriteLine("Server has no authentication configured — login not required.");
@@ -360,11 +368,31 @@ public static class OAuthLoginFlow {
         }
     }
 
-    static async Task<int> HandleGitHubLogin(string serverUrl, AuthDiscoveryResponse config) {
-        var accessToken = await RunDeviceFlowAsync(config.GithubClientId!);
+    static async Task<int> HandleGitHubLogin(string serverUrl, AuthDiscoveryResponse config, bool forceDevice) {
+        var accessToken = await AcquireGitHubTokenAsync(config.GithubClientId!, forceDevice);
         if (accessToken is null) return 1;
 
         return await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider);
+    }
+
+    internal static async Task<string?> AcquireGitHubTokenAsync(string clientId, bool forceDevice) {
+        var headless = HeadlessEnvironment.IsHeadless();
+        var choice   = ChooseGitHubFlow(forceDevice, headless);
+
+        if (choice == GitHubFlow.Browser) {
+            try {
+                var token = await RunGitHubBrowserFlowAsync(clientId);
+                if (token is not null) return token;
+                // Browser flow ran but user cancelled / state mismatch — don't silently fall back.
+                return null;
+            } catch (HttpListenerException ex) {
+                Console.Error.WriteLine($"Could not bind loopback listener ({ex.Message}); falling back to device flow.");
+            } catch (PlatformNotSupportedException ex) {
+                Console.Error.WriteLine($"Loopback listener not supported on this platform ({ex.Message}); falling back to device flow.");
+            }
+        }
+
+        return await RunDeviceFlowAsync(clientId);
     }
 
     static async Task<int> HandleAuth0Login(AuthDiscoveryResponse config) {

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -535,6 +535,7 @@ public static class OAuthLoginFlow {
             }
         }
 
+        if (state is null)            return new(null, "missing_state");
         if (state != expectedState)   return new(null, "state_mismatch");
         if (error is not null)        return new(null, error);
         return string.IsNullOrEmpty(code) ? new(null, "missing_code") : new(code, null);

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -130,6 +130,100 @@ public static class OAuthLoginFlow {
         }
     }
 
+    /// <summary>
+    /// Runs GitHub authorization-code-with-PKCE flow against a localhost loopback
+    /// listener. Opens the system browser to GitHub's authorize page; on callback,
+    /// verifies CSRF state and exchanges code+verifier for an access token.
+    /// Returns the token on success, or <c>null</c> on user cancel, state mismatch,
+    /// or upstream error. Throws if the loopback port can't be bound — the caller
+    /// uses that signal to fall back to device flow.
+    /// </summary>
+    public static async Task<string?> RunGitHubBrowserFlowAsync(string clientId, TimeSpan? timeout = null) {
+        var verifier  = GenerateCodeVerifier();
+        var challenge = GenerateCodeChallenge(verifier);
+        var state     = GenerateCodeVerifier(); // reuse the random source — same entropy is fine
+
+        var port        = GetAvailablePort();
+        var redirectUri = $"http://127.0.0.1:{port}/callback";
+
+        using var listener = new HttpListener();
+        listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+        listener.Start();
+
+        var authUrl = BuildGitHubAuthorizeUrl(clientId, redirectUri, state, challenge);
+
+        await Console.Out.WriteLineAsync("Opening browser for GitHub authentication...");
+        await Console.Out.WriteLineAsync($"  If the browser doesn't open, visit: {authUrl}");
+
+        try {
+            Process.Start(new ProcessStartInfo(authUrl) { UseShellExecute = true });
+        } catch {
+            /* Browser open is best-effort — user can still copy the URL */
+        }
+
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(5));
+
+        HttpListenerContext context;
+        try {
+            context = await listener.GetContextAsync().WaitAsync(cts.Token);
+        } catch (OperationCanceledException) {
+            Console.Error.WriteLine("Timed out waiting for authorization. Re-run `kapacitor login` to try again.");
+            return null;
+        }
+
+        var callback = ParseCallback(context.Request.Url?.Query ?? "", state);
+        await RespondCallbackAsync(context, callback);
+        listener.Stop();
+
+        if (callback.Code is null) {
+            Console.Error.WriteLine($"Authorization failed: {callback.Error}");
+            return null;
+        }
+
+        using var http = new HttpClient();
+        http.DefaultRequestHeaders.Accept.Add(new("application/json"));
+
+        var tokenResponse = await http.PostAsync(
+            "https://github.com/login/oauth/access_token",
+            new FormUrlEncodedContent(new Dictionary<string, string> {
+                ["client_id"]     = clientId,
+                ["code"]          = callback.Code,
+                ["redirect_uri"]  = redirectUri,
+                ["code_verifier"] = verifier,
+                ["grant_type"]    = "authorization_code"
+            }));
+
+        if (!tokenResponse.IsSuccessStatusCode) {
+            Console.Error.WriteLine($"Error exchanging code: {await tokenResponse.Content.ReadAsStringAsync()}");
+            return null;
+        }
+
+        var tokenResult = (await tokenResponse.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.GitHubTokenResponse))!;
+        if (tokenResult.AccessToken is null) {
+            Console.Error.WriteLine($"Error: {tokenResult.Error ?? "no access_token in response"}");
+            return null;
+        }
+
+        await Console.Out.WriteLineAsync("Authorization complete.");
+        return tokenResult.AccessToken;
+    }
+
+    static async Task RespondCallbackAsync(HttpListenerContext ctx, CallbackResult callback) {
+        var (status, message) = callback.Code is not null
+            ? ("Authentication successful!",  "You can close this window and return to the terminal.")
+            : ($"Authentication failed: {callback.Error}", "Return to the terminal for details.");
+
+        var html = $"<html><body style='font-family:system-ui;max-width:480px;margin:80px auto;text-align:center'>"
+                 + $"<h2>{System.Net.WebUtility.HtmlEncode(status)}</h2>"
+                 + $"<p>{System.Net.WebUtility.HtmlEncode(message)}</p></body></html>";
+
+        var buffer = Encoding.UTF8.GetBytes(html);
+        ctx.Response.ContentType     = "text/html";
+        ctx.Response.ContentLength64 = buffer.Length;
+        await ctx.Response.OutputStream.WriteAsync(buffer);
+        ctx.Response.Close();
+    }
+
     public static async Task<int> ExchangeAndSaveAsync(string serverUrl, string githubAccessToken, string provider) {
         if (provider is not AuthProvider.GitHubApp and not AuthProvider.Auth0) {
             Console.Error.WriteLine($"Error: unknown auth provider '{provider}'");

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -356,6 +356,41 @@ public static class OAuthLoginFlow {
         return 0;
     }
 
+    internal readonly record struct CallbackResult(string? Code, string? Error);
+
+    internal static string BuildGitHubAuthorizeUrl(
+            string clientId, string redirectUri, string state, string codeChallenge) =>
+        "https://github.com/login/oauth/authorize?"             +
+        $"client_id={Uri.EscapeDataString(clientId)}"           +
+        $"&redirect_uri={Uri.EscapeDataString(redirectUri)}"    +
+        $"&state={Uri.EscapeDataString(state)}"                 +
+        $"&scope={Uri.EscapeDataString("read:user read:org")}"  +
+        $"&code_challenge={Uri.EscapeDataString(codeChallenge)}"+
+        "&code_challenge_method=S256"                           +
+        "&response_type=code";
+
+    internal static CallbackResult ParseCallback(string queryString, string expectedState) {
+        var qs    = queryString.TrimStart('?');
+        var parts = qs.Split('&', StringSplitOptions.RemoveEmptyEntries);
+        string? code = null, state = null, error = null;
+
+        foreach (var part in parts) {
+            var eq = part.IndexOf('=');
+            if (eq < 0) continue;
+            var key = part[..eq];
+            var val = Uri.UnescapeDataString(part[(eq + 1)..]);
+            switch (key) {
+                case "code":  code  = val; break;
+                case "state": state = val; break;
+                case "error": error = val; break;
+            }
+        }
+
+        if (error is not null)        return new(null, error);
+        if (state != expectedState)   return new(null, "state_mismatch");
+        return string.IsNullOrEmpty(code) ? new(null, "missing_code") : new(code, null);
+    }
+
     static string GenerateCodeVerifier() {
         var bytes = RandomNumberGenerator.GetBytes(32);
 

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -534,8 +534,8 @@ public static class OAuthLoginFlow {
             }
         }
 
-        if (error is not null)        return new(null, error);
         if (state != expectedState)   return new(null, "state_mismatch");
+        if (error is not null)        return new(null, error);
         return string.IsNullOrEmpty(code) ? new(null, "missing_code") : new(code, null);
     }
 

--- a/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Kapacitor.Core/Auth/OAuthLoginFlow.cs
@@ -92,9 +92,11 @@ public static class OAuthLoginFlow {
         var device   = (await deviceResponse.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.GitHubDeviceCodeResponse))!;
         var interval = device.Interval;
 
+        var copied = Clipboard.TryCopy(device.UserCode);
+
         await Console.Out.WriteLineAsync();
-        await Console.Out.WriteLineAsync($"  Enter code: {device.UserCode}");
-        await Console.Out.WriteLineAsync($"  at: {device.VerificationUri}");
+        await Console.Out.WriteLineAsync($"  Code: {device.UserCode}{(copied ? "  (copied to clipboard)" : "")}");
+        await Console.Out.WriteLineAsync($"  Open: {device.VerificationUri}");
         await Console.Out.WriteLineAsync();
 
         try {

--- a/src/Kapacitor.Core/Models.cs
+++ b/src/Kapacitor.Core/Models.cs
@@ -443,6 +443,7 @@ record RepoEntry {
 [JsonSerializable(typeof(Auth.RefreshTokenRequest))]
 [JsonSerializable(typeof(Auth.GitHubDeviceCodeResponse))]
 [JsonSerializable(typeof(Auth.GitHubTokenResponse))]
+[JsonSerializable(typeof(Auth.GitHubCodeExchangeRequest))]
 [JsonSerializable(typeof(Auth.Auth0TokenResponse))]
 [JsonSerializable(typeof(Auth.Auth0IdTokenClaims))]
 [JsonSerializable(typeof(Auth.ProxyConfigResponse))]

--- a/src/Kapacitor.Core/Resources/help-login.txt
+++ b/src/Kapacitor.Core/Resources/help-login.txt
@@ -5,10 +5,12 @@ Usage: kapacitor login [--discover] [--device]
 Opens the system browser for OAuth authentication. The auth method is
 auto-discovered from the server configuration (GitHub App or Auth0).
 
-For GitHub, the default flow uses a localhost callback with PKCE — the
-browser opens straight to the authorize page and the CLI receives the
-code on a loopback listener. In headless environments (SSH, no DISPLAY)
-the CLI automatically falls back to GitHub Device Flow.
+For GitHub, the default flow uses a localhost callback with PKCE when the
+server advertises a code-exchange endpoint — the browser opens straight to
+the authorize page and the CLI receives the code on a loopback listener.
+The CLI falls back to GitHub Device Flow when the server doesn't advertise
+that endpoint, in headless environments (SSH, no DISPLAY), or when the
+loopback port can't be bound.
 
 Options:
   --discover    Run tenant discovery across all your GitHub org memberships.

--- a/src/Kapacitor.Core/Resources/help-login.txt
+++ b/src/Kapacitor.Core/Resources/help-login.txt
@@ -1,12 +1,21 @@
 kapacitor login — Authenticate via OAuth
 
-Usage: kapacitor login [--discover]
+Usage: kapacitor login [--discover] [--device]
 
-Opens a browser for OAuth authentication. The auth method (GitHub Device
-Flow or Auth0 PKCE) is auto-discovered from the server configuration.
+Opens the system browser for OAuth authentication. The auth method is
+auto-discovered from the server configuration (GitHub App or Auth0).
+
+For GitHub, the default flow uses a localhost callback with PKCE — the
+browser opens straight to the authorize page and the CLI receives the
+code on a loopback listener. In headless environments (SSH, no DISPLAY)
+the CLI automatically falls back to GitHub Device Flow.
 
 Options:
   --discover    Run tenant discovery across all your GitHub org memberships.
                 Exchanges tokens for each discovered Capacitor tenant and saves
                 them as named profiles, then sets the picked tenant as the
                 active profile. No existing profile configuration is required.
+
+  --device      Force GitHub Device Flow even when a browser is available.
+                Useful for SSH sessions, containers without a browser, or any
+                environment where the loopback callback can't open.

--- a/src/Kapacitor.Core/Resources/help-setup.txt
+++ b/src/Kapacitor.Core/Resources/help-setup.txt
@@ -7,3 +7,5 @@ Options:
   --daemon-name <name>        Daemon name (skip prompt)
   --default-visibility <vis>  Default visibility: private, org_public, public
   --no-prompt                 Non-interactive mode (requires --server-url)
+  --device                    Force GitHub Device Flow during the login step
+                              (use in SSH / headless envs)

--- a/src/kapacitor/Commands/SetupCommand.cs
+++ b/src/kapacitor/Commands/SetupCommand.cs
@@ -11,6 +11,7 @@ public static class SetupCommand {
     public static async Task<int> HandleAsync(string[] args) {
         var serverUrlArg = GetArg(args, "--server-url");
         var noPrompt     = args.Contains("--no-prompt");
+        var forceDevice  = args.Contains("--device");
 
         AnsiConsole.Write(new Rule("[bold green]Welcome to Kapacitor[/]").Centered());
 
@@ -54,7 +55,7 @@ public static class SetupCommand {
             await Console.Error.WriteLineAsync("  --server-url is required with --no-prompt");
             return 1;
         } else {
-            var discovered = await RunDiscoveryAsync();
+            var discovered = await RunDiscoveryAsync(forceDevice);
             if (discovered is null) return 1;
             (serverUrl, preAuthToken, provider) = discovered.Value;
         }
@@ -76,7 +77,7 @@ public static class SetupCommand {
             var tokens = await TokenStore.LoadAsync();
             AnsiConsole.MarkupLine($"  [green]✓[/] Logged in as [cyan]{Markup.Escape(tokens?.GitHubUsername ?? "?")}[/]");
         } else {
-            var loginResult = await OAuthLoginFlow.LoginWithDiscoveryAsync(serverUrl);
+            var loginResult = await OAuthLoginFlow.LoginWithDiscoveryAsync(serverUrl, forceDevice);
 
             if (loginResult != 0) {
                 await Console.Error.WriteLineAsync("  Login failed.");
@@ -228,7 +229,7 @@ public static class SetupCommand {
         return 0;
     }
 
-    static async Task<(string ServerUrl, string PreAuthToken, string Provider)?> RunDiscoveryAsync() {
+    static async Task<(string ServerUrl, string PreAuthToken, string Provider)?> RunDiscoveryAsync(bool forceDevice) {
         AnsiConsole.MarkupLine($"  Proxy: [dim]{Markup.Escape(AuthProxyEndpoint.Url)}[/]");
 
         using var http  = new HttpClient();
@@ -241,7 +242,7 @@ public static class SetupCommand {
             return null;
         }
 
-        var ghToken = await OAuthLoginFlow.RunDeviceFlowAsync(clientId);
+        var ghToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(clientId, forceDevice);
         if (ghToken is null) return null;
 
         var discovery = new TenantDiscovery(proxyClient, new SpectreTenantPicker());

--- a/src/kapacitor/Commands/SetupCommand.cs
+++ b/src/kapacitor/Commands/SetupCommand.cs
@@ -235,14 +235,15 @@ public static class SetupCommand {
         using var http  = new HttpClient();
         var proxyClient = new AuthProxyClient(http);
 
-        var clientId = await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync("Contacting auth service…",
-            async _ => await proxyClient.GetGitHubClientIdAsync(AuthProxyEndpoint.Url));
-        if (clientId is null) {
+        var proxyConfig = await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync("Contacting auth service…",
+            async _ => await proxyClient.GetConfigAsync(AuthProxyEndpoint.Url));
+        if (proxyConfig is null || string.IsNullOrEmpty(proxyConfig.GitHubClientId)) {
             AnsiConsole.MarkupLine("  [red]✗[/] Cannot reach the Kurrent auth service. Retry later, or pass --server-url <url>.");
             return null;
         }
 
-        var ghToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(clientId, forceDevice);
+        var ghToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(
+            proxyConfig.GitHubClientId, proxyConfig.GitHubCodeExchangeUrl, forceDevice);
         if (ghToken is null) return null;
 
         var discovery = new TenantDiscovery(proxyClient, new SpectreTenantPicker());

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -180,8 +180,10 @@ switch (command) {
         return await WhatsDoneCommand.HandleGenerateWhatsDone(baseUrl!, wdSessionId, wdVendor);
     }
     case "login": {
+        var forceDevice = args.Contains("--device");
+
         if (args.Contains("--discover")) {
-            return await HandleDiscoverLoginAsync();
+            return await HandleDiscoverLoginAsync(forceDevice);
         }
 
         if (baseUrl is null) {
@@ -190,7 +192,7 @@ switch (command) {
             return 1;
         }
 
-        return await OAuthLoginFlow.LoginWithDiscoveryAsync(baseUrl);
+        return await OAuthLoginFlow.LoginWithDiscoveryAsync(baseUrl, forceDevice);
     }
     case "logout": {
         await TokenStore.DeleteAsync();
@@ -855,7 +857,7 @@ void NormalizeGuidField(JsonNode node, string fieldName) {
     }
 }
 
-async Task<int> HandleDiscoverLoginAsync() {
+async Task<int> HandleDiscoverLoginAsync(bool forceDevice) {
     using var http  = new HttpClient();
     var proxyClient = new AuthProxyClient(http);
 
@@ -867,7 +869,7 @@ async Task<int> HandleDiscoverLoginAsync() {
         return 1;
     }
 
-    var ghToken = await OAuthLoginFlow.RunDeviceFlowAsync(clientId);
+    var ghToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(clientId, forceDevice);
     if (ghToken is null) return 1;
 
     var discovery = new TenantDiscovery(proxyClient, new SpectreTenantPicker());

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -861,15 +861,16 @@ async Task<int> HandleDiscoverLoginAsync(bool forceDevice) {
     using var http  = new HttpClient();
     var proxyClient = new AuthProxyClient(http);
 
-    var clientId = await proxyClient.GetGitHubClientIdAsync(AuthProxyEndpoint.Url);
+    var proxyConfig = await proxyClient.GetConfigAsync(AuthProxyEndpoint.Url);
 
-    if (clientId is null) {
+    if (proxyConfig is null || string.IsNullOrEmpty(proxyConfig.GitHubClientId)) {
         await Console.Error.WriteLineAsync("Cannot reach the Kurrent auth service.");
 
         return 1;
     }
 
-    var ghToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(clientId, forceDevice);
+    var ghToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(
+        proxyConfig.GitHubClientId, proxyConfig.GitHubCodeExchangeUrl, forceDevice);
     if (ghToken is null) return 1;
 
     var discovery = new TenantDiscovery(proxyClient, new SpectreTenantPicker());

--- a/test/kapacitor.Tests.Unit/AuthProxyClientTests.cs
+++ b/test/kapacitor.Tests.Unit/AuthProxyClientTests.cs
@@ -7,7 +7,7 @@ namespace kapacitor.Tests.Unit;
 
 public class AuthProxyClientTests {
     [Test]
-    public async Task GetGitHubClientIdAsync_returns_id_on_200() {
+    public async Task GetConfigAsync_returns_client_id_only_when_exchange_url_absent() {
         using var server = WireMockServer.Start();
 
         server.Given(Request.Create().WithPath("/config").UsingGet())
@@ -21,20 +21,44 @@ public class AuthProxyClientTests {
         using var http   = new HttpClient();
         var       client = new AuthProxyClient(http);
 
-        var id = await client.GetGitHubClientIdAsync(server.Urls[0]);
+        var config = await client.GetConfigAsync(server.Urls[0]);
 
-        await Assert.That(id).IsEqualTo("Iv1.abc");
+        await Assert.That(config).IsNotNull();
+        await Assert.That(config!.GitHubClientId).IsEqualTo("Iv1.abc");
+        await Assert.That(config.GitHubCodeExchangeUrl).IsNull();
     }
 
     [Test]
-    public async Task GetGitHubClientIdAsync_returns_null_on_proxy_unreachable() {
+    public async Task GetConfigAsync_returns_exchange_url_when_present() {
+        using var server = WireMockServer.Start();
+
+        server.Given(Request.Create().WithPath("/config").UsingGet())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody("""{"github_client_id":"Iv1.abc","github_code_exchange_url":"https://auth.example/auth/github/code-exchange"}""")
+                    .WithHeader("Content-Type", "application/json")
+            );
+
+        using var http   = new HttpClient();
+        var       client = new AuthProxyClient(http);
+
+        var config = await client.GetConfigAsync(server.Urls[0]);
+
+        await Assert.That(config).IsNotNull();
+        await Assert.That(config!.GitHubClientId).IsEqualTo("Iv1.abc");
+        await Assert.That(config.GitHubCodeExchangeUrl).IsEqualTo("https://auth.example/auth/github/code-exchange");
+    }
+
+    [Test]
+    public async Task GetConfigAsync_returns_null_on_proxy_unreachable() {
         using var http = new HttpClient();
         http.Timeout = TimeSpan.FromMilliseconds(200);
         var client = new AuthProxyClient(http);
 
-        var id = await client.GetGitHubClientIdAsync("http://127.0.0.1:1");
+        var config = await client.GetConfigAsync("http://127.0.0.1:1");
 
-        await Assert.That(id).IsNull();
+        await Assert.That(config).IsNull();
     }
 
     [Test]

--- a/test/kapacitor.Tests.Unit/HeadlessEnvironmentTests.cs
+++ b/test/kapacitor.Tests.Unit/HeadlessEnvironmentTests.cs
@@ -1,0 +1,47 @@
+using kapacitor.Auth;
+
+namespace kapacitor.Tests.Unit;
+
+public class HeadlessEnvironmentTests {
+    [Test]
+    public async Task Detects_ssh_connection() {
+        var env = new Dictionary<string, string?> { ["SSH_CONNECTION"] = "1.2.3.4 5 6.7.8.9 22" };
+        await Assert.That(HeadlessEnvironment.IsHeadless(env, OSPlatformKind.Linux)).IsTrue();
+    }
+
+    [Test]
+    public async Task Detects_ssh_client() {
+        var env = new Dictionary<string, string?> { ["SSH_CLIENT"] = "1.2.3.4 5 22" };
+        await Assert.That(HeadlessEnvironment.IsHeadless(env, OSPlatformKind.Linux)).IsTrue();
+    }
+
+    [Test]
+    public async Task Linux_without_display_is_headless() {
+        var env = new Dictionary<string, string?>();
+        await Assert.That(HeadlessEnvironment.IsHeadless(env, OSPlatformKind.Linux)).IsTrue();
+    }
+
+    [Test]
+    public async Task Linux_with_display_is_not_headless() {
+        var env = new Dictionary<string, string?> { ["DISPLAY"] = ":0" };
+        await Assert.That(HeadlessEnvironment.IsHeadless(env, OSPlatformKind.Linux)).IsFalse();
+    }
+
+    [Test]
+    public async Task Linux_with_wayland_is_not_headless() {
+        var env = new Dictionary<string, string?> { ["WAYLAND_DISPLAY"] = "wayland-0" };
+        await Assert.That(HeadlessEnvironment.IsHeadless(env, OSPlatformKind.Linux)).IsFalse();
+    }
+
+    [Test]
+    public async Task MacOS_default_is_not_headless() {
+        var env = new Dictionary<string, string?>();
+        await Assert.That(HeadlessEnvironment.IsHeadless(env, OSPlatformKind.MacOS)).IsFalse();
+    }
+
+    [Test]
+    public async Task Windows_default_is_not_headless() {
+        var env = new Dictionary<string, string?>();
+        await Assert.That(HeadlessEnvironment.IsHeadless(env, OSPlatformKind.Windows)).IsFalse();
+    }
+}

--- a/test/kapacitor.Tests.Unit/HeadlessEnvironmentTests.cs
+++ b/test/kapacitor.Tests.Unit/HeadlessEnvironmentTests.cs
@@ -16,6 +16,12 @@ public class HeadlessEnvironmentTests {
     }
 
     [Test]
+    public async Task Detects_ssh_on_macos() {
+        var env = new Dictionary<string, string?> { ["SSH_CONNECTION"] = "1.2.3.4 5 6.7.8.9 22" };
+        await Assert.That(HeadlessEnvironment.IsHeadless(env, OSPlatformKind.MacOS)).IsTrue();
+    }
+
+    [Test]
     public async Task Linux_without_display_is_headless() {
         var env = new Dictionary<string, string?>();
         await Assert.That(HeadlessEnvironment.IsHeadless(env, OSPlatformKind.Linux)).IsTrue();

--- a/test/kapacitor.Tests.Unit/OAuthFlowTests.cs
+++ b/test/kapacitor.Tests.Unit/OAuthFlowTests.cs
@@ -73,19 +73,25 @@ public class OAuthFlowTests {
 
     [Test]
     public async Task ChooseGitHubFlow_returns_device_when_forced() {
-        var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: true, isHeadless: false);
+        var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: true, isHeadless: false, hasExchangeUrl: true);
         await Assert.That(choice).IsEqualTo(GitHubFlow.Device);
     }
 
     [Test]
     public async Task ChooseGitHubFlow_returns_device_when_headless() {
-        var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: false, isHeadless: true);
+        var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: false, isHeadless: true, hasExchangeUrl: true);
         await Assert.That(choice).IsEqualTo(GitHubFlow.Device);
     }
 
     [Test]
-    public async Task ChooseGitHubFlow_returns_browser_when_interactive() {
-        var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: false, isHeadless: false);
+    public async Task ChooseGitHubFlow_returns_device_when_no_exchange_url() {
+        var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: false, isHeadless: false, hasExchangeUrl: false);
+        await Assert.That(choice).IsEqualTo(GitHubFlow.Device);
+    }
+
+    [Test]
+    public async Task ChooseGitHubFlow_returns_browser_when_interactive_and_server_supports_it() {
+        var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: false, isHeadless: false, hasExchangeUrl: true);
         await Assert.That(choice).IsEqualTo(GitHubFlow.Browser);
     }
 }

--- a/test/kapacitor.Tests.Unit/OAuthFlowTests.cs
+++ b/test/kapacitor.Tests.Unit/OAuthFlowTests.cs
@@ -60,4 +60,22 @@ public class OAuthFlowTests {
         await Assert.That(result.Code).IsNull();
         await Assert.That(result.Error).IsEqualTo("missing_code");
     }
+
+    [Test]
+    public async Task ChooseGitHubFlow_returns_device_when_forced() {
+        var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: true, isHeadless: false);
+        await Assert.That(choice).IsEqualTo(GitHubFlow.Device);
+    }
+
+    [Test]
+    public async Task ChooseGitHubFlow_returns_device_when_headless() {
+        var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: false, isHeadless: true);
+        await Assert.That(choice).IsEqualTo(GitHubFlow.Device);
+    }
+
+    [Test]
+    public async Task ChooseGitHubFlow_returns_browser_when_interactive() {
+        var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: false, isHeadless: false);
+        await Assert.That(choice).IsEqualTo(GitHubFlow.Browser);
+    }
 }

--- a/test/kapacitor.Tests.Unit/OAuthFlowTests.cs
+++ b/test/kapacitor.Tests.Unit/OAuthFlowTests.cs
@@ -52,9 +52,19 @@ public class OAuthFlowTests {
     }
 
     [Test]
-    public async Task Callback_parser_rejects_error_without_valid_state() {
+    public async Task Callback_parser_reports_missing_state_when_state_param_absent() {
         var result = OAuthLoginFlow.ParseCallback(
             queryString:  "?error=access_denied",
+            expectedState:"expected");
+
+        await Assert.That(result.Code).IsNull();
+        await Assert.That(result.Error).IsEqualTo("missing_state");
+    }
+
+    [Test]
+    public async Task Callback_parser_reports_state_mismatch_when_state_differs() {
+        var result = OAuthLoginFlow.ParseCallback(
+            queryString:  "?error=access_denied&state=attacker",
             expectedState:"expected");
 
         await Assert.That(result.Code).IsNull();

--- a/test/kapacitor.Tests.Unit/OAuthFlowTests.cs
+++ b/test/kapacitor.Tests.Unit/OAuthFlowTests.cs
@@ -1,0 +1,63 @@
+using kapacitor.Auth;
+
+namespace kapacitor.Tests.Unit;
+
+public class OAuthFlowTests {
+    [Test]
+    public async Task GitHub_authorize_url_includes_all_required_params() {
+        var url = OAuthLoginFlow.BuildGitHubAuthorizeUrl(
+            clientId:     "Iv1.abc",
+            redirectUri:  "http://127.0.0.1:54321/callback",
+            state:        "state-xyz",
+            codeChallenge:"challenge-123");
+
+        await Assert.That(url).StartsWith("https://github.com/login/oauth/authorize?");
+        await Assert.That(url).Contains("client_id=Iv1.abc");
+        await Assert.That(url).Contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2Fcallback");
+        await Assert.That(url).Contains("state=state-xyz");
+        await Assert.That(url).Contains("scope=read%3Auser%20read%3Aorg");
+        await Assert.That(url).Contains("code_challenge=challenge-123");
+        await Assert.That(url).Contains("code_challenge_method=S256");
+        await Assert.That(url).Contains("response_type=code");
+    }
+
+    [Test]
+    public async Task Callback_parser_returns_code_when_state_matches() {
+        var result = OAuthLoginFlow.ParseCallback(
+            queryString:  "?code=abc&state=expected",
+            expectedState:"expected");
+
+        await Assert.That(result.Code).IsEqualTo("abc");
+        await Assert.That(result.Error).IsNull();
+    }
+
+    [Test]
+    public async Task Callback_parser_rejects_state_mismatch() {
+        var result = OAuthLoginFlow.ParseCallback(
+            queryString:  "?code=abc&state=attacker",
+            expectedState:"expected");
+
+        await Assert.That(result.Code).IsNull();
+        await Assert.That(result.Error).IsEqualTo("state_mismatch");
+    }
+
+    [Test]
+    public async Task Callback_parser_surfaces_provider_error() {
+        var result = OAuthLoginFlow.ParseCallback(
+            queryString:  "?error=access_denied&state=expected",
+            expectedState:"expected");
+
+        await Assert.That(result.Code).IsNull();
+        await Assert.That(result.Error).IsEqualTo("access_denied");
+    }
+
+    [Test]
+    public async Task Callback_parser_rejects_missing_code() {
+        var result = OAuthLoginFlow.ParseCallback(
+            queryString:  "?state=expected",
+            expectedState:"expected");
+
+        await Assert.That(result.Code).IsNull();
+        await Assert.That(result.Error).IsEqualTo("missing_code");
+    }
+}

--- a/test/kapacitor.Tests.Unit/OAuthFlowTests.cs
+++ b/test/kapacitor.Tests.Unit/OAuthFlowTests.cs
@@ -100,6 +100,38 @@ public class OAuthFlowTests {
     }
 
     [Test]
+    public async Task IsValidExchangeUrl_accepts_https_url() {
+        await Assert.That(OAuthLoginFlow.IsValidExchangeUrl("https://auth.example/auth/github/code-exchange")).IsTrue();
+    }
+
+    [Test]
+    public async Task IsValidExchangeUrl_accepts_http_url() {
+        await Assert.That(OAuthLoginFlow.IsValidExchangeUrl("http://localhost:8080/exchange")).IsTrue();
+    }
+
+    [Test]
+    public async Task IsValidExchangeUrl_rejects_null() {
+        await Assert.That(OAuthLoginFlow.IsValidExchangeUrl(null)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsValidExchangeUrl_rejects_empty_and_whitespace() {
+        await Assert.That(OAuthLoginFlow.IsValidExchangeUrl("")).IsFalse();
+        await Assert.That(OAuthLoginFlow.IsValidExchangeUrl("   ")).IsFalse();
+    }
+
+    [Test]
+    public async Task IsValidExchangeUrl_rejects_relative_path() {
+        await Assert.That(OAuthLoginFlow.IsValidExchangeUrl("/auth/exchange")).IsFalse();
+    }
+
+    [Test]
+    public async Task IsValidExchangeUrl_rejects_non_http_scheme() {
+        await Assert.That(OAuthLoginFlow.IsValidExchangeUrl("javascript:alert(1)")).IsFalse();
+        await Assert.That(OAuthLoginFlow.IsValidExchangeUrl("file:///etc/passwd")).IsFalse();
+    }
+
+    [Test]
     public async Task ChooseGitHubFlow_returns_browser_when_interactive_and_server_supports_it() {
         var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: false, isHeadless: false, hasExchangeUrl: true);
         await Assert.That(choice).IsEqualTo(GitHubFlow.Browser);

--- a/test/kapacitor.Tests.Unit/OAuthFlowTests.cs
+++ b/test/kapacitor.Tests.Unit/OAuthFlowTests.cs
@@ -52,6 +52,16 @@ public class OAuthFlowTests {
     }
 
     [Test]
+    public async Task Callback_parser_rejects_error_without_valid_state() {
+        var result = OAuthLoginFlow.ParseCallback(
+            queryString:  "?error=access_denied",
+            expectedState:"expected");
+
+        await Assert.That(result.Code).IsNull();
+        await Assert.That(result.Error).IsEqualTo("state_mismatch");
+    }
+
+    [Test]
     public async Task Callback_parser_rejects_missing_code() {
         var result = OAuthLoginFlow.ParseCallback(
             queryString:  "?state=expected",


### PR DESCRIPTION
## Summary

- GitHub login uses an OAuth authorization-code + PKCE flow on a loopback `HttpListener` **when the Capacitor server advertises a code-exchange endpoint** (`github_code_exchange_url` in `/auth/config` and proxy `/config`). The user clicks Authorize on the GitHub page and the CLI completes — no codes, no copy-paste.
- When the server doesn't advertise that endpoint (older servers / not yet shipped), `--device` is passed, the env looks headless (SSH, no DISPLAY), or the loopback port can't be bound, the CLI uses Device Flow with the original AI-52 polish (clipboard copy + auto-open of the verification URL).
- Adds CSRF `state` to both GitHub and Auth0 flows. Auth0 listener is now `using`-scoped and writes a browser-visible error on state mismatch.

Linear: [AI-52](https://linear.app/kurrent/issue/AI-52/cli-github-login-via-localhost-callback-pkce-device-flow-as-headless)

## Why server-mediated exchange

GitHub Apps require `client_secret` on `POST /login/oauth/access_token` even with PKCE — see [GitHub docs](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app). PKCE is "strongly recommended" defense-in-depth, not a public-client substitute. The CLI can't ship the secret (extractable from any AOT binary), so the token exchange must be server-mediated. The CLI does the loopback + PKCE half locally and POSTs `{code, code_verifier, redirect_uri}` to the server, which adds `client_id` + `client_secret` and forwards to GitHub.

## Server contract (blocker — not in this PR)

The Capacitor server (per-tenant `/auth/config`) and the shared auth proxy (`/config`) need to:

1. Expose an optional `github_code_exchange_url` field in their config response.
2. Implement an endpoint at that URL that accepts `POST {code, code_verifier, redirect_uri}` (JSON), forwards to GitHub with `client_id` + `client_secret`, and returns GitHub's response verbatim. See AI-52 for the full contract.

Until the server ships this, the CLI silently uses device flow — so this PR is a safe no-op for end users.

## Prerequisite

The Capacitor GitHub App callback URL must include `http://127.0.0.1`. GitHub matches by prefix and allows any port on loopback, so a single entry covers all CLI invocations. One-time config change owned by whoever administers the App.

## Test plan

- [x] Unit tests pass (493/493, including new headless-env, OAuth-flow, and proxy-config tests)
- [x] AOT publish clean (no IL3050/IL2026 warnings)
- [ ] Manual: against a server that does NOT yet advertise `github_code_exchange_url` → `kapacitor login` falls through to device flow (clipboard copy + auto-open hints)
- [ ] Manual: against a server that DOES advertise it (once shipped) → browser opens to GitHub authorize page → click Authorize → CLI prints `Logged in as <user>`
- [ ] Manual: `kapacitor login --device` → device-code text appears with `(copied to clipboard)` hint, browser auto-opens to `https://github.com/login/device`
- [ ] Manual: SSH session, `kapacitor login` → falls through to device flow automatically (no DISPLAY)
- [ ] Manual: cancel the GitHub authorize page → CLI reports `Authorization failed: ...` and exits non-zero
- [ ] Manual: simulate port-bind failure → CLI prints `Could not bind loopback listener (...); falling back to device flow.` and continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)