### PR TITLE
fix: clean up kapacitor → kcap rename leftovers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run unit tests
         # --maximum-parallel-tests 1 serializes the entire unit suite.
         # The codebase has many tests that mutate process-global state
-        # (Environment.SetEnvironmentVariable on HOME/PATH/KAPACITOR_*,
+        # (Environment.SetEnvironmentVariable on HOME/PATH/KCAP_*,
         # Console.SetOut/SetError) and rely on [NotInParallel(group)] to
         # serialize among themselves. Cross-group parallel execution still
         # races the shared process state intermittently on the slower

--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ kcap daemon doctor                  # diagnose lock-file state for every daemon 
 kcap daemon doctor --clean          # also remove stale lock/pid files (held entries are never touched)
 ```
 
+`KCAP_DAEMON_NAME` overrides the active profile's daemon name (superseded by an explicit `--name` flag).
+
 Each daemon process holds an exclusive `flock` on `~/.config/kcap/daemons/<name>.lock` for its entire lifetime. The kernel releases the lock automatically when the daemon exits (including `SIGKILL` or power-off), so leftover lock files on disk are never a blocker — only a live process holding the kernel-level lock can prevent another daemon from acquiring the same name.
 
 Two daemons with **different** `--name` values can run side-by-side. Two daemons under the **same name** on the same machine collide on the flock and the second one exits with code 2. Even if that guard is bypassed somehow, the server rejects the second daemon's `DaemonConnect` with a typed error and the second daemon exits with code 3 — no more silent slot-displacement oscillation.

--- a/npm/kcap/bin/kcap.js
+++ b/npm/kcap/bin/kcap.js
@@ -49,7 +49,7 @@ try {
 }
 
 const ext = process.platform === "win32" ? ".exe" : "";
-const binaryPath = path.join(binaryDir, "bin", `kapacitor${ext}`);
+const binaryPath = path.join(binaryDir, "bin", `kcap${ext}`);
 
 if (!fs.existsSync(binaryPath)) {
   console.error(`Binary not found at ${binaryPath}`);

--- a/scripts/cursor-hook-probe/cursor-hook-probe.sh
+++ b/scripts/cursor-hook-probe/cursor-hook-probe.sh
@@ -41,7 +41,7 @@ cat > "${BASE}.stdin.json" 2>/dev/null || true
     echo
     echo "# env (filtered)"
     env 2>/dev/null \
-        | grep -E '^(CURSOR_|KAPACITOR_|HOME=|PATH=|PWD=|SHELL=|USER=|LOGNAME=|TERM=)' \
+        | grep -E '^(CURSOR_|KCAP_|HOME=|PATH=|PWD=|SHELL=|USER=|LOGNAME=|TERM=)' \
         | sort \
         | sed 's/^/  /'
 } > "${BASE}.meta.txt" 2>/dev/null || true

--- a/src/Capacitor.Cli.Core/Resources/help-codex-hook.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-codex-hook.txt
@@ -20,7 +20,7 @@ install --codex` to register it via Codex's hooks framework.
 
 Daemon-bridge mode
 
-When KAPACITOR_DAEMON_URL is set (i.e. the hook is invoked inside a daemon-
+When KCAP_DAEMON_URL is set (i.e. the hook is invoked inside a daemon-
 launched hosted Codex agent), the PermissionRequest event bounces through the
 local daemon's permission bridge and forwards the dashboard's decision back to
 Codex. The legacy informational POST to the Capacitor server is skipped in
@@ -28,6 +28,6 @@ this mode.
 
 Bridge errors are fail-closed: the hook emits {"behavior": "deny"} and exits
 non-zero rather than falling back to allow. Outside daemon context (no
-KAPACITOR_DAEMON_URL), the hook posts to /hooks/permission-record (fire-and-
+KCAP_DAEMON_URL), the hook posts to /hooks/permission-record (fire-and-
 forget record) and yields without emitting a decision so Codex's own in-CLI
 approval prompt asks the user.

--- a/src/Capacitor.Cli.Core/Resources/help-disable.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-disable.txt
@@ -6,5 +6,5 @@ Stops the watcher, prevents future hook events from being sent,
 and deletes all session data from the server (streams + read models).
 
 Arguments:
-  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+  sessionId               Session ID (defaults to KCAP_SESSION_ID
                           on Claude or CODEX_THREAD_ID on Codex 0.81+)

--- a/src/Capacitor.Cli.Core/Resources/help-errors.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-errors.txt
@@ -6,5 +6,5 @@ Options:
   --chain                 Include all sessions in the continuation chain
 
 Arguments:
-  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+  sessionId               Session ID (defaults to KCAP_SESSION_ID
                           on Claude or CODEX_THREAD_ID on Codex 0.81+)

--- a/src/Capacitor.Cli.Core/Resources/help-eval.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-eval.txt
@@ -28,7 +28,7 @@ Notes:
   - Each judge has no tools — Read, Bash, Grep, WebFetch, etc. are all blocked.
     The full compacted trace is embedded in the prompt.
   - If the session ID is omitted, the currently-recorded session is used —
-    resolved from KAPACITOR_SESSION_ID (Claude) or CODEX_THREAD_ID
+    resolved from KCAP_SESSION_ID (Claude) or CODEX_THREAD_ID
     (Codex 0.81+).
 
 Examples:

--- a/src/Capacitor.Cli.Core/Resources/help-hide.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-hide.txt
@@ -6,5 +6,5 @@ Sets the current session's visibility to owner-only. Other users
 will no longer see this session in the dashboard.
 
 Arguments:
-  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+  sessionId               Session ID (defaults to KCAP_SESSION_ID
                           on Claude or CODEX_THREAD_ID on Codex 0.81+)

--- a/src/Capacitor.Cli.Core/Resources/help-recap.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-recap.txt
@@ -8,5 +8,5 @@ Options:
   --repo                  Show recent session summaries for the current repo
 
 Arguments:
-  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+  sessionId               Session ID (defaults to KCAP_SESSION_ID
                           on Claude or CODEX_THREAD_ID on Codex 0.81+)

--- a/src/Capacitor.Cli.Core/Resources/help-set-title.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-set-title.txt
@@ -6,5 +6,5 @@ Arguments:
   title                   Session title (max 120 characters)
 
 Environment:
-  Session ID is auto-resolved from KAPACITOR_SESSION_ID (Claude)
+  Session ID is auto-resolved from KCAP_SESSION_ID (Claude)
   or CODEX_THREAD_ID (Codex 0.81+).

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -66,7 +66,7 @@ Hook Commands (internal — used by Claude Code plugin):
   codex-hook                       Codex hooks dispatcher (single binary, branches on hook_event_name)
 
 Environment:
-  KAPACITOR_URL              Server URL (overrides config file)
-  KAPACITOR_SESSION_ID       Session ID set by the Claude Code SessionStart hook
+  KCAP_URL              Server URL (overrides config file)
+  KCAP_SESSION_ID       Session ID set by the Claude Code SessionStart hook
   CODEX_THREAD_ID            Session ID exported by Codex CLI 0.81+
-  KAPACITOR_DAEMON_NAME      Daemon name (overrides profile; superseded by --name)
+  KCAP_DAEMON_NAME      Daemon name (overrides profile; superseded by --name)

--- a/src/Capacitor.Cli.Core/Resources/help-validate-plan.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-validate-plan.txt
@@ -3,5 +3,5 @@ kcap validate-plan — Validate plan completion for a session
 Usage: kcap validate-plan [sessionId]
 
 Arguments:
-  sessionId               Session ID (defaults to KAPACITOR_SESSION_ID
+  sessionId               Session ID (defaults to KCAP_SESSION_ID
                           on Claude or CODEX_THREAD_ID on Codex 0.81+)


### PR DESCRIPTION
## Summary

The AI-736 rename (#108) missed three surfaces. This sweep fixes them.

- **`npm/kcap/bin/kcap.js`** looked for `bin/kapacitor`, but CI ships `bin/kcap` (see `release.yml:41,67`). This caused the user-reported failure:

  ```
  $ kcap setup
  Binary not found at /opt/homebrew/lib/node_modules/@kurrent/kcap/node_modules/@kurrent/kcap-darwin-arm64/bin/kapacitor
  ```

- **9× `src/Capacitor.Cli.Core/Resources/help-*.txt`** still documented `KAPACITOR_*` env vars. The code only reads `KCAP_*` (verified via `grep "GetEnvironmentVariable"` — code uses `KCAP_SESSION_ID`, `KCAP_URL`, `KCAP_DAEMON_URL`, `KCAP_DAEMON_NAME`, etc.). Users following `kcap --help` were setting non-existent vars.

- **`scripts/cursor-hook-probe/cursor-hook-probe.sh:44`** env-filter regex matched `KAPACITOR_` prefix, silently dropping `KCAP_*` from the probe output.

- **`.github/workflows/ci.yml:36`** — comment-only stale reference, refreshed for consistency.

Historic `docs/superpowers/plans/` and the local `.capacitor/` recording data are intentionally left alone.

## Test plan

- [x] `dotnet build Capacitor.slnx` — 0 errors
- [x] Unit tests: 1109 pass / 1 pre-existing flake (`Prepare_invokes_codex_config_writer_with_worktree_path`, unrelated — missing temp `.codex/config.toml`); matches main exactly
- [x] `grep -rln -i kapacitor src/ test/ scripts/ .github/ npm/` returns clean
- [ ] After merge & republish of `@kurrent/kcap`, verify `npm install -g @kurrent/kcap && kcap setup` succeeds on a fresh machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)