### PR TITLE
fix: redact secrets in assistant/user text and cover Docker Hub tokens

### DIFF
--- a/src/Capacitor.Cli/SecretRedactor.cs
+++ b/src/Capacitor.Cli/SecretRedactor.cs
@@ -1,6 +1,4 @@
-using System.Text.Json;
 using System.Text.RegularExpressions;
-using Capacitor.Cli.Core;
 
 namespace Capacitor.Cli;
 
@@ -25,56 +23,14 @@ static partial class SecretRedactor {
     public static string RedactLine(string rawJsonlLine) {
         if (rawJsonlLine.Length > MaxRedactableLineChars) return OversizeLinePlaceholder;
 
-        try {
-            using var doc  = JsonDocument.Parse(rawJsonlLine);
-            var       root = doc.RootElement;
-
-            // Resolve the user message element from either format:
-            //   Direct format:   { "type": "user", "message": { "role": "user", "content": [...] } }
-            //   Progress format: { "type": "progress", "data": { "message": { "type": "user", "message": { ... } } } }
-            JsonElement? userMessage;
-
-            if (root.Str("type") == "user") {
-                // Direct format — the root IS the user event; content lives at root.message.content
-                userMessage = root;
-            } else {
-                // Progress wrapper — content lives at data.message.message.content
-                var nested = root.Obj("data")?.Obj("message");
-
-                if (nested is null || nested.Value.Str("type") != "user")
-                    return rawJsonlLine;
-
-                userMessage = nested;
-            }
-
-            var content = userMessage.Value.Obj("message")?.Arr("content");
-
-            if (content is null)
-                return rawJsonlLine;
-
-            var hasToolResult = false;
-
-            foreach (var block in content.Value.EnumerateArray()) {
-                if (block.Str("type") == "tool_result") {
-                    hasToolResult = true;
-
-                    break;
-                }
-            }
-
-            if (!hasToolResult)
-                return rawJsonlLine;
-
-            // We have tool_result blocks — redact the line as a raw string.
-            // Working on the serialized JSON string lets us handle both the
-            // content field and toolUseResult without manual tree rewriting.
-            var redacted = RedactSecrets(rawJsonlLine);
-
-            return redacted == rawJsonlLine ? rawJsonlLine : redacted;
-        } catch {
-            // Malformed JSON — pass through unchanged
-            return rawJsonlLine;
-        }
+        // Scan every line, regardless of message type. The pipeline used to gate on
+        // `user`+`tool_result` on the assumption that secrets only enter the transcript via tool
+        // output, but the assistant routinely paraphrases tool output back into its own narrative
+        // (re-emitting tokens that were already redacted upstream), and human user turns can paste
+        // tokens too. Working on the serialized JSON string handles both `content` and
+        // `toolUseResult` without manual tree rewriting; the patterns are constructed to be safe
+        // against JSON delimiters (excluding `"` and `\` where needed).
+        return RedactSecrets(rawJsonlLine);
     }
 
     static string RedactSecrets(string text) {
@@ -115,7 +71,7 @@ static partial class SecretRedactor {
 
     // Known vendor token prefixes followed by token characters
     // Each prefix is specific enough to avoid false positives
-    [GeneratedRegex(@"(?:ghp_|gho_|ghs_|github_pat_|cfat_|sk-(?:proj-|live_|test_)?|sk_live_|sk_test_|xoxb-|xoxp-|xoxa-|pypi-|npm_|glpat-)[A-Za-z0-9\-_]{10,}", RegexOptions.None)]
+    [GeneratedRegex(@"(?:ghp_|gho_|ghs_|github_pat_|cfat_|sk-(?:proj-|live_|test_)?|sk_live_|sk_test_|xoxb-|xoxp-|xoxa-|pypi-|npm_|glpat-|dckr_pat_|dckr_oat_)[A-Za-z0-9\-_]{10,}", RegexOptions.None)]
     private static partial Regex VendorTokenRx();
 
     static readonly Regex VendorTokenRegex = VendorTokenRx();

--- a/test/Capacitor.Cli.Tests.Unit/SecretRedactorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SecretRedactorTests.cs
@@ -81,7 +81,8 @@ public class SecretRedactorTests {
     }
 
     [Test]
-    public async Task PassesThrough_NonToolResult_Unchanged() {
+    public async Task LeavesAssistantText_Unchanged_WhenNoSecretMatch() {
+        // Plain assistant prose with no secret-matching tokens — scanned, but nothing to redact.
         var line = """{"type":"progress","data":{"message":{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]}}},"uuid":"abc","timestamp":"2026-01-01T00:00:00Z"}""";
 
         var result = SecretRedactor.RedactLine(line);
@@ -90,7 +91,7 @@ public class SecretRedactorTests {
     }
 
     [Test]
-    public async Task PassesThrough_MalformedJson_Unchanged() {
+    public async Task LeavesMalformedJson_Unchanged_WhenNoSecretMatch() {
         var line = "not json at all";
 
         var result = SecretRedactor.RedactLine(line);
@@ -112,6 +113,8 @@ public class SecretRedactorTests {
     [Arguments("pypi-ABCDEFghijklmnop1234567890ab", "PyPI")]
     [Arguments("npm_ABCDEFghijklmnop1234567890ab", "npm")]
     [Arguments("glpat-ABCDEFghijklmnop12345", "GitLab PAT")]
+    [Arguments("dckr_pat_ABCDEFghijklmnop1234567890", "Docker Hub PAT")]
+    [Arguments("dckr_oat_J6Ui9AbcDef123XYZabcdef0987", "Docker Hub OAuth access token")]
     public async Task RedactsLine_VendorToken_InToolResult(string token, string description) {
         var line = $$$"""
             {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"The token is {{{token}}} here","is_error":false}]}}
@@ -243,17 +246,21 @@ public class SecretRedactorTests {
     }
 
     [Test]
-    public async Task PassesThrough_UserMessage_Unchanged() {
+    public async Task LeavesUserText_Unchanged_WhenSecretValueTooShort() {
+        // "hunter2" is below LabeledSecretRegex's 16-char floor; no pattern matches.
+        // (A real high-entropy secret in the same shape WOULD be redacted — see
+        // RedactsLine_VendorToken_InUserTextContent.)
         var line = """{"type":"user","message":{"role":"user","content":"my secret password is hunter2"}}""";
 
         var result = SecretRedactor.RedactLine(line);
 
-        // User messages with string content (not array with tool_result) are not scanned
         await Assert.That(result).IsEqualTo(line);
     }
 
     [Test]
-    public async Task PassesThrough_ToolUse_Unchanged() {
+    public async Task LeavesToolUse_Unchanged_WhenNoSecretMatch() {
+        // tool_use args reference a file path; "/etc/secret.pem" has no key:value or labeled-secret
+        // shape, so the line passes through scanning unmodified.
         var line = """{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"/etc/secret.pem"}}]}}""";
 
         var result = SecretRedactor.RedactLine(line);
@@ -272,6 +279,51 @@ public class SecretRedactorTests {
         await Assert.That(result).DoesNotContain("ghp_abc123");
         await Assert.That(result).DoesNotContain("AKIAIOSFODNN7EXAMPLE");
         await Assert.That(result).DoesNotContain("supersecretvalue123");
+    }
+
+    // Scope-widening coverage — secrets must be redacted regardless of whether they appear in a
+    // tool_result, assistant narrative, or human-authored user turn. The original implementation
+    // only scanned user messages containing a tool_result block, which let the assistant trivially
+    // re-emit a token by quoting it back when explaining what a command did.
+
+    [Test]
+    public async Task RedactsLine_DockerToken_InAssistantText() {
+        // Real leak shape (AI-): agent paraphrased kubectl/docker output into its own narrative,
+        // re-emitting a dckr_oat_ token that had been redacted from the originating tool_result.
+        var line = """
+            {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Image pushed but the pull token (dckr_oat_J6Ui9AbcDef123XYZabcdef0987) used by the cluster's registry-pull Secret is scoped to kurrentplatform/kcap only."}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("dckr_oat_J6Ui9AbcDef123XYZabcdef0987");
+        await Assert.That(result).Contains("[REDACTED]");
+    }
+
+    [Test]
+    public async Task RedactsLine_VendorToken_InAssistantText_ProgressFormat() {
+        var line = """
+            {"type":"progress","data":{"message":{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I used ghp_ABCDEFghijklmnop1234567890abcdef12345678 to authenticate."}]}}},"uuid":"abc","timestamp":"2026-01-01T00:00:00Z"}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("ghp_ABCDEFghijklmnop1234567890abcdef12345678");
+        await Assert.That(result).Contains("[REDACTED]");
+    }
+
+    [Test]
+    public async Task RedactsLine_VendorToken_InUserTextContent() {
+        // Free-form user turn (string content, not the tool_result array form) — a human paste of
+        // a token must also be redacted before the line is uploaded.
+        var line = """
+            {"type":"user","message":{"role":"user","content":"my token is ghp_ABCDEFghijklmnop1234567890abcdef12345678 please rotate"}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("ghp_ABCDEFghijklmnop1234567890abcdef12345678");
+        await Assert.That(result).Contains("[REDACTED]");
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- `SecretRedactor.RedactLine` previously ran the regex pipeline only on `user` messages containing a `tool_result` block. Assistant prose that quoted a token back from tool output (a common pattern when explaining what a command did) bypassed redaction entirely. Drop the gate and scan every in-budget line — the existing patterns already exclude `"` and `\` where needed to stay safe against raw JSON.
- Add `dckr_pat_` and `dckr_oat_` (Docker Hub PAT / OAuth access token) prefixes to `VendorTokenRegex`.
- Three existing pass-through tests pinned the old skip-by-type contract; renamed to reflect that scanning now happens for every message type and these inputs simply contain no secret-matching content.

## Why

Observed leak: an agent's narrative included `"the pull token (dckr_oat_…) used by the cluster's registry-pull Secret is scoped to…"`. Even with the token redacted from the originating tool output, the assistant re-emitted it in its own message and the redactor never looked. Both the scope and the missing Docker prefix needed fixing — the scope is the primary defect, the Docker prefix is required for the redactor to recognize the token even within tool_result content.

## Test plan

- [x] 5 new tests added covering Docker prefixes in tool_result, the exact leaked-token shape in an assistant message, a GitHub token in assistant text (progress-wrapped), and a token in free-form user text. All 5 failed before the fix.
- [x] `dotnet run --project test/Capacitor.Cli.Tests.Unit` — 1279/1279 pass
- [x] `dotnet publish -c Release` — no IL3050/IL2026 AOT warnings
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)