### PR TITLE
[AI-635] Fix Codex stop hook reporting invalid JSON output

### DIFF
--- a/docs/superpowers/specs/2026-05-14-ai-635-codex-stop-hook-invalid-json-design.md
+++ b/docs/superpowers/specs/2026-05-14-ai-635-codex-stop-hook-invalid-json-design.md
@@ -1,0 +1,144 @@
+# AI-635 — Codex Stop hook reports "invalid stop hook JSON output"
+
+**Linear:** [AI-635](https://linear.app/kurrent/issue/AI-635/codex-stop-hook-produces-an-error)
+**Type:** Bug fix
+**Repo:** kapacitor CLI
+
+## Problem
+
+Every Codex turn end produces:
+
+```
+Stop hook (failed)
+error: hook returned invalid stop hook JSON output
+```
+
+The error is non-fatal (Codex still continues) but surfaces to the user as a red diagnostic, and breaks user trust in the recording integration.
+
+## Root cause
+
+Two independent bugs combine to break the Codex Stop hook's stdout contract.
+
+### 1. `HandleStop` emits nothing on stdout
+
+Codex parses `Stop` hook stdout against `codex-rs/hooks/schema/generated/stop.command.output.schema.json`:
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "continue":      { "type": "boolean", "default": true },
+    "decision":      { "enum": ["block"] },
+    "reason":        { "type": "string" },
+    "stopReason":    { "type": "string" },
+    "suppressOutput":{ "type": "boolean", "default": false },
+    "systemMessage": { "type": "string" }
+  },
+  "type": "object"
+}
+```
+
+No `required` fields, but the body must parse as a JSON object. Empty stdout is **not** a valid empty object — it's a parse error.
+
+`CodexHookCommand.HandleStop` (src/kapacitor/Commands/CodexHookCommand.cs:86–107) writes nothing to stdout, then returns 0. Codex tries to parse the empty body, fails, and prints the error.
+
+Compare with `HandlePermissionRequest` (src/kapacitor/Commands/CodexHookCommand.cs:109–124) which correctly writes its `hookSpecificOutput` JSON before returning. The Stop branch never got the equivalent.
+
+### 2. `WatcherManager` writes diagnostic chatter to stdout
+
+`KillWatcher` and `InlineDrainAsync` (both called by `HandleStop`) emit informational status lines via `Console.Out.WriteLineAsync(...)`:
+
+- src/kapacitor/WatcherManager.cs:91 — `Spawned watcher for {key} (PID {pid})`
+- src/kapacitor/WatcherManager.cs:128 — `Watcher {key} (PID {pid}) exited gracefully`
+- src/kapacitor/WatcherManager.cs:138 — `Watcher {key} (PID {pid}) already exited`
+- src/kapacitor/WatcherManager.cs:193 — `Watcher {key} not running, respawning...`
+- src/kapacitor/WatcherManager.cs:227 — `Spawned what's-done generator for {sessionId} (PID {pid})`
+- src/kapacitor/WatcherManager.cs:291 — `Inline drain for {sessionId}: no new lines to send`
+- src/kapacitor/WatcherManager.cs:311 — `Inline drain for {sessionId}: sent {n} line(s)`
+
+These are diagnostic messages, not part of any hook protocol. They pollute the stdout channel of every hook that calls `WatcherManager`. Even after fixing #1, those lines would still corrupt the JSON output and re-trigger the same parse failure.
+
+This is also a latent issue for Claude's `SessionStart` hook (stdout there is interpreted as transcript context), but it has not been observably wrong because the strings are inert prose that Claude silently ignores. Codex's stricter schema validation makes the latent bug visible.
+
+## Fix
+
+### Change 1 — Move WatcherManager diagnostics to stderr
+
+Replace every `Console.Out.WriteLineAsync(...)` / `Console.Out.WriteLine(...)` in `src/kapacitor/WatcherManager.cs` with `Console.Error.WriteLineAsync(...)` / `Console.Error.WriteLine(...)`. The error paths already use `Console.Error` — this just brings the success paths in line.
+
+No existing test pins these strings on stdout (verified by grep over `test/`). The strings remain visible to operators when run interactively (terminals show stderr by default) and to the Capacitor daemon's log capture (which redirects both streams).
+
+### Change 2 — Emit valid Stop output from `HandleStop`
+
+After `KillWatcher` / `InlineDrainAsync` / `PostHookAsync` complete, write to stdout:
+
+```json
+{"continue": true}
+```
+
+`continue: true` is the schema default, so emitting it is semantically a no-op — but it makes the JSON body non-empty and unambiguously typed as an object, which is what Codex's parser needs.
+
+Even after Change 1, we still emit the JSON unconditionally — the stdout channel is now "reserved" for hook output, so populating it is required, not optional.
+
+### What stays the same
+
+- HTTP routing (`/hooks/session-end/codex`) is unchanged.
+- Watcher kill / inline drain ordering is unchanged.
+- Exit codes are unchanged (0 on success, 1 on HTTP failure).
+- `HandlePermissionRequest` already writes correct JSON — no change.
+- `HandleSessionStart` writes nothing to stdout, but Codex's `SessionStart` output schema is also "JSON object required when exit 0". This will need the same `{"continue": true}` write to be fully correct. **In scope for this fix** since both bugs share the same one-line remediation and the same risk profile.
+
+### Decision: include SessionStart fix in same PR
+
+After review, both `HandleStop` and `HandleSessionStart` exit 0 with empty stdout — the SessionStart hook has the same latent bug (it just hasn't surfaced because users haven't reported it yet, possibly because Codex tolerates SessionStart parse failures more quietly). Add the same `{"continue": true}` write to `HandleSessionStart` to close the latent gap before it ships as another bug ticket.
+
+## Files changed
+
+- `src/kapacitor/WatcherManager.cs` — 7 lines: `Console.Out` → `Console.Error` on success-path log messages
+- `src/kapacitor/Commands/CodexHookCommand.cs` — add `Console.Write(StopOutputJson)` in `HandleStop` and `HandleSessionStart`, where `StopOutputJson` is a shared constant `"""{"continue":true}"""`
+- `test/kapacitor.Tests.Unit/CodexHookCommandTests.cs` — extend `Stop_maps_to_session_end_codex_route` (and add `SessionStart_*` assertion) to capture stdout and assert valid JSON
+
+## Test plan
+
+**Unit (TUnit, kapacitor.Tests.Unit):**
+
+1. Extend `Stop_maps_to_session_end_codex_route`:
+   - Capture `Console.Out` via `Console.SetOut` (same pattern as the existing `PermissionRequest_returns_default_allow_decision` test).
+   - Assert exit 0.
+   - Assert the captured stdout parses as a JSON object.
+   - Assert the JSON contains `"continue": true`.
+   - Assert the captured stdout does **not** contain `"Watcher "`, `"Inline drain"`, or `"Spawned"` substrings — i.e. WatcherManager chatter no longer leaks into the hook channel.
+
+2. Extend `SessionStart_posts_to_session_start_codex_with_normalized_session_id` analogously: capture stdout, assert it parses as a JSON object containing `"continue": true`.
+
+3. Existing tests for `PermissionRequest`, swallowed events, malformed JSON, etc. must continue to pass — they don't depend on stdout shape and shouldn't be affected.
+
+**Manual smoke (post-merge):**
+
+- Run a Codex turn locally with the kapacitor hooks installed; confirm no red "Stop hook (failed)" line at turn end.
+- Same for SessionStart at session boot.
+- Confirm Capacitor server still receives `session-start/codex` and `session-end/codex` POSTs (no regression on the HTTP path).
+
+**AOT publish check** (per CLAUDE.md):
+
+```bash
+dotnet publish src/kapacitor/kapacitor.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
+```
+
+No new IL3050/IL2026 warnings expected — the JSON output is a string literal, no reflection.
+
+## Out of scope
+
+- Changing the Codex Stop hook's HTTP behavior or server-side routing.
+- Auditing every Console.Out usage in the CLI for hook-channel pollution (other commands aren't invoked as Codex hooks).
+- Adding a generic "hook output writer" abstraction. One literal in two places isn't worth an abstraction.
+- README updates — this is a pure bug fix with no user-visible CLI surface change.
+
+## Risk
+
+Low. Two single-file changes, both narrowly scoped, no API/contract changes, no schema migrations, no new dependencies. The stderr migration is the only change with observable side effects, and those side effects are improvements (diagnostic chatter no longer pollutes hook stdout).
+
+## Linear
+
+Branch: `alexeyzimarev/ai-635-codex-stop-hook-produces-an-error`
+Parent issue: AI-67 (Codex hook surface)

--- a/src/kapacitor/Commands/CodexHookCommand.cs
+++ b/src/kapacitor/Commands/CodexHookCommand.cs
@@ -19,6 +19,13 @@ namespace kapacitor.Commands;
 ///   PostToolUse       → swallowed
 /// </remarks>
 static class CodexHookCommand {
+    // Codex's Stop and SessionStart hooks parse stdout as the
+    // `stop.command.output` / `session-start.command.output` JSON schema and
+    // reject empty bodies with "hook returned invalid stop hook JSON output".
+    // `continue: true` is the schema default; emitting it explicitly satisfies
+    // the parser without altering behavior. See AI-635.
+    const string SessionScopedOutputJson = """{"continue":true}""";
+
     public static async Task<int> Handle(string baseUrl, TextReader stdin) {
         var body = await stdin.ReadToEndAsync();
 
@@ -67,6 +74,12 @@ static class CodexHookCommand {
         var exit = await PostHookAsync(baseUrl, "session-start/codex", enriched);
         if (exit != 0) return exit;
 
+        // Emit Codex's required JSON output BEFORE spawning the watcher. The
+        // watcher is best-effort and may take time to start; the parent (Codex)
+        // is waiting on stdout, and there's nothing the watcher can contribute
+        // to this response.
+        Console.Write(SessionScopedOutputJson);
+
         var enrichedNode = JsonNode.Parse(enriched);
         var sessionId    = TryGetString(enrichedNode, "session_id");
         var transcript   = TryGetString(enrichedNode, "transcript_path");
@@ -103,7 +116,11 @@ static class CodexHookCommand {
         // Codex's hook event name into Capacitor's canonical hook vocabulary
         // before posting, so the server doesn't have to know about Codex's
         // missing session-end concept.
-        return await PostHookAsync(baseUrl, "session-end/codex", node.ToJsonString());
+        var exit = await PostHookAsync(baseUrl, "session-end/codex", node.ToJsonString());
+        if (exit != 0) return exit;
+
+        Console.Write(SessionScopedOutputJson);
+        return 0;
     }
 
     static async Task<int> HandlePermissionRequest(string baseUrl, JsonNode node) {

--- a/src/kapacitor/WatcherManager.cs
+++ b/src/kapacitor/WatcherManager.cs
@@ -88,7 +88,7 @@ static class WatcherManager {
             process.StandardError.Close();
 
             await File.WriteAllTextAsync(GetPidFilePath(key), process.Id.ToString());
-            await Console.Out.WriteLineAsync($"Spawned watcher for {key} (PID {process.Id})");
+            await Console.Error.WriteLineAsync($"Spawned watcher for {key} (PID {process.Id})");
         } catch (Exception ex) {
             await Console.Error.WriteLineAsync($"Failed to spawn watcher for {key}: {ex.Message}");
         }
@@ -125,7 +125,7 @@ static class WatcherManager {
 
                 try {
                     await process.WaitForExitAsync(cts.Token);
-                    await Console.Out.WriteLineAsync($"Watcher {key} (PID {pid}) exited gracefully");
+                    await Console.Error.WriteLineAsync($"Watcher {key} (PID {pid}) exited gracefully");
                 } catch (OperationCanceledException) {
                     // Force kill if it didn't exit in time
                     process.Kill(entireProcessTree: true);
@@ -135,7 +135,7 @@ static class WatcherManager {
                 return true;
             } catch (ArgumentException) {
                 // Process already exited
-                await Console.Out.WriteLineAsync($"Watcher {key} (PID {pid}) already exited");
+                await Console.Error.WriteLineAsync($"Watcher {key} (PID {pid}) already exited");
 
                 return false;
             }
@@ -190,7 +190,7 @@ static class WatcherManager {
             return;
         }
 
-        await Console.Out.WriteLineAsync($"Watcher {key} not running, respawning...");
+        await Console.Error.WriteLineAsync($"Watcher {key} not running, respawning...");
         await SpawnWatcher(baseUrl, key, transcriptPath, agentId, sessionIdOverride, cwd, skipTitle, vendor);
     }
 
@@ -224,7 +224,7 @@ static class WatcherManager {
             process.StandardOutput.Close();
             process.StandardError.Close();
 
-            Console.Out.WriteLine($"Spawned what's-done generator for {sessionId} (PID {process.Id})");
+            Console.Error.WriteLine($"Spawned what's-done generator for {sessionId} (PID {process.Id})");
         } catch (Exception ex) {
             Console.Error.WriteLine($"Failed to spawn what's-done generator for {sessionId}: {ex.Message}");
         }
@@ -288,7 +288,7 @@ static class WatcherManager {
             }
 
             if (newLines.Count == 0) {
-                await Console.Out.WriteLineAsync($"Inline drain for {sessionId}: no new lines to send");
+                await Console.Error.WriteLineAsync($"Inline drain for {sessionId}: no new lines to send");
 
                 return;
             }
@@ -308,7 +308,7 @@ static class WatcherManager {
                 var resp = await httpClient.PostWithRetryAsync($"{baseUrl}/hooks/transcript", content);
 
                 if (resp.IsSuccessStatusCode) {
-                    await Console.Out.WriteLineAsync($"Inline drain for {sessionId}: sent {newLines.Count} line(s)");
+                    await Console.Error.WriteLineAsync($"Inline drain for {sessionId}: sent {newLines.Count} line(s)");
                 } else {
                     await Console.Error.WriteLineAsync($"Inline drain for {sessionId}: server returned HTTP {(int)resp.StatusCode}");
                     PrintRecoveryHint(sessionId);

--- a/test/kapacitor.Tests.Unit/CodexHookCommandTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexHookCommandTests.cs
@@ -7,6 +7,12 @@ using WireMock.Server;
 namespace kapacitor.Tests.Unit;
 
 public class CodexHookCommandTests : IDisposable {
+    // Shared NotInParallel group for every test that mutates the global
+    // Console.Out. Without a single shared group, tests using SetOut would run
+    // concurrently against the same process-wide writer and interfere with each
+    // other's stdout capture (nondeterministic failures depending on schedule).
+    const string ConsoleSerialGroup = nameof(CodexHookCommandTests) + ".Console";
+
     readonly WireMockServer _server = WireMockServer.Start();
 
     public void Dispose() => _server.Stop();
@@ -46,7 +52,7 @@ public class CodexHookCommandTests : IDisposable {
         // the watcher spawn.
     }
 
-    [Test, NotInParallel(nameof(Stop_maps_to_session_end_codex_route))]
+    [Test, NotInParallel(ConsoleSerialGroup)]
     public async Task Stop_maps_to_session_end_codex_route() {
         _server.Given(Request.Create().WithPath("/hooks/session-end/codex").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
@@ -92,7 +98,7 @@ public class CodexHookCommandTests : IDisposable {
         }
     }
 
-    [Test, NotInParallel(nameof(PermissionRequest_returns_default_allow_decision))]
+    [Test, NotInParallel(ConsoleSerialGroup)]
     public async Task PermissionRequest_returns_default_allow_decision() {
         _server.Given(Request.Create().WithPath("/hooks/permission-request/codex").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));

--- a/test/kapacitor.Tests.Unit/CodexHookCommandTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexHookCommandTests.cs
@@ -36,9 +36,17 @@ public class CodexHookCommandTests : IDisposable {
         var root = JsonDocument.Parse(requests[0].RequestMessage.Body!).RootElement;
         await Assert.That(root.GetProperty("session_id").GetString()).IsEqualTo("019e032205fc7570be6575719c3ea861");
         await Assert.That(root.GetProperty("home_dir").GetString()).IsNotNull();
+
+        // AI-635: SessionStart also writes Codex's required JSON output to stdout.
+        // We can't reliably capture stdout here because the test path spawns a
+        // real watcher child process via Process.Start, which under TUnit's
+        // Console capture corrupts subsequent stdout reads. The Stop test covers
+        // the identical write pattern (Console.Write(SessionScopedOutputJson)),
+        // and HandleSessionStart writes the same constant in the same way before
+        // the watcher spawn.
     }
 
-    [Test]
+    [Test, NotInParallel(nameof(Stop_maps_to_session_end_codex_route))]
     public async Task Stop_maps_to_session_end_codex_route() {
         _server.Given(Request.Create().WithPath("/hooks/session-end/codex").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
@@ -52,18 +60,36 @@ public class CodexHookCommandTests : IDisposable {
             }
             """;
 
-        var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
-        await Assert.That(exit).IsEqualTo(0);
+        var originalOut  = Console.Out;
+        var stdoutWriter = new StringWriter();
+        try {
+            Console.SetOut(stdoutWriter);
 
-        var requests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-end/codex").UsingPost());
-        await Assert.That(requests.Count).IsEqualTo(1);
+            var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
+            await Assert.That(exit).IsEqualTo(0);
 
-        // Confirm Stop is NOT posted to /hooks/stop or /hooks/codex/stop —
-        // this guards the URL-mapping decision against future regressions.
-        var wrong1 = _server.FindLogEntries(Request.Create().WithPath("/hooks/stop").UsingPost());
-        var wrong2 = _server.FindLogEntries(Request.Create().WithPath("/hooks/codex/stop").UsingPost());
-        await Assert.That(wrong1.Count).IsEqualTo(0);
-        await Assert.That(wrong2.Count).IsEqualTo(0);
+            var requests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-end/codex").UsingPost());
+            await Assert.That(requests.Count).IsEqualTo(1);
+
+            // Confirm Stop is NOT posted to /hooks/stop or /hooks/codex/stop —
+            // this guards the URL-mapping decision against future regressions.
+            var wrong1 = _server.FindLogEntries(Request.Create().WithPath("/hooks/stop").UsingPost());
+            var wrong2 = _server.FindLogEntries(Request.Create().WithPath("/hooks/codex/stop").UsingPost());
+            await Assert.That(wrong1.Count).IsEqualTo(0);
+            await Assert.That(wrong2.Count).IsEqualTo(0);
+
+            // AI-635: Stop must emit a valid JSON object on stdout so Codex's
+            // hook output parser doesn't reject it as "invalid stop hook JSON
+            // output". WatcherManager chatter must not leak onto the same channel.
+            var stdout = stdoutWriter.ToString();
+            var doc    = JsonDocument.Parse(stdout);
+            await Assert.That(doc.RootElement.GetProperty("continue").GetBoolean()).IsTrue();
+            await Assert.That(stdout.Contains("Watcher ")).IsFalse();
+            await Assert.That(stdout.Contains("Inline drain")).IsFalse();
+            await Assert.That(stdout.Contains("Spawned")).IsFalse();
+        } finally {
+            Console.SetOut(originalOut);
+        }
     }
 
     [Test, NotInParallel(nameof(PermissionRequest_returns_default_allow_decision))]


### PR DESCRIPTION
## Summary
- Codex's Stop hook parses stdout against `stop.command.output.schema.json` and rejects empty bodies with `error: hook returned invalid stop hook JSON output`. `HandleStop` previously wrote nothing.
- `WatcherManager` success-path diagnostics were on `Console.Out`, so they would also have corrupted the hook channel even if we emitted JSON. Moved them to `Console.Error` (matching the error-path lines).
- `HandleSessionStart` had the same latent bug against `session-start.command.output.schema.json`. Fixed alongside, since it's the same one-line write.

## Test plan
- [x] `dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj` — 607/607 pass
- [x] `dotnet run --project test/kapacitor.Tests.Integration/kapacitor.Tests.Integration.csproj` — 9/9 pass
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — no IL3050/IL2026 warnings
- [x] Stop test asserts JSON on stdout and absence of watcher chatter (`Watcher `, `Inline drain`, `Spawned`)
- [ ] Manual: run Codex with the kapacitor hook installed and confirm no red "Stop hook (failed)" line at turn end

## Notes
- The SessionStart unit test only asserts the HTTP request, not stdout — the test path spawns a real watcher child via `Process.Start`, and TUnit's Console capture interacts with that in a way that makes the stdout assertion brittle. The production code uses the identical `Console.Write(SessionScopedOutputJson)` pattern as `HandleStop` (which is fully unit-tested).
- No README change: this is a pure bug fix with no user-visible CLI surface change.

Design spec: \`docs/superpowers/specs/2026-05-14-ai-635-codex-stop-hook-invalid-json-design.md\`