### PR TITLE
fix: drop Claude CLI responses with is_error:true (AI-755)

### DIFF
--- a/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
+++ b/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
@@ -397,11 +397,22 @@ static class ClaudeCliRunner {
     /// re-serialised to a string so downstream verdict/retrospective parsers
     /// see the same shape they would from a free-form JSON reply.
     /// </para>
+    ///
+    /// <para>
+    /// Rejects responses with <c>is_error: true</c> — the CLI signals API
+    /// failures (overload, rate limit, auth) by setting this flag and writing
+    /// the error text into <c>result</c>. Treating that text as a valid title
+    /// caused AI-755, where API error messages surfaced as session titles.
+    /// </para>
     /// </summary>
     static ClaudeCliResult? ParseJsonResponseOnly(string stdout) {
         try {
             using var doc  = JsonDocument.Parse(stdout);
             var       root = doc.RootElement;
+
+            if (root.TryGetProperty("is_error", out var isErr) && isErr.ValueKind == JsonValueKind.True) {
+                return null;
+            }
 
             if (root.TryGetProperty("structured_output", out var so) && so.ValueKind is JsonValueKind.Object or JsonValueKind.Array) {
                 return BuildResult(root, so.GetRawText());

--- a/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
+++ b/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
@@ -429,11 +429,25 @@ static class ClaudeCliRunner {
     /// <summary>
     /// When the CLI JSON response has an empty <c>result</c> field, extract the session ID,
     /// find the transcript file, and read the last assistant text block as the result.
+    ///
+    /// <para>
+    /// Skipped when the envelope has <c>is_error: true</c>: the transcript's
+    /// last assistant text on a failed turn can be a partial reply or stale
+    /// auto-memory content, and surfacing that as a successful result is the
+    /// AI-755 regression vector the <see cref="ParseJsonResponseOnly"/>
+    /// guard exists to close.
+    /// </para>
     /// </summary>
-    static ClaudeCliResult? TryReadTranscriptFallback(string stdout, Action<string> log) {
+    internal static ClaudeCliResult? TryReadTranscriptFallback(string stdout, Action<string> log) {
         try {
             using var doc  = JsonDocument.Parse(stdout);
             var       root = doc.RootElement;
+
+            if (root.TryGetProperty("is_error", out var isErr) && isErr.ValueKind == JsonValueKind.True) {
+                log("Transcript fallback: skipping because envelope has is_error:true");
+
+                return null;
+            }
 
             var sessionId = root.Str("session_id");
 

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
@@ -151,6 +151,57 @@ public class ClaudeCliRunnerTests {
         await Assert.That(ex?.ParamName).IsEqualTo("allowedTools");
     }
 
+    // AI-755: the CLI returns is_error:true with the API failure text in
+    // `result` when the upstream call fails (overload, rate limit, auth).
+    // Surfacing that text as a title produced session titles like
+    // "Claude API error: Overloaded". Treat it as a failure instead.
+    [Test]
+    public async Task ParseResponse_IsError_ReturnsNull() {
+        const string json = """
+                            {
+                                "result": "Claude API error: Overloaded",
+                                "is_error": true,
+                                "subtype": "error_during_execution",
+                                "total_cost_usd": 0.0
+                            }
+                            """;
+
+        var result = ClaudeCliRunner.ParseResponse(json);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task ParseResponse_IsErrorWithStructuredOutput_ReturnsNull() {
+        const string json = """
+                            {
+                                "result": "",
+                                "structured_output": {"verdict": "pass"},
+                                "is_error": true,
+                                "subtype": "error_max_turns"
+                            }
+                            """;
+
+        var result = ClaudeCliRunner.ParseResponse(json);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task ParseResponse_IsErrorFalse_StillParses() {
+        const string json = """
+                            {
+                                "result": "ok",
+                                "is_error": false
+                            }
+                            """;
+
+        var result = ClaudeCliRunner.ParseResponse(json);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Result).IsEqualTo("ok");
+    }
+
     [Test]
     public async Task ParseResponse_extracts_num_turns_from_json() {
         const string json = """

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
@@ -202,6 +202,29 @@ public class ClaudeCliRunnerTests {
         await Assert.That(result!.Result).IsEqualTo("ok");
     }
 
+    // AI-755 follow-up: if the envelope says is_error:true, the parser
+    // returns null but RunCoreAsync still tries TryReadTranscriptFallback.
+    // The transcript's last assistant block on a failed turn can be a
+    // partial reply or stale auto-memory content, so converting that into
+    // a successful result reintroduces the same regression. The fallback
+    // must short-circuit on is_error before touching the filesystem.
+    [Test]
+    public async Task TryReadTranscriptFallback_IsError_ShortCircuits() {
+        const string json = """
+                            {
+                                "session_id": "should-not-be-looked-up",
+                                "is_error": true,
+                                "result": "Claude API error: Overloaded"
+                            }
+                            """;
+        var logs = new List<string>();
+
+        var result = ClaudeCliRunner.TryReadTranscriptFallback(json, logs.Add);
+
+        await Assert.That(result).IsNull();
+        await Assert.That(logs).Contains(l => l.Contains("is_error", StringComparison.Ordinal));
+    }
+
     [Test]
     public async Task ParseResponse_extracts_num_turns_from_json() {
         const string json = """


### PR DESCRIPTION
## Summary
- Session titles were displaying upstream Claude API error text (e.g. "Claude API error: Overloaded") because `ClaudeCliRunner.ParseJsonResponseOnly` happily returned the `result` field when the CLI signalled failure via `is_error: true`.
- Guard at the parser: reject responses with `is_error: true` before either the `structured_output` or `result` branch. All callers (`TitleGenerator`, `EvalService` verdict + retrospective, `WhatsDoneCommand`) already handle `null` as the expected failure path — title generation keeps the initial truncated-prompt title, eval fails the question, what's-done skips.

Resolves [AI-755](https://linear.app/kurrent/issue/AI-755/session-title-with-api-error).

## Test plan
- [x] Added three `ClaudeCliRunnerTests` cases: `is_error:true` with populated `result`, `is_error:true` with `structured_output` (DEV-1484 retrospective shape), and `is_error:false` happy-path.
- [x] `dotnet run --project test/Capacitor.Cli.Tests.Unit` — 1187/1188 pass; the one unrelated failure is a pre-existing `PluginCommandClaudeTests.Remove_claude_deletes_marker` HOME-env-var ordering flake.
- [x] `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release` — clean, no IL3050/IL2026 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)