### PR TITLE
[AI-50][AI-53] Redact HTTP auth headers and labeled secrets

### DIFF
--- a/src/kapacitor/SecretRedactor.cs
+++ b/src/kapacitor/SecretRedactor.cs
@@ -62,6 +62,8 @@ static partial class SecretRedactor {
         text = AwsUniqueIdRegex.Replace(text, "[REDACTED]");
         text = VendorTokenRegex.Replace(text, "[REDACTED]");
         text = AuthHeaderRegex.Replace(text, "$1[REDACTED]");
+        text = UrlQuerySecretRegex.Replace(text, "$1[REDACTED]");
+        text = UrlUserinfoRegex.Replace(text, "$1[REDACTED]$3");
         text = JsonKeySecretRegex.Replace(text, "$1[REDACTED]$3");
         text = EnvVarSecretRegex.Replace(text, "$1[REDACTED]");
         text = YamlStyleSecretRegex.Replace(text, "$1[REDACTED]");
@@ -129,13 +131,19 @@ static partial class SecretRedactor {
     static readonly Regex ConnectionStringPwdRegex = ConnectionStringPwdRx();
 
     // HTTP auth-bearing headers — redact the entire header value.
-    // Covers Authorization (Bearer/Basic/Digest/etc.), Cookie, Set-Cookie, and common API-key
-    // header variants. Tolerates JSON-escaped quotes around the key and value, so it matches both
-    // raw `Authorization: Bearer xxx` (e.g. inside a curl tool_result) and `\"Authorization\": \"Bearer xxx\"`
-    // (HTTP request logged as a JSON object). Excludes " and \ to stop at JSON string boundaries.
+    // Covers Authorization (Bearer/Basic/Digest/etc.), Cookie, Set-Cookie, CSRF tokens, GitLab
+    // tokens, signature headers, and common API-key header variants. `(?:\\?")?` matches both real
+    // JSON-object form (`"Authorization":"…"`) and the JSON-escaped form found inside a
+    // serialized tool_result content string (`\"Authorization\": \"…\"`).
+    //
+    // Known limitation: header values that embed escaped quotes (e.g. `Set-Cookie: a=\"b\"; …`
+    // inside JSON-encoded content) capture only up to the first `\`. Fixing this properly
+    // requires JSON-tree-aware redaction (parse → walk strings → redact decoded → re-serialize),
+    // tracked as a follow-up — see AI-649.
+    //
     // group 1 = header name + colon + optional opening quote, group 2 = value
     [GeneratedRegex(
-        """((?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|x-auth-token|x-access-token|x-amz-security-token|x-goog-api-key|api-key)(?:\\")?\s*:\s*(?:\\")?\s*)([^\r\n"\\]+)""",
+        """((?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|x-auth-token|x-access-token|x-amz-security-token|x-amz-signature|x-goog-api-key|api-key|private-token|job-token|deploy-token|x-vault-token|x-consul-token|x-csrf-token|x-xsrf-token|x-hub-signature(?:-256)?|x-slack-signature|stripe-signature|x-registry-auth)(?:\\?")?\s*:\s*(?:\\?")?\s*)([^\r\n"\\]+)""",
         RegexOptions.IgnoreCase
     )]
     private static partial Regex AuthHeaderRx();
@@ -145,14 +153,36 @@ static partial class SecretRedactor {
     // Labeled secret — secret keyword followed by whitespace (NOT a colon) and an opaque value.
     // Catches `hcloud:token  9xKMA…` and similar where the keyword is a label, not a key:value
     // separator. The colon form is already covered by YamlStyleSecretRegex.
-    // 16-char minimum + character set [A-Za-z0-9_\-+/=.] keeps this from matching prose like
-    // "the token might fail" while still catching base64/base62/url-safe API tokens.
+    // 16-char minimum on `[^\s"\\]` value covers tokens with punctuation (e.g. `password p@ss!w0rd…`)
+    // while the 16-char floor keeps prose like "the token might fail" from matching.
     // group 1 = keyword + whitespace, group 2 = value
     [GeneratedRegex(
-        @"\b((?:secret|token|password|passwd|pwd|api_key|apikey|private_key|credentials|client_secret|access_key|auth_token)\b[ \t]+)([A-Za-z0-9_\-+/=.]{16,})",
+        """\b((?:secret|token|password|passwd|pwd|api_key|apikey|private_key|credentials|client_secret|access_key|auth_token)\b[ \t]+)([^\s"\\]{16,})""",
         RegexOptions.IgnoreCase
     )]
     private static partial Regex LabeledSecretRx();
 
     static readonly Regex LabeledSecretRegex = LabeledSecretRx();
+
+    // URL query secrets — `?key=value` or `&key=value` where the param name is a known secret-bearing
+    // key. Covers OAuth tokens, signed-URL signatures, AWS pre-signed URL params, and common API-key
+    // query patterns. Stops at `&`, `#`, whitespace, or JSON string boundaries.
+    // group 1 = `[?&]key=`, group 2 = value
+    [GeneratedRegex(
+        """([?&](?:access_token|refresh_token|id_token|client_secret|signature|sig|x-amz-signature|awsaccesskeyid|api_key|apikey|api-key|token|password|secret|auth_token|sas)=)([^&\s"\\#]+)""",
+        RegexOptions.IgnoreCase
+    )]
+    private static partial Regex UrlQuerySecretRx();
+
+    static readonly Regex UrlQuerySecretRegex = UrlQuerySecretRx();
+
+    // URL userinfo — `https://user:password@host` form. Redacts the password component only.
+    // group 1 = scheme + user + colon, group 2 = password, group 3 = @
+    [GeneratedRegex(
+        """(https?://[^:/\s"\\@]+:)([^@\s"\\/]+)(@)""",
+        RegexOptions.IgnoreCase
+    )]
+    private static partial Regex UrlUserinfoRx();
+
+    static readonly Regex UrlUserinfoRegex = UrlUserinfoRx();
 }

--- a/src/kapacitor/SecretRedactor.cs
+++ b/src/kapacitor/SecretRedactor.cs
@@ -61,9 +61,11 @@ static partial class SecretRedactor {
         text = PemBlockRegex.Replace(text, "[REDACTED]");
         text = AwsUniqueIdRegex.Replace(text, "[REDACTED]");
         text = VendorTokenRegex.Replace(text, "[REDACTED]");
+        text = AuthHeaderRegex.Replace(text, "$1[REDACTED]");
         text = JsonKeySecretRegex.Replace(text, "$1[REDACTED]$3");
         text = EnvVarSecretRegex.Replace(text, "$1[REDACTED]");
         text = YamlStyleSecretRegex.Replace(text, "$1[REDACTED]");
+        text = LabeledSecretRegex.Replace(text, "$1[REDACTED]");
         text = ConnectionStringPwdRegex.Replace(text, "$1[REDACTED]$3");
 
         return text;
@@ -125,4 +127,32 @@ static partial class SecretRedactor {
     private static partial Regex ConnectionStringPwdRx();
 
     static readonly Regex ConnectionStringPwdRegex = ConnectionStringPwdRx();
+
+    // HTTP auth-bearing headers — redact the entire header value.
+    // Covers Authorization (Bearer/Basic/Digest/etc.), Cookie, Set-Cookie, and common API-key
+    // header variants. Tolerates JSON-escaped quotes around the key and value, so it matches both
+    // raw `Authorization: Bearer xxx` (e.g. inside a curl tool_result) and `\"Authorization\": \"Bearer xxx\"`
+    // (HTTP request logged as a JSON object). Excludes " and \ to stop at JSON string boundaries.
+    // group 1 = header name + colon + optional opening quote, group 2 = value
+    [GeneratedRegex(
+        """((?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|x-auth-token|x-access-token|x-amz-security-token|x-goog-api-key|api-key)(?:\\")?\s*:\s*(?:\\")?\s*)([^\r\n"\\]+)""",
+        RegexOptions.IgnoreCase
+    )]
+    private static partial Regex AuthHeaderRx();
+
+    static readonly Regex AuthHeaderRegex = AuthHeaderRx();
+
+    // Labeled secret — secret keyword followed by whitespace (NOT a colon) and an opaque value.
+    // Catches `hcloud:token  9xKMA…` and similar where the keyword is a label, not a key:value
+    // separator. The colon form is already covered by YamlStyleSecretRegex.
+    // 16-char minimum + character set [A-Za-z0-9_\-+/=.] keeps this from matching prose like
+    // "the token might fail" while still catching base64/base62/url-safe API tokens.
+    // group 1 = keyword + whitespace, group 2 = value
+    [GeneratedRegex(
+        @"\b((?:secret|token|password|passwd|pwd|api_key|apikey|private_key|credentials|client_secret|access_key|auth_token)\b[ \t]+)([A-Za-z0-9_\-+/=.]{16,})",
+        RegexOptions.IgnoreCase
+    )]
+    private static partial Regex LabeledSecretRx();
+
+    static readonly Regex LabeledSecretRegex = LabeledSecretRx();
 }

--- a/test/kapacitor.Tests.Unit/SecretRedactorTests.cs
+++ b/test/kapacitor.Tests.Unit/SecretRedactorTests.cs
@@ -249,6 +249,122 @@ public class SecretRedactorTests {
         await Assert.That(content[0].GetProperty("is_error").GetBoolean()).IsFalse();
     }
 
+    // AI-50 — auth headers recorded as-is
+
+    [Test]
+    public async Task RedactsLine_AuthorizationBearer_InCurlToolResult() {
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"$ curl -fsS -H \"Authorization: Bearer abc123def456ghi789jkl012mno\" https://api.example.com\n{\"ok\":true}","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("abc123def456ghi789jkl012mno");
+        await Assert.That(result).Contains("Authorization: [REDACTED]");
+    }
+
+    [Test]
+    public async Task RedactsLine_AuthorizationBasic_InToolResult() {
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"Authorization: Basic dXNlcjpwYXNzd29yZA==","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("dXNlcjpwYXNzd29yZA==");
+        await Assert.That(result).Contains("Authorization: [REDACTED]");
+    }
+
+    [Test]
+    public async Task RedactsLine_CookieHeader_InToolResult() {
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"> Cookie: session=abc123def456; csrf=xyz789uvw321","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("session=abc123def456");
+        await Assert.That(result).DoesNotContain("csrf=xyz789uvw321");
+        await Assert.That(result).Contains("Cookie: [REDACTED]");
+    }
+
+    [Test]
+    public async Task RedactsLine_XApiKeyHeader_InToolResult() {
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"X-Api-Key: opaque_value_with_no_known_prefix_12345","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("opaque_value_with_no_known_prefix_12345");
+        await Assert.That(result).Contains("X-Api-Key: [REDACTED]");
+    }
+
+    [Test]
+    public async Task RedactsLine_AuthorizationHeader_AsJsonObjectField() {
+        // HTTP request logged as a JSON object (escaped quotes around key and value).
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"request headers: { \"Authorization\": \"Bearer abc123def456ghi789jkl012mno\", \"Accept\": \"application/json\" }","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("abc123def456ghi789jkl012mno");
+        await Assert.That(result).Contains("[REDACTED]");
+    }
+
+    // AI-53 — labeled secrets with no colon separator (e.g. `hcloud:token  <value>`)
+
+    [Test]
+    public async Task RedactsLine_LabeledSecret_HcloudToken_InToolResult() {
+        // Exact reproduction from AI-53 — `hcloud:token` is a label, not a key:value separator.
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"hcloud:token  9xKMA17r6RGBzkpFQQ2zE6fyuBNgn4IHSH1bZa6sFR14jNOgDRMkfdVEGhDNjHEN","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("9xKMA17r6RGBzkpFQQ2zE6fyuBNgn4IHSH1bZa6sFR14jNOgDRMkfdVEGhDNjHEN");
+        await Assert.That(result).Contains("[REDACTED]");
+    }
+
+    [Test]
+    public async Task RedactsLine_LabeledSecret_PasswordWithSpace() {
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"password    supersecretvalue1234567890","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("supersecretvalue1234567890");
+        await Assert.That(result).Contains("[REDACTED]");
+    }
+
+    [Test]
+    public async Task DoesNotRedact_LabeledSecret_ProseAboutSecrets() {
+        // Negative — prose about secrets must survive. Short word "might" after "token" stops the
+        // 16+ run, and there are no header keywords either.
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"the token might be invalid; refresh it","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).IsEqualTo(line);
+    }
+
+    [Test]
+    public async Task DoesNotRedact_LabeledSecret_ShortValue() {
+        // Negative — values below the 16-char floor are noise (version numbers, IDs, etc.).
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"token short1234","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).IsEqualTo(line);
+    }
+
     [Test]
     public async Task PreservesValidJson_AfterConnectionStringRedaction() {
         var line = """

--- a/test/kapacitor.Tests.Unit/SecretRedactorTests.cs
+++ b/test/kapacitor.Tests.Unit/SecretRedactorTests.cs
@@ -311,6 +311,87 @@ public class SecretRedactorTests {
 
         await Assert.That(result).DoesNotContain("abc123def456ghi789jkl012mno");
         await Assert.That(result).Contains("[REDACTED]");
+
+        // Result must remain valid JSON after redaction.
+        using var doc = System.Text.Json.JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("message").GetProperty("content")[0].GetProperty("is_error").GetBoolean()).IsFalse();
+    }
+
+    [Test]
+    public async Task RedactsLine_AuthorizationHeader_AsRealJsonObject() {
+        // Real JSON object (NOT a string-encoded one) with Authorization as a true key.
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"ok"}]},"toolUseResult":{"headers":{"Authorization":"Bearer opaque-token-1234567890abc"}}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("opaque-token-1234567890abc");
+        await Assert.That(result).Contains("[REDACTED]");
+
+        using var doc = System.Text.Json.JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("toolUseResult").GetProperty("headers").GetProperty("Authorization").GetString()).IsEqualTo("[REDACTED]");
+    }
+
+    [Test]
+    [Arguments("Private-Token", "glpat-AAAAAAAAAAAAAAAAAAAA")]
+    [Arguments("Job-Token", "ci_job_token_value_1234567890")]
+    [Arguments("Deploy-Token", "deploy_token_value_1234567890")]
+    [Arguments("X-Vault-Token", "hvs.AAAAAAAAAAAAAAAAAAAAAAAA")]
+    [Arguments("X-Consul-Token", "00000000-0000-0000-0000-000000000000")]
+    [Arguments("X-CSRF-Token", "csrf_value_abcdef1234567890")]
+    [Arguments("X-XSRF-TOKEN", "xsrf_value_abcdef1234567890")]
+    [Arguments("X-Hub-Signature-256", "sha256=abcdef1234567890abcdef1234567890")]
+    [Arguments("X-Slack-Signature", "v0=abcdef1234567890abcdef1234567890")]
+    [Arguments("Stripe-Signature", "t=1492774577,v1=5257a86")]
+    [Arguments("X-Registry-Auth", "ewogICJhdXRoIjogImFiY2QifQo=")]
+    public async Task RedactsLine_AdditionalAuthHeaders_InToolResult(string header, string value) {
+        var line = $$$"""
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"{{{header}}}: {{{value}}}","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain(value);
+        await Assert.That(result).Contains($"{header}: [REDACTED]");
+    }
+
+    // Finding 4 coverage — URL query secrets and userinfo
+
+    [Test]
+    [Arguments("https://example.com/path?access_token=at_abcdef1234567890&user=alice")]
+    [Arguments("https://example.com/cb?id_token=jwt.eyJhbGciOi.payload&state=xyz")]
+    [Arguments("https://api.example.com/x?signature=abcdef1234567890abcdef&v=1")]
+    [Arguments("https://s3.amazonaws.com/b/k?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Signature=abc%2F123&Expires=1")]
+    [Arguments("https://example.com/h?api_key=key_abcdef1234567890")]
+    public async Task RedactsLine_UrlQuerySecret_InToolResult(string url) {
+        var line = $$$"""
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"GET {{{url}}} -> 200","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).Contains("[REDACTED]");
+        // The secret param value must not survive — check by ensuring no `[?&]<param>=<longvalue>` is left.
+        await Assert.That(result).DoesNotContain("at_abcdef1234567890");
+        await Assert.That(result).DoesNotContain("jwt.eyJhbGciOi.payload");
+        await Assert.That(result).DoesNotContain("abcdef1234567890abcdef");
+        await Assert.That(result).DoesNotContain("AKIAIOSFODNN7EXAMPLE");
+        await Assert.That(result).DoesNotContain("key_abcdef1234567890");
+    }
+
+    [Test]
+    public async Task RedactsLine_UrlUserinfo_InToolResult() {
+        // RFC 3986 userinfo: literal `@` must be percent-encoded, so the password component cannot
+        // legally contain `@`. Realistic test case is a Git URL with an opaque-token password.
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"cloning https://alice:ghp_abcdef1234567890ABCDEF@github.com/org/repo.git","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("ghp_abcdef1234567890ABCDEF");
+        await Assert.That(result).Contains("https://alice:[REDACTED]@github.com");
     }
 
     // AI-53 — labeled secrets with no colon separator (e.g. `hcloud:token  <value>`)
@@ -337,6 +418,21 @@ public class SecretRedactorTests {
         var result = SecretRedactor.RedactLine(line);
 
         await Assert.That(result).DoesNotContain("supersecretvalue1234567890");
+        await Assert.That(result).Contains("[REDACTED]");
+    }
+
+    [Test]
+    public async Task RedactsLine_LabeledSecret_PasswordWithPunctuation() {
+        // Value with `!`, `@`, `#`, etc. — broader charset must catch the full opaque value, not
+        // stop at the first non-alnum char.
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"password abcdefghijklmnop!tail#more$end","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("abcdefghijklmnop!tail#more$end");
+        await Assert.That(result).DoesNotContain("!tail");
         await Assert.That(result).Contains("[REDACTED]");
     }
 


### PR DESCRIPTION
## Summary

Two new rules in `SecretRedactor` close gaps in tool-result transcript redaction:

- **`AuthHeaderRegex`** ([AI-50](https://linear.app/kurrent/issue/AI-50/secret-redaction-auth-headers-recorded-as-is)) — redacts the value of `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, `X-Auth-Token`, `X-Access-Token`, `X-Amz-Security-Token`, `X-Goog-Api-Key`, and `Api-Key` headers. Tolerates both the raw form (`curl -H "Authorization: Bearer xxx"` inside a `tool_result`) and the JSON-object form (`\"Authorization\": \"Bearer xxx\"`).
- **`LabeledSecretRegex`** ([AI-53](https://linear.app/kurrent/issue/AI-53/secret-redaction-some-tokens-are-hard-to-recognize)) — redacts opaque values that follow a secret-keyword label separated by whitespace (no colon), e.g. `hcloud:token  9xKMA…`. The existing `YamlStyleSecretRegex` requires a `:` between keyword and value and so misses this format. A 16-char floor + restricted character set `[A-Za-z0-9_\-+/=.]` avoids matching prose like "the token might fail".

The Hetzner case from AI-53 has no public regex signature (no `ghp_`, `AKIA…`, `sk_live_` style prefix) — the only signal is the adjacent key name `hcloud:token`, which the new rule keys off.

## Test plan

- [x] `RedactsLine_AuthorizationBearer_InCurlToolResult` — curl-style header
- [x] `RedactsLine_AuthorizationBasic_InToolResult` — Basic scheme
- [x] `RedactsLine_CookieHeader_InToolResult` — multi-cookie value
- [x] `RedactsLine_XApiKeyHeader_InToolResult` — no-prefix API key
- [x] `RedactsLine_AuthorizationHeader_AsJsonObjectField` — JSON-escaped form
- [x] `RedactsLine_LabeledSecret_HcloudToken_InToolResult` — exact AI-53 repro
- [x] `RedactsLine_LabeledSecret_PasswordWithSpace`
- [x] `DoesNotRedact_LabeledSecret_ProseAboutSecrets` — negative
- [x] `DoesNotRedact_LabeledSecret_ShortValue` — negative
- [x] All 37 pre-existing `SecretRedactorTests` still pass (46 total)

## Notes

Considered `SecretsScanner.Core` NuGet — wrong shape for this job. It's a repo-at-rest scanner (LibGit2Sharp dep, Roslyn AST for `.cs`, returns `Finding` shapes without value spans), not a library you embed in a streaming redactor. Its provider list also wouldn't catch the Hetzner case since the token has no public prefix.

Trade-off accepted: `LabeledSecretRegex` will redact `password thisIsAReallyLongLiteral16` in non-sensitive prose. Matches the existing two-layer redaction doctrine — false redactions are cheaper than leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)