### PR TITLE
[AI-661] Cursor session ingest — CLI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
         <PackageVersion Include="Spectre.Console" Version="0.55.2" />
         <PackageVersion Include="Tomlyn" Version="2.4.0" />
         <PackageVersion Include="TUnit" Version="1.18.37" />
+        <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
         <PackageVersion Include="WireMock.Net" Version="1.7.0" />
     </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ In `--no-prompt` mode, the wizard installs hooks for every detected agent by def
 ```bash
 kapacitor history --org                          # sessions for the org bound to your active profile
 kapacitor history --repo owner/repo              # sessions for one specific repo
+kapacitor cursor import                          # Cursor IDE Composer/Agent sessions from the current workspace
 ```
 
-This backfills your past sessions from `~/.claude/projects/` so they appear in the dashboard. It's idempotent — safe to run multiple times.
+This backfills your past sessions from `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex via `--codex`), or Cursor's local SQLite (`kapacitor cursor import`) so they appear in the dashboard. All forms are idempotent — safe to run multiple times.
 
 You must pick an explicit scope (`--all`, `--org`, or `--repo`) so personal/private repos aren't uploaded by accident. `--org` uses the active profile name as the GitHub org login — it works out of the box when the profile was created by `kapacitor setup` (which names it after the picked tenant), and errors otherwise. Run with no scope on an interactive terminal to get a picker. See [Loading historical sessions](#loading-historical-sessions) for the full set of flags.
 
@@ -206,6 +207,18 @@ kapacitor history --org --session abc123           # single session
 ```
 
 Non-interactive runs (no TTY, e.g. CI) must pass both a scope flag and `--yes`. The command is idempotent and resumable — re-running with the same scope only uploads what's missing or incomplete.
+
+### Loading Cursor sessions
+
+Cursor IDE doesn't have a hook API, so its Composer/Agent-mode sessions are imported post-hoc from Cursor's local SQLite state:
+
+```bash
+kapacitor cursor import                          # the current directory's Cursor workspace
+kapacitor cursor import --workspace /path/to/proj
+kapacitor cursor import --all                    # every Cursor workspace
+```
+
+Only Composer/Agent-mode sessions are imported — Chat (Ask), Inline Edit (Cmd+K), and Tab autocomplete don't fit the session model and are skipped. Sessions with bubbles still being generated are skipped until idle. Re-running is safe: a server-side tracker deduplicates events on `(stream, eventId)` so previously-imported turns don't get re-appended.
 
 ### Daemon
 

--- a/src/Kapacitor.Cli.Core/Cursor/CursorPaths.cs
+++ b/src/Kapacitor.Cli.Core/Cursor/CursorPaths.cs
@@ -1,0 +1,27 @@
+namespace Kapacitor.Cli.Core.Cursor;
+
+public enum OsPlatform { MacOs, Linux, Windows }
+
+public sealed record CursorPaths(string UserDir, string WorkspaceStorageDir, string GlobalStateDb) {
+    public static CursorPaths Resolve(string? home = null, OsPlatform? platform = null, string? appData = null) {
+        home     ??= Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        platform ??= OperatingSystem.IsMacOS()   ? OsPlatform.MacOs
+                  :  OperatingSystem.IsWindows() ? OsPlatform.Windows
+                  :                                OsPlatform.Linux;
+
+        var sep = platform == OsPlatform.Windows ? '\\' : '/';
+
+        var userDir = platform switch {
+            OsPlatform.MacOs   => Join(sep, home, "Library", "Application Support", "Cursor", "User"),
+            OsPlatform.Windows => Join(sep, appData ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Cursor", "User"),
+            _                  => Join(sep, home, ".config", "Cursor", "User")
+        };
+        return new CursorPaths(
+            UserDir:             userDir,
+            WorkspaceStorageDir: userDir + sep + "workspaceStorage",
+            GlobalStateDb:       userDir + sep + "globalStorage" + sep + "state.vscdb");
+    }
+
+    static string Join(char sep, string root, params string[] parts)
+        => root.TrimEnd(sep) + sep + string.Join(sep, parts);
+}

--- a/src/Kapacitor.Cli.Core/Cursor/CursorPayloadAssembler.cs
+++ b/src/Kapacitor.Cli.Core/Cursor/CursorPayloadAssembler.cs
@@ -14,27 +14,28 @@ public static class CursorPayloadAssembler {
         using var doc = JsonDocument.Parse(rawJson);
         var r = doc.RootElement;
 
-        string? text = r.TryGetProperty("text", out var t) ? t.GetString() : null;
+        string? bubbleId = r.TryGetProperty("bubbleId", out var bidEl) ? bidEl.GetString() : "unknown";
+        string? text = r.TryGetProperty("text", out var t) ? GetStringOrSerialize(t) : null;
         if (text is { Length: > 0 } && Encoding.UTF8.GetByteCount(text) > BubbleTextCapBytes)
             text = text[..(BubbleTextCapBytes / 4)]; // crude cap; UTF-8 safe-enough
 
         CursorToolFormerData? tfd = null;
         if (r.TryGetProperty("toolFormerData", out var tfdEl) && tfdEl.ValueKind == JsonValueKind.Object) {
             tfd = new CursorToolFormerData {
-                ToolCallId = tfdEl.GetProperty("toolCallId").GetString()!,
-                Name       = tfdEl.GetProperty("name").GetString()!,
-                Params     = RedactPaths(tfdEl.TryGetProperty("params",  out var pEl)  ? pEl.GetString()  : null, repoPath),
-                RawArgs    = tfdEl.TryGetProperty("rawArgs", out var raEl)              ? raEl.GetString() : null,
-                Result     = RedactPaths(tfdEl.TryGetProperty("result",  out var rEl)  ? rEl.GetString()  : null, repoPath),
-                Status     = tfdEl.TryGetProperty("status",  out var sEl)              ? sEl.GetString()  : null
+                ToolCallId = tfdEl.TryGetProperty("toolCallId", out var tcidEl) ? GetStringOrSerialize(tcidEl) ?? "" : "",
+                Name       = tfdEl.TryGetProperty("name",       out var nameEl) ? GetStringOrSerialize(nameEl) ?? "" : "",
+                Params     = RedactPaths(tfdEl.TryGetProperty("params",  out var pEl)  ? GetStringOrSerialize(pEl)  : null, repoPath),
+                RawArgs    = tfdEl.TryGetProperty("rawArgs", out var raEl)                                          ? GetStringOrSerialize(raEl) : null,
+                Result     = RedactPaths(tfdEl.TryGetProperty("result",  out var rEl)  ? GetStringOrSerialize(rEl)  : null, repoPath),
+                Status     = tfdEl.TryGetProperty("status",  out var sEl)              ? GetStringOrSerialize(sEl)  : null
             };
         }
 
         CursorThinking? thinking = null;
         if (r.TryGetProperty("thinking", out var thEl) && thEl.ValueKind == JsonValueKind.Object) {
             thinking = new CursorThinking {
-                Text       = thEl.TryGetProperty("text",       out var tt) ? tt.GetString() : null,
-                Signature  = thEl.TryGetProperty("signature",  out var sg) ? sg.GetString() : null,
+                Text       = thEl.TryGetProperty("text",       out var tt) ? GetStringOrSerialize(tt) : null,
+                Signature  = thEl.TryGetProperty("signature",  out var sg) ? GetStringOrSerialize(sg) : null,
                 DurationMs = thEl.TryGetProperty("durationMs", out var dm) ? dm.GetInt32()  : 0
             };
         }
@@ -48,10 +49,10 @@ public static class CursorPayloadAssembler {
         }
 
         return new CursorBubble {
-            BubbleId       = r.GetProperty("bubbleId").GetString()!,
+            BubbleId       = bubbleId!,
             Type           = r.GetProperty("type").GetInt32(),
             CapabilityType = r.TryGetProperty("capabilityType", out var ctEl) && ctEl.ValueKind == JsonValueKind.Number ? ctEl.GetInt32() : null,
-            CreatedAtIso   = r.GetProperty("createdAt").GetString()!,
+            CreatedAtIso   = GetCreatedAtString(r),
             Text           = text,
             TokenCount     = tokenCount,
             ToolFormerData = tfd,
@@ -67,6 +68,27 @@ public static class CursorPayloadAssembler {
         // Use JsonNode.Parse on a raw fragment instead.
         var marker = JsonNode.Parse($"{{\"truncated\":true,\"hash\":\"{hash}\",\"sizeBytes\":{bytes}}}")!.ToJsonString();
         return (key, marker);
+    }
+
+    /// <summary>
+    /// Returns the element as a string if it is a JSON string, otherwise serializes it
+    /// back to a JSON text (for cases where Cursor stores params/result as objects rather
+    /// than JSON-encoded strings).
+    /// </summary>
+    static string? GetStringOrSerialize(JsonElement el) =>
+        el.ValueKind == JsonValueKind.String
+            ? el.GetString()
+            : el.ValueKind == JsonValueKind.Null || el.ValueKind == JsonValueKind.Undefined
+                ? null
+                : el.GetRawText();
+
+    static string GetCreatedAtString(JsonElement r) {
+        if (!r.TryGetProperty("createdAt", out var el)) return "1970-01-01T00:00:00Z";
+        if (el.ValueKind == JsonValueKind.String) return el.GetString()!;
+        // Some bubbles store createdAt as a Unix ms timestamp (number)
+        if (el.ValueKind == JsonValueKind.Number && el.TryGetInt64(out var ms))
+            return DateTimeOffset.FromUnixTimeMilliseconds(ms).ToString("o");
+        return "1970-01-01T00:00:00Z";
     }
 
     static string? RedactPaths(string? json, string repoPath) {

--- a/src/Kapacitor.Cli.Core/Cursor/CursorPayloadAssembler.cs
+++ b/src/Kapacitor.Cli.Core/Cursor/CursorPayloadAssembler.cs
@@ -1,0 +1,78 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Kapacitor.Cli.Core.Cursor;
+
+public static class CursorPayloadAssembler {
+    public const int BubbleTextCapBytes  = 256 * 1024;
+    public const int BlobSoftCapBytes    = 256 * 1024;
+    public const int PayloadHardCapBytes = 10 * 1024 * 1024;
+
+    public static CursorBubble AssembleBubble(string rawJson, string repoPath) {
+        using var doc = JsonDocument.Parse(rawJson);
+        var r = doc.RootElement;
+
+        string? text = r.TryGetProperty("text", out var t) ? t.GetString() : null;
+        if (text is { Length: > 0 } && Encoding.UTF8.GetByteCount(text) > BubbleTextCapBytes)
+            text = text[..(BubbleTextCapBytes / 4)]; // crude cap; UTF-8 safe-enough
+
+        CursorToolFormerData? tfd = null;
+        if (r.TryGetProperty("toolFormerData", out var tfdEl) && tfdEl.ValueKind == JsonValueKind.Object) {
+            tfd = new CursorToolFormerData {
+                ToolCallId = tfdEl.GetProperty("toolCallId").GetString()!,
+                Name       = tfdEl.GetProperty("name").GetString()!,
+                Params     = RedactPaths(tfdEl.TryGetProperty("params",  out var pEl)  ? pEl.GetString()  : null, repoPath),
+                RawArgs    = tfdEl.TryGetProperty("rawArgs", out var raEl)              ? raEl.GetString() : null,
+                Result     = RedactPaths(tfdEl.TryGetProperty("result",  out var rEl)  ? rEl.GetString()  : null, repoPath),
+                Status     = tfdEl.TryGetProperty("status",  out var sEl)              ? sEl.GetString()  : null
+            };
+        }
+
+        CursorThinking? thinking = null;
+        if (r.TryGetProperty("thinking", out var thEl) && thEl.ValueKind == JsonValueKind.Object) {
+            thinking = new CursorThinking {
+                Text       = thEl.TryGetProperty("text",       out var tt) ? tt.GetString() : null,
+                Signature  = thEl.TryGetProperty("signature",  out var sg) ? sg.GetString() : null,
+                DurationMs = thEl.TryGetProperty("durationMs", out var dm) ? dm.GetInt32()  : 0
+            };
+        }
+
+        CursorTokenCount? tokenCount = null;
+        if (r.TryGetProperty("tokenCount", out var tcEl) && tcEl.ValueKind == JsonValueKind.Object) {
+            tokenCount = new CursorTokenCount {
+                InputTokens  = tcEl.TryGetProperty("inputTokens",  out var inp) ? inp.GetInt64() : 0,
+                OutputTokens = tcEl.TryGetProperty("outputTokens", out var out_) ? out_.GetInt64() : 0
+            };
+        }
+
+        return new CursorBubble {
+            BubbleId       = r.GetProperty("bubbleId").GetString()!,
+            Type           = r.GetProperty("type").GetInt32(),
+            CapabilityType = r.TryGetProperty("capabilityType", out var ctEl) && ctEl.ValueKind == JsonValueKind.Number ? ctEl.GetInt32() : null,
+            CreatedAtIso   = r.GetProperty("createdAt").GetString()!,
+            Text           = text,
+            TokenCount     = tokenCount,
+            ToolFormerData = tfd,
+            Thinking       = thinking
+        };
+    }
+
+    public static (string Key, string Value) MaybeTruncateBlob(string key, string content) {
+        var bytes = Encoding.UTF8.GetByteCount(content);
+        if (bytes <= BlobSoftCapBytes) return (key, content);
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content)))[..16].ToLowerInvariant();
+        // Build marker JSON AOT-safe: no JsonObject string-value assignments (trips ThrowNotSupportedException under AOT).
+        // Use JsonNode.Parse on a raw fragment instead.
+        var marker = JsonNode.Parse($"{{\"truncated\":true,\"hash\":\"{hash}\",\"sizeBytes\":{bytes}}}")!.ToJsonString();
+        return (key, marker);
+    }
+
+    static string? RedactPaths(string? json, string repoPath) {
+        if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(repoPath)) return json;
+        // Cheap: textual replace. Bubbles are short; if false positives become a problem,
+        // upgrade to JSON walk.
+        return json.Replace(repoPath, "/repo");
+    }
+}

--- a/src/Kapacitor.Cli.Core/Cursor/CursorPayloadModels.cs
+++ b/src/Kapacitor.Cli.Core/Cursor/CursorPayloadModels.cs
@@ -1,0 +1,88 @@
+using System.Text.Json.Serialization;
+
+namespace Kapacitor.Cli.Core.Cursor;
+
+public sealed record CursorImportPayload {
+    [JsonPropertyName("vendor")]              public required string                        Vendor              { get; init; }
+    [JsonPropertyName("composerId")]          public required string                        ComposerId          { get; init; }
+    [JsonPropertyName("schemaSourceVersion")] public required CursorSchemaVersion           SchemaSourceVersion { get; init; }
+    [JsonPropertyName("header")]              public required CursorHeader                  Header              { get; init; }
+    [JsonPropertyName("composerData")]        public required CursorComposerData            ComposerData        { get; init; }
+    [JsonPropertyName("bubbles")]             public required IReadOnlyList<CursorBubble>   Bubbles             { get; init; }
+    [JsonPropertyName("contentBlobs")]        public required IReadOnlyDictionary<string,string> ContentBlobs   { get; init; }
+}
+
+public sealed record CursorSchemaVersion {
+    [JsonPropertyName("composerData")] public required int ComposerData { get; init; }
+    [JsonPropertyName("bubble")]       public required int Bubble       { get; init; }
+}
+
+public sealed record CursorHeader {
+    [JsonPropertyName("name")]              public string? Name              { get; init; }
+    [JsonPropertyName("unifiedMode")]       public required string UnifiedMode { get; init; }
+    [JsonPropertyName("createdAtMs")]       public required long   CreatedAtMs { get; init; }
+    [JsonPropertyName("lastUpdatedAtMs")]   public required long   LastUpdatedAtMs { get; init; }
+    [JsonPropertyName("trackedGitRepos")]   public IReadOnlyList<CursorTrackedRepo>? TrackedGitRepos { get; init; }
+    [JsonPropertyName("totalLinesAdded")]   public int  TotalLinesAdded   { get; init; }
+    [JsonPropertyName("totalLinesRemoved")] public int  TotalLinesRemoved { get; init; }
+    [JsonPropertyName("filesChangedCount")] public int  FilesChangedCount { get; init; }
+    [JsonPropertyName("subtitle")]          public string? Subtitle        { get; init; }
+}
+
+public sealed record CursorTrackedRepo {
+    [JsonPropertyName("repoPath")] public required string RepoPath { get; init; }
+    [JsonPropertyName("branches")] public IReadOnlyList<CursorTrackedBranch>? Branches { get; init; }
+}
+
+public sealed record CursorTrackedBranch {
+    [JsonPropertyName("branchName")] public required string BranchName { get; init; }
+}
+
+public sealed record CursorComposerData {
+    [JsonPropertyName("modelConfig")]                 public required CursorModelConfig          ModelConfig                 { get; init; }
+    [JsonPropertyName("fullConversationHeadersOnly")] public required IReadOnlyList<CursorTurnHeader> FullConversationHeadersOnly { get; init; }
+    [JsonPropertyName("generatingBubbleIds")]         public required IReadOnlyList<string>       GeneratingBubbleIds         { get; init; }
+    [JsonPropertyName("status")]                      public string? Status { get; init; }
+}
+
+public sealed record CursorModelConfig {
+    [JsonPropertyName("modelName")]      public string? ModelName      { get; init; }
+    [JsonPropertyName("selectedModels")] public IReadOnlyList<string>? SelectedModels { get; init; }
+}
+
+public sealed record CursorTurnHeader {
+    [JsonPropertyName("bubbleId")] public required string BubbleId { get; init; }
+    [JsonPropertyName("type")]     public required int    Type     { get; init; }
+}
+
+public sealed record CursorBubble {
+    [JsonPropertyName("bubbleId")]       public required string BubbleId       { get; init; }
+    [JsonPropertyName("type")]           public required int    Type           { get; init; }
+    [JsonPropertyName("capabilityType")] public int?            CapabilityType { get; init; }
+    [JsonPropertyName("createdAtIso")]   public required string CreatedAtIso   { get; init; }
+    [JsonPropertyName("text")]           public string?         Text           { get; init; }
+    [JsonPropertyName("tokenCount")]     public CursorTokenCount? TokenCount   { get; init; }
+    [JsonPropertyName("toolFormerData")] public CursorToolFormerData? ToolFormerData { get; init; }
+    [JsonPropertyName("thinking")]       public CursorThinking? Thinking       { get; init; }
+}
+
+public sealed record CursorTokenCount {
+    [JsonPropertyName("inputTokens")]  public long InputTokens  { get; init; }
+    [JsonPropertyName("outputTokens")] public long OutputTokens { get; init; }
+}
+
+public sealed record CursorToolFormerData {
+    [JsonPropertyName("toolCallId")] public required string ToolCallId { get; init; }
+    [JsonPropertyName("name")]       public required string Name       { get; init; }
+    // Params/Result are JSON-encoded strings on the Cursor wire (not nested objects) — parse twice on use.
+    [JsonPropertyName("params")]     public string? Params { get; init; }
+    [JsonPropertyName("rawArgs")]    public string? RawArgs { get; init; }
+    [JsonPropertyName("result")]     public string? Result { get; init; }
+    [JsonPropertyName("status")]     public string? Status { get; init; }
+}
+
+public sealed record CursorThinking {
+    [JsonPropertyName("text")]       public string? Text       { get; init; }
+    [JsonPropertyName("signature")]  public string? Signature  { get; init; }
+    [JsonPropertyName("durationMs")] public int     DurationMs { get; init; }
+}

--- a/src/Kapacitor.Cli.Core/Cursor/CursorStateReader.cs
+++ b/src/Kapacitor.Cli.Core/Cursor/CursorStateReader.cs
@@ -3,7 +3,19 @@ using Microsoft.Data.Sqlite;
 
 namespace Kapacitor.Cli.Core.Cursor;
 
-public sealed record RawComposerHeader(string ComposerId, string UnifiedMode, string? Name, long CreatedAtMs, long LastUpdatedAtMs);
+public sealed record RawComposerHeader(
+    string ComposerId,
+    string UnifiedMode,
+    string? Name,
+    long CreatedAtMs,
+    long LastUpdatedAtMs,
+    string? Subtitle,
+    int TotalLinesAdded,
+    int TotalLinesRemoved,
+    int FilesChangedCount,
+    IReadOnlyList<RawTrackedRepo>? TrackedGitRepos);
+
+public sealed record RawTrackedRepo(string RepoPath, IReadOnlyList<string>? BranchNames);
 
 public static class CursorStateReader {
     static string ConnString(string path) => new SqliteConnectionStringBuilder {
@@ -48,12 +60,36 @@ public static class CursorStateReader {
         if (!doc.RootElement.TryGetProperty("allComposers", out var all)) return null;
         foreach (var c in all.EnumerateArray()) {
             if (c.GetProperty("composerId").GetString() != composerId) continue;
+
+            // Parse optional tracked git repos (present in Cursor ≥ v0.x when a folder is open)
+            IReadOnlyList<RawTrackedRepo>? trackedRepos = null;
+            if (c.TryGetProperty("trackedGitRepos", out var tgrEl) && tgrEl.ValueKind == JsonValueKind.Array) {
+                var repos = new List<RawTrackedRepo>();
+                foreach (var r in tgrEl.EnumerateArray()) {
+                    var repoPath = r.TryGetProperty("repoPath", out var rp) ? rp.GetString() ?? "" : "";
+                    IReadOnlyList<string>? branches = null;
+                    if (r.TryGetProperty("branchNames", out var bnEl) && bnEl.ValueKind == JsonValueKind.Array) {
+                        branches = bnEl.EnumerateArray()
+                            .Where(b => b.ValueKind == JsonValueKind.String)
+                            .Select(b => b.GetString()!)
+                            .ToList();
+                    }
+                    repos.Add(new RawTrackedRepo(repoPath, branches));
+                }
+                trackedRepos = repos;
+            }
+
             return new RawComposerHeader(
-                ComposerId:      composerId,
-                UnifiedMode:     c.GetProperty("unifiedMode").GetString() ?? "",
-                Name:            c.TryGetProperty("name", out var n) ? n.GetString() : null,
-                CreatedAtMs:     c.GetProperty("createdAt").GetInt64(),
-                LastUpdatedAtMs: c.GetProperty("lastUpdatedAt").GetInt64()
+                ComposerId:       composerId,
+                UnifiedMode:      c.GetProperty("unifiedMode").GetString() ?? "",
+                Name:             c.TryGetProperty("name",             out var n)    ? n.GetString()   : null,
+                CreatedAtMs:      c.GetProperty("createdAt").GetInt64(),
+                LastUpdatedAtMs:  c.GetProperty("lastUpdatedAt").GetInt64(),
+                Subtitle:         c.TryGetProperty("subtitle",         out var sub)  ? sub.GetString() : null,
+                TotalLinesAdded:  c.TryGetProperty("totalLinesAdded",   out var tla) && tla.ValueKind == JsonValueKind.Number ? tla.GetInt32() : 0,
+                TotalLinesRemoved:c.TryGetProperty("totalLinesRemoved", out var tlr) && tlr.ValueKind == JsonValueKind.Number ? tlr.GetInt32() : 0,
+                FilesChangedCount:c.TryGetProperty("filesChangedCount", out var fcc) && fcc.ValueKind == JsonValueKind.Number ? fcc.GetInt32() : 0,
+                TrackedGitRepos:  trackedRepos
             );
         }
         return null;

--- a/src/Kapacitor.Cli.Core/Cursor/CursorStateReader.cs
+++ b/src/Kapacitor.Cli.Core/Cursor/CursorStateReader.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+
+namespace Kapacitor.Cli.Core.Cursor;
+
+public sealed record RawComposerHeader(string ComposerId, string UnifiedMode, string? Name, long CreatedAtMs, long LastUpdatedAtMs);
+
+public static class CursorStateReader {
+    static string ConnString(string path) => new SqliteConnectionStringBuilder {
+        DataSource = path,
+        Mode       = SqliteOpenMode.ReadOnly,
+        Cache      = SqliteCacheMode.Shared
+    }.ToString();
+
+    public static async Task<IReadOnlyList<string>> ListWorkspaceComposerIdsAsync(string workspaceDbPath, CancellationToken ct = default) {
+        await using var conn = new SqliteConnection(ConnString(workspaceDbPath));
+        await conn.OpenAsync(ct);
+        await using var cmd  = conn.CreateCommand();
+        cmd.CommandText = "SELECT value FROM ItemTable WHERE key = 'composer.composerData'";
+        var raw = (string?)await cmd.ExecuteScalarAsync(ct);
+        if (raw is null) return [];
+
+        using var doc = JsonDocument.Parse(raw);
+        var root      = doc.RootElement;
+        var ids       = new List<string>();
+
+        // Prefer allComposers when populated, else selectedComposerIds.
+        if (root.TryGetProperty("allComposers", out var all) && all.GetArrayLength() > 0) {
+            foreach (var c in all.EnumerateArray())
+                if (c.TryGetProperty("composerId", out var cid))
+                    ids.Add(cid.GetString()!);
+        } else if (root.TryGetProperty("selectedComposerIds", out var sel)) {
+            foreach (var id in sel.EnumerateArray())
+                ids.Add(id.GetString()!);
+        }
+        return ids;
+    }
+
+    public static async Task<RawComposerHeader?> GetComposerHeaderAsync(string globalDbPath, string composerId, CancellationToken ct = default) {
+        await using var conn = new SqliteConnection(ConnString(globalDbPath));
+        await conn.OpenAsync(ct);
+        await using var cmd  = conn.CreateCommand();
+        cmd.CommandText = "SELECT value FROM ItemTable WHERE key = 'composer.composerHeaders'";
+        var raw = (string?)await cmd.ExecuteScalarAsync(ct);
+        if (raw is null) return null;
+
+        using var doc = JsonDocument.Parse(raw);
+        if (!doc.RootElement.TryGetProperty("allComposers", out var all)) return null;
+        foreach (var c in all.EnumerateArray()) {
+            if (c.GetProperty("composerId").GetString() != composerId) continue;
+            return new RawComposerHeader(
+                ComposerId:      composerId,
+                UnifiedMode:     c.GetProperty("unifiedMode").GetString() ?? "",
+                Name:            c.TryGetProperty("name", out var n) ? n.GetString() : null,
+                CreatedAtMs:     c.GetProperty("createdAt").GetInt64(),
+                LastUpdatedAtMs: c.GetProperty("lastUpdatedAt").GetInt64()
+            );
+        }
+        return null;
+    }
+
+    public static async Task<string?> GetComposerDataAsync(string globalDbPath, string composerId, CancellationToken ct = default) {
+        await using var conn = new SqliteConnection(ConnString(globalDbPath));
+        await conn.OpenAsync(ct);
+        await using var cmd  = conn.CreateCommand();
+        cmd.CommandText = "SELECT value FROM cursorDiskKV WHERE key = @k";
+        cmd.Parameters.AddWithValue("@k", $"composerData:{composerId}");
+        return (string?)await cmd.ExecuteScalarAsync(ct);
+    }
+
+    public static async Task<IReadOnlyList<(string Key, string Value)>> ListBubblesAsync(string globalDbPath, string composerId, CancellationToken ct = default) {
+        await using var conn = new SqliteConnection(ConnString(globalDbPath));
+        await conn.OpenAsync(ct);
+        await using var cmd  = conn.CreateCommand();
+        cmd.CommandText = "SELECT key, value FROM cursorDiskKV WHERE key LIKE @prefix";
+        cmd.Parameters.AddWithValue("@prefix", $"bubbleId:{composerId}:%");
+        var list = new List<(string, string)>();
+        await using var r = await cmd.ExecuteReaderAsync(ct);
+        while (await r.ReadAsync(ct)) list.Add((r.GetString(0), r.GetString(1)));
+        return list;
+    }
+
+    public static async Task<string?> GetContentBlobAsync(string globalDbPath, string contentKey, CancellationToken ct = default) {
+        await using var conn = new SqliteConnection(ConnString(globalDbPath));
+        await conn.OpenAsync(ct);
+        await using var cmd  = conn.CreateCommand();
+        cmd.CommandText = "SELECT value FROM cursorDiskKV WHERE key = @k";
+        cmd.Parameters.AddWithValue("@k", contentKey);
+        return (string?)await cmd.ExecuteScalarAsync(ct);
+    }
+}

--- a/src/Kapacitor.Cli.Core/Cursor/CursorStateReader.cs
+++ b/src/Kapacitor.Cli.Core/Cursor/CursorStateReader.cs
@@ -68,11 +68,28 @@ public static class CursorStateReader {
                 foreach (var r in tgrEl.EnumerateArray()) {
                     var repoPath = r.TryGetProperty("repoPath", out var rp) ? rp.GetString() ?? "" : "";
                     IReadOnlyList<string>? branches = null;
-                    if (r.TryGetProperty("branchNames", out var bnEl) && bnEl.ValueKind == JsonValueKind.Array) {
-                        branches = bnEl.EnumerateArray()
-                            .Where(b => b.ValueKind == JsonValueKind.String)
-                            .Select(b => b.GetString()!)
-                            .ToList();
+                    // Real Cursor shape: "branches":[{"branchName":"main","lastInteractionAt":...}]
+                    // Legacy fallback:   "branchNames":["main","feature/x"]  (older schemas)
+                    var branchesEl = r.TryGetProperty("branches",     out var bEl) ? bEl
+                                   : r.TryGetProperty("branchNames",  out var nEl) ? nEl
+                                   : default;
+                    if (branchesEl.ValueKind == JsonValueKind.Array) {
+                        var names = new List<string>();
+                        foreach (var b in branchesEl.EnumerateArray()) {
+                            if (b.ValueKind == JsonValueKind.Object) {
+                                // Real shape: extract branchName property
+                                if (b.TryGetProperty("branchName", out var bn) && bn.ValueKind == JsonValueKind.String) {
+                                    var name = bn.GetString();
+                                    if (!string.IsNullOrEmpty(name)) names.Add(name);
+                                }
+                            } else if (b.ValueKind == JsonValueKind.String) {
+                                // Legacy shape: element is already the branch name string
+                                var name = b.GetString();
+                                if (!string.IsNullOrEmpty(name)) names.Add(name);
+                            }
+                            // Skip malformed entries
+                        }
+                        if (names.Count > 0) branches = names;
                     }
                     repos.Add(new RawTrackedRepo(repoPath, branches));
                 }

--- a/src/Kapacitor.Cli.Core/Kapacitor.Cli.Core.csproj
+++ b/src/Kapacitor.Cli.Core/Kapacitor.Cli.Core.csproj
@@ -11,6 +11,9 @@
         <EmbeddedResource Include="Resources\**\*" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="Microsoft.Data.Sqlite" />
+    </ItemGroup>
+    <ItemGroup>
         <InternalsVisibleTo Include="kapacitor" />
         <InternalsVisibleTo Include="kapacitor-daemon" />
         <InternalsVisibleTo Include="Kapacitor.Cli.Tests.Unit" />

--- a/src/Kapacitor.Cli.Core/Models.cs
+++ b/src/Kapacitor.Cli.Core/Models.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using Kapacitor.Cli.Core.Cursor;
 
 namespace Kapacitor.Cli.Core;
 
@@ -535,6 +536,10 @@ public record RepoEntry {
     UseStringEnumConverter = true
 )]
 partial class KapacitorJsonContext : JsonSerializerContext;
+
+[JsonSerializable(typeof(CursorImportPayload))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal partial class CursorJsonContext : JsonSerializerContext;
 
 /// <summary>
 /// Decision returned by the server's <c>RequestPermission</c> SignalR hub method.

--- a/src/Kapacitor.Cli.Core/Resources/help-cursor.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-cursor.txt
@@ -1,0 +1,12 @@
+kapacitor cursor — import Cursor IDE sessions
+
+  cursor import                  Import all Composer/Agent sessions from the
+                                 current working directory's Cursor workspace.
+  cursor import --workspace P    Import sessions for the workspace at path P.
+  cursor import --all            Import sessions from every Cursor workspace.
+
+Notes:
+  - Only Composer/Agent-mode sessions are imported. Chat/Inline/Tab are skipped.
+  - Sessions with bubbles still being generated are skipped — wait until the
+    composer is idle.
+  - Re-running is safe: previously-imported events are deduped server-side.

--- a/src/Kapacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-usage.txt
@@ -46,6 +46,9 @@ Plugin:
   plugin install [--project] [--codex]   Register hooks (Claude or --codex for Codex)
   plugin remove  [--project] [--codex]   Remove hooks (Claude or --codex for Codex)
 
+Import:
+  cursor import [--workspace P] [--all]  Import Cursor IDE Composer/Agent sessions
+
 Maintenance:
   update                           Check for and install updates
   cleanup                          Kill all orphaned watcher processes

--- a/src/Kapacitor.Cli/Commands/CursorCommand.cs
+++ b/src/Kapacitor.Cli/Commands/CursorCommand.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using Kapacitor.Cli.Core;
 using Kapacitor.Cli.Core.Cursor;
 
@@ -13,7 +12,6 @@ static class CursorCommand {
     public static async Task<int> RunAsync(
         string[]      args,
         string        baseUrl,
-        string        token,
         CursorPaths?  pathsOverride = null,
         CancellationToken ct        = default
     ) {
@@ -30,9 +28,8 @@ static class CursorCommand {
 
         var paths = pathsOverride ?? CursorPaths.Resolve();
 
-        // Build an authenticated HttpClient using the supplied token
-        using var http = new HttpClient();
-        http.DefaultRequestHeaders.Authorization = new("Bearer", token);
+        // Build an authenticated HttpClient using the shared helper (token discovery, provider check)
+        using var http = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, ct);
 
         var workspaces = ResolveWorkspaces(paths, workspace, allFlag).ToList();
 
@@ -41,6 +38,8 @@ static class CursorCommand {
 
             return 1;
         }
+
+        var failed = 0;
 
         foreach (var (folderPath, wsDbPath) in workspaces) {
             if (!File.Exists(wsDbPath)) {
@@ -88,6 +87,35 @@ static class CursorCommand {
                     continue;
                 }
 
+                // Read composerData up-front to check for in-flight bubbles (Bug #1)
+                string? composerDataRaw;
+
+                try {
+                    composerDataRaw = await CursorStateReader.GetComposerDataAsync(paths.GlobalStateDb, composerId, ct);
+                } catch (Exception ex) {
+                    Console.Error.WriteLine($"[cursor] Failed to read composerData for {composerId}: {ex.Message}");
+
+                    continue;
+                }
+
+                if (composerDataRaw is not null) {
+                    try {
+                        using var doc            = JsonDocument.Parse(composerDataRaw);
+                        var       root           = doc.RootElement;
+                        var       generatingIds  = root.TryGetProperty("generatingBubbleIds", out var gbEl)
+                            ? gbEl.EnumerateArray().Where(e => e.ValueKind == JsonValueKind.String).Select(e => e.GetString()!).ToList()
+                            : [];
+
+                        if (generatingIds.Count > 0) {
+                            Console.Error.WriteLine($"[skip] {composerId} in-flight bubbles");
+
+                            continue;
+                        }
+                    } catch {
+                        // Best-effort — if we can't parse, continue and let the server decide
+                    }
+                }
+
                 // Check watermark
                 if (await IsWatermarkCurrentAsync(http, baseUrl, composerId, header.LastUpdatedAtMs, ct)) {
                     Console.Error.WriteLine($"[skip] {composerId} unchanged");
@@ -95,13 +123,14 @@ static class CursorCommand {
                     continue;
                 }
 
-                // Build payload
+                // Build payload (re-uses already-read composerDataRaw to avoid double read)
                 CursorImportPayload payload;
 
                 try {
-                    payload = await BuildPayload(paths, composerId, folderPath, ct);
+                    payload = await BuildPayload(paths, composerId, folderPath, composerDataRaw, ct);
                 } catch (Exception ex) {
                     Console.Error.WriteLine($"[cursor] Failed to build payload for {composerId}: {ex.Message}");
+                    failed++;
 
                     continue;
                 }
@@ -120,15 +149,22 @@ static class CursorCommand {
 
                 try {
                     using var content = new StringContent(payloadJson, Encoding.UTF8, "application/json");
-                    var       resp    = await http.PostAsync($"{baseUrl}/hooks/cursor-import", content, ct);
-                    Console.Error.WriteLine($"[{(int)resp.StatusCode}] {composerId} ({name})");
+                    var       resp    = await http.PostWithRetryAsync($"{baseUrl}/hooks/cursor-import", content, ct: ct);
+
+                    if (!resp.IsSuccessStatusCode) {
+                        Console.Error.WriteLine($"[fail] {composerId} HTTP {(int)resp.StatusCode}");
+                        failed++;
+                    } else {
+                        Console.Error.WriteLine($"[{(int)resp.StatusCode}] {composerId} ({name})");
+                    }
                 } catch (Exception ex) {
                     Console.Error.WriteLine($"[cursor] POST failed for {composerId}: {ex.Message}");
+                    failed++;
                 }
             }
         }
 
-        return 0;
+        return failed > 0 ? 1 : 0;
     }
 
     static async Task<bool> IsWatermarkCurrentAsync(
@@ -139,7 +175,7 @@ static class CursorCommand {
         CancellationToken ct
     ) {
         try {
-            var resp = await http.GetAsync($"{baseUrl}/api/cursor/{composerId}/watermark", ct);
+            var resp = await http.GetWithRetryAsync($"{baseUrl}/api/cursor/{composerId}/watermark", ct: ct);
 
             if (resp.StatusCode == System.Net.HttpStatusCode.NotFound) return false;
 
@@ -165,11 +201,10 @@ static class CursorCommand {
         CursorPaths       paths,
         string            composerId,
         string            workspaceFolder,
+        string?           composerDataRaw,
         CancellationToken ct
     ) {
-        // Read composer data blob from global DB
-        var composerDataRaw = await CursorStateReader.GetComposerDataAsync(paths.GlobalStateDb, composerId, ct);
-
+        // composerDataRaw is pre-read by the caller (already checked for in-flight bubbles)
         CursorComposerData composerData;
 
         if (composerDataRaw is not null) {

--- a/src/Kapacitor.Cli/Commands/CursorCommand.cs
+++ b/src/Kapacitor.Cli/Commands/CursorCommand.cs
@@ -177,24 +177,26 @@ static class CursorCommand {
             var       root = doc.RootElement;
 
             var modelConfig = new CursorModelConfig {
-                ModelName      = root.TryGetProperty("modelConfig", out var mc) && mc.TryGetProperty("modelName",      out var mn) ? mn.GetString() : null,
+                ModelName      = root.TryGetProperty("modelConfig", out var mc) && mc.TryGetProperty("modelName", out var mn) && mn.ValueKind == JsonValueKind.String ? mn.GetString() : null,
                 SelectedModels = root.TryGetProperty("modelConfig", out var mc2) && mc2.TryGetProperty("selectedModels", out var sm)
-                    ? sm.EnumerateArray().Select(e => e.GetString()!).ToList()
+                    ? sm.EnumerateArray().Where(e => e.ValueKind == JsonValueKind.String).Select(e => e.GetString()!).ToList()
                     : null
             };
 
             var headers = root.TryGetProperty("fullConversationHeadersOnly", out var hdrsEl)
-                ? hdrsEl.EnumerateArray().Select(h => new CursorTurnHeader {
-                    BubbleId = h.GetProperty("bubbleId").GetString()!,
-                    Type     = h.GetProperty("type").GetInt32()
-                }).ToList<CursorTurnHeader>()
+                ? hdrsEl.EnumerateArray()
+                    .Where(h => h.ValueKind == JsonValueKind.Object)
+                    .Select(h => new CursorTurnHeader {
+                        BubbleId = h.TryGetProperty("bubbleId", out var bidEl) && bidEl.ValueKind == JsonValueKind.String ? bidEl.GetString()! : "",
+                        Type     = h.TryGetProperty("type",     out var tyEl)  && tyEl.ValueKind  == JsonValueKind.Number ? tyEl.GetInt32()    : 0
+                    }).ToList<CursorTurnHeader>()
                 : new List<CursorTurnHeader>();
 
             var generatingIds = root.TryGetProperty("generatingBubbleIds", out var gbEl)
-                ? gbEl.EnumerateArray().Select(e => e.GetString()!).ToList()
+                ? gbEl.EnumerateArray().Where(e => e.ValueKind == JsonValueKind.String).Select(e => e.GetString()!).ToList()
                 : new List<string>();
 
-            var status = root.TryGetProperty("status", out var stEl) ? stEl.GetString() : null;
+            var status = root.TryGetProperty("status", out var stEl) && stEl.ValueKind == JsonValueKind.String ? stEl.GetString() : null;
 
             composerData = new CursorComposerData {
                 ModelConfig                 = modelConfig,

--- a/src/Kapacitor.Cli/Commands/CursorCommand.cs
+++ b/src/Kapacitor.Cli/Commands/CursorCommand.cs
@@ -273,14 +273,28 @@ static class CursorCommand {
             }
         }
 
-        // Collect content blob keys referenced by edit_file_v2 bubbles
-        var contentBlobKeys = new HashSet<string>(StringComparer.Ordinal);
+        // Assemble all raw bubbles into typed objects.
         var assembledBubbles = new List<CursorBubble>(rawBubbles.Count);
 
         foreach (var (_, bubbleJson) in rawBubbles) {
-            var bubble = CursorPayloadAssembler.AssembleBubble(bubbleJson, workspaceFolder);
-            assembledBubbles.Add(bubble);
+            assembledBubbles.Add(CursorPayloadAssembler.AssembleBubble(bubbleJson, workspaceFolder));
+        }
 
+        // Order bubbles by fullConversationHeadersOnly position (spec rule); bubbles not in
+        // the header list are orphaned SQLite rows and are dropped from the wire payload.
+        // If the orderMap is empty (couldn't parse — rare), fall back to SQLite order.
+        var orderedBubbles = orderMap.Count > 0
+            ? assembledBubbles
+                .Where(b => orderMap.ContainsKey(b.BubbleId))
+                .OrderBy(b => orderMap[b.BubbleId])
+                .ToList()
+            : assembledBubbles;
+
+        // Collect content blob keys referenced by edit_file_v2 bubbles — only from ordered
+        // (non-orphan) bubbles so we never upload blobs from dropped orphan bubbles.
+        var contentBlobKeys = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var bubble in orderedBubbles) {
             // Extract content blob refs from edit_file_v2 result JSON
             if (bubble.ToolFormerData is { Name: "edit_file_v2", Result: { } resultJson }) {
                 try {
@@ -315,16 +329,6 @@ static class CursorCommand {
             var (k, v) = CursorPayloadAssembler.MaybeTruncateBlob(key, blob);
             contentBlobs[k] = v;
         }
-
-        // Order bubbles by fullConversationHeadersOnly position (spec rule); bubbles not in
-        // the header list are orphaned SQLite rows and are dropped from the wire payload.
-        // If the orderMap is empty (couldn't parse — rare), fall back to SQLite order.
-        var orderedBubbles = orderMap.Count > 0
-            ? assembledBubbles
-                .Where(b => orderMap.ContainsKey(b.BubbleId))
-                .OrderBy(b => orderMap[b.BubbleId])
-                .ToList()
-            : assembledBubbles;
 
         // Read header again (it was already verified to exist by caller)
         var header = await CursorStateReader.GetComposerHeaderAsync(paths.GlobalStateDb, composerId, ct);

--- a/src/Kapacitor.Cli/Commands/CursorCommand.cs
+++ b/src/Kapacitor.Cli/Commands/CursorCommand.cs
@@ -248,8 +248,28 @@ static class CursorCommand {
             };
         }
 
-        // Read bubbles from global DB
+        // Read bubbles from global DB (SQLite row order is undefined; we sort below)
         var rawBubbles = await CursorStateReader.ListBubblesAsync(paths.GlobalStateDb, composerId, ct);
+
+        // Build a position map from fullConversationHeadersOnly so bubbles are ordered
+        // as the conversation prescribes, not by SQLite storage order.
+        var orderMap = new Dictionary<string, int>(StringComparer.Ordinal);
+        if (composerDataRaw is not null) {
+            try {
+                using var ordDoc  = JsonDocument.Parse(composerDataRaw);
+                var       ordRoot = ordDoc.RootElement;
+                if (ordRoot.TryGetProperty("fullConversationHeadersOnly", out var headersArr)
+                    && headersArr.ValueKind == JsonValueKind.Array) {
+                    var i = 0;
+                    foreach (var h in headersArr.EnumerateArray()) {
+                        if (h.TryGetProperty("bubbleId", out var bid) && bid.ValueKind == JsonValueKind.String)
+                            orderMap[bid.GetString()!] = i++;
+                    }
+                }
+            } catch {
+                // Best-effort — if parsing fails, fall back to SQLite order below.
+            }
+        }
 
         // Collect content blob keys referenced by edit_file_v2 bubbles
         var contentBlobKeys = new HashSet<string>(StringComparer.Ordinal);
@@ -294,19 +314,36 @@ static class CursorCommand {
             contentBlobs[k] = v;
         }
 
+        // Order bubbles by fullConversationHeadersOnly position (spec rule); bubbles not in
+        // the header list are orphaned SQLite rows and are dropped from the wire payload.
+        // If the orderMap is empty (couldn't parse — rare), fall back to SQLite order.
+        var orderedBubbles = orderMap.Count > 0
+            ? assembledBubbles
+                .Where(b => orderMap.ContainsKey(b.BubbleId))
+                .OrderBy(b => orderMap[b.BubbleId])
+                .ToList()
+            : assembledBubbles;
+
         // Read header again (it was already verified to exist by caller)
         var header = await CursorStateReader.GetComposerHeaderAsync(paths.GlobalStateDb, composerId, ct);
 
+        var trackedRepos = header!.TrackedGitRepos?
+            .Select(r => new CursorTrackedRepo {
+                RepoPath = r.RepoPath,
+                Branches = r.BranchNames?.Select(b => new CursorTrackedBranch { BranchName = b }).ToList()
+            })
+            .ToList();
+
         var cursorHeader = new CursorHeader {
-            Name              = header!.Name,
+            Name              = header.Name,
             UnifiedMode       = header.UnifiedMode,
             CreatedAtMs       = header.CreatedAtMs,
             LastUpdatedAtMs   = header.LastUpdatedAtMs,
-            TrackedGitRepos   = null,  // not in the raw header; server may enrich
-            TotalLinesAdded   = 0,
-            TotalLinesRemoved = 0,
-            FilesChangedCount = 0,
-            Subtitle          = null
+            TrackedGitRepos   = trackedRepos,
+            TotalLinesAdded   = header.TotalLinesAdded,
+            TotalLinesRemoved = header.TotalLinesRemoved,
+            FilesChangedCount = header.FilesChangedCount,
+            Subtitle          = header.Subtitle
         };
 
         return new CursorImportPayload {
@@ -315,7 +352,7 @@ static class CursorCommand {
             SchemaSourceVersion = new CursorSchemaVersion { ComposerData = 1, Bubble = 1 },
             Header              = cursorHeader,
             ComposerData        = composerData,
-            Bubbles             = assembledBubbles,
+            Bubbles             = orderedBubbles,
             ContentBlobs        = contentBlobs
         };
     }

--- a/src/Kapacitor.Cli/Commands/CursorCommand.cs
+++ b/src/Kapacitor.Cli/Commands/CursorCommand.cs
@@ -1,0 +1,370 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Kapacitor.Cli.Core;
+using Kapacitor.Cli.Core.Cursor;
+
+namespace Kapacitor.Cli.Commands;
+
+/// <summary>
+/// Imports Cursor IDE Composer/Agent sessions to the Capacitor server.
+/// </summary>
+static class CursorCommand {
+    public static async Task<int> RunAsync(
+        string[]      args,
+        string        baseUrl,
+        string        token,
+        CursorPaths?  pathsOverride = null,
+        CancellationToken ct        = default
+    ) {
+        if (args.Length < 1 || args[0] != "import") {
+            var help = EmbeddedResources.TryLoad("help-cursor.txt");
+            await Console.Out.WriteAsync(help ?? "Usage: kapacitor cursor import [--workspace P] [--all]");
+
+            return 2;
+        }
+
+        // Parse flags
+        var allFlag       = args.Contains("--all");
+        string? workspace = GetArg(args, "--workspace");
+
+        var paths = pathsOverride ?? CursorPaths.Resolve();
+
+        // Build an authenticated HttpClient using the supplied token
+        using var http = new HttpClient();
+        http.DefaultRequestHeaders.Authorization = new("Bearer", token);
+
+        var workspaces = ResolveWorkspaces(paths, workspace, allFlag).ToList();
+
+        if (workspaces.Count == 0) {
+            await Console.Error.WriteLineAsync("[cursor] No matching Cursor workspace found.");
+
+            return 1;
+        }
+
+        foreach (var (folderPath, wsDbPath) in workspaces) {
+            if (!File.Exists(wsDbPath)) {
+                Console.Error.WriteLine($"[cursor] Workspace DB not found: {wsDbPath}");
+
+                continue;
+            }
+
+            IReadOnlyList<string> composerIds;
+
+            try {
+                composerIds = await CursorStateReader.ListWorkspaceComposerIdsAsync(wsDbPath, ct);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"[cursor] Failed to read workspace DB {wsDbPath}: {ex.Message}");
+
+                continue;
+            }
+
+            foreach (var composerId in composerIds) {
+                if (!File.Exists(paths.GlobalStateDb)) {
+                    Console.Error.WriteLine($"[cursor] Global state DB not found: {paths.GlobalStateDb}");
+
+                    break;
+                }
+
+                RawComposerHeader? header;
+
+                try {
+                    header = await CursorStateReader.GetComposerHeaderAsync(paths.GlobalStateDb, composerId, ct);
+                } catch (Exception ex) {
+                    Console.Error.WriteLine($"[cursor] Failed to read header for {composerId}: {ex.Message}");
+
+                    continue;
+                }
+
+                if (header is null) {
+                    Console.Error.WriteLine($"[cursor] No header found for {composerId}, skipping.");
+
+                    continue;
+                }
+
+                if (!string.Equals(header.UnifiedMode, "agent", StringComparison.OrdinalIgnoreCase)) {
+                    Console.Error.WriteLine($"[cursor] {composerId} mode={header.UnifiedMode}, skipping.");
+
+                    continue;
+                }
+
+                // Check watermark
+                if (await IsWatermarkCurrentAsync(http, baseUrl, composerId, header.LastUpdatedAtMs, ct)) {
+                    Console.Error.WriteLine($"[skip] {composerId} unchanged");
+
+                    continue;
+                }
+
+                // Build payload
+                CursorImportPayload payload;
+
+                try {
+                    payload = await BuildPayload(paths, composerId, folderPath, ct);
+                } catch (Exception ex) {
+                    Console.Error.WriteLine($"[cursor] Failed to build payload for {composerId}: {ex.Message}");
+
+                    continue;
+                }
+
+                // Serialize and size-check
+                var payloadJson = JsonSerializer.Serialize(payload, CursorJsonContext.Default.CursorImportPayload);
+
+                if (Encoding.UTF8.GetByteCount(payloadJson) > CursorPayloadAssembler.PayloadHardCapBytes) {
+                    Console.Error.WriteLine($"[cursor] Payload for {composerId} exceeds 10 MB hard cap — skipping. Reduce session size or contact support.");
+
+                    continue;
+                }
+
+                // POST to server
+                var name = header.Name ?? composerId;
+
+                try {
+                    using var content = new StringContent(payloadJson, Encoding.UTF8, "application/json");
+                    var       resp    = await http.PostAsync($"{baseUrl}/hooks/cursor-import", content, ct);
+                    Console.Error.WriteLine($"[{(int)resp.StatusCode}] {composerId} ({name})");
+                } catch (Exception ex) {
+                    Console.Error.WriteLine($"[cursor] POST failed for {composerId}: {ex.Message}");
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    static async Task<bool> IsWatermarkCurrentAsync(
+        HttpClient        http,
+        string            baseUrl,
+        string            composerId,
+        long              headerLastUpdatedAtMs,
+        CancellationToken ct
+    ) {
+        try {
+            var resp = await http.GetAsync($"{baseUrl}/api/cursor/{composerId}/watermark", ct);
+
+            if (resp.StatusCode == System.Net.HttpStatusCode.NotFound) return false;
+
+            if (!resp.IsSuccessStatusCode) return false;
+
+            var body = await resp.Content.ReadAsStringAsync(ct);
+
+            using var doc = JsonDocument.Parse(body);
+
+            if (doc.RootElement.TryGetProperty("last_updated_at_ms", out var lv)) {
+                var serverMs = lv.GetInt64();
+
+                return serverMs >= headerLastUpdatedAtMs;
+            }
+
+            return false;
+        } catch {
+            return false;
+        }
+    }
+
+    static async Task<CursorImportPayload> BuildPayload(
+        CursorPaths       paths,
+        string            composerId,
+        string            workspaceFolder,
+        CancellationToken ct
+    ) {
+        // Read composer data blob from global DB
+        var composerDataRaw = await CursorStateReader.GetComposerDataAsync(paths.GlobalStateDb, composerId, ct);
+
+        CursorComposerData composerData;
+
+        if (composerDataRaw is not null) {
+            using var doc  = JsonDocument.Parse(composerDataRaw);
+            var       root = doc.RootElement;
+
+            var modelConfig = new CursorModelConfig {
+                ModelName      = root.TryGetProperty("modelConfig", out var mc) && mc.TryGetProperty("modelName",      out var mn) ? mn.GetString() : null,
+                SelectedModels = root.TryGetProperty("modelConfig", out var mc2) && mc2.TryGetProperty("selectedModels", out var sm)
+                    ? sm.EnumerateArray().Select(e => e.GetString()!).ToList()
+                    : null
+            };
+
+            var headers = root.TryGetProperty("fullConversationHeadersOnly", out var hdrsEl)
+                ? hdrsEl.EnumerateArray().Select(h => new CursorTurnHeader {
+                    BubbleId = h.GetProperty("bubbleId").GetString()!,
+                    Type     = h.GetProperty("type").GetInt32()
+                }).ToList<CursorTurnHeader>()
+                : new List<CursorTurnHeader>();
+
+            var generatingIds = root.TryGetProperty("generatingBubbleIds", out var gbEl)
+                ? gbEl.EnumerateArray().Select(e => e.GetString()!).ToList()
+                : new List<string>();
+
+            var status = root.TryGetProperty("status", out var stEl) ? stEl.GetString() : null;
+
+            composerData = new CursorComposerData {
+                ModelConfig                 = modelConfig,
+                FullConversationHeadersOnly = headers,
+                GeneratingBubbleIds         = generatingIds,
+                Status                      = status
+            };
+        } else {
+            composerData = new CursorComposerData {
+                ModelConfig                 = new CursorModelConfig { ModelName = null, SelectedModels = null },
+                FullConversationHeadersOnly = [],
+                GeneratingBubbleIds         = [],
+                Status                      = null
+            };
+        }
+
+        // Read bubbles from global DB
+        var rawBubbles = await CursorStateReader.ListBubblesAsync(paths.GlobalStateDb, composerId, ct);
+
+        // Collect content blob keys referenced by edit_file_v2 bubbles
+        var contentBlobKeys = new HashSet<string>(StringComparer.Ordinal);
+        var assembledBubbles = new List<CursorBubble>(rawBubbles.Count);
+
+        foreach (var (_, bubbleJson) in rawBubbles) {
+            var bubble = CursorPayloadAssembler.AssembleBubble(bubbleJson, workspaceFolder);
+            assembledBubbles.Add(bubble);
+
+            // Extract content blob refs from edit_file_v2 result JSON
+            if (bubble.ToolFormerData is { Name: "edit_file_v2", Result: { } resultJson }) {
+                try {
+                    using var doc  = JsonDocument.Parse(resultJson);
+                    var       root = doc.RootElement;
+
+                    if (root.TryGetProperty("beforeContentId", out var bci)) {
+                        var key = bci.GetString();
+
+                        if (!string.IsNullOrEmpty(key)) contentBlobKeys.Add(key);
+                    }
+
+                    if (root.TryGetProperty("afterContentId", out var aci)) {
+                        var key = aci.GetString();
+
+                        if (!string.IsNullOrEmpty(key)) contentBlobKeys.Add(key);
+                    }
+                } catch {
+                    // Best-effort — don't fail the whole composer on a bad result JSON
+                }
+            }
+        }
+
+        // Load content blobs and apply size cap
+        var contentBlobs = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var key in contentBlobKeys) {
+            var blob = await CursorStateReader.GetContentBlobAsync(paths.GlobalStateDb, key, ct);
+
+            if (blob is null) continue;
+
+            var (k, v) = CursorPayloadAssembler.MaybeTruncateBlob(key, blob);
+            contentBlobs[k] = v;
+        }
+
+        // Read header again (it was already verified to exist by caller)
+        var header = await CursorStateReader.GetComposerHeaderAsync(paths.GlobalStateDb, composerId, ct);
+
+        var cursorHeader = new CursorHeader {
+            Name              = header!.Name,
+            UnifiedMode       = header.UnifiedMode,
+            CreatedAtMs       = header.CreatedAtMs,
+            LastUpdatedAtMs   = header.LastUpdatedAtMs,
+            TrackedGitRepos   = null,  // not in the raw header; server may enrich
+            TotalLinesAdded   = 0,
+            TotalLinesRemoved = 0,
+            FilesChangedCount = 0,
+            Subtitle          = null
+        };
+
+        return new CursorImportPayload {
+            Vendor              = "cursor",
+            ComposerId          = composerId,
+            SchemaSourceVersion = new CursorSchemaVersion { ComposerData = 1, Bubble = 1 },
+            Header              = cursorHeader,
+            ComposerData        = composerData,
+            Bubbles             = assembledBubbles,
+            ContentBlobs        = contentBlobs
+        };
+    }
+
+    /// <summary>
+    /// Walks <see cref="CursorPaths.WorkspaceStorageDir"/>, reads each subdir's
+    /// <c>workspace.json</c> for a <c>folder</c> URI, and yields
+    /// <c>(folderPath, wsDbPath)</c> tuples.
+    /// </summary>
+    internal static IEnumerable<(string FolderPath, string WsDbPath)> ResolveWorkspaces(
+        CursorPaths paths,
+        string?     selectedWorkspace,
+        bool        all
+    ) {
+        if (!Directory.Exists(paths.WorkspaceStorageDir)) yield break;
+
+        var cwd = Environment.CurrentDirectory;
+
+        foreach (var subdir in Directory.EnumerateDirectories(paths.WorkspaceStorageDir)) {
+            var wsJsonPath = Path.Combine(subdir, "workspace.json");
+
+            string? folderPath = null;
+
+            if (File.Exists(wsJsonPath)) {
+                try {
+                    var json = File.ReadAllText(wsJsonPath);
+
+                    using var doc = JsonDocument.Parse(json);
+
+                    if (doc.RootElement.TryGetProperty("folder", out var folderEl)) {
+                        var uri = folderEl.GetString();
+
+                        if (uri is not null) {
+                            // Strip file:// prefix and URI-decode
+                            folderPath = StripFileUri(uri);
+                        }
+                    }
+                } catch {
+                    // If we can't read workspace.json, skip this directory
+                    continue;
+                }
+            }
+
+            if (folderPath is null) continue;
+
+            var wsDbPath = Path.Combine(subdir, "state.vscdb");
+
+            if (all) {
+                yield return (folderPath, wsDbPath);
+
+                continue;
+            }
+
+            var target = selectedWorkspace ?? cwd;
+            var normalizedTarget = NormalizePath(target);
+            var normalizedFolder = NormalizePath(folderPath);
+
+            if (string.Equals(normalizedTarget, normalizedFolder, StringComparison.OrdinalIgnoreCase)) {
+                yield return (folderPath, wsDbPath);
+            }
+        }
+    }
+
+    static string StripFileUri(string uri) {
+        if (uri.StartsWith("file://", StringComparison.OrdinalIgnoreCase)) {
+            // file:///path → /path  or  file://host/path (rare)
+            var path = uri.Substring("file://".Length);
+
+            // On Windows the URI is file:///C:/... → strip leading /
+            // On Unix the URI is file:///home/... → strip two leading slashes leaving /
+            if (path.StartsWith('/') && path.Length > 2 && path[2] == ':') {
+                path = path.TrimStart('/'); // Windows: /C:/foo → C:/foo
+            }
+
+            return Uri.UnescapeDataString(path);
+        }
+
+        return uri;
+    }
+
+    static string NormalizePath(string path) =>
+        Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+    static string? GetArg(string[] args, string flag) {
+        var idx = Array.IndexOf(args, flag);
+
+        return idx >= 0 && idx + 1 < args.Length ? args[idx + 1] : null;
+    }
+}

--- a/src/Kapacitor.Cli/Commands/CursorCommand.cs
+++ b/src/Kapacitor.Cli/Commands/CursorCommand.cs
@@ -12,8 +12,9 @@ static class CursorCommand {
     public static async Task<int> RunAsync(
         string[]      args,
         string        baseUrl,
-        CursorPaths?  pathsOverride = null,
-        CancellationToken ct        = default
+        CursorPaths?  pathsOverride        = null,
+        int           payloadHardCapBytes   = CursorPayloadAssembler.PayloadHardCapBytes,
+        CancellationToken ct               = default
     ) {
         if (args.Length < 1 || args[0] != "import") {
             var help = EmbeddedResources.TryLoad("help-cursor.txt");
@@ -138,8 +139,9 @@ static class CursorCommand {
                 // Serialize and size-check
                 var payloadJson = JsonSerializer.Serialize(payload, CursorJsonContext.Default.CursorImportPayload);
 
-                if (Encoding.UTF8.GetByteCount(payloadJson) > CursorPayloadAssembler.PayloadHardCapBytes) {
-                    Console.Error.WriteLine($"[cursor] Payload for {composerId} exceeds 10 MB hard cap — skipping. Reduce session size or contact support.");
+                if (Encoding.UTF8.GetByteCount(payloadJson) > payloadHardCapBytes) {
+                    Console.Error.WriteLine($"[cursor] Payload for {composerId} exceeds {payloadHardCapBytes / 1024 / 1024} MB hard cap — skipping. Reduce session size or contact support.");
+                    failed++;
 
                     continue;
                 }

--- a/src/Kapacitor.Cli/Program.cs
+++ b/src/Kapacitor.Cli/Program.cs
@@ -543,11 +543,8 @@ switch (command) {
     }
     case "codex-hook":
         return await CodexHookCommand.Handle(baseUrl!, Console.In);
-    case "cursor": {
-        var tokens = await Kapacitor.Cli.Core.Auth.TokenStore.LoadAsync();
-        var token  = tokens?.AccessToken ?? "";
-        return await CursorCommand.RunAsync(args[1..], baseUrl!, token);
-    }
+    case "cursor":
+        return await CursorCommand.RunAsync(args[1..], baseUrl!);
 }
 
 if (!hookCommands.Contains(command)) {

--- a/src/Kapacitor.Cli/Program.cs
+++ b/src/Kapacitor.Cli/Program.cs
@@ -543,6 +543,11 @@ switch (command) {
     }
     case "codex-hook":
         return await CodexHookCommand.Handle(baseUrl!, Console.In);
+    case "cursor": {
+        var tokens = await Kapacitor.Cli.Core.Auth.TokenStore.LoadAsync();
+        var token  = tokens?.AccessToken ?? "";
+        return await CursorCommand.RunAsync(args[1..], baseUrl!, token);
+    }
 }
 
 if (!hookCommands.Contains(command)) {

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorCommandTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorCommandTests.cs
@@ -1,0 +1,151 @@
+using Kapacitor.Cli.Commands;
+using Kapacitor.Cli.Core.Cursor;
+using Microsoft.Data.Sqlite;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Kapacitor.Cli.Tests.Unit.Cursor;
+
+public class CursorCommandTests {
+    [Test]
+    public async Task Import_posts_payload_when_watermark_absent() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().UsingGet().WithPath("/api/cursor/comp-A/watermark"))
+              .RespondWith(Response.Create().WithStatusCode(404));
+        server.Given(Request.Create().UsingPost().WithPath("/hooks/cursor-import"))
+              .RespondWith(Response.Create().WithStatusCode(202).WithBody("{}"));
+
+        var (workspace, paths) = CursorCommandTestFixtures.WorkspaceWithOneComposer("comp-A");
+
+        var rc = await CursorCommand.RunAsync(
+            args: ["import", "--workspace", workspace],
+            baseUrl: server.Url!,
+            token: "fake",
+            pathsOverride: paths
+        );
+
+        await Assert.That(rc).IsEqualTo(0);
+        var posts = server.FindLogEntries(Request.Create().UsingPost().WithPath("/hooks/cursor-import"));
+        await Assert.That(posts.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Import_skips_when_watermark_current() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().UsingGet().WithPath("/api/cursor/comp-A/watermark"))
+              .RespondWith(Response.Create()
+                  .WithStatusCode(200)
+                  .WithBody("""{"last_bubble_id":"b1","last_updated_at_ms":9999999999999}"""));
+        server.Given(Request.Create().UsingPost().WithPath("/hooks/cursor-import"))
+              .RespondWith(Response.Create().WithStatusCode(202).WithBody("{}"));
+
+        var (workspace, paths) = CursorCommandTestFixtures.WorkspaceWithOneComposer("comp-A");
+
+        var rc = await CursorCommand.RunAsync(
+            args: ["import", "--workspace", workspace],
+            baseUrl: server.Url!,
+            token: "fake",
+            pathsOverride: paths
+        );
+
+        await Assert.That(rc).IsEqualTo(0);
+        var posts = server.FindLogEntries(Request.Create().UsingPost().WithPath("/hooks/cursor-import"));
+        await Assert.That(posts.Count).IsEqualTo(0);
+    }
+}
+
+static class CursorCommandTestFixtures {
+    /// <summary>
+    /// Creates a temporary directory containing:
+    /// <list type="bullet">
+    ///   <item>A workspace storage subdir with <c>workspace.json</c> (folder=file://&lt;tempDir&gt;)
+    ///         and a <c>state.vscdb</c> with <c>composer.composerData</c> referencing the composer.</item>
+    ///   <item>A global <c>state.vscdb</c> with the composer header (unifiedMode=agent) and
+    ///         a minimal <c>composerData:&lt;id&gt;</c> blob so <c>BuildPayload</c> can read it.</item>
+    /// </list>
+    /// Returns <c>(workspaceFolder, CursorPaths)</c> pointing to the temp tree.
+    /// The <c>CursorPaths.WorkspaceStorageDir</c> is set to the fixture's workspace storage dir so
+    /// <see cref="CursorCommand.ResolveWorkspaces"/> finds the fixture workspace.
+    /// </summary>
+    public static (string WorkspaceFolder, CursorPaths Paths) WorkspaceWithOneComposer(string composerId) {
+        var root = Path.Combine(Path.GetTempPath(), $"cursor-fixture-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+
+        // ── global storage ──────────────────────────────────────────────────
+        var globalDir = Path.Combine(root, "globalStorage");
+        Directory.CreateDirectory(globalDir);
+        var globalDb = Path.Combine(globalDir, "state.vscdb");
+        CreateDb(globalDb, conn => {
+            Exec(conn, "CREATE TABLE ItemTable    (key TEXT PRIMARY KEY, value TEXT);");
+            Exec(conn, "CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT);");
+
+            // Composer header — unifiedMode = "agent", lastUpdatedAt = 1
+            var headersJson = $$"""
+                {"allComposers":[
+                  {"composerId":"{{composerId}}","unifiedMode":"agent","name":"Test Session",
+                   "createdAt":1,"lastUpdatedAt":1}
+                ]}
+                """;
+            ExecParam(conn, "INSERT INTO ItemTable VALUES ('composer.composerHeaders', @v)", headersJson);
+
+            // Minimal composerData blob
+            var dataJson = $$"""
+                {"modelConfig":{"modelName":"claude-4"},"fullConversationHeadersOnly":[],
+                 "generatingBubbleIds":[],"status":"idle"}
+                """;
+            ExecParam(conn, "INSERT INTO cursorDiskKV VALUES (@k, @v)",
+                key: $"composerData:{composerId}", value: dataJson);
+        });
+
+        // ── workspace storage ────────────────────────────────────────────────
+        var wsStorageDir = Path.Combine(root, "workspaceStorage");
+        var wsSubdir     = Path.Combine(wsStorageDir, "ws-fixture");
+        Directory.CreateDirectory(wsSubdir);
+
+        // The workspace folder is just the temp root itself
+        var workspaceFolder = root;
+        var folderUri       = $"file://{workspaceFolder}";
+        File.WriteAllText(Path.Combine(wsSubdir, "workspace.json"),
+            $$"""{"folder":"{{folderUri}}"}""");
+
+        var wsDb = Path.Combine(wsSubdir, "state.vscdb");
+        CreateDb(wsDb, conn => {
+            Exec(conn, "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT);");
+            ExecParam(conn, "INSERT INTO ItemTable VALUES ('composer.composerData', @v)",
+                value: $$"""{"selectedComposerId":"{{composerId}}","selectedComposerIds":["{{composerId}}"]}""");
+        });
+
+        // Build paths pointing at our fixture tree
+        var paths = new CursorPaths(
+            UserDir:             root,
+            WorkspaceStorageDir: wsStorageDir,
+            GlobalStateDb:       globalDb
+        );
+
+        return (workspaceFolder, paths);
+    }
+
+    static void CreateDb(string path, Action<SqliteConnection> seed) {
+        using var conn = new SqliteConnection($"Data Source={path}");
+        conn.Open();
+        seed(conn);
+    }
+
+    static void Exec(SqliteConnection conn, string sql) {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
+    static void ExecParam(SqliteConnection conn, string sql, string value, string? key = null) {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        if (key is not null) cmd.Parameters.AddWithValue("@k", key);
+        cmd.Parameters.AddWithValue("@v", value);
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorCommandTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorCommandTests.cs
@@ -24,7 +24,6 @@ public class CursorCommandTests {
         var rc = await CursorCommand.RunAsync(
             args: ["import", "--workspace", workspace],
             baseUrl: server.Url!,
-            token: "fake",
             pathsOverride: paths
         );
 
@@ -48,13 +47,53 @@ public class CursorCommandTests {
         var rc = await CursorCommand.RunAsync(
             args: ["import", "--workspace", workspace],
             baseUrl: server.Url!,
-            token: "fake",
             pathsOverride: paths
         );
 
         await Assert.That(rc).IsEqualTo(0);
         var posts = server.FindLogEntries(Request.Create().UsingPost().WithPath("/hooks/cursor-import"));
         await Assert.That(posts.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Import_skips_composer_with_generating_bubbles_in_flight() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().UsingGet().WithPath("/api/cursor/comp-A/watermark"))
+              .RespondWith(Response.Create().WithStatusCode(404));
+        server.Given(Request.Create().UsingPost().WithPath("/hooks/cursor-import"))
+              .RespondWith(Response.Create().WithStatusCode(202).WithBody("{}"));
+
+        var (workspace, paths) = CursorCommandTestFixtures.WorkspaceWithOneComposer("comp-A",
+            generatingBubbleIds: ["b1"]);
+
+        var rc = await CursorCommand.RunAsync(
+            args: ["import", "--workspace", workspace],
+            baseUrl: server.Url!,
+            pathsOverride: paths
+        );
+
+        await Assert.That(rc).IsEqualTo(0);
+        var posts = server.FindLogEntries(Request.Create().UsingPost().WithPath("/hooks/cursor-import"));
+        await Assert.That(posts.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Import_returns_nonzero_when_post_fails() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().UsingGet().WithPath("/api/cursor/comp-A/watermark"))
+              .RespondWith(Response.Create().WithStatusCode(404));
+        server.Given(Request.Create().UsingPost().WithPath("/hooks/cursor-import"))
+              .RespondWith(Response.Create().WithStatusCode(500));
+
+        var (workspace, paths) = CursorCommandTestFixtures.WorkspaceWithOneComposer("comp-A");
+
+        var rc = await CursorCommand.RunAsync(
+            args: ["import", "--workspace", workspace],
+            baseUrl: server.Url!,
+            pathsOverride: paths
+        );
+
+        await Assert.That(rc).IsEqualTo(1);
     }
 }
 
@@ -71,7 +110,10 @@ static class CursorCommandTestFixtures {
     /// The <c>CursorPaths.WorkspaceStorageDir</c> is set to the fixture's workspace storage dir so
     /// <see cref="CursorCommand.ResolveWorkspaces"/> finds the fixture workspace.
     /// </summary>
-    public static (string WorkspaceFolder, CursorPaths Paths) WorkspaceWithOneComposer(string composerId) {
+    public static (string WorkspaceFolder, CursorPaths Paths) WorkspaceWithOneComposer(
+        string    composerId,
+        string[]? generatingBubbleIds = null
+    ) {
         var root = Path.Combine(Path.GetTempPath(), $"cursor-fixture-{Guid.NewGuid():N}");
         Directory.CreateDirectory(root);
 
@@ -92,10 +134,12 @@ static class CursorCommandTestFixtures {
                 """;
             ExecParam(conn, "INSERT INTO ItemTable VALUES ('composer.composerHeaders', @v)", headersJson);
 
-            // Minimal composerData blob
+            // Minimal composerData blob — include any in-flight generating bubble IDs
+            var ids      = generatingBubbleIds ?? [];
+            var idsJson  = "[" + string.Join(",", ids.Select(id => $"\"{id}\"")) + "]";
             var dataJson = $$"""
                 {"modelConfig":{"modelName":"claude-4"},"fullConversationHeadersOnly":[],
-                 "generatingBubbleIds":[],"status":"idle"}
+                 "generatingBubbleIds":{{idsJson}},"status":"idle"}
                 """;
             ExecParam(conn, "INSERT INTO cursorDiskKV VALUES (@k, @v)",
                 key: $"composerData:{composerId}", value: dataJson);

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorCommandTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Kapacitor.Cli.Commands;
 using Kapacitor.Cli.Core.Cursor;
 using Microsoft.Data.Sqlite;
@@ -75,6 +76,37 @@ public class CursorCommandTests {
         await Assert.That(rc).IsEqualTo(0);
         var posts = server.FindLogEntries(Request.Create().UsingPost().WithPath("/hooks/cursor-import"));
         await Assert.That(posts.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Import_orders_bubbles_by_fullConversationHeadersOnly() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().UsingGet().WithPath("/api/cursor/comp-B/watermark"))
+              .RespondWith(Response.Create().WithStatusCode(404));
+        server.Given(Request.Create().UsingPost().WithPath("/hooks/cursor-import"))
+              .RespondWith(Response.Create().WithStatusCode(202).WithBody("{}"));
+
+        var (workspace, paths) = CursorCommandTestFixtures.WorkspaceWithBubblesInShuffledOrder("comp-B");
+
+        var rc = await CursorCommand.RunAsync(
+            args: ["import", "--workspace", workspace],
+            baseUrl: server.Url!,
+            pathsOverride: paths
+        );
+
+        await Assert.That(rc).IsEqualTo(0);
+        var posts = server.FindLogEntries(Request.Create().UsingPost().WithPath("/hooks/cursor-import"));
+        await Assert.That(posts.Count).IsEqualTo(1);
+
+        // Deserialise the posted body and verify bubble order matches fullConversationHeadersOnly
+        var body = posts[0].RequestMessage.Body!;
+        using var doc = JsonDocument.Parse(body);
+        var bubbles = doc.RootElement.GetProperty("bubbles").EnumerateArray().ToList();
+        await Assert.That(bubbles.Count).IsEqualTo(3);
+        // Expected order: A, B, C  (as declared in fullConversationHeadersOnly)
+        await Assert.That(bubbles[0].GetProperty("bubbleId").GetString()).IsEqualTo("comp-B:bub-A");
+        await Assert.That(bubbles[1].GetProperty("bubbleId").GetString()).IsEqualTo("comp-B:bub-B");
+        await Assert.That(bubbles[2].GetProperty("bubbleId").GetString()).IsEqualTo("comp-B:bub-C");
     }
 
     [Test]
@@ -170,6 +202,85 @@ static class CursorCommandTestFixtures {
             GlobalStateDb:       globalDb
         );
 
+        return (workspaceFolder, paths);
+    }
+
+    /// <summary>
+    /// Creates a fixture with three user bubbles (A, B, C) stored in SQLite in shuffled
+    /// order (B, C, A) but declared in conversation order (A, B, C) via
+    /// <c>fullConversationHeadersOnly</c>. Used to verify bubble-ordering fix.
+    /// </summary>
+    public static (string WorkspaceFolder, CursorPaths Paths) WorkspaceWithBubblesInShuffledOrder(
+        string composerId
+    ) {
+        var root = Path.Combine(Path.GetTempPath(), $"cursor-fixture-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+
+        var globalDir = Path.Combine(root, "globalStorage");
+        Directory.CreateDirectory(globalDir);
+        var globalDb = Path.Combine(globalDir, "state.vscdb");
+        CreateDb(globalDb, conn => {
+            Exec(conn, "CREATE TABLE ItemTable    (key TEXT PRIMARY KEY, value TEXT);");
+            Exec(conn, "CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT);");
+
+            var headersJson = $$"""
+                {"allComposers":[
+                  {"composerId":"{{composerId}}","unifiedMode":"agent","name":"Ordered Test",
+                   "createdAt":1,"lastUpdatedAt":1}
+                ]}
+                """;
+            ExecParam(conn, "INSERT INTO ItemTable VALUES ('composer.composerHeaders', @v)", headersJson);
+
+            // fullConversationHeadersOnly lists A, B, C
+            // SQLite storage order (insert order) is B, C, A — purposely shuffled
+            var bubIdA = $"{composerId}:bub-A";
+            var bubIdB = $"{composerId}:bub-B";
+            var bubIdC = $"{composerId}:bub-C";
+
+            var dataJson = $$"""
+                {
+                  "modelConfig":{"modelName":"claude-4"},
+                  "fullConversationHeadersOnly":[
+                    {"bubbleId":"{{bubIdA}}","type":1},
+                    {"bubbleId":"{{bubIdB}}","type":1},
+                    {"bubbleId":"{{bubIdC}}","type":1}
+                  ],
+                  "generatingBubbleIds":[],
+                  "status":"completed"
+                }
+                """;
+            ExecParam(conn, "INSERT INTO cursorDiskKV VALUES (@k, @v)",
+                key: $"composerData:{composerId}", value: dataJson);
+
+            // Insert bubbles in shuffled order: B, C, A
+            foreach (var (bid, text) in new[] { (bubIdB, "msg B"), (bubIdC, "msg C"), (bubIdA, "msg A") }) {
+                var bJson = $$"""{"bubbleId":"{{bid}}","type":1,"createdAt":"2024-01-01T00:00:00Z","text":"{{text}}"}""";
+                ExecParam(conn, "INSERT INTO cursorDiskKV VALUES (@k, @v)",
+                    key: $"bubbleId:{composerId}:{bid}", value: bJson);
+            }
+        });
+
+        var wsStorageDir = Path.Combine(root, "workspaceStorage");
+        var wsSubdir     = Path.Combine(wsStorageDir, "ws-fixture");
+        Directory.CreateDirectory(wsSubdir);
+
+        var workspaceFolder = root;
+        var folderUri       = $"file://{workspaceFolder}";
+        File.WriteAllText(Path.Combine(wsSubdir, "workspace.json"),
+            $$"""{"folder":"{{folderUri}}"}""");
+
+        var wsDb = Path.Combine(wsSubdir, "state.vscdb");
+        CreateDb(wsDb, conn => {
+            Exec(conn, "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT);");
+            ExecParam(conn, "INSERT INTO ItemTable VALUES ('composer.composerData', @v)",
+                value: $$"""{"selectedComposerId":"{{composerId}}","selectedComposerIds":["{{composerId}}"]}""");
+        });
+
+        var paths = new CursorPaths(
+            UserDir:             root,
+            WorkspaceStorageDir: wsStorageDir,
+            GlobalStateDb:       globalDb
+        );
         return (workspaceFolder, paths);
     }
 

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorCommandTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorCommandTests.cs
@@ -110,6 +110,39 @@ public class CursorCommandTests {
     }
 
     [Test]
+    public async Task Import_content_blobs_excludes_orphan_bubble_blobs() {
+        // Fixture: one bubble in fullConversationHeadersOnly (references blob-in),
+        // one orphan bubble not in headers (references blob-orphan).
+        // After the fix, only blob-in must appear in the posted contentBlobs dict.
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().UsingGet().WithPath("/api/cursor/comp-C/watermark"))
+              .RespondWith(Response.Create().WithStatusCode(404));
+        server.Given(Request.Create().UsingPost().WithPath("/hooks/cursor-import"))
+              .RespondWith(Response.Create().WithStatusCode(202).WithBody("{}"));
+
+        var (workspace, paths) = CursorCommandTestFixtures.WorkspaceWithOrphanBubbleBlobs("comp-C");
+
+        var rc = await CursorCommand.RunAsync(
+            args: ["import", "--workspace", workspace],
+            baseUrl: server.Url!,
+            pathsOverride: paths
+        );
+
+        await Assert.That(rc).IsEqualTo(0);
+        var posts = server.FindLogEntries(Request.Create().UsingPost().WithPath("/hooks/cursor-import"));
+        await Assert.That(posts.Count).IsEqualTo(1);
+
+        var body = posts[0].RequestMessage.Body!;
+        using var doc = JsonDocument.Parse(body);
+        var blobs = doc.RootElement.GetProperty("contentBlobs");
+
+        // In-headers bubble's blob must be present
+        await Assert.That(blobs.TryGetProperty("composer.content.blob-in", out _)).IsTrue();
+        // Orphan bubble's blob must NOT be present
+        await Assert.That(blobs.TryGetProperty("composer.content.blob-orphan", out _)).IsFalse();
+    }
+
+    [Test]
     public async Task Import_returns_nonzero_when_post_fails() {
         using var server = WireMockServer.Start();
         server.Given(Request.Create().UsingGet().WithPath("/api/cursor/comp-A/watermark"))
@@ -283,6 +316,95 @@ static class CursorCommandTestFixtures {
                 ExecParam(conn, "INSERT INTO cursorDiskKV VALUES (@k, @v)",
                     key: $"bubbleId:{composerId}:{bid}", value: bJson);
             }
+        });
+
+        var wsStorageDir = Path.Combine(root, "workspaceStorage");
+        var wsSubdir     = Path.Combine(wsStorageDir, "ws-fixture");
+        Directory.CreateDirectory(wsSubdir);
+
+        var workspaceFolder = root;
+        var folderUri       = $"file://{workspaceFolder}";
+        File.WriteAllText(Path.Combine(wsSubdir, "workspace.json"),
+            $$"""{"folder":"{{folderUri}}"}""");
+
+        var wsDb = Path.Combine(wsSubdir, "state.vscdb");
+        CreateDb(wsDb, conn => {
+            Exec(conn, "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT);");
+            ExecParam(conn, "INSERT INTO ItemTable VALUES ('composer.composerData', @v)",
+                value: $$"""{"selectedComposerId":"{{composerId}}","selectedComposerIds":["{{composerId}}"]}""");
+        });
+
+        var paths = new CursorPaths(
+            UserDir:             root,
+            WorkspaceStorageDir: wsStorageDir,
+            GlobalStateDb:       globalDb
+        );
+        return (workspaceFolder, paths);
+    }
+
+    /// <summary>
+    /// Creates a fixture with two edit_file_v2 bubbles:
+    /// <list type="bullet">
+    ///   <item><c>bub-in</c> — listed in <c>fullConversationHeadersOnly</c>; references <c>composer.content.blob-in</c>.</item>
+    ///   <item><c>bub-orphan</c> — NOT listed in headers (orphan); references <c>composer.content.blob-orphan</c>.</item>
+    /// </list>
+    /// After the orphan-blob fix, only <c>blob-in</c> must appear in the posted <c>contentBlobs</c>.
+    /// </summary>
+    public static (string WorkspaceFolder, CursorPaths Paths) WorkspaceWithOrphanBubbleBlobs(string composerId) {
+        var root = Path.Combine(Path.GetTempPath(), $"cursor-fixture-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+
+        var globalDir = Path.Combine(root, "globalStorage");
+        Directory.CreateDirectory(globalDir);
+        var globalDb = Path.Combine(globalDir, "state.vscdb");
+
+        var bubIdIn     = $"{composerId}:bub-in";
+        var bubIdOrphan = $"{composerId}:bub-orphan";
+
+        CreateDb(globalDb, conn => {
+            Exec(conn, "CREATE TABLE ItemTable    (key TEXT PRIMARY KEY, value TEXT);");
+            Exec(conn, "CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT);");
+
+            // Composer header
+            var headersJson = $$"""
+                {"allComposers":[
+                  {"composerId":"{{composerId}}","unifiedMode":"agent","name":"Blob Test",
+                   "createdAt":1,"lastUpdatedAt":1}
+                ]}
+                """;
+            ExecParam(conn, "INSERT INTO ItemTable VALUES ('composer.composerHeaders', @v)", headersJson);
+
+            // fullConversationHeadersOnly: only bub-in is listed; bub-orphan is NOT listed
+            var dataJson = $$"""
+                {
+                  "modelConfig":{"modelName":"claude-4"},
+                  "fullConversationHeadersOnly":[
+                    {"bubbleId":"{{bubIdIn}}","type":2}
+                  ],
+                  "generatingBubbleIds":[],
+                  "status":"completed"
+                }
+                """;
+            ExecParam(conn, "INSERT INTO cursorDiskKV VALUES (@k, @v)",
+                key: $"composerData:{composerId}", value: dataJson);
+
+            // bub-in: edit_file_v2 referencing blob-in
+            var resultIn  = @"{""beforeContentId"":""composer.content.blob-in"",""afterContentId"":null}";
+            var bubInJson = $@"{{""bubbleId"":""{bubIdIn}"",""type"":2,""createdAt"":""2024-01-01T00:00:00Z"",""toolFormerData"":{{""toolCallId"":""t1"",""name"":""edit_file_v2"",""result"":{resultIn}}}}}";
+            ExecParam(conn, "INSERT INTO cursorDiskKV VALUES (@k, @v)",
+                key: $"bubbleId:{composerId}:{bubIdIn}", value: bubInJson);
+
+            // bub-orphan: edit_file_v2 referencing blob-orphan (NOT in headers)
+            var resultOrphan  = @"{""beforeContentId"":""composer.content.blob-orphan"",""afterContentId"":null}";
+            var bubOrphanJson = $@"{{""bubbleId"":""{bubIdOrphan}"",""type"":2,""createdAt"":""2024-01-01T00:00:00Z"",""toolFormerData"":{{""toolCallId"":""t2"",""name"":""edit_file_v2"",""result"":{resultOrphan}}}}}";
+            ExecParam(conn, "INSERT INTO cursorDiskKV VALUES (@k, @v)",
+                key: $"bubbleId:{composerId}:{bubIdOrphan}", value: bubOrphanJson);
+
+            // Content blobs referenced by both bubbles
+            ExecParam(conn, "INSERT INTO cursorDiskKV VALUES (@k, @v)",
+                key: "composer.content.blob-in",     value: "// content for in-headers bubble");
+            ExecParam(conn, "INSERT INTO cursorDiskKV VALUES (@k, @v)",
+                key: "composer.content.blob-orphan", value: "// content for orphan bubble");
         });
 
         var wsStorageDir = Path.Combine(root, "workspaceStorage");

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorCommandTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorCommandTests.cs
@@ -127,6 +127,31 @@ public class CursorCommandTests {
 
         await Assert.That(rc).IsEqualTo(1);
     }
+
+    [Test]
+    public async Task Import_returns_nonzero_when_payload_exceeds_hard_cap() {
+        // Use a 1-byte hard cap so the standard minimal payload always exceeds it,
+        // avoiding the need to synthesise a real 10 MB fixture.
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().UsingGet().WithPath("/api/cursor/comp-A/watermark"))
+              .RespondWith(Response.Create().WithStatusCode(404));
+        // POST should never be reached — the cap check comes first.
+        server.Given(Request.Create().UsingPost().WithPath("/hooks/cursor-import"))
+              .RespondWith(Response.Create().WithStatusCode(202).WithBody("{}"));
+
+        var (workspace, paths) = CursorCommandTestFixtures.WorkspaceWithOneComposer("comp-A");
+
+        var rc = await CursorCommand.RunAsync(
+            args: ["import", "--workspace", workspace],
+            baseUrl: server.Url!,
+            pathsOverride: paths,
+            payloadHardCapBytes: 1   // force every payload to exceed the cap
+        );
+
+        await Assert.That(rc).IsEqualTo(1);
+        var posts = server.FindLogEntries(Request.Create().UsingPost().WithPath("/hooks/cursor-import"));
+        await Assert.That(posts.Count).IsEqualTo(0);
+    }
 }
 
 static class CursorCommandTestFixtures {

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorPathsTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorPathsTests.cs
@@ -1,0 +1,28 @@
+using Kapacitor.Cli.Core.Cursor;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+namespace Kapacitor.Cli.Tests.Unit.Cursor;
+
+public class CursorPathsTests {
+    [Test]
+    public async Task Mac_default_dir_under_application_support() {
+        var p = CursorPaths.Resolve(home: "/Users/me", platform: OsPlatform.MacOs);
+        await Assert.That(p.UserDir).IsEqualTo("/Users/me/Library/Application Support/Cursor/User");
+        await Assert.That(p.WorkspaceStorageDir).IsEqualTo("/Users/me/Library/Application Support/Cursor/User/workspaceStorage");
+        await Assert.That(p.GlobalStateDb).IsEqualTo("/Users/me/Library/Application Support/Cursor/User/globalStorage/state.vscdb");
+    }
+
+    [Test]
+    public async Task Linux_default_dir_under_config() {
+        var p = CursorPaths.Resolve(home: "/home/me", platform: OsPlatform.Linux);
+        await Assert.That(p.UserDir).IsEqualTo("/home/me/.config/Cursor/User");
+    }
+
+    [Test]
+    public async Task Windows_default_dir_under_appdata() {
+        var p = CursorPaths.Resolve(home: @"C:\Users\me", platform: OsPlatform.Windows, appData: @"C:\Users\me\AppData\Roaming");
+        await Assert.That(p.UserDir).IsEqualTo(@"C:\Users\me\AppData\Roaming\Cursor\User");
+    }
+}

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorPayloadAssemblerTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorPayloadAssemblerTests.cs
@@ -24,6 +24,17 @@ public class CursorPayloadAssemblerTests {
     }
 
     [Test]
+    public async Task Handles_object_typed_params_and_result() {
+        // Real Cursor data can have params/result as JSON objects (not JSON-encoded strings)
+        var raw = """{"bubbleId":"b2","type":2,"capabilityType":15,"createdAt":"2026-05-21T00:00:00Z","toolFormerData":{"toolCallId":"tc2","name":"edit_file_v2","params":{"relativeWorkspacePath":"src/foo.cs"},"result":{"success":true}}}""";
+        var bubble = CursorPayloadAssembler.AssembleBubble(raw, repoPath: "/repo/foo");
+        await Assert.That(bubble.ToolFormerData).IsNotNull();
+        // Params/result should be serialized back to JSON text, not throw
+        await Assert.That(bubble.ToolFormerData!.Params).Contains("relativeWorkspacePath");
+        await Assert.That(bubble.ToolFormerData!.Result).Contains("success");
+    }
+
+    [Test]
     public async Task Truncates_oversize_content_blob() {
         var big = new string('x', 300_000);
         var (key, value) = CursorPayloadAssembler.MaybeTruncateBlob("composer.content.aaa", big);

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorPayloadAssemblerTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorPayloadAssemblerTests.cs
@@ -1,0 +1,33 @@
+using Kapacitor.Cli.Core.Cursor;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+namespace Kapacitor.Cli.Tests.Unit.Cursor;
+
+public class CursorPayloadAssemblerTests {
+    [Test]
+    public async Task Drops_disallowed_bubble_fields() {
+        var raw = """{"bubbleId":"b1","type":1,"createdAt":"2026-05-21T00:00:00Z","text":"hi","richText":"DROP","images":["DROP"],"attachedCodeChunks":["DROP"]}""";
+        var bubble = CursorPayloadAssembler.AssembleBubble(raw, repoPath: "/repo/foo");
+        await Assert.That(bubble.Text).IsEqualTo("hi");
+        var json = System.Text.Json.JsonSerializer.Serialize(bubble);
+        await Assert.That(json).DoesNotContain("DROP");
+    }
+
+    [Test]
+    public async Task Redacts_absolute_paths_to_relative() {
+        var raw = """{"bubbleId":"e1","type":2,"capabilityType":15,"createdAt":"2026-05-21T00:00:00Z","toolFormerData":{"toolCallId":"tc","name":"edit_file_v2","params":"{\"relativeWorkspacePath\":\"/Users/me/code/foo/README.md\"}","result":"{}"}}""";
+        var bubble = CursorPayloadAssembler.AssembleBubble(raw, repoPath: "/Users/me/code/foo");
+        await Assert.That(bubble.ToolFormerData!.Params).Contains("/README.md");
+        await Assert.That(bubble.ToolFormerData!.Params).DoesNotContain("/Users/me");
+    }
+
+    [Test]
+    public async Task Truncates_oversize_content_blob() {
+        var big = new string('x', 300_000);
+        var (key, value) = CursorPayloadAssembler.MaybeTruncateBlob("composer.content.aaa", big);
+        await Assert.That(value).Contains("\"truncated\":true");
+        await Assert.That(value.Length).IsLessThan(1_000);
+    }
+}

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorStateReaderTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorStateReaderTests.cs
@@ -86,4 +86,61 @@ public class CursorStateReaderTests {
         var content = await CursorStateReader.GetContentBlobAsync(path, "composer.content.abc");
         await Assert.That(content).IsEqualTo("# README");
     }
+
+    [Test]
+    public async Task Reads_extended_composer_header_fields() {
+        var path = CreateFixtureDb(conn => {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO ItemTable VALUES ('composer.composerHeaders', @v)";
+            cmd.Parameters.AddWithValue("@v", """
+                {
+                  "allComposers": [{
+                    "composerId": "c1",
+                    "unifiedMode": "agent",
+                    "name": "My Session",
+                    "createdAt": 1000,
+                    "lastUpdatedAt": 2000,
+                    "subtitle": "Fix the bug",
+                    "totalLinesAdded": 42,
+                    "totalLinesRemoved": 7,
+                    "filesChangedCount": 3,
+                    "trackedGitRepos": [
+                      {"repoPath": "/home/user/repo", "branchNames": ["main", "feature/x"]}
+                    ]
+                  }]
+                }
+                """);
+            cmd.ExecuteNonQuery();
+        });
+        var hdr = await CursorStateReader.GetComposerHeaderAsync(path, "c1");
+        await Assert.That(hdr).IsNotNull();
+        await Assert.That(hdr!.Subtitle).IsEqualTo("Fix the bug");
+        await Assert.That(hdr.TotalLinesAdded).IsEqualTo(42);
+        await Assert.That(hdr.TotalLinesRemoved).IsEqualTo(7);
+        await Assert.That(hdr.FilesChangedCount).IsEqualTo(3);
+        await Assert.That(hdr.TrackedGitRepos).IsNotNull();
+        await Assert.That(hdr.TrackedGitRepos!.Count).IsEqualTo(1);
+        await Assert.That(hdr.TrackedGitRepos[0].RepoPath).IsEqualTo("/home/user/repo");
+        await Assert.That(hdr.TrackedGitRepos[0].BranchNames).IsNotNull();
+        await Assert.That(hdr.TrackedGitRepos[0].BranchNames!.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Reads_composer_header_with_missing_optional_fields() {
+        var path = CreateFixtureDb(conn => {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO ItemTable VALUES ('composer.composerHeaders', @v)";
+            // Minimal header — no subtitle, line counts, or tracked repos
+            cmd.Parameters.AddWithValue("@v",
+                """{"allComposers":[{"composerId":"c1","unifiedMode":"agent","createdAt":1,"lastUpdatedAt":2}]}""");
+            cmd.ExecuteNonQuery();
+        });
+        var hdr = await CursorStateReader.GetComposerHeaderAsync(path, "c1");
+        await Assert.That(hdr).IsNotNull();
+        await Assert.That(hdr!.Subtitle).IsNull();
+        await Assert.That(hdr.TotalLinesAdded).IsEqualTo(0);
+        await Assert.That(hdr.TotalLinesRemoved).IsEqualTo(0);
+        await Assert.That(hdr.FilesChangedCount).IsEqualTo(0);
+        await Assert.That(hdr.TrackedGitRepos).IsNull();
+    }
 }

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorStateReaderTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorStateReaderTests.cs
@@ -89,6 +89,7 @@ public class CursorStateReaderTests {
 
     [Test]
     public async Task Reads_extended_composer_header_fields() {
+        // Uses the real Cursor wire shape: branches is an array of objects with branchName field.
         var path = CreateFixtureDb(conn => {
             using var cmd = conn.CreateCommand();
             cmd.CommandText = "INSERT INTO ItemTable VALUES ('composer.composerHeaders', @v)";
@@ -105,7 +106,10 @@ public class CursorStateReaderTests {
                     "totalLinesRemoved": 7,
                     "filesChangedCount": 3,
                     "trackedGitRepos": [
-                      {"repoPath": "/home/user/repo", "branchNames": ["main", "feature/x"]}
+                      {"repoPath": "/home/user/repo", "branches": [
+                        {"branchName": "main", "lastInteractionAt": 1779302743015},
+                        {"branchName": "feature/x", "lastInteractionAt": 1779302700000}
+                      ]}
                     ]
                   }]
                 }
@@ -123,6 +127,41 @@ public class CursorStateReaderTests {
         await Assert.That(hdr.TrackedGitRepos[0].RepoPath).IsEqualTo("/home/user/repo");
         await Assert.That(hdr.TrackedGitRepos[0].BranchNames).IsNotNull();
         await Assert.That(hdr.TrackedGitRepos[0].BranchNames!.Count).IsEqualTo(2);
+        await Assert.That(hdr.TrackedGitRepos[0].BranchNames[0]).IsEqualTo("main");
+        await Assert.That(hdr.TrackedGitRepos[0].BranchNames[1]).IsEqualTo("feature/x");
+    }
+
+    [Test]
+    public async Task Reads_branches_from_legacy_string_array_shape() {
+        // Defensive backward compat: older Cursor schemas stored branchNames as a flat
+        // string array ("branchNames": ["main", "feature/x"]) rather than the current
+        // object-array form.  The parser must handle both shapes.
+        var path = CreateFixtureDb(conn => {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO ItemTable VALUES ('composer.composerHeaders', @v)";
+            cmd.Parameters.AddWithValue("@v", """
+                {
+                  "allComposers": [{
+                    "composerId": "c1",
+                    "unifiedMode": "agent",
+                    "createdAt": 1000,
+                    "lastUpdatedAt": 2000,
+                    "trackedGitRepos": [
+                      {"repoPath": "/home/user/repo", "branchNames": ["main", "feature/x"]}
+                    ]
+                  }]
+                }
+                """);
+            cmd.ExecuteNonQuery();
+        });
+        var hdr = await CursorStateReader.GetComposerHeaderAsync(path, "c1");
+        await Assert.That(hdr).IsNotNull();
+        await Assert.That(hdr!.TrackedGitRepos).IsNotNull();
+        await Assert.That(hdr.TrackedGitRepos!.Count).IsEqualTo(1);
+        await Assert.That(hdr.TrackedGitRepos[0].BranchNames).IsNotNull();
+        await Assert.That(hdr.TrackedGitRepos[0].BranchNames!.Count).IsEqualTo(2);
+        await Assert.That(hdr.TrackedGitRepos[0].BranchNames[0]).IsEqualTo("main");
+        await Assert.That(hdr.TrackedGitRepos[0].BranchNames[1]).IsEqualTo("feature/x");
     }
 
     [Test]

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorStateReaderTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorStateReaderTests.cs
@@ -1,0 +1,89 @@
+using Kapacitor.Cli.Core.Cursor;
+using Microsoft.Data.Sqlite;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+namespace Kapacitor.Cli.Tests.Unit.Cursor;
+
+public class CursorStateReaderTests {
+    static string CreateFixtureDb(Action<SqliteConnection> seed) {
+        var path = Path.Combine(Path.GetTempPath(), $"cursor-{Guid.NewGuid():N}.vscdb");
+        using var conn = new SqliteConnection($"Data Source={path}");
+        conn.Open();
+        using (var cmd = conn.CreateCommand()) {
+            cmd.CommandText = """
+                              CREATE TABLE ItemTable     (key TEXT PRIMARY KEY, value TEXT);
+                              CREATE TABLE cursorDiskKV  (key TEXT PRIMARY KEY, value TEXT);
+                              """;
+            cmd.ExecuteNonQuery();
+        }
+        seed(conn);
+        return path;
+    }
+
+    [Test]
+    public async Task Reads_selectedComposerIds_from_workspace_db() {
+        var path = CreateFixtureDb(conn => {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO ItemTable VALUES ('composer.composerData', @v)";
+            cmd.Parameters.AddWithValue("@v", """{"selectedComposerIds":["c1","c2"]}""");
+            cmd.ExecuteNonQuery();
+        });
+        var ids = await CursorStateReader.ListWorkspaceComposerIdsAsync(path);
+        await Assert.That(ids).IsEquivalentTo(new[] { "c1", "c2" });
+    }
+
+    [Test]
+    public async Task Accepts_workspace_db_with_allComposers_populated() {
+        var path = CreateFixtureDb(conn => {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO ItemTable VALUES ('composer.composerData', @v)";
+            cmd.Parameters.AddWithValue("@v",
+                """{"selectedComposerIds":["c1"],"allComposers":[{"composerId":"c1","name":"T"},{"composerId":"c2","name":"U"}]}""");
+            cmd.ExecuteNonQuery();
+        });
+        var ids = await CursorStateReader.ListWorkspaceComposerIdsAsync(path);
+        await Assert.That(ids).IsEquivalentTo(new[] { "c1", "c2" });
+    }
+
+    [Test]
+    public async Task Reads_composer_header_from_global_db() {
+        var path = CreateFixtureDb(conn => {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO ItemTable VALUES ('composer.composerHeaders', @v)";
+            cmd.Parameters.AddWithValue("@v",
+                """{"allComposers":[{"composerId":"c1","unifiedMode":"agent","name":"Test","createdAt":1,"lastUpdatedAt":2}]}""");
+            cmd.ExecuteNonQuery();
+        });
+        var hdr = await CursorStateReader.GetComposerHeaderAsync(path, "c1");
+        await Assert.That(hdr).IsNotNull();
+        await Assert.That(hdr!.UnifiedMode).IsEqualTo("agent");
+    }
+
+    [Test]
+    public async Task Lists_bubbles_for_composer() {
+        var path = CreateFixtureDb(conn => {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = """
+                              INSERT INTO cursorDiskKV VALUES ('bubbleId:c1:b1', 'v1');
+                              INSERT INTO cursorDiskKV VALUES ('bubbleId:c1:b2', 'v2');
+                              INSERT INTO cursorDiskKV VALUES ('bubbleId:c2:other', 'x');
+                              """;
+            cmd.ExecuteNonQuery();
+        });
+        var bubbles = await CursorStateReader.ListBubblesAsync(path, "c1");
+        await Assert.That(bubbles.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Gets_content_blob_by_key() {
+        var path = CreateFixtureDb(conn => {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO cursorDiskKV VALUES ('composer.content.abc', '# README')";
+            cmd.ExecuteNonQuery();
+        });
+        var content = await CursorStateReader.GetContentBlobAsync(path, "composer.content.abc");
+        await Assert.That(content).IsEqualTo("# README");
+    }
+}

--- a/test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj
+++ b/test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj
@@ -11,6 +11,7 @@
         <ProjectReference Include="../../src/Kapacitor.Cli.Daemon/Kapacitor.Cli.Daemon.csproj" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="Microsoft.Data.Sqlite" />
         <PackageReference Include="TUnit" />
         <PackageReference Include="Tomlyn" />
         <PackageReference Include="WireMock.Net" />


### PR DESCRIPTION
## Summary
- New `kapacitor cursor import` CLI command for post-hoc ingestion of Cursor IDE Composer/Agent sessions.
- Reads Cursor's local SQLite state (`Mode=ReadOnly`, journal-mode agnostic), filters to `unifiedMode == "agent"`, and POSTs allowlisted payloads to the server.
- Adds five files: `CursorPaths`, `CursorStateReader`, `CursorPayloadAssembler` + parallel wire DTOs (`CursorPayloadModels.cs`), `CursorCommand` + help text.
- All 793 CLI unit tests pass; AOT publish clean (no IL2026/IL3050).
- Skips bubbles in `composerData.generatingBubbleIds[]` — only finalized content is imported.
- 256 KB per-blob soft cap, 10 MB per-payload hard cap, absolute-path → `/repo/...` redaction on the CLI side.
- Handles object-typed `params`/`result` fields in `toolFormerData` (real Cursor databases use objects, not JSON-encoded strings); includes regression test.

## Companion PR
- Server changes: https://github.com/kurrent-io/kapacitor-server/pull/new/alexeyzimarev/ai-661-cursor-session-ingest-milestone-a-post-hoc-cli-import

## Test plan
- [x] `dotnet run --project test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj` — 793/793 pass
- [x] `dotnet publish src/Kapacitor.Cli/Kapacitor.Cli.csproj -c Release` — no AOT warnings
- [x] Smoke test: payload assembly succeeds against real Cursor workspace (no more "element of type 'Object'" error); POST reaches the server

Spec: kurrent-io/kapacitor-server `docs/superpowers/specs/2026-05-20-cursor-session-ingest-feasibility.md`