### PR TITLE
[AI-652] Advertise daemon's installed vendors over DaemonConnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Non-interactive runs (no TTY, e.g. CI) must pass both a scope flag and `--yes`. 
 
 ### Daemon
 
-The daemon connects to the Capacitor server and runs Claude Code or Codex agents in isolated git worktrees, controlled from the dashboard. The daemon supports hosted Claude and Codex agents on macOS and Linux — choose the vendor from the dashboard's launch dialog.
+The daemon connects to the Capacitor server and runs Claude Code or Codex agents in isolated git worktrees, controlled from the dashboard. The daemon supports hosted Claude and Codex agents on macOS and Linux — choose the vendor from the dashboard's launch dialog. At startup the daemon probes `daemon.claude_path` and `daemon.codex_path` and advertises only the vendors it can actually spawn, so the launch dialog hides whichever agent isn't installed on the selected daemon.
 
 ```bash
 kapacitor daemon start                   # start in foreground (defaults --name to your OS username)

--- a/src/Kapacitor.Cli.Core/Models.cs
+++ b/src/Kapacitor.Cli.Core/Models.cs
@@ -621,13 +621,14 @@ public readonly record struct ResizeTerminalCommand(
 /// each connected daemon is running.</para>
 /// </summary>
 public readonly record struct DaemonConnect(
-        string   Name,
-        string   Platform,
-        string[] RepoPaths,
-        int      MaxAgents,
-        string[] LiveAgentIds,
-        string?  InstanceId = null,
-        string?  Version    = null
+        string    Name,
+        string    Platform,
+        string[]  RepoPaths,
+        int       MaxAgents,
+        string[]  LiveAgentIds,
+        string?   InstanceId       = null,
+        string?   Version          = null,
+        string[]? SupportedVendors = null
     );
 
 public readonly record struct AgentRegistered(

--- a/src/Kapacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Kapacitor.Cli.Daemon/DaemonConfig.cs
@@ -24,6 +24,16 @@ public class DaemonConfig {
     /// </summary>
     public string? Version { get; set; }
 
+    /// <summary>
+    /// Vendor tokens this daemon can actually spawn — populated in
+    /// <c>DaemonRunner.RunAsync</c> by probing each registered
+    /// <c>IHostedAgentLauncher.IsAvailable()</c>. Sent over
+    /// <c>DaemonConnect</c> (AI-652) so the server's launch dialog only
+    /// offers vendors this daemon has installed. <c>null</c> when the
+    /// host hasn't been built yet or in tests that bypass the runner.
+    /// </summary>
+    public string[]? SupportedVendors { get; set; }
+
     public string WorktreeRoot { get; set; } = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
         ".capacitor",

--- a/src/Kapacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Kapacitor.Cli.Daemon/DaemonRunner.cs
@@ -176,6 +176,17 @@ public static partial class DaemonRunner {
         var host   = builder.Build();
         var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("kapacitor.Daemon");
 
+        // AI-652: probe each registered launcher's CLI binary so the
+        // DaemonConnect payload only advertises vendors this daemon can
+        // actually spawn. The launch dialog filters its vendor selector
+        // by this list. Ordered alphabetically so the wire format is
+        // stable across restarts.
+        config.SupportedVendors = host.Services.GetServices<IHostedAgentLauncher>()
+            .Where(l => l.IsAvailable())
+            .Select(l => l.Vendor)
+            .OrderBy(v => v, StringComparer.Ordinal)
+            .ToArray();
+
         LogDaemonStarting(logger, config.Name, config.ServerUrl);
 
         var lifetime   = host.Services.GetRequiredService<IHostApplicationLifetime>();

--- a/src/Kapacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Kapacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -13,6 +13,8 @@ internal sealed partial class ClaudeLauncher(
     public string Vendor  => "claude";
     public string CliPath => config.ClaudePath;
 
+    public bool IsAvailable() => CliResolver.Exists(CliPath);
+
     static readonly Lock                  TrustWriteLock   = new();
     static readonly JsonSerializerOptions IndentedJsonOpts = new() { WriteIndented = true };
 

--- a/src/Kapacitor.Cli.Daemon/Services/CliResolver.cs
+++ b/src/Kapacitor.Cli.Daemon/Services/CliResolver.cs
@@ -3,30 +3,32 @@ namespace Kapacitor.Cli.Daemon.Services;
 /// <summary>
 /// Best-effort lookup that mirrors how a shell finds an executable: if the
 /// configured path is absolute, check the file directly; otherwise walk
-/// <c>PATH</c> (plus <c>PATHEXT</c> on Windows). Used by
+/// <c>PATH</c> (plus <c>PATHEXT</c> on Windows). On Unix, requires at least
+/// one execute bit (mirrors <c>AgentDetector.IsExecutable</c> in the CLI
+/// project — keep the two in sync). Used by
 /// <see cref="IHostedAgentLauncher.IsAvailable"/> at daemon startup (AI-652)
 /// to decide which vendor launchers to advertise over <c>DaemonConnect</c>.
 ///
 /// <para>This intentionally does NOT execute the binary — startup must stay
-/// cheap. False positives (binary present but unusable for some other
-/// reason) surface later as the existing <c>LaunchFailed</c> path.</para>
+/// cheap. False positives (binary present, exec bit set, but unusable for
+/// some other reason) surface later as the existing <c>LaunchFailed</c>
+/// path.</para>
 /// </summary>
 internal static class CliResolver {
     /// <summary>
     /// Returns <c>true</c> when <paramref name="cliPath"/> resolves to an
-    /// existing file — either directly (absolute path) or via <c>PATH</c>
-    /// lookup (bare command).
+    /// existing, executable file — either directly (absolute path) or via
+    /// <c>PATH</c> lookup (bare command).
     /// </summary>
     public static bool Exists(string cliPath) {
         if (string.IsNullOrWhiteSpace(cliPath)) return false;
 
         if (Path.IsPathFullyQualified(cliPath))
-            return File.Exists(cliPath);
+            return IsExecutable(cliPath);
 
         // Bare command — walk PATH. Splitting on the platform separator is
         // sufficient; we don't need to handle quoted PATH entries because
         // POSIX disallows them and Windows tolerates raw paths in PATH.
-        var sep   = OperatingSystem.IsWindows() ? ';' : ':';
         var pathEnv = Environment.GetEnvironmentVariable("PATH");
         if (string.IsNullOrEmpty(pathEnv)) return false;
 
@@ -34,13 +36,34 @@ internal static class CliResolver {
             ? (Environment.GetEnvironmentVariable("PATHEXT") ?? ".EXE;.CMD;.BAT;.COM").Split(';', StringSplitOptions.RemoveEmptyEntries)
             : [""];
 
-        foreach (var dir in pathEnv.Split(sep, StringSplitOptions.RemoveEmptyEntries)) {
+        foreach (var dir in pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)) {
             foreach (var ext in extensions) {
                 var candidate = Path.Combine(dir, cliPath + ext);
-                if (File.Exists(candidate)) return true;
+                if (IsExecutable(candidate)) return true;
             }
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// File exists AND (on Unix) has at least one execute bit set. Kept in
+    /// sync with <c>AgentDetector.IsExecutable</c>; if the heuristic moves
+    /// (e.g. to <c>access(X_OK)</c> via P/Invoke), bump both copies.
+    /// </summary>
+    static bool IsExecutable(string path) {
+        if (!File.Exists(path)) return false;
+        if (OperatingSystem.IsWindows()) return true; // PATHEXT already filtered the candidates
+
+        const UnixFileMode anyExecute =
+            UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
+        try {
+            return (File.GetUnixFileMode(path) & anyExecute) != 0;
+        } catch {
+            // TOCTOU race (file removed between File.Exists and GetUnixFileMode),
+            // permission denied, or other I/O failure — treat as not executable
+            // so the daemon doesn't advertise a vendor it can't actually spawn.
+            return false;
+        }
     }
 }

--- a/src/Kapacitor.Cli.Daemon/Services/CliResolver.cs
+++ b/src/Kapacitor.Cli.Daemon/Services/CliResolver.cs
@@ -1,0 +1,46 @@
+namespace Kapacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Best-effort lookup that mirrors how a shell finds an executable: if the
+/// configured path is absolute, check the file directly; otherwise walk
+/// <c>PATH</c> (plus <c>PATHEXT</c> on Windows). Used by
+/// <see cref="IHostedAgentLauncher.IsAvailable"/> at daemon startup (AI-652)
+/// to decide which vendor launchers to advertise over <c>DaemonConnect</c>.
+///
+/// <para>This intentionally does NOT execute the binary — startup must stay
+/// cheap. False positives (binary present but unusable for some other
+/// reason) surface later as the existing <c>LaunchFailed</c> path.</para>
+/// </summary>
+internal static class CliResolver {
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="cliPath"/> resolves to an
+    /// existing file — either directly (absolute path) or via <c>PATH</c>
+    /// lookup (bare command).
+    /// </summary>
+    public static bool Exists(string cliPath) {
+        if (string.IsNullOrWhiteSpace(cliPath)) return false;
+
+        if (Path.IsPathFullyQualified(cliPath))
+            return File.Exists(cliPath);
+
+        // Bare command — walk PATH. Splitting on the platform separator is
+        // sufficient; we don't need to handle quoted PATH entries because
+        // POSIX disallows them and Windows tolerates raw paths in PATH.
+        var sep   = OperatingSystem.IsWindows() ? ';' : ':';
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathEnv)) return false;
+
+        var extensions = OperatingSystem.IsWindows()
+            ? (Environment.GetEnvironmentVariable("PATHEXT") ?? ".EXE;.CMD;.BAT;.COM").Split(';', StringSplitOptions.RemoveEmptyEntries)
+            : [""];
+
+        foreach (var dir in pathEnv.Split(sep, StringSplitOptions.RemoveEmptyEntries)) {
+            foreach (var ext in extensions) {
+                var candidate = Path.Combine(dir, cliPath + ext);
+                if (File.Exists(candidate)) return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Kapacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Kapacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -12,6 +12,8 @@ internal sealed partial class CodexLauncher(
     public string Vendor  => "codex";
     public string CliPath => config.CodexPath;
 
+    public bool IsAvailable() => CliResolver.Exists(CliPath);
+
     static readonly string[] CriticalHookEvents = ["SessionStart", "Stop", "PermissionRequest"];
 
     public void Prepare(LauncherContext ctx) {

--- a/src/Kapacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs
+++ b/src/Kapacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs
@@ -17,6 +17,14 @@ internal interface IHostedAgentLauncher {
     string CliPath { get; }
 
     /// <summary>
+    /// Reports whether <see cref="CliPath"/> resolves to an executable that
+    /// looks installed. Used at daemon startup (AI-652) to build the list of
+    /// supported vendors advertised over <c>DaemonConnect</c>, so the launch
+    /// dialog only offers vendors the daemon can actually spawn.
+    /// </summary>
+    bool IsAvailable();
+
+    /// <summary>
     /// Per-vendor preparation BEFORE the PTY is spawned. Implementations:
     ///   • Overlay vendor-specific settings dir from source repo into worktree
     ///   • Pre-trust the worktree path in the vendor's config file

--- a/src/Kapacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Kapacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -219,7 +219,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                 "DaemonConnect",
                 new DaemonConnect(
                     _config.Name, platform, repoPaths, _config.MaxConcurrentAgents, liveIds,
-                    _config.InstanceId, _config.Version
+                    _config.InstanceId, _config.Version, _config.SupportedVendors
                 ),
                 cancellationToken: _ct
             );

--- a/test/Kapacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -275,6 +275,8 @@ public class AgentOrchestratorVendorTests {
         public int                 CleanupCalls   { get; private set; }
         public Exception?          PrepareThrow   { get; init; }
 
+        public bool IsAvailable() => true;
+
         public void Prepare(LauncherContext ctx) {
             PrepareCalls++;
             if (PrepareThrow is not null) throw PrepareThrow;

--- a/test/Kapacitor.Cli.Tests.Unit/CliResolverTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/CliResolverTests.cs
@@ -1,0 +1,67 @@
+using Kapacitor.Cli.Daemon.Services;
+
+namespace Kapacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Covers the daemon-startup vendor probe (AI-652). The resolver is the
+/// only place the daemon decides whether to advertise <c>claude</c> /
+/// <c>codex</c> over <c>DaemonConnect</c>, so the launch dialog's vendor
+/// filter is only ever as accurate as this lookup.
+/// </summary>
+public class CliResolverTests {
+    [Test]
+    public async Task ReturnsFalse_ForEmptyInput() {
+        await Assert.That(CliResolver.Exists("")).IsFalse();
+        await Assert.That(CliResolver.Exists("   ")).IsFalse();
+    }
+
+    [Test]
+    public async Task ReturnsTrue_WhenAbsolutePathExists() {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"cli-resolver-test-{Guid.NewGuid():N}");
+        await File.WriteAllTextAsync(tempFile, "#!/bin/sh\necho hi\n");
+
+        try {
+            await Assert.That(CliResolver.Exists(tempFile)).IsTrue();
+        } finally {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task ReturnsFalse_WhenAbsolutePathMissing() {
+        var missing = Path.Combine(Path.GetTempPath(), $"cli-resolver-missing-{Guid.NewGuid():N}");
+
+        await Assert.That(CliResolver.Exists(missing)).IsFalse();
+    }
+
+    [Test]
+    public async Task ReturnsTrue_WhenBareCommandResolvesOnPath() {
+        // Drop a fake "kapacitor-pathprobe-{guid}" binary into a temp dir and
+        // prepend that dir to PATH so the resolver finds it. Touch the
+        // executable bit on POSIX so the binary is plausibly runnable —
+        // the resolver doesn't enforce it, but the file has to exist.
+        var dir = Directory.CreateTempSubdirectory("cli-resolver-path-").FullName;
+        var name = $"kapacitor-pathprobe-{Guid.NewGuid():N}";
+        var binaryName = OperatingSystem.IsWindows() ? name + ".exe" : name;
+        var binaryPath = Path.Combine(dir, binaryName);
+        await File.WriteAllTextAsync(binaryPath, "");
+
+        var savedPath = Environment.GetEnvironmentVariable("PATH");
+        var sep       = OperatingSystem.IsWindows() ? ';' : ':';
+        Environment.SetEnvironmentVariable("PATH", $"{dir}{sep}{savedPath}");
+
+        try {
+            await Assert.That(CliResolver.Exists(name)).IsTrue();
+        } finally {
+            Environment.SetEnvironmentVariable("PATH", savedPath);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ReturnsFalse_WhenBareCommandNotOnPath() {
+        var unlikely = $"kapacitor-not-installed-{Guid.NewGuid():N}";
+
+        await Assert.That(CliResolver.Exists(unlikely)).IsFalse();
+    }
+}

--- a/test/Kapacitor.Cli.Tests.Unit/CliResolverTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/CliResolverTests.cs
@@ -16,12 +16,34 @@ public class CliResolverTests {
     }
 
     [Test]
-    public async Task ReturnsTrue_WhenAbsolutePathExists() {
+    public async Task ReturnsTrue_WhenAbsolutePathIsExecutable() {
         var tempFile = Path.Combine(Path.GetTempPath(), $"cli-resolver-test-{Guid.NewGuid():N}");
         await File.WriteAllTextAsync(tempFile, "#!/bin/sh\necho hi\n");
+        MakeExecutable(tempFile);
 
         try {
             await Assert.That(CliResolver.Exists(tempFile)).IsTrue();
+        } finally {
+            File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// A non-executable file on disk must NOT be advertised as a spawnable
+    /// CLI. The original AI-652 resolver missed this and would have shipped
+    /// "claude" as supported on hosts where the binary existed but couldn't
+    /// be executed (e.g. wrong owner, stripped exec bit).
+    /// </summary>
+    [Test]
+    public async Task ReturnsFalse_WhenAbsolutePathIsNotExecutable() {
+        if (OperatingSystem.IsWindows()) return; // Windows has no exec bit
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"cli-resolver-noexec-{Guid.NewGuid():N}");
+        await File.WriteAllTextAsync(tempFile, "#!/bin/sh\necho hi\n");
+        File.SetUnixFileMode(tempFile, UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        try {
+            await Assert.That(CliResolver.Exists(tempFile)).IsFalse();
         } finally {
             File.Delete(tempFile);
         }
@@ -36,22 +58,45 @@ public class CliResolverTests {
 
     [Test]
     public async Task ReturnsTrue_WhenBareCommandResolvesOnPath() {
-        // Drop a fake "kapacitor-pathprobe-{guid}" binary into a temp dir and
-        // prepend that dir to PATH so the resolver finds it. Touch the
-        // executable bit on POSIX so the binary is plausibly runnable —
-        // the resolver doesn't enforce it, but the file has to exist.
-        var dir = Directory.CreateTempSubdirectory("cli-resolver-path-").FullName;
-        var name = $"kapacitor-pathprobe-{Guid.NewGuid():N}";
+        // Drop a fake "kapacitor-pathprobe-{guid}" binary into a temp dir,
+        // mark it executable on POSIX, and prepend that dir to PATH.
+        var dir        = Directory.CreateTempSubdirectory("cli-resolver-path-").FullName;
+        var name       = $"kapacitor-pathprobe-{Guid.NewGuid():N}";
         var binaryName = OperatingSystem.IsWindows() ? name + ".exe" : name;
         var binaryPath = Path.Combine(dir, binaryName);
         await File.WriteAllTextAsync(binaryPath, "");
+        MakeExecutable(binaryPath);
 
         var savedPath = Environment.GetEnvironmentVariable("PATH");
-        var sep       = OperatingSystem.IsWindows() ? ';' : ':';
-        Environment.SetEnvironmentVariable("PATH", $"{dir}{sep}{savedPath}");
+        Environment.SetEnvironmentVariable("PATH", $"{dir}{Path.PathSeparator}{savedPath}");
 
         try {
             await Assert.That(CliResolver.Exists(name)).IsTrue();
+        } finally {
+            Environment.SetEnvironmentVariable("PATH", savedPath);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The Unix exec-bit check (mirrors <c>AgentDetector.IsExecutable</c>)
+    /// applies to PATH-resolved candidates too, not just absolute paths.
+    /// </summary>
+    [Test]
+    public async Task ReturnsFalse_WhenBareCommandOnPathIsNotExecutable() {
+        if (OperatingSystem.IsWindows()) return;
+
+        var dir        = Directory.CreateTempSubdirectory("cli-resolver-noexec-path-").FullName;
+        var name       = $"kapacitor-pathprobe-noexec-{Guid.NewGuid():N}";
+        var binaryPath = Path.Combine(dir, name);
+        await File.WriteAllTextAsync(binaryPath, "");
+        File.SetUnixFileMode(binaryPath, UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        var savedPath = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", $"{dir}{Path.PathSeparator}{savedPath}");
+
+        try {
+            await Assert.That(CliResolver.Exists(name)).IsFalse();
         } finally {
             Environment.SetEnvironmentVariable("PATH", savedPath);
             Directory.Delete(dir, recursive: true);
@@ -63,5 +108,15 @@ public class CliResolverTests {
         var unlikely = $"kapacitor-not-installed-{Guid.NewGuid():N}";
 
         await Assert.That(CliResolver.Exists(unlikely)).IsFalse();
+    }
+
+    static void MakeExecutable(string path) {
+        if (OperatingSystem.IsWindows()) return;
+        File.SetUnixFileMode(
+            path,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+          | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+          | UnixFileMode.OtherRead | UnixFileMode.OtherExecute
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds \`IHostedAgentLauncher.IsAvailable()\` (backed by a small \`CliResolver\` helper that mimics shell \`PATH\` lookup) so each launcher reports whether its CLI binary is actually installed.
- \`DaemonRunner\` probes every registered launcher at startup and stashes the ordered vendor list on \`DaemonConfig.SupportedVendors\`.
- \`DaemonConnect\` gains a nullable \`SupportedVendors\` field. Daemons on older servers still work — the field is optional on the wire.

This is the daemon-side half of AI-652. The server-side PR ([kapacitor-server#637](https://github.com/kurrent-io/kapacitor-server/pull/637)) consumes \`SupportedVendors\` to filter the launch dialog's vendor selector per-daemon, defaulting to Claude when available and falling back to Codex on Codex-only daemons.

## Test plan

- [x] \`dotnet build Kapacitor.slnx\` clean
- [x] \`Kapacitor.Cli.Tests.Unit\` — 778/778 green, including 5 new \`CliResolverTests\` cases (empty input, absolute path hit/miss, PATH hit/miss).
- [x] \`dotnet publish src/Kapacitor.Cli.Daemon -c Release\` clean (no IL3050/IL2026 trim warnings).
- [ ] Smoke: \`kapacitor daemon start\` with \`daemon.codex_path\` pointed at a missing binary — confirm \`SupportedVendors\` only contains \`claude\` in the \`DaemonConnect\` payload (server-side log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)