### PR TITLE
[AI-630] CLI: per-name flock + instance_id + version + agent doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,13 +194,20 @@ Non-interactive runs (no TTY, e.g. CI) must pass both a scope flag and `--yes`. 
 The agent daemon connects to the Capacitor server and runs Claude Code agents in isolated git worktrees, controlled from the dashboard.
 
 ```bash
-kapacitor agent start              # start in foreground
-kapacitor agent start -d           # start in background (daemonize)
-kapacitor agent status             # check if daemon is running
-kapacitor agent stop               # stop the daemon (foreground or background)
+kapacitor agent start                   # start in foreground (defaults --name to your OS username)
+kapacitor agent start -d                # start in background (daemonize)
+kapacitor agent start --name laptop -d  # run multiple daemons on the same machine by giving each a unique name
+kapacitor agent status                  # list all running daemons
+kapacitor agent status --name laptop    # show status of a specific daemon
+kapacitor agent stop --name laptop      # stop just that one
+kapacitor agent stop --yes              # stop all running daemons unattended (otherwise prompts on multi)
+kapacitor agent doctor                  # diagnose lock-file state for every daemon name
+kapacitor agent doctor --clean          # also remove stale lock/pid files (held entries are never touched)
 ```
 
-`agent start` refuses to launch a second daemon when one is already alive, regardless of mode. Run `kapacitor agent stop` to terminate the existing one first. Two concurrent daemons under the same identity used to silently take down each other's hosted agents on the server.
+Each daemon process holds an exclusive `flock` on `~/.config/kapacitor/agents/<name>.lock` for its entire lifetime. The kernel releases the lock automatically when the daemon exits (including `SIGKILL` or power-off), so leftover lock files on disk are never a blocker — only a live process holding the kernel-level lock can prevent another daemon from acquiring the same name.
+
+Two daemons with **different** `--name` values can run side-by-side. Two daemons under the **same name** on the same machine collide on the flock and the second one exits with code 2. Even if that guard is bypassed somehow, the server rejects the second daemon's `DaemonConnect` with a typed error and the second daemon exits with code 3 — no more silent slot-displacement oscillation.
 
 ### Repository paths
 

--- a/src/Kapacitor.Core/AgentLockMigration.cs
+++ b/src/Kapacitor.Core/AgentLockMigration.cs
@@ -1,0 +1,74 @@
+namespace kapacitor;
+
+/// <summary>
+/// One-shot migration from the pre-AI-630 singleton layout
+/// (<c>~/.config/kapacitor/agent.pid</c>,
+/// <c>~/.config/kapacitor/agent.start.lock</c>) to the per-name layout
+/// (<c>~/.config/kapacitor/agents/&lt;name&gt;.pid</c>, …).
+///
+/// <para>Called from both the daemon binary (before acquiring its own lock)
+/// and the CLI supervisor (before taking the start lock). Best-effort:
+/// any IO failure is swallowed because the new path will be created
+/// fresh anyway — the migration is convenience, not correctness.</para>
+///
+/// <para>Idempotent. Subsequent calls find no legacy files and no-op.</para>
+/// </summary>
+public static class AgentLockMigration {
+    /// <summary>
+    /// Returns the legacy paths under <c>PathHelpers.ConfigPath</c>. Defined
+    /// here (not in <see cref="AgentLockPaths"/>) so the path layout helper
+    /// stays focused on the current layout and doesn't accidentally suggest
+    /// the legacy paths are valid targets.
+    /// </summary>
+    static string LegacyPidPath  => PathHelpers.ConfigPath("agent.pid");
+    static string LegacyLockPath => PathHelpers.ConfigPath("agent.start.lock");
+
+    /// <summary>
+    /// Migrates legacy files (if present) under <paramref name="daemonName"/>.
+    /// Returns the list of files moved so the caller can surface a one-line
+    /// info message. Safe to call repeatedly — no-ops after the first run.
+    /// </summary>
+    public static IReadOnlyList<string> MigrateLegacyFiles(string daemonName) =>
+        MigrateLegacyFiles(daemonName, LegacyPidPath, LegacyLockPath);
+
+    /// <summary>
+    /// Test-friendly overload that takes explicit legacy paths. Production
+    /// callers use the parameterless <see cref="MigrateLegacyFiles(string)"/>
+    /// overload, which reads <see cref="PathHelpers.ConfigPath"/>; tests
+    /// pass scratch paths so they don't depend on (and can't pollute)
+    /// <c>PathHelpers</c>'s once-cached <c>ConfigDir</c>.
+    /// </summary>
+    internal static IReadOnlyList<string> MigrateLegacyFiles(string daemonName, string legacyPidPath, string legacyLockPath) {
+        var moved = new List<string>(2);
+
+        AgentLockPaths.EnsureDirectory();
+
+        TryMove(legacyPidPath,  AgentLockPaths.PidPath(daemonName),       moved);
+        TryMove(legacyLockPath, AgentLockPaths.StartLockPath(daemonName), moved);
+
+        return moved;
+    }
+
+    static void TryMove(string from, string to, List<string> moved) {
+        try {
+            if (!File.Exists(from)) return;
+            if (File.Exists(to)) {
+                // New path already populated — drop the legacy file rather
+                // than overwrite (the new file is authoritative). The
+                // pre-AI-630 daemon that wrote the legacy file is presumed
+                // dead since the new daemon couldn't have written `to`
+                // otherwise.
+                File.Delete(from);
+                return;
+            }
+
+            File.Move(from, to);
+            moved.Add($"{from} → {to}");
+        } catch {
+            // Best-effort. A failed migration shouldn't block the daemon
+            // (or CLI) from starting — the new path will be created fresh
+            // either way. We don't surface this to console because the
+            // daemon's logger may not be initialised yet when this runs.
+        }
+    }
+}

--- a/src/Kapacitor.Core/AgentLockPaths.cs
+++ b/src/Kapacitor.Core/AgentLockPaths.cs
@@ -79,16 +79,23 @@ public static partial class AgentLockPaths {
     public static void EnsureDirectory() => System.IO.Directory.CreateDirectory(Directory);
 
     /// <summary>
-    /// Returns the daemon names visible on disk (one per <c>*.lock</c> file).
-    /// Used by <c>agent stop</c> (no <c>--name</c>) to enumerate candidates and
-    /// by <c>agent doctor</c> to classify held vs stale entries.
+    /// Returns the daemon names visible on disk — the union of names
+    /// derived from <c>*.lock</c> and <c>*.pid</c> files. Used by
+    /// <c>agent doctor</c> to classify held vs stale entries; covers
+    /// orphan PID files that have no matching lock (e.g. a pre-AI-630
+    /// daemon whose migration ran for the PID file but not the start
+    /// lock, or a stop that removed the lock but left the PID behind).
     /// </summary>
     public static IReadOnlyList<string> EnumerateNames() {
         if (!System.IO.Directory.Exists(Directory)) return [];
 
+        var fromLocks = System.IO.Directory.EnumerateFiles(Directory, "*.lock")
+            .Select(Path.GetFileNameWithoutExtension);
+        var fromPids  = System.IO.Directory.EnumerateFiles(Directory, "*.pid")
+            .Select(Path.GetFileNameWithoutExtension);
+
         return [
-            .. System.IO.Directory.EnumerateFiles(Directory, "*.lock")
-                .Select(Path.GetFileNameWithoutExtension)
+            .. fromLocks.Concat(fromPids)
                 .Where(n => !string.IsNullOrEmpty(n))
                 .Select(n => n!)
                 .Distinct()

--- a/src/Kapacitor.Core/AgentLockPaths.cs
+++ b/src/Kapacitor.Core/AgentLockPaths.cs
@@ -1,0 +1,98 @@
+using System.Text.RegularExpressions;
+
+namespace kapacitor;
+
+/// <summary>
+/// Path layout for per-name agent daemon lock + PID + start-lock files (AI-630).
+///
+/// <para>The previous layout used singletons at <c>PathHelpers.ConfigPath("agent.pid")</c>
+/// and <c>PathHelpers.ConfigPath("agent.start.lock")</c>. Two daemons with
+/// different <c>KAPACITOR_CONFIG_DIR</c>s (e.g. an Aspire-spawned dev daemon
+/// using <c>.dev/kapacitor</c> alongside a user-launched daemon using
+/// <c>~/.config/kapacitor</c>) wrote to different singletons and never saw
+/// each other, allowing two daemons under the same name to authenticate as
+/// the same GitHub ID and oscillate the server-side <c>DaemonRegistry</c>
+/// slot. The staging incident that motivated AI-630 was exactly that.</para>
+///
+/// <para>This helper uses a <b>fixed location</b> under the home directory
+/// (<c>~/.config/kapacitor/agents/</c>) regardless of <c>KAPACITOR_CONFIG_DIR</c>,
+/// so cross-config-dir daemons under the same name now collide on the same
+/// <c>flock</c>. Sanitization is intentionally strict to keep filenames
+/// portable: only <c>[a-z0-9._-]</c> survives, anything else maps to <c>-</c>.</para>
+/// </summary>
+public static partial class AgentLockPaths {
+    static readonly string DefaultDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".config", "kapacitor", "agents"
+    );
+
+    static string? _overrideDir;
+
+    /// <summary>Directory where all per-name lock/pid/start files live.</summary>
+    public static string Directory => _overrideDir ?? DefaultDirectory;
+
+    /// <summary>
+    /// Test-only override: redirects the agents directory to a temp path.
+    /// Pass <c>null</c> to restore the default home-directory location.
+    /// Production code never sets this; it's exposed via
+    /// <c>InternalsVisibleTo</c> for the test projects only.
+    /// </summary>
+    internal static void OverrideDirectoryForTesting(string? path) => _overrideDir = path;
+
+    [GeneratedRegex(@"[^a-z0-9._-]")]
+    private static partial Regex DisallowedChars();
+
+    /// <summary>
+    /// Lowercase the input, replace any character outside <c>[a-z0-9._-]</c>
+    /// with <c>-</c>, collapse consecutive separators, and strip leading /
+    /// trailing separators. Empty / whitespace-only input falls back to
+    /// <c>"daemon"</c> so we never produce a file at the directory root.
+    /// </summary>
+    public static string Sanitize(string name) {
+        if (string.IsNullOrWhiteSpace(name)) return "daemon";
+
+        var lowered    = name.Trim().ToLowerInvariant();
+        var normalized = DisallowedChars().Replace(lowered, "-");
+        var collapsed  = string.Join('-', normalized.Split('-', StringSplitOptions.RemoveEmptyEntries));
+
+        return collapsed.Length == 0 ? "daemon" : collapsed;
+    }
+
+    /// <summary>Path to the daemon-held flock file. Content = instance_id GUID.</summary>
+    public static string LockPath(string daemonName) =>
+        Path.Combine(Directory, $"{Sanitize(daemonName)}.lock");
+
+    /// <summary>Path to the PID file. Content = PID + optional StartTicks line.</summary>
+    public static string PidPath(string daemonName) =>
+        Path.Combine(Directory, $"{Sanitize(daemonName)}.pid");
+
+    /// <summary>
+    /// Path to the CLI-side start lock — the brief critical-section lock the
+    /// <c>kapacitor agent start</c> supervisor takes around its
+    /// check-spawn-write-PID sequence. Distinct from <see cref="LockPath"/>,
+    /// which the daemon itself holds for its entire lifetime.
+    /// </summary>
+    public static string StartLockPath(string daemonName) =>
+        Path.Combine(Directory, $"{Sanitize(daemonName)}.start");
+
+    /// <summary>Ensures the parent directory exists. Safe to call repeatedly.</summary>
+    public static void EnsureDirectory() => System.IO.Directory.CreateDirectory(Directory);
+
+    /// <summary>
+    /// Returns the daemon names visible on disk (one per <c>*.lock</c> file).
+    /// Used by <c>agent stop</c> (no <c>--name</c>) to enumerate candidates and
+    /// by <c>agent doctor</c> to classify held vs stale entries.
+    /// </summary>
+    public static IReadOnlyList<string> EnumerateNames() {
+        if (!System.IO.Directory.Exists(Directory)) return [];
+
+        return [
+            .. System.IO.Directory.EnumerateFiles(Directory, "*.lock")
+                .Select(Path.GetFileNameWithoutExtension)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Select(n => n!)
+                .Distinct()
+                .Order()
+        ];
+    }
+}

--- a/src/Kapacitor.Core/DaemonNameResolver.cs
+++ b/src/Kapacitor.Core/DaemonNameResolver.cs
@@ -3,19 +3,26 @@ namespace kapacitor;
 /// <summary>
 /// Shared resolution of the agent daemon's name. Lives in Kapacitor.Core
 /// so the CLI supervisor and the daemon binary agree on which name the
-/// per-name lock / PID files belong to. The precedence below matches the
-/// order historically used by <c>DaemonRunner.RunAsync</c>:
+/// per-name lock / PID files belong to. Precedence — first non-empty
+/// source wins:
 ///
 /// <list type="number">
-/// <item><c>--name &lt;value&gt;</c> on the command line</item>
+/// <item><c>--name &lt;value&gt;</c> on the command line — the most
+///     explicit signal, takes priority over everything else.</item>
+/// <item><c>KAPACITOR_DAEMON_NAME</c> environment variable — useful for
+///     shell scripts that fan out multiple daemons without rewriting
+///     argv (e.g. <c>direnv</c> per shell).</item>
 /// <item><c>profile.daemon.name</c> from the active profile (resolved
-///     via <c>AppConfig.ResolveActiveProfile</c>)</item>
-/// <item><c>KAPACITOR_DAEMON_NAME</c> environment variable (overrides
-///     the profile)</item>
-/// <item>OS username, lowercased</item>
-/// <item>Machine name, lowercased</item>
-/// <item>The literal string <c>"daemon"</c></item>
+///     via <c>AppConfig.ResolveActiveProfile</c>).</item>
+/// <item>OS username, lowercased.</item>
+/// <item>Machine name, lowercased.</item>
+/// <item>The literal string <c>"daemon"</c>.</item>
 /// </list>
+///
+/// <para>Note: pre-AI-630 <c>DaemonRunner.RunAsync</c> had the env var
+/// unconditionally override <c>--name</c>. That was an unintentional
+/// inversion of the usual CLI convention (explicit flag wins). AI-630
+/// fixes it so <c>--name</c> is the strongest signal as users expect.</para>
 /// </summary>
 public static class DaemonNameResolver {
     /// <summary>
@@ -26,34 +33,21 @@ public static class DaemonNameResolver {
     /// resolved name; never null or empty.
     /// </summary>
     public static string Resolve(string[] args, string? profileName = null) {
-        string? name = null;
-
         for (var i = 0; i < args.Length - 1; i++) {
-            if (args[i] == "--name") {
-                name = args[i + 1];
-
-                break;
-            }
+            if (args[i] == "--name" && !string.IsNullOrEmpty(args[i + 1]))
+                return args[i + 1];
         }
 
-        if (string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(profileName))
-            name = profileName;
-
-        // Env var overrides the profile (matches the historical
-        // DaemonRunner.RunAsync ordering — added for shell scripts that
-        // want to fan out daemons without rewriting the profile file).
         if (Environment.GetEnvironmentVariable("KAPACITOR_DAEMON_NAME") is { Length: > 0 } envName)
-            name = envName;
+            return envName;
 
-        if (string.IsNullOrEmpty(name)) {
-            var userName = Environment.UserName;
-            name = !string.IsNullOrEmpty(userName)
-                ? userName.ToLowerInvariant()
-                : !string.IsNullOrEmpty(Environment.MachineName)
-                    ? Environment.MachineName.ToLowerInvariant()
-                    : "daemon";
-        }
+        if (!string.IsNullOrEmpty(profileName))
+            return profileName;
 
-        return name;
+        var userName = Environment.UserName;
+        if (!string.IsNullOrEmpty(userName)) return userName.ToLowerInvariant();
+
+        var machine = Environment.MachineName;
+        return !string.IsNullOrEmpty(machine) ? machine.ToLowerInvariant() : "daemon";
     }
 }

--- a/src/Kapacitor.Core/DaemonNameResolver.cs
+++ b/src/Kapacitor.Core/DaemonNameResolver.cs
@@ -1,0 +1,59 @@
+namespace kapacitor;
+
+/// <summary>
+/// Shared resolution of the agent daemon's name. Lives in Kapacitor.Core
+/// so the CLI supervisor and the daemon binary agree on which name the
+/// per-name lock / PID files belong to. The precedence below matches the
+/// order historically used by <c>DaemonRunner.RunAsync</c>:
+///
+/// <list type="number">
+/// <item><c>--name &lt;value&gt;</c> on the command line</item>
+/// <item><c>profile.daemon.name</c> from the active profile (resolved
+///     via <c>AppConfig.ResolveActiveProfile</c>)</item>
+/// <item><c>KAPACITOR_DAEMON_NAME</c> environment variable (overrides
+///     the profile)</item>
+/// <item>OS username, lowercased</item>
+/// <item>Machine name, lowercased</item>
+/// <item>The literal string <c>"daemon"</c></item>
+/// </list>
+/// </summary>
+public static class DaemonNameResolver {
+    /// <summary>
+    /// Parse the daemon name from <paramref name="args"/>. Pass the
+    /// profile-supplied default (typically
+    /// <c>AppConfig.ResolvedProfile?.Profile?.Daemon?.Name</c>) so callers
+    /// don't need to thread AppConfig into Kapacitor.Core. Returns the
+    /// resolved name; never null or empty.
+    /// </summary>
+    public static string Resolve(string[] args, string? profileName = null) {
+        string? name = null;
+
+        for (var i = 0; i < args.Length - 1; i++) {
+            if (args[i] == "--name") {
+                name = args[i + 1];
+
+                break;
+            }
+        }
+
+        if (string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(profileName))
+            name = profileName;
+
+        // Env var overrides the profile (matches the historical
+        // DaemonRunner.RunAsync ordering — added for shell scripts that
+        // want to fan out daemons without rewriting the profile file).
+        if (Environment.GetEnvironmentVariable("KAPACITOR_DAEMON_NAME") is { Length: > 0 } envName)
+            name = envName;
+
+        if (string.IsNullOrEmpty(name)) {
+            var userName = Environment.UserName;
+            name = !string.IsNullOrEmpty(userName)
+                ? userName.ToLowerInvariant()
+                : !string.IsNullOrEmpty(Environment.MachineName)
+                    ? Environment.MachineName.ToLowerInvariant()
+                    : "daemon";
+        }
+
+        return name;
+    }
+}

--- a/src/Kapacitor.Core/DaemonNameResolver.cs
+++ b/src/Kapacitor.Core/DaemonNameResolver.cs
@@ -33,9 +33,26 @@ public static class DaemonNameResolver {
     /// resolved name; never null or empty.
     /// </summary>
     public static string Resolve(string[] args, string? profileName = null) {
-        for (var i = 0; i < args.Length - 1; i++) {
-            if (args[i] == "--name" && !string.IsNullOrEmpty(args[i + 1]))
-                return args[i + 1];
+        // --name is strict: if present, the next token must exist and not
+        // look like another flag. Silently falling back to env/profile/OS
+        // username when the user typed `--name` with no value would mask
+        // typos and (combined with --yes in CLI command paths) could turn
+        // `agent stop --yes --name` into "stop every daemon I own". The
+        // CLI catches this ArgumentException and surfaces it as a clean
+        // non-zero exit; the daemon binary likewise refuses to start so
+        // a bad systemd unit / npm script invocation fails loudly.
+        for (var i = 0; i < args.Length; i++) {
+            if (args[i] != "--name") continue;
+
+            if (i + 1 >= args.Length || string.IsNullOrEmpty(args[i + 1]) || args[i + 1].StartsWith('-')) {
+                var got = i + 1 < args.Length ? $"'{args[i + 1]}'" : "<end of args>";
+                throw new ArgumentException(
+                    $"--name requires a value (got {got}). " +
+                    "Pass a value (e.g. --name laptop) or omit the flag entirely."
+                );
+            }
+
+            return args[i + 1];
         }
 
         if (Environment.GetEnvironmentVariable("KAPACITOR_DAEMON_NAME") is { Length: > 0 } envName)

--- a/src/Kapacitor.Core/Models.cs
+++ b/src/Kapacitor.Core/Models.cs
@@ -603,13 +603,30 @@ public readonly record struct ResizeTerminalCommand(
         int    Rows
     );
 
-/// <summary>Commands sent from daemon clients to the server via SignalR.</summary>
+/// <summary>
+/// Commands sent from daemon clients to the server via SignalR.
+///
+/// <para><c>InstanceId</c> is a fresh GUID generated at daemon process startup
+/// and held only in memory (also written to the daemon's per-name flock
+/// file content for diagnostics). The server uses it to distinguish a
+/// legitimate reconnect of the same daemon (new SignalR connectionId, same
+/// instance) from a different daemon process claiming the same
+/// <c>(owner, name)</c> slot. Pre-AI-630 daemons sent no <c>InstanceId</c>;
+/// the server still accepts them under a legacy-displacement fallback.</para>
+///
+/// <para><c>Version</c> is the daemon binary's
+/// <c>AssemblyInformationalVersion</c>. Logged on connect and surfaced on
+/// the server's <c>DaemonInfo</c> so the dashboard can show what version
+/// each connected daemon is running.</para>
+/// </summary>
 public readonly record struct DaemonConnect(
         string   Name,
         string   Platform,
         string[] RepoPaths,
         int      MaxAgents,
-        string[] LiveAgentIds
+        string[] LiveAgentIds,
+        string?  InstanceId = null,
+        string?  Version    = null
     );
 
 public readonly record struct AgentRegistered(

--- a/src/Kapacitor.Core/Resources/help-agent.txt
+++ b/src/Kapacitor.Core/Resources/help-agent.txt
@@ -4,19 +4,38 @@ Usage: kapacitor agent <subcommand>
 
 Subcommands:
   start [-d]              Start the agent daemon (foreground, or -d for background)
-  stop                    Stop the agent daemon (foreground or background)
-  status                  Show agent daemon status
+  stop [--name N] [--yes] Stop a running agent daemon (prompts on multi unless --yes)
+  status [--name N]       Show agent daemon status (lists all when --name omitted)
   logs                    Show recent daemon log output
+  doctor [--clean]        Diagnose lock-file state, optionally clean stale entries
 
 Options for start:
-  --name <name>           Daemon name
+  --name <name>           Daemon name (defaults to OS username)
   --server-url <url>      Server URL
   --max-agents <n>        Max concurrent agents (default: 5)
   --log-file <path>       Log to file instead of console
   -d, --detach            Run in background (logs to file automatically)
 
+Options for stop:
+  --name <name>           Stop just the named daemon. Without it, all daemons
+                          are listed and the command asks for confirmation
+                          before stopping them (unless --yes is passed).
+  --yes, -y               Unattended mode: stop all running daemons without
+                          prompting. Useful in cleanup scripts.
+
+Options for doctor:
+  --clean                 Remove stale entries (lock files whose holder is
+                          gone). Held entries are never touched. Without
+                          --clean, doctor reports state without modifying.
+
 Notes:
-  start refuses to launch if another kapacitor-daemon is already running
-  (whether started in foreground or background mode). Use `kapacitor agent stop`
-  to terminate the existing one first. Multiple concurrent daemons under the
-  same identity were taking down each other's hosted agents on the server.
+  Each daemon holds an exclusive flock on ~/.config/kapacitor/agents/<name>.lock
+  for its entire lifetime. The kernel releases the lock automatically on
+  process exit (including SIGKILL or power-off), so stale lock files on disk
+  are never a blocker — only a live process holding the kernel-level lock
+  can prevent another daemon from acquiring the same name.
+
+  Two daemons with different --name values can run side-by-side. Two daemons
+  under the same name on the same machine collide on the flock and the
+  second one exits with code 2. If they somehow both connect to the server
+  anyway, the server-side check rejects the second one with exit code 3.

--- a/src/Kapacitor.Core/Resources/help-usage.txt
+++ b/src/Kapacitor.Core/Resources/help-usage.txt
@@ -21,9 +21,10 @@ Configuration:
   config set <key> <value>         Update a config value
 
 Agent Daemon:
-  agent start [-d]                 Start agent daemon (foreground, or -d for background; refuses if one is already running)
-  agent stop                       Stop the agent daemon (foreground or background)
-  agent status                     Show agent daemon status
+  agent start [-d] [--name N]      Start agent daemon (foreground, or -d for background; refuses on duplicate name)
+  agent stop [--name N] [--yes]    Stop a daemon (prompts on multi unless --yes)
+  agent status [--name N]          Show agent daemon status (lists all when --name omitted)
+  agent doctor [--clean]           Diagnose lock-file state, optionally clean stale entries
   repos                            List known repos (sorted by last used)
   repos add <path>                 Add a repo path (supports "." for cwd)
   repos remove <path>              Remove a repo path

--- a/src/Kapacitor.Core/Resources/help-usage.txt
+++ b/src/Kapacitor.Core/Resources/help-usage.txt
@@ -59,4 +59,4 @@ Hook Commands (internal — used by Claude Code plugin):
 Environment:
   KAPACITOR_URL              Server URL (overrides config file)
   KAPACITOR_SESSION_ID       Session ID (set automatically by SessionStart hook)
-  KAPACITOR_DAEMON_NAME      Daemon name (overrides config file)
+  KAPACITOR_DAEMON_NAME      Daemon name (overrides profile; superseded by --name)

--- a/src/Kapacitor.Daemon/DaemonConfig.cs
+++ b/src/Kapacitor.Daemon/DaemonConfig.cs
@@ -6,6 +6,24 @@ public class DaemonConfig {
     public string[] AllowedRepoPaths    { get; set; } = [];
     public int      MaxConcurrentAgents { get; set; } = 5;
 
+    /// <summary>
+    /// Per-process GUID generated at startup, also written to the daemon's
+    /// flock-file content. Sent over <c>DaemonConnect</c> so the server
+    /// (AI-630) can tell "same daemon reconnecting" from "different daemon
+    /// claiming the same name". Set in <c>DaemonRunner.RunAsync</c> once
+    /// the lock has been acquired; <c>null</c> in tests that bypass lock
+    /// acquisition.
+    /// </summary>
+    public string? InstanceId { get; set; }
+
+    /// <summary>
+    /// Daemon binary version (<c>AssemblyInformationalVersion</c>). Sent
+    /// over <c>DaemonConnect</c> and surfaced on the server's
+    /// <c>Daemon connected:</c> log line + <c>DaemonInfo</c>. Set in
+    /// <c>DaemonRunner.RunAsync</c>.
+    /// </summary>
+    public string? Version { get; set; }
+
     public string WorktreeRoot { get; set; } = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
         ".capacitor",

--- a/src/Kapacitor.Daemon/DaemonLock.cs
+++ b/src/Kapacitor.Daemon/DaemonLock.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics;
+
+namespace kapacitor.Daemon;
+
+/// <summary>
+/// Per-daemon-name exclusive lock and PID file (AI-630). Acquired by the
+/// daemon process for its lifetime; release happens automatically when the
+/// <see cref="FileStream"/> handle closes (process exit, including
+/// <c>SIGKILL</c> / power-off — the kernel releases <c>flock</c>).
+///
+/// <para>The lock content is the daemon's <c>InstanceId</c> (a fresh GUID
+/// generated at startup). The server uses the same GUID — sent over
+/// <c>DaemonConnect</c> — to distinguish a same-process reconnect from a
+/// different-process collision. The lock file's content is therefore
+/// diagnostic only (the wire <c>InstanceId</c> is the authoritative copy);
+/// <c>kapacitor agent doctor</c> reads it to surface human-friendly
+/// "instance=<i>prefix</i>" output without needing a live SignalR session.</para>
+///
+/// <para>The acquisition guards against the AI-630 scenario: two daemons
+/// under the same name on the same machine (regardless of
+/// <c>KAPACITOR_CONFIG_DIR</c> — <see cref="AgentLockPaths"/> uses a fixed
+/// directory). Two daemons with <i>different</i> names are allowed to
+/// coexist; the lock file is per-name.</para>
+/// </summary>
+internal sealed class DaemonLock : IDisposable {
+    readonly FileStream _stream;
+    readonly string     _pidPath;
+    readonly string     _lockPath;
+    bool                _disposed;
+
+    public string InstanceId { get; }
+
+    DaemonLock(FileStream stream, string lockPath, string pidPath, string instanceId) {
+        _stream    = stream;
+        _lockPath  = lockPath;
+        _pidPath   = pidPath;
+        InstanceId = instanceId;
+    }
+
+    /// <summary>
+    /// Try to acquire the per-name lock for <paramref name="daemonName"/>.
+    /// Returns null when another live daemon already holds the lock — the
+    /// caller should print a "name in use" message and exit with code 2.
+    /// </summary>
+    public static DaemonLock? TryAcquire(string daemonName) {
+        AgentLockPaths.EnsureDirectory();
+
+        var lockPath = AgentLockPaths.LockPath(daemonName);
+        var pidPath  = AgentLockPaths.PidPath(daemonName);
+
+        FileStream stream;
+
+        try {
+            // FileShare.None maps to flock(LOCK_EX) on POSIX. Open with
+            // FileAccess.Write so we can rewrite the instance id into the
+            // file content below. FileMode.OpenOrCreate keeps a stale
+            // lockfile on disk from blocking acquisition — flock semantics
+            // mean kernel-managed liveness, not file presence.
+            stream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
+        } catch (IOException) {
+            return null;
+        }
+
+        var instanceId = Guid.NewGuid().ToString("N");
+
+        try {
+            // Rewrite the file content with the fresh instance id. Truncate
+            // first so a smaller new id doesn't leave trailing bytes from
+            // the previous holder.
+            stream.SetLength(0);
+            var bytes = System.Text.Encoding.UTF8.GetBytes(instanceId + "\n");
+            stream.Write(bytes, 0, bytes.Length);
+            stream.Flush();
+
+            WritePidFile(pidPath);
+        } catch {
+            stream.Dispose();
+            throw;
+        }
+
+        return new DaemonLock(stream, lockPath, pidPath, instanceId);
+    }
+
+    static void WritePidFile(string pidPath) {
+        var process    = Process.GetCurrentProcess();
+        long? startTicks = null;
+
+        try {
+            startTicks = process.StartTime.ToUniversalTime().Ticks;
+        } catch {
+            // Best-effort — StartTime can fail on some sandboxed/macOS
+            // permission paths. The PID alone is still useful for stop.
+        }
+
+        var content = startTicks is { } t ? $"{process.Id}\n{t}" : process.Id.ToString();
+        File.WriteAllText(pidPath, content);
+    }
+
+    public void Dispose() {
+        if (_disposed) return;
+        _disposed = true;
+
+        // Releasing the FileStream releases the kernel-level flock. After
+        // that, a follow-up start with the same name can acquire cleanly.
+        try { _stream.Dispose(); }    catch { /* best-effort */ }
+        try { File.Delete(_pidPath); } catch { /* best-effort */ }
+        try { File.Delete(_lockPath); } catch { /* best-effort */ }
+    }
+}

--- a/src/Kapacitor.Daemon/DaemonLock.cs
+++ b/src/Kapacitor.Daemon/DaemonLock.cs
@@ -102,8 +102,40 @@ internal sealed class DaemonLock : IDisposable {
 
         // Releasing the FileStream releases the kernel-level flock. After
         // that, a follow-up start with the same name can acquire cleanly.
-        try { _stream.Dispose(); }    catch { /* best-effort */ }
-        try { File.Delete(_pidPath); } catch { /* best-effort */ }
-        try { File.Delete(_lockPath); } catch { /* best-effort */ }
+        try { _stream.Dispose(); } catch { /* best-effort */ }
+
+        // Do NOT delete the lock file. The kernel flock is what enforces
+        // exclusion; file presence on disk is irrelevant. Deleting it here
+        // races against another daemon that may already have acquired the
+        // path between our Dispose() and the unlink: our `File.Delete`
+        // would unlink the inode they're holding open, and a third daemon
+        // could then create a brand-new `<name>.lock` at the same path
+        // and acquire a SECOND independent flock — defeating the whole
+        // AI-630 guard. `kapacitor agent doctor --clean` removes truly
+        // stale files.
+        //
+        // Delete the PID file only if it still points to our own PID. A
+        // legitimate successor daemon that ran while we were disposing
+        // would have already rewritten the file to its own PID, and an
+        // unconditional Delete here would orphan their entry.
+        try {
+            if (PidFileMatchesCurrentProcess(_pidPath)) File.Delete(_pidPath);
+        } catch { /* best-effort */ }
+    }
+
+    static bool PidFileMatchesCurrentProcess(string pidPath) {
+        try {
+            if (!File.Exists(pidPath)) return false;
+
+            var line = File.ReadAllText(pidPath)
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault();
+
+            return line is not null
+                && int.TryParse(line, out var pid)
+                && pid == Process.GetCurrentProcess().Id;
+        } catch {
+            return false;
+        }
     }
 }

--- a/src/Kapacitor.Daemon/DaemonRunner.cs
+++ b/src/Kapacitor.Daemon/DaemonRunner.cs
@@ -84,8 +84,15 @@ public static partial class DaemonRunner {
         // Shared name resolution with the CLI supervisor — the CLI's
         // AgentCommands and the daemon binary must agree on the name so
         // the per-name PID file the CLI inspects is the one the daemon
-        // writes via DaemonLock.
-        config.Name = DaemonNameResolver.Resolve(args, profileDaemon?.Name);
+        // writes via DaemonLock. Resolve throws on `--name <missing value>`
+        // / `--name <next-is-flag>`; refuse to start in that case rather
+        // than silently defaulting to the OS username.
+        try {
+            config.Name = DaemonNameResolver.Resolve(args, profileDaemon?.Name);
+        } catch (ArgumentException ex) {
+            await Console.Error.WriteLineAsync(ex.Message);
+            return 1;
+        }
 
         var errors = config.Validate();
 

--- a/src/Kapacitor.Daemon/DaemonRunner.cs
+++ b/src/Kapacitor.Daemon/DaemonRunner.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using kapacitor.Config;
 using kapacitor.Daemon.Pty;
 using kapacitor.Daemon.Services;
@@ -10,6 +11,17 @@ namespace kapacitor.Daemon;
 public static partial class DaemonRunner {
     public static readonly string LogPath = PathHelpers.ConfigPath("agent.log");
 
+    /// <summary>
+    /// Daemon binary version from <c>[AssemblyInformationalVersion]</c>,
+    /// baked at build time by MSBuild's git-info integration. Surfaces on
+    /// <c>DaemonConnect</c> so the server's <c>Daemon connected:</c> log
+    /// line and <c>DaemonInfo</c> can show "v0.4.11+sha.abc1234".
+    /// </summary>
+    public static string ResolveDaemonVersion() =>
+        typeof(DaemonRunner).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion ?? "unknown";
+
     public static async Task<int> RunAsync(string[] args) {
         string? logFile = null;
         var     config  = new DaemonConfig();
@@ -21,10 +33,11 @@ public static partial class DaemonRunner {
         await AppConfig.ResolveActiveProfile(args);
         config.ServerUrl = AppConfig.ResolvedServerUrl ?? "";
 
-        // CLI arg overrides for daemon-specific settings — parse before host builder
+        // CLI arg overrides for daemon-specific settings — parse before host builder.
+        // --name is consumed below by DaemonNameResolver (shared with the CLI
+        // supervisor), so we don't parse it here.
         for (var i = 0; i < args.Length - 1; i++) {
             switch (args[i]) {
-                case "--name": config.Name = args[++i]; break;
                 case "--log-file": logFile = args[++i]; break;
                 case "--max-agents" when int.TryParse(args[i + 1], out var n) && n >= 1:
                     config.MaxConcurrentAgents = n;
@@ -58,15 +71,8 @@ public static partial class DaemonRunner {
         // Daemon settings from the active profile, with env overrides
         var profileDaemon = AppConfig.ResolvedProfile?.Profile?.Daemon;
 
-        if (string.IsNullOrEmpty(config.Name) && !string.IsNullOrEmpty(profileDaemon?.Name))
-            config.Name = profileDaemon.Name;
-
         if (config.MaxConcurrentAgents == 5 && profileDaemon is { MaxAgents: var mx and not 5 })
             config.MaxConcurrentAgents = mx;
-
-        if (Environment.GetEnvironmentVariable("KAPACITOR_DAEMON_NAME") is { } envName) {
-            config.Name = envName;
-        }
 
         if (Environment.GetEnvironmentVariable("KAPACITOR_MAX_AGENTS") is { } maxAgents) {
             if (int.TryParse(maxAgents, out var n) && n >= 1)
@@ -75,16 +81,11 @@ public static partial class DaemonRunner {
                 await Console.Error.WriteLineAsync($"Warning: ignoring invalid KAPACITOR_MAX_AGENTS={maxAgents}");
         }
 
-        // Fall back to OS username, then machine name, then a static default
-        if (string.IsNullOrEmpty(config.Name)) {
-            var userName = Environment.UserName;
-
-            config.Name = !string.IsNullOrEmpty(userName)
-                ? userName.ToLowerInvariant()
-                : !string.IsNullOrEmpty(Environment.MachineName)
-                    ? Environment.MachineName.ToLowerInvariant()
-                    : "daemon";
-        }
+        // Shared name resolution with the CLI supervisor — the CLI's
+        // AgentCommands and the daemon binary must agree on the name so
+        // the per-name PID file the CLI inspects is the one the daemon
+        // writes via DaemonLock.
+        config.Name = DaemonNameResolver.Resolve(args, profileDaemon?.Name);
 
         var errors = config.Validate();
 
@@ -98,7 +99,33 @@ public static partial class DaemonRunner {
             return 1;
         }
 
+        // One-shot migration from the pre-AI-630 singleton layout to per-name
+        // files. Runs before lock acquisition so a foreground daemon under
+        // the old layout doesn't get duplicated by a new daemon writing to
+        // the new path. Idempotent — no-op after the first successful run.
+        AgentLockMigration.MigrateLegacyFiles(config.Name);
+
+        // Acquire the per-name flock that prevents another daemon from
+        // running under the same name on this machine. The lock content is
+        // a fresh instance id that we'll also send over DaemonConnect so
+        // the server can refuse a second daemon claiming the same
+        // (owner, name) slot (AI-630).
+        var daemonLock = DaemonLock.TryAcquire(config.Name);
+
+        if (daemonLock is null) {
+            await Console.Error.WriteLineAsync(
+                $"Another kapacitor-daemon is already running under the name '{config.Name}' on this machine. "
+                + $"Either stop it (`kapacitor agent stop --name {config.Name}`) or start this one with a different `--name`."
+            );
+
+            return 2;
+        }
+
+        config.InstanceId = daemonLock.InstanceId;
+        config.Version    = ResolveDaemonVersion();
+
         builder.Services.AddSingleton(config);
+        builder.Services.AddSingleton(daemonLock);
         builder.Services.AddSingleton<ServerConnection>();
 
         // Local HTTP bridge that fronts the server's permission flow. Registered as a
@@ -130,13 +157,36 @@ public static partial class DaemonRunner {
         var lifetime   = host.Services.GetRequiredService<IHostApplicationLifetime>();
         var connection = host.Services.GetRequiredService<ServerConnection>();
 
+        // AI-630: if the server rejects our DaemonConnect because another
+        // live daemon owns the (owner, name) slot, signal host shutdown
+        // and remember to return exit code 3 instead of 0. Subscribe
+        // before ConnectAsync so the initial-connect path is covered.
+        var nameInUse = false;
+
+        connection.OnNameInUse += _ => {
+            nameInUse = true;
+            lifetime.StopApplication();
+        };
+
         // Start hosted services (LocalPermissionBridge in particular) BEFORE the SignalR
         // connection comes up. Otherwise an early LaunchAgent message can arrive while
         // BaseUrl is still null and the spawned Claude falls back to the HTTPS path —
         // exactly what this bridge is meant to avoid.
         await host.StartAsync(lifetime.ApplicationStopping);
 
-        await connection.ConnectAsync(lifetime.ApplicationStopping);
+        try {
+            await connection.ConnectAsync(lifetime.ApplicationStopping);
+        } catch (Exception ex) when (nameInUse) {
+            // ConnectAsync's initial-connect path threw because of
+            // NameInUse. OnNameInUse already fired and set our flag; the
+            // host hasn't started its main loop yet, so just clean up
+            // and exit cleanly with code 3.
+            _ = ex;
+            daemonLock.Dispose();
+            await host.StopAsync();
+
+            return 3;
+        }
 
         var worktreeManager = host.Services.GetRequiredService<WorktreeManager>();
         await worktreeManager.CleanupOrphanedAsync();
@@ -155,12 +205,17 @@ public static partial class DaemonRunner {
             // internally for ApplicationStopping and returns cleanly.
             await host.WaitForShutdownAsync();
         } finally {
+            daemonLock.Dispose();
             await orchestrator.DisposeAsync();
             await connection.DisposeAsync();
             await host.StopAsync();
         }
 
-        return 0;
+        // AI-630: if the daemon was shut down because the server told us
+        // our (owner, name) slot is contested mid-run (heartbeat-triggered
+        // path), exit with code 3 so wrappers (systemd, npm, CI) can tell
+        // this apart from a normal Ctrl+C exit.
+        return nameInUse ? 3 : 0;
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "kapacitor agent '{Name}' starting, connecting to {ServerUrl}")]

--- a/src/Kapacitor.Daemon/Services/DaemonHeartbeatLoop.cs
+++ b/src/Kapacitor.Daemon/Services/DaemonHeartbeatLoop.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 
 namespace kapacitor.Daemon.Services;
@@ -61,6 +62,13 @@ internal sealed class DaemonHeartbeatLoop(IDaemonHeartbeatPort port, TimeSpan pi
     async Task SafeReRegisterAsync() {
         try {
             await port.ReRegisterAsync();
+        } catch (HubException ex) when (ex.Message.StartsWith(ServerConnection.NameInUseErrorCode, StringComparison.Ordinal)) {
+            // AI-630: the server explicitly told us our (owner, name) slot
+            // is held by another live daemon. Force-reconnecting would just
+            // re-trigger the same rejection. ServerConnection already fired
+            // OnNameInUse — DaemonRunner has called lifetime.StopApplication()
+            // and the outer loop will exit on its next WaitForNextTickAsync.
+            // No-op here so we don't escalate.
         } catch (Exception ex) {
             // Re-register itself failed. Escalate to a full reconnect — if
             // SignalR's InvokeAsync rejected, the transport is likely in

--- a/src/Kapacitor.Daemon/Services/ServerConnection.cs
+++ b/src/Kapacitor.Daemon/Services/ServerConnection.cs
@@ -120,6 +120,28 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     volatile bool     _disposed;
     Task?             _eventProcessorTask;
 
+    /// <summary>
+    /// Sentinel prefix the server (<c>DaemonRegistry.NameInUseErrorCode</c>)
+    /// embeds in the <see cref="Microsoft.AspNetCore.SignalR.HubException"/>
+    /// message when <c>DaemonConnect</c> is rejected because another live
+    /// daemon already holds the <c>(owner, name)</c> slot. The daemon parses
+    /// this prefix and exits with code 3 instead of force-reconnecting in a
+    /// loop with the incumbent — see <see cref="OnNameInUse"/>.
+    /// </summary>
+    public const string NameInUseErrorCode = "DAEMON_NAME_IN_USE";
+
+    /// <summary>
+    /// Fires when the server rejected <c>DaemonConnect</c> with the
+    /// <see cref="NameInUseErrorCode"/> prefix. <c>DaemonRunner</c>
+    /// subscribes and signals host shutdown so the binary exits with
+    /// code 3 rather than oscillating with the incumbent daemon.
+    /// </summary>
+    public event Action<string>? OnNameInUse;
+
+    static bool IsNameInUse(Exception ex) =>
+        ex is Microsoft.AspNetCore.SignalR.HubException he
+        && he.Message.StartsWith(NameInUseErrorCode, StringComparison.Ordinal);
+
     public async Task ConnectAsync(CancellationToken ct) {
         _ct                 = ct;
         _eventProcessorTask = ProcessEventQueueAsync(ct);
@@ -139,6 +161,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
 
                 return;
             } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                throw;
+            } catch (Exception ex) when (IsNameInUse(ex)) {
+                // AI-630: server explicitly rejected this daemon because
+                // another live daemon owns the (owner, name) slot. Don't
+                // retry — retrying would just thrash the incumbent.
+                // RegisterDaemon already fired OnNameInUse before re-throwing
+                // here; we just need to propagate so DaemonRunner exits
+                // with code 3 instead of looping forever.
                 throw;
             } catch (Exception ex) {
                 var delay = delays[Math.Min(attempt, delays.Length - 1)];
@@ -163,6 +193,11 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             OnReconnectedCallback?.Invoke();
         } catch (OperationCanceledException) when (_ct.IsCancellationRequested) {
             // Shutting down, ignore
+        } catch (Exception ex2) when (IsNameInUse(ex2)) {
+            // ConnectWithRetryAsync already fired OnNameInUse via
+            // RegisterDaemon and propagated. The host's shutdown handler
+            // will tear everything down; swallow here so OnClosed (an
+            // unobserved Task) doesn't crash the process.
         }
     }
 
@@ -171,11 +206,26 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         var repoPaths = await MergeRepoPathsAsync();
         var liveIds   = GetLiveAgentIds?.Invoke() ?? [];
 
-        await _hub.InvokeAsync(
-            "DaemonConnect",
-            new DaemonConnect(_config.Name, platform, repoPaths, _config.MaxConcurrentAgents, liveIds),
-            cancellationToken: _ct
-        );
+        try {
+            await _hub.InvokeAsync(
+                "DaemonConnect",
+                new DaemonConnect(
+                    _config.Name, platform, repoPaths, _config.MaxConcurrentAgents, liveIds,
+                    _config.InstanceId, _config.Version
+                ),
+                cancellationToken: _ct
+            );
+        } catch (Exception ex) when (IsNameInUse(ex)) {
+            // AI-630: server refused our (owner, name) slot because another
+            // live daemon owns it. Surface to DaemonRunner before re-throwing
+            // so the host can shut down cleanly; the heartbeat loop's
+            // SafeReRegisterAsync filters this exception out so we don't
+            // escalate to a pointless force-reconnect.
+            LogNameInUse(_config.Name, ex.Message);
+            OnNameInUse?.Invoke(ex.Message);
+
+            throw;
+        }
     }
 
     async Task<string[]> MergeRepoPathsAsync() {
@@ -413,6 +463,9 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         _httpClient?.Dispose();
         await _hub.DisposeAsync();
     }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Daemon name '{Name}' is already in use by another live daemon on this account. Server rejected DaemonConnect: {Reason}")]
+    partial void LogNameInUse(string name, string reason);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Connecting to {Url}...")]
     partial void LogConnecting(string url);

--- a/src/kapacitor/Commands/AgentCommands.cs
+++ b/src/kapacitor/Commands/AgentCommands.cs
@@ -1,11 +1,10 @@
 using System.Diagnostics;
+using kapacitor.Config;
 
 namespace kapacitor.Commands;
 
 public static class AgentCommands {
-    static readonly string PidPath  = PathHelpers.ConfigPath("agent.pid");
-    static readonly string LogPath  = PathHelpers.ConfigPath("agent.log");
-    static readonly string LockPath = PathHelpers.ConfigPath("agent.start.lock");
+    static readonly string LogPath = PathHelpers.ConfigPath("agent.log");
 
     public static async Task<int> HandleAsync(string[] args) {
         if (args.Length < 2) {
@@ -19,12 +18,16 @@ public static class AgentCommands {
 
         return subcommand switch {
             "start"  => await StartAsync(remaining),
-            "stop"   => Stop(),
-            "status" => await Status(),
+            "stop"   => await StopAsync(remaining),
+            "status" => await Status(remaining),
             "logs"   => await Logs(),
+            "doctor" => await DoctorAsync(remaining),
             _        => PrintUsage()
         };
     }
+
+    static string ResolveName(string[] args) =>
+        DaemonNameResolver.Resolve(args, AppConfig.ResolvedProfile?.Profile?.Daemon?.Name);
 
     static async Task<int> StartAsync(string[] args) {
         var detached = args.Contains("-d") || args.Contains("--detach");
@@ -33,63 +36,62 @@ public static class AgentCommands {
     }
 
     /// <summary>
-    /// Open <c>agent.start.lock</c> with <c>FileShare.None</c>, giving the
-    /// caller exclusive access for as long as the returned stream is held.
-    /// Returns null if another process already holds the lock — i.e. another
-    /// <c>kapacitor agent start</c> is mid-flight (its check + spawn +
-    /// WritePidFile window) or a foreground daemon is currently running.
-    ///
-    /// This is the OS-level barrier the PID-file guard alone can't provide:
-    /// without it, two starts launched concurrently can both observe an
-    /// absent / stale PID file and both spawn a daemon before either writes.
-    /// On POSIX .NET maps <c>FileShare.None</c> to <c>flock(LOCK_EX)</c>;
-    /// on Windows it's a native sharing-mode constraint. Both are
-    /// per-open-handle, so closing the stream releases the lock — including
-    /// when the parent process is SIGKILL'd.
+    /// Open the per-name <c>&lt;name&gt;.start</c> lock with
+    /// <c>FileShare.None</c> for the CLI-side critical section that wraps
+    /// the PID-file stale-check + daemon spawn. The daemon itself takes a
+    /// separate <c>&lt;name&gt;.lock</c> via <see cref="DaemonLock"/>; this
+    /// lock just keeps two concurrent <c>kapacitor agent start --name X</c>
+    /// invocations from both observing a stale PID file and both spawning.
     /// </summary>
-    static FileStream? TryAcquireStartLock() {
+    static FileStream? TryAcquireStartLock(string daemonName) {
         try {
-            Directory.CreateDirectory(Path.GetDirectoryName(LockPath)!);
+            AgentLockPaths.EnsureDirectory();
 
-            return new FileStream(LockPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
+            return new FileStream(
+                AgentLockPaths.StartLockPath(daemonName),
+                FileMode.OpenOrCreate, FileAccess.Write, FileShare.None
+            );
         } catch (IOException) {
             return null;
         }
     }
 
     static async Task<int> StartForegroundAsync(string[] args) {
-        // Take the exclusive start lock BEFORE the PID-file stale-check —
-        // otherwise two concurrent `kapacitor agent start` invocations can
-        // both observe no live daemon, both spawn, and only one's PID ends
-        // up in the file. We hold this lock for the foreground daemon's
-        // entire lifetime so any further start (foreground or detached)
-        // refuses immediately rather than racing through.
-        var startLock = TryAcquireStartLock();
+        var name = ResolveName(args);
+
+        // One-shot migration of pre-AI-630 legacy files so an earlier
+        // foreground daemon that wrote ~/.config/kapacitor/agent.pid is
+        // visible through our per-name PID-file check below. Idempotent.
+        AgentLockMigration.MigrateLegacyFiles(name);
+
+        var startLock = TryAcquireStartLock(name);
 
         if (startLock is null) {
-            await Console.Error.WriteLineAsync("Another `kapacitor agent start` is already in progress or holds the daemon lock. Run `kapacitor agent stop` first or wait for the other start to complete.");
+            await Console.Error.WriteLineAsync(
+                $"Another `kapacitor agent start --name {name}` is already in progress or holds the daemon lock. "
+                + $"Run `kapacitor agent stop --name {name}` first or wait for the other start to complete."
+            );
 
             return 1;
         }
 
         try {
-            // Defence in depth: the lock prevents a concurrent start from
-            // racing past us, but a stale PID file from a prior cleanly-exited
-            // daemon (or one whose parent was SIGKILL'd) can still be lying
-            // around. IsOurDaemon's StartTime check rejects recycled PIDs.
-            if (ReadPidFile() is { } existing && IsOurDaemon(existing.Pid, existing.StartTicks)) {
-                await Console.Error.WriteLineAsync($"Agent daemon already running (PID {existing.Pid}). Use `kapacitor agent stop` first.");
+            if (ReadPidFile(name) is { } existing && IsOurDaemon(existing.Pid, existing.StartTicks)) {
+                await Console.Error.WriteLineAsync(
+                    $"Agent daemon '{name}' already running (PID {existing.Pid}). "
+                    + $"Use `kapacitor agent stop --name {name}` first."
+                );
 
                 return 1;
             }
 
-            return await SpawnForegroundAsync(args);
+            return await SpawnForegroundAsync(name, args);
         } finally {
             startLock.Dispose();
         }
     }
 
-    static async Task<int> SpawnForegroundAsync(string[] args) {
+    static async Task<int> SpawnForegroundAsync(string name, string[] args) {
         var daemonPath = ResolveDaemonBinary();
 
         if (daemonPath is null) {
@@ -116,28 +118,16 @@ public static class AgentCommands {
             return 1;
         }
 
-        // Write the PID file so the guard above (and `kapacitor agent stop` /
-        // `agent status`) sees the foreground daemon too. Best-effort cleanup
-        // on exit; if the parent dies hard, IsOurDaemon's StartTime check
-        // handles the recycled-PID case so a stale file doesn't lock anyone
-        // out.
-        WritePidFile(process);
+        WritePidFile(name, process);
 
         try {
             await process.WaitForExitAsync();
 
             return process.ExitCode;
         } finally {
-            // Only delete the PID file if it still points at us. A concurrent
-            // legitimate `kapacitor agent start` that ran after our daemon
-            // exited (passing the guard because IsOurDaemon returned false on
-            // our exiting PID) would have rewritten the file to its own PID;
-            // an unconditional delete here would orphan that daemon's PID
-            // file and re-open the duplicate-daemon hole this guard is meant
-            // to close.
             try {
-                if (ReadPidFile() is { } current && current.Pid == process.Id) {
-                    File.Delete(PidPath);
+                if (ReadPidFile(name) is { } current && current.Pid == process.Id) {
+                    File.Delete(AgentLockPaths.PidPath(name));
                 }
             } catch {
                 /* best-effort */
@@ -146,23 +136,28 @@ public static class AgentCommands {
     }
 
     static int StartDetached(string[] args) {
-        // Hold the start lock just for the check + spawn + WritePidFile
-        // window. We can't keep it past method return because the parent
-        // process is about to exit, leaving the daemon detached. Once the
-        // PID file is written, subsequent starts will see it via the
-        // existing stale-check path.
-        var startLock = TryAcquireStartLock();
+        var name = ResolveName(args);
+
+        AgentLockMigration.MigrateLegacyFiles(name);
+
+        var startLock = TryAcquireStartLock(name);
 
         if (startLock is null) {
-            Console.Error.WriteLine("Another `kapacitor agent start` is already in progress or holds the daemon lock. Run `kapacitor agent stop` first or wait for the other start to complete.");
+            Console.Error.WriteLine(
+                $"Another `kapacitor agent start --name {name}` is already in progress or holds the daemon lock. "
+                + $"Run `kapacitor agent stop --name {name}` first or wait for the other start to complete."
+            );
 
             return 1;
         }
 
         using var _ = startLock;
 
-        if (ReadPidFile() is { } existing && IsOurDaemon(existing.Pid, existing.StartTicks)) {
-            Console.Error.WriteLine($"Agent daemon already running (PID {existing.Pid}). Use `kapacitor agent stop` first.");
+        if (ReadPidFile(name) is { } existing && IsOurDaemon(existing.Pid, existing.StartTicks)) {
+            Console.Error.WriteLine(
+                $"Agent daemon '{name}' already running (PID {existing.Pid}). "
+                + $"Use `kapacitor agent stop --name {name}` first."
+            );
 
             return 1;
         }
@@ -196,68 +191,207 @@ public static class AgentCommands {
         // Close stdin so the child doesn't wait for input
         process.StandardInput.Close();
 
-        WritePidFile(process);
+        WritePidFile(name, process);
 
-        Console.Out.WriteLine($"Agent daemon started (PID {process.Id})");
+        Console.Out.WriteLine($"Agent daemon '{name}' started (PID {process.Id})");
         Console.Out.WriteLine($"  Log:       {LogPath}");
-        Console.Out.WriteLine("  Stop with: kapacitor agent stop");
-        Console.Out.WriteLine("  Status:    kapacitor agent status");
+        Console.Out.WriteLine($"  Stop with: kapacitor agent stop --name {name}");
+        Console.Out.WriteLine($"  Status:    kapacitor agent status --name {name}");
 
         return 0;
     }
 
-    static int Stop() {
-        if (ReadPidFile() is not { } entry) {
-            Console.Error.WriteLine("No agent daemon running (no PID file found).");
+    // ── stop ────────────────────────────────────────────────────────────────
+
+    static async Task<int> StopAsync(string[] args) {
+        var name = ExtractFlagValue(args, "--name");
+        var yes  = args.Contains("--yes") || args.Contains("-y");
+
+        if (name is not null) return StopByName(name);
+
+        // No --name: enumerate. Legacy path (pre-AI-630): if no per-name
+        // PID files exist but the legacy `agent.pid` does, migrate it
+        // under the OS-username default name so this command can find it.
+        var candidates = EnumerateRunningNames();
+
+        if (candidates.Count == 0) {
+            await Console.Out.WriteLineAsync("No agent daemons are running.");
+
+            return 0;
+        }
+
+        if (candidates.Count == 1) return StopByName(candidates[0]);
+
+        await Console.Out.WriteLineAsync($"Found {candidates.Count} running daemons:");
+
+        foreach (var n in candidates) {
+            await Console.Out.WriteLineAsync($"  • {n}");
+        }
+
+        if (!yes) {
+            await Console.Out.WriteAsync($"Stop all {candidates.Count}? [y/N] ");
+            var reply = await Console.In.ReadLineAsync();
+
+            if (!string.Equals(reply?.Trim(), "y", StringComparison.OrdinalIgnoreCase)) {
+                await Console.Out.WriteLineAsync("Cancelled.");
+
+                return 0;
+            }
+        }
+
+        var failed = 0;
+
+        foreach (var n in candidates) {
+            if (StopByName(n) != 0) failed++;
+        }
+
+        return failed == 0 ? 0 : 1;
+    }
+
+    static int StopByName(string name) {
+        if (ReadPidFile(name) is not { } entry) {
+            Console.Error.WriteLine($"No agent daemon '{name}' running (no PID file found).");
 
             return 1;
         }
 
         try {
             if (!IsOurDaemon(entry.Pid, entry.StartTicks)) {
-                Console.Out.WriteLine("Agent daemon was not running (stale PID file).");
-                File.Delete(PidPath);
+                Console.Out.WriteLine($"Agent daemon '{name}' was not running (stale PID file).");
+                File.Delete(AgentLockPaths.PidPath(name));
 
                 return 0;
             }
 
             var process = Process.GetProcessById(entry.Pid);
             process.Kill(entireProcessTree: true);
-            Console.Out.WriteLine($"Agent daemon stopped (PID {entry.Pid}).");
+            Console.Out.WriteLine($"Agent daemon '{name}' stopped (PID {entry.Pid}).");
         } catch (ArgumentException) {
-            Console.Out.WriteLine("Agent daemon was not running.");
+            Console.Out.WriteLine($"Agent daemon '{name}' was not running.");
         }
 
-        File.Delete(PidPath);
+        try { File.Delete(AgentLockPaths.PidPath(name)); } catch { /* best-effort */ }
 
         return 0;
     }
 
-    static async Task<int> Status() {
-        if (ReadPidFile() is not { } entry) {
+    // ── status ──────────────────────────────────────────────────────────────
+
+    static async Task<int> Status(string[] args) {
+        var explicitName = ExtractFlagValue(args, "--name");
+
+        var names = explicitName is not null ? [explicitName] : EnumerateRunningNames();
+
+        if (names.Count == 0) {
             await Console.Out.WriteLineAsync("Agent: not running");
 
             return 0;
         }
 
-        if (IsOurDaemon(entry.Pid, entry.StartTicks)) {
-            await Console.Out.WriteLineAsync($"Agent: running (PID {entry.Pid})");
-        } else {
-            await Console.Out.WriteLineAsync("Agent: not running (stale PID file)");
-            File.Delete(PidPath);
+        foreach (var name in names) {
+            if (ReadPidFile(name) is not { } entry) {
+                await Console.Out.WriteLineAsync($"Agent '{name}': not running");
+
+                continue;
+            }
+
+            if (IsOurDaemon(entry.Pid, entry.StartTicks)) {
+                await Console.Out.WriteLineAsync($"Agent '{name}': running (PID {entry.Pid})");
+            } else {
+                await Console.Out.WriteLineAsync($"Agent '{name}': not running (stale PID file)");
+                try { File.Delete(AgentLockPaths.PidPath(name)); } catch { /* best-effort */ }
+            }
         }
 
         return 0;
     }
 
+    // ── doctor ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Lists every <c>agents/&lt;name&gt;.lock</c> entry, attempts a
+    /// non-destructive <c>flock</c> acquire on each to classify it as held
+    /// (another process owns the lock) or stale (file lying around with no
+    /// holder), and prints the holding PID + instance id prefix for each.
+    /// With <c>--clean</c> removes the stale entries.
+    /// </summary>
+    static async Task<int> DoctorAsync(string[] args) {
+        var clean = args.Contains("--clean");
+
+        AgentLockPaths.EnsureDirectory();
+
+        var names = AgentLockPaths.EnumerateNames();
+
+        if (names.Count == 0) {
+            await Console.Out.WriteLineAsync($"No agent daemon files found under {AgentLockPaths.Directory}.");
+
+            return 0;
+        }
+
+        await Console.Out.WriteLineAsync($"Inspecting {AgentLockPaths.Directory}\n");
+        var staleCount = 0;
+        var heldCount  = 0;
+
+        foreach (var name in names) {
+            var lockPath = AgentLockPaths.LockPath(name);
+            var pidPath  = AgentLockPaths.PidPath(name);
+
+            string? instanceId = null;
+            try { instanceId = File.ReadAllText(lockPath).Trim().Split('\n', 2)[0]; }
+            catch { /* best-effort */ }
+
+            var instancePrefix = instanceId is { Length: >= 8 } ? instanceId[..8] : instanceId ?? "(unknown)";
+
+            // Try to acquire the lock non-destructively. If we succeed,
+            // the lock was stale (no live holder). Drop the FileStream
+            // immediately to release.
+            FileStream? probe = null;
+
+            try {
+                probe = new FileStream(lockPath, FileMode.Open, FileAccess.Read, FileShare.None);
+            } catch (IOException) {
+                // Lock is held by a live process, OR the file went away
+                // between EnumerateNames and our open. Either way: treat
+                // as held — we only down-classify to stale when probe
+                // succeeds (which means we DID get the lock cleanly).
+            }
+
+            if (probe is null) {
+                heldCount++;
+                var pidEntry = ReadPidFile(name);
+                var alive    = pidEntry is { } e && IsOurDaemon(e.Pid, e.StartTicks);
+                var pidStr   = pidEntry is { } e2 ? e2.Pid.ToString() : "?";
+                var aliveStr = alive ? $"PID {pidStr}" : pidEntry is null ? "(no pid file)" : "(stale pid)";
+                await Console.Out.WriteLineAsync($"  {name,-20}  HELD     instance={instancePrefix}  {aliveStr}");
+            } else {
+                probe.Dispose();
+                staleCount++;
+                await Console.Out.WriteLineAsync($"  {name,-20}  STALE    instance={instancePrefix}  (no holder)");
+
+                if (clean) {
+                    try { File.Delete(lockPath); } catch { /* best-effort */ }
+                    try { File.Delete(pidPath); }  catch { /* best-effort */ }
+                }
+            }
+        }
+
+        await Console.Out.WriteLineAsync($"\n{heldCount} held, {staleCount} stale.");
+
+        if (staleCount > 0 && !clean) {
+            await Console.Out.WriteLineAsync("Re-run with --clean to remove stale entries.");
+        }
+
+        return 0;
+    }
+
+    // ── shared helpers ──────────────────────────────────────────────────────
+
     record struct PidEntry(int Pid, long? StartTicks);
 
-    static void WritePidFile(Process process) {
-        var dir = Path.GetDirectoryName(PidPath)!;
-        Directory.CreateDirectory(dir);
+    static void WritePidFile(string daemonName, Process process) {
+        var pidPath = AgentLockPaths.PidPath(daemonName);
+        AgentLockPaths.EnsureDirectory();
 
-        // Record StartTime alongside PID so a recycled PID can't be mistaken
-        // for our daemon. UTC ticks are stable across local timezone changes.
         long? startTicks = null;
 
         try {
@@ -272,18 +406,20 @@ public static class AgentCommands {
             ? $"{process.Id}\n{t}"
             : process.Id.ToString();
 
-        File.WriteAllText(PidPath, content);
+        File.WriteAllText(pidPath, content);
     }
 
-    static PidEntry? ReadPidFile() {
-        if (!File.Exists(PidPath)) return null;
+    static PidEntry? ReadPidFile(string daemonName) {
+        var pidPath = AgentLockPaths.PidPath(daemonName);
 
-        var lines = File.ReadAllText(PidPath)
+        if (!File.Exists(pidPath)) return null;
+
+        var lines = File.ReadAllText(pidPath)
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         if (lines.Length == 0 || !int.TryParse(lines[0], out var pid)) {
-            Console.Error.WriteLine($"Invalid PID file: {PidPath}");
-            File.Delete(PidPath);
+            Console.Error.WriteLine($"Invalid PID file: {pidPath}");
+            File.Delete(pidPath);
 
             return null;
         }
@@ -324,6 +460,34 @@ public static class AgentCommands {
         }
     }
 
+    /// <summary>
+    /// Returns the daemon names that currently have a PID file on disk
+    /// (per-name layout under <c>~/.config/kapacitor/agents/</c>). Used by
+    /// <c>agent stop</c> / <c>agent status</c> without <c>--name</c>.
+    /// </summary>
+    static List<string> EnumerateRunningNames() {
+        AgentLockPaths.EnsureDirectory();
+
+        var dir = AgentLockPaths.Directory;
+        if (!Directory.Exists(dir)) return [];
+
+        return [
+            .. Directory.EnumerateFiles(dir, "*.pid")
+                .Select(Path.GetFileNameWithoutExtension)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Select(n => n!)
+                .Order()
+        ];
+    }
+
+    static string? ExtractFlagValue(string[] args, string flag) {
+        for (var i = 0; i < args.Length - 1; i++) {
+            if (args[i] == flag) return args[i + 1];
+        }
+
+        return null;
+    }
+
     static async Task<int> Logs() {
         if (!File.Exists(LogPath)) {
             await Console.Error.WriteLineAsync("No log file found.");
@@ -331,7 +495,6 @@ public static class AgentCommands {
             return 1;
         }
 
-        // Tail last 50 lines
         var lines = await File.ReadAllLinesAsync(LogPath);
         var start = Math.Max(0, lines.Length - 50);
 
@@ -346,8 +509,6 @@ public static class AgentCommands {
 
     /// <summary>
     /// Resolve the kapacitor-daemon executable shipped alongside this binary.
-    /// The daemon is published as a separate AOT binary in the same directory
-    /// as the main kapacitor binary (npm packages bundle both).
     /// </summary>
     static string? ResolveDaemonBinary() {
         var dir = AppContext.BaseDirectory;
@@ -357,20 +518,20 @@ public static class AgentCommands {
         return File.Exists(sibling) ? sibling : null;
     }
 
-    static string DaemonNotFoundMessage() {
-        return $"kapacitor-daemon binary not found next to {AppContext.BaseDirectory}. Reinstall the kapacitor package.";
-    }
+    static string DaemonNotFoundMessage() =>
+        $"kapacitor-daemon binary not found next to {AppContext.BaseDirectory}. Reinstall the kapacitor package.";
 
     static int PrintUsage() {
-        Console.Error.WriteLine("Usage: kapacitor agent <start|stop|status|logs>");
+        Console.Error.WriteLine("Usage: kapacitor agent <start|stop|status|logs|doctor>");
         Console.Error.WriteLine();
-        Console.Error.WriteLine("  start [-d]  Start the agent daemon (foreground, or -d for background)");
-        Console.Error.WriteLine("  stop        Stop the background agent daemon");
-        Console.Error.WriteLine("  status      Show agent daemon status");
-        Console.Error.WriteLine("  logs        Show recent daemon log output");
+        Console.Error.WriteLine("  start [-d] [--name <n>]    Start the agent daemon (foreground, or -d for background)");
+        Console.Error.WriteLine("  stop [--name <n>] [--yes]  Stop a running agent daemon (prompts on multi unless --yes)");
+        Console.Error.WriteLine("  status [--name <n>]        Show agent daemon status (lists all when --name omitted)");
+        Console.Error.WriteLine("  logs                       Show recent daemon log output");
+        Console.Error.WriteLine("  doctor [--clean]           Diagnose lock-file state, optionally clean stale entries");
         Console.Error.WriteLine();
         Console.Error.WriteLine("Options for start:");
-        Console.Error.WriteLine("  --name <name>         Daemon name");
+        Console.Error.WriteLine("  --name <name>         Daemon name (defaults to OS username)");
         Console.Error.WriteLine("  --server-url <url>    Server URL");
         Console.Error.WriteLine("  --max-agents <n>      Max concurrent agents (default: 5)");
         Console.Error.WriteLine("  --log-file <path>     Log to file instead of console");

--- a/src/kapacitor/Commands/AgentCommands.cs
+++ b/src/kapacitor/Commands/AgentCommands.cs
@@ -226,8 +226,14 @@ public static class AgentCommands {
     // ── stop ────────────────────────────────────────────────────────────────
 
     static async Task<int> StopAsync(string[] args) {
-        var name = ExtractFlagValue(args, "--name");
-        var yes  = args.Contains("--yes") || args.Contains("-y");
+        string? name;
+        try {
+            name = ExtractFlagValue(args, "--name");
+        } catch (ArgumentException ex) {
+            await Console.Error.WriteLineAsync(ex.Message);
+            return 1;
+        }
+        var yes = args.Contains("--yes") || args.Contains("-y");
 
         if (name is not null) return StopByName(name);
 
@@ -300,7 +306,13 @@ public static class AgentCommands {
     // ── status ──────────────────────────────────────────────────────────────
 
     static async Task<int> Status(string[] args) {
-        var explicitName = ExtractFlagValue(args, "--name");
+        string? explicitName;
+        try {
+            explicitName = ExtractFlagValue(args, "--name");
+        } catch (ArgumentException ex) {
+            await Console.Error.WriteLineAsync(ex.Message);
+            return 1;
+        }
 
         var names = explicitName is not null ? [explicitName] : EnumerateRunningNames();
 
@@ -519,9 +531,32 @@ public static class AgentCommands {
         ];
     }
 
+    /// <summary>
+    /// Returns the value of <c>--flag &lt;value&gt;</c> from <paramref name="args"/>,
+    /// or <c>null</c> if the flag isn't present.
+    ///
+    /// <para>Throws <see cref="ArgumentException"/> if the flag is present but
+    /// the following token is missing or itself looks like another flag
+    /// (starts with <c>-</c>). The strict-value check protects destructive
+    /// commands like <c>agent stop --yes --name</c> — without it, a missing
+    /// value would silently fall through to the no-<c>--name</c> enumeration
+    /// path and (with <c>--yes</c>) skip the multi-daemon prompt, stopping
+    /// every daemon the user owns. Surfacing the bad invocation forces the
+    /// user to fix their command line before anything destructive happens.</para>
+    /// </summary>
     static string? ExtractFlagValue(string[] args, string flag) {
-        for (var i = 0; i < args.Length - 1; i++) {
-            if (args[i] == flag) return args[i + 1];
+        for (var i = 0; i < args.Length; i++) {
+            if (args[i] != flag) continue;
+
+            if (i + 1 >= args.Length || string.IsNullOrEmpty(args[i + 1]) || args[i + 1].StartsWith('-')) {
+                var got = i + 1 < args.Length ? $"'{args[i + 1]}'" : "<end of args>";
+                throw new ArgumentException(
+                    $"{flag} requires a value (got {got}). " +
+                    "Pass a value (e.g. --name laptop) or omit the flag entirely."
+                );
+            }
+
+            return args[i + 1];
         }
 
         return null;

--- a/src/kapacitor/Commands/AgentCommands.cs
+++ b/src/kapacitor/Commands/AgentCommands.cs
@@ -191,6 +191,28 @@ public static class AgentCommands {
         // Close stdin so the child doesn't wait for input
         process.StandardInput.Close();
 
+        // AI-630: the daemon binary acquires its own per-name flock at
+        // startup and exits with code 2 if another live daemon already
+        // holds it (the race we couldn't catch via the PID-file guard
+        // alone, e.g. when the previous daemon's PID file got wiped but
+        // the process is still alive). Without this short readiness wait
+        // we'd happily write a stale PID file and tell the user the
+        // detached daemon is running when it actually just exited. The
+        // flock acquisition happens *very* early in DaemonRunner.RunAsync
+        // (before SignalR connect), so 1.5s is more than enough to catch
+        // an immediate exit without making the success path feel sluggish.
+        if (process.WaitForExit(1500)) {
+            Console.Error.WriteLine(
+                $"Agent daemon '{name}' failed to start (exit code {process.ExitCode}). "
+                + $"Check `kapacitor agent doctor` to see whether the name is held by another process."
+            );
+
+            // Translate the daemon's flock-conflict exit code straight
+            // through so wrappers / CI can distinguish "name in use" from
+            // a generic spawn failure.
+            return process.ExitCode == 0 ? 1 : process.ExitCode;
+        }
+
         WritePidFile(name, process);
 
         Console.Out.WriteLine($"Agent daemon '{name}' started (PID {process.Id})");
@@ -309,11 +331,12 @@ public static class AgentCommands {
     // ── doctor ──────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Lists every <c>agents/&lt;name&gt;.lock</c> entry, attempts a
-    /// non-destructive <c>flock</c> acquire on each to classify it as held
-    /// (another process owns the lock) or stale (file lying around with no
-    /// holder), and prints the holding PID + instance id prefix for each.
-    /// With <c>--clean</c> removes the stale entries.
+    /// Lists every per-name daemon entry on disk — both <c>*.lock</c> and
+    /// <c>*.pid</c> files. For each, attempts a non-destructive
+    /// <c>flock</c> acquire to classify the entry as HELD (a live daemon
+    /// owns the path) or STALE (file lying around with no holder, or
+    /// orphan PID with no corresponding lock). With <c>--clean</c> removes
+    /// the stale entries (held ones are never touched).
     /// </summary>
     static async Task<int> DoctorAsync(string[] args) {
         var clean = args.Contains("--clean");
@@ -336,33 +359,49 @@ public static class AgentCommands {
             var lockPath = AgentLockPaths.LockPath(name);
             var pidPath  = AgentLockPaths.PidPath(name);
 
+            var hasLock = File.Exists(lockPath);
+            var hasPid  = File.Exists(pidPath);
+
             string? instanceId = null;
-            try { instanceId = File.ReadAllText(lockPath).Trim().Split('\n', 2)[0]; }
-            catch { /* best-effort */ }
+            if (hasLock) {
+                try { instanceId = File.ReadAllText(lockPath).Trim().Split('\n', 2)[0]; }
+                catch { /* best-effort */ }
+            }
 
             var instancePrefix = instanceId is { Length: >= 8 } ? instanceId[..8] : instanceId ?? "(unknown)";
 
-            // Try to acquire the lock non-destructively. If we succeed,
-            // the lock was stale (no live holder). Drop the FileStream
-            // immediately to release.
+            // Probing the lock requires the file to exist. An orphan PID
+            // file (no .lock alongside) is reported as STALE — there's no
+            // live daemon if the flock isn't held by anyone, and a daemon
+            // that's running would always own a .lock too.
             FileStream? probe = null;
 
-            try {
-                probe = new FileStream(lockPath, FileMode.Open, FileAccess.Read, FileShare.None);
-            } catch (IOException) {
-                // Lock is held by a live process, OR the file went away
-                // between EnumerateNames and our open. Either way: treat
-                // as held — we only down-classify to stale when probe
-                // succeeds (which means we DID get the lock cleanly).
+            if (hasLock) {
+                try {
+                    probe = new FileStream(lockPath, FileMode.Open, FileAccess.Read, FileShare.None);
+                } catch (IOException) {
+                    // Lock is held by a live process, OR the file went away
+                    // between EnumerateNames and our open. Either way: treat
+                    // as held — we only down-classify to stale when probe
+                    // succeeds (which means we DID get the lock cleanly).
+                }
             }
 
-            if (probe is null) {
+            if (probe is null && hasLock) {
                 heldCount++;
                 var pidEntry = ReadPidFile(name);
                 var alive    = pidEntry is { } e && IsOurDaemon(e.Pid, e.StartTicks);
                 var pidStr   = pidEntry is { } e2 ? e2.Pid.ToString() : "?";
                 var aliveStr = alive ? $"PID {pidStr}" : pidEntry is null ? "(no pid file)" : "(stale pid)";
                 await Console.Out.WriteLineAsync($"  {name,-20}  HELD     instance={instancePrefix}  {aliveStr}");
+            } else if (probe is null) {
+                // No .lock file at all but a .pid is present — orphan.
+                staleCount++;
+                await Console.Out.WriteLineAsync($"  {name,-20}  STALE    instance=(none)   (orphan pid file, no lock)");
+
+                if (clean) {
+                    try { File.Delete(pidPath); } catch { /* best-effort */ }
+                }
             } else {
                 probe.Dispose();
                 staleCount++;

--- a/src/kapacitor/Commands/StatusCommand.cs
+++ b/src/kapacitor/Commands/StatusCommand.cs
@@ -55,36 +55,75 @@ public static class StatusCommand {
 
         await Console.Out.WriteLineAsync(string.Join("  ", parts));
 
-        // Agent
+        // Agent — AI-630: read per-name PID files under
+        // ~/.config/kapacitor/agents/ instead of the pre-AI-630 singleton
+        // at ~/.config/kapacitor/agent.pid. The top-level `kapacitor status`
+        // must agree with `kapacitor agent status`; previously this
+        // command kept saying "not running" while `agent status` reported
+        // a healthy daemon because new daemons no longer write the legacy
+        // singleton.
         Console.Write("  Agent:   ");
+        await WriteAgentStatusAsync();
 
-        var pidPath = PathHelpers.ConfigPath("agent.pid");
+        return 0;
+    }
 
-        if (File.Exists(pidPath)) {
-            // The PID file is one or two lines: PID, optionally followed by
-            // process StartTicks (UTC ticks of Process.StartTime). Parse only
-            // the first non-empty line as the PID — naively passing the whole
-            // contents to int.TryParse fails on the two-line format and
-            // mis-reports a running daemon as "invalid PID file".
-            var firstLine = (await File.ReadAllTextAsync(pidPath))
+    static async Task WriteAgentStatusAsync() {
+        if (!Directory.Exists(AgentLockPaths.Directory)) {
+            await Console.Out.WriteLineAsync("not running");
+            return;
+        }
+
+        var pidFiles = Directory.EnumerateFiles(AgentLockPaths.Directory, "*.pid")
+            .OrderBy(f => f)
+            .ToList();
+
+        if (pidFiles.Count == 0) {
+            await Console.Out.WriteLineAsync("not running");
+            return;
+        }
+
+        var entries = new List<(string Name, int Pid, bool Alive)>(pidFiles.Count);
+
+        foreach (var pidFile in pidFiles) {
+            var name = Path.GetFileNameWithoutExtension(pidFile);
+            if (string.IsNullOrEmpty(name)) continue;
+
+            var firstLine = (await File.ReadAllTextAsync(pidFile))
                 .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .FirstOrDefault();
 
-            if (int.TryParse(firstLine, out var pid)) {
-                try {
-                    System.Diagnostics.Process.GetProcessById(pid);
-                    await Console.Out.WriteLineAsync($"running (PID {pid})");
-                } catch (ArgumentException) {
-                    await Console.Out.WriteLineAsync("not running (stale PID file)");
-                }
-            } else {
-                await Console.Out.WriteLineAsync("unknown (invalid PID file)");
+            if (!int.TryParse(firstLine, out var pid)) continue;
+
+            var alive = false;
+            try {
+                System.Diagnostics.Process.GetProcessById(pid);
+                alive = true;
+            } catch (ArgumentException) {
+                // process gone; treated as stale below
             }
-        } else {
-            await Console.Out.WriteLineAsync("not running");
+
+            entries.Add((name, pid, alive));
         }
 
-        return 0;
+        var live = entries.Where(e => e.Alive).ToList();
+
+        if (live.Count == 0) {
+            await Console.Out.WriteLineAsync(
+                entries.Count == 0
+                    ? "not running"
+                    : "not running (stale PID files; `kapacitor agent doctor --clean` to remove)"
+            );
+            return;
+        }
+
+        if (live.Count == 1) {
+            await Console.Out.WriteLineAsync($"running — {live[0].Name} (PID {live[0].Pid})");
+            return;
+        }
+
+        var summary = string.Join(", ", live.Select(e => $"{e.Name} (PID {e.Pid})"));
+        await Console.Out.WriteLineAsync($"running ({live.Count}) — {summary}");
     }
 
     /// <summary>

--- a/test/kapacitor.Tests.Unit/AgentLockEnumerationTests.cs
+++ b/test/kapacitor.Tests.Unit/AgentLockEnumerationTests.cs
@@ -1,0 +1,58 @@
+namespace kapacitor.Tests.Unit;
+
+/// <summary>
+/// AI-630 review fix #4: <see cref="AgentLockPaths.EnumerateNames"/> must
+/// union <c>*.lock</c> and <c>*.pid</c> filenames, not just <c>*.lock</c>.
+/// An orphan PID file (no matching lock, e.g. a daemon that stopped via
+/// the AI-78 path before the per-name layout existed) needs to be visible
+/// to <c>kapacitor agent doctor --clean</c>; previously it was invisible.
+/// </summary>
+[NotInParallel(nameof(AgentLockPaths) + ".OverrideDirectoryForTesting")]
+public class AgentLockEnumerationTests {
+    [Test]
+    public async Task EnumerateNames_UnionsLockAndPidFiles() {
+        var dir = Path.Combine(Path.GetTempPath(), "kapacitor-enum-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        AgentLockPaths.OverrideDirectoryForTesting(dir);
+
+        try {
+            // alpha has both lock and pid (held daemon).
+            // beta has only a lock (e.g. doctor just cleaned the pid).
+            // gamma has only a pid (orphan from before AI-630 migration).
+            File.WriteAllText(Path.Combine(dir, "alpha.lock"), "instance-1");
+            File.WriteAllText(Path.Combine(dir, "alpha.pid"),  "12345");
+            File.WriteAllText(Path.Combine(dir, "beta.lock"),  "instance-2");
+            File.WriteAllText(Path.Combine(dir, "gamma.pid"),  "67890");
+
+            var names = AgentLockPaths.EnumerateNames();
+
+            await Assert.That(names).Count().IsEqualTo(3);
+            await Assert.That(names).Contains("alpha");
+            await Assert.That(names).Contains("beta");
+            await Assert.That(names).Contains("gamma");
+        } finally {
+            AgentLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Test]
+    public async Task EnumerateNames_DeduplicatesNamesAppearingInBoth() {
+        var dir = Path.Combine(Path.GetTempPath(), "kapacitor-enum-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        AgentLockPaths.OverrideDirectoryForTesting(dir);
+
+        try {
+            File.WriteAllText(Path.Combine(dir, "alpha.lock"), "instance-1");
+            File.WriteAllText(Path.Combine(dir, "alpha.pid"),  "12345");
+
+            var names = AgentLockPaths.EnumerateNames();
+
+            await Assert.That(names).Count().IsEqualTo(1);
+            await Assert.That(names[0]).IsEqualTo("alpha");
+        } finally {
+            AgentLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/test/kapacitor.Tests.Unit/AgentLockMigrationTests.cs
+++ b/test/kapacitor.Tests.Unit/AgentLockMigrationTests.cs
@@ -1,0 +1,95 @@
+namespace kapacitor.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="AgentLockMigration"/> — the one-shot move of
+/// pre-AI-630 singleton files (<c>agent.pid</c>, <c>agent.start.lock</c>) to
+/// the new per-name layout. The migration must be best-effort (no throws),
+/// idempotent (safe to call repeatedly), and prefer the new path's content
+/// when both exist (the new file is authoritative because a fresh daemon
+/// wrote it after the old one died).
+///
+/// All tests use the internal <see cref="AgentLockMigration.MigrateLegacyFiles(string, string, string)"/>
+/// overload that accepts explicit legacy paths. Production code uses the
+/// public overload backed by <c>PathHelpers.ConfigPath</c>, but injecting
+/// legacy paths here keeps the test from cascading into PathHelpers'
+/// once-cached <c>ConfigDir</c> static-readonly field (which would then
+/// affect every other test in the suite that reads
+/// <c>PathHelpers.ConfigPath</c>).
+/// </summary>
+[NotInParallel(nameof(AgentLockPaths) + ".OverrideDirectoryForTesting")]
+public class AgentLockMigrationTests {
+    static (string Scratch, string NewAgentsDir, string LegacyPid, string LegacyLock) Setup() {
+        var scratch = Path.Combine(Path.GetTempPath(), "kapacitor-migration-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(scratch);
+
+        var newAgentsDir = Path.Combine(scratch, "agents");
+        Directory.CreateDirectory(newAgentsDir);
+        AgentLockPaths.OverrideDirectoryForTesting(newAgentsDir);
+
+        var legacyPid  = Path.Combine(scratch, "agent.pid");
+        var legacyLock = Path.Combine(scratch, "agent.start.lock");
+
+        return (scratch, newAgentsDir, legacyPid, legacyLock);
+    }
+
+    static void TearDown(string scratch) {
+        AgentLockPaths.OverrideDirectoryForTesting(null);
+        try { Directory.Delete(scratch, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [Test]
+    public async Task MigrateLegacyFiles_MovesPidAndLockToNewLayout() {
+        var (scratch, _, legacyPid, legacyLock) = Setup();
+
+        try {
+            File.WriteAllText(legacyPid,  "12345\n637899999999999999");
+            File.WriteAllText(legacyLock, "");
+
+            var moved = AgentLockMigration.MigrateLegacyFiles("alexey", legacyPid, legacyLock);
+
+            await Assert.That(moved).Count().IsEqualTo(2);
+            await Assert.That(File.Exists(legacyPid)).IsFalse();
+            await Assert.That(File.Exists(legacyLock)).IsFalse();
+            await Assert.That(File.Exists(AgentLockPaths.PidPath("alexey"))).IsTrue();
+            await Assert.That(File.Exists(AgentLockPaths.StartLockPath("alexey"))).IsTrue();
+            await Assert.That(File.ReadAllText(AgentLockPaths.PidPath("alexey"))).IsEqualTo("12345\n637899999999999999");
+        } finally {
+            TearDown(scratch);
+        }
+    }
+
+    [Test]
+    public async Task MigrateLegacyFiles_IsIdempotent_WithNoLegacyPresent() {
+        var (scratch, _, legacyPid, legacyLock) = Setup();
+
+        try {
+            var moved = AgentLockMigration.MigrateLegacyFiles("alexey", legacyPid, legacyLock);
+            await Assert.That(moved).IsEmpty();
+
+            var moved2 = AgentLockMigration.MigrateLegacyFiles("alexey", legacyPid, legacyLock);
+            await Assert.That(moved2).IsEmpty();
+        } finally {
+            TearDown(scratch);
+        }
+    }
+
+    [Test]
+    public async Task MigrateLegacyFiles_WhenNewPathAlreadyPopulated_DropsLegacy() {
+        var (scratch, _, legacyPid, legacyLock) = Setup();
+
+        try {
+            // A fresh daemon already wrote to the new path. The legacy file
+            // from an earlier dead daemon must be discarded, not overwriting
+            // the new authoritative file.
+            File.WriteAllText(AgentLockPaths.PidPath("alexey"), "FRESH");
+            File.WriteAllText(legacyPid, "STALE");
+
+            AgentLockMigration.MigrateLegacyFiles("alexey", legacyPid, legacyLock);
+
+            await Assert.That(File.Exists(legacyPid)).IsFalse();
+            await Assert.That(File.ReadAllText(AgentLockPaths.PidPath("alexey"))).IsEqualTo("FRESH");
+        } finally {
+            TearDown(scratch);
+        }
+    }
+}

--- a/test/kapacitor.Tests.Unit/AgentLockPathsTests.cs
+++ b/test/kapacitor.Tests.Unit/AgentLockPathsTests.cs
@@ -1,0 +1,39 @@
+namespace kapacitor.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="AgentLockPaths"/> — the name-sanitization rules and
+/// the per-name path layout that prevents two daemons under the same name
+/// from racing on the AI-630 lock.
+/// </summary>
+public class AgentLockPathsTests {
+    [Test]
+    [Arguments("alexey",            "alexey")]
+    [Arguments("ALEXEY",            "alexey")]
+    [Arguments("My Daemon",         "my-daemon")]
+    [Arguments("user@host",         "user-host")]
+    [Arguments("a/b\\c",             "a-b-c")]
+    [Arguments("  spaced  ",        "spaced")]
+    [Arguments("dots.are.fine",     "dots.are.fine")]
+    [Arguments("dashes-ok",         "dashes-ok")]
+    [Arguments("under_score",       "under_score")] // underscores survive: filesystem-safe and common
+    [Arguments("collapse---dashes", "collapse-dashes")]
+    public async Task Sanitize_NormalisesNames(string input, string expected) {
+        await Assert.That(AgentLockPaths.Sanitize(input)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments("???")]
+    [Arguments("///")]
+    public async Task Sanitize_FallsBackToDaemonForEmptyOrAllInvalid(string input) {
+        await Assert.That(AgentLockPaths.Sanitize(input)).IsEqualTo("daemon");
+    }
+
+    [Test]
+    public async Task LockPidStart_ShareSanitizedName() {
+        await Assert.That(AgentLockPaths.LockPath("My Daemon")).EndsWith("my-daemon.lock");
+        await Assert.That(AgentLockPaths.PidPath("My Daemon")).EndsWith("my-daemon.pid");
+        await Assert.That(AgentLockPaths.StartLockPath("My Daemon")).EndsWith("my-daemon.start");
+    }
+}

--- a/test/kapacitor.Tests.Unit/DaemonLockTests.cs
+++ b/test/kapacitor.Tests.Unit/DaemonLockTests.cs
@@ -111,6 +111,61 @@ public class DaemonLockTests {
         }
     }
 
+    /// <summary>
+    /// AI-630 review fix: <see cref="DaemonLock.Dispose"/> must not delete the
+    /// lock file on disk. If it did, a daemon B that acquired the path between
+    /// our flock release and the unlink would have its inode unlinked under
+    /// it, and a daemon C could then create a fresh file and acquire a SECOND
+    /// independent flock at the same path — reopening the duplicate-name hole.
+    /// </summary>
+    [Test]
+    public async Task Dispose_DoesNotDeleteLockFile() {
+        var dir = CreateScratchDir();
+
+        try {
+            var l = DaemonLock.TryAcquire("alpha")!;
+            var lockPath = AgentLockPaths.LockPath("alpha");
+
+            await Assert.That(File.Exists(lockPath)).IsTrue();
+
+            l.Dispose();
+
+            await Assert.That(File.Exists(lockPath)).IsTrue();
+        } finally {
+            Restore();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// AI-630 review fix: when a successor daemon has already overwritten
+    /// the PID file with its own PID, the disposing daemon must not delete
+    /// it — that would orphan the successor's entry and `agent stop` would
+    /// no longer find the live daemon.
+    /// </summary>
+    [Test]
+    public async Task Dispose_DoesNotDeletePidFile_IfItPointsToSomeoneElsesPid() {
+        var dir = CreateScratchDir();
+
+        try {
+            var l = DaemonLock.TryAcquire("alpha")!;
+            var pidPath = AgentLockPaths.PidPath("alpha");
+
+            // Simulate a successor process that won the race after our
+            // flock release and rewrote the PID file. We pick a PID that
+            // is definitely not us.
+            File.WriteAllText(pidPath, "99999\n637999999999999999");
+
+            l.Dispose();
+
+            await Assert.That(File.Exists(pidPath)).IsTrue();
+            await Assert.That(File.ReadAllText(pidPath)).StartsWith("99999");
+        } finally {
+            Restore();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     [Test]
     public async Task TryAcquire_AfterStaleLockFileLeftBehind_StillAcquires() {
         var dir = CreateScratchDir();

--- a/test/kapacitor.Tests.Unit/DaemonLockTests.cs
+++ b/test/kapacitor.Tests.Unit/DaemonLockTests.cs
@@ -1,0 +1,133 @@
+using kapacitor.Daemon;
+
+namespace kapacitor.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="DaemonLock"/> — the per-name flock the daemon binary
+/// holds for its lifetime. Verifies the AI-630 protection: a second daemon
+/// acquiring the same name on the same machine fails fast.
+///
+/// All tests redirect <see cref="AgentLockPaths"/> to a temp directory so
+/// nothing touches the user's real <c>~/.config/kapacitor/agents</c>. The
+/// per-class isolation pattern (unique subdir per test, restored at the
+/// end) keeps the tests independent of one another's failed/leaked locks.
+/// </summary>
+[NotInParallel(nameof(AgentLockPaths) + ".OverrideDirectoryForTesting")]
+public class DaemonLockTests {
+    static string CreateScratchDir() {
+        var dir = Path.Combine(Path.GetTempPath(), "kapacitor-lock-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        AgentLockPaths.OverrideDirectoryForTesting(dir);
+
+        return dir;
+    }
+
+    static void Restore() => AgentLockPaths.OverrideDirectoryForTesting(null);
+
+    [Test]
+    public async Task TryAcquire_OnFreshSlot_ReturnsLockWithFreshInstanceId() {
+        var dir = CreateScratchDir();
+
+        try {
+            var l = DaemonLock.TryAcquire("alpha");
+
+            await Assert.That(l).IsNotNull();
+            await Assert.That(l!.InstanceId).IsNotEmpty();
+            await Assert.That(l.InstanceId.Length).IsEqualTo(32); // GUID "N" format
+
+            // The lock file is held with FileShare.None, so the test
+            // process can't read it while the daemon owns it (that's the
+            // whole point — would-be duplicates can't peek). Verify the
+            // content after disposal instead.
+            var expected = l.InstanceId;
+            l.Dispose();
+
+            // Dispose deletes the lock file, which is the production
+            // behaviour. Re-acquire to inspect the file content we'd see
+            // mid-lifetime: it'll have a fresh instance id, but the
+            // structure (single 32-char GUID line) is the assertion that
+            // matters.
+            using var reacquired = DaemonLock.TryAcquire("alpha");
+            await Assert.That(reacquired).IsNotNull();
+            await Assert.That(reacquired!.InstanceId).IsNotEqualTo(expected);
+        } finally {
+            Restore();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task TryAcquire_OnSameName_WhileHeld_Fails() {
+        var dir = CreateScratchDir();
+
+        try {
+            using var first = DaemonLock.TryAcquire("alpha");
+            await Assert.That(first).IsNotNull();
+
+            var second = DaemonLock.TryAcquire("alpha");
+            await Assert.That(second).IsNull();
+        } finally {
+            Restore();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task TryAcquire_DifferentNames_BothSucceed() {
+        var dir = CreateScratchDir();
+
+        try {
+            using var alpha = DaemonLock.TryAcquire("alpha");
+            using var beta  = DaemonLock.TryAcquire("beta");
+
+            await Assert.That(alpha).IsNotNull();
+            await Assert.That(beta).IsNotNull();
+            await Assert.That(alpha!.InstanceId).IsNotEqualTo(beta!.InstanceId);
+        } finally {
+            Restore();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Dispose_ReleasesLock_AllowingReAcquisition() {
+        var dir = CreateScratchDir();
+
+        try {
+            var first = DaemonLock.TryAcquire("alpha");
+            await Assert.That(first).IsNotNull();
+
+            // Different instance id should be produced on re-acquire so a
+            // post-disposal observer can tell the daemons apart.
+            var firstId = first!.InstanceId;
+            first.Dispose();
+
+            using var second = DaemonLock.TryAcquire("alpha");
+            await Assert.That(second).IsNotNull();
+            await Assert.That(second!.InstanceId).IsNotEqualTo(firstId);
+        } finally {
+            Restore();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task TryAcquire_AfterStaleLockFileLeftBehind_StillAcquires() {
+        var dir = CreateScratchDir();
+
+        try {
+            // Simulate a daemon that died without cleanup: lockfile exists,
+            // but no process holds the kernel flock. Re-acquisition must
+            // succeed — that's the whole point of flock semantics.
+            AgentLockPaths.EnsureDirectory();
+            File.WriteAllText(AgentLockPaths.LockPath("alpha"), "stale-instance-id");
+
+            using var l = DaemonLock.TryAcquire("alpha");
+            await Assert.That(l).IsNotNull();
+            await Assert.That(l!.InstanceId).IsNotEqualTo("stale-instance-id");
+        } finally {
+            Restore();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/test/kapacitor.Tests.Unit/DaemonNameResolverTests.cs
+++ b/test/kapacitor.Tests.Unit/DaemonNameResolverTests.cs
@@ -50,15 +50,16 @@ public class DaemonNameResolverTests {
     }
 
     [Test]
-    public async Task Resolve_EnvVarAlsoOverridesArg() {
-        // Documented quirk inherited from the pre-AI-630 DaemonRunner.RunAsync
-        // ordering: env var trumps everything so shell scripts can fan out
-        // multiple daemons without rewriting argv.
+    public async Task Resolve_NameArgOverridesEnvVar() {
+        // AI-630 fix: pre-AI-630 DaemonRunner had the env var trump --name,
+        // which inverted the usual CLI convention (explicit flag is the
+        // strongest signal). The new precedence puts --name first so the
+        // user's explicit choice always wins.
         Environment.SetEnvironmentVariable("KAPACITOR_DAEMON_NAME", "from-env");
 
         try {
             var name = DaemonNameResolver.Resolve(["--name", "from-arg"], profileName: "from-profile");
-            await Assert.That(name).IsEqualTo("from-env");
+            await Assert.That(name).IsEqualTo("from-arg");
         } finally {
             Reset();
         }

--- a/test/kapacitor.Tests.Unit/DaemonNameResolverTests.cs
+++ b/test/kapacitor.Tests.Unit/DaemonNameResolverTests.cs
@@ -79,4 +79,31 @@ public class DaemonNameResolverTests {
             Reset();
         }
     }
+
+    [Test]
+    public async Task Resolve_Throws_WhenNameFlagHasNoValue() {
+        Environment.SetEnvironmentVariable("KAPACITOR_DAEMON_NAME", null);
+
+        try {
+            var ex = Assert.Throws<ArgumentException>(() => DaemonNameResolver.Resolve(["--name"]));
+            await Assert.That(ex.Message).Contains("--name requires a value");
+        } finally {
+            Reset();
+        }
+    }
+
+    [Test]
+    public async Task Resolve_Throws_WhenNameFlagValueLooksLikeAnotherFlag() {
+        // Defends against `agent stop --name --yes` (which would otherwise
+        // try to stop a daemon literally named "--yes") and the more
+        // dangerous `agent stop --yes --name` chain — see PR 67 review.
+        Environment.SetEnvironmentVariable("KAPACITOR_DAEMON_NAME", null);
+
+        try {
+            var ex = Assert.Throws<ArgumentException>(() => DaemonNameResolver.Resolve(["--name", "--yes"]));
+            await Assert.That(ex.Message).Contains("--name requires a value");
+        } finally {
+            Reset();
+        }
+    }
 }

--- a/test/kapacitor.Tests.Unit/DaemonNameResolverTests.cs
+++ b/test/kapacitor.Tests.Unit/DaemonNameResolverTests.cs
@@ -1,0 +1,81 @@
+namespace kapacitor.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="DaemonNameResolver"/> — the shared name-resolution
+/// helper used by both the CLI supervisor and the daemon binary. Keeping
+/// these paths in lockstep is critical: a mismatch would mean the CLI
+/// checks one PID file while the daemon writes to a different one, and
+/// the AI-78 PID-file guard would be bypassable again.
+/// </summary>
+[NotInParallel("KAPACITOR_DAEMON_NAME")]
+public class DaemonNameResolverTests {
+    static readonly string? OriginalEnv = Environment.GetEnvironmentVariable("KAPACITOR_DAEMON_NAME");
+
+    static void Reset() => Environment.SetEnvironmentVariable("KAPACITOR_DAEMON_NAME", OriginalEnv);
+
+    [Test]
+    public async Task Resolve_PrefersNameArg() {
+        Environment.SetEnvironmentVariable("KAPACITOR_DAEMON_NAME", null);
+
+        try {
+            var name = DaemonNameResolver.Resolve(["--name", "from-arg"], profileName: "from-profile");
+            await Assert.That(name).IsEqualTo("from-arg");
+        } finally {
+            Reset();
+        }
+    }
+
+    [Test]
+    public async Task Resolve_FallsBackToProfile_WhenNoArgOrEnv() {
+        Environment.SetEnvironmentVariable("KAPACITOR_DAEMON_NAME", null);
+
+        try {
+            var name = DaemonNameResolver.Resolve([], profileName: "from-profile");
+            await Assert.That(name).IsEqualTo("from-profile");
+        } finally {
+            Reset();
+        }
+    }
+
+    [Test]
+    public async Task Resolve_EnvVarOverridesProfile() {
+        Environment.SetEnvironmentVariable("KAPACITOR_DAEMON_NAME", "from-env");
+
+        try {
+            var name = DaemonNameResolver.Resolve([], profileName: "from-profile");
+            await Assert.That(name).IsEqualTo("from-env");
+        } finally {
+            Reset();
+        }
+    }
+
+    [Test]
+    public async Task Resolve_EnvVarAlsoOverridesArg() {
+        // Documented quirk inherited from the pre-AI-630 DaemonRunner.RunAsync
+        // ordering: env var trumps everything so shell scripts can fan out
+        // multiple daemons without rewriting argv.
+        Environment.SetEnvironmentVariable("KAPACITOR_DAEMON_NAME", "from-env");
+
+        try {
+            var name = DaemonNameResolver.Resolve(["--name", "from-arg"], profileName: "from-profile");
+            await Assert.That(name).IsEqualTo("from-env");
+        } finally {
+            Reset();
+        }
+    }
+
+    [Test]
+    public async Task Resolve_FallsBackToUsername_WhenNothingProvided() {
+        Environment.SetEnvironmentVariable("KAPACITOR_DAEMON_NAME", null);
+
+        try {
+            var name = DaemonNameResolver.Resolve([]);
+            // Should at minimum produce a non-empty fallback. The exact value
+            // depends on the test runner environment, so just assert it's
+            // sane.
+            await Assert.That(name).IsNotEmpty();
+        } finally {
+            Reset();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

CLI half of [AI-630](https://linear.app/kurrent/issue/AI-630) — pairs with [kurrent-io/Kurrent.Capacitor#621](https://github.com/kurrent-io/Kurrent.Capacitor/pull/621) (already merged).

Each `kapacitor-daemon` process now holds a kernel-managed `flock` on `~/.config/kapacitor/agents/<name>.lock` for its entire lifetime. The lock file's content is a per-process GUID (`InstanceId`) that's also sent over `DaemonConnect` so the server can distinguish "same daemon reconnecting" from "different daemon process claiming the same name". The lock directory is **fixed under the home directory regardless of `KAPACITOR_CONFIG_DIR`** so cross-config-dir daemons under the same name now collide on the same `flock` instead of writing to separate PID files (the gap that let the original staging incident happen).

## Behaviour after this PR

| Scenario | Before | After |
|---|---|---|
| Two daemons, **same name**, same machine, **same** `KAPACITOR_CONFIG_DIR` | AI-78 PID guard rejects the 2nd | Same |
| Two daemons, same name, **different** `KAPACITOR_CONFIG_DIR` | Both run, silently fight on server | 2nd exits with code 2 (`flock` conflict) |
| Two daemons, same name, **different machines** (same GitHub ID) | Both run, silently fight on server | 2nd exits with code 3 (server `DAEMON_NAME_IN_USE`) |
| One daemon reconnects over fresh SignalR transport (legit) | Allowed (silent) | Allowed (`InstanceId` matches → `Reconnected` outcome) |
| Two daemons, **different names**, same machine | Worked, but `agent stop` couldn't target either specifically | Both run side-by-side; `agent stop --name X` targets one, `agent stop` prompts |

## New surfaces

```bash
kapacitor agent start --name laptop -d  # explicit name (default = OS username)
kapacitor agent stop --name laptop      # stop one specific daemon
kapacitor agent stop                    # enumerate; prompts on multi
kapacitor agent stop --yes              # unattended: stop all
kapacitor agent status                  # lists all running daemons
kapacitor agent status --name laptop    # show one
kapacitor agent doctor                  # classify every agents/*.lock as held vs stale
kapacitor agent doctor --clean          # remove stale entries (held ones untouched)
```

## Files

**New:**
- `src/Kapacitor.Core/AgentLockPaths.cs` — sanitised per-name path layout under the fixed directory.
- `src/Kapacitor.Core/AgentLockMigration.cs` — one-shot move of legacy `agent.pid`/`agent.start.lock` to the new per-name path.
- `src/Kapacitor.Core/DaemonNameResolver.cs` — shared name resolution (CLI + daemon agree).
- `src/Kapacitor.Daemon/DaemonLock.cs` — kernel-managed `flock` (FileShare.None) holder + PID-file writer.
- Tests: 28 new unit tests across all four (`AgentLockPathsTests`, `DaemonLockTests`, `AgentLockMigrationTests`, `DaemonNameResolverTests`).

**Modified:**
- `src/Kapacitor.Core/Models.cs` — `DaemonConnect` gains `InstanceId` and `Version` (nullable, wire-compatible).
- `src/Kapacitor.Daemon/DaemonConfig.cs` — carries `InstanceId` + `Version` (set by `DaemonRunner` at startup).
- `src/Kapacitor.Daemon/DaemonRunner.cs` — migrates legacy files, acquires lock, generates instance id, resolves version from `[AssemblyInformationalVersion]`, subscribes to `OnNameInUse` for clean exit-3.
- `src/Kapacitor.Daemon/Services/ServerConnection.cs` — sends `InstanceId`/`Version` on `DaemonConnect`, exposes `OnNameInUse` event, catches typed `HubException` with `DAEMON_NAME_IN_USE` prefix.
- `src/Kapacitor.Daemon/Services/DaemonHeartbeatLoop.cs` — `SafeReRegisterAsync` skips force-reconnect on `NameInUse` so the daemon shuts down cleanly instead of oscillating.
- `src/kapacitor/Commands/AgentCommands.cs` — refactor to per-name paths, new `--name`/`--yes` flags, new `doctor` subcommand.
- `README.md`, `Resources/help-agent.txt`, `Resources/help-usage.txt` — user-facing docs sync (per the project's README rule).

## Test plan

- [x] `dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj` — 595/595 pass.
- [x] `dotnet publish src/Kapacitor.Daemon/Kapacitor.Daemon.csproj -c Release` — 0 IL3050/IL2026 warnings.
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — 0 IL3050/IL2026 warnings (one pre-existing IDE0200 unrelated to this change).
- [ ] Manual: `kapacitor agent start --name a -d && kapacitor agent start --name a -d` → second exits with code 2 and prints the "already running" message.
- [ ] Manual: `kapacitor agent start --name a` foreground + `kapacitor agent start --name b -d` → both run.
- [ ] Manual: against the staging server (PR 621 already deployed) — restart one daemon, confirm `Reconnected` log on server; spawn a duplicate via two `kapacitor` checkouts pointing at the same server → second exits 3 with `DAEMON_NAME_IN_USE` message.

## Post-merge

Bump the submodule in `kurrent-io/Kurrent.Capacitor` with a `chore: bump kapacitor CLI submodule` commit so the server repo picks up the new CLI for the dev daemon resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)