### PR TITLE
[AI-848] Guard Process.Start against launch failures in CLI runners

### DIFF
--- a/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
+++ b/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
@@ -193,7 +193,7 @@ static class ClaudeCliRunner {
             psi.ArgumentList.Add(arg);
         }
 
-        using var process = Process.Start(psi);
+        using var process = CliProcess.TryStart(psi, log);
 
         if (process is null) {
             log("Failed to start claude process");

--- a/src/Capacitor.Cli.Core/CliProcess.cs
+++ b/src/Capacitor.Cli.Core/CliProcess.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics;
+
+namespace Capacitor.Cli.Core;
+
+static class CliProcess {
+    /// <summary>
+    /// Starts a child process, converting a failed launch into a logged
+    /// <c>null</c> instead of letting the exception escape.
+    ///
+    /// <para>
+    /// A bare <see cref="Process.Start(ProcessStartInfo)"/> throws
+    /// <see cref="System.ComponentModel.Win32Exception"/> when the target
+    /// executable can't be found (e.g. <c>claude</c> not on PATH). In a
+    /// detached hook / what's-done process that exception escapes to
+    /// <c>Main</c> and aborts the whole CLI with SIGABRT — observed as a
+    /// what's-done summary crash when <c>claude</c> was missing from the
+    /// reparented process's PATH. Funnelling the failure to <c>null</c> lets
+    /// callers fall through their existing "process is null → return null"
+    /// handling and exit gracefully.
+    /// </para>
+    /// </summary>
+    internal static Process? TryStart(ProcessStartInfo psi, Action<string> log) {
+        try {
+            return Process.Start(psi);
+        } catch (Exception ex) {
+            log($"Failed to start {psi.FileName}: {ex.Message}");
+
+            return null;
+        }
+    }
+}

--- a/src/Capacitor.Cli.Core/CliProcess.cs
+++ b/src/Capacitor.Cli.Core/CliProcess.cs
@@ -18,12 +18,20 @@ static class CliProcess {
     /// callers fall through their existing "process is null → return null"
     /// handling and exit gracefully.
     /// </para>
+    /// <para>
+    /// The catch is intentionally broad: the whole point is that no launch
+    /// failure — missing executable, denied permission, bad
+    /// <see cref="ProcessStartInfo"/> — may crash the CLI. Narrowing it to a
+    /// known subset would let an unanticipated launch exception escape and
+    /// re-introduce the abort. The exception type is logged so the distinct
+    /// failure modes the broad catch collapses stay diagnosable.
+    /// </para>
     /// </summary>
     internal static Process? TryStart(ProcessStartInfo psi, Action<string> log) {
         try {
             return Process.Start(psi);
         } catch (Exception ex) {
-            log($"Failed to start {psi.FileName}: {ex.Message}");
+            log($"Failed to start {psi.FileName}: {ex.GetType().Name}: {ex.Message}");
 
             return null;
         }

--- a/src/Capacitor.Cli.Core/CodexCliRunner.cs
+++ b/src/Capacitor.Cli.Core/CodexCliRunner.cs
@@ -114,7 +114,7 @@ static class CodexCliRunner {
         // backticks) don't need escaping.
         psi.ArgumentList.Add("-");
 
-        using var process = Process.Start(psi);
+        using var process = CliProcess.TryStart(psi, log);
 
         if (process is null) {
             log("Failed to start codex process");

--- a/test/Capacitor.Cli.Tests.Unit/CliProcessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CliProcessTests.cs
@@ -12,10 +12,14 @@ public class CliProcessTests {
     // "process is null → return null" path instead of crashing the process.
     [Test]
     public async Task TryStart_MissingExecutable_ReturnsNullAndLogs() {
+        // Unique absolute path that cannot exist — deterministic ENOENT on every
+        // OS, independent of the test host's PATH and free of collisions with any
+        // pre-existing temp file.
+        var missing = Path.Combine(Path.GetTempPath(), $"kcap-nonexistent-binary-{Guid.NewGuid():N}");
+        await Assert.That(File.Exists(missing)).IsFalse();
+
         var psi = new ProcessStartInfo {
-            // Absolute path that cannot exist — deterministic ENOENT on every OS,
-            // independent of the test host's PATH.
-            FileName               = Path.Combine(Path.GetTempPath(), "kcap-nonexistent-binary-7f3a2b9c"),
+            FileName               = missing,
             UseShellExecute        = false,
             RedirectStandardOutput = true,
         };

--- a/test/Capacitor.Cli.Tests.Unit/CliProcessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CliProcessTests.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class CliProcessTests {
+    // Regression: a 1-in-111 what's-done generation crashed (SIGABRT) because
+    // `Process.Start("claude")` threw Win32Exception ("No such file or
+    // directory") when `claude` wasn't on the detached process's PATH, and the
+    // throw escaped to Main and aborted the whole CLI. TryStart must convert a
+    // failed launch into a logged null so callers fall through their existing
+    // "process is null → return null" path instead of crashing the process.
+    [Test]
+    public async Task TryStart_MissingExecutable_ReturnsNullAndLogs() {
+        var psi = new ProcessStartInfo {
+            // Absolute path that cannot exist — deterministic ENOENT on every OS,
+            // independent of the test host's PATH.
+            FileName               = Path.Combine(Path.GetTempPath(), "kcap-nonexistent-binary-7f3a2b9c"),
+            UseShellExecute        = false,
+            RedirectStandardOutput = true,
+        };
+        var logs = new List<string>();
+
+        var process = CliProcess.TryStart(psi, logs.Add);
+
+        await Assert.That(process).IsNull();
+        await Assert.That(logs).Contains(l => l.Contains("Failed to start", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
Fixes AI-848.

`ClaudeCliRunner.RunCoreAsync` / `CodexCliRunner.RunCoreAsync` called `Process.Start("claude"/"codex")` unguarded. When the executable isn't on the (often minimal, e.g. launchd) PATH of a detached hook / what's-done process, `Process.Start` throws `Win32Exception`, the throw escapes to `Main`, and the NativeAOT runtime aborts the whole CLI with SIGABRT. Observed as a 1-in-111 what's-done summary crash (`kcap-2026-06-13-112006.ips`) where `claude` (`~/.local/bin/claude`) wasn't reachable on the reparented process's PATH. The existing `if (process is null)` guard only covers `Start` *returning* null, not *throwing*.

## Change
- New `CliProcess.TryStart(psi, log)` — wraps `Process.Start` in try/catch, logs the failure, returns null, so callers fall through their existing `process is null → return null` path instead of crashing.
- Wired into both `ClaudeCliRunner` and `CodexCliRunner`.

## Test plan
- New `CliProcessTests.TryStart_MissingExecutable_ReturnsNullAndLogs` — TDD'd: RED reproduced the `Win32Exception`, GREEN returns null.
- Full unit suite green; `dotnet publish -c Release` (AOT) clean, no IL2026/IL3050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)