### PR TITLE
[AI-55] CLI: daemon-runner sends facts_used in eval-complete POST

### DIFF
--- a/src/Kapacitor.Core/Eval/EvalService.cs
+++ b/src/Kapacitor.Core/Eval/EvalService.cs
@@ -435,6 +435,8 @@ internal static class EvalService {
         // 4. Aggregate per-category + overall scores.
         var aggregate = Aggregate(verdicts, ctx.EvalRunId, model, ctx.Questions);
 
+        aggregate = aggregate with { FactsUsed = BuildFactsUsedSnapshot(ctx.KnownFactsByCategory) };
+
         // 5. Synthesise a retrospective from the per-question verdicts. Non-fatal:
         //    the verdicts are the persistence contract, a failed synthesis
         //    just leaves Retrospective=null on the payload.
@@ -706,6 +708,32 @@ internal static class EvalService {
 
         return text.Trim();
     }
+
+    // ── Facts-used snapshot ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds the <see cref="EvalFactSnapshotPayload"/> list from the
+    /// per-category pool the runner fetched. Rows without a
+    /// <c>FactHash</c> or <c>RetainerGitHubId</c> come from an older server
+    /// that doesn't return those fields yet — they're filtered out so we only
+    /// snapshot facts that can be fully attributed.
+    /// </summary>
+    internal static List<EvalFactSnapshotPayload> BuildFactsUsedSnapshot(
+            IReadOnlyDictionary<string, List<JudgeFact>> knownFactsByCategory
+        ) =>
+        knownFactsByCategory
+            .SelectMany(kv => kv.Value
+                .Where(f => f.FactHash is not null && f.RetainerGitHubId is not null)
+                .Select(f => new EvalFactSnapshotPayload {
+                    Category         = kv.Key,
+                    FactHash         = f.FactHash!,
+                    Fact             = f.Fact,
+                    RetainerGitHubId = f.RetainerGitHubId!.Value,
+                    SourceSessionId  = f.SourceSessionId,
+                    SourceEvalRunId  = f.SourceEvalRunId,
+                    RetainedAt       = f.RetainedAt
+                }))
+            .ToList();
 
     /// <summary>
     /// Prepares untrusted model or subprocess output for embedding in a

--- a/src/Kapacitor.Core/Models.cs
+++ b/src/Kapacitor.Core/Models.cs
@@ -339,8 +339,43 @@ record JudgeFact {
     [JsonPropertyName("category")]
     public required string Category { get; init; }
 
+    // Nullable for backward compat with older servers that don't return this field.
+    [JsonPropertyName("fact_hash")]
+    public string? FactHash { get; init; }
+
     [JsonPropertyName("fact")]
     public required string Fact { get; init; }
+
+    // Nullable for backward compat with older servers that don't return this field.
+    [JsonPropertyName("retainer_github_id")]
+    public long? RetainerGitHubId { get; init; }
+
+    [JsonPropertyName("source_session_id")]
+    public required string SourceSessionId { get; init; }
+
+    [JsonPropertyName("source_eval_run_id")]
+    public required string SourceEvalRunId { get; init; }
+
+    [JsonPropertyName("retained_at")]
+    public required DateTimeOffset RetainedAt { get; init; }
+}
+
+// Snapshot of a judge fact at eval time. Sent in the facts_used field of
+// SessionEvalCompletedPayload so the server can persist which facts were
+// in scope when the eval ran, even if the live judge_facts pool is later
+// modified (muted, deleted, replaced).
+record EvalFactSnapshotPayload {
+    [JsonPropertyName("category")]
+    public required string Category { get; init; }
+
+    [JsonPropertyName("fact_hash")]
+    public required string FactHash { get; init; }
+
+    [JsonPropertyName("fact")]
+    public required string Fact { get; init; }
+
+    [JsonPropertyName("retainer_github_id")]
+    public required long RetainerGitHubId { get; init; }
 
     [JsonPropertyName("source_session_id")]
     public required string SourceSessionId { get; init; }
@@ -371,6 +406,9 @@ record SessionEvalCompletedPayload {
 
     [JsonPropertyName("retrospective")]
     public EvalRetrospective? Retrospective { get; init; }
+
+    [JsonPropertyName("facts_used")]
+    public List<EvalFactSnapshotPayload> FactsUsed { get; init; } = [];
 }
 
 enum HistorySessionStatus { New, Partial, AlreadyLoaded }
@@ -429,6 +467,8 @@ record RepoEntry {
 [JsonSerializable(typeof(SessionEvalCompletedPayload))]
 [JsonSerializable(typeof(JudgeFactPayload))]
 [JsonSerializable(typeof(List<JudgeFact>))]
+[JsonSerializable(typeof(EvalFactSnapshotPayload))]
+[JsonSerializable(typeof(List<EvalFactSnapshotPayload>))]
 [JsonSerializable(typeof(List<ErrorEntry>))]
 [JsonSerializable(typeof(RepositoryPayload))]
 [JsonSerializable(typeof(GitCacheEntry))]

--- a/test/kapacitor.Tests.Unit/EvalServiceTests.cs
+++ b/test/kapacitor.Tests.Unit/EvalServiceTests.cs
@@ -666,4 +666,55 @@ public class EvalServiceTests {
         await Assert.That(facts[0].FactHash).IsNull();
         await Assert.That(facts[0].RetainerGitHubId).IsNull();
     }
+
+    // ── BuildFactsUsedSnapshot ─────────────────────────────────────────────
+
+    [Test]
+    public async Task BuildFactsUsedSnapshot_flattens_per_category_pool_and_filters_unattributed() {
+        var pool = new Dictionary<string, List<JudgeFact>> {
+            ["safety"] = [
+                new JudgeFact {
+                    Category         = "safety",
+                    FactHash         = "h-A",
+                    Fact             = "fact-A",
+                    RetainerGitHubId = 7,
+                    SourceSessionId  = "src",
+                    SourceEvalRunId  = "rA",
+                    RetainedAt       = DateTimeOffset.Parse("2026-05-01T00:00:00Z")
+                },
+                // Old-server row — no fact_hash; must be filtered out.
+                new JudgeFact {
+                    Category         = "safety",
+                    Fact             = "fact-B-no-hash",
+                    SourceSessionId  = "src",
+                    SourceEvalRunId  = "rB",
+                    RetainedAt       = DateTimeOffset.Parse("2026-05-02T00:00:00Z")
+                }
+            ],
+            ["plan_adherence"] = [
+                new JudgeFact {
+                    Category         = "plan_adherence",
+                    FactHash         = "h-C",
+                    Fact             = "fact-C",
+                    RetainerGitHubId = 8,
+                    SourceSessionId  = "src",
+                    SourceEvalRunId  = "rC",
+                    RetainedAt       = DateTimeOffset.Parse("2026-05-03T00:00:00Z")
+                }
+            ]
+        };
+
+        var snapshot = EvalService.BuildFactsUsedSnapshot(pool);
+
+        await Assert.That(snapshot.Count).IsEqualTo(2);
+        await Assert.That(snapshot.Any(s => s.FactHash == "h-A" && s.Category == "safety")).IsTrue();
+        await Assert.That(snapshot.Any(s => s.FactHash == "h-C" && s.Category == "plan_adherence")).IsTrue();
+        await Assert.That(snapshot.All(s => s.Fact != "fact-B-no-hash")).IsTrue();
+    }
+
+    [Test]
+    public async Task BuildFactsUsedSnapshot_returns_empty_for_empty_pool() {
+        var snapshot = EvalService.BuildFactsUsedSnapshot(new Dictionary<string, List<JudgeFact>>());
+        await Assert.That(snapshot.Count).IsEqualTo(0);
+    }
 }

--- a/test/kapacitor.Tests.Unit/EvalServiceTests.cs
+++ b/test/kapacitor.Tests.Unit/EvalServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using kapacitor;
 using kapacitor.Eval;
 
 namespace kapacitor.Tests.Unit;
@@ -633,5 +635,35 @@ public class EvalServiceTests {
 
         await Assert.That(v).IsNotNull();
         await Assert.That(v!.ToolsUsed).IsEqualTo(2);
+    }
+
+    // ── JudgeFact deserialization (new optional fields) ────────────────────
+
+    [Test]
+    public async Task JudgeFact_deserializes_with_new_optional_fields() {
+        const string newServerJson = """
+            [{"category":"safety","fact_hash":"h1","fact":"x","retainer_github_id":42,
+              "source_session_id":"s","source_eval_run_id":"r","retained_at":"2026-05-13T00:00:00Z"}]
+            """;
+
+        var facts = JsonSerializer.Deserialize(newServerJson, KapacitorJsonContext.Default.ListJudgeFact)!;
+
+        await Assert.That(facts.Count).IsEqualTo(1);
+        await Assert.That(facts[0].FactHash).IsEqualTo("h1");
+        await Assert.That(facts[0].RetainerGitHubId).IsEqualTo(42L);
+    }
+
+    [Test]
+    public async Task JudgeFact_deserializes_without_new_fields_from_old_server() {
+        const string oldServerJson = """
+            [{"category":"safety","fact":"x","source_session_id":"s","source_eval_run_id":"r",
+              "retained_at":"2026-05-13T00:00:00Z"}]
+            """;
+
+        var facts = JsonSerializer.Deserialize(oldServerJson, KapacitorJsonContext.Default.ListJudgeFact)!;
+
+        await Assert.That(facts.Count).IsEqualTo(1);
+        await Assert.That(facts[0].FactHash).IsNull();
+        await Assert.That(facts[0].RetainerGitHubId).IsNull();
     }
 }


### PR DESCRIPTION
## Summary

Companion to the server-side PR kurrent-io/Kurrent.Capacitor#616 (already merged). This PR makes the daemon eval runner snapshot the judge_facts pool it actually used into the `facts_used` field on the eval-complete POST body. The server now persists that snapshot and the eval-tab panel renders it.

- Adds optional `FactHash` + `RetainerGitHubId` to the CLI's `JudgeFact` record (nullable for backward compat with older servers that don't return them).
- Adds `EvalFactSnapshotPayload` record and registers it in `KapacitorJsonContext` for AOT-safe serialization.
- Adds `FactsUsed` field to `SessionEvalCompletedPayload` — populated in `FinalizeAsync` from the per-category pool already fetched by `FetchAllJudgeFactsAsync`.
- Filters out rows that lack `FactHash`/`RetainerGitHubId` (handles the deploy gap where this CLI talks to an older server).

## Companion PR

- kurrent-io/Kurrent.Capacitor#616 — server side of AI-55. Already merged.

## After this PR merges

- Cut a CLI release (npm publish).
- Bump the submodule pointer in `kurrent-io/Kurrent.Capacitor` to the released SHA.

## Test plan

- [x] `dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj` — all 566 tests green.
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — no IL3050/IL2026 warnings.
- [ ] Manual end-to-end after release: trigger a daemon-runner eval against the new server, confirm the eval-tab panel renders facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)