### PR TITLE
[AI-666] Reuse SQLite connection for Cursor blob fetches

### DIFF
--- a/src/Kapacitor.Cli.Core/Cursor/CursorStateReader.cs
+++ b/src/Kapacitor.Cli.Core/Cursor/CursorStateReader.cs
@@ -174,7 +174,13 @@ public static class CursorStateReader {
             for (var i = 0; i < batch.Count; i++) cmd.Parameters.AddWithValue("@k" + i, batch[i]);
 
             await using var reader = await cmd.ExecuteReaderAsync(ct);
-            while (await reader.ReadAsync(ct)) result[reader.GetString(0)] = reader.GetString(1);
+            while (await reader.ReadAsync(ct)) {
+                // cursorDiskKV.value is TEXT NULL — skip NULL rows instead of throwing
+                // InvalidCastException from GetString. Matches the singular
+                // GetContentBlobAsync's null-on-NULL contract (callers already filter).
+                if (reader.IsDBNull(1)) continue;
+                result[reader.GetString(0)] = reader.GetString(1);
+            }
         }
 
         return result;

--- a/src/Kapacitor.Cli.Core/Cursor/CursorStateReader.cs
+++ b/src/Kapacitor.Cli.Core/Cursor/CursorStateReader.cs
@@ -141,4 +141,42 @@ public static class CursorStateReader {
         cmd.Parameters.AddWithValue("@k", contentKey);
         return (string?)await cmd.ExecuteScalarAsync(ct);
     }
+
+    /// <summary>
+    /// Fetches multiple <c>composer.content.&lt;sha256&gt;</c> blobs in a single SQLite
+    /// connection and a single query per batch. Missing keys are absent from the
+    /// returned dictionary. Duplicate keys in the input are deduplicated.
+    /// </summary>
+    public static async Task<IReadOnlyDictionary<string, string>> GetContentBlobsAsync(
+        string              globalDbPath,
+        IEnumerable<string> keys,
+        CancellationToken   ct = default
+    ) {
+        var unique = new HashSet<string>(keys, StringComparer.Ordinal);
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (unique.Count == 0) return result;
+
+        await using var conn = new SqliteConnection(ConnString(globalDbPath));
+        await conn.OpenAsync(ct);
+
+        // SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999 (older builds) /
+        // 32766 (newer). 500 is a safe batch size that also keeps the IN clause
+        // small for query-plan purposes.
+        const int batchSize = 500;
+        var pending = unique.ToList();
+
+        for (var offset = 0; offset < pending.Count; offset += batchSize) {
+            var batch = pending.GetRange(offset, Math.Min(batchSize, pending.Count - offset));
+
+            await using var cmd = conn.CreateCommand();
+            var placeholders = string.Join(",", Enumerable.Range(0, batch.Count).Select(i => "@k" + i));
+            cmd.CommandText = $"SELECT key, value FROM cursorDiskKV WHERE key IN ({placeholders})";
+            for (var i = 0; i < batch.Count; i++) cmd.Parameters.AddWithValue("@k" + i, batch[i]);
+
+            await using var reader = await cmd.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct)) result[reader.GetString(0)] = reader.GetString(1);
+        }
+
+        return result;
+    }
 }

--- a/src/Kapacitor.Cli/Commands/CursorCommand.cs
+++ b/src/Kapacitor.Cli/Commands/CursorCommand.cs
@@ -318,14 +318,12 @@ static class CursorCommand {
             }
         }
 
-        // Load content blobs and apply size cap
+        // Load all referenced content blobs in a single connection + single query
+        // (or batched queries when key count is huge), then apply the per-blob size cap.
+        var fetchedBlobs = await CursorStateReader.GetContentBlobsAsync(paths.GlobalStateDb, contentBlobKeys, ct);
         var contentBlobs = new Dictionary<string, string>(StringComparer.Ordinal);
 
-        foreach (var key in contentBlobKeys) {
-            var blob = await CursorStateReader.GetContentBlobAsync(paths.GlobalStateDb, key, ct);
-
-            if (blob is null) continue;
-
+        foreach (var (key, blob) in fetchedBlobs) {
             var (k, v) = CursorPayloadAssembler.MaybeTruncateBlob(key, blob);
             contentBlobs[k] = v;
         }

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorStateReaderTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorStateReaderTests.cs
@@ -88,6 +88,65 @@ public class CursorStateReaderTests {
     }
 
     [Test]
+    public async Task GetContentBlobs_returns_requested_keys_in_one_call() {
+        var path = CreateFixtureDb(conn => {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = """
+                              INSERT INTO cursorDiskKV VALUES ('composer.content.a', 'one');
+                              INSERT INTO cursorDiskKV VALUES ('composer.content.b', 'two');
+                              INSERT INTO cursorDiskKV VALUES ('composer.content.c', 'three');
+                              INSERT INTO cursorDiskKV VALUES ('bubbleId:other',     'noise');
+                              """;
+            cmd.ExecuteNonQuery();
+        });
+        var blobs = await CursorStateReader.GetContentBlobsAsync(path, new[] {
+            "composer.content.a",
+            "composer.content.b",
+            "composer.content.c"
+        });
+        await Assert.That(blobs.Count).IsEqualTo(3);
+        await Assert.That(blobs["composer.content.a"]).IsEqualTo("one");
+        await Assert.That(blobs["composer.content.b"]).IsEqualTo("two");
+        await Assert.That(blobs["composer.content.c"]).IsEqualTo("three");
+    }
+
+    [Test]
+    public async Task GetContentBlobs_omits_missing_keys_and_returns_empty_dict_for_empty_input() {
+        var path = CreateFixtureDb(conn => {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO cursorDiskKV VALUES ('composer.content.a', 'one')";
+            cmd.ExecuteNonQuery();
+        });
+
+        var empty = await CursorStateReader.GetContentBlobsAsync(path, []);
+        await Assert.That(empty.Count).IsEqualTo(0);
+
+        var partial = await CursorStateReader.GetContentBlobsAsync(path, new[] {
+            "composer.content.a",
+            "composer.content.missing"
+        });
+        await Assert.That(partial.Count).IsEqualTo(1);
+        await Assert.That(partial.ContainsKey("composer.content.missing")).IsFalse();
+        await Assert.That(partial["composer.content.a"]).IsEqualTo("one");
+    }
+
+    [Test]
+    public async Task GetContentBlobs_deduplicates_input_keys() {
+        var path = CreateFixtureDb(conn => {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO cursorDiskKV VALUES ('composer.content.a', 'one')";
+            cmd.ExecuteNonQuery();
+        });
+        var blobs = await CursorStateReader.GetContentBlobsAsync(path, new[] {
+            "composer.content.a",
+            "composer.content.a",
+            "composer.content.a"
+        });
+        await Assert.That(blobs.Count).IsEqualTo(1);
+        await Assert.That(blobs["composer.content.a"]).IsEqualTo("one");
+    }
+
+    [Test]
     public async Task Reads_extended_composer_header_fields() {
         // Uses the real Cursor wire shape: branches is an array of objects with branchName field.
         var path = CreateFixtureDb(conn => {

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorStateReaderTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorStateReaderTests.cs
@@ -147,6 +147,28 @@ public class CursorStateReaderTests {
     }
 
     [Test]
+    public async Task GetContentBlobs_skips_rows_with_null_value() {
+        // cursorDiskKV.value is TEXT NULL. The bulk fetcher must not throw
+        // InvalidCastException on NULL — it should silently drop the key, matching
+        // the singular GetContentBlobAsync's null-on-NULL contract.
+        var path = CreateFixtureDb(conn => {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = """
+                              INSERT INTO cursorDiskKV (key, value) VALUES ('composer.content.a', 'one');
+                              INSERT INTO cursorDiskKV (key, value) VALUES ('composer.content.b', NULL);
+                              """;
+            cmd.ExecuteNonQuery();
+        });
+        var blobs = await CursorStateReader.GetContentBlobsAsync(path, new[] {
+            "composer.content.a",
+            "composer.content.b"
+        });
+        await Assert.That(blobs.Count).IsEqualTo(1);
+        await Assert.That(blobs["composer.content.a"]).IsEqualTo("one");
+        await Assert.That(blobs.ContainsKey("composer.content.b")).IsFalse();
+    }
+
+    [Test]
     public async Task Reads_extended_composer_header_fields() {
         // Uses the real Cursor wire shape: branches is an array of objects with branchName field.
         var path = CreateFixtureDb(conn => {


### PR DESCRIPTION
## Summary

- Replace per-blob open/query/close with `CursorStateReader.GetContentBlobsAsync` — one `SqliteConnection`, one `SELECT ... WHERE key IN (...)` per batch (chunks of 500 to stay under `SQLITE_MAX_VARIABLE_NUMBER`).
- Typical 6–12 blobs per Cursor session: 1 connection + 1 query instead of 6–12 of each.
- Keeps the single-blob `GetContentBlobAsync` API for back-compat (still used by tests).

Follow-up from Qodo review on #85 (bug #4 — performance).
Linear: [AI-666](https://linear.app/kurrent/issue/AI-666)

## Test plan

- [x] New `GetContentBlobs_*` unit tests: returns requested keys, omits missing keys, dedupes input, empty-input → empty dict.
- [x] All 26 Cursor unit tests pass.
- [x] All 814 CLI unit tests pass.
- [x] AOT publish clean (no IL3050/IL2026 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)