### PR TITLE
fix: recognise legacy `kapacitor codex-hook` marker in Codex hooks parser

### DIFF
--- a/src/Capacitor.Cli.Core/CodexHooksParser.cs
+++ b/src/Capacitor.Cli.Core/CodexHooksParser.cs
@@ -32,7 +32,8 @@ public static class CodexHooksParser {
         foreach (var hook in hooks) {
             if (hook?["command"] is JsonValue jv &&
                 jv.TryGetValue<string>(out var cmd) &&
-                (cmd.Contains("kcap codex-hook") || cmd.Contains("kapacitor codex-hook"))) {
+                (cmd.Contains("kcap codex-hook", StringComparison.Ordinal)
+              || cmd.Contains("kapacitor codex-hook", StringComparison.Ordinal))) {
                 return true;
             }
         }

--- a/src/Capacitor.Cli.Core/CodexHooksParser.cs
+++ b/src/Capacitor.Cli.Core/CodexHooksParser.cs
@@ -21,7 +21,10 @@ public static class CodexHooksParser {
 
     /// <summary>
     /// Returns true if <paramref name="entry"/> is a hooks.json group whose
-    /// <c>hooks[].command</c> contains <c>kcap codex-hook</c>.
+    /// <c>hooks[].command</c> contains <c>kcap codex-hook</c>, or the
+    /// pre-rename <c>kapacitor codex-hook</c>. Recognising the legacy
+    /// marker lets <c>kcap uninstall</c> (and the upgrade-time refresh)
+    /// clean up entries left over from the kapacitor CLI.
     /// </summary>
     public static bool EntryReferencesCapacitorCodexHook(JsonNode? entry) {
         if (entry?["hooks"] is not JsonArray hooks) return false;
@@ -29,7 +32,7 @@ public static class CodexHooksParser {
         foreach (var hook in hooks) {
             if (hook?["command"] is JsonValue jv &&
                 jv.TryGetValue<string>(out var cmd) &&
-                cmd.Contains("kcap codex-hook")) {
+                (cmd.Contains("kcap codex-hook") || cmd.Contains("kapacitor codex-hook"))) {
                 return true;
             }
         }

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexHooksParserTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexHooksParserTests.cs
@@ -11,6 +11,14 @@ public class CodexHooksParserTests {
     }
 
     [Test]
+    public async Task EntryReferencesCapacitorCodexHook_returns_true_for_legacy_kapacitor_marker() {
+        // Pre-rename installs wrote `kapacitor codex-hook`; uninstall and the
+        // upgrade-time refresh must still recognise them so they can be cleaned.
+        var entry = JsonNode.Parse("""{"hooks":[{"type":"command","command":"kapacitor codex-hook","timeout":30}]}""");
+        await Assert.That(CodexHooksParser.EntryReferencesCapacitorCodexHook(entry)).IsTrue();
+    }
+
+    [Test]
     public async Task EntryReferencesCapacitorCodexHook_returns_false_when_command_does_not_match() {
         var entry = JsonNode.Parse("""{"hooks":[{"type":"command","command":"echo hi","timeout":30}]}""");
         await Assert.That(CodexHooksParser.EntryReferencesCapacitorCodexHook(entry)).IsFalse();

--- a/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -112,6 +112,37 @@ public class UninstallCommandTests {
     }
 
     [Test]
+    public async Task User_level_uninstall_removes_legacy_kapacitor_codex_hooks() {
+        // Regression: a user who installed via the pre-rename `kapacitor` CLI
+        // has hooks.json entries pointing at `kapacitor codex-hook`. Running
+        // `kcap uninstall` must clean those up — the rename PR did not migrate
+        // the detection marker, so legacy entries previously survived.
+        await using var fixture = await Fixture.CreateAsync();
+
+        var codexDir = Path.Combine(fixture.Home, ".codex");
+        Directory.CreateDirectory(codexDir);
+        var codexHooks = Path.Combine(codexDir, "hooks.json");
+        await File.WriteAllTextAsync(codexHooks, """
+            {
+              "hooks": {
+                "SessionStart": [
+                  { "hooks": [{ "type": "command", "command": "user-script", "timeout": 5 }] },
+                  { "hooks": [{ "type": "command", "command": "kapacitor codex-hook", "timeout": 30 }] }
+                ]
+              }
+            }
+            """);
+
+        var exit = await UninstallCommand.HandleAsync(["uninstall", "--yes", "--keep-config"]);
+        await Assert.That(exit).IsEqualTo(0);
+
+        var codexRoot    = JsonNode.Parse(await File.ReadAllTextAsync(codexHooks))!.AsObject();
+        var sessionStart = codexRoot["hooks"]!["SessionStart"]!.AsArray();
+        await Assert.That(sessionStart.Count).IsEqualTo(1);
+        await Assert.That(sessionStart[0]!["hooks"]![0]!["command"]!.GetValue<string>()).IsEqualTo("user-script");
+    }
+
+    [Test]
     public async Task Keep_config_preserves_config_dir_but_removes_integrations() {
         await using var fixture = await Fixture.CreateAsync();
 


### PR DESCRIPTION
## Summary

- `kcap uninstall` previously left pre-rename Codex hook entries in `~/.codex/hooks.json` because the parser only matched the post-rename `kcap codex-hook` marker.
- Extends `CodexHooksParser.EntryReferencesCapacitorCodexHook` to also detect the legacy `kapacitor codex-hook` string. The same parser is reused by `IsInstalled`, `InstallCodexHooks`, and `RemoveCodexHooks`, so the fix unblocks the upgrade-time refresh wired up in `npm/kcap/bin/postinstall.js` as well as the uninstall path.
- Adds a parser unit test and an uninstall regression test that mirror the reported scenario.

Refs [AI-756](https://linear.app/kurrent/issue/AI-756/cli-hook-command-consistency) — this closes the Codex slice; Cursor (`kapacitor hook --cursor`) and Claude (`kapacitor@*` / marketplace `kapacitor`) have the same shape and remain tracked there.

## Test plan

- [x] `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/CodexHooksParserTests/*"`
- [x] `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/UninstallCommandTests/*"`
- [x] Full unit suite (1185 tests) passes.
- [x] `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release` — no IL3050/IL2026 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)