### PR TITLE
feat: recover renamed-cwd sessions via cwd_remap + report missing paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ This backfills your past sessions from `~/.claude/projects/` (Claude), `~/.codex
 
 You must pick an explicit scope (`--all`, `--org`, or `--repo`) so personal/private repos aren't uploaded by accident. `--org` uses the active profile name as the GitHub org login — it works out of the box when the profile was created by `kcap setup` (which names it after the picked tenant), and errors otherwise. Run with no scope on an interactive terminal to get a picker. See [Loading historical sessions](#loading-historical-sessions) for the full set of flags.
 
+If your repo directories have been renamed or deleted on disk, the import prints a list of unresolved cwds up front. See [Renamed repo directories (`cwd_remap`)](#renamed-repo-directories-cwd_remap) to recover those sessions.
+
 ### 4. Open the dashboard
 
 Open the server URL in your browser. The dashboard shows repositories, sessions, and agents. It updates in real time as Claude Code sessions are active.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ kcap import --org --session abc123           # single session
 
 Non-interactive runs (no TTY, e.g. CI) must pass both a scope flag and `--yes`. The command is idempotent and resumable — re-running with the same scope only uploads what's missing or incomplete. A server-side tracker deduplicates events on `(stream, eventId)` so previously-imported turns don't get re-appended.
 
+After discovery, the import surfaces a one-shot report of any transcript working directories that no longer exist on disk (typically deleted worktrees, or local repo dirs that have been renamed). Those sessions won't match an `--org` / `--repo` scope until you tell kcap how their old paths map to the new ones. See [Renamed repo directories (`cwd_remap`)](#renamed-repo-directories-cwd_remap) below for the fix.
+
 ### Daemon
 
 The daemon connects to the Capacitor server and runs Claude Code or Codex agents in isolated git worktrees, controlled from the dashboard. The daemon supports hosted Claude and Codex agents on macOS and Linux — choose the vendor from the dashboard's launch dialog. At startup the daemon probes `daemon.claude_path` and `daemon.codex_path` and advertises only the vendors it can actually spawn, so the launch dialog hides whichever agent isn't installed on the selected daemon.
@@ -460,6 +462,33 @@ kcap ignore --remove ~/code/secret-project
 ```
 
 Entries are stored on the **active profile**, so switching profiles with `kcap use` switches the ignore list too. Symlinks are resolved on both the stored entry and the session's reported cwd, so a worktree symlink and its target match.
+
+#### Renamed repo directories (`cwd_remap`)
+
+Historic transcripts record the absolute working directory they ran in. If you've since renamed or moved that directory on disk (e.g. `~/dev/foo-cli → ~/dev/bar-cli`), `kcap import --org` / `--repo` can't resolve those sessions to a GitHub repo any more and silently drops them from the matched count.
+
+To recover them, add `cwd_remap` to `~/.config/kcap/config.json` (no `kcap config set` shortcut — edit the file directly):
+
+```json
+{
+  "version": 2,
+  "active_profile": "default",
+  "profiles": { "default": { /* ... */ } },
+  "cwd_remap": [
+    { "from": "~/dev/eventstore/foo-cli", "to": "~/dev/eventstore/bar-cli" },
+    { "from": "~/dev/eventstore/foo",     "to": "~/dev/eventstore/bar"     }
+  ]
+}
+```
+
+Semantics:
+
+- `from` / `to` are **path-prefix** rewrites with `~` expanding to the current user's home directory. The match requires a path boundary (`from` exactly equal, or `from` followed by `/`), so `from: "~/dev/foo"` will **not** spuriously rewrite `~/dev/foo-cli`.
+- When multiple rules could apply to the same transcript cwd, the **longest** `from` wins.
+- Rules are applied once (no chaining), so the result of one rule isn't fed into another.
+- Remaps are global, not per-profile — same rename affects all profiles' imports.
+
+After editing, re-run `kcap import --org` (or whatever scope you use). The missing-cwd report at the top of the import will show what's still unresolved.
 
 ### Uninstalling
 

--- a/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
@@ -14,6 +14,25 @@ public record ProfileConfig {
 
     [JsonPropertyName("profile_bindings")]
     public Dictionary<string, string> ProfileBindings { get; init; } = new();
+
+    /// <summary>
+    /// Path-prefix remaps applied to historic transcript cwds before repository
+    /// detection. Useful when a local repo directory has been renamed (e.g.
+    /// <c>~/dev/kapacitor-cli → ~/dev/kcap-cli</c>) so old sessions can still
+    /// be resolved to their org/repo during <c>kcap import</c>.
+    /// Match is a path-boundary prefix (cwd == from || cwd starts with from + "/");
+    /// longest-from wins when multiple rules could apply.
+    /// </summary>
+    [JsonPropertyName("cwd_remap")]
+    public CwdRemap[] CwdRemap { get; init; } = [];
+}
+
+public record CwdRemap {
+    [JsonPropertyName("from")]
+    public string From { get; init; } = "";
+
+    [JsonPropertyName("to")]
+    public string To { get; init; } = "";
 }
 
 public record Profile {

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -1709,13 +1709,18 @@ static class ImportCommand {
 
     /// <summary>
     /// Replace the user's home directory prefix with <c>~</c> for display only.
-    /// Uses path-boundary matching so siblings like <c>/Users/alexeyfoo</c>
-    /// aren't accidentally shortened.
+    /// Uses path-boundary matching (either <c>/</c> or <c>\</c>) so siblings
+    /// like <c>/Users/alexeyfoo</c> aren't accidentally shortened, and follows
+    /// the host filesystem's case-sensitivity policy.
     /// </summary>
     internal static string ShortenHome(string path, string home) {
-        if (string.IsNullOrEmpty(home) || !path.StartsWith(home, StringComparison.Ordinal)) return path;
+        var comparison = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        if (string.IsNullOrEmpty(home) || !path.StartsWith(home, comparison)) return path;
         if (path.Length == home.Length) return "~";
-        return path[home.Length] == '/' ? "~" + path[home.Length..] : path;
+        return CwdRemapper.IsSeparator(path[home.Length]) ? "~" + path[home.Length..] : path;
     }
 
     static async Task<Dictionary<string, (string Owner, string Name)?>> ResolveTranscriptReposAsync(
@@ -1738,7 +1743,13 @@ static class ImportCommand {
 
             perTranscript[i] = (transcripts[i].SessionId, remapped);
 
-            if (remapped is not null) sessionCwds?.Add(transcripts[i].SessionId, remapped);
+            // Indexer assignment (not Add) so duplicate SessionIds across
+            // project dirs / backups can't abort the import. Last-write-wins
+            // is fine for the missing-cwd report — the cwd is functionally
+            // the same path anyway.
+            if (remapped is not null && sessionCwds is not null) {
+                sessionCwds[transcripts[i].SessionId] = remapped;
+            }
         }
 
         var uniqueCwds = perTranscript

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -514,8 +514,13 @@ static class ImportCommand {
 
         // Run file-based repo resolution. The helper takes a single codex bool;
         // since Claude and Codex differ only in cwd-extraction, run it per
-        // vendor and merge.
-        var resolved = new Dictionary<string, (string Owner, string Name)?>(StringComparer.Ordinal);
+        // vendor and merge. User-configured cwd remaps let historic transcripts
+        // referencing since-renamed local repo paths still resolve to a real
+        // git directory.
+        var profileConfig = await AppConfig.LoadProfileConfig();
+        var cwdRemap      = profileConfig.CwdRemap;
+        var resolved      = new Dictionary<string, (string Owner, string Name)?>(StringComparer.Ordinal);
+        var sessionCwds   = new Dictionary<string, string>(StringComparer.Ordinal);
 
         foreach (var vendor in new[] { "claude", "codex" }) {
             var slice = allFileTuples
@@ -525,14 +530,26 @@ static class ImportCommand {
 
             if (slice.Count == 0) continue;
 
-            var partial                                  = await ResolveTranscriptReposAsync(slice, codex: vendor == "codex", display);
+            var partial                                  = await ResolveTranscriptReposAsync(slice, codex: vendor == "codex", display, cwdRemap, sessionCwds);
             foreach (var kv in partial) resolved[kv.Key] = kv.Value;
         }
 
         // Resolve Cursor sessions in parallel by workspace path (dedup like
         // ResolveTranscriptReposAsync).
         if (cursorCwds.Count > 0) {
-            var uniqueWorkspaces = cursorCwds.Values
+            // Remap once per session so repo detection AND the missing-cwd
+            // report below see the same path.
+            var cursorRemapped = cursorCwds.ToDictionary(
+                kv => kv.Key,
+                kv => kv.Value is null ? null : CwdRemapper.Apply(kv.Value, cwdRemap),
+                StringComparer.Ordinal
+            );
+
+            foreach (var (sid, cwd) in cursorRemapped) {
+                if (cwd is not null) sessionCwds[sid] = cwd;
+            }
+
+            var uniqueWorkspaces = cursorRemapped.Values
                 .Where(c => c is not null)
                 .Cast<string>()
                 .Distinct(StringComparer.Ordinal)
@@ -557,10 +574,16 @@ static class ImportCommand {
                 );
             }
 
-            foreach (var (sid, cwd) in cursorCwds) {
+            foreach (var (sid, cwd) in cursorRemapped) {
                 resolved[sid] = cwd is not null && repoByCwd.TryGetValue(cwd, out var r) ? r : null;
             }
         }
+
+        // --- Missing cwd report ---
+        // Surface transcripts whose (possibly remapped) cwd no longer exists on
+        // disk so the user understands why some sessions won't match an org or
+        // repo scope, and can fix it by adding cwd_remap entries.
+        ReportMissingCwds(sessionCwds, cwdRemap, display);
 
         // --- Scope picker ---
         var kcapConfig = await AppConfig.Load();
@@ -1609,16 +1632,113 @@ static class ImportCommand {
     /// parallel, surfacing progress via a Spectre status spinner on a TTY and
     /// a plain status line otherwise.
     /// </summary>
+    /// <summary>
+    /// Print a one-shot summary of transcript cwds that don't exist on disk.
+    /// Most users with a long history accumulate references to deleted
+    /// worktrees and renamed repo directories, and those sessions silently
+    /// fail to match an --org/--repo scope. This output lets them spot the
+    /// gap before the import proceeds.
+    /// </summary>
+    internal static void ReportMissingCwds(
+            IReadOnlyDictionary<string, string> sessionCwds,
+            IReadOnlyList<CwdRemap>?            cwdRemap,
+            ImportDisplay                       display
+        ) {
+        if (sessionCwds.Count == 0) return;
+
+        var uniqueCwds = sessionCwds.Values.Distinct(StringComparer.Ordinal).ToList();
+        var missing    = uniqueCwds.Where(c => !Directory.Exists(c)).ToHashSet(StringComparer.Ordinal);
+
+        if (missing.Count == 0) return;
+
+        // Collapse descendants under missing ancestors — if /repo is missing,
+        // there's no value in also listing /repo/.claude/worktrees/agent-X.
+        var roots = CollapseDescendants(missing);
+
+        var sessionsAffected = sessionCwds.Values.Count(missing.Contains);
+        var sortedRoots      = roots.OrderBy(c => c, StringComparer.Ordinal).ToList();
+        var home             = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        var sessionWord = sessionsAffected == 1 ? "session references" : "sessions reference";
+        var pathWord    = sortedRoots.Count == 1 ? "path that no longer exists" : "distinct paths that no longer exist";
+        display.Line($"{sessionsAffected} {sessionWord} {sortedRoots.Count} {pathWord} on disk:");
+
+        const int sampleSize = 5;
+        foreach (var cwd in sortedRoots.Take(sampleSize)) display.Line($"  {ShortenHome(cwd, home)}");
+
+        if (sortedRoots.Count > sampleSize) {
+            display.Line($"  ... and {sortedRoots.Count - sampleSize} more");
+        }
+
+        var hint = cwdRemap is { Count: > 0 }
+            ? "Update the cwd_remap entries in your kcap config to map these to their new on-disk paths."
+            : "Add cwd_remap entries to your kcap config to map these to their new on-disk paths.";
+
+        display.Line(hint);
+    }
+
+    /// <summary>
+    /// Drop any path from <paramref name="paths"/> whose parent (at any depth)
+    /// is also in the set. Used to collapse worktree-style descendants like
+    /// <c>/repo/.claude/worktrees/agent-X</c> under their already-missing
+    /// parent <c>/repo</c> for a less noisy report.
+    /// </summary>
+    internal static HashSet<string> CollapseDescendants(IReadOnlySet<string> paths) {
+        var roots = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var p in paths) {
+            if (!HasAncestorIn(p, paths)) roots.Add(p);
+        }
+
+        return roots;
+
+        static bool HasAncestorIn(string path, IReadOnlySet<string> set) {
+            // Walk parent directories: /a/b/c → /a/b → /a → / (stop at root or
+            // when GetDirectoryName returns null/empty).
+            var parent = Path.GetDirectoryName(path);
+
+            while (!string.IsNullOrEmpty(parent) && parent != path) {
+                if (set.Contains(parent)) return true;
+                path   = parent;
+                parent = Path.GetDirectoryName(parent);
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Replace the user's home directory prefix with <c>~</c> for display only.
+    /// Uses path-boundary matching so siblings like <c>/Users/alexeyfoo</c>
+    /// aren't accidentally shortened.
+    /// </summary>
+    internal static string ShortenHome(string path, string home) {
+        if (string.IsNullOrEmpty(home) || !path.StartsWith(home, StringComparison.Ordinal)) return path;
+        if (path.Length == home.Length) return "~";
+        return path[home.Length] == '/' ? "~" + path[home.Length..] : path;
+    }
+
     static async Task<Dictionary<string, (string Owner, string Name)?>> ResolveTranscriptReposAsync(
             IReadOnlyList<(string SessionId, string FilePath, string EncodedCwd)> transcripts,
             bool                                                                  codex,
-            ImportDisplay                                                         display
+            ImportDisplay                                                         display,
+            IReadOnlyList<CwdRemap>?                                              cwdRemap    = null,
+            IDictionary<string, string>?                                          sessionCwds = null
         ) {
         // Extract cwd per transcript first (cheap: ≤20-line file read).
+        // Apply user-configured prefix remaps so historic transcripts pointing
+        // at since-renamed local directories still resolve. The per-session
+        // (remapped) cwd is also fed back to the caller via sessionCwds so the
+        // import flow can report which paths are missing on disk.
         var perTranscript = new (string SessionId, string? Cwd)[transcripts.Count];
 
         for (var i = 0; i < transcripts.Count; i++) {
-            perTranscript[i] = (transcripts[i].SessionId, ExtractCwdFromTranscript(transcripts[i].FilePath, codex));
+            var raw      = ExtractCwdFromTranscript(transcripts[i].FilePath, codex);
+            var remapped = raw is null ? null : CwdRemapper.Apply(raw, cwdRemap);
+
+            perTranscript[i] = (transcripts[i].SessionId, remapped);
+
+            if (remapped is not null) sessionCwds?.Add(transcripts[i].SessionId, remapped);
         }
 
         var uniqueCwds = perTranscript

--- a/src/Capacitor.Cli/CwdRemapper.cs
+++ b/src/Capacitor.Cli/CwdRemapper.cs
@@ -1,0 +1,68 @@
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli;
+
+/// <summary>
+/// Applies user-configured path-prefix remaps to a transcript cwd so historic
+/// sessions that recorded a since-renamed local repo path (e.g.
+/// <c>~/dev/kapacitor-cli</c> after rename to <c>~/dev/kcap-cli</c>) can still
+/// be matched to an on-disk git repository during <c>kcap import</c>.
+///
+/// Matching rules:
+/// - <c>~</c> or <c>~/</c> at the start of <c>from</c>/<c>to</c> is expanded to
+///   the current user's home directory (transcript cwds are absolute).
+/// - Path-boundary prefix: <c>cwd == from</c> or <c>cwd starts with from + "/"</c>,
+///   so <c>/dev/kapacitor</c> does NOT spuriously match <c>/dev/kapacitor-cli</c>.
+/// - Longest <c>from</c> wins when multiple rules could apply.
+/// - At most one remap is applied (no chaining), to keep behavior predictable.
+/// </summary>
+static class CwdRemapper {
+    public static string Apply(string cwd, IReadOnlyList<CwdRemap>? rules) =>
+        Apply(cwd, rules, Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+
+    // Internal seam so tests can pin the home directory and stay cross-platform.
+    internal static string Apply(string cwd, IReadOnlyList<CwdRemap>? rules, string home) {
+        if (rules is null or { Count: 0 } || string.IsNullOrEmpty(cwd)) return cwd;
+
+        CwdRemap? best       = null;
+        string?   bestFrom   = null;
+        string?   bestTo     = null;
+        var       bestLen    = -1;
+
+        foreach (var rule in rules) {
+            if (string.IsNullOrEmpty(rule.From) || rule.To is null) continue;
+
+            var from = ExpandHome(rule.From, home);
+
+            if (!IsPrefixMatch(cwd, from)) continue;
+
+            if (from.Length > bestLen) {
+                best     = rule;
+                bestFrom = from;
+                bestTo   = ExpandHome(rule.To, home);
+                bestLen  = from.Length;
+            }
+        }
+
+        if (best is null) return cwd;
+
+        // cwd == from → use 'to' verbatim; otherwise replace prefix + keep the
+        // tail (the leading '/' of the tail was at position from.Length).
+        return cwd.Length == bestFrom!.Length
+            ? bestTo!
+            : bestTo + cwd[bestFrom.Length..];
+    }
+
+    static string ExpandHome(string path, string home) {
+        if (path.Length == 0 || path[0] != '~') return path;
+        if (path.Length == 1) return home;                    // "~"
+        if (path[1] == '/') return home + path[1..];          // "~/foo"
+        return path;                                          // "~user" / "~foo" — leave alone
+    }
+
+    static bool IsPrefixMatch(string cwd, string from) {
+        if (!cwd.StartsWith(from, StringComparison.Ordinal)) return false;
+        if (cwd.Length == from.Length) return true;
+        return cwd[from.Length] == '/';
+    }
+}

--- a/src/Capacitor.Cli/CwdRemapper.cs
+++ b/src/Capacitor.Cli/CwdRemapper.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.Cli;
@@ -9,32 +10,46 @@ namespace Capacitor.Cli;
 /// be matched to an on-disk git repository during <c>kcap import</c>.
 ///
 /// Matching rules:
-/// - <c>~</c> or <c>~/</c> at the start of <c>from</c>/<c>to</c> is expanded to
-///   the current user's home directory (transcript cwds are absolute).
-/// - Path-boundary prefix: <c>cwd == from</c> or <c>cwd starts with from + "/"</c>,
-///   so <c>/dev/kapacitor</c> does NOT spuriously match <c>/dev/kapacitor-cli</c>.
+/// - <c>~</c> or <c>~/</c> (or <c>~\</c> on Windows) at the start of
+///   <c>from</c>/<c>to</c> is expanded to the current user's home directory
+///   (transcript cwds are absolute).
+/// - Path-boundary prefix: <c>cwd == from</c> or <c>cwd starts with from + sep</c>
+///   where <c>sep</c> is either <c>/</c> or <c>\</c>; so <c>/dev/kapacitor</c>
+///   does NOT spuriously match <c>/dev/kapacitor-cli</c>.
+/// - Comparisons are case-insensitive on Windows, case-sensitive elsewhere —
+///   matching the host filesystem's behavior.
 /// - Longest <c>from</c> wins when multiple rules could apply.
 /// - At most one remap is applied (no chaining), to keep behavior predictable.
 /// </summary>
 static class CwdRemapper {
+    static readonly StringComparison PathComparison =
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
     public static string Apply(string cwd, IReadOnlyList<CwdRemap>? rules) =>
         Apply(cwd, rules, Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
 
     // Internal seam so tests can pin the home directory and stay cross-platform.
-    internal static string Apply(string cwd, IReadOnlyList<CwdRemap>? rules, string home) {
+    internal static string Apply(string cwd, IReadOnlyList<CwdRemap>? rules, string home) =>
+        Apply(cwd, rules, home, PathComparison);
+
+    // Internal seam for tests that need to pin the comparison policy (so the
+    // case-sensitivity behavior can be exercised regardless of host OS).
+    internal static string Apply(string cwd, IReadOnlyList<CwdRemap>? rules, string home, StringComparison comparison) {
         if (rules is null or { Count: 0 } || string.IsNullOrEmpty(cwd)) return cwd;
 
-        CwdRemap? best       = null;
-        string?   bestFrom   = null;
-        string?   bestTo     = null;
-        var       bestLen    = -1;
+        CwdRemap? best     = null;
+        string?   bestFrom = null;
+        string?   bestTo   = null;
+        var       bestLen  = -1;
 
         foreach (var rule in rules) {
             if (string.IsNullOrEmpty(rule.From) || rule.To is null) continue;
 
             var from = ExpandHome(rule.From, home);
 
-            if (!IsPrefixMatch(cwd, from)) continue;
+            if (!IsPrefixMatch(cwd, from, comparison)) continue;
 
             if (from.Length > bestLen) {
                 best     = rule;
@@ -47,7 +62,7 @@ static class CwdRemapper {
         if (best is null) return cwd;
 
         // cwd == from → use 'to' verbatim; otherwise replace prefix + keep the
-        // tail (the leading '/' of the tail was at position from.Length).
+        // tail (the leading separator of the tail was at position from.Length).
         return cwd.Length == bestFrom!.Length
             ? bestTo!
             : bestTo + cwd[bestFrom.Length..];
@@ -55,14 +70,16 @@ static class CwdRemapper {
 
     static string ExpandHome(string path, string home) {
         if (path.Length == 0 || path[0] != '~') return path;
-        if (path.Length == 1) return home;                    // "~"
-        if (path[1] == '/') return home + path[1..];          // "~/foo"
-        return path;                                          // "~user" / "~foo" — leave alone
+        if (path.Length == 1) return home;                  // "~"
+        if (IsSeparator(path[1])) return home + path[1..];  // "~/foo" or "~\foo"
+        return path;                                        // "~user" / "~foo" — leave alone
     }
 
-    static bool IsPrefixMatch(string cwd, string from) {
-        if (!cwd.StartsWith(from, StringComparison.Ordinal)) return false;
+    static bool IsPrefixMatch(string cwd, string from, StringComparison comparison) {
+        if (!cwd.StartsWith(from, comparison)) return false;
         if (cwd.Length == from.Length) return true;
-        return cwd[from.Length] == '/';
+        return IsSeparator(cwd[from.Length]);
     }
+
+    internal static bool IsSeparator(char c) => c == '/' || c == '\\';
 }

--- a/test/Capacitor.Cli.Tests.Unit/CwdRemapperTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CwdRemapperTests.cs
@@ -74,6 +74,43 @@ public class CwdRemapperTests {
     }
 
     [Test]
+    public async Task Apply_matches_at_backslash_boundary_on_windows_style_paths() {
+        // Cwd uses Windows separators; rule does too. Boundary check must
+        // accept '\' as a separator regardless of host OS.
+        var rules = new[] { R(@"C:\dev\foo", @"C:\dev\bar") };
+        var result = CwdRemapper.Apply(@"C:\dev\foo\src\X", rules, "/home/u", StringComparison.OrdinalIgnoreCase);
+        await Assert.That(result).IsEqualTo(@"C:\dev\bar\src\X");
+    }
+
+    [Test]
+    public async Task Apply_does_not_cross_backslash_boundary() {
+        var rules = new[] { R(@"C:\dev\foo", @"C:\dev\bar") };
+        var result = CwdRemapper.Apply(@"C:\dev\foobar\x", rules, "/home/u", StringComparison.OrdinalIgnoreCase);
+        await Assert.That(result).IsEqualTo(@"C:\dev\foobar\x");
+    }
+
+    [Test]
+    public async Task Apply_is_case_insensitive_when_comparison_is_OrdinalIgnoreCase() {
+        var rules = new[] { R(@"C:\Users\Alice\Dev", @"C:\Users\Alice\New") };
+        var result = CwdRemapper.Apply(@"c:\users\alice\dev\src", rules, "/home/u", StringComparison.OrdinalIgnoreCase);
+        await Assert.That(result).IsEqualTo(@"C:\Users\Alice\New\src");
+    }
+
+    [Test]
+    public async Task Apply_is_case_sensitive_when_comparison_is_Ordinal() {
+        var rules = new[] { R("/dev/Foo", "/dev/Bar") };
+        var result = CwdRemapper.Apply("/dev/foo/x", rules, "/home/u", StringComparison.Ordinal);
+        await Assert.That(result).IsEqualTo("/dev/foo/x");
+    }
+
+    [Test]
+    public async Task Apply_expands_tilde_with_backslash_separator() {
+        var rules = new[] { R(@"~\dev\foo", @"~\dev\bar") };
+        var result = CwdRemapper.Apply(@"C:\Users\u\dev\foo\src", rules, @"C:\Users\u", StringComparison.OrdinalIgnoreCase);
+        await Assert.That(result).IsEqualTo(@"C:\Users\u\dev\bar\src");
+    }
+
+    [Test]
     public async Task Apply_exact_match_with_trailing_to_uses_to_verbatim() {
         // cwd == from: result is `to` verbatim, no trailing slash added.
         var rules = new[] { R("/dev/a", "/dev/b") };

--- a/test/Capacitor.Cli.Tests.Unit/CwdRemapperTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CwdRemapperTests.cs
@@ -1,0 +1,106 @@
+using Capacitor.Cli;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class CwdRemapperTests {
+    static CwdRemap R(string from, string to) => new() { From = from, To = to };
+
+    [Test]
+    public async Task Apply_with_null_rules_returns_cwd_unchanged() {
+        var result = CwdRemapper.Apply("/Users/alexey/dev/foo", null);
+        await Assert.That(result).IsEqualTo("/Users/alexey/dev/foo");
+    }
+
+    [Test]
+    public async Task Apply_with_empty_rules_returns_cwd_unchanged() {
+        var result = CwdRemapper.Apply("/Users/alexey/dev/foo", []);
+        await Assert.That(result).IsEqualTo("/Users/alexey/dev/foo");
+    }
+
+    [Test]
+    public async Task Apply_exact_prefix_match_rewrites_cwd() {
+        var rules = new[] { R("/dev/kapacitor-cli", "/dev/kcap-cli") };
+        var result = CwdRemapper.Apply("/dev/kapacitor-cli", rules);
+        await Assert.That(result).IsEqualTo("/dev/kcap-cli");
+    }
+
+    [Test]
+    public async Task Apply_path_boundary_prefix_match_preserves_tail() {
+        var rules = new[] { R("/dev/kapacitor-cli", "/dev/kcap-cli") };
+        var result = CwdRemapper.Apply("/dev/kapacitor-cli/src/Foo", rules);
+        await Assert.That(result).IsEqualTo("/dev/kcap-cli/src/Foo");
+    }
+
+    [Test]
+    public async Task Apply_does_not_match_across_path_boundary() {
+        // Rule for "/dev/kapacitor" must NOT match "/dev/kapacitor-cli" — the
+        // next char after the prefix is '-', not '/', so it's a different dir.
+        var rules = new[] { R("/dev/kapacitor", "/dev/kcap") };
+        var result = CwdRemapper.Apply("/dev/kapacitor-cli", rules);
+        await Assert.That(result).IsEqualTo("/dev/kapacitor-cli");
+    }
+
+    [Test]
+    public async Task Apply_longest_prefix_wins() {
+        var rules = new[] {
+            R("/dev/kapacitor",     "/dev/wrong"),
+            R("/dev/kapacitor-cli", "/dev/kcap-cli"),
+        };
+
+        var result = CwdRemapper.Apply("/dev/kapacitor-cli/src", rules);
+        await Assert.That(result).IsEqualTo("/dev/kcap-cli/src");
+    }
+
+    [Test]
+    public async Task Apply_non_matching_cwd_returns_unchanged() {
+        var rules = new[] { R("/dev/kapacitor", "/dev/kcap") };
+        var result = CwdRemapper.Apply("/Users/alexey/other", rules);
+        await Assert.That(result).IsEqualTo("/Users/alexey/other");
+    }
+
+    [Test]
+    public async Task Apply_skips_rules_with_empty_from() {
+        var rules = new[] { R("", "/whatever"), R("/dev/a", "/dev/b") };
+        var result = CwdRemapper.Apply("/dev/a/x", rules);
+        await Assert.That(result).IsEqualTo("/dev/b/x");
+    }
+
+    [Test]
+    public async Task Apply_handles_empty_cwd() {
+        var rules = new[] { R("/dev/a", "/dev/b") };
+        var result = CwdRemapper.Apply("", rules);
+        await Assert.That(result).IsEqualTo("");
+    }
+
+    [Test]
+    public async Task Apply_exact_match_with_trailing_to_uses_to_verbatim() {
+        // cwd == from: result is `to` verbatim, no trailing slash added.
+        var rules = new[] { R("/dev/a", "/dev/b") };
+        var result = CwdRemapper.Apply("/dev/a", rules);
+        await Assert.That(result).IsEqualTo("/dev/b");
+    }
+
+    [Test]
+    public async Task Apply_expands_tilde_in_from_and_to() {
+        var rules = new[] { R("~/dev/kapacitor-cli", "~/dev/kcap-cli") };
+        var result = CwdRemapper.Apply("/home/u/dev/kapacitor-cli/src", rules, "/home/u");
+        await Assert.That(result).IsEqualTo("/home/u/dev/kcap-cli/src");
+    }
+
+    [Test]
+    public async Task Apply_expands_bare_tilde_in_from() {
+        var rules = new[] { R("~", "/elsewhere") };
+        var result = CwdRemapper.Apply("/home/u/x", rules, "/home/u");
+        await Assert.That(result).IsEqualTo("/elsewhere/x");
+    }
+
+    [Test]
+    public async Task Apply_does_not_expand_tilde_username_form() {
+        // "~alice" is the ~user form; we don't expand it. Since the resulting
+        // 'from' starts with '~' and the cwd doesn't, no match → unchanged.
+        var rules = new[] { R("~alice/dev", "/home/alice/dev") };
+        var result = CwdRemapper.Apply("/home/u/dev", rules, "/home/u");
+        await Assert.That(result).IsEqualTo("/home/u/dev");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportMissingCwdsReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportMissingCwdsReportTests.cs
@@ -86,6 +86,14 @@ public class ImportMissingCwdsReportTests {
     }
 
     [Test]
+    public async Task ShortenHome_accepts_backslash_as_path_boundary() {
+        // Even on a non-Windows host the helper must accept '\' as a separator
+        // so transcripts that recorded Windows paths shrink correctly.
+        await Assert.That(ImportCommand.ShortenHome(@"C:\Users\alexey\dev\foo", @"C:\Users\alexey"))
+            .IsEqualTo(@"~\dev\foo");
+    }
+
+    [Test]
     public async Task CollapseDescendants_drops_worktree_when_parent_is_also_missing() {
         var input = new HashSet<string>(StringComparer.Ordinal) {
             "/dev/kapacitor",

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportMissingCwdsReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportMissingCwdsReportTests.cs
@@ -1,0 +1,158 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit.Import;
+
+public class ImportMissingCwdsReportTests {
+    [Test, NotInParallel]
+    public async Task Reports_missing_cwds_with_session_count_and_sample() {
+        var existing = Directory.CreateTempSubdirectory("kcap-cwd-test-").FullName;
+        try {
+            var sessionCwds = new Dictionary<string, string>(StringComparer.Ordinal) {
+                ["s1"] = "/does/not/exist/repo-a",
+                ["s2"] = "/does/not/exist/repo-a", // dup cwd → 1 distinct path, 2 sessions
+                ["s3"] = "/does/not/exist/repo-b",
+                ["s4"] = existing,
+            };
+
+            var output = Capture(d => ImportCommand.ReportMissingCwds(sessionCwds, cwdRemap: null, d));
+
+            await Assert.That(output).Contains("3 sessions reference 2 distinct paths that no longer exist on disk");
+            await Assert.That(output).Contains("/does/not/exist/repo-a");
+            await Assert.That(output).Contains("/does/not/exist/repo-b");
+            await Assert.That(output).DoesNotContain(existing); // existing dir not reported
+            await Assert.That(output).Contains("Add cwd_remap");
+        } finally {
+            Directory.Delete(existing, recursive: true);
+        }
+    }
+
+    [Test, NotInParallel]
+    public async Task Hint_shifts_to_update_when_cwd_remap_already_configured() {
+        var sessionCwds = new Dictionary<string, string>(StringComparer.Ordinal) {
+            ["s1"] = "/does/not/exist/repo-a",
+        };
+
+        var rules  = new[] { new CwdRemap { From = "/old", To = "/new" } };
+        var output = Capture(d => ImportCommand.ReportMissingCwds(sessionCwds, rules, d));
+
+        await Assert.That(output).Contains("Update the cwd_remap entries");
+    }
+
+    [Test, NotInParallel]
+    public async Task Stays_silent_when_all_cwds_exist() {
+        var existing = Directory.CreateTempSubdirectory("kcap-cwd-test-").FullName;
+        try {
+            var sessionCwds = new Dictionary<string, string>(StringComparer.Ordinal) {
+                ["s1"] = existing,
+            };
+
+            var output = Capture(d => ImportCommand.ReportMissingCwds(sessionCwds, cwdRemap: null, d));
+
+            await Assert.That(output).IsEmpty();
+        } finally {
+            Directory.Delete(existing, recursive: true);
+        }
+    }
+
+    [Test, NotInParallel]
+    public async Task Stays_silent_when_no_sessions_have_cwds() {
+        var output = Capture(d => ImportCommand.ReportMissingCwds(new Dictionary<string, string>(), cwdRemap: null, d));
+
+        await Assert.That(output).IsEmpty();
+    }
+
+    [Test]
+    public async Task ShortenHome_rewrites_home_prefix_to_tilde() {
+        await Assert.That(ImportCommand.ShortenHome("/Users/alexey/dev/foo", "/Users/alexey"))
+            .IsEqualTo("~/dev/foo");
+    }
+
+    [Test]
+    public async Task ShortenHome_returns_tilde_for_exact_home() {
+        await Assert.That(ImportCommand.ShortenHome("/Users/alexey", "/Users/alexey")).IsEqualTo("~");
+    }
+
+    [Test]
+    public async Task ShortenHome_does_not_shrink_across_path_boundary() {
+        // /Users/alexeyfoo must NOT become ~foo
+        await Assert.That(ImportCommand.ShortenHome("/Users/alexeyfoo/dev", "/Users/alexey"))
+            .IsEqualTo("/Users/alexeyfoo/dev");
+    }
+
+    [Test]
+    public async Task ShortenHome_passes_through_non_home_paths() {
+        await Assert.That(ImportCommand.ShortenHome("/var/tmp/x", "/Users/alexey")).IsEqualTo("/var/tmp/x");
+    }
+
+    [Test]
+    public async Task CollapseDescendants_drops_worktree_when_parent_is_also_missing() {
+        var input = new HashSet<string>(StringComparer.Ordinal) {
+            "/dev/kapacitor",
+            "/dev/kapacitor/.claude/worktrees/agent-1",
+            "/dev/kapacitor/.claude/worktrees/agent-2",
+        };
+
+        var roots = ImportCommand.CollapseDescendants(input);
+
+        await Assert.That(roots).IsEquivalentTo(new[] { "/dev/kapacitor" });
+    }
+
+    [Test]
+    public async Task CollapseDescendants_keeps_siblings_when_no_common_parent_missing() {
+        // /a/x and /a/y both missing, /a NOT missing → both remain.
+        var input = new HashSet<string>(StringComparer.Ordinal) { "/a/x", "/a/y" };
+
+        var roots = ImportCommand.CollapseDescendants(input);
+
+        await Assert.That(roots).IsEquivalentTo(new[] { "/a/x", "/a/y" });
+    }
+
+    [Test, NotInParallel]
+    public async Task Report_collapses_worktree_descendants_in_output() {
+        var sessionCwds = new Dictionary<string, string>(StringComparer.Ordinal) {
+            ["s1"] = "/dev/kapacitor",
+            ["s2"] = "/dev/kapacitor/.claude/worktrees/agent-1",
+            ["s3"] = "/dev/kapacitor/.claude/worktrees/agent-2",
+            ["s4"] = "/dev/other-repo",
+        };
+
+        var output = Capture(d => ImportCommand.ReportMissingCwds(sessionCwds, cwdRemap: null, d));
+
+        // 2 distinct roots (kapacitor + other-repo), 4 sessions still affected.
+        await Assert.That(output).Contains("4 sessions reference 2 distinct paths");
+        await Assert.That(output).Contains("/dev/kapacitor\n");
+        await Assert.That(output).Contains("/dev/other-repo");
+        await Assert.That(output).DoesNotContain("worktrees/agent-1");
+        await Assert.That(output).DoesNotContain("worktrees/agent-2");
+    }
+
+    [Test, NotInParallel]
+    public async Task Truncates_sample_to_five_distinct_paths() {
+        var sessionCwds = new Dictionary<string, string>(StringComparer.Ordinal) {
+            ["s1"] = "/missing/a",
+            ["s2"] = "/missing/b",
+            ["s3"] = "/missing/c",
+            ["s4"] = "/missing/d",
+            ["s5"] = "/missing/e",
+            ["s6"] = "/missing/f",
+            ["s7"] = "/missing/g",
+        };
+
+        var output = Capture(d => ImportCommand.ReportMissingCwds(sessionCwds, cwdRemap: null, d));
+
+        await Assert.That(output).Contains("... and 2 more");
+    }
+
+    static string Capture(Action<ImportCommand.ImportDisplay> render) {
+        var sw      = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(sw);
+        try {
+            render(new() { Tty = false });
+        } finally {
+            Console.SetOut(prevOut);
+        }
+        return sw.ToString();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `cwd_remap` to the global `~/.config/kcap/config.json` — a list of `{from, to}` path-prefix rewrites with `~` expansion, path-boundary matching, and longest-from-wins. Applied during `kcap import` before `RepositoryDetection.DetectRepositoryAsync`, so historic transcripts whose recorded cwd has since been renamed on disk (e.g. `~/dev/kapacitor-cli → ~/dev/kcap-cli`) can still be matched to an `--org` / `--repo` scope.
- Surfaces a one-shot **missing-cwd report** at the top of every import run: the count of transcripts whose (remapped) cwd still doesn't exist on disk, plus a deduped/sorted sample with the home prefix shortened to `~` and worktree descendants collapsed under already-missing parents. Hint text adapts ("Add" vs "Update the cwd_remap entries") based on whether rules are already configured.
- README updated under **Configuration** with the full schema and semantics, cross-linked from the import section.

## Motivation

Long histories (`~/.claude/projects/*/*.jsonl`, etc.) accumulate references to deleted worktrees and renamed local repo directories. Those sessions silently dropped out of the matched count during `kcap import --org`, with no signal to the user. After this change a 632-session history that was matching 57 surfaces both the recoverable cases (via `cwd_remap`) and the truly-gone ones (deleted worktrees) up-front.

## Test plan

- [x] `dotnet run --project test/Capacitor.Cli.Tests.Unit -- --treenode-filter "/*/*/CwdRemapperTests/*"` — 13/13 pass
- [x] `dotnet run --project test/Capacitor.Cli.Tests.Unit -- --treenode-filter "/*/*/ImportMissingCwdsReportTests/*"` — 12/12 pass
- [x] `dotnet run --project test/Capacitor.Cli.Tests.Unit -- --treenode-filter "/*/*.Import/*/*"` — 122/122 pass (existing import tests, signature change)
- [x] `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release` — no IL3050/IL2026 warnings
- [ ] Manual run: `kcap import --org kurrent-io` on a host with renamed repo dirs; verify report lines + remap recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)