### PR TITLE
fix: escape outer brackets in import skipped/loaded markup

### DIFF
--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -394,6 +394,26 @@ static class ImportCommand {
             bool RequestedSummaries
         );
 
+    /// <summary>
+    /// Builds the Spectre markup for the "✗ Skipping {sid} [reason]" line.
+    /// The outer literal brackets around <paramref name="reason"/> MUST be
+    /// doubled — Spectre treats a bare <c>[word ...]</c> as a markup tag and
+    /// throws InvalidOperationException ("Could not find color or style ...")
+    /// when the first word isn't a known color/style. <see cref="Markup.Escape"/>
+    /// only escapes characters inside the substring, not the literal brackets
+    /// we wrap around it.
+    /// </summary>
+    internal static string FormatSkippedReasonMarkup(string sessionId, string reason) =>
+        $"[red]✗[/] Skipping [cyan]{Markup.Escape(sessionId)}[/] [[{Markup.Escape(reason)}]]";
+
+    /// <summary>
+    /// Builds the Spectre markup for the "✓ Loading {sid}... N lines [verb]"
+    /// line. See <see cref="FormatSkippedReasonMarkup"/> for why the outer
+    /// brackets around <paramref name="verb"/> are doubled.
+    /// </summary>
+    internal static string FormatLoadedSummaryMarkup(string sessionId, int lines, string verb) =>
+        $"[green]✓[/] Loading [cyan]{Markup.Escape(sessionId)}[/]... {lines} lines [[{Markup.Escape(verb)}]]";
+
     public static async Task<int> HandleImport(
             string                        baseUrl,
             string?                       filterCwd,
@@ -885,7 +905,7 @@ static class ImportCommand {
             ),
             OnSessionErrored = (_, sid, reason) => display.Line(
                 $"Skipping {sid} [{reason}]",
-                $"[red]✗[/] Skipping [cyan]{Markup.Escape(sid)}[/] [{Markup.Escape(reason)}]"
+                FormatSkippedReasonMarkup(sid, reason)
             ),
             OnSessionEnded = (_, c, outcome, lines) => {
                 importedSessionIds.Add(c.SessionId);
@@ -896,7 +916,7 @@ static class ImportCommand {
 
                 display.Line(
                     $"Loading {c.SessionId}... {lines} lines [{verb}]",
-                    $"[green]✓[/] Loading [cyan]{Markup.Escape(c.SessionId)}[/]... {lines} lines [{verb}]"
+                    FormatLoadedSummaryMarkup(c.SessionId, lines, verb)
                 );
             },
             OnTitleTaskReady = t => {
@@ -1051,7 +1071,7 @@ static class ImportCommand {
                                     IdleSlot(slot);
                                     // Errors print to scrollback above the live region —
                                     // Spectre.Console.Progress flushes prior writes.
-                                    AnsiConsole.MarkupLine($"[red]✗[/] Skipping [cyan]{Markup.Escape(sid)}[/] [{Markup.Escape(reason)}]");
+                                    AnsiConsole.MarkupLine(FormatSkippedReasonMarkup(sid, reason));
                                 },
                             };
 

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportMarkupEscapeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportMarkupEscapeTests.cs
@@ -1,0 +1,71 @@
+using Capacitor.Cli.Commands;
+using Spectre.Console;
+
+namespace Capacitor.Cli.Tests.Unit.Import;
+
+/// <summary>
+/// Regression tests for a crash reported during import:
+///   System.InvalidOperationException: Could not find color or style 'Could'.
+///   ...
+///   at Spectre.Console.Markup..ctor(String, Nullable`1)
+///   at Capacitor.Cli.Commands.ImportCommand.&lt;HandleImport&gt;b__63(...)
+///
+/// Cause: the per-session "Skipping" log built its markup with LITERAL
+/// outer brackets — <c>$"... [{Markup.Escape(reason)}]"</c>. When a server
+/// error surfaced as "Could not parse JSONL", Spectre saw the rendered
+/// <c>[Could not parse JSONL]</c> as a markup tag and tried to resolve
+/// "Could" as a color/style. <see cref="Markup.Escape"/> only escapes
+/// characters INSIDE the substring; the literal brackets we wrap around it
+/// must be doubled separately.
+/// </summary>
+public class ImportMarkupEscapeTests {
+    [Test]
+    [Arguments("Could not parse JSONL")]
+    [Arguments("server unreachable: HTTP 502")]
+    [Arguments("exit 1")]
+    [Arguments("session-start failed: HTTP 500")]
+    public async Task skipped_reason_markup_parses_without_throwing(string reason) {
+        var markup = ImportCommand.FormatSkippedReasonMarkup("abc123", reason);
+
+        // The Markup ctor parses the string. Before the fix, an unescaped
+        // outer "[Could not parse JSONL]" was treated as a markup tag and
+        // the ctor threw InvalidOperationException.
+        _ = new Markup(markup);
+
+        // After escaping, the literal "[reason]" survives intact in the
+        // raw markup string (as "[[reason]]"), and the inner reason text
+        // appears verbatim.
+        await Assert.That(markup).Contains($"[[{reason}]]");
+    }
+
+    [Test]
+    public async Task skipped_reason_markup_escapes_brackets_in_reason() {
+        // A reason that itself contains square brackets must not break
+        // either the inner escape (Markup.Escape) or the outer literal
+        // brackets.
+        var reason = "got [unexpected] token";
+        var markup = ImportCommand.FormatSkippedReasonMarkup("abc123", reason);
+
+        _ = new Markup(markup);
+    }
+
+    [Test]
+    public async Task skipped_reason_markup_escapes_brackets_in_session_id() {
+        // SessionId values are normally GUIDs but be defensive.
+        var markup = ImportCommand.FormatSkippedReasonMarkup("weird[id]", "boom");
+
+        _ = new Markup(markup);
+    }
+
+    [Test]
+    [Arguments("new")]
+    [Arguments("resuming from line 42")]
+    public async Task loaded_summary_markup_parses_without_throwing(string verb) {
+        var markup = ImportCommand.FormatLoadedSummaryMarkup("abc123", lines: 1234, verb: verb);
+
+        _ = new Markup(markup);
+
+        await Assert.That(markup).Contains($"[[{verb}]]");
+        await Assert.That(markup).Contains("1234 lines");
+    }
+}


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix Spectre markup escaping for import “Skipping/Loading” bracketed text
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary

- Import crashed with `InvalidOperationException: Could not find color or style 'Could'.` when a session error reason like `"Could not parse JSONL"` flowed into the per-session "Skipping" log. The format string wrapped the escaped reason in LITERAL brackets — `$"... [{Markup.Escape(reason)}]"` — so Spectre parsed the resulting `[Could not parse JSONL]` as a markup tag and tried to resolve `"Could"` as a color.
- `Markup.Escape` only escapes characters inside the substring; the literal `[` / `]` we wrap around it must be doubled (`[[` / `]]`).
- Extracted `FormatSkippedReasonMarkup` and `FormatLoadedSummaryMarkup` static helpers, updated all three call sites (two `display.Line` overloads + the TTY scrollback `MarkupLine`), and fixed the same latent shape in the `[{verb}]` "Loading" line.

## Test plan

- [x] New `ImportMarkupEscapeTests` covers the exact `"Could not parse JSONL"` reason plus brackets-in-reason / brackets-in-sessionId / verb variants — all 8 tests pass.
- [x] Verified the tests fail with the original buggy format reintroduced (`InvalidOperationException: Encountered malformed markup tag`).
- [x] Full unit suite: 1287 passed.
- [x] `dotnet publish -c Release` — no IL3050/IL2026 AOT warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Prevent import crashes when error reasons/verbs are wrapped in literal brackets in Spectre markup.
• Centralize “Skipping” and “Loading … [verb]” markup formatting into shared helpers.
• Add regression tests ensuring generated markup always parses, even with brackets in inputs.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Import workflow"] --> B["ImportCommand"] --> C["Per-session log lines"] --> D["Format* markup helpers"] --> E["Spectre markup parser"]
  B --> F["TTY scrollback"] --> D
  G["ImportMarkupEscapeTests"] --> D
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Use Spectre `Text`/`Paragraph` rendering instead of markup strings</b></summary>

- ➕ Avoids manual escaping and bracket-doubling pitfalls entirely
- ➕ Makes output composition safer for arbitrary user/server strings
- ➖ More verbose changes across call sites
- ➖ Harder to keep styling consistent if current codebase standardizes on markup strings

</details>

<details>
<summary><b>2. Escape the whole bracketed fragment via `Markup.Escape($&quot;[{value}]&quot;)`</b></summary>

- ➕ Simple rule: treat the entire bracketed fragment as plain text
- ➖ Easy to apply incorrectly when mixing styled and unstyled segments
- ➖ Still requires discipline at each call site; less self-documenting than helpers

</details>

**Recommendation:** Keep the PR’s approach: centralized helper methods that both document and enforce the correct Spectre escaping rule (double literal outer brackets) and reuse across non-TTY and TTY paths. Consider the `Text`-based rendering alternative only if more complex user-provided strings or additional styled fragments are added in this area.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>ImportCommand.cs</strong> <code>Centralize and fix Spectre markup for skipped/loaded session lines</code> <code>+23/-3</code></summary>

<br/>

>Centralize and fix Spectre markup for skipped/loaded session lines
>
><pre>
>• Introduces &#x27;FormatSkippedReasonMarkup&#x27; and &#x27;FormatLoadedSummaryMarkup&#x27; helpers that double outer brackets (e.g., &#x27;[[...]]&#x27;) while still escaping dynamic content with &#x27;Markup.Escape&#x27;. Updates non-TTY &#x27;display.Line&#x27; and TTY scrollback &#x27;AnsiConsole.MarkupLine&#x27; call sites to use the helpers, preventing &#x27;InvalidOperationException&#x27; when reasons/verbs start with non-style words (e.g., “Could …”).
></pre>
>
><a href='https://github.com/kurrent-io/kcap-cli/pull/131/files#diff-cd79492da1a2a8f0fbeb2e591539699e00acc57fce8175c1734c9acfbaf69183'>src/Capacitor.Cli/Commands/ImportCommand.cs</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>ImportMarkupEscapeTests.cs</strong> <code>Add regression tests for import markup escaping edge cases</code> <code>+71/-0</code></summary>

<br/>

>Add regression tests for import markup escaping edge cases
>
><pre>
>• Adds unit tests that construct Spectre &#x27;Markup&#x27; from the generated strings to ensure parsing never throws. Covers the reported “Could not parse JSONL” reason, additional reason variants, and bracket-containing sessionId/reason inputs, plus the &quot;Loading … [verb]&quot; line formatting.
></pre>
>
><a href='https://github.com/kurrent-io/kcap-cli/pull/131/files#diff-5f578039b9a87f6ef6544718811a58b2d85b92094f69a1df8753cee77fe56714'>test/Capacitor.Cli.Tests.Unit/Import/ImportMarkupEscapeTests.cs</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>