### PR TITLE
[AI-841][AI-842] Fix daemon SignalR UI-broadcast flood and garbled terminal mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,17 @@ KCAP_CLAUDE_PATH=/opt/claude/bin/claude kcap daemon
 KCAP_CODEX_PATH=/opt/codex/bin/codex  kcap daemon
 ```
 
+#### Daemon log verbosity
+
+The daemon logs at `Information` by default. Raise the level for transport diagnostics — for example, per-tick `DaemonPing` round-trip times (logged at `Debug`) are useful for telling whether SignalR reconnects are caused by network/proxy latency. Set it either way:
+
+```bash
+kcap daemon start --log-level debug        # foreground or with -d; forwarded to the daemon
+KCAP_DAEMON_LOG_LEVEL=debug kcap daemon    # env var; read directly, works in any launch mode (service, container)
+```
+
+Accepted values: `trace`, `debug`, `information` (default), `warning`, `error`, `critical`, `none`. The `--log-level` flag wins over the env var when both are set. `Debug` is verbose — it also enables the SignalR client's framework logs — so use it for a diagnostic window rather than steady state.
+
 ### Repository paths
 
 Manage known repo paths for the agent launch dialog. Repos are automatically added when agents are launched, but you can also manage the list manually:

--- a/src/Capacitor.Cli.Core/Resources/help-daemon.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-daemon.txt
@@ -15,6 +15,10 @@ Options for start:
   --server-url <url>      Server URL
   --max-agents <n>        Max concurrent hosted coding agents (default: 5)
   --log-file <path>       Log to file instead of console
+  --log-level <level>     Log verbosity: trace|debug|information|warning|error|
+                          critical|none (default: information). Also settable via
+                          KCAP_DAEMON_LOG_LEVEL; the flag wins when both are set.
+                          Use debug for transport diagnostics (e.g. DaemonPing RTT).
   -d, --detach            Run in background (logs to file automatically)
 
 Options for stop:

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -25,8 +25,9 @@ public static partial class DaemonRunner {
             ?.InformationalVersion ?? "unknown";
 
     public static async Task<int> RunAsync(string[] args) {
-        string? logFile = null;
-        var     config  = new DaemonConfig();
+        string?    logFile     = null;
+        LogLevel?  logLevelArg = null;
+        var        config      = new DaemonConfig();
 
         // Resolve server URL + active profile. The CLI does this in its own
         // Program.cs, but the daemon is a separate process so its statics start
@@ -41,6 +42,7 @@ public static partial class DaemonRunner {
         for (var i = 0; i < args.Length - 1; i++) {
             switch (args[i]) {
                 case "--log-file": logFile = args[++i]; break;
+                case "--log-level": logLevelArg = ParseLogLevel(args[++i]); break;
                 case "--max-agents" when int.TryParse(args[i + 1], out var n) && n >= 1:
                     config.MaxConcurrentAgents = n;
                     i++;
@@ -57,11 +59,20 @@ public static partial class DaemonRunner {
         var hostArgs = Array.Empty<string>();
         var builder  = Host.CreateApplicationBuilder(hostArgs);
 
-        // Configure logging: file when detached, console when foreground
+        // Configure logging: file when detached, console when foreground.
+        // Minimum level defaults to Information; raise verbosity for transport
+        // diagnostics (e.g. per-tick DaemonPing RTT, which logs at Debug) via
+        // --log-level or KCAP_DAEMON_LOG_LEVEL=debug. The --log-level arg wins
+        // over the env var when both are set.
+        var minLevel = logLevelArg
+                    ?? ParseLogLevel(Environment.GetEnvironmentVariable("KCAP_DAEMON_LOG_LEVEL"))
+                    ?? LogLevel.Information;
+
         builder.Logging.ClearProviders();
+        builder.Logging.SetMinimumLevel(minLevel);
 
         if (logFile is not null) {
-            builder.Logging.AddProvider(new RollingFileLoggerProvider(logFile));
+            builder.Logging.AddProvider(new RollingFileLoggerProvider(logFile, minLevel: minLevel));
         } else {
             builder.Logging.AddSimpleConsole(opts => {
                     opts.TimestampFormat = "yyyy-MM-dd HH:mm:ss.fff ";
@@ -275,6 +286,23 @@ public static partial class DaemonRunner {
         // this apart from a normal Ctrl+C exit.
         return nameInUse ? 3 : 0;
     }
+
+    /// <summary>
+    /// Parses a daemon log-level string (case-insensitive, e.g. "debug",
+    /// "trace", "warning") to a <see cref="LogLevel"/>. Returns null for a
+    /// null/blank/unrecognised value so callers can fall through to the next
+    /// source or the Information default rather than silently logging nothing.
+    /// </summary>
+    internal static LogLevel? ParseLogLevel(string? value) => value?.Trim().ToLowerInvariant() switch {
+        "trace" or "trce"              => LogLevel.Trace,
+        "debug" or "dbug"              => LogLevel.Debug,
+        "information" or "info"        => LogLevel.Information,
+        "warning" or "warn"            => LogLevel.Warning,
+        "error" or "fail"              => LogLevel.Error,
+        "critical" or "crit"           => LogLevel.Critical,
+        "none"                         => LogLevel.None,
+        _                              => null
+    };
 
     [LoggerMessage(Level = LogLevel.Information, Message = "kcap daemon '{Name}' starting, connecting to {ServerUrl}")]
     static partial void LogDaemonStarting(ILogger logger, string name, string serverUrl);

--- a/src/Capacitor.Cli.Daemon/RollingFileLoggerProvider.cs
+++ b/src/Capacitor.Cli.Daemon/RollingFileLoggerProvider.cs
@@ -7,16 +7,18 @@ namespace Capacitor.Cli.Daemon;
 /// Keeps one current file and one rolled-over backup (.1).
 /// </summary>
 sealed class RollingFileLoggerProvider : ILoggerProvider {
-    readonly string _path;
-    readonly long   _maxSize;
-    readonly Lock   _lock = new();
-    StreamWriter?   _writer;
+    readonly string   _path;
+    readonly long     _maxSize;
+    readonly LogLevel _minLevel;
+    readonly Lock     _lock = new();
+    StreamWriter?     _writer;
 
     const long DefaultMaxSize = 10 * 1024 * 1024; // 10 MB
 
-    public RollingFileLoggerProvider(string path, long maxSize = DefaultMaxSize) {
-        _path    = path;
-        _maxSize = maxSize;
+    public RollingFileLoggerProvider(string path, long maxSize = DefaultMaxSize, LogLevel minLevel = LogLevel.Information) {
+        _path     = path;
+        _maxSize  = maxSize;
+        _minLevel = minLevel;
 
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
 
@@ -25,7 +27,7 @@ sealed class RollingFileLoggerProvider : ILoggerProvider {
         };
     }
 
-    public ILogger CreateLogger(string categoryName) => new FileLogger(this, categoryName);
+    public ILogger CreateLogger(string categoryName) => new FileLogger(this, categoryName, _minLevel);
 
     void Write(string category, LogLevel level, string message) {
         lock (_lock) {
@@ -82,9 +84,9 @@ sealed class RollingFileLoggerProvider : ILoggerProvider {
         }
     }
 
-    sealed class FileLogger(RollingFileLoggerProvider provider, string category) : ILogger {
+    sealed class FileLogger(RollingFileLoggerProvider provider, string category, LogLevel minLevel) : ILogger {
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-        public bool         IsEnabled(LogLevel        logLevel)                     => logLevel >= LogLevel.Information;
+        public bool         IsEnabled(LogLevel        logLevel)                     => logLevel >= minLevel && logLevel != LogLevel.None;
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) {
             if (!IsEnabled(logLevel)) return;

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -800,10 +800,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     await _server.AgentRegisteredAsync(agent.Id, agent.Prompt, agent.Model, agent.Effort, agent.RepoPath);
                     await _server.AgentStatusChangedAsync(agent.Id, agent.Status, agent.SessionId);
 
-                    // Replay terminal buffer so the UI has terminal history
-                    foreach (var base64 in agent.OutputBuffer.GetAll().Select(Convert.ToBase64String)) {
-                        await _server.SendTerminalOutputAsync(agent.Id, base64);
-                    }
+                    // AI-842: do NOT replay the full output buffer here. The old
+                    // replay re-sent the entire 2 MB ring on every reconnect, which
+                    // the server appended to its own buffer and live-broadcast on
+                    // top of the current screen — duplicated, and interleaved with
+                    // the read loop's concurrent live sends, producing the garbled
+                    // Terminal tab. The server retains its own per-agent buffer
+                    // across a daemon rebind (it only clears on reconcile-to-Failed),
+                    // so late-joining web clients still get history via the server's
+                    // SubscribeToTerminal replay. Continuity of in-flight output is
+                    // handled by TerminalOutputSender, which holds unsent chunks
+                    // while the transport is down and flushes them, in order, once
+                    // the connection is back.
                 } catch (Exception ex) {
                     LogReRegisterFailed(ex, agent.Id);
                 }

--- a/src/Capacitor.Cli.Daemon/Services/DaemonHeartbeatLoop.cs
+++ b/src/Capacitor.Cli.Daemon/Services/DaemonHeartbeatLoop.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 
@@ -22,7 +23,23 @@ internal interface IDaemonHeartbeatPort {
     Task       ForceReconnectAsync();
 }
 
-internal sealed class DaemonHeartbeatLoop(IDaemonHeartbeatPort port, TimeSpan pingDeadline, ILogger logger) {
+internal sealed class DaemonHeartbeatLoop(
+        IDaemonHeartbeatPort port,
+        TimeSpan             pingDeadline,
+        ILogger              logger,
+        TimeSpan?            slowPingThreshold = null
+    ) {
+    /// <summary>
+    /// Round-trip time at or above which a <c>DaemonPing</c> is logged as a
+    /// warning rather than at debug (AI-840 diagnostics). Defaults to half the
+    /// per-tick deadline: pings that take this long aren't yet failing, but the
+    /// transport latency is climbing toward the deadline that triggers a forced
+    /// reconnect, so surfacing them shows degradation building up *before* the
+    /// connection actually flaps — the key signal for deciding whether the
+    /// cloudflared tunnel (vs the server itself) is the latency source.
+    /// </summary>
+    readonly TimeSpan _slowPingThreshold = slowPingThreshold ?? TimeSpan.FromTicks(pingDeadline.Ticks / 2);
+
     /// <summary>
     /// Total — never throws (modulo outer cancellation, which is expected at
     /// shutdown). The loop in <c>AgentOrchestrator.RunDaemonHeartbeatLoopAsync</c>
@@ -32,16 +49,33 @@ internal sealed class DaemonHeartbeatLoop(IDaemonHeartbeatPort port, TimeSpan pi
     /// <see cref="IDaemonHeartbeatPort.ForceReconnectAsync"/>) are individually
     /// guarded since both ultimately call into SignalR (<c>InvokeAsync</c> /
     /// <c>StopAsync</c>) and can throw on transient transport state.
+    ///
+    /// Each tick also records the <c>DaemonPing</c> round-trip time and the
+    /// cause of any forced reconnect, so the daemon log carries the data needed
+    /// to characterise transport stability (RTT distribution over time, and
+    /// whether reconnects are deadline-exceeded vs ping-threw vs slot-displaced).
     /// </summary>
     public async Task TickAsync(CancellationToken ct) {
+        var sw = Stopwatch.StartNew();
+
         try {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(pingDeadline);
 
             var alive = await port.PingAsync(cts.Token);
+            sw.Stop();
+
+            if (sw.Elapsed >= _slowPingThreshold) {
+                logger.LogWarning(
+                    "Heartbeat: DaemonPing slow — {RttMs:F0} ms RTT (deadline {DeadlineMs:F0} ms); transport latency climbing toward a forced reconnect",
+                    sw.Elapsed.TotalMilliseconds, pingDeadline.TotalMilliseconds
+                );
+            } else {
+                logger.LogDebug("Heartbeat: DaemonPing ok — {RttMs:F0} ms RTT", sw.Elapsed.TotalMilliseconds);
+            }
 
             if (!alive) {
-                logger.LogWarning("Heartbeat: server does not recognise this connection — re-registering daemon");
+                logger.LogWarning("Heartbeat: server does not recognise this connection (cause=slot_displaced) — re-registering daemon");
                 await SafeReRegisterAsync();
             }
         } catch (OperationCanceledException) when (!ct.IsCancellationRequested) {
@@ -49,12 +83,16 @@ internal sealed class DaemonHeartbeatLoop(IDaemonHeartbeatPort port, TimeSpan pi
             // WebSocket is hung; force WithAutomaticReconnect by stopping
             // the hub and letting OnClosed → ConnectWithRetryAsync rebuild
             // it under a fresh conn id.
-            logger.LogWarning("Heartbeat: ping exceeded deadline — forcing reconnect");
+            logger.LogWarning(
+                "Heartbeat: DaemonPing exceeded {DeadlineMs:F0} ms deadline (cause=ping_deadline_exceeded) — forcing reconnect",
+                pingDeadline.TotalMilliseconds
+            );
             await SafeForceReconnectAsync();
         } catch (OperationCanceledException) {
             // Outer cancellation (process shutting down) — let the loop exit.
         } catch (Exception ex) {
-            logger.LogWarning(ex, "Heartbeat: ping threw — forcing reconnect");
+            sw.Stop();
+            logger.LogWarning(ex, "Heartbeat: DaemonPing threw after {RttMs:F0} ms (cause=ping_threw) — forcing reconnect", sw.Elapsed.TotalMilliseconds);
             await SafeForceReconnectAsync();
         }
     }

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -128,6 +128,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
 
         _terminalSender = new TerminalOutputSender(
             (agentId, base64, ct) => _hub.SendAsync("SendTerminalOutput", new TerminalOutput(agentId, base64), ct),
+            isConnected: () => _hub.State == HubConnectionState.Connected,
             logger
         );
     }
@@ -170,8 +171,9 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     volatile bool     _disposed;
     Task?             _eventProcessorTask;
 
-    readonly TerminalOutputSender _terminalSender;
-    Task?                         _terminalSenderTask;
+    readonly TerminalOutputSender    _terminalSender;
+    Task?                            _terminalSenderTask;
+    CancellationTokenSource?         _terminalSenderCts;
 
     /// <summary>
     /// <see cref="Stopwatch.GetTimestamp"/> taken each time the hub reaches a
@@ -208,7 +210,11 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public async Task ConnectAsync(CancellationToken ct) {
         _ct                 = ct;
         _eventProcessorTask = ProcessEventQueueAsync(ct);
-        _terminalSenderTask = _terminalSender.RunAsync(ct);
+        // Linked to ct but separately cancellable so DisposeAsync can stop the
+        // sender even if the caller's token never fires — otherwise a chunk held
+        // through an outage could block disposal.
+        _terminalSenderCts  = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _terminalSenderTask = _terminalSender.RunAsync(_terminalSenderCts.Token);
         await ConnectWithRetryAsync(ct);
     }
 
@@ -559,10 +565,17 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             await _eventProcessorTask;
         }
 
+        // Cancel the sender's own token so a chunk being held through an outage
+        // can't block disposal regardless of the caller's token state.
+        if (_terminalSenderCts is not null) {
+            await _terminalSenderCts.CancelAsync();
+        }
+
         if (_terminalSenderTask is not null) {
             await _terminalSenderTask;
         }
 
+        _terminalSenderCts?.Dispose();
         _httpClient?.Dispose();
         await _hub.DisposeAsync();
     }

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
@@ -173,6 +174,16 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     Task?                         _terminalSenderTask;
 
     /// <summary>
+    /// <see cref="Stopwatch.GetTimestamp"/> taken each time the hub reaches a
+    /// connected+registered state. Logged as connection uptime in
+    /// <see cref="OnClosed"/> so the daemon log shows how long each connection
+    /// survived — the cadence that distinguishes a steady transport from one
+    /// flapping every few seconds (AI-840 diagnostics). Zero until the first
+    /// successful connect.
+    /// </summary>
+    long _connectedTimestamp;
+
+    /// <summary>
     /// Sentinel prefix the server (<c>DaemonRegistry.NameInUseErrorCode</c>)
     /// embeds in the <see cref="Microsoft.AspNetCore.SignalR.HubException"/>
     /// message when <c>DaemonConnect</c> is rejected because another live
@@ -210,6 +221,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                 LogConnecting(_config.ServerUrl);
                 await _hub.StartAsync(ct);
                 await RegisterDaemon();
+                _connectedTimestamp = Stopwatch.GetTimestamp();
                 LogConnected(_config.Name);
 
                 return;
@@ -239,7 +251,8 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             return;
         }
 
-        LogConnectionClosed(ex);
+        var uptimeSeconds = _connectedTimestamp == 0 ? 0 : Stopwatch.GetElapsedTime(_connectedTimestamp).TotalSeconds;
+        LogConnectionClosed(ex, uptimeSeconds);
 
         try {
             await ConnectWithRetryAsync(_ct);
@@ -301,6 +314,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     async Task OnReconnected(string? connectionId) {
         LogReconnected();
         await RegisterDaemon();
+        _connectedTimestamp = Stopwatch.GetTimestamp();
         OnReconnectedCallback?.Invoke();
     }
 
@@ -565,8 +579,8 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     [LoggerMessage(Level = LogLevel.Warning, Message = "Connection attempt {Attempt} failed, retrying in {Delay}s")]
     partial void LogConnectionAttemptFailed(Exception ex, int attempt, int delay);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "SignalR connection closed, will reconnect")]
-    partial void LogConnectionClosed(Exception? ex);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "SignalR connection closed after {UptimeSeconds:F1}s uptime, will reconnect")]
+    partial void LogConnectionClosed(Exception? ex, double uptimeSeconds);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Reconnected to server, re-registering daemon")]
     partial void LogReconnected();

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -120,13 +120,57 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         _hub.On<FindRepoForRemoteRequest, string[]>("FindRepoForRemote",
             req => FindRepoForRemoteHandler?.Invoke(req) ?? Task.FromResult(Array.Empty<string>()));
 
+        RegisterUiBroadcastSinks();
+
         _hub.Reconnected += OnReconnected;
         _hub.Closed      += OnClosed;
+
+        _terminalSender = new TerminalOutputSender(
+            (agentId, base64, ct) => _hub.SendAsync("SendTerminalOutput", new TerminalOutput(agentId, base64), ct),
+            logger
+        );
+    }
+
+    /// <summary>
+    /// Registers no-op client handlers for the UI-only broadcasts a daemon can
+    /// receive on its hub connection (AI-841). The server adds every
+    /// authenticated connection — daemons included — to its <c>org-members</c>
+    /// UI group in <c>CapacitorHub.OnConnectedAsync</c>, and only removes the
+    /// daemon again inside <c>DaemonConnect</c>. In the window between the
+    /// WebSocket connecting and <c>DaemonConnect</c> completing — which recurs on
+    /// every (re)connect — the daemon receives these broadcasts with no matching
+    /// handler, and SignalR's <c>JsonHubProtocol</c> logs a "Failed to find
+    /// handler" warning plus an argument-bind failure for each one ("Invocation
+    /// provides N argument(s) but target expects 0"). Registering sinks at the
+    /// server's current arities, with <see cref="JsonElement"/> parameters that
+    /// bind to any payload shape, silences the flood even against an
+    /// already-deployed server. The permanent fix is server-side: never add a
+    /// daemon connection to the UI group in the first place.
+    /// </summary>
+    void RegisterUiBroadcastSinks() {
+        static Task Sink() => Task.CompletedTask;
+
+        _hub.On("AgentInstancesChanged", Sink);
+        _hub.On("DaemonsChanged",        Sink);
+        _hub.On("WelcomeStateChanged",   Sink);
+
+        _hub.On<JsonElement>("ActiveSessionAdded",   _ => Sink());
+        _hub.On<JsonElement>("ActiveSessionChanged", _ => Sink());
+        _hub.On<JsonElement>("ActiveSessionRemoved", _ => Sink());
+
+        _hub.On<JsonElement, JsonElement>("LaunchFailed",        (_, _) => Sink());
+        _hub.On<JsonElement, JsonElement>("PermissionResponded", (_, _) => Sink());
+
+        _hub.On<JsonElement, JsonElement, JsonElement, JsonElement, JsonElement>(
+            "PermissionRequested", (_, _, _, _, _) => Sink());
     }
 
     CancellationToken _ct;
     volatile bool     _disposed;
     Task?             _eventProcessorTask;
+
+    readonly TerminalOutputSender _terminalSender;
+    Task?                         _terminalSenderTask;
 
     /// <summary>
     /// Sentinel prefix the server (<c>DaemonRegistry.NameInUseErrorCode</c>)
@@ -153,6 +197,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public async Task ConnectAsync(CancellationToken ct) {
         _ct                 = ct;
         _eventProcessorTask = ProcessEventQueueAsync(ct);
+        _terminalSenderTask = _terminalSender.RunAsync(ct);
         await ConnectWithRetryAsync(ct);
     }
 
@@ -375,8 +420,18 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             ct
         );
 
-    public virtual Task SendTerminalOutputAsync(string agentId, string base64Data)
-        => _hub.SendAsync("SendTerminalOutput", new TerminalOutput(agentId, base64Data), cancellationToken: _ct);
+    /// <summary>
+    /// Queues a base64 PTY chunk for the hosted-agent terminal mirror. AI-842:
+    /// chunks are drained by <see cref="TerminalOutputSender"/>'s single ordered
+    /// loop instead of being fired at <c>SendAsync</c> fire-and-forget, so they
+    /// reach the server in PTY order and a chunk sent while the transport is down
+    /// is held and retried rather than silently lost mid-escape-sequence.
+    /// </summary>
+    public virtual Task SendTerminalOutputAsync(string agentId, string base64Data) {
+        _terminalSender.Enqueue(agentId, base64Data);
+
+        return Task.CompletedTask;
+    }
 
     // ── Eval progress events (DEV-1440) ────────────────────────────────────
 
@@ -484,9 +539,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public async ValueTask DisposeAsync() {
         _disposed = true;
         _eventChannel.Writer.TryComplete();
+        _terminalSender.Complete();
 
         if (_eventProcessorTask is not null) {
             await _eventProcessorTask;
+        }
+
+        if (_terminalSenderTask is not null) {
+            await _terminalSenderTask;
         }
 
         _httpClient?.Dispose();

--- a/src/Capacitor.Cli.Daemon/Services/TerminalOutputSender.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TerminalOutputSender.cs
@@ -1,0 +1,84 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Serialises hosted-agent terminal output onto a single ordered channel so the
+/// stream the web "Terminal" tab renders is delivered in PTY order and survives a
+/// flapping SignalR connection without corruption (AI-842).
+///
+/// The pre-AI-842 path fired every PTY chunk at <c>HubConnection.SendAsync</c>
+/// with a discarded task. While the hub was disconnected those sends faulted
+/// silently — dropping bytes mid-ANSI-escape-sequence — and the read loop's
+/// concurrent fire-and-forget sends could interleave out of order. A single
+/// consumer draining one channel fixes both: chunks go out strictly in the
+/// order they were produced, and a send that throws because the transport is
+/// down is retried with the SAME chunk (head-of-line, preserving order) until
+/// it lands or the daemon shuts down. The channel is bounded with
+/// <c>DropOldest</c> so a prolonged outage caps memory rather than growing
+/// without bound — mirroring the agent-run event queue in
+/// <see cref="ServerConnection"/>.
+/// </summary>
+internal sealed partial class TerminalOutputSender {
+    readonly Channel<(string AgentId, string Base64Data)> _channel;
+    readonly Func<string, string, CancellationToken, Task> _send;
+    readonly ILogger                                       _logger;
+    readonly TimeSpan                                      _retryDelay;
+
+    public TerminalOutputSender(
+            Func<string, string, CancellationToken, Task> send,
+            ILogger                                        logger,
+            int                                            capacity   = 2000,
+            TimeSpan?                                      retryDelay = null
+        ) {
+        _send       = send;
+        _logger     = logger;
+        _retryDelay = retryDelay ?? TimeSpan.FromMilliseconds(500);
+        _channel = Channel.CreateBounded<(string, string)>(
+            new BoundedChannelOptions(capacity) { FullMode = BoundedChannelFullMode.DropOldest }
+        );
+    }
+
+    /// <summary>Queues a base64 PTY chunk for in-order delivery. Never blocks.</summary>
+    public void Enqueue(string agentId, string base64Data)
+        => _channel.Writer.TryWrite((agentId, base64Data));
+
+    /// <summary>Signals no more chunks will be queued so <see cref="RunAsync"/> can drain and exit.</summary>
+    public void Complete() => _channel.Writer.TryComplete();
+
+    /// <summary>
+    /// Drains the channel, sending each chunk in order. A send that throws is
+    /// retried with the same chunk after <c>retryDelay</c> so a transport outage
+    /// holds the stream in place rather than dropping bytes; cancellation (daemon
+    /// shutdown) ends the loop even while a chunk is being retried.
+    /// </summary>
+    public async Task RunAsync(CancellationToken ct) {
+        try {
+            await foreach (var (agentId, base64) in _channel.Reader.ReadAllAsync(ct)) {
+                while (true) {
+                    try {
+                        await _send(agentId, base64, ct);
+
+                        break;
+                    } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                        return;
+                    } catch (Exception ex) {
+                        LogSendRetry(ex, agentId, _retryDelay.TotalSeconds);
+
+                        try {
+                            await Task.Delay(_retryDelay, ct);
+                        } catch (OperationCanceledException) {
+                            return;
+                        }
+                    }
+                }
+            }
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            // Graceful shutdown — channel read cancelled.
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Terminal output send for agent {AgentId} failed (transport down?), retrying in {Delay}s")]
+    partial void LogSendRetry(Exception ex, string agentId, double delay);
+}

--- a/src/Capacitor.Cli.Daemon/Services/TerminalOutputSender.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TerminalOutputSender.cs
@@ -23,18 +23,21 @@ namespace Capacitor.Cli.Daemon.Services;
 internal sealed partial class TerminalOutputSender {
     readonly Channel<(string AgentId, string Base64Data)> _channel;
     readonly Func<string, string, CancellationToken, Task> _send;
+    readonly Func<bool>                                   _isConnected;
     readonly ILogger                                       _logger;
     readonly TimeSpan                                      _retryDelay;
 
     public TerminalOutputSender(
             Func<string, string, CancellationToken, Task> send,
-            ILogger                                        logger,
-            int                                            capacity   = 2000,
-            TimeSpan?                                      retryDelay = null
+            Func<bool>                                    isConnected,
+            ILogger                                       logger,
+            int                                           capacity   = 2000,
+            TimeSpan?                                     retryDelay = null
         ) {
-        _send       = send;
-        _logger     = logger;
-        _retryDelay = retryDelay ?? TimeSpan.FromMilliseconds(500);
+        _send        = send;
+        _isConnected = isConnected;
+        _logger      = logger;
+        _retryDelay  = retryDelay ?? TimeSpan.FromMilliseconds(500);
         _channel = Channel.CreateBounded<(string, string)>(
             new BoundedChannelOptions(capacity) { FullMode = BoundedChannelFullMode.DropOldest }
         );
@@ -48,10 +51,16 @@ internal sealed partial class TerminalOutputSender {
     public void Complete() => _channel.Writer.TryComplete();
 
     /// <summary>
-    /// Drains the channel, sending each chunk in order. A send that throws is
-    /// retried with the same chunk after <c>retryDelay</c> so a transport outage
-    /// holds the stream in place rather than dropping bytes; cancellation (daemon
-    /// shutdown) ends the loop even while a chunk is being retried.
+    /// Drains the channel, sending each chunk in order. A send that fails
+    /// <em>while the transport is down</em> is retried with the same chunk after
+    /// <c>retryDelay</c>, so a reconnect outage holds the stream in place rather
+    /// than dropping bytes mid-escape-sequence. A send that fails <em>while the
+    /// hub reports Connected</em> won't succeed on blind retry (it's not a
+    /// transport-down condition), so that chunk is logged and dropped and the
+    /// loop moves on — this is the safety valve that stops one stuck chunk from
+    /// wedging the single shared loop (and, with it, <c>DisposeAsync</c>) for
+    /// every later chunk. Cancellation (daemon shutdown) ends the loop even
+    /// while a chunk is being held for retry.
     /// </summary>
     public async Task RunAsync(CancellationToken ct) {
         try {
@@ -64,6 +73,15 @@ internal sealed partial class TerminalOutputSender {
                     } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
                         return;
                     } catch (Exception ex) {
+                        if (_isConnected()) {
+                            // Connected yet the send threw — not a transport
+                            // outage. Retrying the same chunk would spin forever,
+                            // so drop it and continue rather than block the loop.
+                            LogSendDropped(ex, agentId);
+
+                            break;
+                        }
+
                         LogSendRetry(ex, agentId, _retryDelay.TotalSeconds);
 
                         try {
@@ -79,6 +97,9 @@ internal sealed partial class TerminalOutputSender {
         }
     }
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Terminal output send for agent {AgentId} failed (transport down?), retrying in {Delay}s")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Terminal output send for agent {AgentId} failed while transport down, holding and retrying in {Delay}s")]
     partial void LogSendRetry(Exception ex, string agentId, double delay);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Terminal output send for agent {AgentId} failed while connected — dropping chunk and continuing")]
+    partial void LogSendDropped(Exception ex, string agentId);
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonHeartbeatLoopTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonHeartbeatLoopTests.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit.Daemon;
@@ -46,6 +47,76 @@ public class DaemonHeartbeatLoopTests {
 
     static DaemonHeartbeatLoop CreateLoop(FakePort port, TimeSpan? deadline = null)
         => new(port, deadline ?? TimeSpan.FromSeconds(10), NullLogger.Instance);
+
+    /// <summary>Minimal <see cref="ILogger"/> that records the rendered message and level of every entry.</summary>
+    sealed class CaptureLogger : ILogger {
+        public readonly List<(LogLevel Level, string Message)> Entries = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool         IsEnabled(LogLevel logLevel)                            => true;
+
+        public void Log<TState>(LogLevel level, EventId id, TState state, Exception? ex, Func<TState, Exception?, string> formatter)
+            => Entries.Add((level, formatter(state, ex)));
+    }
+
+    [Test]
+    public async Task Tick_HealthyPing_RecordsRttAtDebug() {
+        var logger = new CaptureLogger();
+        var port   = new FakePort { PingHandler = _ => Task.FromResult(true) };
+        var loop   = new DaemonHeartbeatLoop(port, TimeSpan.FromSeconds(5), logger);
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.ForceReconnectCalls).IsEqualTo(0);
+        await Assert.That(logger.Entries).Contains(e => e.Level == LogLevel.Debug && e.Message.Contains("DaemonPing ok") && e.Message.Contains("RTT"));
+    }
+
+    [Test]
+    public async Task Tick_SlowButSuccessfulPing_WarnsBeforeDeadlineWithoutReconnecting() {
+        var logger = new CaptureLogger();
+
+        // Ping succeeds, but takes longer than the slow threshold (and less than
+        // the deadline) — the loop must warn about climbing latency yet NOT force
+        // a reconnect, since the ping still came back in time.
+        var port = new FakePort {
+            PingHandler = async _ => {
+                await Task.Delay(60);
+
+                return true;
+            }
+        };
+        var loop = new DaemonHeartbeatLoop(
+            port,
+            pingDeadline: TimeSpan.FromSeconds(5),
+            logger,
+            slowPingThreshold: TimeSpan.FromMilliseconds(20)
+        );
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.ForceReconnectCalls).IsEqualTo(0);
+        await Assert.That(port.ReRegisterCalls).IsEqualTo(0);
+        await Assert.That(logger.Entries).Contains(e => e.Level == LogLevel.Warning && e.Message.Contains("DaemonPing slow"));
+    }
+
+    [Test]
+    public async Task Tick_DeadlineExceeded_LogsCauseAndForcesReconnect() {
+        var logger = new CaptureLogger();
+        var port = new FakePort {
+            PingHandler = ct => {
+                var tcs = new TaskCompletionSource<bool>();
+                ct.Register(() => tcs.TrySetCanceled(ct));
+
+                return tcs.Task;
+            }
+        };
+        var loop = new DaemonHeartbeatLoop(port, TimeSpan.FromMilliseconds(50), logger);
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.ForceReconnectCalls).IsEqualTo(1);
+        await Assert.That(logger.Entries).Contains(e => e.Message.Contains("cause=ping_deadline_exceeded"));
+    }
 
     [Test]
     public async Task Tick_ServerSaysHealthy_DoesNothing() {

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLogLevelTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLogLevelTests.cs
@@ -1,0 +1,74 @@
+using Capacitor.Cli.Daemon;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// Covers the daemon log-verbosity toggle (AI-840 diagnostics): the
+/// <c>--log-level</c> / <c>KCAP_DAEMON_LOG_LEVEL</c> string parse, and that the
+/// rolling file logger actually honours the configured minimum level — the
+/// per-tick DaemonPing RTT line logs at Debug, which the pre-toggle hardcoded
+/// Information floor silently dropped.
+/// </summary>
+public class DaemonLogLevelTests {
+    [Test]
+    [Arguments("debug", LogLevel.Debug)]
+    [Arguments("DEBUG", LogLevel.Debug)]
+    [Arguments(" Debug ", LogLevel.Debug)]
+    [Arguments("trace", LogLevel.Trace)]
+    [Arguments("info", LogLevel.Information)]
+    [Arguments("information", LogLevel.Information)]
+    [Arguments("warn", LogLevel.Warning)]
+    [Arguments("warning", LogLevel.Warning)]
+    [Arguments("error", LogLevel.Error)]
+    [Arguments("none", LogLevel.None)]
+    public async Task ParseLogLevel_recognised_values(string input, LogLevel expected) {
+        await Assert.That(DaemonRunner.ParseLogLevel(input)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments("verbose")]
+    [Arguments("nonsense")]
+    public async Task ParseLogLevel_returns_null_for_unrecognised_so_caller_can_default(string? input) {
+        await Assert.That(DaemonRunner.ParseLogLevel(input)).IsNull();
+    }
+
+    [Test]
+    public async Task FileLogger_at_Debug_min_level_writes_debug_lines() {
+        var path = Path.Combine(Path.GetTempPath(), "kcap-log-" + Guid.NewGuid().ToString("N")[..8] + ".log");
+
+        try {
+            using (var provider = new RollingFileLoggerProvider(path, minLevel: LogLevel.Debug)) {
+                var logger = provider.CreateLogger("Test");
+                logger.Log(LogLevel.Debug, "DaemonPing ok — 42 ms RTT");
+            }
+
+            var contents = await File.ReadAllTextAsync(path);
+            await Assert.That(contents).Contains("DaemonPing ok");
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task FileLogger_at_default_Information_level_drops_debug_lines() {
+        var path = Path.Combine(Path.GetTempPath(), "kcap-log-" + Guid.NewGuid().ToString("N")[..8] + ".log");
+
+        try {
+            using (var provider = new RollingFileLoggerProvider(path)) {
+                var logger = provider.CreateLogger("Test");
+                logger.Log(LogLevel.Debug, "should be dropped");
+                logger.Log(LogLevel.Information, "should be kept");
+            }
+
+            var contents = await File.ReadAllTextAsync(path);
+            await Assert.That(contents).DoesNotContain("should be dropped");
+            await Assert.That(contents).Contains("should be kept");
+        } finally {
+            File.Delete(path);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/TerminalOutputSenderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/TerminalOutputSenderTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Concurrent;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-842: the hosted-agent terminal mirror must reach the server in PTY order
+/// and survive a flapping SignalR connection without dropping bytes. These tests
+/// pin the two guarantees the single-consumer drain loop provides — strict
+/// ordering and hold-and-retry across transient send failures — without standing
+/// up a real hub.
+/// </summary>
+public class TerminalOutputSenderTests {
+    static readonly TimeSpan FastRetry = TimeSpan.FromMilliseconds(5);
+
+    [Test]
+    public async Task Chunks_are_delivered_in_enqueue_order() {
+        var delivered = new ConcurrentQueue<string>();
+
+        var sender = new TerminalOutputSender(
+            (_, base64, _) => {
+                delivered.Enqueue(base64);
+
+                return Task.CompletedTask;
+            },
+            NullLogger.Instance,
+            retryDelay: FastRetry
+        );
+
+        var run = sender.RunAsync(CancellationToken.None);
+
+        for (var i = 0; i < 50; i++) {
+            sender.Enqueue("agent-1", $"chunk-{i}");
+        }
+
+        sender.Complete();
+        await run;
+
+        await Assert.That(delivered).HasCount().EqualTo(50);
+        await Assert.That(delivered.ToArray()).IsEquivalentTo(Enumerable.Range(0, 50).Select(i => $"chunk-{i}").ToArray());
+    }
+
+    [Test]
+    public async Task Failed_send_is_retried_with_the_same_chunk_so_order_is_preserved_and_nothing_is_lost() {
+        var delivered  = new ConcurrentQueue<string>();
+        var failsLeft  = 5; // first chunk fails 5x (transport "down") before it lands
+
+        var sender = new TerminalOutputSender(
+            (_, base64, _) => {
+                if (base64 == "first" && Interlocked.Decrement(ref failsLeft) >= 0) {
+                    throw new InvalidOperationException("connection is not active");
+                }
+
+                delivered.Enqueue(base64);
+
+                return Task.CompletedTask;
+            },
+            NullLogger.Instance,
+            retryDelay: FastRetry
+        );
+
+        var run = sender.RunAsync(CancellationToken.None);
+
+        sender.Enqueue("agent-1", "first");
+        sender.Enqueue("agent-1", "second");
+        sender.Enqueue("agent-1", "third");
+
+        sender.Complete();
+        await run;
+
+        // "first" must still arrive before "second"/"third" even though it failed
+        // repeatedly: the drain loop holds the head chunk and retries it in place.
+        await Assert.That(delivered.ToArray()).IsEquivalentTo(new[] { "first", "second", "third" });
+    }
+
+    [Test]
+    public async Task Cancellation_stops_the_loop_even_while_holding_a_failing_chunk() {
+        using var cts = new CancellationTokenSource();
+
+        var sender = new TerminalOutputSender(
+            (_, _, _) => throw new InvalidOperationException("connection is not active"),
+            NullLogger.Instance,
+            retryDelay: FastRetry
+        );
+
+        var run = sender.RunAsync(cts.Token);
+
+        sender.Enqueue("agent-1", "stuck");
+        await Task.Delay(50);
+        await cts.CancelAsync();
+
+        // RunAsync must return promptly rather than retrying the failing chunk forever.
+        await run.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/TerminalOutputSenderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/TerminalOutputSenderTests.cs
@@ -24,6 +24,7 @@ public class TerminalOutputSenderTests {
 
                 return Task.CompletedTask;
             },
+            isConnected: () => true,
             NullLogger.Instance,
             retryDelay: FastRetry
         );
@@ -37,8 +38,14 @@ public class TerminalOutputSenderTests {
         sender.Complete();
         await run;
 
-        await Assert.That(delivered).HasCount().EqualTo(50);
-        await Assert.That(delivered.ToArray()).IsEquivalentTo(Enumerable.Range(0, 50).Select(i => $"chunk-{i}").ToArray());
+        // Order-sensitive, by index: IsEquivalentTo is permutation-tolerant and
+        // would pass for any order, defeating the point of an ordering test.
+        var arr = delivered.ToArray();
+        await Assert.That(arr.Length).IsEqualTo(50);
+
+        for (var i = 0; i < 50; i++) {
+            await Assert.That(arr[i]).IsEqualTo($"chunk-{i}");
+        }
     }
 
     [Test]
@@ -56,6 +63,7 @@ public class TerminalOutputSenderTests {
 
                 return Task.CompletedTask;
             },
+            isConnected: () => false, // transport down — failures must be held and retried, not dropped
             NullLogger.Instance,
             retryDelay: FastRetry
         );
@@ -71,7 +79,47 @@ public class TerminalOutputSenderTests {
 
         // "first" must still arrive before "second"/"third" even though it failed
         // repeatedly: the drain loop holds the head chunk and retries it in place.
-        await Assert.That(delivered.ToArray()).IsEquivalentTo(new[] { "first", "second", "third" });
+        // Asserted by index — IsEquivalentTo would pass for any order.
+        var arr = delivered.ToArray();
+        await Assert.That(arr.Length).IsEqualTo(3);
+        await Assert.That(arr[0]).IsEqualTo("first");
+        await Assert.That(arr[1]).IsEqualTo("second");
+        await Assert.That(arr[2]).IsEqualTo("third");
+    }
+
+    [Test]
+    public async Task Send_failure_while_connected_drops_the_chunk_and_keeps_delivering_later_chunks() {
+        var delivered = new ConcurrentQueue<string>();
+
+        // The hub reports Connected, but the send for "poison" throws. A blind
+        // retry would spin forever and wedge the single shared loop; the sender
+        // must instead drop that chunk and keep delivering the rest.
+        var sender = new TerminalOutputSender(
+            (_, base64, _) => {
+                if (base64 == "poison") throw new InvalidOperationException("boom");
+
+                delivered.Enqueue(base64);
+
+                return Task.CompletedTask;
+            },
+            isConnected: () => true,
+            NullLogger.Instance,
+            retryDelay: FastRetry
+        );
+
+        var run = sender.RunAsync(CancellationToken.None);
+
+        sender.Enqueue("agent-1", "poison");
+        sender.Enqueue("agent-1", "after-1");
+        sender.Enqueue("agent-1", "after-2");
+
+        sender.Complete();
+        await run.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var arr = delivered.ToArray();
+        await Assert.That(arr.Length).IsEqualTo(2);
+        await Assert.That(arr[0]).IsEqualTo("after-1");
+        await Assert.That(arr[1]).IsEqualTo("after-2");
     }
 
     [Test]
@@ -80,6 +128,7 @@ public class TerminalOutputSenderTests {
 
         var sender = new TerminalOutputSender(
             (_, _, _) => throw new InvalidOperationException("connection is not active"),
+            isConnected: () => false, // held (not dropped), so the loop is genuinely stuck until cancelled
             NullLogger.Instance,
             retryDelay: FastRetry
         );


### PR DESCRIPTION
Fixes the daemon-side half of the SignalR instability incident, and adds the diagnostics to characterise the underlying flap. The connection *flapping* itself (AI-840 — slow `DaemonPing` exceeding the 5 s heartbeat deadline) is a separate root cause; this PR removes the two daemon-side defects the flapping *exposed* and instruments the transport so we can confirm whether cloudflared is the latency source.

## AI-841 — `ActiveSessionChanged` bind-failure flood
The server adds every authenticated connection — daemons included — to its `org-members` UI broadcast group in `CapacitorHub.OnConnectedAsync`, and only removes the daemon again inside `DaemonConnect`. In the window before `DaemonConnect` completes (recurring on every reconnect) the daemon received UI-only invocations it had no handler for, so `JsonHubProtocol` logged a `Failed to find handler` + argument-bind failure for each (`ActiveSessionChanged` provides 1 arg but target expects 0).

`RegisterUiBroadcastSinks()` registers no-op client handlers at the server's current arities for the eight UI broadcasts (`ActiveSession{Added,Changed,Removed}`, `AgentInstancesChanged`, `DaemonsChanged`, `WelcomeStateChanged`, `LaunchFailed`, `PermissionResponded`, `PermissionRequested`), using `JsonElement` params that bind to any payload shape. Silences the flood even against an already-deployed server.

## AI-842 — garbled hosted-agent Terminal tab
Two causes:
1. PTY chunks were fired at `HubConnection.SendAsync` fire-and-forget; while the hub was reconnecting those sends faulted silently (dropping bytes mid-ANSI-escape), and concurrent sends could interleave out of order. New `TerminalOutputSender` drains a bounded `DropOldest` channel with a single consumer that **holds-and-retries** a chunk while the transport is down, preserving PTY order.
2. `ReRegisterAgents` replayed the entire 2 MB output ring on every reconnect, which the server appended and live-broadcast on top of the current screen, interleaved with live output. Removed the replay — the server retains its own per-agent buffer across a daemon rebind (only cleared on reconcile-to-Failed), so late-joining web clients still get history via `SubscribeToTerminal`.

## AI-840 diagnostics — transport instrumentation
So we can decide whether cloudflared (vs the server) is the latency source, the daemon log now carries:
- `DaemonPing` RTT every heartbeat tick — debug when healthy, **warning once RTT crosses a slow threshold** (default ½ the deadline) so latency climbing toward a forced reconnect is visible before it flaps.
- An explicit `cause=` tag on every forced reconnect / re-register (`ping_deadline_exceeded` | `ping_threw` | `slot_displaced`).
- **Connection uptime at close** (`connection closed after N.Ns uptime`), making the flap cadence visible alongside SignalR's own close exception.

## Follow-up (server-side, separate PR in `kcap-server`)
- AI-841: tag daemon connections at connect time so `OnConnectedAsync` never adds them to the UI group — closes the window permanently instead of add-then-remove.
- AI-842: broadcast a `TerminalReset` (and clear the server buffer) to `terminal:{agentId}` subscribers on daemon rebind, and close the server-side conn-id-gate drop window during re-registration.

## Testing
- `TerminalOutputSenderTests`: ordering, hold-and-retry preserves order with no loss, cancellation stops a stuck retry.
- `DaemonHeartbeatLoopTests`: healthy-RTT-at-debug, slow-ping-warns-without-reconnect, deadline-exceeded-logs-cause (capturing `ILogger`).
- Full unit suite: 1422 passed.
- `kcap` and `kcap-daemon` AOT publish (`-c Release`): no IL2026/IL3050 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)