### PR TITLE
[AI-636] Codex permission hook records and yields, doesn't auto-allow

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ kapacitor plugin remove --codex             # uninstall
 
 After a `--project` install, Codex won't actually run the hooks until you trust the directory: run `codex` once in the repo and accept the trust prompt. Skills are always installed user-wide regardless of `--project`.
 
-Permission prompts stay in Codex's own in-CLI approval flow — kapacitor records each request server-side for observability but never auto-approves on your behalf, so every tool call still asks you the way it does without kapacitor installed.
-
 `kapacitor status` reports installation state for the user-wide Claude Code and Codex hook surfaces — it does not currently detect `--project` installs. For a `--project` install, check that `<repo>/.claude/settings.local.json` or `<repo>/.codex/hooks.json` exists and contains kapacitor entries.
 
 ### 3. Import existing sessions (optional)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ kapacitor plugin remove --codex             # uninstall
 
 After a `--project` install, Codex won't actually run the hooks until you trust the directory: run `codex` once in the repo and accept the trust prompt. Skills are always installed user-wide regardless of `--project`.
 
+Permission prompts stay in Codex's own in-CLI approval flow — kapacitor records each request server-side for observability but never auto-approves on your behalf, so every tool call still asks you the way it does without kapacitor installed.
+
 `kapacitor status` reports installation state for the user-wide Claude Code and Codex hook surfaces — it does not currently detect `--project` installs. For a `--project` install, check that `<repo>/.claude/settings.local.json` or `<repo>/.codex/hooks.json` exists and contains kapacitor entries.
 
 ### 3. Import existing sessions (optional)

--- a/src/Kapacitor.Core/HttpClientExtensions.cs
+++ b/src/Kapacitor.Core/HttpClientExtensions.cs
@@ -14,11 +14,11 @@ static class HttpClientExtensions {
     /// All CLI commands that call the Capacitor server should use this
     /// instead of <c>new HttpClient()</c>.
     /// </summary>
-    public static async Task<HttpClient> CreateAuthenticatedClientAsync(string? baseUrl = null) {
+    public static async Task<HttpClient> CreateAuthenticatedClientAsync(string? baseUrl = null, CancellationToken ct = default) {
         var client = new HttpClient();
 
         baseUrl ??= AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KAPACITOR_URL") ?? "http://localhost:5108";
-        var provider = await DiscoverProviderAsync(baseUrl);
+        var provider = await DiscoverProviderAsync(baseUrl, ct);
 
         if (provider == "None") {
             return client; // No auth needed
@@ -43,7 +43,7 @@ static class HttpClientExtensions {
 
     static string? cachedProvider;
 
-    public static async Task<string> DiscoverProviderAsync(string baseUrl) {
+    public static async Task<string> DiscoverProviderAsync(string baseUrl, CancellationToken ct = default) {
         if (cachedProvider is not null) {
             return cachedProvider;
         }
@@ -56,17 +56,20 @@ static class HttpClientExtensions {
         using var http = new HttpClient();
 
         try {
-            var response = await http.GetAsync($"{baseUrl}/auth/config");
+            var response = await http.GetAsync($"{baseUrl}/auth/config", ct);
 
             if (response.IsSuccessStatusCode) {
-                var config   = await response.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.AuthDiscoveryResponse);
+                var config   = await response.Content.ReadFromJsonAsync(KapacitorJsonContext.Default.AuthDiscoveryResponse, ct);
                 var provider = config?.Provider ?? "None";
                 cachedProvider = provider; // Only cache successful discovery
 
                 return provider;
             }
         } catch {
-            // Server unreachable — don't cache, try tokens as fallback
+            // Server unreachable — don't cache, try tokens as fallback.
+            // Catches both HttpRequestException (connection failures) and
+            // OperationCanceledException (caller's CT fired — fall through to
+            // local-token fallback rather than bubbling the cancellation).
         }
 
         // Fallback: try existing tokens (don't cache — allow re-discovery next time)

--- a/src/Kapacitor.Core/Resources/help-codex-hook.txt
+++ b/src/Kapacitor.Core/Resources/help-codex-hook.txt
@@ -8,7 +8,8 @@ forwards to the Capacitor server. Wired via `kapacitor plugin install --codex`.
 Hook events handled (Codex event → server route):
   SessionStart        → POST /hooks/session-start/codex (also spawns watcher)
   Stop                → POST /hooks/session-end/codex   (kills watcher, drains transcript first)
-  PermissionRequest   → POST /hooks/permission-request/codex (returns local {behavior: "allow"})
+  PermissionRequest   → POST /hooks/permission-record (fire-and-forget record; CLI emits no
+                          decision so Codex's own in-CLI approval prompt asks the user)
   UserPromptSubmit    → swallowed (informational; no server route in v1)
   PreToolUse          → swallowed (informational; no server route in v1)
   PostToolUse         → swallowed (informational; no server route in v1)

--- a/src/kapacitor/Commands/CodexHookCommand.cs
+++ b/src/kapacitor/Commands/CodexHookCommand.cs
@@ -13,7 +13,10 @@ namespace kapacitor.Commands;
 /// Wire contract (Codex event → server route):
 ///   SessionStart      → POST /hooks/session-start/codex
 ///   Stop              → POST /hooks/session-end/codex (Codex has no separate session-end hook)
-///   PermissionRequest → POST /hooks/permission-request/codex (informational; CLI returns local stub)
+///   PermissionRequest → POST /hooks/permission-record (fire-and-forget; CLI emits no decision so
+///                       Codex's normal in-CLI approval prompt takes over). The hosted-agent branch
+///                       (KAPACITOR_DAEMON_URL set) lands in AI-68 and will bounce through the
+///                       daemon's LocalPermissionBridge to wait on the user's UI decision.
 ///   UserPromptSubmit  → swallowed (v1 — neither vendor consumes them)
 ///   PreToolUse        → swallowed
 ///   PostToolUse       → swallowed
@@ -150,19 +153,38 @@ static class CodexHookCommand {
     }
 
     static async Task<int> HandlePermissionRequest(string baseUrl, JsonNode node) {
-        // v1 stub — record the event server-side and return a default allow
-        // so recording-only sessions don't block. Full daemon-bridge
-        // translation lands in AI-68 with hosted Codex agents.
-        await PostHookAsync(baseUrl, "permission-request/codex", node.ToJsonString());
+        // Terminal Codex sessions can't answer a Capacitor UI prompt, so we
+        // record the event server-side (best-effort) and emit no decision —
+        // Codex falls back to its built-in in-CLI approval flow and the user
+        // answers there.
+        //
+        // Do NOT post to /hooks/permission-request/{vendor} — that route runs
+        // RunPermissionFlow which long-polls up to 10 hours waiting for a
+        // hosted-agent UI decision. With Codex's 30 s hook timeout, the hook
+        // process is killed long before the server returns (AI-636).
+        //
+        // The hosted-agent branch (KAPACITOR_DAEMON_URL set) is intentionally
+        // not wired here — it lands with the rest of the hosted-Codex stack
+        // in AI-68 so the wire shape, daemon bridge, and tests change together.
+        try {
+            // Pass baseUrl into CreateAuthenticatedClientAsync so auth-discovery
+            // targets the same server we're about to POST to, not the
+            // AppConfig.ResolvedServerUrl / KAPACITOR_URL / localhost:5108 fallback
+            // chain — the fallback can hang for the full HttpClient default
+            // (100 s) when something on the dev machine accepts connections on
+            // 5108 but never replies, blowing past Codex's 30 s hook timeout.
+            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+            using var content = new StringContent(node.ToJsonString(), Encoding.UTF8, "application/json");
+            using var cts     = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            using var _       = await client.PostAsync($"{baseUrl}/hooks/permission-record", content, cts.Token);
+        } catch {
+            // Best-effort — recording must never block Codex's approval prompt.
+        }
 
-        var response = new JsonObject {
-            ["hookSpecificOutput"] = new JsonObject {
-                ["hookEventName"] = "PermissionRequest",
-                ["decision"] = new JsonObject { ["behavior"] = "allow" }
-            }
-        };
-
-        Console.Write(response.ToJsonString());
+        // Empty hookSpecificOutput → Codex treats it as "no decision" and runs
+        // its normal approval flow. See
+        // codex-rs/hooks/src/events/permission_request.rs in openai/codex.
+        Console.Write("{}");
         return 0;
     }
 

--- a/src/kapacitor/Commands/CodexHookCommand.cs
+++ b/src/kapacitor/Commands/CodexHookCommand.cs
@@ -166,16 +166,18 @@ static class CodexHookCommand {
         // The hosted-agent branch (KAPACITOR_DAEMON_URL set) is intentionally
         // not wired here — it lands with the rest of the hosted-Codex stack
         // in AI-68 so the wire shape, daemon bridge, and tests change together.
+        // Single 2 s deadline covers BOTH the /auth/config discovery inside
+        // CreateAuthenticatedClientAsync and the /hooks/permission-record POST.
+        // Without bounding discovery too, a server that accepts the TCP
+        // connection but stalls on /auth/config can burn the full HttpClient
+        // default (100 s) before we even start the POST, blowing past Codex's
+        // 30 s hook timeout. Passing baseUrl also keeps discovery targeted at
+        // the server we're about to POST to, not the
+        // AppConfig.ResolvedServerUrl / KAPACITOR_URL / localhost:5108 fallback.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
         try {
-            // Pass baseUrl into CreateAuthenticatedClientAsync so auth-discovery
-            // targets the same server we're about to POST to, not the
-            // AppConfig.ResolvedServerUrl / KAPACITOR_URL / localhost:5108 fallback
-            // chain — the fallback can hang for the full HttpClient default
-            // (100 s) when something on the dev machine accepts connections on
-            // 5108 but never replies, blowing past Codex's 30 s hook timeout.
-            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, cts.Token);
             using var content = new StringContent(node.ToJsonString(), Encoding.UTF8, "application/json");
-            using var cts     = new CancellationTokenSource(TimeSpan.FromSeconds(2));
             using var _       = await client.PostAsync($"{baseUrl}/hooks/permission-record", content, cts.Token);
         } catch {
             // Best-effort — recording must never block Codex's approval prompt.

--- a/test/kapacitor.Tests.Unit/CodexHookCommandTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexHookCommandTests.cs
@@ -184,6 +184,43 @@ public class CodexHookCommandTests : IDisposable {
         await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
     }
 
+    // AI-636 / Qodo finding: bounding only the POST left auth discovery
+    // (GET /auth/config) running on HttpClient's 100 s default. Stub
+    // /auth/config slow and assert the hook still returns under 5 s — the
+    // shared 2 s CTS in CodexHookCommand covers discovery too.
+    [Test, NotInParallel("CodexPermissionRequestStdout")]
+    public async Task PermissionRequest_returns_quickly_when_auth_discovery_is_slow() {
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}").WithDelay(TimeSpan.FromSeconds(10)));
+        _server.Given(Request.Create().WithPath("/hooks/permission-record").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        var payload = """
+            {
+              "hook_event_name": "PermissionRequest",
+              "session_id": "abc",
+              "transcript_path": "/tmp/r.jsonl",
+              "cwd": "/tmp",
+              "tool_name": "shell",
+              "tool_input": { "command": "ls" }
+            }
+            """;
+
+        var originalOut  = Console.Out;
+        var stdoutWriter = new StringWriter();
+        var sw           = System.Diagnostics.Stopwatch.StartNew();
+        try {
+            Console.SetOut(stdoutWriter);
+            var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
+            sw.Stop();
+            await Assert.That(exit).IsEqualTo(0);
+        } finally {
+            Console.SetOut(originalOut);
+        }
+
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
+    }
+
     [Test]
     public async Task UserPromptSubmit_PreToolUse_PostToolUse_are_swallowed() {
         // v1: pass-through events not consumed server-side. CLI should

--- a/test/kapacitor.Tests.Unit/CodexHookCommandTests.cs
+++ b/test/kapacitor.Tests.Unit/CodexHookCommandTests.cs
@@ -99,8 +99,13 @@ public class CodexHookCommandTests : IDisposable {
     }
 
     [Test, NotInParallel(ConsoleSerialGroup)]
-    public async Task PermissionRequest_returns_default_allow_decision() {
-        _server.Given(Request.Create().WithPath("/hooks/permission-request/codex").UsingPost())
+    public async Task PermissionRequest_records_event_and_yields_decision_to_codex() {
+        // The Codex permission-request hook must not silently auto-allow tool
+        // calls; it records the request server-side via /hooks/permission-record
+        // (the same fire-and-forget endpoint Claude's terminal path uses) and
+        // emits an empty hookSpecificOutput so Codex's normal in-CLI approval
+        // prompt asks the user. Regression for AI-636.
+        _server.Given(Request.Create().WithPath("/hooks/permission-record").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
 
         var payload = """
@@ -114,7 +119,7 @@ public class CodexHookCommandTests : IDisposable {
             }
             """;
 
-        var originalOut = Console.Out;
+        var originalOut  = Console.Out;
         var stdoutWriter = new StringWriter();
         try {
             Console.SetOut(stdoutWriter);
@@ -122,17 +127,61 @@ public class CodexHookCommandTests : IDisposable {
             var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
 
             await Assert.That(exit).IsEqualTo(0);
+
+            // stdout must NOT carry a hook decision — Codex falls back to its
+            // own approval prompt when hookSpecificOutput.decision is absent.
             var stdout = stdoutWriter.ToString();
             var doc    = JsonDocument.Parse(stdout);
-            await Assert.That(doc.RootElement
-                .GetProperty("hookSpecificOutput")
-                .GetProperty("decision")
-                .GetProperty("behavior")
-                .GetString())
-                .IsEqualTo("allow");
+            var hasDecision = doc.RootElement.TryGetProperty("hookSpecificOutput", out var hso)
+                && hso.TryGetProperty("decision", out _);
+            await Assert.That(hasDecision).IsFalse();
         } finally {
             Console.SetOut(originalOut);
         }
+
+        // Recording must land on /hooks/permission-record, not on the
+        // long-poll /hooks/permission-request/{vendor} route.
+        var recorded = _server.FindLogEntries(Request.Create().WithPath("/hooks/permission-record").UsingPost());
+        await Assert.That(recorded.Count).IsEqualTo(1);
+
+        var wrong = _server.FindLogEntries(Request.Create().WithPath("/hooks/permission-request/codex").UsingPost());
+        await Assert.That(wrong.Count).IsEqualTo(0);
+    }
+
+    // AI-636: the hook must return well under Codex's 30 s timeout even when
+    // the recording endpoint is slow. We cap the HTTP client at 2 s and
+    // swallow the resulting TaskCanceledException — guard against future
+    // regressions where someone reintroduces an unbounded await.
+    [Test, NotInParallel(ConsoleSerialGroup)]
+    public async Task PermissionRequest_returns_quickly_when_server_is_slow() {
+        _server.Given(Request.Create().WithPath("/hooks/permission-record").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}").WithDelay(TimeSpan.FromSeconds(10)));
+
+        var payload = """
+            {
+              "hook_event_name": "PermissionRequest",
+              "session_id": "abc",
+              "transcript_path": "/tmp/r.jsonl",
+              "cwd": "/tmp",
+              "tool_name": "shell",
+              "tool_input": { "command": "ls" }
+            }
+            """;
+
+        var originalOut  = Console.Out;
+        var stdoutWriter = new StringWriter();
+        var sw           = System.Diagnostics.Stopwatch.StartNew();
+        try {
+            Console.SetOut(stdoutWriter);
+            var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
+            sw.Stop();
+            await Assert.That(exit).IsEqualTo(0);
+        } finally {
+            Console.SetOut(originalOut);
+        }
+
+        // 2 s HTTP timeout + a generous slack for build/CI jitter.
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- `CodexHookCommand.HandlePermissionRequest` posted to `/hooks/permission-request/codex`, which on the server runs `RunPermissionFlow` — a 10-hour long-poll designed for hosted agents waiting on a UI decision (`SessionHookHandlers.cs:1020-1091` in kapacitor-server). Codex's 30 s hook timeout killed the process every time. On top of that the v1 stub wrote `{behavior: "allow"}` to stdout, silently approving every tool call.
- Switch to the vendor-agnostic record-only endpoint `/hooks/permission-record` (the same path Claude's terminal `HandleRecordOnly` uses), bound the call with a 2 s `CancellationTokenSource`, swallow all errors, and emit `{}` to stdout so Codex's own in-CLI approval prompt asks the user. The response shape matches the optional `hookSpecificOutput` in Codex's `permission-request.command.output.schema.json`.
- Pass `baseUrl` into `CreateAuthenticatedClientAsync` so auth-discovery targets the same server we're about to POST to. Uncovered by the new regression test: if `AppConfig.ResolvedServerUrl`/`KAPACITOR_URL` aren't set the fallback `localhost:5108` can hang for the full HttpClient default (100 s) when something accepts connections on that port but never replies.
- The hosted-Codex path (`KAPACITOR_DAEMON_URL` set) is intentionally left untouched — that wire shape, daemon bridge, and tests land together in AI-68.

## Test plan

- [x] `dotnet run --project test/kapacitor.Tests.Unit/kapacitor.Tests.Unit.csproj` — 608/608 pass
- [x] New regression test `PermissionRequest_returns_quickly_when_server_is_slow` (WireMock 10 s delay on `/hooks/permission-record`) asserts handler returns in <5 s; would have caught both the wrong-endpoint bug and the auth-discovery fallback hang
- [x] Updated `PermissionRequest_records_event_and_yields_decision_to_codex` asserts request hits `/hooks/permission-record` (not `/hooks/permission-request/codex`) and stdout carries no `decision`
- [x] `dotnet publish src/kapacitor/kapacitor.csproj -c Release` — 0 IL3050/IL2026 warnings
- [x] No README change — bug fix to existing behavior; auto-allow was never a documented feature, and no CLI flags/commands/prerequisites changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)