### PR TITLE
[AI-850] Watcher sends SendTranscriptBatch as a TranscriptBatch object (CLI)

### DIFF
--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -563,23 +563,25 @@ static partial class WatchCommand {
                 return;
             }
 
-            // Serialize repository payload to JSON string for the hub method
-            var repoJson = repoToSend is not null
-                ? JsonSerializer.Serialize(repoToSend, CapacitorJsonContext.Default.RepositoryPayload)
-                : null;
-
             try {
-                // Arg count must match `CapacitorHub.SendTranscriptBatch` exactly —
-                // SignalR's protocol layer does a strict arity match and does NOT
-                // auto-supply defaults for missing args (PR #576 / v0.4.0 incident).
+                // SendTranscriptBatch takes a single TranscriptBatch record (arity 1) —
+                // SignalR matches on argument COUNT and does NOT auto-supply C# optional
+                // defaults (PR #576 / v0.4.0 incident), so a parameter object keeps the
+                // contract stable: adding a field stays backward-compatible (this client
+                // omits a null vendor; servers ignore unknown fields). This calls the
+                // record-based `SendTranscriptBatch2` added in AI-850 (the legacy
+                // positional `SendTranscriptBatch` stays on the server for older CLIs),
+                // so it requires a server deployed with that method — server-before-CLI.
                 await hubConnection.InvokeAsync(
-                    "SendTranscriptBatch",
-                    sessionId,
-                    agentId,
-                    newLines.ToArray(),
-                    newLineNumbers.ToArray(),
-                    repoJson,
-                    vendor,
+                    "SendTranscriptBatch2",
+                    new TranscriptBatch {
+                        SessionId   = sessionId,
+                        AgentId     = agentId,
+                        Lines       = newLines.ToArray(),
+                        LineNumbers = newLineNumbers.ToArray(),
+                        Repository  = repoToSend,
+                        Vendor      = vendor,
+                    },
                     ct
                 );
 


### PR DESCRIPTION
Part 2 of 2 for AI-850 (CLI; server: kurrent-io/kcap-server#735).

The watcher now calls the new record-based `SendTranscriptBatch2` with a single `TranscriptBatch` object (repository as the nested `RepositoryPayload`, not a pre-serialised JSON string). `TranscriptBatch` is already in `CapacitorJsonContext` → AOT-safe.

**Non-breaking:** the server keeps the legacy positional `SendTranscriptBatch` for already-deployed CLIs (#735), so this isn't a lockstep cutover — it only needs the server (with `SendTranscriptBatch2`) deployed **before** this CLI ships. Older CLIs keep working throughout.

## Tests
Unit suite green; `dotnet publish -c Release` (AOT) clean. Server-side `SendTranscriptBatchWireTests` pins this exact object shape (`SendTranscriptBatch2`) over a real SignalR connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)