### PR TITLE
[AI-755] scrub provider API keys before spawning headless agent CLIs

### DIFF
--- a/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
+++ b/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
@@ -178,6 +178,9 @@ static class ClaudeCliRunner {
         };
         psi.Environment.Remove("CLAUDECODE");
         psi.Environment.Remove("CLAUDE_CODE_ENTRYPOINT");
+        // A globally-set ANTHROPIC_API_KEY overrides subscription auth in `claude -p`,
+        // which surfaced as AI-755 (API error text leaking into session titles).
+        psi.Environment.Remove("ANTHROPIC_API_KEY");
         psi.ArgumentList.Add("-p");
 
         if (!promptViaStdin) {

--- a/src/Capacitor.Cli.Core/CodexCliRunner.cs
+++ b/src/Capacitor.Cli.Core/CodexCliRunner.cs
@@ -80,6 +80,8 @@ static class CodexCliRunner {
                 ["KCAP_SKIP"] = "1"
             }
         };
+        // A globally-set OPENAI_API_KEY overrides ChatGPT subscription auth in `codex exec`.
+        psi.Environment.Remove("OPENAI_API_KEY");
 
         psi.ArgumentList.Add("exec");
         psi.ArgumentList.Add("--ephemeral");


### PR DESCRIPTION
## Summary

- Quick fix for the residual AI-755 symptom: a globally-set `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` for Codex) overrides subscription auth in `claude -p` / `codex exec`, so the headless title-generation call fails and users get a truncated fallback title.
- The AI-755 parser hardening (commit `9062a3a2`) stopped error text from *leaking into* titles; this change removes the upstream cause for users on subscription auth.
- Two-line change matching the existing `CLAUDECODE` / `CLAUDE_CODE_ENTRYPOINT` env-scrub pattern in both runners. Silent on purpose for consistency — follow-up AI-776 tracks making it configurable and surfacing it during `kcap setup`.

## Test plan

- [x] `dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj` clean
- [x] `ClaudeCliRunnerTests` 16/16 pass
- [x] `dotnet publish -c Release` zero IL2xxx/IL3xxx warnings
- [ ] Manual: set `ANTHROPIC_API_KEY` in shell, start a Claude Code session, verify generated title is non-error text

🤖 Generated with [Claude Code](https://claude.com/claude-code)