### PR TITLE
[AI-815] GitHub Copilot CLI session ingest (hooks, watcher, import, setup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The CLI is compiled with NativeAOT — fast startup, no runtime dependency.
 > **npm 11+ blocks install scripts by default.** You'll see a warning like
 > `1 package has install scripts not yet covered by allowScripts`. The `kcap`
 > binary works without the script; it only refreshes already-installed agent
-> plugins (Claude / Codex / Cursor) on upgrade. The warning suggests
+> plugins (Claude / Codex / Cursor / Copilot) on upgrade. The warning suggests
 > `npm approve-scripts @kurrent/kcap`, but that command rejects global installs
 > (`EGLOBAL`) — a known npm UX bug. Instead, opt in one of two ways:
 >
@@ -44,7 +44,7 @@ The CLI is compiled with NativeAOT — fast startup, no runtime dependency.
 > allow-scripts[]=@kurrent/kcap
 > ```
 >
-> Without either, re-run `kcap plugin install [--codex|--cursor|--skills] --if-installed` manually after each upgrade.
+> Without either, re-run `kcap plugin install [--codex|--cursor|--copilot|--skills] --if-installed` manually after each upgrade.
 
 ### 2. Run setup
 
@@ -57,7 +57,7 @@ The setup wizard walks you through:
 1. **Server URL** — enter the URL your admin provided
 2. **Login** — authenticates via GitHub Device Flow (if the server requires auth)
 3. **Default visibility** — choose how your sessions are visible to others
-4. **Coding-agent hooks** — detects Claude Code and Codex CLI on `PATH`, and Cursor by user-dir presence (`~/.cursor/`), then offers to install hooks/skills for each (user-wide)
+4. **Coding-agent hooks** — detects Claude Code and Codex CLI on `PATH`, Cursor by user-dir presence (`~/.cursor/`), and GitHub Copilot CLI by `~/.copilot/` or `copilot` on `PATH`, then offers to install hooks/skills for each (user-wide)
 5. **Daemon** — configure the daemon name for remote agent execution
 
 When setup finishes, `kcap` sends a best-effort POST to the server's `/api/users/me/cli-setup` endpoint so the dashboard can mark your CLI as registered and surface the import-past-sessions hint. The call is capped at 5 seconds and failures are silent — they do not affect setup completion.
@@ -70,10 +70,10 @@ For non-interactive environments:
 kcap setup --server-url https://my-tenant.kcap.ai --default-visibility org_public --no-prompt
 ```
 
-In `--no-prompt` mode, the wizard installs hooks for every detected agent by default. Opt out per agent with `--skip-claude-hooks`, `--skip-codex-hooks`, and/or `--skip-cursor-hooks`.
+In `--no-prompt` mode, the wizard installs hooks for every detected agent by default. Opt out per agent with `--skip-claude-hooks`, `--skip-codex-hooks`, `--skip-cursor-hooks`, and/or `--skip-copilot-hooks`.
 
 > **Need hooks for an agent installed after setup, or scoped to a single repo?**
-> Run `kcap plugin install [--codex|--cursor]` (omit the flag for the Claude Code plugin), or pair Codex with `--project` for a per-repo install. Use `--skills` instead of `--codex` if you only want the agent skills without Codex hooks. Cursor uses user-scope only — `--project` has no effect with `--cursor`. After installing Codex hooks, the next `codex` launch prompts to trust the new hooks — accept once to trust them all (run `/hooks` inside Codex if you'd rather trust each entry individually). After a `--project` install, also run `codex` once in the repo and accept the workspace trust prompt. Re-running after a kcap upgrade is rarely needed for user-scope installs — the npm postinstall hook auto-refreshes them on every `npm install -g @kurrent/kcap` (npm 11+ blocks install scripts by default; add `allow-scripts[]=@kurrent/kcap` to `~/.npmrc` to opt in once).
+> Run `kcap plugin install [--codex|--cursor|--copilot]` (omit the flag for the Claude Code plugin), or pair Codex with `--project` for a per-repo install. Use `--skills` instead of `--codex` if you only want the agent skills without Codex hooks. Cursor uses user-scope only — `--project` has no effect with `--cursor`. After installing Codex hooks, the next `codex` launch prompts to trust the new hooks — accept once to trust them all (run `/hooks` inside Codex if you'd rather trust each entry individually). After a `--project` install, also run `codex` once in the repo and accept the workspace trust prompt. Re-running after a kcap upgrade is rarely needed for user-scope installs — the npm postinstall hook auto-refreshes them on every `npm install -g @kurrent/kcap` (npm 11+ blocks install scripts by default; add `allow-scripts[]=@kurrent/kcap` to `~/.npmrc` to opt in once).
 
 > **Need at least one agent to capture sessions:** the setup wizard runs to completion without an agent CLI on `PATH` (it'll still configure your profile, auth, and daemon), but kcap only records work once Claude Code or Codex CLI is installed and the hooks are in place.
 
@@ -82,13 +82,14 @@ In `--no-prompt` mode, the wizard installs hooks for every detected agent by def
 ### 3. Import existing sessions (optional)
 
 ```bash
-kcap import                     # every detected agent (Claude, Codex, Cursor)
+kcap import                     # every detected agent (Claude, Codex, Cursor, Copilot)
 kcap import --org               # sessions for the org bound to your active profile
 kcap import --repo owner/repo   # sessions for one specific repo
 kcap import --cursor            # only Cursor
+kcap import --copilot           # only Copilot
 ```
 
-This backfills your past sessions from `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex), and `~/.cursor/projects/.../agent-transcripts/` (Cursor) so they appear in the dashboard. All agents are discovered automatically — pass `--claude`, `--codex`, or `--cursor` (one or more) to narrow the run. All forms are idempotent — safe to run multiple times.
+This backfills your past sessions from `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex), `~/.cursor/projects/.../agent-transcripts/` (Cursor), and `~/.copilot/session-state/` (Copilot) so they appear in the dashboard. All agents are discovered automatically — pass `--claude`, `--codex`, `--cursor`, or `--copilot` (one or more) to narrow the run. All forms are idempotent — safe to run multiple times.
 
 You must pick an explicit scope (`--all`, `--org`, or `--repo`) so personal/private repos aren't uploaded by accident. `--org` uses the active profile name as the GitHub org login — it works out of the box when the profile was created by `kcap setup` (which names it after the picked tenant), and errors otherwise. Run with no scope on an interactive terminal to get a picker. See [Loading historical sessions](#loading-historical-sessions) for the full set of flags.
 
@@ -124,7 +125,7 @@ kcap setup                                   # interactive wizard
 kcap setup --server-url <url> --no-prompt    # CI / scripted
 ```
 
-The setup wizard detects every supported coding agent and offers to install hooks for each, then configures the daemon. Claude Code and Codex CLI are detected via `PATH`; Cursor is detected by user-dir presence (`~/.cursor/`), so IDE users without the `cursor` shell command are covered. Re-run any time to update the configuration.
+The setup wizard detects every supported coding agent and offers to install hooks for each, then configures the daemon. Claude Code and Codex CLI are detected via `PATH`; Cursor is detected by user-dir presence (`~/.cursor/`), so IDE users without the `cursor` shell command are covered; GitHub Copilot CLI is detected via `~/.copilot/` or `copilot` on `PATH`. Re-run any time to update the configuration.
 
 In `--no-prompt` mode, hooks install for every detected agent by default. Opt out per agent:
 
@@ -257,7 +258,7 @@ The server is repo-aware — it resolves the current working directory to a repo
 
 ### Loading historical sessions
 
-Backfill older sessions from every detected coding agent in a single run. All three agents ship per-session `.jsonl` transcripts (`~/.claude/projects/`, `~/.codex/sessions/`, `~/.cursor/projects/<sanitized-workspace>/agent-transcripts/`). They're discovered automatically and the command requires an explicit scope so personal/private repos aren't uploaded by accident:
+Backfill older sessions from every detected coding agent in a single run. All four agents ship per-session `.jsonl` transcripts (`~/.claude/projects/`, `~/.codex/sessions/`, `~/.cursor/projects/<sanitized-workspace>/agent-transcripts/`, `~/.copilot/session-state/`). They're discovered automatically and the command requires an explicit scope so personal/private repos aren't uploaded by accident:
 
 ```bash
 kcap import --all                            # every discovered session from every agent
@@ -277,6 +278,7 @@ kcap import --claude --org                   # only Claude transcripts
 kcap import --codex --org                    # only Codex rollouts
 kcap import --cursor --all                   # only Cursor — every discovered transcript
 kcap import --cursor --cwd /path/to/proj     # only Cursor sessions whose workspace folder matches
+kcap import --copilot --all                  # only Copilot — every discovered transcript
 ```
 
 Cursor historical import walks every JSONL transcript under `~/.cursor/projects/*/agent-transcripts/*/*.jsonl` and posts each line through the same `POST /hooks/transcript` route the live hook path uses, so live and historical ingest converge on one canonical event stream. The walker resolves each session's working directory by matching its sanitized workspace name against `~/Library/Application Support/Cursor/User/workspaceStorage/*/workspace.json` (on Linux: `~/.config/Cursor/User/...`); sessions whose workspace can't be resolved are still imported, just without `cwd` and git owner/repo enrichment.
@@ -377,6 +379,17 @@ Cursor is detected by the presence of `~/.cursor/` — you don't need the `curso
 kcap plugin install --cursor                # writes ~/.cursor/hooks.json
 kcap plugin remove --cursor                 # remove Cursor hooks
 ```
+
+#### GitHub Copilot CLI hooks
+
+Copilot CLI is detected via `~/.copilot/` (created on Copilot's first run) or the `copilot` binary on `PATH`. kcap writes its own hooks file — Copilot merges every `*.json` under `~/.copilot/hooks/`, so your other hook files are never touched. Copilot loads hook config at startup: restart any running `copilot` session after installing.
+
+```bash
+kcap plugin install --copilot               # writes ~/.copilot/hooks/kcap.json
+kcap plugin remove --copilot                # deletes ~/.copilot/hooks/kcap.json
+```
+
+Live sessions stream from `~/.copilot/session-state/<session-id>/events.jsonl` (`$COPILOT_HOME` is honoured); historical sessions import via `kcap import --copilot`, which also forwards Copilot's auto-generated session names as titles. Sessions resumed with `copilot --continue` / `--resume` reattach to the same recorded session.
 
 Cursor uses a single user-scope `hooks.json`; there is no project-scope variant.
 

--- a/npm/kcap/bin/postinstall.js
+++ b/npm/kcap/bin/postinstall.js
@@ -33,10 +33,11 @@ const launcher = path.join(__dirname, "kcap.js");
 // One entry per agent. Order is independent — each refresh is gated by
 // its own marker.
 const refreshes = [
-  ["plugin", "install", "--skills", "--if-installed"],
-  ["plugin", "install", "--codex",  "--if-installed"],
-  ["plugin", "install", "--cursor", "--if-installed"],
-  ["plugin", "install",             "--if-installed"], // Claude
+  ["plugin", "install", "--skills",  "--if-installed"],
+  ["plugin", "install", "--codex",   "--if-installed"],
+  ["plugin", "install", "--cursor",  "--if-installed"],
+  ["plugin", "install", "--copilot", "--if-installed"],
+  ["plugin", "install",              "--if-installed"], // Claude
 ];
 
 for (const argv of refreshes) {

--- a/src/Capacitor.Cli.Core/Copilot/CopilotHooksInstaller.cs
+++ b/src/Capacitor.Cli.Core/Copilot/CopilotHooksInstaller.cs
@@ -1,0 +1,65 @@
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Core.Copilot;
+
+/// <summary>
+/// Marker + detection helpers for <c>~/.copilot/hooks/kcap.json</c>. Mirror of
+/// <see cref="CursorHooksInstaller"/>: the npm postinstall hook calls
+/// <see cref="IsInstalled"/> to gate the upgrade-time refresh, and
+/// <see cref="WriteMarker"/> stamps the version after a successful write.
+/// </summary>
+public static class CopilotHooksInstaller {
+    public const string MarkerFileName = ".kcap-hooks-version";
+
+    /// <summary>
+    /// True when the user has previously installed Copilot hooks via setup or
+    /// <c>kcap plugin install --copilot</c>. Marker file presence OR an
+    /// existing <c>kcap hook --copilot</c> entry in kcap.json — the
+    /// hooks-json fallback covers pre-marker installs.
+    /// </summary>
+    public static bool IsInstalled(string hooksPath) {
+        var dir = Path.GetDirectoryName(hooksPath);
+        if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir)) return false;
+
+        if (File.Exists(Path.Combine(dir, MarkerFileName))) return true;
+        if (!File.Exists(hooksPath)) return false;
+
+        try {
+            if (JsonNode.Parse(File.ReadAllText(hooksPath)) is not JsonObject root) return false;
+            if (root["hooks"] is not JsonObject hooks) return false;
+
+            foreach (var (_, entries) in hooks) {
+                if (entries is not JsonArray arr) continue;
+
+                if (arr.Any(CopilotHooksParser.EntryReferencesCapacitorCopilotHook)) {
+                    return true;
+                }
+            }
+        } catch { /* Malformed → treat as not installed. */ }
+        return false;
+    }
+
+    public static string? ReadMarker(string hooksPath) {
+        var dir = Path.GetDirectoryName(hooksPath);
+        if (string.IsNullOrEmpty(dir)) return null;
+        var marker = Path.Combine(dir, MarkerFileName);
+        try { return File.Exists(marker) ? File.ReadAllText(marker).Trim() : null; }
+        catch { return null; }
+    }
+
+    public static void WriteMarker(string hooksPath) {
+        var dir = Path.GetDirectoryName(hooksPath);
+        if (string.IsNullOrEmpty(dir)) return;
+        try {
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, MarkerFileName), CapacitorVersion.Current());
+        } catch { /* best effort */ }
+    }
+
+    public static void DeleteMarker(string hooksPath) {
+        var dir = Path.GetDirectoryName(hooksPath);
+        if (string.IsNullOrEmpty(dir)) return;
+        var marker = Path.Combine(dir, MarkerFileName);
+        try { if (File.Exists(marker)) File.Delete(marker); } catch { }
+    }
+}

--- a/src/Capacitor.Cli.Core/Copilot/CopilotHooksParser.cs
+++ b/src/Capacitor.Cli.Core/Copilot/CopilotHooksParser.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Core.Copilot;
+
+/// <summary>
+/// Parsing helpers for kcap's Copilot hooks file
+/// (<c>~/.copilot/hooks/kcap.json</c>). Copilot's schema is
+/// <c>{"version": 1, "hooks": {eventName: [entry…]}}</c> where each command
+/// entry carries the shell command under <c>command</c> (cross-platform),
+/// <c>bash</c>, or <c>powershell</c>.
+/// </summary>
+public static class CopilotHooksParser {
+    /// <summary>
+    /// The Copilot hook events kcap subscribes to. Deliberately minimal —
+    /// every hook execution writes a hook.start/hook.end noise pair into the
+    /// session's events.jsonl, so per-tool events (preToolUse/postToolUse/
+    /// permissionRequest) would double transcript noise for content the
+    /// transcript already carries. sessionStart/sessionEnd own lifecycle,
+    /// agentStop refreshes watcher liveness each turn, notification forwards
+    /// to the server's notification record.
+    /// </summary>
+    public static readonly string[] CopilotHookEvents = [
+        "sessionStart",
+        "sessionEnd",
+        "agentStop",
+        "notification"
+    ];
+
+    /// <summary>
+    /// True if <paramref name="entry"/> is a command entry referencing the
+    /// kcap Copilot hook dispatcher, in any of the three command fields.
+    /// </summary>
+    public static bool EntryReferencesCapacitorCopilotHook(JsonNode? entry) {
+        return FieldContains(entry, "command")
+            || FieldContains(entry, "bash")
+            || FieldContains(entry, "powershell");
+
+        static bool FieldContains(JsonNode? entry, string field) =>
+            entry?[field] is JsonValue jv
+         && jv.TryGetValue<string>(out var cmd)
+         && cmd.Contains("kcap hook --copilot", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// True if every event in <paramref name="events"/> has at least one
+    /// entry referencing the kcap copilot command.
+    /// </summary>
+    public static bool HasCapacitorHooksFor(JsonObject root, IEnumerable<string> events) {
+        if (root["hooks"] is not JsonObject hooks) return false;
+
+        foreach (var evt in events) {
+            if (hooks[evt] is not JsonArray entries) return false;
+
+            if (!entries.Any(EntryReferencesCapacitorCopilotHook)) return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Capacitor.Cli.Core/Copilot/CopilotPaths.cs
+++ b/src/Capacitor.Cli.Core/Copilot/CopilotPaths.cs
@@ -1,0 +1,62 @@
+namespace Capacitor.Cli.Core.Copilot;
+
+/// <summary>
+/// Filesystem layout for GitHub Copilot CLI state. Everything lives under a
+/// single root: <c>$COPILOT_HOME</c> when set (Copilot relocates its entire
+/// tree through that variable — hooks inherit it from the spawning process),
+/// otherwise <c>~/.copilot</c> on every OS.
+/// </summary>
+public static class CopilotPaths {
+    public static string Root(string? home = null, string? copilotHome = null) {
+        copilotHome ??= Environment.GetEnvironmentVariable("COPILOT_HOME");
+        if (!string.IsNullOrEmpty(copilotHome)) return copilotHome;
+
+        home ??= Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".copilot");
+    }
+
+    /// <summary>
+    /// Detection by root-dir presence — Copilot CLI creates <c>~/.copilot</c>
+    /// on first run, and (unlike Codex) the binary name <c>copilot</c> is too
+    /// generic for a PATH probe to be the only signal. Callers that want the
+    /// PATH probe too OR this with <c>AgentDetector.IsInstalled("copilot")</c>.
+    /// </summary>
+    public static bool IsInstalled(string? home = null, string? copilotHome = null)
+        => Directory.Exists(Root(home, copilotHome));
+
+    /// <summary>
+    /// User-level hooks directory. Copilot merges every <c>*.json</c> file in
+    /// here at startup, so kcap owns its own file (<see cref="KcapHooksJson"/>)
+    /// instead of merging into a shared one the way the Cursor installer must.
+    /// </summary>
+    public static string HooksDir(string? home = null, string? copilotHome = null)
+        => Path.Combine(Root(home, copilotHome), "hooks");
+
+    public static string KcapHooksJson(string? home = null, string? copilotHome = null)
+        => Path.Combine(HooksDir(home, copilotHome), "kcap.json");
+
+    /// <summary>
+    /// Per-session state root: one subdirectory per session (named with the
+    /// dashed session uuid) containing <c>events.jsonl</c> (append-only
+    /// transcript), <c>workspace.yaml</c> (cwd/repo/title metadata), and
+    /// checkpoint artifacts. Directories WITHOUT an events.jsonl are
+    /// failed-startup scaffolding and must be skipped by discovery.
+    /// </summary>
+    public static string SessionStateDir(string? home = null, string? copilotHome = null)
+        => Path.Combine(Root(home, copilotHome), "session-state");
+
+    /// <summary>
+    /// Pre-GA session storage (Copilot migrated to <c>session-state/</c> in
+    /// late 2025; old sessions are only migrated lazily on resume). Import
+    /// walks both roots.
+    /// </summary>
+    public static string LegacySessionStateDir(string? home = null, string? copilotHome = null)
+        => Path.Combine(Root(home, copilotHome), "history-session-state");
+
+    /// <summary>Transcript path for a session dir name (the dashed session uuid).</summary>
+    public static string EventsJsonl(string sessionStateDir, string sessionDirName)
+        => Path.Combine(sessionStateDir, sessionDirName, "events.jsonl");
+
+    public static string WorkspaceYaml(string sessionStateDir, string sessionDirName)
+        => Path.Combine(sessionStateDir, sessionDirName, "workspace.yaml");
+}

--- a/src/Capacitor.Cli.Core/Resources/help-hook.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-hook.txt
@@ -9,13 +9,16 @@ Description:
   dispatcher; the event is taken from the payload.
 
   The command is registered via 'kcap setup' or
-  'kcap plugin install [--claude|--codex|--cursor]', which writes the
-  appropriate hook configuration for the detected vendor.
+  'kcap plugin install [--claude|--codex|--cursor|--copilot]', which writes
+  the appropriate hook configuration for the detected vendor.
 
 Options:
   --claude    Dispatch the event as a Claude Code hook.
   --codex     Dispatch the event as a Codex CLI hook.
   --cursor    Dispatch the event as a Cursor IDE hook.
+  --copilot   Dispatch the event as a GitHub Copilot CLI hook. Copilot
+              payloads carry no event-name field, so the installer embeds
+              it in the registered command (--event <name>).
 
 Exit codes:
   0   Normal exit (including budget expiry, malformed payload, and

--- a/src/Capacitor.Cli.Core/Resources/help-import.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-import.txt
@@ -1,11 +1,13 @@
 kcap import — Import local sessions from every detected coding agent
 
-Discovers Claude, Codex, and Cursor sessions on this machine and imports them
-in a single run. Each agent ships a per-session .jsonl transcript:
-  Claude — ~/.claude/projects/<encoded-cwd>/<sid>.jsonl
-  Codex  — ~/.codex/sessions/.../rollout-<sid>.jsonl
-  Cursor — ~/.cursor/projects/<sanitized-workspace>/agent-transcripts/<sid>/<sid>.jsonl
-kcap walks all three the same way.
+Discovers Claude, Codex, Cursor, and Copilot sessions on this machine and
+imports them in a single run. Each agent ships a per-session .jsonl transcript:
+  Claude  — ~/.claude/projects/<encoded-cwd>/<sid>.jsonl
+  Codex   — ~/.codex/sessions/.../rollout-<sid>.jsonl
+  Cursor  — ~/.cursor/projects/<sanitized-workspace>/agent-transcripts/<sid>/<sid>.jsonl
+  Copilot — ~/.copilot/session-state/<sid>/events.jsonl (plus the pre-GA
+            history-session-state/ root; dirs without events.jsonl are skipped)
+kcap walks all four the same way.
 
 Usage: kcap import [vendor-filters] [scope] [options]
 
@@ -17,6 +19,7 @@ Vendor filters (additive — pass one or more to restrict the run):
   --claude                Import Claude transcripts
   --codex                 Import Codex rollouts
   --cursor                Import Cursor agent-session transcripts
+  --copilot               Import GitHub Copilot CLI session transcripts
 
 Scope (one of, required for non-interactive use):
   --all                   Import every discovered session

--- a/src/Capacitor.Cli.Core/Resources/help-plugin.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-plugin.txt
@@ -1,4 +1,4 @@
-kcap plugin — Manage hooks and skills for Claude Code, Codex CLI, Cursor, and other agents
+kcap plugin — Manage hooks and skills for Claude Code, Codex CLI, Cursor, Copilot CLI, and other agents
 
 Usage: kcap plugin <subcommand> [options]
 
@@ -13,6 +13,10 @@ Options:
   --cursor            Target Cursor IDE: install hooks to ~/.cursor/hooks.json.
                       Detected by user-dir presence, not PATH, so users without
                       the cursor shell command are covered.
+  --copilot           Target GitHub Copilot CLI: write kcap's own hooks file to
+                      ~/.copilot/hooks/kcap.json (honours $COPILOT_HOME). Copilot
+                      merges every *.json in that directory, so user-authored
+                      hook files are never touched.
   --skills            Install only the agent-agnostic skills to ~/.agents/skills/.
                       Use this if you only have Cursor (or another agent that
                       reads ~/.agents/skills/) and don't want Codex hooks.
@@ -39,6 +43,12 @@ Notes:
   install --codex and install --skills both clean up legacy ~/.codex/skills/kcap-*
   folders from prior installer versions.
 
+  --copilot writes the four events kcap subscribes to (sessionStart, sessionEnd,
+  agentStop, notification) with the event name embedded in each command —
+  Copilot hook payloads don't carry one. Copilot loads hook config at startup,
+  so restart any running copilot session after install. Copilot has no
+  project-scope hooks dir, so --project has no effect with --copilot.
+
   --if-installed is scoped to user-wide installs only — the npm postinstall hook
   does not refresh --project installs.
 
@@ -48,9 +58,11 @@ Examples:
   kcap plugin install --codex               # Install Codex hooks + agent skills (user)
   kcap plugin install --project --codex     # Codex hooks in <repo>/.codex/hooks.json, skills user-wide
   kcap plugin install --cursor              # Install Cursor hooks (~/.cursor/hooks.json)
+  kcap plugin install --copilot             # Install Copilot hooks (~/.copilot/hooks/kcap.json)
   kcap plugin install --skills --if-installed   # Refresh skills if previously installed (used by npm postinstall)
   kcap plugin install --codex --if-installed    # Refresh Codex hooks if previously installed (used by npm postinstall)
   kcap plugin install --if-installed            # Refresh Claude plugin registration if previously installed
   kcap plugin remove --codex                # Remove Codex hooks + agent skills + legacy ~/.codex/skills
   kcap plugin remove --cursor               # Remove Cursor hooks from ~/.cursor/hooks.json
+  kcap plugin remove --copilot              # Delete ~/.copilot/hooks/kcap.json
   kcap plugin remove --skills               # Remove agent skills + legacy ~/.codex/skills

--- a/src/Capacitor.Cli.Core/Resources/help-setup.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-setup.txt
@@ -15,6 +15,8 @@ Options:
                               the codex CLI is detected on PATH.
   --skip-cursor-hooks         Don't install Cursor hooks even if the Cursor
                               user-dir is detected (~/.cursor/).
+  --skip-copilot-hooks        Don't install Copilot CLI hooks even if Copilot
+                              is detected (~/.copilot/ or copilot on PATH).
   --use-provider-api-key <v>  In --no-prompt mode, set whether kcap keeps
                               ANTHROPIC_API_KEY / OPENAI_API_KEY in headless
                               agent spawns. Accepts true/1/yes/on or
@@ -25,11 +27,11 @@ Options:
 
 The setup wizard detects every supported coding agent: Claude Code and Codex CLI
 via PATH; Cursor via user-dir presence (~/.cursor/) so IDE-only users without
-the cursor shell command are covered. One yes/no prompt is shown per detected
-agent. Hooks are installed user-wide. For project-scope or post-setup
-re-installs, use:
+the cursor shell command are covered; Copilot CLI via ~/.copilot/ or the
+copilot binary on PATH. One yes/no prompt is shown per detected agent. Hooks
+are installed user-wide. For project-scope or post-setup re-installs, use:
 
-  kcap plugin install [--codex] [--cursor] [--project]
+  kcap plugin install [--codex] [--cursor] [--copilot] [--project]
 
 Legacy:
   --plugin-scope <user|project|skip>

--- a/src/Capacitor.Cli.Core/Resources/help-uninstall.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-uninstall.txt
@@ -3,7 +3,8 @@ kcap uninstall — Remove kcap configuration from this machine
 Usage: kcap uninstall [options]
 
 Stops any running daemons and watcher processes, strips kcap entries from
-user-level Claude Code, Codex CLI, and Cursor hook files, removes agent skills
+user-level Claude Code, Codex CLI, and Cursor hook files, deletes kcap's
+Copilot hooks file (~/.copilot/hooks/kcap.json), removes agent skills
 (and any legacy ~/.codex/skills/kcap-* folders), and deletes the kcap
 config directory.
 
@@ -23,7 +24,7 @@ Options:
 
 Notes:
   Per-agent selective cleanup is not exposed here — uninstall always touches
-  all known agents. Use `kcap plugin remove [--codex|--cursor|--skills]`
+  all known agents. Use `kcap plugin remove [--codex|--cursor|--copilot|--skills]`
   for finer-grained removal.
 
   Project-scope hooks installed in a directory other than the cwd's git root

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -42,7 +42,7 @@ Session:
   validate-plan [id]               Validate plan completion for a session
   eval [--model N] [--chain] [id]  Run LLM-as-judge evaluation over a session
   generate-whats-done [--codex] <id>  Generate what's-done summary (--codex uses `codex exec`)
-  import [vendor-filters] [options]   Import local sessions (Claude, Codex, Cursor)
+  import [vendor-filters] [options]   Import local sessions (Claude, Codex, Cursor, Copilot)
   set-title <title>                Set session title
   disable                          Stop recording and delete session data
   hide                             Hide session (owner-only visibility)
@@ -64,10 +64,11 @@ Maintenance:
   --version                        Show version
   --help                           Show this help
 
-Hooks (internal — invoked by Claude Code / Codex / Cursor):
+Hooks (internal — invoked by Claude Code / Codex / Cursor / Copilot):
   hook --claude                    Dispatch a Claude Code hook event (reads payload from stdin)
   hook --codex                     Dispatch a Codex CLI hook event
   hook --cursor                    Dispatch a Cursor IDE hook event
+  hook --copilot --event <name>    Dispatch a GitHub Copilot CLI hook event
 
 Environment:
   KCAP_URL              Server URL (overrides config file)

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -8,9 +8,9 @@ namespace Capacitor.Cli.Commands;
 /// can drive every branch without touching ~/.claude, ~/.codex, or AnsiConsole.
 /// </summary>
 internal static class CodingAgentsStep {
-    internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool NoPrompt);
+    internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool SkipCopilot, bool NoPrompt);
 
-    internal record DetectedAgents(bool Claude, bool Codex, bool Cursor);
+    internal record DetectedAgents(bool Claude, bool Codex, bool Cursor, bool Copilot);
 
     internal record Paths(
             string  ClaudeSettingsPath,
@@ -18,6 +18,7 @@ internal static class CodingAgentsStep {
             string? PluginDir,
             string  CodexHooksPath,
             string  CursorHooksPath,
+            string  CopilotHooksPath,
             string  AgentsSkillsDir,
             string  LegacyCodexSkillsDir
         );
@@ -26,6 +27,7 @@ internal static class CodingAgentsStep {
             Func<string /*settingsPath*/, string /*pluginDir*/, bool> InstallClaudePlugin,
             Func<string /*hooksPath*/, bool>                          InstallCodexHooks,
             Func<string /*hooksPath*/, bool>                          InstallCursorHooks,
+            Func<string /*hooksPath*/, bool>                          InstallCopilotHooks,
             Func<bool>                                                CapacitorOnPath,
             Func<string /*srcDir*/, string /*dstDir*/, bool>          InstallAgentSkills,
             Func<string /*legacyDir*/, bool>                          CleanLegacyCodexSkills
@@ -35,7 +37,8 @@ internal static class CodingAgentsStep {
             bool ClaudeInstalled,
             bool CodexHooksInstalled,
             bool CodexSkillsInstalled,
-            bool CursorHooksInstalled
+            bool CursorHooksInstalled,
+            bool CopilotHooksInstalled
         );
 
     /// <summary>
@@ -51,13 +54,14 @@ internal static class CodingAgentsStep {
             Func<string, bool> prompt,
             Action<string>     writeLine
         ) {
-        var claudeInstalled      = HandleClaude(options, detected, paths, installers, prompt, writeLine);
-        var codexHooksInstalled  = HandleCodexHooks(options, detected, paths, installers, prompt, writeLine);
-        var codexSkillsInstalled = codexHooksInstalled && HandleCodexSkills(paths, installers, writeLine);
-        var cursorHooksInstalled = HandleCursorHooks(options, detected, paths, installers, prompt, writeLine);
+        var claudeInstalled       = HandleClaude(options, detected, paths, installers, prompt, writeLine);
+        var codexHooksInstalled   = HandleCodexHooks(options, detected, paths, installers, prompt, writeLine);
+        var codexSkillsInstalled  = codexHooksInstalled && HandleCodexSkills(paths, installers, writeLine);
+        var cursorHooksInstalled  = HandleCursorHooks(options, detected, paths, installers, prompt, writeLine);
+        var copilotHooksInstalled = HandleCopilotHooks(options, detected, paths, installers, prompt, writeLine);
 
-        if (detected is { Claude: false, Codex: false, Cursor: false }) {
-            writeLine("  [yellow]⚠ No supported agent CLI detected.[/] Install Claude Code, Codex CLI, or Cursor to start capturing sessions.");
+        if (detected is { Claude: false, Codex: false, Cursor: false, Copilot: false }) {
+            writeLine("  [yellow]⚠ No supported agent CLI detected.[/] Install Claude Code, Codex CLI, Cursor, or Copilot CLI to start capturing sessions.");
         }
 
         return Task.FromResult(
@@ -65,9 +69,63 @@ internal static class CodingAgentsStep {
                 claudeInstalled,
                 codexHooksInstalled,
                 codexSkillsInstalled,
-                cursorHooksInstalled
+                cursorHooksInstalled,
+                copilotHooksInstalled
             )
         );
+    }
+
+    static bool HandleCopilotHooks(
+            Options            options,
+            DetectedAgents     detected,
+            Paths              paths,
+            Installers         installers,
+            Func<string, bool> prompt,
+            Action<string>     writeLine
+        ) {
+        if (!detected.Copilot) {
+            writeLine("  [dim]· Copilot CLI not detected — skipping[/]");
+
+            return false;
+        }
+
+        writeLine("  [green]✓[/] Copilot CLI detected");
+
+        if (options.SkipCopilot) {
+            writeLine("  [dim]· Copilot CLI hooks skipped by flag[/]");
+
+            return false;
+        }
+
+        var shouldInstall = options.NoPrompt || prompt("Install Copilot CLI hooks?");
+
+        if (!shouldInstall) {
+            writeLine("  [dim]· Copilot hooks not installed (you can run kcap plugin install --copilot later)[/]");
+
+            return false;
+        }
+
+        // kcap.json writes the bare "kcap hook --copilot" command and relies
+        // on Copilot finding it on PATH — same precheck as the Cursor branch.
+        if (!installers.CapacitorOnPath()) {
+            writeLine("  [yellow]⚠[/] Copilot hooks not installed — 'kcap' is not on PATH.");
+            writeLine("    [dim]Re-install via npm: [/][cyan]npm install -g @kurrent/kcap[/]");
+
+            return false;
+        }
+
+        var ok = installers.InstallCopilotHooks(paths.CopilotHooksPath);
+
+        if (!ok) {
+            writeLine("  [yellow]⚠[/] Could not write Copilot hooks file.");
+
+            return false;
+        }
+
+        writeLine($"  [green]✓[/] Copilot hooks installed ({Markup.Escape(paths.CopilotHooksPath)})");
+        writeLine("  [dim]  Note: Copilot loads hook config at startup — restart any running copilot session to pick them up.[/]");
+
+        return true;
     }
 
     static bool HandleCodexSkills(

--- a/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
@@ -75,6 +75,15 @@ static class CopilotHookCommand {
 
         if (string.IsNullOrEmpty(dashedSessionId)) return 0;
 
+        // Copilot session ids are UUIDs (the session-state dir name) — but
+        // subagent-scoped hook firings reuse the spawning toolCallId as
+        // sessionId (captured v1.0.61 agentStop: sessionId:"toolu_01…",
+        // transcriptPath:""). Those are not sessions: routing them onward
+        // would spawn idle watchers (pid files + SignalR registrations) keyed
+        // on tool-call ids. Subagent activity is already inlined in the
+        // parent session's transcript, so dropping these loses nothing.
+        if (!Guid.TryParse(dashedSessionId, out _)) return 0;
+
         var sessionId = dashedSessionId.Replace("-", "");
 
         // Mirror the Claude/Codex disabled-session fast path: `kcap disable`
@@ -263,8 +272,12 @@ static class CopilotHookCommand {
 
     static async Task EnsureWatcherAsync(string baseUrl, string dashedSessionId, string sessionId, JsonNode node, string? cwd) {
         // agentStop payloads carry transcriptPath; sessionStart's don't —
-        // derive it from the session-state layout in that case.
-        var transcriptPath = TryGetString(node, "transcriptPath") ?? TranscriptPathFor(dashedSessionId);
+        // derive it from the session-state layout in that case. Copilot also
+        // ships transcriptPath as an EMPTY STRING on some firings, so treat
+        // empty as absent rather than spawning a watcher on "".
+        var transcriptPath = TryGetString(node, "transcriptPath") is { Length: > 0 } tp
+            ? tp
+            : TranscriptPathFor(dashedSessionId);
 
         await WatcherManager.EnsureWatcherRunning(
             baseUrl, sessionId, transcriptPath,

--- a/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
@@ -223,11 +223,16 @@ static class CopilotHookCommand {
     }
 
     static async Task<int> HandleNotification(string baseUrl, JsonNode node, string sessionId, string? cwd) {
-        // The server's NotificationHook requires message + notification_type;
-        // Copilot's payload carries both natively (it already ships the
-        // Claude-compatible snake_case keys for them).
+        // The server's NotificationHook requires message + notification_type.
+        // Copilot's command-hook stdin ships the Claude-compatible snake_case
+        // key today (verified against captured v1.0.61 payloads), but its
+        // internal event model uses camelCase `notificationType` (visible in
+        // the transcript's hook.start input echo) — read both so a future
+        // Copilot release dropping the compat transformation degrades to
+        // "still recorded" instead of silently losing every notification.
         var message          = TryGetString(node, "message");
-        var notificationType = TryGetString(node, "notification_type");
+        var notificationType = TryGetString(node, "notification_type")
+                            ?? TryGetString(node, "notificationType");
 
         if (message is null || notificationType is null) return 0;
 

--- a/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
@@ -1,0 +1,330 @@
+using System.Text;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.Copilot;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// Single-binary dispatcher for GitHub Copilot CLI hooks (AI-815). Copilot
+/// command-hook payloads carry no uniform event-name field (sessionStart's
+/// payload is just <c>{sessionId, timestamp, cwd, source, initialPrompt}</c>),
+/// so the kcap hooks installer writes one entry per event with the event name
+/// embedded in the command: <c>kcap hook --copilot --event sessionStart</c>.
+/// </summary>
+/// <remarks>
+/// Wire contract (Copilot event → server route):
+///   sessionStart → POST /hooks/session-start/copilot, then spawn the watcher
+///                  tailing $COPILOT_HOME/session-state/{sid}/events.jsonl
+///                  with vendor=copilot (the server's CopilotTranscriptNormalizer
+///                  owns content; the hook owns lifecycle). Fires with
+///                  source:"resume" on the same session id for --continue /
+///                  --resume — the server's deterministic lifecycle event ids
+///                  make the re-POST idempotent and the watcher resumes from
+///                  the server watermark.
+///   sessionEnd   → kill watcher + capped inline drain (mirrors Claude's
+///                  AI-813 pre-drain cap), then POST /hooks/session-end/copilot.
+///   agentStop    → no server POST. Fires at every turn end; used only to
+///                  re-enliven a crashed watcher (mirrors Codex's Stop).
+///   notification → best-effort forward to the Claude-shaped /hooks/notification
+///                  (Copilot's payload already carries message / title /
+///                  notification_type in the compatible shape).
+/// Copilot treats hook stdout as optional, so this dispatcher emits nothing.
+/// </remarks>
+static class CopilotHookCommand {
+    // Mirror of ClaudeHookCommand.PreHookDrainCap (AI-813): Copilot kills the
+    // sessionEnd hook at its configured timeout (default 30s, but kcap.json
+    // entries set 30 and users can lower it) — the drain must never starve the
+    // session-end POST, or the session sticks "Active" forever.
+    static readonly TimeSpan PreHookDrainCap = TimeSpan.FromSeconds(8);
+
+    // Notification forwarding is telemetry — a stalled server must not block
+    // Copilot's turn loop. Single budget covers auth discovery + POST.
+    static readonly TimeSpan NotificationPostBudget = TimeSpan.FromSeconds(2);
+
+    public static async Task<int> Handle(string baseUrl, TextReader stdin, string[] args) {
+        var eventName = GetArg(args, "--event");
+
+        if (string.IsNullOrWhiteSpace(eventName)) {
+            Console.Error.WriteLine(
+                "kcap hook --copilot requires --event <name> (the kcap hooks installer writes it; "
+              + "re-run: kcap plugin install --copilot)");
+            return 1;
+        }
+
+        var body = await stdin.ReadToEndAsync();
+
+        JsonNode? node;
+
+        try {
+            node = JsonNode.Parse(body);
+        } catch {
+            // Best effort — never crash the host CLI on a malformed payload.
+            return 0;
+        }
+
+        if (node is null) return 0;
+
+        // Copilot payloads carry the dashed session uuid under camelCase
+        // `sessionId`. Keep the dashed form for filesystem lookups (the
+        // session-state dir name is dashed) and the dashless form for the
+        // server (AgentSession-{dashless} stream convention shared by every
+        // vendor dispatcher).
+        var dashedSessionId = TryGetString(node, "sessionId");
+
+        if (string.IsNullOrEmpty(dashedSessionId)) return 0;
+
+        var sessionId = dashedSessionId.Replace("-", "");
+
+        // Mirror the Claude/Codex disabled-session fast path: `kcap disable`
+        // must stop every POST and watcher restart for the session.
+        if (DisabledSessions.IsDisabled(sessionId)) {
+            if (eventName == "sessionEnd") DisabledSessions.RemoveMarker(sessionId);
+            return 0;
+        }
+
+        var cwd           = TryGetString(node, "cwd");
+        var activeProfile = await AppConfig.GetActiveProfileAsync();
+
+        // Path exclusion is a cheap string-prefix compare — safe on every
+        // event (agentStop fires per turn). Repo exclusion runs once inside
+        // sessionStart after enrichment, then marks the session disabled so
+        // later events take the fast path above (same split as Codex).
+        if (activeProfile?.ExcludedPaths is { Length: > 0 } excludedPaths
+         && PathExclusion.IsExcluded(cwd, excludedPaths)) {
+            return 0;
+        }
+
+        return eventName switch {
+            "sessionStart" => await HandleSessionStart(baseUrl, node, dashedSessionId, sessionId, cwd, activeProfile),
+            "sessionEnd"   => await HandleSessionEnd(baseUrl, node, dashedSessionId, sessionId, cwd),
+            "agentStop"    => await HandleAgentStop(baseUrl, node, dashedSessionId, sessionId, cwd),
+            "notification" => await HandleNotification(baseUrl, node, sessionId, cwd),
+            _              => 0   // unknown — silently ignore (fail-open like the other dispatchers)
+        };
+    }
+
+    static async Task<int> HandleSessionStart(
+            string    baseUrl,
+            JsonNode  node,
+            string    dashedSessionId,
+            string    sessionId,
+            string?   cwd,
+            Profile?  activeProfile
+        ) {
+        var source = TryGetString(node, "source") is { Length: > 0 } s ? s : "startup";
+
+        var forwarded = new JsonObject {
+            ["hook_event_name"] = "sessionStart",
+            ["session_id"]      = sessionId,
+            ["source"]          = source,
+            ["home_dir"]        = PathHelpers.HomeDirectory
+        };
+
+        if (cwd is not null) forwarded["cwd"] = cwd;
+
+        if (TryGetString(node, "initialPrompt") is { } prompt) {
+            forwarded["initial_prompt"] = prompt;
+        }
+
+        // Copilot stamps hook payloads with a unix-ms timestamp; forward it as
+        // started_at so canonical SessionStarted carries the real start time
+        // (the server falls back to UtcNow when absent — AI-739 precedent).
+        if (TryGetUnixMillis(node, "timestamp") is { } startedAt) {
+            forwarded["started_at"] = startedAt.ToString("O");
+        }
+
+        if (Environment.GetEnvironmentVariable("KCAP_AGENT_ID") is { } agentHostId) {
+            forwarded["agent_host_id"] = agentHostId;
+        }
+
+        // Same rationale as the Codex dispatcher: stamp default visibility
+        // BEFORE enrichment so it survives the JsonString round-trip.
+        if (activeProfile?.DefaultVisibility is { } visibility) {
+            forwarded["default_visibility"] = visibility;
+        }
+
+        var enriched = await RepositoryDetection.EnrichWithRepositoryInfo(forwarded.ToJsonString());
+
+        // Repo exclusion after enrichment (fast in-payload path) — mark the
+        // session so per-turn agentStop events skip via DisabledSessions.
+        if (activeProfile?.ExcludedRepos is { Length: > 0 } excludedRepos
+         && await RepoExclusion.IsExcludedAsync(enriched, excludedRepos)) {
+            DisabledSessions.Mark(sessionId);
+            return 0;
+        }
+
+        var exit = await PostHookAsync(baseUrl, "session-start/copilot", enriched);
+        if (exit != 0) return exit;
+
+        await EnsureWatcherAsync(baseUrl, dashedSessionId, sessionId, node, cwd);
+        return 0;
+    }
+
+    static async Task<int> HandleSessionEnd(
+            string   baseUrl,
+            JsonNode node,
+            string   dashedSessionId,
+            string   sessionId,
+            string?  cwd
+        ) {
+        var transcriptPath = TranscriptPathFor(dashedSessionId);
+
+        // Kill watcher + inline-drain BEFORE the POST so the server computes
+        // stats over the full transcript — capped so a slow drain can't starve
+        // the session-end POST (mirror of ClaudeHookCommand / AI-813).
+        try {
+            var drained = await TimeBudget.RunCappedAsync(
+                async () => {
+                    await WatcherManager.KillWatcher(sessionId);
+                    await WatcherManager.InlineDrainAsync(baseUrl, sessionId, transcriptPath, agentId: null, vendor: "copilot");
+                },
+                PreHookDrainCap
+            );
+
+            if (!drained) {
+                await Console.Error.WriteLineAsync(
+                    $"[kcap] copilot session-end pre-drain cap ({PreHookDrainCap.TotalSeconds:0}s) elapsed; proceeding to POST. "
+                  + $"Transcript tail may be incomplete — recoverable via: kcap import --copilot --session {sessionId}"
+                );
+            }
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"[kcap] copilot session-end pre-hook failed: {ex.Message}");
+        }
+
+        var forwarded = new JsonObject {
+            ["hook_event_name"] = "sessionEnd",
+            ["session_id"]      = sessionId,
+            ["reason"]          = TryGetString(node, "reason") ?? "complete",
+            ["home_dir"]        = PathHelpers.HomeDirectory
+        };
+
+        if (cwd is not null) forwarded["cwd"] = cwd;
+
+        if (TryGetUnixMillis(node, "timestamp") is { } endedAt) {
+            forwarded["ended_at"] = endedAt.ToString("O");
+        }
+
+        if (Environment.GetEnvironmentVariable("KCAP_AGENT_ID") is { } agentHostId) {
+            forwarded["agent_host_id"] = agentHostId;
+        }
+
+        return await PostHookAsync(baseUrl, "session-end/copilot", forwarded.ToJsonString());
+    }
+
+    static async Task<int> HandleAgentStop(string baseUrl, JsonNode node, string dashedSessionId, string sessionId, string? cwd) {
+        // Fires at every turn end — no server POST (sessionEnd owns lifecycle;
+        // turn content arrives via the transcript). Just keep the watcher
+        // alive in case it crashed mid-session, mirroring Codex's Stop branch.
+        _ = node;
+        await EnsureWatcherAsync(baseUrl, dashedSessionId, sessionId, node, cwd);
+        return 0;
+    }
+
+    static async Task<int> HandleNotification(string baseUrl, JsonNode node, string sessionId, string? cwd) {
+        // The server's NotificationHook requires message + notification_type;
+        // Copilot's payload carries both natively (it already ships the
+        // Claude-compatible snake_case keys for them).
+        var message          = TryGetString(node, "message");
+        var notificationType = TryGetString(node, "notification_type");
+
+        if (message is null || notificationType is null) return 0;
+
+        var forwarded = new JsonObject {
+            ["hook_event_name"]   = "Notification",
+            ["session_id"]        = sessionId,
+            ["message"]           = message,
+            ["notification_type"] = notificationType,
+            ["home_dir"]          = PathHelpers.HomeDirectory
+        };
+
+        if (TryGetString(node, "title") is { } title) forwarded["title"] = title;
+        if (cwd is not null) forwarded["cwd"] = cwd;
+
+        // Best-effort telemetry — bounded like the Codex permission-record
+        // path so a stalled server can't block Copilot's loop.
+        using var cts = new CancellationTokenSource(NotificationPostBudget);
+        try {
+            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, cts.Token);
+            using var content = new StringContent(forwarded.ToJsonString(), Encoding.UTF8, "application/json");
+            using var _       = await client.PostAsync($"{baseUrl}/hooks/notification", content, cts.Token);
+        } catch {
+            // Recording must never fail the hook.
+        }
+
+        return 0;
+    }
+
+    static async Task EnsureWatcherAsync(string baseUrl, string dashedSessionId, string sessionId, JsonNode node, string? cwd) {
+        // agentStop payloads carry transcriptPath; sessionStart's don't —
+        // derive it from the session-state layout in that case.
+        var transcriptPath = TryGetString(node, "transcriptPath") ?? TranscriptPathFor(dashedSessionId);
+
+        await WatcherManager.EnsureWatcherRunning(
+            baseUrl, sessionId, transcriptPath,
+            agentId: null, sessionIdOverride: null, cwd: cwd,
+            skipTitle: false, vendor: "copilot"
+        );
+    }
+
+    /// <summary>
+    /// events.jsonl path for a session. Prefers the current
+    /// <c>session-state/</c> root; falls back to the pre-GA
+    /// <c>history-session-state/</c> when only the legacy dir has the file.
+    /// When neither exists yet (sessionStart can fire before Copilot's first
+    /// event write) returns the current-layout path — the watcher tolerates a
+    /// not-yet-created file and picks it up on its next poll.
+    /// </summary>
+    static string TranscriptPathFor(string dashedSessionId) {
+        var current = CopilotPaths.EventsJsonl(CopilotPaths.SessionStateDir(), dashedSessionId);
+
+        if (File.Exists(current)) return current;
+
+        var legacy = CopilotPaths.EventsJsonl(CopilotPaths.LegacySessionStateDir(), dashedSessionId);
+
+        return File.Exists(legacy) ? legacy : current;
+    }
+
+    static async Task<int> PostHookAsync(string baseUrl, string endpoint, string body) {
+        using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        try {
+            var resp = await client.PostWithRetryAsync($"{baseUrl}/hooks/{endpoint}", content);
+
+            if (!resp.IsSuccessStatusCode) {
+                Console.Error.WriteLine($"[kcap] copilot-hook {endpoint}: HTTP {(int)resp.StatusCode}");
+                return 1;
+            }
+
+            return 0;
+        } catch (HttpRequestException ex) {
+            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
+            return 1;
+        }
+    }
+
+    static string? GetArg(string[] args, string flag) {
+        var idx = Array.IndexOf(args, flag);
+
+        return idx >= 0 && idx + 1 < args.Length ? args[idx + 1] : null;
+    }
+
+    static DateTimeOffset? TryGetUnixMillis(JsonNode? node, string fieldName) {
+        if (node?[fieldName] is not JsonValue v) return null;
+
+        if (v.TryGetValue<long>(out var ms) && ms > 0) return DateTimeOffset.FromUnixTimeMilliseconds(ms);
+        if (v.TryGetValue<double>(out var dms) && dms > 0) return DateTimeOffset.FromUnixTimeMilliseconds((long)dms);
+
+        return null;
+    }
+
+    static string? TryGetString(JsonNode? node, string fieldName) {
+        if (node?[fieldName] is JsonValue v && v.TryGetValue<string>(out var s)) {
+            return s;
+        }
+
+        return null;
+    }
+}

--- a/src/Capacitor.Cli/Commands/CopilotImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CopilotImportSource.cs
@@ -444,7 +444,7 @@ internal sealed record CopilotWorkspaceYaml(string? Cwd, string? Name, DateTimeO
                 if (idx <= 0) continue;
 
                 var key   = line[..idx].Trim();
-                var value = line[(idx + 2)..].Trim();
+                var value = Unquote(line[(idx + 2)..].Trim());
 
                 if (value.Length == 0) continue;
 
@@ -462,9 +462,29 @@ internal sealed record CopilotWorkspaceYaml(string? Cwd, string? Name, DateTimeO
         }
     }
 
+    /// <summary>
+    /// Strips matching YAML scalar quotes. Copilot quotes values that contain
+    /// YAML-special sequences (e.g. <c>name: 'Reply with exactly: ok'</c>) —
+    /// without this the literal quotes leak into imported session titles.
+    /// Handles the two YAML escape forms we can hit on one line: doubled
+    /// single-quotes inside single-quoted scalars, and backslash-escaped
+    /// double-quotes inside double-quoted scalars.
+    /// </summary>
+    internal static string Unquote(string value) {
+        if (value.Length >= 2 && value[0] == '\'' && value[^1] == '\'') {
+            return value[1..^1].Replace("''", "'");
+        }
+
+        if (value.Length >= 2 && value[0] == '"' && value[^1] == '"') {
+            return value[1..^1].Replace("\\\"", "\"");
+        }
+
+        return value;
+    }
+
     static DateTimeOffset? ParseTimestamp(string value) =>
         DateTimeOffset.TryParse(
-            value.Trim('\'', '"'),
+            value,
             System.Globalization.CultureInfo.InvariantCulture,
             System.Globalization.DateTimeStyles.RoundtripKind,
             out var ts)

--- a/src/Capacitor.Cli/Commands/CopilotImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CopilotImportSource.cs
@@ -1,0 +1,473 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Copilot;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// Discover + classify + import historical GitHub Copilot CLI sessions from
+/// <c>$COPILOT_HOME/session-state/&lt;dashed-sid&gt;/events.jsonl</c> (and the
+/// pre-GA <c>history-session-state/</c> root). Each events.jsonl is one
+/// session in Copilot's native envelope format — the same raw lines the live
+/// watcher streams, so historical and live import converge on the server's
+/// <c>CopilotTranscriptNormalizer</c>.
+///
+/// <para>
+/// Unlike Cursor there is no lossy workspace encoding to reverse:
+/// <c>workspace.yaml</c> in each session dir carries <c>cwd</c>,
+/// <c>created_at</c>/<c>updated_at</c>, and Copilot's auto-generated session
+/// <c>name</c> (forwarded as the session title via <c>/hooks/set-title</c>,
+/// which is why <see cref="SupportsTitleGeneration"/> is false). Session dirs
+/// WITHOUT an events.jsonl are failed-startup scaffolding and are skipped.
+/// </para>
+/// </summary>
+internal sealed class CopilotImportSource : IImportSource {
+    readonly string                                 _sessionStateDir;
+    readonly string                                 _legacySessionStateDir;
+    readonly Func<string, Task<RepositoryPayload?>> _repoDetector;
+
+    public CopilotImportSource(
+        string?                                 sessionStateDirOverride = null,
+        string?                                 legacyDirOverride       = null,
+        Func<string, Task<RepositoryPayload?>>? repoDetector            = null
+    ) {
+        _sessionStateDir       = sessionStateDirOverride ?? CopilotPaths.SessionStateDir();
+        _legacySessionStateDir = legacyDirOverride       ?? CopilotPaths.LegacySessionStateDir();
+        _repoDetector          = repoDetector ?? RepositoryDetection.DetectRepositoryAsync;
+    }
+
+    static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+    static string NormalizeForComparison(string path) {
+        try {
+            return Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        } catch {
+            return path.TrimEnd('/', '\\');
+        }
+    }
+
+    public string Vendor => "copilot";
+
+    public bool IsAvailable => Directory.Exists(_sessionStateDir) || Directory.Exists(_legacySessionStateDir);
+
+    /// <summary>
+    /// False — Copilot names every session itself (workspace.yaml <c>name</c>);
+    /// ImportSessionAsync forwards it via /hooks/set-title, so the LLM title
+    /// pipeline would only burn tokens to overwrite a good title.
+    /// </summary>
+    public bool SupportsTitleGeneration => false;
+
+    public Task<IReadOnlyList<DiscoveredSession>> DiscoverAsync(DiscoveryFilters filters, CancellationToken ct) {
+        var sessionFilter = filters.FilterSession is { } sf ? ImportCommand.NormalizeGuid(sf) : null;
+        var normalizedCwd = filters.FilterCwd is { } cwd ? NormalizeForComparison(cwd) : null;
+        var sinceUtc      = filters.Since is { } since
+            ? new DateTimeOffset(since.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc), TimeSpan.Zero)
+            : (DateTimeOffset?)null;
+
+        var result = new List<DiscoveredSession>();
+        var seen   = new HashSet<string>(StringComparer.Ordinal);
+
+        // Current root first — when a pre-GA session was migrated on resume it
+        // exists in both roots, and session-state/ has the longer transcript.
+        foreach (var root in new[] { _sessionStateDir, _legacySessionStateDir }) {
+            if (!Directory.Exists(root)) continue;
+
+            foreach (var sessionDir in Directory.EnumerateDirectories(root)) {
+                var dirName = Path.GetFileName(sessionDir);
+                var jsonl   = CopilotPaths.EventsJsonl(root, dirName);
+
+                // Dirs without events.jsonl are failed-startup scaffolding
+                // (workspace.yaml + checkpoints only) — nothing to import.
+                if (!File.Exists(jsonl)) continue;
+
+                var dashless = dirName.Replace("-", "");
+
+                if (!seen.Add(dashless)) continue;
+                if (sessionFilter is not null && !string.Equals(dashless, sessionFilter, StringComparison.Ordinal))
+                    continue;
+
+                var meta = CopilotWorkspaceYaml.TryRead(CopilotPaths.WorkspaceYaml(root, dirName));
+
+                if (normalizedCwd is not null
+                 && (meta?.Cwd is null
+                  || !NormalizeForComparison(meta.Cwd).Equals(normalizedCwd, PathComparison))) {
+                    continue;
+                }
+
+                // Session-start proxy: workspace.yaml created_at is written by
+                // Copilot at session creation; fall back to the transcript's
+                // filesystem birth time (same degradation notes as Cursor —
+                // Linux ext4 reports mtime).
+                var firstTimestamp = meta?.CreatedAt;
+                if (firstTimestamp is null) {
+                    try { firstTimestamp = File.GetCreationTimeUtc(jsonl); } catch { /* best effort */ }
+                }
+
+                if (sinceUtc is { } cutoff && firstTimestamp is { } ts && ts < cutoff) continue;
+
+                result.Add(new DiscoveredSession(
+                    SessionId:      dashless,
+                    Vendor:         Vendor,
+                    Cwd:            meta?.Cwd,
+                    FirstTimestamp: firstTimestamp,
+                    SourceMeta:     new Dictionary<string, object?> {
+                        ["TranscriptPath"] = jsonl,
+                        ["Cwd"]            = meta?.Cwd,
+                        ["Name"]           = meta?.Name,
+                    }));
+            }
+
+            ct.ThrowIfCancellationRequested();
+        }
+
+        return Task.FromResult<IReadOnlyList<DiscoveredSession>>(result);
+    }
+
+    public async Task<IReadOnlyList<ImportCommand.SessionClassification>> ClassifyAsync(
+            IReadOnlyList<DiscoveredSession> sessions,
+            ClassifyContext                  ctx,
+            CancellationToken                ct
+        ) {
+        var results = new List<ImportCommand.SessionClassification>(sessions.Count);
+
+        // Per-cwd repo cache — sessions cluster inside the same workspace, so
+        // RepositoryDetection runs once per unique cwd (mirrors Cursor).
+        var repoCache   = new Dictionary<string, string?>(StringComparer.Ordinal);
+        var hasExcludes = ctx.ExcludedRepos is { Count: > 0 };
+
+        foreach (var s in sessions) {
+            var transcriptPath = (string)s.SourceMeta!["TranscriptPath"]!;
+
+            var meta = new SessionMetadata {
+                SessionId      = s.SessionId,
+                Cwd            = s.Cwd,
+                FirstTimestamp = s.FirstTimestamp,
+            };
+
+            int? lastNonBlankIndex;
+            int  nonBlankCount;
+            try {
+                (lastNonBlankIndex, nonBlankCount) = await ReadTranscriptStatsAsync(transcriptPath, ct);
+            } catch {
+                results.Add(MakeClassification(s, meta, ImportCommand.ClassificationStatus.ProbeError, totalLines: 0,
+                                               probeErrorReason: "transcript read failed"));
+                continue;
+            }
+
+            if (lastNonBlankIndex is null) {
+                results.Add(MakeClassification(s, meta, ImportCommand.ClassificationStatus.ProbeError, totalLines: 0,
+                                               probeErrorReason: "empty transcript"));
+                continue;
+            }
+
+            if (nonBlankCount < ctx.MinLines) {
+                results.Add(MakeClassification(s, meta, ImportCommand.ClassificationStatus.TooShort, totalLines: nonBlankCount));
+                continue;
+            }
+
+            int? serverLastLine;
+            try {
+                serverLastLine = await FetchServerLastLineAsync(ctx.HttpClient, ctx.BaseUrl, s.SessionId, ct);
+            } catch {
+                results.Add(MakeClassification(s, meta, ImportCommand.ClassificationStatus.ProbeError, totalLines: nonBlankCount,
+                                               probeErrorReason: "watermark probe failed"));
+                continue;
+            }
+
+            // workspace.yaml's updated_at is stamped when Copilot assigns the
+            // session name (near session START), not at session end — the
+            // transcript file's last-write time is the only reliable
+            // end-time proxy (same approach as Cursor).
+            meta.LastTimestamp = TryGetLastWriteUtc(transcriptPath);
+
+            string? repoKey = null;
+            if (hasExcludes && s.Cwd is { } cwd) {
+                if (!repoCache.TryGetValue(cwd, out repoKey)) {
+                    try {
+                        var repo = await _repoDetector(cwd);
+                        repoKey = repo is { Owner: { } o, RepoName: { } n } ? $"{o}/{n}" : null;
+                    } catch {
+                        repoKey = null;
+                    }
+                    repoCache[cwd] = repoKey;
+                }
+            }
+
+            var (excludedRepoKey, excludedPathKey) = ResolveExclusions(s.Cwd, repoKey, ctx);
+
+            var status       = ImportCommand.ClassificationStatus.New;
+            var resumeFromLn = 0;
+
+            if (serverLastLine is { } srv) {
+                if (srv >= lastNonBlankIndex.Value) {
+                    status = ImportCommand.ClassificationStatus.AlreadyLoaded;
+                } else {
+                    status       = ImportCommand.ClassificationStatus.Partial;
+                    resumeFromLn = srv + 1;
+                }
+            }
+
+            results.Add(new ImportCommand.SessionClassification {
+                SessionId       = s.SessionId,
+                // Empty FilePath keeps Copilot on the routed phase
+                // (ImportSessionAsync below) instead of the Claude/Codex chain
+                // worker — same contract as CursorImportSource.
+                FilePath        = "",
+                EncodedCwd      = "",
+                Meta            = meta,
+                Status          = status,
+                Vendor          = Vendor,
+                ResumeFromLine  = resumeFromLn,
+                ExcludedRepoKey = excludedRepoKey,
+                ExcludedPathKey = excludedPathKey,
+                TotalLines      = nonBlankCount,
+                SourceMeta      = s.SourceMeta,
+            });
+        }
+
+        return results;
+    }
+
+    public async Task<ImportOutcome> ImportSessionAsync(
+            ImportCommand.SessionClassification classification,
+            ImportContext                       ctx,
+            CancellationToken                   ct
+        ) {
+        var transcriptPath = (string)classification.SourceMeta!["TranscriptPath"]!;
+
+        if (!File.Exists(transcriptPath)) return ImportOutcome.Failed;
+
+        var cwd = classification.SourceMeta!.TryGetValue("Cwd", out var cwdObj) ? cwdObj as string : null;
+
+        // Lifecycle-before-transcript ordering contract: see
+        // CursorImportSource.ImportSessionAsync — a transcript that advances
+        // the watermark past a failed lifecycle POST would leave the session
+        // permanently lifecycle-less. Re-runs are idempotent server-side
+        // (deterministic lifecycle event ids).
+        var startOk = await PostSyntheticHookAsync(
+            ctx.HttpClient, ctx.BaseUrl, "session-start/copilot",
+            BuildSessionStartPayload(classification.SessionId, cwd, classification.Meta.FirstTimestamp),
+            ct);
+        if (!startOk) return ImportOutcome.Failed;
+
+        var startLine = classification.Status switch {
+            ImportCommand.ClassificationStatus.Partial       => classification.ResumeFromLine,
+            ImportCommand.ClassificationStatus.AlreadyLoaded => classification.TotalLines,
+            _                                                => 0,
+        };
+
+        int sent;
+        try {
+            sent = await SessionImporter.SendTranscriptBatches(
+                httpClient: ctx.HttpClient,
+                baseUrl:    ctx.BaseUrl,
+                sessionId:  classification.SessionId,
+                filePath:   transcriptPath,
+                agentId:    null,
+                startLine:  startLine,
+                vendor:     Vendor);
+        } catch {
+            return ImportOutcome.Failed;
+        }
+
+        // Copilot auto-names every session (workspace.yaml `name`) — forward
+        // it as the title. Best-effort: a title miss must not fail the import.
+        if (classification.SourceMeta!.TryGetValue("Name", out var nameObj)
+         && nameObj is string name
+         && !string.IsNullOrWhiteSpace(name)) {
+            await PostSetTitleAsync(ctx.HttpClient, ctx.BaseUrl, classification.SessionId, name, ct);
+        }
+
+        var endOk = await PostSyntheticHookAsync(
+            ctx.HttpClient, ctx.BaseUrl, "session-end/copilot",
+            BuildSessionEndPayload(classification.SessionId, cwd, classification.Meta.LastTimestamp),
+            ct);
+        if (!endOk) return ImportOutcome.Failed;
+
+        if (sent == 0) return startLine > 0 ? ImportOutcome.Resumed : ImportOutcome.Skipped;
+
+        return startLine > 0 ? ImportOutcome.Resumed : ImportOutcome.Loaded;
+    }
+
+    static JsonObject BuildSessionStartPayload(string sessionId, string? cwd, DateTimeOffset? startedAt) {
+        var payload = new JsonObject {
+            ["hook_event_name"] = "sessionStart",
+            ["session_id"]      = sessionId,
+            ["source"]          = "startup",
+        };
+        if (cwd is not null) payload["cwd"] = cwd;
+        if (startedAt is { } ts) payload["started_at"] = ts.ToString("O");
+        return payload;
+    }
+
+    static JsonObject BuildSessionEndPayload(string sessionId, string? cwd, DateTimeOffset? endedAt) {
+        var payload = new JsonObject {
+            ["hook_event_name"] = "sessionEnd",
+            ["session_id"]      = sessionId,
+            ["reason"]          = "historical-import",
+        };
+        if (cwd is not null) payload["cwd"] = cwd;
+        if (endedAt is { } ts) payload["ended_at"] = ts.ToString("O");
+        return payload;
+    }
+
+    static async Task<bool> PostSyntheticHookAsync(
+        HttpClient client, string baseUrl, string routeSegment, JsonObject payload, CancellationToken ct
+    ) {
+        try {
+            using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+            using var resp    = await client.PostWithRetryAsync($"{baseUrl}/hooks/{routeSegment}", content, ct: ct);
+            return resp.IsSuccessStatusCode;
+        } catch {
+            return false;
+        }
+    }
+
+    static async Task PostSetTitleAsync(HttpClient client, string baseUrl, string sessionId, string title, CancellationToken ct) {
+        if (title.Length > 120) title = title[..120];
+
+        var payload = new JsonObject {
+            ["session_id"] = sessionId,
+            ["title"]      = title,
+        };
+
+        try {
+            using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+            using var _       = await client.PostWithRetryAsync($"{baseUrl}/hooks/set-title", content, ct: ct);
+        } catch {
+            // Best effort.
+        }
+    }
+
+    static DateTimeOffset? TryGetLastWriteUtc(string path) {
+        try { return File.GetLastWriteTimeUtc(path); } catch { return null; }
+    }
+
+    static ImportCommand.SessionClassification MakeClassification(
+        DiscoveredSession                  s,
+        SessionMetadata                    meta,
+        ImportCommand.ClassificationStatus status,
+        int                                totalLines,
+        string?                            probeErrorReason = null
+    ) => new() {
+        SessionId        = s.SessionId,
+        FilePath         = "",
+        EncodedCwd       = "",
+        Meta             = meta,
+        Status           = status,
+        Vendor           = "copilot",
+        ProbeErrorReason = probeErrorReason,
+        TotalLines       = totalLines,
+        SourceMeta       = s.SourceMeta,
+    };
+
+    static async Task<(int? LastNonBlankIndex, int NonBlankCount)> ReadTranscriptStatsAsync(
+        string transcriptPath, CancellationToken ct
+    ) {
+        await using var stream = new FileStream(transcriptPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var       reader = new StreamReader(stream);
+
+        int? lastIdx = null;
+        var  count   = 0;
+        var  lineIdx = 0;
+
+        while (await reader.ReadLineAsync(ct) is { } line) {
+            if (!string.IsNullOrWhiteSpace(line)) {
+                lastIdx = lineIdx;
+                count++;
+            }
+            lineIdx++;
+        }
+        return (lastIdx, count);
+    }
+
+    static async Task<int?> FetchServerLastLineAsync(HttpClient http, string baseUrl, string sessionId, CancellationToken ct) {
+        using var resp = await http.GetWithRetryAsync($"{baseUrl}/api/sessions/{sessionId}/last-line", ct: ct);
+
+        if (resp.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.NoContent) return null;
+        if (!resp.IsSuccessStatusCode) throw new HttpRequestException($"watermark probe returned {(int)resp.StatusCode}");
+
+        var       body = await resp.Content.ReadAsStringAsync(ct);
+        using var doc  = JsonDocument.Parse(body);
+
+        return doc.RootElement.TryGetProperty("last_line_number", out var ln) && ln.ValueKind == JsonValueKind.Number
+            ? ln.GetInt32()
+            : null;
+    }
+
+    static (string? ExcludedRepoKey, string? ExcludedPathKey) ResolveExclusions(
+        string? cwd, string? repoKey, ClassifyContext ctx
+    ) {
+        string? excludedRepoKey = null;
+        if (repoKey is not null && ctx.ExcludedRepos is { Count: > 0 } repos
+         && repos.Any(r => string.Equals(r, repoKey, StringComparison.OrdinalIgnoreCase))) {
+            excludedRepoKey = repoKey;
+        }
+
+        string? excludedPathKey = null;
+        if (cwd is not null && ctx.ExcludedPaths is { Count: > 0 } paths) {
+            foreach (var entry in paths) {
+                if (PathExclusion.IsExcluded(cwd, [entry])) {
+                    excludedPathKey = PathExclusion.Normalize(entry);
+                    break;
+                }
+            }
+        }
+        return (excludedRepoKey, excludedPathKey);
+    }
+}
+
+/// <summary>
+/// Minimal reader for Copilot's per-session <c>workspace.yaml</c>. The file is
+/// flat <c>key: value</c> lines (no nesting, no quoting in practice) — a full
+/// YAML dependency would be overkill for the four fields we need, and a parse
+/// failure must never break discovery (returns null / partial data instead).
+/// </summary>
+internal sealed record CopilotWorkspaceYaml(string? Cwd, string? Name, DateTimeOffset? CreatedAt, DateTimeOffset? UpdatedAt) {
+    public static CopilotWorkspaceYaml? TryRead(string path) {
+        try {
+            if (!File.Exists(path)) return null;
+
+            string? cwd       = null;
+            string? name      = null;
+            DateTimeOffset? createdAt = null;
+            DateTimeOffset? updatedAt = null;
+
+            foreach (var line in File.ReadLines(path)) {
+                var idx = line.IndexOf(": ", StringComparison.Ordinal);
+                if (idx <= 0) continue;
+
+                var key   = line[..idx].Trim();
+                var value = line[(idx + 2)..].Trim();
+
+                if (value.Length == 0) continue;
+
+                switch (key) {
+                    case "cwd":        cwd  = value; break;
+                    case "name":       name = value; break;
+                    case "created_at": createdAt = ParseTimestamp(value); break;
+                    case "updated_at": updatedAt = ParseTimestamp(value); break;
+                }
+            }
+
+            return new CopilotWorkspaceYaml(cwd, name, createdAt, updatedAt);
+        } catch {
+            return null;
+        }
+    }
+
+    static DateTimeOffset? ParseTimestamp(string value) =>
+        DateTimeOffset.TryParse(
+            value.Trim('\'', '"'),
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.RoundtripKind,
+            out var ts)
+            ? ts
+            : null;
+}

--- a/src/Capacitor.Cli/Commands/CopilotImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CopilotImportSource.cs
@@ -151,9 +151,10 @@ internal sealed class CopilotImportSource : IImportSource {
             };
 
             int? lastNonBlankIndex;
+            int? lastRelevantIndex;
             int  nonBlankCount;
             try {
-                (lastNonBlankIndex, nonBlankCount) = await ReadTranscriptStatsAsync(transcriptPath, ct);
+                (lastNonBlankIndex, lastRelevantIndex, nonBlankCount) = await ReadTranscriptStatsAsync(transcriptPath, ct);
             } catch {
                 results.Add(MakeClassification(s, meta, ImportCommand.ClassificationStatus.ProbeError, totalLines: 0,
                                                probeErrorReason: "transcript read failed"));
@@ -204,8 +205,19 @@ internal sealed class CopilotImportSource : IImportSource {
             var status       = ImportCommand.ClassificationStatus.New;
             var resumeFromLn = 0;
 
+            // Compare the server watermark against the last IMPORT-RELEVANT
+            // line, not the last raw line: the watermark is the max persisted
+            // canonical $lineNumber, and every Copilot transcript ENDS with
+            // lines the server normalizer intentionally skips
+            // (session.shutdown plus the hook.start/hook.end pair the
+            // sessionEnd hook itself writes). Compared against the raw tail, a
+            // fully-imported session would re-classify Partial on every run,
+            // forever re-sending noise lines that can never advance the
+            // watermark.
+            var lastImportable = lastRelevantIndex ?? lastNonBlankIndex.Value;
+
             if (serverLastLine is { } srv) {
-                if (srv >= lastNonBlankIndex.Value) {
+                if (srv >= lastImportable) {
                     status = ImportCommand.ClassificationStatus.AlreadyLoaded;
                 } else {
                     status       = ImportCommand.ClassificationStatus.Partial;
@@ -367,24 +379,63 @@ internal sealed class CopilotImportSource : IImportSource {
         SourceMeta       = s.SourceMeta,
     };
 
-    static async Task<(int? LastNonBlankIndex, int NonBlankCount)> ReadTranscriptStatsAsync(
+    static async Task<(int? LastNonBlankIndex, int? LastRelevantIndex, int NonBlankCount)> ReadTranscriptStatsAsync(
         string transcriptPath, CancellationToken ct
     ) {
         await using var stream = new FileStream(transcriptPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         using var       reader = new StreamReader(stream);
 
-        int? lastIdx = null;
-        var  count   = 0;
-        var  lineIdx = 0;
+        int? lastIdx         = null;
+        int? lastRelevantIdx = null;
+        var  count           = 0;
+        var  lineIdx         = 0;
 
         while (await reader.ReadLineAsync(ct) is { } line) {
             if (!string.IsNullOrWhiteSpace(line)) {
                 lastIdx = lineIdx;
                 count++;
+
+                if (IsImportRelevantLine(line)) lastRelevantIdx = lineIdx;
             }
             lineIdx++;
         }
-        return (lastIdx, count);
+        return (lastIdx, lastRelevantIdx, count);
+    }
+
+    /// <summary>
+    /// True when the line maps to at least one canonical event under the
+    /// server's CopilotTranscriptNormalizer — the contract this mirrors:
+    /// <c>session.start</c> always emits; <c>user.message</c> emits for
+    /// non-empty <c>content</c>; <c>assistant.message</c> emits per non-empty
+    /// reasoningText / content / toolRequests entry;
+    /// <c>tool.execution_complete</c> emits when <c>toolCallId</c> is present.
+    /// Everything else (hook.*, system.*, assistant.turn_*, session.* telemetry,
+    /// subagent.*, tool.execution_start) is skipped server-side and can never
+    /// advance the transcript watermark. Fail direction on drift: treating a
+    /// skipped line as relevant re-classifies a complete session as Partial
+    /// (today's bug); treating an emitting line as noise marks AlreadyLoaded
+    /// while its events are unsent — so keep this list in sync with the
+    /// normalizer when the mapping grows.
+    /// </summary>
+    internal static bool IsImportRelevantLine(string line) {
+        try {
+            using var doc  = JsonDocument.Parse(line);
+            var       root = doc.RootElement;
+
+            if (root.Obj("data") is not { } data) return false;
+
+            return root.Str("type") switch {
+                "session.start"           => true,
+                "user.message"            => data.Str("content") is { Length: > 0 },
+                "assistant.message"       => data.Str("content") is { Length: > 0 }
+                                          || data.Str("reasoningText") is { Length: > 0 }
+                                          || data.Arr("toolRequests") is { } requests && requests.GetArrayLength() > 0,
+                "tool.execution_complete" => data.Str("toolCallId") is not null,
+                _                         => false
+            };
+        } catch {
+            return false;
+        }
     }
 
     static async Task<int?> FetchServerLastLineAsync(HttpClient http, string baseUrl, string sessionId, CancellationToken ct) {

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Copilot;
 using Capacitor.Cli.Core.Cursor;
 
 namespace Capacitor.Cli.Commands;
@@ -8,8 +9,9 @@ namespace Capacitor.Cli.Commands;
 public static class PluginCommand {
     static readonly JsonSerializerOptions WriteOpts = new() { WriteIndented = true };
 
-    const string CodexHookCommand  = "kcap hook --codex";
-    const string CursorHookCommand = "kcap hook --cursor";
+    const string CodexHookCommand   = "kcap hook --codex";
+    const string CursorHookCommand  = "kcap hook --cursor";
+    const string CopilotHookCommand = "kcap hook --copilot";
 
     // PermissionRequest must wait for the dashboard's decision; the daemon-side
     // bridge call is intentionally infinite. 86400s = 24h keeps Codex from
@@ -33,12 +35,15 @@ public static class PluginCommand {
         };
     }
 
+    static readonly string[] ExclusiveTargetFlags = ["--codex", "--cursor", "--copilot", "--skills"];
+
+    static bool HasConflictingTargets(string[] args) =>
+        ExclusiveTargetFlags.Count(args.Contains) > 1;
+
     static async Task<int> Install(string[] args, PluginEnvironment env) {
-        if ((args.Contains("--codex")  && args.Contains("--skills"))
-         || (args.Contains("--cursor") && args.Contains("--skills"))
-         || (args.Contains("--cursor") && args.Contains("--codex"))) {
+        if (HasConflictingTargets(args)) {
             await env.Stderr.WriteLineAsync(
-                "--cursor, --codex, and --skills are mutually exclusive."
+                "--cursor, --codex, --copilot, and --skills are mutually exclusive."
             );
 
             return 1;
@@ -47,16 +52,15 @@ public static class PluginCommand {
         if (args.Contains("--skills")) return await InstallSkills(args, env);
         if (args.Contains("--codex")) return await InstallCodex(args, env);
         if (args.Contains("--cursor")) return await InstallCursor(args, env);
+        if (args.Contains("--copilot")) return await InstallCopilot(args, env);
 
         return await InstallClaude(args, env);
     }
 
     static async Task<int> Remove(string[] args, PluginEnvironment env) {
-        if ((args.Contains("--codex")  && args.Contains("--skills"))
-         || (args.Contains("--cursor") && args.Contains("--skills"))
-         || (args.Contains("--cursor") && args.Contains("--codex"))) {
+        if (HasConflictingTargets(args)) {
             await env.Stderr.WriteLineAsync(
-                "--cursor, --codex, and --skills are mutually exclusive."
+                "--cursor, --codex, --copilot, and --skills are mutually exclusive."
             );
 
             return 1;
@@ -65,6 +69,7 @@ public static class PluginCommand {
         if (args.Contains("--skills")) return await RemoveSkills(args, env);
         if (args.Contains("--codex")) return await RemoveCodex(args, env);
         if (args.Contains("--cursor")) return await RemoveCursor(args, env);
+        if (args.Contains("--copilot")) return await RemoveCopilot(args, env);
 
         return await RemoveClaude(args, env);
     }
@@ -666,6 +671,117 @@ public static class PluginCommand {
 
             return true;
         } catch { return false; }
+    }
+
+    static async Task<int> InstallCopilot(string[] args, PluginEnvironment env) {
+        var hooksPath = GetArg(args, "--copilot-hooks-path") ?? env.CopilotKcapHooksJson;
+
+        var refreshOnly = args.Contains("--if-installed");
+
+        switch (refreshOnly) {
+            case true when !CopilotHooksInstaller.IsInstalled(hooksPath):
+            case true when CopilotHooksInstaller.ReadMarker(hooksPath) == CapacitorVersion.Current():
+                return 0;
+            // Same PATH precheck rationale as Cursor: kcap.json writes the bare
+            // `kcap hook --copilot` command, so Copilot must find kcap on PATH.
+            // Skipped on the postinstall (--if-installed) path — see InstallCursor.
+            case false when !AgentDetector.IsInstalled("kcap"):
+                await env.Stderr.WriteLineAsync(
+                    "Cannot install Copilot hooks: 'kcap' is not on PATH. "
+                  + "Re-install kcap via npm: npm install -g @kurrent/kcap"
+                );
+
+                return 1;
+        }
+
+        if (!InstallCopilotHooks(hooksPath)) {
+            if (refreshOnly) return 0;
+
+            await env.Stderr.WriteLineAsync("Could not write Copilot hooks file.");
+
+            return 1;
+        }
+
+        await env.Stdout.WriteLineAsync(
+            refreshOnly
+                ? $"Copilot hooks refreshed ({hooksPath})"
+                : $"Copilot hooks installed ({hooksPath})"
+        );
+
+        return 0;
+    }
+
+    static async Task<int> RemoveCopilot(string[] args, PluginEnvironment env) {
+        var hooksPath = GetArg(args, "--copilot-hooks-path") ?? env.CopilotKcapHooksJson;
+
+        try {
+            var removed = RemoveCopilotHooks(hooksPath);
+
+            await env.Stdout.WriteLineAsync(
+                removed
+                    ? $"Copilot hooks removed ({hooksPath})"
+                    : "Nothing to remove — Copilot hooks file not found."
+            );
+
+            return 0;
+        } catch (Exception ex) {
+            await env.Stderr.WriteLineAsync($"Could not remove Copilot hooks at {hooksPath}: {ex.Message}");
+
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// Writes kcap's own Copilot hooks file. Copilot merges every
+    /// <c>*.json</c> under <c>~/.copilot/hooks/</c> at startup, so kcap owns
+    /// <c>kcap.json</c> wholesale — no merge with user-authored entries is
+    /// needed (unlike the shared-file Cursor/Codex installers). Each entry
+    /// embeds the event name in the command because Copilot hook payloads
+    /// carry no uniform event-name field (see <see cref="CopilotHookCommand"/>).
+    /// </summary>
+    public static bool InstallCopilotHooks(string hooksPath) {
+        try {
+            var hooks = new JsonObject();
+
+            foreach (var evt in CopilotHooksParser.CopilotHookEvents) {
+                hooks[evt] = new JsonArray(
+                    new JsonObject {
+                        ["type"]       = "command",
+                        ["command"]    = $"{CopilotHookCommand} --event {evt}",
+                        ["timeoutSec"] = DefaultHookTimeout
+                    }
+                );
+            }
+
+            var root = new JsonObject {
+                ["version"] = 1,
+                ["hooks"]   = hooks
+            };
+
+            Directory.CreateDirectory(Path.GetDirectoryName(hooksPath)!);
+            File.WriteAllText(hooksPath, root.ToJsonString(WriteOpts));
+            CopilotHooksInstaller.WriteMarker(hooksPath);
+
+            return true;
+        } catch { return false; }
+    }
+
+    /// <summary>
+    /// Deletes kcap's Copilot hooks file (kcap owns it wholesale — there are
+    /// no user-authored entries to preserve). Returns true when the file
+    /// existed; throws on I/O failure.
+    /// </summary>
+    public static bool RemoveCopilotHooks(string hooksPath) {
+        var removed = false;
+
+        if (File.Exists(hooksPath)) {
+            File.Delete(hooksPath);
+            removed = true;
+        }
+
+        CopilotHooksInstaller.DeleteMarker(hooksPath);
+
+        return removed;
     }
 
     /// <summary>

--- a/src/Capacitor.Cli/Commands/PluginEnvironment.cs
+++ b/src/Capacitor.Cli/Commands/PluginEnvironment.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Copilot;
 using Capacitor.Cli.Core.Cursor;
 
 namespace Capacitor.Cli.Commands;
@@ -25,6 +26,7 @@ public sealed record PluginEnvironment(
     public string CodexHome           => Path.Combine(HomeDirectory, ".codex");
     public string CodexUserHooksJson  => Path.Combine(CodexHome, "hooks.json");
     public string CursorUserHooksJson => CursorPaths.UserHooksJson(HomeDirectory);
+    public string CopilotKcapHooksJson => CopilotPaths.KcapHooksJson(HomeDirectory);
     public string AgentsSkillsDir     => Path.Combine(HomeDirectory, ".agents", "skills");
     public string LegacyCodexSkills   => Path.Combine(CodexHome, "skills");
 

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.Copilot;
 using Capacitor.Cli.Core.Cursor;
 using Spectre.Console;
 using Profile = Capacitor.Cli.Core.Config.Profile;
@@ -17,6 +18,7 @@ public static class SetupCommand {
         var skipClaudeFlag   = args.Contains("--skip-claude-hooks");
         var skipCodexFlag    = args.Contains("--skip-codex-hooks");
         var skipCursorFlag   = args.Contains("--skip-cursor-hooks");
+        var skipCopilotFlag  = args.Contains("--skip-copilot-hooks");
         var legacyPluginScope = GetArg(args, "--plugin-scope"); // "user" | "project" | "skip" | null
         var skipClaude       = skipClaudeFlag || legacyPluginScope == "skip";
         var legacyProjectScope = legacyPluginScope == "project";
@@ -165,9 +167,13 @@ public static class SetupCommand {
 
         var pluginPath = ResolvePluginPath();
         var detected   = new CodingAgentsStep.DetectedAgents(
-            Claude: AgentDetector.IsInstalled("claude"),
-            Codex:  AgentDetector.IsInstalled("codex"),
-            Cursor: CursorPaths.IsInstalled());
+            Claude:  AgentDetector.IsInstalled("claude"),
+            Codex:   AgentDetector.IsInstalled("codex"),
+            Cursor:  CursorPaths.IsInstalled(),
+            // Dir presence covers users who launch Copilot through an IDE
+            // wrapper; the PATH probe covers fresh installs that haven't run
+            // yet (no ~/.copilot until first launch).
+            Copilot: CopilotPaths.IsInstalled() || AgentDetector.IsInstalled("copilot"));
 
         // gitRoot is guaranteed non-null here when legacyProjectScope is true (the early
         // guard at the top of HandleAsync returns 1 otherwise).
@@ -176,10 +182,11 @@ public static class SetupCommand {
             : ClaudePaths.UserSettings;
 
         var stepOptions = new CodingAgentsStep.Options(
-            SkipClaude: skipClaude,
-            SkipCodex:  skipCodexFlag,
-            SkipCursor: skipCursorFlag,
-            NoPrompt:   noPrompt);
+            SkipClaude:  skipClaude,
+            SkipCodex:   skipCodexFlag,
+            SkipCursor:  skipCursorFlag,
+            SkipCopilot: skipCopilotFlag,
+            NoPrompt:    noPrompt);
 
         var stepPaths = new CodingAgentsStep.Paths(
             ClaudeSettingsPath:   claudeSettingsPath,
@@ -187,6 +194,7 @@ public static class SetupCommand {
             PluginDir:            pluginPath,
             CodexHooksPath:       CodexPaths.UserHooksJson,
             CursorHooksPath:      CursorPaths.UserHooksJson(),
+            CopilotHooksPath:     CopilotPaths.KcapHooksJson(),
             AgentsSkillsDir:      AgentsPaths.UserSkillsDir,
             LegacyCodexSkillsDir: Path.Combine(CodexPaths.Home, "skills"));
 
@@ -194,6 +202,7 @@ public static class SetupCommand {
             InstallClaudePlugin:    InstallPlugin,
             InstallCodexHooks:      PluginCommand.InstallCodexHooks,
             InstallCursorHooks:     PluginCommand.InstallCursorHooks,
+            InstallCopilotHooks:    PluginCommand.InstallCopilotHooks,
             CapacitorOnPath:        () => AgentDetector.IsInstalled("kcap"),
             InstallAgentSkills:     AgentsSkillsInstaller.Install,
             CleanLegacyCodexSkills: legacyDir => AgentsSkillsInstaller.CleanLegacyCodexSkills(legacyDir).RemovedAny);

--- a/src/Capacitor.Cli/Commands/UninstallCommand.cs
+++ b/src/Capacitor.Cli/Commands/UninstallCommand.cs
@@ -44,6 +44,7 @@ public static class UninstallCommand {
         await Console.Out.WriteLineAsync($"  • Remove kcap entries from {ClaudePaths.UserSettings}");
         await Console.Out.WriteLineAsync($"  • Remove kcap entries from {CodexPaths.UserHooksJson}");
         await Console.Out.WriteLineAsync($"  • Remove kcap entries from {CursorPaths.UserHooksJson()}");
+        await Console.Out.WriteLineAsync($"  • Remove {Capacitor.Cli.Core.Copilot.CopilotPaths.KcapHooksJson()}");
         await Console.Out.WriteLineAsync($"  • Remove agent skills under {AgentsPaths.UserSkillsDir}");
 
         if (projectRoot is not null) {
@@ -107,6 +108,7 @@ public static class UninstallCommand {
         if (await PluginCommand.HandleAsync(["plugin", "remove"]) != 0) hadFailures = true;            // Claude
         if (await PluginCommand.HandleAsync(["plugin", "remove", "--codex"]) != 0) hadFailures = true; // Codex hooks + skills + legacy
         if (await PluginCommand.HandleAsync(["plugin", "remove", "--cursor"]) != 0) hadFailures = true;
+        if (await PluginCommand.HandleAsync(["plugin", "remove", "--copilot"]) != 0) hadFailures = true;
 
         // Skills are removed by --codex above, but call --skills explicitly in
         // case the user only ever installed Cursor / agent-agnostic skills and

--- a/src/Capacitor.Cli/Commands/VendorSelection.cs
+++ b/src/Capacitor.Cli/Commands/VendorSelection.cs
@@ -12,28 +12,29 @@ public static class VendorSelection {
         public bool HasError => Error is not null;
     }
 
-    static readonly string[] KnownVendorFlags = ["--claude", "--codex", "--cursor"];
+    static readonly string[] KnownVendorFlags = ["--claude", "--codex", "--cursor", "--copilot"];
 
     public static Result Parse(string[] args) {
         var vendors = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var a in args) {
             switch (a) {
-                case "--claude": vendors.Add("claude"); break;
-                case "--codex":  vendors.Add("codex");  break;
-                case "--cursor": vendors.Add("cursor"); break;
+                case "--claude":  vendors.Add("claude");  break;
+                case "--codex":   vendors.Add("codex");   break;
+                case "--cursor":  vendors.Add("cursor");  break;
+                case "--copilot": vendors.Add("copilot"); break;
             }
         }
 
-        // Reject unknown --cursor-/--claude-/--codex- prefixed flags. The legacy
-        // SQLite-era options (--cursor-workspace, --cursor-all-workspaces) were
-        // dropped in AI-737; the JSONL walker doesn't need workspace filtering
-        // since the transcript path already encodes the workspace.
+        // Reject unknown vendor-prefixed flags. The legacy SQLite-era options
+        // (--cursor-workspace, --cursor-all-workspaces) were dropped in
+        // AI-737; the JSONL walkers don't need workspace filtering since the
+        // transcript path already encodes the workspace.
         foreach (var a in args) {
             if (!a.StartsWith("--")) continue;
             if (Array.IndexOf(KnownVendorFlags, a) >= 0) continue;
 
-            if (a.StartsWith("--cursor-") || a.StartsWith("--claude-") || a.StartsWith("--codex-")) {
+            if (a.StartsWith("--cursor-") || a.StartsWith("--claude-") || a.StartsWith("--codex-") || a.StartsWith("--copilot-")) {
                 return new(vendors, $"Unknown source option: {a}.");
             }
         }
@@ -42,7 +43,7 @@ public static class VendorSelection {
         foreach (var a in args) {
             if (!a.StartsWith("--")) continue;
             if (Array.IndexOf(KnownVendorFlags, a) >= 0) continue;
-            if (a.StartsWith("--cursor-") || a.StartsWith("--claude-") || a.StartsWith("--codex-")) continue;
+            if (a.StartsWith("--cursor-") || a.StartsWith("--claude-") || a.StartsWith("--codex-") || a.StartsWith("--copilot-")) continue;
 
             string? hint = null;
             var bestDist = int.MaxValue;

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -307,7 +307,7 @@ static partial class WatchCommand {
     /// Used to reject unexpected --vendor input before interpolating into the URL
     /// path (defence-in-depth against path traversal even though the CLI runs locally).
     /// </summary>
-    static readonly HashSet<string> KnownVendors = new(StringComparer.Ordinal) { "claude", "codex" };
+    static readonly HashSet<string> KnownVendors = new(StringComparer.Ordinal) { "claude", "codex", "copilot" };
 
     /// <summary>
     /// Total time budget for the parent-exit session-end POST. Covers /auth/config
@@ -632,9 +632,11 @@ static partial class WatchCommand {
     }
 
     internal static string? TryExtractAssistantText(string line, string vendor = "claude") =>
-        vendor == "codex"
-            ? TryExtractCodexAssistantText(line)
-            : TryExtractClaudeAssistantText(line);
+        vendor switch {
+            "codex"   => TryExtractCodexAssistantText(line),
+            "copilot" => TryExtractCopilotAssistantText(line),
+            _         => TryExtractClaudeAssistantText(line)
+        };
 
     static string? TryExtractClaudeAssistantText(string line) {
         try {
@@ -687,6 +689,14 @@ static partial class WatchCommand {
             using var doc  = JsonDocument.Parse(line);
             var       root = doc.RootElement;
 
+            if (vendor == "copilot") {
+                // user.message / assistant.message are the only conversational
+                // envelopes; everything else (hook.*, system.*, tool.*,
+                // session.*) is plumbing and must not count toward the
+                // title-generation event threshold.
+                return root.Str("type") is "user.message" or "assistant.message";
+            }
+
             if (vendor == "codex") {
                 // Codex rolls everything into a top-level response_item envelope;
                 // a "message" payload (user or assistant) is the analog of Claude's
@@ -718,9 +728,52 @@ static partial class WatchCommand {
     }
 
     internal static string? TryExtractUserText(string line, string vendor = "claude") =>
-        vendor == "codex"
-            ? TryExtractCodexUserText(line)
-            : TryExtractClaudeUserText(line);
+        vendor switch {
+            "codex"   => TryExtractCodexUserText(line),
+            "copilot" => TryExtractCopilotUserText(line),
+            _         => TryExtractClaudeUserText(line)
+        };
+
+    // ── Copilot extractors (AI-815) ────────────────────────────────────────
+    //
+    // Copilot's events.jsonl envelope: {type, data, id, timestamp, parentId,
+    // agentId?}. Subagent-tagged events (agentId set) are skipped — a
+    // subagent's user.message is the parent's task prompt, not something the
+    // human typed, and using it for the title would mislabel the session.
+
+    static string? TryExtractCopilotUserText(string line) {
+        try {
+            using var doc  = JsonDocument.Parse(line);
+            var       root = doc.RootElement;
+
+            if (root.Str("type") != "user.message") return null;
+            if (root.Str("agentId") is not null) return null;
+
+            // data.content is the clean prompt; transformedContent wraps it in
+            // injected <current_datetime>/<system_reminder> noise.
+            var text = root.Obj("data")?.Str("content")?.Trim();
+
+            return string.IsNullOrEmpty(text) ? null : text;
+        } catch {
+            return null;
+        }
+    }
+
+    static string? TryExtractCopilotAssistantText(string line) {
+        try {
+            using var doc  = JsonDocument.Parse(line);
+            var       root = doc.RootElement;
+
+            if (root.Str("type") != "assistant.message") return null;
+            if (root.Str("agentId") is not null) return null;
+
+            var text = root.Obj("data")?.Str("content")?.Trim();
+
+            return string.IsNullOrEmpty(text) ? null : text;
+        } catch {
+            return null;
+        }
+    }
 
     static string? TryExtractClaudeUserText(string line) {
         try {

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -38,7 +38,7 @@ var command = args[0];
 // nested headless invocation.
 if (Environment.GetEnvironmentVariable("KCAP_SKIP") is "1"
  && command == "hook"
- && (args.Contains("--claude") || args.Contains("--cursor"))) {
+ && (args.Contains("--claude") || args.Contains("--cursor") || args.Contains("--copilot"))) {
     return 0;
 }
 
@@ -458,6 +458,7 @@ switch (command) {
             new ClaudeImportSource(),
             new CodexImportSource(),
             new CursorImportSource(),
+            new CopilotImportSource(),
         };
         IReadOnlyList<IImportSource> sources = explicitVendorSelection
             ? allSources.Where(s => vsel.Vendors.Contains(s.Vendor)).ToList()
@@ -500,7 +501,7 @@ switch (command) {
             currentRepo:             currentRepo);
     }
     case "watch" when args.Length < 3:
-        Console.Error.WriteLine("Usage: kcap watch <sessionId> <transcriptPath> [--agent-id <agentId>] [--cwd <cwd>] [--skip-title] [--parent-pid <pid>] [--vendor claude|codex]");
+        Console.Error.WriteLine("Usage: kcap watch <sessionId> <transcriptPath> [--agent-id <agentId>] [--cwd <cwd>] [--skip-title] [--parent-pid <pid>] [--vendor claude|codex|copilot]");
 
         return 1;
     case "watch": {
@@ -594,8 +595,11 @@ switch (command) {
         if (args.Contains("--cursor")) {
             return await CursorHookCommand.Handle(baseUrl!, Console.In);
         }
+        if (args.Contains("--copilot")) {
+            return await CopilotHookCommand.Handle(baseUrl!, Console.In, args);
+        }
         Console.Error.WriteLine("kcap hook requires a vendor flag (for example --claude)");
-        Console.Error.WriteLine("Supported vendors: --claude, --codex, --cursor");
+        Console.Error.WriteLine("Supported vendors: --claude, --codex, --cursor, --copilot");
         return 1;
     }
     case "cursor":

--- a/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
@@ -7,9 +7,9 @@ public class CodingAgentsStepTests {
     public async Task Claude_detected_and_accepted_calls_installer_with_settings_path() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: false, SkipCodex: true, SkipCursor: true, NoPrompt: false);
+        var options  = new Options(SkipClaude: false, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
         var paths    = TestPaths();
-        var detected = new DetectedAgents(Claude: true, Codex: false, Cursor: false);
+        var detected = new DetectedAgents(Claude: true, Codex: false, Cursor: false, Copilot: false);
 
         var result = await RunAsync(
             options,
@@ -29,8 +29,8 @@ public class CodingAgentsStepTests {
     public async Task Claude_detected_and_declined_skips_installer() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: false, SkipCodex: true, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: true, Codex: false, Cursor: false);
+        var options  = new Options(SkipClaude: false, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: true, Codex: false, Cursor: false, Copilot: false);
 
         var result = await RunAsync(
             options,
@@ -51,8 +51,8 @@ public class CodingAgentsStepTests {
         var sink        = new Sink();
         var calls       = new InstallerCalls();
         var promptCount = 0;
-        var options     = new Options(SkipClaude: false, SkipCodex: true, SkipCursor: true, NoPrompt: false);
-        var detected    = new DetectedAgents(Claude: false, Codex: false, Cursor: false);
+        var options     = new Options(SkipClaude: false, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected    = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false);
 
         var result = await RunAsync(
             options,
@@ -77,8 +77,8 @@ public class CodingAgentsStepTests {
     public async Task Claude_installer_failure_emits_warning_and_returns_false() {
         var sink     = new Sink();
         var calls    = new InstallerCalls { ClaudeReturns = false };
-        var options  = new Options(SkipClaude: false, SkipCodex: true, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: true, Codex: false, Cursor: false);
+        var options  = new Options(SkipClaude: false, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: true, Codex: false, Cursor: false, Copilot: false);
 
         var result = await RunAsync(
             options,
@@ -98,8 +98,8 @@ public class CodingAgentsStepTests {
     public async Task Codex_detected_and_accepted_installs_hooks_and_prints_trust_hint() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false);
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
 
         var result = await RunAsync(
             options,
@@ -120,8 +120,8 @@ public class CodingAgentsStepTests {
     public async Task Codex_detected_and_declined_skips_installer_and_trust_hint() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false);
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
 
         var result = await RunAsync(
             options,
@@ -141,8 +141,8 @@ public class CodingAgentsStepTests {
     public async Task Codex_not_detected_skips_prompt_and_emits_skip_line() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false);
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false);
 
         var result = await RunAsync(
             options,
@@ -162,8 +162,8 @@ public class CodingAgentsStepTests {
     public async Task Codex_hooks_installer_failure_emits_warning_and_skips_trust_hint() {
         var sink     = new Sink();
         var calls    = new InstallerCalls { CodexHooksReturns = false };
-        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false);
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
 
         var result = await RunAsync(
             options,
@@ -184,8 +184,8 @@ public class CodingAgentsStepTests {
     public async Task Codex_skills_installed_when_hooks_succeed_and_plugin_dir_present() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false);
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
 
         var result = await RunAsync(
             options,
@@ -205,8 +205,8 @@ public class CodingAgentsStepTests {
     public async Task Codex_skills_not_attempted_when_hooks_fail() {
         var sink     = new Sink();
         var calls    = new InstallerCalls { CodexHooksReturns = false };
-        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false);
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
 
         var result = await RunAsync(
             options,
@@ -225,8 +225,8 @@ public class CodingAgentsStepTests {
     public async Task Codex_skills_failure_still_keeps_trust_hint() {
         var sink     = new Sink();
         var calls    = new InstallerCalls { AgentSkillsReturns = false };
-        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false);
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
 
         var result = await RunAsync(
             options,
@@ -247,8 +247,8 @@ public class CodingAgentsStepTests {
     public async Task Plugin_dir_null_skips_claude_install_but_keeps_codex_hooks() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: false, SkipCodex: false, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: true, Codex: true, Cursor: false);
+        var options  = new Options(SkipClaude: false, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: true, Codex: true, Cursor: false, Copilot: false);
         var paths    = TestPaths() with { PluginDir = null };
 
         var result = await RunAsync(
@@ -274,8 +274,8 @@ public class CodingAgentsStepTests {
     public async Task Neither_detected_emits_warning_and_no_installer_calls() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: false, SkipCodex: false, SkipCursor: false, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false);
+        var options  = new Options(SkipClaude: false, SkipCodex: false, SkipCursor: false, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false);
 
         var result = await RunAsync(
             options,
@@ -299,8 +299,8 @@ public class CodingAgentsStepTests {
     public async Task Project_scope_claude_path_is_passed_through_to_installer() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: false, SkipCodex: true, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: true, Codex: false, Cursor: false);
+        var options  = new Options(SkipClaude: false, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: true, Codex: false, Cursor: false, Copilot: false);
 
         // Caller (SetupCommand) selects the project-scope path AND the matching label.
         // The step's contract is to honour both faithfully.
@@ -327,8 +327,8 @@ public class CodingAgentsStepTests {
     public async Task Legacy_cleanup_invoked_after_successful_codex_skills_install() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false);
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
 
         await RunAsync(
             options,
@@ -347,8 +347,8 @@ public class CodingAgentsStepTests {
     public async Task Legacy_cleanup_not_invoked_when_codex_skills_install_fails() {
         var sink     = new Sink();
         var calls    = new InstallerCalls { AgentSkillsReturns = false };
-        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false);
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
 
         await RunAsync(
             options,
@@ -367,8 +367,8 @@ public class CodingAgentsStepTests {
     public async Task Claude_path_with_markup_special_chars_does_not_break_output() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: false, SkipCodex: true, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: true, Codex: false, Cursor: false);
+        var options  = new Options(SkipClaude: false, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: true, Codex: false, Cursor: false, Copilot: false);
 
         // [ and ] are legal in paths; if not escaped, Spectre.MarkupLine throws.
         var paths = TestPaths() with {
@@ -394,8 +394,8 @@ public class CodingAgentsStepTests {
     public async Task Cursor_detected_and_accepted_installs_hooks() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true);
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true, Copilot: false);
 
         var result = await RunAsync(
             options, detected, TestPaths(), calls.AsInstallers(),
@@ -410,8 +410,8 @@ public class CodingAgentsStepTests {
     public async Task Cursor_detected_and_declined_skips_installer() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true);
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true, Copilot: false);
 
         var result = await RunAsync(
             options, detected, TestPaths(), calls.AsInstallers(),
@@ -426,8 +426,8 @@ public class CodingAgentsStepTests {
     public async Task Cursor_not_detected_emits_skip_line() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false);
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false);
 
         await RunAsync(
             options, detected, TestPaths(), calls.AsInstallers(),
@@ -441,8 +441,8 @@ public class CodingAgentsStepTests {
     public async Task Cursor_skipped_by_flag_emits_skip_line() {
         var sink     = new Sink();
         var calls    = new InstallerCalls();
-        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true);
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true, Copilot: false);
 
         await RunAsync(
             options, detected, TestPaths(), calls.AsInstallers(),
@@ -456,8 +456,8 @@ public class CodingAgentsStepTests {
     public async Task Cursor_installer_failure_emits_warning() {
         var sink     = new Sink();
         var calls    = new InstallerCalls { CursorHooksReturns = false };
-        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true);
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true, Copilot: false);
 
         var result = await RunAsync(
             options, detected, TestPaths(), calls.AsInstallers(),
@@ -472,8 +472,8 @@ public class CodingAgentsStepTests {
     public async Task Cursor_kcap_not_on_path_aborts_install_without_writing_hooks() {
         var sink     = new Sink();
         var calls    = new InstallerCalls { CapacitorOnPathReturns = false };
-        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, NoPrompt: false);
-        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true);
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true, Copilot: false);
 
         var result = await RunAsync(
             options, detected, TestPaths(), calls.AsInstallers(),
@@ -485,12 +485,109 @@ public class CodingAgentsStepTests {
         await Assert.That(sink.Lines).Contains(l => l.Contains("'kcap' is not on PATH"));
     }
 
+    [Test]
+    public async Task Copilot_detected_and_accepted_installs_hooks() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: false, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.CopilotHooksInstalled).IsTrue();
+        await Assert.That(calls.CopilotHooksArg).IsEqualTo("/fake/.copilot/hooks/kcap.json");
+        await Assert.That(sink.Lines).Contains(l => l.Contains("Copilot hooks installed"));
+        await Assert.That(sink.Lines).Contains(l => l.Contains("restart any running copilot session"));
+    }
+
+    [Test]
+    public async Task Copilot_detected_and_declined_skips_installer() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: false, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => false, writeLine: sink.Write);
+
+        await Assert.That(result.CopilotHooksInstalled).IsFalse();
+        await Assert.That(calls.CopilotHooksCalled).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("Copilot hooks not installed"));
+    }
+
+    [Test]
+    public async Task Copilot_not_detected_emits_skip_line() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: false, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false);
+
+        await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(calls.CopilotHooksCalled).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("Copilot CLI not detected"));
+    }
+
+    [Test]
+    public async Task Copilot_skipped_by_flag_emits_skip_line() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: true);
+
+        await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(calls.CopilotHooksCalled).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("Copilot CLI hooks skipped by flag"));
+    }
+
+    [Test]
+    public async Task Copilot_installer_failure_emits_warning() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { CopilotHooksReturns = false };
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: false, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.CopilotHooksInstalled).IsFalse();
+        await Assert.That(calls.CopilotHooksCalled).IsTrue();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("Could not write Copilot hooks"));
+    }
+
+    [Test]
+    public async Task Copilot_kcap_not_on_path_aborts_install_without_writing_hooks() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { CapacitorOnPathReturns = false };
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: false, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.CopilotHooksInstalled).IsFalse();
+        await Assert.That(calls.CapacitorOnPathCalled).IsTrue();
+        await Assert.That(calls.CopilotHooksCalled).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("'kcap' is not on PATH"));
+    }
+
     static Paths TestPaths() => new(
         ClaudeSettingsPath:   "/fake/.claude/settings.json",
         ClaudeScopeLabel:     "user",
         PluginDir:            "/fake/plugin",
         CodexHooksPath:       "/fake/.codex/hooks.json",
         CursorHooksPath:      "/fake/.cursor/hooks.json",
+        CopilotHooksPath:     "/fake/.copilot/hooks/kcap.json",
         AgentsSkillsDir:      "/fake/.agents/skills",
         LegacyCodexSkillsDir: "/fake/.codex/skills"
     );
@@ -512,6 +609,10 @@ public class CodingAgentsStepTests {
         public bool    CursorHooksCalled  { get; private set; }
         public string? CursorHooksArg     { get; private set; }
         public bool    CursorHooksReturns { get; set; } = true;
+
+        public bool    CopilotHooksCalled  { get; private set; }
+        public string? CopilotHooksArg     { get; private set; }
+        public bool    CopilotHooksReturns { get; set; } = true;
 
         public bool CapacitorOnPathCalled  { get; private set; }
         public bool CapacitorOnPathReturns { get; set; } = true;
@@ -542,6 +643,12 @@ public class CodingAgentsStepTests {
                 CursorHooksArg    = h;
 
                 return CursorHooksReturns;
+            },
+            InstallCopilotHooks: h => {
+                CopilotHooksCalled = true;
+                CopilotHooksArg    = h;
+
+                return CopilotHooksReturns;
             },
             CapacitorOnPath: () => {
                 CapacitorOnPathCalled = true;

--- a/test/Capacitor.Cli.Tests.Unit/CopilotHooksTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CopilotHooksTests.cs
@@ -1,0 +1,119 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core.Copilot;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Covers the Copilot hooks writer (<see cref="PluginCommand.InstallCopilotHooks"/> /
+/// <see cref="PluginCommand.RemoveCopilotHooks"/>), the installer marker
+/// helpers, and the parser. Unlike Cursor/Codex, kcap owns its own file under
+/// <c>~/.copilot/hooks/</c> (Copilot merges all *.json in that dir), so there
+/// is no user-entry preservation to test — install is a wholesale write and
+/// remove is a delete.
+/// </summary>
+public class CopilotHooksTests {
+    [Test]
+    public async Task fresh_install_writes_all_subscribed_events_with_embedded_event_names() {
+        using var tmp = new TempDir();
+        var hooksPath = Path.Combine(tmp.Path, "hooks", "kcap.json");
+
+        var ok = PluginCommand.InstallCopilotHooks(hooksPath);
+        await Assert.That(ok).IsTrue();
+
+        var root = JsonNode.Parse(await File.ReadAllTextAsync(hooksPath))!.AsObject();
+        await Assert.That(root["version"]!.GetValue<int>()).IsEqualTo(1);
+
+        var hooks = root["hooks"]!.AsObject();
+
+        foreach (var evt in new[] { "sessionStart", "sessionEnd", "agentStop", "notification" }) {
+            var entries = hooks[evt]!.AsArray();
+            await Assert.That(entries.Count).IsEqualTo(1);
+
+            var entry = entries[0]!.AsObject();
+            await Assert.That(entry["type"]!.GetValue<string>()).IsEqualTo("command");
+            // Copilot payloads carry no uniform event-name field, so the
+            // command embeds the event for the dispatcher.
+            await Assert.That(entry["command"]!.GetValue<string>()).IsEqualTo($"kcap hook --copilot --event {evt}");
+            await Assert.That(entry["timeoutSec"]!.GetValue<int>()).IsEqualTo(30);
+        }
+    }
+
+    [Test]
+    public async Task install_writes_marker_and_remove_deletes_file_and_marker() {
+        using var tmp = new TempDir();
+        var hooksPath = Path.Combine(tmp.Path, "hooks", "kcap.json");
+
+        PluginCommand.InstallCopilotHooks(hooksPath);
+
+        await Assert.That(CopilotHooksInstaller.IsInstalled(hooksPath)).IsTrue();
+        await Assert.That(CopilotHooksInstaller.ReadMarker(hooksPath)).IsNotNull();
+
+        var removed = PluginCommand.RemoveCopilotHooks(hooksPath);
+
+        await Assert.That(removed).IsTrue();
+        await Assert.That(File.Exists(hooksPath)).IsFalse();
+        await Assert.That(CopilotHooksInstaller.IsInstalled(hooksPath)).IsFalse();
+        await Assert.That(CopilotHooksInstaller.ReadMarker(hooksPath)).IsNull();
+    }
+
+    [Test]
+    public async Task remove_without_install_reports_nothing_removed() {
+        using var tmp = new TempDir();
+        var hooksPath = Path.Combine(tmp.Path, "hooks", "kcap.json");
+
+        await Assert.That(PluginCommand.RemoveCopilotHooks(hooksPath)).IsFalse();
+    }
+
+    [Test]
+    public async Task is_installed_detects_pre_marker_installs_from_file_content() {
+        using var tmp = new TempDir();
+        var hooksDir  = Path.Combine(tmp.Path, "hooks");
+        var hooksPath = Path.Combine(hooksDir, "kcap.json");
+
+        Directory.CreateDirectory(hooksDir);
+        await File.WriteAllTextAsync(hooksPath, """
+            {"version":1,"hooks":{"sessionStart":[{"type":"command","command":"kcap hook --copilot --event sessionStart"}]}}
+        """);
+
+        await Assert.That(CopilotHooksInstaller.IsInstalled(hooksPath)).IsTrue();
+    }
+
+    [Test]
+    public async Task parser_matches_command_bash_and_powershell_fields() {
+        await Assert.That(CopilotHooksParser.EntryReferencesCapacitorCopilotHook(
+            JsonNode.Parse("""{"command":"kcap hook --copilot --event sessionStart"}"""))).IsTrue();
+        await Assert.That(CopilotHooksParser.EntryReferencesCapacitorCopilotHook(
+            JsonNode.Parse("""{"bash":"kcap hook --copilot --event sessionEnd"}"""))).IsTrue();
+        await Assert.That(CopilotHooksParser.EntryReferencesCapacitorCopilotHook(
+            JsonNode.Parse("""{"powershell":"kcap hook --copilot --event agentStop"}"""))).IsTrue();
+        await Assert.That(CopilotHooksParser.EntryReferencesCapacitorCopilotHook(
+            JsonNode.Parse("""{"command":"/usr/local/bin/other"}"""))).IsFalse();
+        await Assert.That(CopilotHooksParser.EntryReferencesCapacitorCopilotHook(
+            JsonNode.Parse("""{"url":"https://hooks.example.com"}"""))).IsFalse();
+    }
+
+    [Test]
+    public async Task has_capacitor_hooks_for_requires_every_event() {
+        using var tmp = new TempDir();
+        var hooksPath = Path.Combine(tmp.Path, "hooks", "kcap.json");
+
+        PluginCommand.InstallCopilotHooks(hooksPath);
+
+        var root = JsonNode.Parse(await File.ReadAllTextAsync(hooksPath))!.AsObject();
+
+        await Assert.That(CopilotHooksParser.HasCapacitorHooksFor(root, CopilotHooksParser.CopilotHookEvents)).IsTrue();
+        await Assert.That(CopilotHooksParser.HasCapacitorHooksFor(root, ["sessionStart", "someFutureEvent"])).IsFalse();
+    }
+
+    sealed class TempDir : IDisposable {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            $"kcap-copilot-hooks-test-{Guid.NewGuid().ToString("N")[..8]}"
+        );
+        public TempDir() => Directory.CreateDirectory(Path);
+        public void Dispose() {
+            try { Directory.Delete(Path, true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/CopilotImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CopilotImportSourceTests.cs
@@ -1,0 +1,165 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Discovery-phase tests for <see cref="CopilotImportSource"/> against fake
+/// <c>session-state/</c> trees: scaffolding-dir skipping, current-root
+/// precedence over the legacy root, workspace.yaml metadata extraction, and
+/// the --session / --cwd / --since filters.
+/// </summary>
+public class CopilotImportSourceTests {
+    const string Sid1 = "1053bee4-574f-40e3-84ca-463bd7a82dc2";
+    const string Sid2 = "4ae28a73-dd66-46ac-81d2-be94b5e87079";
+
+    [Test]
+    public async Task discovery_skips_scaffolding_dirs_without_events_jsonl() {
+        using var tmp = new TempDir();
+        WriteSession(tmp.Path, Sid1, cwd: "/work/a");
+        // Failed-startup scaffolding: workspace.yaml but no events.jsonl.
+        Directory.CreateDirectory(Path.Combine(tmp.Path, Sid2));
+        await File.WriteAllTextAsync(Path.Combine(tmp.Path, Sid2, "workspace.yaml"), $"id: {Sid2}\ncwd: /work/b\n");
+
+        var source   = new CopilotImportSource(tmp.Path, legacyDirOverride: Path.Combine(tmp.Path, "none"));
+        var sessions = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+
+        await Assert.That(sessions.Count).IsEqualTo(1);
+        await Assert.That(sessions[0].SessionId).IsEqualTo(Sid1.Replace("-", ""));
+        await Assert.That(sessions[0].Vendor).IsEqualTo("copilot");
+    }
+
+    [Test]
+    public async Task discovery_reads_workspace_yaml_metadata() {
+        using var tmp = new TempDir();
+        WriteSession(
+            tmp.Path, Sid1,
+            cwd: "/work/a",
+            name: "Create a file hello.txt containing 'hello world'",
+            createdAt: "2026-06-10T20:23:25.556Z");
+
+        var source   = new CopilotImportSource(tmp.Path, legacyDirOverride: Path.Combine(tmp.Path, "none"));
+        var sessions = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+
+        await Assert.That(sessions.Count).IsEqualTo(1);
+        await Assert.That(sessions[0].Cwd).IsEqualTo("/work/a");
+        await Assert.That(sessions[0].FirstTimestamp).IsEqualTo(DateTimeOffset.Parse("2026-06-10T20:23:25.556Z"));
+        await Assert.That(sessions[0].SourceMeta["Name"]).IsEqualTo("Create a file hello.txt containing 'hello world'");
+    }
+
+    [Test]
+    public async Task discovery_prefers_current_root_over_legacy_for_same_session() {
+        using var tmp = new TempDir();
+        var current = Path.Combine(tmp.Path, "session-state");
+        var legacy  = Path.Combine(tmp.Path, "history-session-state");
+
+        WriteSession(current, Sid1, cwd: "/work/current");
+        WriteSession(legacy, Sid1, cwd: "/work/legacy");
+        WriteSession(legacy, Sid2, cwd: "/work/legacy-only");
+
+        var source   = new CopilotImportSource(current, legacy);
+        var sessions = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+
+        await Assert.That(sessions.Count).IsEqualTo(2);
+
+        var migrated = sessions.Single(s => s.SessionId == Sid1.Replace("-", ""));
+        await Assert.That(migrated.Cwd).IsEqualTo("/work/current");
+        await Assert.That(sessions.Any(s => s.SessionId == Sid2.Replace("-", ""))).IsTrue();
+    }
+
+    [Test]
+    public async Task session_filter_matches_dashless_and_dashed_input() {
+        using var tmp = new TempDir();
+        WriteSession(tmp.Path, Sid1, cwd: "/work/a");
+        WriteSession(tmp.Path, Sid2, cwd: "/work/b");
+
+        var source = new CopilotImportSource(tmp.Path, legacyDirOverride: Path.Combine(tmp.Path, "none"));
+
+        var byDashed = await source.DiscoverAsync(new DiscoveryFilters(null, Sid1, null, 0), CancellationToken.None);
+        await Assert.That(byDashed.Count).IsEqualTo(1);
+        await Assert.That(byDashed[0].SessionId).IsEqualTo(Sid1.Replace("-", ""));
+
+        var byDashless = await source.DiscoverAsync(
+            new DiscoveryFilters(null, Sid1.Replace("-", ""), null, 0), CancellationToken.None);
+        await Assert.That(byDashless.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task cwd_filter_excludes_other_workspaces_and_sessions_without_cwd() {
+        using var tmp = new TempDir();
+        WriteSession(tmp.Path, Sid1, cwd: "/work/a");
+        WriteSession(tmp.Path, Sid2, cwd: null);   // no workspace.yaml cwd
+
+        var source  = new CopilotImportSource(tmp.Path, legacyDirOverride: Path.Combine(tmp.Path, "none"));
+        var matched = await source.DiscoverAsync(new DiscoveryFilters("/work/a", null, null, 0), CancellationToken.None);
+
+        await Assert.That(matched.Count).IsEqualTo(1);
+        await Assert.That(matched[0].SessionId).IsEqualTo(Sid1.Replace("-", ""));
+    }
+
+    [Test]
+    public async Task since_filter_gates_on_session_start() {
+        using var tmp = new TempDir();
+        WriteSession(tmp.Path, Sid1, cwd: "/work/a", createdAt: "2026-06-01T10:00:00Z");
+        WriteSession(tmp.Path, Sid2, cwd: "/work/b", createdAt: "2026-06-09T10:00:00Z");
+
+        var source  = new CopilotImportSource(tmp.Path, legacyDirOverride: Path.Combine(tmp.Path, "none"));
+        var matched = await source.DiscoverAsync(
+            new DiscoveryFilters(null, null, new DateOnly(2026, 6, 5), 0), CancellationToken.None);
+
+        await Assert.That(matched.Count).IsEqualTo(1);
+        await Assert.That(matched[0].SessionId).IsEqualTo(Sid2.Replace("-", ""));
+    }
+
+    [Test]
+    public async Task workspace_yaml_parser_tolerates_missing_file_and_colon_values() {
+        using var tmp = new TempDir();
+
+        await Assert.That(CopilotWorkspaceYaml.TryRead(Path.Combine(tmp.Path, "absent.yaml"))).IsNull();
+
+        var path = Path.Combine(tmp.Path, "workspace.yaml");
+        await File.WriteAllTextAsync(path, """
+            id: 4ae28a73-dd66-46ac-81d2-be94b5e87079
+            cwd: /private/tmp/work
+            name: Fix the bug: timestamps are wrong
+            user_named: false
+            created_at: 2026-06-10T20:23:25.556Z
+            updated_at: 2026-06-10T20:23:37.838Z
+            """);
+
+        var meta = CopilotWorkspaceYaml.TryRead(path);
+
+        await Assert.That(meta).IsNotNull();
+        await Assert.That(meta!.Cwd).IsEqualTo("/private/tmp/work");
+        // Values containing ": " must not be truncated at the second colon.
+        await Assert.That(meta.Name).IsEqualTo("Fix the bug: timestamps are wrong");
+        await Assert.That(meta.CreatedAt).IsEqualTo(DateTimeOffset.Parse("2026-06-10T20:23:25.556Z"));
+        await Assert.That(meta.UpdatedAt).IsEqualTo(DateTimeOffset.Parse("2026-06-10T20:23:37.838Z"));
+    }
+
+    static void WriteSession(string root, string dashedSid, string? cwd, string? name = null, string? createdAt = null) {
+        var dir = Path.Combine(root, dashedSid);
+        Directory.CreateDirectory(dir);
+
+        File.WriteAllText(
+            Path.Combine(dir, "events.jsonl"),
+            """{"type":"session.start","data":{"sessionId":"x"},"id":"11111111-1111-4111-8111-111111111111","timestamp":"2026-06-10T20:23:49.371Z","parentId":null}"""
+          + "\n");
+
+        var yaml = $"id: {dashedSid}\n";
+        if (cwd is not null) yaml       += $"cwd: {cwd}\n";
+        if (name is not null) yaml      += $"name: {name}\n";
+        if (createdAt is not null) yaml += $"created_at: {createdAt}\n";
+        File.WriteAllText(Path.Combine(dir, "workspace.yaml"), yaml);
+    }
+
+    sealed class TempDir : IDisposable {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            $"kcap-copilot-import-test-{Guid.NewGuid().ToString("N")[..8]}"
+        );
+        public TempDir() => Directory.CreateDirectory(Path);
+        public void Dispose() {
+            try { Directory.Delete(Path, true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/CopilotImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CopilotImportSourceTests.cs
@@ -170,6 +170,30 @@ public class CopilotImportSourceTests {
         await Assert.That(CopilotWorkspaceYaml.Unquote(raw)).IsEqualTo(expected);
     }
 
+    // The server watermark is the max persisted canonical $lineNumber, and
+    // every Copilot transcript ends with lines the server normalizer skips
+    // (session.shutdown + the sessionEnd hook's own hook.start/hook.end pair).
+    // Classification must compare against the last RELEVANT line or complete
+    // imports re-classify Partial forever.
+    [Test]
+    [Arguments("""{"type":"session.start","data":{"sessionId":"x","context":{"cwd":"/w"}},"id":"1","timestamp":"2026-06-10T20:23:49Z","parentId":null}""", true)]
+    [Arguments("""{"type":"user.message","data":{"content":"hi","transformedContent":"<x/>hi"},"id":"2","timestamp":"2026-06-10T20:23:50Z","parentId":null}""", true)]
+    [Arguments("""{"type":"user.message","data":{"content":"","attachments":[]},"id":"3","timestamp":"2026-06-10T20:23:50Z","parentId":null}""", false)]
+    [Arguments("""{"type":"assistant.message","data":{"content":"ok","toolRequests":[],"outputTokens":5},"id":"4","timestamp":"2026-06-10T20:23:55Z","parentId":null}""", true)]
+    [Arguments("""{"type":"assistant.message","data":{"content":"","toolRequests":[{"toolCallId":"t1","name":"write","arguments":{}}]},"id":"5","timestamp":"2026-06-10T20:23:55Z","parentId":null}""", true)]
+    [Arguments("""{"type":"assistant.message","data":{"content":"","reasoningText":"thinking","toolRequests":[]},"id":"6","timestamp":"2026-06-10T20:23:55Z","parentId":null}""", true)]
+    [Arguments("""{"type":"assistant.message","data":{"content":"","toolRequests":[]},"id":"7","timestamp":"2026-06-10T20:23:55Z","parentId":null}""", false)]
+    [Arguments("""{"type":"tool.execution_complete","data":{"toolCallId":"t1","success":true,"result":{"content":"done"}},"id":"8","timestamp":"2026-06-10T20:23:56Z","parentId":null}""", true)]
+    [Arguments("""{"type":"tool.execution_start","data":{"toolCallId":"t1","toolName":"write"},"id":"9","timestamp":"2026-06-10T20:23:56Z","parentId":null}""", false)]
+    [Arguments("""{"type":"session.shutdown","data":{"shutdownType":"routine","totalPremiumRequests":1},"id":"10","timestamp":"2026-06-10T20:24:40Z","parentId":null}""", false)]
+    [Arguments("""{"type":"hook.start","data":{"hookInvocationId":"h1","hookType":"sessionEnd","input":{}},"id":"11","timestamp":"2026-06-10T20:24:41Z","parentId":null}""", false)]
+    [Arguments("""{"type":"hook.end","data":{"hookInvocationId":"h1","hookType":"sessionEnd","success":true},"id":"12","timestamp":"2026-06-10T20:24:41Z","parentId":null}""", false)]
+    [Arguments("""{"type":"assistant.turn_end","data":{"turnId":"0"},"id":"13","timestamp":"2026-06-10T20:23:59Z","parentId":null}""", false)]
+    [Arguments("not json", false)]
+    public async Task import_relevance_mirrors_the_server_normalizer_mapping(string line, bool expected) {
+        await Assert.That(CopilotImportSource.IsImportRelevantLine(line)).IsEqualTo(expected);
+    }
+
     static void WriteSession(string root, string dashedSid, string? cwd, string? name = null, string? createdAt = null) {
         var dir = Path.Combine(root, dashedSid);
         Directory.CreateDirectory(dir);

--- a/test/Capacitor.Cli.Tests.Unit/CopilotImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CopilotImportSourceTests.cs
@@ -136,6 +136,40 @@ public class CopilotImportSourceTests {
         await Assert.That(meta.UpdatedAt).IsEqualTo(DateTimeOffset.Parse("2026-06-10T20:23:37.838Z"));
     }
 
+    [Test]
+    public async Task workspace_yaml_parser_strips_scalar_quotes_from_names() {
+        // Copilot quotes the name when it contains YAML-special sequences —
+        // the captured fixture has `name: 'Reply with exactly: ok'`. Without
+        // unquoting, the literal quotes leak into imported session titles.
+        using var tmp = new TempDir();
+
+        var path = Path.Combine(tmp.Path, "workspace.yaml");
+        await File.WriteAllTextAsync(path, """
+            id: e18d0fe8-95e1-4bd3-87e1-54318e4f3c54
+            cwd: '/private/tmp/quoted dir'
+            name: 'Reply with exactly: ok'
+            created_at: '2026-06-10T20:23:21.000Z'
+            """);
+
+        var meta = CopilotWorkspaceYaml.TryRead(path);
+
+        await Assert.That(meta).IsNotNull();
+        await Assert.That(meta!.Name).IsEqualTo("Reply with exactly: ok");
+        await Assert.That(meta.Cwd).IsEqualTo("/private/tmp/quoted dir");
+        await Assert.That(meta.CreatedAt).IsEqualTo(DateTimeOffset.Parse("2026-06-10T20:23:21.000Z"));
+    }
+
+    [Test]
+    [Arguments("'Reply with exactly: ok'", "Reply with exactly: ok")]
+    [Arguments("'It''s done: finally'", "It's done: finally")]
+    [Arguments("\"Fix the \\\"bug\\\": now\"", "Fix the \"bug\": now")]
+    [Arguments("plain value", "plain value")]
+    [Arguments("'unterminated", "'unterminated")]
+    [Arguments("''", "")]
+    public async Task unquote_handles_yaml_scalar_quote_forms(string raw, string expected) {
+        await Assert.That(CopilotWorkspaceYaml.Unquote(raw)).IsEqualTo(expected);
+    }
+
     static void WriteSession(string root, string dashedSid, string? cwd, string? name = null, string? createdAt = null) {
         var dir = Path.Combine(root, dashedSid);
         Directory.CreateDirectory(dir);


### PR DESCRIPTION
## Summary

CLI side (Phase 2) of [AI-815](https://linear.app/kurrent/issue/AI-815/support-github-copilot-cli-sessions-live-ingest-import): records GitHub Copilot CLI sessions as a fourth vendor — **sessions only**, no hosted-agent launcher. Server counterpart (vendor, normalizer, hook routes): [kcap-server#721](https://github.com/kurrent-io/kcap-server/pull/721).

Follows the Codex pattern: **hooks own lifecycle, the transcript owns content** — `sessionStart` spawns the existing watcher on `$COPILOT_HOME/session-state/{sid}/events.jsonl` with `vendor=copilot`; the server's `CopilotTranscriptNormalizer` converts the raw lines.

## What's included

- **`kcap hook --copilot --event <name>`** — Copilot's command-hook payloads carry no uniform event-name field (sessionStart's payload is just `{sessionId, timestamp, cwd, source, initialPrompt}`), so the installer embeds the event in each registered command. `sessionStart` → repo-enriched, visibility-stamped POST + watcher spawn (resume re-fires on the same session id and free-dedupes server-side); `sessionEnd` → watcher kill + inline drain behind the AI-813-style 8s cap, then POST; `agentStop` → watcher liveness refresh per turn (Codex `Stop` precedent, no POST); `notification` → best-effort 2s-budget forward to the wire-compatible `/hooks/notification`. Deliberately minimal subscription set — every hook execution writes a `hook.start`/`hook.end` noise pair into Copilot's transcript, so per-tool hooks would double transcript noise for content the transcript already carries.
- **`kcap import --copilot`** — `CopilotImportSource` walks `session-state/` + the pre-GA `history-session-state/` root (current root wins for resume-migrated sessions), skips failed-startup scaffolding (dirs without `events.jsonl`), reads cwd/created_at/name from `workspace.yaml` (minimal flat parser, no YAML dependency), routes through the Cursor-style routed phase, and forwards Copilot's auto-generated session name via `/hooks/set-title` (`SupportsTitleGeneration` false — no LLM tokens burned on titles Copilot already wrote). `ended_at` uses the transcript mtime; workspace.yaml's `updated_at` is stamped at naming time, not session end.
- **`kcap plugin install/remove --copilot`** — writes kcap's **own** `~/.copilot/hooks/kcap.json` wholesale: Copilot merges every `*.json` under the hooks dir natively, so user-authored hook files are never touched and removal is a file delete (no Cursor-style merge machinery). Wired into `kcap setup` (detection via `~/.copilot/` or `copilot` on PATH; `--skip-copilot-hooks`), `kcap uninstall`, and the npm postinstall `--if-installed` refresh.
- **Watcher** — copilot title extractors (clean `data.content`, never `transformedContent`; subagent-tagged envelopes excluded so the parent's task prompt can't mislabel the session) + `copilot` in the parent-exit session-end vendor allow-list.
- **Docs** — README (getting started, import, hooks sections) + the six vendor-mentioning `help-*.txt` files.

## Validation

- 1373 unit tests pass (incl. new `CopilotHooksTests`, `CopilotImportSourceTests`, and Copilot cases in `CodingAgentsStepTests`); 30 integration tests pass.
- AOT publish clean — zero IL3050/IL2026 warnings.
- **End-to-end against the server branch** (local KurrentDB + `Auth: None`): `kcap import --copilot` loaded all 4 real captured Copilot CLI v1.0.61 sessions with vendor/model/title/per-model token stats/correct durations, and the live path (`sessionStart` hook → watcher SignalR streaming → `sessionEnd` drain) produced a complete ended session (37 events, model + stats backfilled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)