### PR TITLE
Adjust the default visibility wording to make clear it is scoped to account (tenant)

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,12 +476,12 @@ kcap config show    # show current configuration
 kcap config set <key> <value>
 ```
 
-**Default session visibility** controls how your sessions appear to other users. Set during `kcap setup` or change at any time:
+**Default session visibility** controls how your sessions appear to other users in the same Kurrent Capacitor account. Set during `kcap setup` or change at any time:
 
 ```bash
 kcap config set default_visibility private      # only you can see your sessions
 kcap config set default_visibility org_public   # org repos visible, others private (default)
-kcap config set default_visibility public       # all sessions visible to everyone
+kcap config set default_visibility public       # all sessions visible to others in your account
 ```
 
 **Repository exclusions** prevent specific repos from sending any data to the server — hooks are silently skipped, no session is recorded:

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -148,12 +148,12 @@ public static class SetupCommand {
         } else {
             defaultVisibility = AnsiConsole.Prompt(
                 new SelectionPrompt<string>()
-                    .Title("How should your sessions be visible to others by default?")
+                    .Title("Which of your sessions should be readable by other users in the same Kurrent Capacitor account by default?")
                     .AddChoices("org_public", "private", "public")
                     .UseConverter(v => v switch {
                         "private"    => "All private — only you can see your sessions",
                         "org_public" => "Org repos public, others private (default)",
-                        "public"     => "All public — everyone can see all your sessions",
+                        "public"     => "All public — others can see all your sessions",
                         _            => v
                     }));
         }


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Clarify default session visibility prompt as account-scoped (tenant)
<code>✨ Enhancement</code> <code>🕐 Less than 5 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Clarify the setup prompt that “default visibility” applies within the same Capacitor account
  (tenant).
• Adjust the “public” option wording to reflect visibility to other account users, not everyone.
</pre>
</details>

<details>
<summary>High-Level Assessment</summary>

<br/>

Updating the CLI prompt/choice wording in-place is the simplest and least risky way to remove ambiguity without changing configuration semantics.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>SetupCommand.cs</strong> <code>Clarify default visibility prompt/option text as account-scoped</code> <code>+2/-2</code></summary>

<br/>

>Clarify default visibility prompt/option text as account-scoped
>
><pre>
>• Updates the SelectionPrompt title to explicitly state visibility is for other users in the same Kurrent Capacitor account. Tweaks the &quot;public&quot; option description to avoid implying global/public internet visibility.
></pre>
>
><a href='https://github.com/kurrent-io/kcap-cli/pull/144/files#diff-1fed5800bbb471856925cd3a848f8c553f1ec67a6490961dc2a4bc7e8d2f1ba9'>src/Capacitor.Cli/Commands/SetupCommand.cs</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>