### PR TITLE
ci: skip CI for doc-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,12 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
     tags:
       - 'v*'
 


### PR DESCRIPTION
## Summary

Adds `paths-ignore: ['**.md']` to the `pull_request` and `push` triggers of `.github/workflows/ci.yml`. Pure docs PRs (README, plan files, etc.) no longer spin up the build/test job and the two AOT publish matrix legs. Mixed PRs that touch both `.md` and code still trigger CI as before — `paths-ignore` only suppresses the workflow when *every* changed path matches the pattern.

Motivation: the recent docs-only PRs (#60, #61) burned ~3-5 CI minutes each for changes the workflow cannot meaningfully verify.

## Caveats

- If any of these jobs is ever marked **required** in branch protection, doc-only PRs would be blocked indefinitely waiting for a check that never runs. Currently nothing is required (PR #60 merged cleanly with `--auto` while two checks were still pending), so this is safe today — but worth flagging before adding required checks later.
- This PR itself only touches `.github/workflows/ci.yml`, so CI will still run on it (paths-ignore is evaluated on the changes in the PR, and a workflow change is not an `.md` change).

## Test plan

- [x] YAML diff reviewed.
- [ ] After merge: open a follow-up doc-only PR and confirm no CI runs are created.
- [ ] Follow-up mixed PR (one .md + one .cs) confirms CI still triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)