### PR TITLE
[AI-752] Ping server after `kcap setup` completes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The setup wizard walks you through:
 4. **Coding-agent hooks** — detects Claude Code and Codex CLI on `PATH`, and Cursor by user-dir presence (`~/.cursor/`), then offers to install hooks/skills for each (user-wide)
 5. **Daemon** — configure the daemon name for remote agent execution
 
+When setup finishes, `kcap` sends a best-effort POST to the server's `/api/users/me/cli-setup` endpoint so the dashboard can mark your CLI as registered and surface the import-past-sessions hint. The call is capped at 5 seconds and failures are silent — they do not affect setup completion.
+
 Verify with `kcap whoami` and `kcap status`.
 
 For non-interactive environments:

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -244,6 +244,12 @@ public static class SetupCommand {
         await AppConfig.SaveProfileConfig(profileConfig);
 
         var finalTokens = await TokenStore.LoadAsync();
+
+        // AI-752: tell the server this user has finished CLI setup, so the dashboard
+        // can flip the new-tenant welcome modal from "Waiting for CLI to register"
+        // to "Registered". Best-effort — never block setup completion on this.
+        await PingCliSetupAsync(serverUrl);
+
         AnsiConsole.Write(new Rule("[green]Setup complete[/]").LeftJustified());
 
         var grid = new Grid().AddColumn().AddColumn();
@@ -349,6 +355,31 @@ public static class SetupCommand {
         var repoPlugin = Path.GetFullPath(Path.Combine(exeDir, "..", "..", "kcap"));
 
         return Directory.Exists(repoPlugin) ? repoPlugin : null;
+    }
+
+    // AI-752 — best-effort signal to the server that this user has completed CLI setup.
+    // Silently swallows network/auth/server errors: the welcome-modal nudge is a UX
+    // affordance, not part of the contract of `kcap setup`.
+    static async Task PingCliSetupAsync(string serverUrl) {
+        try {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(serverUrl, cts.Token);
+
+            // No bearer header => server uses Auth:None or our local tokens are gone.
+            // Either way the welcome modal doesn't gate startup, so just skip silently.
+            if (client.DefaultRequestHeaders.Authorization is null) return;
+
+            var version = typeof(SetupCommand).Assembly.GetName().Version?.ToString();
+            var payload = new StringContent(
+                $$"""{"cliVersion":{{(version is null ? "null" : "\"" + version + "\"")}}}""",
+                System.Text.Encoding.UTF8,
+                "application/json");
+
+            using var response = await client.PostAsync($"{serverUrl.TrimEnd('/')}/api/users/me/cli-setup", payload, cts.Token);
+            // 204 NoContent on success; anything else just means "older server / down" — that's fine.
+        } catch {
+            // Swallow — see method-doc.
+        }
     }
 
     static string? GetArg(string[] args, string name) {

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -360,14 +360,25 @@ public static class SetupCommand {
     // AI-752 — best-effort signal to the server that this user has completed CLI setup.
     // Silently swallows network/auth/server errors: the welcome-modal nudge is a UX
     // affordance, not part of the contract of `kcap setup`.
+    //
+    // Two reliability rules (kcap-cli#113 review):
+    //   • Don't use HttpClientExtensions.CreateAuthenticatedClientAsync — its
+    //     TokenStore.GetValidTokensAsync refresh path makes HTTP calls that
+    //     don't honor a CancellationToken and can block far longer than any
+    //     CTS-based timeout. The user just logged in moments ago in this same
+    //     command, so a non-expired token is the expected case; if it's
+    //     missing or expired we silently skip rather than triggering a refresh.
+    //   • Cap the operation with Task.WhenAny(ping, Task.Delay(5s)) so the
+    //     wall-clock bound is enforced independently of what HttpClient does
+    //     internally. If the delay wins, HttpClient disposal on method-exit
+    //     cancels the in-flight POST.
     static async Task PingCliSetupAsync(string serverUrl) {
         try {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(serverUrl, cts.Token);
+            var tokens = await TokenStore.LoadAsync();
+            if (tokens is null || tokens.IsExpired) return;
 
-            // No bearer header => server uses Auth:None or our local tokens are gone.
-            // Either way the welcome modal doesn't gate startup, so just skip silently.
-            if (client.DefaultRequestHeaders.Authorization is null) return;
+            using var http = new HttpClient();
+            http.DefaultRequestHeaders.Authorization = new("Bearer", tokens.AccessToken);
 
             var version = typeof(SetupCommand).Assembly.GetName().Version?.ToString();
             var payload = new StringContent(
@@ -375,8 +386,24 @@ public static class SetupCommand {
                 System.Text.Encoding.UTF8,
                 "application/json");
 
-            using var response = await client.PostAsync($"{serverUrl.TrimEnd('/')}/api/users/me/cli-setup", payload, cts.Token);
-            // 204 NoContent on success; anything else just means "older server / down" — that's fine.
+            var pingTask = http.PostAsync($"{serverUrl.TrimEnd('/')}/api/users/me/cli-setup", payload);
+            var winner   = await Task.WhenAny(pingTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+            if (winner == pingTask) {
+                // Observe the result so any exception is consumed by the outer
+                // catch (instead of surfacing as UnobservedTaskException later).
+                (await pingTask).Dispose();
+            } else {
+                // Wall-clock cap hit. HttpClient.Dispose() at method-exit
+                // cancels the in-flight POST; observe the orphan so its
+                // cancellation exception doesn't go unhandled.
+                _ = pingTask.ContinueWith(
+                    t => {
+                        if (t.IsCompletedSuccessfully) t.Result.Dispose();
+                        _ = t.Exception; // mark observed
+                    },
+                    TaskScheduler.Default);
+            }
         } catch {
             // Swallow — see method-doc.
         }


### PR DESCRIPTION
## Summary

- `kcap setup` ends with a best-effort 5s-timeout POST to `/api/users/me/cli-setup` so the new dashboard welcome modal (see [kcap-server#687](https://github.com/kurrent-io/kcap-server/pull/687)) can live-flip from "Waiting for CLI to register" to the import-past-sessions prompt without the user reloading.
- All failures (network, missing tokens, server too old) are swallowed — the welcome modal is purely a UX affordance and must never affect the contract of `kcap setup`.

Pairs with [AI-752 in Linear](https://linear.app/kurrent/issue/AI-752/more-welcoming-new-tenant-needed) and [kcap-server#687](https://github.com/kurrent-io/kcap-server/pull/687); merge order doesn't matter — older CLIs / older servers both gracefully skip.

## Test plan

- [ ] `kcap setup` against a server running kcap-server#687: dashboard modal flips live after the final "Setup complete" rule renders.
- [ ] `kcap setup` against an older server (no `/api/users/me/cli-setup` route): completes normally, no error surfaced to the user.
- [ ] `kcap setup` with no network: completes normally, no error surfaced to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)