### PR TITLE
fix: read default_visibility and excluded_repos from active V2 profile

### DIFF
--- a/src/Capacitor.Cli.Core/Config/AppConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/AppConfig.cs
@@ -280,7 +280,34 @@ public static class AppConfig {
             }
         }
 
-        return result.Config;
+        return NormalizeProfileVisibilities(result.Config);
+    }
+
+    /// <summary>
+    /// Coerce each profile's <c>default_visibility</c> to the same set the
+    /// legacy <see cref="Load"/> path enforced (lowercase, restricted to
+    /// <see cref="ValidVisibilities"/>; fall back to <c>org_public</c>
+    /// otherwise). Manual edits and v1→v2 migrations bypass the validation
+    /// that <c>kcap config set</c> / <c>kcap setup</c> apply at write time,
+    /// so a profile on disk can carry through values like <c>"Private"</c>
+    /// or <c>"foo"</c> that the server would reject.
+    /// </summary>
+    static ProfileConfig NormalizeProfileVisibilities(ProfileConfig config) {
+        Dictionary<string, Profile>? rebuilt = null;
+
+        foreach (var (name, profile) in config.Profiles) {
+            var raw        = profile.DefaultVisibility ?? "org_public";
+            var normalized = raw.ToLowerInvariant();
+
+            if (!ValidVisibilities.Contains(normalized)) normalized = "org_public";
+
+            if (normalized == profile.DefaultVisibility) continue;
+
+            rebuilt                                                 ??= new(config.Profiles);
+            rebuilt[name] = profile with { DefaultVisibility = normalized };
+        }
+
+        return rebuilt is null ? config : config with { Profiles = rebuilt };
     }
 
     public static async Task SaveProfileConfig(ProfileConfig config) {

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -94,16 +94,20 @@ public static class ClaudeHookCommand {
             body = await RepositoryDetection.EnrichWithRepositoryInfo(body);
         }
 
-        // Load config once for exclusion check and default_visibility injection.
-        var kcapConfig = await AppConfig.Load();
+        // Resolve the V2 profile once for repo/path exclusion and
+        // default_visibility injection. Reading these off the legacy top-level
+        // CapacitorConfig silently misses v2 settings (the fields live under
+        // the active profile), so per-profile `excluded_repos` / `private`
+        // visibility were being ignored.
+        var activeProfile = await AppConfig.GetActiveProfileAsync();
 
         // Check repo exclusion — silently exit for excluded repos.
-        if (kcapConfig?.ExcludedRepos is { Length: > 0 } repos && await RepoExclusion.IsExcludedAsync(body, repos)) {
+        if (activeProfile?.ExcludedRepos is { Length: > 0 } repos && await RepoExclusion.IsExcludedAsync(body, repos)) {
             return 0;
         }
 
         // Check path exclusion against the V2 profile that applies to this process.
-        if ((await AppConfig.GetActiveProfileAsync())?.ExcludedPaths is { Length: > 0 } paths) {
+        if (activeProfile?.ExcludedPaths is { Length: > 0 } paths) {
             try {
                 var cwd = JsonNode.Parse(body)?["cwd"]?.GetValue<string>();
 
@@ -113,8 +117,12 @@ public static class ClaudeHookCommand {
             }
         }
 
-        // Inject default_visibility from config for session-start hooks.
-        if (command == "session-start" && kcapConfig?.DefaultVisibility is { } vis) {
+        // Inject default_visibility from the active V2 profile for session-start
+        // hooks. The legacy top-level CapacitorConfig.DefaultVisibility shape is
+        // not populated by v2 configs (the field lives under the profile), so
+        // reading it there silently fell back to "org_public" and ignored
+        // per-profile `private` settings.
+        if (command == "session-start" && activeProfile?.DefaultVisibility is { } vis) {
             try {
                 var node = JsonNode.Parse(body);
 

--- a/test/Capacitor.Cli.Tests.Integration/SessionStartVisibilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/SessionStartVisibilityTests.cs
@@ -1,0 +1,105 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// Verifies that <see cref="ClaudeHookCommand"/> stamps the
+/// <c>default_visibility</c> from the active V2 profile onto the
+/// session-start payload — not from the legacy top-level config
+/// shape, which would silently fall back to <c>org_public</c> on
+/// every current (v2) config and ignore per-profile <c>private</c>
+/// settings.
+/// </summary>
+public class SessionStartVisibilityTests : IDisposable {
+    readonly WireMockServer _server = WireMockServer.Start();
+    readonly string         _configPath = PathHelpers.ConfigPath("config.json");
+    readonly string?        _previousConfig;
+
+    public SessionStartVisibilityTests() {
+        _previousConfig = File.Exists(_configPath) ? File.ReadAllText(_configPath) : null;
+    }
+
+    public void Dispose() {
+        _server.Stop();
+
+        if (_previousConfig is null) {
+            if (File.Exists(_configPath)) File.Delete(_configPath);
+        } else {
+            File.WriteAllText(_configPath, _previousConfig);
+        }
+    }
+
+    static string SessionStartPayloadWithoutTranscriptPath() =>
+        """
+        {
+          "cwd":             "/tmp/test",
+          "model":           "claude-sonnet-4-6",
+          "source":          "startup",
+          "hook_event_name": "session-start"
+        }
+        """;
+
+    [Test, NotInParallel("AppConfig_FileState")]
+    public async Task Stamps_private_visibility_from_active_profile_v2_config() {
+        var config = new ProfileConfig {
+            ActiveProfile = "work",
+            Profiles = new() {
+                ["work"] = new Profile {
+                    ServerUrl         = _server.Url,
+                    DefaultVisibility = "private"
+                }
+            }
+        };
+        await AppConfig.SaveProfileConfig(config);
+
+        _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        await ClaudeHookCommand.Handle(_server.Url!, new StringReader(SessionStartPayloadWithoutTranscriptPath()));
+
+        var requests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-start").UsingPost());
+        await Assert.That(requests.Count).IsEqualTo(1);
+
+        var body = JsonNode.Parse(requests[0].RequestMessage.Body!)!;
+        await Assert.That(body["default_visibility"]?.GetValue<string>()).IsEqualTo("private");
+    }
+
+    [Test, NotInParallel("AppConfig_FileState")]
+    public async Task Skips_session_start_when_repo_is_excluded_by_active_profile_v2_config() {
+        var config = new ProfileConfig {
+            ActiveProfile = "work",
+            Profiles = new() {
+                ["work"] = new Profile {
+                    ServerUrl     = _server.Url,
+                    ExcludedRepos = ["acme/secret-repo"]
+                }
+            }
+        };
+        await AppConfig.SaveProfileConfig(config);
+
+        _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        const string payload =
+            """
+            {
+              "cwd":             "/tmp/test",
+              "model":           "claude-sonnet-4-6",
+              "source":          "startup",
+              "hook_event_name": "session-start",
+              "repository":      { "owner": "acme", "repo_name": "secret-repo" }
+            }
+            """;
+
+        await ClaudeHookCommand.Handle(_server.Url!, new StringReader(payload));
+
+        var requests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-start").UsingPost());
+        await Assert.That(requests.Count).IsEqualTo(0);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Integration/SessionStartVisibilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/SessionStartVisibilityTests.cs
@@ -71,6 +71,56 @@ public class SessionStartVisibilityTests : IDisposable {
     }
 
     [Test, NotInParallel("AppConfig_FileState")]
+    public async Task Lowercases_mixedcase_visibility_from_v2_config() {
+        var config = new ProfileConfig {
+            ActiveProfile = "work",
+            Profiles = new() {
+                ["work"] = new Profile {
+                    ServerUrl         = _server.Url,
+                    DefaultVisibility = "Private"
+                }
+            }
+        };
+        await AppConfig.SaveProfileConfig(config);
+
+        _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        await ClaudeHookCommand.Handle(_server.Url!, new StringReader(SessionStartPayloadWithoutTranscriptPath()));
+
+        var requests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-start").UsingPost());
+        await Assert.That(requests.Count).IsEqualTo(1);
+
+        var body = JsonNode.Parse(requests[0].RequestMessage.Body!)!;
+        await Assert.That(body["default_visibility"]?.GetValue<string>()).IsEqualTo("private");
+    }
+
+    [Test, NotInParallel("AppConfig_FileState")]
+    public async Task Falls_back_to_org_public_when_v2_config_visibility_is_invalid() {
+        var config = new ProfileConfig {
+            ActiveProfile = "work",
+            Profiles = new() {
+                ["work"] = new Profile {
+                    ServerUrl         = _server.Url,
+                    DefaultVisibility = "totally-bogus"
+                }
+            }
+        };
+        await AppConfig.SaveProfileConfig(config);
+
+        _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        await ClaudeHookCommand.Handle(_server.Url!, new StringReader(SessionStartPayloadWithoutTranscriptPath()));
+
+        var requests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-start").UsingPost());
+        await Assert.That(requests.Count).IsEqualTo(1);
+
+        var body = JsonNode.Parse(requests[0].RequestMessage.Body!)!;
+        await Assert.That(body["default_visibility"]?.GetValue<string>()).IsEqualTo("org_public");
+    }
+
+    [Test, NotInParallel("AppConfig_FileState")]
     public async Task Skips_session_start_when_repo_is_excluded_by_active_profile_v2_config() {
         var config = new ProfileConfig {
             ActiveProfile = "work",


### PR DESCRIPTION
## Summary

- A user reported that sessions were being shared to the org despite their profile having `default_visibility: private`.
- Root cause: `ClaudeHookCommand` read `default_visibility` and `excluded_repos` from `AppConfig.Load()` — the legacy v1 `CapacitorConfig` schema. On v2 configs (current format) those fields live under the active profile, not at the top level, so the legacy read silently fell back to defaults: visibility became `org_public` and per-profile `excluded_repos` was ignored entirely.
- Fix: read both settings from `AppConfig.GetActiveProfileAsync()`, matching the pattern already used two lines above for `excluded_paths`. The legacy `AppConfig.Load()` call is dropped from this code path.

The `ProfileCommand show` view already reads from the profile, so users would see `private` configured and have no indication the hook was ignoring it.

## Test plan

- [x] New failing integration test `SessionStartVisibilityTests.Stamps_private_visibility_from_active_profile_v2_config` reproduces the privacy bug (asserted `private`, got `org_public` before fix).
- [x] New failing integration test `Skips_session_start_when_repo_is_excluded_by_active_profile_v2_config` reproduces the excluded-repo bug (asserted 0 requests, got 1 before fix).
- [x] Both tests pass after the fix.
- [x] Full unit suite (1272 tests) and integration suite (25 tests) pass.
- [x] `dotnet publish -c Release` emits no IL3050/IL2026 AOT warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)