### PR TITLE
watcher: detach from controlling terminal to survive terminal close

### DIFF
--- a/src/Kapacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Kapacitor.Cli/Commands/WatchCommand.cs
@@ -30,7 +30,27 @@ static partial class WatchCommand {
         Console.SetOut(logWriter);
         Console.SetError(logWriter);
 
+        // Detach from controlling terminal so closing the parent's terminal does
+        // not deliver SIGHUP to the watcher. Without this, both the coding agent
+        // and the watcher die simultaneously when the user closes the terminal
+        // window, and the parent-PID poll below never fires — leaving the
+        // session stuck "active" because session-end is never POSTed.
+        if (!ProcessHelpers.DetachFromControllingTerminal()) {
+            Log("setsid() failed; SIGHUP from terminal close may kill the watcher");
+        }
+
         using var cts = new CancellationTokenSource();
+
+        // Tracks whether shutdown was triggered by the parent coding-agent process
+        // dying without firing session-end. When true (1), the watcher takes over the
+        // server's session-end POST (which the parent normally fires) so the read
+        // model doesn't keep the session "active" forever.
+        //
+        // Written by the parent-PID monitor task and signal handlers, read on the
+        // main thread — use Interlocked/Volatile so the C# memory model formally
+        // guarantees the write is observed even though awaits already act as memory
+        // barriers in practice.
+        var parentExited = 0;
 
         // Handle SIGTERM/SIGINT for graceful shutdown
         Console.CancelKeyPress += (_, e) => {
@@ -39,16 +59,17 @@ static partial class WatchCommand {
         };
         PosixSignalRegistration.Create(PosixSignal.SIGTERM, _ => cts.Cancel());
 
-        // Tracks whether shutdown was triggered by the parent coding-agent process
-        // dying without firing session-end. When true (1), the watcher takes over the
-        // server's session-end POST (which the parent normally fires) so the read
-        // model doesn't keep the session "active" forever.
-        //
-        // Written by the parent-PID monitor task, read on the main thread —
-        // use Interlocked/Volatile so the C# memory model formally guarantees the
-        // write is observed even though awaits already act as memory barriers in
-        // practice.
-        var parentExited = 0;
+        // SIGHUP defense-in-depth: setsid above should prevent the kernel from
+        // delivering SIGHUP to us, but if a shell forwards SIGHUP explicitly to
+        // its process group children before our setsid lands, or if setsid
+        // failed, this handler keeps the watcher alive long enough to run the
+        // parent-exit cleanup path (drain + session-end POST).
+        PosixSignalRegistration.Create(PosixSignal.SIGHUP, ctx => {
+            Log("Received SIGHUP; treating as parent-exit");
+            Interlocked.Exchange(ref parentExited, 1);
+            cts.Cancel();
+            ctx.Cancel = true;
+        });
 
         // Watch the spawning claude process. If it dies without firing session-end
         // (crash, force-kill, IDE-detach), self-terminate within ~5s instead of orphaning.

--- a/src/Kapacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Kapacitor.Cli/Commands/WatchCommand.cs
@@ -52,19 +52,33 @@ static partial class WatchCommand {
         // barriers in practice.
         var parentExited = 0;
 
-        // Handle SIGTERM/SIGINT for graceful shutdown
+        // Handle SIGTERM/SIGINT for graceful shutdown.
+        //
+        // PosixSignalRegistration.Create returns an IDisposable that owns the
+        // underlying handler slot; if it's not rooted for the lifetime of the
+        // method the finalizer silently unregisters the handler. `using var`
+        // keeps both registrations alive until RunWatch returns and disposes
+        // them deterministically.
+        //
+        // For SIGTERM and SIGHUP, ctx.Cancel = true is required: .NET runs the
+        // signal's default action (terminate) after the handler unless the
+        // context is cancelled, which would kill the watcher before the main
+        // loop notices cts and the drain / session-end POST never run.
         Console.CancelKeyPress += (_, e) => {
             e.Cancel = true;
             cts.Cancel();
         };
-        PosixSignalRegistration.Create(PosixSignal.SIGTERM, _ => cts.Cancel());
+        using var sigtermReg = PosixSignalRegistration.Create(PosixSignal.SIGTERM, ctx => {
+            cts.Cancel();
+            ctx.Cancel = true;
+        });
 
         // SIGHUP defense-in-depth: setsid above should prevent the kernel from
         // delivering SIGHUP to us, but if a shell forwards SIGHUP explicitly to
         // its process group children before our setsid lands, or if setsid
         // failed, this handler keeps the watcher alive long enough to run the
         // parent-exit cleanup path (drain + session-end POST).
-        PosixSignalRegistration.Create(PosixSignal.SIGHUP, ctx => {
+        using var sighupReg = PosixSignalRegistration.Create(PosixSignal.SIGHUP, ctx => {
             Log("Received SIGHUP; treating as parent-exit");
             Interlocked.Exchange(ref parentExited, 1);
             cts.Cancel();

--- a/src/Kapacitor.Cli/ProcessHelpers.cs
+++ b/src/Kapacitor.Cli/ProcessHelpers.cs
@@ -26,6 +26,10 @@ static partial class ProcessHelpers {
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial int kill_native(int pid, int sig);
 
+    [LibraryImport("libc", EntryPoint = "setsid", SetLastError = true)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial int setsid_native();
+
     [LibraryImport("kernel32.dll", SetLastError = true)]
     private static partial nint OpenProcess(uint dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, uint dwProcessId);
 
@@ -114,6 +118,49 @@ static partial class ProcessHelpers {
         var pgid = getpgrp_native();
 
         return pgid > 1 && pgid != getpid_native() ? pgid : getppid_native();
+    }
+
+    /// <summary>
+    /// Detaches the current process from its controlling terminal on Unix so that
+    /// closing the parent terminal does not deliver SIGHUP to this process.
+    /// </summary>
+    /// <remarks>
+    /// The watcher is forked by the coding-agent's hook executor and inherits the
+    /// agent's process group and controlling terminal. When the user closes the
+    /// terminal, the kernel sends SIGHUP to the controlling-terminal's foreground
+    /// process group — that includes the watcher, which has no SIGHUP handler and
+    /// dies instantly with default action <c>terminate</c>. The parent-PID poll in
+    /// <c>WatchCommand.RunWatch</c> never gets to fire, so the watcher never
+    /// POSTs session-end and the session stays "active" forever in the read model.
+    ///
+    /// <c>setsid()</c> moves the watcher into a new session with no controlling
+    /// terminal. The captured <c>parentPid</c> (the coding-agent's PGID, recorded
+    /// before the watcher was spawned) is unchanged and still resolves to the
+    /// agent's actual PID — when the agent dies the 5s polling loop detects it
+    /// and runs the cleanup path that POSTs session-end.
+    ///
+    /// No-op on Windows (no equivalent terminal-session abstraction; closing a
+    /// console window kills the watcher via a different mechanism and the
+    /// codex/Windows combination is uncommon).
+    /// </remarks>
+    /// <returns>
+    /// <c>true</c> if the process was successfully detached (or if running on
+    /// Windows where the call is intentionally a no-op). <c>false</c> if
+    /// <c>setsid()</c> failed — typically because the process is already a
+    /// process-group leader, which means it's already isolated and the call
+    /// would be redundant anyway.
+    /// </returns>
+    public static bool DetachFromControllingTerminal() {
+        if (OperatingSystem.IsWindows()) {
+            return true;
+        }
+
+        // setsid() fails with EPERM if the caller is already a process-group
+        // leader. That's fine — it means we're already isolated. Any other
+        // failure is logged by the caller but isn't fatal: SIGHUP delivery may
+        // kill the watcher in that edge case, but the worst outcome is the
+        // pre-existing bug, not a regression.
+        return setsid_native() != -1;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Watcher inherits the coding agent's controlling terminal and process group. When the user closes the terminal, the kernel delivers `SIGHUP` to every process in the foreground group — codex/Claude **and** the watcher — and the watcher dies instantly (no `SIGHUP` handler, default action = `terminate`). The 5-second parent-PID poll added in #75 never gets to run, so `PostSessionEndOnParentExitAsync` never fires and the session stays "active" in the UI forever. Reproduced with codex session `019e5e36ce9c7053a8ef8adfb67d7857` — log ends mid-stream at 11:08:08 with no shutdown markers, both watcher (22271) and parent (21667) gone.
- Fix: call `setsid()` at watcher startup so the process moves to a new session with no controlling terminal, and SIGHUP from terminal close no longer reaches it. The captured `parentPid` (coding agent's PGID, recorded **before** the watcher spawned) is unchanged and still resolves to the agent's PID, so the existing 5s poll fires when the agent dies and the cleanup path runs as designed.
- Defense-in-depth: also register a `SIGHUP` handler that mirrors the parent-exit cleanup (set `parentExited=1`, cancel the CTS, `ctx.Cancel = true` to suppress the default terminate). Covers the edge case where a shell explicitly forwards `SIGHUP` to its process-group children before `setsid` lands, or where `setsid` fails.
- Vendor-agnostic: same `WatcherManager.SpawnWatcher` path runs for Claude and Codex. Claude sessions are usually rescued by Claude's own `SessionEnd` hook firing independently of the watcher, but the watcher is now a reliable backstop for crashes, IDE detach, or `SessionEnd` failures.

## Test plan

- [x] `dotnet build src/Kapacitor.Cli/Kapacitor.Cli.csproj` — clean
- [x] `dotnet publish src/Kapacitor.Cli/Kapacitor.Cli.csproj -c Release` — no `IL3050`/`IL2026` AOT warnings
- [x] `ProcessHelpersTests` (7/7), `WatchCommandTests` (1/1), `WatcherManagerSpawnArgsTests` (4/4) pass
- [ ] Manual: start a fresh codex session under a new terminal, close the terminal, verify watcher log shows either `Parent pid X exited; shutting down watcher` (within ~5s) or `Received SIGHUP; treating as parent-exit` (immediate), followed by `Parent-exit session-end POST succeeded`, and that the session no longer shows "active" in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)