### PR TITLE
[AI-830] Echo selected default visibility after interactive setup prompt

### DIFF
--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -156,6 +156,8 @@ public static class SetupCommand {
                         "public"     => "All public — everyone can see all your sessions",
                         _            => v
                     }));
+
+            await Console.Out.WriteLineAsync($"  Default visibility: {defaultVisibility}");
         }
 
         await Console.Out.WriteLineAsync();


### PR DESCRIPTION
## Summary

In `kcap setup` Step 3 (Default session visibility), the interactive branch uses a Spectre `SelectionPrompt` that erases itself from the terminal after selection. The interactive branch never echoed the chosen value, so the "Step 3/5 — Default session visibility" section was left blank in scrollback with no record of what was selected (you had to wait for the final summary's `Visibility` row).

This echoes the chosen value after selection, matching what the `--no-prompt` branch already does (`SetupCommand.cs:147`).

## Test plan

- Run `kcap setup` interactively, select a visibility at Step 3, and confirm the section now shows `Default visibility: <value>` instead of collapsing to blank.

Fixes AI-830.

🤖 Generated with [Claude Code](https://claude.com/claude-code)