### PR TITLE
[AI-742] CLI: add `kapacitor uninstall` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,23 @@ kapacitor ignore --remove ~/code/secret-project
 
 Entries are stored on the **active profile**, so switching profiles with `kapacitor use` switches the ignore list too. Symlinks are resolved on both the stored entry and the session's reported cwd, so a worktree symlink and its target match.
 
+### Uninstalling
+
+To remove kapacitor from this machine, run:
+
+```bash
+kapacitor uninstall                  # interactive, user-scope removal
+kapacitor uninstall --yes            # non-interactive
+kapacitor uninstall --project --yes  # also strip project-scope hooks in cwd's repo
+kapacitor uninstall --keep-config    # remove integrations, keep ~/.config/kapacitor
+```
+
+`uninstall` covers every supported agent: it stops running daemons and watcher processes, strips kapacitor entries from user-level Claude Code, Codex CLI, and Cursor hook files (preserving any non-kapacitor entries), removes agent skills under `~/.agents/skills/` (plus the legacy `~/.codex/skills/kapacitor-*` folders), and deletes `~/.config/kapacitor/`.
+
+`--project` additionally cleans up `<repo>/.claude/settings.local.json` and `<repo>/.codex/hooks.json` in the current git working tree (errors if you're not inside one). Cursor only has a user-scope `hooks.json`, so `--project` does not affect it. Project-scope hooks in other repos are not touched — re-run from each repo that has them.
+
+Use `--keep-config` to preserve profiles, tokens, and ignore lists when you plan to reinstall. Per-agent selective cleanup is not exposed here — use `kapacitor plugin remove [--codex|--cursor|--skills]` for finer-grained removal.
+
 ### Other commands
 
 ```bash

--- a/src/Kapacitor.Cli.Core/Resources/help-uninstall.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-uninstall.txt
@@ -1,0 +1,37 @@
+kapacitor uninstall — Remove kapacitor configuration from this machine
+
+Usage: kapacitor uninstall [options]
+
+Stops any running daemons and watcher processes, strips kapacitor entries from
+user-level Claude Code, Codex CLI, and Cursor hook files, removes agent skills
+(and any legacy ~/.codex/skills/kapacitor-* folders), and deletes the kapacitor
+config directory.
+
+Non-kapacitor entries in shared files (settings.json, hooks.json) are preserved.
+
+Options:
+  --project           Also remove kapacitor entries from project-scope files
+                      under the current git working tree:
+                        <repo>/.claude/settings.local.json
+                        <repo>/.codex/hooks.json
+                      Errors if not inside a git repository. Cursor only has
+                      a user-scope hooks file, so --project does not affect it.
+  --keep-config       Don't delete the kapacitor config directory; only remove
+                      the agent-side integrations. Useful when reinstalling
+                      while preserving profiles, tokens, and ignore lists.
+  --yes, -y           Skip the confirmation prompt.
+
+Notes:
+  Per-agent selective cleanup is not exposed here — uninstall always touches
+  all known agents. Use `kapacitor plugin remove [--codex|--cursor|--skills]`
+  for finer-grained removal.
+
+  Project-scope hooks installed in a directory other than the cwd's git root
+  are not removed. Re-run uninstall --project from inside each repo that has
+  them.
+
+Examples:
+  kapacitor uninstall                    # User-level removal, interactive prompt
+  kapacitor uninstall --yes              # Non-interactive
+  kapacitor uninstall --project --yes    # Also strip project-scope hooks in cwd's repo
+  kapacitor uninstall --keep-config      # Remove integrations, keep ~/.config/kapacitor

--- a/src/Kapacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Kapacitor.Cli.Core/Resources/help-usage.txt
@@ -57,6 +57,7 @@ Plugin:
 Maintenance:
   update                           Check for and install updates
   cleanup                          Kill all orphaned watcher processes
+  uninstall [--project] [--yes]    Remove kapacitor config + all agent integrations
   --version                        Show version
   --help                           Show this help
 

--- a/src/Kapacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Kapacitor.Cli/Commands/PluginCommand.cs
@@ -373,7 +373,17 @@ public static class PluginCommand {
             ? Path.Combine(Environment.CurrentDirectory, ".codex", "hooks.json")
             : CodexPaths.UserHooksJson;
 
-        var hooksRemoved = File.Exists(hooksPath) && RemoveCodexHooks(hooksPath);
+        var hooksRemoved = false;
+        var hooksFailed  = false;
+
+        if (File.Exists(hooksPath)) {
+            try {
+                hooksRemoved = RemoveCodexHooks(hooksPath);
+            } catch (Exception ex) {
+                await Console.Error.WriteLineAsync($"Could not update Codex hooks at {hooksPath}: {ex.Message}");
+                hooksFailed = true;
+            }
+        }
 
         if (hooksRemoved) {
             await Console.Out.WriteLineAsync($"Codex hooks removed ({scope}: {hooksPath})");
@@ -387,9 +397,9 @@ public static class PluginCommand {
 
         var legacy = AgentsSkillsInstaller.CleanLegacyCodexSkills(Path.Combine(CodexPaths.Home, "skills"));
 
-        if (agents.HadErrors || legacy.HadErrors) {
+        if (hooksFailed || agents.HadErrors || legacy.HadErrors) {
             await Console.Out.WriteLineAsync("Removal incomplete — see errors above.");
-            return 0;
+            return 1;
         }
 
         if (!hooksRemoved && !agents.RemovedAny && !legacy.RemovedAny) {
@@ -467,44 +477,42 @@ public static class PluginCommand {
     /// <summary>
     /// Removes every entry in <paramref name="hooksPath"/> whose command
     /// invokes <c>kapacitor codex-hook</c>. Other entries are preserved.
-    /// Returns true if any entries were removed.
+    /// Returns true if any entries were removed. Throws on I/O failure
+    /// (caller decides how to surface partial writes); returns false only
+    /// when there was genuinely nothing to remove.
     /// </summary>
     public static bool RemoveCodexHooks(string hooksPath) {
-        try {
-            if (!File.Exists(hooksPath)) return false;
+        if (!File.Exists(hooksPath)) return false;
 
-            if (JsonNode.Parse(File.ReadAllText(hooksPath)) is not JsonObject root) return false;
-            if (root["hooks"] is not JsonObject hooks) return false;
+        if (JsonNode.Parse(File.ReadAllText(hooksPath)) is not JsonObject root) return false;
+        if (root["hooks"] is not JsonObject hooks) return false;
 
-            var changed = false;
+        var changed = false;
 
-            foreach (var evt in CodexHooksParser.CodexHookEvents) {
-                if (hooks[evt] is not JsonArray entries) continue;
+        foreach (var evt in CodexHooksParser.CodexHookEvents) {
+            if (hooks[evt] is not JsonArray entries) continue;
 
-                var preserved = new JsonArray();
+            var preserved = new JsonArray();
 
-                foreach (var entry in entries) {
-                    if (entry is null) continue;
+            foreach (var entry in entries) {
+                if (entry is null) continue;
 
-                    if (CodexHooksParser.EntryReferencesKapacitorCodexHook(entry)) {
-                        changed = true;
-                    } else {
-                        preserved.Add(entry.DeepClone());
-                    }
+                if (CodexHooksParser.EntryReferencesKapacitorCodexHook(entry)) {
+                    changed = true;
+                } else {
+                    preserved.Add(entry.DeepClone());
                 }
-
-                hooks[evt] = preserved;
             }
 
-            if (changed) {
-                File.WriteAllText(hooksPath, root.ToJsonString(WriteOpts));
-                CodexHooksInstaller.DeleteMarker(hooksPath);
-            }
-
-            return changed;
-        } catch {
-            return false;
+            hooks[evt] = preserved;
         }
+
+        if (changed) {
+            File.WriteAllText(hooksPath, root.ToJsonString(WriteOpts));
+            CodexHooksInstaller.DeleteMarker(hooksPath);
+        }
+
+        return changed;
     }
 
     static async Task<int> InstallCursor(string[] args) {
@@ -548,11 +556,17 @@ public static class PluginCommand {
             await Console.Out.WriteLineAsync("Nothing to remove — Cursor hooks file not found.");
             return 0;
         }
-        var removed = RemoveCursorHooks(hooksPath);
-        await Console.Out.WriteLineAsync(removed
-            ? $"Cursor hooks removed ({hooksPath})"
-            : "Cursor hooks were not installed.");
-        return 0;
+
+        try {
+            var removed = RemoveCursorHooks(hooksPath);
+            await Console.Out.WriteLineAsync(removed
+                ? $"Cursor hooks removed ({hooksPath})"
+                : "Cursor hooks were not installed.");
+            return 0;
+        } catch (Exception ex) {
+            await Console.Error.WriteLineAsync($"Could not update Cursor hooks at {hooksPath}: {ex.Message}");
+            return 1;
+        }
     }
 
     /// <summary>
@@ -602,35 +616,35 @@ public static class PluginCommand {
     /// <summary>
     /// Removes every entry in <paramref name="hooksPath"/> whose command
     /// invokes <c>kapacitor hook --cursor</c>. Other entries are preserved.
-    /// Returns true if any entries were removed.
+    /// Returns true if any entries were removed. Throws on I/O failure
+    /// (caller decides how to surface partial writes); returns false only
+    /// when there was genuinely nothing to remove.
     /// </summary>
     public static bool RemoveCursorHooks(string hooksPath) {
-        try {
-            if (!File.Exists(hooksPath)) return false;
-            if (JsonNode.Parse(File.ReadAllText(hooksPath)) is not JsonObject root) return false;
-            if (root["hooks"] is not JsonObject hooks) return false;
+        if (!File.Exists(hooksPath)) return false;
+        if (JsonNode.Parse(File.ReadAllText(hooksPath)) is not JsonObject root) return false;
+        if (root["hooks"] is not JsonObject hooks) return false;
 
-            var changed = false;
-            foreach (var evt in CursorHooksParser.CursorHookEvents) {
-                if (hooks[evt] is not JsonArray entries) continue;
-                var preserved = new JsonArray();
-                foreach (var entry in entries) {
-                    if (entry is null) continue;
-                    if (CursorHooksParser.EntryReferencesKapacitorCursorHook(entry)) {
-                        changed = true;
-                    } else {
-                        preserved.Add(entry.DeepClone());
-                    }
+        var changed = false;
+        foreach (var evt in CursorHooksParser.CursorHookEvents) {
+            if (hooks[evt] is not JsonArray entries) continue;
+            var preserved = new JsonArray();
+            foreach (var entry in entries) {
+                if (entry is null) continue;
+                if (CursorHooksParser.EntryReferencesKapacitorCursorHook(entry)) {
+                    changed = true;
+                } else {
+                    preserved.Add(entry.DeepClone());
                 }
-                hooks[evt] = preserved;
             }
+            hooks[evt] = preserved;
+        }
 
-            if (changed) {
-                File.WriteAllText(hooksPath, root.ToJsonString(WriteOpts));
-                CursorHooksInstaller.DeleteMarker(hooksPath);
-            }
-            return changed;
-        } catch { return false; }
+        if (changed) {
+            File.WriteAllText(hooksPath, root.ToJsonString(WriteOpts));
+            CursorHooksInstaller.DeleteMarker(hooksPath);
+        }
+        return changed;
     }
 
     static string? GetArg(string[] args, string flag) {

--- a/src/Kapacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Kapacitor.Cli/Commands/PluginCommand.cs
@@ -122,32 +122,18 @@ public static class PluginCommand {
         }
 
         try {
-            var text = await File.ReadAllTextAsync(settingsPath);
+            var outcome = RemoveClaudePlugin(settingsPath);
 
-            if (JsonNode.Parse(text) is not JsonObject root) {
-                await Console.Out.WriteLineAsync("Nothing to remove.");
-
-                return 0;
-            }
-
-            var changed = false;
-
-            if (root["enabledPlugins"] is JsonObject enabled) {
-                changed |= enabled.Remove("kapacitor@kapacitor");
-                changed |= enabled.Remove("kapacitor@kurrent");
-            }
-
-            if (root["extraKnownMarketplaces"] is JsonObject marketplaces) {
-                changed |= marketplaces.Remove("kapacitor");
-                changed |= marketplaces.Remove("kurrent");
-            }
-
-            if (changed) {
-                await File.WriteAllTextAsync(settingsPath, root.ToJsonString(WriteOpts));
-                ClaudePluginInstaller.DeleteMarker(settingsPath);
-                await Console.Out.WriteLineAsync($"Plugin removed ({scope}: {settingsPath})");
-            } else {
-                await Console.Out.WriteLineAsync("Plugin was not installed.");
+            switch (outcome) {
+                case ClaudeRemovalOutcome.Removed:
+                    await Console.Out.WriteLineAsync($"Plugin removed ({scope}: {settingsPath})");
+                    break;
+                case ClaudeRemovalOutcome.NotInstalled:
+                    await Console.Out.WriteLineAsync("Plugin was not installed.");
+                    break;
+                case ClaudeRemovalOutcome.Malformed:
+                    await Console.Out.WriteLineAsync("Nothing to remove.");
+                    break;
             }
 
             return 0;
@@ -156,6 +142,47 @@ public static class PluginCommand {
 
             return 1;
         }
+    }
+
+    /// <summary>
+    /// Removes kapacitor's marketplace + enabledPlugins entries (including the
+    /// legacy <c>kurrent</c> keys) from the Claude Code settings file at
+    /// <paramref name="settingsPath"/>, and deletes the version marker. Non-kapacitor
+    /// settings are preserved. Throws on I/O failure so callers can decide how to
+    /// report it; returns <see cref="ClaudeRemovalOutcome.NotInstalled"/> when the
+    /// file exists but contains no kapacitor entries.
+    /// </summary>
+    public static ClaudeRemovalOutcome RemoveClaudePlugin(string settingsPath) {
+        if (!File.Exists(settingsPath)) return ClaudeRemovalOutcome.NotInstalled;
+
+        var text = File.ReadAllText(settingsPath);
+
+        if (JsonNode.Parse(text) is not JsonObject root) return ClaudeRemovalOutcome.Malformed;
+
+        var changed = false;
+
+        if (root["enabledPlugins"] is JsonObject enabled) {
+            changed |= enabled.Remove("kapacitor@kapacitor");
+            changed |= enabled.Remove("kapacitor@kurrent");
+        }
+
+        if (root["extraKnownMarketplaces"] is JsonObject marketplaces) {
+            changed |= marketplaces.Remove("kapacitor");
+            changed |= marketplaces.Remove("kurrent");
+        }
+
+        if (!changed) return ClaudeRemovalOutcome.NotInstalled;
+
+        File.WriteAllText(settingsPath, root.ToJsonString(WriteOpts));
+        ClaudePluginInstaller.DeleteMarker(settingsPath);
+
+        return ClaudeRemovalOutcome.Removed;
+    }
+
+    public enum ClaudeRemovalOutcome {
+        Removed,
+        NotInstalled,
+        Malformed
     }
 
     static async Task<int> InstallSkills(string[] args) {

--- a/src/Kapacitor.Cli/Commands/UninstallCommand.cs
+++ b/src/Kapacitor.Cli/Commands/UninstallCommand.cs
@@ -1,0 +1,137 @@
+using Kapacitor.Cli.Core;
+using Kapacitor.Cli.Core.Cursor;
+
+namespace Kapacitor.Cli.Commands;
+
+/// <summary>
+/// Completely removes kapacitor from the local machine: stops daemons, kills
+/// watcher processes, strips kapacitor entries from user-level Claude / Codex /
+/// Cursor hook files, removes agent skills (and legacy Codex skills), and
+/// deletes the kapacitor config directory.
+///
+/// With <c>--project</c>, also strips kapacitor entries from the cwd's git-root
+/// <c>.claude/settings.local.json</c> and <c>.codex/hooks.json</c>. Project-scope
+/// Cursor hooks are not a thing — Cursor only reads its user-scope hooks.json.
+/// Per-agent selective cleanup is intentionally out of scope here; this command
+/// covers all known agents.
+/// </summary>
+public static class UninstallCommand {
+    public static async Task<int> HandleAsync(string[] args) {
+        var skipPrompt     = args.Contains("--yes") || args.Contains("-y");
+        var keepConfig     = args.Contains("--keep-config");
+        var includeProject = args.Contains("--project");
+
+        string? projectRoot = null;
+
+        if (includeProject) {
+            projectRoot = GitRepository.FindRoot(Environment.CurrentDirectory);
+
+            if (projectRoot is null) {
+                await Console.Error.WriteLineAsync(
+                    $"--project requires a git working tree, but '{Environment.CurrentDirectory}' is not inside one.");
+                await Console.Error.WriteLineAsync(
+                    "Re-run from inside your repo, or drop --project to only remove user-level configuration.");
+
+                return 1;
+            }
+        }
+
+        var configDir = ResolveConfigDir();
+
+        await Console.Out.WriteLineAsync("This will remove kapacitor from your machine:");
+        await Console.Out.WriteLineAsync("  • Stop any running daemons and watcher processes");
+        await Console.Out.WriteLineAsync($"  • Remove kapacitor entries from {ClaudePaths.UserSettings}");
+        await Console.Out.WriteLineAsync($"  • Remove kapacitor entries from {CodexPaths.UserHooksJson}");
+        await Console.Out.WriteLineAsync($"  • Remove kapacitor entries from {CursorPaths.UserHooksJson()}");
+        await Console.Out.WriteLineAsync($"  • Remove agent skills under {AgentsPaths.UserSkillsDir}");
+
+        if (projectRoot is not null) {
+            await Console.Out.WriteLineAsync(
+                $"  • Remove kapacitor entries from {Path.Combine(projectRoot, ".claude", "settings.local.json")}");
+            await Console.Out.WriteLineAsync(
+                $"  • Remove kapacitor entries from {Path.Combine(projectRoot, ".codex", "hooks.json")}");
+        }
+
+        if (!keepConfig) {
+            await Console.Out.WriteLineAsync($"  • Delete the kapacitor config directory ({configDir})");
+        }
+
+        if (!skipPrompt) {
+            await Console.Out.WriteAsync("Proceed? [y/N] ");
+            var reply = await Console.In.ReadLineAsync();
+
+            if (!string.Equals(reply?.Trim(), "y", StringComparison.OrdinalIgnoreCase)) {
+                await Console.Out.WriteLineAsync("Cancelled.");
+
+                return 0;
+            }
+        }
+
+        // Stop daemons first — they hold lock files inside the config dir we're
+        // about to delete. --yes silences the multi-daemon confirmation so this
+        // works non-interactively.
+        await DaemonCommands.HandleAsync(["daemon", "stop", "--yes"]);
+
+        // Kill any orphaned watcher PIDs that the daemon stop didn't catch.
+        await CleanupCommand.HandleCleanup();
+
+        // User-level agent integrations. Each remove command is idempotent and
+        // no-ops if the target file doesn't exist, so it's safe to call all of
+        // them unconditionally without sniffing which agents are installed.
+        await PluginCommand.HandleAsync(["plugin", "remove"]);            // Claude
+        await PluginCommand.HandleAsync(["plugin", "remove", "--codex"]); // Codex hooks + skills + legacy
+        await PluginCommand.HandleAsync(["plugin", "remove", "--cursor"]);
+
+        // Skills are removed by --codex above, but call --skills explicitly in
+        // case the user only ever installed Cursor / agent-agnostic skills and
+        // never had Codex hooks (the --codex path short-circuits on a missing
+        // hooks file).
+        await PluginCommand.HandleAsync(["plugin", "remove", "--skills"]);
+
+        if (projectRoot is not null) {
+            var claudeProject = Path.Combine(projectRoot, ".claude", "settings.local.json");
+            var codexProject  = Path.Combine(projectRoot, ".codex", "hooks.json");
+
+            var claudeOutcome = PluginCommand.RemoveClaudePlugin(claudeProject);
+
+            if (claudeOutcome == PluginCommand.ClaudeRemovalOutcome.Removed) {
+                await Console.Out.WriteLineAsync($"Plugin removed (project: {claudeProject})");
+            }
+
+            if (File.Exists(codexProject) && PluginCommand.RemoveCodexHooks(codexProject)) {
+                await Console.Out.WriteLineAsync($"Codex hooks removed (project: {codexProject})");
+            }
+        }
+
+        if (!keepConfig && Directory.Exists(configDir)) {
+            try {
+                Directory.Delete(configDir, recursive: true);
+                await Console.Out.WriteLineAsync($"Removed config directory: {configDir}");
+            } catch (Exception ex) {
+                await Console.Error.WriteLineAsync($"Could not remove config directory {configDir}: {ex.Message}");
+
+                return 1;
+            }
+        }
+
+        await Console.Out.WriteLineAsync("kapacitor uninstalled.");
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Resolves the kapacitor config directory the same way
+    /// <see cref="PathHelpers"/> would on a fresh process — read
+    /// <c>KAPACITOR_CONFIG_DIR</c> first, fall back to
+    /// <c>$HOME/.config/kapacitor</c>. Re-evaluates every call so tests that
+    /// override <c>HOME</c> see the override even after <c>PathHelpers</c>
+    /// has captured a different value into its static cache.
+    /// </summary>
+    static string ResolveConfigDir() {
+        var env = Environment.GetEnvironmentVariable("KAPACITOR_CONFIG_DIR");
+
+        return !string.IsNullOrWhiteSpace(env)
+            ? env
+            : Path.Combine(PathHelpers.HomeDirectory, ".config", "kapacitor");
+    }
+}

--- a/src/Kapacitor.Cli/Commands/UninstallCommand.cs
+++ b/src/Kapacitor.Cli/Commands/UninstallCommand.cs
@@ -67,51 +67,98 @@ public static class UninstallCommand {
             }
         }
 
+        // Track every step's success so we can surface failures in the exit
+        // code AND keep ~/.config/kapacitor in place when something went wrong
+        // (so the user can re-run rather than losing local state on a partial
+        // removal). Individual remove commands keep printing their own output
+        // — this flag captures the boolean for the final decision only.
+        var hadFailures = false;
+
         // Stop daemons first — they hold lock files inside the config dir we're
         // about to delete. --yes silences the multi-daemon confirmation so this
-        // works non-interactively.
-        await DaemonCommands.HandleAsync(["daemon", "stop", "--yes"]);
+        // works non-interactively. A non-zero exit code means at least one
+        // daemon couldn't be stopped; we leave the config dir alone in that case.
+        if (await DaemonCommands.HandleAsync(["daemon", "stop", "--yes"]) != 0) hadFailures = true;
 
         // Kill any orphaned watcher PIDs that the daemon stop didn't catch.
-        await CleanupCommand.HandleCleanup();
+        if (await CleanupCommand.HandleCleanup() != 0) hadFailures = true;
 
         // User-level agent integrations. Each remove command is idempotent and
         // no-ops if the target file doesn't exist, so it's safe to call all of
         // them unconditionally without sniffing which agents are installed.
-        await PluginCommand.HandleAsync(["plugin", "remove"]);            // Claude
-        await PluginCommand.HandleAsync(["plugin", "remove", "--codex"]); // Codex hooks + skills + legacy
-        await PluginCommand.HandleAsync(["plugin", "remove", "--cursor"]);
+        if (await PluginCommand.HandleAsync(["plugin", "remove"]) != 0) hadFailures = true;            // Claude
+        if (await PluginCommand.HandleAsync(["plugin", "remove", "--codex"]) != 0) hadFailures = true; // Codex hooks + skills + legacy
+        if (await PluginCommand.HandleAsync(["plugin", "remove", "--cursor"]) != 0) hadFailures = true;
 
         // Skills are removed by --codex above, but call --skills explicitly in
         // case the user only ever installed Cursor / agent-agnostic skills and
         // never had Codex hooks (the --codex path short-circuits on a missing
         // hooks file).
-        await PluginCommand.HandleAsync(["plugin", "remove", "--skills"]);
+        if (await PluginCommand.HandleAsync(["plugin", "remove", "--skills"]) != 0) hadFailures = true;
+
+        // Belt-and-braces marker cleanup. Plugin remove deletes the marker
+        // only when JSON entries changed; if the user manually pruned the
+        // entries earlier (or installed via a pre-marker build that later
+        // wrote a marker on first refresh), the marker survives and IsInstalled
+        // still reports kapacitor as installed. uninstall promises a full
+        // wipe, so always nuke the markers regardless of what the JSON state
+        // looked like going in.
+        ClaudePluginInstaller.DeleteMarker(ClaudePaths.UserSettings);
+        CodexHooksInstaller.DeleteMarker(CodexPaths.UserHooksJson);
+        CursorHooksInstaller.DeleteMarker(CursorPaths.UserHooksJson());
+
+        // Skill installer Remove uses the current SourceNames list, so any
+        // kapacitor-* folder from an older release (renamed/retired skill)
+        // would survive. Sweep the directory for our prefix to catch those.
+        // Same for legacy ~/.codex/skills/.
+        SweepKapacitorPrefixedDirs(AgentsPaths.UserSkillsDir);
+        SweepKapacitorPrefixedDirs(Path.Combine(CodexPaths.Home, "skills"));
 
         if (projectRoot is not null) {
             var claudeProject = Path.Combine(projectRoot, ".claude", "settings.local.json");
             var codexProject  = Path.Combine(projectRoot, ".codex", "hooks.json");
 
-            var claudeOutcome = PluginCommand.RemoveClaudePlugin(claudeProject);
+            try {
+                var claudeOutcome = PluginCommand.RemoveClaudePlugin(claudeProject);
 
-            if (claudeOutcome == PluginCommand.ClaudeRemovalOutcome.Removed) {
-                await Console.Out.WriteLineAsync($"Plugin removed (project: {claudeProject})");
+                if (claudeOutcome == PluginCommand.ClaudeRemovalOutcome.Removed) {
+                    await Console.Out.WriteLineAsync($"Plugin removed (project: {claudeProject})");
+                }
+            } catch (Exception ex) {
+                await Console.Error.WriteLineAsync($"Could not update {claudeProject}: {ex.Message}");
+                hadFailures = true;
             }
 
             if (File.Exists(codexProject) && PluginCommand.RemoveCodexHooks(codexProject)) {
                 await Console.Out.WriteLineAsync($"Codex hooks removed (project: {codexProject})");
             }
+
+            // Same marker-survives-after-manual-edit story as the user scope.
+            ClaudePluginInstaller.DeleteMarker(claudeProject);
+            CodexHooksInstaller.DeleteMarker(codexProject);
         }
 
-        if (!keepConfig && Directory.Exists(configDir)) {
-            try {
-                Directory.Delete(configDir, recursive: true);
-                await Console.Out.WriteLineAsync($"Removed config directory: {configDir}");
-            } catch (Exception ex) {
-                await Console.Error.WriteLineAsync($"Could not remove config directory {configDir}: {ex.Message}");
-
-                return 1;
+        if (!keepConfig) {
+            if (hadFailures) {
+                await Console.Error.WriteLineAsync(
+                    $"Skipping config-directory delete because earlier steps failed: {configDir}");
+                await Console.Error.WriteLineAsync(
+                    "Investigate the errors above, then re-run `kapacitor uninstall` to finish.");
+            } else if (Directory.Exists(configDir)) {
+                try {
+                    Directory.Delete(configDir, recursive: true);
+                    await Console.Out.WriteLineAsync($"Removed config directory: {configDir}");
+                } catch (Exception ex) {
+                    await Console.Error.WriteLineAsync($"Could not remove config directory {configDir}: {ex.Message}");
+                    hadFailures = true;
+                }
             }
+        }
+
+        if (hadFailures) {
+            await Console.Error.WriteLineAsync("kapacitor uninstall finished with errors — see above.");
+
+            return 1;
         }
 
         await Console.Out.WriteLineAsync("kapacitor uninstalled.");
@@ -133,5 +180,25 @@ public static class UninstallCommand {
         return !string.IsNullOrWhiteSpace(env)
             ? env
             : Path.Combine(PathHelpers.HomeDirectory, ".config", "kapacitor");
+    }
+
+    /// <summary>
+    /// Deletes every <c>kapacitor-*</c> directory directly under
+    /// <paramref name="root"/>. Catches the cases where the installer's
+    /// fixed name list doesn't match what's on disk: a skill renamed,
+    /// retired, or added between releases. <c>kapacitor-</c> is our
+    /// namespace prefix so this is safe; user-authored folders without it
+    /// are untouched.
+    /// </summary>
+    static void SweepKapacitorPrefixedDirs(string root) {
+        if (!Directory.Exists(root)) return;
+
+        foreach (var dir in Directory.EnumerateDirectories(root, "kapacitor-*")) {
+            try {
+                Directory.Delete(dir, recursive: true);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"Could not remove {dir}: {ex.Message}");
+            }
+        }
     }
 }

--- a/src/Kapacitor.Cli/Commands/UninstallCommand.cs
+++ b/src/Kapacitor.Cli/Commands/UninstallCommand.cs
@@ -111,8 +111,8 @@ public static class UninstallCommand {
         // kapacitor-* folder from an older release (renamed/retired skill)
         // would survive. Sweep the directory for our prefix to catch those.
         // Same for legacy ~/.codex/skills/.
-        SweepKapacitorPrefixedDirs(AgentsPaths.UserSkillsDir);
-        SweepKapacitorPrefixedDirs(Path.Combine(CodexPaths.Home, "skills"));
+        if (!SweepKapacitorPrefixedDirs(AgentsPaths.UserSkillsDir))            hadFailures = true;
+        if (!SweepKapacitorPrefixedDirs(Path.Combine(CodexPaths.Home, "skills"))) hadFailures = true;
 
         if (projectRoot is not null) {
             var claudeProject = Path.Combine(projectRoot, ".claude", "settings.local.json");
@@ -129,8 +129,15 @@ public static class UninstallCommand {
                 hadFailures = true;
             }
 
-            if (File.Exists(codexProject) && PluginCommand.RemoveCodexHooks(codexProject)) {
-                await Console.Out.WriteLineAsync($"Codex hooks removed (project: {codexProject})");
+            if (File.Exists(codexProject)) {
+                try {
+                    if (PluginCommand.RemoveCodexHooks(codexProject)) {
+                        await Console.Out.WriteLineAsync($"Codex hooks removed (project: {codexProject})");
+                    }
+                } catch (Exception ex) {
+                    await Console.Error.WriteLineAsync($"Could not update Codex hooks at {codexProject}: {ex.Message}");
+                    hadFailures = true;
+                }
             }
 
             // Same marker-survives-after-manual-edit story as the user scope.
@@ -188,17 +195,32 @@ public static class UninstallCommand {
     /// fixed name list doesn't match what's on disk: a skill renamed,
     /// retired, or added between releases. <c>kapacitor-</c> is our
     /// namespace prefix so this is safe; user-authored folders without it
-    /// are untouched.
+    /// are untouched. Returns true on full success, false when any deletion
+    /// (or the enumeration itself) failed — callers feed the result into
+    /// their failure aggregator so a stuck folder doesn't get masked by
+    /// a "kapacitor uninstalled." exit.
     /// </summary>
-    static void SweepKapacitorPrefixedDirs(string root) {
-        if (!Directory.Exists(root)) return;
+    static bool SweepKapacitorPrefixedDirs(string root) {
+        if (!Directory.Exists(root)) return true;
 
-        foreach (var dir in Directory.EnumerateDirectories(root, "kapacitor-*")) {
+        IEnumerable<string> dirs;
+        try {
+            dirs = Directory.EnumerateDirectories(root, "kapacitor-*").ToArray();
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Could not enumerate {root}: {ex.Message}");
+            return false;
+        }
+
+        var ok = true;
+        foreach (var dir in dirs) {
             try {
                 Directory.Delete(dir, recursive: true);
             } catch (Exception ex) {
                 Console.Error.WriteLine($"Could not remove {dir}: {ex.Message}");
+                ok = false;
             }
         }
+
+        return ok;
     }
 }

--- a/src/Kapacitor.Cli/Program.cs
+++ b/src/Kapacitor.Cli/Program.cs
@@ -52,8 +52,11 @@ if (Environment.GetEnvironmentVariable("KAPACITOR_SKIP") is "1"
 
 var baseUrl = await AppConfig.ResolveServerUrl(args);
 
-// Fire-and-forget update check (prints hint to stderr after command finishes)
-var   noUpdateCheck   = args.Contains("--no-update-check");
+// Fire-and-forget update check (prints hint to stderr after command finishes).
+// Skipped for `uninstall` — the check writes ~/.config/kapacitor/update-check.json,
+// which would race with uninstall's `rm -rf` of the config dir and recreate it
+// after the command has reported success.
+var   noUpdateCheck   = args.Contains("--no-update-check") || command == "uninstall";
 Task? updateCheckTask = null;
 
 if (!noUpdateCheck) {

--- a/src/Kapacitor.Cli/Program.cs
+++ b/src/Kapacitor.Cli/Program.cs
@@ -72,7 +72,7 @@ if (args.Skip(1).Any(a => a is "--help" or "-h")) {
 }
 
 // Commands that don't need a server URL
-string[] offlineCommands = ["--help", "-h", "help", "--version", "-v", "logout", "cleanup", "config", "daemon", "setup", "status", "update", "plugin", "profile", "use", "repos", "login", "ignore"];
+string[] offlineCommands = ["--help", "-h", "help", "--version", "-v", "logout", "cleanup", "config", "daemon", "setup", "status", "update", "plugin", "profile", "use", "repos", "login", "ignore", "uninstall"];
 
 if (baseUrl is null && !offlineCommands.Contains(command)) {
     Console.Error.WriteLine("No server configured. Run `kapacitor setup` or set KAPACITOR_URL.");
@@ -309,6 +309,8 @@ switch (command) {
     }
     case "cleanup":
         return await CleanupCommand.HandleCleanup();
+    case "uninstall":
+        return await UninstallCommand.HandleAsync(args);
     case "disable": {
         // The sessionId is consumed as a filesystem path component
         // (watcher PID files, disabled marker file). Validate strictly as a

--- a/test/Kapacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -328,6 +328,68 @@ public class UninstallCommandTests {
         }
     }
 
+    [Test]
+    public async Task Cursor_hooks_write_failure_propagates_to_exit_code() {
+        // Cursor's RemoveCursor previously returned 0 even when the helper's
+        // inner try/catch swallowed a write failure. The helper now throws,
+        // RemoveCursor catches + returns 1, and uninstall aggregates that
+        // into hadFailures.
+        if (OperatingSystem.IsWindows()) return;
+
+        await using var fixture = await Fixture.CreateAsync();
+
+        var cursorDir = Path.Combine(fixture.Home, ".cursor");
+        Directory.CreateDirectory(cursorDir);
+        var hooksPath = Path.Combine(cursorDir, "hooks.json");
+        await File.WriteAllTextAsync(hooksPath, """
+            {"version":1,"hooks":{"sessionStart":[{"command":"kapacitor hook --cursor"}]}}
+            """);
+        File.SetUnixFileMode(hooksPath, UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        try {
+            var exit = await UninstallCommand.HandleAsync(["uninstall", "--yes"]);
+
+            await Assert.That(exit).IsEqualTo(1);
+            // Failure path skips the config-dir delete so the user can re-run.
+            await Assert.That(Directory.Exists(fixture.ConfigDir)).IsTrue();
+        } finally {
+            File.SetUnixFileMode(hooksPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+    }
+
+    [Test]
+    public async Task Sweep_failure_propagates_to_exit_code() {
+        // SweepKapacitorPrefixedDirs previously logged Directory.Delete errors
+        // but never flipped hadFailures, so a stuck kapacitor-* folder under
+        // ~/.agents/skills/ would leave uninstall claiming success.
+        if (OperatingSystem.IsWindows()) return;
+
+        await using var fixture = await Fixture.CreateAsync();
+
+        var skillsDir = Path.Combine(fixture.Home, ".agents", "skills");
+        Directory.CreateDirectory(skillsDir);
+        Directory.CreateDirectory(Path.Combine(skillsDir, "kapacitor-stuck"));
+
+        // Strip write permission on the parent. Directory.Delete on a child
+        // needs write+exec on the parent on every Unix; without write the
+        // unlink fails with EACCES and Directory.Delete surfaces it.
+        File.SetUnixFileMode(skillsDir,
+            UnixFileMode.UserRead | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+        try {
+            var exit = await UninstallCommand.HandleAsync(["uninstall", "--yes"]);
+
+            await Assert.That(exit).IsEqualTo(1);
+            await Assert.That(Directory.Exists(fixture.ConfigDir)).IsTrue();
+        } finally {
+            // Restore so the fixture can be cleaned up.
+            File.SetUnixFileMode(skillsDir,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
     sealed class Fixture : IAsyncDisposable {
         public required string Home      { get; init; }
         public required string ConfigDir { get; init; }

--- a/test/Kapacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -212,6 +212,122 @@ public class UninstallCommandTests {
         }
     }
 
+    [Test]
+    public async Task Marker_only_install_is_purged_even_when_json_has_no_kapacitor_entries() {
+        // Regression for the "marker survives manual JSON edit" leak: the
+        // upstream plugin removers delete the marker only when JSON entries
+        // changed. If a user removed kapacitor entries by hand earlier, the
+        // marker survives and IsInstalled keeps returning true. uninstall
+        // must always nuke the markers.
+        await using var fixture = await Fixture.CreateAsync();
+
+        var claudeDir = Path.Combine(fixture.Home, ".claude");
+        Directory.CreateDirectory(claudeDir);
+        // settings.json present but no kapacitor entries.
+        await File.WriteAllTextAsync(Path.Combine(claudeDir, "settings.json"), """{"userKey":"x"}""");
+        await File.WriteAllTextAsync(
+            Path.Combine(claudeDir, ClaudePluginInstaller.MarkerFileName),
+            KapacitorVersion.Current());
+
+        var codexDir = Path.Combine(fixture.Home, ".codex");
+        Directory.CreateDirectory(codexDir);
+        await File.WriteAllTextAsync(Path.Combine(codexDir, "hooks.json"), """{"hooks":{}}""");
+        await File.WriteAllTextAsync(
+            Path.Combine(codexDir, CodexHooksInstaller.MarkerFileName),
+            KapacitorVersion.Current());
+
+        var cursorDir = Path.Combine(fixture.Home, ".cursor");
+        Directory.CreateDirectory(cursorDir);
+        await File.WriteAllTextAsync(Path.Combine(cursorDir, "hooks.json"), """{"version":1,"hooks":{}}""");
+        await File.WriteAllTextAsync(
+            Path.Combine(cursorDir, CursorHooksInstaller.MarkerFileName),
+            KapacitorVersion.Current());
+
+        var exit = await UninstallCommand.HandleAsync(["uninstall", "--yes", "--keep-config"]);
+        await Assert.That(exit).IsEqualTo(0);
+
+        await Assert.That(File.Exists(Path.Combine(claudeDir, ClaudePluginInstaller.MarkerFileName))).IsFalse();
+        await Assert.That(File.Exists(Path.Combine(codexDir,  CodexHooksInstaller.MarkerFileName))).IsFalse();
+        await Assert.That(File.Exists(Path.Combine(cursorDir, CursorHooksInstaller.MarkerFileName))).IsFalse();
+    }
+
+    [Test]
+    public async Task Sweep_removes_kapacitor_prefixed_skill_folders_not_in_current_source_list() {
+        // Regression for the "retired/renamed skill folder survives" leak:
+        // AgentsSkillsInstaller.Remove uses the current SourceNames list, so
+        // a kapacitor-* folder from an older release isn't matched. uninstall
+        // must sweep the directory for our prefix to catch those.
+        await using var fixture = await Fixture.CreateAsync();
+
+        var skillsDir = Path.Combine(fixture.Home, ".agents", "skills");
+        Directory.CreateDirectory(skillsDir);
+
+        // A skill from the current list (handled by Remove) and a retired one
+        // (only handled by the sweep). Plus a user-authored folder that must
+        // survive both.
+        var currentSkill = Path.Combine(skillsDir, $"kapacitor-{AgentsSkillsInstaller.SourceNames[0]}");
+        var retiredSkill = Path.Combine(skillsDir, "kapacitor-retired-from-v0.42");
+        var userSkill    = Path.Combine(skillsDir, "user-authored");
+        Directory.CreateDirectory(currentSkill);
+        Directory.CreateDirectory(retiredSkill);
+        Directory.CreateDirectory(userSkill);
+
+        // Legacy Codex skills dir: same story.
+        var legacyDir = Path.Combine(fixture.Home, ".codex", "skills");
+        Directory.CreateDirectory(legacyDir);
+        var legacyRetired = Path.Combine(legacyDir, "kapacitor-also-retired");
+        Directory.CreateDirectory(legacyRetired);
+
+        var exit = await UninstallCommand.HandleAsync(["uninstall", "--yes", "--keep-config"]);
+        await Assert.That(exit).IsEqualTo(0);
+
+        await Assert.That(Directory.Exists(currentSkill)).IsFalse();
+        await Assert.That(Directory.Exists(retiredSkill)).IsFalse();
+        await Assert.That(Directory.Exists(legacyRetired)).IsFalse();
+        await Assert.That(Directory.Exists(userSkill)).IsTrue();
+    }
+
+    [Test]
+    public async Task Config_dir_is_preserved_when_user_level_steps_fail() {
+        // Regression for the "discarded return codes" issue: when a step
+        // returns non-zero, uninstall must NOT delete ~/.config/kapacitor —
+        // doing so destroys the only state that lets the user re-run and
+        // finish, and it would silently report success.
+        //
+        // Windows file ACLs would need an entirely different setup, so this
+        // case is Unix-only. The aggregation logic is the same on every
+        // platform; covering Unix is sufficient for regression purposes.
+        if (OperatingSystem.IsWindows()) return;
+
+        await using var fixture = await Fixture.CreateAsync();
+
+        // Force PluginCommand's Claude remove to return 1 by leaving a valid
+        // kapacitor entry behind a read-only file: File.Exists passes, JSON
+        // parses cleanly, then File.WriteAllText hits UnauthorizedAccessException
+        // — which the remover's catch translates into exit code 1.
+        var claudeDir = Path.Combine(fixture.Home, ".claude");
+        Directory.CreateDirectory(claudeDir);
+        var settingsPath = Path.Combine(claudeDir, "settings.json");
+        await File.WriteAllTextAsync(settingsPath, """
+            {"enabledPlugins": {"kapacitor@kapacitor": true}}
+            """);
+        File.SetUnixFileMode(settingsPath, UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        var sentinel = Path.Combine(fixture.ConfigDir, "profiles.json");
+        await File.WriteAllTextAsync(sentinel, """{"sentinel":"survives-partial-failure"}""");
+
+        try {
+            var exit = await UninstallCommand.HandleAsync(["uninstall", "--yes"]);
+
+            await Assert.That(exit).IsEqualTo(1);
+            await Assert.That(Directory.Exists(fixture.ConfigDir)).IsTrue();
+            await Assert.That(await File.ReadAllTextAsync(sentinel)).Contains("survives-partial-failure");
+        } finally {
+            // Restore write so the test fixture can be deleted.
+            File.SetUnixFileMode(settingsPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+    }
+
     sealed class Fixture : IAsyncDisposable {
         public required string Home      { get; init; }
         public required string ConfigDir { get; init; }

--- a/test/Kapacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Kapacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -1,0 +1,250 @@
+using System.Text.Json.Nodes;
+using Kapacitor.Cli.Commands;
+using Kapacitor.Cli.Core;
+
+namespace Kapacitor.Cli.Tests.Unit;
+
+// HomeEnvVarMutation: uninstall reads HOME via PathHelpers.HomeDirectory to
+// resolve every user-level path (~/.claude, ~/.codex, ~/.cursor, ~/.agents).
+// ConfigDirEnvVar: uninstall reads KAPACITOR_CONFIG_DIR fresh on every call,
+// so we mutate it per-test to point at the test's temp dir without disturbing
+// the assembly-wide value pinned by RepoPathStoreGlobalSetup.
+[NotInParallel(["HomeEnvVarMutation", "ConfigDirEnvVar", "CwdMutation"])]
+public class UninstallCommandTests {
+    [Test]
+    public async Task User_level_uninstall_removes_kapacitor_entries_and_preserves_user_data() {
+        await using var fixture = await Fixture.CreateAsync();
+
+        // Seed Claude user settings with kapacitor + user-authored content.
+        var claudeDir = Path.Combine(fixture.Home, ".claude");
+        Directory.CreateDirectory(claudeDir);
+        var claudeSettings = Path.Combine(claudeDir, "settings.json");
+        await File.WriteAllTextAsync(claudeSettings, """
+            {
+              "userKey": "must-survive",
+              "extraKnownMarketplaces": {
+                "kapacitor":  { "source": { "source": "directory", "path": "/p" } },
+                "userMarket": { "source": { "source": "directory", "path": "/u" } }
+              },
+              "enabledPlugins": { "kapacitor@kapacitor": true, "user@market": true }
+            }
+            """);
+        await File.WriteAllTextAsync(
+            Path.Combine(claudeDir, ClaudePluginInstaller.MarkerFileName),
+            KapacitorVersion.Current());
+
+        // Codex user hooks with a non-kapacitor entry alongside kapacitor.
+        var codexDir = Path.Combine(fixture.Home, ".codex");
+        Directory.CreateDirectory(codexDir);
+        var codexHooks = Path.Combine(codexDir, "hooks.json");
+        await File.WriteAllTextAsync(codexHooks, """
+            {
+              "hooks": {
+                "SessionStart": [
+                  { "hooks": [{ "type": "command", "command": "user-script", "timeout": 5 }] },
+                  { "hooks": [{ "type": "command", "command": "kapacitor codex-hook", "timeout": 30 }] }
+                ]
+              }
+            }
+            """);
+
+        // Cursor user hooks similarly.
+        var cursorDir = Path.Combine(fixture.Home, ".cursor");
+        Directory.CreateDirectory(cursorDir);
+        var cursorHooks = Path.Combine(cursorDir, "hooks.json");
+        await File.WriteAllTextAsync(cursorHooks, """
+            {
+              "version": 1,
+              "hooks": {
+                "sessionStart": [
+                  { "command": "user-script" },
+                  { "command": "kapacitor hook --cursor" }
+                ]
+              }
+            }
+            """);
+
+        // Skills present in ~/.agents/skills with marker.
+        var skillsDir = Path.Combine(fixture.Home, ".agents", "skills");
+        Directory.CreateDirectory(skillsDir);
+        foreach (var name in AgentsSkillsInstaller.SourceNames) {
+            Directory.CreateDirectory(Path.Combine(skillsDir, $"kapacitor-{name}"));
+        }
+        var userSkill = Path.Combine(skillsDir, "user-authored");
+        Directory.CreateDirectory(userSkill);
+        await File.WriteAllTextAsync(Path.Combine(userSkill, "SKILL.md"), "user content");
+
+        // Seed config dir with a real file so we can verify deletion.
+        await File.WriteAllTextAsync(Path.Combine(fixture.ConfigDir, "profiles.json"), "{}");
+
+        var exit = await UninstallCommand.HandleAsync(["uninstall", "--yes"]);
+        await Assert.That(exit).IsEqualTo(0);
+
+        // Claude: kapacitor entries gone, user entries preserved, marker removed.
+        var claudeRoot = JsonNode.Parse(await File.ReadAllTextAsync(claudeSettings))!.AsObject();
+        await Assert.That(claudeRoot["userKey"]!.GetValue<string>()).IsEqualTo("must-survive");
+        await Assert.That(claudeRoot["enabledPlugins"]!["kapacitor@kapacitor"]).IsNull();
+        await Assert.That(claudeRoot["enabledPlugins"]!["user@market"]!.GetValue<bool>()).IsTrue();
+        await Assert.That(claudeRoot["extraKnownMarketplaces"]!["kapacitor"]).IsNull();
+        await Assert.That(claudeRoot["extraKnownMarketplaces"]!["userMarket"]).IsNotNull();
+        await Assert.That(File.Exists(Path.Combine(claudeDir, ClaudePluginInstaller.MarkerFileName))).IsFalse();
+
+        // Codex: kapacitor entry gone, user entry preserved.
+        var codexRoot = JsonNode.Parse(await File.ReadAllTextAsync(codexHooks))!.AsObject();
+        var sessionStart = codexRoot["hooks"]!["SessionStart"]!.AsArray();
+        await Assert.That(sessionStart.Count).IsEqualTo(1);
+        await Assert.That(sessionStart[0]!["hooks"]![0]!["command"]!.GetValue<string>()).IsEqualTo("user-script");
+
+        // Cursor: kapacitor entry gone, user entry preserved.
+        var cursorRoot   = JsonNode.Parse(await File.ReadAllTextAsync(cursorHooks))!.AsObject();
+        var sessionStart2 = cursorRoot["hooks"]!["sessionStart"]!.AsArray();
+        await Assert.That(sessionStart2.Count).IsEqualTo(1);
+        await Assert.That(sessionStart2[0]!["command"]!.GetValue<string>()).IsEqualTo("user-script");
+
+        // Skills: kapacitor-* folders removed, user-authored folder intact.
+        foreach (var name in AgentsSkillsInstaller.SourceNames) {
+            await Assert.That(Directory.Exists(Path.Combine(skillsDir, $"kapacitor-{name}"))).IsFalse();
+        }
+        await Assert.That(Directory.Exists(userSkill)).IsTrue();
+
+        // Config dir fully deleted.
+        await Assert.That(Directory.Exists(fixture.ConfigDir)).IsFalse();
+    }
+
+    [Test]
+    public async Task Keep_config_preserves_config_dir_but_removes_integrations() {
+        await using var fixture = await Fixture.CreateAsync();
+
+        var claudeDir = Path.Combine(fixture.Home, ".claude");
+        Directory.CreateDirectory(claudeDir);
+        var claudeSettings = Path.Combine(claudeDir, "settings.json");
+        await File.WriteAllTextAsync(claudeSettings, """
+            {"enabledPlugins": {"kapacitor@kapacitor": true}}
+            """);
+
+        var sentinel = Path.Combine(fixture.ConfigDir, "profiles.json");
+        await File.WriteAllTextAsync(sentinel, """{"sentinel":"keep"}""");
+
+        var exit = await UninstallCommand.HandleAsync(["uninstall", "--yes", "--keep-config"]);
+        await Assert.That(exit).IsEqualTo(0);
+
+        var root = JsonNode.Parse(await File.ReadAllTextAsync(claudeSettings))!.AsObject();
+        await Assert.That(root["enabledPlugins"]!["kapacitor@kapacitor"]).IsNull();
+
+        await Assert.That(Directory.Exists(fixture.ConfigDir)).IsTrue();
+        await Assert.That(await File.ReadAllTextAsync(sentinel)).Contains("keep");
+    }
+
+    [Test]
+    public async Task Project_flag_strips_project_scope_entries() {
+        await using var fixture = await Fixture.CreateAsync();
+
+        // Fake project: a temp dir with a .git directory makes GitRepository.FindRoot
+        // return it as the working tree root.
+        var projectDir = Directory.CreateTempSubdirectory("kapacitor-uninstall-project-");
+        Directory.CreateDirectory(Path.Combine(projectDir.FullName, ".git"));
+
+        var projectClaude = Path.Combine(projectDir.FullName, ".claude", "settings.local.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(projectClaude)!);
+        await File.WriteAllTextAsync(projectClaude, """
+            {
+              "userLocal": "keep",
+              "enabledPlugins": { "kapacitor@kapacitor": true }
+            }
+            """);
+
+        var projectCodex = Path.Combine(projectDir.FullName, ".codex", "hooks.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(projectCodex)!);
+        await File.WriteAllTextAsync(projectCodex, """
+            {
+              "hooks": {
+                "SessionStart": [
+                  { "hooks": [{ "type": "command", "command": "user-script", "timeout": 5 }] },
+                  { "hooks": [{ "type": "command", "command": "kapacitor codex-hook", "timeout": 30 }] }
+                ]
+              }
+            }
+            """);
+
+        var originalCwd = Environment.CurrentDirectory;
+        try {
+            Environment.CurrentDirectory = projectDir.FullName;
+
+            var exit = await UninstallCommand.HandleAsync(["uninstall", "--yes", "--project", "--keep-config"]);
+            await Assert.That(exit).IsEqualTo(0);
+
+            var claudeRoot = JsonNode.Parse(await File.ReadAllTextAsync(projectClaude))!.AsObject();
+            await Assert.That(claudeRoot["userLocal"]!.GetValue<string>()).IsEqualTo("keep");
+            await Assert.That(claudeRoot["enabledPlugins"]!["kapacitor@kapacitor"]).IsNull();
+
+            var codexRoot    = JsonNode.Parse(await File.ReadAllTextAsync(projectCodex))!.AsObject();
+            var sessionStart = codexRoot["hooks"]!["SessionStart"]!.AsArray();
+            await Assert.That(sessionStart.Count).IsEqualTo(1);
+            await Assert.That(sessionStart[0]!["hooks"]![0]!["command"]!.GetValue<string>()).IsEqualTo("user-script");
+        } finally {
+            Environment.CurrentDirectory = originalCwd;
+            projectDir.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    [NotInParallel(["ConsoleStreams", "HomeEnvVarMutation", "ConfigDirEnvVar", "CwdMutation"])]
+    public async Task Project_flag_errors_when_not_inside_git_tree() {
+        await using var fixture = await Fixture.CreateAsync();
+
+        // A scratch dir with NO .git anywhere up the tree.
+        var noRepoDir = Directory.CreateTempSubdirectory("kapacitor-uninstall-norepo-");
+        var originalCwd = Environment.CurrentDirectory;
+        var originalErr = Console.Error;
+        var capturedErr = new StringWriter();
+
+        try {
+            Environment.CurrentDirectory = noRepoDir.FullName;
+            Console.SetError(capturedErr);
+
+            var exit = await UninstallCommand.HandleAsync(["uninstall", "--yes", "--project"]);
+            await Assert.That(exit).IsEqualTo(1);
+            await Assert.That(capturedErr.ToString()).Contains("--project requires a git working tree");
+        } finally {
+            Console.SetError(originalErr);
+            Environment.CurrentDirectory = originalCwd;
+            noRepoDir.Delete(recursive: true);
+        }
+    }
+
+    sealed class Fixture : IAsyncDisposable {
+        public required string Home      { get; init; }
+        public required string ConfigDir { get; init; }
+
+        public string? OriginalHome      { get; init; }
+        public string? OriginalConfigDir { get; init; }
+
+        public static Task<Fixture> CreateAsync() {
+            var home      = Directory.CreateTempSubdirectory("kapacitor-uninstall-home-").FullName;
+            var configDir = Path.Combine(home, ".config", "kapacitor");
+            Directory.CreateDirectory(configDir);
+
+            var f = new Fixture {
+                Home              = home,
+                ConfigDir         = configDir,
+                OriginalHome      = Environment.GetEnvironmentVariable("HOME"),
+                OriginalConfigDir = Environment.GetEnvironmentVariable("KAPACITOR_CONFIG_DIR"),
+            };
+
+            Environment.SetEnvironmentVariable("HOME", home);
+            // Pin the config dir under the test home so uninstall's
+            // Directory.Delete only touches the test's temp tree, never the
+            // assembly-wide config dir pinned by RepoPathStoreGlobalSetup.
+            Environment.SetEnvironmentVariable("KAPACITOR_CONFIG_DIR", configDir);
+
+            return Task.FromResult(f);
+        }
+
+        public ValueTask DisposeAsync() {
+            Environment.SetEnvironmentVariable("HOME", OriginalHome);
+            Environment.SetEnvironmentVariable("KAPACITOR_CONFIG_DIR", OriginalConfigDir);
+            try { Directory.Delete(Home, recursive: true); } catch { /* best effort */ }
+            return ValueTask.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `kapacitor uninstall` command: stops daemons + watchers, strips kapacitor entries from user-level Claude/Codex/Cursor hook files (preserving non-kapacitor entries), removes `~/.agents/skills/kapacitor-*` (+ legacy `~/.codex/skills/`), and deletes `~/.config/kapacitor/`.
- Flags: `--project` (also clean cwd's git-root `.claude/settings.local.json` + `.codex/hooks.json`; errors if not in a repo), `--keep-config` (preserve `~/.config/kapacitor` for reinstall), `--yes`/`-y` (skip prompt).
- Refactor: extracted `PluginCommand.RemoveClaudePlugin(settingsPath)` as a public helper so project-scope Claude removal doesn't have to mutate cwd.

Resolves [AI-742](https://linear.app/kurrent/issue/AI-742/cli-kapacitor-uninstall-command-for-full-local-removal).

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet publish -c Release` — no IL3050/IL2026 AOT warnings
- [x] Unit suite 1105/1105 passes (two consecutive runs locally)
- [x] New `UninstallCommandTests`:
  - user-level removal preserves non-kapacitor entries in `settings.json` / `hooks.json`
  - `--keep-config` preserves `~/.config/kapacitor`
  - `--project` strips project-scope entries
  - `--project` errors when not inside a git working tree
- [x] README updated with `### Uninstalling` subsection (per CLAUDE.md README-sync rule)
- [x] `help-uninstall.txt` resource added; `help-usage.txt` lists the new command
- [ ] Companion docs update on `kapacitor-web` (follow-up branch)

## Out of scope

Per-agent selective cleanup via `uninstall` (`kapacitor plugin remove [--codex|--cursor|--skills]` still handles that). Server-side daemon deregistration — local removal only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)