### PR TITLE
docs: require README updates alongside CLI changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,3 +47,4 @@ dotnet publish src/kapacitor/kapacitor.csproj -c Release 2>&1 | grep -E 'IL[23][
 - **JsonArray collection expressions** — `[item1, item2]` compiles to `Add<T>()` which requires dynamic code. Use `new JsonArray(item1, item2)` constructor instead.
 - **TUnit test filtering** — Use `--treenode-filter` with glob syntax, NOT `--filter`.
 - **macOS AOT binary code signing** — After copying an AOT binary, run `codesign --force --sign -` to re-sign.
+- **README sync on CLI changes** — Any change to user-facing CLI surface (new command, new/renamed/removed flag, changed default behavior, new prerequisite) must update `README.md` in the *same* PR. Check both the quick-start (`## Getting started`) and the per-command section under `## CLI commands`. Updating only `src/Kapacitor.Core/Resources/help-*.txt` is not enough — the README is the public-facing docs. This has been missed repeatedly and has required follow-up doc-only PRs (#60, #61).


### PR DESCRIPTION
## Summary

Adds a CLAUDE.md note (under **Common mistakes to avoid**) instructing future contributors — human and AI — to update `README.md` in the same PR as any user-facing CLI change.

The trigger: AI-613 (PR #58) and AI-70 (PR #55) both shipped substantial CLI surface changes without touching `README.md`, requiring follow-up doc-only PRs (#60 and #61). The new bullet:

- names the kinds of changes that require a README update (new command, new/renamed/removed flag, default-behavior shift, new prerequisite)
- points at the two README sections that typically need touching (`## Getting started` quick-start and `## CLI commands` per-command sections)
- calls out that updating only `src/Kapacitor.Core/Resources/help-*.txt` isn't enough — `--help` output is internal, the README is the public docs.

## Test plan

- [x] Diff reviewed — single bullet appended to existing list, no other changes.
- [ ] Validate next CLI-touching PR includes README updates (the test of whether this note actually helps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)