### PR TITLE
[AI-629] Install Codex skills alongside hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ kapacitor plugin install --codex --project  # this repo only (<repo>/.codex/hook
 kapacitor plugin remove --codex             # uninstall
 ```
 
-After a `--project` install, Codex won't actually run the hooks until you trust the directory: run `codex` once in the repo and accept the trust prompt.
+`--codex` also installs two Codex skills into `~/.codex/skills/` — `kapacitor-recap` and `kapacitor-errors` — so the Codex CLI can pull repo session summaries and tool-error reports on demand. Codex sessions don't auto-populate `KAPACITOR_SESSION_ID`, so the recap skill leads with `kapacitor recap --repo` and falls back to explicit session IDs. The `validate-plan` skill is Claude Code–only (no Codex plan mode equivalent).
+
+After a `--project` install, Codex won't actually run the hooks until you trust the directory: run `codex` once in the repo and accept the trust prompt. Skills are always installed user-wide regardless of `--project`.
 
 `kapacitor status` reports installation state for the user-wide Claude Code and Codex hook surfaces — it does not currently detect `--project` installs. For a `--project` install, check that `<repo>/.claude/settings.local.json` or `<repo>/.codex/hooks.json` exists and contains kapacitor entries.
 

--- a/kapacitor/codex-skills/kapacitor-errors/SKILL.md
+++ b/kapacitor/codex-skills/kapacitor-errors/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: kapacitor-errors
+description: >-
+  Use when the user asks to "show errors", "extract errors", "what went wrong",
+  "find tool errors", "review errors from session", "check session errors",
+  "list failures", "what failed in session X", "error report", "show mistakes",
+  or wants to review tool call errors from a recorded session. Extracts tool
+  errors via the `kapacitor errors` CLI.
+---
+
+# Kapacitor Errors
+
+Extract tool call errors from a session recorded by Kurrent Capacitor. The output lists each failed tool call — shell commands, file reads/writes, agent delegations, etc. — along with the error message and the tool that caused it.
+
+## Usage
+
+Codex sessions do not export `KAPACITOR_SESSION_ID`, so you must pass the session ID explicitly. To find recent session IDs, run `kapacitor recap --repo` first.
+
+```bash
+# Errors from a specific session
+kapacitor errors <sessionId>
+
+# Errors from the full continuation chain starting at a session
+kapacitor errors --chain <sessionId>
+```
+
+## Output Format
+
+Each error is printed as a block with:
+
+- **Session ID** and optional **agent ID** (if the error occurred in a subagent)
+- **Event number** and **timestamp**
+- **Tool name** — the tool that failed (e.g., Bash, Read, Edit, Write, Grep, Glob)
+- **Error message** — the error output or failure reason
+
+When using `--chain`, errors from all sessions in the continuation chain are included, ordered chronologically.
+
+## When to Use Each Flag
+
+- **No flag** (`kapacitor errors <sessionId>`) — reviewing errors from one specific session
+- **`--chain <sessionId>`** — reviewing errors across a full task that spanned multiple sessions
+
+## Practical Applications
+
+- **Post-mortem review** — after finishing a session, identify recurring mistakes and update project rules (CLAUDE.md / AGENTS.md) with avoidance guidance.
+- **Debugging** — quickly find what went wrong in a session without scrolling through the full timeline.
+- **Pattern detection** — use `--chain` across a multi-session task to spot repeated error patterns (e.g., wrong file paths, incorrect API usage).
+
+## Environment
+
+`KAPACITOR_URL` overrides the default server URL (`http://localhost:5108`).
+
+## Tips
+
+- After extracting errors, look for patterns: the same tool failing repeatedly, or the same type of mistake across sessions.
+- Propose concrete avoidance rules based on the errors found — these can be added to AGENTS.md / CLAUDE.md.
+- The `kapacitor` CLI must be available on PATH (typically installed at `~/.local/bin/kapacitor`).
+
+## Error Handling
+
+- If the session is not found, the command prints an error and exits with code 1.
+- If no errors are found, the command prints "No errors found." — this is a good outcome.
+- If the Kurrent Capacitor server is unreachable, the command prints an HTTP error. Ensure the server is running.

--- a/kapacitor/codex-skills/kapacitor-recap/SKILL.md
+++ b/kapacitor/codex-skills/kapacitor-recap/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: kapacitor-recap
+description: >-
+  Use when the user asks to "read a previous session", "get session history",
+  "recap session", "what happened in session X", "load context from a previous
+  session", "continue from session", "what did we do last time", "catch me up",
+  "summarize session", "what have we been working on", "recent changes",
+  "recent sessions", or references prior work in this repo. Retrieves session
+  summaries recorded by Kurrent Capacitor via the `kapacitor recap` CLI.
+---
+
+# Kapacitor Recap
+
+Retrieve session history recorded by Kurrent Capacitor. Inside Codex, the recommended entry point is the **repository recap** — Codex sessions do not export a `KAPACITOR_SESSION_ID` environment variable, so the "current session" shortcut is unavailable. Drill into a specific session by passing its ID explicitly.
+
+## Usage
+
+Run the `kapacitor recap` CLI via the shell. Do NOT call the HTTP API directly — the CLI handles formatting, error handling, and server URL resolution.
+
+```bash
+# Recent session summaries for the current repository (start here)
+kapacitor recap --repo
+
+# Drill into a specific session by ID (from --repo output)
+kapacitor recap <sessionId>
+
+# Full transcript for a specific session
+kapacitor recap --full <sessionId>
+
+# Full continuation chain (all linked sessions, oldest first)
+kapacitor recap --chain <sessionId>
+
+# Both: full transcript across all chained sessions
+kapacitor recap --chain --full <sessionId>
+```
+
+## Repository Recap (`--repo`)
+
+Returns AI-generated summaries from the most recent ended sessions in the current git repository. Each entry includes the session title, date, summary, and the session ID needed to drill in further.
+
+**Use this when:**
+- The user says "what have we been working on recently?"
+- The user references prior work ("recently we implemented X")
+- You need context about recent changes in this repo
+- Starting a new session and want to understand recent activity
+
+**Progressive disclosure:** Start with `--repo` for the overview. If a specific session's summary is relevant, drill into it with `kapacitor recap --full <sessionId>` to get the complete transcript. This avoids loading full transcripts for all sessions into context.
+
+## Session Recap (`<sessionId>`)
+
+Shows the plan (if any) and an AI-generated summary with:
+- **Context** — why the work was done
+- **Key decisions** — trade-offs and design choices that matter for future work
+- **Unfinished/Risks** — anything deferred or left incomplete
+
+If no summary is available (e.g., active session), a hint is shown to use `--full`.
+
+## Full Output (`--full`)
+
+The complete transcript with these section types:
+
+- **`## User Prompt`** — what the user asked
+- **`## Assistant`** — text responses
+- **`## Plan`** — plans that were created (Claude Code sessions only)
+- **`## Write <path>`** — files that were created (with syntax-highlighted content)
+- **`## Edit <path>`** — files that were edited (with diff content)
+
+When using `--chain`, sessions are separated by `# Session <id>` headers, and agent activity appears under `### Agent (<type>)` sub-headers.
+
+## When to Use Each Flag
+
+- **`--repo`** — recent session summaries across the repo (start here)
+- **`<sessionId>`** — quick context on a specific session (from `--repo` output)
+- **`--full <sessionId>`** — when you need exact prompts, responses, or file contents
+- **`--chain <sessionId>`** — understanding the full history of a task that spanned multiple sessions
+- **`--chain --full <sessionId>`** — complete transcript across all continuations
+
+## Environment
+
+`KAPACITOR_URL` overrides the default server URL (`http://localhost:5108`).
+
+## Tips
+
+- Always start with `--repo` — it gives the overview without flooding context.
+- Summarize key decisions and changes for the user rather than echoing the full recap output verbatim.
+- The `kapacitor` CLI must be available on PATH (typically installed at `~/.local/bin/kapacitor`).
+
+## Error Handling
+
+- If the session is not found, the command prints "Session not found" and exits with code 1.
+- If not in a git repository (for `--repo`), the command prints an error and exits with code 1.
+- If the Kurrent Capacitor server is unreachable, the command prints an HTTP error. Ensure the server is running.

--- a/src/Kapacitor.Core/CodexPaths.cs
+++ b/src/Kapacitor.Core/CodexPaths.cs
@@ -4,6 +4,7 @@ static class CodexPaths {
     public static string Home          { get; } = Path.Combine(PathHelpers.HomeDirectory, ".codex");
     public static string Sessions      { get; } = Path.Combine(Path.Combine(PathHelpers.HomeDirectory, ".codex"), "sessions");
     public static string UserHooksJson { get; } = Path.Combine(Path.Combine(PathHelpers.HomeDirectory, ".codex"), "hooks.json");
+    public static string UserSkillsDir { get; } = Path.Combine(Path.Combine(PathHelpers.HomeDirectory, ".codex"), "skills");
 
     /// <summary>
     /// Walk <c>~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl</c>, optionally pruning

--- a/src/Kapacitor.Core/Resources/help-plugin.txt
+++ b/src/Kapacitor.Core/Resources/help-plugin.txt
@@ -1,17 +1,22 @@
-kapacitor plugin — Manage hooks for Claude Code and Codex CLI
+kapacitor plugin — Manage hooks and skills for Claude Code and Codex CLI
 
 Usage: kapacitor plugin <subcommand> [options]
 
 Subcommands:
-  install             Register the plugin / hooks
-  remove              Remove the plugin / hooks
+  install             Register the plugin / hooks / skills
+  remove              Remove the plugin / hooks / skills
 
 Options:
   --project           Apply to current project only (default: user-wide)
-  --codex             Target Codex CLI (~/.codex/hooks.json) instead of Claude Code
+  --codex             Target Codex CLI instead of Claude Code
+
+Notes:
+  --codex installs hooks (~/.codex/hooks.json or <repo>/.codex/hooks.json with
+  --project) plus kapacitor-recap and kapacitor-errors skills in
+  ~/.codex/skills/. Skills are always user-wide; --project only affects hooks.
 
 Examples:
-  kapacitor plugin install                  # Install Claude Code plugin (user)
-  kapacitor plugin install --codex          # Install Codex hooks (~/.codex/hooks.json)
-  kapacitor plugin install --project --codex  # Install Codex hooks in <repo>/.codex/hooks.json
-  kapacitor plugin remove --codex           # Remove Codex hooks
+  kapacitor plugin install                    # Install Claude Code plugin (user)
+  kapacitor plugin install --codex            # Install Codex hooks + skills (user)
+  kapacitor plugin install --project --codex  # Install Codex hooks in <repo>/.codex/hooks.json (skills still user)
+  kapacitor plugin remove --codex             # Remove Codex hooks and skills

--- a/src/kapacitor/Commands/PluginCommand.cs
+++ b/src/kapacitor/Commands/PluginCommand.cs
@@ -160,7 +160,11 @@ public static class PluginCommand {
             if (InstallCodexSkills(skillsSource, CodexPaths.UserSkillsDir)) {
                 await Console.Out.WriteLineAsync($"Codex skills installed (user: {CodexPaths.UserSkillsDir})");
             } else {
+                // Hooks succeeded but skills failed — `--codex` is a hooks AND
+                // skills contract, so surface the partial failure via exit code
+                // so callers (CI, scripts) can detect it.
                 await Console.Error.WriteLineAsync("Could not install Codex skills.");
+                return 1;
             }
         }
 
@@ -354,8 +358,10 @@ public static class PluginCommand {
             try {
                 Directory.Delete(dst, recursive: true);
                 changed = true;
-            } catch {
-                // best effort
+            } catch (Exception ex) {
+                // Log so the user knows a skill is stuck. Exit code stays 0 for
+                // parity with RemoveCodexHooks, which also degrades gracefully.
+                Console.Error.WriteLine($"Could not remove Codex skill '{name}': {ex.Message}");
             }
         }
 

--- a/src/kapacitor/Commands/PluginCommand.cs
+++ b/src/kapacitor/Commands/PluginCommand.cs
@@ -15,6 +15,15 @@ public static class PluginCommand {
         "Stop"
     ];
 
+    // Folders inside <plugin>/codex-skills/ that we ship to Codex. Each name is
+    // also the target folder under <codex>/skills/, so on remove we can delete
+    // them without re-reading the source tree. Add a new skill here when adding
+    // it to codex-skills/.
+    static readonly string[] CodexSkillNames = [
+        "kapacitor-recap",
+        "kapacitor-errors"
+    ];
+
     const string CodexHookCommand = "kapacitor codex-hook";
 
     public static async Task<int> HandleAsync(string[] args) {
@@ -140,6 +149,21 @@ public static class PluginCommand {
 
         await Console.Out.WriteLineAsync($"Codex hooks installed ({scope}: {hooksPath})");
 
+        // Skills are user-scoped only. Codex auto-discovers from
+        // ~/.codex/skills (or $CODEX_HOME/skills), and project-level skill
+        // discovery isn't documented — so we keep behaviour consistent and
+        // predictable by always installing them user-wide.
+        var pluginPath = SetupCommand.ResolvePluginPath();
+        var skillsSource = pluginPath is null ? null : Path.Combine(pluginPath, "codex-skills");
+
+        if (skillsSource is not null && Directory.Exists(skillsSource)) {
+            if (InstallCodexSkills(skillsSource, CodexPaths.UserSkillsDir)) {
+                await Console.Out.WriteLineAsync($"Codex skills installed (user: {CodexPaths.UserSkillsDir})");
+            } else {
+                await Console.Error.WriteLineAsync("Could not install Codex skills.");
+            }
+        }
+
         if (scope == "project") {
             await Console.Out.WriteLineAsync(
                 "Note: Codex requires the project's .codex directory to be trusted. " +
@@ -157,16 +181,21 @@ public static class PluginCommand {
             ? Path.Combine(Environment.CurrentDirectory, ".codex", "hooks.json")
             : CodexPaths.UserHooksJson;
 
-        if (!File.Exists(hooksPath)) {
-            await Console.Out.WriteLineAsync("Nothing to remove — hooks file not found.");
+        var hooksRemoved = File.Exists(hooksPath) && RemoveCodexHooks(hooksPath);
 
-            return 0;
+        if (hooksRemoved) {
+            await Console.Out.WriteLineAsync($"Codex hooks removed ({scope}: {hooksPath})");
         }
 
-        if (RemoveCodexHooks(hooksPath)) {
-            await Console.Out.WriteLineAsync($"Codex hooks removed ({scope}: {hooksPath})");
-        } else {
-            await Console.Out.WriteLineAsync("Codex hooks were not installed.");
+        // Skills always installed user-wide — remove them regardless of scope.
+        var skillsRemoved = RemoveCodexSkills(CodexPaths.UserSkillsDir);
+
+        if (skillsRemoved) {
+            await Console.Out.WriteLineAsync($"Codex skills removed (user: {CodexPaths.UserSkillsDir})");
+        }
+
+        if (!hooksRemoved && !skillsRemoved) {
+            await Console.Out.WriteLineAsync("Nothing to remove — hooks and skills were not installed.");
         }
 
         return 0;
@@ -273,6 +302,75 @@ public static class PluginCommand {
             return changed;
         } catch {
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Copies every skill folder in <paramref name="sourceDir"/> (each
+    /// containing a <c>SKILL.md</c>) into <paramref name="targetDir"/>, one
+    /// subdirectory per skill. Existing kapacitor-owned folders (by name) are
+    /// replaced wholesale so the bundled SKILL.md stays current after a CLI
+    /// upgrade. Foreign folders in <paramref name="targetDir"/> are untouched.
+    /// </summary>
+    public static bool InstallCodexSkills(string sourceDir, string targetDir) {
+        if (!Directory.Exists(sourceDir)) return false;
+
+        try {
+            Directory.CreateDirectory(targetDir);
+
+            foreach (var name in CodexSkillNames) {
+                var src = Path.Combine(sourceDir, name);
+
+                if (!Directory.Exists(src)) continue;
+
+                var dst = Path.Combine(targetDir, name);
+
+                if (Directory.Exists(dst)) Directory.Delete(dst, recursive: true);
+
+                CopyDirectory(src, dst);
+            }
+
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Deletes every kapacitor-owned skill folder from <paramref name="targetDir"/>.
+    /// Returns true if any folder was actually removed. Foreign folders are
+    /// left intact.
+    /// </summary>
+    public static bool RemoveCodexSkills(string targetDir) {
+        if (!Directory.Exists(targetDir)) return false;
+
+        var changed = false;
+
+        foreach (var name in CodexSkillNames) {
+            var dst = Path.Combine(targetDir, name);
+
+            if (!Directory.Exists(dst)) continue;
+
+            try {
+                Directory.Delete(dst, recursive: true);
+                changed = true;
+            } catch {
+                // best effort
+            }
+        }
+
+        return changed;
+    }
+
+    static void CopyDirectory(string source, string destination) {
+        Directory.CreateDirectory(destination);
+
+        foreach (var file in Directory.GetFiles(source)) {
+            File.Copy(file, Path.Combine(destination, Path.GetFileName(file)), overwrite: true);
+        }
+
+        foreach (var dir in Directory.GetDirectories(source)) {
+            CopyDirectory(dir, Path.Combine(destination, Path.GetFileName(dir)));
         }
     }
 

--- a/test/kapacitor.Tests.Unit/PluginCommandCodexTests.cs
+++ b/test/kapacitor.Tests.Unit/PluginCommandCodexTests.cs
@@ -169,6 +169,101 @@ public class PluginCommandCodexTests {
         await Assert.That(PluginCommand.EntryReferencesKapacitorCodexHook(null)).IsFalse();
     }
 
+    // ---- Codex skill install / remove ----
+
+    [Test]
+    public async Task InstallCodexSkills_copies_known_skills() {
+        using var tmp    = new TempDir();
+        var       source = Path.Combine(tmp.Path, "codex-skills");
+        var       target = Path.Combine(tmp.Path, "skills");
+        WriteSkill(source, "kapacitor-recap",  "recap body");
+        WriteSkill(source, "kapacitor-errors", "errors body");
+
+        var ok = PluginCommand.InstallCodexSkills(source, target);
+        await Assert.That(ok).IsTrue();
+
+        var recap  = await File.ReadAllTextAsync(Path.Combine(target, "kapacitor-recap",  "SKILL.md"));
+        var errors = await File.ReadAllTextAsync(Path.Combine(target, "kapacitor-errors", "SKILL.md"));
+        await Assert.That(recap).IsEqualTo("recap body");
+        await Assert.That(errors).IsEqualTo("errors body");
+    }
+
+    [Test]
+    public async Task InstallCodexSkills_overwrites_existing_kapacitor_skill() {
+        using var tmp    = new TempDir();
+        var       source = Path.Combine(tmp.Path, "codex-skills");
+        var       target = Path.Combine(tmp.Path, "skills");
+        WriteSkill(source, "kapacitor-recap",  "new recap");
+        WriteSkill(source, "kapacitor-errors", "new errors");
+
+        // Pre-existing stale copy in target.
+        WriteSkill(target, "kapacitor-recap", "stale recap");
+
+        PluginCommand.InstallCodexSkills(source, target);
+
+        var recap = await File.ReadAllTextAsync(Path.Combine(target, "kapacitor-recap", "SKILL.md"));
+        await Assert.That(recap).IsEqualTo("new recap");
+    }
+
+    [Test]
+    public async Task InstallCodexSkills_preserves_foreign_skills() {
+        using var tmp    = new TempDir();
+        var       source = Path.Combine(tmp.Path, "codex-skills");
+        var       target = Path.Combine(tmp.Path, "skills");
+        WriteSkill(source, "kapacitor-recap",  "recap");
+        WriteSkill(source, "kapacitor-errors", "errors");
+
+        // Foreign skill the user installed themselves — must not be touched.
+        WriteSkill(target, "user-skill", "user content");
+
+        PluginCommand.InstallCodexSkills(source, target);
+
+        var foreign = await File.ReadAllTextAsync(Path.Combine(target, "user-skill", "SKILL.md"));
+        await Assert.That(foreign).IsEqualTo("user content");
+    }
+
+    [Test]
+    public async Task InstallCodexSkills_returns_false_for_missing_source() {
+        using var tmp    = new TempDir();
+        var       source = Path.Combine(tmp.Path, "nonexistent");
+        var       target = Path.Combine(tmp.Path, "skills");
+
+        var ok = PluginCommand.InstallCodexSkills(source, target);
+        await Assert.That(ok).IsFalse();
+    }
+
+    [Test]
+    public async Task RemoveCodexSkills_deletes_known_skills_only() {
+        using var tmp    = new TempDir();
+        var       target = Path.Combine(tmp.Path, "skills");
+        WriteSkill(target, "kapacitor-recap",  "recap");
+        WriteSkill(target, "kapacitor-errors", "errors");
+        WriteSkill(target, "user-skill",       "user content");
+
+        var ok = PluginCommand.RemoveCodexSkills(target);
+        await Assert.That(ok).IsTrue();
+
+        await Assert.That(Directory.Exists(Path.Combine(target, "kapacitor-recap"))).IsFalse();
+        await Assert.That(Directory.Exists(Path.Combine(target, "kapacitor-errors"))).IsFalse();
+        await Assert.That(File.Exists(Path.Combine(target, "user-skill", "SKILL.md"))).IsTrue();
+    }
+
+    [Test]
+    public async Task RemoveCodexSkills_returns_false_when_nothing_to_remove() {
+        using var tmp    = new TempDir();
+        var       target = Path.Combine(tmp.Path, "skills");
+        Directory.CreateDirectory(target);
+
+        var ok = PluginCommand.RemoveCodexSkills(target);
+        await Assert.That(ok).IsFalse();
+    }
+
+    static void WriteSkill(string root, string name, string body) {
+        var dir = Path.Combine(root, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), body);
+    }
+
     sealed class TempDir : IDisposable {
         public string Path { get; } = System.IO.Path.Combine(
             System.IO.Path.GetTempPath(),


### PR DESCRIPTION
## Summary

- `kapacitor plugin install --codex` now installs two auto-discovered skills (`kapacitor-recap`, `kapacitor-errors`) into `~/.codex/skills/` alongside the existing hooks, so Codex CLI sessions can pull repo recaps and tool-error reports the same way Claude Code does.
- Skills are tailored for Codex: lead with `kapacitor recap --repo` and require explicit `<sessionId>` for `kapacitor errors`, since Codex sessions don't auto-populate `KAPACITOR_SESSION_ID` (no `CLAUDE_ENV_FILE` equivalent in the Codex hook spec).
- `validate-plan` deliberately omitted — no Codex plan-mode equivalent.
- Skills are always user-scoped; `--project` still scopes hooks to `<repo>/.codex/hooks.json` but Codex skill auto-discovery is only documented for `~/.codex/skills`.

Linear: [AI-629](https://linear.app/kurrent/issue/AI-629/support-kapacitor-skills-for-codex)

## Test plan

- [x] `dotnet build src/kapacitor/kapacitor.csproj` clean
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` clean (no IL3050/IL2026 AOT warnings)
- [x] All 573 unit tests pass, including 6 new ones covering install/remove + foreign-skill preservation + missing-source handling
- [ ] Manual: `kapacitor plugin install --codex` lands `kapacitor-recap/SKILL.md` and `kapacitor-errors/SKILL.md` under `~/.codex/skills/`
- [ ] Manual: `kapacitor plugin remove --codex` cleans both hooks and skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)