### PR TITLE
Log every daemon-process exit reason (death rattle)

### DIFF
--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -336,13 +336,19 @@ public static partial class DaemonRunner {
         // SIGQUIT are NOT caught by ConsoleLifetime, so for those we both log
         // AND call StopApplication ourselves — otherwise the OS would terminate
         // us before the host's finally-block could run.
+        //
+        // The returned PosixSignalRegistration IS the registration's lifetime
+        // anchor — if it's GC'd and finalized the handler unregisters silently
+        // and the signal goes back to its default OS action (terminate the
+        // process for SIGHUP, etc). Root them in a static list so they live
+        // as long as the DaemonRunner type — i.e. the process.
         foreach (var signal in new[] { PosixSignal.SIGINT, PosixSignal.SIGTERM, PosixSignal.SIGHUP, PosixSignal.SIGQUIT }) {
             try {
-                PosixSignalRegistration.Create(signal, ctx => {
+                _signalRegistrations.Add(PosixSignalRegistration.Create(signal, ctx => {
                     LogPosixSignal(logger, ctx.Signal);
                     ctx.Cancel = true;
                     lifetime.StopApplication();
-                });
+                }));
             } catch (PlatformNotSupportedException) {
                 // Signal not supported on this OS — skip silently. SIGHUP/SIGQUIT
                 // are unsupported on Windows; SIGINT/SIGTERM are supported
@@ -350,4 +356,16 @@ public static partial class DaemonRunner {
             }
         }
     }
+
+    /// <summary>
+    /// Roots <see cref="PosixSignalRegistration"/> instances for the lifetime
+    /// of the process. <see cref="PosixSignalRegistration.Create"/> returns an
+    /// <see cref="IDisposable"/> whose finalizer unregisters the handler;
+    /// without a strong reference the registration is eligible for GC the
+    /// moment <see cref="RegisterDeathRattle"/> returns, which would silently
+    /// re-arm the OS default for SIGHUP/SIGQUIT (= terminate the daemon
+    /// before the finally-block runs). Static field on a static class = same
+    /// lifetime as the process.
+    /// </summary>
+    static readonly List<PosixSignalRegistration> _signalRegistrations = [];
 }

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Capacitor.Cli.Daemon.Pty;
 using Capacitor.Cli.Daemon.Pty.Unix;
 using Capacitor.Cli.Daemon.Pty.Windows;
@@ -190,6 +191,21 @@ public static partial class DaemonRunner {
         var lifetime   = host.Services.GetRequiredService<IHostApplicationLifetime>();
         var connection = host.Services.GetRequiredService<ServerConnection>();
 
+        // Death-rattle instrumentation: without these, a daemon dying mid-run
+        // (signal, OOM, unobserved-task FailFast, native crash) leaves no trace
+        // in the log and we can't tell a clean shutdown from a kill. Each hook
+        // best-effort logs *why* the process is going away before the runtime
+        // tears down the logging pipeline. Lifetime is captured so SIGHUP
+        // (terminal closed) can be turned into a cooperative StopApplication
+        // — without that, the host's finally-block cleanup never runs.
+        RegisterDeathRattle(logger, lifetime);
+
+        // Lifetime-driven log lines — pair with the AppDomain/signal hooks so
+        // we can distinguish a cooperative StopApplication (e.g. NameInUse,
+        // Ctrl+C consumed by ConsoleLifetime) from an outside-the-runtime kill.
+        lifetime.ApplicationStopping.Register(() => LogLifetimeStopping(logger));
+        lifetime.ApplicationStopped.Register(() => LogLifetimeStopped(logger));
+
         // AI-630: if the server rejects our DaemonConnect because another
         // live daemon owns the (owner, name) slot, signal host shutdown
         // and remember to return exit code 3 instead of 0. Subscribe
@@ -237,11 +253,14 @@ public static partial class DaemonRunner {
             // would surface as OperationCanceledException. The no-arg overload listens
             // internally for ApplicationStopping and returns cleanly.
             await host.WaitForShutdownAsync();
+            LogWaitForShutdownReturned(logger);
         } finally {
+            LogEnteringCleanup(logger);
             daemonLock.Dispose();
             await orchestrator.DisposeAsync();
             await connection.DisposeAsync();
             await host.StopAsync();
+            LogCleanupCompleted(logger);
         }
 
         // AI-630: if the daemon was shut down because the server told us
@@ -253,4 +272,82 @@ public static partial class DaemonRunner {
 
     [LoggerMessage(Level = LogLevel.Information, Message = "kcap daemon '{Name}' starting, connecting to {ServerUrl}")]
     static partial void LogDaemonStarting(ILogger logger, string name, string serverUrl);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Lifetime: ApplicationStopping fired")]
+    static partial void LogLifetimeStopping(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Lifetime: ApplicationStopped fired")]
+    static partial void LogLifetimeStopped(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "WaitForShutdownAsync returned — entering cleanup")]
+    static partial void LogWaitForShutdownReturned(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Cleanup: disposing daemon resources")]
+    static partial void LogEnteringCleanup(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Cleanup: completed, daemon exiting")]
+    static partial void LogCleanupCompleted(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Critical, Message = "AppDomain.UnhandledException (terminating={IsTerminating})")]
+    static partial void LogUnhandledException(ILogger logger, Exception ex, bool isTerminating);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "TaskScheduler.UnobservedTaskException — observed and swallowed")]
+    static partial void LogUnobservedTaskException(ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "AppDomain.ProcessExit fired (this is the last log line)")]
+    static partial void LogProcessExit(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Received POSIX signal {Signal} — requesting cooperative shutdown")]
+    static partial void LogPosixSignal(ILogger logger, PosixSignal signal);
+
+    /// <summary>
+    /// Wires AppDomain + TaskScheduler + POSIX-signal hooks so whenever the
+    /// daemon process is going away we get a last log line before the runtime
+    /// tears down. Without these, the only signal we'd see is "the log ends" —
+    /// indistinguishable between SIGTERM, SIGHUP (terminal closed), OOM kill,
+    /// an unobserved Task FailFast, or a clean StopApplication. SIGHUP is the
+    /// top suspect for "daemon dies silently after a foreground run", since
+    /// ConsoleLifetime doesn't register for it and the OS default is SIGTERM
+    /// the process. Routing it through <paramref name="lifetime"/> turns the
+    /// hard kill into a cooperative shutdown so the cleanup finally-block
+    /// gets to run.
+    /// </summary>
+    static void RegisterDeathRattle(ILogger logger, IHostApplicationLifetime lifetime) {
+        AppDomain.CurrentDomain.UnhandledException += (_, args) => {
+            if (args.ExceptionObject is Exception ex) {
+                LogUnhandledException(logger, ex, args.IsTerminating);
+            }
+        };
+
+        TaskScheduler.UnobservedTaskException += (_, args) => {
+            LogUnobservedTaskException(logger, args.Exception);
+            // Mark observed so the default policy (a no-op in .NET 5+, but a
+            // process-killing rethrow on legacy/AOT configurations) can't
+            // escalate this past the logging step.
+            args.SetObserved();
+        };
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => LogProcessExit(logger);
+
+        // POSIX signal hooks. ConsoleLifetime already wires SIGINT and SIGTERM
+        // to lifetime.StopApplication(); our registration is additive (multiple
+        // PosixSignalRegistration handlers all run) so it just guarantees a
+        // log line lands before the cooperative shutdown begins. SIGHUP and
+        // SIGQUIT are NOT caught by ConsoleLifetime, so for those we both log
+        // AND call StopApplication ourselves — otherwise the OS would terminate
+        // us before the host's finally-block could run.
+        foreach (var signal in new[] { PosixSignal.SIGINT, PosixSignal.SIGTERM, PosixSignal.SIGHUP, PosixSignal.SIGQUIT }) {
+            try {
+                PosixSignalRegistration.Create(signal, ctx => {
+                    LogPosixSignal(logger, ctx.Signal);
+                    ctx.Cancel = true;
+                    lifetime.StopApplication();
+                });
+            } catch (PlatformNotSupportedException) {
+                // Signal not supported on this OS — skip silently. SIGHUP/SIGQUIT
+                // are unsupported on Windows; SIGINT/SIGTERM are supported
+                // everywhere.
+            }
+        }
+    }
 }


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add shutdown/exception/signal “death rattle” logging to daemon runner
<code>🐞 Bug fix</code> <code>✨ Enhancement</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary

- Adds AppDomain.UnhandledException, TaskScheduler.UnobservedTaskException, AppDomain.ProcessExit, ApplicationStopping/Stopped, and the four POSIX signal hooks (SIGINT/SIGTERM/SIGHUP/SIGQUIT) to `DaemonRunner.RunAsync`.
- SIGHUP and SIGQUIT are additionally routed to `lifetime.StopApplication()` since `ConsoleLifetime` doesn't catch them — terminal-close (which used to silently kill the daemon) now triggers cooperative shutdown so the `finally`-block worktree/connection cleanup actually runs.
- Hooks are inert during normal operation; steady-state log is unchanged.

## Why

When the daemon dies mid-run today, the log just ends — there's no way to distinguish a clean StopApplication from SIGHUP, SIGTERM, OOM kill, an unobserved Task FailFast, or a native crash. With these hooks the next crash leaves exactly one line of evidence telling us which path it took out.

## Test plan

- [ ] `dotnet build` clean
- [ ] `dotnet publish src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj -c Release` no new AOT warnings (verified locally)
- [ ] Start daemon foreground, send SIGTERM: expect `Received POSIX signal SIGTERM` → `Lifetime: ApplicationStopping fired` → cleanup logs → `AppDomain.ProcessExit fired`
- [ ] Start daemon foreground, close terminal (SIGHUP): expect same sequence with `SIGHUP` instead of being killed silently
- [ ] Start daemon, send SIGKILL: expect log ends abruptly (signal can't be caught — this is the OOM-killer equivalent and now provably distinct from SIGTERM/SIGHUP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Log explicit exit reasons via AppDomain, TaskScheduler, lifetime, and POSIX signal hooks.
• Route SIGHUP/SIGQUIT into StopApplication so foreground terminal-close triggers cooperative
  cleanup.
• Add cleanup-phase log markers to distinguish normal shutdown from abrupt termination.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["DaemonRunner.RunAsync"] --> B["RegisterDeathRattle()"] --> C["Unhandled/Unobserved hooks"]
  B --> D["POSIX signal hooks"] --> E["Host lifetime events"] --> F["WaitForShutdownAsync"] --> G["Cleanup finally-block"] --> H["ProcessExit log"]
  C --> H
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Move death-rattle wiring into an IHostedService</b></summary>

- ➕ Keeps DaemonRunner.RunAsync focused on orchestration; encapsulates lifecycle instrumentation in one service
- ➕ Easier to unit test registration logic via DI (to the extent possible for static events)
- ➖ Registration would occur later (after host start), potentially missing very-early failures before hosted services start
- ➖ Still relies on static/global hooks; doesn’t materially reduce risk vs current approach

</details>

<details>
<summary><b>2. Rely solely on ConsoleLifetime/Systemd integration for signals</b></summary>

- ➕ Less custom code; uses standard host lifetime integrations
- ➖ Doesn’t cover SIGHUP/SIGQUIT gaps (the motivating bug) and won’t log AppDomain/TaskScheduler termination reasons
- ➖ Still wouldn’t produce a single definitive ‘why we exited’ line for many crash paths

</details>

**Recommendation:** Current approach is appropriate because it registers hooks as early as possible (before the main wait loop) and explicitly addresses SIGHUP/SIGQUIT to ensure cooperative shutdown and cleanup. Consider the IHostedService refactor only if you want stricter separation, but it risks missing early-exit scenarios.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>DaemonRunner.cs</strong> <code>Add exit-reason instrumentation and cooperative shutdown for extra POSIX signals</code> <code>+97/-0</code></summary>

<br/>

>Add exit-reason instrumentation and cooperative shutdown for extra POSIX signals
>
><pre>
>• Registers AppDomain, TaskScheduler, ProcessExit, host lifetime, and POSIX signal handlers to emit one-line “death rattle” logs on daemon termination paths. Routes SIGHUP/SIGQUIT into StopApplication to ensure the shutdown finally-block runs, and adds explicit log markers around WaitForShutdownAsync return and cleanup completion.
></pre>
>
><a href='https://github.com/kurrent-io/kcap-cli/pull/133/files#diff-58fe0f1e1e0ea55e28cf0a70203cc204c3bbd47a2fef6fcf4429946fe8d9bdaf'>src/Capacitor.Cli.Daemon/DaemonRunner.cs</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>