### PR TITLE
[AI-643] Point repo refs at renamed GitHub slugs

### DIFF
--- a/npm/kapacitor/README.md
+++ b/npm/kapacitor/README.md
@@ -1,6 +1,6 @@
 # @kurrent/kapacitor
 
-CLI companion for [Kurrent Capacitor](https://github.com/kurrent-io/kapacitor) — records and visualizes Claude Code sessions.
+CLI companion for [Kurrent Capacitor](https://github.com/kurrent-io/kapacitor-cli) — records and visualizes Claude Code sessions.
 
 ## Install
 

--- a/test/kapacitor.Tests.Unit/GitUrlParserTests.cs
+++ b/test/kapacitor.Tests.Unit/GitUrlParserTests.cs
@@ -2,7 +2,7 @@ namespace kapacitor.Tests.Unit;
 
 public class GitUrlParserTests {
     [Test]
-    [Arguments("https://github.com/kurrent-io/kapacitor", "kurrent-io", "kapacitor")]
+    [Arguments("https://github.com/kurrent-io/kapacitor-cli", "kurrent-io", "kapacitor-cli")]
     [Arguments("https://github.com/kurrent-io/kapacitor.git", "kurrent-io", "kapacitor")]
     [Arguments("https://github.com/owner/repo-name", "owner", "repo-name")]
     [Arguments("https://github.com/owner/repo-name.git", "owner", "repo-name")]
@@ -10,8 +10,8 @@ public class GitUrlParserTests {
     [Arguments("http://github.com/owner/repo.git", "owner", "repo")]
     [Arguments("https://gitlab.com/my-org/my-repo", "my-org", "my-repo")]
     [Arguments("https://gitlab.com/my-org/my-repo.git", "my-org", "my-repo")]
-    [Arguments("https://github.com/kurrent-io/Kurrent.Capacitor", "kurrent-io", "Kurrent.Capacitor")]
-    [Arguments("https://github.com/kurrent-io/Kurrent.Capacitor.git", "kurrent-io", "Kurrent.Capacitor")]
+    [Arguments("https://github.com/kurrent-io/kapacitor-server", "kurrent-io", "kapacitor-server")]
+    [Arguments("https://github.com/kurrent-io/kapacitor-server.git", "kurrent-io", "kapacitor-server")]
     [Arguments("https://github.com/owner/a.b.c.git", "owner", "a.b.c")]
     public async Task ParseRemoteUrl_HttpsUrls_ReturnsOwnerAndRepo(string url, string expectedOwner, string expectedRepo) {
         var (owner, repoName) = GitUrlParser.ParseRemoteUrl(url);
@@ -21,15 +21,15 @@ public class GitUrlParserTests {
     }
 
     [Test]
-    [Arguments("git@github.com:kurrent-io/kapacitor", "kurrent-io", "kapacitor")]
+    [Arguments("git@github.com:kurrent-io/kapacitor-cli", "kurrent-io", "kapacitor-cli")]
     [Arguments("git@github.com:kurrent-io/kapacitor.git", "kurrent-io", "kapacitor")]
     [Arguments("git@github.com:owner/repo-name", "owner", "repo-name")]
     [Arguments("git@github.com:owner/repo-name.git", "owner", "repo-name")]
     [Arguments("git@gitlab.com:my-org/my-repo", "my-org", "my-repo")]
     [Arguments("git@gitlab.com:my-org/my-repo.git", "my-org", "my-repo")]
     [Arguments("git@my-host.example.com:org/repo", "org", "repo")]
-    [Arguments("git@github.com:kurrent-io/Kurrent.Capacitor", "kurrent-io", "Kurrent.Capacitor")]
-    [Arguments("git@github.com:kurrent-io/Kurrent.Capacitor.git", "kurrent-io", "Kurrent.Capacitor")]
+    [Arguments("git@github.com:kurrent-io/kapacitor-server", "kurrent-io", "kapacitor-server")]
+    [Arguments("git@github.com:kurrent-io/kapacitor-server.git", "kurrent-io", "kapacitor-server")]
     [Arguments("git@github.com:owner/a.b.c.git", "owner", "a.b.c")]
     public async Task ParseRemoteUrl_SshUrls_ReturnsOwnerAndRepo(string url, string expectedOwner, string expectedRepo) {
         var (owner, repoName) = GitUrlParser.ParseRemoteUrl(url);


### PR DESCRIPTION
## Summary

Both GitHub repos were renamed:
- \`kurrent-io/kapacitor\` → \`kurrent-io/kapacitor-cli\`
- \`kurrent-io/Kurrent.Capacitor\` → \`kurrent-io/kapacitor-server\`

GitHub auto-redirects keep the old URLs working, but the in-repo docs and test fixtures should reflect current reality.

Changes:
- \`npm/kapacitor/README.md\`: bump the "open source at" link to the new \`kapacitor-cli\` slug. (npm package name unchanged.)
- \`test/kapacitor.Tests.Unit/GitUrlParserTests.cs\`: refresh the URL fixtures used by the GitUrlParser tests to the new slugs. Legacy \`.git\` variants (\`kurrent-io/kapacitor.git\`) kept to prove redirect-era URLs still parse correctly.

## Test plan

- [x] 771 / 771 \`kapacitor.Tests.Unit\` tests pass locally
- [ ] CI green