### PR TITLE
setup: silence git stderr in non-repo cwd

### DIFF
--- a/src/Kapacitor.Cli.Core/Config/AppConfig.cs
+++ b/src/Kapacitor.Cli.Core/Config/AppConfig.cs
@@ -157,6 +157,7 @@ public static class AppConfig {
         try {
             var psi = new ProcessStartInfo("git", "remote -v") {
                 RedirectStandardOutput = true,
+                RedirectStandardError  = true,
                 UseShellExecute        = false,
                 CreateNoWindow         = true
             };
@@ -188,6 +189,7 @@ public static class AppConfig {
         try {
             var psi = new ProcessStartInfo("git", "rev-parse --show-toplevel") {
                 RedirectStandardOutput = true,
+                RedirectStandardError  = true,
                 UseShellExecute        = false,
                 CreateNoWindow         = true
             };


### PR DESCRIPTION
## Summary
- `Program.cs` unconditionally calls `AppConfig.ResolveServerUrl`, which uses `RepoRoot` (→ `git rev-parse --show-toplevel`) and `GetGitRemoteUrls` (→ `git remote -v`).
- Both `ProcessStartInfo`s set `RedirectStandardOutput = true` but left `StandardError` inherited, so git's `fatal: not a git repository` printed to the user's terminal whenever the CLI ran outside a working tree — including `kapacitor setup`, despite #83's in-command guard.
- Adding `RedirectStandardError = true` matches the pattern already used by `RepositoryDetection.RunCommandAsync` and silences the leak without changing any control flow (failed runs were already swallowed via empty output / non-zero exit code).

## Test plan
- [x] `dotnet build src/Kapacitor.Cli/Kapacitor.Cli.csproj -c Release` clean
- [x] All 818 unit tests pass
- [x] `kapacitor --version` from a non-git temp dir: no `fatal:` line
- [x] `kapacitor setup --no-prompt` from a non-git temp dir: no `fatal:` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)