### PR TITLE
[AI-795] V2 retrospective payload + agent-tagged suggestion routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Once set up, Capacitor runs silently in the background. Every Claude Code (and C
 - **Token consumption** — input/output/cache token counts per interaction
 - **Repository context** — git repo, branch, and PR linkage
 - **In-agent upgrade prompts** — in Claude Code sessions, when the server is running a newer kcap release than the local CLI, additional context is injected into the session so the agent can offer the user an upgrade via `npm install -g @kurrent/kcap`. The stderr `kcap` update hint continues to fire for direct command-line use.
+- **SessionStart context injection** — at every session start the server injects top evaluation-derived fact clusters for the current repo into Claude's `additionalContext`. The injected block is split into two sections: `## Known patterns` (repo/project facts relevant to any reader) and `## Guidance from past sessions` (agent-targeted action items derived from prior eval suggestions with `audience: "agent"`). Opt out by setting `disable_session_guidelines: true` in `~/.config/kcap/config.json` or via `kcap config set disable_session_guidelines true`.
 
 ## CLI commands
 

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -743,7 +743,7 @@ public static class EvalService {
             var root = doc.RootElement;
             if (root.ValueKind != JsonValueKind.Object) return null;
 
-            var overall   = root.TryGetProperty("overall",   out var ov) ? (ov.GetString() ?? "") : "";
+            var overall   = ReadString(root, "overall") ?? "";
             var strengths = ReadStringArray(root, "strengths");
             var issues    = ReadStringArray(root, "issues");
             var suggestions = ReadSuggestionsV2(root);
@@ -773,15 +773,21 @@ public static class EvalService {
                     break;
 
                 case JsonValueKind.Object:
-                    var text     = item.TryGetProperty("text",     out var t) ? (t.GetString() ?? "") : "";
-                    var audience = item.TryGetProperty("audience", out var a) ? (a.GetString() ?? "human") : "human";
-                    if (audience != "agent" && audience != "human") audience = "human";
+                    var text         = ReadString(item, "text") ?? "";
+                    var audienceRaw  = ReadString(item, "audience");
+                    var normalized   = audienceRaw?.Trim().ToLowerInvariant();
+                    var audience     = normalized == "agent" || normalized == "human" ? normalized : "human";
                     list.Add(new RetrospectiveSuggestion { Text = text, Audience = audience });
                     break;
             }
         }
 
         return list;
+    }
+
+    static string? ReadString(JsonElement parent, string propertyName) {
+        if (!parent.TryGetProperty(propertyName, out var prop)) return null;
+        return prop.ValueKind == JsonValueKind.String ? prop.GetString() : null;
     }
 
     static List<string> ReadStringArray(JsonElement root, string propertyName) {

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -144,7 +144,7 @@ public static class EvalService {
     /// <see cref="IEvalObserver.OnFailed"/> either way.
     /// </para>
     /// </summary>
-    public static async Task<SessionEvalCompletedPayload?> RunAsync(
+    public static async Task<SessionEvalCompletedPayloadV2?> RunAsync(
             string                          baseUrl,
             HttpClient                      httpClient,
             string                          sessionId,
@@ -425,7 +425,7 @@ public static class EvalService {
 
     // ── Phase 3: Finalize ──────────────────────────────────────────────────
 
-    public static async Task<SessionEvalCompletedPayload?> FinalizeAsync(
+    public static async Task<SessionEvalCompletedPayloadV2?> FinalizeAsync(
             EvalContext                        ctx,
             HttpClient                         httpClient,
             string                             baseUrl,
@@ -440,7 +440,8 @@ public static class EvalService {
             return null;
         }
 
-        // 4. Aggregate per-category + overall scores.
+        // 4. Aggregate per-category + overall scores. AI-795 T18: V2 payload
+        //    with structured RetrospectiveSuggestion items.
         var aggregate = Aggregate(verdicts, ctx.EvalRunId, model, ctx.Questions);
 
         // FactsUsed stays empty: nothing was injected into the judge prompt,
@@ -471,9 +472,39 @@ public static class EvalService {
         );
         aggregate = aggregate with { Retrospective = retrospective };
 
-        // 6. Persist the aggregate to the server.
-        var       postUrl     = $"{baseUrl}/api/sessions/{ctx.EncodedSessionId}/evals";
-        var       payloadJson = JsonSerializer.Serialize(aggregate, CapacitorJsonContext.Default.SessionEvalCompletedPayload);
+        // 6. Persist the aggregate to the server via the V2 route.
+        var ok = await PersistAggregateV2Async(httpClient, baseUrl, ctx.EncodedSessionId, aggregate, observer, ct);
+        if (!ok) return null;
+
+        observer.OnFinished(aggregate);
+
+        return aggregate;
+    }
+
+    /// <summary>
+    /// Persists a V2 aggregate to <c>POST /api/sessions/{id}/evals/v2</c>.
+    /// Extracted from <see cref="FinalizeAsync"/> as a public seam so the
+    /// daemon's wire-format contract can be tested without driving a full
+    /// retrospective synthesis (the latter requires the <c>claude</c> CLI
+    /// which isn't available in CI).
+    ///
+    /// <para>
+    /// Reports failures through <paramref name="observer"/>.OnFailed and
+    /// returns <c>false</c>; on HTTP success returns <c>true</c> without
+    /// touching the observer (caller is responsible for firing
+    /// OnFinished — see <see cref="FinalizeAsync"/>).
+    /// </para>
+    /// </summary>
+    public static async Task<bool> PersistAggregateV2Async(
+            HttpClient                    httpClient,
+            string                        baseUrl,
+            string                        encodedSessionId,
+            SessionEvalCompletedPayloadV2 aggregate,
+            IEvalObserver                 observer,
+            CancellationToken             ct
+        ) {
+        var       postUrl     = $"{baseUrl}/api/sessions/{encodedSessionId}/evals/v2";
+        var       payloadJson = JsonSerializer.Serialize(aggregate, CapacitorJsonContext.Default.SessionEvalCompletedPayloadV2);
         using var httpContent = new StringContent(payloadJson, Encoding.UTF8, "application/json");
 
         try {
@@ -481,17 +512,15 @@ public static class EvalService {
             if (!postResp.IsSuccessStatusCode) {
                 observer.OnFailed($"failed to persist eval result: HTTP {(int)postResp.StatusCode}");
 
-                return null;
+                return false;
             }
         } catch (HttpRequestException ex) {
             observer.OnFailed($"server unreachable for POST: {ex.Message}");
 
-            return null;
+            return false;
         }
 
-        observer.OnFinished(aggregate);
-
-        return aggregate;
+        return true;
     }
 
     // ── Prompt construction ────────────────────────────────────────────────
@@ -855,7 +884,7 @@ public static class EvalService {
 
     // ── Aggregation ────────────────────────────────────────────────────────
 
-    public static SessionEvalCompletedPayload Aggregate(
+    public static SessionEvalCompletedPayloadV2 Aggregate(
             IReadOnlyList<EvalQuestionVerdict> verdicts,
             string                             evalRunId,
             string                             model,
@@ -883,7 +912,7 @@ public static class EvalService {
         var summary = $"Evaluated {verdicts.Count}/{questions.Count} questions "
             + $"across {byCategory.Count} categories. Overall: {overall}/5 ({VerdictForScore(overall)}).";
 
-        return new SessionEvalCompletedPayload {
+        return new SessionEvalCompletedPayloadV2 {
             EvalRunId    = evalRunId,
             JudgeModel   = model,
             Categories   = byCategory,
@@ -921,12 +950,12 @@ public static class EvalService {
     /// <see cref="OperationCanceledException"/> propagates so upstream
     /// cancellation still cancels the eval run.
     /// </summary>
-    static async Task<EvalRetrospective?> RunRetrospectiveAsync(
+    static async Task<EvalRetrospectiveV2?> RunRetrospectiveAsync(
             string                             evalRunId,
             string                             sessionId,
             string                             model,
             string                             baseUrl,
-            SessionEvalCompletedPayload        aggregate,
+            SessionEvalCompletedPayloadV2      aggregate,
             IReadOnlyList<EvalQuestionVerdict> verdicts,
             IEvalObserver                      observer,
             CancellationToken                  ct
@@ -990,7 +1019,10 @@ public static class EvalService {
                 return null;
             }
 
-            var retrospective = ParseRetrospective(result.Result);
+            // AI-795 T18: V2 parser — tolerant of bare-string suggestion items
+            // and missing audience field (coerces to "human"). Server-side V2
+            // route accepts both shapes.
+            var retrospective = ParseRetrospectiveV2(result.Result);
             if (retrospective is null) {
                 observer.OnRetrospectiveFailed($"retrospective response did not parse as expected JSON shape; raw response: {Truncate(result.Result, 500)}");
 
@@ -1080,13 +1112,13 @@ public static class EvalService {
         public void OnRetrospectiveStarted() =>
             Safe(inner.OnRetrospectiveStarted, nameof(OnRetrospectiveStarted));
 
-        public void OnRetrospectiveCompleted(EvalRetrospective retrospective) =>
+        public void OnRetrospectiveCompleted(EvalRetrospectiveV2 retrospective) =>
             Safe(() => inner.OnRetrospectiveCompleted(retrospective), nameof(OnRetrospectiveCompleted));
 
         public void OnRetrospectiveFailed(string reason) =>
             Safe(() => inner.OnRetrospectiveFailed(reason), nameof(OnRetrospectiveFailed));
 
-        public void OnFinished(SessionEvalCompletedPayload aggregate) =>
+        public void OnFinished(SessionEvalCompletedPayloadV2 aggregate) =>
             Safe(() => inner.OnFinished(aggregate), nameof(OnFinished));
 
         public void OnFailed(string reason) =>

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -674,6 +674,90 @@ public static class EvalService {
     }
 
     /// <summary>
+    /// Parses a V2 retrospective synthesis response into
+    /// <see cref="EvalRetrospectiveV2"/> with defensive coercions:
+    /// <list type="bullet">
+    ///   <item>Code fences stripped before parsing.</item>
+    ///   <item>Legacy bare-string suggestion items coerced to
+    ///     <c>{ Text = s, Audience = "human" }</c>.</item>
+    ///   <item>Missing <c>audience</c> field → <c>"human"</c>.</item>
+    ///   <item>Unknown <c>audience</c> values (not <c>"agent"</c> or
+    ///     <c>"human"</c>) → <c>"human"</c>.</item>
+    /// </list>
+    /// Returns <c>null</c> on null/empty/whitespace input, malformed JSON,
+    /// or a non-object root. Synthesis failure is non-fatal — the caller
+    /// leaves <see cref="SessionEvalCompletedPayloadV2.Retrospective"/> as
+    /// null.
+    /// </summary>
+    public static EvalRetrospectiveV2? ParseRetrospectiveV2(string rawResponse) {
+        if (string.IsNullOrWhiteSpace(rawResponse)) return null;
+
+        var json = StripCodeFences(rawResponse.Trim());
+
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(json); }
+        catch { return null; }
+
+        using (doc) {
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return null;
+
+            var overall   = root.TryGetProperty("overall",   out var ov) ? (ov.GetString() ?? "") : "";
+            var strengths = ReadStringArray(root, "strengths");
+            var issues    = ReadStringArray(root, "issues");
+            var suggestions = ReadSuggestionsV2(root);
+
+            return new EvalRetrospectiveV2 {
+                OverallSummary = overall,
+                Strengths      = strengths,
+                Issues         = issues,
+                Suggestions    = suggestions
+            };
+        }
+    }
+
+    static List<RetrospectiveSuggestion> ReadSuggestionsV2(JsonElement root) {
+        if (!root.TryGetProperty("suggestions", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var list = new List<RetrospectiveSuggestion>(arr.GetArrayLength());
+
+        foreach (var item in arr.EnumerateArray()) {
+            switch (item.ValueKind) {
+                case JsonValueKind.String:
+                    list.Add(new RetrospectiveSuggestion {
+                        Text     = item.GetString() ?? "",
+                        Audience = "human"
+                    });
+                    break;
+
+                case JsonValueKind.Object:
+                    var text     = item.TryGetProperty("text",     out var t) ? (t.GetString() ?? "") : "";
+                    var audience = item.TryGetProperty("audience", out var a) ? (a.GetString() ?? "human") : "human";
+                    if (audience != "agent" && audience != "human") audience = "human";
+                    list.Add(new RetrospectiveSuggestion { Text = text, Audience = audience });
+                    break;
+            }
+        }
+
+        return list;
+    }
+
+    static List<string> ReadStringArray(JsonElement root, string propertyName) {
+        if (!root.TryGetProperty(propertyName, out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var list = new List<string>(arr.GetArrayLength());
+        foreach (var item in arr.EnumerateArray()) {
+            if (item.ValueKind == JsonValueKind.String) {
+                list.Add(item.GetString() ?? "");
+            }
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Extracts the optional <c>retain_fact</c> string from a raw judge
     /// response. Returns null when absent, explicitly null, empty, or when
     /// the response isn't parseable JSON. Independent of

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -32,9 +32,21 @@ public static class EvalService {
     // strengths/issues and five suggestions. Enforcing this at the schema
     // level keeps retrospectives cheap and prevents the model from padding
     // lists with low-signal bullets just because the schema would let it.
+    //
+    // AI-795: suggestions.items is an object with {text, audience} — NOT a
+    // bare string. The previous string-items schema forced the model to
+    // ignore the prompt's {text, audience} instruction, which meant every
+    // suggestion landed as audience="human" and no agent_guidance was ever
+    // produced by CLI-driven evals.
     const string RetrospectiveJsonSchema = """
-        {"type":"object","properties":{"overall":{"type":"string"},"strengths":{"type":"array","maxItems":3,"items":{"type":"string"}},"issues":{"type":"array","maxItems":3,"items":{"type":"string"}},"suggestions":{"type":"array","maxItems":5,"items":{"type":"string"}}},"required":["overall","strengths","issues","suggestions"],"additionalProperties":false}
+        {"type":"object","properties":{"overall":{"type":"string"},"strengths":{"type":"array","maxItems":3,"items":{"type":"string"}},"issues":{"type":"array","maxItems":3,"items":{"type":"string"}},"suggestions":{"type":"array","maxItems":5,"items":{"type":"object","properties":{"text":{"type":"string"},"audience":{"type":"string","enum":["agent","human"]}},"required":["text","audience"],"additionalProperties":false}}},"required":["overall","strengths","issues","suggestions"],"additionalProperties":false}
         """;
+
+    /// <summary>
+    /// Exposes <see cref="RetrospectiveJsonSchema"/> for test-time schema
+    /// validation. Production callers reference the constant directly.
+    /// </summary>
+    internal static string GetRetrospectiveJsonSchema() => RetrospectiveJsonSchema;
 
     // Claude CLI spends one turn calling the synthetic StructuredOutput tool
     // and a second turn emitting the end-of-turn, so eval calls need at

--- a/src/Capacitor.Cli.Core/Eval/IEvalObserver.cs
+++ b/src/Capacitor.Cli.Core/Eval/IEvalObserver.cs
@@ -50,13 +50,13 @@ public interface IEvalObserver {
     void OnRetrospectiveStarted();
 
     /// <summary>Fired after the retrospective completed successfully and its payload was parsed.</summary>
-    void OnRetrospectiveCompleted(EvalRetrospective retrospective);
+    void OnRetrospectiveCompleted(EvalRetrospectiveV2 retrospective);
 
     /// <summary>Fired when retrospective synthesis failed (null Claude result, unparseable JSON, etc.); the eval still completes.</summary>
     void OnRetrospectiveFailed(string reason);
 
     /// <summary>Fired once after all judges finished, results aggregated, and the aggregate POSTed to the server.</summary>
-    void OnFinished(SessionEvalCompletedPayload aggregate);
+    void OnFinished(SessionEvalCompletedPayloadV2 aggregate);
 
     /// <summary>Fired when the eval failed before producing an aggregate (e.g. context fetch failed, all judges failed, persist failed).</summary>
     void OnFailed(string reason);

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -411,6 +411,60 @@ public record SessionEvalCompletedPayload {
     public List<EvalFactSnapshotPayload> FactsUsed { get; init; } = [];
 }
 
+// V2 retrospective types — structured suggestions with audience tag.
+// Mirror of server-side RetrospectiveSuggestion / EvalRetrospectiveV2 /
+// SessionEvalCompletedPayloadV2 in Capacitor.Server.Core.
+// Wire shape must stay 1:1 with the server so the V2 POST route deserializes
+// correctly (snake_case field names enforced by [JsonPropertyName] below).
+
+public record RetrospectiveSuggestion {
+    [JsonPropertyName("text")]     public required string Text     { get; init; }
+    [JsonPropertyName("audience")] public required string Audience { get; init; } // "agent" | "human"
+}
+
+public record EvalRetrospectiveV2 {
+    // Backing fields coerce an explicit JSON `null` to an empty list so a
+    // judge response like `"strengths": null` deserializes to an empty list
+    // rather than a null field, keeping downstream code null-safe.
+
+    [JsonPropertyName("overall")]
+    public required string OverallSummary { get; init; }
+
+    [JsonPropertyName("strengths")]
+    public List<string> Strengths { get; init => field = value ?? []; } = [];
+
+    [JsonPropertyName("issues")]
+    public List<string> Issues { get; init => field = value ?? []; } = [];
+
+    [JsonPropertyName("suggestions")]
+    public List<RetrospectiveSuggestion> Suggestions { get; init => field = value ?? []; } = [];
+}
+
+// Posted to POST /api/sessions/{id}/evals/v2.
+// Differs from SessionEvalCompletedPayload only in Retrospective type.
+public record SessionEvalCompletedPayloadV2 {
+    [JsonPropertyName("eval_run_id")]
+    public required string EvalRunId { get; init; }
+
+    [JsonPropertyName("judge_model")]
+    public required string JudgeModel { get; init; }
+
+    [JsonPropertyName("categories")]
+    public List<EvalCategoryResult> Categories { get; init; } = [];
+
+    [JsonPropertyName("overall_score")]
+    public required int OverallScore { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("retrospective")]
+    public EvalRetrospectiveV2? Retrospective { get; init; }
+
+    [JsonPropertyName("facts_used")]
+    public List<EvalFactSnapshotPayload> FactsUsed { get; init; } = [];
+}
+
 enum HistorySessionStatus { New, Partial, AlreadyLoaded }
 
 class SessionMetadata {
@@ -465,6 +519,9 @@ public record RepoEntry {
 [JsonSerializable(typeof(IReadOnlyList<EvalQuestionVerdict>))]
 [JsonSerializable(typeof(EvalRetrospective))]
 [JsonSerializable(typeof(SessionEvalCompletedPayload))]
+[JsonSerializable(typeof(RetrospectiveSuggestion))]
+[JsonSerializable(typeof(EvalRetrospectiveV2))]
+[JsonSerializable(typeof(SessionEvalCompletedPayloadV2))]
 [JsonSerializable(typeof(JudgeFactPayload))]
 [JsonSerializable(typeof(List<JudgeFact>))]
 [JsonSerializable(typeof(EvalFactSnapshotPayload))]

--- a/src/Capacitor.Cli.Core/Resources/prompt-eval-retrospective.txt
+++ b/src/Capacitor.Cli.Core/Resources/prompt-eval-retrospective.txt
@@ -24,19 +24,32 @@ Budget: at most 6 tool calls. Prefer summary → search → targeted fetch over 
 # Task
 Produce a structured retrospective that calls out what went well, what went poorly, and concrete CLAUDE.md-style suggestions the user can apply to their next session in this project.
 
+Tag each suggestion's `audience`:
+- `"agent"` — directive an autonomous coding agent can act on next session
+  (tooling, workflow, repo conventions, build commands, automated checks).
+- `"human"` — observation a human reviewer needs (process, design judgment,
+  prioritization, scope, organizational coordination).
+
 Respond with exactly this JSON shape — no prose outside the JSON, no markdown code fences, no comments, no extra fields:
 {
   "overall":     "<1-2 sentence headline capturing the run's overall character>",
   "strengths":   ["<short bullet>", ...],
   "issues":      ["<short bullet>", ...],
-  "suggestions": ["<CLAUDE.md-style bullet, phrased as a rule or instruction>", ...]
+  "suggestions": [
+    {"text": "<CLAUDE.md-style bullet, phrased as a rule or instruction>", "audience": "agent" | "human"},
+    ...
+  ]
 }
+
+Example suggestion entries:
+  {"text": "Run `dotnet publish` after touching src/cli/ to surface AOT warnings", "audience": "agent"}
+  {"text": "Discuss the trade-offs of the dual-store approach with the team", "audience": "human"}
 
 Guidance:
 - `overall` names the pattern, not the score. Example: "Clean run with careful test coverage but an unguarded destructive command on turn 412." For a truly uneventful session, a short line is fine: "Clean run, nothing worth retrospecting."
 - `strengths` and `issues` each capture at most three items. Empty arrays are correct for a clean run or a trivially-failed run.
-- `suggestions` hold at most five items and are the reason this feature exists. Phrase them so the user could paste one into CLAUDE.md without editing. Prefer specific over general; prefer one concrete rule over two vague ones. Reference file paths, commands, or patterns from the session where helpful.
-- Good suggestion: "Before any `rm -rf`, require the agent to echo the expanded path and ask for confirmation."
-- Bad suggestion:  "Be more careful with destructive commands."
+- `suggestions` hold at most five items and are the reason this feature exists. Phrase the `text` field so the user could paste it into CLAUDE.md without editing. Prefer specific over general; prefer one concrete rule over two vague ones. Reference file paths, commands, or patterns from the session where helpful.
+- Good suggestion: {"text": "Before any `rm -rf`, require the agent to echo the expanded path and ask for confirmation.", "audience": "agent"}
+- Bad suggestion:  {"text": "Be more careful with destructive commands.", "audience": "agent"}
 - If there is genuinely nothing worth suggesting, return an empty `suggestions` array. Do not pad.
 - Emit only the four fields above. Do not include a `notes`, `metadata`, or any other top-level field.

--- a/src/Capacitor.Cli.Daemon/Services/EvalRunner.cs
+++ b/src/Capacitor.Cli.Daemon/Services/EvalRunner.cs
@@ -133,6 +133,11 @@ internal sealed class EvalRunner {
         try {
             // FinalizeAsync signature was updated in Task 6.5 — the taxonomy is
             // carried on ctx.Questions, not passed separately.
+            // AI-795 T18: FinalizeAsync now returns SessionEvalCompletedPayloadV2;
+            // FinalizeResult.Aggregate is the V1 wire DTO held by the server
+            // orchestrator, which only inspects Success on this result so we
+            // pass null for Aggregate. The V2 payload is already persisted to
+            // /api/sessions/{id}/evals/v2 inside FinalizeAsync.
             var aggregate = await EvalService.FinalizeAsync(
                 ctx,
                 httpClient,
@@ -143,7 +148,7 @@ internal sealed class EvalRunner {
                 _shutdownToken
             );
 
-            return new(aggregate is not null, aggregate is null ? "finalize failed" : null, aggregate);
+            return new(aggregate is not null, aggregate is null ? "finalize failed" : null, null);
         } catch (Exception ex) {
             _logger.LogError(ex, "FinalizeEval failed for {RunId}", cmd.EvalRunId);
 
@@ -233,7 +238,7 @@ sealed class DaemonEvalObserver(
         Relay(() => connection.EvalRetrospectiveStartedAsync(sessionId, evalRunId), "EvalRetrospectiveStarted");
     }
 
-    public void OnRetrospectiveCompleted(EvalRetrospective retrospective) {
+    public void OnRetrospectiveCompleted(EvalRetrospectiveV2 retrospective) {
         logger.LogInformation("[eval {Run}] retrospective completed", evalRunId);
         Relay(() => connection.EvalRetrospectiveCompletedAsync(sessionId, evalRunId), "EvalRetrospectiveCompleted");
     }
@@ -243,7 +248,7 @@ sealed class DaemonEvalObserver(
         Relay(() => connection.EvalRetrospectiveFailedAsync(sessionId, evalRunId, reason), "EvalRetrospectiveFailed");
     }
 
-    public void OnFinished(SessionEvalCompletedPayload aggregate) {
+    public void OnFinished(SessionEvalCompletedPayloadV2 aggregate) {
         logger.LogInformation("Eval {Run} finished on session {Sid}: {Score}/5", evalRunId, sessionId, aggregate.OverallScore);
         Relay(() => connection.EvalFinishedAsync(evalRunId, sessionId, aggregate.OverallScore, aggregate.Summary), "EvalFinished");
     }

--- a/src/Capacitor.Cli/Commands/EvalCommand.cs
+++ b/src/Capacitor.Cli/Commands/EvalCommand.cs
@@ -77,7 +77,7 @@ static class EvalCommand {
         return csv?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
     }
 
-    static void Render(SessionEvalCompletedPayload agg, string sessionId) {
+    static void Render(SessionEvalCompletedPayloadV2 agg, string sessionId) {
         var output = Console.Out;
         output.WriteLine();
         output.WriteLine($"Eval results for session {sessionId}");
@@ -137,13 +137,13 @@ static class EvalCommand {
         public void OnRetrospectiveStarted() =>
             Log("  Synthesising retrospective…");
 
-        public void OnRetrospectiveCompleted(EvalRetrospective retrospective) =>
+        public void OnRetrospectiveCompleted(EvalRetrospectiveV2 retrospective) =>
             Log($"  Retrospective: {retrospective.OverallSummary}");
 
         public void OnRetrospectiveFailed(string reason) =>
             Log($"  Retrospective failed: {reason}");
 
-        public void OnFinished(SessionEvalCompletedPayload aggregate) =>
+        public void OnFinished(SessionEvalCompletedPayloadV2 aggregate) =>
             Log("Eval result persisted.");
 
         public void OnFailed(string reason) =>

--- a/src/Capacitor.Cli/SessionGuidelinesEmitter.cs
+++ b/src/Capacitor.Cli/SessionGuidelinesEmitter.cs
@@ -1,17 +1,24 @@
+using System.Text;
 using System.Text.Json.Nodes;
 
 namespace Capacitor.Cli;
 
 /// <summary>
-/// Builds the "recurring lessons from prior sessions" text fragment from a
-/// server <c>/hooks/session-start</c> response body. Returns plain text, not
+/// Builds the session guidelines text fragment from a server
+/// <c>/hooks/session-start</c> response body. Returns plain text, not
 /// a JSON envelope — the caller (see <c>SessionStartAdditionalContext</c>)
 /// joins this fragment with other fragments (e.g. the version-upgrade nudge)
 /// and serializes a single Claude Code <c>hookSpecificOutput</c> envelope.
+/// <para>
+/// <c>top_clusters</c> entries are grouped by <c>category</c>:
+/// <c>agent_guidance</c> entries render under <b>"Guidance from past sessions"</b>;
+/// everything else renders under <b>"Known patterns"</b>.
+/// Only non-empty blocks are emitted.
+/// </para>
 /// </summary>
 static class SessionGuidelinesEmitter {
     /// <summary>
-    /// Returns the lessons block text, or <c>null</c> when there is nothing
+    /// Returns the guidelines block text, or <c>null</c> when there is nothing
     /// to emit (no <c>top_clusters</c>, all empty, user opted out, malformed
     /// response).
     /// </summary>
@@ -22,23 +29,41 @@ static class SessionGuidelinesEmitter {
         if (responseNode is not JsonObject obj) return null;
         if (obj["top_clusters"] is not JsonArray topClusters || topClusters.Count == 0) return null;
 
-        var lines = new List<string>(topClusters.Count);
+        var patterns = new List<string>();
+        var guidance = new List<string>();
 
         foreach (var node in topClusters) {
-            string? text = null;
+            if (node is null) continue;
 
-            try {
-                text = node?["text"]?.GetValue<string>();
-            } catch {
-                // Tolerate non-string/missing text entries.
-            }
+            string? text;
+            try { text = node["text"]?.GetValue<string>(); }
+            catch { continue; }
 
-            if (!string.IsNullOrWhiteSpace(text)) lines.Add($"- {text}");
+            if (string.IsNullOrWhiteSpace(text)) continue;
+
+            string? category;
+            try { category = node["category"]?.GetValue<string>(); }
+            catch { category = null; }
+
+            var target = category == "agent_guidance" ? guidance : patterns;
+            target.Add($"- {text}");
         }
 
-        if (lines.Count == 0) return null;
+        if (patterns.Count == 0 && guidance.Count == 0) return null;
 
-        return "Recurring lessons from prior sessions in this repo (no action required unless relevant):\n"
-             + string.Join("\n", lines);
+        var sb = new StringBuilder();
+
+        if (patterns.Count > 0) {
+            sb.AppendLine("## Known patterns");
+            foreach (var l in patterns) sb.AppendLine(l);
+        }
+
+        if (guidance.Count > 0) {
+            if (sb.Length > 0) sb.AppendLine();
+            sb.AppendLine("## Guidance from past sessions");
+            foreach (var l in guidance) sb.AppendLine(l);
+        }
+
+        return sb.ToString().TrimEnd();
     }
 }

--- a/test/Capacitor.Cli.Tests.Integration/ClaudeHookStdoutTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/ClaudeHookStdoutTests.cs
@@ -76,7 +76,8 @@ public class ClaudeHookStdoutTests : IDisposable {
         var ctx = json["hookSpecificOutput"]!["additionalContext"]!.GetValue<string>();
         await Assert.That(ctx).Contains("999.0.0");
         await Assert.That(ctx).Contains("npm install -g @kurrent/kcap");
-        await Assert.That(ctx).DoesNotContain("Recurring lessons");
+        await Assert.That(ctx).DoesNotContain("## Known patterns");
+        await Assert.That(ctx).DoesNotContain("## Guidance from past sessions");
     }
 
     [Test, NotInParallel("Console_Out")]
@@ -112,7 +113,8 @@ public class ClaudeHookStdoutTests : IDisposable {
 
         var json = JsonNode.Parse(trimmed);
         var ctx  = json!["hookSpecificOutput"]!["additionalContext"]!.GetValue<string>();
-        await Assert.That(ctx).Contains("Recurring lessons");
+        // "safety" is not agent_guidance, so the cluster lands in the patterns block.
+        await Assert.That(ctx).Contains("## Known patterns");
         await Assert.That(ctx).Contains("- always close the writer");
         await Assert.That(ctx).Contains("999.0.0");
         await Assert.That(ctx).Contains("npm install -g @kurrent/kcap");

--- a/test/Capacitor.Cli.Tests.Integration/EvalRunnerV2PostTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/EvalRunnerV2PostTests.cs
@@ -1,0 +1,104 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Eval;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// AI-795 Task 18: locks in the daemon's V2 wire-format migration. After
+/// migrating <see cref="EvalService.Aggregate"/> to return
+/// <see cref="SessionEvalCompletedPayloadV2"/>, the persistence step must
+/// POST to <c>/api/sessions/{id}/evals/v2</c> (not the legacy V1 route)
+/// and the body must carry structured suggestions with both
+/// <c>text</c> and <c>audience</c> fields.
+///
+/// <para>
+/// Drives <see cref="EvalService.PersistAggregateV2Async"/> directly — the
+/// minimal seam extracted from <see cref="EvalService.FinalizeAsync"/> for
+/// testing. Going through FinalizeAsync would require shelling out to the
+/// claude CLI for the retrospective synthesis step, which isn't available
+/// in CI; the persistence step is the load-bearing wire contract here.
+/// </para>
+/// </summary>
+public class EvalRunnerV2PostTests : IDisposable {
+    readonly WireMockServer _server = WireMockServer.Start();
+
+    public void Dispose() => _server.Stop();
+
+    [Test]
+    public async Task Daemon_persists_aggregate_to_v2_route_with_structured_suggestions() {
+        // Auth discovery: tests don't have real tokens; CreateAuthenticatedClientAsync
+        // is bypassed because we construct the HttpClient directly here.
+        _server.Given(Request.Create().WithPath("/api/sessions/sess-1/evals/v2").UsingPost())
+               .RespondWith(Response.Create().WithStatusCode(200));
+
+        // V1 route still wired but should NOT be hit. Respond 410 so any
+        // accidental fallback would surface as a HTTP failure, not a silent
+        // success.
+        _server.Given(Request.Create().WithPath("/api/sessions/sess-1/evals").UsingPost())
+               .RespondWith(Response.Create().WithStatusCode(410));
+
+        var aggregate = new SessionEvalCompletedPayloadV2 {
+            EvalRunId    = "run-1",
+            JudgeModel   = "claude-sonnet-4-6",
+            OverallScore = 4,
+            Summary      = "ok",
+            Categories   = [],
+            Retrospective = new EvalRetrospectiveV2 {
+                OverallSummary = "fine",
+                Suggestions = [
+                    new RetrospectiveSuggestion { Text = "Run tests before commit",  Audience = "agent" },
+                    new RetrospectiveSuggestion { Text = "Discuss design with team", Audience = "human" }
+                ]
+            }
+        };
+
+        var observer = new RecordingObserver();
+        using var httpClient = new HttpClient();
+
+        var ok = await EvalService.PersistAggregateV2Async(
+            httpClient:       httpClient,
+            baseUrl:          _server.Url!,
+            encodedSessionId: "sess-1",
+            aggregate:        aggregate,
+            observer:         observer,
+            ct:               CancellationToken.None
+        );
+
+        await Assert.That(ok).IsTrue();
+
+        var v2Hits = _server.FindLogEntries(Request.Create().WithPath("/api/sessions/sess-1/evals/v2").UsingPost());
+        var v1Hits = _server.FindLogEntries(Request.Create().WithPath("/api/sessions/sess-1/evals").UsingPost());
+
+        await Assert.That(v2Hits.Count).IsEqualTo(1);
+        await Assert.That(v1Hits.Count).IsEqualTo(0);
+
+        var body = v2Hits[0].RequestMessage.Body!;
+
+        // V2 wire shape: snake_case top-level fields, structured suggestions
+        // with text + audience keys.
+        await Assert.That(body).Contains(@"""eval_run_id"":""run-1""");
+        await Assert.That(body).Contains(@"""judge_model"":""claude-sonnet-4-6""");
+        await Assert.That(body).Contains(@"""suggestions""");
+        await Assert.That(body).Contains(@"""audience""");
+        await Assert.That(body).Contains(@"""agent""");
+        await Assert.That(body).Contains(@"""human""");
+    }
+
+    sealed class RecordingObserver : IEvalObserver {
+        public void OnInfo(string message) { }
+        public void OnStarted(string runId, string judgeModel, int totalQuestions) { }
+        public void OnContextFetched(int e, int c, int t, int tr, long b) { }
+        public void OnQuestionStarted(int i, int t, string c, string q) { }
+        public void OnQuestionCompleted(int i, int t, EvalQuestionVerdict v, long it, long ot) { }
+        public void OnQuestionFailed(int i, int t, string c, string q, string r) { }
+        public void OnFactRetained(string c, string f) { }
+        public void OnRetrospectiveStarted() { }
+        public void OnRetrospectiveCompleted(EvalRetrospectiveV2 r) { }
+        public void OnRetrospectiveFailed(string r) { }
+        public void OnFinished(SessionEvalCompletedPayloadV2 a) { }
+        public void OnFailed(string r) { }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/EvalQuestionCatalogClientTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalQuestionCatalogClientTests.cs
@@ -31,11 +31,11 @@ public class EvalQuestionCatalogClientTests : IDisposable {
 
         public void OnRetrospectiveStarted() { }
 
-        public void OnRetrospectiveCompleted(EvalRetrospective retrospective) { }
+        public void OnRetrospectiveCompleted(EvalRetrospectiveV2 retrospective) { }
 
         public void OnRetrospectiveFailed(string reason) { }
 
-        public void OnFinished(SessionEvalCompletedPayload aggregate) { }
+        public void OnFinished(SessionEvalCompletedPayloadV2 aggregate) { }
 
         public void OnFailed(string reason) => FailureMessages.Add(reason);
     }

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceJsonSchemaTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceJsonSchemaTests.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+using Capacitor.Cli.Core.Eval;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Validates that <see cref="EvalService.GetRetrospectiveJsonSchema()"/> encodes
+/// the structured <c>{text, audience}</c> suggestion shape so that the
+/// Claude CLI judge is actually constrained to emit objects — not bare
+/// strings — for every suggestion item. Regression guard for AI-795.
+/// </summary>
+public class EvalServiceJsonSchemaTests {
+    // EvalService is internal; Capacitor.Cli.Core ships InternalsVisibleTo
+    // for Capacitor.Cli.Tests.Unit so the const is directly accessible.
+
+    [Test]
+    public async Task RetrospectiveJsonSchema_suggestions_items_is_object_not_string() {
+        using var doc  = JsonDocument.Parse(EvalService.GetRetrospectiveJsonSchema());
+        var root       = doc.RootElement;
+
+        var itemsType = root
+            .GetProperty("properties")
+            .GetProperty("suggestions")
+            .GetProperty("items")
+            .GetProperty("type")
+            .GetString();
+
+        await Assert.That(itemsType).IsEqualTo("object");
+    }
+
+    [Test]
+    public async Task RetrospectiveJsonSchema_suggestions_items_has_text_and_audience_properties() {
+        using var doc = JsonDocument.Parse(EvalService.GetRetrospectiveJsonSchema());
+        var root      = doc.RootElement;
+
+        var itemProps = root
+            .GetProperty("properties")
+            .GetProperty("suggestions")
+            .GetProperty("items")
+            .GetProperty("properties");
+
+        await Assert.That(itemProps.TryGetProperty("text",     out _)).IsTrue();
+        await Assert.That(itemProps.TryGetProperty("audience", out _)).IsTrue();
+    }
+
+    [Test]
+    public async Task RetrospectiveJsonSchema_audience_enum_contains_agent_and_human() {
+        using var doc = JsonDocument.Parse(EvalService.GetRetrospectiveJsonSchema());
+        var root      = doc.RootElement;
+
+        var audienceEnum = root
+            .GetProperty("properties")
+            .GetProperty("suggestions")
+            .GetProperty("items")
+            .GetProperty("properties")
+            .GetProperty("audience")
+            .GetProperty("enum");
+
+        var values = audienceEnum.EnumerateArray()
+            .Select(e => e.GetString())
+            .ToList();
+
+        await Assert.That(values).Contains("agent");
+        await Assert.That(values).Contains("human");
+    }
+
+    [Test]
+    public async Task RetrospectiveJsonSchema_suggestions_items_required_includes_text_and_audience() {
+        using var doc = JsonDocument.Parse(EvalService.GetRetrospectiveJsonSchema());
+        var root      = doc.RootElement;
+
+        var required = root
+            .GetProperty("properties")
+            .GetProperty("suggestions")
+            .GetProperty("items")
+            .GetProperty("required");
+
+        var fields = required.EnumerateArray()
+            .Select(e => e.GetString())
+            .ToList();
+
+        await Assert.That(fields).Contains("text");
+        await Assert.That(fields).Contains("audience");
+    }
+
+    [Test]
+    public async Task RetrospectiveJsonSchema_outer_required_includes_all_top_level_fields() {
+        using var doc = JsonDocument.Parse(EvalService.GetRetrospectiveJsonSchema());
+        var root      = doc.RootElement;
+
+        var required = root
+            .GetProperty("required")
+            .EnumerateArray()
+            .Select(e => e.GetString())
+            .ToList();
+
+        await Assert.That(required).Contains("overall");
+        await Assert.That(required).Contains("strengths");
+        await Assert.That(required).Contains("issues");
+        await Assert.That(required).Contains("suggestions");
+    }
+
+    [Test]
+    public async Task RetrospectiveJsonSchema_suggestions_maxItems_is_five() {
+        using var doc = JsonDocument.Parse(EvalService.GetRetrospectiveJsonSchema());
+        var root      = doc.RootElement;
+
+        var maxItems = root
+            .GetProperty("properties")
+            .GetProperty("suggestions")
+            .GetProperty("maxItems")
+            .GetInt32();
+
+        await Assert.That(maxItems).IsEqualTo(5);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceParseRetrospectiveV2Tests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceParseRetrospectiveV2Tests.cs
@@ -78,6 +78,69 @@ public class EvalServiceParseRetrospectiveV2Tests {
     }
 
     [Test]
+    public async Task Parser_returns_null_when_root_field_is_wrong_type() {
+        // `overall` as a number, not a string — must not throw, parser returns
+        // a retrospective with overall = "" rather than throwing.
+        var json = """
+            { "overall": 42, "strengths": [], "issues": [], "suggestions": [] }
+            """;
+        var retro = EvalService.ParseRetrospectiveV2(json);
+        await Assert.That(retro).IsNotNull();
+        await Assert.That(retro!.OverallSummary).IsEqualTo("");
+    }
+
+    [Test]
+    public async Task Parser_tolerates_suggestion_text_wrong_type() {
+        // `text` as a boolean — must not throw; coerce to empty text.
+        var json = """
+            { "overall": "x", "strengths": [], "issues": [],
+              "suggestions": [ { "text": false, "audience": "agent" } ] }
+            """;
+        var retro = EvalService.ParseRetrospectiveV2(json);
+        await Assert.That(retro!.Suggestions[0].Text).IsEqualTo("");
+    }
+
+    [Test]
+    public async Task Parser_normalizes_case_in_audience() {
+        var json = """
+            { "overall": "x", "strengths": [], "issues": [],
+              "suggestions": [ { "text": "y", "audience": "Agent" } ] }
+            """;
+        var retro = EvalService.ParseRetrospectiveV2(json);
+        await Assert.That(retro!.Suggestions[0].Audience).IsEqualTo("agent");
+    }
+
+    [Test]
+    public async Task Parser_normalizes_whitespace_in_audience() {
+        var json = """
+            { "overall": "x", "strengths": [], "issues": [],
+              "suggestions": [ { "text": "y", "audience": " human " } ] }
+            """;
+        var retro = EvalService.ParseRetrospectiveV2(json);
+        await Assert.That(retro!.Suggestions[0].Audience).IsEqualTo("human");
+    }
+
+    [Test]
+    public async Task Parser_normalizes_uppercase_audience() {
+        var json = """
+            { "overall": "x", "strengths": [], "issues": [],
+              "suggestions": [ { "text": "y", "audience": "AGENT" } ] }
+            """;
+        var retro = EvalService.ParseRetrospectiveV2(json);
+        await Assert.That(retro!.Suggestions[0].Audience).IsEqualTo("agent");
+    }
+
+    [Test]
+    public async Task Parser_tolerates_audience_wrong_type() {
+        var json = """
+            { "overall": "x", "strengths": [], "issues": [],
+              "suggestions": [ { "text": "y", "audience": 1 } ] }
+            """;
+        var retro = EvalService.ParseRetrospectiveV2(json);
+        await Assert.That(retro!.Suggestions[0].Audience).IsEqualTo("human");
+    }
+
+    [Test]
     public async Task Mixed_input_parses_all_three_audience_paths() {
         var json = """
             {

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceParseRetrospectiveV2Tests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceParseRetrospectiveV2Tests.cs
@@ -1,0 +1,102 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Eval;
+using TUnit.Core;
+using TUnit.Assertions;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class EvalServiceParseRetrospectiveV2Tests {
+    [Test]
+    public async Task Parses_structured_suggestions_with_audience() {
+        var json = """
+            {
+              "overall": "fine",
+              "strengths": [],
+              "issues": [],
+              "suggestions": [
+                { "text": "Run tests", "audience": "agent" },
+                { "text": "Discuss with team", "audience": "human" }
+              ]
+            }
+            """;
+
+        var retro = EvalService.ParseRetrospectiveV2(json);
+
+        await Assert.That(retro).IsNotNull();
+        await Assert.That(retro!.Suggestions[0].Text).IsEqualTo("Run tests");
+        await Assert.That(retro!.Suggestions[0].Audience).IsEqualTo("agent");
+        await Assert.That(retro!.Suggestions[1].Audience).IsEqualTo("human");
+    }
+
+    [Test]
+    public async Task Coerces_unknown_audience_to_human() {
+        var json = """
+            { "overall": "x", "strengths": [], "issues": [],
+              "suggestions": [ { "text": "y", "audience": "bot" } ] }
+            """;
+        var retro = EvalService.ParseRetrospectiveV2(json);
+        await Assert.That(retro!.Suggestions[0].Audience).IsEqualTo("human");
+    }
+
+    [Test]
+    public async Task Coerces_missing_audience_to_human() {
+        var json = """
+            { "overall": "x", "strengths": [], "issues": [],
+              "suggestions": [ { "text": "y" } ] }
+            """;
+        var retro = EvalService.ParseRetrospectiveV2(json);
+        await Assert.That(retro!.Suggestions[0].Audience).IsEqualTo("human");
+    }
+
+    [Test]
+    public async Task Coerces_legacy_string_suggestion_to_human() {
+        var json = """
+            { "overall": "x", "strengths": [], "issues": [],
+              "suggestions": [ "Run tests" ] }
+            """;
+        var retro = EvalService.ParseRetrospectiveV2(json);
+        await Assert.That(retro!.Suggestions[0].Text).IsEqualTo("Run tests");
+        await Assert.That(retro!.Suggestions[0].Audience).IsEqualTo("human");
+    }
+
+    [Test]
+    public async Task Strips_code_fences() {
+        var json = """
+            ```json
+            { "overall": "x", "suggestions": [] }
+            ```
+            """;
+        var retro = EvalService.ParseRetrospectiveV2(json);
+        await Assert.That(retro).IsNotNull();
+        await Assert.That(retro!.OverallSummary).IsEqualTo("x");
+    }
+
+    [Test]
+    public async Task Returns_null_on_malformed_json() {
+        await Assert.That(EvalService.ParseRetrospectiveV2("{not json")).IsNull();
+        await Assert.That(EvalService.ParseRetrospectiveV2("")).IsNull();
+    }
+
+    [Test]
+    public async Task Mixed_input_parses_all_three_audience_paths() {
+        var json = """
+            {
+              "overall": "x",
+              "strengths": [],
+              "issues": [],
+              "suggestions": [
+                "legacy string",
+                { "text": "tagged agent", "audience": "agent" },
+                { "text": "unknown audience", "audience": "bot" }
+              ]
+            }
+            """;
+        var retro = EvalService.ParseRetrospectiveV2(json);
+
+        await Assert.That(retro).IsNotNull();
+        await Assert.That(retro!.Suggestions.Count).IsEqualTo(3);
+        await Assert.That(retro!.Suggestions[0].Audience).IsEqualTo("human"); // legacy
+        await Assert.That(retro!.Suggestions[1].Audience).IsEqualTo("agent"); // tagged
+        await Assert.That(retro!.Suggestions[2].Audience).IsEqualTo("human"); // unknown → human
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/SessionGuidelinesEmitterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionGuidelinesEmitterTests.cs
@@ -3,58 +3,110 @@ using System.Text.Json.Nodes;
 namespace Capacitor.Cli.Tests.Unit;
 
 public class SessionGuidelinesEmitterTests {
-    [Test]
-    public async Task BuildFragment_returns_lessons_text_when_server_returns_top_clusters() {
-        var body = """
-                   {
-                     "top_clusters": [
-                       { "category": "safety",          "text": "always close the writer" },
-                       { "category": "maintainability", "text": "prefer JsonNode.Parse for AOT-safe string assignment" }
-                     ]
-                   }
-                   """;
+    static JsonArray Top(params (string text, string category)[] items) {
+        var arr = new JsonArray();
+        foreach (var (text, cat) in items) {
+            arr.Add(new JsonObject { ["text"] = text, ["category"] = cat });
+        }
+        return arr;
+    }
 
-        var fragment = SessionGuidelinesEmitter.BuildFragment(JsonNode.Parse(body), disabled: false);
+    [Test]
+    public async Task Renders_both_blocks_when_mixed() {
+        var body = new JsonObject {
+            ["top_clusters"] = Top(
+                ("tests need docker", "quality"),
+                ("run tests first",   "agent_guidance"),
+                ("seal secrets",      "safety"),
+                ("avoid force-push",  "agent_guidance")
+            )
+        };
+
+        var fragment = SessionGuidelinesEmitter.BuildFragment(body, disabled: false);
 
         await Assert.That(fragment).IsNotNull();
-        await Assert.That(fragment!).Contains("Recurring lessons");
-        await Assert.That(fragment).Contains("- always close the writer");
-        await Assert.That(fragment).Contains("- prefer JsonNode.Parse for AOT-safe string assignment");
-        await Assert.That(fragment.TrimStart().StartsWith("{")).IsFalse(); // not a JSON envelope
-        await Assert.That(fragment).DoesNotContain("hookSpecificOutput");
-        await Assert.That(fragment).DoesNotContain("hookEventName");
+        await Assert.That(fragment!).Contains("## Known patterns");
+        await Assert.That(fragment!).Contains("- tests need docker");
+        await Assert.That(fragment!).Contains("- seal secrets");
+        await Assert.That(fragment!).Contains("## Guidance from past sessions");
+        await Assert.That(fragment!).Contains("- run tests first");
+        await Assert.That(fragment!).Contains("- avoid force-push");
     }
 
     [Test]
-    public async Task BuildFragment_returns_null_when_top_clusters_absent() {
-        var body     = """{ "slug": "some-resumed-session" }""";
-        var fragment = SessionGuidelinesEmitter.BuildFragment(JsonNode.Parse(body), disabled: false);
-        await Assert.That(fragment).IsNull();
+    public async Task Renders_only_guidance_block_when_only_agent_guidance() {
+        var body = new JsonObject {
+            ["top_clusters"] = Top(("run tests first", "agent_guidance"))
+        };
+
+        var fragment = SessionGuidelinesEmitter.BuildFragment(body, disabled: false);
+
+        await Assert.That(fragment).IsNotNull();
+        await Assert.That(fragment!).Contains("## Guidance from past sessions");
+        await Assert.That(fragment!).Contains("- run tests first");
+        await Assert.That(fragment!).DoesNotContain("## Known patterns");
     }
 
     [Test]
-    public async Task BuildFragment_returns_null_when_disabled_flag_set() {
-        var body = """{ "top_clusters": [ { "category": "safety", "text": "x" } ] }""";
-        var fragment = SessionGuidelinesEmitter.BuildFragment(JsonNode.Parse(body), disabled: true);
-        await Assert.That(fragment).IsNull();
+    public async Task Renders_only_patterns_block_when_no_agent_guidance() {
+        var body = new JsonObject {
+            ["top_clusters"] = Top(("tests need docker", "quality"))
+        };
+
+        var fragment = SessionGuidelinesEmitter.BuildFragment(body, disabled: false);
+
+        await Assert.That(fragment).IsNotNull();
+        await Assert.That(fragment!).Contains("## Known patterns");
+        await Assert.That(fragment!).Contains("- tests need docker");
+        await Assert.That(fragment!).DoesNotContain("## Guidance from past sessions");
     }
 
     [Test]
-    public async Task BuildFragment_returns_null_when_top_clusters_empty_array() {
-        var body = """{ "top_clusters": [] }""";
-        var fragment = SessionGuidelinesEmitter.BuildFragment(JsonNode.Parse(body), disabled: false);
-        await Assert.That(fragment).IsNull();
+    public async Task Returns_null_when_disabled() {
+        var body = new JsonObject {
+            ["top_clusters"] = Top(("x", "agent_guidance"))
+        };
+        await Assert.That(SessionGuidelinesEmitter.BuildFragment(body, disabled: true)).IsNull();
     }
 
     [Test]
-    public async Task BuildFragment_returns_null_when_top_clusters_is_object_not_array() {
+    public async Task Returns_null_when_top_clusters_empty() {
+        var body = new JsonObject { ["top_clusters"] = new JsonArray() };
+        await Assert.That(SessionGuidelinesEmitter.BuildFragment(body, disabled: false)).IsNull();
+    }
+
+    [Test]
+    public async Task Returns_null_when_top_clusters_missing() {
+        var body = new JsonObject();
+        await Assert.That(SessionGuidelinesEmitter.BuildFragment(body, disabled: false)).IsNull();
+    }
+
+    [Test]
+    public async Task Skips_entries_with_no_text() {
+        var body = new JsonObject {
+            ["top_clusters"] = new JsonArray(
+                new JsonObject { ["text"] = "good", ["category"] = "agent_guidance" },
+                new JsonObject {                     ["category"] = "agent_guidance" },  // no text
+                new JsonObject { ["text"] = "",      ["category"] = "agent_guidance" }   // empty text
+            )
+        };
+
+        var fragment = SessionGuidelinesEmitter.BuildFragment(body, disabled: false);
+
+        await Assert.That(fragment).IsNotNull();
+        await Assert.That(fragment!).Contains("- good");
+        await Assert.That(fragment!.Split('\n').Count(l => l.StartsWith("- "))).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Returns_null_when_top_clusters_is_object_not_array() {
         var body = """{ "top_clusters": { "category": "safety", "text": "x" } }""";
         var fragment = SessionGuidelinesEmitter.BuildFragment(JsonNode.Parse(body), disabled: false);
         await Assert.That(fragment).IsNull();
     }
 
     [Test]
-    public async Task BuildFragment_returns_null_when_response_is_top_level_array() {
+    public async Task Returns_null_when_response_is_top_level_array() {
         var body = """[ { "category": "safety", "text": "x" } ]""";
         var fragment = SessionGuidelinesEmitter.BuildFragment(JsonNode.Parse(body), disabled: false);
         await Assert.That(fragment).IsNull();
@@ -62,20 +114,29 @@ public class SessionGuidelinesEmitterTests {
 
     [Test]
     public async Task BuildFragment_skips_entries_with_blank_text() {
-        var body = """
-                   {
-                     "top_clusters": [
-                       { "category": "safety", "text": ""    },
-                       { "category": "safety", "text": "   " },
-                       { "category": "safety", "text": "real lesson" }
-                     ]
-                   }
-                   """;
-        var fragment = SessionGuidelinesEmitter.BuildFragment(JsonNode.Parse(body), disabled: false);
+        var body = new JsonObject {
+            ["top_clusters"] = new JsonArray(
+                new JsonObject { ["text"] = "",    ["category"] = "safety" },
+                new JsonObject { ["text"] = "   ", ["category"] = "safety" },
+                new JsonObject { ["text"] = "real lesson", ["category"] = "quality" }
+            )
+        };
+        var fragment = SessionGuidelinesEmitter.BuildFragment(body, disabled: false);
         await Assert.That(fragment).IsNotNull();
         await Assert.That(fragment!).Contains("- real lesson");
         var bullets = fragment.Split('\n').Count(l => l.StartsWith("- "));
         await Assert.That(bullets).IsEqualTo(1);
-        await Assert.That(fragment).DoesNotContain("- \n"); // no bullet with empty body
+    }
+
+    [Test]
+    public async Task Fragment_is_not_a_json_envelope() {
+        var body = new JsonObject {
+            ["top_clusters"] = Top(("always close the writer", "safety"))
+        };
+        var fragment = SessionGuidelinesEmitter.BuildFragment(body, disabled: false);
+        await Assert.That(fragment).IsNotNull();
+        await Assert.That(fragment!.TrimStart().StartsWith("{")).IsFalse();
+        await Assert.That(fragment).DoesNotContain("hookSpecificOutput");
+        await Assert.That(fragment).DoesNotContain("hookEventName");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/V2ModelSerializationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/V2ModelSerializationTests.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using TUnit.Core;
+using TUnit.Assertions;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class V2ModelSerializationTests {
+    [Test]
+    public async Task SessionEvalCompletedPayloadV2_round_trips_with_structured_suggestions() {
+        var src = new SessionEvalCompletedPayloadV2 {
+            EvalRunId    = "run-1",
+            JudgeModel   = "claude-opus-4-7",
+            OverallScore = 4,
+            Summary      = "ok",
+            Categories   = [],
+            Retrospective = new EvalRetrospectiveV2 {
+                OverallSummary = "fine",
+                Suggestions    = [
+                    new RetrospectiveSuggestion { Text = "Run tests before commit",  Audience = "agent" },
+                    new RetrospectiveSuggestion { Text = "Discuss design with team", Audience = "human" }
+                ]
+            }
+        };
+
+        var json = JsonSerializer.Serialize(src, CapacitorJsonContext.Default.SessionEvalCompletedPayloadV2);
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.SessionEvalCompletedPayloadV2)!;
+
+        await Assert.That(back.Retrospective!.Suggestions[0].Audience).IsEqualTo("agent");
+        await Assert.That(back.Retrospective!.Suggestions[1].Text).IsEqualTo("Discuss design with team");
+    }
+
+    [Test]
+    public async Task EvalRetrospectiveV2_coerces_null_lists_to_empty() {
+        var json = """{"overall":"x","strengths":null,"issues":null,"suggestions":null}""";
+        var parsed = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.EvalRetrospectiveV2)!;
+
+        await Assert.That(parsed.Strengths).IsNotNull();
+        await Assert.That(parsed.Issues).IsNotNull();
+        await Assert.That(parsed.Suggestions).IsNotNull();
+        await Assert.That(parsed.Suggestions.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Wire_shape_matches_server_snake_case_keys() {
+        // The server's V2 route deserializes via the snake_case naming policy
+        // PLUS explicit [JsonPropertyName] decorators on the payload type.
+        // This test locks in the wire field names so the CLI cannot
+        // accidentally rename a field without breaking the server contract.
+        var src = new SessionEvalCompletedPayloadV2 {
+            EvalRunId    = "run-1",
+            JudgeModel   = "j",
+            OverallScore = 4,
+            Summary      = "s",
+            Categories   = [],
+            Retrospective = new EvalRetrospectiveV2 {
+                OverallSummary = "x",
+                Suggestions    = [new() { Text = "t", Audience = "agent" }]
+            }
+        };
+
+        var json = JsonSerializer.Serialize(src, CapacitorJsonContext.Default.SessionEvalCompletedPayloadV2);
+
+        await Assert.That(json).Contains(@"""eval_run_id""");
+        await Assert.That(json).Contains(@"""judge_model""");
+        await Assert.That(json).Contains(@"""overall_score""");
+        await Assert.That(json).Contains(@"""retrospective""");
+        await Assert.That(json).Contains(@"""suggestions""");
+        await Assert.That(json).Contains(@"""text""");
+        await Assert.That(json).Contains(@"""audience""");
+        await Assert.That(json).Contains(@"""overall"":"); // EvalRetrospectiveV2.OverallSummary maps to "overall"
+    }
+}


### PR DESCRIPTION
## Summary

CLI half of [AI-795](https://linear.app/kurrent/issue/AI-795/reuse-retrospective-try-next-time-suggestions-via-the-factscuration) — the server-side wiring lives in a coordinated PR in `kurrent-io/kcap-server`. This PR:

- Adds V2 retrospective + payload types (`RetrospectiveSuggestion { text, audience }`, `EvalRetrospectiveV2`, `SessionEvalCompletedPayloadV2`) registered in `CapacitorJsonContext` with snake_case wire shape matching the server.
- Updates the daemon retrospective prompt to ask for `suggestions: [{text, audience}]` with an `agent` vs `human` audience rubric.
- Adds `EvalService.ParseRetrospectiveV2` with defensive coercions: legacy string items, missing audience, and unknown audience values all coerce to `audience = "human"` so the daemon never POSTs an unknown value to the server's V2 validator.
- Switches `EvalService.Aggregate` / `RunAsync` / `FinalizeAsync` and `EvalRunner.OnFinished` to the V2 payload, POSTing to the server's new `POST /api/sessions/{sessionId}/evals/v2` route.
- Rewrites `SessionGuidelinesEmitter.BuildFragment` to group `top_clusters` entries by category, rendering two markdown sections: `## Known patterns` (facts) and `## Guidance from past sessions` (`agent_guidance` clusters). Single-section rendering when only one bucket has entries.

## Coordination

- The server `POST /api/sessions/{id}/evals/v2` route, validator, writer, projector, candidate emitter, and curation UI ship in a parallel `kcap-server` PR. Server lands first; this PR can land any time after that.
- After both land, the server repo bumps the `src/cli` submodule.
- `FinalizeResult.Aggregate` is set to `null` on the SignalR result envelope — the server orchestrator only inspects `fr.Success`, verified with grep. If anything later wants to consume the aggregate over the SignalR result, the wire DTO needs a V2 bump (out of scope for this PR).

Spec + plan live in the server repo at `docs/superpowers/specs/2026-06-09-ai-795-reuse-retrospective-suggestions-design.md` and `docs/superpowers/plans/2026-06-09-ai-795-reuse-retrospective-suggestions.md`.

## Test plan

- [x] `Capacitor.Cli.Tests.Unit` — 1306/1306 passing (includes new tests: V2 model serialization, `ParseRetrospectiveV2` defensive coercion, `SessionGuidelinesEmitter` category grouping)
- [x] `Capacitor.Cli.Tests.Integration` — 30/30 passing (includes new `EvalRunnerV2PostTests` WireMock test asserting POST to `/evals/v2` with `audience` field present and V1 route NOT hit)
- [x] AOT publish: `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release` — no IL2026 / IL3050 warnings
- [ ] Cross-repo smoke after server-side PR merges + submodule bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)