### PR TITLE
Highlight matched-session count in import scope summary

### DIFF
--- a/src/Capacitor.Cli/Commands/ImportScopePrompt.cs
+++ b/src/Capacitor.Cli/Commands/ImportScopePrompt.cs
@@ -143,12 +143,36 @@ public static partial class ImportScopePrompt {
             bool                  skip
         ) {
         var summary = FormatSummary(scope, matchedCount, repoSamples, visibilityDescription);
-        Console.Error.WriteLine(summary);
+        WriteSummaryToStderr(summary, matchedCount);
 
         if (skip) return true;
 
         return AnsiConsole.Prompt(
             new ConfirmationPrompt("Continue?") { DefaultValue = false }
         );
+    }
+
+    // Render the summary to stderr (visible even when stdout is redirected),
+    // highlighting the matched-session count so it's the line the operator's
+    // eye lands on. Spectre auto-strips markup on non-TTY stderr (e.g. CI),
+    // so the printed text stays equivalent to FormatSummary's plain form.
+    static void WriteSummaryToStderr(string summary, int matchedCount) {
+        var console = AnsiConsole.Create(
+            new AnsiConsoleSettings { Out = new AnsiConsoleOutput(Console.Error) }
+        );
+
+        const string matchedPrefix = "  matched: ";
+        var          countStr      = matchedCount.ToString();
+
+        foreach (var rawLine in summary.Split('\n')) {
+            var line = rawLine.TrimEnd('\r');
+
+            if (line.StartsWith(matchedPrefix, StringComparison.Ordinal)) {
+                var tail = line[(matchedPrefix.Length + countStr.Length)..];
+                console.MarkupLine($"{matchedPrefix}[bold cyan]{countStr}[/]{Markup.Escape(tail)}");
+            } else {
+                console.WriteLine(line);
+            }
+        }
     }
 }

--- a/src/Capacitor.Cli/Commands/ImportScopePrompt.cs
+++ b/src/Capacitor.Cli/Commands/ImportScopePrompt.cs
@@ -47,29 +47,40 @@ public static partial class ImportScopePrompt {
             IReadOnlyList<string> repoSamples,
             string                visibilityDescription
         ) {
-        var scopeLabel = scope switch {
-            ImportScope.All    => "everything",
-            ImportScope.Org o  => $"org repos only ({o.OrgLogin})",
-            ImportScope.Repo r => $"repository {r.Owner}/{r.Name}",
-            _                  => "?"
-        };
+        var sb = new StringBuilder();
+        sb.AppendLine("About to import:");
+        sb.AppendLine($"  scope:   {ScopeLabel(scope)}");
+        sb.AppendLine($"{MatchedPrefix}{matchedCount}{MatchedSuffix(matchedCount, repoSamples.Count)}");
+        sb.AppendLine($"  repos:   {RepoLine(repoSamples)}");
+        sb.Append($"  visibility: {visibilityDescription}");
 
+        return sb.ToString();
+    }
+
+    // Shared between the plain-text FormatSummary and the colored stderr
+    // renderer in PromptConfirm so both code paths stay byte-for-byte
+    // identical to each other without either one parsing the other's
+    // output.
+    const string MatchedPrefix = "  matched: ";
+
+    static string ScopeLabel(ImportScope scope) => scope switch {
+        ImportScope.All    => "everything",
+        ImportScope.Org o  => $"org repos only ({o.OrgLogin})",
+        ImportScope.Repo r => $"repository {r.Owner}/{r.Name}",
+        _                  => "?"
+    };
+
+    static string MatchedSuffix(int matchedCount, int repoCount) =>
+        $" session{(matchedCount == 1 ? "" : "s")} across {repoCount} repo{(repoCount == 1 ? "" : "s")}";
+
+    static string RepoLine(IReadOnlyList<string> repoSamples) {
         const int sampleLimit = 5;
         var       samples     = repoSamples.Take(sampleLimit).ToArray();
         var       more        = repoSamples.Count - samples.Length;
 
-        var repoLine = samples.Length == 0
+        return samples.Length == 0
             ? "(none)"
             : string.Join(", ", samples) + (more > 0 ? $", +{more} more" : "");
-
-        var sb = new StringBuilder();
-        sb.AppendLine("About to import:");
-        sb.AppendLine($"  scope:   {scopeLabel}");
-        sb.AppendLine($"  matched: {matchedCount} session{(matchedCount == 1 ? "" : "s")} across {repoSamples.Count} repo{(repoSamples.Count == 1 ? "" : "s")}");
-        sb.AppendLine($"  repos:   {repoLine}");
-        sb.Append($"  visibility: {visibilityDescription}");
-
-        return sb.ToString();
     }
 }
 
@@ -142,8 +153,7 @@ public static partial class ImportScopePrompt {
             string                visibilityDescription,
             bool                  skip
         ) {
-        var summary = FormatSummary(scope, matchedCount, repoSamples, visibilityDescription);
-        WriteSummaryToStderr(summary, matchedCount);
+        WriteSummaryToStderr(scope, matchedCount, repoSamples, visibilityDescription);
 
         if (skip) return true;
 
@@ -154,25 +164,27 @@ public static partial class ImportScopePrompt {
 
     // Render the summary to stderr (visible even when stdout is redirected),
     // highlighting the matched-session count so it's the line the operator's
-    // eye lands on. Spectre auto-strips markup on non-TTY stderr (e.g. CI),
-    // so the printed text stays equivalent to FormatSummary's plain form.
-    static void WriteSummaryToStderr(string summary, int matchedCount) {
+    // eye lands on. Lines are composed from the same per-component helpers
+    // FormatSummary uses, so the rendered text stays in lock-step with the
+    // canonical form without parsing it. Spectre auto-strips markup on
+    // non-TTY stderr (e.g. CI), so the printed text matches FormatSummary
+    // byte-for-byte in CI logs.
+    static void WriteSummaryToStderr(
+            ImportScope           scope,
+            int                   matchedCount,
+            IReadOnlyList<string> repoSamples,
+            string                visibilityDescription
+        ) {
         var console = AnsiConsole.Create(
             new AnsiConsoleSettings { Out = new AnsiConsoleOutput(Console.Error) }
         );
 
-        const string matchedPrefix = "  matched: ";
-        var          countStr      = matchedCount.ToString();
-
-        foreach (var rawLine in summary.Split('\n')) {
-            var line = rawLine.TrimEnd('\r');
-
-            if (line.StartsWith(matchedPrefix, StringComparison.Ordinal)) {
-                var tail = line[(matchedPrefix.Length + countStr.Length)..];
-                console.MarkupLine($"{matchedPrefix}[bold cyan]{countStr}[/]{Markup.Escape(tail)}");
-            } else {
-                console.WriteLine(line);
-            }
-        }
+        console.WriteLine("About to import:");
+        console.WriteLine($"  scope:   {ScopeLabel(scope)}");
+        console.MarkupLine(
+            $"{MatchedPrefix}[bold cyan]{matchedCount}[/]{Markup.Escape(MatchedSuffix(matchedCount, repoSamples.Count))}"
+        );
+        console.WriteLine($"  repos:   {RepoLine(repoSamples)}");
+        console.WriteLine($"  visibility: {visibilityDescription}");
     }
 }


### PR DESCRIPTION
## Summary
- Render the `matched: N sessions` line in bold cyan when stderr is a TTY, so the number the operator is about to confirm stands out from the rest of the scope/visibility/repos block.
- `FormatSummary` stays plain text (it's the canonical form for CI logs and unit tests). The new helper renders via a stderr-wired Spectre console; Spectre auto-strips markup on non-TTY stderr, so CI output is unchanged.

## Test plan
- [x] `dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj` — clean
- [x] `dotnet run --project test/Capacitor.Cli.Tests.Unit -- --treenode-filter '/*/*/ImportScopePromptTests/*'` — 7/7 pass (existing assertions on plain text still hold)
- [ ] Eyeball `kcap import --org kurrent-io` in a real terminal — confirm the count pops

🤖 Generated with [Claude Code](https://claude.com/claude-code)