### PR TITLE
[AI-660] Watcher monitors process group leader, not getppid()

### DIFF
--- a/src/Kapacitor.Cli/ProcessHelpers.cs
+++ b/src/Kapacitor.Cli/ProcessHelpers.cs
@@ -104,22 +104,18 @@ static partial class ProcessHelpers {
     /// covered by Claude's own SessionEnd hook.
     /// </remarks>
     public static int? GetCodingAgentPid() {
-        try {
-            if (OperatingSystem.IsWindows()) {
-                return GetParentPidWindows();
-            }
-
-            var pgid = getpgrp_native();
-
-            if (pgid <= 1) {
-                return getppid_native();
-            }
-
-            // Avoid self-monitoring when this process happens to be its own group leader.
-            return pgid == getpid_native() ? getppid_native() : pgid;
-        } catch {
-            return null;
+        if (OperatingSystem.IsWindows()) {
+            return GetParentPidWindows();
         }
+
+        var pgid = getpgrp_native();
+
+        if (pgid <= 1) {
+            return getppid_native();
+        }
+
+        // Avoid self-monitoring when this process happens to be its own group leader.
+        return pgid == getpid_native() ? getppid_native() : pgid;
     }
 
     /// <summary>

--- a/src/Kapacitor.Cli/ProcessHelpers.cs
+++ b/src/Kapacitor.Cli/ProcessHelpers.cs
@@ -14,6 +14,14 @@ static partial class ProcessHelpers {
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial int getppid_native();
 
+    [LibraryImport("libc", EntryPoint = "getpgrp")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial int getpgrp_native();
+
+    [LibraryImport("libc", EntryPoint = "getpid")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial int getpid_native();
+
     [LibraryImport("libc", EntryPoint = "kill", SetLastError = true)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial int kill_native(int pid, int sig);
@@ -70,6 +78,48 @@ static partial class ProcessHelpers {
         var status = NtQueryInformationProcess(handle, 0, ref pbi, Unsafe.SizeOf<ProcessBasicInformation>(), out _);
 
         return status == 0 ? (int)pbi.InheritedFromUniqueProcessId : null;
+    }
+
+    /// <summary>
+    /// Returns the PID of the long-lived coding-agent process (codex/claude) that
+    /// owns this hook invocation, suitable for passing to a spawned watcher via
+    /// <c>--parent-pid</c>.
+    /// </summary>
+    /// <remarks>
+    /// On Unix, returns the process group id (<c>getpgrp</c>). Both Codex and
+    /// Claude run as process group leaders (PGID == PID), and any descendant —
+    /// including the hook process — inherits that PGID through fork/exec. Using
+    /// PGID bypasses the short-lived hook-executor process that <c>getppid</c>
+    /// would point to and that dies the moment the hook returns, which is the
+    /// bug that left Codex sessions stuck "active" because the watcher's
+    /// <c>IsProcessAlive(getppid())</c> check fired against an already-dead PID
+    /// at startup.
+    ///
+    /// Defensive: if PGID equals our own PID (we're somehow the group leader)
+    /// the fallback is <c>getppid</c> — monitoring ourselves would let the
+    /// watcher self-terminate immediately.
+    ///
+    /// On Windows there's no process-group equivalent so we fall back to the
+    /// parent PID. Codex on Windows is uncommon and the Claude path is already
+    /// covered by Claude's own SessionEnd hook.
+    /// </remarks>
+    public static int? GetCodingAgentPid() {
+        try {
+            if (OperatingSystem.IsWindows()) {
+                return GetParentPidWindows();
+            }
+
+            var pgid = getpgrp_native();
+
+            if (pgid <= 1) {
+                return getppid_native();
+            }
+
+            // Avoid self-monitoring when this process happens to be its own group leader.
+            return pgid == getpid_native() ? getppid_native() : pgid;
+        } catch {
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/Kapacitor.Cli/ProcessHelpers.cs
+++ b/src/Kapacitor.Cli/ProcessHelpers.cs
@@ -108,14 +108,12 @@ static partial class ProcessHelpers {
             return GetParentPidWindows();
         }
 
+        // Fall back to getppid for the degenerate cases: pgid <= 1 means no
+        // group / init, and pgid == our own pid means we're our own group
+        // leader — monitoring ourselves would let the watcher self-terminate.
         var pgid = getpgrp_native();
 
-        if (pgid <= 1) {
-            return getppid_native();
-        }
-
-        // Avoid self-monitoring when this process happens to be its own group leader.
-        return pgid == getpid_native() ? getppid_native() : pgid;
+        return pgid > 1 && pgid != getpid_native() ? pgid : getppid_native();
     }
 
     /// <summary>

--- a/src/Kapacitor.Cli/WatcherManager.cs
+++ b/src/Kapacitor.Cli/WatcherManager.cs
@@ -65,7 +65,12 @@ static class WatcherManager {
             Directory.CreateDirectory(watcherDir);
 
             var kapacitorPath = Environment.ProcessPath ?? "kapacitor";
-            var parentPid     = ProcessHelpers.GetParentPid();
+            // Use the coding-agent's PID (process group leader on Unix) rather than
+            // getppid(): coding agents invoke hooks through a transient executor that
+            // dies the moment the hook returns, so by the time the watcher checks
+            // IsProcessAlive it sees a dead PID and never starts the monitor task —
+            // leaving Codex sessions stuck "active" because session-end is never POSTed.
+            var parentPid     = ProcessHelpers.GetCodingAgentPid();
             var arguments     = BuildSpawnArgs(key, transcriptPath, agentId, sessionIdOverride, cwd, skipTitle, parentPid, vendor);
 
             var psi = new ProcessStartInfo(kapacitorPath, arguments) {

--- a/test/Kapacitor.Cli.Tests.Unit/ProcessHelpersTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/ProcessHelpersTests.cs
@@ -65,4 +65,26 @@ public class ProcessHelpersTests {
         await Assert.That(ppid).IsNotNull();
         await Assert.That(ProcessHelpers.IsProcessAlive(ppid!.Value)).IsTrue();
     }
+
+    [Test]
+    public async Task GetCodingAgentPid_returns_a_live_process() {
+        // The whole point of GetCodingAgentPid is to identify a process that's
+        // still alive when the watcher boots up — i.e. the long-lived coding
+        // agent, not the short-lived hook executor. Anything it returns must
+        // therefore answer "yes" to IsProcessAlive at the moment of the call.
+        var pid = ProcessHelpers.GetCodingAgentPid();
+
+        await Assert.That(pid).IsNotNull();
+        await Assert.That(ProcessHelpers.IsProcessAlive(pid!.Value)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetCodingAgentPid_does_not_return_own_pid() {
+        // Self-monitoring would let the watcher self-terminate as soon as it
+        // starts. The Unix branch falls back to getppid when the process group
+        // leader is the calling process itself.
+        var pid = ProcessHelpers.GetCodingAgentPid();
+
+        await Assert.That(pid).IsNotEqualTo(Environment.ProcessId);
+    }
 }


### PR DESCRIPTION
## Summary

- Finished Codex sessions stayed "Active" forever because the watcher's parent-PID monitor (AI-647) never started: `getppid()` from inside the hook process points at a transient intermediate executor that has already exited by the time the watcher boots up, so `IsProcessAlive(ppid)` returns false and the monitor task is silently skipped.
- Switch `WatcherManager.SpawnWatcher` to use the process group id (`getpgrp`) — both Codex and Claude run as PGID leaders, so the PGID resolves directly to the long-lived coding-agent PID regardless of any executor in between.
- Adds `ProcessHelpers.GetCodingAgentPid()` with a self-monitoring guard and a Windows fallback to the existing `getppid` path (Codex on Windows is rare; Claude has its own SessionEnd hook).

## Evidence

- 0 of 19 examined Codex watcher logs (`019e*.log`) contain the "Monitoring parent pid X" startup line that proves the monitor task started.
- Live process tree on the reporter's machine: codex PID 53327, watcher's `--parent-pid 54212` is a dead intermediate, while the watcher and codex share PGID 53327.

## Test plan

- [x] `dotnet build src/Kapacitor.Cli/Kapacitor.Cli.csproj` — clean
- [x] `dotnet publish -c Release` — no IL3050 / IL2026 AOT warnings
- [x] 786/786 unit tests pass (incl. 2 new `ProcessHelpersTests` covering live-process and no-self-monitor invariants)
- [x] 13/13 integration tests pass (existing `WatcherParentExitPostTests` continues to validate the POST flow)
- [ ] After install, start a fresh Codex session, quit it, confirm session leaves "Active" within ~15s and the watcher log contains "Monitoring parent pid …" and "Parent pid … exited; shutting down watcher".

Refs Linear AI-660. Closes the regression introduced by AI-647 for the Codex path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)