### PR TITLE
[AI-643] Rename server test assemblies in InternalsVisibleTo

### DIFF
--- a/src/Kapacitor.Core/Kapacitor.Core.csproj
+++ b/src/Kapacitor.Core/Kapacitor.Core.csproj
@@ -19,15 +19,15 @@
         <InternalsVisibleTo Include="kapacitor.Tests.Unit" />
         <InternalsVisibleTo Include="kapacitor.Tests.Integration" />
         <!-- Used when referenced as a submodule from the server repo -->
-        <InternalsVisibleTo Include="Kurrent.Capacitor.TestHelpers" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Agents" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Auth" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Chat" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Evals" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Ingest" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Notify" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Read" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.UI" />
+        <InternalsVisibleTo Include="Kapacitor.Server.TestHelpers" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Agents" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Auth" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Chat" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Evals" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Ingest" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Notify" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Read" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.UI" />
     </ItemGroup>
 </Project>

--- a/src/Kapacitor.Core/Models.cs
+++ b/src/Kapacitor.Core/Models.cs
@@ -233,7 +233,7 @@ record EvalContextResult {
 /// <summary>
 /// Wire-format DTO for a single eval question served by
 /// <c>GET /api/eval/questions</c>. Mirrors the shape of
-/// <c>Kurrent.Capacitor.EvalQuestionMetadata.Question</c> on the server —
+/// <c>Kurrent.Kapacitor.EvalQuestionMetadata.Question</c> on the server —
 /// the CLI cannot reference the Shared library (standalone submodule),
 /// so the shape is duplicated here.
 /// </summary>

--- a/src/Kapacitor.Daemon/Kapacitor.Daemon.csproj
+++ b/src/Kapacitor.Daemon/Kapacitor.Daemon.csproj
@@ -21,16 +21,16 @@
         <InternalsVisibleTo Include="kapacitor.Tests.Unit" />
         <InternalsVisibleTo Include="kapacitor.Tests.Integration" />
         <!-- Used when referenced as a submodule from the server repo -->
-        <InternalsVisibleTo Include="Kurrent.Capacitor.TestHelpers" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Agents" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Auth" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Chat" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Evals" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Ingest" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Notify" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Read" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.UI" />
+        <InternalsVisibleTo Include="Kapacitor.Server.TestHelpers" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Agents" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Auth" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Chat" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Evals" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Ingest" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Notify" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Read" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.UI" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />

--- a/src/kapacitor/kapacitor.csproj
+++ b/src/kapacitor/kapacitor.csproj
@@ -16,16 +16,16 @@
         <InternalsVisibleTo Include="kapacitor.Tests.Unit" />
         <InternalsVisibleTo Include="kapacitor.Tests.Integration" />
         <!-- Used when referenced as a submodule from the server repo -->
-        <InternalsVisibleTo Include="Kurrent.Capacitor.TestHelpers" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Agents" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Auth" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Chat" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Evals" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Ingest" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Notify" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.Read" />
-        <InternalsVisibleTo Include="Kurrent.Capacitor.Tests.UI" />
+        <InternalsVisibleTo Include="Kapacitor.Server.TestHelpers" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Agents" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Auth" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Chat" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Evals" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Ingest" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Notify" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.Read" />
+        <InternalsVisibleTo Include="Kapacitor.Server.Tests.UI" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Kapacitor.Core\Kapacitor.Core.csproj" />


### PR DESCRIPTION
## Summary

The server repo (private) renames its test projects from `Kurrent.Capacitor.Tests.*` / `Kurrent.Capacitor.TestHelpers` to `Kapacitor.Server.Tests.*` / `Kapacitor.Server.TestHelpers`. Update the CLI's `InternalsVisibleTo` entries so `TranscriptImportHelper` and other test helpers can still reach `HistoryCommand` / `SessionImporter`.

Also fixes a stale doc comment in `Models.cs` that referenced `Kurrent.Capacitor.EvalQuestionMetadata` — the server type now lives in `Kurrent.Kapacitor.*`.

## Test plan

- [x] `dotnet build src/kapacitor/kapacitor.csproj` succeeds locally
- [ ] After this merges, bump the submodule pointer in the server repo so its `Kapacitor.Server.Tests.*` projects can reach internal CLI types

🤖 Generated with [Claude Code](https://claude.com/claude-code)