### PR TITLE
[AI-757] codex: stop pinning gpt-5.3-codex for title generation

### DIFF
--- a/src/Capacitor.Cli.Core/CodexCliRunner.cs
+++ b/src/Capacitor.Cli.Core/CodexCliRunner.cs
@@ -95,7 +95,9 @@ static class CodexCliRunner {
         // Only pin a model when the caller explicitly asks. Letting codex pick its
         // own default keeps title generation working for ChatGPT-account auth
         // (which rejects model names like "gpt-5.3-codex" with a 400 — AI-757).
-        if (model is not null) {
+        // Empty/whitespace is treated the same as null to match CodexLauncher's
+        // argv-building behaviour — passing `-m ""` to codex is never useful.
+        if (!string.IsNullOrWhiteSpace(model)) {
             psi.ArgumentList.Add("-m");
             psi.ArgumentList.Add(model);
         }
@@ -150,7 +152,7 @@ static class CodexCliRunner {
                 // useful part (AI-757). Keep the last 800 chars so 4xx/5xx bodies
                 // and skill-loader warnings further down still make it into the log.
                 var stderrTail = stderr.Length > 800 ? "…" + stderr[^800..] : stderr;
-                log($"Codex exited with code {process.ExitCode}, stderr: {stderrTail}");
+                log($"Codex exited with code {process.ExitCode}, stderr: {SanitizeForLog(stderrTail)}");
 
                 return null;
             }
@@ -197,5 +199,27 @@ static class CodexCliRunner {
 
             return null;
         }
+    }
+
+    /// <summary>
+    /// Collapses newlines and drops other control characters so codex's multi-line
+    /// stderr lands as a single log line — keeps the timestamp/prefix added by the
+    /// caller's <c>log</c> aligned with the rest of the entry.
+    /// </summary>
+    static string SanitizeForLog(string value) {
+        var sb = new StringBuilder(value.Length);
+
+        foreach (var ch in value) {
+            if (ch is '\r' or '\n') {
+                sb.Append("\\n");
+                continue;
+            }
+
+            if (char.IsControl(ch)) continue;
+
+            sb.Append(ch);
+        }
+
+        return sb.ToString();
     }
 }

--- a/src/Capacitor.Cli.Core/CodexCliRunner.cs
+++ b/src/Capacitor.Cli.Core/CodexCliRunner.cs
@@ -20,7 +20,7 @@ static class CodexCliRunner {
             string            prompt,
             TimeSpan          timeout,
             Action<string>    log,
-            string            model         = "gpt-5.3-codex",
+            string?           model         = null,
             string            reasoning     = "low",
             CancellationToken ct            = default
         ) {
@@ -62,7 +62,7 @@ static class CodexCliRunner {
             Action<string>    log,
             string            workingDir,
             string            lastMessageFile,
-            string            model,
+            string?           model,
             string            reasoning,
             CancellationToken ct
         ) {
@@ -92,8 +92,13 @@ static class CodexCliRunner {
         psi.ArgumentList.Add("never");
         psi.ArgumentList.Add("-c");
         psi.ArgumentList.Add($"model_reasoning_effort=\"{reasoning}\"");
-        psi.ArgumentList.Add("-m");
-        psi.ArgumentList.Add(model);
+        // Only pin a model when the caller explicitly asks. Letting codex pick its
+        // own default keeps title generation working for ChatGPT-account auth
+        // (which rejects model names like "gpt-5.3-codex" with a 400 — AI-757).
+        if (model is not null) {
+            psi.ArgumentList.Add("-m");
+            psi.ArgumentList.Add(model);
+        }
         psi.ArgumentList.Add("--output-last-message");
         psi.ArgumentList.Add(lastMessageFile);
         // Read prompt from stdin via the literal "-" placeholder so titles longer
@@ -140,8 +145,12 @@ static class CodexCliRunner {
             var stderr = await stderrTask;
 
             if (process.ExitCode != 0) {
-                var stderrPreview = stderr.Length > 200 ? stderr[..200] : stderr;
-                log($"Codex exited with code {process.ExitCode}, stderr: {stderrPreview}");
+                // Tail-truncate: codex prints a multi-line session header before any
+                // error message lands on stderr, so head-truncation discarded the
+                // useful part (AI-757). Keep the last 800 chars so 4xx/5xx bodies
+                // and skill-loader warnings further down still make it into the log.
+                var stderrTail = stderr.Length > 800 ? "…" + stderr[^800..] : stderr;
+                log($"Codex exited with code {process.ExitCode}, stderr: {stderrTail}");
 
                 return null;
             }


### PR DESCRIPTION
## Summary
- `CodexCliRunner` hardcoded `-m gpt-5.3-codex`, which Codex rejects with HTTP 400 (`"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."`). Every title-generation attempt for a Codex session failed all 5 retries, leaving the truncated user prompt as the persisted title.
- Drop the hardcoded model and let `codex exec` pick its account-appropriate default. The `model` parameter stays available for callers that want to pin one explicitly.
- Tail-truncate stderr on failure: `codex` prints a ~20-line session header before any actual error, so the previous 200-char head-truncation hid the only diagnostic info. This is what made the bug hard to spot in `~/.config/kcap/logs/<sessionId>.log`.

## Repro / verification
Repro on a ChatGPT-account auth (default for most dev machines):
```
echo "Title:" | codex exec --ephemeral --ignore-user-config --ignore-rules \
  --skip-git-repo-check --sandbox read-only --color never \
  -c model_reasoning_effort="low" -m gpt-5.3-codex \
  --output-last-message /tmp/last.txt -
# EXIT=1, stderr ends with: invalid_request_error: model not supported
```
After the fix (no `-m`): exit 0, last-message contains a real title.

Confirmed against the failing session referenced in AI-757 (`019e9778ca5675b1ae6630a6d3b984a2`) whose watcher log showed all 5 retries exiting with code 1.

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet publish -c Release` — no IL3050/IL2026 AOT warnings
- [x] Unit tests pass (1 unrelated pre-existing flake in `PluginCommandClaudeTests.Remove_claude_deletes_marker` — directory cleanup race, passes in isolation)
- [x] Live `codex exec` smoke test with the new argv produces a real title
- [ ] Capture a fresh Codex session and verify the LLM title replaces the initial truncated-prompt title in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)