### PR TITLE
fix: don't crash import on HttpClient.Timeout (default 100s)

### DIFF
--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -223,11 +223,22 @@ public static class HttpClientExtensions {
             TimeSpan                                           perAttemptTimeout,
             CancellationToken                                  ct
         ) {
-        var sw      = Stopwatch.StartNew();
-        var delayMs = 250;
+        var        sw        = Stopwatch.StartNew();
+        var        delayMs   = 250;
+        Exception? lastError = null;
 
         while (true) {
-            using var attemptCts = new CancellationTokenSource(perAttemptTimeout);
+            // Hard wall-clock guard: never start a new attempt (or sleep) past totalTimeout,
+            // even when perAttemptTimeout would otherwise allow it. Without this, a default
+            // call (total=30s, per-attempt=60s) against a hung server still blocks for ~60s.
+            var remaining = totalTimeout - sw.Elapsed;
+
+            if (remaining <= TimeSpan.Zero)
+                throw BudgetExhausted(totalTimeout, perAttemptTimeout, lastError);
+
+            var attemptCap = remaining < perAttemptTimeout ? remaining : perAttemptTimeout;
+
+            using var attemptCts = new CancellationTokenSource(attemptCap);
             using var linkedCts  = CancellationTokenSource.CreateLinkedTokenSource(ct, attemptCts.Token);
 
             try {
@@ -235,28 +246,44 @@ public static class HttpClientExtensions {
             } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
                 // Caller cancelled — surface as cancellation, never retry.
                 throw;
-            } catch (HttpRequestException) when (sw.Elapsed < totalTimeout) {
+            } catch (HttpRequestException ex) when (sw.Elapsed < totalTimeout) {
                 // Transient transport error within retry budget — back off and try again.
-            } catch (OperationCanceledException) when (sw.Elapsed < totalTimeout) {
+                lastError = ex;
+            } catch (OperationCanceledException ex) when (sw.Elapsed < totalTimeout) {
                 // Per-attempt timeout fired (linked CTS, not caller's ct) and retry budget
                 // remains — back off and try again. Without this branch the same condition
                 // would surface as an unhandled TaskCanceledException at every call site
                 // that only catches HttpRequestException (import probes, transcript POSTs,
                 // session-start hooks, ...).
-            } catch (OperationCanceledException ex) {
-                // Per-attempt timeout fired but retry budget is exhausted. Convert to
-                // HttpRequestException so existing `catch (HttpRequestException)` handlers
-                // — which all the import / hook call sites already have — degrade the
-                // session to ProbeError / "server unreachable" instead of crashing.
+                lastError = ex;
+            } catch (HttpRequestException ex) {
+                // Budget exhausted on transport error — surface as HttpRequestException so
+                // existing `catch (HttpRequestException)` handlers degrade gracefully.
                 throw new HttpRequestException(
-                    $"Request did not complete within the {perAttemptTimeout.TotalSeconds:F0}s " +
-                    $"per-attempt timeout (retry budget of {totalTimeout.TotalSeconds:F0}s exhausted).",
+                    $"Request failed after exhausting the {totalTimeout.TotalSeconds:F0}s retry budget.",
                     ex
                 );
+            } catch (OperationCanceledException ex) {
+                throw BudgetExhausted(totalTimeout, perAttemptTimeout, ex);
             }
 
-            await Task.Delay(delayMs, ct);
+            // Cap the backoff sleep to the remaining budget so a retry delay can never push
+            // us past totalTimeout. If nothing's left, jump back to the loop top so the
+            // hard-guard above throws with lastError preserved as the inner exception.
+            var remainingAfter = totalTimeout - sw.Elapsed;
+
+            if (remainingAfter <= TimeSpan.Zero) continue;
+
+            var actualDelayMs = (int)Math.Min(delayMs, remainingAfter.TotalMilliseconds);
+            await Task.Delay(actualDelayMs, ct);
             delayMs = Math.Min(delayMs * 2, (int)MaxDelay.TotalMilliseconds);
         }
+
+        static HttpRequestException BudgetExhausted(TimeSpan totalTimeout, TimeSpan perAttemptTimeout, Exception? inner) =>
+            new(
+                $"Request did not complete within the {totalTimeout.TotalSeconds:F0}s retry budget "      +
+                $"(per-attempt timeout {perAttemptTimeout.TotalSeconds:F0}s).",
+                inner
+            );
     }
 }

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -79,6 +79,16 @@ public static class HttpClientExtensions {
     static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
     static readonly TimeSpan MaxDelay       = TimeSpan.FromSeconds(4);
 
+    /// <summary>
+    /// Per-attempt cap on a single HTTP call inside <see cref="SendWithRetryAsync(Func{CancellationToken, Task{HttpResponseMessage}}, TimeSpan, CancellationToken)"/>.
+    /// Enforced via a linked <see cref="CancellationTokenSource"/> so the wall-clock cap
+    /// is observable on the token we pass to <see cref="HttpClient"/> — not on the
+    /// client's own <see cref="HttpClient.Timeout"/> (default 100s), which would
+    /// otherwise raise an unhandled <see cref="TaskCanceledException"/> at every call
+    /// site whose <c>catch</c> only covers <see cref="HttpRequestException"/>.
+    /// </summary>
+    internal static readonly TimeSpan PerAttemptTimeout = TimeSpan.FromSeconds(60);
+
     const string UnreachableHint =
         "Kurrent Capacitor API cannot be reached, is it running? "                    +
         "Make sure the URL is correctly configured and the service is running. "      +
@@ -117,12 +127,12 @@ public static class HttpClientExtensions {
                 CancellationToken ct      = default
             ) {
             EnsureAbsolute(url);
-            return SendWithRetryAsync(() => client.PostAsync(url, content, ct), timeout ?? DefaultTimeout, ct);
+            return SendWithRetryAsync(token => client.PostAsync(url, content, token), timeout ?? DefaultTimeout, ct);
         }
 
         public Task<HttpResponseMessage> GetWithRetryAsync(string url, TimeSpan? timeout = null, CancellationToken ct = default) {
             EnsureAbsolute(url);
-            return SendWithRetryAsync(() => client.GetAsync(url, ct), timeout ?? DefaultTimeout, ct);
+            return SendWithRetryAsync(token => client.GetAsync(url, token), timeout ?? DefaultTimeout, ct);
         }
 
         public Task<HttpResponseMessage> PutWithRetryAsync(
@@ -132,12 +142,12 @@ public static class HttpClientExtensions {
                 CancellationToken ct      = default
             ) {
             EnsureAbsolute(url);
-            return SendWithRetryAsync(() => client.PutAsync(url, content, ct), timeout ?? DefaultTimeout, ct);
+            return SendWithRetryAsync(token => client.PutAsync(url, content, token), timeout ?? DefaultTimeout, ct);
         }
 
         public Task<HttpResponseMessage> DeleteWithRetryAsync(string url, TimeSpan? timeout = null, CancellationToken ct = default) {
             EnsureAbsolute(url);
-            return SendWithRetryAsync(() => client.DeleteAsync(url, ct), timeout ?? DefaultTimeout, ct);
+            return SendWithRetryAsync(token => client.DeleteAsync(url, token), timeout ?? DefaultTimeout, ct);
         }
 
         /// <summary>
@@ -201,17 +211,52 @@ public static class HttpClientExtensions {
         return true;
     }
 
-    static async Task<HttpResponseMessage> SendWithRetryAsync(Func<Task<HttpResponseMessage>> send, TimeSpan timeout, CancellationToken ct) {
+    internal static Task<HttpResponseMessage> SendWithRetryAsync(
+            Func<CancellationToken, Task<HttpResponseMessage>> send,
+            TimeSpan                                           totalTimeout,
+            CancellationToken                                  ct
+        ) => SendWithRetryAsync(send, totalTimeout, PerAttemptTimeout, ct);
+
+    internal static async Task<HttpResponseMessage> SendWithRetryAsync(
+            Func<CancellationToken, Task<HttpResponseMessage>> send,
+            TimeSpan                                           totalTimeout,
+            TimeSpan                                           perAttemptTimeout,
+            CancellationToken                                  ct
+        ) {
         var sw      = Stopwatch.StartNew();
         var delayMs = 250;
 
         while (true) {
+            using var attemptCts = new CancellationTokenSource(perAttemptTimeout);
+            using var linkedCts  = CancellationTokenSource.CreateLinkedTokenSource(ct, attemptCts.Token);
+
             try {
-                return await send();
-            } catch (HttpRequestException) when (!ct.IsCancellationRequested && sw.Elapsed < timeout) {
-                await Task.Delay(delayMs, ct);
-                delayMs = Math.Min(delayMs * 2, (int)MaxDelay.TotalMilliseconds);
+                return await send(linkedCts.Token);
+            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                // Caller cancelled — surface as cancellation, never retry.
+                throw;
+            } catch (HttpRequestException) when (sw.Elapsed < totalTimeout) {
+                // Transient transport error within retry budget — back off and try again.
+            } catch (OperationCanceledException) when (sw.Elapsed < totalTimeout) {
+                // Per-attempt timeout fired (linked CTS, not caller's ct) and retry budget
+                // remains — back off and try again. Without this branch the same condition
+                // would surface as an unhandled TaskCanceledException at every call site
+                // that only catches HttpRequestException (import probes, transcript POSTs,
+                // session-start hooks, ...).
+            } catch (OperationCanceledException ex) {
+                // Per-attempt timeout fired but retry budget is exhausted. Convert to
+                // HttpRequestException so existing `catch (HttpRequestException)` handlers
+                // — which all the import / hook call sites already have — degrade the
+                // session to ProbeError / "server unreachable" instead of crashing.
+                throw new HttpRequestException(
+                    $"Request did not complete within the {perAttemptTimeout.TotalSeconds:F0}s " +
+                    $"per-attempt timeout (retry budget of {totalTimeout.TotalSeconds:F0}s exhausted).",
+                    ex
+                );
             }
+
+            await Task.Delay(delayMs, ct);
+            delayMs = Math.Min(delayMs * 2, (int)MaxDelay.TotalMilliseconds);
         }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/HttpClientExtensionsRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/HttpClientExtensionsRetryTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using Capacitor.Cli.Core;
 
@@ -20,8 +21,8 @@ public class HttpClientExtensionsRetryTests {
 
         var ex = await Assert.That(async () => await HttpClientExtensions.SendWithRetryAsync(
                     Send,
-                    totalTimeout: TimeSpan.FromMilliseconds(400),
-                    perAttemptTimeout: TimeSpan.FromMilliseconds(50),
+                    totalTimeout: TimeSpan.FromMilliseconds(1_200),
+                    perAttemptTimeout: TimeSpan.FromMilliseconds(150),
                     ct: CancellationToken.None
                 )
             )
@@ -29,6 +30,34 @@ public class HttpClientExtensionsRetryTests {
 
         await Assert.That(ex!.InnerException).IsTypeOf<TaskCanceledException>();
         await Assert.That(attempts).IsGreaterThan(1);
+    }
+
+    [Test]
+    public async Task SendWithRetry_enforces_total_timeout_even_when_per_attempt_is_larger() {
+        // Regression for Qodo finding: with total < per-attempt, a hung request
+        // must not block past totalTimeout. The implementation caps each attempt
+        // at min(perAttemptTimeout, remainingBudget) instead of always using the
+        // full per-attempt cap.
+        async Task<HttpResponseMessage> Send(CancellationToken token) {
+            await Task.Delay(Timeout.Infinite, token);
+            return new HttpResponseMessage(HttpStatusCode.OK); // unreachable
+        }
+
+        var sw = Stopwatch.StartNew();
+
+        await Assert.That(async () => await HttpClientExtensions.SendWithRetryAsync(
+                    Send,
+                    totalTimeout: TimeSpan.FromMilliseconds(300),
+                    perAttemptTimeout: TimeSpan.FromSeconds(30),
+                    ct: CancellationToken.None
+                )
+            )
+            .Throws<HttpRequestException>();
+
+        sw.Stop();
+        // Generous upper bound: a strict enforcement should be ~300ms; even
+        // under heavy CI load it should be well under 2s.
+        await Assert.That(sw.ElapsedMilliseconds).IsLessThan(2_000);
     }
 
     [Test]
@@ -48,8 +77,8 @@ public class HttpClientExtensionsRetryTests {
 
         var resp = await HttpClientExtensions.SendWithRetryAsync(
             Send,
-            totalTimeout: TimeSpan.FromSeconds(2),
-            perAttemptTimeout: TimeSpan.FromMilliseconds(50),
+            totalTimeout: TimeSpan.FromSeconds(5),
+            perAttemptTimeout: TimeSpan.FromMilliseconds(150),
             ct: CancellationToken.None
         );
 
@@ -92,7 +121,7 @@ public class HttpClientExtensionsRetryTests {
 
         var resp = await HttpClientExtensions.SendWithRetryAsync(
             Send,
-            totalTimeout: TimeSpan.FromSeconds(2),
+            totalTimeout: TimeSpan.FromSeconds(5),
             perAttemptTimeout: TimeSpan.FromSeconds(1),
             ct: CancellationToken.None
         );

--- a/test/Capacitor.Cli.Tests.Unit/HttpClientExtensionsRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/HttpClientExtensionsRetryTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class HttpClientExtensionsRetryTests {
+    [Test]
+    public async Task SendWithRetry_converts_per_attempt_timeout_to_HttpRequestException_after_budget_exhausted() {
+        // Simulates the original bug: a slow server holds the request open past the
+        // per-attempt cap. The retry loop must surface the failure as
+        // HttpRequestException so the import's `catch (HttpRequestException)` blocks
+        // can degrade gracefully instead of crashing with TaskCanceledException.
+        var attempts = 0;
+
+        async Task<HttpResponseMessage> Send(CancellationToken token) {
+            Interlocked.Increment(ref attempts);
+            await Task.Delay(Timeout.Infinite, token);
+            return new HttpResponseMessage(HttpStatusCode.OK); // unreachable — per-attempt CTS fires first.
+        }
+
+        var ex = await Assert.That(async () => await HttpClientExtensions.SendWithRetryAsync(
+                    Send,
+                    totalTimeout: TimeSpan.FromMilliseconds(400),
+                    perAttemptTimeout: TimeSpan.FromMilliseconds(50),
+                    ct: CancellationToken.None
+                )
+            )
+            .Throws<HttpRequestException>();
+
+        await Assert.That(ex!.InnerException).IsTypeOf<TaskCanceledException>();
+        await Assert.That(attempts).IsGreaterThan(1);
+    }
+
+    [Test]
+    public async Task SendWithRetry_retries_after_first_attempt_times_out_then_succeeds() {
+        var attempts = 0;
+
+        async Task<HttpResponseMessage> Send(CancellationToken token) {
+            var attempt = Interlocked.Increment(ref attempts);
+
+            if (attempt == 1) {
+                // First attempt: hang until the per-attempt CTS cancels it.
+                await Task.Delay(Timeout.Infinite, token);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+
+        var resp = await HttpClientExtensions.SendWithRetryAsync(
+            Send,
+            totalTimeout: TimeSpan.FromSeconds(2),
+            perAttemptTimeout: TimeSpan.FromMilliseconds(50),
+            ct: CancellationToken.None
+        );
+
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task SendWithRetry_propagates_caller_cancellation_without_converting_to_HttpRequestException() {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        static Task<HttpResponseMessage> Send(CancellationToken token) {
+            token.ThrowIfCancellationRequested();
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+
+        await Assert.That(async () => await HttpClientExtensions.SendWithRetryAsync(
+                    Send,
+                    totalTimeout: TimeSpan.FromSeconds(1),
+                    perAttemptTimeout: TimeSpan.FromSeconds(1),
+                    ct: cts.Token
+                )
+            )
+            .Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task SendWithRetry_retries_transient_HttpRequestException_within_total_timeout() {
+        var attempts = 0;
+
+        Task<HttpResponseMessage> Send(CancellationToken token) {
+            var attempt = Interlocked.Increment(ref attempts);
+
+            return attempt < 3
+                ? Task.FromException<HttpResponseMessage>(new HttpRequestException("connect refused"))
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+
+        var resp = await HttpClientExtensions.SendWithRetryAsync(
+            Send,
+            totalTimeout: TimeSpan.FromSeconds(2),
+            perAttemptTimeout: TimeSpan.FromSeconds(1),
+            ct: CancellationToken.None
+        );
+
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(attempts).IsEqualTo(3);
+    }
+}


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix HttpClient retry timeouts to avoid import crash and add regression tests
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary

- `kcap import` crashed mid-run with an unhandled `TaskCanceledException` whenever a single HTTP call exceeded the .NET default `HttpClient.Timeout` of 100s. `SendWithRetryAsync` only caught `HttpRequestException`, so the timeout-induced cancellation escaped every retry / catch block. Most visibly this killed the classification probe (`GET /api/sessions/{id}/last-line`) — one slow probe out of 145 would terminate the whole import with no progress shown.
- Each retry attempt now runs under a linked `CancellationTokenSource` with an explicit per-attempt cap (60s default), and an exhausted-budget timeout is wrapped as `HttpRequestException` so the existing `catch (HttpRequestException)` blocks at the import / hook call sites degrade the session to `ProbeError` / "server unreachable" instead of crashing.
- New `HttpClientExtensionsRetryTests` cover: per-attempt timeout → `HttpRequestException` after budget exhausted, retry-and-recover on a single slow attempt, caller cancellation still propagates as `OperationCanceledException`, transient `HttpRequestException` retries within budget.

## Test plan

- [x] `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj` → 1283/1283 pass
- [x] `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release` → no IL3050/IL2026 AOT warnings
- [ ] Repro on a slow / hung server: probe times out → "Skipping {sid} [server unreachable]" instead of crash; import continues
- [ ] Smoke test a normal `kcap import` against a healthy server (no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Enforce per-attempt HTTP timeouts in retry loop to prevent import crashing on slow calls.
• Convert exhausted timeout cancellations into HttpRequestException for existing error handling.
• Add unit coverage for retry, timeout, and cancellation propagation behaviors.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  callers["Import/Hook callers"] --> retry["HttpClientExtensions.SendWithRetryAsync"] --> client["HttpClient"] --> api{{"Capacitor API"}}
  callerCt(("Caller CT")) --> retry
  attemptCt(("Per-attempt CTS")) --> retry
  retry --> outcome["HttpResponse or HttpRequestException"]

  subgraph Legend
    direction LR
    _cmp["Component"] ~~~ _tok(("Token/CTS")) ~~~ _ext{{"External"}}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Set HttpClient.Timeout explicitly (or to Infinite) at client construction</b></summary>

- ➕ Centralizes timeout behavior without changing retry helper signature
- ➕ Avoids per-call CancellationTokenSource allocations
- ➖ Does not provide per-attempt vs total-budget separation
- ➖ Still risks TaskCanceledException surfacing at call sites depending on how requests are issued/handled
- ➖ Harder to ensure consistent behavior across all HTTP usages

</details>

<details>
<summary><b>2. Adopt a resiliency library (e.g., Polly) for retries/timeouts</b></summary>

- ➕ Standardized policies for retries, timeouts, jitter, and circuit breaking
- ➕ Clearer separation of concerns and richer telemetry hooks
- ➖ Adds dependency and policy configuration complexity
- ➖ Potentially more invasive refactor than needed for this specific crash

</details>

**Recommendation:** Keep the PR’s approach: enforcing a linked per-attempt timeout inside SendWithRetryAsync and converting exhausted-budget timeouts to HttpRequestException directly matches existing error-handling expectations at call sites while preserving caller-initiated cancellation semantics. Alternatives were considered, but they either don’t address the call-site exception shape consistently or add unnecessary dependency/complexity for the scope.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>HttpClientExtensions.cs</strong> <code>Add per-attempt timeout + cancellation-aware retry semantics</code> <code>+54/-9</code></summary>

<br/>

>Add per-attempt timeout + cancellation-aware retry semantics
>
><pre>
>• Introduces a per-attempt timeout (default 60s) enforced via a linked CancellationTokenSource for each retry attempt. Refactors SendWithRetryAsync to accept a token-aware send delegate, distinguishes caller cancellation from attempt timeout, and wraps exhausted-budget timeout cancellations into HttpRequestException so existing handlers degrade gracefully instead of crashing.
></pre>
>
><a href='https://github.com/kurrent-io/kcap-cli/pull/132/files#diff-d9f99e37d6bb8ead39379b9163fb92986560c5ba43d2c93f314ca5885fd12c2d'>src/Capacitor.Cli.Core/HttpClientExtensions.cs</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>HttpClientExtensionsRetryTests.cs</strong> <code>Add regression tests for retry timeout and cancellation behavior</code> <code>+103/-0</code></summary>

<br/>

>Add regression tests for retry timeout and cancellation behavior
>
><pre>
>• Adds unit tests validating that per-attempt timeouts retry within the total budget and eventually surface as HttpRequestException when exhausted. Also covers retry recovery after a single slow attempt, propagation of caller cancellation as OperationCanceledException, and retrying transient HttpRequestException failures.
></pre>
>
><a href='https://github.com/kurrent-io/kcap-cli/pull/132/files#diff-8f52aa08653c01f83cc0c8a07488f9d38b2b2808f79c6cbc33efae067c92f05a'>test/Capacitor.Cli.Tests.Unit/HttpClientExtensionsRetryTests.cs</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>