### PR TITLE
setup: warn on non-git cwd and gate --plugin-scope project on a working tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ After installing Codex hooks, run `/hooks` inside Codex and trust each kapacitor
 Legacy `--plugin-scope <user|project|skip>` is retained for backwards compatibility:
 
 - `user` — no-op (matches the new default)
-- `project` — install the Claude Code plugin into `<repo>/.claude/settings.local.json`
+- `project` — install the Claude Code plugin into `<repo>/.claude/settings.local.json`. Must be run from inside a git working tree; setup exits with an error otherwise.
 - `skip` — alias for `--skip-claude-hooks`
 
 New scripts should prefer `--skip-claude-hooks` / `--skip-codex-hooks` and `kapacitor plugin install --project` for project scope.
+
+If you run `kapacitor setup` outside any git working tree, it still completes — hooks install user-scope and fire for every session — but a tip at the end reminds you that sessions recorded from non-repo directories won't capture owner/repo/branch/PR context.
 
 ### Session recap
 

--- a/src/Kapacitor.Cli.Core/GitRepository.cs
+++ b/src/Kapacitor.Cli.Core/GitRepository.cs
@@ -1,0 +1,30 @@
+namespace Kapacitor.Cli.Core;
+
+public static class GitRepository {
+    /// <summary>
+    /// Walks up the directory tree from <paramref name="startDir"/> looking for a
+    /// <c>.git</c> entry (either a directory, as in a normal working tree, or a file,
+    /// as in submodules and linked worktrees). Returns the path that contains the
+    /// <c>.git</c> entry, or <c>null</c> if no working tree is found before reaching
+    /// the filesystem root. Filesystem errors are treated as "not found" rather than
+    /// thrown — callers use this as a heuristic, not an authoritative check.
+    /// </summary>
+    public static string? FindRoot(string startDir) {
+        if (string.IsNullOrEmpty(startDir)) return null;
+
+        try {
+            var dir = new DirectoryInfo(startDir);
+            while (dir is not null) {
+                var dotGit = Path.Combine(dir.FullName, ".git");
+                if (Directory.Exists(dotGit) || File.Exists(dotGit)) return dir.FullName;
+                dir = dir.Parent;
+            }
+        } catch {
+            // I/O errors (permission denied on parent traversal, etc.) — treat as no repo.
+        }
+
+        return null;
+    }
+
+    public static bool IsInsideRepo(string startDir) => FindRoot(startDir) is not null;
+}

--- a/src/Kapacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Kapacitor.Cli/Commands/SetupCommand.cs
@@ -19,6 +19,17 @@ public static class SetupCommand {
         var skipClaude       = skipClaudeFlag || legacyPluginScope == "skip";
         var legacyProjectScope = legacyPluginScope == "project";
 
+        // --plugin-scope project writes ./.claude/settings.local.json into cwd. That only
+        // makes sense inside a git working tree — otherwise the hooks land in a directory
+        // that has no relationship to any project the user is recording sessions for.
+        if (legacyProjectScope && !GitRepository.IsInsideRepo(Environment.CurrentDirectory)) {
+            await Console.Error.WriteLineAsync(
+                $"--plugin-scope project requires a git working tree, but '{Environment.CurrentDirectory}' is not inside one.");
+            await Console.Error.WriteLineAsync(
+                "Either re-run `kapacitor setup` from inside your repo, or drop --plugin-scope project to install user-scope hooks.");
+            return 1;
+        }
+
         AnsiConsole.Write(new Rule("[bold green]Welcome to Kapacitor[/]").Centered());
 
         // Check if already configured
@@ -231,6 +242,19 @@ public static class SetupCommand {
         grid.AddRow("[bold]Config[/]", Markup.Escape(AppConfig.GetConfigPath()));
 
         AnsiConsole.Write(grid);
+
+        // Setup itself is user-scope and works fine outside a repo, but sessions recorded
+        // from non-repo directories have no owner/repo/branch/PR enrichment (see
+        // RepositoryDetection.DetectRepositoryAsync), which weakens grouping in the UI.
+        if (!GitRepository.IsInsideRepo(Environment.CurrentDirectory)) {
+            AnsiConsole.MarkupLine(
+                $"\n[yellow]Tip:[/] you ran setup outside a git working tree ([dim]{Markup.Escape(Environment.CurrentDirectory)}[/]).");
+            AnsiConsole.MarkupLine(
+                "  Hooks fire from any directory, but sessions recorded outside a repo won't include owner/repo/branch context.");
+            AnsiConsole.MarkupLine(
+                "  [dim]cd[/] into your project before recording to capture full session context.");
+        }
+
         AnsiConsole.MarkupLine("\n[dim]Optional:[/] start the daemon with [cyan]kapacitor daemon start -d[/]");
         AnsiConsole.MarkupLine("[dim]Optional:[/] import past sessions with [cyan]kapacitor history --org[/]");
 

--- a/src/Kapacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Kapacitor.Cli/Commands/SetupCommand.cs
@@ -19,10 +19,15 @@ public static class SetupCommand {
         var skipClaude       = skipClaudeFlag || legacyPluginScope == "skip";
         var legacyProjectScope = legacyPluginScope == "project";
 
-        // --plugin-scope project writes ./.claude/settings.local.json into cwd. That only
-        // makes sense inside a git working tree — otherwise the hooks land in a directory
-        // that has no relationship to any project the user is recording sessions for.
-        if (legacyProjectScope && !GitRepository.IsInsideRepo(Environment.CurrentDirectory)) {
+        // Resolve repo root once and reuse for both the project-scope install path and the
+        // non-repo tip at the end. --plugin-scope project writes hooks at <repo>/.claude/...,
+        // so it requires a working tree; without one the hooks would land in a directory
+        // unrelated to any project, or — worse — under a subdirectory of the repo if we
+        // used cwd directly, which means two devs running setup from different subdirs
+        // install hooks in different places.
+        var gitRoot = GitRepository.FindRoot(Environment.CurrentDirectory);
+
+        if (legacyProjectScope && gitRoot is null) {
             await Console.Error.WriteLineAsync(
                 $"--plugin-scope project requires a git working tree, but '{Environment.CurrentDirectory}' is not inside one.");
             await Console.Error.WriteLineAsync(
@@ -161,8 +166,10 @@ public static class SetupCommand {
             Claude: AgentDetector.IsInstalled("claude"),
             Codex:  AgentDetector.IsInstalled("codex"));
 
+        // gitRoot is guaranteed non-null here when legacyProjectScope is true (the early
+        // guard at the top of HandleAsync returns 1 otherwise).
         var claudeSettingsPath = legacyProjectScope
-            ? Path.Combine(Environment.CurrentDirectory, ".claude", "settings.local.json")
+            ? Path.Combine(gitRoot!, ".claude", "settings.local.json")
             : ClaudePaths.UserSettings;
 
         var stepOptions = new CodingAgentsStep.Options(
@@ -246,7 +253,7 @@ public static class SetupCommand {
         // Setup itself is user-scope and works fine outside a repo, but sessions recorded
         // from non-repo directories have no owner/repo/branch/PR enrichment (see
         // RepositoryDetection.DetectRepositoryAsync), which weakens grouping in the UI.
-        if (!GitRepository.IsInsideRepo(Environment.CurrentDirectory)) {
+        if (gitRoot is null) {
             AnsiConsole.MarkupLine(
                 $"\n[yellow]Tip:[/] you ran setup outside a git working tree ([dim]{Markup.Escape(Environment.CurrentDirectory)}[/]).");
             AnsiConsole.MarkupLine(

--- a/test/Kapacitor.Cli.Tests.Unit/GitRepositoryTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/GitRepositoryTests.cs
@@ -1,0 +1,75 @@
+using Kapacitor.Cli.Core;
+
+namespace Kapacitor.Cli.Tests.Unit;
+
+public class GitRepositoryTests {
+    [Test]
+    public async Task FindRoot_returns_null_for_directory_with_no_git_entry_anywhere() {
+        var tmp = Directory.CreateTempSubdirectory("kapacitor-git-test-");
+        try {
+            var nested = Path.Combine(tmp.FullName, "a", "b", "c");
+            Directory.CreateDirectory(nested);
+
+            await Assert.That(GitRepository.FindRoot(nested)).IsNull();
+        } finally {
+            tmp.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task FindRoot_returns_directory_when_dot_git_directory_is_present() {
+        var tmp = Directory.CreateTempSubdirectory("kapacitor-git-test-");
+        try {
+            Directory.CreateDirectory(Path.Combine(tmp.FullName, ".git"));
+
+            await Assert.That(GitRepository.FindRoot(tmp.FullName)).IsEqualTo(tmp.FullName);
+        } finally {
+            tmp.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task FindRoot_returns_directory_when_dot_git_is_a_file_as_in_worktrees_or_submodules() {
+        var tmp = Directory.CreateTempSubdirectory("kapacitor-git-test-");
+        try {
+            await File.WriteAllTextAsync(Path.Combine(tmp.FullName, ".git"), "gitdir: ../parent/.git/worktrees/x\n");
+
+            await Assert.That(GitRepository.FindRoot(tmp.FullName)).IsEqualTo(tmp.FullName);
+        } finally {
+            tmp.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task FindRoot_walks_up_and_returns_the_ancestor_holding_the_dot_git_entry() {
+        var tmp = Directory.CreateTempSubdirectory("kapacitor-git-test-");
+        try {
+            Directory.CreateDirectory(Path.Combine(tmp.FullName, ".git"));
+            var nested = Path.Combine(tmp.FullName, "a", "b", "c");
+            Directory.CreateDirectory(nested);
+
+            await Assert.That(GitRepository.FindRoot(nested)).IsEqualTo(tmp.FullName);
+        } finally {
+            tmp.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task FindRoot_returns_null_for_empty_input() {
+        await Assert.That(GitRepository.FindRoot("")).IsNull();
+    }
+
+    [Test]
+    public async Task IsInsideRepo_matches_FindRoot_result() {
+        var tmp = Directory.CreateTempSubdirectory("kapacitor-git-test-");
+        try {
+            await Assert.That(GitRepository.IsInsideRepo(tmp.FullName)).IsFalse();
+
+            Directory.CreateDirectory(Path.Combine(tmp.FullName, ".git"));
+
+            await Assert.That(GitRepository.IsInsideRepo(tmp.FullName)).IsTrue();
+        } finally {
+            tmp.Delete(recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `kapacitor setup` is now aware of whether cwd is a git working tree. Adds `GitRepository.FindRoot` / `IsInsideRepo` (walks up for a `.git` entry, handles both directory and file form so worktrees and submodules are detected).
- `--plugin-scope project` now errors out early when run outside a working tree, instead of silently writing `./.claude/settings.local.json` into a non-repo directory.
- When cwd has no `.git`, the setup summary prints a soft tip explaining that hooks fire user-scope regardless, but sessions recorded from non-repo directories won't include owner/repo/branch/PR context (see `RepositoryDetection.DetectRepositoryAsync`).
- README updated under the legacy `--plugin-scope` section to document the new prerequisite and the tip.

Motivated by a fresh-laptop `kapacitor setup` run that completed from a non-repo directory with no warning. The 502 in that session was unrelated (server-side, tracked separately on kapacitor-server#642).

## Test plan

- [x] `dotnet build src/Kapacitor.Cli/Kapacitor.Cli.csproj` — clean, 0 warnings
- [x] `dotnet run --project test/Kapacitor.Cli.Tests.Unit/...` — 786/786 pass, including the 6 new `GitRepositoryTests` covering: no `.git` anywhere, `.git` directory, `.git` file (worktree/submodule), walk-up multiple levels, empty input, `IsInsideRepo` parity
- [x] `dotnet publish src/Kapacitor.Cli/Kapacitor.Cli.csproj -c Release` — no IL3050/IL2026 AOT warnings
- [ ] Manual: run `kapacitor setup --no-prompt --server-url ...` from `/tmp` (no `.git`) and confirm the tip appears
- [ ] Manual: run `kapacitor setup --plugin-scope project` from `/tmp` and confirm it exits 1 with the expected error before any UI is drawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)