### PR TITLE
[AI-634] CLI: codex title + what's-done generation

### DIFF
--- a/src/kapacitor/Commands/CodexHookCommand.cs
+++ b/src/kapacitor/Commands/CodexHookCommand.cs
@@ -103,7 +103,36 @@ static class CodexHookCommand {
         // Codex's hook event name into Capacitor's canonical hook vocabulary
         // before posting, so the server doesn't have to know about Codex's
         // missing session-end concept.
-        return await PostHookAsync(baseUrl, "session-end/codex", node.ToJsonString());
+        var (exit, responseBody) = await PostHookWithResponseAsync(baseUrl, "session-end/codex", node.ToJsonString());
+
+        if (exit != 0) return exit;
+
+        // Mirror the Claude session-end path in Program.cs: if the server flags
+        // generate_whats_done, spawn the summary generator as a detached process
+        // with --codex so it goes through codex exec, matching the vendor that
+        // produced the work being summarised.
+        if (sessionId is not null && ShouldSpawnWhatsDone(responseBody)) {
+            WatcherManager.SpawnWhatsDoneGenerator(baseUrl, sessionId, vendor: "codex");
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Parses the session-end response body and returns whether the server asked
+    /// the CLI to generate a what's-done summary. Extracted so the response-parsing
+    /// branch is testable without actually spawning a subprocess.
+    /// </summary>
+    internal static bool ShouldSpawnWhatsDone(string? responseBody) {
+        if (responseBody is null) return false;
+
+        try {
+            var responseNode = JsonNode.Parse(responseBody);
+            return responseNode?["generate_whats_done"]?.GetValue<bool>() == true;
+        } catch {
+            // Best effort — non-JSON or wrong-typed flag both fall through to "no spawn"
+            return false;
+        }
     }
 
     static async Task<int> HandlePermissionRequest(string baseUrl, JsonNode node) {
@@ -124,6 +153,11 @@ static class CodexHookCommand {
     }
 
     static async Task<int> PostHookAsync(string baseUrl, string endpoint, string body) {
+        var (exit, _) = await PostHookWithResponseAsync(baseUrl, endpoint, body);
+        return exit;
+    }
+
+    static async Task<(int Exit, string? ResponseBody)> PostHookWithResponseAsync(string baseUrl, string endpoint, string body) {
         using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
 
@@ -131,13 +165,14 @@ static class CodexHookCommand {
             var resp = await client.PostWithRetryAsync($"{baseUrl}/hooks/{endpoint}", content);
             if (!resp.IsSuccessStatusCode) {
                 Console.Error.WriteLine($"[kapacitor] codex-hook {endpoint}: HTTP {(int)resp.StatusCode}");
-                return 1;
+                return (1, null);
             }
 
-            return 0;
+            var responseBody = await resp.Content.ReadAsStringAsync();
+            return (0, responseBody);
         } catch (HttpRequestException ex) {
             HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
-            return 1;
+            return (1, null);
         }
     }
 

--- a/src/kapacitor/Commands/TitleGenerator.cs
+++ b/src/kapacitor/Commands/TitleGenerator.cs
@@ -271,12 +271,12 @@ static partial class TitleGenerator {
     ///   which can land before a follow-up prompt in the same session.</item>
     /// </list>
     /// </summary>
-    static bool IsCodexInjectedUserPrelude(string text) =>
+    internal static bool IsCodexInjectedUserPrelude(string text) =>
         text.StartsWith("<environment_context>",     StringComparison.Ordinal)
      || text.StartsWith("# AGENTS.md instructions",  StringComparison.Ordinal)
      || text.StartsWith("<turn_aborted>",            StringComparison.Ordinal);
 
-    static string? ExtractCodexBlockText(JsonElement payload, string blockType) {
+    internal static string? ExtractCodexBlockText(JsonElement payload, string blockType) {
         if (payload.Arr("content") is not { } content) return null;
 
         foreach (var block in content.EnumerateArray()) {

--- a/src/kapacitor/Commands/WatchCommand.cs
+++ b/src/kapacitor/Commands/WatchCommand.cs
@@ -532,7 +532,7 @@ static partial class WatchCommand {
 
             if (payload?.Str("type") != "message" || payload.Value.Str("role") != "assistant") return null;
 
-            return ExtractCodexBlockText(payload.Value, "output_text")?.Trim() is { Length: > 0 } text ? text : null;
+            return TitleGenerator.ExtractCodexBlockText(payload.Value, "output_text")?.Trim() is { Length: > 0 } text ? text : null;
         } catch {
             return null;
         }
@@ -546,13 +546,25 @@ static partial class WatchCommand {
             if (vendor == "codex") {
                 // Codex rolls everything into a top-level response_item envelope;
                 // a "message" payload (user or assistant) is the analog of Claude's
-                // user/assistant event for title-threshold purposes.
+                // user/assistant event for title-threshold purposes. User-role
+                // payloads that are codex-injected preludes
+                // (<environment_context>, AGENTS.md, <turn_aborted>) must NOT
+                // count — otherwise a fresh session with no real prompts can
+                // reach the 5-event threshold and produce a low-context title.
                 if (root.Str("type") != "response_item") return false;
 
                 var payload = root.Obj("payload");
 
-                return payload?.Str("type") == "message"
-                 && payload.Value.Str("role") is "user" or "assistant";
+                if (payload?.Str("type") != "message") return false;
+
+                var role = payload.Value.Str("role");
+
+                return role switch {
+                    "assistant" => true,
+                    "user"      => TitleGenerator.ExtractCodexBlockText(payload.Value, "input_text") is { } text
+                                && !TitleGenerator.IsCodexInjectedUserPrelude(text),
+                    _           => false
+                };
             }
 
             return root.Str("type") is "user" or "assistant";
@@ -616,13 +628,13 @@ static partial class WatchCommand {
 
             if (payload?.Str("type") != "message" || payload.Value.Str("role") != "user") return null;
 
-            var text = ExtractCodexBlockText(payload.Value, "input_text");
-
             // Skip codex-injected wrappers (environment_context, AGENTS.md, turn_aborted).
             // These role:"user" payloads precede the real prompt and would otherwise be
-            // used as the title context. The same prelude list lives in TitleGenerator
-            // for the offline import path.
-            return text is null || IsCodexInjectedUserPrelude(text) ? null : text;
+            // used as the title context. Prelude list and block extractor live in
+            // TitleGenerator so the offline-import and live-watch paths stay in sync.
+            var text = TitleGenerator.ExtractCodexBlockText(payload.Value, "input_text");
+
+            return text is null || TitleGenerator.IsCodexInjectedUserPrelude(text) ? null : text;
         } catch (Exception ex) {
             if (!parseErrorLogged) {
                 parseErrorLogged = true;
@@ -632,23 +644,6 @@ static partial class WatchCommand {
 
         return null;
     }
-
-    static string? ExtractCodexBlockText(JsonElement payload, string blockType) {
-        if (payload.Arr("content") is not { } content) return null;
-
-        foreach (var block in content.EnumerateArray()) {
-            if (block.Str("type") == blockType && block.Str("text") is { Length: > 0 } text) {
-                return text;
-            }
-        }
-
-        return null;
-    }
-
-    static bool IsCodexInjectedUserPrelude(string text) =>
-        text.StartsWith("<environment_context>",    StringComparison.Ordinal)
-     || text.StartsWith("# AGENTS.md instructions", StringComparison.Ordinal)
-     || text.StartsWith("<turn_aborted>",           StringComparison.Ordinal);
 
     /// <summary>
     /// Strips XML-like system instruction blocks from user text so they don't pollute title generation.

--- a/src/kapacitor/Commands/WatchCommand.cs
+++ b/src/kapacitor/Commands/WatchCommand.cs
@@ -295,7 +295,7 @@ static partial class WatchCommand {
                                 continue;
                             }
 
-                            var userText = TryExtractUserText(scanLine);
+                            var userText = TryExtractUserText(scanLine, vendor);
 
                             if (userText is null) {
                                 continue;
@@ -316,7 +316,7 @@ static partial class WatchCommand {
 
                 // Also check new lines (normal path)
                 if (state.FirstUserText is null && newLines.Count > 0) {
-                    foreach (var userText in newLines.Select(TryExtractUserText).OfType<string>()) {
+                    foreach (var userText in newLines.Select(line => TryExtractUserText(line, vendor)).OfType<string>()) {
                         SetFirstUserText(state, userText);
 
                         if (state.FirstUserText is not null) {
@@ -340,12 +340,12 @@ static partial class WatchCommand {
             // Count events and capture assistant context for LLM title generation
             if (state is { TitleGenerated: false } && agentId is null && newLines.Count > 0) {
                 foreach (var line in newLines) {
-                    if (IsEvent(line)) {
+                    if (IsEvent(line, vendor)) {
                         state.EventCount++;
                     }
 
                     if (state.FirstAssistantText is null) {
-                        var assistantText = TryExtractAssistantText(line);
+                        var assistantText = TryExtractAssistantText(line, vendor);
 
                         if (assistantText is not null) {
                             state.FirstAssistantText = assistantText.Length > 300 ? assistantText[..300] : assistantText;
@@ -364,7 +364,7 @@ static partial class WatchCommand {
                 Log($"Triggering LLM title generation (attempt {state.TitleAttempts + 1}/5, events: {state.EventCount})");
                 state.TitleInFlight = true;
                 state.TitleAttempts++;
-                _ = GenerateTitleAsync(hubConnection, sessionId, state);
+                _ = GenerateTitleAsync(hubConnection, sessionId, state, vendor);
             }
 
             switch (agentId) {
@@ -487,7 +487,12 @@ static partial class WatchCommand {
         state.FirstUserText = userText;
     }
 
-    static string? TryExtractAssistantText(string line) {
+    internal static string? TryExtractAssistantText(string line, string vendor = "claude") =>
+        vendor == "codex"
+            ? TryExtractCodexAssistantText(line)
+            : TryExtractClaudeAssistantText(line);
+
+    static string? TryExtractClaudeAssistantText(string line) {
         try {
             using var doc  = JsonDocument.Parse(line);
             var       root = doc.RootElement;
@@ -516,10 +521,39 @@ static partial class WatchCommand {
         return null;
     }
 
-    static bool IsEvent(string line) {
+    static string? TryExtractCodexAssistantText(string line) {
         try {
             using var doc  = JsonDocument.Parse(line);
             var       root = doc.RootElement;
+
+            if (root.Str("type") != "response_item") return null;
+
+            var payload = root.Obj("payload");
+
+            if (payload?.Str("type") != "message" || payload.Value.Str("role") != "assistant") return null;
+
+            return ExtractCodexBlockText(payload.Value, "output_text")?.Trim() is { Length: > 0 } text ? text : null;
+        } catch {
+            return null;
+        }
+    }
+
+    internal static bool IsEvent(string line, string vendor = "claude") {
+        try {
+            using var doc  = JsonDocument.Parse(line);
+            var       root = doc.RootElement;
+
+            if (vendor == "codex") {
+                // Codex rolls everything into a top-level response_item envelope;
+                // a "message" payload (user or assistant) is the analog of Claude's
+                // user/assistant event for title-threshold purposes.
+                if (root.Str("type") != "response_item") return false;
+
+                var payload = root.Obj("payload");
+
+                return payload?.Str("type") == "message"
+                 && payload.Value.Str("role") is "user" or "assistant";
+            }
 
             return root.Str("type") is "user" or "assistant";
         } catch {
@@ -527,7 +561,12 @@ static partial class WatchCommand {
         }
     }
 
-    internal static string? TryExtractUserText(string line) {
+    internal static string? TryExtractUserText(string line, string vendor = "claude") =>
+        vendor == "codex"
+            ? TryExtractCodexUserText(line)
+            : TryExtractClaudeUserText(line);
+
+    static string? TryExtractClaudeUserText(string line) {
         try {
             using var doc  = JsonDocument.Parse(line);
             var       root = doc.RootElement;
@@ -566,6 +605,51 @@ static partial class WatchCommand {
         return null;
     }
 
+    static string? TryExtractCodexUserText(string line) {
+        try {
+            using var doc  = JsonDocument.Parse(line);
+            var       root = doc.RootElement;
+
+            if (root.Str("type") != "response_item") return null;
+
+            var payload = root.Obj("payload");
+
+            if (payload?.Str("type") != "message" || payload.Value.Str("role") != "user") return null;
+
+            var text = ExtractCodexBlockText(payload.Value, "input_text");
+
+            // Skip codex-injected wrappers (environment_context, AGENTS.md, turn_aborted).
+            // These role:"user" payloads precede the real prompt and would otherwise be
+            // used as the title context. The same prelude list lives in TitleGenerator
+            // for the offline import path.
+            return text is null || IsCodexInjectedUserPrelude(text) ? null : text;
+        } catch (Exception ex) {
+            if (!parseErrorLogged) {
+                parseErrorLogged = true;
+                Log($"TryExtractUserText (codex) parse error (further errors suppressed): {ex.Message}");
+            }
+        }
+
+        return null;
+    }
+
+    static string? ExtractCodexBlockText(JsonElement payload, string blockType) {
+        if (payload.Arr("content") is not { } content) return null;
+
+        foreach (var block in content.EnumerateArray()) {
+            if (block.Str("type") == blockType && block.Str("text") is { Length: > 0 } text) {
+                return text;
+            }
+        }
+
+        return null;
+    }
+
+    static bool IsCodexInjectedUserPrelude(string text) =>
+        text.StartsWith("<environment_context>",    StringComparison.Ordinal)
+     || text.StartsWith("# AGENTS.md instructions", StringComparison.Ordinal)
+     || text.StartsWith("<turn_aborted>",           StringComparison.Ordinal);
+
     /// <summary>
     /// Strips XML-like system instruction blocks from user text so they don't pollute title generation.
     /// Removes content between tags like &lt;system_instructions&gt;, &lt;system-reminder&gt;, etc.
@@ -585,9 +669,9 @@ static partial class WatchCommand {
 
     static readonly Regex SystemInstructionsRegex = SystemInstructionsRx();
 
-    static async Task GenerateTitleAsync(HubConnection hubConnection, string sessionId, WatchState state) {
+    static async Task GenerateTitleAsync(HubConnection hubConnection, string sessionId, WatchState state, string vendor) {
         try {
-            var result = await TitleGenerator.GenerateAsync(state.FirstUserText!, state.FirstAssistantText, Log);
+            var result = await TitleGenerator.GenerateAsync(state.FirstUserText!, state.FirstAssistantText, Log, vendor);
 
             if (result is null) {
                 Log($"Title generation attempt {state.TitleAttempts}/5 returned no usable result (CLI failure, refusal-like output, or empty title)");

--- a/src/kapacitor/WatcherManager.cs
+++ b/src/kapacitor/WatcherManager.cs
@@ -194,7 +194,7 @@ static class WatcherManager {
         await SpawnWatcher(baseUrl, key, transcriptPath, agentId, sessionIdOverride, cwd, skipTitle, vendor);
     }
 
-    public static void SpawnWhatsDoneGenerator(string baseUrl, string sessionId) {
+    public static void SpawnWhatsDoneGenerator(string baseUrl, string sessionId, string vendor = "claude") {
         try {
             var kapacitorPath = Environment.ProcessPath ?? "kapacitor";
 
@@ -210,6 +210,12 @@ static class WatcherManager {
             };
             psi.ArgumentList.Add("generate-whats-done");
             psi.ArgumentList.Add(sessionId);
+
+            // The child process picks the headless CLI runner from this flag —
+            // matches the `generate-whats-done [--codex] <id>` surface in Program.cs.
+            if (vendor == "codex") {
+                psi.ArgumentList.Add("--codex");
+            }
 
             var process = Process.Start(psi);
 

--- a/test/kapacitor.Tests.Unit/CodexHookCommandTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexHookCommandTests.cs
@@ -165,6 +165,24 @@ public class CodexHookCommandTests : IDisposable {
         await Assert.That(_server.LogEntries.Count()).IsEqualTo(0);
     }
 
+    [Test]
+    [Arguments("""{"generate_whats_done":true}""",  true)]
+    [Arguments("""{"generate_whats_done":false}""", false)]
+    [Arguments("""{"other_field":"x"}""",           false)]
+    [Arguments("""{"generate_whats_done":"yes"}""", false)] // wrong type — fall through
+    [Arguments("not json",                          false)]
+    [Arguments("",                                  false)]
+    public async Task ShouldSpawnWhatsDone_ParsesGenerateFlag(string responseBody, bool expected) {
+        var result = CodexHookCommand.ShouldSpawnWhatsDone(responseBody);
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ShouldSpawnWhatsDone_NullBody_ReturnsFalse() {
+        var result = CodexHookCommand.ShouldSpawnWhatsDone(null);
+        await Assert.That(result).IsFalse();
+    }
+
     // Fix #3: non-string session_id in a Stop payload must not crash.
     [Test]
     public async Task Stop_with_numeric_session_id_returns_zero_without_crash() {

--- a/test/kapacitor.Tests.Unit/WatchCommandTests.cs
+++ b/test/kapacitor.Tests.Unit/WatchCommandTests.cs
@@ -205,3 +205,80 @@ public class WatchCommandTests {
         await Assert.That(vendorParam.DefaultValue).IsEqualTo("claude");
     }
 }
+
+public class CodexTranscriptExtractionTests {
+    // Codex wraps every event in a response_item envelope; user prompts are
+    // role:"user" message payloads with input_text blocks. See TitleGenerator
+    // for the offline-import analog of this extraction.
+
+    [Test]
+    public async Task UserText_Extracts_InputText_FromResponseItem() {
+        const string line = """
+            {"type":"response_item","payload":{"type":"message","role":"user",
+             "content":[{"type":"input_text","text":"fix the bug"}]}}
+            """;
+
+        var result = Commands.WatchCommand.TryExtractUserText(line, "codex");
+
+        await Assert.That(result).IsEqualTo("fix the bug");
+    }
+
+    [Test]
+    [Arguments("<environment_context>\nworkspace=/tmp\n</environment_context>")]
+    [Arguments("# AGENTS.md instructions for /tmp\n\nUse pnpm.")]
+    [Arguments("<turn_aborted>user pressed esc</turn_aborted>")]
+    public async Task UserText_Skips_CodexInjectedPreludes(string preludeText) {
+        var encoded = System.Text.Json.JsonSerializer.Serialize(preludeText);
+        var line    = "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":" + encoded + "}]}}";
+
+        var result = Commands.WatchCommand.TryExtractUserText(line, "codex");
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    [Arguments("""{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}}""")]
+    [Arguments("""{"type":"response_item","payload":{"type":"reasoning","summary":[]}}""")]
+    [Arguments("""{"type":"response_item","payload":{"type":"message","role":"user","content":[]}}""")]
+    [Arguments("""{"type":"user","message":{"content":"claude-shape"}}""")]
+    [Arguments("not json")]
+    public async Task UserText_ReturnsNull_ForUnrelatedCodexLines(string line) {
+        var result = Commands.WatchCommand.TryExtractUserText(line, "codex");
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task AssistantText_Extracts_OutputText_FromResponseItem() {
+        const string line = """
+            {"type":"response_item","payload":{"type":"message","role":"assistant",
+             "content":[{"type":"output_text","text":"Sure, let me look into that"}]}}
+            """;
+
+        var result = Commands.WatchCommand.TryExtractAssistantText(line, "codex");
+
+        await Assert.That(result).IsEqualTo("Sure, let me look into that");
+    }
+
+    [Test]
+    [Arguments("""{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"prompt"}]}}""")]
+    [Arguments("""{"type":"response_item","payload":{"type":"reasoning"}}""")]
+    [Arguments("""{"type":"assistant","message":{"content":[{"type":"text","text":"claude-shape"}]}}""")]
+    public async Task AssistantText_ReturnsNull_ForUnrelatedCodexLines(string line) {
+        var result = Commands.WatchCommand.TryExtractAssistantText(line, "codex");
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    [Arguments("""{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}}""", true)]
+    [Arguments("""{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}}""", true)]
+    [Arguments("""{"type":"response_item","payload":{"type":"reasoning"}}""", false)]
+    [Arguments("""{"type":"response_item","payload":{"type":"function_call"}}""", false)]
+    [Arguments("""{"type":"user","message":{"content":"claude shape"}}""", false)]
+    public async Task IsEvent_Codex_OnlyCountsMessagePayloads(string line, bool expected) {
+        var result = Commands.WatchCommand.IsEvent(line, "codex");
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+}

--- a/test/kapacitor.Tests.Unit/WatchCommandTests.cs
+++ b/test/kapacitor.Tests.Unit/WatchCommandTests.cs
@@ -276,9 +276,27 @@ public class CodexTranscriptExtractionTests {
     [Arguments("""{"type":"response_item","payload":{"type":"reasoning"}}""", false)]
     [Arguments("""{"type":"response_item","payload":{"type":"function_call"}}""", false)]
     [Arguments("""{"type":"user","message":{"content":"claude shape"}}""", false)]
+    [Arguments("""{"type":"response_item","payload":{"type":"message","role":"user","content":[]}}""", false)]
     public async Task IsEvent_Codex_OnlyCountsMessagePayloads(string line, bool expected) {
         var result = Commands.WatchCommand.IsEvent(line, "codex");
 
         await Assert.That(result).IsEqualTo(expected);
+    }
+
+    // Critical: prelude user-role payloads must NOT count toward the 5-event
+    // title threshold. Otherwise a fresh Codex session with a few injected
+    // <environment_context>/AGENTS.md entries before any real prompt can trip
+    // the threshold and produce a title from prelude content alone.
+    [Test]
+    [Arguments("<environment_context>\nworkspace=/tmp\n</environment_context>")]
+    [Arguments("# AGENTS.md instructions for /tmp\n\nUse pnpm.")]
+    [Arguments("<turn_aborted>user pressed esc</turn_aborted>")]
+    public async Task IsEvent_Codex_SkipsInjectedUserPreludes(string preludeText) {
+        var encoded = System.Text.Json.JsonSerializer.Serialize(preludeText);
+        var line    = "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":" + encoded + "}]}}";
+
+        var result = Commands.WatchCommand.IsEvent(line, "codex");
+
+        await Assert.That(result).IsFalse();
     }
 }


### PR DESCRIPTION
## Summary
- Make session-title generation work for Codex sessions — watcher extractors and the title LLM call are now vendor-aware (`TryExtractUserText`/`TryExtractAssistantText`/`IsEvent` parse Codex `response_item` envelopes and skip codex-injected user preludes; `GenerateTitleAsync` forwards `vendor` to `TitleGenerator.GenerateAsync` so the call goes through `codex exec`).
- Add what's-done summary generation for Codex sessions — `CodexHookCommand.HandleStop` now reads the `/hooks/session-end/codex` response body and spawns `generate-whats-done --codex <id>` when the server flags `generate_whats_done: true`. `WatcherManager.SpawnWhatsDoneGenerator` takes a `vendor` arg to thread `--codex` to the child process.
- Both flows had been live for Claude Code (parent issue AI-67) but Codex was silently missing both.

## Test plan
- [x] `dotnet run --project test/kapacitor.Tests.Unit/...` — 632/632 pass (18 new tests covering Codex transcript extraction and `ShouldSpawnWhatsDone` response parsing)
- [x] `dotnet run --project test/kapacitor.Tests.Integration/...` — 9/9 pass
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — no IL3050/IL2026 AOT warnings
- [ ] Smoke test on a real Codex session: title appears in dashboard after ~5 message events; what's-done summary appears after session stop

Closes [AI-634](https://linear.app/kurrent/issue/AI-634/codex-support-session-title-and-outcome-generation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)