### PR TITLE
docs: update Codex trust-hooks hint to reflect launch-time prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ kcap setup --server-url https://my-tenant.kcap.ai --default-visibility org_publi
 In `--no-prompt` mode, the wizard installs hooks for every detected agent by default. Opt out per agent with `--skip-claude-hooks`, `--skip-codex-hooks`, and/or `--skip-cursor-hooks`.
 
 > **Need hooks for an agent installed after setup, or scoped to a single repo?**
-> Run `kcap plugin install [--codex|--cursor]` (omit the flag for the Claude Code plugin), or pair Codex with `--project` for a per-repo install. Use `--skills` instead of `--codex` if you only want the agent skills without Codex hooks. Cursor uses user-scope only — `--project` has no effect with `--cursor`. After installing Codex hooks, run `/hooks` inside Codex and trust each kcap entry — Codex doesn't execute hooks until each is explicitly trusted. After a `--project` install, also run `codex` once in the repo and accept the trust prompt. Re-running after a kcap upgrade is rarely needed for user-scope installs — the npm postinstall hook auto-refreshes them on every `npm install -g @kurrent/kcap` (npm 11+ blocks install scripts by default; add `allow-scripts[]=@kurrent/kcap` to `~/.npmrc` to opt in once).
+> Run `kcap plugin install [--codex|--cursor]` (omit the flag for the Claude Code plugin), or pair Codex with `--project` for a per-repo install. Use `--skills` instead of `--codex` if you only want the agent skills without Codex hooks. Cursor uses user-scope only — `--project` has no effect with `--cursor`. After installing Codex hooks, the next `codex` launch prompts to trust the new hooks — accept once to trust them all (run `/hooks` inside Codex if you'd rather trust each entry individually). After a `--project` install, also run `codex` once in the repo and accept the workspace trust prompt. Re-running after a kcap upgrade is rarely needed for user-scope installs — the npm postinstall hook auto-refreshes them on every `npm install -g @kurrent/kcap` (npm 11+ blocks install scripts by default; add `allow-scripts[]=@kurrent/kcap` to `~/.npmrc` to opt in once).
 
 > **Need at least one agent to capture sessions:** the setup wizard runs to completion without an agent CLI on `PATH` (it'll still configure your profile, auth, and daemon), but kcap only records work once Claude Code or Codex CLI is installed and the hooks are in place.
 
@@ -131,7 +131,7 @@ kcap setup --server-url <url> --no-prompt --skip-claude-hooks --skip-cursor-hook
 kcap setup --server-url <url> --no-prompt --skip-claude-hooks --skip-codex-hooks   # only Cursor
 ```
 
-After installing Codex hooks, run `/hooks` inside Codex and trust each kcap entry — Codex does not execute hooks until each is explicitly trusted. For project-scope installs (a single repo), use `kcap plugin install [--codex] --project` after setup.
+After installing Codex hooks, the next `codex` launch prompts to trust the new hooks — accept once to trust them all (run `/hooks` inside Codex if you'd rather trust each entry individually). For project-scope installs (a single repo), use `kcap plugin install [--codex] --project` after setup.
 
 Legacy `--plugin-scope <user|project|skip>` is retained for backwards compatibility:
 

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -137,7 +137,7 @@ internal static class CodingAgentsStep {
 
         writeLine($"  [green]✓[/] Codex hooks installed (user: {Markup.Escape(paths.CodexHooksPath)})");
         writeLine("  [dim]  Next: Codex will prompt to trust the kcap hooks on its next launch —[/]");
-        writeLine("  [dim]  accept once to trust them all (or run /hooks to trust them individually).[/]");
+        writeLine("  [dim]  accept once to trust them all (or run /hooks inside Codex to trust them individually).[/]");
 
         return true;
     }

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -136,8 +136,8 @@ internal static class CodingAgentsStep {
         }
 
         writeLine($"  [green]✓[/] Codex hooks installed (user: {Markup.Escape(paths.CodexHooksPath)})");
-        writeLine("  [dim]  Next: run /hooks inside Codex and trust each kcap entry —[/]");
-        writeLine("  [dim]  Codex won't execute hooks until each is explicitly trusted.[/]");
+        writeLine("  [dim]  Next: Codex will prompt to trust the kcap hooks on its next launch —[/]");
+        writeLine("  [dim]  accept once to trust them all (or run /hooks to trust them individually).[/]");
 
         return true;
     }

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -368,7 +368,7 @@ public static class PluginCommand {
 
         await env.Stdout.WriteLineAsync(
             "Next: Codex will prompt to trust the kcap hooks on its next launch — " +
-            "accept once to trust them all (or run /hooks to trust them individually)."
+            "accept once to trust them all (or run /hooks inside Codex to trust them individually)."
         );
 
         // Skills are user-scoped only. Written to ~/.agents/skills/ so they

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -367,8 +367,8 @@ public static class PluginCommand {
         await env.Stdout.WriteLineAsync($"Codex hooks installed ({scope}: {hooksPath})");
 
         await env.Stdout.WriteLineAsync(
-            "Next: run /hooks inside Codex and trust each kcap entry — " +
-            "Codex won't execute hooks until each is explicitly trusted."
+            "Next: Codex will prompt to trust the kcap hooks on its next launch — " +
+            "accept once to trust them all (or run /hooks to trust them individually)."
         );
 
         // Skills are user-scoped only. Written to ~/.agents/skills/ so they


### PR DESCRIPTION
## Summary
- Latest Codex prompts to trust newly-added hooks on next launch with a 'trust all' option, so the post-install hint shouldn't push users straight into `/hooks` to trust entries individually.
- Update the user-facing strings emitted by `kcap plugin install --codex` and the setup wizard, plus the matching README callouts, to lead with the accept-once flow and keep `/hooks` as the per-entry fallback.

## Test plan
- [x] `dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj` — clean
- [x] `dotnet run --project test/Capacitor.Cli.Tests.Unit/...` filtered to `CodingAgentsStepTests` and `PluginCommandCodex*` — green (existing `/hooks`+`trust` assertions still match because the new copy keeps both tokens on the same line)

Companion docs PR: kurrent-io/kapacitor-web#27

🤖 Generated with [Claude Code](https://claude.com/claude-code)