### PR TITLE
[AI-836] Tell users to restart their session for live recording after setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The setup wizard walks you through:
 
 When setup finishes, `kcap` sends a best-effort POST to the server's `/api/users/me/cli-setup` endpoint so the dashboard can mark your CLI as registered and surface the import-past-sessions hint. The call is capped at 5 seconds and failures are silent — they do not affect setup completion.
 
+> **Restart your coding agent for live recording to begin.** Hooks only load at session start, so a session that was already running when you ran setup keeps running without them and won't stream live. Start a new session (or `claude --continue`) to pick the hooks up — setup prints this reminder when it installs any hooks. A manual `kcap import` of the in-progress session only yields a frozen snapshot.
+
 Verify with `kcap whoami` and `kcap status`.
 
 For non-interactive environments:

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -39,7 +39,17 @@ internal static class CodingAgentsStep {
             bool CodexSkillsInstalled,
             bool CursorHooksInstalled,
             bool CopilotHooksInstalled
-        );
+        ) {
+        /// <summary>
+        /// True when at least one agent's hooks were installed — i.e. there's a
+        /// session that will start streaming on the agent's next launch. Skills-only
+        /// installs don't count: skills add recall/commands, not the SessionStart hook
+        /// that records transcripts. Co-located with the record so the set stays in sync
+        /// as agents are added (consumers like SetupCommand's restart tip key off this).
+        /// </summary>
+        internal bool AnyHooksInstalled =>
+            ClaudeInstalled || CodexHooksInstalled || CursorHooksInstalled || CopilotHooksInstalled;
+    }
 
     /// <summary>
     /// Drives the agent-detection branches and dispatches to the installer

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -112,6 +112,17 @@ public static class PluginCommand {
                     ? $"Plugin refreshed ({scope}: {settingsPath})"
                     : $"Plugin installed ({scope}: {settingsPath})"
             );
+
+            // AI-836: Claude Code only loads hooks at session start. A fresh install from
+            // inside a running session won't record it live until the user restarts. The
+            // refresh path (npm postinstall) is silent — it isn't an interactive moment and
+            // existing sessions already had hooks, so the reminder would be noise.
+            if (!refreshOnly) {
+                await env.Stdout.WriteLineAsync(
+                    "Live recording begins on a new Claude Code session — restart Claude "
+                  + "(or run `claude --continue`) for the hooks to take effect."
+                );
+            }
         } else {
             if (refreshOnly) return 0;
 

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -214,7 +214,7 @@ public static class SetupCommand {
 
         void WriteLine(string line) => AnsiConsole.MarkupLine(line);
 
-        var _ = await CodingAgentsStep.RunAsync(
+        var installResult = await CodingAgentsStep.RunAsync(
             stepOptions, detected, stepPaths, stepInstallers, PromptYesNo, WriteLine);
 
         // Provider API key handling. kcap scrubs ANTHROPIC_API_KEY / OPENAI_API_KEY
@@ -323,6 +323,13 @@ public static class SetupCommand {
         grid.AddRow("[bold]Config[/]", Markup.Escape(AppConfig.GetConfigPath()));
 
         AnsiConsole.Write(grid);
+
+        // AI-836: hooks only load at coding-agent session start. The common case is a user
+        // running `kcap setup` from inside an already-running session, which won't stream
+        // live until it restarts — so tell them, but only when something was actually
+        // installed (no point promising recording we never wired up).
+        var restartTip = LiveRecordingRestartTip(installResult);
+        if (restartTip is not null) AnsiConsole.MarkupLine($"\n{restartTip}");
 
         // Setup itself is user-scope and works fine outside a repo, but sessions recorded
         // from non-repo directories have no owner/repo/branch/PR enrichment (see
@@ -466,6 +473,28 @@ public static class SetupCommand {
         } catch {
             // Swallow — see method-doc.
         }
+    }
+
+    /// <summary>
+    /// AI-836 — the end-of-setup reminder that live recording only starts on a
+    /// <em>new</em> coding-agent session. Claude Code (and the other agents) load hooks
+    /// at session start, so a session that was already running when setup installed the
+    /// hooks keeps running without them and never streams live. Returns the Spectre-markup
+    /// note when at least one agent's hooks were installed, or <c>null</c> when nothing was
+    /// wired up (so we don't promise recording that can't happen).
+    /// </summary>
+    internal static string? LiveRecordingRestartTip(CodingAgentsStep.Result result) {
+        var anyInstalled = result.ClaudeInstalled
+                        || result.CodexHooksInstalled
+                        || result.CursorHooksInstalled
+                        || result.CopilotHooksInstalled;
+
+        if (!anyInstalled) return null;
+
+        return
+            "[yellow]![/] Live recording begins on a [bold]new[/] coding-agent session — hooks only load at session start.\n"
+          + "  Restart your agent (or run [cyan]claude --continue[/]) to begin streaming; a session that was already\n"
+          + "  running when you ran setup isn't being recorded yet.";
     }
 
     static string? GetArg(string[] args, string name) {

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -484,12 +484,7 @@ public static class SetupCommand {
     /// wired up (so we don't promise recording that can't happen).
     /// </summary>
     internal static string? LiveRecordingRestartTip(CodingAgentsStep.Result result) {
-        var anyInstalled = result.ClaudeInstalled
-                        || result.CodexHooksInstalled
-                        || result.CursorHooksInstalled
-                        || result.CopilotHooksInstalled;
-
-        if (!anyInstalled) return null;
+        if (!result.AnyHooksInstalled) return null;
 
         return
             "[yellow]![/] Live recording begins on a [bold]new[/] coding-agent session — hooks only load at session start.\n"

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandClaudeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandClaudeTests.cs
@@ -104,6 +104,49 @@ public class PluginCommandClaudeTests {
     }
 
     [Test]
+    public async Task Install_claude_fresh_prints_restart_reminder() {
+        using var fakeHome  = new TempDir();
+        using var pluginDir = new TempDir();
+        var       stdout    = new StringWriter();
+
+        var env  = TestEnv(fakeHome.Path, pluginPath: pluginDir.Path, stdout: stdout);
+        var exit = await PluginCommand.HandleAsync(["plugin", "install"], env);
+
+        await Assert.That(exit).IsEqualTo(0);
+
+        var output = stdout.ToString();
+        await Assert.That(output).Contains("Plugin installed");
+        await Assert.That(output).Contains("new Claude Code session");
+        await Assert.That(output).Contains("claude --continue");
+    }
+
+    [Test]
+    public async Task Install_claude_refresh_omits_restart_reminder() {
+        using var fakeHome  = new TempDir();
+        using var pluginDir = new TempDir();
+        var       stdout    = new StringWriter();
+
+        // Seed a pre-marker install so --if-installed proceeds to refresh.
+        var claudeDir = Path.Combine(fakeHome.Path, ".claude");
+        Directory.CreateDirectory(claudeDir);
+        await File.WriteAllTextAsync(Path.Combine(claudeDir, "settings.json"), """
+            {
+              "extraKnownMarketplaces": { "kcap": { "source": { "source": "directory", "path": "/old/path" } } },
+              "enabledPlugins": { "kcap@kcap": true }
+            }
+            """);
+
+        var env  = TestEnv(fakeHome.Path, pluginPath: pluginDir.Path, stdout: stdout);
+        var exit = await PluginCommand.HandleAsync(["plugin", "install", "--if-installed"], env);
+
+        await Assert.That(exit).IsEqualTo(0);
+
+        var output = stdout.ToString();
+        await Assert.That(output).Contains("Plugin refreshed");
+        await Assert.That(output).DoesNotContain("claude --continue");
+    }
+
+    [Test]
     public async Task Remove_claude_deletes_marker() {
         using var fakeHome = new TempDir();
 

--- a/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
@@ -139,6 +139,47 @@ public class SetupCommandTests {
         await Assert.That(reloaded.Profiles["acme"].ServerUrl).IsEqualTo("https://a.example");
     }
 
+    [Test]
+    public async Task LiveRecordingRestartTip_returns_note_when_any_agent_installed() {
+        var result = new CodingAgentsStep.Result(
+            ClaudeInstalled:       true,
+            CodexHooksInstalled:   false,
+            CodexSkillsInstalled:  false,
+            CursorHooksInstalled:  false,
+            CopilotHooksInstalled: false);
+
+        var tip = SetupCommand.LiveRecordingRestartTip(result);
+
+        await Assert.That(tip).IsNotNull();
+        await Assert.That(tip!).Contains("new");
+        await Assert.That(tip!).Contains("claude --continue");
+    }
+
+    [Test]
+    public async Task LiveRecordingRestartTip_note_fires_for_non_claude_agents_too() {
+        var result = new CodingAgentsStep.Result(
+            ClaudeInstalled:       false,
+            CodexHooksInstalled:   false,
+            CodexSkillsInstalled:  false,
+            CursorHooksInstalled:  false,
+            CopilotHooksInstalled: true);
+
+        await Assert.That(SetupCommand.LiveRecordingRestartTip(result)).IsNotNull();
+    }
+
+    [Test]
+    public async Task LiveRecordingRestartTip_is_null_when_nothing_installed() {
+        // Skills-only (e.g. all agents declined) shouldn't promise live recording.
+        var result = new CodingAgentsStep.Result(
+            ClaudeInstalled:       false,
+            CodexHooksInstalled:   false,
+            CodexSkillsInstalled:  true,
+            CursorHooksInstalled:  false,
+            CopilotHooksInstalled: false);
+
+        await Assert.That(SetupCommand.LiveRecordingRestartTip(result)).IsNull();
+    }
+
     sealed class TempDir : IDisposable {
         public string Path { get; } = System.IO.Path.Combine(
             System.IO.Path.GetTempPath(),

--- a/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
@@ -168,12 +168,13 @@ public class SetupCommandTests {
     }
 
     [Test]
-    public async Task LiveRecordingRestartTip_is_null_when_nothing_installed() {
-        // Skills-only (e.g. all agents declined) shouldn't promise live recording.
+    public async Task LiveRecordingRestartTip_is_null_when_no_hooks_installed() {
+        // No hooks wired up (e.g. every agent declined or none detected) — don't
+        // promise live recording that won't happen.
         var result = new CodingAgentsStep.Result(
             ClaudeInstalled:       false,
             CodexHooksInstalled:   false,
-            CodexSkillsInstalled:  true,
+            CodexSkillsInstalled:  false,
             CursorHooksInstalled:  false,
             CopilotHooksInstalled: false);
 


### PR DESCRIPTION
## Problem

When `kcap setup` (or `kcap plugin install`) installs the Claude Code plugin/hooks into a coding-agent session that is **already running**, recording doesn't start for that session — Claude Code only loads hooks at session start, so the SessionStart hook (which spawns the watcher and streams the transcript) never fires until the user starts a new session or `--continue`s. Setup gave no indication of this, so users reasonably assumed their current session was being recorded live when it wasn't (at best a manual `kcap import` yields a frozen snapshot).

Fixes [AI-836](https://linear.app/kurrent/issue/AI-836).

## Changes

- **`SetupCommand`** now prints a clear end-of-setup reminder when any agent hooks were installed:
  > **!** Live recording begins on a **new** coding-agent session — hooks only load at session start. Restart your agent (or run `claude --continue`) to begin streaming; a session that was already running when you ran setup isn't being recorded yet.

  The logic is a testable pure helper `LiveRecordingRestartTip(Result)` that returns `null` when nothing was actually installed (skills-only / all declined), so we never promise recording that can't happen.
- **`kcap plugin install`** (Claude path) prints the same reminder on a fresh install. The npm-postinstall refresh path (`--if-installed`) stays silent — it isn't interactive and existing sessions already had hooks.
- **README** getting-started gains a matching callout (per the repo's README-sync rule), consistent with the existing Copilot restart note.

The pre-existing inline notes (Copilot "restart any running copilot session", Codex trust-prompt hint) were left untouched; the unified end-of-setup reminder sits on top and covers Claude — the agent in the bug report — plus all others.

## Testing

- 3 new cases in `SetupCommandTests` (note fires for Claude, fires for non-Claude agents, null when nothing installed).
- 2 new cases in `PluginCommandClaudeTests` (fresh install prints reminder, refresh omits it).
- Full unit suite: 1407 passed, 0 failed.
- `dotnet publish -c Release`: no IL2026/IL3050 AOT warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)