### PR TITLE
[AI-803] Keep --strict-mcp-config on for tool-using headless judges

### DIFF
--- a/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
+++ b/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
@@ -66,14 +66,17 @@ static class ClaudeCliRunner {
     /// during the run (today: the DEV-1484 retrospective judge, which
     /// pulls session details via <c>kcap mcp judge</c> instead of
     /// having the full trace embedded in its prompt). When
-    /// <paramref name="mcpConfigJson"/> is supplied, the runner flips out
-    /// of the text-only lockdown (<c>--strict-mcp-config</c> / empty
-    /// <c>--tools</c> / <c>--disallowedTools LSP</c>) and instead loads
-    /// the caller-supplied MCP config via <c>--mcp-config</c>, restricting
-    /// the model to exactly <paramref name="allowedTools"/> via
-    /// <c>--allowedTools</c>. <c>--disable-slash-commands</c> stays on in
-    /// both modes. Leaving both null preserves the text-only behaviour
-    /// every other caller relies on.
+    /// <paramref name="mcpConfigJson"/> is supplied, the runner loads the
+    /// caller-supplied MCP config via <c>--mcp-config</c> and restricts the
+    /// model to exactly <paramref name="allowedTools"/> via
+    /// <c>--allowedTools</c>, dropping only the text-only tool lockdown
+    /// (empty <c>--tools</c> / <c>--disallowedTools LSP</c>).
+    /// <c>--strict-mcp-config</c> and <c>--disable-slash-commands</c> stay
+    /// on in both modes — strict-mcp-config is what keeps the user's global
+    /// or plugin MCP servers (e.g. <c>kcap-sessions</c> from the kcap Claude
+    /// Code plugin) from leaking in and getting permission-blocked under
+    /// the allowlist (AI-803). Leaving both null preserves the text-only
+    /// behaviour every other caller relies on.
     /// </para>
     ///
     /// <para>
@@ -185,74 +188,9 @@ static class ClaudeCliRunner {
         if (!ProviderApiKeyPolicy.ShouldKeepProviderKey()) {
             psi.Environment.Remove("ANTHROPIC_API_KEY");
         }
-        psi.ArgumentList.Add("-p");
 
-        if (!promptViaStdin) {
-            // When piping stdin, `claude -p` reads the prompt from stdin; don't
-            // also pass it as a positional arg.
-            psi.ArgumentList.Add(prompt);
-        }
-
-        psi.ArgumentList.Add("--output-format");
-        psi.ArgumentList.Add("json");
-        psi.ArgumentList.Add("--max-turns");
-        psi.ArgumentList.Add(maxTurns.ToString());
-        psi.ArgumentList.Add("--model");
-        psi.ArgumentList.Add(model);
-
-        if (maxBudgetUsd is { } budget) {
-            psi.ArgumentList.Add("--max-budget-usd");
-            psi.ArgumentList.Add(budget.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture));
-        }
-
-        if (mcpConfigJson is null) {
-            // Text-only mode (title generation, per-question judges): block
-            // MCP servers, all tools, and the LSP probe.
-            //
-            // `--tools ""` is not enough for headless single-turn judge runs:
-            //   - MCP servers from the user's global config still load, so we
-            //     need `--strict-mcp-config` (with no `--mcp-config`) to load zero.
-            //   - The built-in `LSP` tool is attached regardless of `--tools`,
-            //     and Claude eagerly probes any file paths it sees in the
-            //     compacted trace, blowing past `--max-turns 1` with
-            //     `stop_reason=tool_use`. `--disallowedTools LSP` blocks it.
-            // Without both flags, real eval traces (which mention file paths)
-            // fail every question with `error_max_turns`.
-            psi.ArgumentList.Add("--strict-mcp-config");
-            psi.ArgumentList.Add("--tools");
-            psi.ArgumentList.Add("");
-            psi.ArgumentList.Add("--disallowedTools");
-            psi.ArgumentList.Add("LSP");
-        } else {
-            // Tool-using mode (DEV-1484 retrospective): load the caller-supplied
-            // MCP config, and restrict the model to exactly the MCP tools the
-            // caller named. The `--tools ""` / `--disallowedTools LSP` lockdown
-            // from the text-only branch is dropped — the explicit `--allowedTools`
-            // allowlist is the only tool surface the model sees.
-            psi.ArgumentList.Add("--mcp-config");
-            psi.ArgumentList.Add(mcpConfigJson);
-            if (allowedTools is { Length: > 0 }) {
-                psi.ArgumentList.Add("--allowedTools");
-                psi.ArgumentList.Add(string.Join(",", allowedTools));
-            }
-        }
-
-        // Skills load ~200 entries into the system prompt and the
-        // `using-superpowers` skill auto-invokes `Skill` on every session.
-        // Both are pure overhead for a headless judge: they inflate the
-        // prompt (contributing to the 200K-token auto-compact that
-        // destroys verdicts) and burn turns on skill dispatch that never
-        // produces a StructuredOutput reply. Applies in both text-only and
-        // tool-using modes.
-        psi.ArgumentList.Add("--disable-slash-commands");
-
-        if (!string.IsNullOrEmpty(jsonSchema)) {
-            // --json-schema makes the CLI enforce a structured reply via an
-            // internal StructuredOutput tool; the matched object lands in
-            // the top-level `structured_output` field (and `result` is
-            // empty). ParseJsonResponseOnly prefers that field.
-            psi.ArgumentList.Add("--json-schema");
-            psi.ArgumentList.Add(jsonSchema);
+        foreach (var arg in BuildClaudeArgs(prompt, promptViaStdin, model, maxTurns, jsonSchema, mcpConfigJson, allowedTools, maxBudgetUsd)) {
+            psi.ArgumentList.Add(arg);
         }
 
         using var process = Process.Start(psi);
@@ -372,6 +310,106 @@ static class ClaudeCliRunner {
 
             return null;
         }
+    }
+
+    /// <summary>
+    /// Builds the ordered <c>claude</c> CLI argument list for a headless run.
+    /// Extracted as an internal seam so the flag composition (especially the
+    /// MCP / text-only branching) can be asserted in unit tests without
+    /// spawning the real <c>claude</c> binary.
+    /// </summary>
+    internal static List<string> BuildClaudeArgs(
+            string    prompt,
+            bool      promptViaStdin,
+            string    model,
+            int       maxTurns,
+            string?   jsonSchema,
+            string?   mcpConfigJson,
+            string[]? allowedTools,
+            double?   maxBudgetUsd
+        ) {
+        var args = new List<string> { "-p" };
+
+        if (!promptViaStdin) {
+            // When piping stdin, `claude -p` reads the prompt from stdin; don't
+            // also pass it as a positional arg.
+            args.Add(prompt);
+        }
+
+        args.Add("--output-format");
+        args.Add("json");
+        args.Add("--max-turns");
+        args.Add(maxTurns.ToString());
+        args.Add("--model");
+        args.Add(model);
+
+        if (maxBudgetUsd is { } budget) {
+            args.Add("--max-budget-usd");
+            args.Add(budget.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        // `--strict-mcp-config` is on in BOTH modes: it tells claude to load
+        // ONLY the servers from `--mcp-config` (or zero servers when none is
+        // given), ignoring the user's global/project/plugin MCP config.
+        //   - Text-only mode: no `--mcp-config`, so zero MCP servers load.
+        //   - MCP mode: only the caller's inline session-scoped judge server
+        //     loads. Without this, a client with the `kcap` Claude Code plugin
+        //     installed would leak its global `kcap-sessions` (and a colliding
+        //     `kcap-review`) servers into the headless judge; the judge then
+        //     reaches for those un-allowlisted tools and every call is blocked
+        //     by permission restrictions, degrading verdicts to "unable to
+        //     investigate" (AI-803).
+        args.Add("--strict-mcp-config");
+
+        if (mcpConfigJson is null) {
+            // Text-only mode (title generation, per-question judges): block
+            // all tools and the LSP probe on top of loading zero MCP servers.
+            //
+            // `--tools ""` is not enough for headless single-turn judge runs:
+            //   - The built-in `LSP` tool is attached regardless of `--tools`,
+            //     and Claude eagerly probes any file paths it sees in the
+            //     compacted trace, blowing past `--max-turns 1` with
+            //     `stop_reason=tool_use`. `--disallowedTools LSP` blocks it.
+            // Without these, real eval traces (which mention file paths)
+            // fail every question with `error_max_turns`.
+            args.Add("--tools");
+            args.Add("");
+            args.Add("--disallowedTools");
+            args.Add("LSP");
+        } else {
+            // Tool-using mode (DEV-1484 retrospective + DEV-1486 per-question):
+            // load the caller-supplied MCP config and restrict the model to
+            // exactly the MCP tools the caller named. The `--tools ""` /
+            // `--disallowedTools LSP` lockdown from the text-only branch is
+            // dropped — the explicit `--allowedTools` allowlist is the only
+            // tool surface the model sees.
+            args.Add("--mcp-config");
+            args.Add(mcpConfigJson);
+            if (allowedTools is { Length: > 0 }) {
+                args.Add("--allowedTools");
+                args.Add(string.Join(",", allowedTools));
+            }
+        }
+
+        // Skills load ~200 entries into the system prompt and the
+        // `using-superpowers` skill auto-invokes `Skill` on every session.
+        // Both are pure overhead for a headless judge: they inflate the
+        // prompt (contributing to the 200K-token auto-compact that
+        // destroys verdicts) and burn turns on skill dispatch that never
+        // produces a StructuredOutput reply. Applies in both text-only and
+        // tool-using modes.
+        args.Add("--disable-slash-commands");
+
+        if (!string.IsNullOrEmpty(jsonSchema)) {
+            // --json-schema makes the CLI enforce a structured reply via an
+            // internal StructuredOutput tool; the matched object lands in
+            // the top-level `structured_output` field (and `result` is
+            // empty). ParseJsonResponseOnly prefers that field.
+            args.Add("--json-schema");
+            args.Add(jsonSchema);
+        }
+
+        return args;
     }
 
     internal static ClaudeCliResult? ParseResponse(string stdout) {

--- a/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
+++ b/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
@@ -354,10 +354,10 @@ static class ClaudeCliRunner {
         //   - Text-only mode: no `--mcp-config`, so zero MCP servers load.
         //   - MCP mode: only the caller's inline session-scoped judge server
         //     loads. Without this, a client with the `kcap` Claude Code plugin
-        //     installed would leak its global `kcap-sessions` (and a colliding
-        //     `kcap-review`) servers into the headless judge; the judge then
-        //     reaches for those un-allowlisted tools and every call is blocked
-        //     by permission restrictions, degrading verdicts to "unable to
+        //     installed would leak its global `kcap-sessions` server (and
+        //     others) into the headless judge; the judge then reaches for
+        //     those un-allowlisted tools and every call is blocked by
+        //     permission restrictions, degrading verdicts to "unable to
         //     investigate" (AI-803).
         args.Add("--strict-mcp-config");
 

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -83,18 +83,48 @@ public static class EvalService {
 
     static readonly TimeSpan ToolsPerQuestionTimeout = TimeSpan.FromMinutes(10);
 
+    // The inline judge MCP server is registered under this key in the
+    // --mcp-config we pass to claude; the key becomes the `mcp__<key>__<tool>`
+    // prefix claude uses. Named after `kcap mcp judge`'s own serverInfo so it
+    // never collides with the plugin-registered `kcap-review` (`kcap mcp
+    // review`) server when both load (AI-803).
+    internal const string JudgeMcpServerName = "kcap-judge";
+
     // Shared between RunRetrospectiveAsync and the tools-enabled per-question
-    // branch of RunQuestionAsync. Keeping a single list keeps the
-    // call_id → tool_name accounting surface aligned across both judge runs
-    // and prevents drift when new MCP tools are added.
-    static readonly string[] JudgeMcpAllowedTools = [
-        "mcp__kcap-review__get_session_recap",
-        "mcp__kcap-review__get_session_errors",
-        "mcp__kcap-review__get_transcript",
-        "mcp__kcap-review__get_session_summary",
-        "mcp__kcap-review__search_session",
-        "mcp__kcap-review__get_tool_result"
+    // branch of RunQuestionAsync. Built from JudgeMcpServerName so the
+    // allowlist prefix can never drift from the server key we register —
+    // a mismatch would push every judge tool call outside the allowlist and
+    // get it permission-blocked. Keeping a single list keeps the call_id →
+    // tool_name accounting surface aligned across both judge runs.
+    internal static readonly string[] JudgeMcpAllowedTools = [
+        $"mcp__{JudgeMcpServerName}__get_session_recap",
+        $"mcp__{JudgeMcpServerName}__get_session_errors",
+        $"mcp__{JudgeMcpServerName}__get_transcript",
+        $"mcp__{JudgeMcpServerName}__get_session_summary",
+        $"mcp__{JudgeMcpServerName}__search_session",
+        $"mcp__{JudgeMcpServerName}__get_tool_result"
     ];
+
+    /// <summary>
+    /// Builds the inline <c>--mcp-config</c> JSON for a session-scoped judge
+    /// run: a single <see cref="JudgeMcpServerName"/> server that shells out
+    /// to <c>kcap mcp judge --session &lt;id&gt;</c> with <c>KCAP_URL</c>
+    /// pinned to the resolved server. Shared by the per-question and
+    /// retrospective judge paths so the two never drift. <paramref name="baseUrl"/>
+    /// is injected so the child uses the exact server the parent resolved
+    /// (which may have come from <c>--server-url</c> and so isn't reachable
+    /// via the child's own config lookup).
+    /// </summary>
+    internal static string BuildJudgeMcpConfig(string commandPath, string sessionId, string baseUrl) =>
+        new JsonObject {
+            ["mcpServers"] = new JsonObject {
+                [JudgeMcpServerName] = new JsonObject {
+                    ["command"] = commandPath,
+                    ["args"]    = new JsonArray("mcp", "judge", "--session", sessionId),
+                    ["env"]     = new JsonObject { ["KCAP_URL"] = baseUrl }
+                }
+            }
+        }.ToJsonString();
 
     /// <summary>
     /// Resolves a caller-supplied model alias to the variant we actually
@@ -349,16 +379,7 @@ public static class EvalService {
                 ctx.ToolsPromptTemplate, ctx.SessionId, ctx.EvalRunId, question, patterns);
 
             var commandPath = Environment.ProcessPath ?? "kcap";
-
-            var mcpConfig = new JsonObject {
-                ["mcpServers"] = new JsonObject {
-                    ["kcap-review"] = new JsonObject {
-                        ["command"] = commandPath,
-                        ["args"]    = new JsonArray("mcp", "judge", "--session", ctx.SessionId),
-                        ["env"]     = new JsonObject { ["KCAP_URL"] = baseUrl }
-                    }
-                }
-            }.ToJsonString();
+            var mcpConfig   = BuildJudgeMcpConfig(commandPath, ctx.SessionId, baseUrl);
 
             result = await ClaudeCliRunner.RunAsync(
                 prompt,
@@ -996,24 +1017,9 @@ public static class EvalService {
         // DEV-1484: instead of embedding the compacted trace (which blew
         // past Sonnet's 200K-token window on real sessions), launch a
         // per-session MCP judge server and let the judge pull recap /
-        // errors / transcript slices on demand. MCP config built with
-        // JsonObject/JsonArray — same pattern as ReviewCommand.cs.
+        // errors / transcript slices on demand.
         var commandPath = Environment.ProcessPath ?? "kcap";
-
-        // Inject KCAP_URL so the child process uses the exact server the
-        // parent daemon resolved (which may have come from --server-url and
-        // therefore isn't reachable via the child's own config lookup).
-        // Matches the pattern in ReviewCommand.cs for the `kcap review`
-        // MCP launch.
-        var mcpConfig = new JsonObject {
-            ["mcpServers"] = new JsonObject {
-                ["kcap-review"] = new JsonObject {
-                    ["command"] = commandPath,
-                    ["args"]    = new JsonArray("mcp", "judge", "--session", sessionId),
-                    ["env"]     = new JsonObject { ["KCAP_URL"] = baseUrl }
-                }
-            }
-        }.ToJsonString();
+        var mcpConfig   = BuildJudgeMcpConfig(commandPath, sessionId, baseUrl);
 
         try {
             var result = await ClaudeCliRunner.RunAsync(

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
@@ -123,12 +123,13 @@ public class ClaudeCliRunnerTests {
     }
 
     // DEV-1484 contract: when a caller opts into MCP mode, they must name the
-    // tools they want exposed. Without an allowlist the runner would drop the
-    // built-in lockdown (no --strict-mcp-config / --tools "") without a
-    // replacement restriction — effectively widening the permission surface to
-    // every tool on every configured MCP server. Guard at the entry point so
-    // the misuse surfaces as an ArgumentException instead of a silent
-    // broadening.
+    // tools they want exposed. `--strict-mcp-config` already limits which MCP
+    // *servers* load to just the caller's inline config (AI-803), but without
+    // an allowlist the runner would drop the text-only `--tools ""` lockdown
+    // and expose every tool that inline config's servers offer. Requiring a
+    // non-empty allowlist keeps the callable-tool surface explicit. Guard at
+    // the entry point so the misuse surfaces as an ArgumentException instead
+    // of a silent broadening.
     [Test]
     public async Task RunAsync_WithMcpConfigAndNullAllowedTools_Throws() =>
         await AssertAllowedToolsGuard(allowedTools: null);
@@ -149,6 +150,79 @@ public class ClaudeCliRunnerTests {
         );
 
         await Assert.That(ex?.ParamName).IsEqualTo("allowedTools");
+    }
+
+    // AI-803: the tool-using (MCP) judge branch must keep `--strict-mcp-config`
+    // on so claude loads ONLY the caller's inline session-scoped judge server.
+    // Without it, a client machine with the `kcap` Claude Code plugin installed
+    // leaks its global `kcap-sessions` server into the headless judge; the judge
+    // calls those un-allowlisted tools and every call is blocked by permission
+    // restrictions, degrading the verdict to "unable to investigate".
+    [Test]
+    public async Task BuildClaudeArgs_McpMode_IncludesStrictMcpConfig() {
+        var args = ClaudeCliRunner.BuildClaudeArgs(
+            prompt:         "irrelevant",
+            promptViaStdin: true,
+            model:          "sonnet[1m]",
+            maxTurns:       15,
+            jsonSchema:     null,
+            mcpConfigJson:  """{"mcpServers":{"kcap-review":{"command":"kcap","args":["mcp","judge"]}}}""",
+            allowedTools:   ["mcp__kcap-review__get_session_summary"],
+            maxBudgetUsd:   1.0
+        );
+
+        await Assert.That(args).Contains("--strict-mcp-config");
+    }
+
+    [Test]
+    public async Task BuildClaudeArgs_McpMode_PassesConfigAndAllowlist() {
+        const string mcpConfig = """{"mcpServers":{"kcap-review":{"command":"kcap"}}}""";
+
+        var args = ClaudeCliRunner.BuildClaudeArgs(
+            prompt:         "irrelevant",
+            promptViaStdin: true,
+            model:          "sonnet[1m]",
+            maxTurns:       15,
+            jsonSchema:     null,
+            mcpConfigJson:  mcpConfig,
+            allowedTools:   ["mcp__kcap-review__get_session_summary", "mcp__kcap-review__search_session"],
+            maxBudgetUsd:   null
+        );
+
+        await Assert.That(FlagValue(args, "--mcp-config")).IsEqualTo(mcpConfig);
+        await Assert.That(FlagValue(args, "--allowedTools"))
+            .IsEqualTo("mcp__kcap-review__get_session_summary,mcp__kcap-review__search_session");
+        // The text-only lockdown flags must NOT leak into MCP mode — the
+        // allowlist is the tool restriction there, not `--tools ""`.
+        await Assert.That(args).DoesNotContain("--tools");
+        await Assert.That(args).DoesNotContain("LSP");
+    }
+
+    [Test]
+    public async Task BuildClaudeArgs_TextOnlyMode_LocksDownToolsAndMcp() {
+        var args = ClaudeCliRunner.BuildClaudeArgs(
+            prompt:         "irrelevant",
+            promptViaStdin: true,
+            model:          "haiku",
+            maxTurns:       1,
+            jsonSchema:     null,
+            mcpConfigJson:  null,
+            allowedTools:   null,
+            maxBudgetUsd:   null
+        );
+
+        await Assert.That(args).Contains("--strict-mcp-config");
+        await Assert.That(args).Contains("--tools");
+        await Assert.That(FlagValue(args, "--disallowedTools")).IsEqualTo("LSP");
+        // No MCP config means no caller-supplied servers.
+        await Assert.That(args).DoesNotContain("--mcp-config");
+        await Assert.That(args).DoesNotContain("--allowedTools");
+    }
+
+    /// <summary>Returns the argument immediately following <paramref name="flag"/>, or null.</summary>
+    static string? FlagValue(List<string> args, string flag) {
+        var i = args.IndexOf(flag);
+        return i >= 0 && i + 1 < args.Count ? args[i + 1] : null;
     }
 
     // AI-755: the CLI returns is_error:true with the API failure text in

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
@@ -166,8 +166,8 @@ public class ClaudeCliRunnerTests {
             model:          "sonnet[1m]",
             maxTurns:       15,
             jsonSchema:     null,
-            mcpConfigJson:  """{"mcpServers":{"kcap-review":{"command":"kcap","args":["mcp","judge"]}}}""",
-            allowedTools:   ["mcp__kcap-review__get_session_summary"],
+            mcpConfigJson:  """{"mcpServers":{"kcap-judge":{"command":"kcap","args":["mcp","judge"]}}}""",
+            allowedTools:   ["mcp__kcap-judge__get_session_summary"],
             maxBudgetUsd:   1.0
         );
 
@@ -176,7 +176,7 @@ public class ClaudeCliRunnerTests {
 
     [Test]
     public async Task BuildClaudeArgs_McpMode_PassesConfigAndAllowlist() {
-        const string mcpConfig = """{"mcpServers":{"kcap-review":{"command":"kcap"}}}""";
+        const string mcpConfig = """{"mcpServers":{"kcap-judge":{"command":"kcap"}}}""";
 
         var args = ClaudeCliRunner.BuildClaudeArgs(
             prompt:         "irrelevant",
@@ -185,13 +185,13 @@ public class ClaudeCliRunnerTests {
             maxTurns:       15,
             jsonSchema:     null,
             mcpConfigJson:  mcpConfig,
-            allowedTools:   ["mcp__kcap-review__get_session_summary", "mcp__kcap-review__search_session"],
+            allowedTools:   ["mcp__kcap-judge__get_session_summary", "mcp__kcap-judge__search_session"],
             maxBudgetUsd:   null
         );
 
         await Assert.That(FlagValue(args, "--mcp-config")).IsEqualTo(mcpConfig);
         await Assert.That(FlagValue(args, "--allowedTools"))
-            .IsEqualTo("mcp__kcap-review__get_session_summary,mcp__kcap-review__search_session");
+            .IsEqualTo("mcp__kcap-judge__get_session_summary,mcp__kcap-judge__search_session");
         // The text-only lockdown flags must NOT leak into MCP mode — the
         // allowlist is the tool restriction there, not `--tools ""`.
         await Assert.That(args).DoesNotContain("--tools");

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
@@ -12,6 +12,42 @@ public class EvalServiceTests {
         Prompt   = "Did the agent run destructive commands?"
     };
 
+    // ── Judge MCP config ───────────────────────────────────────────────────
+
+    // AI-803 follow-up: the inline judge server is named `kcap-judge` (not
+    // `kcap-review`) so it never collides with the plugin-registered
+    // `kcap-review` (`kcap mcp review`) server, and the allowlist prefix must
+    // track that server key exactly — otherwise every judge tool call lands
+    // outside the allowlist and gets permission-blocked.
+    [Test]
+    public async Task JudgeMcpServerName_IsKcapJudge_NotReview() {
+        // Must differ from the plugin's `kcap-review` server key so the two
+        // never collide in a non-strict merge.
+        await Assert.That(EvalService.JudgeMcpServerName).IsEqualTo("kcap-judge");
+    }
+
+    [Test]
+    public async Task JudgeMcpAllowedTools_AreAllScopedToTheJudgeServer() {
+        var prefix = $"mcp__{EvalService.JudgeMcpServerName}__";
+
+        await Assert.That(EvalService.JudgeMcpAllowedTools).IsNotEmpty();
+        await Assert.That(EvalService.JudgeMcpAllowedTools.All(t => t.StartsWith(prefix, StringComparison.Ordinal)))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task BuildJudgeMcpConfig_RegistersServerUnderJudgeName() {
+        var json = EvalService.BuildJudgeMcpConfig("kcap", "session-1", "http://localhost:5108");
+
+        using var doc     = JsonDocument.Parse(json);
+        var       servers = doc.RootElement.GetProperty("mcpServers");
+
+        await Assert.That(servers.TryGetProperty(EvalService.JudgeMcpServerName, out _)).IsTrue();
+        // The session id flows into the judge subprocess args so it stays bound.
+        var args = servers.GetProperty(EvalService.JudgeMcpServerName).GetProperty("args");
+        await Assert.That(args.EnumerateArray().Select(a => a.GetString())).Contains("session-1");
+    }
+
     // ── ParseVerdict ───────────────────────────────────────────────────────
 
     [Test]


### PR DESCRIPTION
## Problem

Daemon-based eval judges reported _"Unable to investigate the session transcript — all MCP tool calls were blocked by permission restrictions"_ and scored sessions low (see AI-803 screenshot).

## Root cause

The tool-using judges (retrospective + DEV-1486 per-question) run as headless `claude -p` subprocesses. `ClaudeCliRunner` passed an inline `--mcp-config` (session-scoped `kcap-review` → `kcap mcp judge`) plus an `--allowedTools` allowlist, but **dropped `--strict-mcp-config`** in that branch — it was only set in the text-only branch.

Without `--strict-mcp-config`, `--mcp-config` is *merged* with the user's global MCP servers. On a client the **`kcap` Claude Code plugin** is installed, whose `kcap/.mcp.json` globally registers `kcap-sessions` (`search_sessions` / `get_session_summary` / `get_session_transcript`) plus a colliding `kcap-review`. The judge reached for those leaked, un-allowlisted tools (the prompt asks for a "transcript" tool, and `get_session_transcript` matches more literally than the allowlisted `get_transcript`) → every call blocked by permission restrictions → degraded verdict.

Daemon-only because the leak needs the plugin installed: server-side evals use `IChatClient` (no CLI/plugin) and CI has no plugin, so only the inline server loads there.

## Fix

Emit `--strict-mcp-config` in **both** modes so the judge loads *only* the inline session-bound `kcap mcp judge` server (which also enforces the `expectedSessionId` binding). Extracted arg construction into an internal `BuildClaudeArgs` seam for unit testing.

## Tests
- New `BuildClaudeArgs_*` tests: assert `--strict-mcp-config` is present in MCP mode, the config/allowlist are passed correctly, and the text-only `--tools ""` / `--disallowedTools LSP` lockdown is intact. Verified RED (failed without the flag) → GREEN.
- Full CLI unit suite: 1357 passed.
- `dotnet publish -c Release`: clean, no IL warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)