### PR TITLE
[AI-813] Cap session-end hook pre-POST drain so the session-end POST isn't starved

### DIFF
--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -175,7 +175,7 @@ public static class ClaudeHookCommand {
                     var transcriptPath = node?["transcript_path"]?.GetValue<string>();
 
                     if (sessionId is not null) {
-                        await TimeBudget.RunCappedAsync(
+                        var drained = await TimeBudget.RunCappedAsync(
                             async () => {
                                 await WatcherManager.KillWatcher(sessionId);
 
@@ -185,6 +185,13 @@ public static class ClaudeHookCommand {
                             },
                             PreHookDrainCap
                         );
+
+                        if (!drained) {
+                            await Console.Error.WriteLineAsync(
+                                $"[kcap] session-end pre-drain cap ({PreHookDrainCap.TotalSeconds:0}s) elapsed; proceeding to POST. "
+                              + $"Transcript tail may be incomplete — recoverable via: kcap import --session {sessionId}"
+                            );
+                        }
                     }
                 } catch (Exception ex) {
                     Console.Error.WriteLine($"[kcap] session-end pre-hook failed: {ex.Message}");
@@ -202,7 +209,7 @@ public static class ClaudeHookCommand {
                     var transcriptPath = node?["transcript_path"]?.GetValue<string>();
 
                     if (sessionId is not null && agentId is not null) {
-                        await TimeBudget.RunCappedAsync(
+                        var drained = await TimeBudget.RunCappedAsync(
                             async () => {
                                 await WatcherManager.KillWatcher($"{sessionId}-{agentId}");
 
@@ -214,6 +221,12 @@ public static class ClaudeHookCommand {
                             },
                             PreHookDrainCap
                         );
+
+                        if (!drained) {
+                            await Console.Error.WriteLineAsync(
+                                $"[kcap] subagent-stop pre-drain cap ({PreHookDrainCap.TotalSeconds:0}s) elapsed; proceeding to POST"
+                            );
+                        }
                     }
                 } catch (Exception ex) {
                     Console.Error.WriteLine($"[kcap] subagent-stop pre-hook failed: {ex.Message}");

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -14,6 +14,14 @@ namespace Capacitor.Cli.Commands;
 /// <see cref="CursorHookCommand"/>.
 /// </summary>
 public static class ClaudeHookCommand {
+    // Hard ceiling on the best-effort pre-POST drain (watcher kill + inline transcript
+    // drain) for session-end / subagent-stop. Claude kills the SessionEnd hook at its
+    // configured timeout (15s); a slow or retrying remote call in the drain could consume
+    // all of it (the HTTP retry helper alone allows up to 30s) and the session-end POST
+    // would never be sent, leaving the session stuck "Active". 8s leaves ample headroom to
+    // send the POST; the server's StopAndDrain + the "kcap import" hint recover the rest.
+    static readonly TimeSpan PreHookDrainCap = TimeSpan.FromSeconds(8);
+
     public static async Task<int> Handle(string baseUrl, TextReader stdin, Task? updateCheckTask = null) {
         var body = await stdin.ReadToEndAsync();
 
@@ -167,11 +175,16 @@ public static class ClaudeHookCommand {
                     var transcriptPath = node?["transcript_path"]?.GetValue<string>();
 
                     if (sessionId is not null) {
-                        await WatcherManager.KillWatcher(sessionId);
+                        await TimeBudget.RunCappedAsync(
+                            async () => {
+                                await WatcherManager.KillWatcher(sessionId);
 
-                        if (transcriptPath is not null) {
-                            await WatcherManager.InlineDrainAsync(baseUrl, sessionId, transcriptPath, agentId: null);
-                        }
+                                if (transcriptPath is not null) {
+                                    await WatcherManager.InlineDrainAsync(baseUrl, sessionId, transcriptPath, agentId: null);
+                                }
+                            },
+                            PreHookDrainCap
+                        );
                     }
                 } catch (Exception ex) {
                     Console.Error.WriteLine($"[kcap] session-end pre-hook failed: {ex.Message}");
@@ -189,13 +202,18 @@ public static class ClaudeHookCommand {
                     var transcriptPath = node?["transcript_path"]?.GetValue<string>();
 
                     if (sessionId is not null && agentId is not null) {
-                        await WatcherManager.KillWatcher($"{sessionId}-{agentId}");
+                        await TimeBudget.RunCappedAsync(
+                            async () => {
+                                await WatcherManager.KillWatcher($"{sessionId}-{agentId}");
 
-                        if (transcriptPath is not null) {
-                            var sessionDir          = Path.ChangeExtension(transcriptPath, null);
-                            var agentTranscriptPath = Path.Combine(sessionDir, "subagents", $"agent-{agentId}.jsonl");
-                            await WatcherManager.InlineDrainAsync(baseUrl, sessionId, agentTranscriptPath, agentId);
-                        }
+                                if (transcriptPath is not null) {
+                                    var sessionDir          = Path.ChangeExtension(transcriptPath, null);
+                                    var agentTranscriptPath = Path.Combine(sessionDir, "subagents", $"agent-{agentId}.jsonl");
+                                    await WatcherManager.InlineDrainAsync(baseUrl, sessionId, agentTranscriptPath, agentId);
+                                }
+                            },
+                            PreHookDrainCap
+                        );
                     }
                 } catch (Exception ex) {
                     Console.Error.WriteLine($"[kcap] subagent-stop pre-hook failed: {ex.Message}");

--- a/src/Capacitor.Cli/TimeBudget.cs
+++ b/src/Capacitor.Cli/TimeBudget.cs
@@ -3,9 +3,10 @@ namespace Capacitor.Cli;
 public static class TimeBudget {
     /// <summary>
     /// Runs <paramref name="work"/> but returns after at most <paramref name="cap"/>.
-    /// If the cap elapses first, the work is abandoned (left running, its result/fault
-    /// unobserved) and control returns to the caller. Exceptions are propagated only when
-    /// the work completes within the cap.
+    /// Returns <c>true</c> when the work finished within the cap (its exception, if any, is
+    /// propagated), or <c>false</c> when the cap elapsed first and the work was abandoned
+    /// (left running, its later result/fault unobserved). The boolean lets callers log that
+    /// the work was cut short.
     ///
     /// Used to keep best-effort hook pre-work — killing the watcher and inline-draining the
     /// transcript — from consuming the entire SessionEnd hook timeout. A slow or retrying
@@ -14,20 +15,27 @@ public static class TimeBudget {
     /// forever. The server's own StopAndDrain plus the "kcap import" recovery hint cover
     /// anything an abandoned drain didn't finish.
     /// </summary>
-    public static async Task RunCappedAsync(Func<Task> work, TimeSpan cap) {
+    public static async Task<bool> RunCappedAsync(Func<Task> work, TimeSpan cap) {
         var workTask = work();
 
         using var cts       = new CancellationTokenSource();
         var       delayTask = Task.Delay(cap, cts.Token);
 
-        if (await Task.WhenAny(workTask, delayTask) == workTask) {
-            await cts.CancelAsync(); // stop the timer
-            await workTask;          // observe result / propagate exception
-            return;
+        await Task.WhenAny(workTask, delayTask);
+        await cts.CancelAsync(); // stop the timer either way
+
+        // Observe the work whenever it has actually finished — even if the delay "won" a
+        // near-boundary race — so a completed task's result/exception is never silently
+        // dropped. Only abandon when the work is genuinely still running past the cap.
+        if (workTask.IsCompleted) {
+            await workTask; // propagate exception if faulted
+            return true;
         }
 
         // Cap elapsed: abandon the work. Swallow any later fault so it doesn't surface as an
         // UnobservedTaskException — the hook process exits shortly after the POST anyway.
         _ = workTask.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
+
+        return false;
     }
 }

--- a/src/Capacitor.Cli/TimeBudget.cs
+++ b/src/Capacitor.Cli/TimeBudget.cs
@@ -1,0 +1,33 @@
+namespace Capacitor.Cli;
+
+public static class TimeBudget {
+    /// <summary>
+    /// Runs <paramref name="work"/> but returns after at most <paramref name="cap"/>.
+    /// If the cap elapses first, the work is abandoned (left running, its result/fault
+    /// unobserved) and control returns to the caller. Exceptions are propagated only when
+    /// the work completes within the cap.
+    ///
+    /// Used to keep best-effort hook pre-work — killing the watcher and inline-draining the
+    /// transcript — from consuming the entire SessionEnd hook timeout. A slow or retrying
+    /// remote call here could otherwise burn the whole 15s budget (the retry helper alone
+    /// allows up to 30s) and starve the session-end POST, leaving the session stuck "Active"
+    /// forever. The server's own StopAndDrain plus the "kcap import" recovery hint cover
+    /// anything an abandoned drain didn't finish.
+    /// </summary>
+    public static async Task RunCappedAsync(Func<Task> work, TimeSpan cap) {
+        var workTask = work();
+
+        using var cts       = new CancellationTokenSource();
+        var       delayTask = Task.Delay(cap, cts.Token);
+
+        if (await Task.WhenAny(workTask, delayTask) == workTask) {
+            await cts.CancelAsync(); // stop the timer
+            await workTask;          // observe result / propagate exception
+            return;
+        }
+
+        // Cap elapsed: abandon the work. Swallow any later fault so it doesn't surface as an
+        // UnobservedTaskException — the hook process exits shortly after the POST anyway.
+        _ = workTask.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/TimeBudgetTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TimeBudgetTests.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics;
+using Capacitor.Cli;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// <see cref="TimeBudget.RunCappedAsync"/> bounds best-effort hook pre-work (watcher
+/// kill + inline transcript drain) so a slow/retrying remote call can't consume the
+/// whole SessionEnd hook timeout and starve the critical session-end POST that follows
+/// — the failure that left sessions stuck "Active" after a clean exit.
+/// </summary>
+public class TimeBudgetTests {
+    [Test]
+    public async Task RunCappedAsync_ReturnsAtCap_WhenWorkExceedsIt() {
+        var sw = Stopwatch.StartNew();
+
+        await TimeBudget.RunCappedAsync(() => Task.Delay(TimeSpan.FromSeconds(5)), TimeSpan.FromMilliseconds(200));
+
+        sw.Stop();
+
+        // Returns at ~the cap, NOT after the 5s work — proves a slow drain is abandoned
+        // so the session-end POST still gets to run inside the hook budget.
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(2));
+    }
+
+    [Test]
+    public async Task RunCappedAsync_ReturnsWhenWorkCompletes_WithoutWaitingForCap() {
+        var sw = Stopwatch.StartNew();
+
+        await TimeBudget.RunCappedAsync(() => Task.CompletedTask, TimeSpan.FromSeconds(30));
+
+        sw.Stop();
+
+        // Fast work returns immediately — the cap is a ceiling, not a fixed delay.
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task RunCappedAsync_PropagatesException_WhenWorkFailsWithinCap() {
+        await Assert.That(async () =>
+                await TimeBudget.RunCappedAsync(
+                    () => Task.FromException(new InvalidOperationException("drain blew up")),
+                    TimeSpan.FromSeconds(30)
+                )
+            )
+            .Throws<InvalidOperationException>();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/TimeBudgetTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TimeBudgetTests.cs
@@ -11,27 +11,30 @@ namespace Capacitor.Cli.Tests.Unit;
 /// </summary>
 public class TimeBudgetTests {
     [Test]
-    public async Task RunCappedAsync_ReturnsAtCap_WhenWorkExceedsIt() {
+    public async Task RunCappedAsync_ReturnsFalseAtCap_WhenWorkExceedsIt() {
         var sw = Stopwatch.StartNew();
 
-        await TimeBudget.RunCappedAsync(() => Task.Delay(TimeSpan.FromSeconds(5)), TimeSpan.FromMilliseconds(200));
+        var completed = await TimeBudget.RunCappedAsync(() => Task.Delay(TimeSpan.FromSeconds(5)), TimeSpan.FromMilliseconds(200));
 
         sw.Stop();
 
         // Returns at ~the cap, NOT after the 5s work — proves a slow drain is abandoned
-        // so the session-end POST still gets to run inside the hook budget.
+        // so the session-end POST still gets to run inside the hook budget. The `false`
+        // result lets the caller log that the drain was cut short.
+        await Assert.That(completed).IsFalse();
         await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(2));
     }
 
     [Test]
-    public async Task RunCappedAsync_ReturnsWhenWorkCompletes_WithoutWaitingForCap() {
+    public async Task RunCappedAsync_ReturnsTrueWhenWorkCompletes_WithoutWaitingForCap() {
         var sw = Stopwatch.StartNew();
 
-        await TimeBudget.RunCappedAsync(() => Task.CompletedTask, TimeSpan.FromSeconds(30));
+        var completed = await TimeBudget.RunCappedAsync(() => Task.CompletedTask, TimeSpan.FromSeconds(30));
 
         sw.Stop();
 
-        // Fast work returns immediately — the cap is a ceiling, not a fixed delay.
+        // Fast work returns immediately (true) — the cap is a ceiling, not a fixed delay.
+        await Assert.That(completed).IsTrue();
         await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
     }
 


### PR DESCRIPTION
## Problem

Claude sessions can stay **Active** in the UI forever after a clean `/exit` — the `AgentSession-…` stream has no `SessionEnded` marker at all, because the terminal signal never reached the server.

The `SessionEnd` hook (`kcap hook --claude`) does `KillWatcher` (≤5s) + `InlineDrainAsync` **before** POSTing `/hooks/session-end`. `InlineDrainAsync`'s `/last-line` GET uses the retry helper's **30s** total timeout — double the **15s** SessionEnd hook budget. Against a slow/remote server this burns the whole budget, Claude kills the hook at its timeout, and the session-end POST is never sent. (The server-side write is fine — it uses `CancellationToken.None` — so the only way `SessionEnded` goes missing is the POST never arriving.)

## Fix

Cap the best-effort pre-POST drain (`KillWatcher` + `InlineDrainAsync`) at **8s** via a new `TimeBudget.RunCappedAsync`, for both `session-end` and `subagent-stop`. If the cap elapses the drain is abandoned and we proceed straight to the POST, guaranteeing it runs within the hook budget. The server's own `StopAndDrain` and the `kcap import` recovery hint cover anything an abandoned drain didn't finish.

Pairs with the server-side safety net in kcap-server (stale-watcher session reaper) — this PR reduces how often the signal is lost; that one guarantees a lost signal can't strand a session forever.

## Tests

`TimeBudgetTests` (new, 3): returns at the cap when work exceeds it; returns immediately when work completes; propagates exceptions raised within the cap.

- Full CLI unit suite: 1321/1321 ✅
- Hook-path integration tests (`ClaudeHookStdoutTests`, `WatcherParentExitPostTests`) ✅
- AOT publish: clean, no IL warnings ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)