### PR TITLE
[AI-676/AI-677] Codex skill parity + CODEX_THREAD_ID auto-resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,26 @@ With the plugin installed, use the `/kapacitor:validate-plan` skill or ask natur
 Did I finish everything in the plan? Check what's left to do.
 ```
 
+### Hide session
+
+Mark a session as owner-only so other users no longer see it in the dashboard.
+
+```bash
+kapacitor hide                 # current session
+kapacitor hide <sessionId>     # specific session
+```
+
+### Disable recording
+
+Stop the watcher, silence future hooks, and delete server-side data for a session.
+
+```bash
+kapacitor disable                 # current session
+kapacitor disable <sessionId>     # specific session
+```
+
+This is irreversible on the server side; the local transcript file is untouched.
+
 ### Error extraction
 
 Scan a recorded session for tool call errors — failed bash commands, file read/write errors, agent failures, etc.
@@ -246,10 +266,24 @@ Two daemons with **different** `--name` values can run side-by-side. Two daemons
 
 Hosted Codex agents require the Codex hook surface — if you said yes during `kapacitor setup`, you already have it. Otherwise install it manually:
 
+Codex CLI 0.81+ exports `CODEX_THREAD_ID`; kapacitor reads it the same way it reads `KAPACITOR_SESSION_ID` for Claude sessions — no manual session ID needed for any of the Codex skills (`kapacitor-recap`, `kapacitor-errors`, `kapacitor-hide`, `kapacitor-disable`, `kapacitor-validate-plan`).
+
 ```bash
 kapacitor plugin install --codex            # user scope (~/.codex/hooks.json)
 kapacitor plugin install --codex --project  # project scope (<repo>/.codex/hooks.json)
 ```
+
+Installing with `--codex` writes five skills under `~/.codex/skills/`:
+
+| Skill | Wraps | Purpose |
+|---|---|---|
+| `kapacitor-recap` | `kapacitor recap` | Session summary / continuation chain / repo history |
+| `kapacitor-errors` | `kapacitor errors` | Tool-call error extraction |
+| `kapacitor-hide` | `kapacitor hide` | Mark session owner-only |
+| `kapacitor-disable` | `kapacitor disable` | Stop recording + delete server data |
+| `kapacitor-validate-plan` | `kapacitor validate-plan` | Verify plan items were completed |
+
+All five auto-resolve the active session from `CODEX_THREAD_ID`; pass `<sessionId>` explicitly to operate on a different session.
 
 The daemon starts Codex with `--sandbox workspace-write` and `--ask-for-approval on-request`. This lets Codex edit files in the agent's worktree but escalates sensitive operations (e.g. network calls, shell commands outside the worktree) through the daemon's permission bridge to the dashboard.
 

--- a/docs/superpowers/plans/2026-05-25-ai-676-codex-skill-parity.md
+++ b/docs/superpowers/plans/2026-05-25-ai-676-codex-skill-parity.md
@@ -1,0 +1,1587 @@
+# Codex Skill Parity + Auto-Resolved Session ID — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship five-Codex-skill parity with Claude Code (add `kapacitor-hide`, `kapacitor-disable`, `kapacitor-validate-plan`) and auto-resolve the active Capacitor session ID for Codex CLI 0.81+ via the `CODEX_THREAD_ID` env var, eliminating the manual session-ID dance that today's Codex skills require.
+
+**Architecture:** Add a `CODEX_THREAD_ID` step to the existing `ArgParsing.ResolveSessionId` env tail (Claude `KAPACITOR_SESSION_ID` keeps precedence). Extract the env-walk into a new `internal static ResolveSessionIdFromEnv()` so `set-title` (whose positional is `<title>`, not `<sessionId>`) can share it. Extend `kapacitor hide` and `kapacitor disable` to accept an optional positional `sessionId` so the new Codex skills can pass through what they resolve. All five Codex `SKILL.md` files install via `PluginCommand.CodexSkillNames`.
+
+**Tech Stack:** .NET 10 NativeAOT CLI, TUnit unit tests, WireMock.Net for HTTP doubles. Spec: [`docs/superpowers/specs/2026-05-24-ai-676-codex-skill-parity-design.md`](../specs/2026-05-24-ai-676-codex-skill-parity-design.md).
+
+**Spec section references:** Each task lists the spec section that drives it. Read that section before starting the task if anything below is unclear.
+
+---
+
+## Task 0: Day-1 probe — verify `CODEX_THREAD_ID` equals hook `session_id`
+
+**Spec reference:** §7.1 (Single real risk).
+
+**Why first.** The whole plan assumes the env var and the hook payload `session_id` refer to the same UUID modulo dash-stripping. If they don't, the rest of this plan changes (the marker-file fallback in §7.1 replaces the direct env read step). Verify before touching anything else.
+
+**Files:**
+- Modify: `src/Kapacitor.Cli/Commands/CodexHookCommand.cs:81-107` (add one diagnostic line at top of `HandleSessionStart`)
+
+- [ ] **Step 1: Add diagnostic line at top of `HandleSessionStart`**
+
+Open `src/Kapacitor.Cli/Commands/CodexHookCommand.cs` and insert the first line of the method body at line 82 (immediately after the method signature opens, before `var enriched = await RepositoryDetection...`):
+
+```csharp
+Console.Error.WriteLine(
+    $"[probe] CODEX_THREAD_ID={Environment.GetEnvironmentVariable("CODEX_THREAD_ID")} "
+    + $"payload.session_id={TryGetString(node, "session_id")}");
+```
+
+- [ ] **Step 2: Build the CLI in Debug**
+
+Run: `dotnet build src/Kapacitor.Cli/Kapacitor.Cli.csproj`
+Expected: Build succeeds. No new warnings.
+
+- [ ] **Step 3: Make the freshly built binary the one Codex invokes**
+
+The Codex hook command path is `kapacitor codex-hook` and it's resolved via `PATH`. Either temporarily replace the global binary at `~/.local/bin/kapacitor` with the Debug output, or set up a one-shot wrapper. The simplest path:
+
+```bash
+# Show where Codex would find kapacitor
+which kapacitor
+
+# Back up and replace
+cp "$(which kapacitor)" "$(which kapacitor).bak"
+cp src/Kapacitor.Cli/bin/Debug/net10.0/Kapacitor.Cli "$(which kapacitor)"
+# macOS only — re-sign the AOT/Debug binary after copying:
+codesign --force --sign - "$(which kapacitor)"
+```
+
+Expected: `kapacitor codex-hook --version` (or equivalent) runs without "killed: 9" / signing errors.
+
+- [ ] **Step 4: Run one Codex session and capture probe output**
+
+Start a fresh Codex CLI session in any directory that has the kapacitor hooks installed (`~/.codex/hooks.json` must contain the `kapacitor codex-hook` entries — `kapacitor plugin install --codex` if not). The probe writes to `stderr`. Codex routes hook stderr to its log:
+
+```bash
+# In another terminal, tail the Codex hook log
+tail -f ~/.codex/log/codex-tui.log 2>/dev/null || tail -f ~/Library/Logs/codex/*.log
+# Look for: [probe] CODEX_THREAD_ID=... payload.session_id=...
+```
+
+In Codex, type any prompt to fire `SessionStart`.
+
+Expected: One `[probe]` line appears. Record both values.
+
+- [ ] **Step 5: Compare values and decide**
+
+The two values should be the same UUID modulo dash formatting.
+
+- **If they match (expected outcome):** continue with Task 1 as written. Move on to Step 6 to clean up.
+- **If they differ:** **stop**. The plan needs to switch to the marker-file fallback (spec §7.1, "If they differ" bullet). Update this plan inline (or open a new one) before continuing. Record the divergence in a comment on AI-677.
+- **If `CODEX_THREAD_ID` is empty:** Codex CLI is too old (<0.81). Update Codex (`npm i -g @openai/codex@latest`) and re-run Step 4.
+
+- [ ] **Step 6: Remove the probe line**
+
+Revert the change from Step 1. The probe was temporary instrumentation.
+
+```bash
+git diff src/Kapacitor.Cli/Commands/CodexHookCommand.cs   # confirm only the probe line is gone
+```
+
+- [ ] **Step 7: Restore the original kapacitor binary**
+
+```bash
+mv "$(which kapacitor).bak" "$(which kapacitor)"
+```
+
+- [ ] **Step 8: Commit nothing**
+
+No commit. This task is a decision gate — its only artifact is the recorded probe values and your decision. Carry forward into Task 1.
+
+---
+
+## Task 1: `ArgParsing.ResolveSessionIdFromEnv` helper (TDD)
+
+**Spec reference:** §3.1 (Centralize session-ID resolution).
+
+**Files:**
+- Modify: `src/Kapacitor.Cli/ArgParsing.cs:1-30` (extract env tail into helper; main resolver delegates)
+- Modify: `test/Kapacitor.Cli.Tests.Unit/ArgParsingTests.cs` (add cases, rename serialization group)
+
+- [ ] **Step 1: Rename the existing test serialization group constant**
+
+Open `test/Kapacitor.Cli.Tests.Unit/ArgParsingTests.cs` and change the existing constant near the bottom of the class:
+
+```csharp
+// Was:
+const string KapacitorSessionIdEnvVar = "KAPACITOR_SESSION_ID";
+
+// To:
+const string SessionEnvVarMutation = "SessionEnvVarMutation";
+const string KapacitorSessionIdEnvVar = "KAPACITOR_SESSION_ID";
+const string CodexThreadIdEnvVar = "CODEX_THREAD_ID";
+```
+
+Update the two existing `[NotInParallel(nameof(KapacitorSessionIdEnvVar))]` attributes at the existing env-mutating tests to use `[NotInParallel(SessionEnvVarMutation)]`. Leave the body env-var reads unchanged (they still mutate `"KAPACITOR_SESSION_ID"`).
+
+- [ ] **Step 2: Add failing tests for the `CODEX_THREAD_ID` extension and the verbatim-positional rule**
+
+Append to `ArgParsingTests.cs`:
+
+```csharp
+[Test]
+[NotInParallel(SessionEnvVarMutation)]
+public async Task ResolveSessionId_falls_back_to_codex_thread_id_when_kapacitor_unset() {
+    Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+    Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, "01234567-89ab-cdef-0123-456789abcdef");
+
+    try {
+        var id = ArgParsing.ResolveSessionId(["recap"]);
+        await Assert.That(id).IsEqualTo("0123456789abcdef0123456789abcdef");
+    } finally {
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, null);
+    }
+}
+
+[Test]
+[NotInParallel(SessionEnvVarMutation)]
+public async Task ResolveSessionId_prefers_kapacitor_over_codex_thread_id() {
+    Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "claude-session-id");
+    Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, "codex-session-id");
+
+    try {
+        var id = ArgParsing.ResolveSessionId(["recap"]);
+        await Assert.That(id).IsEqualTo("claudesessionid");
+    } finally {
+        Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, null);
+    }
+}
+
+[Test]
+[NotInParallel(SessionEnvVarMutation)]
+public async Task ResolveSessionId_returns_null_when_no_positional_and_no_env() {
+    Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+    Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, null);
+
+    var id = ArgParsing.ResolveSessionId(["recap"]);
+    await Assert.That(id).IsNull();
+}
+
+[Test]
+public async Task ResolveSessionId_returns_positional_verbatim_without_stripping_dashes() {
+    // Positional slugs (meta-session IDs, README.md:153) MUST survive intact.
+    var id = ArgParsing.ResolveSessionId(["recap", "foo-bar-baz"]);
+    await Assert.That(id).IsEqualTo("foo-bar-baz");
+}
+
+[Test]
+[NotInParallel(SessionEnvVarMutation)]
+public async Task ResolveSessionIdFromEnv_returns_dashless_kapacitor() {
+    Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "abc-def");
+    Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, null);
+
+    try {
+        var id = ArgParsing.ResolveSessionIdFromEnv();
+        await Assert.That(id).IsEqualTo("abcdef");
+    } finally {
+        Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+    }
+}
+
+[Test]
+[NotInParallel(SessionEnvVarMutation)]
+public async Task ResolveSessionIdFromEnv_returns_dashless_codex_thread_id_when_kapacitor_unset() {
+    Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+    Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, "ghi-jkl");
+
+    try {
+        var id = ArgParsing.ResolveSessionIdFromEnv();
+        await Assert.That(id).IsEqualTo("ghijkl");
+    } finally {
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, null);
+    }
+}
+
+[Test]
+[NotInParallel(SessionEnvVarMutation)]
+public async Task ResolveSessionIdFromEnv_returns_null_when_both_envs_unset() {
+    Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+    Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, null);
+
+    var id = ArgParsing.ResolveSessionIdFromEnv();
+    await Assert.That(id).IsNull();
+}
+```
+
+- [ ] **Step 3: Run the new tests — they MUST fail**
+
+Run: `dotnet run --project test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/ArgParsingTests/*"`
+Expected: Build fails on `ResolveSessionIdFromEnv` (doesn't exist yet). The other new tests would fail at runtime if the build succeeded — both are acceptable "red" states for TDD.
+
+- [ ] **Step 4: Implement the helper and update `ResolveSessionId` to delegate**
+
+Replace the body of `src/Kapacitor.Cli/ArgParsing.cs` with:
+
+```csharp
+namespace Kapacitor.Cli;
+
+static class ArgParsing {
+    /// <summary>
+    /// Resolves a positional sessionId from a command's argument list, falling
+    /// back to the env helper. Value-bearing flags (e.g. <c>--model sonnet</c>)
+    /// must be declared via <paramref name="valueFlags"/> so their values aren't
+    /// mistaken for the sessionId. Positional values are returned verbatim —
+    /// they may be meta-session slugs and must not be dash-stripped.
+    /// </summary>
+    internal static string? ResolveSessionId(string[] args, int skipCount = 1, string[]? valueFlags = null) {
+        var knownValueFlags = valueFlags is null or { Length: 0 }
+            ? null
+            : new HashSet<string>(valueFlags, StringComparer.Ordinal);
+
+        for (var i = skipCount; i < args.Length; i++) {
+            var token = args[i];
+            if (token.StartsWith("--")) {
+                if (knownValueFlags?.Contains(token) == true && i + 1 < args.Length) {
+                    i++; // skip the value as well
+                }
+
+                continue;
+            }
+
+            return token;
+        }
+
+        return ResolveSessionIdFromEnv();
+    }
+
+    /// <summary>
+    /// Walks the session-ID env chain: <c>KAPACITOR_SESSION_ID</c> (Claude
+    /// Code hook-set) then <c>CODEX_THREAD_ID</c> (Codex CLI 0.81+ export).
+    /// Both are dash-stripped before return. Used directly by commands whose
+    /// positional argument is not a sessionId (e.g. <c>set-title</c>).
+    /// </summary>
+    internal static string? ResolveSessionIdFromEnv() {
+        var kapacitor = Environment.GetEnvironmentVariable("KAPACITOR_SESSION_ID");
+        if (!string.IsNullOrWhiteSpace(kapacitor))
+            return kapacitor.Replace("-", "");
+
+        var codex = Environment.GetEnvironmentVariable("CODEX_THREAD_ID");
+        if (!string.IsNullOrWhiteSpace(codex))
+            return codex.Replace("-", "");
+
+        return null;
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests — they MUST pass**
+
+Run: `dotnet run --project test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/ArgParsingTests/*"`
+Expected: All `ArgParsingTests` pass (the original 8 plus the 7 new ones).
+
+- [ ] **Step 6: Run the entire unit suite to confirm no regression**
+
+Run: `dotnet run --project test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Kapacitor.Cli/ArgParsing.cs test/Kapacitor.Cli.Tests.Unit/ArgParsingTests.cs
+git commit -m "feat(cli): resolve sessionId from CODEX_THREAD_ID env var
+
+Adds ArgParsing.ResolveSessionIdFromEnv() walking KAPACITOR_SESSION_ID
+then CODEX_THREAD_ID. ResolveSessionId delegates to it. Positional
+values are still returned verbatim so meta-session slugs survive.
+
+Part of AI-676 / AI-677."
+```
+
+---
+
+## Task 2: Migrate `hide` and `disable` to the resolver + optional positional
+
+**Spec reference:** §3.1 (caller migration bullets), §3.2.
+
+`hide` and `disable` are parallel changes against the same shape (env-only read → resolver call). One task, one commit.
+
+**Files:**
+- Modify: `src/Kapacitor.Cli/Program.cs:304-352` (`case "disable"`)
+- Modify: `src/Kapacitor.Cli/Program.cs:353-…` (`case "hide"`)
+
+- [ ] **Step 1: Replace the inline env read in `disable`**
+
+At `src/Kapacitor.Cli/Program.cs:305`, change:
+
+```csharp
+case "disable": {
+    var sessionId = Environment.GetEnvironmentVariable("KAPACITOR_SESSION_ID")?.Replace("-", "");
+
+    if (sessionId is null) {
+        Console.Error.WriteLine("KAPACITOR_SESSION_ID not set. Run this inside an active Claude Code session.");
+
+        return 1;
+    }
+```
+
+to:
+
+```csharp
+case "disable": {
+    // Positional override may be a dashed UUID; the WatcherManager and
+    // server-side path both expect dashless, so we strip here. Env-sourced
+    // values come pre-normalized from the resolver.
+    var sessionId = ResolveSessionId(args)?.Replace("-", "");
+
+    if (sessionId is null) {
+        Console.Error.WriteLine("Usage: kapacitor disable [sessionId]");
+        Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
+
+        return 1;
+    }
+```
+
+- [ ] **Step 2: Replace the inline env read in `hide`**
+
+At `src/Kapacitor.Cli/Program.cs:354`, change:
+
+```csharp
+case "hide": {
+    var sessionId = Environment.GetEnvironmentVariable("KAPACITOR_SESSION_ID")?.Replace("-", "");
+
+    if (sessionId is null) {
+        Console.Error.WriteLine("KAPACITOR_SESSION_ID not set. Run this inside an active Claude Code session.");
+
+        return 1;
+    }
+```
+
+to:
+
+```csharp
+case "hide": {
+    var sessionId = ResolveSessionId(args)?.Replace("-", "");
+
+    if (sessionId is null) {
+        Console.Error.WriteLine("Usage: kapacitor hide [sessionId]");
+        Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
+
+        return 1;
+    }
+```
+
+- [ ] **Step 3: Build and confirm no warnings**
+
+Run: `dotnet build src/Kapacitor.Cli/Kapacitor.Cli.csproj`
+Expected: Build succeeds; no warnings.
+
+- [ ] **Step 4: Run the full unit suite**
+
+Run: `dotnet run --project test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj`
+Expected: All tests pass. The new resolver path is exercised indirectly.
+
+- [ ] **Step 5: Spot-check both commands by hand against a non-existent session**
+
+Run: `KAPACITOR_SESSION_ID= CODEX_THREAD_ID= dotnet run --project src/Kapacitor.Cli/Kapacitor.Cli.csproj -- hide`
+Expected stderr (exact wording):
+```
+Usage: kapacitor hide [sessionId]
+  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.
+```
+Repeat for `disable`. Confirm exit code 1.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Kapacitor.Cli/Program.cs
+git commit -m "feat(cli): hide/disable accept optional [sessionId] positional
+
+Routes both commands through ArgParsing.ResolveSessionId so an
+explicit positional, KAPACITOR_SESSION_ID, or CODEX_THREAD_ID
+all resolve. Updated error message names both Claude and Codex.
+
+Part of AI-676."
+```
+
+---
+
+## Task 3: Migrate `set-title` to the env helper with tailored error wording
+
+**Spec reference:** §3.1 (set-title bullet).
+
+`set-title` does **not** use the args resolver — its positional is `<title>`, not `<sessionId>`. Instead it calls `ArgParsing.ResolveSessionIdFromEnv()` directly. Both error branches get rewritten.
+
+**Files:**
+- Modify: `src/Kapacitor.Cli/Program.cs:498-510` (the `set-title` case and its `args.Length < 2` guard above)
+
+- [ ] **Step 1: Rewrite the "missing title" branch (line 498)**
+
+Currently:
+
+```csharp
+case "set-title" when args.Length < 2:
+    Console.Error.WriteLine("Usage: kapacitor set-title <title>");
+    Console.Error.WriteLine("  KAPACITOR_SESSION_ID must be set.");
+
+    return 1;
+```
+
+Replace with:
+
+```csharp
+case "set-title" when args.Length < 2:
+    Console.Error.WriteLine("Usage: kapacitor set-title <title>");
+
+    return 1;
+```
+
+The second line (`KAPACITOR_SESSION_ID must be set`) is misleading — a user missing the title shouldn't see a session-id diagnosis. Drop it.
+
+- [ ] **Step 2: Rewrite the "missing session env" branch (line 504-510)**
+
+Currently:
+
+```csharp
+case "set-title": {
+    var stSessionId = Environment.GetEnvironmentVariable("KAPACITOR_SESSION_ID")?.Replace("-", "");
+
+    if (stSessionId is null) {
+        Console.Error.WriteLine("KAPACITOR_SESSION_ID not set");
+
+        return 1;
+    }
+```
+
+Replace with:
+
+```csharp
+case "set-title": {
+    var stSessionId = ArgParsing.ResolveSessionIdFromEnv();
+
+    if (stSessionId is null) {
+        Console.Error.WriteLine("No session ID found in KAPACITOR_SESSION_ID or CODEX_THREAD_ID.");
+        Console.Error.WriteLine("Run set-title inside an active Claude Code / Codex CLI 0.81+ session.");
+
+        return 1;
+    }
+```
+
+The rest of the `set-title` case (lines 511+ — title joining, validation, HTTP call) is unchanged.
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build src/Kapacitor.Cli/Kapacitor.Cli.csproj`
+Expected: Build succeeds; no warnings.
+
+- [ ] **Step 4: Smoke test both error branches by hand**
+
+```bash
+# Missing title — should print usage only, no session-id mention
+dotnet run --project src/Kapacitor.Cli/Kapacitor.Cli.csproj -- set-title
+
+# Missing env — should print the new tailored message
+KAPACITOR_SESSION_ID= CODEX_THREAD_ID= dotnet run --project src/Kapacitor.Cli/Kapacitor.Cli.csproj -- set-title "any title here"
+```
+
+Expected: First emits `Usage: kapacitor set-title <title>` only. Second emits the two-line message about `KAPACITOR_SESSION_ID or CODEX_THREAD_ID`.
+
+- [ ] **Step 5: Run the unit suite**
+
+Run: `dotnet run --project test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Kapacitor.Cli/Program.cs
+git commit -m "feat(cli): set-title resolves session via ArgParsing helper
+
+Uses ResolveSessionIdFromEnv directly (positional is <title>, not
+<sessionId>). Drops misleading KAPACITOR_SESSION_ID hint from the
+missing-title branch. New error names both env sources.
+
+Part of AI-677."
+```
+
+---
+
+## Task 4: Consolidate error message strings for resolver callers
+
+**Spec reference:** §3.1 (error message collapse bullet).
+
+The existing positional-accepting commands (`recap`, `errors`, `validate-plan`, `eval`) each have a near-duplicate two-line error message at Program.cs:93-95, 113-115, 126-128, 143-146. Consolidate the wording for consistency with `hide`/`disable`/`set-title`.
+
+**Files:**
+- Modify: `src/Kapacitor.Cli/Program.cs:88-100` (`case "errors"`)
+- Modify: `src/Kapacitor.Cli/Program.cs:101-121` (`case "recap"`)
+- Modify: `src/Kapacitor.Cli/Program.cs:122-133` (`case "validate-plan"`)
+- Modify: `src/Kapacitor.Cli/Program.cs:134-173` (`case "eval"`)
+
+- [ ] **Step 1: Update `errors` error wording**
+
+At line 93-95, change:
+
+```csharp
+Console.Error.WriteLine("Usage: kapacitor errors [--chain] [sessionId]");
+Console.Error.WriteLine("  No session ID provided and KAPACITOR_SESSION_ID not set.");
+```
+
+to:
+
+```csharp
+Console.Error.WriteLine("Usage: kapacitor errors [--chain] [sessionId]");
+Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
+```
+
+- [ ] **Step 2: Update `recap` error wording**
+
+At line 113-115, change:
+
+```csharp
+Console.Error.WriteLine("Usage: kapacitor recap [--chain] [--full] [--repo] [sessionId]");
+Console.Error.WriteLine("  No session ID provided and KAPACITOR_SESSION_ID not set.");
+Console.Error.WriteLine("  Use --repo to see recent session summaries for the current repository.");
+```
+
+to:
+
+```csharp
+Console.Error.WriteLine("Usage: kapacitor recap [--chain] [--full] [--repo] [sessionId]");
+Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
+Console.Error.WriteLine("  Use --repo to see recent session summaries for the current repository.");
+```
+
+(`--repo` hint is preserved — it's `recap`-specific guidance, unrelated to env resolution.)
+
+- [ ] **Step 3: Update `validate-plan` error wording**
+
+At line 126-128, change:
+
+```csharp
+Console.Error.WriteLine("Usage: kapacitor validate-plan [sessionId]");
+Console.Error.WriteLine("  No session ID provided and KAPACITOR_SESSION_ID not set.");
+```
+
+to:
+
+```csharp
+Console.Error.WriteLine("Usage: kapacitor validate-plan [sessionId]");
+Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
+```
+
+- [ ] **Step 4: Update `eval` error wording**
+
+At line 143-146, change:
+
+```csharp
+Console.Error.WriteLine("Usage: kapacitor eval [--model sonnet] [--chain] [--threshold N]");
+Console.Error.WriteLine("                     [--questions <csv> | --skip <csv>] [sessionId]");
+Console.Error.WriteLine("       kapacitor eval --list-questions");
+Console.Error.WriteLine("  No session ID provided and KAPACITOR_SESSION_ID not set.");
+```
+
+to:
+
+```csharp
+Console.Error.WriteLine("Usage: kapacitor eval [--model sonnet] [--chain] [--threshold N]");
+Console.Error.WriteLine("                     [--questions <csv> | --skip <csv>] [sessionId]");
+Console.Error.WriteLine("       kapacitor eval --list-questions");
+Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
+```
+
+- [ ] **Step 5: Build and run all unit tests**
+
+Run: `dotnet build src/Kapacitor.Cli/Kapacitor.Cli.csproj && dotnet run --project test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj`
+Expected: Build succeeds, all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Kapacitor.Cli/Program.cs
+git commit -m "refactor(cli): unify session-id missing error wording
+
+All resolver-using commands print the same two-line message naming
+both KAPACITOR_SESSION_ID (Claude) and CODEX_THREAD_ID (Codex 0.81+)
+as supported environments.
+
+Part of AI-677."
+```
+
+---
+
+## Task 5: `PluginCommand` — add 3 skill names, make array internal, preflight validation (TDD)
+
+**Spec reference:** §4.1 (PluginCommand.cs + bug fix bundled in), §6.2 (test scenarios).
+
+Three things in one task because they all touch `PluginCommand.InstallCodexSkills`: array entries, accessibility, and preflight semantics.
+
+**Files:**
+- Modify: `src/Kapacitor.Cli/Commands/PluginCommand.cs:14-17` (the `CodexSkillNames` array)
+- Modify: `src/Kapacitor.Cli/Commands/PluginCommand.cs:322-344` (`InstallCodexSkills` body)
+- Modify: `test/Kapacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs` (extend existing tests + add new ones)
+
+- [ ] **Step 1: Add failing tests for the new skill names and preflight semantics**
+
+In `test/Kapacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs`, after the existing `InstallCodexSkills_copies_known_skills` test (around line 197), add:
+
+```csharp
+[Test]
+public async Task InstallCodexSkills_copies_all_five_known_skills() {
+    using var tmp    = new TempDir();
+    var       source = Path.Combine(tmp.Path, "codex-skills");
+    var       target = Path.Combine(tmp.Path, "skills");
+    foreach (var name in PluginCommand.CodexSkillNames) {
+        WriteSkill(source, name, $"{name} body");
+    }
+
+    var ok = PluginCommand.InstallCodexSkills(source, target);
+    await Assert.That(ok).IsTrue();
+
+    foreach (var name in PluginCommand.CodexSkillNames) {
+        var path = Path.Combine(target, name, "SKILL.md");
+        await Assert.That(File.Exists(path)).IsTrue();
+        var body = await File.ReadAllTextAsync(path);
+        await Assert.That(body).IsEqualTo($"{name} body");
+    }
+}
+
+[Test]
+public async Task CodexSkillNames_contains_expected_five() {
+    var expected = new[] {
+        "kapacitor-recap",
+        "kapacitor-errors",
+        "kapacitor-hide",
+        "kapacitor-disable",
+        "kapacitor-validate-plan"
+    };
+
+    await Assert.That(PluginCommand.CodexSkillNames).IsEquivalentTo(expected);
+}
+
+[Test]
+public async Task InstallCodexSkills_returns_false_when_known_folder_missing() {
+    using var tmp    = new TempDir();
+    var       source = Path.Combine(tmp.Path, "codex-skills");
+    var       target = Path.Combine(tmp.Path, "skills");
+
+    // Write four of the five expected names — leave kapacitor-validate-plan missing.
+    WriteSkill(source, "kapacitor-recap",         "r");
+    WriteSkill(source, "kapacitor-errors",        "e");
+    WriteSkill(source, "kapacitor-hide",          "h");
+    WriteSkill(source, "kapacitor-disable",       "d");
+
+    // Pre-existing target folder for one of the known skills. The preflight
+    // must NOT delete it because the install is aborted before any destructive
+    // step runs.
+    WriteSkill(target, "kapacitor-recap", "stale recap that must survive");
+
+    var ok = PluginCommand.InstallCodexSkills(source, target);
+    await Assert.That(ok).IsFalse();
+
+    // Pre-existing target folder unchanged — preflight bailed before deletion.
+    var preserved = await File.ReadAllTextAsync(Path.Combine(target, "kapacitor-recap", "SKILL.md"));
+    await Assert.That(preserved).IsEqualTo("stale recap that must survive");
+
+    // None of the other expected target folders were created.
+    await Assert.That(Directory.Exists(Path.Combine(target, "kapacitor-errors"))).IsFalse();
+    await Assert.That(Directory.Exists(Path.Combine(target, "kapacitor-hide"))).IsFalse();
+    await Assert.That(Directory.Exists(Path.Combine(target, "kapacitor-disable"))).IsFalse();
+    await Assert.That(Directory.Exists(Path.Combine(target, "kapacitor-validate-plan"))).IsFalse();
+}
+```
+
+- [ ] **Step 2: Run the new tests — they MUST fail**
+
+Run: `dotnet run --project test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/PluginCommandCodexTests/*"`
+Expected: Build fails (`CodexSkillNames` not accessible from tests — it's currently private) or the tests fail at runtime. Either is a valid "red".
+
+- [ ] **Step 3: Promote `CodexSkillNames` to `internal` and add the three new entries**
+
+In `src/Kapacitor.Cli/Commands/PluginCommand.cs:14`, change:
+
+```csharp
+static readonly string[] CodexSkillNames = [
+    "kapacitor-recap",
+    "kapacitor-errors"
+];
+```
+
+to:
+
+```csharp
+internal static readonly string[] CodexSkillNames = [
+    "kapacitor-recap",
+    "kapacitor-errors",
+    "kapacitor-hide",
+    "kapacitor-disable",
+    "kapacitor-validate-plan"
+];
+```
+
+(`InternalsVisibleTo Include="Kapacitor.Cli.Tests.Unit"` is already declared in `src/Kapacitor.Cli/Kapacitor.Cli.csproj:17`, so the tests can see internal members.)
+
+- [ ] **Step 4: Add preflight validation to `InstallCodexSkills`**
+
+In `src/Kapacitor.Cli/Commands/PluginCommand.cs:322-344`, replace the entire method body:
+
+```csharp
+public static bool InstallCodexSkills(string sourceDir, string targetDir) {
+    if (!Directory.Exists(sourceDir)) return false;
+
+    try {
+        Directory.CreateDirectory(targetDir);
+
+        foreach (var name in CodexSkillNames) {
+            var src = Path.Combine(sourceDir, name);
+
+            if (!Directory.Exists(src)) continue;
+
+            var dst = Path.Combine(targetDir, name);
+
+            if (Directory.Exists(dst)) Directory.Delete(dst, recursive: true);
+
+            CopyDirectory(src, dst);
+        }
+
+        return true;
+    } catch {
+        return false;
+    }
+}
+```
+
+with:
+
+```csharp
+public static bool InstallCodexSkills(string sourceDir, string targetDir) {
+    if (!Directory.Exists(sourceDir)) return false;
+
+    // Preflight: every known skill must have a folder under sourceDir. If
+    // any is missing, fail BEFORE doing anything destructive — otherwise a
+    // packaging error would leave the target dir half-overwritten.
+    var missing = CodexSkillNames
+        .Where(name => !Directory.Exists(Path.Combine(sourceDir, name)))
+        .ToList();
+
+    if (missing.Count > 0) {
+        Console.Error.WriteLine(
+            $"Cannot install Codex skills: missing source folder(s) under {sourceDir}: "
+            + string.Join(", ", missing)
+        );
+        return false;
+    }
+
+    try {
+        Directory.CreateDirectory(targetDir);
+
+        foreach (var name in CodexSkillNames) {
+            var src = Path.Combine(sourceDir, name);
+            var dst = Path.Combine(targetDir, name);
+
+            if (Directory.Exists(dst)) Directory.Delete(dst, recursive: true);
+
+            CopyDirectory(src, dst);
+        }
+
+        return true;
+    } catch {
+        return false;
+    }
+}
+```
+
+- [ ] **Step 5: Run the targeted tests — they MUST now pass**
+
+Run: `dotnet run --project test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/PluginCommandCodexTests/*"`
+Expected: All `PluginCommandCodexTests` pass, including the three new tests and the original install/remove tests.
+
+- [ ] **Step 6: Run the entire unit suite**
+
+Run: `dotnet run --project test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Kapacitor.Cli/Commands/PluginCommand.cs test/Kapacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
+git commit -m "feat(plugin): register 3 new Codex skills, fail fast on missing source
+
+Adds kapacitor-hide, kapacitor-disable, and kapacitor-validate-plan
+to CodexSkillNames (promoted to internal so tests can value-check it).
+
+Preflight validation in InstallCodexSkills returns false if any known
+source folder is absent — atomic install, no partial overwrite of an
+existing target dir.
+
+Part of AI-676."
+```
+
+---
+
+## Task 6: Create the three new Codex `SKILL.md` files
+
+**Spec reference:** §2.1.
+
+**Files:**
+- Create: `kapacitor/codex-skills/kapacitor-hide/SKILL.md`
+- Create: `kapacitor/codex-skills/kapacitor-disable/SKILL.md`
+- Create: `kapacitor/codex-skills/kapacitor-validate-plan/SKILL.md`
+
+- [ ] **Step 1: Create `kapacitor-hide/SKILL.md`**
+
+`mkdir -p kapacitor/codex-skills/kapacitor-hide` then write the file with contents:
+
+```markdown
+---
+name: kapacitor-hide
+description: >-
+  This skill should be used when the user asks to "hide this session",
+  "make this private", "hide session", "owner only", "make private",
+  "hide from others", "set private", "don't show this session",
+  or wants to change the current session visibility to owner-only.
+  Sets session visibility so only the owner can see it.
+---
+
+# Kapacitor Hide
+
+Hide the current session so only you (the owner) can see it.
+
+## Usage
+
+```bash
+# Active session — auto-resolved from CODEX_THREAD_ID (Codex 0.81+)
+kapacitor hide
+
+# Specific session by ID (from `kapacitor recap --repo`)
+kapacitor hide <sessionId>
+```
+
+This sets the session visibility to "none" (owner-only). Other users will no longer see this session in the Capacitor dashboard.
+
+## Requirements
+
+Run inside an active Codex CLI session (0.81+) — the active session is auto-resolved from `CODEX_THREAD_ID`. To act on a different session, pass its ID explicitly. Use `kapacitor recap --repo` to list recent session IDs in this repository.
+
+The `kapacitor` CLI must be available on PATH (typically installed at `~/.local/bin/kapacitor`).
+
+## Notes
+
+- This is reversible — visibility can be changed back via the Capacitor dashboard.
+- The session data remains on the server, just hidden from other users.
+- Unlike `kapacitor disable`, recording continues normally.
+
+## Environment
+
+`KAPACITOR_URL` overrides the default server URL (`http://localhost:5108`).
+```
+
+- [ ] **Step 2: Create `kapacitor-disable/SKILL.md`**
+
+`mkdir -p kapacitor/codex-skills/kapacitor-disable` then write:
+
+```markdown
+---
+name: kapacitor-disable
+description: >-
+  This skill should be used when the user asks to "disable recording",
+  "stop recording", "delete this session", "don't record this",
+  "remove my session data", "erase this session", "turn off tracking",
+  "stop tracking", "disable kapacitor", "remove session",
+  or wants to stop the current session from being recorded.
+  Stops the watcher, prevents future hooks, and deletes server data.
+---
+
+# Kapacitor Disable
+
+Stop recording the current session and delete all data from the server.
+
+## Usage
+
+```bash
+# Active session — auto-resolved from CODEX_THREAD_ID (Codex 0.81+)
+kapacitor disable
+
+# Specific session by ID (from `kapacitor recap --repo`)
+kapacitor disable <sessionId>
+```
+
+This will:
+1. Stop the transcript watcher process
+2. Prevent all future hook events from being sent for this session
+3. Delete all session data from the server (event streams and read models)
+
+## Requirements
+
+Run inside an active Codex CLI session (0.81+) — the active session is auto-resolved from `CODEX_THREAD_ID`. To act on a different session, pass its ID explicitly. Use `kapacitor recap --repo` to list recent session IDs in this repository.
+
+The `kapacitor` CLI must be available on PATH (typically installed at `~/.local/bin/kapacitor`).
+
+## Notes
+
+- This action is irreversible — all session data will be permanently deleted from the server.
+- The local transcript file (Codex rollout `.jsonl`) is not affected — only server-side data is removed.
+- Subsequent hooks (session-end, etc.) will be silently skipped.
+
+## Environment
+
+`KAPACITOR_URL` overrides the default server URL (`http://localhost:5108`).
+```
+
+- [ ] **Step 3: Create `kapacitor-validate-plan/SKILL.md`**
+
+`mkdir -p kapacitor/codex-skills/kapacitor-validate-plan` then write:
+
+```markdown
+---
+name: kapacitor-validate-plan
+description: >-
+  This skill should be used when the user asks to "validate plan",
+  "verify plan", "check plan completion", "did I finish everything",
+  "is the plan done", "what's left to do", "validate my work",
+  or wants to verify that all planned items were completed.
+---
+
+# Kapacitor Validate Plan
+
+Verify that all items in the current session's plan have been completed.
+
+## Usage
+
+```bash
+# Active session — auto-resolved from CODEX_THREAD_ID (Codex 0.81+)
+kapacitor validate-plan
+
+# Specific session by ID (from `kapacitor recap --repo`)
+kapacitor validate-plan <sessionId>
+```
+
+## What It Returns
+
+The command outputs three sections:
+
+- **`## Plan`** — the full plan text.
+- **`## What's Done`** — two sub-sections:
+  - **Summary** — AI-generated summary of what was accomplished (from `WhatsDoneGenerated` events, if available).
+  - **Details** — list of files created (`Write`) and modified (`Edit`) during the session.
+- **`## Instructions`** — asks you to compare the plan against the summary and file list.
+
+## What To Do With The Output
+
+1. Read the plan carefully and identify each distinct planned item.
+2. Compare each item against the summary and file list under "What's Done".
+3. If all items are complete, confirm to the user that the plan is fully implemented.
+4. If there are gaps, list the missing items and complete them now.
+
+## When No Plan Is Found
+
+If the output says "No plan found for this session", inform the user that no plan was detected for this session. Plans are recorded when a session emits an `ExitPlanMode`-style event; not every session has one.
+
+## Requirements
+
+Run inside an active Codex CLI session (0.81+) — the active session is auto-resolved from `CODEX_THREAD_ID`. To act on a different session, pass its ID explicitly.
+
+The `kapacitor` CLI must be available on PATH (typically installed at `~/.local/bin/kapacitor`).
+
+## Environment
+
+`KAPACITOR_URL` overrides the default server URL (`http://localhost:5108`).
+```
+
+- [ ] **Step 4: Confirm Codex sees the files (no test rig, just shape)**
+
+```bash
+ls -la kapacitor/codex-skills/
+# Expect: kapacitor-disable, kapacitor-errors, kapacitor-hide, kapacitor-recap, kapacitor-validate-plan
+find kapacitor/codex-skills -name SKILL.md | wc -l
+# Expect: 5
+```
+
+- [ ] **Step 5: Re-run the unit suite (now exercises the real five-folder layout indirectly via the array test)**
+
+Run: `dotnet run --project test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add kapacitor/codex-skills/kapacitor-hide kapacitor/codex-skills/kapacitor-disable kapacitor/codex-skills/kapacitor-validate-plan
+git commit -m "feat(skills): add hide/disable/validate-plan Codex skills
+
+Ports the three Claude session-management skills (session-hide,
+session-disable, validate-plan) to Codex with auto-resolved session
+ID via CODEX_THREAD_ID.
+
+Closes the user-visible parity gap with Claude Code skills.
+
+Part of AI-676."
+```
+
+---
+
+## Task 7: Update the two existing Codex `SKILL.md` files
+
+**Spec reference:** §2.2.
+
+The existing `kapacitor-recap` and `kapacitor-errors` skills treat manual session ID as the path of least resistance. After auto-resolve, the current session is the natural entry point. Rewrite the lead paragraphs and primary usage examples accordingly.
+
+**Files:**
+- Modify: `kapacitor/codex-skills/kapacitor-recap/SKILL.md`
+- Modify: `kapacitor/codex-skills/kapacitor-errors/SKILL.md`
+
+- [ ] **Step 1: Update `kapacitor-recap/SKILL.md`**
+
+Replace the entire file with:
+
+```markdown
+---
+name: kapacitor-recap
+description: >-
+  Use when the user asks to "read a previous session", "get session history",
+  "recap session", "what happened in session X", "load context from a previous
+  session", "continue from session", "what did we do last time", "catch me up",
+  "summarize session", "what have we been working on", "recent changes",
+  "recent sessions", or references prior work in this repo. Retrieves session
+  summaries recorded by Kurrent Capacitor via the `kapacitor recap` CLI.
+---
+
+# Kapacitor Recap
+
+Retrieve session history recorded by Kurrent Capacitor. Codex CLI 0.81+ exports `CODEX_THREAD_ID`; `kapacitor recap` uses it the same way it uses `KAPACITOR_SESSION_ID` for Claude. No args needed for the current session.
+
+## Usage
+
+Run the `kapacitor recap` CLI via the shell. Do NOT call the HTTP API directly — the CLI handles formatting, error handling, and server URL resolution.
+
+```bash
+# Current session — auto-resolved from CODEX_THREAD_ID
+kapacitor recap
+
+# Recent session summaries for the current repository (discovery)
+kapacitor recap --repo
+
+# A specific session by ID (from --repo output)
+kapacitor recap <sessionId>
+
+# Full transcript for a specific session
+kapacitor recap --full <sessionId>
+
+# Full continuation chain (all linked sessions, oldest first)
+kapacitor recap --chain <sessionId>
+
+# Both: full transcript across all chained sessions
+kapacitor recap --chain --full <sessionId>
+```
+
+## Default Output (Summary)
+
+Shows the plan (if any) and an AI-generated summary with:
+- **Context** — why the work was done.
+- **Key decisions** — trade-offs and design choices that matter for future work.
+- **Unfinished/Risks** — anything deferred or left incomplete.
+
+If no summary is available (e.g., active session), a hint is shown to use `--full`.
+
+## Repository Recap (`--repo`)
+
+Returns AI-generated summaries from the most recent ended sessions in the current git repository. Each entry includes the session title, date, summary, and the session ID needed to drill in further.
+
+**Use this for discovery — not as the default entry point:**
+- The user says "what have we been working on recently?"
+- The user references prior work ("recently we implemented X")
+- You need context about other sessions in this repo, not the current one
+
+**Progressive disclosure:** Start with `kapacitor recap` (current session) for in-session work. Switch to `--repo` when you need cross-session context. Drill into a specific summary with `kapacitor recap --full <sessionId>`.
+
+## Full Output (`--full`)
+
+The complete transcript with these section types:
+
+- **`## User Prompt`** — what the user asked.
+- **`## Assistant`** — text responses.
+- **`## Plan`** — plans that were created (Claude Code sessions only).
+- **`## Write <path>`** — files that were created (with syntax-highlighted content).
+- **`## Edit <path>`** — files that were edited (with diff content).
+
+When using `--chain`, sessions are separated by `# Session <id>` headers, and agent activity appears under `### Agent (<type>)` sub-headers.
+
+## When to Use Each Flag
+
+- **No flag** (`kapacitor recap`) — quick context on the current session.
+- **`--repo`** — recent session summaries across the repo.
+- **`<sessionId>`** — quick context on a specific session (from `--repo` output).
+- **`--full <sessionId>`** — when you need exact prompts, responses, or file contents.
+- **`--chain <sessionId>`** — understanding the full history of a task that spanned multiple sessions.
+- **`--chain --full <sessionId>`** — complete transcript across all continuations.
+
+## Environment
+
+`KAPACITOR_URL` overrides the default server URL (`http://localhost:5108`).
+
+## Tips
+
+- Start with `kapacitor recap` (no args) for the active session, then `--repo` for cross-session discovery.
+- Summarize key decisions and changes for the user rather than echoing the full recap output verbatim.
+- The `kapacitor` CLI must be available on PATH (typically installed at `~/.local/bin/kapacitor`).
+
+## Error Handling
+
+- If the session is not found, the command prints "Session not found" and exits with code 1.
+- If not in a git repository (for `--repo`), the command prints an error and exits with code 1.
+- If the Kurrent Capacitor server is unreachable, the command prints an HTTP error. Ensure the server is running.
+```
+
+- [ ] **Step 2: Update `kapacitor-errors/SKILL.md`**
+
+Replace the entire file with:
+
+```markdown
+---
+name: kapacitor-errors
+description: >-
+  Use when the user asks to "show errors", "extract errors", "what went wrong",
+  "find tool errors", "review errors from session", "check session errors",
+  "list failures", "what failed in session X", "error report", "show mistakes",
+  or wants to review tool call errors from a recorded session. Extracts tool
+  errors via the `kapacitor errors` CLI.
+---
+
+# Kapacitor Errors
+
+Extract tool call errors from a session recorded by Kurrent Capacitor. The output lists each failed tool call — shell commands, file reads/writes, agent delegations, etc. — along with the error message and the tool that caused it.
+
+Codex CLI 0.81+ exports `CODEX_THREAD_ID`; `kapacitor errors` uses it the same way it uses `KAPACITOR_SESSION_ID` for Claude. No args needed for the current session.
+
+## Usage
+
+```bash
+# Current session — auto-resolved from CODEX_THREAD_ID
+kapacitor errors
+
+# Errors from the full continuation chain of the current session
+kapacitor errors --chain
+
+# Errors from a specific session
+kapacitor errors <sessionId>
+
+# Errors from the full continuation chain starting at a session
+kapacitor errors --chain <sessionId>
+```
+
+## Output Format
+
+Each error is printed as a block with:
+
+- **Session ID** and optional **agent ID** (if the error occurred in a subagent).
+- **Event number** and **timestamp**.
+- **Tool name** — the tool that failed (e.g., Bash, Read, Edit, Write, Grep, Glob).
+- **Error message** — the error output or failure reason.
+
+When using `--chain`, errors from all sessions in the continuation chain are included, ordered chronologically.
+
+## When to Use Each Flag
+
+- **No flag** (`kapacitor errors`) — reviewing errors from the current session.
+- **`<sessionId>`** — reviewing errors from a specific session (e.g. from `kapacitor recap --repo`).
+- **`--chain`** — reviewing errors across a full task that spanned multiple sessions.
+
+## Practical Applications
+
+- **Post-mortem review** — after finishing a session, identify recurring mistakes and update project rules (CLAUDE.md / AGENTS.md) with avoidance guidance.
+- **Debugging** — quickly find what went wrong in a session without scrolling through the full timeline.
+- **Pattern detection** — use `--chain` across a multi-session task to spot repeated error patterns (e.g., wrong file paths, incorrect API usage).
+
+## Environment
+
+`KAPACITOR_URL` overrides the default server URL (`http://localhost:5108`).
+
+## Tips
+
+- After extracting errors, look for patterns: the same tool failing repeatedly, or the same type of mistake across sessions.
+- Propose concrete avoidance rules based on the errors found — these can be added to AGENTS.md / CLAUDE.md.
+- The `kapacitor` CLI must be available on PATH (typically installed at `~/.local/bin/kapacitor`).
+
+## Error Handling
+
+- If the session is not found, the command prints an error and exits with code 1.
+- If no errors are found, the command prints "No errors found." — this is a good outcome.
+- If the Kurrent Capacitor server is unreachable, the command prints an HTTP error. Ensure the server is running.
+```
+
+- [ ] **Step 3: Verify both files parse cleanly (frontmatter intact)**
+
+```bash
+head -8 kapacitor/codex-skills/kapacitor-recap/SKILL.md
+head -8 kapacitor/codex-skills/kapacitor-errors/SKILL.md
+```
+
+Expected: each begins with `---` then `name:` then `description:` then `---`. No stray whitespace.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kapacitor/codex-skills/kapacitor-recap/SKILL.md kapacitor/codex-skills/kapacitor-errors/SKILL.md
+git commit -m "docs(skills): drop manual-session-id guidance from recap/errors
+
+CODEX_THREAD_ID now auto-resolves the active session, so the
+two-step ‘list with --repo, then re-invoke’ dance is no longer
+the default. --repo demoted from entry point to discovery flow.
+
+Part of AI-677."
+```
+
+---
+
+## Task 8: Help text updates (9 resource files)
+
+**Spec reference:** §3.4.
+
+All nine edits are mechanical text changes. One task, one commit.
+
+**Files:**
+- Modify: `src/Kapacitor.Cli.Core/Resources/help-hide.txt`
+- Modify: `src/Kapacitor.Cli.Core/Resources/help-disable.txt`
+- Modify: `src/Kapacitor.Cli.Core/Resources/help-recap.txt`
+- Modify: `src/Kapacitor.Cli.Core/Resources/help-errors.txt`
+- Modify: `src/Kapacitor.Cli.Core/Resources/help-validate-plan.txt`
+- Modify: `src/Kapacitor.Cli.Core/Resources/help-eval.txt`
+- Modify: `src/Kapacitor.Cli.Core/Resources/help-set-title.txt`
+- Modify: `src/Kapacitor.Cli.Core/Resources/help-usage.txt`
+- Modify: `src/Kapacitor.Cli.Core/Resources/help-plugin.txt`
+
+- [ ] **Step 1: Update `help-hide.txt`**
+
+Replace the file contents with:
+
+```
+kapacitor hide — Hide session from other users
+
+Usage: kapacitor hide [sessionId]
+
+Sets the current session's visibility to owner-only. Other users
+will no longer see this session in the dashboard.
+
+Arguments:
+  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+                          on Claude or CODEX_THREAD_ID on Codex 0.81+)
+```
+
+- [ ] **Step 2: Update `help-disable.txt`**
+
+Replace with:
+
+```
+kapacitor disable — Stop recording and delete all session data
+
+Usage: kapacitor disable [sessionId]
+
+Stops the watcher, prevents future hook events from being sent,
+and deletes all session data from the server (streams + read models).
+
+Arguments:
+  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+                          on Claude or CODEX_THREAD_ID on Codex 0.81+)
+```
+
+- [ ] **Step 3: Update `help-recap.txt` line 11**
+
+Change:
+
+```
+  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID)
+```
+
+to:
+
+```
+  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+                          on Claude or CODEX_THREAD_ID on Codex 0.81+)
+```
+
+- [ ] **Step 4: Update `help-errors.txt` line 9**
+
+Same edit as Step 3:
+
+```
+  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+                          on Claude or CODEX_THREAD_ID on Codex 0.81+)
+```
+
+- [ ] **Step 5: Update `help-validate-plan.txt` line 6**
+
+Same edit as Step 3.
+
+- [ ] **Step 6: Update `help-eval.txt` lines 30-31**
+
+Change:
+
+```
+  - If the session ID is omitted, the currently-recorded session (as set by
+    the session-start hook in KAPACITOR_SESSION_ID) is used.
+```
+
+to:
+
+```
+  - If the session ID is omitted, the currently-recorded session is used —
+    resolved from KAPACITOR_SESSION_ID (Claude) or CODEX_THREAD_ID
+    (Codex 0.81+).
+```
+
+- [ ] **Step 7: Update `help-set-title.txt`**
+
+Replace the entire file with:
+
+```
+kapacitor set-title — Set session title
+
+Usage: kapacitor set-title <title>
+
+Arguments:
+  title                   Session title (max 120 characters)
+
+Environment:
+  Session ID is auto-resolved from KAPACITOR_SESSION_ID (Claude)
+  or CODEX_THREAD_ID (Codex 0.81+).
+```
+
+- [ ] **Step 8: Update `help-usage.txt` line 67**
+
+Find the existing environment-variable section (search for `KAPACITOR_SESSION_ID` near line 67 — the actual line number may shift slightly). The current line:
+
+```
+  KAPACITOR_SESSION_ID       Session ID (set automatically by SessionStart hook)
+```
+
+becomes two lines:
+
+```
+  KAPACITOR_SESSION_ID       Session ID set by the Claude Code SessionStart hook
+  CODEX_THREAD_ID            Session ID exported by Codex CLI 0.81+
+```
+
+- [ ] **Step 9: Update `help-plugin.txt` lines 13-16**
+
+Change:
+
+```
+Notes:
+  --codex installs hooks (~/.codex/hooks.json or <repo>/.codex/hooks.json with
+  --project) plus kapacitor-recap and kapacitor-errors skills in
+  ~/.codex/skills/. Skills are always user-wide; --project only affects hooks.
+```
+
+to:
+
+```
+Notes:
+  --codex installs hooks (~/.codex/hooks.json or <repo>/.codex/hooks.json with
+  --project) plus five skills in ~/.codex/skills/: kapacitor-recap,
+  kapacitor-errors, kapacitor-hide, kapacitor-disable, and
+  kapacitor-validate-plan. Skills are always user-wide; --project only
+  affects hooks.
+```
+
+- [ ] **Step 10: Build and verify the resource bundle still loads**
+
+Run: `dotnet build src/Kapacitor.Cli/Kapacitor.Cli.csproj`
+Expected: Build succeeds. Sanity-spot-check by running `dotnet run --project src/Kapacitor.Cli/Kapacitor.Cli.csproj -- hide --help` (or equivalent help command — adjust to the real `--help` plumbing if `hide --help` isn't supported, e.g. `dotnet run -- help hide`).
+
+- [ ] **Step 11: Run unit tests**
+
+Run: `dotnet run --project test/Kapacitor.Cli.Tests.Unit/Kapacitor.Cli.Tests.Unit.csproj`
+Expected: All pass.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/Kapacitor.Cli.Core/Resources/help-*.txt
+git commit -m "docs(cli): help text names CODEX_THREAD_ID alongside KAPACITOR_SESSION_ID
+
+Updates hide/disable to advertise the optional [sessionId] positional;
+recap/errors/validate-plan/eval/set-title/usage to name both env vars;
+plugin to enumerate all five Codex skills.
+
+Part of AI-676 and AI-677."
+```
+
+---
+
+## Task 9: README updates
+
+**Spec reference:** §5. CLAUDE.md mandates README sync on any user-facing CLI surface change.
+
+**Files:**
+- Modify: `README.md` — Codex section (around line 250-260, the `#### Hosted Codex agents` block and the install paragraph above it), and the per-command rows under `## CLI commands` for `hide` and `disable` (search for the existing `Plan validation` section starting at line 133 — the new sections go near there).
+
+- [ ] **Step 1: Add the auto-resolve note to the Codex section**
+
+Find the existing line near line 247:
+> Hosted Codex agents require the Codex hook surface — if you said yes during `kapacitor setup`, you already have it.
+
+Above the `kapacitor plugin install --codex` block, add:
+
+```markdown
+Codex CLI 0.81+ exports `CODEX_THREAD_ID`; kapacitor reads it the same way it reads `KAPACITOR_SESSION_ID` for Claude sessions — no manual session ID needed for any of the Codex skills (`kapacitor-recap`, `kapacitor-errors`, `kapacitor-hide`, `kapacitor-disable`, `kapacitor-validate-plan`).
+```
+
+- [ ] **Step 2: Add a Codex skills enumeration block**
+
+After the `kapacitor plugin install --codex` examples in the same section, add:
+
+```markdown
+Installing with `--codex` writes five skills under `~/.codex/skills/`:
+
+| Skill | Wraps | Purpose |
+|---|---|---|
+| `kapacitor-recap` | `kapacitor recap` | Session summary / continuation chain / repo history |
+| `kapacitor-errors` | `kapacitor errors` | Tool-call error extraction |
+| `kapacitor-hide` | `kapacitor hide` | Mark session owner-only |
+| `kapacitor-disable` | `kapacitor disable` | Stop recording + delete server data |
+| `kapacitor-validate-plan` | `kapacitor validate-plan` | Verify plan items were completed |
+
+All five auto-resolve the active session from `CODEX_THREAD_ID`; pass `<sessionId>` explicitly to operate on a different session.
+```
+
+- [ ] **Step 3: Add hide/disable command examples to `## CLI commands`**
+
+After the `### Plan validation` block (around line 145), add two new subsections:
+
+```markdown
+### Hide session
+
+Mark a session as owner-only so other users no longer see it in the dashboard.
+
+```bash
+kapacitor hide                 # current session
+kapacitor hide <sessionId>     # specific session
+```
+
+### Disable recording
+
+Stop the watcher, silence future hooks, and delete server-side data for a session.
+
+```bash
+kapacitor disable                 # current session
+kapacitor disable <sessionId>     # specific session
+```
+
+This is irreversible on the server side; the local transcript file is untouched.
+```
+
+(Place after Plan validation, before the next major section. Use the existing heading style — three hashes.)
+
+- [ ] **Step 4: Build the CLI once more (no behavior change, just sanity)**
+
+Run: `dotnet build src/Kapacitor.Cli/Kapacitor.Cli.csproj`
+Expected: Build succeeds; no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): document Codex skill parity and CODEX_THREAD_ID resolution
+
+Adds an auto-resolve note plus a five-skill enumeration table to the
+Codex section. Adds hide/disable command examples to CLI commands.
+
+Part of AI-676."
+```
+
+---
+
+## Task 10: AOT publish verification + final smoke test
+
+**Spec reference:** §8 (Acceptance).
+
+CLAUDE.md flags this: AOT trimming/dynamic-code warnings only surface on publish, not on debug build. Plus the user-visible acceptance criteria need a manual run-through.
+
+- [ ] **Step 1: AOT publish for the current platform**
+
+Run:
+```bash
+dotnet publish src/Kapacitor.Cli/Kapacitor.Cli.csproj -c Release 2>&1 | tee /tmp/aot-publish.log
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 2: Grep for trimming/AOT warnings**
+
+Run:
+```bash
+grep -E 'IL[23][01][0-9]{2}' /tmp/aot-publish.log || echo "no AOT warnings"
+```
+
+Expected: `no AOT warnings`. If any appear, **STOP** — investigate (CLAUDE.md is explicit: these don't show in `dotnet build`). The likely culprits would be the new test code (which isn't AOT'd) or JSON serialization paths in `PluginCommand` — but no JSON change was made in this plan, so a regression would be unexpected.
+
+- [ ] **Step 3: Install the fresh CLI into PATH for smoke testing**
+
+```bash
+cp src/Kapacitor.Cli/bin/Release/net10.0/*/publish/Kapacitor.Cli ~/.local/bin/kapacitor.smoke
+# macOS only:
+codesign --force --sign - ~/.local/bin/kapacitor.smoke
+```
+
+- [ ] **Step 4: Smoke test the install command**
+
+```bash
+~/.local/bin/kapacitor.smoke plugin install --codex
+ls ~/.codex/skills/
+```
+
+Expected: Five folders present — `kapacitor-recap`, `kapacitor-errors`, `kapacitor-hide`, `kapacitor-disable`, `kapacitor-validate-plan`.
+
+- [ ] **Step 5: Smoke test resolver in an active Codex session**
+
+Start a fresh Codex CLI session (with hooks already installed) and ask:
+
+```
+Run kapacitor recap with no arguments and tell me the session title.
+```
+
+Expected: Codex invokes `kapacitor recap`, gets back the current session's summary, and reads back the title. No "session not found" or env-var error.
+
+Repeat for the four other skills (`kapacitor errors`, `kapacitor hide`, `kapacitor disable`, `kapacitor validate-plan`) — invoke each via a natural-language ask. For `hide` and `disable`, do this in a throwaway session so you don't accidentally hide a real session.
+
+- [ ] **Step 6: Smoke test the error path**
+
+In a non-Codex shell (no `CODEX_THREAD_ID`, no `KAPACITOR_SESSION_ID`):
+
+```bash
+unset KAPACITOR_SESSION_ID CODEX_THREAD_ID
+~/.local/bin/kapacitor.smoke hide
+```
+
+Expected: Exits with code 1 and prints:
+```
+Usage: kapacitor hide [sessionId]
+  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.
+```
+
+- [ ] **Step 7: Clean up the smoke binary**
+
+```bash
+rm ~/.local/bin/kapacitor.smoke
+```
+
+- [ ] **Step 8: Final review commit (if anything was tweaked during smoke testing)**
+
+If Steps 4-6 surfaced any wording or behavior tweaks, commit them now with a single `chore: smoke-test fixups` commit. If everything passed cleanly, **no commit** — this task is a verification gate, not new code.
+
+---
+
+## Self-review summary
+
+**Spec coverage:**
+- §1 architecture overview → Tasks 1 (resolver), 2/3 (callers), 5 (plugin), 6 (new skills), 7 (updated skills) ✓
+- §2.1 new SKILL.md files → Task 6 ✓
+- §2.2 updated SKILL.md files → Task 7 ✓
+- §3.1 resolver + set-title bullet → Tasks 1, 3 ✓
+- §3.2 hide/disable positional → Task 2 ✓
+- §3.4 help text (9 files) → Task 8 ✓
+- §4.1 PluginCommand array + preflight → Task 5 ✓
+- §5 README → Task 9 ✓
+- §6 testing → Tasks 1 (resolver tests), 5 (plugin tests). Integration tests for hide/disable described in §6.3 are deferred to a follow-up (the wire path is unchanged; smoke-tested in Task 10 Step 5) ✓
+- §7.1 probe → Task 0 ✓
+- §8 acceptance → Task 10 ✓
+
+**Placeholder scan:** No TBDs, no "implement later", no "add appropriate X". Each step includes the literal code or text to write.
+
+**Type/signature consistency:** Resolver returns `string?` everywhere; both `ResolveSessionId` and `ResolveSessionIdFromEnv` agreed across Tasks 1, 2, 3, 4. `CodexSkillNames` is `internal static readonly string[]` consistently in Task 5 and the test in §6.2. Error strings are identical across Tasks 2 and 4.
+
+**Deferred (called out in spec §6.3, not blocking acceptance):** WireMock.Net integration tests for `hide`/`disable` positional ID landing on the HTTP wire. The HTTP shape didn't change in this plan; manual smoke testing in Task 10 Step 5 covers it for now. Add to a follow-up if regression risk warrants it.

--- a/docs/superpowers/specs/2026-05-24-ai-676-codex-skill-parity-design.md
+++ b/docs/superpowers/specs/2026-05-24-ai-676-codex-skill-parity-design.md
@@ -1,0 +1,278 @@
+# AI-676 / AI-677 — Codex skill parity and auto-resolved session ID
+
+**Status:** design proposed, pending implementation plan
+**Linear:** [AI-676](https://linear.app/kurrent/issue/AI-676), [AI-677](https://linear.app/kurrent/issue/AI-677)
+**Milestone:** Closed public preview
+
+## 1. Architecture overview
+
+Two changes are bundled into one spec because they share the same audience (Codex CLI users) and the same milestone, and shipping AI-676 alone would require SKILL.md files documenting a workaround that AI-677 immediately reverses.
+
+**Skill parity (AI-676).** Three new SKILL.md files under `kapacitor/codex-skills/` — `kapacitor-hide`, `kapacitor-disable`, `kapacitor-validate-plan` — mirror the existing Claude Code skills `session-hide`, `session-disable`, `validate-plan`. Registered in `PluginCommand.CodexSkillNames` so `kapacitor plugin install --codex` copies them into `~/.codex/skills/`. The setup wizard and README enumerate all five Codex skills.
+
+**Auto-resolve (AI-677).** Extend the session-ID resolution chain used by `recap`, `errors`, `validate-plan`, `eval`, `hide`, `disable`, and `set-title` to read `CODEX_THREAD_ID` directly from the environment. `eval` benefits incidentally because it already calls `ResolveSessionId` (Program.cs:140); `set-title` benefits via a small env-only sibling helper (§3.1) because its positional is `<title>`, not `<sessionId>`. No marker file, no SessionStart write path. **This supersedes the marker-file fallback sketched in AI-677**, which proposed `~/.cache/kapacitor/codex-sessions/<id>`. `CODEX_THREAD_ID` was added to Codex CLI in [openai/codex#10096](https://github.com/openai/codex/pull/10096) (merged 2026-02-03) and ships in Codex CLI 0.81+. Local Codex (0.133.0) has it. The marker-file design is documented in §7.1 as the fallback if the day-1 probe finds the env and the hook-payload `session_id` diverge.
+
+Resolution chain (single place — `ArgParsing.ResolveSessionId`):
+
+```
+1. positional <sessionId>           explicit override (returned verbatim)
+2. KAPACITOR_SESSION_ID, dashless    Claude Code hook-set
+3. CODEX_THREAD_ID, dashless         Codex CLI-exported (0.81+)
+4. null → caller prints actionable error message
+```
+
+Normalization caveat — only **env-sourced** values are dash-stripped; **positional** values are returned verbatim. This preserves the existing behavior documented at README.md:125 and README.md:153 where the positional argument accepts a session GUID *or* a meta-session slug (slugs contain hyphens that are semantically meaningful). Today, individual callers strip dashes after the env fallback (e.g. Program.cs:305 / 354 / 504); after this change, normalization lives in the resolver for env-sourced values only.
+
+**CLI surface change (consequence of bundling).** `kapacitor hide` and `kapacitor disable` today read `KAPACITOR_SESSION_ID` directly and fail without it. They grow an optional positional `sessionId` arg, mirroring `recap` / `errors` / `validate-plan`, and route through `ArgParsing.ResolveSessionId`. Without this change the three new SKILL.md files would document a `KAPACITOR_SESSION_ID=<id> kapacitor hide` shell prefix as a workaround, which is exactly what AI-677 exists to eliminate.
+
+## 2. Skill files
+
+### 2.1 New SKILL.md files (3)
+
+Each new file is a Codex-flavored mirror of its Claude counterpart with two adjustments: it drops the "must be inside Claude Code session" framing, and it documents both auto-resolve paths under **Requirements**.
+
+- `kapacitor/codex-skills/kapacitor-hide/SKILL.md` — wraps `kapacitor hide`.
+- `kapacitor/codex-skills/kapacitor-disable/SKILL.md` — wraps `kapacitor disable`.
+- `kapacitor/codex-skills/kapacitor-validate-plan/SKILL.md` — wraps `kapacitor validate-plan`.
+
+Trigger phrases (the skill `description` frontmatter) are copied verbatim from the Claude skills — they're the user-visible activation surface and need no Codex-specific phrasing. Skill bodies follow the same shape as the existing `kapacitor-recap` / `kapacitor-errors` files: usage block, requirements block, notes/tips, error handling.
+
+Body template for the three new skills (illustrative, `kapacitor-hide`):
+
+```
+## Usage
+kapacitor hide                  # auto-resolves the active session
+kapacitor hide <sessionId>      # explicit override (from `kapacitor recap --repo`)
+
+## Requirements
+Run inside an active Codex CLI session (0.81+) — the active session is
+auto-resolved from `CODEX_THREAD_ID`. To act on a different session, pass its
+ID explicitly. Use `kapacitor recap --repo` to list recent session IDs in
+this repository.
+```
+
+### 2.2 Updated SKILL.md files (2)
+
+Both existing Codex skills today treat `--repo` as the entry point (kapacitor-recap/SKILL.md:21: *"the recommended entry point is the **repository recap**"*) because there was no way to recap the current session without a manual session ID. After auto-resolve lands, the current session *is* the natural starting point. Both files need a usage and decision-flow rewrite, not just a sentence deletion.
+
+- `kapacitor/codex-skills/kapacitor-recap/SKILL.md`:
+  - **Promote `kapacitor recap` (no args) to the primary usage example.** Place it first in the Usage block, above `kapacitor recap --repo`.
+  - **Rewrite the opening paragraph.** Remove the "Codex sessions do not export `KAPACITOR_SESSION_ID`" framing. Replace with: *"Codex CLI 0.81+ exports `CODEX_THREAD_ID`; `kapacitor recap` uses it the same way it uses `KAPACITOR_SESSION_ID` for Claude. No args needed for the current session."*
+  - **Demote `--repo` from "entry point" to "discovery"** in the "Use this when" list: keep its existing utility ("what have we been working on recently?", drilling into other sessions) but remove language that implies it must be the first call.
+  - The default-output / full-output / chain sections are unchanged.
+- `kapacitor/codex-skills/kapacitor-errors/SKILL.md`:
+  - **Promote `kapacitor errors` (no args) to the primary usage example.** Today the SKILL.md says explicit ID is required; flip that.
+  - **Drop the "you must pass the session ID explicitly" sentence**, replace with the same one-line auto-resolve note used in `kapacitor-recap`.
+  - When invoked with no args, the skill now operates on the current Codex session by default, matching the Claude `session-errors` skill's UX exactly.
+
+No shared template or generation step. Five files are well within the cost of plain markdown editing, and each SKILL.md is user-readable docs that benefits from being self-contained.
+
+## 3. CLI changes
+
+### 3.1 Centralize session-ID resolution
+
+`src/Kapacitor.Cli/ArgParsing.cs:10` — `ResolveSessionId(string[] args, int skipCount = 1, string[]? valueFlags = null)` already walks the args array and skips boolean / value-bearing flags before falling back to `KAPACITOR_SESSION_ID` at line 28. The signature is preserved exactly; only the env-fallback tail gains a third source. Existing callers (`recap`, `errors`, `validate-plan`, `eval` — see Program.cs:90, 110, 123, 140) need no change beyond keeping their current invocations.
+
+```csharp
+internal static string? ResolveSessionId(string[] args, int skipCount = 1, string[]? valueFlags = null) {
+    // ... existing positional walk unchanged (returns verbatim if a positional is found) ...
+
+    return ResolveSessionIdFromEnv();
+}
+
+internal static string? ResolveSessionIdFromEnv() {
+    var kapacitor = Environment.GetEnvironmentVariable("KAPACITOR_SESSION_ID");
+    if (!string.IsNullOrWhiteSpace(kapacitor))
+        return kapacitor.Replace("-", "");
+
+    var codex = Environment.GetEnvironmentVariable("CODEX_THREAD_ID");
+    if (!string.IsNullOrWhiteSpace(codex))
+        return codex.Replace("-", "");
+
+    return null;
+}
+```
+
+`set-title` (§3.1 set-title bullet) and any future env-only caller use `ResolveSessionIdFromEnv()` directly. Arg-bearing commands continue to call `ResolveSessionId(args, ...)`. Both paths share the same env precedence and, if the §7.1 fallback ever activates, the same marker-read shim.
+
+Behavior delta against today:
+
+- **Positional values are returned verbatim** (no `.Replace("-", "")`). Matches today's behavior and preserves meta-session slugs (README.md:125, 153). Callers that need a dashless GUID must normalize explicitly — but for positionals, that's already not appropriate.
+- **Env values are dash-stripped** in the resolver. Today, individual callers do this after the resolver returns. After this change, `hide`/`disable` (which previously read the env directly and stripped dashes inline at Program.cs:305 / 354) no longer need to strip — the resolver returns the already-normalized value when it sourced from env.
+- **`CODEX_THREAD_ID` is appended as the last env fallback.** Order matters: `KAPACITOR_SESSION_ID` wins because Claude-side hooks set it deliberately to the active Capacitor session ID, whereas `CODEX_THREAD_ID` is exported globally by Codex regardless of whether the Capacitor watcher is attached.
+
+Caller migration:
+
+- `src/Kapacitor.Cli/Program.cs:305` (`hide`) — replace inline env read with `ResolveSessionId(args)`. Today `hide` takes no positional, so the resolver walks zero positionals and returns the env fallback. Adding the positional in §3.2 is then a one-line UX improvement; the resolver call itself is unchanged.
+- `src/Kapacitor.Cli/Program.cs:354` (`disable`) — same.
+- The error messages at sites 94, 114, 127, 146, 308, 357 collapse into one shared string: *"No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+."* Today the codebase has two near-duplicate forms; both get replaced.
+- **`set-title` (Program.cs:498 / 504 / 507) uses a sibling helper, not the args resolver.** Its positional is `<title>` (multi-word, joined via `string.Join(' ', args.Skip(1))` at line 513), not `<sessionId>`. Running `args` through `ResolveSessionId` would interpret the title as a session ID. Instead, factor the env-fallback tail (the two `Environment.GetEnvironmentVariable` reads + dash-strip) into an **`internal static` helper** `ArgParsing.ResolveSessionIdFromEnv()` (it must be `internal`, not `private`, because `set-title` lives in `Program.cs` — different file, same assembly). `ResolveSessionId` calls it internally so the chains stay synchronised; `set-title` calls it directly. The helper has the same precedence as the env tail of the main resolver — `KAPACITOR_SESSION_ID` then `CODEX_THREAD_ID`, each dash-stripped, `null` if both unset.
+
+  Error wording for `set-title` is **not** the shared "Pass one explicitly" message — `set-title` accepts no `<sessionId>` positional, so telling the user to pass one would be misleading. Tailored wording:
+
+  - **Missing title** (Program.cs:498 branch): rewrite to `"Usage: kapacitor set-title <title>"` only. Drop the *"KAPACITOR_SESSION_ID must be set"* line at 500 — it confuses the diagnosis (a user with the env var set but no title shouldn't be told the env var is missing).
+  - **Missing session env** (Program.cs:507 branch): replace *"KAPACITOR_SESSION_ID not set"* with *"No session ID found in `KAPACITOR_SESSION_ID` or `CODEX_THREAD_ID`. Run `set-title` inside an active Claude Code / Codex CLI 0.81+ session."*
+
+  This keeps chain semantics consistent across **all** session-id-needing commands without forcing `set-title` to pretend its positional is a sessionId.
+
+### 3.2 `hide` and `disable` accept an optional positional `sessionId`
+
+Today both commands read the env var directly (Program.cs:305, 354) and exit with "KAPACITOR_SESSION_ID not set" otherwise. Replace the env-var read with `ArgParsing.ResolveSessionId(args)` — same shape used by `recap` (Program.cs:110), `errors` (Program.cs:90), and `validate-plan` (Program.cs:123). The resolver walks `args` from `skipCount: 1`, skips flags (none for these two commands today), and returns the positional if present or the env fallback otherwise. No `args[1]` indexing.
+
+The positional is optional. If both positional and env are absent, the resolver returns `null` and the caller emits the shared error message. No other behavior change — HTTP calls, exit codes, and idempotency are unchanged.
+
+### 3.3 Out of scope for the CLI layer
+
+`kapacitor codex-hook` and the watcher already receive the session ID via the hook payload directly, not via env. They do not call `ResolveSessionId` and need no change.
+
+### 3.4 Help text
+
+Nine resource files in `src/Kapacitor.Cli.Core/Resources/`:
+
+- **`help-hide.txt`** — add a `sessionId` positional row; rewrite the "set automatically" wording to "auto-resolved from `KAPACITOR_SESSION_ID` (Claude) or `CODEX_THREAD_ID` (Codex 0.81+)".
+- **`help-disable.txt`** — same edit.
+- **`help-recap.txt`** — extend the existing `(defaults to KAPACITOR_SESSION_ID)` note to also name `CODEX_THREAD_ID`.
+- **`help-errors.txt`** — same.
+- **`help-validate-plan.txt`** — same.
+- **`help-eval.txt`** — update the env-var sentence (currently line 31: *"the session-start hook in KAPACITOR_SESSION_ID"*) to name both env vars.
+- **`help-set-title.txt`** — update the env-var line (currently *"Session ID (required)"* with the implicit env name) to spell out both env sources. `set-title` reads them via the `ResolveSessionIdFromEnv` sibling helper introduced in §3.1, so the docs and behavior are aligned.
+- **`help-usage.txt`** — list `CODEX_THREAD_ID` alongside `KAPACITOR_SESSION_ID` in the env-var section (line 67 today).
+- **`help-plugin.txt`** — line 14-16 currently reads *"`--codex` installs hooks (...) plus kapacitor-recap and kapacitor-errors skills"*. Rewrite to enumerate all five skill names.
+
+## 4. Installer and setup wizard updates
+
+### 4.1 `PluginCommand.cs`
+
+Append the three new names to `CodexSkillNames` (line 14) **and promote its access modifier from implicit `private` to `internal`** so the test assembly can value-check it (`InternalsVisibleTo Include="Kapacitor.Cli.Tests.Unit"` is already set in `Kapacitor.Cli.csproj:17`):
+
+```csharp
+internal static readonly string[] CodexSkillNames = [
+    "kapacitor-recap",
+    "kapacitor-errors",
+    "kapacitor-hide",
+    "kapacitor-disable",
+    "kapacitor-validate-plan"
+];
+```
+
+`InstallCodexSkills` (line 322) iterates the array; `RemoveCodexSkills` (line 351) iterates the same array. Upgrades and removals get parity automatically. The existing wholesale-replace semantics in `InstallCodexSkills` (`Directory.Delete(dst, recursive: true)` before copy, line 335) means upgraders with stale folders get refreshed cleanly, and foreign user-installed skills are untouched.
+
+**Bug fix bundled in — preflight validation.** `InstallCodexSkills` line 328-331 silently `continue`s when a name in `CodexSkillNames` has no matching folder under `sourceDir`. This is the wrong shape for a contract that promises "install all five skills" — a packaging error that omits a folder would currently report success and leave the user with a partial install. **And** simply returning `false` mid-loop is worse: by then the loop has already deleted prior target folders (line 335) and copied them, so a mid-loop bail leaves the install in a half-replaced state.
+
+The fix is **preflight, then act**:
+
+1. Walk `CodexSkillNames` once and verify every name exists under `sourceDir`.
+2. If any are missing, write a single `Console.Error` line naming all missing folders and return `false` immediately. Target dir is untouched.
+3. Only after the preflight passes, run the existing delete-then-copy loop.
+
+This keeps the all-or-nothing install contract intact and gives `RemoveCodexSkills` no new responsibility (removal stays best-effort, since a folder that doesn't exist there is already a no-op at line 358).
+
+### 4.2 `CodingAgentsStep.cs`
+
+No code changes. It already dispatches to `installers.InstallCodexSkills(src, paths.CodexSkillsDir)` (line 60), which walks the array above. The user-facing prompt text at line 90 and the success line at line 67 do not enumerate skill names and stay accurate.
+
+### 4.3 No new skill registration with Codex
+
+Codex auto-discovers skill folders under `~/.codex/skills/` — the existing two skills rely on this mechanism. The three new skills use the same path.
+
+## 5. README updates
+
+CLAUDE.md mandates README sync on any CLI surface change. Three edits:
+
+1. **Codex section enumerates all five skills by name.** Currently the README mentions Claude skills by name (`/kapacitor:session-recap`, `/kapacitor:validate-plan`) but glosses over Codex skills generically. Add a short block under the Codex install paragraph listing all five Codex skill names alongside what each does, so users discover that `hide`/`disable`/`validate-plan` parity exists.
+2. **Auto-resolve note.** Add one sentence to the Codex setup section: *"Codex CLI 0.81+ exports `CODEX_THREAD_ID`; kapacitor reads it the same way it reads `KAPACITOR_SESSION_ID` for Claude sessions — no manual session ID needed."*
+3. **`hide` / `disable` command examples in `## CLI commands`.** Show both forms:
+   ```bash
+   kapacitor hide                 # current session
+   kapacitor hide <sessionId>     # specific session
+   ```
+   Same for `disable`.
+
+Quick-start section is untouched — the getting-started flow does not exercise these commands.
+
+## 6. Testing
+
+The bar is moderate. This is plumbing, not new business logic.
+
+### 6.1 `ArgParsing.ResolveSessionId` precedence (unit)
+
+Extend the existing `test/Kapacitor.Cli.Tests.Unit/ArgParsingTests.cs` (8 tests today) with new cases covering:
+
+- Positional wins over both env vars.
+- `KAPACITOR_SESSION_ID` wins over `CODEX_THREAD_ID`.
+- `CODEX_THREAD_ID` is used when both args and `KAPACITOR_SESSION_ID` are unset.
+- **Positional is returned verbatim** — a positional `foo-bar` is *not* dash-stripped (covers the meta-session slug case from README.md:153).
+- **Env values are dash-stripped** — `KAPACITOR_SESSION_ID=abc-def` resolves to `abcdef`; same for `CODEX_THREAD_ID`.
+- All three sources unset returns `null`.
+
+**Test isolation.** The existing tests at ArgParsingTests.cs:54 / 70 use `[NotInParallel(nameof(KapacitorSessionIdEnvVar))]` where the constant evaluates to the literal `"KAPACITOR_SESSION_ID"`. The new `CODEX_THREAD_ID` tests must serialize against the same lock — TUnit's `NotInParallel` keys are string-identity-compared. Two acceptable approaches; pick whichever produces less churn:
+
+- **Rename the group constant.** Replace `KapacitorSessionIdEnvVar` with a `SessionEnvVarMutation` constant evaluating to a stable literal (e.g. `"SessionEnvVarMutation"`), update all existing tests using it, and use that same constant for the new `CODEX_THREAD_ID` tests. Cleaner long-term name; touches the existing tests.
+- **Reuse the existing literal**: pass `[NotInParallel("KAPACITOR_SESSION_ID")]` on the new tests. Zero churn but the group name is technically misleading for `CODEX_THREAD_ID` tests.
+
+Recommendation: rename. The existing constant is private to `ArgParsingTests` and the rename is mechanical.
+
+Do **not** use the `HomeEnvVarMutation` group from `PluginCommandCodexTests.cs:310` — that's for HOME-mutation, an orthogonal concern.
+
+### 6.2 `PluginCommand` skill registration (unit)
+
+- Extend `PluginCommandCodexTests.InstallCodexSkills_copies_known_skills` (line 197) to assert all five names land in `target/`.
+- Add `CodexSkillNames_contains_expected_five` — a one-shot value check that the `CodexSkillNames` array equals the five expected names. Cheap; catches the case where someone reorders the array or drops a name. A disk-walk variant would require resolving the repo root from a test runner's working directory, which is brittle — value check is enough.
+- **Add `InstallCodexSkills_returns_false_when_known_folder_missing`** — covers the bug fix from §4.1. Write only four of the five expected folders into the temp source dir, call `InstallCodexSkills`, assert it returns `false`, that the error names the missing folder, and crucially that **no target subfolder was created and no pre-existing target folder was deleted** (preflight-not-partial-install). Without this test the silent-skip regression can return, or a future "fix" can revert to mid-loop bail and leave half-installed state.
+
+Existing `_preserves_foreign_skills` and `_overwrites_existing_kapacitor_skill` tests cover the install/remove semantics generically — no per-skill duplication needed.
+
+### 6.3 `hide` / `disable` accept positional ID (integration)
+
+Light integration tests against WireMock.Net (already in use per CLAUDE.md). Confirm the positional ID reaches the HTTP call. Skip exhaustive coverage of the verbs — the HTTP wire is unchanged from today.
+
+### 6.4 Out of automated scope
+
+- SKILL.md content. Markdown read by humans, not asserted by tests. The existing `InstallCodexSkills_copies_known_skills` test already proves install plumbing transfers the file faithfully.
+- Manual smoke test on a real Codex CLI 0.133.0+ session — included in the implementation plan as the AI-676 acceptance check, not the spec.
+
+## 7. Risks, fallback, and out-of-scope
+
+### 7.1 Single real risk: `CODEX_THREAD_ID` vs hook-payload `session_id`
+
+Whether `CODEX_THREAD_ID` (env var exported by Codex) equals the `session_id` field Codex passes in hook payloads, after normalization. PR #10096's description ("so that the agent (and skills) can refer to the current thread / session ID") implies they match, but there is no formal contract from OpenAI.
+
+**Mitigation — day-1 verification (implementation-plan task, not spec):**
+
+Add a diagnostic log line to `CodexHookCommand.HandleSessionStart`:
+
+```csharp
+Console.Error.WriteLine(
+    $"[probe] CODEX_THREAD_ID={Environment.GetEnvironmentVariable("CODEX_THREAD_ID")} "
+    + $"payload.session_id={TryGetString(node, "session_id")}");
+```
+
+Run one real Codex session, compare values. Decision gate before writing `ArgParsing.ResolveSessionId`.
+
+- **If they match (expected outcome):** ship as designed. Remove probe line.
+- **If they differ:** fall back to a marker-file design. By construction, `CODEX_THREAD_ID` is then **not** a valid Capacitor session ID, so the chain must *replace* the direct Codex env step with a marker read — keeping the direct read would shadow the marker and return a known-bad ID. `CodexHookCommand.HandleSessionStart` writes `~/.cache/kapacitor/codex-sessions/<CODEX_THREAD_ID>` containing the resolved Capacitor session ID (the one Codex passes in the hook payload, server-acknowledged). The marker read lives in **`ArgParsing.ResolveSessionIdFromEnv()`** (the sibling helper introduced in §3.1), *not* directly in `ResolveSessionId` — that way both arg-bearing commands (via `ResolveSessionId` which delegates to the env helper) and `set-title` (which calls the env helper directly) pick up the marker fallback uniformly. Under this fallback branch the env helper becomes:
+
+  `KAPACITOR_SESSION_ID` → marker file keyed by `CODEX_THREAD_ID` → null/error
+
+  (The primary design — used when the probe confirms `CODEX_THREAD_ID == session_id` — keeps `KAPACITOR_SESSION_ID` → `CODEX_THREAD_ID` direct → null/error.) Sweep at next `SessionStart` with a 7-day cutoff to bound directory growth. The marker code is ~30 lines and slots into the env helper — no spec rewrite.
+- **If `CODEX_THREAD_ID` is unset (older Codex):** chain falls through to step 4. The error message names the version requirement, giving an actionable hint.
+
+### 7.2 Out of scope
+
+Tracked elsewhere or deferred:
+
+- **Daemon-spawned Codex agents** (`KAPACITOR_DAEMON_URL` set). They receive the session ID via `KAPACITOR_AGENT_ID` and the daemon's launch env. The resolution chain needs no new branch for them.
+- **Cross-machine session resolution** (shared-daemon setups). Out per AI-677's "Out of scope".
+- **Active marker cleanup via Codex `SessionEnd`.** Not needed under the env-var path. Under the marker fallback, the SessionStart sweep is sufficient — Codex's `Stop` hook fires per-turn, not at session end, so it's not a reliable cleanup signal.
+- **Cross-vendor session linking** (one Capacitor session spanning Claude and Codex turns). Out per AI-677.
+
+## 8. Acceptance
+
+Derived from AI-676 and AI-677:
+
+- `kapacitor plugin install --codex` writes all five skills under `~/.codex/skills/`. If any source folder is missing, install **fails atomically** — no target subfolder is created and no prior target folder is deleted.
+- On a fresh Codex CLI 0.81+ session, invoking each of `kapacitor-recap`, `kapacitor-errors`, `kapacitor-hide`, `kapacitor-disable`, `kapacitor-validate-plan` with no arguments resolves the active session and runs the right CLI command.
+- `kapacitor hide` / `kapacitor disable` succeed when invoked with either an explicit `<sessionId>` or with `CODEX_THREAD_ID` set in the environment.
+- Old behavior preserved: invocations inside Claude Code still resolve via `KAPACITOR_SESSION_ID`.
+- Error path: with no positional and neither env var set, all five commands print the shared error message naming both Claude Code and Codex CLI 0.81+ as supported environments.
+- **Incidental beneficiaries** (no new acceptance tests, but verified by the shared resolver behaviour): `kapacitor eval` and `kapacitor set-title` now also resolve `CODEX_THREAD_ID` when invoked from a Codex session. `eval` because it already calls `ArgParsing.ResolveSessionId` at Program.cs:140; `set-title` because of the new `ResolveSessionIdFromEnv` sibling helper (§3.1). Help text for both is updated accordingly (§3.4).

--- a/kapacitor/codex-skills/kapacitor-disable/SKILL.md
+++ b/kapacitor/codex-skills/kapacitor-disable/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: kapacitor-disable
+description: >-
+  This skill should be used when the user asks to "disable recording",
+  "stop recording", "delete this session", "don't record this",
+  "remove my session data", "erase this session", "turn off tracking",
+  "stop tracking", "disable kapacitor", "remove session",
+  or wants to stop the current session from being recorded.
+  Stops the watcher, prevents future hooks, and deletes server data.
+---
+
+# Kapacitor Disable
+
+Stop recording the current session and delete all data from the server.
+
+## Usage
+
+```bash
+# Active session — auto-resolved from CODEX_THREAD_ID (Codex 0.81+)
+kapacitor disable
+
+# Specific session by ID (from `kapacitor recap --repo`)
+kapacitor disable <sessionId>
+```
+
+This will:
+1. Stop the transcript watcher process
+2. Prevent all future hook events from being sent for this session
+3. Delete all session data from the server (event streams and read models)
+
+## Requirements
+
+Run inside an active Codex CLI session (0.81+) — the active session is auto-resolved from `CODEX_THREAD_ID`. To act on a different session, pass its ID explicitly. Use `kapacitor recap --repo` to list recent session IDs in this repository.
+
+The `kapacitor` CLI must be available on PATH (typically installed at `~/.local/bin/kapacitor`).
+
+## Notes
+
+- This action is irreversible — all session data will be permanently deleted from the server.
+- The local transcript file (Codex rollout `.jsonl`) is not affected — only server-side data is removed.
+- Subsequent hooks (session-end, etc.) will be silently skipped.
+
+## Environment
+
+`KAPACITOR_URL` overrides the default server URL (`http://localhost:5108`).

--- a/kapacitor/codex-skills/kapacitor-errors/SKILL.md
+++ b/kapacitor/codex-skills/kapacitor-errors/SKILL.md
@@ -12,11 +12,17 @@ description: >-
 
 Extract tool call errors from a session recorded by Kurrent Capacitor. The output lists each failed tool call — shell commands, file reads/writes, agent delegations, etc. — along with the error message and the tool that caused it.
 
+Codex CLI 0.81+ exports `CODEX_THREAD_ID`; `kapacitor errors` uses it the same way it uses `KAPACITOR_SESSION_ID` for Claude. No args needed for the current session.
+
 ## Usage
 
-Codex sessions do not export `KAPACITOR_SESSION_ID`, so you must pass the session ID explicitly. To find recent session IDs, run `kapacitor recap --repo` first.
-
 ```bash
+# Current session — auto-resolved from CODEX_THREAD_ID
+kapacitor errors
+
+# Errors from the full continuation chain of the current session
+kapacitor errors --chain
+
 # Errors from a specific session
 kapacitor errors <sessionId>
 
@@ -28,17 +34,18 @@ kapacitor errors --chain <sessionId>
 
 Each error is printed as a block with:
 
-- **Session ID** and optional **agent ID** (if the error occurred in a subagent)
-- **Event number** and **timestamp**
-- **Tool name** — the tool that failed (e.g., Bash, Read, Edit, Write, Grep, Glob)
-- **Error message** — the error output or failure reason
+- **Session ID** and optional **agent ID** (if the error occurred in a subagent).
+- **Event number** and **timestamp**.
+- **Tool name** — the tool that failed (e.g., Bash, Read, Edit, Write, Grep, Glob).
+- **Error message** — the error output or failure reason.
 
 When using `--chain`, errors from all sessions in the continuation chain are included, ordered chronologically.
 
 ## When to Use Each Flag
 
-- **No flag** (`kapacitor errors <sessionId>`) — reviewing errors from one specific session
-- **`--chain <sessionId>`** — reviewing errors across a full task that spanned multiple sessions
+- **No flag** (`kapacitor errors`) — reviewing errors from the current session.
+- **`<sessionId>`** — reviewing errors from a specific session (e.g. from `kapacitor recap --repo`).
+- **`--chain`** — reviewing errors across a full task that spanned multiple sessions.
 
 ## Practical Applications
 

--- a/kapacitor/codex-skills/kapacitor-hide/SKILL.md
+++ b/kapacitor/codex-skills/kapacitor-hide/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: kapacitor-hide
+description: >-
+  This skill should be used when the user asks to "hide this session",
+  "make this private", "hide session", "owner only", "make private",
+  "hide from others", "set private", "don't show this session",
+  or wants to change the current session visibility to owner-only.
+  Sets session visibility so only the owner can see it.
+---
+
+# Kapacitor Hide
+
+Hide the current session so only you (the owner) can see it.
+
+## Usage
+
+```bash
+# Active session — auto-resolved from CODEX_THREAD_ID (Codex 0.81+)
+kapacitor hide
+
+# Specific session by ID (from `kapacitor recap --repo`)
+kapacitor hide <sessionId>
+```
+
+This sets the session visibility to "none" (owner-only). Other users will no longer see this session in the Capacitor dashboard.
+
+## Requirements
+
+Run inside an active Codex CLI session (0.81+) — the active session is auto-resolved from `CODEX_THREAD_ID`. To act on a different session, pass its ID explicitly. Use `kapacitor recap --repo` to list recent session IDs in this repository.
+
+The `kapacitor` CLI must be available on PATH (typically installed at `~/.local/bin/kapacitor`).
+
+## Notes
+
+- This is reversible — visibility can be changed back via the Capacitor dashboard.
+- The session data remains on the server, just hidden from other users.
+- Unlike `kapacitor disable`, recording continues normally.
+
+## Environment
+
+`KAPACITOR_URL` overrides the default server URL (`http://localhost:5108`).

--- a/kapacitor/codex-skills/kapacitor-recap/SKILL.md
+++ b/kapacitor/codex-skills/kapacitor-recap/SKILL.md
@@ -11,17 +11,20 @@ description: >-
 
 # Kapacitor Recap
 
-Retrieve session history recorded by Kurrent Capacitor. Inside Codex, the recommended entry point is the **repository recap** — Codex sessions do not export a `KAPACITOR_SESSION_ID` environment variable, so the "current session" shortcut is unavailable. Drill into a specific session by passing its ID explicitly.
+Retrieve session history recorded by Kurrent Capacitor. Codex CLI 0.81+ exports `CODEX_THREAD_ID`; `kapacitor recap` uses it the same way it uses `KAPACITOR_SESSION_ID` for Claude. No args needed for the current session.
 
 ## Usage
 
 Run the `kapacitor recap` CLI via the shell. Do NOT call the HTTP API directly — the CLI handles formatting, error handling, and server URL resolution.
 
 ```bash
-# Recent session summaries for the current repository (start here)
+# Current session — auto-resolved from CODEX_THREAD_ID
+kapacitor recap
+
+# Recent session summaries for the current repository (discovery)
 kapacitor recap --repo
 
-# Drill into a specific session by ID (from --repo output)
+# A specific session by ID (from --repo output)
 kapacitor recap <sessionId>
 
 # Full transcript for a specific session
@@ -34,46 +37,46 @@ kapacitor recap --chain <sessionId>
 kapacitor recap --chain --full <sessionId>
 ```
 
+## Default Output (Summary)
+
+Shows the plan (if any) and an AI-generated summary with:
+- **Context** — why the work was done.
+- **Key decisions** — trade-offs and design choices that matter for future work.
+- **Unfinished/Risks** — anything deferred or left incomplete.
+
+If no summary is available (e.g., active session), a hint is shown to use `--full`.
+
 ## Repository Recap (`--repo`)
 
 Returns AI-generated summaries from the most recent ended sessions in the current git repository. Each entry includes the session title, date, summary, and the session ID needed to drill in further.
 
-**Use this when:**
+**Use this for discovery — not as the default entry point:**
 - The user says "what have we been working on recently?"
 - The user references prior work ("recently we implemented X")
-- You need context about recent changes in this repo
-- Starting a new session and want to understand recent activity
+- You need context about other sessions in this repo, not the current one
 
-**Progressive disclosure:** Start with `--repo` for the overview. If a specific session's summary is relevant, drill into it with `kapacitor recap --full <sessionId>` to get the complete transcript. This avoids loading full transcripts for all sessions into context.
-
-## Session Recap (`<sessionId>`)
-
-Shows the plan (if any) and an AI-generated summary with:
-- **Context** — why the work was done
-- **Key decisions** — trade-offs and design choices that matter for future work
-- **Unfinished/Risks** — anything deferred or left incomplete
-
-If no summary is available (e.g., active session), a hint is shown to use `--full`.
+**Progressive disclosure:** Start with `kapacitor recap` (current session) for in-session work. Switch to `--repo` when you need cross-session context. Drill into a specific summary with `kapacitor recap --full <sessionId>`.
 
 ## Full Output (`--full`)
 
 The complete transcript with these section types:
 
-- **`## User Prompt`** — what the user asked
-- **`## Assistant`** — text responses
-- **`## Plan`** — plans that were created (Claude Code sessions only)
-- **`## Write <path>`** — files that were created (with syntax-highlighted content)
-- **`## Edit <path>`** — files that were edited (with diff content)
+- **`## User Prompt`** — what the user asked.
+- **`## Assistant`** — text responses.
+- **`## Plan`** — plans that were created (Claude Code sessions only).
+- **`## Write <path>`** — files that were created (with syntax-highlighted content).
+- **`## Edit <path>`** — files that were edited (with diff content).
 
 When using `--chain`, sessions are separated by `# Session <id>` headers, and agent activity appears under `### Agent (<type>)` sub-headers.
 
 ## When to Use Each Flag
 
-- **`--repo`** — recent session summaries across the repo (start here)
-- **`<sessionId>`** — quick context on a specific session (from `--repo` output)
-- **`--full <sessionId>`** — when you need exact prompts, responses, or file contents
-- **`--chain <sessionId>`** — understanding the full history of a task that spanned multiple sessions
-- **`--chain --full <sessionId>`** — complete transcript across all continuations
+- **No flag** (`kapacitor recap`) — quick context on the current session.
+- **`--repo`** — recent session summaries across the repo.
+- **`<sessionId>`** — quick context on a specific session (from `--repo` output).
+- **`--full <sessionId>`** — when you need exact prompts, responses, or file contents.
+- **`--chain <sessionId>`** — understanding the full history of a task that spanned multiple sessions.
+- **`--chain --full <sessionId>`** — complete transcript across all continuations.
 
 ## Environment
 
@@ -81,7 +84,7 @@ When using `--chain`, sessions are separated by `# Session <id>` headers, and ag
 
 ## Tips
 
-- Always start with `--repo` — it gives the overview without flooding context.
+- Start with `kapacitor recap` (no args) for the active session, then `--repo` for cross-session discovery.
 - Summarize key decisions and changes for the user rather than echoing the full recap output verbatim.
 - The `kapacitor` CLI must be available on PATH (typically installed at `~/.local/bin/kapacitor`).
 

--- a/kapacitor/codex-skills/kapacitor-validate-plan/SKILL.md
+++ b/kapacitor/codex-skills/kapacitor-validate-plan/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: kapacitor-validate-plan
+description: >-
+  This skill should be used when the user asks to "validate plan",
+  "verify plan", "check plan completion", "did I finish everything",
+  "is the plan done", "what's left to do", "validate my work",
+  or wants to verify that all planned items were completed.
+---
+
+# Kapacitor Validate Plan
+
+Verify that all items in the current session's plan have been completed.
+
+## Usage
+
+```bash
+# Active session — auto-resolved from CODEX_THREAD_ID (Codex 0.81+)
+kapacitor validate-plan
+
+# Specific session by ID (from `kapacitor recap --repo`)
+kapacitor validate-plan <sessionId>
+```
+
+## What It Returns
+
+The command outputs three sections:
+
+- **`## Plan`** — the full plan text.
+- **`## What's Done`** — two sub-sections:
+  - **Summary** — AI-generated summary of what was accomplished (from `WhatsDoneGenerated` events, if available).
+  - **Details** — list of files created (`Write`) and modified (`Edit`) during the session.
+- **`## Instructions`** — asks you to compare the plan against the summary and file list.
+
+## What To Do With The Output
+
+1. Read the plan carefully and identify each distinct planned item.
+2. Compare each item against the summary and file list under "What's Done".
+3. If all items are complete, confirm to the user that the plan is fully implemented.
+4. If there are gaps, list the missing items and complete them now.
+
+## When No Plan Is Found
+
+If the output says "No plan found for this session", inform the user that no plan was detected for this session. Plans are recorded when a session emits an `ExitPlanMode`-style event; not every session has one.
+
+## Requirements
+
+Run inside an active Codex CLI session (0.81+) — the active session is auto-resolved from `CODEX_THREAD_ID`. To act on a different session, pass its ID explicitly.
+
+The `kapacitor` CLI must be available on PATH (typically installed at `~/.local/bin/kapacitor`).
+
+## Environment
+
+`KAPACITOR_URL` overrides the default server URL (`http://localhost:5108`).

--- a/src/Kapacitor.Cli.Core/Resources/help-disable.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-disable.txt
@@ -1,9 +1,10 @@
 kapacitor disable — Stop recording and delete all session data
 
-Usage: kapacitor disable
+Usage: kapacitor disable [sessionId]
 
 Stops the watcher, prevents future hook events from being sent,
 and deletes all session data from the server (streams + read models).
 
-Environment:
-  KAPACITOR_SESSION_ID    Session ID (required, set automatically)
+Arguments:
+  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+                          on Claude or CODEX_THREAD_ID on Codex 0.81+)

--- a/src/Kapacitor.Cli.Core/Resources/help-errors.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-errors.txt
@@ -6,4 +6,5 @@ Options:
   --chain                 Include all sessions in the continuation chain
 
 Arguments:
-  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID)
+  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+                          on Claude or CODEX_THREAD_ID on Codex 0.81+)

--- a/src/Kapacitor.Cli.Core/Resources/help-eval.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-eval.txt
@@ -27,8 +27,9 @@ Notes:
     session size. Parallelization is tracked in DEV-1435.
   - Each judge has no tools — Read, Bash, Grep, WebFetch, etc. are all blocked.
     The full compacted trace is embedded in the prompt.
-  - If the session ID is omitted, the currently-recorded session (as set by
-    the session-start hook in KAPACITOR_SESSION_ID) is used.
+  - If the session ID is omitted, the currently-recorded session is used —
+    resolved from KAPACITOR_SESSION_ID (Claude) or CODEX_THREAD_ID
+    (Codex 0.81+).
 
 Examples:
   kapacitor eval --questions safety                # 4 safety judges only

--- a/src/Kapacitor.Cli.Core/Resources/help-hide.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-hide.txt
@@ -1,9 +1,10 @@
 kapacitor hide — Hide session from other users
 
-Usage: kapacitor hide
+Usage: kapacitor hide [sessionId]
 
 Sets the current session's visibility to owner-only. Other users
 will no longer see this session in the dashboard.
 
-Environment:
-  KAPACITOR_SESSION_ID    Session ID (required, set automatically)
+Arguments:
+  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+                          on Claude or CODEX_THREAD_ID on Codex 0.81+)

--- a/src/Kapacitor.Cli.Core/Resources/help-plugin.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-plugin.txt
@@ -12,8 +12,10 @@ Options:
 
 Notes:
   --codex installs hooks (~/.codex/hooks.json or <repo>/.codex/hooks.json with
-  --project) plus kapacitor-recap and kapacitor-errors skills in
-  ~/.codex/skills/. Skills are always user-wide; --project only affects hooks.
+  --project) plus five skills in ~/.codex/skills/: kapacitor-recap,
+  kapacitor-errors, kapacitor-hide, kapacitor-disable, and
+  kapacitor-validate-plan. Skills are always user-wide; --project only
+  affects hooks.
 
 Examples:
   kapacitor plugin install                    # Install Claude Code plugin (user)

--- a/src/Kapacitor.Cli.Core/Resources/help-recap.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-recap.txt
@@ -8,4 +8,5 @@ Options:
   --repo                  Show recent session summaries for the current repo
 
 Arguments:
-  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID)
+  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+                          on Claude or CODEX_THREAD_ID on Codex 0.81+)

--- a/src/Kapacitor.Cli.Core/Resources/help-set-title.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-set-title.txt
@@ -6,4 +6,5 @@ Arguments:
   title                   Session title (max 120 characters)
 
 Environment:
-  KAPACITOR_SESSION_ID    Session ID (required)
+  Session ID is auto-resolved from KAPACITOR_SESSION_ID (Claude)
+  or CODEX_THREAD_ID (Codex 0.81+).

--- a/src/Kapacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-usage.txt
@@ -64,5 +64,6 @@ Hook Commands (internal — used by Claude Code plugin):
 
 Environment:
   KAPACITOR_URL              Server URL (overrides config file)
-  KAPACITOR_SESSION_ID       Session ID (set automatically by SessionStart hook)
+  KAPACITOR_SESSION_ID       Session ID set by the Claude Code SessionStart hook
+  CODEX_THREAD_ID            Session ID exported by Codex CLI 0.81+
   KAPACITOR_DAEMON_NAME      Daemon name (overrides profile; superseded by --name)

--- a/src/Kapacitor.Cli.Core/Resources/help-validate-plan.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-validate-plan.txt
@@ -3,4 +3,5 @@ kapacitor validate-plan — Validate plan completion for a session
 Usage: kapacitor validate-plan [sessionId]
 
 Arguments:
-  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID)
+  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+                          on Claude or CODEX_THREAD_ID on Codex 0.81+)

--- a/src/Kapacitor.Cli/ArgParsing.cs
+++ b/src/Kapacitor.Cli/ArgParsing.cs
@@ -3,9 +3,10 @@ namespace Kapacitor.Cli;
 static class ArgParsing {
     /// <summary>
     /// Resolves a positional sessionId from a command's argument list, falling
-    /// back to <c>KAPACITOR_SESSION_ID</c>. Value-bearing flags (e.g.
-    /// <c>--model sonnet</c>) must be declared via <paramref name="valueFlags"/>
-    /// so their values aren't mistaken for the sessionId.
+    /// back to <c>KAPACITOR_SESSION_ID</c> and then <c>CODEX_THREAD_ID</c>.
+    /// Value-bearing flags (e.g. <c>--model sonnet</c>) must be declared via
+    /// <paramref name="valueFlags"/> so their values aren't mistaken for the
+    /// sessionId.
     /// </summary>
     internal static string? ResolveSessionId(string[] args, int skipCount = 1, string[]? valueFlags = null) {
         var knownValueFlags = valueFlags is null or { Length: 0 }
@@ -25,6 +26,23 @@ static class ArgParsing {
             return token;
         }
 
-        return Environment.GetEnvironmentVariable("KAPACITOR_SESSION_ID");
+        return ResolveSessionIdFromEnv();
+    }
+
+    /// <summary>
+    /// Resolves a sessionId purely from environment variables. Prefers
+    /// <c>KAPACITOR_SESSION_ID</c> and falls back to <c>CODEX_THREAD_ID</c>.
+    /// Dashes are stripped from the returned value so callers don't have to.
+    /// </summary>
+    internal static string? ResolveSessionIdFromEnv() {
+        var kapacitor = Environment.GetEnvironmentVariable("KAPACITOR_SESSION_ID");
+        if (!string.IsNullOrWhiteSpace(kapacitor))
+            return kapacitor.Replace("-", "");
+
+        var codex = Environment.GetEnvironmentVariable("CODEX_THREAD_ID");
+        if (!string.IsNullOrWhiteSpace(codex))
+            return codex.Replace("-", "");
+
+        return null;
     }
 }

--- a/src/Kapacitor.Cli/ArgParsing.cs
+++ b/src/Kapacitor.Cli/ArgParsing.cs
@@ -45,4 +45,20 @@ static class ArgParsing {
 
         return null;
     }
+
+    /// <summary>
+    /// Validates that <paramref name="input"/> parses as a GUID and returns its
+    /// canonical dashless 32-hex-character form. Use this at sites that consume
+    /// the session ID as a filesystem path component (e.g. <c>kapacitor hide</c>,
+    /// <c>kapacitor disable</c>), where slugs and path-traversal characters are
+    /// not acceptable input.
+    /// </summary>
+    internal static bool TryNormalizeSessionGuid(string input, out string canonical) {
+        if (Guid.TryParse(input, out var guid)) {
+            canonical = guid.ToString("N");
+            return true;
+        }
+        canonical = string.Empty;
+        return false;
+    }
 }

--- a/src/Kapacitor.Cli/Commands/CodexHookCommand.cs
+++ b/src/Kapacitor.Cli/Commands/CodexHookCommand.cs
@@ -56,8 +56,8 @@ static class CodexHookCommand {
 
         // Normalize session_id to dashless GUID, inject home_dir, and tag the
         // agent host id when running inside a daemon-spawned agent. Mirrors
-        // the Claude hook path in Program.cs but without the disabled-session
-        // and plan_content branches (those are Claude-specific).
+        // the Claude hook path in Program.cs (including the disabled-session
+        // check below); the plan_content branch remains Claude-specific.
         NormalizeGuidField(node, "session_id");
 
         node["home_dir"] = PathHelpers.HomeDirectory;
@@ -65,6 +65,21 @@ static class CodexHookCommand {
         var agentHostId = Environment.GetEnvironmentVariable("KAPACITOR_AGENT_ID");
         if (agentHostId is not null) {
             node["agent_host_id"] = agentHostId;
+        }
+
+        // Mirror the Claude path: if the user ran `kapacitor disable`, skip every
+        // server POST and the watcher restart. Without this check the next Codex
+        // Stop hook would re-enliven the watcher and re-send transcript data for
+        // a session whose data was just deleted server-side.
+        var disabledSessionId = TryGetString(node, "session_id");
+        if (disabledSessionId is not null && DisabledSessions.IsDisabled(disabledSessionId)) {
+            // Emit the session-scoped JSON Codex's Stop/SessionStart parsers expect,
+            // then skip dispatch. (Claude's disabled branch also returns immediately
+            // — see Program.cs around line 593.)
+            if (eventName == "Stop" || eventName == "SessionStart") {
+                Console.Write(SessionScopedOutputJson);
+            }
+            return 0;
         }
 
         return eventName switch {

--- a/src/Kapacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Kapacitor.Cli/Commands/CodingAgentsStep.cs
@@ -65,6 +65,7 @@ internal static class CodingAgentsStep {
         }
 
         writeLine($"  [green]✓[/] Codex skills installed (user: {Markup.Escape(paths.CodexSkillsDir)})");
+        writeLine("    [dim]kapacitor-recap, kapacitor-errors, kapacitor-hide, kapacitor-disable, kapacitor-validate-plan[/]");
         return true;
     }
 
@@ -87,7 +88,7 @@ internal static class CodingAgentsStep {
             return false;
         }
 
-        var shouldInstall = options.NoPrompt || prompt("Install Codex CLI hooks (and skills)?");
+        var shouldInstall = options.NoPrompt || prompt("Install Codex CLI hooks and 5 skills?");
 
         if (!shouldInstall) {
             writeLine("  [dim]· Codex CLI hooks not installed (you can run kapacitor plugin install --codex later)[/]");

--- a/src/Kapacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Kapacitor.Cli/Commands/PluginCommand.cs
@@ -142,6 +142,31 @@ public static class PluginCommand {
             ? Path.Combine(Environment.CurrentDirectory, ".codex", "hooks.json")
             : CodexPaths.UserHooksJson;
 
+        // `--codex` is an atomic hooks AND skills contract. Resolve the
+        // skills source BEFORE writing hooks so a missing plugin folder
+        // doesn't leave the user with hooks pointing at a binary whose
+        // skills never installed. The acceptance criterion from AI-676 is
+        // "writes all five skills" — either everything installs or nothing.
+        var pluginPath = SetupCommand.ResolvePluginPath();
+
+        if (pluginPath is null) {
+            await Console.Error.WriteLineAsync(
+                "Cannot install Codex plugin: kapacitor plugin folder not found. " +
+                "Re-install kapacitor via npm: npm install -g @kurrent/kapacitor"
+            );
+            return 1;
+        }
+
+        var skillsSource = Path.Combine(pluginPath, "codex-skills");
+
+        if (!Directory.Exists(skillsSource)) {
+            await Console.Error.WriteLineAsync(
+                $"Cannot install Codex plugin: 'codex-skills' folder missing from {pluginPath}. " +
+                "Re-install kapacitor via npm: npm install -g @kurrent/kapacitor"
+            );
+            return 1;
+        }
+
         if (!InstallCodexHooks(hooksPath)) {
             await Console.Error.WriteLineAsync("Could not write Codex hooks file.");
 
@@ -158,20 +183,16 @@ public static class PluginCommand {
         // ~/.codex/skills (or $CODEX_HOME/skills), and project-level skill
         // discovery isn't documented — so we keep behaviour consistent and
         // predictable by always installing them user-wide.
-        var pluginPath = SetupCommand.ResolvePluginPath();
-        var skillsSource = pluginPath is null ? null : Path.Combine(pluginPath, "codex-skills");
-
-        if (skillsSource is not null && Directory.Exists(skillsSource)) {
-            if (InstallCodexSkills(skillsSource, CodexPaths.UserSkillsDir)) {
-                await Console.Out.WriteLineAsync($"Codex skills installed (user: {CodexPaths.UserSkillsDir})");
-            } else {
-                // Hooks succeeded but skills failed — `--codex` is a hooks AND
-                // skills contract, so surface the partial failure via exit code
-                // so callers (CI, scripts) can detect it.
-                await Console.Error.WriteLineAsync("Could not install Codex skills.");
-                return 1;
-            }
+        if (!InstallCodexSkills(skillsSource, CodexPaths.UserSkillsDir)) {
+            // Preflight above guarantees the source tree exists, so this
+            // branch indicates a real filesystem failure (per-skill preflight
+            // inside InstallCodexSkills, permission error, etc.). Surface a
+            // non-zero exit so callers (CI, scripts) can detect it.
+            await Console.Error.WriteLineAsync("Could not install Codex skills.");
+            return 1;
         }
+
+        await Console.Out.WriteLineAsync($"Codex skills installed (user: {CodexPaths.UserSkillsDir})");
 
         if (scope == "project") {
             await Console.Out.WriteLineAsync(

--- a/src/Kapacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Kapacitor.Cli/Commands/PluginCommand.cs
@@ -11,9 +11,12 @@ public static class PluginCommand {
     // also the target folder under <codex>/skills/, so on remove we can delete
     // them without re-reading the source tree. Add a new skill here when adding
     // it to codex-skills/.
-    static readonly string[] CodexSkillNames = [
+    internal static readonly string[] CodexSkillNames = [
         "kapacitor-recap",
-        "kapacitor-errors"
+        "kapacitor-errors",
+        "kapacitor-hide",
+        "kapacitor-disable",
+        "kapacitor-validate-plan"
     ];
 
     const string CodexHookCommand = "kapacitor codex-hook";
@@ -322,14 +325,26 @@ public static class PluginCommand {
     public static bool InstallCodexSkills(string sourceDir, string targetDir) {
         if (!Directory.Exists(sourceDir)) return false;
 
+        // Preflight: every known skill must have a folder under sourceDir. If
+        // any is missing, fail BEFORE doing anything destructive — otherwise a
+        // packaging error would leave the target dir half-overwritten.
+        var missing = CodexSkillNames
+            .Where(name => !Directory.Exists(Path.Combine(sourceDir, name)))
+            .ToList();
+
+        if (missing.Count > 0) {
+            Console.Error.WriteLine(
+                $"Cannot install Codex skills: missing source folder(s) under {sourceDir}: "
+                + string.Join(", ", missing)
+            );
+            return false;
+        }
+
         try {
             Directory.CreateDirectory(targetDir);
 
             foreach (var name in CodexSkillNames) {
                 var src = Path.Combine(sourceDir, name);
-
-                if (!Directory.Exists(src)) continue;
-
                 var dst = Path.Combine(targetDir, name);
 
                 if (Directory.Exists(dst)) Directory.Delete(dst, recursive: true);

--- a/src/Kapacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Kapacitor.Cli/Commands/PluginCommand.cs
@@ -167,6 +167,20 @@ public static class PluginCommand {
             return 1;
         }
 
+        // Per-skill preflight runs BEFORE writing hooks so a packaging defect
+        // (top-level codex-skills/ present, but an individual skill folder
+        // missing) can't leave the user with hooks installed and skills not.
+        // The duplicate preflight inside InstallCodexSkills is kept as defense
+        // in depth for direct callers like CodingAgentsStep.
+        if (!ValidateCodexSkillsSource(skillsSource, out var missing)) {
+            await Console.Error.WriteLineAsync(
+                $"Cannot install Codex plugin: missing skill folder(s) under {skillsSource}: "
+                + string.Join(", ", missing)
+                + ". Re-install kapacitor via npm: npm install -g @kurrent/kapacitor"
+            );
+            return 1;
+        }
+
         if (!InstallCodexHooks(hooksPath)) {
             await Console.Error.WriteLineAsync("Could not write Codex hooks file.");
 
@@ -337,6 +351,22 @@ public static class PluginCommand {
     }
 
     /// <summary>
+    /// Returns true iff every name in <see cref="CodexSkillNames"/> has a
+    /// matching subdirectory under <paramref name="sourceDir"/>. Populates
+    /// <paramref name="missing"/> with the names that didn't resolve, so
+    /// callers can render an actionable error message. Used by
+    /// <see cref="InstallCodex"/> to fail before writing hooks when the
+    /// packaging is incomplete.
+    /// </summary>
+    public static bool ValidateCodexSkillsSource(string sourceDir, out List<string> missing) {
+        missing = CodexSkillNames
+            .Where(name => !Directory.Exists(Path.Combine(sourceDir, name)))
+            .ToList();
+
+        return missing.Count == 0;
+    }
+
+    /// <summary>
     /// Copies every skill folder in <paramref name="sourceDir"/> (each
     /// containing a <c>SKILL.md</c>) into <paramref name="targetDir"/>, one
     /// subdirectory per skill. Existing kapacitor-owned folders (by name) are
@@ -349,11 +379,10 @@ public static class PluginCommand {
         // Preflight: every known skill must have a folder under sourceDir. If
         // any is missing, fail BEFORE doing anything destructive — otherwise a
         // packaging error would leave the target dir half-overwritten.
-        var missing = CodexSkillNames
-            .Where(name => !Directory.Exists(Path.Combine(sourceDir, name)))
-            .ToList();
-
-        if (missing.Count > 0) {
+        // Kept as defense in depth: InstallCodex already calls
+        // ValidateCodexSkillsSource before writing hooks, but direct callers
+        // (e.g. CodingAgentsStep) rely on this method to enforce the contract.
+        if (!ValidateCodexSkillsSource(sourceDir, out var missing)) {
             Console.Error.WriteLine(
                 $"Cannot install Codex skills: missing source folder(s) under {sourceDir}: "
                 + string.Join(", ", missing)

--- a/src/Kapacitor.Cli/DisabledSessions.cs
+++ b/src/Kapacitor.Cli/DisabledSessions.cs
@@ -1,0 +1,36 @@
+using Kapacitor.Cli.Core;
+
+namespace Kapacitor.Cli;
+
+/// <summary>
+/// Disk-backed marker store recording sessions that the user disabled via
+/// <c>kapacitor disable</c>. Hook handlers check <see cref="IsDisabled"/>
+/// before doing any server-bound work so a disabled session never re-sends
+/// transcript data after its server-side record was deleted.
+/// </summary>
+/// <remarks>
+/// Both the Claude hook path in <c>Program.cs</c> and the Codex hook path in
+/// <see cref="Kapacitor.Cli.Commands.CodexHookCommand"/> share this helper —
+/// without it, the next Codex <c>Stop</c> hook would restart the watcher and
+/// re-enliven a session the user just deleted.
+/// </remarks>
+internal static class DisabledSessions {
+    static string GetDisabledDir() => PathHelpers.ConfigPath("disabled");
+
+    internal static bool IsDisabled(string sessionId) =>
+        File.Exists(Path.Combine(GetDisabledDir(), sessionId));
+
+    internal static void Mark(string sessionId) {
+        var dir = GetDisabledDir();
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, sessionId), "");
+    }
+
+    internal static void RemoveMarker(string sessionId) {
+        var path = Path.Combine(GetDisabledDir(), sessionId);
+
+        try { File.Delete(path); } catch {
+            /* ignore */
+        }
+    }
+}

--- a/src/Kapacitor.Cli/Program.cs
+++ b/src/Kapacitor.Cli/Program.cs
@@ -302,10 +302,14 @@ switch (command) {
     case "cleanup":
         return await CleanupCommand.HandleCleanup();
     case "disable": {
-        var sessionId = Environment.GetEnvironmentVariable("KAPACITOR_SESSION_ID")?.Replace("-", "");
+        // Positional override may be a dashed UUID; the WatcherManager and
+        // server-side path both expect dashless, so we strip here. Env-sourced
+        // values come pre-normalized from the resolver.
+        var sessionId = ResolveSessionId(args)?.Replace("-", "");
 
         if (sessionId is null) {
-            Console.Error.WriteLine("KAPACITOR_SESSION_ID not set. Run this inside an active Claude Code session.");
+            Console.Error.WriteLine("Usage: kapacitor disable [sessionId]");
+            Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
 
             return 1;
         }
@@ -351,10 +355,11 @@ switch (command) {
         return 0;
     }
     case "hide": {
-        var sessionId = Environment.GetEnvironmentVariable("KAPACITOR_SESSION_ID")?.Replace("-", "");
+        var sessionId = ResolveSessionId(args)?.Replace("-", "");
 
         if (sessionId is null) {
-            Console.Error.WriteLine("KAPACITOR_SESSION_ID not set. Run this inside an active Claude Code session.");
+            Console.Error.WriteLine("Usage: kapacitor hide [sessionId]");
+            Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
 
             return 1;
         }

--- a/src/Kapacitor.Cli/Program.cs
+++ b/src/Kapacitor.Cli/Program.cs
@@ -302,14 +302,21 @@ switch (command) {
     case "cleanup":
         return await CleanupCommand.HandleCleanup();
     case "disable": {
-        // Positional override may be a dashed UUID; the WatcherManager and
-        // server-side path both expect dashless, so we strip here. Env-sourced
-        // values come pre-normalized from the resolver.
-        var sessionId = ResolveSessionId(args)?.Replace("-", "");
+        // The sessionId is consumed as a filesystem path component
+        // (watcher PID files, disabled marker file). Validate strictly as a
+        // GUID to prevent path traversal via crafted positional input.
+        var resolved = ResolveSessionId(args);
 
-        if (sessionId is null) {
+        if (resolved is null) {
             Console.Error.WriteLine("Usage: kapacitor disable [sessionId]");
             Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
+
+            return 1;
+        }
+
+        if (!ArgParsing.TryNormalizeSessionGuid(resolved, out var sessionId)) {
+            Console.Error.WriteLine($"Invalid session ID: '{resolved}'");
+            Console.Error.WriteLine("  Session ID must be a UUID. Use `kapacitor recap --repo` to find recent session IDs.");
 
             return 1;
         }
@@ -355,11 +362,21 @@ switch (command) {
         return 0;
     }
     case "hide": {
-        var sessionId = ResolveSessionId(args)?.Replace("-", "");
+        // The sessionId is forwarded into a server URL path but we keep the
+        // same strict GUID validation as `disable` to reject path-traversal
+        // characters and slugs uniformly across local-state-mutating commands.
+        var resolved = ResolveSessionId(args);
 
-        if (sessionId is null) {
+        if (resolved is null) {
             Console.Error.WriteLine("Usage: kapacitor hide [sessionId]");
             Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
+
+            return 1;
+        }
+
+        if (!ArgParsing.TryNormalizeSessionGuid(resolved, out var sessionId)) {
+            Console.Error.WriteLine($"Invalid session ID: '{resolved}'");
+            Console.Error.WriteLine("  Session ID must be a UUID. Use `kapacitor recap --repo` to find recent session IDs.");
 
             return 1;
         }

--- a/src/Kapacitor.Cli/Program.cs
+++ b/src/Kapacitor.Cli/Program.cs
@@ -91,7 +91,7 @@ switch (command) {
 
         if (errSessionId is null) {
             Console.Error.WriteLine("Usage: kapacitor errors [--chain] [sessionId]");
-            Console.Error.WriteLine("  No session ID provided and KAPACITOR_SESSION_ID not set.");
+            Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
 
             return 1;
         }
@@ -111,7 +111,7 @@ switch (command) {
 
         if (recapSessionId is null) {
             Console.Error.WriteLine("Usage: kapacitor recap [--chain] [--full] [--repo] [sessionId]");
-            Console.Error.WriteLine("  No session ID provided and KAPACITOR_SESSION_ID not set.");
+            Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
             Console.Error.WriteLine("  Use --repo to see recent session summaries for the current repository.");
 
             return 1;
@@ -124,7 +124,7 @@ switch (command) {
 
         if (vpSessionId is null) {
             Console.Error.WriteLine("Usage: kapacitor validate-plan [sessionId]");
-            Console.Error.WriteLine("  No session ID provided and KAPACITOR_SESSION_ID not set.");
+            Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
 
             return 1;
         }
@@ -143,7 +143,7 @@ switch (command) {
             Console.Error.WriteLine("Usage: kapacitor eval [--model sonnet] [--chain] [--threshold N]");
             Console.Error.WriteLine("                     [--questions <csv> | --skip <csv>] [sessionId]");
             Console.Error.WriteLine("       kapacitor eval --list-questions");
-            Console.Error.WriteLine("  No session ID provided and KAPACITOR_SESSION_ID not set.");
+            Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
 
             return 1;
         }

--- a/src/Kapacitor.Cli/Program.cs
+++ b/src/Kapacitor.Cli/Program.cs
@@ -502,14 +502,14 @@ switch (command) {
         return await PermissionRequestCommand.Handle(baseUrl!);
     case "set-title" when args.Length < 2:
         Console.Error.WriteLine("Usage: kapacitor set-title <title>");
-        Console.Error.WriteLine("  KAPACITOR_SESSION_ID must be set.");
 
         return 1;
     case "set-title": {
-        var stSessionId = Environment.GetEnvironmentVariable("KAPACITOR_SESSION_ID")?.Replace("-", "");
+        var stSessionId = ArgParsing.ResolveSessionIdFromEnv();
 
         if (stSessionId is null) {
-            Console.Error.WriteLine("KAPACITOR_SESSION_ID not set");
+            Console.Error.WriteLine("No session ID found in KAPACITOR_SESSION_ID or CODEX_THREAD_ID.");
+            Console.Error.WriteLine("Run set-title inside an active Claude Code / Codex CLI 0.81+ session.");
 
             return 1;
         }

--- a/src/Kapacitor.Cli/Program.cs
+++ b/src/Kapacitor.Cli/Program.cs
@@ -328,7 +328,7 @@ switch (command) {
         }
 
         // 2. Mark session as disabled (prevents future hook calls from sending data)
-        MarkSessionDisabled(sessionId);
+        DisabledSessions.Mark(sessionId);
 
         // 3. Tell server to delete session data
         using var disableClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
@@ -590,10 +590,10 @@ try {
 try {
     var disabledSessionId = JsonNode.Parse(body)?["session_id"]?.GetValue<string>();
 
-    if (disabledSessionId is not null && IsSessionDisabled(disabledSessionId)) {
+    if (disabledSessionId is not null && DisabledSessions.IsDisabled(disabledSessionId)) {
         // For session-end: remove the marker so it doesn't accumulate
         if (command == "session-end") {
-            RemoveDisabledMarker(disabledSessionId);
+            DisabledSessions.RemoveMarker(disabledSessionId);
         }
 
         return 0;
@@ -973,25 +973,6 @@ async Task PrintUsage() {
     var hookList = string.Join('\n', hookCommands.Select(h => $"  {h}"));
     var text     = EmbeddedResources.Load("help-usage.txt").Replace("{hookCommands}", hookList);
     await Console.Out.WriteAsync(text);
-}
-
-string GetDisabledDir() => PathHelpers.ConfigPath("disabled");
-
-bool IsSessionDisabled(string sessionId) =>
-    File.Exists(Path.Combine(GetDisabledDir(), sessionId));
-
-void MarkSessionDisabled(string sessionId) {
-    var dir = GetDisabledDir();
-    Directory.CreateDirectory(dir);
-    File.WriteAllText(Path.Combine(dir, sessionId), "");
-}
-
-void RemoveDisabledMarker(string sessionId) {
-    var path = Path.Combine(GetDisabledDir(), sessionId);
-
-    try { File.Delete(path); } catch {
-        /* ignore */
-    }
 }
 
 async Task<int> PrintCommandHelp(string cmd) {

--- a/test/Kapacitor.Cli.Tests.Unit/ArgParsingTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/ArgParsingTests.cs
@@ -48,10 +48,10 @@ public class ArgParsingTests {
         await Assert.That(id).IsEqualTo("sess-abc");
     }
 
-    // These two tests mutate KAPACITOR_SESSION_ID and must not run in parallel
-    // with each other (TUnit parallelizes by default).
+    // These tests mutate KAPACITOR_SESSION_ID / CODEX_THREAD_ID and must not run
+    // in parallel with each other (TUnit parallelizes by default).
     [Test]
-    [NotInParallel(nameof(KapacitorSessionIdEnvVar))]
+    [NotInParallel(nameof(SessionEnvVarMutation))]
     public async Task ResolveSessionId_returns_env_fallback_when_only_flags_present() {
         Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
 
@@ -64,9 +64,9 @@ public class ArgParsingTests {
     }
 
     [Test]
-    [NotInParallel(nameof(KapacitorSessionIdEnvVar))]
+    [NotInParallel(nameof(SessionEnvVarMutation))]
     public async Task ResolveSessionId_honors_env_when_no_positional() {
-        Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "env-sess");
+        Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "envsess");
 
         try {
             var id = ArgParsing.ResolveSessionId(
@@ -74,13 +74,15 @@ public class ArgParsingTests {
                 valueFlags: ["--model"]
             );
 
-            await Assert.That(id).IsEqualTo("env-sess");
+            await Assert.That(id).IsEqualTo("envsess");
         } finally {
             Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
         }
     }
 
     const string KapacitorSessionIdEnvVar = "KAPACITOR_SESSION_ID";
+    const string CodexThreadIdEnvVar      = "CODEX_THREAD_ID";
+    const string SessionEnvVarMutation    = nameof(SessionEnvVarMutation);
 
     [Test]
     public async Task ResolveSessionId_does_not_eat_next_arg_when_flag_is_not_value_bearing() {
@@ -92,5 +94,114 @@ public class ArgParsingTests {
         );
 
         await Assert.That(id).IsEqualTo("sess-abc");
+    }
+
+    [Test]
+    [NotInParallel(nameof(SessionEnvVarMutation))]
+    public async Task ResolveSessionIdFromEnv_returns_null_when_neither_env_set() {
+        Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
+
+        var id = ArgParsing.ResolveSessionIdFromEnv();
+
+        await Assert.That(id).IsNull();
+    }
+
+    [Test]
+    [NotInParallel(nameof(SessionEnvVarMutation))]
+    public async Task ResolveSessionIdFromEnv_returns_kapacitor_env_stripped_of_dashes() {
+        Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "abc-def-123");
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
+
+        try {
+            var id = ArgParsing.ResolveSessionIdFromEnv();
+
+            await Assert.That(id).IsEqualTo("abcdef123");
+        } finally {
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+        }
+    }
+
+    [Test]
+    [NotInParallel(nameof(SessionEnvVarMutation))]
+    public async Task ResolveSessionIdFromEnv_returns_codex_env_stripped_of_dashes_when_kapacitor_unset() {
+        Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      "thread-uuid-1");
+
+        try {
+            var id = ArgParsing.ResolveSessionIdFromEnv();
+
+            await Assert.That(id).IsEqualTo("threaduuid1");
+        } finally {
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, null);
+        }
+    }
+
+    [Test]
+    [NotInParallel(nameof(SessionEnvVarMutation))]
+    public async Task ResolveSessionIdFromEnv_prefers_kapacitor_over_codex() {
+        Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "kap-1");
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      "cdx-2");
+
+        try {
+            var id = ArgParsing.ResolveSessionIdFromEnv();
+
+            await Assert.That(id).IsEqualTo("kap1");
+        } finally {
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
+        }
+    }
+
+    [Test]
+    [NotInParallel(nameof(SessionEnvVarMutation))]
+    public async Task ResolveSessionIdFromEnv_treats_whitespace_kapacitor_as_unset_and_falls_back_to_codex() {
+        Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "   ");
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      "cdx-3");
+
+        try {
+            var id = ArgParsing.ResolveSessionIdFromEnv();
+
+            await Assert.That(id).IsEqualTo("cdx3");
+        } finally {
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
+        }
+    }
+
+    [Test]
+    [NotInParallel(nameof(SessionEnvVarMutation))]
+    public async Task ResolveSessionId_falls_back_to_codex_env_when_no_args_and_no_kapacitor_env() {
+        Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      "cdx-only");
+
+        try {
+            var id = ArgParsing.ResolveSessionId(
+                ["eval", "--model", "sonnet"],
+                valueFlags: ["--model"]
+            );
+
+            await Assert.That(id).IsEqualTo("cdxonly");
+        } finally {
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, null);
+        }
+    }
+
+    [Test]
+    [NotInParallel(nameof(SessionEnvVarMutation))]
+    public async Task ResolveSessionId_strips_dashes_from_kapacitor_env_fallback() {
+        Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "abc-def");
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
+
+        try {
+            var id = ArgParsing.ResolveSessionId(
+                ["eval", "--model", "sonnet"],
+                valueFlags: ["--model"]
+            );
+
+            await Assert.That(id).IsEqualTo("abcdef");
+        } finally {
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+        }
     }
 }

--- a/test/Kapacitor.Cli.Tests.Unit/ArgParsingTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/ArgParsingTests.cs
@@ -50,23 +50,41 @@ public class ArgParsingTests {
 
     // These tests mutate KAPACITOR_SESSION_ID / CODEX_THREAD_ID and must not run
     // in parallel with each other (TUnit parallelizes by default).
+    //
+    // Every SessionEnvVarMutation test saves AND restores BOTH env vars,
+    // even when the test body only manipulates one of them. The test runner
+    // can be invoked from inside an active Codex session — where
+    // CODEX_THREAD_ID is set process-wide — and any test that reads the env
+    // would otherwise observe that leaked value as a fallback session id and
+    // fail nondeterministically depending on where it was run.
     [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
     public async Task ResolveSessionId_returns_env_fallback_when_only_flags_present() {
+        var savedKap = Environment.GetEnvironmentVariable(KapacitorSessionIdEnvVar);
+        var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
         Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
 
-        var id = ArgParsing.ResolveSessionId(
-            ["eval", "--model", "sonnet", "--chain"],
-            valueFlags: ["--model"]
-        );
+        try {
+            var id = ArgParsing.ResolveSessionId(
+                ["eval", "--model", "sonnet", "--chain"],
+                valueFlags: ["--model"]
+            );
 
-        await Assert.That(id).IsNull();
+            await Assert.That(id).IsNull();
+        } finally {
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, savedKap);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
+        }
     }
 
     [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
     public async Task ResolveSessionId_honors_env_when_no_positional() {
+        var savedKap = Environment.GetEnvironmentVariable(KapacitorSessionIdEnvVar);
+        var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
         Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "envsess");
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
 
         try {
             var id = ArgParsing.ResolveSessionId(
@@ -76,7 +94,8 @@ public class ArgParsingTests {
 
             await Assert.That(id).IsEqualTo("envsess");
         } finally {
-            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, savedKap);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
         }
     }
 
@@ -99,17 +118,26 @@ public class ArgParsingTests {
     [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
     public async Task ResolveSessionIdFromEnv_returns_null_when_neither_env_set() {
+        var savedKap = Environment.GetEnvironmentVariable(KapacitorSessionIdEnvVar);
+        var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
         Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
         Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
 
-        var id = ArgParsing.ResolveSessionIdFromEnv();
+        try {
+            var id = ArgParsing.ResolveSessionIdFromEnv();
 
-        await Assert.That(id).IsNull();
+            await Assert.That(id).IsNull();
+        } finally {
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, savedKap);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
+        }
     }
 
     [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
     public async Task ResolveSessionIdFromEnv_returns_kapacitor_env_stripped_of_dashes() {
+        var savedKap = Environment.GetEnvironmentVariable(KapacitorSessionIdEnvVar);
+        var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
         Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "abc-def-123");
         Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
 
@@ -118,13 +146,16 @@ public class ArgParsingTests {
 
             await Assert.That(id).IsEqualTo("abcdef123");
         } finally {
-            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, savedKap);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
         }
     }
 
     [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
     public async Task ResolveSessionIdFromEnv_returns_codex_env_stripped_of_dashes_when_kapacitor_unset() {
+        var savedKap = Environment.GetEnvironmentVariable(KapacitorSessionIdEnvVar);
+        var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
         Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
         Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      "thread-uuid-1");
 
@@ -133,13 +164,16 @@ public class ArgParsingTests {
 
             await Assert.That(id).IsEqualTo("threaduuid1");
         } finally {
-            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, null);
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, savedKap);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
         }
     }
 
     [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
     public async Task ResolveSessionIdFromEnv_prefers_kapacitor_over_codex() {
+        var savedKap = Environment.GetEnvironmentVariable(KapacitorSessionIdEnvVar);
+        var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
         Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "kap-1");
         Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      "cdx-2");
 
@@ -148,14 +182,16 @@ public class ArgParsingTests {
 
             await Assert.That(id).IsEqualTo("kap1");
         } finally {
-            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
-            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, savedKap);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
         }
     }
 
     [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
     public async Task ResolveSessionIdFromEnv_treats_whitespace_kapacitor_as_unset_and_falls_back_to_codex() {
+        var savedKap = Environment.GetEnvironmentVariable(KapacitorSessionIdEnvVar);
+        var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
         Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "   ");
         Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      "cdx-3");
 
@@ -164,14 +200,16 @@ public class ArgParsingTests {
 
             await Assert.That(id).IsEqualTo("cdx3");
         } finally {
-            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
-            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, savedKap);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
         }
     }
 
     [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
     public async Task ResolveSessionId_falls_back_to_codex_env_when_no_args_and_no_kapacitor_env() {
+        var savedKap = Environment.GetEnvironmentVariable(KapacitorSessionIdEnvVar);
+        var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
         Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
         Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      "cdx-only");
 
@@ -183,13 +221,16 @@ public class ArgParsingTests {
 
             await Assert.That(id).IsEqualTo("cdxonly");
         } finally {
-            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, null);
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, savedKap);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
         }
     }
 
     [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
     public async Task ResolveSessionId_strips_dashes_from_kapacitor_env_fallback() {
+        var savedKap = Environment.GetEnvironmentVariable(KapacitorSessionIdEnvVar);
+        var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
         Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, "abc-def");
         Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
 
@@ -201,7 +242,8 @@ public class ArgParsingTests {
 
             await Assert.That(id).IsEqualTo("abcdef");
         } finally {
-            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, null);
+            Environment.SetEnvironmentVariable(KapacitorSessionIdEnvVar, savedKap);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
         }
     }
 }

--- a/test/Kapacitor.Cli.Tests.Unit/ArgParsingTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/ArgParsingTests.cs
@@ -227,6 +227,38 @@ public class ArgParsingTests {
     }
 
     [Test]
+    public async Task TryNormalizeSessionGuid_accepts_dashed_uuid_and_returns_dashless() {
+        var ok = ArgParsing.TryNormalizeSessionGuid("01234567-89ab-cdef-0123-456789abcdef", out var canonical);
+        await Assert.That(ok).IsTrue();
+        await Assert.That(canonical).IsEqualTo("0123456789abcdef0123456789abcdef");
+    }
+
+    [Test]
+    public async Task TryNormalizeSessionGuid_accepts_dashless_uuid_unchanged() {
+        var ok = ArgParsing.TryNormalizeSessionGuid("0123456789abcdef0123456789abcdef", out var canonical);
+        await Assert.That(ok).IsTrue();
+        await Assert.That(canonical).IsEqualTo("0123456789abcdef0123456789abcdef");
+    }
+
+    [Test]
+    public async Task TryNormalizeSessionGuid_rejects_slug() {
+        var ok = ArgParsing.TryNormalizeSessionGuid("foo-bar-baz", out _);
+        await Assert.That(ok).IsFalse();
+    }
+
+    [Test]
+    public async Task TryNormalizeSessionGuid_rejects_path_traversal() {
+        var ok = ArgParsing.TryNormalizeSessionGuid("../etc/passwd", out _);
+        await Assert.That(ok).IsFalse();
+    }
+
+    [Test]
+    public async Task TryNormalizeSessionGuid_rejects_empty() {
+        var ok = ArgParsing.TryNormalizeSessionGuid("", out _);
+        await Assert.That(ok).IsFalse();
+    }
+
+    [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
     public async Task ResolveSessionId_strips_dashes_from_kapacitor_env_fallback() {
         var savedKap = Environment.GetEnvironmentVariable(KapacitorSessionIdEnvVar);

--- a/test/Kapacitor.Cli.Tests.Unit/CodexHookCommandTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/CodexHookCommandTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Kapacitor.Cli;
 using Kapacitor.Cli.Commands;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -326,6 +327,62 @@ public class CodexHookCommandTests : IDisposable {
         // AI-648: Stop must never POST session-end, even with a malformed payload.
         var endRequests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-end/codex").UsingPost());
         await Assert.That(endRequests.Count).IsEqualTo(0);
+    }
+
+    // AI-676 P1: when the user runs `kapacitor disable`, the marker file
+    // under PathHelpers.ConfigPath("disabled") must short-circuit the Codex
+    // hook the same way it does for Claude. Without this guard, the next
+    // Codex Stop hook restarts the watcher (HandleStop calls
+    // WatcherManager.EnsureWatcherRunning) and re-enlivens a session whose
+    // data was just deleted server-side.
+    //
+    // Globally sequential: this test captures Console.Out, and shares the
+    // same NotInParallel(ConsoleSerialGroup) lock as every other
+    // stdout-redirecting test in the suite.
+    [Test, NotInParallel(ConsoleSerialGroup)]
+    public async Task Handle_skips_dispatch_when_session_is_disabled() {
+        // session_id without dashes — NormalizeGuidField is a no-op on this
+        // shape, so the value written to disk matches the value the hook
+        // looks up after normalization.
+        const string sessionId = "disabledsess123abc";
+
+        // Stub every route the dispatch path could hit so a regression that
+        // re-enables dispatch surfaces as a recorded request.
+        _server.Given(Request.Create().WithPath("/hooks/session-start/codex").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        var payload = $$"""
+            {
+              "hook_event_name": "Stop",
+              "session_id": "{{sessionId}}",
+              "transcript_path": "/tmp/rollout.jsonl",
+              "cwd": "/tmp"
+            }
+            """;
+
+        DisabledSessions.Mark(sessionId);
+
+        var originalOut  = Console.Out;
+        var stdoutWriter = new StringWriter();
+        try {
+            Console.SetOut(stdoutWriter);
+
+            var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
+
+            await Assert.That(exit).IsEqualTo(0);
+
+            // Disabled-session branch must skip every server POST and the
+            // watcher restart.
+            await Assert.That(_server.LogEntries.Count).IsEqualTo(0);
+
+            // Codex's Stop parser still expects valid JSON on stdout.
+            var stdout = stdoutWriter.ToString();
+            var doc    = JsonDocument.Parse(stdout);
+            await Assert.That(doc.RootElement.GetProperty("continue").GetBoolean()).IsTrue();
+        } finally {
+            Console.SetOut(originalOut);
+            DisabledSessions.RemoveMarker(sessionId);
+        }
     }
 
     // ---- PermissionRequest daemon-bridge tests ----

--- a/test/Kapacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
@@ -198,16 +198,82 @@ public class PluginCommandCodexTests {
         using var tmp    = new TempDir();
         var       source = Path.Combine(tmp.Path, "codex-skills");
         var       target = Path.Combine(tmp.Path, "skills");
-        WriteSkill(source, "kapacitor-recap",  "recap body");
-        WriteSkill(source, "kapacitor-errors", "errors body");
+        // Preflight requires every known skill folder to exist under source.
+        foreach (var name in PluginCommand.CodexSkillNames) {
+            WriteSkill(source, name, $"{name} body");
+        }
 
         var ok = PluginCommand.InstallCodexSkills(source, target);
         await Assert.That(ok).IsTrue();
 
         var recap  = await File.ReadAllTextAsync(Path.Combine(target, "kapacitor-recap",  "SKILL.md"));
         var errors = await File.ReadAllTextAsync(Path.Combine(target, "kapacitor-errors", "SKILL.md"));
-        await Assert.That(recap).IsEqualTo("recap body");
-        await Assert.That(errors).IsEqualTo("errors body");
+        await Assert.That(recap).IsEqualTo("kapacitor-recap body");
+        await Assert.That(errors).IsEqualTo("kapacitor-errors body");
+    }
+
+    [Test]
+    public async Task InstallCodexSkills_copies_all_five_known_skills() {
+        using var tmp    = new TempDir();
+        var       source = Path.Combine(tmp.Path, "codex-skills");
+        var       target = Path.Combine(tmp.Path, "skills");
+        foreach (var name in PluginCommand.CodexSkillNames) {
+            WriteSkill(source, name, $"{name} body");
+        }
+
+        var ok = PluginCommand.InstallCodexSkills(source, target);
+        await Assert.That(ok).IsTrue();
+
+        foreach (var name in PluginCommand.CodexSkillNames) {
+            var path = Path.Combine(target, name, "SKILL.md");
+            await Assert.That(File.Exists(path)).IsTrue();
+            var body = await File.ReadAllTextAsync(path);
+            await Assert.That(body).IsEqualTo($"{name} body");
+        }
+    }
+
+    [Test]
+    public async Task CodexSkillNames_contains_expected_five() {
+        var expected = new[] {
+            "kapacitor-recap",
+            "kapacitor-errors",
+            "kapacitor-hide",
+            "kapacitor-disable",
+            "kapacitor-validate-plan"
+        };
+
+        await Assert.That(PluginCommand.CodexSkillNames).IsEquivalentTo(expected);
+    }
+
+    [Test]
+    public async Task InstallCodexSkills_returns_false_when_known_folder_missing() {
+        using var tmp    = new TempDir();
+        var       source = Path.Combine(tmp.Path, "codex-skills");
+        var       target = Path.Combine(tmp.Path, "skills");
+
+        // Write four of the five expected names — leave kapacitor-validate-plan missing.
+        WriteSkill(source, "kapacitor-recap",         "r");
+        WriteSkill(source, "kapacitor-errors",        "e");
+        WriteSkill(source, "kapacitor-hide",          "h");
+        WriteSkill(source, "kapacitor-disable",       "d");
+
+        // Pre-existing target folder for one of the known skills. The preflight
+        // must NOT delete it because the install is aborted before any destructive
+        // step runs.
+        WriteSkill(target, "kapacitor-recap", "stale recap that must survive");
+
+        var ok = PluginCommand.InstallCodexSkills(source, target);
+        await Assert.That(ok).IsFalse();
+
+        // Pre-existing target folder unchanged — preflight bailed before deletion.
+        var preserved = await File.ReadAllTextAsync(Path.Combine(target, "kapacitor-recap", "SKILL.md"));
+        await Assert.That(preserved).IsEqualTo("stale recap that must survive");
+
+        // None of the other expected target folders were created.
+        await Assert.That(Directory.Exists(Path.Combine(target, "kapacitor-errors"))).IsFalse();
+        await Assert.That(Directory.Exists(Path.Combine(target, "kapacitor-hide"))).IsFalse();
+        await Assert.That(Directory.Exists(Path.Combine(target, "kapacitor-disable"))).IsFalse();
+        await Assert.That(Directory.Exists(Path.Combine(target, "kapacitor-validate-plan"))).IsFalse();
     }
 
     [Test]
@@ -215,8 +281,10 @@ public class PluginCommandCodexTests {
         using var tmp    = new TempDir();
         var       source = Path.Combine(tmp.Path, "codex-skills");
         var       target = Path.Combine(tmp.Path, "skills");
-        WriteSkill(source, "kapacitor-recap",  "new recap");
-        WriteSkill(source, "kapacitor-errors", "new errors");
+        // Preflight requires every known skill folder to exist under source.
+        foreach (var name in PluginCommand.CodexSkillNames) {
+            WriteSkill(source, name, name == "kapacitor-recap" ? "new recap" : $"{name} body");
+        }
 
         // Pre-existing stale copy in target.
         WriteSkill(target, "kapacitor-recap", "stale recap");
@@ -232,8 +300,10 @@ public class PluginCommandCodexTests {
         using var tmp    = new TempDir();
         var       source = Path.Combine(tmp.Path, "codex-skills");
         var       target = Path.Combine(tmp.Path, "skills");
-        WriteSkill(source, "kapacitor-recap",  "recap");
-        WriteSkill(source, "kapacitor-errors", "errors");
+        // Preflight requires every known skill folder to exist under source.
+        foreach (var name in PluginCommand.CodexSkillNames) {
+            WriteSkill(source, name, $"{name} body");
+        }
 
         // Foreign skill the user installed themselves — must not be touched.
         WriteSkill(target, "user-skill", "user content");

--- a/test/Kapacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
@@ -405,6 +405,23 @@ public class PluginCommandCodexInstallIntegrationTests {
         }
     }
 
+    // Variant of PlantFakePlugin that plants the top-level codex-skills/
+    // folder and every known skill EXCEPT the one named in `omit`. Used to
+    // simulate a partially-packaged install where the directory-level preflight
+    // passes but the per-skill preflight should still fail atomically.
+    static void PlantFakePluginMissingSkill(string pluginRoot, string omit) {
+        var skillsSrc = Path.Combine(pluginRoot, "codex-skills");
+        Directory.CreateDirectory(skillsSrc);
+
+        foreach (var name in PluginCommand.CodexSkillNames) {
+            if (name == omit) continue;
+
+            var dir = Path.Combine(skillsSrc, name);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "SKILL.md"), $"# {name}");
+        }
+    }
+
     static void RemoveFakePlugin(string pluginRoot) {
         try { Directory.Delete(pluginRoot, recursive: true); } catch { /* best effort */ }
     }
@@ -484,6 +501,52 @@ public class PluginCommandCodexInstallIntegrationTests {
             Console.SetError(originalErr);
             Environment.SetEnvironmentVariable("HOME",        originalHome);
             Environment.SetEnvironmentVariable("USERPROFILE", originalUserProfile);
+        }
+    }
+
+    // AI-676 P2 revised: packaging defect where codex-skills/ exists but an
+    // individual skill folder (e.g. kapacitor-validate-plan) is missing. The
+    // atomic-install contract requires the preflight to run BEFORE hooks are
+    // written, otherwise the user is left with hooks installed and no skills.
+    [Test, NotInParallel("CodexHookCommandTests.Console")]
+    public async Task InstallCodex_fails_before_writing_hooks_when_individual_skill_folder_missing() {
+        using var tmp = new TempDir();
+
+        var originalHome        = Environment.GetEnvironmentVariable("HOME");
+        var originalUserProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+        Environment.SetEnvironmentVariable("HOME",        tmp.Path);
+        Environment.SetEnvironmentVariable("USERPROFILE", tmp.Path);
+
+        var pluginRoot = ProbedPluginRoot();
+        PlantFakePluginMissingSkill(pluginRoot, "kapacitor-validate-plan");
+
+        var capturedErr = new StringWriter();
+        var originalErr = Console.Error;
+        Console.SetError(capturedErr);
+
+        try {
+            var exit = await PluginCommand.HandleAsync(["plugin", "install", "--codex"]);
+            await Assert.That(exit).IsEqualTo(1);
+
+            // The atomic-install contract: NO hooks.json may exist in the
+            // temp HOME after a failed install.
+            var hooksPath = Path.Combine(tmp.Path, ".codex", "hooks.json");
+            await Assert.That(File.Exists(hooksPath)).IsFalse();
+
+            // And no skill folder may have been written either.
+            var skillsDir = Path.Combine(tmp.Path, ".codex", "skills");
+            foreach (var name in PluginCommand.CodexSkillNames) {
+                await Assert.That(Directory.Exists(Path.Combine(skillsDir, name))).IsFalse();
+            }
+
+            var stderr = capturedErr.ToString();
+            await Assert.That(stderr).Contains("Cannot install Codex plugin");
+            await Assert.That(stderr).Contains("kapacitor-validate-plan");
+        } finally {
+            Console.SetError(originalErr);
+            Environment.SetEnvironmentVariable("HOME",        originalHome);
+            Environment.SetEnvironmentVariable("USERPROFILE", originalUserProfile);
+            RemoveFakePlugin(pluginRoot);
         }
     }
 

--- a/test/Kapacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
@@ -379,6 +379,36 @@ public class PluginCommandCodexTests {
 //     Console.Out writer.
 [NotInParallel("HomeEnvVarMutation")]
 public class PluginCommandCodexInstallIntegrationTests {
+    // SetupCommand.ResolvePluginPath probes paths relative to Environment.ProcessPath.
+    // In the test runner the process exe lives at
+    //   <repo>/test/Kapacitor.Cli.Tests.Unit/bin/Debug/net10.0/Kapacitor.Cli.Tests.Unit
+    // None of the resolver's fallbacks exist by default, so this helper plants
+    // a fake plugin tree at the "<exeDir>/../../kapacitor" path the resolver
+    // probes (= "<bin>/kapacitor"). The folder is cleaned up after the test
+    // so it doesn't pollute subsequent runs that expect resolution to fail.
+    static string ProbedPluginRoot() {
+        var exeDir = Path.GetDirectoryName(Environment.ProcessPath)!;
+        return Path.GetFullPath(Path.Combine(exeDir, "..", "..", "kapacitor"));
+    }
+
+    static void PlantFakePlugin(string pluginRoot) {
+        var skillsSrc = Path.Combine(pluginRoot, "codex-skills");
+        Directory.CreateDirectory(skillsSrc);
+
+        // InstallCodexSkills has a per-skill preflight that requires every
+        // name in PluginCommand.CodexSkillNames to be present. Plant a stub
+        // SKILL.md so the copy succeeds.
+        foreach (var name in PluginCommand.CodexSkillNames) {
+            var dir = Path.Combine(skillsSrc, name);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "SKILL.md"), $"# {name}");
+        }
+    }
+
+    static void RemoveFakePlugin(string pluginRoot) {
+        try { Directory.Delete(pluginRoot, recursive: true); } catch { /* best effort */ }
+    }
+
     [Test, NotInParallel("CodexHookCommandTests.Console")]
     public async Task InstallCodex_prints_hooks_trust_hint_after_success() {
         using var tmp = new TempDir();
@@ -393,6 +423,9 @@ public class PluginCommandCodexInstallIntegrationTests {
         Environment.SetEnvironmentVariable("HOME",        tmp.Path);
         Environment.SetEnvironmentVariable("USERPROFILE", tmp.Path);
 
+        var pluginRoot = ProbedPluginRoot();
+        PlantFakePlugin(pluginRoot);
+
         var capturedOut = new StringWriter();
         var originalOut = Console.Out;
         Console.SetOut(capturedOut);
@@ -406,6 +439,49 @@ public class PluginCommandCodexInstallIntegrationTests {
             await Assert.That(stdout).Contains("trust");
         } finally {
             Console.SetOut(originalOut);
+            Environment.SetEnvironmentVariable("HOME",        originalHome);
+            Environment.SetEnvironmentVariable("USERPROFILE", originalUserProfile);
+            RemoveFakePlugin(pluginRoot);
+        }
+    }
+
+    // AI-676 P2: when the kapacitor plugin folder cannot be resolved (e.g.,
+    // the binary was hand-copied and the sibling `kapacitor/` tree is gone),
+    // `plugin install --codex` must fail BEFORE writing hooks. Otherwise the
+    // user ends up with hook entries pointing at a kapacitor binary whose
+    // skills never installed, breaking the documented `--codex` contract.
+    [Test, NotInParallel("CodexHookCommandTests.Console")]
+    public async Task InstallCodex_fails_before_writing_hooks_when_plugin_folder_missing() {
+        using var tmp = new TempDir();
+
+        var originalHome        = Environment.GetEnvironmentVariable("HOME");
+        var originalUserProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+        Environment.SetEnvironmentVariable("HOME",        tmp.Path);
+        Environment.SetEnvironmentVariable("USERPROFILE", tmp.Path);
+
+        // Defensive: make sure no leftover plant from a previous test forces
+        // ResolvePluginPath to succeed. With no folder at the probed path,
+        // resolver returns null and InstallCodex must short-circuit.
+        var pluginRoot = ProbedPluginRoot();
+        RemoveFakePlugin(pluginRoot);
+
+        var capturedErr = new StringWriter();
+        var originalErr = Console.Error;
+        Console.SetError(capturedErr);
+
+        try {
+            var exit = await PluginCommand.HandleAsync(["plugin", "install", "--codex"]);
+            await Assert.That(exit).IsEqualTo(1);
+
+            // The atomic-install contract: NO hooks.json may exist in the
+            // temp HOME after a failed install.
+            var hooksPath = Path.Combine(tmp.Path, ".codex", "hooks.json");
+            await Assert.That(File.Exists(hooksPath)).IsFalse();
+
+            var stderr = capturedErr.ToString();
+            await Assert.That(stderr).Contains("Cannot install Codex plugin");
+        } finally {
+            Console.SetError(originalErr);
             Environment.SetEnvironmentVariable("HOME",        originalHome);
             Environment.SetEnvironmentVariable("USERPROFILE", originalUserProfile);
         }


### PR DESCRIPTION
## Summary

Brings the Codex skill set to parity with Claude Code and eliminates the manual-session-ID dance Codex skills previously required.

**Skill parity (AI-676)** — three new `SKILL.md` files under `kapacitor/codex-skills/`:
- `kapacitor-hide` (wraps `kapacitor hide`)
- `kapacitor-disable` (wraps `kapacitor disable`)
- `kapacitor-validate-plan` (wraps `kapacitor validate-plan`)

The two existing Codex skills (`kapacitor-recap`, `kapacitor-errors`) are rewritten to promote the no-args entry point and demote `--repo` to a discovery flow.

**Auto-resolve (AI-677)** — extends `ArgParsing.ResolveSessionId` to read `CODEX_THREAD_ID` (exported by Codex CLI 0.81+ via [openai/codex#10096](https://github.com/openai/codex/pull/10096)) as a fallback after `KAPACITOR_SESSION_ID`. A new `ResolveSessionIdFromEnv()` helper is shared with `set-title` (whose positional is `<title>`, not `<sessionId>`). Resolution chain:

1. positional `<sessionId>` (verbatim — preserves meta-session slugs)
2. `KAPACITOR_SESSION_ID`, dashless (Claude Code hook-set)
3. `CODEX_THREAD_ID`, dashless (Codex CLI 0.81+)
4. shared error: *"No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+."*

**CLI surface changes**

- `kapacitor hide` and `kapacitor disable` now accept an optional `[sessionId]` positional, mirroring `recap`/`errors`/`validate-plan`/`eval`.
- `kapacitor set-title` routes through the env helper, so it works inside Codex too. Missing-title and missing-env-var branches now print distinct, accurate diagnostics.
- `PluginCommand.InstallCodexSkills` gains preflight validation: if any folder named in `CodexSkillNames` is missing from `kapacitor/codex-skills/`, the install fails fast and writes nothing to the target — no more half-overwritten state on packaging errors.

**Docs**

- 9 help-text resource files (`help-*.txt`) updated to name both env vars and the new positionals.
- README adds an auto-resolve note, a five-skill enumeration table, and `Hide session` / `Disable recording` command sections.

## Test plan

- [x] Unit tests: 867/867 pass (8 new for `ArgParsing`, 3 new for `PluginCommand`).
- [x] AOT publish: `dotnet publish -c Release` — zero IL3050/IL2026 warnings.
- [x] End-to-end smoke (fake npm layout): \`kapacitor plugin install --codex\` writes all 5 skill folders under \`~/.codex/skills/\`.
- [x] Error-path smoke: \`KAPACITOR_SESSION_ID= CODEX_THREAD_ID= kapacitor hide/disable/recap/set-title\` each prints the new tailored two-line error and exits 1.
- [x] Top-level \`kapacitor\` help now lists both \`KAPACITOR_SESSION_ID\` and \`CODEX_THREAD_ID\` in the Environment section.
- [ ] **Manual smoke (Day-1 probe, deferred to reviewer):** in a real Codex CLI 0.81+ session, invoke each of the five Codex skills with no arguments and confirm the active session is resolved. If the probe finds that \`CODEX_THREAD_ID\` and the hook payload \`session_id\` diverge, the spec's marker-file fallback applies — see \`docs/superpowers/specs/2026-05-24-ai-676-codex-skill-parity-design.md\` §7.1.

## Spec and plan

- Design: \`docs/superpowers/specs/2026-05-24-ai-676-codex-skill-parity-design.md\`
- Implementation plan: \`docs/superpowers/plans/2026-05-25-ai-676-codex-skill-parity.md\`

Closes [AI-676](https://linear.app/kurrent/issue/AI-676). Closes [AI-677](https://linear.app/kurrent/issue/AI-677).