### PR TITLE
fix: P/Invoke forkpty from libc so daemon launches on glibc 2.34+

### DIFF
--- a/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyInterop.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyInterop.cs
@@ -6,11 +6,10 @@ namespace Capacitor.Cli.Daemon.Pty.Unix;
 internal static partial class UnixPtyInterop {
     static readonly bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
-    // forkpty is in libutil on both macOS and Linux
-
-    // On macOS, forkpty takes a pointer to struct winsize. We pass IntPtr.Zero and set size after fork.
-    // Alternate overload that takes WinSize ref for Linux where we can pass it directly:
-    [LibraryImport("libutil", EntryPoint = "forkpty", SetLastError = true)]
+    // forkpty: glibc 2.34+ consolidated libutil into libc, and Ubuntu 24.04 ships only
+    // libutil.so.1 (no unversioned libutil.so), so DllImport("libutil") fails to resolve.
+    // libc works on Linux (glibc 2.34+) and on macOS (libSystem re-exports forkpty).
+    [LibraryImport("libc", EntryPoint = "forkpty", SetLastError = true)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial int forkpty(out int master, IntPtr name, IntPtr termp, ref WinSize winp);
 

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/PtyInteropTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/PtyInteropTests.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Capacitor.Cli.Daemon.Pty.Unix;
+using Capacitor.Cli.Daemon.Pty.Windows;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// Library-resolution smoke tests for the PTY native interop. For each
+/// <c>[LibraryImport]</c> P/Invoke we read the attribute's library name +
+/// entry point at runtime, then mirror the CLR's first-call binding with
+/// <see cref="NativeLibrary.Load(string, Assembly, DllImportSearchPath?)"/>
+/// and <see cref="NativeLibrary.GetExport"/>. The runtime throws if either
+/// the library or the symbol can't be resolved.
+///
+/// <para>We can't use <see cref="Marshal.Prelink"/> here because
+/// <c>[LibraryImport]</c> generates the marshalling stub at compile time —
+/// Prelink only binds legacy <c>[DllImport]</c> methods.</para>
+///
+/// <para>Reading the attribute via reflection (instead of hard-coding the
+/// library name in the test) keeps the test in sync with production: if
+/// someone re-introduces <c>libutil</c> on the forkpty import, this test
+/// fails on glibc 2.34+ runners exactly the way the daemon did at launch.</para>
+/// </summary>
+public class PtyInteropTests {
+    [Test]
+    public Task Forkpty_PInvoke_resolves_on_unix() {
+        if (OperatingSystem.IsWindows()) return Task.CompletedTask;
+
+        AssertLibraryImportResolves(typeof(UnixPtyInterop), nameof(UnixPtyInterop.forkpty));
+        return Task.CompletedTask;
+    }
+
+    [Test]
+    public Task PtySetWinsizeShim_PInvoke_resolves_on_macos() {
+        // The C shim (libpty_shim.dylib) is built and copied next to the
+        // binary only on macOS — that's where the ARM64 variadic-ioctl ABI
+        // quirk forces us to call through it. If the native build/copy step
+        // ever breaks, this fires.
+        if (!OperatingSystem.IsMacOS()) return Task.CompletedTask;
+
+        AssertLibraryImportResolves(typeof(UnixPtyInterop), "pty_set_winsize_shim");
+        return Task.CompletedTask;
+    }
+
+    [Test]
+    public Task CreatePseudoConsole_PInvoke_resolves_on_windows() {
+        if (!OperatingSystem.IsWindows()) return Task.CompletedTask;
+
+        AssertLibraryImportResolves(typeof(ConPtyInterop), nameof(ConPtyInterop.CreatePseudoConsole));
+        return Task.CompletedTask;
+    }
+
+    static void AssertLibraryImportResolves(Type type, string methodName) {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+        var method = type.GetMethod(methodName, flags)
+                  ?? throw new InvalidOperationException(
+                         $"P/Invoke method {type.Name}.{methodName} not found");
+
+        var attr = method.GetCustomAttribute<LibraryImportAttribute>()
+                ?? throw new InvalidOperationException(
+                       $"{type.Name}.{methodName} is not marked [LibraryImport]");
+
+        var entryPoint = attr.EntryPoint ?? methodName;
+        var handle     = NativeLibrary.Load(attr.LibraryName, type.Assembly, searchPath: null);
+        try {
+            // GetExport throws EntryPointNotFoundException if the symbol is
+            // missing — both branches (bad library / bad symbol) fail the test.
+            NativeLibrary.GetExport(handle, entryPoint);
+        } finally {
+            NativeLibrary.Free(handle);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `DllImport("libutil")` on `forkpty` fails on glibc 2.34+ (Ubuntu 22.04/24.04, RHEL 9, Debian 12): glibc consolidated libutil into libc and only `libutil.so.1` ships — no unversioned `libutil.so` — so the daemon throws `DllNotFoundException` and refuses to launch.
- Switch the `forkpty` `[LibraryImport]` from `libutil` to `libc`. macOS still works because libSystem re-exports `forkpty` (verified by `dlsym` returning the same address from `libc.dylib` and `libutil.dylib`).
- Add `PtyInteropTests` covering the three PTY P/Invoke targets — `forkpty` (Unix), `pty_set_winsize_shim` (macOS), `CreatePseudoConsole` (Windows). Tests read each method's `[LibraryImport]` attribute via reflection and exercise `NativeLibrary.Load` + `GetExport`, so they fail automatically if anyone re-introduces a wrong library name.

## Caveat
Linux hosts on glibc < 2.34 (Ubuntu 20.04, RHEL 8) keep `forkpty` only in `libutil.so.1` — those are not in scope here. Ubuntu 20.04 reached EOL in April 2025. If older-glibc support is needed later, a `NativeLibrary.SetDllImportResolver` fallback would handle it.

## Test plan
- [x] `dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj` clean
- [x] `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release` — no IL3050/IL2026 AOT warnings
- [x] `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/PtyInteropTests/*"` — 3 / 3 pass on macOS arm64
- [x] Regression check: re-introducing `[LibraryImport("libutil-does-not-exist")]` causes the forkpty test to fail with `DllNotFoundException` as expected
- [ ] CI Linux runner (glibc 2.34+) exercises `Forkpty_PInvoke_resolves_on_unix`
- [ ] CI Windows runner exercises `CreatePseudoConsole_PInvoke_resolves_on_windows`

🤖 Generated with [Claude Code](https://claude.com/claude-code)