### PR TITLE
feat: add `kcap remap` command for managing import cwd rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This backfills your past sessions from `~/.claude/projects/` (Claude), `~/.codex
 
 You must pick an explicit scope (`--all`, `--org`, or `--repo`) so personal/private repos aren't uploaded by accident. `--org` uses the active profile name as the GitHub org login — it works out of the box when the profile was created by `kcap setup` (which names it after the picked tenant), and errors otherwise. Run with no scope on an interactive terminal to get a picker. See [Loading historical sessions](#loading-historical-sessions) for the full set of flags.
 
-If your repo directories have been renamed or deleted on disk, the import prints a list of unresolved cwds up front. See [Renamed repo directories (`cwd_remap`)](#renamed-repo-directories-cwd_remap) to recover those sessions.
+If your repo directories have been renamed or deleted on disk, the import prints a list of unresolved cwds up front. See [Renamed repo directories (`kcap remap`)](#renamed-repo-directories-kcap-remap) to recover those sessions.
 
 ### 4. Open the dashboard
 
@@ -287,7 +287,7 @@ kcap import --org --session abc123           # single session
 
 Non-interactive runs (no TTY, e.g. CI) must pass both a scope flag and `--yes`. The command is idempotent and resumable — re-running with the same scope only uploads what's missing or incomplete. A server-side tracker deduplicates events on `(stream, eventId)` so previously-imported turns don't get re-appended.
 
-After discovery, the import surfaces a one-shot report of any transcript working directories that no longer exist on disk (typically deleted worktrees, or local repo dirs that have been renamed). Those sessions won't match an `--org` / `--repo` scope until you tell kcap how their old paths map to the new ones. See [Renamed repo directories (`cwd_remap`)](#renamed-repo-directories-cwd_remap) below for the fix.
+After discovery, the import surfaces a one-shot report of any transcript working directories that no longer exist on disk (typically deleted worktrees, or local repo dirs that have been renamed). Those sessions won't match an `--org` / `--repo` scope until you tell kcap how their old paths map to the new ones. See [Renamed repo directories (`kcap remap`)](#renamed-repo-directories-kcap-remap) below for the fix.
 
 ### Daemon
 
@@ -465,32 +465,29 @@ kcap ignore --remove ~/code/secret-project
 
 Entries are stored on the **active profile**, so switching profiles with `kcap use` switches the ignore list too. Symlinks are resolved on both the stored entry and the session's reported cwd, so a worktree symlink and its target match.
 
-#### Renamed repo directories (`cwd_remap`)
+#### Renamed repo directories (`kcap remap`)
 
 Historic transcripts record the absolute working directory they ran in. If you've since renamed or moved that directory on disk (e.g. `~/dev/foo-cli → ~/dev/bar-cli`), `kcap import --org` / `--repo` can't resolve those sessions to a GitHub repo any more and silently drops them from the matched count.
 
-To recover them, add `cwd_remap` to `~/.config/kcap/config.json` (no `kcap config set` shortcut — edit the file directly):
+Manage the rewrites with `kcap remap`:
 
-```json
-{
-  "version": 2,
-  "active_profile": "default",
-  "profiles": { "default": { /* ... */ } },
-  "cwd_remap": [
-    { "from": "~/dev/eventstore/foo-cli", "to": "~/dev/eventstore/bar-cli" },
-    { "from": "~/dev/eventstore/foo",     "to": "~/dev/eventstore/bar"     }
-  ]
-}
+```bash
+kcap remap ~/dev/eventstore/foo-cli ~/dev/eventstore/bar-cli   # add or replace a mapping
+kcap remap --list                                              # show all mappings
+kcap remap --remove ~/dev/eventstore/foo-cli                   # drop one
 ```
+
+Entries are stored at the top of `~/.config/kcap/config.json` under `cwd_remap` (a top-level JSON array of `{ "from": ..., "to": ... }` objects) — you can also edit the file directly for bulk changes.
 
 Semantics:
 
-- `from` / `to` are **path-prefix** rewrites with `~` expanding to the current user's home directory. The match requires a path boundary (`from` exactly equal, or `from` followed by `/`), so `from: "~/dev/foo"` will **not** spuriously rewrite `~/dev/foo-cli`.
+- `from` / `to` are **path-prefix** rewrites with `~` expanding to the current user's home directory (`~\` is also accepted on Windows). The match requires a path boundary (`from` exactly equal, or `from` followed by `/` — or `\` on Windows), so `from: "~/dev/foo"` will **not** spuriously rewrite `~/dev/foo-cli`.
+- Comparisons follow the host filesystem's case policy: case-insensitive on Windows, case-sensitive elsewhere.
 - When multiple rules could apply to the same transcript cwd, the **longest** `from` wins.
 - Rules are applied once (no chaining), so the result of one rule isn't fed into another.
 - Remaps are global, not per-profile — same rename affects all profiles' imports.
 
-After editing, re-run `kcap import --org` (or whatever scope you use). The missing-cwd report at the top of the import will show what's still unresolved.
+After adding a remap, re-run `kcap import --org` (or whichever scope you use). The missing-cwd report at the top of the import will show what's still unresolved — typically deleted worktrees that no remap can recover.
 
 ### Uninstalling
 

--- a/src/Capacitor.Cli.Core/Resources/help-remap.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-remap.txt
@@ -1,0 +1,33 @@
+kcap remap — Rewrite recorded transcript cwds during import
+
+Usage: kcap remap <from> <to>
+       kcap remap --list
+       kcap remap --remove <from>
+
+Historic transcripts record an absolute working directory. If you've since
+renamed or moved that directory on disk (e.g. ~/dev/foo-cli → ~/dev/bar-cli),
+`kcap import --org` / `--repo` can't resolve those sessions to a GitHub repo
+because git can no longer be run inside a path that doesn't exist. The
+import command prints a one-shot report of missing cwds at the top of every
+run; add a remap for each one you want to recover.
+
+Matching semantics (applied by `kcap import`):
+  - Path-prefix rewrite: `cwd == from` or `cwd starts with from + sep`,
+    where sep is `/` (or `\` on Windows). So `~/dev/foo` will NOT match
+    `~/dev/foo-cli`.
+  - `~` (and `~\` on Windows) expand to the current user's home directory
+    at apply time, so entries stay portable across users / hosts.
+  - Comparison follows the host filesystem's case policy:
+    case-insensitive on Windows, case-sensitive elsewhere.
+  - Longest `from` wins when multiple rules apply.
+  - Rules are applied once (no chaining).
+
+Scope:
+  Stored at the **top level** of `~/.config/kcap/config.json` — remaps are
+  GLOBAL across all profiles, since the same on-disk rename affects every
+  profile's import.
+
+Examples:
+  kcap remap ~/dev/eventstore/foo-cli ~/dev/eventstore/bar-cli
+  kcap remap --list
+  kcap remap --remove ~/dev/eventstore/foo-cli

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -22,6 +22,9 @@ Configuration:
   ignore <path>                    Exclude a path (and descendants) from session recording
   ignore --list                    List excluded paths in the active profile
   ignore --remove <path>           Remove a path from the exclusion list
+  remap <from> <to>                Rewrite a recorded transcript cwd prefix during import (renamed/moved repos)
+  remap --list                     List configured cwd remaps
+  remap --remove <from>            Remove a cwd remap entry
 
 Daemon:
   daemon start [-d] [--name N]     Start the daemon (foreground, or -d for background; refuses on duplicate name)

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -1671,8 +1671,8 @@ static class ImportCommand {
         }
 
         var hint = cwdRemap is { Count: > 0 }
-            ? "Update the cwd_remap entries in your kcap config to map these to their new on-disk paths."
-            : "Add cwd_remap entries to your kcap config to map these to their new on-disk paths.";
+            ? "Run `kcap remap <from> <to>` to update or add mappings to their new on-disk paths."
+            : "Run `kcap remap <from> <to>` to map these to their new on-disk paths.";
 
         display.Line(hint);
     }

--- a/src/Capacitor.Cli/Commands/RemapCommand.cs
+++ b/src/Capacitor.Cli/Commands/RemapCommand.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.Cli.Commands;
@@ -14,6 +15,18 @@ namespace Capacitor.Cli.Commands;
 /// by <see cref="CwdRemapper"/>.
 /// </summary>
 public static class RemapCommand {
+    /// <summary>
+    /// Mirror <see cref="CwdRemapper"/>'s policy so a stored entry and the
+    /// argument typed at the CLI compare with the same case sensitivity that
+    /// the import-time matcher uses. Otherwise a user on Windows could type
+    /// <c>~/Dev/Foo</c> once and <c>~/dev/foo</c> later and end up with two
+    /// stored rules that both fire at import time.
+    /// </summary>
+    static readonly StringComparison FromComparison =
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
     public static async Task<int> HandleAsync(string[] args) {
         // args[0] == "remap"; --help / -h is handled by the dispatcher in Program.cs.
         if (args.Length < 2) return Usage();
@@ -104,13 +117,18 @@ public static class RemapCommand {
     /// Returns the new array and a flag indicating whether an existing entry
     /// was overwritten. Exposed for testing.
     /// </summary>
-    public static (CwdRemap[] Next, bool Replaced) ApplyAdd(CwdRemap[]? current, string from, string to) {
-        var arr  = current ?? [];
-        var next = new CwdRemap[arr.Length];
+    public static (CwdRemap[] Next, bool Replaced) ApplyAdd(CwdRemap[]? current, string from, string to) =>
+        ApplyAdd(current, from, to, FromComparison);
+
+    // Internal seam for tests that need to pin the comparison policy
+    // regardless of host OS.
+    internal static (CwdRemap[] Next, bool Replaced) ApplyAdd(CwdRemap[]? current, string from, string to, StringComparison comparison) {
+        var arr      = current ?? [];
+        var next     = new CwdRemap[arr.Length];
         var replaced = false;
 
         for (var i = 0; i < arr.Length; i++) {
-            if (SameFrom(arr[i].From, from)) {
+            if (SameFrom(arr[i].From, from, comparison)) {
                 next[i]  = new() { From = from, To = to };
                 replaced = true;
             } else {
@@ -128,14 +146,19 @@ public static class RemapCommand {
     /// <paramref name="from"/>. Returns the unchanged array if no match.
     /// Exposed for testing.
     /// </summary>
-    public static CwdRemap[] ApplyRemove(CwdRemap[]? current, string from) {
+    public static CwdRemap[] ApplyRemove(CwdRemap[]? current, string from) =>
+        ApplyRemove(current, from, FromComparison);
+
+    // Internal seam for tests that need to pin the comparison policy
+    // regardless of host OS.
+    internal static CwdRemap[] ApplyRemove(CwdRemap[]? current, string from, StringComparison comparison) {
         var arr = current ?? [];
 
-        return arr.Where(r => !SameFrom(r.From, from)).ToArray();
+        return arr.Where(r => !SameFrom(r.From, from, comparison)).ToArray();
     }
 
-    static bool SameFrom(string stored, string input) =>
-        string.Equals(Normalize(stored), Normalize(input), StringComparison.Ordinal);
+    static bool SameFrom(string stored, string input, StringComparison comparison) =>
+        string.Equals(Normalize(stored), Normalize(input), comparison);
 
     static bool TryNormalize(string path, out string normalized, out string error) {
         var n = Normalize(path);

--- a/src/Capacitor.Cli/Commands/RemapCommand.cs
+++ b/src/Capacitor.Cli/Commands/RemapCommand.cs
@@ -1,0 +1,181 @@
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// CLI surface for managing <see cref="ProfileConfig.CwdRemap"/> — the
+/// path-prefix rewrites that <c>kcap import</c> applies before repository
+/// detection, so historic transcripts referencing since-renamed local repo
+/// directories can still match an <c>--org</c>/<c>--repo</c> scope.
+///
+/// Entries are stored at the top of <c>~/.config/kcap/config.json</c>
+/// (global, not per-profile) — the same rename affects every profile's
+/// import. <c>~</c> is kept literal in storage and expanded at apply time
+/// by <see cref="CwdRemapper"/>.
+/// </summary>
+public static class RemapCommand {
+    public static async Task<int> HandleAsync(string[] args) {
+        // args[0] == "remap"; --help / -h is handled by the dispatcher in Program.cs.
+        if (args.Length < 2) return Usage();
+
+        switch (args[1]) {
+            case "--list":
+                return await List();
+            case "--remove" when args.Length < 3:
+                await Console.Error.WriteLineAsync("Usage: kcap remap --remove <from>");
+
+                return 1;
+            case "--remove":
+                return await Remove(args[2]);
+            default:
+                if (args.Length < 3) return Usage();
+
+                return await Add(args[1], args[2]);
+        }
+    }
+
+    static async Task<int> Add(string from, string to) {
+        if (!TryNormalize(from, out var nFrom, out var fromError)) {
+            await Console.Error.WriteLineAsync($"Invalid from path '{from}': {fromError}");
+
+            return 1;
+        }
+
+        if (!TryNormalize(to, out var nTo, out var toError)) {
+            await Console.Error.WriteLineAsync($"Invalid to path '{to}': {toError}");
+
+            return 1;
+        }
+
+        var config = await AppConfig.LoadProfileConfig();
+        var (next, replaced) = ApplyAdd(config.CwdRemap, nFrom, nTo);
+        await AppConfig.SaveProfileConfig(config with { CwdRemap = next });
+
+        await Console.Out.WriteLineAsync(replaced
+            ? $"Updated remap: {nFrom} → {nTo}"
+            : $"Added remap: {nFrom} → {nTo}");
+
+        return 0;
+    }
+
+    static async Task<int> Remove(string from) {
+        if (!TryNormalize(from, out var nFrom, out var error)) {
+            await Console.Error.WriteLineAsync($"Invalid from path '{from}': {error}");
+
+            return 1;
+        }
+
+        var config = await AppConfig.LoadProfileConfig();
+        var next = ApplyRemove(config.CwdRemap, nFrom);
+
+        if (next.Length == (config.CwdRemap?.Length ?? 0)) {
+            await Console.Out.WriteLineAsync($"Not in remap list: {nFrom}");
+
+            return 0;
+        }
+
+        await AppConfig.SaveProfileConfig(config with { CwdRemap = next });
+        await Console.Out.WriteLineAsync($"Removed remap: {nFrom}");
+
+        return 0;
+    }
+
+    static async Task<int> List() {
+        var config = await AppConfig.LoadProfileConfig();
+        var rules  = config.CwdRemap ?? [];
+
+        if (rules.Length == 0) {
+            await Console.Out.WriteLineAsync("No remap entries.");
+
+            return 0;
+        }
+
+        await Console.Out.WriteLineAsync("Cwd remaps:");
+
+        foreach (var r in rules) {
+            await Console.Out.WriteLineAsync($"  {r.From} → {r.To}");
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Pure: add or replace a remap entry keyed by normalized <c>from</c>.
+    /// Returns the new array and a flag indicating whether an existing entry
+    /// was overwritten. Exposed for testing.
+    /// </summary>
+    public static (CwdRemap[] Next, bool Replaced) ApplyAdd(CwdRemap[]? current, string from, string to) {
+        var arr  = current ?? [];
+        var next = new CwdRemap[arr.Length];
+        var replaced = false;
+
+        for (var i = 0; i < arr.Length; i++) {
+            if (SameFrom(arr[i].From, from)) {
+                next[i]  = new() { From = from, To = to };
+                replaced = true;
+            } else {
+                next[i] = arr[i];
+            }
+        }
+
+        return replaced
+            ? (next, true)
+            : ([..arr, new CwdRemap { From = from, To = to }], false);
+    }
+
+    /// <summary>
+    /// Pure: drop the entry whose normalized <c>from</c> equals
+    /// <paramref name="from"/>. Returns the unchanged array if no match.
+    /// Exposed for testing.
+    /// </summary>
+    public static CwdRemap[] ApplyRemove(CwdRemap[]? current, string from) {
+        var arr = current ?? [];
+
+        return arr.Where(r => !SameFrom(r.From, from)).ToArray();
+    }
+
+    static bool SameFrom(string stored, string input) =>
+        string.Equals(Normalize(stored), Normalize(input), StringComparison.Ordinal);
+
+    static bool TryNormalize(string path, out string normalized, out string error) {
+        var n = Normalize(path);
+
+        if (string.IsNullOrEmpty(n)) {
+            normalized = "";
+            error      = "path is empty";
+
+            return false;
+        }
+
+        normalized = n;
+        error      = "";
+
+        return true;
+    }
+
+    /// <summary>
+    /// Trim whitespace and trailing path separators (both <c>/</c> and <c>\</c>),
+    /// so users adding the same prefix with or without a trailing slash hit the
+    /// same stored entry. Otherwise stored as-is — <c>~</c> stays literal so
+    /// the value remains portable across users / hosts, and is expanded at
+    /// apply time by <see cref="CwdRemapper"/>.
+    /// </summary>
+    internal static string Normalize(string? path) {
+        if (string.IsNullOrWhiteSpace(path)) return "";
+
+        var trimmed = path.Trim();
+        // Preserve a single leading "/" or "\" — only strip trailing separators.
+        var end = trimmed.Length;
+        while (end > 1 && (trimmed[end - 1] == '/' || trimmed[end - 1] == '\\')) end--;
+
+        return trimmed[..end];
+    }
+
+    static int Usage() {
+        Console.Error.WriteLine("Usage: kcap remap <from> <to>");
+        Console.Error.WriteLine("       kcap remap --list");
+        Console.Error.WriteLine("       kcap remap --remove <from>");
+
+        return 1;
+    }
+}

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -75,7 +75,7 @@ if (args.Skip(1).Any(a => a is "--help" or "-h")) {
 }
 
 // Commands that don't need a server URL
-string[] offlineCommands = ["--help", "-h", "help", "--version", "-v", "logout", "cleanup", "config", "daemon", "setup", "status", "update", "plugin", "profile", "use", "repos", "login", "ignore", "uninstall"];
+string[] offlineCommands = ["--help", "-h", "help", "--version", "-v", "logout", "cleanup", "config", "daemon", "setup", "status", "update", "plugin", "profile", "use", "repos", "login", "ignore", "remap", "uninstall"];
 
 if (baseUrl is null && !offlineCommands.Contains(command)) {
     Console.Error.WriteLine("No server configured. Run `kcap setup` or set KCAP_URL.");
@@ -252,6 +252,8 @@ switch (command) {
         return await ConfigCommand.HandleAsync(args);
     case "ignore":
         return await IgnoreCommand.HandleAsync(args);
+    case "remap":
+        return await RemapCommand.HandleAsync(args);
     case "repos":
         return await ReposCommand.HandleAsync(args);
     case "update":

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportMissingCwdsReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportMissingCwdsReportTests.cs
@@ -21,7 +21,7 @@ public class ImportMissingCwdsReportTests {
             await Assert.That(output).Contains("/does/not/exist/repo-a");
             await Assert.That(output).Contains("/does/not/exist/repo-b");
             await Assert.That(output).DoesNotContain(existing); // existing dir not reported
-            await Assert.That(output).Contains("Add cwd_remap");
+            await Assert.That(output).Contains("kcap remap");
         } finally {
             Directory.Delete(existing, recursive: true);
         }
@@ -36,7 +36,7 @@ public class ImportMissingCwdsReportTests {
         var rules  = new[] { new CwdRemap { From = "/old", To = "/new" } };
         var output = Capture(d => ImportCommand.ReportMissingCwds(sessionCwds, rules, d));
 
-        await Assert.That(output).Contains("Update the cwd_remap entries");
+        await Assert.That(output).Contains("update or add mappings");
     }
 
     [Test, NotInParallel]

--- a/test/Capacitor.Cli.Tests.Unit/RemapCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RemapCommandTests.cs
@@ -100,4 +100,45 @@ public class RemapCommandTests {
     public async Task Normalize_trims_whitespace_around_path() {
         await Assert.That(RemapCommand.Normalize("  /a/b  ")).IsEqualTo("/a/b");
     }
+
+    [Test]
+    public async Task ApplyAdd_with_OrdinalIgnoreCase_replaces_case_variant_entry() {
+        // On Windows, "C:\Users\Alice" and "c:\users\alice" refer to the same
+        // dir at import time, so kcap remap should replace — not duplicate —
+        // when the user re-adds with different casing.
+        var current = new[] { R(@"C:\Users\Alice\Dev", @"C:\Users\Alice\Old") };
+        var (next, replaced) = RemapCommand.ApplyAdd(
+            current, @"c:\users\alice\dev", @"C:\Users\Alice\New", StringComparison.OrdinalIgnoreCase);
+
+        await Assert.That(replaced).IsTrue();
+        await Assert.That(next).HasCount(1);
+        await Assert.That(next[0].From).IsEqualTo(@"c:\users\alice\dev"); // new casing wins
+        await Assert.That(next[0].To).IsEqualTo(@"C:\Users\Alice\New");
+    }
+
+    [Test]
+    public async Task ApplyAdd_with_Ordinal_keeps_case_variant_as_separate_entry() {
+        // On non-Windows hosts, case differences must stay distinct — two
+        // separate paths.
+        var current = new[] { R("/dev/Foo", "/dev/v1") };
+        var (next, replaced) = RemapCommand.ApplyAdd(
+            current, "/dev/foo", "/dev/v2", StringComparison.Ordinal);
+
+        await Assert.That(replaced).IsFalse();
+        await Assert.That(next).HasCount(2);
+    }
+
+    [Test]
+    public async Task ApplyRemove_with_OrdinalIgnoreCase_removes_case_variant_entry() {
+        var current = new[] { R(@"C:\Users\Alice\Dev", @"C:\Users\Alice\New") };
+        var next    = RemapCommand.ApplyRemove(current, @"c:\users\alice\dev", StringComparison.OrdinalIgnoreCase);
+        await Assert.That(next).IsEmpty();
+    }
+
+    [Test]
+    public async Task ApplyRemove_with_Ordinal_keeps_case_variant_entry() {
+        var current = new[] { R("/dev/Foo", "/dev/x") };
+        var next    = RemapCommand.ApplyRemove(current, "/dev/foo", StringComparison.Ordinal);
+        await Assert.That(next).HasCount(1);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/RemapCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RemapCommandTests.cs
@@ -1,0 +1,103 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class RemapCommandTests {
+    static CwdRemap R(string from, string to) => new() { From = from, To = to };
+
+    [Test]
+    public async Task ApplyAdd_appends_new_entry() {
+        var (next, replaced) = RemapCommand.ApplyAdd([], "/old", "/new");
+
+        await Assert.That(replaced).IsFalse();
+        await Assert.That(next).HasCount(1);
+        await Assert.That(next[0].From).IsEqualTo("/old");
+        await Assert.That(next[0].To).IsEqualTo("/new");
+    }
+
+    [Test]
+    public async Task ApplyAdd_to_null_current_treats_as_empty() {
+        var (next, replaced) = RemapCommand.ApplyAdd(null, "/old", "/new");
+
+        await Assert.That(replaced).IsFalse();
+        await Assert.That(next).HasCount(1);
+    }
+
+    [Test]
+    public async Task ApplyAdd_replaces_when_from_already_exists() {
+        var current          = new[] { R("/old", "/v1"), R("/other", "/keep") };
+        var (next, replaced) = RemapCommand.ApplyAdd(current, "/old", "/v2");
+
+        await Assert.That(replaced).IsTrue();
+        await Assert.That(next).HasCount(2);
+        await Assert.That(next.Single(r => r.From == "/old").To).IsEqualTo("/v2");
+        await Assert.That(next.Single(r => r.From == "/other").To).IsEqualTo("/keep");
+    }
+
+    [Test]
+    public async Task ApplyAdd_treats_trailing_slash_as_same_entry() {
+        // Normalize trims trailing separators, so "/old" and "/old/" collide.
+        var current          = new[] { R("/old", "/v1") };
+        var (next, replaced) = RemapCommand.ApplyAdd(current, "/old/", "/v2");
+
+        await Assert.That(replaced).IsTrue();
+        await Assert.That(next).HasCount(1);
+        // Note: ApplyAdd does NOT normalize the args itself (HandleAsync does
+        // that before calling). This test exercises the SameFrom comparator.
+    }
+
+    [Test]
+    public async Task ApplyRemove_drops_matching_entry() {
+        var current = new[] { R("/a", "/x"), R("/b", "/y") };
+        var next    = RemapCommand.ApplyRemove(current, "/a");
+
+        await Assert.That(next).HasCount(1);
+        await Assert.That(next[0].From).IsEqualTo("/b");
+    }
+
+    [Test]
+    public async Task ApplyRemove_returns_same_count_when_not_found() {
+        var current = new[] { R("/a", "/x") };
+        var next    = RemapCommand.ApplyRemove(current, "/missing");
+
+        await Assert.That(next).HasCount(1);
+    }
+
+    [Test]
+    public async Task ApplyRemove_on_null_current_returns_empty() {
+        var next = RemapCommand.ApplyRemove(null, "/a");
+        await Assert.That(next).IsEmpty();
+    }
+
+    [Test]
+    public async Task ApplyRemove_treats_trailing_slash_as_same_entry() {
+        var current = new[] { R("/a", "/x") };
+        var next    = RemapCommand.ApplyRemove(current, "/a/");
+        await Assert.That(next).IsEmpty();
+    }
+
+    [Test]
+    public async Task Normalize_trims_trailing_separators() {
+        await Assert.That(RemapCommand.Normalize("/a/b/")).IsEqualTo("/a/b");
+        await Assert.That(RemapCommand.Normalize(@"C:\a\b\")).IsEqualTo(@"C:\a\b");
+    }
+
+    [Test]
+    public async Task Normalize_preserves_root_separator() {
+        // "/" and "\" alone must not collapse to empty.
+        await Assert.That(RemapCommand.Normalize("/")).IsEqualTo("/");
+        await Assert.That(RemapCommand.Normalize(@"\")).IsEqualTo(@"\");
+    }
+
+    [Test]
+    public async Task Normalize_returns_empty_for_whitespace() {
+        await Assert.That(RemapCommand.Normalize("   ")).IsEqualTo("");
+        await Assert.That(RemapCommand.Normalize(null)).IsEqualTo("");
+    }
+
+    [Test]
+    public async Task Normalize_trims_whitespace_around_path() {
+        await Assert.That(RemapCommand.Normalize("  /a/b  ")).IsEqualTo("/a/b");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a dedicated `kcap remap` subcommand for managing the `cwd_remap` entries introduced in #111. Two-field `{from, to}` records don't fit cleanly into the comma-separated `kcap config set excluded_repos "..."` shape, so this mirrors the `kcap ignore` pattern instead.

```bash
kcap remap ~/dev/eventstore/foo-cli ~/dev/eventstore/bar-cli   # add or replace
kcap remap --list
kcap remap --remove ~/dev/eventstore/foo-cli
```

- `RemapCommand` writes to `ProfileConfig.CwdRemap` (top-level, global) via the existing `AppConfig.LoadProfileConfig` / `SaveProfileConfig` path.
- Adding a duplicate `from` replaces the existing entry (`Updated remap:` feedback). Trailing `/` and `\` are trimmed so `/a` and `/a/` collide on the same key. `~` is kept literal in storage and expanded at apply time by `CwdRemapper`.
- The missing-cwd report hint now says **"Run \`kcap remap <from> <to>\`..."** instead of pointing at the JSON file. Existing `ImportMissingCwdsReportTests` updated to match.
- `help-remap.txt` covers full matching semantics; `help-usage.txt` lists the three new lines.
- README's "Renamed repo directories" section now leads with the command; the JSON layout stays documented for bulk edits.

## Test plan

- [x] \`dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj -c Release\` — clean
- [x] \`dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release\` — no IL3050/IL2026
- [x] \`RemapCommandTests\` — 12/12 pass
- [x] \`ImportMissingCwdsReportTests\` — 13/13 pass (hint text updated)
- [x] Smoke: \`kcap remap --help\` / \`kcap remap --list\` against the AOT-published binary

## Follow-up

kcap-web docs PR #23 will be updated in a follow-up commit (already drafted locally) to lead with \`kcap remap\` instead of "edit the JSON".

🤖 Generated with [Claude Code](https://claude.com/claude-code)