### PR TITLE
[AI-829] Instruct the user to authorize in browser during device flow

### DIFF
--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -94,18 +94,32 @@ public static class OAuthLoginFlow {
 
         var copied = Clipboard.TryCopy(device.UserCode);
 
-        await Console.Out.WriteLineAsync();
-        await Console.Out.WriteLineAsync($"  Code: {device.UserCode}{(copied ? "  (copied to clipboard)" : "")}");
-        await Console.Out.WriteLineAsync($"  Open: {device.VerificationUri}");
-        await Console.Out.WriteLineAsync();
+        bool browserOpened;
 
         try {
             Process.Start(new ProcessStartInfo(device.VerificationUri) { UseShellExecute = true });
+            browserOpened = true;
         } catch {
-            /* Browser open is best-effort */
+            // Browser open is best-effort — headless environments (devcontainers, SSH) have none.
+            browserOpened = false;
         }
 
-        Console.Write("Waiting for authorization...");
+        await Console.Out.WriteLineAsync();
+        await Console.Out.WriteLineAsync("To finish signing in to GitHub:");
+        await Console.Out.WriteLineAsync();
+        await Console.Out.WriteLineAsync(
+            browserOpened
+                ? $"  1. Your browser should have opened {device.VerificationUri}"
+                : $"  1. Open {device.VerificationUri} in a browser"
+        );
+
+        if (browserOpened) await Console.Out.WriteLineAsync("     (if it didn't open, go to that URL yourself)");
+
+        await Console.Out.WriteLineAsync($"  2. Enter the code: {device.UserCode}{(copied ? "  (copied to clipboard)" : "")}");
+        await Console.Out.WriteLineAsync("  3. Approve access when GitHub asks.");
+        await Console.Out.WriteLineAsync();
+
+        Console.Write("Waiting for you to authorize...");
 
         while (true) {
             await Task.Delay(TimeSpan.FromSeconds(interval));


### PR DESCRIPTION
## Problem

When `kcap setup` falls back to GitHub **device flow** (e.g. in a headless devcontainer where the browser can't auto-open), the output printed a code, a URL, and `Waiting for authorization...`, then silently accumulated dots. It gave no indication that the user must open the URL, enter the code, and approve access — so it read as if the CLI had hung.

```
  Code: 88D3-7121
  Open: https://github.com/login/device

Waiting for authorization............
```

## Fix

In `RunDeviceFlowAsync` (`src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs`):

- Run the best-effort browser open **first** and record whether it succeeded, so the instructions can adapt.
- Replace the bare `Code:` / `Open:` lines with numbered steps that name each action: open the URL, enter the code, and **approve access**.
- When the browser opened, step 1 says so and offers a manual fallback; in a headless environment (where `Process.Start` throws), it tells the user to open the URL themselves.
- The wait line now reads `Waiting for you to authorize...` so the dots clearly mean we're waiting on the user.

New output (headless case):

```
To finish signing in to GitHub:

  1. Open https://github.com/login/device in a browser
  2. Enter the code: 88D3-7121  (copied to clipboard)
  3. Approve access when GitHub asks.

Waiting for you to authorize...
```

## Notes

- Output-string change only — no command, flag, default, or prerequisite change, so no README sync required.
- No tests assert on this text. Core project builds clean (0 warnings).

Closes AI-829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)