### PR TITLE
[AI-776] make provider API key scrub configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,15 @@ kcap ignore --remove ~/code/secret-project
 
 Entries are stored on the **active profile**, so switching profiles with `kcap use` switches the ignore list too. Symlinks are resolved on both the stored entry and the session's reported cwd, so a worktree symlink and its target match.
 
+**Provider API keys for headless calls.** Title generation, summaries, and judges shell out to `claude -p` / `codex exec` in the background. By default kcap scrubs `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from those spawns so your subscription login (claude.ai / ChatGPT account) is used — a globally-set key would otherwise override subscription auth and fail the call. If you intentionally authenticate via API key (PAYG), opt back in:
+
+```bash
+kcap config set use_provider_api_key true     # keep keys in headless spawns
+KCAP_USE_PROVIDER_API_KEY=1 kcap recap …      # one-off override
+```
+
+`kcap setup` also prompts for this when it detects either key in the current environment. The env var (`1`/`true`/`yes`/`on` or `0`/`false`/`no`/`off`) wins over the profile setting.
+
 #### Renamed repo directories (`kcap remap`)
 
 Historic transcripts record the absolute working directory they ran in. If you've since renamed or moved that directory on disk (e.g. `~/dev/foo-cli → ~/dev/bar-cli`), `kcap import --org` / `--repo` can't resolve those sessions to a GitHub repo any more and silently drops them from the matched count.

--- a/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
+++ b/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
@@ -180,7 +180,11 @@ static class ClaudeCliRunner {
         psi.Environment.Remove("CLAUDE_CODE_ENTRYPOINT");
         // A globally-set ANTHROPIC_API_KEY overrides subscription auth in `claude -p`,
         // which surfaced as AI-755 (API error text leaking into session titles).
-        psi.Environment.Remove("ANTHROPIC_API_KEY");
+        // Users on PAYG/API-key auth opt back in via profile flag or
+        // KCAP_USE_PROVIDER_API_KEY=1 (AI-776).
+        if (!ProviderApiKeyPolicy.ShouldKeepProviderKey()) {
+            psi.Environment.Remove("ANTHROPIC_API_KEY");
+        }
         psi.ArgumentList.Add("-p");
 
         if (!promptViaStdin) {

--- a/src/Capacitor.Cli.Core/CodexCliRunner.cs
+++ b/src/Capacitor.Cli.Core/CodexCliRunner.cs
@@ -81,7 +81,11 @@ static class CodexCliRunner {
             }
         };
         // A globally-set OPENAI_API_KEY overrides ChatGPT subscription auth in `codex exec`.
-        psi.Environment.Remove("OPENAI_API_KEY");
+        // Users on PAYG/API-key auth opt back in via profile flag or
+        // KCAP_USE_PROVIDER_API_KEY=1 (AI-776).
+        if (!ProviderApiKeyPolicy.ShouldKeepProviderKey()) {
+            psi.Environment.Remove("OPENAI_API_KEY");
+        }
 
         psi.ArgumentList.Add("exec");
         psi.ArgumentList.Add("--ephemeral");

--- a/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
@@ -48,6 +48,16 @@ public record Profile {
     [JsonPropertyName("disable_session_guidelines")]
     public bool? DisableSessionGuidelines { get; init; }
 
+    /// <summary>
+    /// When true, kcap keeps <c>ANTHROPIC_API_KEY</c> / <c>OPENAI_API_KEY</c>
+    /// in the spawn environment for headless agent CLIs (title generation,
+    /// summaries, judges). Default <c>false</c> scrubs them so subscription
+    /// auth (claude.ai / ChatGPT account) is used instead — see AI-755.
+    /// Override at runtime with <c>KCAP_USE_PROVIDER_API_KEY=1</c>.
+    /// </summary>
+    [JsonPropertyName("use_provider_api_key")]
+    public bool UseProviderApiKey { get; init; }
+
     [JsonPropertyName("update_check")]
     public bool UpdateCheck { get; init; } = true;
 

--- a/src/Capacitor.Cli.Core/ProviderApiKeyPolicy.cs
+++ b/src/Capacitor.Cli.Core/ProviderApiKeyPolicy.cs
@@ -1,0 +1,52 @@
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Core;
+
+/// <summary>
+/// Decides whether to keep provider API keys (<c>ANTHROPIC_API_KEY</c>,
+/// <c>OPENAI_API_KEY</c>) in the spawn environment for headless agent CLIs.
+///
+/// <para>
+/// Default behaviour scrubs them so subscription auth (claude.ai login,
+/// ChatGPT account login) is used by <c>claude -p</c> / <c>codex exec</c>;
+/// a globally-set key would otherwise override subscription auth and break
+/// title generation / summaries (AI-755).
+/// </para>
+///
+/// <para>
+/// Users on PAYG / API-key auth opt in via <c>use_provider_api_key: true</c>
+/// on their active profile, or via <c>KCAP_USE_PROVIDER_API_KEY=1</c> as a
+/// runtime escape hatch. The env var wins when set to a recognised value.
+/// </para>
+/// </summary>
+public static class ProviderApiKeyPolicy {
+    public const string EnvVarName = "KCAP_USE_PROVIDER_API_KEY";
+
+    /// <summary>
+    /// Convenience entry point: reads the env var and the active profile.
+    /// </summary>
+    public static bool ShouldKeepProviderKey() => ShouldKeepProviderKey(
+        Environment.GetEnvironmentVariable(EnvVarName),
+        AppConfig.ResolvedProfile?.Profile);
+
+    /// <summary>
+    /// Pure resolver — exposed for testing.
+    /// </summary>
+    public static bool ShouldKeepProviderKey(string? envValue, Profile? profile) {
+        if (TryParseEnv(envValue) is { } envOverride) {
+            return envOverride;
+        }
+
+        return profile?.UseProviderApiKey ?? false;
+    }
+
+    static bool? TryParseEnv(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+
+        return value.Trim().ToLowerInvariant() switch {
+            "1" or "true"  or "yes" or "on"  => true,
+            "0" or "false" or "no"  or "off" => false,
+            _                                => null
+        };
+    }
+}

--- a/src/Capacitor.Cli.Core/ProviderApiKeyPolicy.cs
+++ b/src/Capacitor.Cli.Core/ProviderApiKeyPolicy.cs
@@ -33,14 +33,19 @@ public static class ProviderApiKeyPolicy {
     /// Pure resolver — exposed for testing.
     /// </summary>
     public static bool ShouldKeepProviderKey(string? envValue, Profile? profile) {
-        if (TryParseEnv(envValue) is { } envOverride) {
+        if (TryParseBool(envValue) is { } envOverride) {
             return envOverride;
         }
 
         return profile?.UseProviderApiKey ?? false;
     }
 
-    static bool? TryParseEnv(string? value) {
+    /// <summary>
+    /// Parses a user-supplied truthy/falsy string. Returns <c>null</c> for
+    /// unrecognised or empty input so callers can error out (e.g. CLI flag
+    /// validation) instead of silently coercing to <c>false</c>.
+    /// </summary>
+    public static bool? TryParseBool(string? value) {
         if (string.IsNullOrWhiteSpace(value)) return null;
 
         return value.Trim().ToLowerInvariant() switch {

--- a/src/Capacitor.Cli.Core/Resources/help-setup.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-setup.txt
@@ -17,9 +17,11 @@ Options:
                               user-dir is detected (~/.cursor/).
   --use-provider-api-key <v>  In --no-prompt mode, set whether kcap keeps
                               ANTHROPIC_API_KEY / OPENAI_API_KEY in headless
-                              agent spawns. true/1/yes opts in; anything else
-                              preserves the previous profile setting.
-                              Default scrub keeps subscription auth working.
+                              agent spawns. Accepts true/1/yes/on or
+                              false/0/no/off; any other value exits with an
+                              error. Omit the flag to preserve the existing
+                              profile setting. Default scrub keeps
+                              subscription auth working.
 
 The setup wizard detects every supported coding agent: Claude Code and Codex CLI
 via PATH; Cursor via user-dir presence (~/.cursor/) so IDE-only users without

--- a/src/Capacitor.Cli.Core/Resources/help-setup.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-setup.txt
@@ -15,6 +15,11 @@ Options:
                               the codex CLI is detected on PATH.
   --skip-cursor-hooks         Don't install Cursor hooks even if the Cursor
                               user-dir is detected (~/.cursor/).
+  --use-provider-api-key <v>  In --no-prompt mode, set whether kcap keeps
+                              ANTHROPIC_API_KEY / OPENAI_API_KEY in headless
+                              agent spawns. true/1/yes opts in; anything else
+                              preserves the previous profile setting.
+                              Default scrub keeps subscription auth working.
 
 The setup wizard detects every supported coding agent: Claude Code and Codex CLI
 via PATH; Cursor via user-dir presence (~/.cursor/) so IDE-only users without

--- a/src/Capacitor.Cli/Commands/ConfigCommand.cs
+++ b/src/Capacitor.Cli/Commands/ConfigCommand.cs
@@ -76,6 +76,8 @@ public static class ConfigCommand {
             "update_check" => throw new ArgumentException($"Invalid value for update_check: '{value}'. Must be true or false."),
             "disable_session_guidelines" when bool.TryParse(value, out var b) => profile with { DisableSessionGuidelines = b },
             "disable_session_guidelines" => throw new ArgumentException($"Invalid value for disable_session_guidelines: '{value}'. Must be true or false."),
+            "use_provider_api_key" when bool.TryParse(value, out var b) => profile with { UseProviderApiKey = b },
+            "use_provider_api_key" => throw new ArgumentException($"Invalid value for use_provider_api_key: '{value}'. Must be true or false."),
             "default_visibility" when value is "private" or "org_public" or "public" => profile with { DefaultVisibility = value },
             "default_visibility" => throw new ArgumentException("Invalid value. Must be: private, org_public, or public"),
             "excluded_repos" => profile with { ExcludedRepos = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) },
@@ -94,6 +96,7 @@ public static class ConfigCommand {
         Console.Error.WriteLine("  update_check                Enable update check (true/false)");
         Console.Error.WriteLine("  default_visibility          Default session visibility (private, org_public, public)");
         Console.Error.WriteLine("  disable_session_guidelines  Skip injecting recurring-lessons context at SessionStart (true/false)");
+        Console.Error.WriteLine("  use_provider_api_key        Keep ANTHROPIC_API_KEY/OPENAI_API_KEY in headless agent spawns (true/false)");
         Console.Error.WriteLine("  excluded_repos              Excluded repos, comma-separated (owner/repo,owner/repo)");
         Console.Error.WriteLine();
         Console.Error.WriteLine("Flags:");

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -206,6 +206,43 @@ public static class SetupCommand {
         var _ = await CodingAgentsStep.RunAsync(
             stepOptions, detected, stepPaths, stepInstallers, PromptYesNo, WriteLine);
 
+        // Provider API key handling. kcap scrubs ANTHROPIC_API_KEY / OPENAI_API_KEY
+        // from headless agent CLI spawns by default (AI-755) so subscription auth
+        // wins. PAYG users with the keys set in their environment can opt back in
+        // here; the rest never see this prompt.
+        var anthropicSet     = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY"));
+        var openaiSet        = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
+        var promptApiKey      = (anthropicSet && !skipClaude) || (openaiSet && !skipCodexFlag);
+        // Preserve any previous opt-in when no key is in the current env (we just
+        // don't have anything to prompt about; the on-disk value is still valid).
+        var useProviderApiKey = existing?.UseProviderApiKey ?? false;
+
+        if (promptApiKey) {
+            await Console.Out.WriteLineAsync();
+
+            var keys = (anthropicSet, openaiSet) switch {
+                (true, true)  => "ANTHROPIC_API_KEY and OPENAI_API_KEY are set",
+                (true, false) => "ANTHROPIC_API_KEY is set",
+                (false, true) => "OPENAI_API_KEY is set",
+                _             => ""
+            };
+
+            AnsiConsole.MarkupLine($"  [dim]{Markup.Escape(keys)} in your environment.[/]");
+            AnsiConsole.MarkupLine("  [dim]By default kcap scrubs these when spawning Claude/Codex for headless calls so your[/]");
+            AnsiConsole.MarkupLine("  [dim]subscription login is used. Keep them if you authenticate via API key (PAYG).[/]");
+
+            if (noPrompt) {
+                var flagValue = GetArg(args, "--use-provider-api-key");
+                if (flagValue is not null) {
+                    useProviderApiKey = flagValue is "1" or "true" or "yes";
+                }
+                await Console.Out.WriteLineAsync($"  Use provider API key: {useProviderApiKey}");
+            } else {
+                useProviderApiKey = AnsiConsole.Prompt(
+                    new ConfirmationPrompt("  Use these API keys for kcap's headless calls?") { DefaultValue = useProviderApiKey });
+            }
+        }
+
         await Console.Out.WriteLineAsync();
 
         // Step 5: Daemon name + save
@@ -232,9 +269,10 @@ public static class SetupCommand {
         var defaultProfile = profileConfig.Profiles.GetValueOrDefault(activeName) ?? new Profile();
 
         defaultProfile = defaultProfile with {
-            ServerUrl         = serverUrl,
-            DefaultVisibility = defaultVisibility,
-            Daemon            = (defaultProfile.Daemon ?? new DaemonSettings()) with { Name = daemonName }
+            ServerUrl          = serverUrl,
+            DefaultVisibility  = defaultVisibility,
+            UseProviderApiKey  = useProviderApiKey,
+            Daemon             = (defaultProfile.Daemon ?? new DaemonSettings()) with { Name = daemonName }
         };
 
         var profiles = new Dictionary<string, Profile>(profileConfig.Profiles) {
@@ -256,6 +294,10 @@ public static class SetupCommand {
         grid.AddRow("[bold]Server[/]",     Markup.Escape(serverUrl));
         grid.AddRow("[bold]Visibility[/]", Markup.Escape(defaultVisibility));
         grid.AddRow("[bold]Daemon[/]",     Markup.Escape(daemonName));
+
+        if (useProviderApiKey) {
+            grid.AddRow("[bold]Provider API key[/]", "kept in headless spawns");
+        }
 
         if (finalTokens is not null) {
             grid.AddRow("[bold]Auth[/]", Markup.Escape($"{finalTokens.GitHubUsername} ({finalTokens.Provider})"));

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -234,7 +234,13 @@ public static class SetupCommand {
             if (noPrompt) {
                 var flagValue = GetArg(args, "--use-provider-api-key");
                 if (flagValue is not null) {
-                    useProviderApiKey = flagValue is "1" or "true" or "yes";
+                    var parsed = ProviderApiKeyPolicy.TryParseBool(flagValue);
+                    if (parsed is null) {
+                        await Console.Error.WriteLineAsync(
+                            $"  Invalid value for --use-provider-api-key: '{flagValue}'. Must be true/1/yes/on or false/0/no/off.");
+                        return 1;
+                    }
+                    useProviderApiKey = parsed.Value;
                 }
                 await Console.Out.WriteLineAsync($"  Use provider API key: {useProviderApiKey}");
             } else {

--- a/test/Capacitor.Cli.Tests.Unit/ProviderApiKeyPolicyTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProviderApiKeyPolicyTests.cs
@@ -1,0 +1,53 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class ProviderApiKeyPolicyTests {
+    [Test]
+    public async Task Default_scrubs_when_no_env_and_no_profile() {
+        await Assert.That(ProviderApiKeyPolicy.ShouldKeepProviderKey(envValue: null, profile: null)).IsFalse();
+    }
+
+    [Test]
+    public async Task Default_scrubs_when_profile_opts_out() {
+        var profile = new Profile { UseProviderApiKey = false };
+        await Assert.That(ProviderApiKeyPolicy.ShouldKeepProviderKey(null, profile)).IsFalse();
+    }
+
+    [Test]
+    public async Task Profile_opt_in_keeps_key() {
+        var profile = new Profile { UseProviderApiKey = true };
+        await Assert.That(ProviderApiKeyPolicy.ShouldKeepProviderKey(null, profile)).IsTrue();
+    }
+
+    [Test]
+    [Arguments("1")]
+    [Arguments("true")]
+    [Arguments("TRUE")]
+    [Arguments("yes")]
+    [Arguments("on")]
+    public async Task Env_var_truthy_overrides_profile_off(string envValue) {
+        var profile = new Profile { UseProviderApiKey = false };
+        await Assert.That(ProviderApiKeyPolicy.ShouldKeepProviderKey(envValue, profile)).IsTrue();
+    }
+
+    [Test]
+    [Arguments("0")]
+    [Arguments("false")]
+    [Arguments("no")]
+    [Arguments("off")]
+    public async Task Env_var_falsy_overrides_profile_on(string envValue) {
+        var profile = new Profile { UseProviderApiKey = true };
+        await Assert.That(ProviderApiKeyPolicy.ShouldKeepProviderKey(envValue, profile)).IsFalse();
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments("maybe")]
+    public async Task Env_var_unrecognised_falls_through_to_profile(string envValue) {
+        var profile = new Profile { UseProviderApiKey = true };
+        await Assert.That(ProviderApiKeyPolicy.ShouldKeepProviderKey(envValue, profile)).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/ProviderApiKeyPolicyTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProviderApiKeyPolicyTests.cs
@@ -50,4 +50,27 @@ public class ProviderApiKeyPolicyTests {
         var profile = new Profile { UseProviderApiKey = true };
         await Assert.That(ProviderApiKeyPolicy.ShouldKeepProviderKey(envValue, profile)).IsTrue();
     }
+
+    [Test]
+    [Arguments("1",     true)]
+    [Arguments("true",  true)]
+    [Arguments("YES",   true)]
+    [Arguments("on",    true)]
+    [Arguments("0",     false)]
+    [Arguments("false", false)]
+    [Arguments("no",    false)]
+    [Arguments("off",   false)]
+    public async Task TryParseBool_recognises_truthy_and_falsy(string value, bool expected) {
+        await Assert.That(ProviderApiKeyPolicy.TryParseBool(value)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments("maybe")]
+    [Arguments("2")]
+    public async Task TryParseBool_returns_null_on_unrecognised(string? value) {
+        await Assert.That(ProviderApiKeyPolicy.TryParseBool(value)).IsNull();
+    }
 }


### PR DESCRIPTION
## Summary

- AI-755 unconditionally scrubbed `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` before spawning headless agent CLIs so a globally-set key wouldn't override subscription auth. PAYG users had no way to keep their key intentionally.
- Adds `Profile.UseProviderApiKey` (default `false` — existing scrub behaviour) and `KCAP_USE_PROVIDER_API_KEY` as a runtime escape hatch. `kcap setup` prompts when either key is in the current environment and the relevant agent isn't being skipped. `kcap config set use_provider_api_key true|false` toggles without re-running setup.
- Resolver lives in `ProviderApiKeyPolicy.ShouldKeepProviderKey()`; env var (truthy: `1`/`true`/`yes`/`on`; falsy: `0`/`false`/`no`/`off`) wins over the profile flag.

## Test plan

- [x] Unit tests cover env-var precedence, profile fallback, unrecognised env values, and default scrub (`ProviderApiKeyPolicyTests`, 15 cases).
- [x] `dotnet build` clean.
- [x] `dotnet publish -c Release` produces no IL3050/IL2026 warnings.
- [ ] Manual: run `kcap setup` with `ANTHROPIC_API_KEY` set; confirm the new prompt appears and the profile persists `use_provider_api_key`.
- [ ] Manual: confirm `KCAP_USE_PROVIDER_API_KEY=1 kcap recap …` keeps the key in the spawn while the on-disk profile is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)