### PR TITLE
[AI-702] Stop sending vendor over RequestPermission SignalR wire

### DIFF
--- a/docs/superpowers/plans/2026-05-14-ai-68-codex-hosted-agents.md
+++ b/docs/superpowers/plans/2026-05-14-ai-68-codex-hosted-agents.md
@@ -1136,6 +1136,8 @@ git commit -m "[AI-68] models: required Vendor field on AgentRunStarted"
 
 ### Task 9: Update `ServerConnection.RequestPermissionAsync` to take `vendor`
 
+> **Superseded by AI-702 (2026-05-27).** The 5-arg wire-shape change planned in this task was rolled back. `JsonHubProtocol.BindArguments` strict-count-matches arguments against the target hub method and does not honour C# default values, so adding a 5th positional `vendor` arg without a coordinated server-side hub method bump made every hosted-agent permission prompt fall back to deny. The fix kept `vendor` local to `LocalPermissionBridge` (used in `BuildHookResponseJson` to shape the Claude vs Codex response envelope) and removed it from `ServerConnection.RequestPermissionAsync` and from `_hub.InvokeAsync(...)`. The instructions below are kept as a historical record of what was attempted — do **not** follow them on a fresh implementation.
+
 **Files:**
 - Modify: `src/Kapacitor.Daemon/Services/ServerConnection.cs`
 - Modify: `src/Kapacitor.Daemon/Services/LocalPermissionBridge.cs`

--- a/docs/superpowers/specs/2026-05-14-ai-68-codex-hosted-agents-design.md
+++ b/docs/superpowers/specs/2026-05-14-ai-68-codex-hosted-agents-design.md
@@ -434,6 +434,8 @@ Path expected: `/{token}/{vendor}/permission-request`. The handler asserts vendo
 
 ### 6.2 Server SignalR call
 
+> **Superseded by AI-702 (2026-05-27).** The 5-arg server hub plan below was never landed — `vendor` is **not** sent over the SignalR wire. `JsonHubProtocol.BindArguments` enforces strict `paramIndex == paramCount` matching and does not honour C# default values, so adding a positional `vendor` arg without a coordinated server bump breaks every hosted-agent permission prompt. Vendor stays local in `LocalPermissionBridge.BuildHookResponseJson` (which already has it in scope from the URL segment in §6.1) to pick the response shape; the server's permission flow is vendor-agnostic. The current wire shape is the original 4-arg `(sessionId, toolName, toolInput, suggestions)`. The bridge tests now assert response envelope shape directly instead of capturing a `vendor` parameter.
+
 The bridge today invokes `server.RequestPermissionAsync(sessionId, toolName, toolInput, suggestions, ct)`. With cross-repo scope (§3.5), the daemon-side wrapper `ServerConnection.RequestPermissionAsync` gains a required `string vendor` parameter and the hub method `RequestPermission` is bumped to five args server-side (no V2 alias). New signature:
 
 ```csharp

--- a/src/Kapacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Kapacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -199,7 +199,7 @@ internal sealed partial class LocalPermissionBridge(
             PermissionDecision decision;
 
             try {
-                decision = await server.RequestPermissionAsync(sessionId, toolName, toolInput, suggestions, vendor, ct);
+                decision = await server.RequestPermissionAsync(sessionId, toolName, toolInput, suggestions, ct);
             } catch (Exception ex) {
                 LogRequestPermissionFailed(logger, ex, sessionId);
                 decision = new PermissionDecision("deny", null, null);

--- a/src/Kapacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Kapacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -350,13 +350,20 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// in the bridge doesn't surface a per-request "client disconnected" signal, so a
     /// Claude process exiting mid-wait won't cancel this call. Switching the bridge to
     /// Kestrel + <c>HttpContext.RequestAborted</c> would give us per-request cancellation.
+    ///
+    /// The bridge knows the vendor ("claude" or "codex") locally to pick the right hook
+    /// response shape in <c>LocalPermissionBridge.BuildHookResponseJson</c>, but the
+    /// server's permission flow is vendor-agnostic so it is NOT forwarded over the wire.
+    /// Sending it would add a 5th positional argument that <c>JsonHubProtocol.BindArguments</c>
+    /// strict-count-matches against the server signature (default values are not honoured
+    /// by the binder), breaking every hosted-agent permission prompt against any server
+    /// build whose hub method doesn't declare a matching 5th parameter.
     /// </summary>
     public virtual Task<PermissionDecision> RequestPermissionAsync(
             string            sessionId,
             string?           toolName,
             JsonElement?      toolInput,
             JsonElement?      suggestions,
-            string            vendor,
             CancellationToken ct = default
         ) =>
         _hub.InvokeAsync<PermissionDecision>(
@@ -365,7 +372,6 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             toolName,
             toolInput,
             suggestions,
-            vendor,
             ct
         );
 

--- a/test/Kapacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -374,7 +374,6 @@ public class AgentOrchestratorVendorTests {
                 string?           toolName,
                 JsonElement?      toolInput,
                 JsonElement?      suggestions,
-                string            vendor,
                 CancellationToken ct = default
             ) => Task.FromResult(new PermissionDecision("deny", null, null));
     }

--- a/test/Kapacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -339,7 +339,12 @@ public class LocalPermissionBridgeTests {
     }
 
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
-    public async Task Codex_path_invokes_server_with_vendor_codex() {
+    public async Task Codex_path_invokes_server_and_shapes_codex_response() {
+        // The bridge derives the vendor from the URL path segment and uses it
+        // LOCALLY to pick the hook response shape. The vendor is intentionally
+        // NOT forwarded over the SignalR wire — JsonHubProtocol's strict arg-count
+        // binder would reject any extra argument the server hub method doesn't
+        // declare. The proof of correct vendor routing is the response shape.
         var (bridge, server) = CreateBridge();
         try {
             await bridge.StartAsync(CancellationToken.None);
@@ -349,14 +354,23 @@ public class LocalPermissionBridgeTests {
 
             await Assert.That((int)response.StatusCode).IsEqualTo(200);
             await Assert.That(server.Calls.Count).IsEqualTo(1);
-            await Assert.That(server.Calls[0].Vendor).IsEqualTo("codex");
+
+            // Codex hook schema: hookSpecificOutput.decision.behavior, no applyPermissions / updatedInput.
+            var body = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            var decision = doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("decision");
+            await Assert.That(decision.GetProperty("behavior").GetString()).IsEqualTo("allow");
+            await Assert.That(body.Contains("applyPermissions")).IsFalse();
+            await Assert.That(body.Contains("updatedInput")).IsFalse();
         } finally {
             await bridge.DisposeAsync();
         }
     }
 
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
-    public async Task Claude_path_invokes_server_with_vendor_claude() {
+    public async Task Claude_path_invokes_server_and_shapes_claude_response() {
+        // Mirror of the Codex test: vendor is local-only state in the bridge, used
+        // to pick the Claude-flavoured hookSpecificOutput envelope. Not on the wire.
         var (bridge, server) = CreateBridge();
         try {
             await bridge.StartAsync(CancellationToken.None);
@@ -366,7 +380,12 @@ public class LocalPermissionBridgeTests {
 
             await Assert.That((int)response.StatusCode).IsEqualTo(200);
             await Assert.That(server.Calls.Count).IsEqualTo(1);
-            await Assert.That(server.Calls[0].Vendor).IsEqualTo("claude");
+
+            var body = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            var hookOutput = doc.RootElement.GetProperty("hookSpecificOutput");
+            await Assert.That(hookOutput.GetProperty("hookEventName").GetString()).IsEqualTo("PermissionRequest");
+            await Assert.That(hookOutput.GetProperty("decision").GetProperty("behavior").GetString()).IsEqualTo("allow");
         } finally {
             await bridge.DisposeAsync();
         }
@@ -411,7 +430,7 @@ public class LocalPermissionBridgeTests {
 
             await Assert.That((int)response.StatusCode).IsEqualTo(200);
             await Assert.That(server.Calls.Count).IsEqualTo(1);
-            await Assert.That(server.Calls[0].Vendor).IsEqualTo("claude");
+            await Assert.That(server.Calls[0].ToolName).IsEqualTo("Bash");
         } finally {
             await bridge.DisposeAsync();
         }
@@ -442,15 +461,14 @@ sealed class FakeServerConnection : ServerConnection {
             string?           toolName,
             JsonElement?      toolInput,
             JsonElement?      suggestions,
-            string            vendor,
             CancellationToken ct = default
         ) {
-        Calls.Add(new Call(sessionId, toolName, toolInput, suggestions, vendor));
+        Calls.Add(new Call(sessionId, toolName, toolInput, suggestions));
 
         return _respond is null
             ? Task.FromResult(new PermissionDecision("allow", null, null))
             : _respond(sessionId, toolName, toolInput, suggestions, ct);
     }
 
-    public sealed record Call(string SessionId, string? ToolName, JsonElement? ToolInput, JsonElement? Suggestions, string Vendor);
+    public sealed record Call(string SessionId, string? ToolName, JsonElement? ToolInput, JsonElement? Suggestions);
 }

--- a/test/Kapacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -273,8 +273,10 @@ public class LocalPermissionBridgeTests {
             await Assert.That((int)response.StatusCode).IsEqualTo(200);
 
             var body = await response.Content.ReadAsStringAsync();
-            await Assert.That(body.Contains("applyPermissions")).IsTrue();
-            await Assert.That(body.Contains("updatedInput")).IsTrue();
+            using var doc    = JsonDocument.Parse(body);
+            var       decision = doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("decision");
+            await Assert.That(decision.TryGetProperty("applyPermissions", out _)).IsTrue();
+            await Assert.That(decision.TryGetProperty("updatedInput",     out _)).IsTrue();
         } finally {
             await bridge.DisposeAsync();
         }
@@ -301,8 +303,8 @@ public class LocalPermissionBridgeTests {
             using var doc    = JsonDocument.Parse(body);
             var       decision = doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("decision");
             await Assert.That(decision.GetProperty("behavior").GetString()).IsEqualTo("allow");
-            await Assert.That(body.Contains("applyPermissions")).IsFalse();
-            await Assert.That(body.Contains("updatedInput")).IsFalse();
+            await Assert.That(decision.TryGetProperty("applyPermissions", out _)).IsFalse();
+            await Assert.That(decision.TryGetProperty("updatedInput",     out _)).IsFalse();
         } finally {
             await bridge.DisposeAsync();
         }
@@ -360,8 +362,8 @@ public class LocalPermissionBridgeTests {
             using var doc = JsonDocument.Parse(body);
             var decision = doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("decision");
             await Assert.That(decision.GetProperty("behavior").GetString()).IsEqualTo("allow");
-            await Assert.That(body.Contains("applyPermissions")).IsFalse();
-            await Assert.That(body.Contains("updatedInput")).IsFalse();
+            await Assert.That(decision.TryGetProperty("applyPermissions", out _)).IsFalse();
+            await Assert.That(decision.TryGetProperty("updatedInput",     out _)).IsFalse();
         } finally {
             await bridge.DisposeAsync();
         }
@@ -408,7 +410,9 @@ public class LocalPermissionBridgeTests {
             await Assert.That((int)response.StatusCode).IsEqualTo(200);
 
             var body = await response.Content.ReadAsStringAsync();
-            await Assert.That(body.Contains("applyPermissions")).IsFalse();
+            using var doc = JsonDocument.Parse(body);
+            var decision = doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("decision");
+            await Assert.That(decision.TryGetProperty("applyPermissions", out _)).IsFalse();
         } finally {
             await bridge.DisposeAsync();
         }


### PR DESCRIPTION
## Summary

- Fixes hosted-agent permission prompts auto-denying: `HubException: Failed to invoke 'RequestPermission' due to an error on the server.`
- AI-652 added a 5th positional `vendor` argument to `ServerConnection.RequestPermissionAsync` (and the matching `_hub.InvokeAsync` call) but the server's `KapacitorHub.RequestPermission` hub method was never updated. SignalR's `JsonHubProtocol.BindArguments` enforces a strict `paramIndex == paramCount` equality check and does NOT honour C# default values (`HubMethodDescriptor` builds `ParameterTypes` from raw `MethodParameters`), so the binder fails on the server and the daemon falls back to deny.
- `vendor` is needed only locally in `LocalPermissionBridge.BuildHookResponseJson` to pick the Claude vs Codex hook response envelope. The server's permission flow is vendor-agnostic. Drop it from the wire.

## Changes

- `ServerConnection.RequestPermissionAsync`: drop `string vendor` parameter and stop sending it in `InvokeAsync`. Added doc comment explaining why it stays off the wire.
- `LocalPermissionBridge.HandleAsync`: drop `vendor` from the `RequestPermissionAsync` call. `vendor` still in scope at the `BuildHookResponseJson(decision, vendor)` callsite as before.
- `LocalPermissionBridgeTests`: `FakeServerConnection` override and `Call` record updated; vendor-routing tests now assert the response envelope shape directly (Codex strips `applyPermissions` / `updatedInput`, Claude includes `hookSpecificOutput.hookEventName`).
- `AgentOrchestratorVendorTests`: override updated to match.

## Test plan

- [x] `dotnet build src/Kapacitor.Cli.Daemon/Kapacitor.Cli.Daemon.csproj` — clean
- [x] `LocalPermissionBridgeTests` — 19/19 pass
- [x] `AgentOrchestratorVendorTests` — 5/5 pass
- [x] `dotnet publish src/Kapacitor.Cli/Kapacitor.Cli.csproj -c Release` — 0 IL3050/IL2026 AOT warnings
- [ ] After merge: bump submodule in kapacitor-server and revert the matching server-side stopgap (server PR pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)