### PR TITLE
[AI-846] Make hosted-agent terminal stream loss-free under tunnel back-pressure

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -429,6 +429,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     }
 
     async Task ReadAgentOutputAsync(AgentInstance agent) {
+        // The terminal-output enqueue back-pressures (awaits) when the send queue is
+        // full. Tie that await to BOTH this agent's stop (ReadCts) and daemon shutdown
+        // so HandleStopAgent releasing ReadCts unblocks the read loop — otherwise a
+        // stop mid-outage would leave the finally-block finalization/cleanup stalled
+        // until the whole daemon exits (AI-846).
+        using var sendCts = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
+
         try {
             await foreach (var data in agent.Process.ReadOutputAsync(agent.ReadCts.Token)) {
                 agent.LastOutputAt      = DateTime.UtcNow;
@@ -444,7 +451,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 // Await the enqueue: TerminalOutputSender back-pressures here when its
                 // queue is full (slow/down transport) so a chunk is never dropped to
                 // keep up — losing one byte garbles the whole redraw-TUI mirror (AI-844).
-                await _server.SendTerminalOutputAsync(agent.Id, base64);
+                // sendCts releases this await on agent stop or daemon shutdown (AI-846).
+                await _server.SendTerminalOutputAsync(agent.Id, base64, sendCts.Token);
             }
         } catch (OperationCanceledException) {
             /* expected on stop */
@@ -1027,6 +1035,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// without going through SignalR. Keeps the private handler private to everyone else.
     /// </summary>
     internal Task HandleLaunchAgentForTest(LaunchAgentCommand cmd) => HandleLaunchAgent(cmd);
+
+    /// <summary>Test-only entry point to the private stop handler (mirrors <see cref="HandleLaunchAgentForTest"/>).</summary>
+    internal Task HandleStopAgentForTest(string agentId) => HandleStopAgent(agentId);
 }
 
 /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -441,7 +441,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
                 agent.OutputBuffer.Append(data);
                 var base64 = Convert.ToBase64String(data);
-                _ = _server.SendTerminalOutputAsync(agent.Id, base64);
+                // Await the enqueue: TerminalOutputSender back-pressures here when its
+                // queue is full (slow/down transport) so a chunk is never dropped to
+                // keep up — losing one byte garbles the whole redraw-TUI mirror (AI-844).
+                await _server.SendTerminalOutputAsync(agent.Id, base64);
             }
         } catch (OperationCanceledException) {
             /* expected on stop */

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -441,17 +441,16 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         );
 
     /// <summary>
-    /// Queues a base64 PTY chunk for the hosted-agent terminal mirror. AI-842:
-    /// chunks are drained by <see cref="TerminalOutputSender"/>'s single ordered
-    /// loop instead of being fired at <c>SendAsync</c> fire-and-forget, so they
-    /// reach the server in PTY order and a chunk sent while the transport is down
-    /// is held and retried rather than silently lost mid-escape-sequence.
+    /// Queues a base64 PTY chunk for the hosted-agent terminal mirror. AI-842/AI-844:
+    /// chunks are drained by <see cref="TerminalOutputSender"/>'s single ordered loop
+    /// instead of being fired at <c>SendAsync</c> fire-and-forget, so they reach the
+    /// server in PTY order. The enqueue awaits when the queue is full — the caller
+    /// (the PTY read loop) awaits this, so a stalled transport back-pressures the PTY
+    /// rather than dropping bytes mid-escape-sequence. Bound to the daemon lifetime
+    /// token so a blocked enqueue unblocks on shutdown.
     /// </summary>
-    public virtual Task SendTerminalOutputAsync(string agentId, string base64Data) {
-        _terminalSender.Enqueue(agentId, base64Data);
-
-        return Task.CompletedTask;
-    }
+    public virtual Task SendTerminalOutputAsync(string agentId, string base64Data) =>
+        _terminalSender.EnqueueAsync(agentId, base64Data, _ct).AsTask();
 
     // ── Eval progress events (DEV-1440) ────────────────────────────────────
 

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -446,11 +446,16 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// instead of being fired at <c>SendAsync</c> fire-and-forget, so they reach the
     /// server in PTY order. The enqueue awaits when the queue is full — the caller
     /// (the PTY read loop) awaits this, so a stalled transport back-pressures the PTY
-    /// rather than dropping bytes mid-escape-sequence. Bound to the daemon lifetime
-    /// token so a blocked enqueue unblocks on shutdown.
+    /// rather than dropping bytes mid-escape-sequence.
     /// </summary>
-    public virtual Task SendTerminalOutputAsync(string agentId, string base64Data) =>
-        _terminalSender.EnqueueAsync(agentId, base64Data, _ct).AsTask();
+    /// <param name="ct">
+    /// Cancels a blocked (back-pressured) enqueue. The read loop passes a token tied
+    /// to BOTH the per-agent stop (<c>ReadCts</c>) and daemon shutdown, so stopping a
+    /// single agent releases its read loop even mid-outage — otherwise the loop's
+    /// finally-block finalization/cleanup would stall until daemon shutdown (AI-846).
+    /// </param>
+    public virtual Task SendTerminalOutputAsync(string agentId, string base64Data, CancellationToken ct = default) =>
+        _terminalSender.EnqueueAsync(agentId, base64Data, ct).AsTask();
 
     // ── Eval progress events (DEV-1440) ────────────────────────────────────
 

--- a/src/Capacitor.Cli.Daemon/Services/TerminalOutputSender.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TerminalOutputSender.cs
@@ -6,19 +6,37 @@ namespace Capacitor.Cli.Daemon.Services;
 /// <summary>
 /// Serialises hosted-agent terminal output onto a single ordered channel so the
 /// stream the web "Terminal" tab renders is delivered in PTY order and survives a
-/// flapping SignalR connection without corruption (AI-842).
+/// flapping SignalR connection <em>without losing bytes</em> (AI-842, AI-844).
 ///
 /// The pre-AI-842 path fired every PTY chunk at <c>HubConnection.SendAsync</c>
 /// with a discarded task. While the hub was disconnected those sends faulted
 /// silently — dropping bytes mid-ANSI-escape-sequence — and the read loop's
 /// concurrent fire-and-forget sends could interleave out of order. A single
-/// consumer draining one channel fixes both: chunks go out strictly in the
-/// order they were produced, and a send that throws because the transport is
-/// down is retried with the SAME chunk (head-of-line, preserving order) until
-/// it lands or the daemon shuts down. The channel is bounded with
-/// <c>DropOldest</c> so a prolonged outage caps memory rather than growing
-/// without bound — mirroring the agent-run event queue in
-/// <see cref="ServerConnection"/>.
+/// consumer draining one channel fixes the ordering and the silent-fault problem.
+///
+/// AI-842 capped that channel with <c>DropOldest</c>, which re-introduced silent
+/// loss: under back-pressure (a slow/flapping tunnel) it discarded the oldest
+/// queued chunks. Claude Code's TUI is a cursor-addressing redraw stream — a
+/// single dropped or reordered chunk desyncs every later repaint, so the
+/// "Terminal" tab rendered garbled output with lost history (AI-844). The queue
+/// is therefore loss-free:
+/// <list type="bullet">
+///   <item>The bounded channel uses <see cref="BoundedChannelFullMode.Wait"/>, so
+///   a full queue back-pressures the producer (<see cref="EnqueueAsync"/> awaits)
+///   instead of dropping. The PTY read loop awaits the enqueue, so a stalled
+///   transport naturally back-pressures the PTY (and thus the agent) rather than
+///   corrupting the mirror; memory stays bounded by <c>capacity</c>.</item>
+///   <item>A send that fails <em>while the transport is down</em> is held and
+///   retried with the same chunk (head-of-line), so a reconnect outage preserves
+///   PTY order and loses nothing.</item>
+///   <item>A send that fails <em>while the hub reports Connected</em> is bounded-
+///   retried up to <c>maxConnectedAttempts</c>; only if it still won't land — an
+///   anomaly that blind retry can't fix and that would otherwise wedge the single
+///   shared loop — is that one chunk dropped, counted (<see cref="DroppedChunks"/>),
+///   and logged at Warning. This is the sole remaining drop path, and it is never
+///   silent.</item>
+/// </list>
+/// Cancellation (daemon shutdown) ends the loop even while a chunk is being held.
 /// </summary>
 internal sealed partial class TerminalOutputSender {
     readonly Channel<(string AgentId, string Base64Data)> _channel;
@@ -26,45 +44,62 @@ internal sealed partial class TerminalOutputSender {
     readonly Func<bool>                                   _isConnected;
     readonly ILogger                                       _logger;
     readonly TimeSpan                                      _retryDelay;
+    readonly int                                           _maxConnectedAttempts;
+    long                                                   _dropped;
 
     public TerminalOutputSender(
             Func<string, string, CancellationToken, Task> send,
             Func<bool>                                    isConnected,
             ILogger                                       logger,
-            int                                           capacity   = 2000,
-            TimeSpan?                                     retryDelay = null
+            int                                           capacity             = 2000,
+            TimeSpan?                                     retryDelay           = null,
+            int                                           maxConnectedAttempts = 5
         ) {
-        _send        = send;
-        _isConnected = isConnected;
-        _logger      = logger;
-        _retryDelay  = retryDelay ?? TimeSpan.FromMilliseconds(500);
+        _send                 = send;
+        _isConnected          = isConnected;
+        _logger               = logger;
+        _retryDelay           = retryDelay ?? TimeSpan.FromMilliseconds(500);
+        _maxConnectedAttempts = Math.Max(1, maxConnectedAttempts);
         _channel = Channel.CreateBounded<(string, string)>(
-            new BoundedChannelOptions(capacity) { FullMode = BoundedChannelFullMode.DropOldest }
+            new BoundedChannelOptions(capacity) {
+                FullMode     = BoundedChannelFullMode.Wait,
+                SingleReader = true
+            }
         );
     }
 
-    /// <summary>Queues a base64 PTY chunk for in-order delivery. Never blocks.</summary>
-    public void Enqueue(string agentId, string base64Data)
-        => _channel.Writer.TryWrite((agentId, base64Data));
+    /// <summary>Total chunks dropped because a connected send kept failing past the retry budget.</summary>
+    public long DroppedChunks => Interlocked.Read(ref _dropped);
+
+    /// <summary>
+    /// Queues a base64 PTY chunk for in-order delivery, awaiting if the queue is
+    /// full so the producer is back-pressured rather than any chunk being dropped.
+    /// Returns once the chunk is queued (or silently on shutdown, when the channel
+    /// is completed or <paramref name="ct"/> is cancelled — nothing left to deliver).
+    /// </summary>
+    public async ValueTask EnqueueAsync(string agentId, string base64Data, CancellationToken ct = default) {
+        try {
+            await _channel.Writer.WriteAsync((agentId, base64Data), ct);
+        } catch (OperationCanceledException) {
+            // Daemon shutdown / agent stop — drop the in-flight enqueue silently.
+        } catch (ChannelClosedException) {
+            // Complete() was called as part of teardown — nothing more to deliver.
+        }
+    }
 
     /// <summary>Signals no more chunks will be queued so <see cref="RunAsync"/> can drain and exit.</summary>
     public void Complete() => _channel.Writer.TryComplete();
 
     /// <summary>
-    /// Drains the channel, sending each chunk in order. A send that fails
-    /// <em>while the transport is down</em> is retried with the same chunk after
-    /// <c>retryDelay</c>, so a reconnect outage holds the stream in place rather
-    /// than dropping bytes mid-escape-sequence. A send that fails <em>while the
-    /// hub reports Connected</em> won't succeed on blind retry (it's not a
-    /// transport-down condition), so that chunk is logged and dropped and the
-    /// loop moves on — this is the safety valve that stops one stuck chunk from
-    /// wedging the single shared loop (and, with it, <c>DisposeAsync</c>) for
-    /// every later chunk. Cancellation (daemon shutdown) ends the loop even
-    /// while a chunk is being held for retry.
+    /// Drains the channel, sending each chunk in order. See the type remarks for the
+    /// hold-and-retry (transport down) vs. bounded-retry-then-counted-drop
+    /// (connected) policies. Cancellation ends the loop even while holding a chunk.
     /// </summary>
     public async Task RunAsync(CancellationToken ct) {
         try {
             await foreach (var (agentId, base64) in _channel.Reader.ReadAllAsync(ct)) {
+                var connectedAttempts = 0;
+
                 while (true) {
                     try {
                         await _send(agentId, base64, ct);
@@ -74,15 +109,26 @@ internal sealed partial class TerminalOutputSender {
                         return;
                     } catch (Exception ex) {
                         if (_isConnected()) {
-                            // Connected yet the send threw — not a transport
-                            // outage. Retrying the same chunk would spin forever,
-                            // so drop it and continue rather than block the loop.
-                            LogSendDropped(ex, agentId);
+                            // Connected yet the send threw — not a transport outage.
+                            // Bounded-retry so a transient blip still lands in order;
+                            // give up (drop + count + log) once the budget is spent so
+                            // one stuck chunk can't wedge the loop (and DisposeAsync).
+                            if (++connectedAttempts >= _maxConnectedAttempts) {
+                                var total = Interlocked.Increment(ref _dropped);
+                                LogSendDropped(ex, agentId, connectedAttempts, total);
 
-                            break;
+                                break;
+                            }
+
+                            LogSendRetryConnected(ex, agentId, connectedAttempts, _maxConnectedAttempts);
+                        } else {
+                            // Transport down: hold this chunk and retry it indefinitely
+                            // (the channel back-pressures the producer, so this can't
+                            // grow memory without bound). Reset the connected budget —
+                            // it only counts consecutive failures while Connected.
+                            connectedAttempts = 0;
+                            LogSendRetry(ex, agentId, _retryDelay.TotalSeconds);
                         }
-
-                        LogSendRetry(ex, agentId, _retryDelay.TotalSeconds);
 
                         try {
                             await Task.Delay(_retryDelay, ct);
@@ -100,6 +146,9 @@ internal sealed partial class TerminalOutputSender {
     [LoggerMessage(Level = LogLevel.Debug, Message = "Terminal output send for agent {AgentId} failed while transport down, holding and retrying in {Delay}s")]
     partial void LogSendRetry(Exception ex, string agentId, double delay);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Terminal output send for agent {AgentId} failed while connected — dropping chunk and continuing")]
-    partial void LogSendDropped(Exception ex, string agentId);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Terminal output send for agent {AgentId} failed while connected (attempt {Attempt}/{Max}), retrying")]
+    partial void LogSendRetryConnected(Exception ex, string agentId, int attempt, int max);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Terminal output send for agent {AgentId} still failing while connected after {Attempts} attempts — dropping chunk (total dropped this session: {TotalDropped})")]
+    partial void LogSendDropped(Exception ex, string agentId, int attempts, long totalDropped);
 }

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -285,6 +285,50 @@ public class AgentOrchestratorVendorTests {
         }
     }
 
+    [Test]
+    public async Task Stopping_an_agent_releases_a_read_loop_blocked_on_a_full_terminal_queue() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            // The send blocks (full/down queue) until its ct cancels; the PTY keeps the
+            // stream open so the read loop is genuinely parked inside the blocked send.
+            var sendEntered   = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var sendUnblocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var server     = new CaptureServerConnection { SendEntered = sendEntered, SendUnblocked = sendUnblocked };
+            var ptyFactory = new FixedPtyProcessFactory(new OneChunkThenBlockPtyProcess());
+            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude");
+
+            var launchers = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
+
+            await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                AgentId: "agent-bp",
+                Prompt: "go",
+                Model: "opus",
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "claude"
+            ));
+
+            // Wait until the read loop has produced a chunk and is parked in the blocked send.
+            await sendEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // Stopping the agent cancels ReadCts. The blocked enqueue MUST be released by
+            // that cancellation; otherwise the read loop (and its finally-block cleanup)
+            // stalls until daemon shutdown (AI-846). Before the fix the enqueue awaited the
+            // daemon-lifetime token instead, so this never completes.
+            await orch.HandleStopAgentForTest("agent-bp");
+
+            await sendUnblocked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        } finally {
+            cleanup();
+        }
+    }
+
     // ── Test doubles ─────────────────────────────────────────────────────
 
     sealed class SpyHostedAgentLauncher(string vendor, string cliPath) : IHostedAgentLauncher {
@@ -313,6 +357,46 @@ public class AgentOrchestratorVendorTests {
         public void Cleanup(AgentInstance agent) {
             CleanupCalls++;
         }
+    }
+
+    /// <summary>Returns a caller-supplied PTY process so a test can control its output behaviour.</summary>
+    sealed class FixedPtyProcessFactory(IPtyProcess process) : IPtyProcessFactory {
+        public IPtyProcess Spawn(
+                string                      command,
+                string[]                    args,
+                string                      cwd,
+                Dictionary<string, string>? extraEnv = null,
+                ushort                      cols     = 120,
+                ushort                      rows     = 40
+            ) => process;
+    }
+
+    /// <summary>
+    /// Emits one chunk (so the read loop calls SendTerminalOutputAsync) then keeps the
+    /// stream open by awaiting the read token — the loop parks in the blocked send until
+    /// the agent is stopped. HasExited is true so HandleStopAgent's graceful path is quick.
+    /// </summary>
+    sealed class OneChunkThenBlockPtyProcess : IPtyProcess {
+        public int  Pid       => 4242;
+        public bool HasExited => true;
+        public int? ExitCode  => 0;
+
+        public ValueTask DisposeAsync() => default;
+        public Task WaitForExitAsync(TimeSpan? _) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan?   _) => Task.CompletedTask;
+
+        public async IAsyncEnumerable<byte[]> ReadOutputAsync([EnumeratorCancellation] CancellationToken ct = default) {
+            yield return "x"u8.ToArray();
+
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+
+            yield break;
+        }
+
+        public Task WriteAsync(string _) => Task.CompletedTask;
+        public Task WriteAsync(byte[] _) => Task.CompletedTask;
+        public void Resize(ushort     _, ushort __) { }
+        public void SendInterrupt() { }
     }
 
     sealed class SpyPtyProcessFactory : IPtyProcessFactory {
@@ -389,8 +473,25 @@ public class AgentOrchestratorVendorTests {
         public override Task UpdateRepoPathsAsync()
             => Task.CompletedTask;
 
-        public override Task SendTerminalOutputAsync(string agentId, string base64Data)
-            => Task.CompletedTask;
+        /// <summary>Set both to make the send block (simulating a full/down terminal
+        /// queue) until its <c>ct</c> is cancelled — used by the AI-846 back-pressure
+        /// test. Left null for every other test, where the send is a no-op.</summary>
+        public TaskCompletionSource? SendEntered   { get; init; }
+        public TaskCompletionSource? SendUnblocked { get; init; }
+
+        public override async Task SendTerminalOutputAsync(string agentId, string base64Data, CancellationToken ct = default) {
+            if (SendEntered is null) return;
+
+            SendEntered.TrySetResult();
+
+            try {
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            } catch (OperationCanceledException) {
+                /* released by the read loop's stop-linked token */
+            } finally {
+                SendUnblocked?.TrySetResult();
+            }
+        }
 
         public override Task AppendAgentRunEventAsync(string agentId, object evt)
             => Task.CompletedTask;

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/TerminalOutputSenderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/TerminalOutputSenderTests.cs
@@ -5,11 +5,16 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-842: the hosted-agent terminal mirror must reach the server in PTY order
-/// and survive a flapping SignalR connection without dropping bytes. These tests
-/// pin the two guarantees the single-consumer drain loop provides — strict
-/// ordering and hold-and-retry across transient send failures — without standing
-/// up a real hub.
+/// AI-842 / AI-844: the hosted-agent terminal mirror must reach the server in PTY
+/// order and survive a flapping SignalR connection <em>without dropping bytes</em>.
+/// AI-842 routed the stream through a single ordered drain loop but capped it with a
+/// <c>DropOldest</c> channel — under back-pressure that silently discarded the
+/// oldest chunks, severing a redraw-TUI stream mid-escape-sequence (the garbled
+/// "Terminal" tab). AI-844 makes the queue loss-free: a full channel back-pressures
+/// the producer instead of dropping, and the only remaining drop — a send that keeps
+/// throwing while the hub reports Connected — is bounded-retried, then counted and
+/// logged rather than silently lost. These tests pin those guarantees without
+/// standing up a real hub.
 /// </summary>
 public class TerminalOutputSenderTests {
     static readonly TimeSpan FastRetry = TimeSpan.FromMilliseconds(5);
@@ -32,7 +37,7 @@ public class TerminalOutputSenderTests {
         var run = sender.RunAsync(CancellationToken.None);
 
         for (var i = 0; i < 50; i++) {
-            sender.Enqueue("agent-1", $"chunk-{i}");
+            await sender.EnqueueAsync("agent-1", $"chunk-{i}", CancellationToken.None);
         }
 
         sender.Complete();
@@ -46,12 +51,14 @@ public class TerminalOutputSenderTests {
         for (var i = 0; i < 50; i++) {
             await Assert.That(arr[i]).IsEqualTo($"chunk-{i}");
         }
+
+        await Assert.That(sender.DroppedChunks).IsEqualTo(0L);
     }
 
     [Test]
-    public async Task Failed_send_is_retried_with_the_same_chunk_so_order_is_preserved_and_nothing_is_lost() {
-        var delivered  = new ConcurrentQueue<string>();
-        var failsLeft  = 5; // first chunk fails 5x (transport "down") before it lands
+    public async Task Failed_send_while_transport_down_is_held_and_retried_so_order_is_preserved_and_nothing_is_lost() {
+        var delivered = new ConcurrentQueue<string>();
+        var failsLeft = 5; // first chunk fails 5x (transport "down") before it lands
 
         var sender = new TerminalOutputSender(
             (_, base64, _) => {
@@ -70,30 +77,117 @@ public class TerminalOutputSenderTests {
 
         var run = sender.RunAsync(CancellationToken.None);
 
-        sender.Enqueue("agent-1", "first");
-        sender.Enqueue("agent-1", "second");
-        sender.Enqueue("agent-1", "third");
+        await sender.EnqueueAsync("agent-1", "first", CancellationToken.None);
+        await sender.EnqueueAsync("agent-1", "second", CancellationToken.None);
+        await sender.EnqueueAsync("agent-1", "third", CancellationToken.None);
 
         sender.Complete();
         await run;
 
         // "first" must still arrive before "second"/"third" even though it failed
         // repeatedly: the drain loop holds the head chunk and retries it in place.
-        // Asserted by index — IsEquivalentTo would pass for any order.
         var arr = delivered.ToArray();
         await Assert.That(arr.Length).IsEqualTo(3);
         await Assert.That(arr[0]).IsEqualTo("first");
         await Assert.That(arr[1]).IsEqualTo("second");
         await Assert.That(arr[2]).IsEqualTo("third");
+        await Assert.That(sender.DroppedChunks).IsEqualTo(0L);
     }
 
     [Test]
-    public async Task Send_failure_while_connected_drops_the_chunk_and_keeps_delivering_later_chunks() {
+    public async Task A_full_queue_back_pressures_the_producer_instead_of_dropping() {
+        var delivered = new ConcurrentQueue<string>();
+        var gate            = new TaskCompletionSource();
+        var firstSendBegan  = new TaskCompletionSource();
+        var firstSend       = true;
+
+        // Capacity 1 + a consumer that blocks on the first send: the channel fills,
+        // so the third EnqueueAsync must wait (back-pressure) rather than evicting
+        // the oldest queued chunk the way DropOldest did.
+        var sender = new TerminalOutputSender(
+            async (_, base64, _) => {
+                if (firstSend) {
+                    firstSend = false;
+                    firstSendBegan.TrySetResult();
+                    await gate.Task;
+                }
+
+                delivered.Enqueue(base64);
+            },
+            isConnected: () => true,
+            NullLogger.Instance,
+            capacity: 1,
+            retryDelay: FastRetry
+        );
+
+        var run = sender.RunAsync(CancellationToken.None);
+
+        await sender.EnqueueAsync("agent-1", "c0", CancellationToken.None); // consumer takes it, blocks
+        await firstSendBegan.Task;
+        await sender.EnqueueAsync("agent-1", "c1", CancellationToken.None); // fills the capacity-1 channel
+
+        // c2 cannot be queued until the consumer drains — EnqueueAsync stays pending.
+        var enq2 = sender.EnqueueAsync("agent-1", "c2", CancellationToken.None).AsTask();
+        var winner = await Task.WhenAny(enq2, Task.Delay(250));
+        await Assert.That(winner).IsNotEqualTo(enq2); // still back-pressured, nothing dropped
+
+        gate.TrySetResult(); // release the consumer; everything drains in order
+        await enq2;
+        sender.Complete();
+        await run.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var arr = delivered.ToArray();
+        await Assert.That(arr.Length).IsEqualTo(3);
+        await Assert.That(arr[0]).IsEqualTo("c0");
+        await Assert.That(arr[1]).IsEqualTo("c1");
+        await Assert.That(arr[2]).IsEqualTo("c2");
+        await Assert.That(sender.DroppedChunks).IsEqualTo(0L);
+    }
+
+    [Test]
+    public async Task Transient_send_failure_while_connected_is_retried_and_eventually_delivered() {
+        var delivered = new ConcurrentQueue<string>();
+        var failsLeft = 2; // fails twice (< maxConnectedAttempts), then lands
+
+        var sender = new TerminalOutputSender(
+            (_, base64, _) => {
+                if (base64 == "flaky" && Interlocked.Decrement(ref failsLeft) >= 0) {
+                    throw new InvalidOperationException("transient");
+                }
+
+                delivered.Enqueue(base64);
+
+                return Task.CompletedTask;
+            },
+            isConnected: () => true,
+            NullLogger.Instance,
+            retryDelay: FastRetry,
+            maxConnectedAttempts: 5
+        );
+
+        var run = sender.RunAsync(CancellationToken.None);
+
+        await sender.EnqueueAsync("agent-1", "flaky", CancellationToken.None);
+        await sender.EnqueueAsync("agent-1", "next", CancellationToken.None);
+
+        sender.Complete();
+        await run.WaitAsync(TimeSpan.FromSeconds(2));
+
+        // A transient failure must NOT be dropped — it recovers within the budget.
+        var arr = delivered.ToArray();
+        await Assert.That(arr.Length).IsEqualTo(2);
+        await Assert.That(arr[0]).IsEqualTo("flaky");
+        await Assert.That(arr[1]).IsEqualTo("next");
+        await Assert.That(sender.DroppedChunks).IsEqualTo(0L);
+    }
+
+    [Test]
+    public async Task Send_that_keeps_failing_while_connected_is_dropped_after_max_attempts_and_counted() {
         var delivered = new ConcurrentQueue<string>();
 
-        // The hub reports Connected, but the send for "poison" throws. A blind
-        // retry would spin forever and wedge the single shared loop; the sender
-        // must instead drop that chunk and keep delivering the rest.
+        // The hub reports Connected but "poison" always throws. Retrying forever
+        // would wedge the single shared loop, so after a bounded number of attempts
+        // the sender drops that one chunk, counts it, and keeps delivering the rest.
         var sender = new TerminalOutputSender(
             (_, base64, _) => {
                 if (base64 == "poison") throw new InvalidOperationException("boom");
@@ -104,14 +198,15 @@ public class TerminalOutputSenderTests {
             },
             isConnected: () => true,
             NullLogger.Instance,
-            retryDelay: FastRetry
+            retryDelay: FastRetry,
+            maxConnectedAttempts: 3
         );
 
         var run = sender.RunAsync(CancellationToken.None);
 
-        sender.Enqueue("agent-1", "poison");
-        sender.Enqueue("agent-1", "after-1");
-        sender.Enqueue("agent-1", "after-2");
+        await sender.EnqueueAsync("agent-1", "poison", CancellationToken.None);
+        await sender.EnqueueAsync("agent-1", "after-1", CancellationToken.None);
+        await sender.EnqueueAsync("agent-1", "after-2", CancellationToken.None);
 
         sender.Complete();
         await run.WaitAsync(TimeSpan.FromSeconds(2));
@@ -120,6 +215,7 @@ public class TerminalOutputSenderTests {
         await Assert.That(arr.Length).IsEqualTo(2);
         await Assert.That(arr[0]).IsEqualTo("after-1");
         await Assert.That(arr[1]).IsEqualTo("after-2");
+        await Assert.That(sender.DroppedChunks).IsEqualTo(1L);
     }
 
     [Test]
@@ -135,7 +231,7 @@ public class TerminalOutputSenderTests {
 
         var run = sender.RunAsync(cts.Token);
 
-        sender.Enqueue("agent-1", "stuck");
+        await sender.EnqueueAsync("agent-1", "stuck", CancellationToken.None);
         await Task.Delay(50);
         await cts.CancelAsync();
 


### PR DESCRIPTION
## Problem

Follow-up to **AI-842** (marked Done), where the hosted-agent **Terminal** tab still renders garbled output, frequently "resets to current output," and loses scrollback history — reproduced on a **fresh** session viewed on the web.

## Root cause

The Terminal tab mirrors Claude Code's **cursor-addressing redraw TUI** by forwarding the raw PTY byte stream. That stream is intolerant of a single dropped or reordered chunk — every later relative repaint then lands on the wrong rows (garbled) and content that should have scrolled into history never arrives (history lost).

AI-842 fixed fire-and-forget drops and the daemon's replay-on-reconnect, but routed the stream through a bounded channel with `BoundedChannelFullMode.DropOldest` (`TerminalOutputSender`, capacity 2000). Under back-pressure from the slow/flapping production tunnel (the condition AI-840's instrumentation was added to characterise), that channel **silently discards the oldest queued chunks and keeps the newest** — and these drops weren't logged. For a redraw TUI that produces exactly the reported symptoms: "resets to current output" (newest frame kept, history evicted), "history lost," "garbled."

It's a daemon-side (stream) issue, not a client reconnect issue: on the web path `AgentStoreDataService.OnReconnected` is an explicit no-op, so the client-side `term.reset()`-on-reconnect machinery never runs for the web viewer — the corruption arrives in the stream, upstream of the server.

## Fix — loss-free + logging

- **`TerminalOutputSender`**: channel `DropOldest` → `Wait`. `EnqueueAsync` awaits when the queue is full; the PTY read loop (`AgentOrchestrator.ReadAgentOutputAsync`) now awaits the enqueue, so a stalled/flapping transport **back-pressures the PTY** (and thus the agent) instead of dropping bytes to keep up. Memory stays bounded by `capacity`.
- **Connected-but-throws path**: immediate silent drop → **bounded retry** (transient blips recover in order); only after the budget is spent is that one chunk dropped, **counted (`DroppedChunks`)** and **logged at Warning**. This is now the sole remaining drop path, and it is never silent — it only guards against one stuck chunk wedging the shared loop.
- Reconnect-cause + RTT logging already present from AI-840.

### Tradeoff
Loss-free means a sustained daemon→server outage with heavy output (≈2000 chunks / minutes of buffer) back-pressures the PTY and pauses Claude's output until reconnect, then flushes in order. Brief flaps (seconds — the common tunnel case) are absorbed with no pause. This replaces "agent keeps working but mirror corrupts" with "mirror stays correct, agent briefly pauses on long outages."

This PR is also the hypothesis test: if garbling persists after deploy, byte-loss wasn't the (whole) cause and we escalate to **Option B** (server-side VT emulator that sends clean current-screen snapshots instead of replaying raw bytes).

## Tests
`TerminalOutputSenderTests` rewritten TDD-first:
- back-pressure-not-drop (full queue → producer waits, nothing dropped)
- transient-connected-failure recovers and is delivered (not dropped)
- keeps-failing-while-connected → dropped after max attempts and counted
- ordering, hold-and-retry-while-down, cancellation (retained)

Full unit suite green (1442/1442). `kcap` AOT publish clean (no IL2026/IL3050).

🤖 Generated with [Claude Code](https://claude.com/claude-code)