### PR TITLE
[AI-613] history: explicit scope selection + --private

### DIFF
--- a/docs/superpowers/plans/2026-05-13-ai-613-history-import-scope.md
+++ b/docs/superpowers/plans/2026-05-13-ai-613-history-import-scope.md
@@ -1,0 +1,1548 @@
+# [AI-613] History Import Scope Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the default-import behaviour of `kapacitor history` with an explicit scope choice (flag or picker) and a mandatory confirmation prompt, so users can't accidentally upload sessions from personal/private repos.
+
+**Architecture:** Add a small `ImportScope` record hierarchy and three pure helpers — flag parser, scope filter, picker/confirmation formatter — then wire two new pipeline steps into `HandleHistory` (resolve scope → confirm) plus a post-import visibility loop for `--private`. The pure helpers carry the logic; Spectre.Console code is a thin glue layer.
+
+**Tech Stack:** .NET 10 (NativeAOT), Spectre.Console for prompts, TUnit on Microsoft Testing Platform for tests, WireMock.Net for the visibility-PUT integration test.
+
+**Spec:** `docs/superpowers/specs/2026-05-13-ai-613-history-import-scope-design.md`
+
+---
+
+## File Map
+
+**Create:**
+- `src/kapacitor/Commands/ImportScope.cs` — record hierarchy (`All` / `Org(orgLogin)` / `Repo(owner, name)`).
+- `src/kapacitor/Commands/ImportScopeArgs.cs` — pure flag parser + resolver returning either a resolved `ImportScope` or an error message.
+- `src/kapacitor/Commands/HistoryScopeFilter.cs` — pure async filter `Apply(transcripts, scope, resolveRepo)` returning the kept subset.
+- `src/kapacitor/Commands/HistoryScopePrompt.cs` — Spectre pickers + confirmation prompt. Logic lives in pure helpers (`BuildRepoChoices`, `FormatSummary`); the Spectre layer is thin.
+- `test/kapacitor.Tests.Unit/ImportScopeArgsTests.cs` — parser + resolver TDD.
+- `test/kapacitor.Tests.Unit/HistoryScopeFilterTests.cs` — filter TDD.
+- `test/kapacitor.Tests.Unit/HistoryScopePromptTests.cs` — formatter + repo-choices TDD.
+- `test/kapacitor.Tests.Integration/HistoryPrivateImportTests.cs` — WireMock for `--private` post-import flow.
+
+**Modify:**
+- `src/kapacitor/Commands/HistoryCommand.cs` — extend `HandleHistory(...)` with `(ImportScope scope, bool yes, bool forcePrivate)`; insert scope-filter step after pre-filters; insert confirmation step; collect imported session ids; add post-import visibility loop.
+- `src/kapacitor/Program.cs` — wire `ImportScopeArgs.ParseFlags` + `Resolve` into the `case "history"` block; pass results into `HandleHistory`.
+- `src/kapacitor/Commands/SetupCommand.cs` — append a one-line tip after the final summary.
+- `src/Kapacitor.Core/Resources/help-history.txt` — document the new flags.
+
+---
+
+## Task 1: ImportScope record hierarchy
+
+**Files:**
+- Create: `src/kapacitor/Commands/ImportScope.cs`
+
+- [ ] **Step 1: Create the file**
+
+```csharp
+namespace kapacitor.Commands;
+
+/// <summary>
+/// Selected history import scope, resolved from CLI flags or the interactive picker.
+/// </summary>
+public abstract record ImportScope {
+    public sealed record All  : ImportScope;
+    public sealed record Org  (string OrgLogin) : ImportScope;
+    public sealed record Repo (string Owner, string Name) : ImportScope;
+
+    private ImportScope() { }
+}
+```
+
+The private constructor + sealed record subtypes make the hierarchy closed — exhaustive `switch` over `ImportScope` won't need a default arm.
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build src/kapacitor/kapacitor.csproj
+```
+
+Expected: build succeeds with 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/kapacitor/Commands/ImportScope.cs
+git commit -m "[AI-613] add ImportScope record hierarchy"
+```
+
+---
+
+## Task 2: Flag parser + scope resolver (pure)
+
+**Files:**
+- Create: `src/kapacitor/Commands/ImportScopeArgs.cs`
+- Create: `test/kapacitor.Tests.Unit/ImportScopeArgsTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+`test/kapacitor.Tests.Unit/ImportScopeArgsTests.cs`:
+
+```csharp
+using kapacitor.Commands;
+
+namespace kapacitor.Tests.Unit;
+
+public class ImportScopeArgsTests {
+    [Test]
+    public async Task ParseFlags_reads_all() {
+        var f = ImportScopeArgs.ParseFlags(["history", "--all"]);
+        await Assert.That(f.All).IsTrue();
+        await Assert.That(f.Org).IsFalse();
+        await Assert.That(f.RepoArg).IsNull();
+        await Assert.That(f.Yes).IsFalse();
+        await Assert.That(f.Private).IsFalse();
+    }
+
+    [Test]
+    public async Task ParseFlags_reads_repo_value() {
+        var f = ImportScopeArgs.ParseFlags(["history", "--repo", "EventStore/kapacitor"]);
+        await Assert.That(f.RepoArg).IsEqualTo("EventStore/kapacitor");
+    }
+
+    [Test]
+    public async Task ParseFlags_reads_yes_short_form() {
+        var f = ImportScopeArgs.ParseFlags(["history", "--all", "-y"]);
+        await Assert.That(f.Yes).IsTrue();
+    }
+
+    [Test]
+    public async Task ParseFlags_reads_private() {
+        var f = ImportScopeArgs.ParseFlags(["history", "--all", "--private"]);
+        await Assert.That(f.Private).IsTrue();
+    }
+
+    [Test]
+    public async Task Resolve_errors_when_two_scope_flags_set() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: true, Org: true, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error).IsNotNull();
+        await Assert.That(r.Error!).Contains("mutually exclusive");
+    }
+
+    [Test]
+    public async Task Resolve_returns_All_for_all_flag() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: true, Org: false, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "default",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsTypeOf<ImportScope.All>();
+        await Assert.That(r.Error).IsNull();
+    }
+
+    [Test]
+    public async Task Resolve_returns_Org_with_active_profile() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsTypeOf<ImportScope.Org>();
+        await Assert.That(((ImportScope.Org)r.Scope!).OrgLogin).IsEqualTo("EventStore");
+    }
+
+    [Test]
+    public async Task Resolve_errors_on_Org_when_profile_is_default() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "default",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error!).Contains("tenant-bound profile");
+    }
+
+    [Test]
+    public async Task Resolve_returns_Repo_for_owner_slash_name() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: "EventStore/kapacitor", Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        var repo = (ImportScope.Repo)r.Scope!;
+        await Assert.That(repo.Owner).IsEqualTo("EventStore");
+        await Assert.That(repo.Name).IsEqualTo("kapacitor");
+    }
+
+    [Test]
+    public async Task Resolve_repo_dot_uses_current_repo() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: ".", Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: ("EventStore", "kapacitor"));
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        var repo = (ImportScope.Repo)r.Scope!;
+        await Assert.That(repo.Owner).IsEqualTo("EventStore");
+        await Assert.That(repo.Name).IsEqualTo("kapacitor");
+    }
+
+    [Test]
+    public async Task Resolve_repo_current_alias_uses_current_repo() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: "current", Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: ("EventStore", "kapacitor"));
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        var repo = (ImportScope.Repo)r.Scope!;
+        await Assert.That(repo.Owner).IsEqualTo("EventStore");
+        await Assert.That(repo.Name).IsEqualTo("kapacitor");
+    }
+
+    [Test]
+    public async Task Resolve_repo_dot_errors_when_cwd_has_no_repo() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: ".", Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error!).Contains("not a git repo");
+    }
+
+    [Test]
+    public async Task Resolve_errors_on_malformed_repo_arg() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: "no-slash", Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error!).Contains("owner/name");
+    }
+
+    [Test]
+    public async Task Resolve_returns_NeedsPicker_when_no_flag_and_interactive() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error).IsNull();
+        await Assert.That(r.NeedsPicker).IsTrue();
+    }
+
+    [Test]
+    public async Task Resolve_errors_when_no_flag_and_non_interactive() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: false,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.NeedsPicker).IsFalse();
+        await Assert.That(r.Error!).Contains("--all, --org, or --repo");
+    }
+
+    [Test]
+    public async Task Resolve_errors_when_flag_set_and_non_interactive_without_yes() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: true, Org: false, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: false,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error!).Contains("--yes");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/ImportScopeArgsTests/*"
+```
+
+Expected: every test FAILS — `ImportScopeArgs` does not exist yet.
+
+- [ ] **Step 3: Implement `ImportScopeArgs`**
+
+`src/kapacitor/Commands/ImportScopeArgs.cs`:
+
+```csharp
+namespace kapacitor.Commands;
+
+/// <summary>
+/// Pure flag parser and resolver for `kapacitor history` scope selection.
+/// Performs no I/O — current-repo lookup is the caller's job; the resolved
+/// result is passed in via <see cref="ResolveInput.CurrentRepo"/>.
+/// </summary>
+public static class ImportScopeArgs {
+    public sealed record ParsedFlags(
+        bool    All,
+        bool    Org,
+        string? RepoArg,
+        bool    Yes,
+        bool    Private);
+
+    public sealed record ResolveInput(
+        ParsedFlags                         Flags,
+        string                              ActiveProfile,
+        bool                                IsInteractive,
+        (string Owner, string Name)?        CurrentRepo);
+
+    public sealed record ResolveResult(
+        ImportScope? Scope,        // null => either picker needed or error
+        bool         Yes,
+        bool         Private,
+        bool         NeedsPicker,
+        string?      Error);
+
+    public static ParsedFlags ParseFlags(string[] args) {
+        string? repo = null;
+        var idx = Array.IndexOf(args, "--repo");
+        if (idx >= 0 && idx + 1 < args.Length) repo = args[idx + 1];
+
+        return new(
+            All:     args.Contains("--all"),
+            Org:     args.Contains("--org"),
+            RepoArg: repo,
+            Yes:     args.Contains("--yes") || args.Contains("-y"),
+            Private: args.Contains("--private"));
+    }
+
+    public static ResolveResult Resolve(ResolveInput input) {
+        var f = input.Flags;
+        var count = (f.All ? 1 : 0) + (f.Org ? 1 : 0) + (f.RepoArg is null ? 0 : 1);
+
+        if (count > 1) {
+            return new(null, f.Yes, f.Private, false,
+                "--all, --org, and --repo are mutually exclusive.");
+        }
+
+        if (count == 0) {
+            if (input.IsInteractive) {
+                return new(null, f.Yes, f.Private, NeedsPicker: true, Error: null);
+            }
+            return new(null, f.Yes, f.Private, false,
+                "--all, --org, or --repo <owner/name> is required for non-interactive use.");
+        }
+
+        // A scope flag is set: enforce --yes for non-interactive runs.
+        if (!input.IsInteractive && !f.Yes) {
+            return new(null, f.Yes, f.Private, false,
+                "--yes is required for non-interactive use.");
+        }
+
+        if (f.All) {
+            return new(new ImportScope.All(), f.Yes, f.Private, false, null);
+        }
+
+        if (f.Org) {
+            if (string.IsNullOrEmpty(input.ActiveProfile) || input.ActiveProfile == "default") {
+                return new(null, f.Yes, f.Private, false,
+                    "--org requires a tenant-bound profile. Run `kapacitor setup` first, or use --all / --repo <owner/name>.");
+            }
+            return new(new ImportScope.Org(input.ActiveProfile), f.Yes, f.Private, false, null);
+        }
+
+        // --repo <value>
+        var value = f.RepoArg!;
+        if (value is "." or "current") {
+            if (input.CurrentRepo is null) {
+                return new(null, f.Yes, f.Private, false,
+                    "--repo . requires the current directory to be a git repo with an origin remote.");
+            }
+            var (owner, name) = input.CurrentRepo.Value;
+            return new(new ImportScope.Repo(owner, name), f.Yes, f.Private, false, null);
+        }
+
+        var parts = value.Split('/');
+        if (parts.Length != 2 || parts[0].Length == 0 || parts[1].Length == 0) {
+            return new(null, f.Yes, f.Private, false,
+                $"--repo expects owner/name (got '{value}').");
+        }
+
+        return new(new ImportScope.Repo(parts[0], parts[1]), f.Yes, f.Private, false, null);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/ImportScopeArgsTests/*"
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kapacitor/Commands/ImportScopeArgs.cs test/kapacitor.Tests.Unit/ImportScopeArgsTests.cs
+git commit -m "[AI-613] add ImportScopeArgs parser + resolver"
+```
+
+---
+
+## Task 3: Pure scope filter
+
+**Files:**
+- Create: `src/kapacitor/Commands/HistoryScopeFilter.cs`
+- Create: `test/kapacitor.Tests.Unit/HistoryScopeFilterTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+`test/kapacitor.Tests.Unit/HistoryScopeFilterTests.cs`:
+
+```csharp
+using kapacitor.Commands;
+
+namespace kapacitor.Tests.Unit;
+
+public class HistoryScopeFilterTests {
+    static (string SessionId, string FilePath, string EncodedCwd) T(string id) =>
+        (id, $"/tmp/{id}.jsonl", $"-tmp-proj-{id}");
+
+    static Func<(string SessionId, string FilePath, string EncodedCwd), CancellationToken, ValueTask<(string? Owner, string? Name)>>
+        Resolver(Dictionary<string, (string Owner, string Name)?> map) =>
+        (t, _) => new ValueTask<(string?, string?)>(
+            map.TryGetValue(t.SessionId, out var v) && v is { } x ? (x.Owner, x.Name) : (null, null));
+
+    [Test]
+    public async Task Apply_All_returns_every_transcript_including_unresolved() {
+        var transcripts = new[] { T("a"), T("b"), T("c") };
+        var resolver = Resolver(new() { ["a"] = ("EventStore", "kapacitor"), ["b"] = null });
+
+        var kept = await HistoryScopeFilter.Apply(transcripts, new ImportScope.All(), resolver);
+
+        await Assert.That(kept.Select(x => x.SessionId).ToArray()).IsEquivalentTo(new[] { "a", "b", "c" });
+    }
+
+    [Test]
+    public async Task Apply_Org_keeps_only_matching_owner() {
+        var transcripts = new[] { T("a"), T("b"), T("c") };
+        var resolver = Resolver(new() {
+            ["a"] = ("EventStore", "kapacitor"),
+            ["b"] = ("kurrent-io", "secret"),
+            ["c"] = ("EventStore", "kurrentdb"),
+        });
+
+        var kept = await HistoryScopeFilter.Apply(transcripts, new ImportScope.Org("EventStore"), resolver);
+
+        await Assert.That(kept.Select(x => x.SessionId).ToArray()).IsEquivalentTo(new[] { "a", "c" });
+    }
+
+    [Test]
+    public async Task Apply_Org_matches_case_insensitively() {
+        var transcripts = new[] { T("a") };
+        var resolver = Resolver(new() { ["a"] = ("eventstore", "kapacitor") });
+
+        var kept = await HistoryScopeFilter.Apply(transcripts, new ImportScope.Org("EventStore"), resolver);
+
+        await Assert.That(kept).HasCount(1);
+    }
+
+    [Test]
+    public async Task Apply_Org_drops_unresolved_repos() {
+        var transcripts = new[] { T("a") };
+        var resolver = Resolver(new() { ["a"] = null });
+
+        var kept = await HistoryScopeFilter.Apply(transcripts, new ImportScope.Org("EventStore"), resolver);
+
+        await Assert.That(kept).IsEmpty();
+    }
+
+    [Test]
+    public async Task Apply_Repo_keeps_only_exact_match() {
+        var transcripts = new[] { T("a"), T("b"), T("c") };
+        var resolver = Resolver(new() {
+            ["a"] = ("EventStore", "kapacitor"),
+            ["b"] = ("EventStore", "kurrentdb"),
+            ["c"] = ("EventStore", "kapacitor"),
+        });
+
+        var kept = await HistoryScopeFilter.Apply(
+            transcripts, new ImportScope.Repo("EventStore", "kapacitor"), resolver);
+
+        await Assert.That(kept.Select(x => x.SessionId).ToArray()).IsEquivalentTo(new[] { "a", "c" });
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/HistoryScopeFilterTests/*"
+```
+
+Expected: tests FAIL — `HistoryScopeFilter` does not exist.
+
+- [ ] **Step 3: Implement the filter**
+
+`src/kapacitor/Commands/HistoryScopeFilter.cs`:
+
+```csharp
+namespace kapacitor.Commands;
+
+/// <summary>
+/// Pure scope filter for the history pipeline. The repo resolver is injected
+/// so unit tests can stub out repository detection; production wires it to
+/// the cwd-extractor + RepositoryDetection.DetectRepositoryAsync.
+/// </summary>
+public static class HistoryScopeFilter {
+    public static async Task<List<(string SessionId, string FilePath, string EncodedCwd)>> Apply(
+        IReadOnlyList<(string SessionId, string FilePath, string EncodedCwd)>                       transcripts,
+        ImportScope                                                                                  scope,
+        Func<(string SessionId, string FilePath, string EncodedCwd), CancellationToken,
+             ValueTask<(string? Owner, string? Name)>>                                               resolveRepo,
+        CancellationToken                                                                            ct = default) {
+        if (scope is ImportScope.All) return [..transcripts];
+
+        var kept = new List<(string, string, string)>(transcripts.Count);
+
+        foreach (var t in transcripts) {
+            ct.ThrowIfCancellationRequested();
+            var (owner, name) = await resolveRepo(t, ct);
+
+            var match = (scope, owner, name) switch {
+                (ImportScope.Org o,  not null, _) => string.Equals(owner, o.OrgLogin, StringComparison.OrdinalIgnoreCase),
+                (ImportScope.Repo r, not null, not null) =>
+                    string.Equals(owner, r.Owner, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(name,  r.Name,  StringComparison.OrdinalIgnoreCase),
+                _ => false,
+            };
+
+            if (match) kept.Add(t);
+        }
+
+        return kept;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/HistoryScopeFilterTests/*"
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kapacitor/Commands/HistoryScopeFilter.cs test/kapacitor.Tests.Unit/HistoryScopeFilterTests.cs
+git commit -m "[AI-613] add HistoryScopeFilter (pure scope filter)"
+```
+
+---
+
+## Task 4: Picker helpers + summary formatter (pure)
+
+**Files:**
+- Create: `src/kapacitor/Commands/HistoryScopePrompt.cs`
+- Create: `test/kapacitor.Tests.Unit/HistoryScopePromptTests.cs`
+
+This task builds **only** the pure helpers — `BuildRepoChoices` and `FormatSummary`. The Spectre.Console wrappers come in the next task on top of these.
+
+- [ ] **Step 1: Write the failing tests**
+
+`test/kapacitor.Tests.Unit/HistoryScopePromptTests.cs`:
+
+```csharp
+using kapacitor.Commands;
+
+namespace kapacitor.Tests.Unit;
+
+public class HistoryScopePromptTests {
+    // --- BuildRepoChoices ---
+
+    [Test]
+    public async Task BuildRepoChoices_orders_current_first_then_alphabetical() {
+        var choices = HistoryScopePrompt.BuildRepoChoices(
+            currentRepo: ("EventStore", "kapacitor"),
+            discoveredRepos: [
+                ("EventStore", "kurrentdb"),
+                ("EventStore", "kapacitor"),  // dup with current
+                ("alexeyzimarev", "scratchpad"),
+            ]);
+
+        await Assert.That(choices).IsEquivalentTo(new[] {
+            "EventStore/kapacitor (current)",
+            "alexeyzimarev/scratchpad",
+            "EventStore/kurrentdb",
+        });
+    }
+
+    [Test]
+    public async Task BuildRepoChoices_no_current_repo_just_sorts_alphabetically() {
+        var choices = HistoryScopePrompt.BuildRepoChoices(
+            currentRepo: null,
+            discoveredRepos: [("Z-org", "z"), ("A-org", "a"), ("M-org", "m")]);
+
+        await Assert.That(choices).IsEquivalentTo(new[] {
+            "A-org/a",
+            "M-org/m",
+            "Z-org/z",
+        });
+    }
+
+    [Test]
+    public async Task BuildRepoChoices_deduplicates_discovered_set() {
+        var choices = HistoryScopePrompt.BuildRepoChoices(
+            currentRepo: null,
+            discoveredRepos: [("A", "x"), ("A", "x"), ("A", "y")]);
+
+        await Assert.That(choices).IsEquivalentTo(new[] { "A/x", "A/y" });
+    }
+
+    // --- FormatSummary ---
+
+    [Test]
+    public async Task FormatSummary_All_scope() {
+        var s = HistoryScopePrompt.FormatSummary(
+            scope: new ImportScope.All(),
+            matchedCount: 47,
+            repoSamples: ["EventStore/kapacitor", "EventStore/kurrentdb"],
+            visibilityDescription: "org_public (from profile)");
+
+        await Assert.That(s).Contains("scope:   everything");
+        await Assert.That(s).Contains("matched: 47 sessions");
+        await Assert.That(s).Contains("visibility: org_public (from profile)");
+    }
+
+    [Test]
+    public async Task FormatSummary_Org_includes_org_name() {
+        var s = HistoryScopePrompt.FormatSummary(
+            scope: new ImportScope.Org("EventStore"),
+            matchedCount: 5,
+            repoSamples: ["EventStore/kapacitor"],
+            visibilityDescription: "private (--private)");
+
+        await Assert.That(s).Contains("org repos only (EventStore)");
+        await Assert.That(s).Contains("visibility: private (--private)");
+    }
+
+    [Test]
+    public async Task FormatSummary_Repo_includes_owner_name() {
+        var s = HistoryScopePrompt.FormatSummary(
+            scope: new ImportScope.Repo("EventStore", "kapacitor"),
+            matchedCount: 3,
+            repoSamples: ["EventStore/kapacitor"],
+            visibilityDescription: "org_public (from profile)");
+
+        await Assert.That(s).Contains("repository EventStore/kapacitor");
+    }
+
+    [Test]
+    public async Task FormatSummary_caps_repo_samples_at_5() {
+        var samples = Enumerable.Range(1, 9).Select(i => $"EventStore/r{i}").ToArray();
+        var s = HistoryScopePrompt.FormatSummary(
+            scope: new ImportScope.All(),
+            matchedCount: 50,
+            repoSamples: samples,
+            visibilityDescription: "org_public (from profile)");
+
+        await Assert.That(s).Contains("EventStore/r1");
+        await Assert.That(s).Contains("EventStore/r5");
+        await Assert.That(s).DoesNotContain("EventStore/r6");
+        await Assert.That(s).Contains("+4 more");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/HistoryScopePromptTests/*"
+```
+
+Expected: FAIL — `HistoryScopePrompt` does not exist.
+
+- [ ] **Step 3: Implement the pure helpers**
+
+`src/kapacitor/Commands/HistoryScopePrompt.cs`:
+
+```csharp
+using System.Text;
+
+namespace kapacitor.Commands;
+
+/// <summary>
+/// Spectre.Console-backed pickers for history import scope, plus the pure
+/// helpers that drive their content. Pure helpers are public for unit testing;
+/// Spectre wrappers are added in a separate task.
+/// </summary>
+public static partial class HistoryScopePrompt {
+    /// <summary>
+    /// Build the option strings for the "specific repository" sub-picker.
+    /// The current cwd's repo (if any) is pinned to the top with a "(current)"
+    /// marker; the rest are alphabetized and deduplicated against the current.
+    /// </summary>
+    public static string[] BuildRepoChoices(
+        (string Owner, string Name)?              currentRepo,
+        IReadOnlyList<(string Owner, string Name)> discoveredRepos) {
+        var distinct = discoveredRepos
+            .Select(r => $"{r.Owner}/{r.Name}")
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (currentRepo is { } current) {
+            var currentKey = $"{current.Owner}/{current.Name}";
+            distinct.RemoveAll(s => s.Equals(currentKey, StringComparison.OrdinalIgnoreCase));
+            distinct.Sort(StringComparer.OrdinalIgnoreCase);
+            return [$"{currentKey} (current)", .. distinct];
+        }
+
+        distinct.Sort(StringComparer.OrdinalIgnoreCase);
+        return [.. distinct];
+    }
+
+    /// <summary>
+    /// Build the confirmation summary block printed before the y/N prompt.
+    /// The same text is printed in non-TTY runs (with --yes) so the imported
+    /// scope is recorded in CI logs.
+    /// </summary>
+    public static string FormatSummary(
+        ImportScope            scope,
+        int                    matchedCount,
+        IReadOnlyList<string>  repoSamples,
+        string                 visibilityDescription) {
+        var scopeLabel = scope switch {
+            ImportScope.All      => "everything",
+            ImportScope.Org o    => $"org repos only ({o.OrgLogin})",
+            ImportScope.Repo r   => $"repository {r.Owner}/{r.Name}",
+            _                    => "?"
+        };
+
+        const int sampleLimit = 5;
+        var samples = repoSamples.Take(sampleLimit).ToArray();
+        var more    = repoSamples.Count - samples.Length;
+        var repoLine = samples.Length == 0
+            ? "(none)"
+            : string.Join(", ", samples) + (more > 0 ? $", +{more} more" : "");
+
+        var sb = new StringBuilder();
+        sb.AppendLine("About to import:");
+        sb.AppendLine($"  scope:   {scopeLabel}");
+        sb.AppendLine($"  matched: {matchedCount} session{(matchedCount == 1 ? "" : "s")} across {repoSamples.Count} repo{(repoSamples.Count == 1 ? "" : "s")}");
+        sb.AppendLine($"  repos:   {repoLine}");
+        sb.Append   ($"  visibility: {visibilityDescription}");
+        return sb.ToString();
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/HistoryScopePromptTests/*"
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kapacitor/Commands/HistoryScopePrompt.cs test/kapacitor.Tests.Unit/HistoryScopePromptTests.cs
+git commit -m "[AI-613] add picker/summary pure helpers"
+```
+
+---
+
+## Task 5: Spectre wrappers for picker + confirmation
+
+**Files:**
+- Modify: `src/kapacitor/Commands/HistoryScopePrompt.cs`
+
+This adds the Spectre.Console glue on top of Task 4's pure helpers. No unit tests — Spectre prompts read from `Console.In` and are exercised by the manual smoke test (Task 9).
+
+- [ ] **Step 1: Add the Spectre wrappers (partial class extension)**
+
+Append to `src/kapacitor/Commands/HistoryScopePrompt.cs`:
+
+```csharp
+using Spectre.Console;
+
+namespace kapacitor.Commands;
+
+public static partial class HistoryScopePrompt {
+    /// <summary>
+    /// Run the top-level scope picker. Returns the resolved scope, or null
+    /// when the user picks "specific repository" but the sub-picker has no
+    /// options (no current repo + no detected repos).
+    /// </summary>
+    public static ImportScope? RunPicker(
+        string                                     activeProfile,
+        (string Owner, string Name)?               currentRepo,
+        IReadOnlyList<(string Owner, string Name)> discoveredRepos) {
+        var choice = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("What would you like to import?")
+                .AddChoices("all", "org", "repo")
+                .UseConverter(c => c switch {
+                    "all"  => "Everything",
+                    "org"  => $"Org repos only ({activeProfile})",
+                    "repo" => "Specific repository",
+                    _      => c,
+                }));
+
+        if (choice == "all")  return new ImportScope.All();
+        if (choice == "org") {
+            if (string.IsNullOrEmpty(activeProfile) || activeProfile == "default") {
+                AnsiConsole.MarkupLine("[red]Active profile has no org. Run `kapacitor setup`.[/]");
+                return null;
+            }
+            return new ImportScope.Org(activeProfile);
+        }
+
+        var repoChoices = BuildRepoChoices(currentRepo, discoveredRepos);
+        if (repoChoices.Length == 0) {
+            AnsiConsole.MarkupLine("[red]No repositories detected in discovered sessions.[/]");
+            return null;
+        }
+
+        var picked = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("Which repository?")
+                .PageSize(15)
+                .AddChoices(repoChoices));
+
+        // Strip the trailing " (current)" marker before splitting on '/'.
+        var clean = picked.EndsWith(" (current)") ? picked[..^" (current)".Length] : picked;
+        var parts = clean.Split('/');
+        return new ImportScope.Repo(parts[0], parts[1]);
+    }
+
+    /// <summary>
+    /// Print the summary block to stderr (visible even when stdout is
+    /// redirected) and prompt y/N if <paramref name="skip"/> is false.
+    /// Returns true to proceed with the import.
+    /// </summary>
+    public static bool PromptConfirm(
+        ImportScope            scope,
+        int                    matchedCount,
+        IReadOnlyList<string>  repoSamples,
+        string                 visibilityDescription,
+        bool                   skip) {
+        var summary = FormatSummary(scope, matchedCount, repoSamples, visibilityDescription);
+        Console.Error.WriteLine(summary);
+
+        if (skip) return true;
+
+        return AnsiConsole.Prompt(
+            new ConfirmationPrompt("Continue?") { DefaultValue = false });
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build src/kapacitor/kapacitor.csproj
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Re-run the unit tests for the file to confirm nothing broke**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/HistoryScopePromptTests/*"
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/kapacitor/Commands/HistoryScopePrompt.cs
+git commit -m "[AI-613] add Spectre picker + confirmation wrappers"
+```
+
+---
+
+## Task 6: Integrate scope resolution + filter + confirmation into `HandleHistory`
+
+**Files:**
+- Modify: `src/kapacitor/Commands/HistoryCommand.cs`
+
+This wires the new pure helpers into the pipeline. Three insertion points:
+- **Before classify**: resolve scope (picker if needed), apply filter.
+- **Before classify**: print confirmation; bail if user says no.
+- **Track imported session ids** for the post-import visibility loop (Task 7 uses them).
+
+- [ ] **Step 1: Extend the `HandleHistory` signature**
+
+Modify `src/kapacitor/Commands/HistoryCommand.cs` around line 179. Change:
+
+```csharp
+public static async Task<int> HandleHistory(
+        string     baseUrl,
+        string?    filterCwd,
+        string?    filterSession    = null,
+        int        minLines         = 15,
+        bool       generateSummaries = false,
+        bool       codex            = false,
+        DateOnly?  since            = null
+    ) {
+```
+
+to:
+
+```csharp
+public static async Task<int> HandleHistory(
+        string       baseUrl,
+        string?      filterCwd,
+        string?      filterSession     = null,
+        int          minLines          = 15,
+        bool         generateSummaries = false,
+        bool         codex             = false,
+        DateOnly?    since             = null,
+        ImportScope? scope             = null,
+        bool         skipConfirmation  = false,
+        bool         forcePrivate      = false,
+        string       activeProfile     = "default",
+        (string Owner, string Name)? currentRepo = null
+    ) {
+```
+
+- [ ] **Step 2: Insert the scope step after pre-filters and before classify**
+
+In `HandleHistory`, locate the block ending with:
+
+```csharp
+display.Line($"Found {transcriptFiles.Count} {vendor} session{...");
+```
+
+(around line 247). Immediately after that line, insert:
+
+```csharp
+// --- Scope: pre-detect repos for the filter and (if needed) the picker ---
+async ValueTask<(string? Owner, string? Name)> ResolveRepoAsync(
+    (string SessionId, string FilePath, string EncodedCwd) t,
+    CancellationToken                                       ctInner) {
+    var cwd = ExtractCwdFromTranscript(t.FilePath, codex);
+    if (cwd is null) return (null, null);
+    var repo = await RepositoryDetection.DetectRepositoryAsync(cwd);
+    return (repo?.Owner, repo?.RepoName);
+}
+
+// If we landed without a resolved scope, run the picker. The picker needs
+// the set of distinct repos to drive its "specific repository" sub-picker,
+// so detect ahead of time and reuse the results in the filter pass.
+if (scope is null) {
+    var resolved = new Dictionary<string, (string Owner, string Name)?>(StringComparer.Ordinal);
+    foreach (var t in transcriptFiles) {
+        var (o, n) = await ResolveRepoAsync(t, CancellationToken.None);
+        resolved[t.SessionId] = (o is not null && n is not null) ? (o, n) : null;
+    }
+    var distinct = resolved.Values
+        .Where(v => v is not null)
+        .Select(v => v!.Value)
+        .ToList();
+
+    scope = HistoryScopePrompt.RunPicker(activeProfile, currentRepo, distinct);
+    if (scope is null) {
+        await Console.Error.WriteLineAsync("Scope selection cancelled.");
+        return 1;
+    }
+
+    // Reuse the cached lookup in the filter pass below.
+    transcriptFiles = await HistoryScopeFilter.Apply(
+        transcriptFiles,
+        scope,
+        (t, _) => new ValueTask<(string?, string?)>(
+            resolved.TryGetValue(t.SessionId, out var v) && v is { } x ? (x.Owner, x.Name) : (null, null)));
+} else {
+    transcriptFiles = await HistoryScopeFilter.Apply(transcriptFiles, scope, ResolveRepoAsync);
+}
+
+if (transcriptFiles.Count == 0) {
+    display.Line("No sessions match the selected scope.");
+    return 0;
+}
+
+// --- Confirmation ---
+var sampleRepos = new List<string>();
+{
+    var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    foreach (var t in transcriptFiles) {
+        var (o, n) = await ResolveRepoAsync(t, CancellationToken.None);
+        if (o is null || n is null) continue;
+        if (seen.Add($"{o}/{n}")) sampleRepos.Add($"{o}/{n}");
+    }
+}
+
+var visibilityDesc = forcePrivate
+    ? "private (--private)"
+    : $"{(await AppConfig.Load())?.DefaultVisibility ?? "org_public"} (from profile)";
+
+if (!HistoryScopePrompt.PromptConfirm(
+        scope, transcriptFiles.Count, sampleRepos, visibilityDesc, skipConfirmation)) {
+    await Console.Error.WriteLineAsync("Import cancelled.");
+    return 0;
+}
+```
+
+- [ ] **Step 3: Track imported session ids for the --private loop**
+
+Below the existing `OnSessionEnded` handler (search for `OnSessionEnded = (_, c, outcome, lines) =>`), add a `ConcurrentBag<string>` for imported ids and append to it from the handler:
+
+Find this block (around line 384):
+
+```csharp
+            OnSessionEnded = (_, c, outcome, lines) => {
+                var verb = outcome == SessionImportOutcome.Resumed
+                    ? $"resuming from line {c.ResumeFromLine}"
+                    : "new";
+
+                display.Line(
+                    $"Loading {c.SessionId}... {lines} lines [{verb}]",
+                    $"[green]✓[/] Loading [cyan]{Markup.Escape(c.SessionId)}[/]... {lines} lines [{verb}]"
+                );
+            },
+```
+
+Just above the `var events = new ChainWorkerEvents { ... }` declaration, add:
+
+```csharp
+var importedSessionIds = new System.Collections.Concurrent.ConcurrentBag<string>();
+```
+
+Then in **both** `OnSessionEnded` handlers (the non-TTY one above and the TTY-wrapped one in the Progress block below), add `importedSessionIds.Add(c.SessionId);` as the first line of the lambda. For the TTY-wrapped handler (which uses `_` for the classification), change the parameter to a name (e.g. `c`) and add the line there too.
+
+Concretely, change the non-TTY handler to:
+
+```csharp
+            OnSessionEnded = (_, c, outcome, lines) => {
+                importedSessionIds.Add(c.SessionId);
+                var verb = outcome == SessionImportOutcome.Resumed
+                    ? $"resuming from line {c.ResumeFromLine}"
+                    : "new";
+
+                display.Line(
+                    $"Loading {c.SessionId}... {lines} lines [{verb}]",
+                    $"[green]✓[/] Loading [cyan]{Markup.Escape(c.SessionId)}[/]... {lines} lines [{verb}]"
+                );
+            },
+```
+
+And the TTY-wrapped handler (currently using `(slot, _, _, _) => { ... bar.Increment(1); slots[slot].IsIndeterminate = false; }`) to:
+
+```csharp
+                                OnSessionEnded = (slot, c, _, _) => {
+                                    importedSessionIds.Add(c.SessionId);
+                                    bar.Increment(1);
+                                    slots[slot].IsIndeterminate = false;
+                                },
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+dotnet build src/kapacitor/kapacitor.csproj
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 5: Re-run all existing history unit tests to confirm no regression**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj -- --treenode-filter "/*/*/History*/*"
+```
+
+Expected: all PASS. (Some tests already exercise `HandleHistory`'s internals — none should fail because the only new parameters are optional.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/kapacitor/Commands/HistoryCommand.cs
+git commit -m "[AI-613] wire scope resolution + confirmation into HandleHistory"
+```
+
+---
+
+## Task 7: `--private` post-import visibility loop
+
+**Files:**
+- Modify: `src/kapacitor/Commands/HistoryCommand.cs`
+- Create: `test/kapacitor.Tests.Integration/HistoryPrivateImportTests.cs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+`test/kapacitor.Tests.Integration/HistoryPrivateImportTests.cs`:
+
+```csharp
+using kapacitor.Commands;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace kapacitor.Tests.Integration;
+
+public class HistoryPrivateImportTests : IDisposable {
+    readonly WireMockServer _server  = WireMockServer.Start();
+    readonly string         _tempDir = Directory.CreateTempSubdirectory("kapacitor-private-test").FullName;
+
+    public void Dispose() {
+        _server.Stop();
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Test]
+    public async Task SetVisibilityNoneForAll_calls_PUT_for_each_session_id() {
+        _server.Given(Request.Create().WithPath("/api/sessions/*/visibility").UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        using var client = new HttpClient();
+
+        await HistoryCommand.SetVisibilityNoneForAll(
+            client,
+            _server.Url!,
+            ["sess1", "sess2", "sess3"]);
+
+        var calls = _server.LogEntries
+            .Where(e => e.RequestMessage.Method == "PUT")
+            .Select(e => e.RequestMessage.Path)
+            .OrderBy(p => p)
+            .ToArray();
+
+        await Assert.That(calls).IsEquivalentTo(new[] {
+            "/api/sessions/sess1/visibility",
+            "/api/sessions/sess2/visibility",
+            "/api/sessions/sess3/visibility",
+        });
+    }
+
+    [Test]
+    public async Task SetVisibilityNoneForAll_continues_on_per_session_failure() {
+        _server.Given(Request.Create().WithPath("/api/sessions/sess2/visibility").UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(500));
+        _server.Given(Request.Create().WithPath("/api/sessions/sess*/visibility").UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        using var client = new HttpClient();
+
+        // Should not throw even though sess2 returns 500.
+        await HistoryCommand.SetVisibilityNoneForAll(
+            client,
+            _server.Url!,
+            ["sess1", "sess2", "sess3"]);
+
+        var attempted = _server.LogEntries
+            .Where(e => e.RequestMessage.Method == "PUT")
+            .Count();
+
+        await Assert.That(attempted).IsEqualTo(3);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Integration/kapacitor.Tests.Integration.csproj -- --treenode-filter "/*/*/HistoryPrivateImportTests/*"
+```
+
+Expected: FAIL — `SetVisibilityNoneForAll` does not exist.
+
+- [ ] **Step 3: Add the helper and call it post-import**
+
+In `src/kapacitor/Commands/HistoryCommand.cs`, add this internal helper near the end of the class (just before the closing brace):
+
+```csharp
+    /// <summary>
+    /// PUT visibility=none for every imported session id. Failures are logged
+    /// inline (one line per session) but never throw — the import already
+    /// succeeded; users can re-run `kapacitor hide` for any that failed.
+    /// </summary>
+    internal static async Task SetVisibilityNoneForAll(
+        HttpClient            httpClient,
+        string                baseUrl,
+        IReadOnlyList<string> sessionIds) {
+        foreach (var sessionId in sessionIds) {
+            var payload = new System.Text.Json.Nodes.JsonObject { ["visibility"] = "none" };
+            using var content = new StringContent(payload.ToJsonString(), System.Text.Encoding.UTF8, "application/json");
+            try {
+                using var resp = await httpClient.PutWithRetryAsync(
+                    $"{baseUrl}/api/sessions/{sessionId}/visibility", content);
+                if (!resp.IsSuccessStatusCode) {
+                    await Console.Error.WriteLineAsync(
+                        $"  ! visibility=none failed for {sessionId}: HTTP {(int)resp.StatusCode}");
+                }
+            } catch (Exception ex) {
+                await Console.Error.WriteLineAsync(
+                    $"  ! visibility=none failed for {sessionId}: {ex.Message}");
+            }
+        }
+    }
+```
+
+Then call it after the import loop completes. In `HandleHistory`, just before the `// --- Background phase ---` comment (around line 552), insert:
+
+```csharp
+// --- --private: mark all imported sessions owner-only ---
+if (forcePrivate && !importedSessionIds.IsEmpty) {
+    display.BeginPhase("Marking imported sessions private");
+    await SetVisibilityNoneForAll(httpClient, baseUrl, [.. importedSessionIds]);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Integration/kapacitor.Tests.Integration.csproj -- --treenode-filter "/*/*/HistoryPrivateImportTests/*"
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kapacitor/Commands/HistoryCommand.cs test/kapacitor.Tests.Integration/HistoryPrivateImportTests.cs
+git commit -m "[AI-613] post-import --private visibility loop"
+```
+
+---
+
+## Task 8: Wire argument parser in Program.cs
+
+**Files:**
+- Modify: `src/kapacitor/Program.cs`
+
+- [ ] **Step 1: Update the `case "history"` block**
+
+Locate the `case "history"` block (around line 382). Replace the entire block's body with the version below — note the new flag parsing, current-repo resolution, and the updated `HandleHistory` call.
+
+```csharp
+    case "history": {
+        string?   filterCwd     = null;
+        string?   filterSession = null;
+        var       minLines      = 15;
+        DateOnly? since         = null;
+        var       codex         = args.Contains("--codex");
+        var       cwdArgIdx     = Array.IndexOf(args, "--cwd");
+
+        if (cwdArgIdx >= 0 && cwdArgIdx + 1 < args.Length) {
+            filterCwd = args[cwdArgIdx + 1];
+        }
+
+        var sessionArgIdx = Array.IndexOf(args, "--session");
+
+        if (sessionArgIdx >= 0 && sessionArgIdx + 1 < args.Length) {
+            filterSession = args[sessionArgIdx + 1];
+        }
+
+        var minLinesIdx = Array.IndexOf(args, "--min-lines");
+
+        if (minLinesIdx >= 0 && minLinesIdx + 1 < args.Length && int.TryParse(args[minLinesIdx + 1], out var parsed)) {
+            minLines = parsed;
+        }
+
+        var sinceIdx = Array.IndexOf(args, "--since");
+
+        if (sinceIdx >= 0 && sinceIdx + 1 < args.Length) {
+            if (!DateOnly.TryParseExact(args[sinceIdx + 1], "yyyy-MM-dd", out var parsedSince)) {
+                Console.Error.WriteLine("--since must be YYYY-MM-DD");
+
+                return 1;
+            }
+
+            since = parsedSince;
+        }
+
+        var generateSummaries = args.Contains("--generate-summaries");
+
+        // --- Scope resolution (AI-613) ---
+        var profileConfig = await AppConfig.LoadProfileConfig();
+        var activeProfile = string.IsNullOrEmpty(profileConfig.ActiveProfile) ? "default" : profileConfig.ActiveProfile;
+
+        var currentRepoDetected = await RepositoryDetection.DetectRepositoryAsync(Environment.CurrentDirectory);
+        (string Owner, string Name)? currentRepo = currentRepoDetected is { Owner: { } o, RepoName: { } n }
+            ? (o, n)
+            : null;
+
+        var flags = ImportScopeArgs.ParseFlags(args);
+        var resolveResult = ImportScopeArgs.Resolve(new(
+            Flags:         flags,
+            ActiveProfile: activeProfile,
+            IsInteractive: !Console.IsInputRedirected && !Console.IsOutputRedirected,
+            CurrentRepo:   currentRepo));
+
+        if (resolveResult.Error is not null) {
+            Console.Error.WriteLine(resolveResult.Error);
+            return 1;
+        }
+
+        return await HistoryCommand.HandleHistory(
+            baseUrl!,
+            filterCwd,
+            filterSession,
+            minLines,
+            generateSummaries,
+            codex,
+            since,
+            scope:            resolveResult.Scope,     // null => HandleHistory runs picker
+            skipConfirmation: resolveResult.Yes,
+            forcePrivate:     resolveResult.Private,
+            activeProfile:    activeProfile,
+            currentRepo:      currentRepo);
+    }
+```
+
+Add the using at the top of the file if not already present:
+
+```csharp
+using kapacitor.Commands;
+```
+
+(Check first; the file already references several `kapacitor.Commands` types — the using is likely already imported.)
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build src/kapacitor/kapacitor.csproj
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Verify no AOT warnings on publish**
+
+```bash
+dotnet publish src/kapacitor/kapacitor.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}' | head
+```
+
+Expected: no output (no AOT trim/dynamic-code warnings).
+
+- [ ] **Step 4: Run the full unit test suite**
+
+```bash
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kapacitor/Program.cs
+git commit -m "[AI-613] wire history scope flags in Program.cs"
+```
+
+---
+
+## Task 9: Setup tip, help text, manual smoke test
+
+**Files:**
+- Modify: `src/kapacitor/Commands/SetupCommand.cs`
+- Modify: `src/Kapacitor.Core/Resources/help-history.txt`
+
+- [ ] **Step 1: Append the tip to setup**
+
+In `src/kapacitor/Commands/SetupCommand.cs`, find the line:
+
+```csharp
+        AnsiConsole.MarkupLine("\n[dim]Optional:[/] start the agent daemon with [cyan]kapacitor agent start -d[/]");
+```
+
+Add a second tip line directly after it:
+
+```csharp
+        AnsiConsole.MarkupLine("[dim]Optional:[/] import past sessions with [cyan]kapacitor history --org[/]");
+```
+
+- [ ] **Step 2: Update the help text**
+
+Replace `src/Kapacitor.Core/Resources/help-history.txt` with:
+
+```
+kapacitor history — Import local transcript history to server
+
+Usage: kapacitor history [scope] [options]
+
+Scope (one of, required for non-interactive use):
+  --all                   Import every discovered session
+  --org                   Import only sessions from your active profile's org
+  --repo <owner/name>     Import only sessions from a specific repo
+  --repo .                Import only sessions from the current cwd's repo
+
+Without a scope flag on an interactive terminal, an interactive picker is shown.
+
+Options:
+  --yes, -y               Skip the confirmation prompt
+  --private               Mark every imported session as Only Visible to You
+  --codex                 Import Codex rollouts from ~/.codex/sessions instead of Claude
+  --since YYYY-MM-DD      Only import sessions started on or after this date
+  --cwd <path>            Filter by working directory (composes with scope)
+  --session <id>          Import a specific session only (composes with scope)
+  --min-lines <n>         Skip sessions shorter than n lines (default: 15)
+  --generate-summaries    Also generate per-session what's-done summaries
+```
+
+- [ ] **Step 3: Build and run the full test suite**
+
+```bash
+dotnet build src/kapacitor/kapacitor.csproj
+dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj
+dotnet run --project test/kapacitor.Tests.Integration/kapacitor.Tests.Integration.csproj
+```
+
+Expected: 0 build errors; all tests PASS.
+
+- [ ] **Step 4: AOT publish check**
+
+```bash
+dotnet publish src/kapacitor/kapacitor.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
+```
+
+Expected: empty output.
+
+- [ ] **Step 5: Manual smoke test**
+
+Run each of these against a real kapacitor server (or one started locally) and verify the noted behaviour:
+
+1. **Picker path:**
+   ```bash
+   kapacitor history
+   ```
+   - Expect: three-option picker (`Everything` / `Org repos only (<your profile>)` / `Specific repository`).
+   - Pick "Specific repository" — verify the sub-picker lists distinct repos and pins the current cwd's repo at the top.
+   - Verify the confirmation summary prints and `n` cancels (exit 0, no imports).
+
+2. **`--all` happy path:**
+   ```bash
+   kapacitor history --all --yes
+   ```
+   - Expect: no picker, summary block, immediate proceed, normal import.
+
+3. **`--org` missing profile guard:**
+   ```bash
+   KAPACITOR_PROFILE=default kapacitor history --org
+   ```
+   - Expect: error message mentioning "tenant-bound profile", exit 1.
+
+4. **`--repo .` happy path** (run inside a git repo):
+   ```bash
+   kapacitor history --repo . --yes
+   ```
+   - Expect: summary names the current repo, only its sessions match.
+
+5. **`--repo .` outside a git repo:**
+   ```bash
+   cd /tmp && kapacitor history --repo .
+   ```
+   - Expect: error "not a git repo with an origin remote", exit 1.
+
+6. **`--private`:**
+   ```bash
+   kapacitor history --repo EventStore/kapacitor --yes --private
+   ```
+   - Expect: summary shows `visibility: private (--private)`; after import, every imported session shows `visibility: none` on the server.
+
+7. **Non-TTY without flag:**
+   ```bash
+   kapacitor history < /dev/null
+   ```
+   - Expect: error "--all, --org, or --repo <owner/name> is required for non-interactive use", exit 1.
+
+8. **Non-TTY with flag but no `--yes`:**
+   ```bash
+   kapacitor history --all < /dev/null
+   ```
+   - Expect: error "--yes is required for non-interactive use", exit 1.
+
+9. **Mutual exclusivity:**
+   ```bash
+   kapacitor history --all --org --yes
+   ```
+   - Expect: error "mutually exclusive", exit 1.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/kapacitor/Commands/SetupCommand.cs src/Kapacitor.Core/Resources/help-history.txt
+git commit -m "[AI-613] setup tip + history help text"
+```
+
+- [ ] **Step 7: Open the PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --title "[AI-613] history: explicit scope selection + --private" --body "$(cat <<'EOF'
+## Summary
+- Adds `--all` / `--org` / `--repo <owner/name>` / `--repo .` scope flags to `kapacitor history`, plus an interactive picker when no flag is passed on a TTY.
+- Always prints a confirmation summary before classify/import; `--yes` skips the prompt.
+- Adds `--private` to post-import PUT `visibility=none` for every imported session.
+- Non-interactive use without a scope flag now errors (exit 1) to prevent accidental uploads — release-note this.
+
+## Test plan
+- [x] Unit: `ImportScopeArgsTests`, `HistoryScopeFilterTests`, `HistoryScopePromptTests`
+- [x] Integration: `HistoryPrivateImportTests` (WireMock for visibility PUT)
+- [x] AOT publish: no IL2026/IL3050 warnings
+- [x] Manual smoke: picker, `--all --yes`, `--org` guard, `--repo .`, `--private`, non-TTY no-flag error
+
+Closes [AI-613](https://linear.app/kurrent/issue/AI-613).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+Spec coverage check (compared with `2026-05-13-ai-613-history-import-scope-design.md`):
+
+- Scope flags `--all`/`--org`/`--repo <owner/name>`/`--repo .` — Tasks 2, 8.
+- Mutual exclusivity — Task 2.
+- Interactive picker (main + sub-picker, current-repo pinned) — Tasks 4, 5, 6.
+- Confirmation summary + y/N — Tasks 4, 5, 6.
+- `--yes` skip — Tasks 2, 5, 6.
+- `--private` post-import PUT visibility=none — Task 7.
+- Non-TTY no-flag error — Task 2.
+- Non-TTY flag-without-`--yes` error — Task 2.
+- `--repo .` errors when cwd has no repo — Task 2.
+- `--org` errors when profile is `default` — Task 2.
+- Compose with `--cwd`/`--session`/`--min-lines`/`--since` + `excluded_repos` — unchanged in the pipeline; verified in Task 6 by re-running existing tests.
+- Setup tip + help text — Task 9.
+- AOT publish check — Tasks 8, 9.
+
+No placeholders, no TODOs, no "similar to Task N" hand-waves. Type names consistent across tasks (`ImportScope.All`, `ImportScope.Org(string)`, `ImportScope.Repo(string, string)`; `ImportScopeArgs.ParsedFlags`, `ResolveInput`, `ResolveResult`).

--- a/docs/superpowers/specs/2026-05-13-ai-613-history-import-scope-design.md
+++ b/docs/superpowers/specs/2026-05-13-ai-613-history-import-scope-design.md
@@ -1,0 +1,215 @@
+# AI-613 — History import scope: explicit opt-in
+
+## Problem
+
+`kapacitor history` discovers every transcript under `~/.claude/projects` (and Codex sessions) and uploads them by default. The only filter is `excluded_repos` (a denylist with a per-repo y/N prompt on TTY, auto-skip on non-TTY). Users with personal projects mixed in with work repos can accidentally leak private sessions on the first import. The CLI already warns about this, but the warning is easy to miss and the consequences (sensitive content on a shared server) are hard to undo.
+
+AI-613 wants the default to flip: the user explicitly chooses what to import, and gets a confirmation prompt before anything moves to the server.
+
+## Goal
+
+Make `kapacitor history` require an explicit scope choice — either via a flag or an interactive picker — and always show a confirmation summary before any session is sent.
+
+## Out of scope
+
+- Server-side visibility-on-private-repo auto-flagging. AI-613's second bullet ("mark as Only Visible to You") is honoured here through the existing `default_visibility` config plus a new `--private` flag, not through automatic per-repo inference. Keeping defaults consistent across modes avoids surprising users who have already configured `default_visibility`.
+- Identity verification via `claude auth status` / `codex auth`. Considered and rejected: Claude reports a Claude.ai identity (email, org name), not a GitHub identity that maps to repo ownership, and Codex doesn't expose an equivalent. Active profile already names the GitHub org.
+
+## Design
+
+### Scope flags
+
+History gains four mutually-exclusive scope flags. Exactly one must resolve before classify/import runs:
+
+| Flag | Behaviour |
+|------|-----------|
+| `--all` | Every discovered session. |
+| `--org` | Only sessions whose detected repo `owner` matches the active profile's GitHub org (i.e. `ProfileConfig.ActiveProfile`). |
+| `--repo <owner/name>` | Only sessions whose detected repo matches that exact `owner/name`. |
+| `--repo .` (alias `--repo current`) | Only sessions whose detected repo matches the repo at the current working directory (resolved via `RepositoryDetection.DetectRepositoryAsync`). |
+
+Sessions without a detectable repo (cwd outside a git working tree, no `origin` remote, parse failure) are only included under `--all`.
+
+### Plus
+
+- `--yes` / `-y` — skip the confirmation prompt.
+- `--private` — after import, PUT `visibility=none` for every session imported by this run (same endpoint as `kapacitor hide`). Overrides `default_visibility`.
+
+### Interactive picker
+
+When stdin and stdout are both interactive and no scope flag is passed, present a Spectre `SelectionPrompt`:
+
+1. **Everything** — every discovered session.
+2. **Org repos only (`<ActiveProfile>`)** — display the resolved org name.
+3. **Specific repository** — opens a sub-picker.
+
+The sub-picker is built from:
+- The current cwd's repo (if any), marked `(current)` and pinned to the top.
+- The union of distinct `owner/name` values detected across discovered transcripts (alphabetised after the current entry).
+
+### Confirmation step
+
+Once scope is resolved (flag or picker), always print a summary block and prompt y/N — unless `--yes` is set:
+
+```
+About to import:
+  scope:   org repos only (EventStore)
+  matched: 47 sessions across 6 repos
+  repos:   EventStore/kapacitor, EventStore/kurrentdb, …
+  visibility: org_public (from profile)        # or 'private (--private)'
+Continue? [y/N]
+```
+
+`--yes` prints the same summary, skips the prompt.
+
+### Non-interactive handling
+
+| TTY? | Scope flag? | `--yes`? | Behaviour |
+|------|-------------|----------|-----------|
+| yes | no | — | Show picker, then confirmation prompt |
+| yes | yes | no | Show confirmation prompt |
+| yes | yes | yes | Print summary, proceed |
+| no | yes | yes | Print summary, proceed |
+| no | yes | no | **Error**: `--yes is required for non-interactive use` |
+| no | no | — | **Error**: `--all, --org, or --repo <owner/name> is required for non-interactive use` |
+
+Error exit code is 1. Erring rather than defaulting to a safe scope is intentional: AI-613 is about *eliminating* accidental imports, and a default scope in CI/scripts can drift over time.
+
+### Composition with existing filters
+
+These continue to work unchanged and are applied **before** scope filtering:
+
+- `--cwd <path>` — path filter at discovery.
+- `--session <id>` — exact id filter; bypasses the picker but still subject to confirmation (so the user sees what's about to happen).
+- `--min-lines <n>` — transcript length floor.
+- `--since YYYY-MM-DD` — date filter.
+
+`excluded_repos` (profile config) continues to apply as an **additional denylist** after scope filtering. Rationale: it composes well — a user with `--org` who wants to skip one specific org repo can still do so via `excluded_repos`, and profile-scoped denylists already work today.
+
+### Resolving "your org"
+
+`ProfileConfig.ActiveProfile` is the org's GitHub login (set by `TenantDiscovery.MergeProfiles` at setup time). `--org` uses it directly.
+
+If the active profile is `"default"` (no tenant discovery has run), `--org` errors:
+
+```
+--org requires a tenant-bound profile. Run `kapacitor setup` first,
+or use --all / --repo <owner/name>.
+```
+
+### Visibility behaviour
+
+- Default path: no change. `default_visibility` from the active profile flows through `session-start` hooks today and applies to imported sessions identically.
+- `--private` path: after the import phase completes (and before background title/summary work), iterate over the successfully-imported `SessionId` list and `PUT /api/sessions/{id}/visibility {"visibility":"none"}` for each. Reuse the same retry/auth client used by `Program.cs`'s `hide` case.
+- Failures here are logged inline (one line per session) but do not fail the run — the import already succeeded and the user can re-run `kapacitor hide` if needed.
+
+### Setup-time touchpoint
+
+`kapacitor setup` does **not** change its step list. AI-613 mentions "as part of setup OR history" — handling it in `history` is sufficient because (a) setup runs once but history runs repeatedly, and (b) a setup-time choice can't reflect repos discovered after the fact. We add a one-line nudge at the end of setup:
+
+```
+Tip: run `kapacitor history --org` to import sessions from your org's repos.
+```
+
+## Implementation outline
+
+### File changes
+
+- `src/kapacitor/Program.cs` — extend the `history` argument parser; add `--all`, `--org`, `--repo <value>`, `--yes`/`-y`, `--private`. Validate mutual exclusivity. Pass through to `HandleHistory`.
+- `src/kapacitor/Commands/HistoryCommand.cs` — extend `HandleHistory` signature with `ImportScope scope`, `bool yes`, `bool forcePrivate`. Insert two new pipeline steps after discovery + pre-filters: (1) scope resolution (picker or flag), (2) confirmation. Wire a post-import visibility loop for `--private`.
+- `src/kapacitor/Commands/HistoryScopePrompt.cs` (new) — Spectre picker for scope selection and the "specific repository" sub-picker.
+- `src/kapacitor/Commands/SetupCommand.cs` — append the one-line tip after setup completes.
+- `test/kapacitor.Tests.Unit/Commands/HistoryScopeTests.cs` (new) — pure-function tests for the scope filter and flag validation.
+- `test/kapacitor.Tests.Integration/HistoryImportPrivateTests.cs` (new) — WireMock test exercising the `--private` post-import visibility loop.
+
+### New types
+
+```csharp
+internal abstract record ImportScope {
+    public sealed record All  : ImportScope;
+    public sealed record Org  (string OrgLogin) : ImportScope;
+    public sealed record Repo (string Owner, string Name) : ImportScope;
+}
+```
+
+`ImportScope.Org`'s `OrgLogin` is resolved once at flag-parse time from `ProfileConfig.ActiveProfile`.
+
+### Scope filter (pure function)
+
+```csharp
+internal static List<(string SessionId, string FilePath, string EncodedCwd)>
+    ApplyScopeFilter(
+        List<(string SessionId, string FilePath, string EncodedCwd)> transcripts,
+        ImportScope scope,
+        Func<string, Task<(string? Owner, string? Name)>> resolveRepo)
+```
+
+Returns the filtered list. `resolveRepo` is injected so unit tests can stub it; production wires it to `RepositoryDetection.DetectRepositoryAsync` over the transcript's cwd.
+
+### Argument parsing
+
+Mutual exclusivity check runs in `Program.cs` before `HandleHistory` is called. Order of resolution:
+
+1. Parse `--all`, `--org`, `--repo <value>`. Count true/non-null among the three; if >1 error.
+2. If 0 and stdin is a TTY → leave `scope = null`, picker runs in `HandleHistory`.
+3. If 0 and stdin is not a TTY → error.
+4. If `--repo` value is `.` or `current` → resolve cwd's repo synchronously; if no repo, error with "cwd is not a git repo with an origin remote".
+5. If `--org` → check `ProfileConfig.ActiveProfile != "default"`; error otherwise.
+
+### Confirmation
+
+Shared `PromptConfirm(scope, count, repoSamples, visibility)` writes the summary to stderr (so stdout redirection doesn't hide it), then reads from stdin if `--yes` is not set.
+
+### `--private` post-import
+
+After `ImportChainsAsync` returns:
+
+```csharp
+if (forcePrivate) {
+    foreach (var sessionId in importedSessionIds) {
+        var payload = new JsonObject { ["visibility"] = "none" };
+        await httpClient.PutWithRetryAsync(
+            $"{baseUrl}/api/sessions/{sessionId}/visibility",
+            new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json"));
+    }
+}
+```
+
+Failures are caught per-session and logged, never thrown.
+
+## Testing
+
+### Unit
+
+- `ApplyScopeFilter` exhaustive cases:
+  - `All` includes everything (including sessions without detectable repo).
+  - `Org("EventStore")` includes EventStore-owned, excludes others.
+  - `Repo("EventStore", "kapacitor")` includes exact match only.
+  - `Org` excludes sessions where `resolveRepo` returns `(null, null)`.
+- Flag-parse mutual exclusivity (every conflicting pair errors).
+- `--repo .` with cwd outside a git repo errors with the expected message.
+- `--org` with `ActiveProfile == "default"` errors.
+
+### Integration
+
+- WireMock fixture: 3 imported sessions + `PUT /api/sessions/{id}/visibility` returns 200 for each. Verify the loop posts exactly the right ids with the right body.
+- WireMock fixture: visibility PUT returns 500 for one session — run still completes with exit 0, the failure is logged.
+
+### Manual smoke
+
+- Run `kapacitor history` in a directory containing both `EventStore/kapacitor` sessions and personal sessions; pick "Org repos only", verify only EventStore sessions appear in the matched list.
+- Run `kapacitor history --repo . --yes --private` inside `EventStore/kapacitor`; verify only this repo's sessions import and all show `visibility: none` on the server.
+- Run `kapacitor history --org` in CI (no TTY, no `--yes`) → expect error and exit code 1.
+
+## Migration / compatibility
+
+- Existing callers that script `kapacitor history` without flags on a TTY will now see the picker. This is a behaviour change but matches the issue's intent.
+- Existing CI/automation calling `kapacitor history` without flags on non-TTY will start erroring. Document this prominently in the release notes; suggest `--all --yes` for the previous behaviour.
+- `excluded_repos` config is preserved.
+- `default_visibility` config is preserved.
+- No config schema changes.
+
+## Open implementation questions
+
+- Confirmation summary's `repos:` line — cap at 5 with `, …+N more` after to avoid wall-of-text for large imports?
+- Should `--private` be the default when `--repo <single>` resolves to a repo outside the active profile's org? Probably no (consistency with rule b), but worth a re-read once the patch is up.

--- a/src/Kapacitor.Core/Resources/help-history.txt
+++ b/src/Kapacitor.Core/Resources/help-history.txt
@@ -1,11 +1,21 @@
 kapacitor history — Import local transcript history to server
 
-Usage: kapacitor history [options]
+Usage: kapacitor history [scope] [options]
+
+Scope (one of, required for non-interactive use):
+  --all                   Import every discovered session
+  --org                   Import only sessions from your active profile's org
+  --repo <owner/name>     Import only sessions from a specific repo
+  --repo .                Import only sessions from the current cwd's repo
+
+Without a scope flag on an interactive terminal, an interactive picker is shown.
 
 Options:
+  --yes, -y               Skip the confirmation prompt
+  --private               Mark every imported session as Only Visible to You
   --codex                 Import Codex rollouts from ~/.codex/sessions instead of Claude
   --since YYYY-MM-DD      Only import sessions started on or after this date
-  --cwd <path>            Filter by working directory
-  --session <id>          Import a specific session only
+  --cwd <path>            Filter by working directory (composes with scope)
+  --session <id>          Import a specific session only (composes with scope)
   --min-lines <n>         Skip sessions shorter than n lines (default: 15)
   --generate-summaries    Also generate per-session what's-done summaries

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -177,13 +177,18 @@ static class HistoryCommand {
         );
 
     public static async Task<int> HandleHistory(
-            string     baseUrl,
-            string?    filterCwd,
-            string?    filterSession    = null,
-            int        minLines         = 15,
-            bool       generateSummaries = false,
-            bool       codex            = false,
-            DateOnly?  since            = null
+            string       baseUrl,
+            string?      filterCwd,
+            string?      filterSession     = null,
+            int          minLines          = 15,
+            bool         generateSummaries = false,
+            bool         codex             = false,
+            DateOnly?    since             = null,
+            ImportScope? scope             = null,
+            bool         skipConfirmation  = false,
+            bool         forcePrivate      = false,
+            string       activeProfile     = "default",
+            (string Owner, string Name)? currentRepo = null
         ) {
         using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
         var       display    = HistoryDisplay.Create();
@@ -245,6 +250,81 @@ static class HistoryCommand {
 
         var projectCount = transcriptFiles.Select(t => t.EncodedCwd).Distinct().Count();
         display.Line($"Found {transcriptFiles.Count} {vendor} session{(transcriptFiles.Count == 1 ? "" : "s")} in {projectCount} project{(projectCount == 1 ? "" : "s")}");
+
+        // --- Scope: pre-detect repos for the filter and (if needed) the picker ---
+        async ValueTask<(string? Owner, string? Name)> ResolveRepoAsync(
+            (string SessionId, string FilePath, string EncodedCwd) t,
+            CancellationToken                                       ctInner) {
+            var cwd = ExtractCwdFromTranscript(t.FilePath, codex);
+            if (cwd is null) return (null, null);
+            var repo = await RepositoryDetection.DetectRepositoryAsync(cwd);
+            return (repo?.Owner, repo?.RepoName);
+        }
+
+        // If we landed without a resolved scope, run the picker. The picker needs
+        // the set of distinct repos to drive its "specific repository" sub-picker,
+        // so detect ahead of time and reuse the results in the filter pass.
+        // Hoist the cache outside the if/else so sampleRepos can reuse it.
+        Dictionary<string, (string Owner, string Name)?>? resolved = null;
+
+        if (scope is null) {
+            resolved = new(StringComparer.Ordinal);
+            foreach (var t in transcriptFiles) {
+                var (o, n) = await ResolveRepoAsync(t, CancellationToken.None);
+                resolved[t.SessionId] = (o is not null && n is not null) ? (o, n) : null;
+            }
+            var distinct = resolved.Values
+                .Where(v => v is not null)
+                .Select(v => v!.Value)
+                .ToList();
+
+            scope = HistoryScopePrompt.RunPicker(activeProfile, currentRepo, distinct);
+            if (scope is null) {
+                await Console.Error.WriteLineAsync("Scope selection cancelled.");
+                return 1;
+            }
+
+            // Reuse the cached lookup in the filter pass below.
+            transcriptFiles = await HistoryScopeFilter.Apply(
+                transcriptFiles,
+                scope,
+                (t, _) => new ValueTask<(string?, string?)>(
+                    resolved.TryGetValue(t.SessionId, out var v) && v is { } x ? (x.Owner, x.Name) : (null, null)));
+        } else {
+            transcriptFiles = await HistoryScopeFilter.Apply(transcriptFiles, scope, ResolveRepoAsync);
+        }
+
+        if (transcriptFiles.Count == 0) {
+            display.Line("No sessions match the selected scope.");
+            return 0;
+        }
+
+        // --- Confirmation ---
+        var sampleRepos = new List<string>();
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var t in transcriptFiles) {
+                string? o;
+                string? n;
+                if (resolved is not null && resolved.TryGetValue(t.SessionId, out var cached)) {
+                    (o, n) = cached is { } x ? (x.Owner, x.Name) : (null, null);
+                } else {
+                    (o, n) = await ResolveRepoAsync(t, CancellationToken.None);
+                }
+                if (o is null || n is null) continue;
+                if (seen.Add($"{o}/{n}")) sampleRepos.Add($"{o}/{n}");
+            }
+        }
+
+        var visibilityDesc = forcePrivate
+            ? "private (--private)"
+            : $"{(await AppConfig.Load())?.DefaultVisibility ?? "org_public"} (from profile)";
+
+        if (!HistoryScopePrompt.PromptConfirm(
+                scope, transcriptFiles.Count, sampleRepos, visibilityDesc, skipConfirmation)) {
+            await Console.Error.WriteLineAsync("Import cancelled.");
+            return 0;
+        }
 
         // --- Classify (parallel probes) ---
         var                         excludedRepos = (await AppConfig.Load())?.ExcludedRepos;
@@ -369,6 +449,7 @@ static class HistoryCommand {
         var       summariesFailed    = 0;
         var       titleFailures      = new System.Collections.Concurrent.ConcurrentBag<(string SessionId, string Reason)>();
         var       summaryFailures    = new System.Collections.Concurrent.ConcurrentBag<(string SessionId, string Reason)>();
+        var       importedSessionIds = new System.Collections.Concurrent.ConcurrentBag<string>();
 
         var events = new ChainWorkerEvents {
             OnSessionStarted  = (_, _) => { },    // non-TTY: session start is silent; TTY overrides below
@@ -382,6 +463,7 @@ static class HistoryCommand {
                 $"[red]✗[/] Skipping [cyan]{Markup.Escape(sid)}[/] [{Markup.Escape(reason)}]"
             ),
             OnSessionEnded = (_, c, outcome, lines) => {
+                importedSessionIds.Add(c.SessionId);
                 var verb = outcome == SessionImportOutcome.Resumed
                     ? $"resuming from line {c.ResumeFromLine}"
                     : "new";
@@ -500,7 +582,8 @@ static class HistoryCommand {
                                         );
                                     }
                                 },
-                                OnSessionEnded = (slot, _, _, _) => {
+                                OnSessionEnded = (slot, c, _, _) => {
+                                    importedSessionIds.Add(c.SessionId);
                                     // Description stays on the just-finished session until
                                     // the next OnSessionStarted swaps it. We only flip the
                                     // stripe off here so a slot that drains (queue empty)

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -283,7 +283,9 @@ static class HistoryCommand {
 
             scope = HistoryScopePrompt.RunPicker(activeProfile, currentRepo, distinct);
             if (scope is null) {
-                await Console.Error.WriteLineAsync("Scope selection cancelled.");
+                // RunPicker has already printed the specific reason (e.g. "Active profile
+                // has no org" or "No repositories detected in discovered sessions") via
+                // AnsiConsole. Don't tack on a misleading "cancelled" message.
                 return 1;
             }
 

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -252,6 +252,8 @@ static class HistoryCommand {
         var projectCount = transcriptFiles.Select(t => t.EncodedCwd).Distinct().Count();
         display.Line($"Found {transcriptFiles.Count} {vendor} session{(transcriptFiles.Count == 1 ? "" : "s")} in {projectCount} project{(projectCount == 1 ? "" : "s")}");
 
+        var kapacitorConfig = await AppConfig.Load();
+
         // --- Scope: pre-detect repos for the filter and (if needed) the picker ---
         async ValueTask<(string? Owner, string? Name)> ResolveRepoAsync(
             (string SessionId, string FilePath, string EncodedCwd) t,
@@ -319,7 +321,7 @@ static class HistoryCommand {
 
         var visibilityDesc = forcePrivate
             ? "private (--private)"
-            : $"{(await AppConfig.Load())?.DefaultVisibility ?? "org_public"} (from profile)";
+            : $"{kapacitorConfig?.DefaultVisibility ?? "org_public"} (from profile)";
 
         if (!HistoryScopePrompt.PromptConfirm(
                 scope, transcriptFiles.Count, sampleRepos, visibilityDesc, skipConfirmation)) {
@@ -328,7 +330,7 @@ static class HistoryCommand {
         }
 
         // --- Classify (parallel probes) ---
-        var                         excludedRepos = (await AppConfig.Load())?.ExcludedRepos;
+        var                         excludedRepos = kapacitorConfig?.ExcludedRepos;
         List<SessionClassification> classifications;
 
         if (display.Tty) {

--- a/src/kapacitor/Commands/HistoryCommand.cs
+++ b/src/kapacitor/Commands/HistoryCommand.cs
@@ -2,6 +2,7 @@ using Spectre.Console;
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading.Channels;
 using kapacitor.Config;
 
@@ -629,6 +630,12 @@ static class HistoryCommand {
             }
         } else {
             importResult = new(0, 0, 0);
+        }
+
+        // --- --private: mark all imported sessions owner-only ---
+        if (forcePrivate && !importedSessionIds.IsEmpty) {
+            display.BeginPhase("Marking imported sessions private");
+            await SetVisibilityNoneForAll(httpClient, baseUrl, [.. importedSessionIds]);
         }
 
         // --- Background phase (titles / summaries) ---
@@ -1621,6 +1628,32 @@ static class HistoryCommand {
             // transcript as "not too short" so the caller proceeds to probe/import
             // rather than silently classifying it as TooShort and skipping forever.
             return threshold;
+        }
+    }
+
+    /// <summary>
+    /// PUT visibility=none for every imported session id. Failures are logged
+    /// inline (one line per session) but never throw — the import already
+    /// succeeded; users can re-run `kapacitor hide` for any that failed.
+    /// </summary>
+    internal static async Task SetVisibilityNoneForAll(
+        HttpClient            httpClient,
+        string                baseUrl,
+        IReadOnlyList<string> sessionIds) {
+        foreach (var sessionId in sessionIds) {
+            var payload = new JsonObject { ["visibility"] = "none" };
+            using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+            try {
+                using var resp = await httpClient.PutWithRetryAsync(
+                    $"{baseUrl}/api/sessions/{sessionId}/visibility", content);
+                if (!resp.IsSuccessStatusCode) {
+                    await Console.Error.WriteLineAsync(
+                        $"  ! visibility=none failed for {sessionId}: HTTP {(int)resp.StatusCode}");
+                }
+            } catch (Exception ex) {
+                await Console.Error.WriteLineAsync(
+                    $"  ! visibility=none failed for {sessionId}: {ex.Message}");
+            }
         }
     }
 }

--- a/src/kapacitor/Commands/HistoryScopeFilter.cs
+++ b/src/kapacitor/Commands/HistoryScopeFilter.cs
@@ -1,0 +1,36 @@
+namespace kapacitor.Commands;
+
+/// <summary>
+/// Pure scope filter for the history pipeline. The repo resolver is injected
+/// so unit tests can stub out repository detection; production wires it to
+/// the cwd-extractor + RepositoryDetection.DetectRepositoryAsync.
+/// </summary>
+public static class HistoryScopeFilter {
+    public static async Task<List<(string SessionId, string FilePath, string EncodedCwd)>> Apply(
+        IReadOnlyList<(string SessionId, string FilePath, string EncodedCwd)>                       transcripts,
+        ImportScope                                                                                  scope,
+        Func<(string SessionId, string FilePath, string EncodedCwd), CancellationToken,
+             ValueTask<(string? Owner, string? Name)>>                                               resolveRepo,
+        CancellationToken                                                                            ct = default) {
+        if (scope is ImportScope.All) return [..transcripts];
+
+        var kept = new List<(string, string, string)>(transcripts.Count);
+
+        foreach (var t in transcripts) {
+            ct.ThrowIfCancellationRequested();
+            var (owner, name) = await resolveRepo(t, ct);
+
+            var match = (scope, owner, name) switch {
+                (ImportScope.Org o,  not null, _) => string.Equals(owner, o.OrgLogin, StringComparison.OrdinalIgnoreCase),
+                (ImportScope.Repo r, not null, not null) =>
+                    string.Equals(owner, r.Owner, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(name,  r.Name,  StringComparison.OrdinalIgnoreCase),
+                _ => false,
+            };
+
+            if (match) kept.Add(t);
+        }
+
+        return kept;
+    }
+}

--- a/src/kapacitor/Commands/HistoryScopePrompt.cs
+++ b/src/kapacitor/Commands/HistoryScopePrompt.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Spectre.Console;
 
 namespace kapacitor.Commands;
 
@@ -63,5 +64,74 @@ public static partial class HistoryScopePrompt {
         sb.AppendLine($"  repos:   {repoLine}");
         sb.Append   ($"  visibility: {visibilityDescription}");
         return sb.ToString();
+    }
+}
+
+public static partial class HistoryScopePrompt {
+    /// <summary>
+    /// Run the top-level scope picker. Returns the resolved scope, or null
+    /// when the user picks "specific repository" but the sub-picker has no
+    /// options (no current repo + no detected repos).
+    /// </summary>
+    public static ImportScope? RunPicker(
+        string                                     activeProfile,
+        (string Owner, string Name)?               currentRepo,
+        IReadOnlyList<(string Owner, string Name)> discoveredRepos) {
+        var choice = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("What would you like to import?")
+                .AddChoices("all", "org", "repo")
+                .UseConverter(c => c switch {
+                    "all"  => "Everything",
+                    "org"  => $"Org repos only ({activeProfile})",
+                    "repo" => "Specific repository",
+                    _      => c,
+                }));
+
+        if (choice == "all")  return new ImportScope.All();
+        if (choice == "org") {
+            if (string.IsNullOrEmpty(activeProfile) || activeProfile == "default") {
+                AnsiConsole.MarkupLine("[red]Active profile has no org. Run `kapacitor setup`.[/]");
+                return null;
+            }
+            return new ImportScope.Org(activeProfile);
+        }
+
+        var repoChoices = BuildRepoChoices(currentRepo, discoveredRepos);
+        if (repoChoices.Length == 0) {
+            AnsiConsole.MarkupLine("[red]No repositories detected in discovered sessions.[/]");
+            return null;
+        }
+
+        var picked = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("Which repository?")
+                .PageSize(15)
+                .AddChoices(repoChoices));
+
+        // Strip the trailing " (current)" marker before splitting on '/'.
+        var clean = picked.EndsWith(" (current)") ? picked[..^" (current)".Length] : picked;
+        var parts = clean.Split('/');
+        return new ImportScope.Repo(parts[0], parts[1]);
+    }
+
+    /// <summary>
+    /// Print the summary block to stderr (visible even when stdout is
+    /// redirected) and prompt y/N if <paramref name="skip"/> is false.
+    /// Returns true to proceed with the import.
+    /// </summary>
+    public static bool PromptConfirm(
+        ImportScope            scope,
+        int                    matchedCount,
+        IReadOnlyList<string>  repoSamples,
+        string                 visibilityDescription,
+        bool                   skip) {
+        var summary = FormatSummary(scope, matchedCount, repoSamples, visibilityDescription);
+        Console.Error.WriteLine(summary);
+
+        if (skip) return true;
+
+        return AnsiConsole.Prompt(
+            new ConfirmationPrompt("Continue?") { DefaultValue = false });
     }
 }

--- a/src/kapacitor/Commands/HistoryScopePrompt.cs
+++ b/src/kapacitor/Commands/HistoryScopePrompt.cs
@@ -1,0 +1,67 @@
+using System.Text;
+
+namespace kapacitor.Commands;
+
+/// <summary>
+/// Spectre.Console-backed pickers for history import scope, plus the pure
+/// helpers that drive their content. Pure helpers are public for unit testing;
+/// Spectre wrappers are added in a separate task.
+/// </summary>
+public static partial class HistoryScopePrompt {
+    /// <summary>
+    /// Build the option strings for the "specific repository" sub-picker.
+    /// The current cwd's repo (if any) is pinned to the top with a "(current)"
+    /// marker; the rest are alphabetized and deduplicated against the current.
+    /// </summary>
+    public static string[] BuildRepoChoices(
+        (string Owner, string Name)?              currentRepo,
+        IReadOnlyList<(string Owner, string Name)> discoveredRepos) {
+        var distinct = discoveredRepos
+            .Select(r => $"{r.Owner}/{r.Name}")
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (currentRepo is { } current) {
+            var currentKey = $"{current.Owner}/{current.Name}";
+            distinct.RemoveAll(s => s.Equals(currentKey, StringComparison.OrdinalIgnoreCase));
+            distinct.Sort(StringComparer.OrdinalIgnoreCase);
+            return [$"{currentKey} (current)", .. distinct];
+        }
+
+        distinct.Sort(StringComparer.OrdinalIgnoreCase);
+        return [.. distinct];
+    }
+
+    /// <summary>
+    /// Build the confirmation summary block printed before the y/N prompt.
+    /// The same text is printed in non-TTY runs (with --yes) so the imported
+    /// scope is recorded in CI logs.
+    /// </summary>
+    public static string FormatSummary(
+        ImportScope            scope,
+        int                    matchedCount,
+        IReadOnlyList<string>  repoSamples,
+        string                 visibilityDescription) {
+        var scopeLabel = scope switch {
+            ImportScope.All      => "everything",
+            ImportScope.Org o    => $"org repos only ({o.OrgLogin})",
+            ImportScope.Repo r   => $"repository {r.Owner}/{r.Name}",
+            _                    => "?"
+        };
+
+        const int sampleLimit = 5;
+        var samples = repoSamples.Take(sampleLimit).ToArray();
+        var more    = repoSamples.Count - samples.Length;
+        var repoLine = samples.Length == 0
+            ? "(none)"
+            : string.Join(", ", samples) + (more > 0 ? $", +{more} more" : "");
+
+        var sb = new StringBuilder();
+        sb.AppendLine("About to import:");
+        sb.AppendLine($"  scope:   {scopeLabel}");
+        sb.AppendLine($"  matched: {matchedCount} session{(matchedCount == 1 ? "" : "s")} across {repoSamples.Count} repo{(repoSamples.Count == 1 ? "" : "s")}");
+        sb.AppendLine($"  repos:   {repoLine}");
+        sb.Append   ($"  visibility: {visibilityDescription}");
+        return sb.ToString();
+    }
+}

--- a/src/kapacitor/Commands/ImportScope.cs
+++ b/src/kapacitor/Commands/ImportScope.cs
@@ -1,0 +1,12 @@
+namespace kapacitor.Commands;
+
+/// <summary>
+/// Selected history import scope, resolved from CLI flags or the interactive picker.
+/// </summary>
+public abstract record ImportScope {
+    public sealed record All  : ImportScope;
+    public sealed record Org  (string OrgLogin) : ImportScope;
+    public sealed record Repo (string Owner, string Name) : ImportScope;
+
+    private ImportScope() { }
+}

--- a/src/kapacitor/Commands/ImportScopeArgs.cs
+++ b/src/kapacitor/Commands/ImportScopeArgs.cs
@@ -1,0 +1,96 @@
+namespace kapacitor.Commands;
+
+/// <summary>
+/// Pure flag parser and resolver for `kapacitor history` scope selection.
+/// Performs no I/O — current-repo lookup is the caller's job; the resolved
+/// result is passed in via <see cref="ResolveInput.CurrentRepo"/>.
+/// </summary>
+public static class ImportScopeArgs {
+    public sealed record ParsedFlags(
+        bool    All,
+        bool    Org,
+        string? RepoArg,
+        bool    Yes,
+        bool    Private);
+
+    public sealed record ResolveInput(
+        ParsedFlags                         Flags,
+        string                              ActiveProfile,
+        bool                                IsInteractive,
+        (string Owner, string Name)?        CurrentRepo);
+
+    public sealed record ResolveResult(
+        ImportScope? Scope,        // null => either picker needed or error
+        bool         Yes,
+        bool         Private,
+        bool         NeedsPicker,
+        string?      Error);
+
+    public static ParsedFlags ParseFlags(string[] args) {
+        string? repo = null;
+        var idx = Array.IndexOf(args, "--repo");
+        if (idx >= 0 && idx + 1 < args.Length) repo = args[idx + 1];
+
+        return new(
+            All:     args.Contains("--all"),
+            Org:     args.Contains("--org"),
+            RepoArg: repo,
+            Yes:     args.Contains("--yes") || args.Contains("-y"),
+            Private: args.Contains("--private"));
+    }
+
+    public static ResolveResult Resolve(ResolveInput input) {
+        var f = input.Flags;
+        var count = (f.All ? 1 : 0) + (f.Org ? 1 : 0) + (f.RepoArg is null ? 0 : 1);
+
+        if (count > 1) {
+            return new(null, f.Yes, f.Private, false,
+                "--all, --org, and --repo are mutually exclusive.");
+        }
+
+        if (count == 0) {
+            if (input.IsInteractive) {
+                return new(null, f.Yes, f.Private, NeedsPicker: true, Error: null);
+            }
+            return new(null, f.Yes, f.Private, false,
+                "--all, --org, or --repo <owner/name> is required for non-interactive use.");
+        }
+
+        // A scope flag is set: enforce --yes for non-interactive runs.
+        if (!input.IsInteractive && !f.Yes) {
+            return new(null, f.Yes, f.Private, false,
+                "--yes is required for non-interactive use.");
+        }
+
+        if (f.All) {
+            return new(new ImportScope.All(), f.Yes, f.Private, false, null);
+        }
+
+        if (f.Org) {
+            if (string.IsNullOrEmpty(input.ActiveProfile) || input.ActiveProfile == "default") {
+                return new(null, f.Yes, f.Private, false,
+                    "--org requires a tenant-bound profile. Run `kapacitor setup` first, or use --all / --repo <owner/name>.");
+            }
+            return new(new ImportScope.Org(input.ActiveProfile), f.Yes, f.Private, false, null);
+        }
+
+        // --repo <value>
+        var value = f.RepoArg!;
+        if (value is "." or "current") {
+            if (input.CurrentRepo is null) {
+                return new(null, f.Yes, f.Private, false,
+                    "--repo . requires the current directory to be in a git repo with an origin remote.");
+            }
+            var (owner, name) = input.CurrentRepo.Value;
+            return new(new ImportScope.Repo(owner, name), f.Yes, f.Private, false, null);
+        }
+
+        var parts = value.Split('/');
+        if (parts.Length != 2 || parts[0].Length == 0 || parts[1].Length == 0) {
+            return new(null, f.Yes, f.Private, false,
+                $"--repo expects owner/name (got '{value}').");
+        }
+
+        return new(new ImportScope.Repo(parts[0], parts[1]), f.Yes, f.Private, false, null);
+    }
+}

--- a/src/kapacitor/Commands/ImportScopeArgs.cs
+++ b/src/kapacitor/Commands/ImportScopeArgs.cs
@@ -23,7 +23,6 @@ public static class ImportScopeArgs {
         ImportScope? Scope,        // null => either picker needed or error
         bool         Yes,
         bool         Private,
-        bool         NeedsPicker,
         string?      Error);
 
     public static ParsedFlags ParseFlags(string[] args) {
@@ -44,53 +43,53 @@ public static class ImportScopeArgs {
         var count = (f.All ? 1 : 0) + (f.Org ? 1 : 0) + (f.RepoArg is null ? 0 : 1);
 
         if (count > 1) {
-            return new(null, f.Yes, f.Private, false,
+            return new(null, f.Yes, f.Private,
                 "--all, --org, and --repo are mutually exclusive.");
         }
 
         if (count == 0) {
             if (input.IsInteractive) {
-                return new(null, f.Yes, f.Private, NeedsPicker: true, Error: null);
+                return new(null, f.Yes, f.Private, Error: null);
             }
-            return new(null, f.Yes, f.Private, false,
+            return new(null, f.Yes, f.Private,
                 "--all, --org, or --repo <owner/name> is required for non-interactive use.");
         }
 
         // A scope flag is set: enforce --yes for non-interactive runs.
         if (!input.IsInteractive && !f.Yes) {
-            return new(null, f.Yes, f.Private, false,
+            return new(null, f.Yes, f.Private,
                 "--yes is required for non-interactive use.");
         }
 
         if (f.All) {
-            return new(new ImportScope.All(), f.Yes, f.Private, false, null);
+            return new(new ImportScope.All(), f.Yes, f.Private, null);
         }
 
         if (f.Org) {
             if (string.IsNullOrEmpty(input.ActiveProfile) || input.ActiveProfile == "default") {
-                return new(null, f.Yes, f.Private, false,
+                return new(null, f.Yes, f.Private,
                     "--org requires a tenant-bound profile. Run `kapacitor setup` first, or use --all / --repo <owner/name>.");
             }
-            return new(new ImportScope.Org(input.ActiveProfile), f.Yes, f.Private, false, null);
+            return new(new ImportScope.Org(input.ActiveProfile), f.Yes, f.Private, null);
         }
 
         // --repo <value>
         var value = f.RepoArg!;
         if (value is "." or "current") {
             if (input.CurrentRepo is null) {
-                return new(null, f.Yes, f.Private, false,
+                return new(null, f.Yes, f.Private,
                     "--repo . requires the current directory to be in a git repo with an origin remote.");
             }
             var (owner, name) = input.CurrentRepo.Value;
-            return new(new ImportScope.Repo(owner, name), f.Yes, f.Private, false, null);
+            return new(new ImportScope.Repo(owner, name), f.Yes, f.Private, null);
         }
 
         var parts = value.Split('/');
         if (parts.Length != 2 || parts[0].Length == 0 || parts[1].Length == 0) {
-            return new(null, f.Yes, f.Private, false,
+            return new(null, f.Yes, f.Private,
                 $"--repo expects owner/name (got '{value}').");
         }
 
-        return new(new ImportScope.Repo(parts[0], parts[1]), f.Yes, f.Private, false, null);
+        return new(new ImportScope.Repo(parts[0], parts[1]), f.Yes, f.Private, null);
     }
 }

--- a/src/kapacitor/Commands/SetupCommand.cs
+++ b/src/kapacitor/Commands/SetupCommand.cs
@@ -225,6 +225,7 @@ public static class SetupCommand {
 
         AnsiConsole.Write(grid);
         AnsiConsole.MarkupLine("\n[dim]Optional:[/] start the agent daemon with [cyan]kapacitor agent start -d[/]");
+        AnsiConsole.MarkupLine("[dim]Optional:[/] import past sessions with [cyan]kapacitor history --org[/]");
 
         return 0;
     }

--- a/src/kapacitor/Program.cs
+++ b/src/kapacitor/Program.cs
@@ -417,7 +417,40 @@ switch (command) {
 
         var generateSummaries = args.Contains("--generate-summaries");
 
-        return await HistoryCommand.HandleHistory(baseUrl!, filterCwd, filterSession, minLines, generateSummaries, codex, since);
+        // --- Scope resolution (AI-613) ---
+        var profileConfig = await AppConfig.LoadProfileConfig();
+        var activeProfile = string.IsNullOrEmpty(profileConfig.ActiveProfile) ? "default" : profileConfig.ActiveProfile;
+
+        var currentRepoDetected = await RepositoryDetection.DetectRepositoryAsync(Environment.CurrentDirectory);
+        (string Owner, string Name)? currentRepo = currentRepoDetected is { Owner: { } o, RepoName: { } n }
+            ? (o, n)
+            : null;
+
+        var flags = ImportScopeArgs.ParseFlags(args);
+        var resolveResult = ImportScopeArgs.Resolve(new(
+            Flags:         flags,
+            ActiveProfile: activeProfile,
+            IsInteractive: !Console.IsInputRedirected && !Console.IsOutputRedirected,
+            CurrentRepo:   currentRepo));
+
+        if (resolveResult.Error is not null) {
+            Console.Error.WriteLine(resolveResult.Error);
+            return 1;
+        }
+
+        return await HistoryCommand.HandleHistory(
+            baseUrl!,
+            filterCwd,
+            filterSession,
+            minLines,
+            generateSummaries,
+            codex,
+            since,
+            scope:            resolveResult.Scope,     // null => HandleHistory runs picker
+            skipConfirmation: resolveResult.Yes,
+            forcePrivate:     resolveResult.Private,
+            activeProfile:    activeProfile,
+            currentRepo:      currentRepo);
     }
     case "watch" when args.Length < 3:
         Console.Error.WriteLine("Usage: kapacitor watch <sessionId> <transcriptPath> [--agent-id <agentId>] [--cwd <cwd>] [--skip-title] [--parent-pid <pid>] [--vendor claude|codex]");

--- a/test/kapacitor.Tests.Integration/HistoryPrivateImportTests.cs
+++ b/test/kapacitor.Tests.Integration/HistoryPrivateImportTests.cs
@@ -1,0 +1,63 @@
+using kapacitor.Commands;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace kapacitor.Tests.Integration;
+
+public class HistoryPrivateImportTests : IDisposable {
+    readonly WireMockServer _server  = WireMockServer.Start();
+    readonly string         _tempDir = Directory.CreateTempSubdirectory("kapacitor-private-test").FullName;
+
+    public void Dispose() {
+        _server.Stop();
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Test]
+    public async Task SetVisibilityNoneForAll_calls_PUT_for_each_session_id() {
+        _server.Given(Request.Create().WithPath("/api/sessions/*/visibility").UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        using var client = new HttpClient();
+
+        await HistoryCommand.SetVisibilityNoneForAll(
+            client,
+            _server.Url!,
+            ["sess1", "sess2", "sess3"]);
+
+        var calls = _server.LogEntries
+            .Where(e => e.RequestMessage.Method == "PUT")
+            .Select(e => e.RequestMessage.Path)
+            .OrderBy(p => p)
+            .ToArray();
+
+        await Assert.That(calls).IsEquivalentTo(new[] {
+            "/api/sessions/sess1/visibility",
+            "/api/sessions/sess2/visibility",
+            "/api/sessions/sess3/visibility",
+        });
+    }
+
+    [Test]
+    public async Task SetVisibilityNoneForAll_continues_on_per_session_failure() {
+        _server.Given(Request.Create().WithPath("/api/sessions/sess2/visibility").UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(500));
+        _server.Given(Request.Create().WithPath("/api/sessions/sess*/visibility").UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        using var client = new HttpClient();
+
+        // Should not throw even though sess2 returns 500.
+        await HistoryCommand.SetVisibilityNoneForAll(
+            client,
+            _server.Url!,
+            ["sess1", "sess2", "sess3"]);
+
+        var attempted = _server.LogEntries
+            .Where(e => e.RequestMessage.Method == "PUT")
+            .Count();
+
+        await Assert.That(attempted).IsEqualTo(3);
+    }
+}

--- a/test/kapacitor.Tests.Integration/HistoryPrivateImportTests.cs
+++ b/test/kapacitor.Tests.Integration/HistoryPrivateImportTests.cs
@@ -26,17 +26,20 @@ public class HistoryPrivateImportTests : IDisposable {
             _server.Url!,
             ["sess1", "sess2", "sess3"]);
 
-        var calls = _server.LogEntries
+        var requests = _server.LogEntries
             .Where(e => e.RequestMessage.Method == "PUT")
-            .Select(e => e.RequestMessage.Path)
-            .OrderBy(p => p)
+            .OrderBy(e => e.RequestMessage.Path)
             .ToArray();
 
-        await Assert.That(calls).IsEquivalentTo(new[] {
+        await Assert.That(requests.Select(r => r.RequestMessage.Path).ToArray()).IsEquivalentTo(new[] {
             "/api/sessions/sess1/visibility",
             "/api/sessions/sess2/visibility",
             "/api/sessions/sess3/visibility",
         });
+
+        foreach (var r in requests) {
+            await Assert.That(r.RequestMessage.Body).IsEqualTo("""{"visibility":"none"}""");
+        }
     }
 
     [Test]

--- a/test/kapacitor.Tests.Unit/HistoryScopeFilterTests.cs
+++ b/test/kapacitor.Tests.Unit/HistoryScopeFilterTests.cs
@@ -1,0 +1,72 @@
+using kapacitor.Commands;
+
+namespace kapacitor.Tests.Unit;
+
+public class HistoryScopeFilterTests {
+    static (string SessionId, string FilePath, string EncodedCwd) T(string id) =>
+        (id, $"/tmp/{id}.jsonl", $"-tmp-proj-{id}");
+
+    static Func<(string SessionId, string FilePath, string EncodedCwd), CancellationToken, ValueTask<(string? Owner, string? Name)>>
+        Resolver(Dictionary<string, (string Owner, string Name)?> map) =>
+        (t, _) => new ValueTask<(string?, string?)>(
+            map.TryGetValue(t.SessionId, out var v) && v is { } x ? (x.Owner, x.Name) : (null, null));
+
+    [Test]
+    public async Task Apply_All_returns_every_transcript_including_unresolved() {
+        var transcripts = new[] { T("a"), T("b"), T("c") };
+        var resolver = Resolver(new() { ["a"] = ("EventStore", "kapacitor"), ["b"] = null });
+
+        var kept = await HistoryScopeFilter.Apply(transcripts, new ImportScope.All(), resolver);
+
+        await Assert.That(kept.Select(x => x.SessionId).ToArray()).IsEquivalentTo(new[] { "a", "b", "c" });
+    }
+
+    [Test]
+    public async Task Apply_Org_keeps_only_matching_owner() {
+        var transcripts = new[] { T("a"), T("b"), T("c") };
+        var resolver = Resolver(new() {
+            ["a"] = ("EventStore", "kapacitor"),
+            ["b"] = ("kurrent-io", "secret"),
+            ["c"] = ("EventStore", "kurrentdb"),
+        });
+
+        var kept = await HistoryScopeFilter.Apply(transcripts, new ImportScope.Org("EventStore"), resolver);
+
+        await Assert.That(kept.Select(x => x.SessionId).ToArray()).IsEquivalentTo(new[] { "a", "c" });
+    }
+
+    [Test]
+    public async Task Apply_Org_matches_case_insensitively() {
+        var transcripts = new[] { T("a") };
+        var resolver = Resolver(new() { ["a"] = ("eventstore", "kapacitor") });
+
+        var kept = await HistoryScopeFilter.Apply(transcripts, new ImportScope.Org("EventStore"), resolver);
+
+        await Assert.That(kept).HasCount(1);
+    }
+
+    [Test]
+    public async Task Apply_Org_drops_unresolved_repos() {
+        var transcripts = new[] { T("a") };
+        var resolver = Resolver(new() { ["a"] = null });
+
+        var kept = await HistoryScopeFilter.Apply(transcripts, new ImportScope.Org("EventStore"), resolver);
+
+        await Assert.That(kept).IsEmpty();
+    }
+
+    [Test]
+    public async Task Apply_Repo_keeps_only_exact_match() {
+        var transcripts = new[] { T("a"), T("b"), T("c") };
+        var resolver = Resolver(new() {
+            ["a"] = ("EventStore", "kapacitor"),
+            ["b"] = ("EventStore", "kurrentdb"),
+            ["c"] = ("EventStore", "kapacitor"),
+        });
+
+        var kept = await HistoryScopeFilter.Apply(
+            transcripts, new ImportScope.Repo("EventStore", "kapacitor"), resolver);
+
+        await Assert.That(kept.Select(x => x.SessionId).ToArray()).IsEquivalentTo(new[] { "a", "c" });
+    }
+}

--- a/test/kapacitor.Tests.Unit/HistoryScopePromptTests.cs
+++ b/test/kapacitor.Tests.Unit/HistoryScopePromptTests.cs
@@ -1,0 +1,99 @@
+using kapacitor.Commands;
+
+namespace kapacitor.Tests.Unit;
+
+public class HistoryScopePromptTests {
+    // --- BuildRepoChoices ---
+
+    [Test]
+    public async Task BuildRepoChoices_orders_current_first_then_alphabetical() {
+        var choices = HistoryScopePrompt.BuildRepoChoices(
+            currentRepo: ("EventStore", "kapacitor"),
+            discoveredRepos: [
+                ("EventStore", "kurrentdb"),
+                ("EventStore", "kapacitor"),  // dup with current
+                ("alexeyzimarev", "scratchpad"),
+            ]);
+
+        await Assert.That(choices).IsEquivalentTo(new[] {
+            "EventStore/kapacitor (current)",
+            "alexeyzimarev/scratchpad",
+            "EventStore/kurrentdb",
+        });
+    }
+
+    [Test]
+    public async Task BuildRepoChoices_no_current_repo_just_sorts_alphabetically() {
+        var choices = HistoryScopePrompt.BuildRepoChoices(
+            currentRepo: null,
+            discoveredRepos: [("Z-org", "z"), ("A-org", "a"), ("M-org", "m")]);
+
+        await Assert.That(choices).IsEquivalentTo(new[] {
+            "A-org/a",
+            "M-org/m",
+            "Z-org/z",
+        });
+    }
+
+    [Test]
+    public async Task BuildRepoChoices_deduplicates_discovered_set() {
+        var choices = HistoryScopePrompt.BuildRepoChoices(
+            currentRepo: null,
+            discoveredRepos: [("A", "x"), ("A", "x"), ("A", "y")]);
+
+        await Assert.That(choices).IsEquivalentTo(new[] { "A/x", "A/y" });
+    }
+
+    // --- FormatSummary ---
+
+    [Test]
+    public async Task FormatSummary_All_scope() {
+        var s = HistoryScopePrompt.FormatSummary(
+            scope: new ImportScope.All(),
+            matchedCount: 47,
+            repoSamples: ["EventStore/kapacitor", "EventStore/kurrentdb"],
+            visibilityDescription: "org_public (from profile)");
+
+        await Assert.That(s).Contains("scope:   everything");
+        await Assert.That(s).Contains("matched: 47 sessions");
+        await Assert.That(s).Contains("visibility: org_public (from profile)");
+    }
+
+    [Test]
+    public async Task FormatSummary_Org_includes_org_name() {
+        var s = HistoryScopePrompt.FormatSummary(
+            scope: new ImportScope.Org("EventStore"),
+            matchedCount: 5,
+            repoSamples: ["EventStore/kapacitor"],
+            visibilityDescription: "private (--private)");
+
+        await Assert.That(s).Contains("org repos only (EventStore)");
+        await Assert.That(s).Contains("visibility: private (--private)");
+    }
+
+    [Test]
+    public async Task FormatSummary_Repo_includes_owner_name() {
+        var s = HistoryScopePrompt.FormatSummary(
+            scope: new ImportScope.Repo("EventStore", "kapacitor"),
+            matchedCount: 3,
+            repoSamples: ["EventStore/kapacitor"],
+            visibilityDescription: "org_public (from profile)");
+
+        await Assert.That(s).Contains("repository EventStore/kapacitor");
+    }
+
+    [Test]
+    public async Task FormatSummary_caps_repo_samples_at_5() {
+        var samples = Enumerable.Range(1, 9).Select(i => $"EventStore/r{i}").ToArray();
+        var s = HistoryScopePrompt.FormatSummary(
+            scope: new ImportScope.All(),
+            matchedCount: 50,
+            repoSamples: samples,
+            visibilityDescription: "org_public (from profile)");
+
+        await Assert.That(s).Contains("EventStore/r1");
+        await Assert.That(s).Contains("EventStore/r5");
+        await Assert.That(s).DoesNotContain("EventStore/r6");
+        await Assert.That(s).Contains("+4 more");
+    }
+}

--- a/test/kapacitor.Tests.Unit/ImportScopeArgsTests.cs
+++ b/test/kapacitor.Tests.Unit/ImportScopeArgsTests.cs
@@ -1,0 +1,207 @@
+using kapacitor.Commands;
+
+namespace kapacitor.Tests.Unit;
+
+public class ImportScopeArgsTests {
+    [Test]
+    public async Task ParseFlags_reads_all() {
+        var f = ImportScopeArgs.ParseFlags(["history", "--all"]);
+        await Assert.That(f.All).IsTrue();
+        await Assert.That(f.Org).IsFalse();
+        await Assert.That(f.RepoArg).IsNull();
+        await Assert.That(f.Yes).IsFalse();
+        await Assert.That(f.Private).IsFalse();
+    }
+
+    [Test]
+    public async Task ParseFlags_reads_repo_value() {
+        var f = ImportScopeArgs.ParseFlags(["history", "--repo", "EventStore/kapacitor"]);
+        await Assert.That(f.RepoArg).IsEqualTo("EventStore/kapacitor");
+    }
+
+    [Test]
+    public async Task ParseFlags_reads_yes_short_form() {
+        var f = ImportScopeArgs.ParseFlags(["history", "--all", "-y"]);
+        await Assert.That(f.Yes).IsTrue();
+    }
+
+    [Test]
+    public async Task ParseFlags_reads_private() {
+        var f = ImportScopeArgs.ParseFlags(["history", "--all", "--private"]);
+        await Assert.That(f.Private).IsTrue();
+    }
+
+    [Test]
+    public async Task Resolve_errors_when_two_scope_flags_set() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: true, Org: true, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error).IsNotNull();
+        await Assert.That(r.Error!).Contains("mutually exclusive");
+    }
+
+    [Test]
+    public async Task Resolve_returns_All_for_all_flag() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: true, Org: false, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "default",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsTypeOf<ImportScope.All>();
+        await Assert.That(r.Error).IsNull();
+    }
+
+    [Test]
+    public async Task Resolve_returns_Org_with_active_profile() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsTypeOf<ImportScope.Org>();
+        await Assert.That(((ImportScope.Org)r.Scope!).OrgLogin).IsEqualTo("EventStore");
+    }
+
+    [Test]
+    public async Task Resolve_errors_on_Org_when_profile_is_default() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "default",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error!).Contains("tenant-bound profile");
+    }
+
+    [Test]
+    public async Task Resolve_returns_Repo_for_owner_slash_name() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: "EventStore/kapacitor", Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        var repo = (ImportScope.Repo)r.Scope!;
+        await Assert.That(repo.Owner).IsEqualTo("EventStore");
+        await Assert.That(repo.Name).IsEqualTo("kapacitor");
+    }
+
+    [Test]
+    public async Task Resolve_repo_dot_uses_current_repo() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: ".", Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: ("EventStore", "kapacitor"));
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        var repo = (ImportScope.Repo)r.Scope!;
+        await Assert.That(repo.Owner).IsEqualTo("EventStore");
+        await Assert.That(repo.Name).IsEqualTo("kapacitor");
+    }
+
+    [Test]
+    public async Task Resolve_repo_current_alias_uses_current_repo() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: "current", Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: ("EventStore", "kapacitor"));
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        var repo = (ImportScope.Repo)r.Scope!;
+        await Assert.That(repo.Owner).IsEqualTo("EventStore");
+        await Assert.That(repo.Name).IsEqualTo("kapacitor");
+    }
+
+    [Test]
+    public async Task Resolve_repo_dot_errors_when_cwd_has_no_repo() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: ".", Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error!).Contains("git repo with an origin remote");
+    }
+
+    [Test]
+    public async Task Resolve_errors_on_malformed_repo_arg() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: "no-slash", Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error!).Contains("owner/name");
+    }
+
+    [Test]
+    public async Task Resolve_returns_NeedsPicker_when_no_flag_and_interactive() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error).IsNull();
+        await Assert.That(r.NeedsPicker).IsTrue();
+    }
+
+    [Test]
+    public async Task Resolve_errors_when_no_flag_and_non_interactive() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: false, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: false,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.NeedsPicker).IsFalse();
+        await Assert.That(r.Error!).Contains("--all, --org, or --repo");
+    }
+
+    [Test]
+    public async Task Resolve_errors_when_flag_set_and_non_interactive_without_yes() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: true, Org: false, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: false,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error!).Contains("--yes");
+    }
+}

--- a/test/kapacitor.Tests.Unit/ImportScopeArgsTests.cs
+++ b/test/kapacitor.Tests.Unit/ImportScopeArgsTests.cs
@@ -162,7 +162,7 @@ public class ImportScopeArgsTests {
     }
 
     [Test]
-    public async Task Resolve_returns_NeedsPicker_when_no_flag_and_interactive() {
+    public async Task Resolve_returns_null_scope_and_null_error_when_no_flag_and_interactive() {
         var input = new ImportScopeArgs.ResolveInput(
             Flags: new(All: false, Org: false, RepoArg: null, Yes: false, Private: false),
             ActiveProfile: "EventStore",
@@ -173,7 +173,6 @@ public class ImportScopeArgsTests {
 
         await Assert.That(r.Scope).IsNull();
         await Assert.That(r.Error).IsNull();
-        await Assert.That(r.NeedsPicker).IsTrue();
     }
 
     [Test]
@@ -187,7 +186,6 @@ public class ImportScopeArgsTests {
         var r = ImportScopeArgs.Resolve(input);
 
         await Assert.That(r.Scope).IsNull();
-        await Assert.That(r.NeedsPicker).IsFalse();
         await Assert.That(r.Error!).Contains("--all, --org, or --repo");
     }
 

--- a/test/kapacitor.Tests.Unit/SessionImporterProgressTests.cs
+++ b/test/kapacitor.Tests.Unit/SessionImporterProgressTests.cs
@@ -10,6 +10,17 @@ public class SessionImporterProgressTests : IDisposable {
 
     public void Dispose() => _server.Stop();
 
+    /// <summary>
+    /// Synchronous IProgress&lt;T&gt;: appends to the callback in the calling
+    /// thread, unlike <see cref="Progress{T}"/> which marshals via the captured
+    /// SynchronizationContext and required a 50ms sleep after each test's
+    /// await — flaky on Linux CI where the marshalling sometimes slipped past
+    /// the deadline.
+    /// </summary>
+    sealed class SyncProgress<T>(Action<T> onReport) : IProgress<T> {
+        public void Report(T value) => onReport(value);
+    }
+
     [Test]
     public async Task SendTranscriptBatches_fires_BatchFlushed_per_100_lines() {
         _server.Given(Request.Create().WithPath("/hooks/transcript").UsingPost())
@@ -23,7 +34,7 @@ public class SessionImporterProgressTests : IDisposable {
             ));
 
             var events = new List<ImportProgress>();
-            var progress = new Progress<ImportProgress>(events.Add);
+            var progress = new SyncProgress<ImportProgress>(events.Add);
 
             using var client = new HttpClient();
             var totalSent = await SessionImporter.SendTranscriptBatches(
@@ -32,9 +43,6 @@ public class SessionImporterProgressTests : IDisposable {
             );
 
             await Assert.That(totalSent).IsEqualTo(250);
-
-            // Progress<T> marshals via SynchronizationContext; give it a tick
-            await Task.Delay(50);
 
             var flushes = events.OfType<BatchFlushed>().ToList();
             await Assert.That(flushes.Count).IsEqualTo(3);
@@ -79,7 +87,7 @@ public class SessionImporterProgressTests : IDisposable {
             ]);
 
             var events   = new List<ImportProgress>();
-            var progress = new Progress<ImportProgress>(events.Add);
+            var progress = new SyncProgress<ImportProgress>(events.Add);
 
             using var client = new HttpClient();
             var result = await SessionImporter.ImportSessionAsync(
@@ -87,8 +95,6 @@ public class SessionImporterProgressTests : IDisposable {
                 new SessionMetadata { Cwd = "/x" }, encodedCwd: null,
                 progress: progress
             );
-
-            await Task.Delay(50);
 
             await Assert.That(result.AgentIds).Contains(agentId);
 


### PR DESCRIPTION
## Summary

Replaces the default-import behaviour of `kapacitor history` with an explicit scope choice and a mandatory confirmation prompt, so users can't accidentally upload sessions from personal/private repos.

- New scope flags: `--all`, `--org`, `--repo <owner/name>`, `--repo .` (current cwd's repo). Mutually exclusive.
- Interactive Spectre picker when no flag is passed on a TTY (three top-level choices; "Specific repository" opens a sub-picker that pins the current repo at the top).
- Mandatory confirmation summary (scope, matched count, repo samples, visibility); skip with `--yes` / `-y`.
- `--private`: after import, `PUT /api/sessions/{id}/visibility {"visibility":"none"}` for every session imported in this run.
- Non-interactive runs require both a scope flag and `--yes` — missing either errors with exit 1.

`--cwd`, `--session`, `--min-lines`, `--since`, and the `excluded_repos` profile setting continue to work and compose as additional filters on top of the new scope step.

Setup gains a one-line tip after completion: `Optional: import past sessions with kapacitor history --org`. Help text is updated to document every flag and the picker fallback.

## Migration

CI/scripts currently calling `kapacitor history` without a flag on non-TTY will start erroring. Pass `--all --yes` for the prior behaviour. This is intentional — AI-613 is specifically about eliminating accidental uploads, and a silent default in automation can drift over time.

## Test plan

- [x] Unit: `ImportScopeArgsTests` (parser + resolver, 15 tests), `HistoryScopeFilterTests` (5 tests), `HistoryScopePromptTests` (formatter + repo-choices, 7 tests). All 528 unit tests pass.
- [x] Integration: `HistoryPrivateImportTests` (WireMock — verifies one PUT per session id, request body `{"visibility":"none"}`, and that one 500 doesn't abort the loop). All 6 integration tests pass.
- [x] AOT publish: zero IL2026/IL3050 warnings.
- [ ] Manual smoke (recommended before merge):
  - `kapacitor history` (picker path; pick each of the three options; verify confirmation; answer N cancels with exit 0)
  - `kapacitor history --all --yes` (no picker, no prompt, immediate import)
  - `KAPACITOR_PROFILE=default kapacitor history --org` (errors with "tenant-bound profile")
  - `kapacitor history --repo . --yes` inside a git repo (only this repo's sessions match)
  - `cd /tmp && kapacitor history --repo .` (errors with "not a git repo")
  - `kapacitor history --repo EventStore/kapacitor --yes --private` (summary shows `visibility: private (--private)`; imported sessions show `visibility: none` on the server)
  - `kapacitor history < /dev/null` (errors "--all, --org, or --repo")
  - `kapacitor history --all < /dev/null` (errors "--yes is required")
  - `kapacitor history --all --org --yes` (errors "mutually exclusive")

Spec: `docs/superpowers/specs/2026-05-13-ai-613-history-import-scope-design.md`
Plan: `docs/superpowers/plans/2026-05-13-ai-613-history-import-scope.md`

Closes [AI-613](https://linear.app/kurrent/issue/AI-613).

🤖 Generated with [Claude Code](https://claude.com/claude-code)