### PR TITLE
[AI-665] Normalize workspaceFolder before Cursor path redaction

### DIFF
--- a/src/Kapacitor.Cli.Core/Cursor/CursorPayloadAssembler.cs
+++ b/src/Kapacitor.Cli.Core/Cursor/CursorPayloadAssembler.cs
@@ -93,8 +93,36 @@ public static class CursorPayloadAssembler {
 
     static string? RedactPaths(string? json, string repoPath) {
         if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(repoPath)) return json;
-        // Cheap: textual replace. Bubbles are short; if false positives become a problem,
-        // upgrade to JSON walk.
-        return json.Replace(repoPath, "/repo");
+
+        // Trim trailing path separators so a repoPath ending in '/' or '\\'
+        // matches the same as one without.
+        var trimmed = repoPath.TrimEnd('/', '\\');
+        if (trimmed.Length == 0) return json;
+
+        // Variants we might find in bubble JSON:
+        //   forward          — POSIX-style forward slashes.
+        //   backward         — Windows-native backslashes.
+        //   backwardEscaped  — Windows backslashes in their JSON-escaped form,
+        //                      which is how they appear inside the bubble JSON
+        //                      when params/result was originally JSON-encoded
+        //                      (one '\\' → two characters '\\\\').
+        var forward         = trimmed.Replace('\\', '/');
+        var backward        = trimmed.Replace('/', '\\');
+        var backwardEscaped = backward.Replace("\\", "\\\\");
+
+        // Windows filesystems are case-insensitive; POSIX is case-sensitive.
+        var cmp = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        // Replace the escaped Windows form first — its substring 'backward' must
+        // not be consumed mid-escape before we get a chance to see the full pair.
+        var result = json;
+        if (!string.Equals(forward, backward, StringComparison.Ordinal)) {
+            result = result.Replace(backwardEscaped, "/repo", cmp);
+            result = result.Replace(backward, "/repo", cmp);
+        }
+        result = result.Replace(forward, "/repo", cmp);
+        return result;
     }
 }

--- a/src/Kapacitor.Cli/Commands/CursorCommand.cs
+++ b/src/Kapacitor.Cli/Commands/CursorCommand.cs
@@ -409,7 +409,8 @@ static class CursorCommand {
             string normalizedFolder;
             try {
                 normalizedFolder = NormalizePath(folderPath);
-            } catch {
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"[cursor] Skipping workspace {subdir}: invalid folder path '{folderPath}' ({ex.Message})");
                 continue;
             }
 

--- a/src/Kapacitor.Cli/Commands/CursorCommand.cs
+++ b/src/Kapacitor.Cli/Commands/CursorCommand.cs
@@ -404,20 +404,28 @@ static class CursorCommand {
 
             if (folderPath is null) continue;
 
+            // Normalize once so downstream consumers (path-redaction in particular)
+            // see a canonical native form, not whatever shape workspace.json used.
+            string normalizedFolder;
+            try {
+                normalizedFolder = NormalizePath(folderPath);
+            } catch {
+                continue;
+            }
+
             var wsDbPath = Path.Combine(subdir, "state.vscdb");
 
             if (all) {
-                yield return (folderPath, wsDbPath);
+                yield return (normalizedFolder, wsDbPath);
 
                 continue;
             }
 
             var target = selectedWorkspace ?? cwd;
             var normalizedTarget = NormalizePath(target);
-            var normalizedFolder = NormalizePath(folderPath);
 
             if (string.Equals(normalizedTarget, normalizedFolder, StringComparison.OrdinalIgnoreCase)) {
-                yield return (folderPath, wsDbPath);
+                yield return (normalizedFolder, wsDbPath);
             }
         }
     }

--- a/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorPayloadAssemblerTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/Cursor/CursorPayloadAssemblerTests.cs
@@ -24,6 +24,49 @@ public class CursorPayloadAssemblerTests {
     }
 
     [Test]
+    public async Task Redacts_paths_with_trailing_separator_on_repoPath() {
+        // repoPath ends with '/' — bubble JSON has the same path without trailing '/'.
+        // Trailing-separator handling must make these equivalent for redaction.
+        var raw = """{"bubbleId":"e1","type":2,"capabilityType":15,"createdAt":"2026-05-21T00:00:00Z","toolFormerData":{"toolCallId":"tc","name":"edit_file_v2","params":"{\"relativeWorkspacePath\":\"/Users/me/code/foo/README.md\"}","result":"{}"}}""";
+        var bubble = CursorPayloadAssembler.AssembleBubble(raw, repoPath: "/Users/me/code/foo/");
+        await Assert.That(bubble.ToolFormerData!.Params).DoesNotContain("/Users/me");
+    }
+
+    [Test]
+    public async Task Redacts_backslash_paths_when_repoPath_uses_forward_slash() {
+        // Windows scenario: workspace.json yields C:/Users/me/code/foo (forward slashes
+        // via file:// URI), but bubble tool params encode native paths as
+        // "C:\\Users\\me\\code\\foo\\X.cs" (one backslash escaped to two in JSON).
+        // RedactPaths must match the backslash-escaped form even when repoPath is
+        // given with forward slashes.
+        var raw = """{"bubbleId":"e1","type":2,"capabilityType":15,"createdAt":"2026-05-21T00:00:00Z","toolFormerData":{"toolCallId":"tc","name":"edit_file_v2","params":"{\"absPath\":\"C:\\\\Users\\\\me\\\\code\\\\foo\\\\X.cs\"}","result":"{}"}}""";
+        var bubble = CursorPayloadAssembler.AssembleBubble(raw, repoPath: "C:/Users/me/code/foo");
+        await Assert.That(bubble.ToolFormerData!.Params).DoesNotContain("C:");
+        await Assert.That(bubble.ToolFormerData!.Params).DoesNotContain("Users");
+    }
+
+    [Test]
+    public async Task Redacts_forward_slash_paths_when_repoPath_uses_backslash() {
+        // Inverse Windows scenario: repoPath comes in with backslashes (post Path.GetFullPath
+        // on Windows yields native form), but the bubble JSON has the path with forward
+        // slashes (e.g., from an internal API that POSIX-ifies paths).
+        var raw = """{"bubbleId":"e1","type":2,"capabilityType":15,"createdAt":"2026-05-21T00:00:00Z","toolFormerData":{"toolCallId":"tc","name":"edit_file_v2","params":"{\"absPath\":\"C:/Users/me/code/foo/X.cs\"}","result":"{}"}}""";
+        var bubble = CursorPayloadAssembler.AssembleBubble(raw, repoPath: @"C:\Users\me\code\foo");
+        await Assert.That(bubble.ToolFormerData!.Params).DoesNotContain("C:");
+        await Assert.That(bubble.ToolFormerData!.Params).DoesNotContain("Users");
+    }
+
+    [Test]
+    public async Task Redacts_unescaped_backslash_paths_in_object_typed_params() {
+        // When params is a JSON object (not a JSON-encoded string), GetRawText() returns
+        // the literal JSON text where each backslash is encoded as "\\". The redaction
+        // must still strip the leaked absolute path.
+        var raw = """{"bubbleId":"e1","type":2,"capabilityType":15,"createdAt":"2026-05-21T00:00:00Z","toolFormerData":{"toolCallId":"tc","name":"edit_file_v2","params":{"absPath":"C:\\Users\\me\\code\\foo\\X.cs"},"result":{}}}""";
+        var bubble = CursorPayloadAssembler.AssembleBubble(raw, repoPath: @"C:\Users\me\code\foo");
+        await Assert.That(bubble.ToolFormerData!.Params).DoesNotContain("Users");
+    }
+
+    [Test]
     public async Task Handles_object_typed_params_and_result() {
         // Real Cursor data can have params/result as JSON objects (not JSON-encoded strings)
         var raw = """{"bubbleId":"b2","type":2,"capabilityType":15,"createdAt":"2026-05-21T00:00:00Z","toolFormerData":{"toolCallId":"tc2","name":"edit_file_v2","params":{"relativeWorkspacePath":"src/foo.cs"},"result":{"success":true}}}""";


### PR DESCRIPTION
## Summary

- `CursorCommand.ResolveWorkspaces` now normalises `folderPath` once (`Path.GetFullPath` + `TrimEnd`) and yields the canonical native form to all call sites.
- `CursorPayloadAssembler.RedactPaths` tries three variants of the (trimmed) `repoPath` — forward-slash, native backslash, and JSON-escaped backslash (`\\\\`) — replacing the escaped form first so we don't consume half of an escape sequence. Comparison is `OrdinalIgnoreCase` on Windows, `Ordinal` on POSIX.
- Closes the Windows-only path-leak gap where bubble JSON used backslashes and `workspace.json` used forward slashes (or vice versa).

Follow-up from Qodo review on #85 (bug #3 — Windows correctness).
Linear: [AI-665](https://linear.app/kurrent/issue/AI-665)

## Test plan

- [x] `Redacts_paths_with_trailing_separator_on_repoPath` — trailing-slash variant matches.
- [x] `Redacts_backslash_paths_when_repoPath_uses_forward_slash` — escaped Windows form in bubble JSON is stripped.
- [x] `Redacts_forward_slash_paths_when_repoPath_uses_backslash` — inverse case.
- [x] `Redacts_unescaped_backslash_paths_in_object_typed_params` — object-typed params via GetRawText().
- [x] Existing `Redacts_absolute_paths_to_relative` still passes.
- [x] All 26 Cursor unit tests + 814 CLI unit tests pass.
- [x] AOT publish clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)