### PR TITLE
fix: route history imports to /hooks/session-start/{vendor}

### DIFF
--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -2120,7 +2120,6 @@ static class ImportCommand {
         if (meta.FirstTimestamp is not null) startHook["started_at"]                = meta.FirstTimestamp.Value.ToString("O");
         if (session.PreviousSessionId is not null) startHook["previous_session_id"] = session.PreviousSessionId;
         if (meta.Slug is not null) startHook["slug"]                                = meta.Slug;
-        if (session.Vendor != "claude") startHook["vendor"]                         = session.Vendor;
 
         // Codex sessions carry a `git` block on session_meta — prefer it over a fresh
         // RepositoryDetection probe (which reads the live git config and might disagree
@@ -2155,9 +2154,15 @@ static class ImportCommand {
             }
         }
 
+        // The /hooks/session-start route binds vendor from the URL path
+        // (/session-start/{vendor=claude}); a body-level `vendor` field is
+        // ignored. Codex history imports that posted to /hooks/session-start
+        // (no path vendor) silently landed as claude-tagged SessionStarted
+        // events on KurrentDB, and the projector then wrote sessions.vendor =
+        // claude even though the transcript was a codex rollout.
         try {
             using var startContent = new StringContent(startHook.ToJsonString(), Encoding.UTF8, "application/json");
-            using var startResp    = await httpClient.PostWithRetryAsync($"{baseUrl}/hooks/session-start", startContent, ct: ct);
+            using var startResp    = await httpClient.PostWithRetryAsync($"{baseUrl}/hooks/session-start/{session.Vendor}", startContent, ct: ct);
 
             if (!startResp.IsSuccessStatusCode) {
                 events.OnSessionErrored(slot, session.SessionId, $"session-start failed: HTTP {(int)startResp.StatusCode}");
@@ -2204,9 +2209,11 @@ static class ImportCommand {
 
         var generateWhatsDone = false;
 
+        // Same vendor-in-URL contract applies to /hooks/session-end (see the
+        // session-start comment above) — symmetric route, same default of claude.
         try {
             using var endContent = new StringContent(endHook.ToJsonString(), Encoding.UTF8, "application/json");
-            using var endResp    = await httpClient.PostWithRetryAsync($"{baseUrl}/hooks/session-end", endContent, ct: ct);
+            using var endResp    = await httpClient.PostWithRetryAsync($"{baseUrl}/hooks/session-end/{session.Vendor}", endContent, ct: ct);
 
             if (endResp.IsSuccessStatusCode) {
                 try {

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportChainsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportChainsTests.cs
@@ -20,9 +20,12 @@ public class ImportChainsTests : IDisposable {
     void StubAllHookEndpoints() {
         _server.Given(Request.Create().WithPath("/hooks/transcript").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200));
-        _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
+        // Match both the legacy un-vendored path and the new vendor-routed
+        // path the importer uses now (/hooks/session-start/{vendor}) so codex
+        // imports can't silently land as claude-tagged SessionStarted events.
+        _server.Given(Request.Create().WithPath("/hooks/session-start*").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200));
-        _server.Given(Request.Create().WithPath("/hooks/session-end").UsingPost())
+        _server.Given(Request.Create().WithPath("/hooks/session-end*").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
         _server.Given(Request.Create().WithPath("/hooks/subagent-start").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200));
@@ -124,6 +127,42 @@ public class ImportChainsTests : IDisposable {
     }
 
     [Test]
+    public async Task ImportChainsAsync_routes_codex_session_to_vendor_specific_url() {
+        // Regression: kcap import --codex used to POST to /hooks/session-start
+        // (no vendor in path), which routes to the {vendor=claude} default and
+        // wrote claude-tagged SessionStarted events for every codex rollout.
+        // Asserting on the URL path here keeps that bug from re-appearing.
+        StubAllHookEndpoints();
+
+        var session = MakeNew("codex-routing", 10) with { Vendor = "codex" };
+        var chains  = new List<List<ImportCommand.SessionClassification>> { new() { session } };
+
+        var events = new ImportCommand.ChainWorkerEvents {
+            OnSessionStarted      = (_, _) => { },
+            OnSubagentStarted     = (_, _, _) => { },
+            OnSubagentFinished    = (_, _, _, _) => { },
+            OnSessionErrored      = (_, _, _) => { },
+            OnSessionEnded        = (_, _, _, _) => { },
+            OnTitleTaskReady      = _ => { },
+            OnBackgroundWorkReady = _ => { },
+        };
+
+        using var client = new HttpClient();
+        await ImportCommand.ImportChainsAsync(client, _server.Url!, chains, events, CancellationToken.None);
+
+        var startHits = _server.LogEntries
+            .Count(e => e.RequestMessage.Path == "/hooks/session-start/codex");
+        var endHits = _server.LogEntries
+            .Count(e => e.RequestMessage.Path == "/hooks/session-end/codex");
+        var legacyHits = _server.LogEntries
+            .Count(e => e.RequestMessage.Path is "/hooks/session-start" or "/hooks/session-end");
+
+        await Assert.That(startHits).IsEqualTo(1);
+        await Assert.That(endHits).IsEqualTo(1);
+        await Assert.That(legacyHits).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ImportChainsAsync_dispatches_independent_chains_in_parallel() {
         // WireMock adds a 200ms server-side delay to every transcript POST.
         // If chains run serially: 4 × 200ms = 800ms minimum.
@@ -132,9 +171,9 @@ public class ImportChainsTests : IDisposable {
         // well under 200ms (they all start roughly simultaneously).
         _server.Given(Request.Create().WithPath("/hooks/transcript").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200).WithDelay(TimeSpan.FromMilliseconds(200)));
-        _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
+        _server.Given(Request.Create().WithPath("/hooks/session-start*").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200));
-        _server.Given(Request.Create().WithPath("/hooks/session-end").UsingPost())
+        _server.Given(Request.Create().WithPath("/hooks/session-end*").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
         _server.Given(Request.Create().WithPath("/hooks/subagent-start").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200));


### PR DESCRIPTION
## Summary

- `kcap import --codex` posted to `/hooks/session-start` (no vendor in path), so codex rollouts silently landed as claude-tagged SessionStarted events on KurrentDB. The companion server fix (kcap-server PR #689) made the writer respect the route vendor, but historical imports bypassed it.
- Switch to `/hooks/session-start/{session.Vendor}` (and `/hooks/session-end/{session.Vendor}`) and drop the now-meaningless body-level `vendor` key the server doesn't bind.
- Test stub widened to match the vendor-suffixed path; new `ImportChainsAsync_routes_codex_session_to_vendor_specific_url` locks in `/hooks/session-{start,end}/codex` for codex imports and asserts zero hits on the legacy URL.

## Test plan

- [x] `dotnet build src/Capacitor.Cli` — clean.
- [x] `dotnet run --project test/Capacitor.Cli.Tests.Unit -- --treenode-filter "/*/*/ImportChainsTests/*"` — 4/4 passing including the new regression test.

## Required follow-up

The kcap-server submodule pointer needs bumping to include this commit after merge so production picks up the routing fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)