### PR TITLE
[AI-717] PR review: lift PR identity to per-tool argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,12 @@ Expect ~1-3 minutes total depending on the model and session size — judges run
 ### PR review with full context
 
 ```bash
-kapacitor review <pr-url>
+kapacitor review <pr-url-or-owner/repo#number>
 ```
 
 Launches a Claude Code session equipped with MCP tools that query the implementation transcripts. Reviewers can ask *why* code was changed, understand design decisions, check what alternatives were considered, and verify test coverage — all grounded in what actually happened during development.
+
+The same MCP server (`kapacitor-review`) is also auto-registered by the Kapacitor plugin and available in any Claude Code session, not just ones launched via `kapacitor review`. Each PR-scoped tool (`get_pr_summary`, `list_pr_files`, `get_file_context`, `search_context`, `list_sessions`) accepts an optional `pr` argument — pass `"owner/repo#123"` or a GitHub PR URL to review any PR from any branch. When omitted, the server falls back to the PR passed at startup (set by `kapacitor review <pr>`) or to git auto-detection against the current branch. `get_transcript` keys off `session_id` and doesn't need a `pr` argument.
 
 ### Sessions MCP server (for agents)
 

--- a/kapacitor/.mcp.json
+++ b/kapacitor/.mcp.json
@@ -3,7 +3,7 @@
     "kapacitor-review": {
       "command": "kapacitor",
       "args": ["mcp", "review"],
-      "description": "PR review context tools — query implementation session transcripts to understand why code was changed"
+      "description": "PR review context tools — query implementation session transcripts to understand why code was changed. Pass the target PR as a `pr` argument to each tool (e.g. 'owner/repo#123' or a github.com URL) or run from a branch with an open PR for auto-detection."
     },
     "kapacitor-sessions": {
       "command": "kapacitor",

--- a/kapacitor/README.md
+++ b/kapacitor/README.md
@@ -20,16 +20,16 @@ Repo-aware: it resolves the cwd to a repo hash at startup, so `search_sessions` 
 
 ### `kapacitor-review`
 
-PR review context tools, available automatically when the agent is on a branch with an open PR. The MCP server auto-detects the current repo and PR from git; if you're not on a PR branch, the tools return a helpful message suggesting `kapacitor review <pr>`.
+PR review context tools. Each PR-scoped tool accepts an optional `pr` argument (`"owner/repo#123"` or a GitHub PR URL), so you can review any PR from any branch — no need to check it out first. When `pr` is omitted, the server falls back to the PR passed at startup (set by `kapacitor review <pr>`) or to git auto-detection against the current branch.
 
-| Tool | Description |
-|------|-------------|
-| `get_pr_summary` | Overview: sessions, files changed, test runs |
-| `list_pr_files` | Files changed with session links and event counts |
-| `get_file_context` | Why a specific file was changed, with transcript excerpts |
-| `search_context` | Free-text search across session transcripts |
-| `list_sessions` | Sessions that contributed to the PR |
-| `get_transcript` | Full transcript of a specific session |
+| Tool | Description | `pr` arg |
+|------|-------------|----------|
+| `get_pr_summary` | Overview: sessions, files changed, test runs | optional |
+| `list_pr_files` | Files changed with session links and event counts | optional |
+| `get_file_context` | Why a specific file was changed, with transcript excerpts | optional |
+| `search_context` | Free-text search across session transcripts | optional |
+| `list_sessions` | Sessions that contributed to the PR | optional |
+| `get_transcript` | Full transcript of a specific session | n/a (keys off `session_id`) |
 
 `kapacitor mcp judge` is intentionally not auto-registered. Add it with `claude mcp add kapacitor-judge -- kapacitor mcp judge` if you want it.
 

--- a/src/Kapacitor.Cli.Core/Commands/PrRefParser.cs
+++ b/src/Kapacitor.Cli.Core/Commands/PrRefParser.cs
@@ -1,0 +1,46 @@
+using System.Text.RegularExpressions;
+
+namespace Kapacitor.Cli.Core.Commands;
+
+/// <summary>
+/// Parses a PR reference in either shorthand (<c>owner/repo#123</c>) or
+/// github.com URL form. Shared by the <c>kapacitor review</c> CLI command
+/// and the <c>kapacitor mcp review</c> server's per-tool PR argument.
+/// </summary>
+public static partial class PrRefParser {
+    public static bool TryParse(string input, out string owner, out string repo, out int prNumber) {
+        owner    = "";
+        repo     = "";
+        prNumber = 0;
+
+        if (string.IsNullOrWhiteSpace(input)) return false;
+
+        var urlMatch = UrlPattern().Match(input);
+
+        if (urlMatch.Success) {
+            owner    = urlMatch.Groups[1].Value;
+            repo     = urlMatch.Groups[2].Value;
+            prNumber = int.Parse(urlMatch.Groups[3].Value);
+
+            return true;
+        }
+
+        var shortMatch = ShorthandPattern().Match(input);
+
+        if (shortMatch.Success) {
+            owner    = shortMatch.Groups[1].Value;
+            repo     = shortMatch.Groups[2].Value;
+            prNumber = int.Parse(shortMatch.Groups[3].Value);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    [GeneratedRegex(@"^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:/.*)?$")]
+    private static partial Regex UrlPattern();
+
+    [GeneratedRegex(@"^([^/]+)/([^#]+)#(\d+)$")]
+    private static partial Regex ShorthandPattern();
+}

--- a/src/Kapacitor.Cli.Core/Commands/PrRefParser.cs
+++ b/src/Kapacitor.Cli.Core/Commands/PrRefParser.cs
@@ -15,6 +15,8 @@ public static partial class PrRefParser {
 
         if (string.IsNullOrWhiteSpace(input)) return false;
 
+        input = input.Trim();
+
         var urlMatch = UrlPattern().Match(input);
 
         if (urlMatch.Success) {
@@ -38,9 +40,13 @@ public static partial class PrRefParser {
         return false;
     }
 
-    [GeneratedRegex(@"^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:/.*)?$")]
+    // Accept any of: trailing `/...`, `?query`, `#fragment` — browser-copied
+    // GitHub URLs commonly include these suffixes.
+    [GeneratedRegex(@"^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$")]
     private static partial Regex UrlPattern();
 
-    [GeneratedRegex(@"^([^/]+)/([^#]+)#(\d+)$")]
+    // Repo group forbids `/` — GitHub repo names can't contain it, and allowing
+    // it would let `owner/foo/bar#42` parse into a malformed API URL segment.
+    [GeneratedRegex(@"^([^/]+)/([^/#]+)#(\d+)$")]
     private static partial Regex ShorthandPattern();
 }

--- a/src/Kapacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-mcp.txt
@@ -11,11 +11,18 @@ Subcommands:
                           inspect past Kurrent Capacitor sessions.
 
 Options for review:
-  --owner <owner>         Repository owner
-  --repo <repo>           Repository name
-  --pr <number>           PR number
+  --owner <owner>         Repository owner (session default)
+  --repo <repo>           Repository name (session default)
+  --pr <number>           PR number (session default)
 
-If --owner/--repo/--pr are omitted, auto-detects from git.
+Per-tool PR override: each PR-scoped tool (`get_pr_summary`,
+`list_pr_files`, `get_file_context`, `search_context`, `list_sessions`)
+accepts an optional `pr` argument (`"owner/repo#123"` or a GitHub URL),
+so a single MCP server can answer about any PR from any branch.
+
+Resolution order per tool call: tool `pr` arg → startup `--owner/--repo/--pr`
+→ git auto-detect from current branch. `get_transcript` keys off
+`session_id` and doesn't need `pr`.
 
 Options for judge:
   --session <sessionId>   Bind the judge to a specific session

--- a/src/Kapacitor.Cli.Core/Resources/prompt-review.txt
+++ b/src/Kapacitor.Cli.Core/Resources/prompt-review.txt
@@ -1,5 +1,9 @@
 You are helping a reviewer understand PR #{prNumber} in {owner}/{repo}.
 
+The PR reference for every tool call is `{owner}/{repo}#{prNumber}`. Pass it as
+the `pr` argument on every `kapacitor-review` tool call so the server doesn't
+have to guess from the current git branch — the reviewer may be on any branch.
+
 You have MCP tools from "kapacitor-review" that query the implementation context
 from the Claude Code sessions that built this PR. The data comes from Kurrent
 Capacitor, which records full session transcripts including user prompts, assistant
@@ -7,14 +11,17 @@ reasoning, tool calls, and test results.
 
 ## Recommended workflow
 
-1. Start with `get_pr_summary` to see which sessions contributed, which files
-   changed, and what tests were run.
+1. Start with `get_pr_summary` (pass `pr: "{owner}/{repo}#{prNumber}"`) to see
+   which sessions contributed, which files changed, and what tests were run.
 2. When asked about a specific file, use `get_file_context` with the file path
-   to see which sessions touched it and find relevant transcript excerpts.
+   and the same `pr` argument to see which sessions touched it and find relevant
+   transcript excerpts.
 3. For "why" questions (e.g., "why was retry logic added?"), use `search_context`
-   with a natural language query to search across all session transcripts.
+   with a natural language query and the same `pr` argument to search across all
+   session transcripts.
 4. To go deep into a specific session's reasoning, use `get_transcript` with the
    session ID (from the summary). Use the `file_path` filter to scope results.
+   `get_transcript` doesn't need a `pr` argument — it keys off `session_id`.
 5. You also have the local repo checked out — use git commands and file reads to
    see the actual code. The MCP tools provide the *reasoning* behind it.
 

--- a/src/Kapacitor.Cli/Commands/McpReviewServer.cs
+++ b/src/Kapacitor.Cli/Commands/McpReviewServer.cs
@@ -135,7 +135,9 @@ static class McpReviewServer {
             PrIdentity? pr
         ) {
         try {
-            var prBase = pr is null ? null : $"{baseUrl}/api/review/{pr.Owner}/{pr.Repo}/pulls/{pr.PrNumber}";
+            var prBase = pr is null
+                ? null
+                : $"{baseUrl}/api/review/{Uri.EscapeDataString(pr.Owner)}/{Uri.EscapeDataString(pr.Repo)}/pulls/{pr.PrNumber}";
 
             var httpResponse = toolName switch {
                 "get_pr_summary"   => await client.GetAsync(prBase),

--- a/src/Kapacitor.Cli/Commands/McpReviewServer.cs
+++ b/src/Kapacitor.Cli/Commands/McpReviewServer.cs
@@ -5,34 +5,32 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Kapacitor.Cli.Core;
+using Kapacitor.Cli.Core.Commands;
 
 namespace Kapacitor.Cli.Commands;
 
 static class McpReviewServer {
     /// <summary>
-    /// Run with explicit PR context (used by `kapacitor review`).
+    /// Run with an explicit session-default PR (used by <c>kapacitor review &lt;pr&gt;</c>).
+    /// Tool calls may still override the default by passing a <c>pr</c> argument.
     /// </summary>
     public static Task<int> RunAsync(string baseUrl, string owner, string repo, int prNumber)
-        => RunCoreAsync(baseUrl, owner, repo, prNumber);
+        => RunCoreAsync(baseUrl, new PrIdentity(owner, repo, prNumber));
 
     /// <summary>
-    /// Run with auto-detection from git/gh in current directory (used by plugin MCP server).
+    /// Run without an explicit session default (used by the plugin's argless MCP
+    /// registration). PR identity comes from each tool call's <c>pr</c> argument,
+    /// or as a fallback from git auto-detection against the current branch.
     /// </summary>
-    public static Task<int> RunAutoAsync(string baseUrl) => RunCoreAsync(baseUrl, null, null, null);
+    public static Task<int> RunAutoAsync(string baseUrl) => RunCoreAsync(baseUrl, null);
 
-    static async Task<int> RunCoreAsync(string baseUrl, string? owner, string? repo, int? prNumber) {
+    static async Task<int> RunCoreAsync(string baseUrl, PrIdentity? startupDefault) {
         using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
 
-        // Auto-detect from git if not provided
-        if (owner is null || repo is null || prNumber is null) {
-            var detected = await DetectPrFromGitAsync();
-
-            if (detected is not null) {
-                owner    ??= detected.Value.Owner;
-                repo     ??= detected.Value.Repo;
-                prNumber ??= detected.Value.PrNumber;
-            }
-        }
+        // Compute the session default once: explicit startup args win; otherwise
+        // try git auto-detect. Result is cached for the lifetime of the server
+        // and used as the fallback when a tool call doesn't carry an explicit `pr`.
+        var sessionDefault = startupDefault ?? await DetectPrFromGitAsync();
 
         var tools = BuildToolsList();
 
@@ -61,24 +59,12 @@ static class McpReviewServer {
             // Notifications have no id — don't send a response
             if (id is null) continue;
 
-            string response;
-
-            if (method == "tools/call" && (owner is null || repo is null || prNumber is null)) {
-                response = BuildToolResult(
-                    id,
-                    "No PR detected for current branch. Either:\n"                      +
-                    "- Switch to a branch with an open PR and restart the MCP server\n" +
-                    "- Use `kapacitor review <pr>` to launch a dedicated review session",
-                    isError: true
-                );
-            } else {
-                response = method switch {
-                    "initialize" => BuildInitializeResponse(id),
-                    "tools/list" => BuildToolsListResponse(id, tools),
-                    "tools/call" => await HandleToolCallAsync(id, request, client, baseUrl, owner!, repo!, prNumber!.Value),
-                    _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
-                };
-            }
+            var response = method switch {
+                "initialize" => BuildInitializeResponse(id),
+                "tools/list" => BuildToolsListResponse(id, tools),
+                "tools/call" => await HandleToolCallAsync(id, request, client, baseUrl, sessionDefault),
+                _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
+            };
 
             await writer.WriteLineAsync(response);
         }
@@ -86,13 +72,13 @@ static class McpReviewServer {
         return 0;
     }
 
-    static async Task<(string Owner, string Repo, int PrNumber)?> DetectPrFromGitAsync() {
+    static async Task<PrIdentity?> DetectPrFromGitAsync() {
         try {
             var cwd      = Directory.GetCurrentDirectory();
             var repoInfo = await RepositoryDetection.DetectRepositoryAsync(cwd);
 
             if (repoInfo?.Owner is not null && repoInfo.RepoName is not null && repoInfo.PrNumber is not null) {
-                return (repoInfo.Owner, repoInfo.RepoName, repoInfo.PrNumber.Value);
+                return new PrIdentity(repoInfo.Owner, repoInfo.RepoName, repoInfo.PrNumber.Value);
             }
 
             return null;
@@ -112,13 +98,11 @@ static class McpReviewServer {
         ToResponse(id, new McpToolsResult(tools), McpJsonContext.Default.McpToolsResult);
 
     static async Task<string> HandleToolCallAsync(
-            JsonNode   id,
-            JsonObject request,
-            HttpClient client,
-            string     baseUrl,
-            string     owner,
-            string     repo,
-            int        prNumber
+            JsonNode    id,
+            JsonObject  request,
+            HttpClient  client,
+            string      baseUrl,
+            PrIdentity? sessionDefault
         ) {
         var paramsNode = request["params"]?.AsObject();
         var toolName   = paramsNode?["name"]?.GetValue<string>();
@@ -128,8 +112,30 @@ static class McpReviewServer {
             return BuildErrorResponse(id, -32602, "Missing params.name");
         }
 
+        // get_transcript keys off session_id, not PR — skip PR resolution.
+        if (toolName == "get_transcript") {
+            return await DispatchAsync(id, toolName, arguments, client, baseUrl, pr: null);
+        }
+
+        var resolution = PrResolution.Resolve(arguments, sessionDefault);
+
+        if (resolution.Identity is null) {
+            return BuildToolResult(id, resolution.Error!, isError: true);
+        }
+
+        return await DispatchAsync(id, toolName, arguments, client, baseUrl, resolution.Identity);
+    }
+
+    static async Task<string> DispatchAsync(
+            JsonNode    id,
+            string      toolName,
+            JsonObject? arguments,
+            HttpClient  client,
+            string      baseUrl,
+            PrIdentity? pr
+        ) {
         try {
-            var prBase = $"{baseUrl}/api/review/{owner}/{repo}/pulls/{prNumber}";
+            var prBase = pr is null ? null : $"{baseUrl}/api/review/{pr.Owner}/{pr.Repo}/pulls/{pr.PrNumber}";
 
             var httpResponse = toolName switch {
                 "get_pr_summary"   => await client.GetAsync(prBase),
@@ -209,55 +215,117 @@ static class McpReviewServer {
         return envelope.ToJsonString();
     }
 
-    static McpTool[] BuildToolsList() => [
-        new(
-            "get_pr_summary",
-            "Get an overview of the PR: which Claude Code sessions contributed, which files were changed (with event counts), and what test commands were run with their pass/fail outcomes. Call this first to orient yourself.",
-            new("object", [], [])
-        ),
-        new(
-            "list_pr_files",
-            "List all files changed in the PR with aggregated metadata: change types (read/edit/create), how many sessions touched each file, and total event count. Use this to understand the scope of changes.",
-            new("object", [], [])
-        ),
-        new(
-            "get_file_context",
-            "Get deep context for a specific file: which sessions modified it, when, and relevant transcript excerpts where the file was discussed or changed. Use this when a reviewer asks 'why was this file changed?'",
+    static McpTool[] BuildToolsList() {
+        const string PrArgDescription =
+            "Optional PR reference (e.g. 'owner/repo#123' or a github.com PR URL). " +
+            "Defaults to the session's PR if launched via `kapacitor review`, otherwise auto-detected from current branch.";
+
+        return [
             new(
-                "object",
-                new() { ["file_path"] = new("string", "Path of the file to get context for") },
-                ["file_path"]
-            )
-        ),
-        new(
-            "search_context",
-            "Full-text search across all session transcripts linked to this PR. Returns ranked excerpts with speaker (user/assistant/tool), content, and highlighted snippets. Use for 'why' questions: 'why retry logic', 'what alternatives', 'error handling rationale'.",
+                "get_pr_summary",
+                "Get an overview of the PR: which Claude Code sessions contributed, which files were changed (with event counts), and what test commands were run with their pass/fail outcomes. Call this first to orient yourself.",
+                new("object", new() { ["pr"] = new("string", PrArgDescription) }, [])
+            ),
             new(
-                "object",
-                new() { ["query"] = new("string", "Free-text search query") },
-                ["query"]
-            )
-        ),
-        new(
-            "list_sessions",
-            "List all Claude Code sessions that contributed to this PR, with session IDs, titles, timestamps, and models used. Use this to understand the work timeline and pick sessions to drill into with get_transcript.",
-            new("object", [], [])
-        ),
-        new(
-            "get_transcript",
-            "Get the full transcript of a specific session: user messages, assistant reasoning, tool calls, and results. Paginated (default 100 events). Use file_path filter to scope to events mentioning a specific file. This is the deepest level of detail — use when you need to trace the exact reasoning chain.",
+                "list_pr_files",
+                "List all files changed in the PR with aggregated metadata: change types (read/edit/create), how many sessions touched each file, and total event count. Use this to understand the scope of changes.",
+                new("object", new() { ["pr"] = new("string", PrArgDescription) }, [])
+            ),
             new(
-                "object",
-                new() {
-                    ["session_id"] = new("string", "Session ID to retrieve the transcript for"),
-                    ["file_path"]  = new("string", "Optional file path to filter transcript events"),
-                    ["skip"]       = new("integer", "Number of events to skip (for pagination)"),
-                    ["take"]       = new("integer", "Number of events to return (for pagination)")
-                },
-                ["session_id"]
+                "get_file_context",
+                "Get deep context for a specific file: which sessions modified it, when, and relevant transcript excerpts where the file was discussed or changed. Use this when a reviewer asks 'why was this file changed?'",
+                new(
+                    "object",
+                    new() {
+                        ["file_path"] = new("string", "Path of the file to get context for"),
+                        ["pr"]        = new("string", PrArgDescription)
+                    },
+                    ["file_path"]
+                )
+            ),
+            new(
+                "search_context",
+                "Full-text search across all session transcripts linked to this PR. Returns ranked excerpts with speaker (user/assistant/tool), content, and highlighted snippets. Use for 'why' questions: 'why retry logic', 'what alternatives', 'error handling rationale'.",
+                new(
+                    "object",
+                    new() {
+                        ["query"] = new("string", "Free-text search query"),
+                        ["pr"]    = new("string", PrArgDescription)
+                    },
+                    ["query"]
+                )
+            ),
+            new(
+                "list_sessions",
+                "List all Claude Code sessions that contributed to this PR, with session IDs, titles, timestamps, and models used. Use this to understand the work timeline and pick sessions to drill into with get_transcript.",
+                new("object", new() { ["pr"] = new("string", PrArgDescription) }, [])
+            ),
+            new(
+                "get_transcript",
+                "Get the full transcript of a specific session: user messages, assistant reasoning, tool calls, and results. Paginated (default 100 events). Use file_path filter to scope to events mentioning a specific file. This is the deepest level of detail — use when you need to trace the exact reasoning chain.",
+                new(
+                    "object",
+                    new() {
+                        ["session_id"] = new("string", "Session ID to retrieve the transcript for"),
+                        ["file_path"]  = new("string", "Optional file path to filter transcript events"),
+                        ["skip"]       = new("integer", "Number of events to skip (for pagination)"),
+                        ["take"]       = new("integer", "Number of events to return (for pagination)")
+                    },
+                    ["session_id"]
+                )
             )
-        )
-    ];
+        ];
+    }
+}
+
+/// <summary>
+/// PR identity resolved from one of: a tool call's <c>pr</c> argument, the
+/// server's startup args, or git auto-detection at startup.
+/// </summary>
+record PrIdentity(string Owner, string Repo, int PrNumber);
+
+/// <summary>
+/// Resolves a tool call's effective PR identity. Tool args take precedence
+/// over the session default. Returning a <c>null</c> identity carries an
+/// error message ready to surface to the LLM.
+/// </summary>
+static class PrResolution {
+    public readonly record struct Result(PrIdentity? Identity, string? Error);
+
+    public static Result Resolve(JsonObject? toolArgs, PrIdentity? sessionDefault) {
+        if (TryGetStringArg(toolArgs, "pr", out var prRef)) {
+            if (PrRefParser.TryParse(prRef, out var owner, out var repo, out var prNumber)) {
+                return new Result(new PrIdentity(owner, repo, prNumber), null);
+            }
+
+            return new Result(
+                null,
+                $"Could not parse `pr` argument: '{prRef}'. Use 'owner/repo#123' or a github.com PR URL."
+            );
+        }
+
+        if (sessionDefault is not null) {
+            return new Result(sessionDefault, null);
+        }
+
+        return new Result(
+            null,
+            "This tool needs a PR reference. Pass `pr` as a tool argument " +
+            "(e.g. 'owner/repo#123' or a github.com PR URL), or run from a " +
+            "branch with an open PR for auto-detection."
+        );
+    }
+
+    static bool TryGetStringArg(JsonObject? args, string name, out string value) {
+        value = "";
+
+        if (args?[name] is not JsonValue node) return false;
+        if (!node.TryGetValue<string>(out var s) || string.IsNullOrWhiteSpace(s)) return false;
+
+        value = s;
+
+        return true;
+    }
 }
 
 // MCP protocol types — serialized with source-generated McpJsonContext for AOT compatibility

--- a/src/Kapacitor.Cli/Commands/ReviewCommand.cs
+++ b/src/Kapacitor.Cli/Commands/ReviewCommand.cs
@@ -1,14 +1,13 @@
 using System.Diagnostics;
-using System.Text.RegularExpressions;
 using Kapacitor.Cli.Core;
 using Kapacitor.Cli.Core.Commands;
 
 namespace Kapacitor.Cli.Commands;
 
-static partial class ReviewCommand {
+static class ReviewCommand {
     public static async Task<int> HandleReview(string baseUrl, string prIdentifier) {
         // Parse PR identifier
-        if (!TryParsePr(prIdentifier, out var owner, out var repo, out var prNumber)) {
+        if (!PrRefParser.TryParse(prIdentifier, out var owner, out var repo, out var prNumber)) {
             await Console.Error.WriteLineAsync($"Could not parse PR identifier: {prIdentifier}");
             await Console.Error.WriteLineAsync("Expected formats:");
             await Console.Error.WriteLineAsync("  URL:       https://github.com/owner/repo/pull/123");
@@ -80,39 +79,4 @@ static partial class ReviewCommand {
         }
     }
 
-    static bool TryParsePr(string input, out string owner, out string repo, out int prNumber) {
-        owner    = "";
-        repo     = "";
-        prNumber = 0;
-
-        // Try URL format: https://github.com/owner/repo/pull/123
-        var urlMatch = UrlPattern().Match(input);
-
-        if (urlMatch.Success) {
-            owner    = urlMatch.Groups[1].Value;
-            repo     = urlMatch.Groups[2].Value;
-            prNumber = int.Parse(urlMatch.Groups[3].Value);
-
-            return true;
-        }
-
-        // Try shorthand format: owner/repo#123
-        var shortMatch = ShorthandPattern().Match(input);
-
-        if (shortMatch.Success) {
-            owner    = shortMatch.Groups[1].Value;
-            repo     = shortMatch.Groups[2].Value;
-            prNumber = int.Parse(shortMatch.Groups[3].Value);
-
-            return true;
-        }
-
-        return false;
-    }
-
-    [GeneratedRegex(@"^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:/.*)?$")]
-    private static partial Regex UrlPattern();
-
-    [GeneratedRegex(@"^([^/]+)/([^#]+)#(\d+)$")]
-    private static partial Regex ShorthandPattern();
 }

--- a/src/Kapacitor.Cli/Commands/ReviewCommand.cs
+++ b/src/Kapacitor.Cli/Commands/ReviewCommand.cs
@@ -22,7 +22,8 @@ static class ReviewCommand {
         using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
 
         try {
-            var response = await client.GetAsync($"{baseUrl}/api/review/{owner}/{repo}/pulls/{prNumber}");
+            var response = await client.GetAsync(
+                $"{baseUrl}/api/review/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/pulls/{prNumber}");
 
             if (!response.IsSuccessStatusCode) {
                 var status = (int)response.StatusCode;

--- a/test/Kapacitor.Cli.Tests.Unit/PrRefParserTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/PrRefParserTests.cs
@@ -1,0 +1,81 @@
+using Kapacitor.Cli.Core.Commands;
+
+namespace Kapacitor.Cli.Tests.Unit;
+
+public class PrRefParserTests {
+    [Test]
+    public async Task Shorthand_form_parses() {
+        var ok = PrRefParser.TryParse("kurrent-io/kapacitor-cli#101", out var owner, out var repo, out var pr);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(owner).IsEqualTo("kurrent-io");
+        await Assert.That(repo).IsEqualTo("kapacitor-cli");
+        await Assert.That(pr).IsEqualTo(101);
+    }
+
+    [Test]
+    public async Task Plain_url_parses() {
+        var ok = PrRefParser.TryParse("https://github.com/kurrent-io/kapacitor-cli/pull/101", out var owner, out var repo, out var pr);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(owner).IsEqualTo("kurrent-io");
+        await Assert.That(repo).IsEqualTo("kapacitor-cli");
+        await Assert.That(pr).IsEqualTo(101);
+    }
+
+    [Test]
+    public async Task Url_with_query_parses() {
+        var ok = PrRefParser.TryParse("https://github.com/kurrent-io/kapacitor-cli/pull/101?diff=split", out var owner, out var repo, out var pr);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(owner).IsEqualTo("kurrent-io");
+        await Assert.That(repo).IsEqualTo("kapacitor-cli");
+        await Assert.That(pr).IsEqualTo(101);
+    }
+
+    [Test]
+    public async Task Url_with_fragment_parses() {
+        var ok = PrRefParser.TryParse("https://github.com/kurrent-io/kapacitor-cli/pull/101#issuecomment-12345", out var owner, out var repo, out var pr);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(pr).IsEqualTo(101);
+    }
+
+    [Test]
+    public async Task Url_with_trailing_path_parses() {
+        var ok = PrRefParser.TryParse("https://github.com/kurrent-io/kapacitor-cli/pull/101/files", out var owner, out var repo, out var pr);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(pr).IsEqualTo(101);
+    }
+
+    [Test]
+    public async Task Input_with_surrounding_whitespace_is_trimmed() {
+        var ok = PrRefParser.TryParse("  kurrent-io/kapacitor-cli#101  ", out var owner, out var repo, out var pr);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(owner).IsEqualTo("kurrent-io");
+        await Assert.That(repo).IsEqualTo("kapacitor-cli");
+    }
+
+    [Test]
+    public async Task Shorthand_rejects_slash_in_repo() {
+        // Without the fix this parsed `repo = "foo/bar"`, producing a malformed
+        // API URL path segment when interpolated.
+        var ok = PrRefParser.TryParse("owner/foo/bar#42", out _, out _, out _);
+
+        await Assert.That(ok).IsFalse();
+    }
+
+    [Test]
+    public async Task Empty_input_rejected() {
+        await Assert.That(PrRefParser.TryParse("", out _, out _, out _)).IsFalse();
+        await Assert.That(PrRefParser.TryParse("   ", out _, out _, out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task Garbage_input_rejected() {
+        await Assert.That(PrRefParser.TryParse("not-a-pr-ref", out _, out _, out _)).IsFalse();
+        await Assert.That(PrRefParser.TryParse("https://gitlab.com/owner/repo/pull/1", out _, out _, out _)).IsFalse();
+    }
+}

--- a/test/Kapacitor.Cli.Tests.Unit/PrResolutionTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/PrResolutionTests.cs
@@ -1,0 +1,82 @@
+using System.Text.Json.Nodes;
+using Kapacitor.Cli.Commands;
+
+namespace Kapacitor.Cli.Tests.Unit;
+
+public class PrResolutionTests {
+    static readonly PrIdentity SessionDefault = new("owner-default", "repo-default", 100);
+
+    [Test]
+    public async Task Tool_arg_shorthand_wins_over_session_default() {
+        var args = new JsonObject { ["pr"] = "kurrent-io/kapacitor#42" };
+
+        var result = PrResolution.Resolve(args, SessionDefault);
+
+        await Assert.That(result.Identity).IsEqualTo(new PrIdentity("kurrent-io", "kapacitor", 42));
+        await Assert.That(result.Error).IsNull();
+    }
+
+    [Test]
+    public async Task Tool_arg_url_form_is_parsed() {
+        var args = new JsonObject { ["pr"] = "https://github.com/kurrent-io/kapacitor-server/pull/717" };
+
+        var result = PrResolution.Resolve(args, sessionDefault: null);
+
+        await Assert.That(result.Identity).IsEqualTo(new PrIdentity("kurrent-io", "kapacitor-server", 717));
+    }
+
+    [Test]
+    public async Task Malformed_tool_arg_returns_parse_error_and_does_not_fall_through() {
+        var args = new JsonObject { ["pr"] = "this is not a PR ref" };
+
+        var result = PrResolution.Resolve(args, SessionDefault);
+
+        await Assert.That(result.Identity).IsNull();
+        await Assert.That(result.Error).IsNotNull();
+        await Assert.That(result.Error!).Contains("Could not parse");
+    }
+
+    [Test]
+    public async Task No_tool_arg_falls_back_to_session_default() {
+        var args = new JsonObject { ["query"] = "retry logic" };
+
+        var result = PrResolution.Resolve(args, SessionDefault);
+
+        await Assert.That(result.Identity).IsEqualTo(SessionDefault);
+        await Assert.That(result.Error).IsNull();
+    }
+
+    [Test]
+    public async Task Null_args_falls_back_to_session_default() {
+        var result = PrResolution.Resolve(toolArgs: null, SessionDefault);
+
+        await Assert.That(result.Identity).IsEqualTo(SessionDefault);
+    }
+
+    [Test]
+    public async Task No_sources_returns_actionable_error() {
+        var result = PrResolution.Resolve(toolArgs: null, sessionDefault: null);
+
+        await Assert.That(result.Identity).IsNull();
+        await Assert.That(result.Error!).Contains("Pass `pr` as a tool argument");
+        await Assert.That(result.Error!).DoesNotContain("kapacitor review");
+    }
+
+    [Test]
+    public async Task Whitespace_pr_arg_is_treated_as_absent() {
+        var args = new JsonObject { ["pr"] = "   " };
+
+        var result = PrResolution.Resolve(args, SessionDefault);
+
+        await Assert.That(result.Identity).IsEqualTo(SessionDefault);
+    }
+
+    [Test]
+    public async Task Non_string_pr_arg_is_treated_as_absent() {
+        var args = new JsonObject { ["pr"] = 42 };
+
+        var result = PrResolution.Resolve(args, SessionDefault);
+
+        await Assert.That(result.Identity).IsEqualTo(SessionDefault);
+    }
+}


### PR DESCRIPTION
## Summary

- The kapacitor Claude plugin registers a `kapacitor-review` MCP server with no PR args (auto-detects from `gh pr view`). `kapacitor review <pr>` writes a temp `--mcp-config` defining the same key with explicit `--owner/--repo/--pr`. Since `--mcp-config` is additive — not replacing — per `ClaudeCliRunner.cs:206-207`, the plugin's argless entry shadowed the explicit one and users on any branch without a matching open PR saw the misleading "use `kapacitor review <pr>`" loop (exactly what they just ran).
- Fix: PR identity is now a **per-tool argument** rather than server-startup config. The five PR-scoped tools (`get_pr_summary`, `list_pr_files`, `get_file_context`, `search_context`, `list_sessions`) gain an optional `pr` arg (`"owner/repo#123"` or github.com URL). One MCP server can now answer about any PR from any branch. `get_transcript` is unchanged — it keys off `session_id`.
- `kapacitor review <pr>` still passes `--owner/--repo/--pr` as startup defaults so the interactive UX is preserved; explicit `pr` tool args override per call. `prompt-review.txt` instructs the LLM to pass the canonical ref on every call.

## Test plan

- [x] `dotnet build src/Kapacitor.Cli/Kapacitor.Cli.csproj -c Release` — clean
- [x] `dotnet publish src/Kapacitor.Cli/Kapacitor.Cli.csproj -c Release` — no IL3050/IL2026 warnings
- [x] `dotnet run --project test/Kapacitor.Cli.Tests.Unit` — 987/987 passing, including 8 new `PrResolutionTests`
- [ ] Manual: on a branch with no open PR, run `kapacitor review owner/repo#N` and ask "what's in this PR?" — `get_pr_summary` should be called with `pr` set and return real data
- [ ] Manual: from any branch with the plugin installed (no wrapper), ask about a specific PR by ref — LLM should pass `pr` to each tool

Fixes AI-717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)