### PR TITLE
[AI-847] Report local transcript line count on WatcherConnect (CLI)

### DIFF
--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -167,7 +167,7 @@ static partial class WatchCommand {
 
             // Re-register with server and check if it's behind us (gap recovery)
             try {
-                var serverPosition = await hubConnection.InvokeAsync<int>("WatcherConnect", sessionId, agentId, cancellationToken: cts.Token);
+                var serverPosition = await hubConnection.InvokeAsync<int>("WatcherConnect", sessionId, agentId, CountFileLines(transcriptPath), cancellationToken: cts.Token);
 
                 if (serverPosition < state.LinesProcessed) {
                     Log($"Server behind ({serverPosition} vs {state.LinesProcessed}), rewinding to resend gap");
@@ -218,8 +218,11 @@ static partial class WatchCommand {
             return 0;
         }
 
-        // Register with server and get resume position
-        state.LinesProcessed = await hubConnection.InvokeAsync<int>("WatcherConnect", sessionId, agentId, cts.Token);
+        // Register with server and get resume position. Report our local transcript
+        // line count so the server can tell a genuine resume of an ended session
+        // (we have lines past its resume point) from a watcher with nothing new —
+        // the former must not be stopped with session_already_ended.
+        state.LinesProcessed = await hubConnection.InvokeAsync<int>("WatcherConnect", sessionId, agentId, CountFileLines(transcriptPath), cancellationToken: cts.Token);
         Log($"Connected via SignalR, resuming from line {state.LinesProcessed}");
 
         try {

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -167,7 +167,7 @@ static partial class WatchCommand {
 
             // Re-register with server and check if it's behind us (gap recovery)
             try {
-                var serverPosition = await hubConnection.InvokeAsync<int>("WatcherConnect", sessionId, agentId, CountFileLines(transcriptPath), cancellationToken: cts.Token);
+                var serverPosition = await hubConnection.InvokeAsync<int>("WatcherConnect", sessionId, agentId, LocalLineCountForConnect(transcriptPath), cancellationToken: cts.Token);
 
                 if (serverPosition < state.LinesProcessed) {
                     Log($"Server behind ({serverPosition} vs {state.LinesProcessed}), rewinding to resend gap");
@@ -221,8 +221,10 @@ static partial class WatchCommand {
         // Register with server and get resume position. Report our local transcript
         // line count so the server can tell a genuine resume of an ended session
         // (we have lines past its resume point) from a watcher with nothing new —
-        // the former must not be stopped with session_already_ended.
-        state.LinesProcessed = await hubConnection.InvokeAsync<int>("WatcherConnect", sessionId, agentId, CountFileLines(transcriptPath), cancellationToken: cts.Token);
+        // the former must not be stopped with session_already_ended. A missing or
+        // unreadable transcript reports -1 ("unknown") so the server fails open
+        // rather than mistaking it for an empty (nothing-new) transcript.
+        state.LinesProcessed = await hubConnection.InvokeAsync<int>("WatcherConnect", sessionId, agentId, LocalLineCountForConnect(transcriptPath), cancellationToken: cts.Token);
         Log($"Connected via SignalR, resuming from line {state.LinesProcessed}");
 
         try {
@@ -971,22 +973,38 @@ static partial class WatchCommand {
 
     public static int CountFileLines(string path) {
         try {
-            if (!File.Exists(path)) {
-                return 0;
-            }
-
-            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using var reader = new StreamReader(stream);
-            var       count  = 0;
-
-            while (reader.ReadLine() is not null) {
-                count++;
-            }
-
-            return count;
+            return File.Exists(path) ? CountLines(path) : 0;
         } catch {
             return 0;
         }
+    }
+
+    /// <summary>
+    /// Local transcript line count to report on <c>WatcherConnect</c>, or <c>-1</c>
+    /// when the file is missing or can't be read. A negative ("unknown") count makes
+    /// the server's resume guard fail open — it won't stop a possibly-resuming watcher
+    /// without a confirmed count — whereas a fabricated <c>0</c> (which is what
+    /// <see cref="CountFileLines"/> returns on a read failure) would read as "nothing
+    /// new" and wrongly stop a live resume. (Qodo review on #151 / AI-847.)
+    /// </summary>
+    public static int LocalLineCountForConnect(string path) {
+        try {
+            return File.Exists(path) ? CountLines(path) : -1;
+        } catch {
+            return -1;
+        }
+    }
+
+    static int CountLines(string path) {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream);
+        var       count  = 0;
+
+        while (reader.ReadLine() is not null) {
+            count++;
+        }
+
+        return count;
     }
 
     [GeneratedRegex("<command-name>(.*?)</command-name>", RegexOptions.Compiled)]

--- a/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
@@ -193,6 +193,27 @@ public class CountFileLinesTests {
     [Test]
     public async Task MissingFile_ReturnsZero() =>
         await Assert.That(WatchCommand.CountFileLines("/tmp/nonexistent_" + Guid.NewGuid())).IsEqualTo(0);
+
+    // LocalLineCountForConnect mirrors CountFileLines for a readable file but reports
+    // -1 ("unknown") when the file is missing/unreadable, so the server's resume guard
+    // fails open instead of mistaking an unreadable transcript for an empty one.
+    [Test]
+    [Arguments("line1\nline2\nline3\n", 3)]
+    [Arguments("", 0)]
+    public async Task LocalLineCountForConnect_CountsReadableFile(string content, int expected) {
+        var path = Path.GetTempFileName();
+
+        try {
+            await File.WriteAllTextAsync(path, content);
+            await Assert.That(WatchCommand.LocalLineCountForConnect(path)).IsEqualTo(expected);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task LocalLineCountForConnect_MissingFile_ReturnsMinusOne() =>
+        await Assert.That(WatchCommand.LocalLineCountForConnect("/tmp/nonexistent_" + Guid.NewGuid())).IsEqualTo(-1);
 }
 
 public class WatchCommandTests {


### PR DESCRIPTION
Part 2 of 2 for AI-847 (CLI side; server side: kurrent-io/kcap-server#733).

Pairs with the server-side resume guard. The watcher now passes its current local transcript line count (`CountFileLines(transcriptPath)`) to `WatcherConnect` at both call sites (initial connect + reconnect) so the server can tell a genuine resume of an ended session (local transcript has lines past the server's resume point) from a watcher with nothing new — only the latter gets `session_already_ended`.

The reconnect path also covers the overnight reconnect-to-ended case (the `Server behind (2188 vs 2192)` loop), where a still-running watcher reconnects after the server has marked the session ended.

## Compatibility
- Older servers ignore the extra arg; older watchers send none and the new server falls back to its `-1` sentinel (preserving today's behaviour).

## Test plan
- CLI unit suite green; `dotnet publish -c Release` (AOT) clean, no IL2026/IL3050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)