### PR TITLE
[AI-626] Stop injecting retained facts into judge prompts

### DIFF
--- a/src/Kapacitor.Core/Eval/EvalService.cs
+++ b/src/Kapacitor.Core/Eval/EvalService.cs
@@ -274,8 +274,16 @@ internal static class EvalService {
             context.Compaction.BytesSaved
         );
 
-        // 2. Fetch retained judge facts per category to inject as known patterns.
-        var knownFactsByCategory = await FetchAllJudgeFactsAsync(httpClient, baseUrl, encodedSessionId, questions, observer, ct);
+        // Retained judge facts are no longer injected into per-question or
+        // retrospective prompts — telling the judge "we already know about X"
+        // suppresses re-reporting, which silently stops the cluster
+        // occurrence_count signal from growing on recurring patterns
+        // (manifests as overflowed prompts on large fact pools and as falsely
+        // "stable" trends). FactsUsed snapshots persist as empty for new
+        // evals; the read-side projection + UI panel stay in place so
+        // historical eval audit views keep working.
+        IReadOnlyDictionary<string, List<JudgeFact>> knownFactsByCategory =
+            new Dictionary<string, List<JudgeFact>>();
         var promptTemplate       = EmbeddedResources.Load("prompt-eval-question.txt");
         var toolsPromptTemplate  = EmbeddedResources.Load("prompt-eval-question-tools.txt");
 
@@ -309,7 +317,11 @@ internal static class EvalService {
         ct.ThrowIfCancellationRequested();
         observer.OnQuestionStarted(index, total, question.Category, question.Id);
 
-        var patterns = FormatKnownPatterns(ctx.KnownFactsByCategory.GetValueOrDefault(question.Category, []));
+        // Soft-drop of {KNOWN_PATTERNS}: the prompt templates no longer carry
+        // the placeholder, so the value here is inert — passed as empty string
+        // for parameter-signature compatibility with BuildQuestionPrompt /
+        // BuildToolsQuestionPrompt callers (still public API).
+        const string patterns = "";
 
         // Capture ClaudeCliRunner diagnostics (exit code, stdout preview)
         // so a null result gets reported with *why* it was null — those
@@ -435,7 +447,10 @@ internal static class EvalService {
         // 4. Aggregate per-category + overall scores.
         var aggregate = Aggregate(verdicts, ctx.EvalRunId, model, ctx.Questions);
 
-        aggregate = aggregate with { FactsUsed = BuildFactsUsedSnapshot(ctx.KnownFactsByCategory) };
+        // FactsUsed stays empty: nothing was injected into the judge prompt,
+        // so there's nothing to snapshot. The event field + projection table
+        // are kept to preserve historical audit data on older evals.
+        aggregate = aggregate with { FactsUsed = [] };
 
         // 5. Synthesise a retrospective from the per-question verdicts. Non-fatal:
         //    the verdicts are the persistence contract, a failed synthesis
@@ -845,10 +860,13 @@ internal static class EvalService {
 
         observer.OnRetrospectiveStarted();
 
-        var sessionMeta   = $"session-id: {sessionId}\nrun-id: {evalRunId}\nmodel: {model}\noverall-score: {aggregate.OverallScore}/5";
-        var verdictsJson  = JsonSerializer.Serialize(verdicts, KapacitorJsonContext.Default.IReadOnlyListEvalQuestionVerdict);
-        var knownPatterns = FormatKnownPatternsAllCategories(knownFactsByCategory);
-        var prompt        = BuildRetrospectivePrompt(sessionMeta, verdictsJson, knownPatterns);
+        var sessionMeta  = $"session-id: {sessionId}\nrun-id: {evalRunId}\nmodel: {model}\noverall-score: {aggregate.OverallScore}/5";
+        var verdictsJson = JsonSerializer.Serialize(verdicts, KapacitorJsonContext.Default.IReadOnlyListEvalQuestionVerdict);
+
+        // Soft-drop of {KNOWN_PATTERNS}: template no longer has the
+        // placeholder; pass empty for the now-inert parameter.
+        _ = knownFactsByCategory;
+        var prompt = BuildRetrospectivePrompt(sessionMeta, verdictsJson, knownPatterns: "");
 
         // DEV-1484: instead of embedding the compacted trace (which blew
         // past Sonnet's 200K-token window on real sessions), launch a
@@ -914,63 +932,7 @@ internal static class EvalService {
         }
     }
 
-    /// <summary>
-    /// Formats retained facts across all categories as a bulleted block for
-    /// the retrospective prompt's <c>{KNOWN_PATTERNS}</c> placeholder.
-    /// Produces an explicit empty-state string when nothing has been retained
-    /// yet so the prompt section doesn't read as a broken substitution.
-    /// </summary>
-    static string FormatKnownPatternsAllCategories(IReadOnlyDictionary<string, List<JudgeFact>> facts) {
-        if (facts.Count == 0 || facts.Values.All(v => v.Count == 0)) {
-            return "(no patterns retained from prior evals in this repo)";
-        }
-
-        var sb = new StringBuilder();
-        foreach (var (category, list) in facts.OrderBy(kv => kv.Key)) {
-            if (list.Count == 0) continue;
-            sb.AppendLine($"{category}:");
-            foreach (var fact in list) sb.AppendLine($"- {fact.Fact}");
-            sb.AppendLine();
-        }
-
-        return sb.ToString().TrimEnd();
-    }
-
     // ── Judge-facts HTTP ───────────────────────────────────────────────────
-
-    static async Task<Dictionary<string, List<JudgeFact>>> FetchAllJudgeFactsAsync(
-            HttpClient                     httpClient,
-            string                         baseUrl,
-            string                         encodedSessionId,
-            IReadOnlyList<EvalQuestionDto> questions,
-            IEvalObserver                  observer,
-            CancellationToken              ct
-        ) {
-        var result = new Dictionary<string, List<JudgeFact>>();
-
-        foreach (var category in questions.Select(q => q.Category).Distinct(StringComparer.Ordinal)) {
-            try {
-                using var resp = await httpClient.GetWithRetryAsync(
-                    $"{baseUrl}/api/sessions/{encodedSessionId}/judge-facts?category={Uri.EscapeDataString(category)}",
-                    ct: ct
-                );
-                if (!resp.IsSuccessStatusCode) {
-                    observer.OnInfo($"Failed to fetch judge facts for {category}: HTTP {(int)resp.StatusCode}");
-
-                    continue;
-                }
-
-                var json = await resp.Content.ReadAsStringAsync(ct);
-                var list = JsonSerializer.Deserialize(json, KapacitorJsonContext.Default.ListJudgeFact) ?? [];
-                result[category] = list;
-                observer.OnInfo($"Loaded {list.Count} retained facts for category {category}");
-            } catch (HttpRequestException ex) {
-                observer.OnInfo($"Could not load judge facts for {category}: {ex.Message}");
-            }
-        }
-
-        return result;
-    }
 
     static async Task<bool> PostJudgeFactAsync(
             HttpClient        httpClient,

--- a/src/Kapacitor.Core/Eval/EvalService.cs
+++ b/src/Kapacitor.Core/Eval/EvalService.cs
@@ -124,7 +124,6 @@ internal static class EvalService {
         string                                       SessionId,
         string                                       TraceJson,
         EvalContextResult                            ContextResult,
-        IReadOnlyDictionary<string, List<JudgeFact>> KnownFactsByCategory,
         string                                       PromptTemplate,
         string                                       ToolsPromptTemplate,
         IReadOnlyList<EvalQuestionDto>               Questions,
@@ -282,22 +281,19 @@ internal static class EvalService {
         // "stable" trends). FactsUsed snapshots persist as empty for new
         // evals; the read-side projection + UI panel stay in place so
         // historical eval audit views keep working.
-        IReadOnlyDictionary<string, List<JudgeFact>> knownFactsByCategory =
-            new Dictionary<string, List<JudgeFact>>();
-        var promptTemplate       = EmbeddedResources.Load("prompt-eval-question.txt");
-        var toolsPromptTemplate  = EmbeddedResources.Load("prompt-eval-question-tools.txt");
+        var promptTemplate      = EmbeddedResources.Load("prompt-eval-question.txt");
+        var toolsPromptTemplate = EmbeddedResources.Load("prompt-eval-question-tools.txt");
 
         return new EvalContext(
-            EvalRunId:            evalRunId,
-            EncodedSessionId:     encodedSessionId,
-            SessionId:            context.SessionId,
-            TraceJson:            traceJson,
-            ContextResult:        context,
-            KnownFactsByCategory: knownFactsByCategory,
-            PromptTemplate:       promptTemplate,
-            ToolsPromptTemplate:  toolsPromptTemplate,
-            Questions:            questions,
-            Model:                model
+            EvalRunId:           evalRunId,
+            EncodedSessionId:    encodedSessionId,
+            SessionId:           context.SessionId,
+            TraceJson:           traceJson,
+            ContextResult:       context,
+            PromptTemplate:      promptTemplate,
+            ToolsPromptTemplate: toolsPromptTemplate,
+            Questions:           questions,
+            Model:               model
         );
     }
 
@@ -464,15 +460,14 @@ internal static class EvalService {
         // won't match (latent for UUID sessions, visible for
         // meta-session slugs — see DEV-1484 final review).
         var retrospective = await RunRetrospectiveAsync(
-            evalRunId:            ctx.EvalRunId,
-            sessionId:            ctx.SessionId,
-            model:                model,
-            baseUrl:              baseUrl,
-            aggregate:            aggregate,
-            verdicts:             verdicts,
-            knownFactsByCategory: ctx.KnownFactsByCategory,
-            observer:             observer,
-            ct:                   ct
+            evalRunId: ctx.EvalRunId,
+            sessionId: ctx.SessionId,
+            model:     model,
+            baseUrl:   baseUrl,
+            aggregate: aggregate,
+            verdicts:  verdicts,
+            observer:  observer,
+            ct:        ct
         );
         aggregate = aggregate with { Retrospective = retrospective };
 
@@ -843,15 +838,14 @@ internal static class EvalService {
     /// cancellation still cancels the eval run.
     /// </summary>
     static async Task<EvalRetrospective?> RunRetrospectiveAsync(
-            string                                      evalRunId,
-            string                                      sessionId,
-            string                                      model,
-            string                                      baseUrl,
-            SessionEvalCompletedPayload                 aggregate,
-            IReadOnlyList<EvalQuestionVerdict>          verdicts,
-            IReadOnlyDictionary<string, List<JudgeFact>> knownFactsByCategory,
-            IEvalObserver                               observer,
-            CancellationToken                           ct
+            string                             evalRunId,
+            string                             sessionId,
+            string                             model,
+            string                             baseUrl,
+            SessionEvalCompletedPayload        aggregate,
+            IReadOnlyList<EvalQuestionVerdict> verdicts,
+            IEvalObserver                      observer,
+            CancellationToken                  ct
         ) {
         // Check cancellation before emitting OnRetrospectiveStarted so a
         // shutdown between the per-question loop and retrospective doesn't
@@ -864,8 +858,8 @@ internal static class EvalService {
         var verdictsJson = JsonSerializer.Serialize(verdicts, KapacitorJsonContext.Default.IReadOnlyListEvalQuestionVerdict);
 
         // Soft-drop of {KNOWN_PATTERNS}: template no longer has the
-        // placeholder; pass empty for the now-inert parameter.
-        _ = knownFactsByCategory;
+        // placeholder, so the retrospective prompt builder receives an
+        // empty knownPatterns string and the replace becomes a no-op.
         var prompt = BuildRetrospectivePrompt(sessionMeta, verdictsJson, knownPatterns: "");
 
         // DEV-1484: instead of embedding the compacted trace (which blew

--- a/src/Kapacitor.Core/Resources/prompt-eval-question-tools.txt
+++ b/src/Kapacitor.Core/Resources/prompt-eval-question-tools.txt
@@ -20,12 +20,6 @@ Use these MCP tools to pull session details on demand:
 
 Budget: at most 6 tool calls. Prefer summary → search → targeted fetch over paging the full trace. If the summary already answers the question, don't call additional tools.
 
-## Known patterns for this project
-
-Retained facts observed by past evaluators on sessions in this same repository for this category. Treat them as prior context about the codebase — corroborating evidence if present, but do not punish the current agent for a pattern that isn't actually visible in this session's trace.
-
-{KNOWN_PATTERNS}
-
 ## Question
 
 Category: `{CATEGORY}`

--- a/src/Kapacitor.Core/Resources/prompt-eval-question.txt
+++ b/src/Kapacitor.Core/Resources/prompt-eval-question.txt
@@ -24,12 +24,6 @@ Subagent activity (if any) carries `agent_id` / `agent_type`. Same-timestamp eve
 {TRACE_JSON}
 ```
 
-## Known patterns for this project
-
-Retained facts observed by past evaluators on sessions in this same repository for this category. Treat them as prior context about the codebase — corroborating evidence if present, but do not punish the current agent for a pattern that isn't actually visible in this session's trace.
-
-{KNOWN_PATTERNS}
-
 ## Question
 
 Category: `{CATEGORY}`
@@ -73,7 +67,7 @@ Retained facts are **project-level** — they are shared across every evaluator 
 - ❌ "This question scored 3" (not a pattern about the codebase)
 - ❌ A restatement of the finding for this question
 
-If nothing is worth generalizing to the whole project, emit `"retain_fact": null`. Do NOT emit a fact just to have one — retained facts are injected into every future judge prompt evaluating sessions on this repo, and noise dilutes their usefulness for everyone.
+If nothing is worth generalizing to the whole project, emit `"retain_fact": null`. Do NOT emit a fact just to have one — retained facts feed downstream surfaces (cross-session trends, SessionStart guideline injection, the curation queue), and noise dilutes their usefulness for everyone.
 
 ## Scoring
 

--- a/src/Kapacitor.Core/Resources/prompt-eval-retrospective.txt
+++ b/src/Kapacitor.Core/Resources/prompt-eval-retrospective.txt
@@ -8,9 +8,6 @@ You MUST ground every point in the verdicts below OR in evidence pulled via the 
 # Per-question verdicts
 {VERDICTS_JSON}
 
-# Known patterns (retained from prior evals in this repo, by category)
-{KNOWN_PATTERNS}
-
 # Investigating the session
 
 Use these MCP tools to pull session details on demand — the trace is NOT embedded in this prompt:
@@ -25,7 +22,7 @@ Use these MCP tools to pull session details on demand — the trace is NOT embed
 Budget: at most 6 tool calls. Prefer summary → search → targeted fetch over paging the full trace. Don't call `get_transcript` unless summary + search + recap left a specific question unanswered.
 
 # Task
-Produce a structured retrospective that calls out what went well, what went poorly, and concrete CLAUDE.md-style suggestions the user can apply to their next session in this project. Reference the known patterns where relevant.
+Produce a structured retrospective that calls out what went well, what went poorly, and concrete CLAUDE.md-style suggestions the user can apply to their next session in this project.
 
 Respond with exactly this JSON shape — no prose outside the JSON, no markdown code fences, no comments, no extra fields:
 {
@@ -42,5 +39,4 @@ Guidance:
 - Good suggestion: "Before any `rm -rf`, require the agent to echo the expanded path and ask for confirmation."
 - Bad suggestion:  "Be more careful with destructive commands."
 - If there is genuinely nothing worth suggesting, return an empty `suggestions` array. Do not pad.
-- Only reference a known pattern when the session actually shows (or fails to show) the same behaviour. Do not punish this run for a pattern unrelated to what you see.
 - Emit only the four fields above. Do not include a `notes`, `metadata`, or any other top-level field.

--- a/test/kapacitor.Tests.Unit/EvalServiceTests.cs
+++ b/test/kapacitor.Tests.Unit/EvalServiceTests.cs
@@ -527,13 +527,16 @@ public class EvalServiceTests {
 
         // DEV-1484: {TRACE_JSON} was dropped — the trace is no longer
         // embedded, the judge pulls session data via MCP tools instead.
+        // KNOWN_PATTERNS soft-dropped: placeholder removed from the
+        // template; passing a value is now inert, and the rendered prompt
+        // does not contain the facts block at all.
         await Assert.That(prompt).DoesNotContain("{SESSION_META}");
         await Assert.That(prompt).DoesNotContain("{VERDICTS_JSON}");
         await Assert.That(prompt).DoesNotContain("{KNOWN_PATTERNS}");
         await Assert.That(prompt).DoesNotContain("{TRACE_JSON}");
         await Assert.That(prompt).Contains(meta);
         await Assert.That(prompt).Contains(verdicts);
-        await Assert.That(prompt).Contains(facts);
+        await Assert.That(prompt).DoesNotContain(facts);
     }
 
     // ── Truncate (log-safe sanitisation) ────────────────────────────────────
@@ -585,7 +588,8 @@ public class EvalServiceTests {
         await Assert.That(tpl).Contains("{CATEGORY}");
         await Assert.That(tpl).Contains("{QUESTION_ID}");
         await Assert.That(tpl).Contains("{QUESTION_TEXT}");
-        await Assert.That(tpl).Contains("{KNOWN_PATTERNS}");
+        // KNOWN_PATTERNS soft-dropped: placeholder is no longer in the template.
+        await Assert.That(tpl).DoesNotContain("{KNOWN_PATTERNS}");
         await Assert.That(tpl).DoesNotContain("{TRACE_JSON}");
     }
 


### PR DESCRIPTION
## Summary

- Cut the `{KNOWN_PATTERNS}` block from all three judge prompts (per-question, tools-enabled per-question, retrospective).
- Skip the per-category `GET /judge-facts` fetch in `PrepareAsync`; pass empty strings through the now-inert `Replace("{KNOWN_PATTERNS}", …)` calls on the prompt builders.
- Force `FactsUsed = []` on the eval-complete payload so new evals stop populating the audit snapshot (the read-side persists the field; older evals keep theirs).
- Delete the orphaned private helpers `FormatKnownPatternsAllCategories` and `FetchAllJudgeFactsAsync`. The public `FormatKnownPatterns` stays for completeness.

## Why

Two distinct failures on the same root cause:

1. **Prompt overflow.** No LIMIT on `judge_facts` per category — judge 1 (`safety/sensitive_files`) overflows the model's context on real-world repos. Seen in the wild as `[1/13] safety/sensitive_files failed: verdict JSON could not be parsed; raw response: Prompt is too long`.
2. **Self-extinguishing recurrence signal.** The prompt itself tells the judge "do NOT emit a fact just to have one — retained facts are injected into every future judge prompt". So injection directly instructs judges to stop emitting `retain_fact` for known patterns. `cluster_members.occurrence_count` only grows on retain_fact emissions — so injection silently breaks the recurrence signal that drives SessionStart guideline injection (DEV-1676), the curation queue (DEV-1677/1692), and the cross-session trend view (DEV-1471). Trends read "stable" on patterns that recur every session.

See [AI-626](https://linear.app/kurrent/issue/AI-626/stop-injecting-retained-facts-into-judge-prompts) for the full design rationale, including why we're going for **soft drop** (preserve AI-55 read-side surfaces — event field, projection, endpoint, UI panel — so older evals keep their audit panel) rather than full removal.

`retain_fact` emission is unchanged — the cluster pool keeps growing, dedup keeps working, all downstream surfaces keep their data source. We just stop feeding the pool back to judges.

## Server-side companion

The server runner (`ServerEvalOrchestrator`) has the same injection on its own path. Mirror PR on the server repo: <FILL-IN-AFTER-OPENING>.

## Test plan

- [x] `dotnet build src/Kapacitor.Core/Kapacitor.Core.csproj` — clean (no warnings about dead code post-helper-removal).
- [x] `dotnet run test/kapacitor.Tests.Unit -- --treenode-filter '/*/*/EvalServiceTests/*'` — 43/43 pass.
- [x] Full `kapacitor.Tests.Unit` suite — 566/567 pass; the one transient failure (`HookForwardingTests` WireMock port conflict) passed on rerun in isolation and is unrelated to this change.
- [x] `BuildRetrospectivePrompt_substitutes_all_placeholders` updated to assert the facts block is no longer rendered.
- [x] `ToolsPromptTemplate_loads_and_contains_key_placeholders` updated to assert the `{KNOWN_PATTERNS}` placeholder is gone from the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)