### PR TITLE
Suppress TaskCanceledException noise during daemon termination

### DIFF
--- a/src/Kapacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Kapacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -415,86 +415,97 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         } catch (Exception ex) {
             LogOutputReadError(ex, agent.Id);
         } finally {
-            try {
-                // PTY output can end before waitpid reports the child as exited.
-                // Wait briefly for the process to finalize so we get a real exit code.
-                await agent.Process.WaitForExitAsync(TimeSpan.FromSeconds(5));
-
-                var exitCode = agent.Process.ExitCode;
-
-                var status = agent.Process.HasExited
-                    ? exitCode is null or 0 ? "Completed" : "Failed"
-                    : "Failed";
-
-                if (agent.Status is not "Completed" and not "Failed") {
-                    // A startup failure means the process exited before establishing
-                    // a real interactive session (CLI config error, auth issue, immediate
-                    // crash). A real session keeps producing output throughout its
-                    // lifetime, so the gap between CreatedAt and LastOutputAt is the
-                    // discriminator: tiny gap → startup failure; sustained → real session.
-                    //
-                    // We avoid agent.Status because the first output chunk flips it to
-                    // "Running" — a one-line error banner triggers that flip too. We
-                    // also avoid wall-clock since spawn: a user who types /exit shortly
-                    // after starting produces a short-but-real session that must not be
-                    // flagged as a launch failure (AI-572). HasReceivedOutput guards
-                    // against a no-output process whose CreatedAt/LastOutputAt
-                    // initializers happened to straddle a long pause.
-                    if (IsStartupFailure(agent.CreatedAt, agent.LastOutputAt, agent.HasReceivedOutput)) {
-                        var output = ExtractTerminalText(agent.OutputBuffer);
-
-                        var reason = !string.IsNullOrWhiteSpace(output)
-                            ? output
-                            : exitCode is null or 0
-                                ? "Process exited before establishing a session"
-                                : $"Process exited immediately (exit code {exitCode})";
-
-                        status = "Failed";
-
-                        LogStartupFailed(agent.Id, exitCode, reason);
-
-                        _ = _server.LaunchFailedAsync(agent.Id, reason);
-                    }
-
-                    agent.Status = status;
-                    _            = _server.AgentStatusChangedAsync(agent.Id, status, agent.SessionId);
-
-                    var stopReason = status == "Completed" ? "exited" : "failed";
-
-                    _ = _server.AppendAgentRunEventAsync(
-                        agent.Id,
-                        new AgentRunStopped(stopReason, exitCode)
-                    );
-                }
-
-                LogAgentExited(agent.Id, exitCode);
-
-                // Tell the server to end the AgentSession. Claude doesn't reliably fire
-                // its own session-end hook on SIGTERM/exit, so without this call the
-                // session would stay "active" forever in the read model. Server-side is
-                // idempotent — if claude did fire session-end first, this is a no-op.
-                // Reason is read from agent.PendingEndReason so that if HandleStopAgent's
-                // own call failed (transient SignalR error) and this finally-block call
-                // is the one that lands, a user-initiated stop is still recorded as
-                // "agent_stopped" rather than "agent_exited".
-                try {
-                    var result = await _server.EndAgentSessionAsync(agent.Id, agent.PendingEndReason);
-
-                    // The daemon doesn't track sessionId on its own (only agentId), so
-                    // the server returns it in the result. Spawn what's-done locally
-                    // when the server says yes.
-                    if (result.GenerateWhatsDone && result.SessionId is not null) {
-                        SpawnWhatsDoneGenerator(result.SessionId);
-                    }
-                } catch (Exception ex) {
-                    LogEndSessionFailed(ex, agent.Id);
-                }
-
-                // Clean up worktree and unregister from server
-                await CleanupAgentAsync(agent.Id);
-            } catch (Exception ex) {
-                LogCleanupError(ex, agent.Id);
+            // Daemon shutdown: ServerConnection's _ct (= lifetime.ApplicationStopping)
+            // is cancelled and the hub is being disposed, so every server call here
+            // would throw TaskCanceledException. DisposeAsync owns the local cleanup
+            // path for in-flight agents; the server detects the daemon disconnection
+            // and ends its sessions on its own. Skip to avoid noisy warnings.
+            if (!_shutdownCts.IsCancellationRequested) {
+                await FinalizeAgentRunAsync(agent);
             }
+        }
+    }
+
+    async Task FinalizeAgentRunAsync(AgentInstance agent) {
+        try {
+            // PTY output can end before waitpid reports the child as exited.
+            // Wait briefly for the process to finalize so we get a real exit code.
+            await agent.Process.WaitForExitAsync(TimeSpan.FromSeconds(5));
+
+            var exitCode = agent.Process.ExitCode;
+
+            var status = agent.Process.HasExited
+                ? exitCode is null or 0 ? "Completed" : "Failed"
+                : "Failed";
+
+            if (agent.Status is not "Completed" and not "Failed") {
+                // A startup failure means the process exited before establishing
+                // a real interactive session (CLI config error, auth issue, immediate
+                // crash). A real session keeps producing output throughout its
+                // lifetime, so the gap between CreatedAt and LastOutputAt is the
+                // discriminator: tiny gap → startup failure; sustained → real session.
+                //
+                // We avoid agent.Status because the first output chunk flips it to
+                // "Running" — a one-line error banner triggers that flip too. We
+                // also avoid wall-clock since spawn: a user who types /exit shortly
+                // after starting produces a short-but-real session that must not be
+                // flagged as a launch failure (AI-572). HasReceivedOutput guards
+                // against a no-output process whose CreatedAt/LastOutputAt
+                // initializers happened to straddle a long pause.
+                if (IsStartupFailure(agent.CreatedAt, agent.LastOutputAt, agent.HasReceivedOutput)) {
+                    var output = ExtractTerminalText(agent.OutputBuffer);
+
+                    var reason = !string.IsNullOrWhiteSpace(output)
+                        ? output
+                        : exitCode is null or 0
+                            ? "Process exited before establishing a session"
+                            : $"Process exited immediately (exit code {exitCode})";
+
+                    status = "Failed";
+
+                    LogStartupFailed(agent.Id, exitCode, reason);
+
+                    _ = _server.LaunchFailedAsync(agent.Id, reason);
+                }
+
+                agent.Status = status;
+                _            = _server.AgentStatusChangedAsync(agent.Id, status, agent.SessionId);
+
+                var stopReason = status == "Completed" ? "exited" : "failed";
+
+                _ = _server.AppendAgentRunEventAsync(
+                    agent.Id,
+                    new AgentRunStopped(stopReason, exitCode)
+                );
+            }
+
+            LogAgentExited(agent.Id, exitCode);
+
+            // Tell the server to end the AgentSession. Claude doesn't reliably fire
+            // its own session-end hook on SIGTERM/exit, so without this call the
+            // session would stay "active" forever in the read model. Server-side is
+            // idempotent — if claude did fire session-end first, this is a no-op.
+            // Reason is read from agent.PendingEndReason so that if HandleStopAgent's
+            // own call failed (transient SignalR error) and this finally-block call
+            // is the one that lands, a user-initiated stop is still recorded as
+            // "agent_stopped" rather than "agent_exited".
+            try {
+                var result = await _server.EndAgentSessionAsync(agent.Id, agent.PendingEndReason);
+
+                // The daemon doesn't track sessionId on its own (only agentId), so
+                // the server returns it in the result. Spawn what's-done locally
+                // when the server says yes.
+                if (result.GenerateWhatsDone && result.SessionId is not null) {
+                    SpawnWhatsDoneGenerator(result.SessionId);
+                }
+            } catch (Exception ex) {
+                LogEndSessionFailed(ex, agent.Id);
+            }
+
+            // Clean up worktree and unregister from server
+            await CleanupAgentAsync(agent.Id);
+        } catch (Exception ex) {
+            LogCleanupError(ex, agent.Id);
         }
     }
 
@@ -836,7 +847,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         try { await WorktreeManager.RemoveAsync(agent.Worktree); } catch (Exception ex) { LogCleanupStepFailed(ex, "removing worktree", agentId); }
 
-        try { await _server.AgentUnregisteredAsync(agentId); } catch (Exception ex) { LogCleanupStepFailed(ex, "unregistering", agentId); }
+        // Skip server unregister during shutdown — _ct is cancelled and the call
+        // would throw TaskCanceledException. The server detects the daemon
+        // disconnection through SignalR's transport-level signals.
+        if (!_shutdownCts.IsCancellationRequested) {
+            try { await _server.AgentUnregisteredAsync(agentId); } catch (Exception ex) { LogCleanupStepFailed(ex, "unregistering", agentId); }
+        }
     }
 
     public async ValueTask DisposeAsync() {

--- a/src/Kapacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Kapacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -7,6 +7,7 @@ using Kapacitor.Cli.Core.Auth;
 using Kapacitor.Cli.Core.Commands;
 using Kapacitor.Cli.Core.Config;
 using Kapacitor.Cli.Daemon.Pty;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Kapacitor.Cli.Daemon.Services;
@@ -85,7 +86,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // application-level liveness probe.
     readonly PeriodicTimer                               _daemonHeartbeat = new(TimeSpan.FromSeconds(7));
     static readonly TimeSpan                             _pingDeadline    = TimeSpan.FromSeconds(5);
-    readonly CancellationTokenSource                     _shutdownCts     = new();
+    // Linked to IHostApplicationLifetime.ApplicationStopping so the shutdown gate
+    // trips as soon as the host begins stopping — the same instant ServerConnection's
+    // _ct (also ApplicationStopping) cancels SignalR calls. Otherwise there's a
+    // window between ApplicationStopping firing and DisposeAsync running where
+    // server calls would still throw TaskCanceledException unguarded.
+    readonly CancellationTokenSource                     _shutdownCts;
 
     public AgentOrchestrator(
             DaemonConfig                                       config,
@@ -96,8 +102,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             IHttpClientFactory                                 httpClientFactory,
             LocalPermissionBridge                              permissionBridge,
             IReadOnlyDictionary<string, IHostedAgentLauncher>  launchers,
+            IHostApplicationLifetime                           lifetime,
             ILogger<AgentOrchestrator>                         logger
         ) {
+        _shutdownCts = CancellationTokenSource.CreateLinkedTokenSource(lifetime.ApplicationStopping);
         _config            = config;
         _server            = server;
         _worktreeManager   = worktreeManager;
@@ -498,6 +506,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 if (result.GenerateWhatsDone && result.SessionId is not null) {
                     SpawnWhatsDoneGenerator(result.SessionId);
                 }
+            } catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) {
+                // Shutdown fired mid-call — connection is being torn down. Server
+                // detects daemon disconnection independently. No warning needed.
             } catch (Exception ex) {
                 LogEndSessionFailed(ex, agent.Id);
             }
@@ -849,9 +860,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         // Skip server unregister during shutdown — _ct is cancelled and the call
         // would throw TaskCanceledException. The server detects the daemon
-        // disconnection through SignalR's transport-level signals.
+        // disconnection through SignalR's transport-level signals. Filtered
+        // catch covers the residual race where shutdown fires mid-call.
         if (!_shutdownCts.IsCancellationRequested) {
-            try { await _server.AgentUnregisteredAsync(agentId); } catch (Exception ex) { LogCleanupStepFailed(ex, "unregistering", agentId); }
+            try { await _server.AgentUnregisteredAsync(agentId); }
+            catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) { }
+            catch (Exception ex) { LogCleanupStepFailed(ex, "unregistering", agentId); }
         }
     }
 

--- a/test/Kapacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -4,6 +4,7 @@ using Kapacitor.Cli.Core;
 using Kapacitor.Cli.Daemon;
 using Kapacitor.Cli.Daemon.Pty;
 using Kapacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Kapacitor.Cli.Tests.Unit;
@@ -79,8 +80,16 @@ public class AgentOrchestratorVendorTests {
             httpFactory,
             permissionBridge,
             launchers,
+            new StubHostLifetime(),
             NullLogger<Daemon.Services.AgentOrchestrator>.Instance
         );
+    }
+
+    sealed class StubHostLifetime : IHostApplicationLifetime {
+        public CancellationToken ApplicationStarted  => CancellationToken.None;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped  => CancellationToken.None;
+        public void StopApplication() { }
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- `ReadAgentOutputAsync` is a fire-and-forget task. On daemon shutdown its `finally` block races against connection teardown and calls server methods bound to `lifetime.ApplicationStopping` — every call throws `TaskCanceledException` and gets logged as a warning with a stack trace.
- Extracted the read-loop's finally body into `FinalizeAgentRunAsync`, gated on `!_shutdownCts.IsCancellationRequested`. During shutdown, `DisposeAsync` handles local cleanup and the server detects the daemon disconnection through SignalR transport signals.
- Gated `CleanupAgentAsync`'s `AgentUnregisteredAsync` call on the same condition to silence the symmetric `Error unregistering` warning.

## Test plan
- [x] `dotnet build src/Kapacitor.Cli.Daemon` — clean
- [x] Full unit suite — 921/921 passing
- [x] `dotnet publish -c Release` — no IL3050/IL2026 AOT warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)