### PR TITLE
[AI-70] docs: document Codex hook installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ kapacitor plugin install --codex --project  # this repo only (<repo>/.codex/hook
 kapacitor plugin remove --codex             # uninstall
 ```
 
-`kapacitor status` reports installation state for both the Claude Code and Codex hook surfaces, so you can verify each is wired up.
+After a `--project` install, Codex won't actually run the hooks until you trust the directory: run `codex` once in the repo and accept the trust prompt.
+
+`kapacitor status` reports installation state for the user-wide Claude Code and Codex hook surfaces — it does not currently detect `--project` installs. For a `--project` install, check that `<repo>/.claude/settings.local.json` or `<repo>/.codex/hooks.json` exists and contains kapacitor entries.
 
 ### 3. Import existing sessions (optional)
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ For non-interactive environments:
 kapacitor setup --server-url https://capacitor.example.com --default-visibility org_public --no-prompt
 ```
 
+#### Also using Codex CLI?
+
+`setup` installs Claude Code hooks only. If you also use Codex CLI and want those sessions captured too, install the Codex hook surface separately:
+
+```bash
+kapacitor plugin install --codex            # user-wide  (~/.codex/hooks.json)
+kapacitor plugin install --codex --project  # this repo only (<repo>/.codex/hooks.json)
+kapacitor plugin remove --codex             # uninstall
+```
+
+`kapacitor status` reports installation state for both the Claude Code and Codex hook surfaces, so you can verify each is wired up.
+
 ### 3. Import existing sessions (optional)
 
 ```bash
@@ -62,7 +74,7 @@ Open the server URL in your browser. The dashboard shows repositories, sessions,
 
 ## What it records
 
-Once set up, Capacitor runs silently in the background. Every Claude Code session is captured automatically via hooks:
+Once set up, Capacitor runs silently in the background. Every Claude Code (and Codex CLI, if you installed those hooks) session is captured automatically:
 
 - **Session lifecycle** — start, end, interruptions, context compaction
 - **Transcript data** — streamed in real time via a background watcher process over SignalR


### PR DESCRIPTION
## Summary

Documents the Codex hook surface shipped in PR #55 (AI-70). `kapacitor setup` only installs the Claude Code plugin, so Codex users had no in-README path to discovering `kapacitor plugin install --codex`.

- Adds a short **Also using Codex CLI?** subsection right after the setup step, covering:
  - `kapacitor plugin install --codex` (user-wide, writes `~/.codex/hooks.json`)
  - `--project` variant (`<repo>/.codex/hooks.json`)
  - `kapacitor plugin remove --codex`
  - That `kapacitor status` reports both hook surfaces.
- Light update to the **What it records** intro line to acknowledge that Codex CLI sessions are captured too when those hooks are installed.

Deliberately scoped:

- `kapacitor codex-hook` is the internal dispatcher (only invoked from `hooks.json`), so it isn't documented as a user-facing command.
- The top-of-README tagline still says "Claude Code sessions" — leaving that rephrase for a separate marketing pass.

## Test plan

- [x] `git diff main` reviewed — only README.md, only the Codex additions.
- [ ] Render check on GitHub (subsection nests correctly under "Run setup").

🤖 Generated with [Claude Code](https://claude.com/claude-code)