### PR TITLE
[AI-691] Auto-register kapacitor-sessions in plugin manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,19 @@ You must pick an explicit scope (`--all`, `--org`, or `--repo`) so personal/priv
 
 Open the server URL in your browser. The dashboard shows repositories, sessions, and agents. It updates in real time as Claude Code sessions are active.
 
-### Installing the sessions MCP server (for agents)
+### Sessions MCP server for agents
 
-To let coding agents (Claude Code, Codex) search and recall past Capacitor sessions:
+The `kapacitor mcp sessions` stdio server lets coding agents search and recall past Capacitor sessions without leaving the chat.
 
-    claude mcp add kapacitor-sessions -- kapacitor mcp sessions
+For Claude Code users, the Kapacitor plugin (installed by `kapacitor setup`) **auto-registers it** — no extra step. The server is repo-aware: `cd` into a project before spawning your agent and `search_sessions` defaults to that repo's sessions.
 
-The server is repo-aware: `cd` into a project before spawning your agent, and `search_sessions` defaults to that repo's sessions.
+Codex CLI has no equivalent plugin-MCP convention, so Codex users wire it up manually once:
+
+    [kapacitor-sessions]
+    command = "kapacitor"
+    args    = ["mcp", "sessions"]
+
+(in `~/.config/codex/mcp_servers.toml`).
 
 ## What it records
 
@@ -216,9 +222,13 @@ Launches a Claude Code session equipped with MCP tools that query the implementa
 kapacitor mcp sessions
 ```
 
-Stdio MCP server that exposes past Capacitor sessions to coding agents (Claude Code, Codex) so they can search and recall prior work without leaving the chat. Install once with:
+Stdio MCP server that exposes past Capacitor sessions to coding agents (Claude Code, Codex) so they can search and recall prior work without leaving the chat.
 
-    claude mcp add kapacitor-sessions -- kapacitor mcp sessions
+For Claude Code, the Kapacitor plugin (installed by `kapacitor setup`) auto-registers this server via its `mcpServers` manifest entry — nothing extra to do. For Codex, add it to `~/.config/codex/mcp_servers.toml`:
+
+    [kapacitor-sessions]
+    command = "kapacitor"
+    args    = ["mcp", "sessions"]
 
 It provides three tools:
 

--- a/README.md
+++ b/README.md
@@ -72,17 +72,7 @@ Open the server URL in your browser. The dashboard shows repositories, sessions,
 
 ### Sessions MCP server for agents
 
-The `kapacitor mcp sessions` stdio server lets coding agents search and recall past Capacitor sessions without leaving the chat.
-
-For Claude Code users, the Kapacitor plugin (installed by `kapacitor setup`) **auto-registers it** — no extra step. The server is repo-aware: `cd` into a project before spawning your agent and `search_sessions` defaults to that repo's sessions.
-
-Codex CLI has no equivalent plugin-MCP convention, so Codex users wire it up manually once:
-
-    [kapacitor-sessions]
-    command = "kapacitor"
-    args    = ["mcp", "sessions"]
-
-(in `~/.config/codex/mcp_servers.toml`).
+The `kapacitor mcp sessions` stdio server lets coding agents search and recall past Capacitor sessions without leaving the chat. The Kapacitor plugin (installed by `kapacitor setup`) **auto-registers it for both Claude Code and Codex CLI** — no manual `claude mcp add` or TOML edit. The server is repo-aware: `cd` into a project before spawning your agent and `search_sessions` defaults to that repo's sessions.
 
 ## What it records
 
@@ -222,13 +212,7 @@ Launches a Claude Code session equipped with MCP tools that query the implementa
 kapacitor mcp sessions
 ```
 
-Stdio MCP server that exposes past Capacitor sessions to coding agents (Claude Code, Codex) so they can search and recall prior work without leaving the chat.
-
-For Claude Code, the Kapacitor plugin (installed by `kapacitor setup`) auto-registers this server via its `mcpServers` manifest entry — nothing extra to do. For Codex, add it to `~/.config/codex/mcp_servers.toml`:
-
-    [kapacitor-sessions]
-    command = "kapacitor"
-    args    = ["mcp", "sessions"]
+Stdio MCP server that exposes past Capacitor sessions to coding agents (Claude Code, Codex) so they can search and recall prior work without leaving the chat. The Kapacitor plugin auto-registers it for both Claude Code (via `.mcp.json`) and Codex CLI (via `.codex-plugin/plugin.json` → `.codex-mcp.json`), so there's nothing extra to do after `kapacitor setup`.
 
 It provides three tools:
 

--- a/kapacitor/.claude-plugin/plugin.json
+++ b/kapacitor/.claude-plugin/plugin.json
@@ -1,12 +1,5 @@
 {
   "name": "kapacitor",
   "version": "1.6.0",
-  "description": "Records and visualizes Claude Code sessions via kapacitor CLI hooks",
-  "mcpServers": {
-    "kapacitor-sessions": {
-      "command": "kapacitor",
-      "args": ["mcp", "sessions"],
-      "cwd": "${CLAUDE_PROJECT_DIR}"
-    }
-  }
+  "description": "Records and visualizes Claude Code sessions via kapacitor CLI hooks"
 }

--- a/kapacitor/.claude-plugin/plugin.json
+++ b/kapacitor/.claude-plugin/plugin.json
@@ -1,5 +1,12 @@
 {
   "name": "kapacitor",
-  "version": "1.5.0",
-  "description": "Records and visualizes Claude Code sessions via kapacitor CLI hooks"
+  "version": "1.6.0",
+  "description": "Records and visualizes Claude Code sessions via kapacitor CLI hooks",
+  "mcpServers": {
+    "kapacitor-sessions": {
+      "command": "kapacitor",
+      "args": ["mcp", "sessions"],
+      "cwd": "${CLAUDE_PROJECT_DIR}"
+    }
+  }
 }

--- a/kapacitor/.codex-mcp.json
+++ b/kapacitor/.codex-mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcp_servers": {
+    "kapacitor-review": {
+      "command": "kapacitor",
+      "args": ["mcp", "review"]
+    },
+    "kapacitor-sessions": {
+      "command": "kapacitor",
+      "args": ["mcp", "sessions"]
+    }
+  }
+}

--- a/kapacitor/.codex-plugin/plugin.json
+++ b/kapacitor/.codex-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "kapacitor",
+  "version": "1.6.0",
+  "description": "Records and visualizes Codex CLI sessions via kapacitor CLI hooks",
+  "skills": "./codex-skills/",
+  "mcpServers": "./.codex-mcp.json"
+}

--- a/kapacitor/.mcp.json
+++ b/kapacitor/.mcp.json
@@ -4,6 +4,11 @@
       "command": "kapacitor",
       "args": ["mcp", "review"],
       "description": "PR review context tools — query implementation session transcripts to understand why code was changed"
+    },
+    "kapacitor-sessions": {
+      "command": "kapacitor",
+      "args": ["mcp", "sessions"],
+      "cwd": "${CLAUDE_PROJECT_DIR}"
     }
   }
 }

--- a/kapacitor/README.md
+++ b/kapacitor/README.md
@@ -1,10 +1,26 @@
-# Kapacitor Plugin for Claude Code
+# Kapacitor Plugin
 
-This plugin integrates [Kurrent Capacitor](../README.md) with Claude Code by automatically registering lifecycle hooks, providing skills for session review, and exposing MCP tools for PR review context.
+This plugin integrates [Kurrent Capacitor](../README.md) with Claude Code and Codex CLI by automatically registering lifecycle hooks, providing skills for session review, and auto-installing MCP servers that expose past-session context to the agent.
 
 ## What it does
 
-**MCP Tools** — PR review context tools, available automatically when you're on a branch with an open PR. Claude can query implementation session transcripts to understand why code was changed:
+**MCP servers** — Two stdio servers, both auto-registered on plugin install (no manual `claude mcp add` or `~/.config/codex/mcp_servers.toml` edit):
+
+### `kapacitor-sessions`
+
+Search and recall past Kurrent Capacitor sessions from inside the agent.
+
+| Tool | Description |
+|------|-------------|
+| `search_sessions` | Free-text + author search over past sessions (and subagent transcripts), defaulted to the cwd's repo |
+| `get_session_summary` | Concise `summary_text` + `plan` for a session |
+| `get_session_transcript` | Speaker-tagged transcript window, with `around_event` drill-in for search hits |
+
+Repo-aware: it resolves the cwd to a repo hash at startup, so `search_sessions` defaults to *this* repo.
+
+### `kapacitor-review`
+
+PR review context tools, available automatically when the agent is on a branch with an open PR. The MCP server auto-detects the current repo and PR from git; if you're not on a PR branch, the tools return a helpful message suggesting `kapacitor review <pr>`.
 
 | Tool | Description |
 |------|-------------|
@@ -15,7 +31,7 @@ This plugin integrates [Kurrent Capacitor](../README.md) with Claude Code by aut
 | `list_sessions` | Sessions that contributed to the PR |
 | `get_transcript` | Full transcript of a specific session |
 
-The MCP server auto-detects the current repo and PR from git. If you're not on a PR branch, the tools return a helpful message suggesting `kapacitor review <pr>`.
+`kapacitor mcp judge` is intentionally not auto-registered. Add it with `claude mcp add kapacitor-judge -- kapacitor mcp judge` if you want it.
 
 **Hooks** — Automatically captures session activity and forwards it to the Kurrent Capacitor server:
 
@@ -30,17 +46,19 @@ The MCP server auto-detects the current repo and PR from git. If you're not on a
 
 Each hook pipes its JSON payload through the `kapacitor` CLI, which enriches it with git/PR info and forwards it to the server. A background watcher process streams transcript lines in real time.
 
-**Skills** — Slash commands for reviewing recorded sessions:
+**Skills** — Slash commands for reviewing recorded sessions. Available on both harnesses (Claude reads `skills/`, Codex reads `codex-skills/`):
 
-- `/kapacitor:session-recap` — Retrieve a structured summary of a session (user prompts, assistant responses, plans, file changes)
-- `/kapacitor:session-errors` — Extract tool call errors from a session for post-session review and pattern detection
-- `/kapacitor:validate-plan` — Verify that all planned items were completed
-- `/kapacitor:session-disable` — Stop recording and delete all server data for the current session
-- `/kapacitor:session-hide` — Hide the current session (owner-only visibility)
+- `kapacitor-recap` — Retrieve a structured summary of a session (user prompts, assistant responses, plans, file changes)
+- `kapacitor-errors` — Extract tool call errors from a session for post-session review and pattern detection
+- `kapacitor-validate-plan` — Verify that all planned items were completed
+- `kapacitor-disable` — Stop recording and delete all server data for the current session
+- `kapacitor-hide` — Hide the current session (owner-only visibility)
+
+In Claude they're invoked as `/kapacitor:session-recap`, `/kapacitor:session-errors`, etc.
 
 ## Prerequisites
 
-- The `kapacitor` CLI must be on your PATH (see [publishing instructions](../README.md#2-publish-the-cli-tool))
+- The `kapacitor` CLI must be on your PATH (`npm install -g @kurrent/kapacitor`)
 - The Kurrent Capacitor server must be running (default: `http://localhost:5108`)
 
 ## Installation
@@ -48,14 +66,15 @@ Each hook pipes its JSON payload through the `kapacitor` CLI, which enriches it 
 ### Option A: CLI command (recommended)
 
 ```bash
-kapacitor plugin install
+kapacitor plugin install            # Claude Code, user-wide
+kapacitor plugin install --codex    # Codex CLI, user-wide
+kapacitor plugin install --project  # current project only
 ```
-
-This registers the plugin user-wide. Use `--project` to install for the current project only.
 
 ### Option B: Interactive plugin manager
 
-From inside a Claude Code session, run `/plugin` and browse the **Installed** tab.
+- Claude Code: run `/plugin` inside a session and browse the **Installed** tab.
+- Codex CLI: `codex plugin marketplace add kurrent-io/kapacitor-cli` then enable from the marketplace.
 
 ### Option C: Settings file (manual)
 
@@ -79,7 +98,8 @@ Add to `.claude/settings.local.json` or `~/.claude/settings.json`:
 
 ### Verify
 
-Run `/hooks` in Claude Code to confirm the kapacitor hooks are registered.
+- Claude Code: `/hooks` (hooks) and `claude mcp list` (MCP servers).
+- Codex CLI: `/hooks` (then trust each kapacitor entry) and `codex mcp list`.
 
 ## Configuration
 
@@ -94,20 +114,36 @@ export KAPACITOR_URL=http://my-server:5108
 ```
 kapacitor/
   .claude-plugin/
-    plugin.json          — Plugin manifest (name, version, description)
+    plugin.json          — Claude manifest (name, version, description)
     marketplace.json     — Marketplace manifest for plugin discovery
-  .mcp.json              — MCP server config (PR review context tools)
+  .codex-plugin/
+    plugin.json          — Codex manifest (refs ./.codex-mcp.json and ./codex-skills/)
+  .mcp.json              — Claude MCP servers (camelCase mcpServers shape)
+  .codex-mcp.json        — Codex MCP servers (snake_case mcp_servers shape)
   hooks/
-    hooks.json           — Hook definitions for all lifecycle events
+    hooks.json           — Hook definitions for all Claude lifecycle events
   skills/
     session-recap/
-      SKILL.md           — /kapacitor:session-recap skill
+      SKILL.md           — /kapacitor:session-recap skill (Claude)
     session-errors/
-      SKILL.md           — /kapacitor:session-errors skill
+      SKILL.md
     validate-plan/
-      SKILL.md           — /kapacitor:validate-plan skill
+      SKILL.md
     session-disable/
-      SKILL.md           — /kapacitor:session-disable skill
+      SKILL.md
     session-hide/
-      SKILL.md           — /kapacitor:session-hide skill
+      SKILL.md
+  codex-skills/
+    kapacitor-recap/
+      SKILL.md           — same skill, Codex variant
+    kapacitor-errors/
+      SKILL.md
+    kapacitor-validate-plan/
+      SKILL.md
+    kapacitor-disable/
+      SKILL.md
+    kapacitor-hide/
+      SKILL.md
 ```
+
+The two MCP files exist because Claude requires top-level `mcpServers` (camelCase) while Codex accepts only `mcp_servers` (snake_case) or a bare server map — the schemas don't overlap. Keep them in sync when adding or removing servers.

--- a/src/Kapacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Kapacitor.Cli.Core/HttpClientExtensions.cs
@@ -29,7 +29,7 @@ public static class HttpClientExtensions {
         if (tokens is not null) {
             client.DefaultRequestHeaders.Authorization = new("Bearer", tokens.AccessToken);
         } else {
-            var stored = TokenStore.LoadAsync();
+            var stored = await TokenStore.LoadAsync();
 
             if (stored is not null) {
                 await Console.Error.WriteLineAsync("Authentication token has expired. Run 'kapacitor login' to re-authenticate.");

--- a/src/Kapacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-mcp.txt
@@ -29,9 +29,12 @@ mcp sessions:
 INSTALL
 
   Claude Code:
-    claude mcp add kapacitor-review   -- kapacitor mcp review
-    claude mcp add kapacitor-judge    -- kapacitor mcp judge
-    claude mcp add kapacitor-sessions -- kapacitor mcp sessions
+    The Kapacitor plugin auto-registers `kapacitor-sessions` via its
+    `mcpServers` manifest entry, so no manual `claude mcp add` is needed
+    after `kapacitor setup`. The other two are still added explicitly:
+
+      claude mcp add kapacitor-review -- kapacitor mcp review
+      claude mcp add kapacitor-judge  -- kapacitor mcp judge
 
   Codex (~/.config/codex/mcp_servers.toml):
 

--- a/src/Kapacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-mcp.txt
@@ -28,24 +28,19 @@ mcp sessions:
 
 INSTALL
 
-  Claude Code:
-    The Kapacitor plugin auto-registers `kapacitor-sessions` via its
-    `mcpServers` manifest entry, so no manual `claude mcp add` is needed
-    after `kapacitor setup`. The other two are still added explicitly:
+  The Kapacitor plugin auto-registers `kapacitor-sessions` and
+  `kapacitor-review` for both Claude Code (via the plugin's `.mcp.json`)
+  and Codex CLI (via `.codex-plugin/plugin.json` -> `.codex-mcp.json`),
+  so no manual `claude mcp add` or TOML edit is needed after
+  `kapacitor setup`.
 
-      claude mcp add kapacitor-review -- kapacitor mcp review
-      claude mcp add kapacitor-judge  -- kapacitor mcp judge
+  `kapacitor-judge` is not auto-registered. Add it explicitly if you
+  want it:
 
-  Codex (~/.config/codex/mcp_servers.toml):
+    Claude Code:
+      claude mcp add kapacitor-judge -- kapacitor mcp judge
 
-    [kapacitor-review]
-    command = "kapacitor"
-    args    = ["mcp", "review"]
-
-    [kapacitor-judge]
-    command = "kapacitor"
-    args    = ["mcp", "judge"]
-
-    [kapacitor-sessions]
-    command = "kapacitor"
-    args    = ["mcp", "sessions"]
+    Codex (~/.config/codex/mcp_servers.toml):
+      [kapacitor-judge]
+      command = "kapacitor"
+      args    = ["mcp", "judge"]

--- a/src/Kapacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Kapacitor.Cli/Commands/McpSessionsServer.cs
@@ -13,9 +13,17 @@ static class McpSessionsServer {
     internal const string NotLoggedInMessage = "Not logged in. Run 'kapacitor login' on the host shell.";
 
     public static async Task<int> RunAsync(string baseUrl) {
-        using var client      = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
-        var       cwdRepoHash = await ResolveCwdRepoHashAsync();
-        var       tools       = BuildToolsList();
+        var cwdRepoHash = await ResolveCwdRepoHashAsync();
+        var tools       = BuildToolsList();
+
+        // Defer the authenticated-client creation until the first tools/call.
+        // Under the plugin's auto-register manifest, Claude Code spawns
+        // `kapacitor mcp sessions` for every session, so an eager
+        // CreateAuthenticatedClientAsync (which does GET /auth/config + token
+        // load) would charge every session the network round-trip even when
+        // the agent never invokes a sessions tool. initialize / tools/list
+        // don't need auth, so we keep startup local-only.
+        var clientLazy = new Lazy<Task<HttpClient>>(() => HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl));
 
         await using var stdin  = Console.OpenStandardInput();
         await using var stdout = Console.OpenStandardOutput();
@@ -23,33 +31,39 @@ static class McpSessionsServer {
         await using var writer = new StreamWriter(stdout, new UTF8Encoding(false));
         writer.AutoFlush = true;
 
-        while (await reader.ReadLineAsync() is { } line) {
-            if (string.IsNullOrWhiteSpace(line)) continue;
+        try {
+            while (await reader.ReadLineAsync() is { } line) {
+                if (string.IsNullOrWhiteSpace(line)) continue;
 
-            JsonObject? request;
+                JsonObject? request;
 
-            try {
-                request = JsonNode.Parse(line)?.AsObject();
-            } catch {
-                continue; // skip malformed JSON
+                try {
+                    request = JsonNode.Parse(line)?.AsObject();
+                } catch {
+                    continue; // skip malformed JSON
+                }
+
+                if (request is null) continue;
+
+                var id     = request["id"];
+                var method = request["method"]?.GetValue<string>();
+
+                // Notifications have no id — don't send a response
+                if (id is null) continue;
+
+                var response = method switch {
+                    "initialize" => BuildInitializeResponse(id),
+                    "tools/list" => BuildToolsListResponse(id, tools),
+                    "tools/call" => await HandleToolCallAsync(id, request, await clientLazy.Value, baseUrl, cwdRepoHash),
+                    _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
+                };
+
+                await writer.WriteLineAsync(response);
             }
-
-            if (request is null) continue;
-
-            var id     = request["id"];
-            var method = request["method"]?.GetValue<string>();
-
-            // Notifications have no id — don't send a response
-            if (id is null) continue;
-
-            var response = method switch {
-                "initialize" => BuildInitializeResponse(id),
-                "tools/list" => BuildToolsListResponse(id, tools),
-                "tools/call" => await HandleToolCallAsync(id, request, client, baseUrl, cwdRepoHash),
-                _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
-            };
-
-            await writer.WriteLineAsync(response);
+        } finally {
+            if (clientLazy.IsValueCreated) {
+                try { (await clientLazy.Value).Dispose(); } catch { /* swallow — best-effort cleanup */ }
+            }
         }
 
         return 0;


### PR DESCRIPTION
## Summary

Auto-register `kapacitor-sessions` (and consolidate `kapacitor-review`) via the Kapacitor plugin so they're available out of the box on **both** Claude Code and Codex CLI after `kapacitor setup` — no more manual `claude mcp add` or `~/.config/codex/mcp_servers.toml` edits.

Layout:

- `kapacitor/.mcp.json` — Claude format (`mcpServers` camelCase, with `cwd: ${CLAUDE_PROJECT_DIR}` for sessions). Single source of truth for Claude; picked up automatically by the plugin loader.
- `kapacitor/.codex-plugin/plugin.json` — new Codex manifest. Required `name/version/description` plus `mcpServers: "./.codex-mcp.json"` and `skills: "./codex-skills/"`.
- `kapacitor/.codex-mcp.json` — new file in Codex's `mcp_servers` (snake_case) wrapped shape per [Codex plugin docs](https://developers.openai.com/codex/plugins/build).
- `.claude-plugin/plugin.json` — version bump 1.5.0 → 1.6.0; reverted the inline `mcpServers` block I added in the first commit (now lives in `.mcp.json`).

## Why two MCP files?

Claude Code's `.mcp.json` requires a top-level `mcpServers` (camelCase). Codex's accepts either a bare server map or a `mcp_servers` (snake_case) wrapper, but **not** `mcpServers`. The schemas don't overlap, so a single file can't satisfy both loaders — confirmed against the official docs.

## Not in scope

- **`kapacitor-review` per-PR launcher** — `kapacitor review <pr-url>` keeps writing a temp `--mcp-config` with explicit `--owner/--repo/--pr`. The plugin's auto-registered `kapacitor-review` covers the *opportunistic* case (agent inside a repo with an open PR; CLI auto-detects).
- **`kapacitor mcp judge`** — kept opt-in; behavioral fit for blanket auto-register isn't obvious yet.

## Test plan

- [ ] Fresh `kapacitor setup` → `claude mcp list` shows `kapacitor-sessions` and `kapacitor-review`.
- [ ] Fresh `kapacitor setup` with Codex on PATH → `codex mcp list` shows the same two.
- [ ] Ask the agent *"have we worked on this before?"* in a captured repo — `search_sessions` is invoked without any manual MCP wiring.
- [ ] `kapacitor mcp --help` output is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)