### PR TITLE
[AI-860] Local terminal attach for hosted agents (Phase 1: run-agent / attach / ls)

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,29 @@ KCAP_DAEMON_LOG_LEVEL=debug kcap daemon    # env var; read directly, works in an
 
 Accepted values: `trace`, `debug`, `information` (default), `warning`, `error`, `critical`, `none`. The `--log-level` flag wins over the env var when both are set. `Debug` is verbose — it also enables the SignalR client's framework logs — so use it for a diagnostic window rather than steady state.
 
+### Local agents (run-agent / attach / ls)
+
+Start a coding agent from your own terminal that the daemon hosts for you. Because the daemon owns the agent (not your terminal), you can **detach and the agent keeps running**, then **re-attach later** — like `tmux` for your coding agent.
+
+```bash
+kcap run-agent claude                       # start Claude in the current directory, attached
+kcap run-agent claude -- --model opus       # everything after `--` is passed to the agent CLI verbatim
+kcap run-agent codex --worktree -- -m gpt-5 # run in an isolated git worktree instead of in place
+kcap run-agent claude --detached            # start without attaching; prints the agent id
+```
+
+- **`--` boundary:** flags before `--` are kcap's; everything after `--` is forwarded to the `claude`/`codex` CLI unchanged. kcap flags: `--worktree`, `--name <daemon>`, `--detached`.
+- **Work location:** by default the agent runs **in place in your current directory** (it edits your real files). Pass `--worktree` to run in a throwaway git worktree instead.
+- **Detach** without stopping the agent with the prefix key **`Ctrl-Q` then `d`**. The agent keeps running in the daemon.
+- **Permissions** prompt natively in your terminal, exactly like running the agent directly.
+
+```bash
+kcap ls                 # list daemon-hosted agents (id, status, repo)
+kcap attach <agent-id>  # re-attach your terminal to a running agent
+```
+
+`run-agent` auto-starts the daemon if one isn't already running. It needs a configured server (like the rest of kcap) — it is not an offline command. This release is **local-only**: starting an agent locally does not yet expose it to teammates in the web UI (planned for a later release). Unix only for now.
+
 ### Repository paths
 
 Manage known repo paths for the agent launch dialog. Repos are automatically added when agents are launched, but you can also manage the list manually:

--- a/docs/superpowers/plans/2026-06-14-local-attach-phase1.md
+++ b/docs/superpowers/plans/2026-06-14-local-attach-phase1.md
@@ -815,20 +815,20 @@ git commit -m "feat(daemon): PrivateLocal agents make no per-agent server calls 
 - Modify: `AgentOrchestrator.cs` (`:294-309`) and `UnixPtyProcess.Spawn` (`:54-66`).
 - Test: extend `PrivateLocalNoServerCallsTests.cs` with an env-assertion test (capture the env dict passed to a fake `IPtyProcessFactory`).
 
-- [ ] **Step 1: Failing test** — fake `IPtyProcessFactory` records `extraEnv`; assert for a private local launch: `KCAP_URL` present, `KCAP_AGENT_ID` present, `KCAP_RENDERED_AGENT` **absent**, `KCAP_DAEMON_URL` **absent**; and that `ANTHROPIC_API_KEY` is **not** scrubbed (local-interactive keeps user auth).
+- [ ] **Step 1: Failing test** — fake `IPtyProcessFactory` records `extraEnv`; assert for a private local launch: `KCAP_URL` present, `ANTHROPIC_API_KEY` present (local-interactive keeps user auth), and `KCAP_AGENT_ID` / `KCAP_RENDERED_AGENT` / `KCAP_DAEMON_URL` all **absent** (plain local session — no `agent_host_id` tag; native terminal permissions).
 
 - [ ] **Step 2: Run, expect FAIL.**
 
-- [ ] **Step 3: Implement** — build the env conditionally:
+- [ ] **Step 3: Implement** — a Phase 1 local agent records as a *plain local session*: keep `KCAP_URL`, re-add `ANTHROPIC_API_KEY`, and omit the hosted-agent vars entirely:
 ```csharp
-var env = new Dictionary<string, string> { ["KCAP_AGENT_ID"] = agentId };
+var env = new Dictionary<string, string>();
 if (!string.IsNullOrEmpty(_config.ServerUrl)) env["KCAP_URL"] = _config.ServerUrl;
-if (!isLocalInteractive) {                       // headless hosted only
-    env["KCAP_RENDERED_AGENT"] = "1";
-    if (_permissionBridge.BaseUrl is { } u) env["KCAP_DAEMON_URL"] = u;
-}
+var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
+if (!string.IsNullOrEmpty(apiKey)) env["ANTHROPIC_API_KEY"] = apiKey;
+// KCAP_AGENT_ID / KCAP_RENDERED_AGENT / KCAP_DAEMON_URL omitted — not a registered hosted
+// agent yet (Phase 2 adds them with registration).
 ```
-Thread `isLocalInteractive` from the spawn path (Task D5). In `UnixPtyProcess.Spawn`, gate the `unsetenv("ANTHROPIC_API_KEY")` on a `scrubProviderKeys` parameter (true for hosted, false for local-interactive).
+`UnixPtyProcess.Spawn` unsets `KCAP_AGENT_ID`/`KCAP_RENDERED_AGENT`/`KCAP_DAEMON_URL` (and `ANTHROPIC_API_KEY`) in the PTY child before applying `extraEnv`, so re-adding `ANTHROPIC_API_KEY` here restores the user's auth while the omitted hosted-agent vars stay unset (no leak from the daemon's own env).
 
 - [ ] **Step 4: Run, expect PASS.** Commit:
 ```bash

--- a/docs/superpowers/plans/2026-06-14-local-attach-phase1.md
+++ b/docs/superpowers/plans/2026-06-14-local-attach-phase1.md
@@ -1,0 +1,1183 @@
+# Local Terminal Attach — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user start a daemon-hosted coding agent from their own terminal (`kcap run-agent`), drive it live over a local socket, detach without killing it, and reattach — "tmux for your agent," entirely local, with no new server contract.
+
+**Architecture:** The daemon already owns the agent PTY and streams it to one client (the web UI over SignalR). Phase 1 generalizes "one client" to "N local-socket clients": a new Unix-domain-socket (named-pipe on Windows) control channel in the daemon, a per-sink lossless terminal fan-out, a local-launch path that runs the agent **`PrivateLocal`** (no server calls) in a **borrowed cwd** or owned worktree, and a thin raw-mode CLI client. Sharing to the web (`Shared`) is Phase 2 and out of scope here.
+
+**Tech Stack:** .NET 10 NativeAOT, `System.Net.Sockets.UnixDomainSocketEndPoint`, `System.Threading.Channels`, `LibraryImport` P/Invoke (termios), TUnit on Microsoft Testing Platform.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md`
+
+---
+
+## Conventions used by every task
+
+- **Run all unit tests:** `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj`
+- **Run one test class (TUnit uses `--treenode-filter`, NOT `--filter`):**
+  `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/FrameCodecTests/*"`
+- **AOT warning gate (run after each milestone):**
+  `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` → expect **no output**.
+- **AOT rule:** no reflection-based serializers in the framing; hand-roll bytes. `JsonArray` collection-expressions are banned (use `new JsonArray(...)`).
+- **Commit** after each task with the message shown in its final step.
+
+---
+
+## File Structure
+
+**New (shared — `Capacitor.Cli.Core`, referenced by both CLI and daemon):**
+- `src/Capacitor.Cli.Core/LocalIpc/FrameType.cs` — the frame-type enum (wire contract).
+- `src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs` — frame payload records.
+- `src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs` — length-prefixed binary read/write.
+- `src/Capacitor.Cli.Core/LocalIpc/LocalSocketPaths.cs` — per-daemon-name socket path.
+- `src/Capacitor.Cli.Core/RunAgentArgs.cs` — parses `run-agent` kcap-flags vs `--` passthrough.
+
+**New (daemon — `Capacitor.Cli.Daemon`):**
+- `src/Capacitor.Cli.Daemon/Services/ITerminalSink.cs` — one output consumer.
+- `src/Capacitor.Cli.Daemon/Services/LocalSocketSink.cs` — per-local-client lossless queue + force-detach.
+- `src/Capacitor.Cli.Daemon/Services/TerminalFanout.cs` — N-sink registry per agent.
+- `src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs` — socket listener + connection handler.
+
+**New (CLI — `Capacitor.Cli`):**
+- `src/Capacitor.Cli/Local/TerminalRawMode.cs` — termios raw-mode set/restore (P/Invoke).
+- `src/Capacitor.Cli/Local/LocalAgentClient.cs` — connect, pumps, resize, detach scan.
+- `src/Capacitor.Cli/Commands/RunAgentCommand.cs` — `run-agent` / `attach` / `ls` dispatch + ensure-daemon.
+
+**Modified (daemon):**
+- `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` — `WorkLocationKind` + `IsPrivate` on `AgentInstance`; `SpawnLocalAgentAsync`; deny-all server guard; cleanup guard; fan-out wiring; conditional env.
+- `src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs` + `ClaudeLauncher.cs` + `CodexLauncher.cs` — passthrough `BuildArgs` path + borrowed-cwd `Prepare` skip.
+- `src/Capacitor.Cli.Daemon/DaemonRunner.cs` — register `LocalControlServer` hosted service.
+
+**Modified (CLI):**
+- `src/Capacitor.Cli/Program.cs` — dispatch `run-agent`/`attach`/`ls`.
+- `README.md` — quick-start + per-command docs (required by CLAUDE.md).
+
+---
+
+## Milestone A — Frame protocol (pure, fully testable)
+
+### Task A1: Frame types
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/LocalIpc/FrameType.cs`
+- Create: `src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs`
+
+- [ ] **Step 1: Write the enum + payloads**
+
+`FrameType.cs`:
+```csharp
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// Wire contract for the daemon↔local-client socket. Values are explicit and
+/// MUST be append-only — they are serialized as a single byte (see FrameCodec).
+public enum FrameType : byte {
+    // client → daemon
+    Spawn   = 1,
+    Attach  = 2,
+    Stdin   = 3,
+    Resize  = 4,
+    Detach  = 5,
+    List    = 6,   // request the daemon's agent list (for `kcap ls`)
+    // daemon → client
+    Attached  = 64,
+    Stdout    = 65,
+    Exited    = 66,
+    Error     = 67,
+    AgentList = 68, // UTF-8 table payload: one `id\tstatus\tcwd` line per agent
+}
+```
+
+`LocalFrame.cs`:
+```csharp
+namespace Capacitor.Cli.Core.LocalIpc;
+
+public enum WorkLocation : byte { BorrowedCwd = 0, OwnedWorktree = 1 }
+
+/// A decoded frame. Exactly one of the payload properties is meaningful per Type;
+/// the codec owns which. Bytes are raw (Stdin/Stdout); strings are UTF-8.
+public sealed record LocalFrame(FrameType Type) {
+    public byte[]      Bytes   { get; init; } = [];
+    public string      Text    { get; init; } = "";
+    public ushort      Cols    { get; init; }
+    public ushort      Rows    { get; init; }
+    public WorkLocation Work   { get; init; }
+    public int         ExitCode { get; init; }
+
+    public static LocalFrame Stdin(byte[] b)            => new(FrameType.Stdin)  { Bytes = b };
+    public static LocalFrame Stdout(byte[] b)           => new(FrameType.Stdout) { Bytes = b };
+    public static LocalFrame Resize(ushort c, ushort r) => new(FrameType.Resize) { Cols = c, Rows = r };
+    public static LocalFrame Detach()                   => new(FrameType.Detach);
+    public static LocalFrame Exited(int code)           => new(FrameType.Exited) { ExitCode = code };
+    public static LocalFrame Error(string m)            => new(FrameType.Error)  { Text = m };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/LocalIpc/FrameType.cs src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs
+git commit -m "feat(local-ipc): frame types for daemon-client socket"
+```
+
+### Task A2: Frame codec (length-prefixed, AOT-safe)
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/FrameCodecTests.cs`
+
+**Wire format per frame:** `[1 byte Type][4 byte big-endian payload length N][N payload bytes]`. Payload layout by type: `Spawn` = `[1 byte WorkLocation][2-byte BE cols][2-byte BE rows][4-byte BE vendorLen][vendor utf8][4-byte BE cwdLen][cwd utf8][4-byte BE argCount]{[4-byte BE argLen][arg utf8]}*`; `Attach` = utf8 agentId; `Stdin`/`Stdout` = raw bytes; `Resize` = `[2-byte BE cols][2-byte BE rows]`; `Exited` = `[4-byte BE int]`; `Error`/`Attached` = utf8 (Attached also carries the replay snapshot as the payload tail — encoded as `[4-byte BE agentIdLen][agentId utf8][snapshot bytes...]`); `Detach` = empty.
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+`FrameCodecTests.cs`:
+```csharp
+using System.IO;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class FrameCodecTests {
+    static async Task<LocalFrame> RoundTrip(LocalFrame f) {
+        using var ms = new MemoryStream();
+        await FrameCodec.WriteAsync(ms, f, default);
+        ms.Position = 0;
+        var read = await FrameCodec.ReadAsync(ms, default);
+        return read!;
+    }
+
+    [Test]
+    public async Task Stdin_round_trips_raw_bytes() {
+        var f = LocalFrame.Stdin([0x00, 0x1b, 0x5b, 0x41, 0xff]);
+        var r = await RoundTrip(f);
+        await Assert.That(r.Type).IsEqualTo(FrameType.Stdin);
+        await Assert.That(r.Bytes).IsEquivalentTo(new byte[] { 0x00, 0x1b, 0x5b, 0x41, 0xff });
+    }
+
+    [Test]
+    public async Task Resize_round_trips_dimensions() {
+        var r = await RoundTrip(LocalFrame.Resize(203, 51));
+        await Assert.That(r.Cols).IsEqualTo((ushort)203);
+        await Assert.That(r.Rows).IsEqualTo((ushort)51);
+    }
+
+    [Test]
+    public async Task Spawn_round_trips_vendor_cwd_args_and_worklocation() {
+        var f = new LocalFrame(FrameType.Spawn) {
+            Work = WorkLocation.BorrowedCwd, Cols = 120, Rows = 40,
+            Text = "claude", Bytes = [],
+        };
+        // Args carried via a dedicated builder — see FrameCodec.Spawn(...)
+        var built = FrameCodec.Spawn("codex", WorkLocation.OwnedWorktree, "/repo", ["--model", "opus", "fix it"], 100, 30);
+        var r = await RoundTrip(built);
+        await Assert.That(r.Type).IsEqualTo(FrameType.Spawn);
+        await Assert.That(r.Text).IsEqualTo("codex");
+        await Assert.That(r.Work).IsEqualTo(WorkLocation.OwnedWorktree);
+        await Assert.That(FrameCodec.SpawnCwd(r)).IsEqualTo("/repo");
+        await Assert.That(FrameCodec.SpawnArgs(r)).IsEquivalentTo(new[] { "--model", "opus", "fix it" });
+    }
+
+    [Test]
+    public async Task ReadAsync_returns_null_on_clean_eof() {
+        using var ms = new MemoryStream();
+        await Assert.That(await FrameCodec.ReadAsync(ms, default)).IsNull();
+    }
+
+    [Test]
+    public async Task ReadAsync_reassembles_across_short_reads() {
+        var f = LocalFrame.Stdout(new byte[5000]); // > one socket read
+        using var ms = new MemoryStream();
+        await FrameCodec.WriteAsync(ms, f, default);
+        ms.Position = 0;
+        using var choppy = new ChoppyStream(ms.ToArray(), chunk: 7);
+        var r = await FrameCodec.ReadAsync(choppy, default);
+        await Assert.That(r!.Bytes.Length).IsEqualTo(5000);
+    }
+}
+
+/// Stream that returns at most `chunk` bytes per ReadAsync to simulate partial socket reads.
+sealed class ChoppyStream(byte[] data, int chunk) : Stream {
+    int _pos;
+    public override int Read(byte[] buffer, int offset, int count) {
+        if (_pos >= data.Length) return 0;
+        var n = Math.Min(Math.Min(chunk, count), data.Length - _pos);
+        Array.Copy(data, _pos, buffer, offset, n); _pos += n; return n;
+    }
+    public override ValueTask<int> ReadAsync(Memory<byte> b, CancellationToken ct = default) {
+        if (_pos >= data.Length) return ValueTask.FromResult(0);
+        var n = Math.Min(Math.Min(chunk, b.Length), data.Length - _pos);
+        data.AsSpan(_pos, n).CopyTo(b.Span); _pos += n; return ValueTask.FromResult(n);
+    }
+    public override bool CanRead => true; public override bool CanSeek => false; public override bool CanWrite => false;
+    public override long Length => data.Length; public override long Position { get => _pos; set => _pos = (int)value; }
+    public override void Flush() { } public override long Seek(long o, SeekOrigin s) => 0;
+    public override void SetLength(long v) { } public override void Write(byte[] b, int o, int c) { }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/FrameCodecTests/*"`
+Expected: FAIL — `FrameCodec` does not exist.
+
+- [ ] **Step 3: Implement `FrameCodec`**
+
+`FrameCodec.cs`:
+```csharp
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// Length-prefixed binary codec: [1B type][4B BE len][len payload]. No reflection /
+/// JSON — AOT-safe and allocation-light. Spawn/Attached have structured payloads
+/// (helpers below); other frames are trivial.
+public static class FrameCodec {
+    const int MaxPayload = 8 * 1024 * 1024; // hard cap; oversized => protocol error
+
+    public static async Task WriteAsync(Stream s, LocalFrame f, CancellationToken ct) {
+        var payload = Encode(f);
+        var head = new byte[5];
+        head[0] = (byte)f.Type;
+        BinaryPrimitives.WriteInt32BigEndian(head.AsSpan(1), payload.Length);
+        await s.WriteAsync(head, ct);
+        if (payload.Length > 0) await s.WriteAsync(payload, ct);
+        await s.FlushAsync(ct);
+    }
+
+    /// Returns null on clean EOF (peer closed between frames).
+    public static async Task<LocalFrame?> ReadAsync(Stream s, CancellationToken ct) {
+        var head = new byte[5];
+        if (!await ReadExactlyOrEof(s, head, ct)) return null;
+        var type = (FrameType)head[0];
+        var len  = BinaryPrimitives.ReadInt32BigEndian(head.AsSpan(1));
+        if (len is < 0 or > MaxPayload) throw new InvalidDataException($"frame len {len}");
+        var payload = len == 0 ? [] : new byte[len];
+        if (len > 0 && !await ReadExactlyOrEof(s, payload, ct))
+            throw new EndOfStreamException("truncated frame payload");
+        return Decode(type, payload);
+    }
+
+    static async Task<bool> ReadExactlyOrEof(Stream s, byte[] buf, CancellationToken ct) {
+        var off = 0;
+        while (off < buf.Length) {
+            var n = await s.ReadAsync(buf.AsMemory(off), ct);
+            if (n == 0) return off != 0 ? throw new EndOfStreamException("truncated frame header") : false;
+            off += n;
+        }
+        return true;
+    }
+
+    static byte[] Encode(LocalFrame f) => f.Type switch {
+        FrameType.Stdin or FrameType.Stdout => f.Bytes,
+        FrameType.Resize                    => Dims(f.Cols, f.Rows),
+        FrameType.Detach or FrameType.List  => [],
+        FrameType.Exited                    => BeInt(f.ExitCode),
+        FrameType.Error or FrameType.Attach or FrameType.AgentList => Encoding.UTF8.GetBytes(f.Text),
+        FrameType.Attached                  => f.Bytes,           // pre-encoded by Attached(...)
+        FrameType.Spawn                     => f.Bytes,           // pre-encoded by Spawn(...)
+        _ => throw new InvalidDataException($"unencodable frame {f.Type}"),
+    };
+
+    static LocalFrame Decode(FrameType t, byte[] p) => t switch {
+        FrameType.Stdin or FrameType.Stdout => new(t) { Bytes = p },
+        FrameType.Resize  => new(t) { Cols = Be16(p, 0), Rows = Be16(p, 2) },
+        FrameType.Detach or FrameType.List => new(t),
+        FrameType.Exited  => new(t) { ExitCode = BinaryPrimitives.ReadInt32BigEndian(p) },
+        FrameType.Error or FrameType.Attach or FrameType.AgentList => new(t) { Text = Encoding.UTF8.GetString(p) },
+        FrameType.Attached or FrameType.Spawn => new(t) { Bytes = p },
+        _ => throw new InvalidDataException($"undecodable frame {t}"),
+    };
+
+    // --- Spawn structured payload ---
+    public static LocalFrame Spawn(string vendor, WorkLocation work, string cwd, IReadOnlyList<string> args, ushort cols, ushort rows) {
+        using var ms = new MemoryStream();
+        ms.WriteByte((byte)work);
+        WriteBe16(ms, cols); WriteBe16(ms, rows);
+        WriteLp(ms, vendor); WriteLp(ms, cwd);
+        WriteBe32(ms, args.Count);
+        foreach (var a in args) WriteLp(ms, a);
+        return new(FrameType.Spawn) { Bytes = ms.ToArray(), Text = vendor, Work = work, Cols = cols, Rows = rows };
+    }
+    public static string SpawnCwd(LocalFrame f) { var (s, _) = ParseSpawn(f.Bytes); return s.cwd; }
+    public static string[] SpawnArgs(LocalFrame f) { var (s, _) = ParseSpawn(f.Bytes); return s.args; }
+    public static (string vendor, WorkLocation work, string cwd, string[] args, ushort cols, ushort rows) Spawn(LocalFrame f)
+        => ParseSpawn(f.Bytes).s;
+
+    static ((string vendor, WorkLocation work, string cwd, string[] args, ushort cols, ushort rows) s, int end) ParseSpawn(byte[] p) {
+        var o = 0;
+        var work = (WorkLocation)p[o++];
+        var cols = Be16(p, o); o += 2; var rows = Be16(p, o); o += 2;
+        var vendor = ReadLp(p, ref o); var cwd = ReadLp(p, ref o);
+        var n = BinaryPrimitives.ReadInt32BigEndian(p.AsSpan(o)); o += 4;
+        var args = new string[n];
+        for (var i = 0; i < n; i++) args[i] = ReadLp(p, ref o);
+        return ((vendor, work, cwd, args, cols, rows), o);
+    }
+
+    // --- Attached structured payload: [4B agentIdLen][agentId][snapshot...] ---
+    public static LocalFrame Attached(string agentId, byte[] snapshot) {
+        using var ms = new MemoryStream();
+        WriteLp(ms, agentId);
+        ms.Write(snapshot);
+        return new(FrameType.Attached) { Bytes = ms.ToArray(), Text = agentId };
+    }
+    public static (string agentId, byte[] snapshot) Attached(LocalFrame f) {
+        var o = 0; var id = ReadLp(f.Bytes, ref o);
+        return (id, f.Bytes[o..]);
+    }
+
+    // --- byte helpers ---
+    static byte[] Dims(ushort c, ushort r) { var b = new byte[4]; BinaryPrimitives.WriteUInt16BigEndian(b, c); BinaryPrimitives.WriteUInt16BigEndian(b.AsSpan(2), r); return b; }
+    static byte[] BeInt(int v) { var b = new byte[4]; BinaryPrimitives.WriteInt32BigEndian(b, v); return b; }
+    static ushort Be16(byte[] p, int o) => BinaryPrimitives.ReadUInt16BigEndian(p.AsSpan(o));
+    static void WriteBe16(Stream s, ushort v) { var b = new byte[2]; BinaryPrimitives.WriteUInt16BigEndian(b, v); s.Write(b); }
+    static void WriteBe32(Stream s, int v) { var b = new byte[4]; BinaryPrimitives.WriteInt32BigEndian(b, v); s.Write(b); }
+    static void WriteLp(Stream s, string v) { var u = Encoding.UTF8.GetBytes(v); WriteBe32(s, u.Length); s.Write(u); }
+    static string ReadLp(byte[] p, ref int o) { var n = BinaryPrimitives.ReadInt32BigEndian(p.AsSpan(o)); o += 4; var v = Encoding.UTF8.GetString(p, o, n); o += n; return v; }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/FrameCodecTests/*"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: AOT gate + commit**
+
+```bash
+dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'   # expect no output
+git add src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs test/Capacitor.Cli.Tests.Unit/FrameCodecTests.cs
+git commit -m "feat(local-ipc): length-prefixed AOT-safe frame codec + tests"
+```
+
+---
+
+## Milestone B — Daemon local socket listener
+
+### Task B1: Socket path
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/LocalIpc/LocalSocketPaths.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/LocalSocketPathsTests.cs`
+
+- [ ] **Step 1: Failing test**
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class LocalSocketPathsTests {
+    [Test]
+    public async Task Socket_path_is_under_daemon_dir_and_name_sanitized() {
+        var p = LocalSocketPaths.Socket("My Daemon!");
+        await Assert.That(p).EndsWith("my-daemon.sock");
+        await Assert.That(p).StartsWith(DaemonLockPaths.Directory);
+    }
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL** (`LocalSocketPaths` missing).
+  Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/LocalSocketPathsTests/*"`
+
+- [ ] **Step 3: Implement**
+
+```csharp
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// Per-daemon-name local control socket, colocated with the daemon's lock/pid files.
+public static class LocalSocketPaths {
+    public static string Socket(string daemonName)
+        => Path.Combine(DaemonLockPaths.Directory, $"{DaemonLockPaths.Sanitize(daemonName)}.sock");
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/LocalIpc/LocalSocketPaths.cs test/Capacitor.Cli.Tests.Unit/LocalSocketPathsTests.cs
+git commit -m "feat(local-ipc): per-daemon-name socket path"
+```
+
+### Task B2: `LocalControlServer` hosted service
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs`
+- Modify: `src/Capacitor.Cli.Daemon/DaemonRunner.cs` (register hosted service — near the other `AddSingleton`/`AddHostedService` calls around `:161`).
+
+> This task is I/O glue; its correctness is covered by the integration test in Task B3. Build-only verification here.
+
+- [ ] **Step 1: Implement the listener**
+
+`LocalControlServer.cs` — a `BackgroundService`. Binds a `Socket(AddressFamily.Unix, …)` to a `UnixDomainSocketEndPoint`, deletes any stale socket file first, sets `0600`, accept-loops, and hands each connection to a handler that decodes frames via `FrameCodec` and calls into `AgentOrchestrator` (Task D5/C2). Mirror the death-rattle/lifetime patterns already in the daemon.
+
+```csharp
+using System.Net.Sockets;
+using Capacitor.Cli.Core.LocalIpc;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+internal sealed partial class LocalControlServer(
+        DaemonConfig config, AgentOrchestrator orchestrator, ILogger<LocalControlServer> logger
+    ) : BackgroundService {
+    protected override async Task ExecuteAsync(CancellationToken ct) {
+        var path = LocalSocketPaths.Socket(config.Name);
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* stale; bind will fail loudly below */ }
+
+        using var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        listener.Bind(new UnixDomainSocketEndPoint(path));
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite); // 0600
+        listener.Listen(16);
+        LogListening(path);
+
+        try {
+            while (!ct.IsCancellationRequested) {
+                var conn = await listener.AcceptAsync(ct);
+                _ = HandleConnectionAsync(conn, ct); // fire-and-forget; handler owns its lifetime
+            }
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) { /* shutdown */ }
+        finally { try { File.Delete(path); } catch { /* best-effort */ } }
+    }
+
+    async Task HandleConnectionAsync(Socket conn, CancellationToken ct) {
+        using var _ = conn;
+        using var stream = new NetworkStream(conn, ownsSocket: false);
+        try {
+            var first = await FrameCodec.ReadAsync(stream, ct);
+            if (first is null) return;
+            switch (first.Type) {
+                case FrameType.Spawn:  await orchestrator.HandleLocalSpawnAsync(first, stream, ct); break;
+                case FrameType.Attach: await orchestrator.HandleLocalAttachAsync(first.Text, stream, ct); break;
+                case FrameType.List:   await orchestrator.HandleLocalListAsync(stream, ct); break;
+                default: await FrameCodec.WriteAsync(stream, LocalFrame.Error($"expected Spawn/Attach/List, got {first.Type}"), ct); break;
+            }
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            LogConnectionError(ex);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Local control socket listening at {Path}")]
+    partial void LogListening(string path);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Local control connection faulted")]
+    partial void LogConnectionError(Exception ex);
+}
+```
+
+(`HandleLocalSpawnAsync` (D5), `HandleLocalAttachAsync` (C2), and `HandleLocalListAsync` (E4) are added later; until then, stub all three on `AgentOrchestrator` returning `Task.CompletedTask` so this compiles.)
+
+- [ ] **Step 2: Register in DI**
+
+In `DaemonRunner.cs`, beside the existing `AddSingleton`/`AddHostedService` block (~`:161`):
+```csharp
+builder.Services.AddSingleton<LocalControlServer>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<LocalControlServer>());
+```
+
+- [ ] **Step 3: Build + AOT gate**
+
+Run: `dotnet build src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj` → expect success.
+Run AOT gate (publish CLI) → expect no `IL30xx/IL20xx`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs src/Capacitor.Cli.Daemon/DaemonRunner.cs
+git commit -m "feat(daemon): local control socket listener (0600), routed to orchestrator"
+```
+
+### Task B3: End-to-end socket smoke test (echo PTY)
+
+**Files:**
+- Test: `test/Capacitor.Cli.Tests.Integration/LocalSocketSpawnTests.cs`
+
+- [ ] **Step 1: Write the integration test** — start a real daemon host (or the `LocalControlServer` + a fake orchestrator) on a temp socket dir (`DaemonLockPaths.OverrideDirectoryForTesting`), connect a client `Socket`, send `Spawn("/bin/cat", BorrowedCwd, tmpdir, [], 80, 24)`, write a `Stdin` frame `"hi\n"`, and assert a `Stdout` frame containing `hi` comes back; then send `Detach` and assert the connection closes while the daemon-side agent stays registered. Use `[Test]` + `Skip` on Windows.
+
+- [ ] **Step 2: Run, expect FAIL** until C2/D5 land. (This test is the acceptance gate for Milestones C+D; mark it `[Skip("enable after Task D5")]` initially, then un-skip in D5.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/Capacitor.Cli.Tests.Integration/LocalSocketSpawnTests.cs
+git commit -m "test(local-ipc): end-to-end socket spawn/stdin/stdout smoke (skipped until D5)"
+```
+
+---
+
+## Milestone C — N-client terminal fan-out
+
+### Task C1: `ITerminalSink` + `LocalSocketSink` (lossless, force-detach on overflow)
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/ITerminalSink.cs`
+- Create: `src/Capacitor.Cli.Daemon/Services/LocalSocketSink.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/LocalSocketSinkTests.cs`
+
+**Design (from spec §b.2):** each sink owns a bounded channel. The fan-out enqueue is **non-blocking** (`TryWrite`); on overflow the sink marks itself **detached** (its run loop ends, the client is dropped and must reattach for a fresh replay) — it never drops mid-stream silently and never blocks the shared PTY loop.
+
+- [ ] **Step 1: Failing test**
+
+```csharp
+using System.Threading.Channels;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class LocalSocketSinkTests {
+    [Test]
+    public async Task Delivers_chunks_in_order() {
+        var got = new List<string>();
+        var sink = new LocalSocketSink(capacity: 8, async (b, _) => got.Add(System.Text.Encoding.UTF8.GetString(b)));
+        var run = sink.RunAsync(default);
+        foreach (var s in new[] { "a", "b", "c" }) sink.TryEnqueue(System.Text.Encoding.UTF8.GetBytes(s));
+        sink.Complete(); await run;
+        await Assert.That(got).IsEquivalentTo(new[] { "a", "b", "c" });
+    }
+
+    [Test]
+    public async Task Overflow_marks_detached_and_never_blocks_producer() {
+        // writer never drains; tiny capacity → overflow
+        var tcs = new TaskCompletionSource();
+        var sink = new LocalSocketSink(capacity: 2, async (_, ct) => await tcs.Task.WaitAsync(ct));
+        var run = sink.RunAsync(default);
+        for (var i = 0; i < 100; i++) sink.TryEnqueue([1]); // must not block
+        await Assert.That(sink.Detached).IsTrue();
+        tcs.SetResult(); sink.Complete();
+    }
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+  `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/LocalSocketSinkTests/*"`
+
+- [ ] **Step 3: Implement**
+
+`ITerminalSink.cs`:
+```csharp
+namespace Capacitor.Cli.Daemon.Services;
+
+/// One consumer of an agent's PTY output. The fan-out calls TryEnqueue (non-blocking);
+/// each sink drains itself on its own loop so one slow sink can't stall the others.
+internal interface ITerminalSink {
+    void TryEnqueue(byte[] chunk);
+    bool Detached { get; }
+}
+```
+
+`LocalSocketSink.cs`:
+```csharp
+using System.Threading.Channels;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+internal sealed class LocalSocketSink : ITerminalSink {
+    readonly Channel<byte[]> _ch;
+    readonly Func<byte[], CancellationToken, Task> _send;
+    public bool Detached { get; private set; }
+
+    public LocalSocketSink(int capacity, Func<byte[], CancellationToken, Task> send) {
+        _send = send;
+        _ch = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(capacity) {
+            FullMode = BoundedChannelFullMode.DropWrite, // we detect overflow ourselves; never silently lose mid-stream
+            SingleReader = true,
+        });
+    }
+
+    public void TryEnqueue(byte[] chunk) {
+        if (Detached) return;
+        if (!_ch.Writer.TryWrite(chunk)) { Detached = true; _ch.Writer.TryComplete(); } // overflow → drop this client
+    }
+
+    public void Complete() => _ch.Writer.TryComplete();
+
+    public async Task RunAsync(CancellationToken ct) {
+        try {
+            await foreach (var chunk in _ch.Reader.ReadAllAsync(ct)) {
+                try { await _send(chunk, ct); }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested) { return; }
+                catch { Detached = true; _ch.Writer.TryComplete(); return; } // socket write failed → drop client
+            }
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+    }
+}
+```
+
+> Note: `DropWrite` + our own `Detached` flag guarantees the *producer* never blocks; the moment a write would drop, we instead mark the whole client detached (forcing a clean reattach+replay) rather than silently losing one chunk and corrupting the stream.
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/ITerminalSink.cs src/Capacitor.Cli.Daemon/Services/LocalSocketSink.cs test/Capacitor.Cli.Tests.Unit/LocalSocketSinkTests.cs
+git commit -m "feat(daemon): per-client lossless terminal sink with force-detach on overflow"
+```
+
+### Task C2: Fan-out wiring in the read loop
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` — add `List<ITerminalSink> LocalSinks` + a `Lock` to `AgentInstance`; in `ReadAgentOutputAsync` (`:431`), after `agent.OutputBuffer.Append(data)`, fan out to local sinks; keep the existing SignalR call **only when the agent is not private** (Task D3 adds `IsPrivate`). Add `HandleLocalAttachAsync(agentId, stream, ct)`: register a `LocalSocketSink` that writes `Stdout` frames to the stream, send an `Attached` replay of `OutputBuffer`, then run the sink and a stdin/resize read loop until the client detaches/disconnects.
+
+- [ ] **Step 1: Add sink registry to `AgentInstance`** (in `AgentOrchestrator.cs`):
+```csharp
+public List<ITerminalSink> LocalSinks { get; } = [];
+public Lock              SinksLock { get; } = new();
+```
+
+- [ ] **Step 2: Fan out in the read loop** — replace the body around `:449-455`:
+```csharp
+agent.OutputBuffer.Append(data);
+ITerminalSink[] sinks;
+lock (agent.SinksLock) sinks = agent.LocalSinks.ToArray();
+foreach (var sink in sinks) sink.TryEnqueue(data);
+if (!agent.IsPrivate)            // Phase 1 local agents are always private → no server stream
+    await _server.SendTerminalOutputAsync(agent.Id, Convert.ToBase64String(data), sendCts.Token);
+```
+
+- [ ] **Step 3: Implement `HandleLocalAttachAsync`** — full method on `AgentOrchestrator`:
+```csharp
+public async Task HandleLocalAttachAsync(string agentId, Stream stream, CancellationToken ct) {
+    if (!_agents.TryGetValue(agentId, out var agent)) {
+        await FrameCodec.WriteAsync(stream, LocalFrame.Error($"no such agent {agentId}"), ct);
+        return;
+    }
+    await AttachClientLoopAsync(agent, stream, ct);
+}
+
+// Shared by attach and spawn. Registers a sink, replays the buffer, then pumps client input.
+async Task AttachClientLoopAsync(AgentInstance agent, Stream stream, CancellationToken ct) {
+    var writeLock = new SemaphoreSlim(1, 1);
+    async Task Send(LocalFrame f) { await writeLock.WaitAsync(ct); try { await FrameCodec.WriteAsync(stream, f, ct); } finally { writeLock.Release(); } }
+
+    var sink = new LocalSocketSink(capacity: 4096, (chunk, c) => Send(LocalFrame.Stdout(chunk)));
+    lock (agent.SinksLock) agent.LocalSinks.Add(sink);
+    await Send(FrameCodec.Attached(agent.Id, agent.OutputBuffer.Snapshot())); // bounded replay before live chunks
+    var pump = sink.RunAsync(ct);
+
+    try {
+        while (!ct.IsCancellationRequested) {
+            var f = await FrameCodec.ReadAsync(stream, ct);
+            if (f is null || f.Type == FrameType.Detach) break;
+            switch (f.Type) {
+                case FrameType.Stdin:  await agent.Process.WriteAsync(f.Bytes); break;
+                case FrameType.Resize: ApplyResizeClamp(agent, sink, f.Cols, f.Rows); break;
+            }
+        }
+    } catch (Exception ex) when (ex is EndOfStreamException or IOException or OperationCanceledException) { /* client gone */ }
+    finally {
+        lock (agent.SinksLock) { agent.LocalSinks.Remove(sink); agent.ClientDims.Remove(sink); }
+        sink.Complete();
+        await pump.ConfigureAwait(false);
+        if (agent.HasExited) await Send(LocalFrame.Exited(agent.Process.ExitCode ?? 0));
+    }
+}
+```
+
+- [ ] **Step 4: Add `TerminalOutputBuffer.Snapshot()`** (in `AgentOrchestrator.cs`, on the `TerminalOutputBuffer` class near `:47`):
+```csharp
+public byte[] Snapshot() { lock (_chunks) { var ms = new MemoryStream(_totalBytes); foreach (var c in _chunks) ms.Write(c); return ms.ToArray(); } }
+```
+(Confirm the existing `_chunks`/`_totalBytes` fields; add a `lock (_chunks)` to `Append` too if not already synchronized.)
+
+- [ ] **Step 5: Resize min-clamp helper** (the daemon owns the clamp). Add `public Dictionary<ITerminalSink, Dim> ClientDims { get; } = [];` and `public readonly record struct Dim(ushort Cols, ushort Rows);` to `AgentInstance`, then:
+```csharp
+// Min-clamp across all attached local clients (tmux semantics): the PTY is sized to the
+// smallest cols × rows any attached client reports, so no client's redraw is corrupted.
+void ApplyResizeClamp(AgentInstance agent, ITerminalSink sink, ushort cols, ushort rows) {
+    lock (agent.SinksLock) {
+        agent.ClientDims[sink] = new AgentInstance.Dim(cols, rows);
+        if (agent.ClientDims.Count == 0) { agent.Process.Resize(cols, rows); return; }
+        var c = agent.ClientDims.Values.Min(d => d.Cols);
+        var r = agent.ClientDims.Values.Min(d => d.Rows);
+        agent.Process.Resize(c, r);
+    }
+}
+```
+
+- [ ] **Step 6: Build, then run unit suite** → expect green; commit.
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+git commit -m "feat(daemon): N-client terminal fan-out + local attach loop + resize min-clamp"
+```
+
+---
+
+## Milestone D — Local-launch semantics
+
+### Task D1: Work-location kind + cleanup guard
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (`AgentInstance` + `CleanupAgentAsync` `:888`).
+- Test: `test/Capacitor.Cli.Tests.Unit/LocalCleanupGuardTests.cs`
+
+- [ ] **Step 1: Failing test** — construct an `AgentInstance` with `Work = BorrowedCwd` pointing at a temp git repo, call the cleanup, assert the directory and its branch still exist. (Use the existing orchestrator test seams; if `CleanupAgentAsync` is private, add an `internal` test hook mirroring `HandleLaunchAgentForTest`.)
+
+```csharp
+[Test]
+public async Task Borrowed_cwd_cleanup_does_not_delete_user_dir_or_branch() {
+    var dir = Directory.CreateTempSubdirectory("kcap-inplace-");
+    // ... init a git repo + branch in `dir`, build an orchestrator with a fake server,
+    // register a BorrowedCwd agent whose Worktree.Path == dir.FullName, run cleanup ...
+    await Assert.That(Directory.Exists(dir.FullName)).IsTrue();
+    // and the branch still exists (git branch --list)
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL** (cleanup currently deletes it).
+
+- [ ] **Step 3: Add `Work` to `AgentInstance` + guard cleanup**
+
+On `AgentInstance`: `public WorkLocation Work { get; init; } = WorkLocation.OwnedWorktree;`
+
+In `CleanupAgentAsync` (`:900`), wrap the removal:
+```csharp
+if (agent.Work == WorkLocation.OwnedWorktree) {
+    try { await WorktreeManager.RemoveAsync(agent.Worktree); } catch (Exception ex) { LogCleanupStepFailed(ex, "removing worktree", agentId); }
+}
+// BorrowedCwd: never remove the user's directory or branch.
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs test/Capacitor.Cli.Tests.Unit/LocalCleanupGuardTests.cs
+git commit -m "feat(daemon): owned-vs-borrowed work location; never remove a borrowed cwd"
+```
+
+### Task D2: Borrowed-cwd `Prepare` skip
+
+**Files:**
+- Modify: `IHostedAgentLauncher.cs` (`LauncherContext` gains `WorkLocation Work`), `ClaudeLauncher.cs:21`, `CodexLauncher.cs:18`.
+- Test: `test/Capacitor.Cli.Tests.Unit/InPlacePrepareTests.cs`
+
+- [ ] **Step 1: Failing test** — call `ClaudeLauncher.Prepare(ctx)` with `Work = BorrowedCwd` and `Worktree.Path` = temp dir; assert no `.mcp.json` / `.claude/settings.local.json` were created in it.
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement** — add `Work` to `LauncherContext`; at the top of each `Prepare`, early-return the repo-mutating work for borrowed cwd:
+```csharp
+public void Prepare(LauncherContext ctx) {
+    if (ctx.Work == WorkLocation.BorrowedCwd) return; // user's own repo: already trusted/configured; touch nothing
+    // ... existing worktree-mirroring logic unchanged ...
+}
+```
+For `CodexLauncher`, keep **only** the hooks preflight (read-only check) for borrowed cwd; skip overlay + trust writes:
+```csharp
+public void Prepare(LauncherContext ctx) {
+    if (ctx.Work == WorkLocation.OwnedWorktree) { /* existing overlay */ }
+    RunHooksPreflight(ctx);   // read-only; throws CodexHooksNotInstalledException if missing
+    if (ctx.Work == WorkLocation.OwnedWorktree) { /* existing trust write */ }
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.** Commit:
+```bash
+git add src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs test/Capacitor.Cli.Tests.Unit/InPlacePrepareTests.cs
+git commit -m "feat(daemon): borrowed-cwd launches skip repo-mutating Prepare steps"
+```
+
+### Task D3: `PrivateLocal` deny-all server guard
+
+**Files:**
+- Modify: `AgentOrchestrator.cs` — add `bool IsPrivate` to `AgentInstance`; route every per-agent `_server.*` call for a private agent through a no-op.
+- Test: `test/Capacitor.Cli.Tests.Unit/PrivateLocalNoServerCallsTests.cs`
+
+- [ ] **Step 1: Failing test** — a strict mock `ServerConnection` (or its interface seam) whose every per-agent method throws `Assert.Fail`. Drive a private agent through launch→exit→cleanup; assert no method fired.
+  > If `AgentOrchestrator` takes a concrete `ServerConnection`, extract an `IAgentServer` interface for the per-agent calls (`AgentRegisteredAsync`, `AppendAgentRunEventAsync`, `DaemonUpdateRepoPaths`, `LaunchFailedAsync`, `AgentStatusChangedAsync`, `EndAgentSessionAsync`, `AgentUnregisteredAsync`) in this task so it can be mocked. This refactor is part of the task.
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement** — the simplest correct form: a private agent skips the calls at each site, e.g.
+```csharp
+if (!agent.IsPrivate) await _server.AgentRegisteredAsync(...);
+if (!agent.IsPrivate) _ = _server.AppendAgentRunEventAsync(...);
+```
+Apply at every site listed in the spec (`:327,:329,:334,:512,:516,:520,:534`, reconnect `:811`, heartbeat `:862`). Prefer a single private-aware wrapper (`AgentServerCalls` helper that no-ops when `IsPrivate`) so a future call can't forget the guard.
+
+- [ ] **Step 4: Run, expect PASS.** Commit:
+```bash
+git add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs test/Capacitor.Cli.Tests.Unit/PrivateLocalNoServerCallsTests.cs
+git commit -m "feat(daemon): PrivateLocal agents make no per-agent server calls (deny-all + strict-mock test)"
+```
+
+### Task D4: Conditional launch env
+
+**Files:**
+- Modify: `AgentOrchestrator.cs` (`:294-309`) and `UnixPtyProcess.Spawn` (`:54-66`).
+- Test: extend `PrivateLocalNoServerCallsTests.cs` with an env-assertion test (capture the env dict passed to a fake `IPtyProcessFactory`).
+
+- [ ] **Step 1: Failing test** — fake `IPtyProcessFactory` records `extraEnv`; assert for a private local launch: `KCAP_URL` present, `KCAP_AGENT_ID` present, `KCAP_RENDERED_AGENT` **absent**, `KCAP_DAEMON_URL` **absent**; and that `ANTHROPIC_API_KEY` is **not** scrubbed (local-interactive keeps user auth).
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement** — build the env conditionally:
+```csharp
+var env = new Dictionary<string, string> { ["KCAP_AGENT_ID"] = agentId };
+if (!string.IsNullOrEmpty(_config.ServerUrl)) env["KCAP_URL"] = _config.ServerUrl;
+if (!isLocalInteractive) {                       // headless hosted only
+    env["KCAP_RENDERED_AGENT"] = "1";
+    if (_permissionBridge.BaseUrl is { } u) env["KCAP_DAEMON_URL"] = u;
+}
+```
+Thread `isLocalInteractive` from the spawn path (Task D5). In `UnixPtyProcess.Spawn`, gate the `unsetenv("ANTHROPIC_API_KEY")` on a `scrubProviderKeys` parameter (true for hosted, false for local-interactive).
+
+- [ ] **Step 4: Run, expect PASS.** Commit:
+```bash
+git commit -am "feat(daemon): conditional hook env for local-interactive launches (native perms, keep auth)"
+```
+
+### Task D5: `HandleLocalSpawnAsync` (the local-launch entry)
+
+**Files:**
+- Modify: `AgentOrchestrator.cs` — new public method invoked by `LocalControlServer`.
+
+- [ ] **Step 1: Implement** — decode the `Spawn` frame, build a `LauncherContext` with `Work` + passthrough args, run `Prepare`, `forkpty` via `_ptyFactory.Spawn` with the conditional env, create the `AgentInstance { IsPrivate = true, Work = ... }`, start `ReadAgentOutputAsync`, then call `AttachClientLoopAsync(agent, stream, ct)` (Task C2) so the spawning client is immediately attached. Mirror `HandleLaunchAgent` but: no server calls, passthrough `BuildArgs`, `isLocalInteractive: true`.
+
+```csharp
+public async Task HandleLocalSpawnAsync(LocalFrame spawn, Stream stream, CancellationToken ct) {
+    var (vendor, work, cwd, args, cols, rows) = FrameCodec.Spawn(spawn);
+    if (!_launchers.TryGetValue(vendor, out var launcher)) {
+        await FrameCodec.WriteAsync(stream, LocalFrame.Error($"unknown vendor {vendor}"), ct); return;
+    }
+    var agentId = Guid.NewGuid().ToString("N");
+    // OwnedWorktree: reuse the exact worktree-creation call HandleLaunchAgent already makes
+    // (via WorktreeManager). BorrowedCwd: a new WorktreeInfo.Borrowed(cwd) factory whose
+    // Work=BorrowedCwd guarantees Task D1's cleanup guard never removes it.
+    var worktree = work == WorkLocation.OwnedWorktree
+        ? await CreateOwnedWorktreeAsync(cwd, agentId)               // extract from HandleLaunchAgent's existing creation
+        : WorktreeInfo.Borrowed(cwd);
+    var ctx = new LauncherContext(agentId, cwd, worktree, Prompt: null, Model: "", Effort: null,
+                                  Tools: null, IsReview: false, Review: null, ReviewLaunch: null) { Work = work };
+    try { launcher.Prepare(ctx); } catch (Exception ex) { await FrameCodec.WriteAsync(stream, LocalFrame.Error(ex.Message), ct); return; }
+    var built = launcher.BuildPassthrough(ctx, args);                // Task E5
+    var env   = BuildLaunchEnv(agentId, isLocalInteractive: true);   // Task D4
+    var proc  = _ptyFactory.Spawn(launcher.CliPath, built.Args, cwd, env, cols, rows, scrubProviderKeys: false);
+    var agent = new AgentInstance(agentId, null, "", null, cwd, vendor, proc, worktree, new CancellationTokenSource()) {
+        IsPrivate = true, Work = work,
+    };
+    _agents[agentId] = agent;
+    _ = ReadAgentOutputAsync(agent);
+    await AttachClientLoopAsync(agent, stream, ct);
+}
+```
+> Add `WorktreeInfo.Borrowed(cwd)` (a borrowed-cwd `WorktreeInfo` with `IsStandalone = false` and a sentinel that `RemoveAsync` is never called on — guaranteed by Task D1's `Work` guard). Add `IPtyProcessFactory.Spawn` overload params `(cols, rows, scrubProviderKeys)` (default to current behavior for the server path).
+
+- [ ] **Step 2: Un-skip the B3 integration test; run it.**
+  Run: `dotnet run --project test/Capacitor.Cli.Tests.Integration/Capacitor.Cli.Tests.Integration.csproj -- --treenode-filter "/*/*/LocalSocketSpawnTests/*"`
+  Expected: PASS (spawn `/bin/cat`, echo round-trips, detach leaves it running).
+
+- [ ] **Step 3: AOT gate + commit**
+
+```bash
+dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'   # expect none
+git commit -am "feat(daemon): local spawn entry — PrivateLocal, passthrough, attach spawning client"
+```
+
+---
+
+## Milestone E — CLI client
+
+### Task E1: termios raw mode
+
+**Files:**
+- Create: `src/Capacitor.Cli/Local/TerminalRawMode.cs`
+
+- [ ] **Step 1: Implement** (P/Invoke mirroring `UnixPtyInterop` style; AOT-safe `LibraryImport`):
+```csharp
+using System.Runtime.InteropServices;
+namespace Capacitor.Cli.Local;
+
+internal static partial class TerminalRawMode {
+    [LibraryImport("libc", SetLastError = true)] [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial int tcgetattr(int fd, out Termios t);
+    [LibraryImport("libc", SetLastError = true)] [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial int tcsetattr(int fd, int optionalActions, ref Termios t);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Termios { public uint c_iflag, c_oflag, c_cflag, c_lflag; [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)] public byte[] c_cc; public uint c_ispeed, c_ospeed; }
+    // NOTE: termios layout differs Linux vs macOS; the implementer MUST verify field offsets
+    // per-platform (use cfmakeraw if available to avoid hand-flag math).
+
+    const int STDIN = 0, TCSANOW = 0;
+    const uint ICANON = 0x2, ECHO = 0x8, ISIG = 0x1, IEXTEN = 0x400; // verify per-platform
+
+    /// Returns a token whose Dispose restores the original mode. Idempotent + exception-safe.
+    public static IDisposable Enable() {
+        if (tcgetattr(STDIN, out var orig) != 0) return new Noop();
+        var raw = orig;
+        raw.c_lflag &= ~(ICANON | ECHO | ISIG | IEXTEN);
+        tcsetattr(STDIN, TCSANOW, ref raw);
+        return new Restore(orig);
+    }
+    sealed class Restore(Termios orig) : IDisposable { public void Dispose() { var t = orig; tcsetattr(STDIN, TCSANOW, ref t); } }
+    sealed class Noop : IDisposable { public void Dispose() { } }
+}
+```
+> Implementer task: prefer linking `cfmakeraw` if present; otherwise verify `Termios` layout + flag constants against `<termios.h>` for both Linux and macOS. Add a manual checklist note in the PR.
+
+- [ ] **Step 2: Build** → success. Commit:
+```bash
+git add src/Capacitor.Cli/Local/TerminalRawMode.cs
+git commit -m "feat(cli): termios raw-mode enable/restore (P/Invoke)"
+```
+
+### Task E2: `RunAgentArgs` parsing
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/RunAgentArgs.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/RunAgentArgsTests.cs`
+
+- [ ] **Step 1: Failing test**
+```csharp
+using Capacitor.Cli.Core;
+namespace Capacitor.Cli.Tests.Unit;
+public class RunAgentArgsTests {
+    [Test] public async Task Splits_kcap_flags_from_passthrough_at_double_dash() {
+        var a = RunAgentArgs.Parse(["claude", "--worktree", "--name", "dev", "--", "--model", "opus", "fix"]);
+        await Assert.That(a.Vendor).IsEqualTo("claude");
+        await Assert.That(a.Worktree).IsTrue();
+        await Assert.That(a.DaemonName).IsEqualTo("dev");
+        await Assert.That(a.Passthrough).IsEquivalentTo(new[] { "--model", "opus", "fix" });
+    }
+    [Test] public async Task Default_is_in_place_no_passthrough() {
+        var a = RunAgentArgs.Parse(["codex"]);
+        await Assert.That(a.Worktree).IsFalse();
+        await Assert.That(a.Passthrough).IsEmpty();
+    }
+    [Test] public async Task Missing_vendor_is_an_error() {
+        await Assert.That(RunAgentArgs.Parse([]).Error).IsNotNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement**
+```csharp
+namespace Capacitor.Cli.Core;
+public sealed record RunAgentArgs {
+    public string Vendor = ""; public bool Worktree; public string? DaemonName; public bool Detached;
+    public string[] Passthrough = []; public string? Error;
+    public static RunAgentArgs Parse(string[] args) {
+        var r = new RunAgentArgs();
+        if (args.Length == 0) { r.Error = "usage: kcap run-agent <vendor> [--worktree] [--name <id>] [--detached] [-- <agent args>]"; return r; }
+        var dash = Array.IndexOf(args, "--");
+        var kcap = dash < 0 ? args : args[..dash];
+        r.Passthrough = dash < 0 ? [] : args[(dash + 1)..];
+        r.Vendor = kcap[0];
+        for (var i = 1; i < kcap.Length; i++) switch (kcap[i]) {
+            case "--worktree": r.Worktree = true; break;
+            case "--detached": r.Detached = true; break;
+            case "--name": r.DaemonName = i + 1 < kcap.Length ? kcap[++i] : null; break;
+            case "--share": r.Error = "--share is Phase 2 and not yet supported"; break;
+            default: r.Error = $"unknown flag {kcap[i]} (did you mean to put it after `--`?)"; break;
+        }
+        return r;
+    }
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.** Commit:
+```bash
+git add src/Capacitor.Cli.Core/RunAgentArgs.cs test/Capacitor.Cli.Tests.Unit/RunAgentArgsTests.cs
+git commit -m "feat(cli): run-agent arg parsing (-- boundary, kcap flags)"
+```
+
+### Task E3: `LocalAgentClient`
+
+**Files:**
+- Create: `src/Capacitor.Cli/Local/LocalAgentClient.cs`
+
+- [ ] **Step 1: Implement** — connect to the socket, send the opening `Spawn` (or `Attach`) frame, run two pumps: (a) stdout-frame → `Console.OpenStandardOutput()`, (b) raw stdin → scan for the detach prefix, else `Stdin` frame. Install a `PosixSignalRegistration` for `SIGWINCH` that sends a `Resize` frame with the current `Console.WindowWidth/Height`. Wrap the whole run in `using (TerminalRawMode.Enable())`. On `Exited`/EOF, return the exit code.
+
+```csharp
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using Capacitor.Cli.Core.LocalIpc;
+namespace Capacitor.Cli.Local;
+
+internal sealed class LocalAgentClient {
+    // Detach prefix: Ctrl-Q (0x11) then 'd'. Intercepted before forwarding.
+    static readonly byte[] DetachPrefix = [0x11];
+
+    public static async Task<int> RunAsync(string socketPath, LocalFrame opening, CancellationToken ct) {
+        using var sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        await sock.ConnectAsync(new UnixDomainSocketEndPoint(socketPath), ct);
+        using var stream = new NetworkStream(sock, ownsSocket: false);
+        await FrameCodec.WriteAsync(stream, opening, ct);
+
+        using var raw = TerminalRawMode.Enable();
+        using var _ = PosixSignalRegistration.Create((PosixSignal)28 /* SIGWINCH */, _ =>
+            _ = FrameCodec.WriteAsync(stream, LocalFrame.Resize((ushort)Console.WindowWidth, (ushort)Console.WindowHeight), ct));
+
+        var stdout = Console.OpenStandardOutput();
+        var outPump = Task.Run(async () => {
+            while (!ct.IsCancellationRequested) {
+                var f = await FrameCodec.ReadAsync(stream, ct);
+                if (f is null) return 0;
+                switch (f.Type) {
+                    case FrameType.Stdout: await stdout.WriteAsync(f.Bytes, ct); await stdout.FlushAsync(ct); break;
+                    case FrameType.Attached: var (_, snap) = FrameCodec.Attached(f); await stdout.WriteAsync(snap, ct); await stdout.FlushAsync(ct);
+                        await FrameCodec.WriteAsync(stream, LocalFrame.Resize((ushort)Console.WindowWidth, (ushort)Console.WindowHeight), ct); break; // nudge repaint
+                    case FrameType.Exited: return f.ExitCode;
+                    case FrameType.Error: await Console.Error.WriteLineAsync($"\r\n[kcap] {f.Text}"); return 1;
+                }
+            }
+            return 0;
+        }, ct);
+
+        var stdin = Console.OpenStandardInput();
+        var buf = new byte[4096];
+        try {
+            while (!ct.IsCancellationRequested && !outPump.IsCompleted) {
+                var n = await stdin.ReadAsync(buf, ct);
+                if (n == 0) break;
+                if (n >= DetachPrefix.Length && buf[0] == DetachPrefix[0]) { // simplistic; real impl tracks prefix state across reads
+                    await FrameCodec.WriteAsync(stream, LocalFrame.Detach(), ct); break;
+                }
+                await FrameCodec.WriteAsync(stream, LocalFrame.Stdin(buf[..n]), ct);
+            }
+        } catch (Exception ex) when (ex is IOException or OperationCanceledException) { }
+        return await outPump;
+    }
+}
+```
+> Implementer task: the detach-prefix scan must be a tiny state machine across reads (prefix byte `0x11` then `d` within the next read), matching the `FrameCodecTests`-style "prefix split across reads" unit test — add that unit test for the scanner extracted as a pure function `DetachScanner.Feed(byte) -> (forward, detach)`.
+
+- [ ] **Step 2: Build** → success. Commit:
+```bash
+git add src/Capacitor.Cli/Local/LocalAgentClient.cs
+git commit -m "feat(cli): local agent client — pumps, SIGWINCH resize, detach, replay repaint"
+```
+
+### Task E4: `run-agent` / `attach` / `ls` dispatch
+
+**Files:**
+- Create: `src/Capacitor.Cli/Commands/RunAgentCommand.cs`
+- Modify: `src/Capacitor.Cli/Program.cs` (add `case "run-agent":`, `case "attach":`, `case "ls":` in the main switch; do **not** add them to `offlineCommands` — they need a configured server-backed daemon).
+
+- [ ] **Step 1: Implement `RunAgentCommand.HandleAsync(args)`** — parse via `RunAgentArgs`; resolve daemon name (`DaemonNameResolver`); **ensure the daemon is running** (reuse `DaemonCommands` start path; if no live daemon, start one detached and poll for `LocalSocketPaths.Socket(name)` to appear, ~5s timeout); build the `Spawn` frame with cwd = `Environment.CurrentDirectory`, work = `--worktree ? OwnedWorktree : BorrowedCwd`, passthrough args, initial `Console.WindowWidth/Height`; call `LocalAgentClient.RunAsync(LocalSocketPaths.Socket(name), spawnFrame, ct)` and return its exit code.
+  - `AttachAsync(args)` resolves the daemon + sends an `Attach` frame (agentId = `args[0]`) instead of `Spawn`.
+  - `ListAsync(args)` connects, sends a `List` frame, reads one `AgentList` text frame, and prints its tab-separated `id\tstatus\tcwd` lines as an aligned table (no live attach; closes after printing).
+
+- [ ] **Step 1b: Daemon side of `ls` — implement `HandleLocalListAsync` on `AgentOrchestrator`:**
+```csharp
+public async Task HandleLocalListAsync(Stream stream, CancellationToken ct) {
+    var lines = _agents.Values.Select(a => $"{a.Id}\t{a.Status}\t{a.RepoPath}");
+    await FrameCodec.WriteAsync(stream, new LocalFrame(FrameType.AgentList) { Text = string.Join('\n', lines) }, ct);
+}
+```
+
+- [ ] **Step 2: Wire dispatch in `Program.cs`:**
+```csharp
+case "run-agent": return await RunAgentCommand.HandleAsync(args[1..]);
+case "attach":    return await RunAgentCommand.AttachAsync(args[1..]);
+case "ls":        return await RunAgentCommand.ListAsync(args[1..]);
+```
+
+- [ ] **Step 3: Manual smoke** (no automated TTY test):
+```
+# terminal 1
+dotnet run --project src/Capacitor.Cli/Capacitor.Cli.csproj -- run-agent claude -- --model sonnet
+# type, see output; press Ctrl-Q then d to detach
+dotnet run --project src/Capacitor.Cli/Capacitor.Cli.csproj -- ls           # shows the running agent
+dotnet run --project src/Capacitor.Cli/Capacitor.Cli.csproj -- attach <id>  # reattach, screen repaints
+```
+Expected: interactive session works, Ctrl-C reaches Claude, detach leaves it running, attach repaints.
+
+- [ ] **Step 4: AOT gate + commit**
+```bash
+dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'   # expect none
+git add src/Capacitor.Cli/Commands/RunAgentCommand.cs src/Capacitor.Cli/Program.cs
+git commit -m "feat(cli): run-agent / attach / ls commands + ensure-daemon"
+```
+
+### Task E5: Launcher-agnostic passthrough `BuildArgs`
+
+**Files:**
+- Modify: `IHostedAgentLauncher.cs` (add `LaunchArgs BuildPassthrough(LauncherContext ctx, IReadOnlyList<string> userArgs)`), `ClaudeLauncher.cs`, `CodexLauncher.cs`.
+- Test: `test/Capacitor.Cli.Tests.Unit/PassthroughBuildArgsTests.cs`
+
+- [ ] **Step 1: Failing tests**
+```csharp
+[Test] public async Task Claude_passthrough_is_verbatim() {
+    var a = new ClaudeLauncher(Cfg(), Log()).BuildPassthrough(Ctx(WorkLocation.BorrowedCwd, "/r"), ["--model", "opus", "hi"]);
+    await Assert.That(a.Args).IsEquivalentTo(new[] { "--model", "opus", "hi" });
+}
+[Test] public async Task Codex_injects_mandatory_then_appends_user_args() {
+    var a = new CodexLauncher(Cfg(), Log()).BuildPassthrough(Ctx(WorkLocation.BorrowedCwd, "/r"), ["-m", "gpt"]);
+    await Assert.That(a.Args).Contains("--cd"); await Assert.That(a.Args).Contains("--no-alt-screen");
+    await Assert.That(a.Args[^2]).IsEqualTo("-m"); await Assert.That(a.Args[^1]).IsEqualTo("gpt");
+}
+[Test] public async Task Codex_rejects_user_duplicate_of_mandatory_flag() {
+    await Assert.That(() => new CodexLauncher(Cfg(), Log()).BuildPassthrough(Ctx(WorkLocation.BorrowedCwd, "/r"), ["--cd", "/elsewhere"]))
+        .Throws<ArgumentException>();
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement**
+- Claude: `BuildPassthrough(ctx, userArgs) => new([.. userArgs], McpConfigPath: null);`
+- Codex:
+```csharp
+public LaunchArgs BuildPassthrough(LauncherContext ctx, IReadOnlyList<string> userArgs) {
+    string[] mandatory = ["--cd", "--no-alt-screen"];
+    foreach (var m in mandatory)
+        if (userArgs.Contains(m)) throw new ArgumentException($"{m} is set by kcap and cannot be overridden");
+    var args = new List<string> { "--cd", ctx.Worktree.Path, "--sandbox", "workspace-write", "--ask-for-approval", "on-request", "--no-alt-screen" };
+    args.AddRange(userArgs);
+    return new([.. args], McpConfigPath: null);
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.** Commit:
+```bash
+git add src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs test/Capacitor.Cli.Tests.Unit/PassthroughBuildArgsTests.cs
+git commit -m "feat(daemon): launcher-agnostic passthrough BuildArgs (Codex mandatory-flag enforcement)"
+```
+
+---
+
+## Milestone F — Docs & final verification
+
+### Task F1: README
+
+**Files:**
+- Modify: `README.md` — add `run-agent`/`attach`/`ls` to `## Getting started` and a per-command section under `## CLI commands`, covering `--worktree` (default in-place), the `--` boundary, the detach key (Ctrl-Q d), and that it's local-only in this release (no web sharing yet).
+
+- [ ] **Step 1: Write the docs. Step 2: Commit.**
+```bash
+git add README.md
+git commit -m "docs: document run-agent / attach / ls (local terminal attach, Phase 1)"
+```
+
+### Task F2: Full suite + AOT gate
+
+- [ ] **Step 1: Full unit + integration suites green**
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj
+dotnet run --project test/Capacitor.Cli.Tests.Integration/Capacitor.Cli.Tests.Integration.csproj
+```
+- [ ] **Step 2: AOT publish clean**
+```bash
+dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'   # expect no output
+```
+- [ ] **Step 3: macOS — re-sign the AOT binary if copied** (`codesign --force --sign - <binary>`).
+
+---
+
+## Notes for the implementer
+
+- **Windows:** the socket uses `UnixDomainSocketEndPoint`, which works on Win10+; `File.SetUnixFileMode` is a no-op there (guarded by `OperatingSystem.IsWindows()`). `TerminalRawMode` is Unix-only — Phase 1 targets Unix; gate `run-agent` with a clear "not supported on Windows yet" message if `OperatingSystem.IsWindows()`.
+- **Phase 2 (out of scope):** `kcap share` / `--share`, the daemon→server announce, `PrivateLocal`→`Shared` transition with one-time replay, session tag-and-link, and web-client resize aggregation. The `IsPrivate`/`Work`/sink abstractions added here are the seams Phase 2 builds on.
+- **Detach key** default is Ctrl-Q then `d`; make it overridable later via config — not required for Phase 1.

--- a/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
@@ -72,8 +72,9 @@ kcap ls
 | Transport | **Hybrid.** Local terminal over a new local socket; teammates + continue-remotely over existing SignalR. |
 | Server dependency | **Phase 1 adds no new server *contract*, but is not offline.** The daemon still requires `ServerUrl` + a SignalR connection at startup exactly as today; local attach rides alongside it. True offline-daemon operation is a possible later enhancement, not in scope. |
 | Remote control (Phase 2) | **Write by default once shared**, mirroring current hosted-agent run permissions. Observe-only is served by the existing read-only session-sharing path, not by attach. |
-| Resize | **Clamp the one PTY to the smallest attached client** (tmux semantics); no last-writer fighting. |
-| Terminal stream | **Lossless per sink.** Never `DropOldest`; a sink that overflows is force-detached and replays on rejoin (see plumbing). |
+| Resize | **Min-clamp the PTY across attached *local* clients** (tmux semantics) in Phase 1; clamping web clients too needs a Phase 2 server-side resize contract (SignalR has only one agent-level resize today). |
+| Terminal stream | **No silent partial-stream corruption.** Never `DropOldest`; an overflowing sink is force-detached and re-syncs via a clean replay on rejoin (bounded by the 2 MB `OutputBuffer`) rather than rendering a corrupted partial stream (see plumbing). |
+| Vendor passthrough | **Launcher-agnostic.** Part of the `IHostedAgentLauncher` contract; both `run-agent claude` and `run-agent codex` work in v1. |
 
 ### Out of scope (explicitly deferred / rejected)
 
@@ -125,9 +126,9 @@ connects to it over the local socket. The daemon still requires `ServerUrl` + Si
 start (`DaemonConfig.Validate` `DaemonConfig.cs:58`, gated at `DaemonRunner.cs:122`;
 `ConnectAsync` at `DaemonRunner.cs:244`), so `run-agent` is **not** an offline command and
 is **not** added to the `offlineCommands` list. `--worktree` is consumed by kcap (never
-forwarded). Args after `--` flow into a **new passthrough branch** of
-`ClaudeLauncher.BuildArgs` (`src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs:57`),
-distinct from the existing structured server-request branch in the same method.
+forwarded). Args after `--` are forwarded verbatim via a **launcher-agnostic passthrough contract**
+on `IHostedAgentLauncher` (see *Vendor passthrough* under Plumbing), not by re-deriving
+each flag — so `run-agent codex -- …` works too, not just Claude.
 
 ## Plumbing
 
@@ -166,7 +167,7 @@ alongside the PID/lock files in the existing daemon-file lifecycle.
 
 1. **Socket listener** — a new hosted service that accepts local connections, parses
    frames, and routes them to `AgentOrchestrator`. This is the only net-new subsystem.
-2. **N-client output fan-out (lossless per sink)** — `ReadAgentOutputAsync`
+2. **N-client output fan-out (per sink, no partial-stream corruption)** — `ReadAgentOutputAsync`
    (`AgentOrchestrator.cs:431`) currently calls `SendTerminalOutputAsync` for the single
    web sink. Refactor to push each PTY chunk to a **list of registered sinks**: the
    SignalR sink (existing `TerminalOutputSender`) plus zero or more local-socket sinks.
@@ -175,14 +176,16 @@ alongside the PID/lock files in the existing daemon-file lifecycle.
    silently discarded chunks under back-pressure and desynced Claude's cursor-addressing
    redraw stream (AI-844), so it now uses `BoundedChannelFullMode.Wait`. The per-client
    design must hold two things at once:
-   - **No silent byte loss** — a sink at capacity must not discard terminal bytes.
+   - **No silent partial-stream corruption** — a sink must never render a stream with a
+     hole in it; one dropped or reordered chunk desyncs every later repaint.
    - **No cross-client coupling** — one slow/stalled sink must not stall the shared PTY
      read loop (and thus the agent and every *other* client), which is exactly what
      naive `Wait` back-pressure on a shared producer would cause.
    Resolution: the fan-out enqueue is **non-blocking per sink**; when a single sink's
    bounded queue overflows, that **one client is force-detached and marked dirty**, and on
-   reattach it gets a fresh `OutputBuffer` replay + repaint — recovering losslessly from a
-   clean frame rather than consuming a corrupted partial stream. Other sinks and the PTY
+   reattach it gets a fresh `OutputBuffer` replay + repaint — re-syncing from a clean frame
+   (bounded by the 2 MB `OutputBuffer`: a long stall may lose scrollback, but the live view
+   is never corrupted) rather than consuming a partial stream. Other sinks and the PTY
    loop are unaffected. (Implementation-plan detail: whether the existing web/SignalR sink
    keeps its current agent-back-pressure-on-tunnel-stall behaviour or also adopts
    force-detach is settled in the Phase 1 plan, biased toward **not** coupling local
@@ -192,26 +195,44 @@ alongside the PID/lock files in the existing daemon-file lifecycle.
    arbitration, all writers hit the one master fd. Raw local Ctrl-C flows through as byte
    `0x03`; the PTY line discipline turns it into SIGINT for the agent (no special
    handling, unlike the web `SendInterrupt` path). **Resize is the exception to
-   free-for-all:** each client reports its own dimensions and the daemon sets the one PTY
-   to the **smallest cols × smallest rows across all attached clients** (tmux semantics)
-   via `Resize` (`:786`), re-clamped on every attach/detach/resize. Last-writer-wins would
-   let a large web viewer and a small local terminal fight and corrupt each other's
-   redraw; min-clamp keeps every attached client's view valid.
-4. **Local-launch path + owned-vs-borrowed cwd** — a `Spawn` frame runs the same
-   orchestrator launch the server uses (vendor `Prepare()`, `forkpty`), differing in two
-   ways: a **passthrough** `LaunchArgs` from the verbatim args, and an explicit
-   **work-location kind** on the agent:
-   - `--worktree` → an **owned worktree** the daemon created (safe to remove on cleanup,
-     exactly as today).
-   - default in-place → a **borrowed cwd** the user owns.
+   free-for-all.** In **Phase 1** the daemon min-clamps the PTY to the smallest cols ×
+   rows across the **local socket clients** (each reports its dimensions via `Resize`,
+   re-clamped on attach/detach/resize) — tmux semantics, so two local terminals of
+   different sizes don't corrupt each other. The existing web `ResizeTerminal` (`:786`)
+   stays agent-level as today. **Phase 2 caveat:** SignalR carries only one agent-level
+   `ResizeTerminalCommand` (`ServerConnection.cs:29,102`) with no per-web-client
+   attach/dimensions, so clamping local *and* web together needs server-side aggregate
+   dimensions or a new per-client resize contract — tracked under Phase 2, not assumed here.
+4. **Local-launch path: passthrough, work-location, server-privacy** — a `Spawn` frame
+   runs the orchestrator launch (vendor `Prepare()`, `forkpty`) with three deviations from
+   the server path:
+   - **Passthrough args** — `LaunchArgs` from the verbatim post-`--` args (see *Vendor
+     passthrough*), not structured fields.
+   - **Work-location kind** — `--worktree` → an **owned worktree** the daemon created (safe
+     to remove on cleanup, as today); default in-place → a **borrowed cwd the user owns**.
+     For a borrowed cwd, vendor `Prepare()` MUST skip its repo-mutating steps — it must not
+     write into the user's checkout or global vendor config. Today `Prepare()` overlays
+     settings, writes `.mcp.json`, edits `.claude/settings.local.json` + `~/.claude.json`
+     trust (`ClaudeLauncher.cs:37,43,325`), and for Codex overlays `.codex`, enforces
+     hooks, and trusts the cwd in `~/.codex/config.toml` (`CodexLauncher.cs:18-54`) — all
+     to make a *fresh worktree* mirror the source repo. The user's own checkout is already
+     a trusted, configured repo, so the only allowed pre-launch effects for a borrowed cwd
+     are read-only/idempotent ones (e.g. Codex's hooks preflight *check*, which fails fast
+     without writing). A test asserts an in-place launch creates/modifies no repo or
+     global-config files.
+   - **Private-local server state** — a locally-launched agent starts **`PrivateLocal`**:
+     the orchestrator suppresses *all* server interaction — no `AgentRegisteredAsync`
+     (`AgentOrchestrator.cs:327`), no run-started/status events (`:329`), no
+     `SendTerminalOutputAsync` (`:455`), no `AgentUnregisteredAsync`. The SignalR sink is
+     simply **not attached** to this agent's fan-out; the agent exists only on the local
+     socket until an explicit share (Phase 2) transitions it.
    `CleanupAgentAsync` (`AgentOrchestrator.cs:888`) today unconditionally calls
-   `WorktreeManager.RemoveAsync(agent.Worktree)` (`:900`), which does
-   `Directory.Delete(path, recursive)` for a standalone worktree or `git worktree remove
-   --force` + `git branch -D` otherwise (`WorktreeManager.cs:54-67`). **For a borrowed cwd
-   that is catastrophic** — it would delete the user's working directory and branch on
-   agent exit. Cleanup MUST skip all worktree/branch removal for borrowed-cwd agents and
-   only ever remove daemon-owned worktrees. This is the single most important safety
-   invariant in the design and has an explicit test (below).
+   `WorktreeManager.RemoveAsync(agent.Worktree)` (`:900`) — `Directory.Delete(path,
+   recursive)` for standalone or `git worktree remove --force` + `git branch -D` otherwise
+   (`WorktreeManager.cs:54-67`). **For a borrowed cwd that is catastrophic** — it would
+   delete the user's working directory and branch on exit. Cleanup MUST skip all
+   worktree/branch removal for borrowed-cwd agents. This is the top safety invariant, with
+   an explicit test (below).
 5. **Conditional env handling** — `UnixPtyProcess.Spawn` currently scrubs
    `ANTHROPIC_API_KEY` and unsets `CLAUDECODE`/`CLAUDE_CODE_ENTRYPOINT`
    (`UnixPtyProcess.cs:58`). That is correct for headless hosted launches but wrong for
@@ -219,11 +240,13 @@ alongside the PID/lock files in the existing daemon-file lifecycle.
    auth. Env scrubbing becomes **conditional on launch type** (headless-hosted vs
    local-interactive). This interacts with the provider-API-key-scrub policy
    (`ProviderApiKeyPolicy` / `KCAP_USE_PROVIDER_API_KEY`).
-6. **Server-announce (Phase 2 only)** — so teammates see a locally-started agent in the
-   web UI, the daemon registers it with the server as if it were server-initiated.
-   Today launches flow server→daemon; this adds a daemon→server "I started agent X"
-   registration. **This is the one place the server contract changes**, which is why it
-   is deferred to Phase 2.
+6. **Share = `PrivateLocal`→`Shared` transition (Phase 2 only)** — an explicit `kcap
+   share` flips the agent from `PrivateLocal` to `Shared`: it attaches the SignalR sink,
+   runs the deferred `AgentRegisteredAsync` + run-started event, and begins streaming, so
+   teammates see the agent in the web UI as if it were server-initiated. Today launches
+   flow server→daemon; this adds a daemon→server "I started agent X" registration. **This
+   is the one place the server contract changes** — which, with all web involvement, is why
+   it is deferred to Phase 2.
 
 ### c) Local terminal client (`kcap run-agent` / `kcap attach`)
 
@@ -242,6 +265,24 @@ A thin foreground process — the dumb-pipe end of the socket:
 5. **Replay + repaint on attach** — render the `Attached` buffer snapshot, then send one
    `Resize` to nudge the TUI's alternate-screen buffer to repaint cleanly (raw scrollback
    replay alone can leave cursor artifacts; a resize-triggered repaint is the cheap fix).
+
+### d) Vendor passthrough (launcher-agnostic)
+
+`<vendor>` is generic, so passthrough is part of the `IHostedAgentLauncher` contract — not
+Claude-specific. Today `ClaudeLauncher.BuildArgs` (`ClaudeLauncher.cs:57`) and
+`CodexLauncher.BuildArgs` (`CodexLauncher.cs:56`) each *construct* argv from structured
+server fields. Add a passthrough mode each launcher implements: emit only the **mandatory
+daemon-level flags** the launcher must always set, then append the user's verbatim
+post-`--` args.
+
+- **Claude** — nothing mandatory (cwd is set via `forkpty` chdir); append verbatim.
+- **Codex** — must still inject `--cd <cwd>` and `--no-alt-screen` (the terminal mirror and
+  buffer replay depend on the primary screen) and run its hooks preflight in `Prepare()`;
+  its sandbox/approval defaults are emitted unless the user overrides them in the verbatim
+  args.
+
+Conflict policy: a user-supplied flag that collides with a non-mandatory daemon default
+wins; the mandatory flags (`--cd`, `--no-alt-screen`) are always enforced.
 
 ## Lifecycle & edge cases
 
@@ -287,7 +328,8 @@ A thin foreground process — the dumb-pipe end of the socket:
 ## Phasing
 
 - **Phase 1 — "tmux for your agent" (no web involvement, no new server contract).** Local
-  socket + framing, daemon N-client fan-out refactor (lossless per sink), resize
+  socket + framing, daemon N-client fan-out refactor (per-sink, no partial-stream
+  corruption), resize
   min-clamp, `run-agent`/`attach`/`ls`, raw-mode client, detach/reattach, persistence, the
   **owned-vs-borrowed cleanup guard**, conditional env handling. Delivers: start local →
   detach → reattach → survives terminal close. The daemon still connects to the server as
@@ -303,14 +345,21 @@ A thin foreground process — the dumb-pipe end of the socket:
 ## Testing
 
 - **Unit:** frame codec round-trips; N-client fan-out (a slow/dead sink is force-detached
-  and replays on rejoin — **never drops bytes and never stalls the shared PTY loop or
-  other sinks**); resize min-clamp across two clients with different dimensions;
-  detach-sequence scanner (including a prefix split across reads); passthrough arg
-  assembly + `--worktree` consumption.
-- **Cleanup safety (the critical one):** an in-place (borrowed-cwd) agent exiting — and
-  daemon `DisposeAsync` — leaves the user's cwd **and** its git branch fully intact (no
-  `Directory.Delete`, no `git worktree remove`, no `git branch -D`); conversely an
-  owned-worktree agent is still cleaned up exactly as today.
+  and re-syncs via clean replay on rejoin — **never renders a corrupted partial stream and
+  never stalls the shared PTY loop or other sinks**; replay bounded by the 2 MB
+  `OutputBuffer`); resize min-clamp across two *local* clients of different dimensions;
+  detach-sequence scanner (including a prefix split across reads); launcher-agnostic
+  passthrough assembly for **both** Claude and Codex (incl. Codex's mandatory `--cd` /
+  `--no-alt-screen` injection) + `--worktree` consumption.
+- **In-place safety (the critical one):** for a borrowed-cwd agent, (a) `Prepare()` writes
+  **no** files into the user's checkout or global vendor config (`.mcp.json`,
+  `settings.local.json`, `~/.claude.json`, `~/.codex/config.toml` untouched), and (b) exit
+  + daemon `DisposeAsync` leave the cwd **and** its git branch fully intact (no
+  `Directory.Delete` / `git worktree remove` / `git branch -D`). Conversely an owned-
+  worktree agent is still prepared and cleaned up exactly as today.
+- **Privacy:** a `PrivateLocal` agent makes **zero** server calls (no `AgentRegistered`,
+  status, run events, terminal output, or unregister) across its whole lifecycle until an
+  explicit share; only after share do registration + streaming begin.
 - **Integration:** spawn a trivial PTY program (e.g. a tiny echo / `cat`) over the
   socket; assert stdin→stdout round-trip, resize, detach-leaves-running, and
   reattach-replays-buffer. TUnit + existing PTY test patterns.

--- a/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
@@ -1,0 +1,256 @@
+# Local terminal attach for hosted agents (co-driven sessions)
+
+## Problem
+
+The hosted-agents story today is entirely **server-orchestrated and headless**. The
+server pushes a launch command to the daemon; the daemon spawns the agent CLI via
+`forkpty` into an isolated git worktree (`UnixPtyProcess.Spawn`,
+`src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs:47`) and mirrors the PTY to a
+single client — the web UI "Terminal" tab — over SignalR
+(`AgentOrchestrator.ReadAgentOutputAsync` → `ServerConnection.SendTerminalOutputAsync`,
+`src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs:431`). Input flows the other
+way as composed messages and discrete special keys (`HandleSendMessage` `:682`,
+`HandleSendSpecialKey` `:687`, `HandleResizeTerminal` `:784`).
+
+That web terminal is the *only* way a human touches a hosted agent, and its UX is the
+source of the issues currently being chased. Two capabilities are missing:
+
+1. **Pair programming** — let a human at their own terminal drive the agent directly,
+   while teammates can also see and interact via the web UI.
+2. **Start local, continue remotely** — start an agent from the terminal, walk away,
+   and keep driving it from the web (Claude-remote-control style).
+
+A naive "just run `claude` in a pipe and forward stdin" approach fails the user's core
+worry — with an anonymous-pipe redirect the user's keyboard is disconnected. But the
+daemon already uses a **PTY**, and a PTY master is not single-owner: multiple input
+sources can write to it and its output can fan out to multiple consumers (this is how
+`tmux`/`screen`/`tmate` work). The capability is therefore feasible on top of the
+existing PTY plumbing — what's missing is a local client and a local launch trigger.
+
+## Scope
+
+Generalize the daemon from **one client** to **N clients across two transports**, and
+add a local launch path:
+
+```
+kcap run-agent <vendor> [kcap flags] -- [agent args passed verbatim]
+kcap attach <agent>
+kcap ls
+```
+
+- The **agent always lives in the persistent daemon** (never the terminal). That is
+  what makes "close the terminal, keep going, drive from the web" work — the terminal
+  is an *attachable/detachable client*, never the owner.
+- The **local terminal** attaches over a **new local IPC socket** (low latency,
+  offline-capable, detach/reattach).
+- **Teammates / remote control** attach over the **existing SignalR** channel.
+- Both are interchangeable *clients* of one PTY: output is fanned to all of them,
+  input is **merged with no arbitration (free-for-all)**, and a newly-attached client
+  gets the existing per-agent `OutputBuffer` replayed so its screen is populated.
+
+```
+                         ┌─────────────── daemon (persistent) ───────────────┐
+  local terminal ──UDS/pipe──▶ local socket listener ─┐                       │
+  (kcap run-agent)  ◀──────────                        ├─▶ AgentOrchestrator   │
+                         │                              │     owns IPtyProcess  │
+  web client ───SignalR──▶ ServerConnection ───────────┘     N-client fan-out  │
+  (teammate)    ◀────────                                    free-for-all input │
+                         │                                    OutputBuffer replay│
+                         └────────────────────────────────────────────────────┘
+```
+
+### Confirmed design decisions
+
+| Decision | Choice |
+|---|---|
+| Process owner | The **daemon** owns the PTY/agent always; terminals are clients. |
+| Work location | **Configurable per launch.** Default **in-place** (agent works in your cwd); `--worktree` opts into today's isolated-worktree behavior. |
+| Arg passing | **Thin-wrapper passthrough** with a `--` boundary. kcap flags before `--`; everything after is handed to the agent CLI verbatim. |
+| Concurrent input | **Free-for-all.** All clients' input feeds the one PTY master; humans coordinate socially (like pairing in tmux). No driver lock. |
+| Transport | **Hybrid.** Local terminal over a new local socket; teammates + continue-remotely over existing SignalR. |
+
+### Out of scope (explicitly deferred / rejected)
+
+- **Driver-lock / turn-taking / request-control.** Free-for-all chosen for v1.
+- **Cross-machine local attach.** The agent runs on *your* daemon; the only "remote"
+  control is the web/SignalR path. There is no local socket across machines.
+- **A server-side screen model for pixel-perfect replay.** Raw `OutputBuffer` replay
+  plus a resize-triggered repaint is sufficient.
+- **Windows polish beyond "named pipe compiles and basically works"** if users are
+  Unix-first (revisit if Windows becomes a target).
+
+## Command surface
+
+```
+kcap run-agent <vendor> [kcap flags] -- [agent args passed verbatim]
+    # ensures the daemon is running, asks it to spawn the agent, then attaches
+    # your terminal. Blocks until you detach or the agent exits.
+    #
+    # kcap flags (before --):  --worktree (default: in-place),
+    #                          --name <id>      select which daemon (existing convention),
+    #                          --detached       spawn without attaching this terminal
+    #                                           (start in background, attach later)
+    # everything after --:     handed to the `claude`/`codex` CLI as-is
+
+kcap ls
+    # lists daemon-hosted agents (local + server-initiated): id, status, attached clients
+
+kcap attach <agent>
+    # re-attaches your terminal to a running agent (after detach, or to join one
+    # you started earlier on this machine)
+
+# detach without killing: a configurable tmux-style prefix sequence (e.g. Ctrl-q d).
+# The local client intercepts it before it reaches the agent.
+```
+
+Example:
+
+```
+kcap run-agent claude --worktree -- --model opus --resume "fix the bug"
+       └─ kcap ─┘  └────── verbatim to the `claude` CLI ──────┘
+```
+
+`run-agent` joins the top-level command switch in `src/Capacitor.Cli/Program.cs` and
+the `offlineCommands` list (`Program.cs:70`) — it ensures a *local* daemon and does not
+itself require the cloud. `--worktree` is consumed by kcap (never forwarded). Args after
+`--` flow into a **new passthrough branch** of `ClaudeLauncher.BuildArgs`
+(`src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs:57`), distinct from the existing
+structured server-request branch in the same method.
+
+## Plumbing
+
+### a) Local IPC channel (the one genuinely new subsystem)
+
+Today there is **no local IPC** between the CLI and the daemon — `kcap daemon` commands
+talk to a running daemon only through PID/lock files and signals (`DaemonLockPaths`,
+`src/Capacitor.Cli/Commands/DaemonCommands.cs`). This adds a length-prefixed binary
+framing over:
+
+- **Unix domain socket** on Unix — path under `DaemonLockPaths.Directory`, e.g.
+  `<name>.sock`, mirroring the per-daemon-name file convention.
+- **Named pipe** on Windows.
+
+Hand-rolled frames (no reflection-based serializer) keep it **AOT-friendly**. Frame
+types:
+
+| Direction | Frame | Payload |
+|---|---|---|
+| client→daemon | `Spawn` | vendor, worktree-or-in-place, cwd, verbatim agent args, initial cols/rows |
+| client→daemon | `Attach` | agentId |
+| client→daemon | `Stdin` | raw bytes |
+| client→daemon | `Resize` | cols, rows |
+| client→daemon | `Detach` | — (graceful; agent keeps running) |
+| daemon→client | `Attached` | agentId, current `OutputBuffer` snapshot (replay) |
+| daemon→client | `Stdout` | raw PTY bytes |
+| daemon→client | `Exited` | exit code |
+| daemon→client | `Error` | message (spawn failed, unknown agent, etc.) |
+
+The socket file is created with **owner-only permissions (0600)**: anything that can
+open it can spawn processes and stream a terminal, so it sits at the same trust boundary
+as the daemon PID/lock files and is locked to the OS user. The socket file is cleaned up
+alongside the PID/lock files in the existing daemon-file lifecycle.
+
+### b) Daemon changes
+
+1. **Socket listener** — a new hosted service that accepts local connections, parses
+   frames, and routes them to `AgentOrchestrator`. This is the only net-new subsystem.
+2. **N-client output fan-out** — `ReadAgentOutputAsync` (`AgentOrchestrator.cs:431`)
+   currently calls `SendTerminalOutputAsync` for the single web sink. Refactor to push
+   each PTY chunk to a **list of registered sinks**: the SignalR sink (existing
+   `TerminalOutputSender`) plus zero or more local-socket sinks. **Each sink keeps its
+   own bounded, drop-oldest, ordered queue** — the `TerminalOutputSender` pattern
+   (`src/Capacitor.Cli.Daemon/Services/TerminalOutputSender.cs`) generalized per-client,
+   so a stalled local socket cannot wedge the web stream and vice-versa.
+3. **Input merge** — local `Stdin`/`Resize` frames call the same
+   `agent.Process.WriteAsync` / `Resize` the web handlers already use (`:682`, `:786`).
+   Free-for-all = no arbitration; all writers hit the one master fd. Raw local Ctrl-C
+   flows through as byte `0x03`; the PTY line discipline turns it into SIGINT for the
+   agent (no special handling, unlike the web `SendInterrupt` path).
+4. **Local-launch path** — a `Spawn` frame runs the same orchestrator launch the server
+   uses (worktree prep *or* in-place, vendor `Prepare()`, `forkpty`), differing in one
+   branch: a **passthrough** `LaunchArgs` built from the verbatim args rather than
+   structured fields.
+5. **Conditional env handling** — `UnixPtyProcess.Spawn` currently scrubs
+   `ANTHROPIC_API_KEY` and unsets `CLAUDECODE`/`CLAUDE_CODE_ENTRYPOINT`
+   (`UnixPtyProcess.cs:58`). That is correct for headless hosted launches but wrong for
+   an interactive agent the user started themselves — it should keep their normal local
+   auth. Env scrubbing becomes **conditional on launch type** (headless-hosted vs
+   local-interactive). This interacts with the provider-API-key-scrub policy
+   (`ProviderApiKeyPolicy` / `KCAP_USE_PROVIDER_API_KEY`).
+6. **Server-announce (Phase 2 only)** — so teammates see a locally-started agent in the
+   web UI, the daemon registers it with the server as if it were server-initiated.
+   Today launches flow server→daemon; this adds a daemon→server "I started agent X"
+   registration. **This is the one place the server contract changes**, which is why it
+   is deferred to Phase 2.
+
+### c) Local terminal client (`kcap run-agent` / `kcap attach`)
+
+A thin foreground process — the dumb-pipe end of the socket:
+
+1. **Raw mode** — `tcgetattr`/`tcsetattr` to put the real terminal into raw mode, and
+   **restore on every exit path** (detach, agent exit, signal, crash) via a guaranteed
+   cleanup. This is **new CLI-side native interop** — the daemon has PTY interop, but the
+   *client* tty handling is separate. The detached-stdio-hang history (commit
+   `a76fdfdd6`) is the cautionary precedent.
+2. **Two pumps** — stdin → `Stdin` frames; `Stdout` frames → stdout.
+3. **Detach interception** — the client scans its stdin stream for the configurable
+   detach prefix **before** forwarding, so the sequence detaches instead of reaching the
+   agent.
+4. **Resize** — a `SIGWINCH` handler reads the new size and sends a `Resize` frame.
+5. **Replay + repaint on attach** — render the `Attached` buffer snapshot, then send one
+   `Resize` to nudge the TUI's alternate-screen buffer to repaint cleanly (raw scrollback
+   replay alone can leave cursor artifacts; a resize-triggered repaint is the cheap fix).
+
+## Lifecycle & edge cases
+
+- **Daemon ensure.** `run-agent` reuses the existing start path (`DaemonCommands`) to
+  auto-start the daemon if no live one is found for the resolved name, then connects.
+- **Agent exit while attached.** Daemon sends `Exited`; client restores the terminal,
+  prints and returns the exit code (so `kcap run-agent … && …` chains sensibly).
+- **Detach while running.** Agent keeps running in the daemon; `kcap ls` shows it;
+  `kcap attach` rejoins. This is the "continue later" path even without the web side.
+- **Multiple local attachers.** Two local terminals on one agent are just two socket
+  sinks — falls out of the N-client fan-out, no extra work. Free-for-all applies.
+- **Daemon dies / socket drops.** Client restores the terminal and reports the
+  disconnect. The agent dies with the daemon (it is a daemon child) — consistent with
+  hosted agents today. No auto-resurrection.
+- **Stale socket file.** Cleaned up alongside the PID/lock files in the existing daemon
+  file lifecycle.
+
+## Security & visibility
+
+- **Local socket = owner-only (0600).** Same trust level as the daemon PID files,
+  locked to the OS user.
+- **Visibility (Phase 2).** A locally-started agent announced to the server follows the
+  existing **account-scoped** visibility model (per commit `b77e9f97c`) — visible to
+  your account/tenant by default so teammates can join, not public. No new visibility
+  concept.
+
+## Phasing
+
+- **Phase 1 — "tmux for your agent" (local only, no server contract change).** Local
+  socket + framing, daemon N-client fan-out refactor, `run-agent`/`attach`/`ls`,
+  raw-mode client, detach/reattach, persistence, conditional env handling. Delivers:
+  start local → detach → reattach → survives terminal close. De-risks all the new infra
+  before touching the server.
+- **Phase 2 — pairing & continue-from-web.** Daemon→server announce of local agents +
+  web clients attaching/injecting via the existing SignalR fan-out (now just another
+  sink). Delivers both headline goals: pair programming and continue-from-anywhere.
+
+## Testing
+
+- **Unit:** frame codec round-trips; N-client fan-out (one slow/dead sink does not stall
+  others; drop-oldest under load); detach-sequence scanner (including a prefix split
+  across reads); passthrough arg assembly + `--worktree` consumption.
+- **Integration:** spawn a trivial PTY program (e.g. a tiny echo / `cat`) over the
+  socket; assert stdin→stdout round-trip, resize, detach-leaves-running, and
+  reattach-replays-buffer. TUnit + existing PTY test patterns.
+- **Manual:** a real `claude` raw-mode session — repaint-on-attach, and the terminal
+  restored on every exit path.
+
+## Docs
+
+Per `CLAUDE.md`, any change to the user-facing CLI surface updates `README.md` in the
+same PR — both the quick-start (`## Getting started`) and a new per-command section for
+`run-agent` / `attach` / `ls` under `## CLI commands`. Updating only the `help-*.txt`
+resources is not sufficient.

--- a/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
@@ -50,6 +50,12 @@ kcap ls
   input is **merged with no arbitration (free-for-all)**, and a newly-attached client
   gets the existing per-agent `OutputBuffer` replayed so its screen is populated.
 
+> **Phasing:** the **local-socket transport** (terminal client) is **Phase 1**; the
+> **web/SignalR client** and the agent being **registered/visible in the web UI** are
+> **Phase 2** (see *Phasing*). The "interchangeable clients / drive-from-the-web" picture
+> here is the full design the architecture supports — **Phase 1 ships terminal-only**: a
+> local agent is unregistered and not yet visible from the web.
+
 ```
                          ┌─────────────── daemon (persistent) ───────────────┐
   local terminal ──UDS/pipe──▶ local socket listener ─┐                       │

--- a/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
@@ -99,7 +99,9 @@ kcap run-agent <vendor> [kcap flags] -- [agent args passed verbatim]
     # kcap flags (before --):  --worktree (default: in-place),
     #                          --name <id>      select which daemon (existing convention),
     #                          --detached       spawn without attaching this terminal
-    #                                           (start in background, attach later)
+    #                                           (start in background, attach later),
+    #                          --share          [Phase 2] announce to the account so
+    #                                           teammates can join (default: private)
     # everything after --:     handed to the `claude`/`codex` CLI as-is
 
 kcap ls
@@ -220,12 +222,30 @@ alongside the PID/lock files in the existing daemon-file lifecycle.
      are read-only/idempotent ones (e.g. Codex's hooks preflight *check*, which fails fast
      without writing). A test asserts an in-place launch creates/modifies no repo or
      global-config files.
-   - **Private-local server state** — a locally-launched agent starts **`PrivateLocal`**:
-     the orchestrator suppresses *all* server interaction — no `AgentRegisteredAsync`
-     (`AgentOrchestrator.cs:327`), no run-started/status events (`:329`), no
-     `SendTerminalOutputAsync` (`:455`), no `AgentUnregisteredAsync`. The SignalR sink is
-     simply **not attached** to this agent's fan-out; the agent exists only on the local
-     socket until an explicit share (Phase 2) transitions it.
+   - **Private-local state — two channels to silence.** A locally-launched agent starts
+     **`PrivateLocal`**, and "private" must hold on *both* paths that reach the server:
+     1. **Orchestrator → server (control plane): deny-all.** The orchestrator makes **no
+        per-agent `ServerConnection` call whatsoever** for a `PrivateLocal` agent — not
+        just `AgentRegisteredAsync` (`:327`) and `SendTerminalOutputAsync` (`:455`), but
+        also `AppendAgentRunEvent` started/stopped (`:329`/`:520`), the repo-path announce
+        `DaemonUpdateRepoPaths` (`:334`/`ServerConnection.cs:406`), `LaunchFailedAsync`
+        (`:512`), `AgentStatusChangedAsync` (`:516`), `EndAgentSessionAsync` (`:534`),
+        reconnect re-register (`:811`), and the per-agent heartbeat (`:862`). Implement as
+        a single guard — route every per-agent server call through one gate that no-ops for
+        `PrivateLocal` — enforced by a **strict mock `ServerConnection` that fails the test
+        on *any* method invoked for a private agent**. The SignalR output sink is simply
+        not attached.
+     2. **Spawned agent → server (its own kcap hooks).** The launch env (`:294-309`) sets
+        `KCAP_RENDERED_AGENT`, `KCAP_AGENT_ID`, `KCAP_URL`, `KCAP_DAEMON_URL`; the agent's
+        Claude/Codex hooks use these to post events and bridge permissions independently of
+        the orchestrator. A private launch **omits the hosted-agent vars** (`KCAP_AGENT_ID`,
+        `KCAP_DAEMON_URL`, `KCAP_RENDERED_AGENT`) so the agent behaves like a normal local
+        run — **permission prompts render natively in the terminal** (no daemon
+        permission-bridge) and it is not a controllable hosted agent. `KCAP_URL` is
+        **kept**, so the session records to the account exactly like any local
+        kcap-instrumented run (per the recording decision): "private" means *not a live,
+        controllable hosted agent*, **not** *unrecorded*. On share, the hosted-agent env is
+        applied to *subsequent* hook invocations.
    `CleanupAgentAsync` (`AgentOrchestrator.cs:888`) today unconditionally calls
    `WorktreeManager.RemoveAsync(agent.Worktree)` (`:900`) — `Directory.Delete(path,
    recursive)` for standalone or `git worktree remove --force` + `git branch -D` otherwise
@@ -241,12 +261,17 @@ alongside the PID/lock files in the existing daemon-file lifecycle.
    local-interactive). This interacts with the provider-API-key-scrub policy
    (`ProviderApiKeyPolicy` / `KCAP_USE_PROVIDER_API_KEY`).
 6. **Share = `PrivateLocal`→`Shared` transition (Phase 2 only)** — an explicit `kcap
-   share` flips the agent from `PrivateLocal` to `Shared`: it attaches the SignalR sink,
-   runs the deferred `AgentRegisteredAsync` + run-started event, and begins streaming, so
-   teammates see the agent in the web UI as if it were server-initiated. Today launches
-   flow server→daemon; this adds a daemon→server "I started agent X" registration. **This
-   is the one place the server contract changes** — which, with all web involvement, is why
-   it is deferred to Phase 2.
+   share` flips the agent from `PrivateLocal` to `Shared`: it runs the deferred
+   `AgentRegisteredAsync` + run-started event, **replays the agent's accumulated terminal
+   history**, then attaches the SignalR sink for live chunks, so teammates see the agent in
+   the web UI as if it were server-initiated. **The one-time replay is required and
+   special:** the reconnect path deliberately does *not* replay the `OutputBuffer` (`:814`)
+   because the server keeps its own per-agent buffer across a daemon rebind — but a
+   freshly-shared `PrivateLocal` agent **the server has never seen has no such buffer**, so
+   share sends a one-time, bounded (2 MB `OutputBuffer`) replay *before* the first live
+   chunk, ordered ahead of the live stream. Today launches flow server→daemon; this adds a
+   daemon→server "I started agent X" registration. **This is the one place the server
+   contract changes** — which, with all web involvement, is why it is deferred to Phase 2.
 
 ### c) Local terminal client (`kcap run-agent` / `kcap attach`)
 
@@ -304,10 +329,14 @@ wins; the mandatory flags (`--cd`, `--no-alt-screen`) are always enforced.
 
 - **Local socket = owner-only (0600).** Same trust level as the daemon PID files,
   locked to the OS user.
-- **Private until shared (Phase 2).** A locally-started agent is reachable only over the
-  owner's local socket by default. It becomes visible to teammates only via an
-  **explicit** share/announce action (`kcap share <agent>` or `run-agent --share`) — it is
-  never auto-exposed by merely launching it.
+- **Private until shared (Phase 2).** A locally-started agent is reachable as a *live,
+  controllable hosted agent* only over the owner's local socket by default. It becomes a
+  joinable hosted agent for teammates only via an **explicit** share/announce action
+  (`kcap share <agent>` or `run-agent --share`) — never auto-exposed by merely launching
+  it. "Private" is about live control/visibility, **not** recording: the session still
+  records its transcript to the account through the normal hooks and is viewable in recap,
+  like any local kcap session (see the `PrivateLocal` two-channel rule under *Daemon
+  changes*).
 - **Visibility = account-scoped, never public.** Once shared, the agent follows the
   existing account/tenant visibility model (per commit `b77e9f97c`). No new visibility
   concept.
@@ -357,9 +386,13 @@ wins; the mandatory flags (`--cd`, `--no-alt-screen`) are always enforced.
   + daemon `DisposeAsync` leave the cwd **and** its git branch fully intact (no
   `Directory.Delete` / `git worktree remove` / `git branch -D`). Conversely an owned-
   worktree agent is still prepared and cleaned up exactly as today.
-- **Privacy:** a `PrivateLocal` agent makes **zero** server calls (no `AgentRegistered`,
-  status, run events, terminal output, or unregister) across its whole lifecycle until an
-  explicit share; only after share do registration + streaming begin.
+- **Privacy (strict mock):** with a mock `ServerConnection` that **fails the test on any
+  per-agent method call**, a `PrivateLocal` agent's full lifecycle (launch → run →
+  heartbeat → exit/finalize → cleanup, incl. a simulated reconnect) triggers **none** of
+  them; the spawn env omits the hosted-agent vars
+  (`KCAP_AGENT_ID`/`KCAP_DAEMON_URL`/`KCAP_RENDERED_AGENT`) while `KCAP_URL` is present
+  (recording stays on). On share: registration + a one-time bounded buffer replay + live
+  streaming begin.
 - **Integration:** spawn a trivial PTY program (e.g. a tiny echo / `cat`) over the
   socket; assert stdin→stdout round-trip, resize, detach-leaves-running, and
   reattach-replays-buffer. TUnit + existing PTY test patterns.

--- a/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
@@ -71,7 +71,8 @@ kcap ls
 | Concurrent input | **Free-for-all.** All clients' input feeds the one PTY master; humans coordinate socially (like pairing in tmux). No driver lock. |
 | Transport | **Hybrid.** Local terminal over a new local socket; teammates + continue-remotely over existing SignalR. |
 | Server dependency | **Phase 1 adds no new server *contract*, but is not offline.** The daemon still requires `ServerUrl` + a SignalR connection at startup exactly as today; local attach rides alongside it. True offline-daemon operation is a possible later enhancement, not in scope. |
-| Remote control (Phase 2) | **Write by default once shared**, mirroring current hosted-agent run permissions. Observe-only is served by the existing read-only session-sharing path, not by attach. |
+| Visibility & sharing (Phase 2) | A local agent **registers exactly like a UI-launched agent** and inherits the *identical, server-authoritative* model: **owner-only by default** — visible/controllable by you across your own surfaces (terminal **and** your web UI) immediately — and shared to teammates via the **existing web UI "share"**. Not a kcap concept; no bespoke daemon→server share contract. A convenience `kcap share` CLI (in-chat skill, like `kcap hide`) is a later follow-up (AI-861). |
+| Remote control once shared (Phase 2) | When *you* share to teammates, they get the same **write/input** control today's hosted agents grant — sharing is for control, mirroring hosted-agent permissions. |
 | Resize | **Min-clamp the PTY across attached *local* clients** (tmux semantics) in Phase 1; clamping web clients too needs a Phase 2 server-side resize contract (SignalR has only one agent-level resize today). |
 | Terminal stream | **No silent partial-stream corruption.** Never `DropOldest`; an overflowing sink is force-detached and re-syncs via a clean replay on rejoin (bounded by the 2 MB `OutputBuffer`) rather than rendering a corrupted partial stream (see plumbing). |
 | Vendor passthrough | **Launcher-agnostic.** Part of the `IHostedAgentLauncher` contract; both `run-agent claude` and `run-agent codex` work in v1. |
@@ -82,6 +83,10 @@ kcap ls
 - **Offline-daemon mode (no `ServerUrl`).** The daemon still requires the server at
   startup exactly as today; running fully cloud-less is a possible later enhancement, not
   this design.
+- **A kcap-specific share command / `--share` flag.** Sharing is server/UI-authoritative
+  (agents are owner-only until the web UI "share"); local agents inherit it by registering
+  like a UI-launched agent. A convenience `kcap share` CLI (an in-chat skill, like
+  `kcap hide`) is a later follow-up tracked as **AI-861**, not this design.
 - **Cross-machine local attach.** The agent runs on *your* daemon; the only "remote"
   control is the web/SignalR path. There is no local socket across machines.
 - **A server-side screen model for pixel-perfect replay.** Raw `OutputBuffer` replay
@@ -99,9 +104,7 @@ kcap run-agent <vendor> [kcap flags] -- [agent args passed verbatim]
     # kcap flags (before --):  --worktree (default: in-place),
     #                          --name <id>      select which daemon (existing convention),
     #                          --detached       spawn without attaching this terminal
-    #                                           (start in background, attach later),
-    #                          --share          [Phase 2] announce to the account so
-    #                                           teammates can join (default: private)
+    #                                           (start in background, attach later)
     # everything after --:     handed to the `claude`/`codex` CLI as-is
 
 kcap ls
@@ -235,28 +238,24 @@ alongside the PID/lock files in the existing daemon-file lifecycle.
         `PrivateLocal` — enforced by a **strict mock `ServerConnection` that fails the test
         on *any* method invoked for a private agent**. The SignalR output sink is simply
         not attached.
-     2. **Spawned agent → server (its own kcap hooks).** The launch env (`:294-309`) sets
+     2. **Spawned agent → server (its own kcap hooks).** The launch env (`:294-309`) can set
         `KCAP_RENDERED_AGENT`, `KCAP_AGENT_ID`, `KCAP_URL`, `KCAP_DAEMON_URL`; the agent's
         Claude/Codex hooks read these at runtime to tag events and bridge permissions
         independently of the orchestrator — and **process env is fixed at `execvp`
-        (`UnixPtyProcess.cs:62`), so it can never change after spawn.** A private launch
-        therefore sets, once, the env it wants for the agent's *whole life*:
-        - **`KCAP_URL` kept** — the session records to the account like any local
-          kcap-instrumented run. "Private" means *not a live, controllable hosted agent*,
-          **not** *unrecorded*.
-        - **`KCAP_AGENT_ID` kept** — it is only a tag (sets `agent_host_id` on recorded
-          events, `ClaudeHookCommand.cs:49` / `CodexHookCommand.cs:87`) and triggers **no**
-          server call, so the deny-all above is unaffected. Keeping it makes the transcript
-          **link-ready**: when the agent is later shared, the server associates the
-          already-tagged session with the now-registered hosted agent (the *tag-and-link*
-          decision). The server must tolerate events carrying an `agent_host_id` for an
-          agent it has not yet seen registered — part of the Phase 2 contract.
+        (`UnixPtyProcess.cs:62`), so it can never change after spawn.** A **Phase 1** local
+        launch sets, once, the env of a *plain local run*:
+        - **`KCAP_URL` kept** — the session records to the account exactly like a normal
+          local `claude`/`codex` run (subject to the user's `default_visibility`).
+        - **`KCAP_AGENT_ID` omitted in Phase 1** — the agent isn't a registered hosted agent
+          yet, so its events carry **no** `agent_host_id` and it records as an ordinary local
+          session (no dangling tag, no server-tolerance assumption). Phase 2 — which registers
+          the agent like a UI launch — sets it so the session links to the hosted agent the
+          normal way.
         - **`KCAP_RENDERED_AGENT` + `KCAP_DAEMON_URL` omitted** — the agent isn't treated as
-          headless and there is no daemon permission-bridge, so **permission prompts render
-          natively in the terminal** where the local user answers them. Because env is fixed
-          at spawn, this holds for the agent's whole life — **sharing does not move
-          permission prompts to the web UI** (an accepted limitation; the local driver, or a
-          remote one via the mirrored PTY, answers in-band).
+          headless and there's no daemon permission-bridge, so **permission prompts render
+          natively in the terminal**. Env is fixed at spawn, so this holds for the agent's
+          whole life — even after a Phase 2 share, prompts stay native (the local driver, or
+          a remote one via the mirrored PTY, answers in-band).
    `CleanupAgentAsync` (`AgentOrchestrator.cs:888`) today unconditionally calls
    `WorktreeManager.RemoveAsync(agent.Worktree)` (`:900`) — `Directory.Delete(path,
    recursive)` for standalone or `git worktree remove --force` + `git branch -D` otherwise
@@ -271,24 +270,19 @@ alongside the PID/lock files in the existing daemon-file lifecycle.
    auth. Env scrubbing becomes **conditional on launch type** (headless-hosted vs
    local-interactive). This interacts with the provider-API-key-scrub policy
    (`ProviderApiKeyPolicy` / `KCAP_USE_PROVIDER_API_KEY`).
-6. **Share = `PrivateLocal`→`Shared` transition (Phase 2 only)** — an explicit `kcap
-   share` flips the agent from `PrivateLocal` to `Shared`: it runs the deferred
-   `AgentRegisteredAsync` + run-started event using the **same `KCAP_AGENT_ID`** the agent
-   was launched with, so the server **links** the already-recorded transcript (whose events
-   were tagged with that `agent_host_id`) to the now-live hosted agent — one unified record
-   (the *tag-and-link* decision). It then **replays the agent's accumulated terminal
-   history** and attaches the SignalR sink for live chunks, so teammates see the agent in
-   the web UI as if it were server-initiated. **The one-time replay is required and
-   special:** the reconnect path deliberately does *not* replay the `OutputBuffer` (`:814`)
-   because the server keeps its own per-agent buffer across a daemon rebind — but a
-   freshly-shared `PrivateLocal` agent **the server has never seen has no such buffer**, so
-   share sends a one-time, bounded (2 MB `OutputBuffer`) replay *before* the first live
-   chunk, ordered ahead of the live stream. Permission routing is **not** changed by share
-   (env is fixed at spawn — see the `PrivateLocal` rule); prompts stay native. Today
-   launches flow server→daemon; this adds a daemon→server "I started agent X" registration
-   **plus the server tolerating and late-linking a pre-tagged session**. **This is where the
-   server contract changes** — which, with all web involvement, is why it is deferred to
-   Phase 2.
+6. **Server registration = Phase 2 (the one server-contract change).** Phase 1 keeps a
+   local agent **unregistered** — terminal-only, no `AgentRegistered`/status/stream (that is
+   the deny-all above: "not registered yet", not a privacy model). **Phase 2** registers it
+   on spawn **exactly like a UI-launched agent** (`AgentRegisteredAsync` + run-started, then
+   the SignalR sink joins the fan-out as just another client), so the **owner sees and
+   drives it from their web UI immediately** — owner-only by the server's model until they
+   hit **share** in the UI. Because it registers from the start, the recorded session links
+   the normal way (no "tag-and-link a pre-registered agent"). **Replay caveat:** the
+   reconnect path skips `OutputBuffer` replay (`:814`) because the server keeps its own
+   buffer across a daemon rebind; a web client *first* subscribing to an agent that started
+   locally has no server-side buffer yet, so that first subscribe needs a one-time bounded
+   replay. Permission routing stays native in the terminal (env is fixed at spawn — see
+   channel 2). Sharing is a UI action; a `kcap share` CLI is a later follow-up (AI-861).
 
 ### c) Local terminal client (`kcap run-agent` / `kcap attach`)
 
@@ -350,30 +344,25 @@ user-tunable.)
 
 - **Local socket = owner-only (0600).** Same trust level as the daemon PID files,
   locked to the OS user.
-- **Private until shared (Phase 2).** A locally-started agent is reachable as a *live,
-  controllable hosted agent* only over the owner's local socket by default. It becomes a
-  joinable hosted agent for teammates only via an **explicit** share/announce action
-  (`kcap share <agent>` or `run-agent --share`) — never auto-exposed by merely launching
-  it. "Private" is about live control/visibility, **not** recording: the session still
-  records its transcript to the account through the normal hooks and is viewable in recap,
-  like any local kcap session (see the `PrivateLocal` two-channel rule under *Daemon
-  changes*).
-- **Visibility = account-scoped, never public.** Once shared, the agent follows the
-  existing account/tenant visibility model (per commit `b77e9f97c`). No new visibility
-  concept.
-- **Remote control defaults to write — by design.** Once shared, a teammate attaching via
-  the web UI gets the same **write/input** control today's hosted agents grant. This is
-  deliberate: a *view-only* attach would be a strictly worse version of the existing
-  read-only session-sharing feature, so **observe-only is served by sharing, and attach is
-  for control**. We therefore do **not** gate input behind a separate control-grant; the
-  permission model mirrors hosted-agent runs exactly.
-- **Accepted trade-off (noted for reviewers).** This intentionally widens the *blast
-  radius* versus today's hosted agents, though not the *permission model*: a hosted agent
-  runs in an **isolated worktree under daemon-managed auth**, whereas a default in-place
-  local agent runs in the **user's real checkout with the user's personal credentials**.
-  The accepted mitigations are (a) private-until-explicitly-shared, (b) account-scoped
-  (never public) visibility, and (c) `--worktree` for users who want isolation. A tighter
-  per-session boundary is out of scope unless later required.
+- **Visibility/sharing is server-authoritative — local agents inherit the UI model.** This
+  repo defines no agent visibility: `AgentRegistered` carries only
+  `(agentId, prompt, model, effort, repoPath)` (`Models.cs:691`), and there is no "share"
+  concept in the CLI/daemon. The server decides, keyed on the authenticated owner. A
+  locally-launched agent **registers exactly like a UI-launched one** (Phase 2) and gets the
+  *same* behavior: **owner-only by default** — you see and drive it from your own web UI
+  immediately (your "remote control"), with no extra step — and teammates get access only
+  when you hit **share** in the web UI. Seeing your *own* agent on another of your surfaces
+  is **not** sharing and crosses no new trust boundary.
+- **Recording is independent of all this.** The transcript records to the account via the
+  normal hooks under the existing `default_visibility` setting (private/org_public/public,
+  commit `b77e9f97c`) like any local kcap run — orthogonal to the live hosted-agent surface.
+- **The in-place / local-creds blast radius applies only once you share to others.** A
+  hosted agent runs in an isolated worktree under daemon-managed auth; a default in-place
+  local agent runs in your real checkout with your personal credentials. By default that's
+  fine (owner-only). When you *share*, teammates get write control (same as hosted-agent
+  runs) over a process in your checkout with your creds — a conscious, owner-initiated
+  trade-off, with `--worktree` available for isolation. Same permission model as any shared
+  hosted agent; larger exposure only because of in-place + local auth.
 
 ## Phasing
 
@@ -386,11 +375,13 @@ user-tunable.)
   it does today — Phase 1 is *not* offline; it simply adds no new server endpoints and the
   local-attach feature involves no web client. De-risks all the new infra before touching
   the server.
-- **Phase 2 — pairing & continue-from-web.** An **explicit** daemon→server announce
-  (`kcap share <agent>` / `run-agent --share`; private to the launching user until then)
-  + web clients attaching/injecting via the existing SignalR fan-out (now just another
-  sink), with **write control by default once shared** (see *Security, visibility &
-  control*). Delivers both headline goals: pair programming and continue-from-anywhere.
+- **Phase 2 — continue-from-web, then pairing.** Register the local agent on spawn **like a
+  UI-launched agent** (the one server-contract change) so the **owner** sees and drives it
+  from their own web UI immediately (continue-from-anywhere) — owner-only until they hit
+  **share** in the UI, which widens to teammates (pairing, write control) via the existing
+  mechanism. Web clients attach/inject through the existing SignalR fan-out (now just another
+  sink). No kcap-specific share/visibility logic; a `kcap share` CLI convenience is a
+  follow-up (AI-861).
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
@@ -42,7 +42,9 @@ kcap ls
   what makes "close the terminal, keep going, drive from the web" work — the terminal
   is an *attachable/detachable client*, never the owner.
 - The **local terminal** attaches over a **new local IPC socket** (low latency,
-  offline-capable, detach/reattach).
+  detach/reattach). The local socket is for *latency* — keystrokes don't round-trip
+  through the cloud — **not** an offline-operation claim; the daemon still requires
+  `ServerUrl` + SignalR as today (see *Server dependency* in the decisions table).
 - **Teammates / remote control** attach over the **existing SignalR** channel.
 - Both are interchangeable *clients* of one PTY: output is fanned to all of them,
   input is **merged with no arbitration (free-for-all)**, and a newly-attached client
@@ -68,10 +70,17 @@ kcap ls
 | Arg passing | **Thin-wrapper passthrough** with a `--` boundary. kcap flags before `--`; everything after is handed to the agent CLI verbatim. |
 | Concurrent input | **Free-for-all.** All clients' input feeds the one PTY master; humans coordinate socially (like pairing in tmux). No driver lock. |
 | Transport | **Hybrid.** Local terminal over a new local socket; teammates + continue-remotely over existing SignalR. |
+| Server dependency | **Phase 1 adds no new server *contract*, but is not offline.** The daemon still requires `ServerUrl` + a SignalR connection at startup exactly as today; local attach rides alongside it. True offline-daemon operation is a possible later enhancement, not in scope. |
+| Remote control (Phase 2) | **Write by default once shared**, mirroring current hosted-agent run permissions. Observe-only is served by the existing read-only session-sharing path, not by attach. |
+| Resize | **Clamp the one PTY to the smallest attached client** (tmux semantics); no last-writer fighting. |
+| Terminal stream | **Lossless per sink.** Never `DropOldest`; a sink that overflows is force-detached and replays on rejoin (see plumbing). |
 
 ### Out of scope (explicitly deferred / rejected)
 
 - **Driver-lock / turn-taking / request-control.** Free-for-all chosen for v1.
+- **Offline-daemon mode (no `ServerUrl`).** The daemon still requires the server at
+  startup exactly as today; running fully cloud-less is a possible later enhancement, not
+  this design.
 - **Cross-machine local attach.** The agent runs on *your* daemon; the only "remote"
   control is the web/SignalR path. There is no local socket across machines.
 - **A server-side screen model for pixel-perfect replay.** Raw `OutputBuffer` replay
@@ -110,12 +119,15 @@ kcap run-agent claude --worktree -- --model opus --resume "fix the bug"
        └─ kcap ─┘  └────── verbatim to the `claude` CLI ──────┘
 ```
 
-`run-agent` joins the top-level command switch in `src/Capacitor.Cli/Program.cs` and
-the `offlineCommands` list (`Program.cs:70`) — it ensures a *local* daemon and does not
-itself require the cloud. `--worktree` is consumed by kcap (never forwarded). Args after
-`--` flow into a **new passthrough branch** of `ClaudeLauncher.BuildArgs`
-(`src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs:57`), distinct from the existing
-structured server-request branch in the same method.
+`run-agent` joins the top-level command switch in `src/Capacitor.Cli/Program.cs`. It
+ensures a daemon is running for the resolved name (auto-starting one if needed) and
+connects to it over the local socket. The daemon still requires `ServerUrl` + SignalR to
+start (`DaemonConfig.Validate` `DaemonConfig.cs:58`, gated at `DaemonRunner.cs:122`;
+`ConnectAsync` at `DaemonRunner.cs:244`), so `run-agent` is **not** an offline command and
+is **not** added to the `offlineCommands` list. `--worktree` is consumed by kcap (never
+forwarded). Args after `--` flow into a **new passthrough branch** of
+`ClaudeLauncher.BuildArgs` (`src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs:57`),
+distinct from the existing structured server-request branch in the same method.
 
 ## Plumbing
 
@@ -135,7 +147,7 @@ types:
 
 | Direction | Frame | Payload |
 |---|---|---|
-| client→daemon | `Spawn` | vendor, worktree-or-in-place, cwd, verbatim agent args, initial cols/rows |
+| client→daemon | `Spawn` | vendor, work-location kind (owned-worktree \| borrowed-cwd), cwd, verbatim agent args, initial cols/rows |
 | client→daemon | `Attach` | agentId |
 | client→daemon | `Stdin` | raw bytes |
 | client→daemon | `Resize` | cols, rows |
@@ -154,22 +166,52 @@ alongside the PID/lock files in the existing daemon-file lifecycle.
 
 1. **Socket listener** — a new hosted service that accepts local connections, parses
    frames, and routes them to `AgentOrchestrator`. This is the only net-new subsystem.
-2. **N-client output fan-out** — `ReadAgentOutputAsync` (`AgentOrchestrator.cs:431`)
-   currently calls `SendTerminalOutputAsync` for the single web sink. Refactor to push
-   each PTY chunk to a **list of registered sinks**: the SignalR sink (existing
-   `TerminalOutputSender`) plus zero or more local-socket sinks. **Each sink keeps its
-   own bounded, drop-oldest, ordered queue** — the `TerminalOutputSender` pattern
-   (`src/Capacitor.Cli.Daemon/Services/TerminalOutputSender.cs`) generalized per-client,
-   so a stalled local socket cannot wedge the web stream and vice-versa.
-3. **Input merge** — local `Stdin`/`Resize` frames call the same
-   `agent.Process.WriteAsync` / `Resize` the web handlers already use (`:682`, `:786`).
-   Free-for-all = no arbitration; all writers hit the one master fd. Raw local Ctrl-C
-   flows through as byte `0x03`; the PTY line discipline turns it into SIGINT for the
-   agent (no special handling, unlike the web `SendInterrupt` path).
-4. **Local-launch path** — a `Spawn` frame runs the same orchestrator launch the server
-   uses (worktree prep *or* in-place, vendor `Prepare()`, `forkpty`), differing in one
-   branch: a **passthrough** `LaunchArgs` built from the verbatim args rather than
-   structured fields.
+2. **N-client output fan-out (lossless per sink)** — `ReadAgentOutputAsync`
+   (`AgentOrchestrator.cs:431`) currently calls `SendTerminalOutputAsync` for the single
+   web sink. Refactor to push each PTY chunk to a **list of registered sinks**: the
+   SignalR sink (existing `TerminalOutputSender`) plus zero or more local-socket sinks.
+   Each sink keeps its **own bounded, ordered, *lossless* queue — never `DropOldest`**.
+   `TerminalOutputSender` (`TerminalOutputSender.cs:17-38`) documents why: `DropOldest`
+   silently discarded chunks under back-pressure and desynced Claude's cursor-addressing
+   redraw stream (AI-844), so it now uses `BoundedChannelFullMode.Wait`. The per-client
+   design must hold two things at once:
+   - **No silent byte loss** — a sink at capacity must not discard terminal bytes.
+   - **No cross-client coupling** — one slow/stalled sink must not stall the shared PTY
+     read loop (and thus the agent and every *other* client), which is exactly what
+     naive `Wait` back-pressure on a shared producer would cause.
+   Resolution: the fan-out enqueue is **non-blocking per sink**; when a single sink's
+   bounded queue overflows, that **one client is force-detached and marked dirty**, and on
+   reattach it gets a fresh `OutputBuffer` replay + repaint — recovering losslessly from a
+   clean frame rather than consuming a corrupted partial stream. Other sinks and the PTY
+   loop are unaffected. (Implementation-plan detail: whether the existing web/SignalR sink
+   keeps its current agent-back-pressure-on-tunnel-stall behaviour or also adopts
+   force-detach is settled in the Phase 1 plan, biased toward **not** coupling local
+   terminal responsiveness to a remote tunnel stall.)
+3. **Input merge + resize arbitration** — local `Stdin` frames call the same
+   `agent.Process.WriteAsync` the web handler uses (`:682`); free-for-all = no
+   arbitration, all writers hit the one master fd. Raw local Ctrl-C flows through as byte
+   `0x03`; the PTY line discipline turns it into SIGINT for the agent (no special
+   handling, unlike the web `SendInterrupt` path). **Resize is the exception to
+   free-for-all:** each client reports its own dimensions and the daemon sets the one PTY
+   to the **smallest cols × smallest rows across all attached clients** (tmux semantics)
+   via `Resize` (`:786`), re-clamped on every attach/detach/resize. Last-writer-wins would
+   let a large web viewer and a small local terminal fight and corrupt each other's
+   redraw; min-clamp keeps every attached client's view valid.
+4. **Local-launch path + owned-vs-borrowed cwd** — a `Spawn` frame runs the same
+   orchestrator launch the server uses (vendor `Prepare()`, `forkpty`), differing in two
+   ways: a **passthrough** `LaunchArgs` from the verbatim args, and an explicit
+   **work-location kind** on the agent:
+   - `--worktree` → an **owned worktree** the daemon created (safe to remove on cleanup,
+     exactly as today).
+   - default in-place → a **borrowed cwd** the user owns.
+   `CleanupAgentAsync` (`AgentOrchestrator.cs:888`) today unconditionally calls
+   `WorktreeManager.RemoveAsync(agent.Worktree)` (`:900`), which does
+   `Directory.Delete(path, recursive)` for a standalone worktree or `git worktree remove
+   --force` + `git branch -D` otherwise (`WorktreeManager.cs:54-67`). **For a borrowed cwd
+   that is catastrophic** — it would delete the user's working directory and branch on
+   agent exit. Cleanup MUST skip all worktree/branch removal for borrowed-cwd agents and
+   only ever remove daemon-owned worktrees. This is the single most important safety
+   invariant in the design and has an explicit test (below).
 5. **Conditional env handling** — `UnixPtyProcess.Spawn` currently scrubs
    `ANTHROPIC_API_KEY` and unsets `CLAUDECODE`/`CLAUDE_CODE_ENTRYPOINT`
    (`UnixPtyProcess.cs:58`). That is correct for headless hosted launches but wrong for
@@ -217,31 +259,58 @@ A thin foreground process — the dumb-pipe end of the socket:
 - **Stale socket file.** Cleaned up alongside the PID/lock files in the existing daemon
   file lifecycle.
 
-## Security & visibility
+## Security, visibility & control
 
 - **Local socket = owner-only (0600).** Same trust level as the daemon PID files,
   locked to the OS user.
-- **Visibility (Phase 2).** A locally-started agent announced to the server follows the
-  existing **account-scoped** visibility model (per commit `b77e9f97c`) — visible to
-  your account/tenant by default so teammates can join, not public. No new visibility
+- **Private until shared (Phase 2).** A locally-started agent is reachable only over the
+  owner's local socket by default. It becomes visible to teammates only via an
+  **explicit** share/announce action (`kcap share <agent>` or `run-agent --share`) — it is
+  never auto-exposed by merely launching it.
+- **Visibility = account-scoped, never public.** Once shared, the agent follows the
+  existing account/tenant visibility model (per commit `b77e9f97c`). No new visibility
   concept.
+- **Remote control defaults to write — by design.** Once shared, a teammate attaching via
+  the web UI gets the same **write/input** control today's hosted agents grant. This is
+  deliberate: a *view-only* attach would be a strictly worse version of the existing
+  read-only session-sharing feature, so **observe-only is served by sharing, and attach is
+  for control**. We therefore do **not** gate input behind a separate control-grant; the
+  permission model mirrors hosted-agent runs exactly.
+- **Accepted trade-off (noted for reviewers).** This intentionally widens the *blast
+  radius* versus today's hosted agents, though not the *permission model*: a hosted agent
+  runs in an **isolated worktree under daemon-managed auth**, whereas a default in-place
+  local agent runs in the **user's real checkout with the user's personal credentials**.
+  The accepted mitigations are (a) private-until-explicitly-shared, (b) account-scoped
+  (never public) visibility, and (c) `--worktree` for users who want isolation. A tighter
+  per-session boundary is out of scope unless later required.
 
 ## Phasing
 
-- **Phase 1 — "tmux for your agent" (local only, no server contract change).** Local
-  socket + framing, daemon N-client fan-out refactor, `run-agent`/`attach`/`ls`,
-  raw-mode client, detach/reattach, persistence, conditional env handling. Delivers:
-  start local → detach → reattach → survives terminal close. De-risks all the new infra
-  before touching the server.
-- **Phase 2 — pairing & continue-from-web.** Daemon→server announce of local agents +
-  web clients attaching/injecting via the existing SignalR fan-out (now just another
-  sink). Delivers both headline goals: pair programming and continue-from-anywhere.
+- **Phase 1 — "tmux for your agent" (no web involvement, no new server contract).** Local
+  socket + framing, daemon N-client fan-out refactor (lossless per sink), resize
+  min-clamp, `run-agent`/`attach`/`ls`, raw-mode client, detach/reattach, persistence, the
+  **owned-vs-borrowed cleanup guard**, conditional env handling. Delivers: start local →
+  detach → reattach → survives terminal close. The daemon still connects to the server as
+  it does today — Phase 1 is *not* offline; it simply adds no new server endpoints and the
+  local-attach feature involves no web client. De-risks all the new infra before touching
+  the server.
+- **Phase 2 — pairing & continue-from-web.** An **explicit** daemon→server announce
+  (`kcap share <agent>` / `run-agent --share`; private to the launching user until then)
+  + web clients attaching/injecting via the existing SignalR fan-out (now just another
+  sink), with **write control by default once shared** (see *Security, visibility &
+  control*). Delivers both headline goals: pair programming and continue-from-anywhere.
 
 ## Testing
 
-- **Unit:** frame codec round-trips; N-client fan-out (one slow/dead sink does not stall
-  others; drop-oldest under load); detach-sequence scanner (including a prefix split
-  across reads); passthrough arg assembly + `--worktree` consumption.
+- **Unit:** frame codec round-trips; N-client fan-out (a slow/dead sink is force-detached
+  and replays on rejoin — **never drops bytes and never stalls the shared PTY loop or
+  other sinks**); resize min-clamp across two clients with different dimensions;
+  detach-sequence scanner (including a prefix split across reads); passthrough arg
+  assembly + `--worktree` consumption.
+- **Cleanup safety (the critical one):** an in-place (borrowed-cwd) agent exiting — and
+  daemon `DisposeAsync` — leaves the user's cwd **and** its git branch fully intact (no
+  `Directory.Delete`, no `git worktree remove`, no `git branch -D`); conversely an
+  owned-worktree agent is still cleaned up exactly as today.
 - **Integration:** spawn a trivial PTY program (e.g. a tiny echo / `cat`) over the
   socket; assert stdin→stdout round-trip, resize, detach-leaves-running, and
   reattach-replays-buffer. TUnit + existing PTY test patterns.

--- a/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
@@ -237,15 +237,26 @@ alongside the PID/lock files in the existing daemon-file lifecycle.
         not attached.
      2. **Spawned agent → server (its own kcap hooks).** The launch env (`:294-309`) sets
         `KCAP_RENDERED_AGENT`, `KCAP_AGENT_ID`, `KCAP_URL`, `KCAP_DAEMON_URL`; the agent's
-        Claude/Codex hooks use these to post events and bridge permissions independently of
-        the orchestrator. A private launch **omits the hosted-agent vars** (`KCAP_AGENT_ID`,
-        `KCAP_DAEMON_URL`, `KCAP_RENDERED_AGENT`) so the agent behaves like a normal local
-        run — **permission prompts render natively in the terminal** (no daemon
-        permission-bridge) and it is not a controllable hosted agent. `KCAP_URL` is
-        **kept**, so the session records to the account exactly like any local
-        kcap-instrumented run (per the recording decision): "private" means *not a live,
-        controllable hosted agent*, **not** *unrecorded*. On share, the hosted-agent env is
-        applied to *subsequent* hook invocations.
+        Claude/Codex hooks read these at runtime to tag events and bridge permissions
+        independently of the orchestrator — and **process env is fixed at `execvp`
+        (`UnixPtyProcess.cs:62`), so it can never change after spawn.** A private launch
+        therefore sets, once, the env it wants for the agent's *whole life*:
+        - **`KCAP_URL` kept** — the session records to the account like any local
+          kcap-instrumented run. "Private" means *not a live, controllable hosted agent*,
+          **not** *unrecorded*.
+        - **`KCAP_AGENT_ID` kept** — it is only a tag (sets `agent_host_id` on recorded
+          events, `ClaudeHookCommand.cs:49` / `CodexHookCommand.cs:87`) and triggers **no**
+          server call, so the deny-all above is unaffected. Keeping it makes the transcript
+          **link-ready**: when the agent is later shared, the server associates the
+          already-tagged session with the now-registered hosted agent (the *tag-and-link*
+          decision). The server must tolerate events carrying an `agent_host_id` for an
+          agent it has not yet seen registered — part of the Phase 2 contract.
+        - **`KCAP_RENDERED_AGENT` + `KCAP_DAEMON_URL` omitted** — the agent isn't treated as
+          headless and there is no daemon permission-bridge, so **permission prompts render
+          natively in the terminal** where the local user answers them. Because env is fixed
+          at spawn, this holds for the agent's whole life — **sharing does not move
+          permission prompts to the web UI** (an accepted limitation; the local driver, or a
+          remote one via the mirrored PTY, answers in-band).
    `CleanupAgentAsync` (`AgentOrchestrator.cs:888`) today unconditionally calls
    `WorktreeManager.RemoveAsync(agent.Worktree)` (`:900`) — `Directory.Delete(path,
    recursive)` for standalone or `git worktree remove --force` + `git branch -D` otherwise
@@ -262,16 +273,22 @@ alongside the PID/lock files in the existing daemon-file lifecycle.
    (`ProviderApiKeyPolicy` / `KCAP_USE_PROVIDER_API_KEY`).
 6. **Share = `PrivateLocal`→`Shared` transition (Phase 2 only)** — an explicit `kcap
    share` flips the agent from `PrivateLocal` to `Shared`: it runs the deferred
-   `AgentRegisteredAsync` + run-started event, **replays the agent's accumulated terminal
-   history**, then attaches the SignalR sink for live chunks, so teammates see the agent in
+   `AgentRegisteredAsync` + run-started event using the **same `KCAP_AGENT_ID`** the agent
+   was launched with, so the server **links** the already-recorded transcript (whose events
+   were tagged with that `agent_host_id`) to the now-live hosted agent — one unified record
+   (the *tag-and-link* decision). It then **replays the agent's accumulated terminal
+   history** and attaches the SignalR sink for live chunks, so teammates see the agent in
    the web UI as if it were server-initiated. **The one-time replay is required and
    special:** the reconnect path deliberately does *not* replay the `OutputBuffer` (`:814`)
    because the server keeps its own per-agent buffer across a daemon rebind — but a
    freshly-shared `PrivateLocal` agent **the server has never seen has no such buffer**, so
    share sends a one-time, bounded (2 MB `OutputBuffer`) replay *before* the first live
-   chunk, ordered ahead of the live stream. Today launches flow server→daemon; this adds a
-   daemon→server "I started agent X" registration. **This is the one place the server
-   contract changes** — which, with all web involvement, is why it is deferred to Phase 2.
+   chunk, ordered ahead of the live stream. Permission routing is **not** changed by share
+   (env is fixed at spawn — see the `PrivateLocal` rule); prompts stay native. Today
+   launches flow server→daemon; this adds a daemon→server "I started agent X" registration
+   **plus the server tolerating and late-linking a pre-tagged session**. **This is where the
+   server contract changes** — which, with all web involvement, is why it is deferred to
+   Phase 2.
 
 ### c) Local terminal client (`kcap run-agent` / `kcap attach`)
 
@@ -307,7 +324,11 @@ post-`--` args.
   args.
 
 Conflict policy: a user-supplied flag that collides with a non-mandatory daemon default
-wins; the mandatory flags (`--cd`, `--no-alt-screen`) are always enforced.
+wins. A user-supplied **duplicate of a mandatory flag** (`--cd`, `--no-alt-screen`) is
+**rejected with a clear error**, not appended — relying on Codex's arg precedence (last-
+vs first-wins) to make the daemon's value stick is fragile, so the collision is refused
+outright. (Working dir and primary-screen mirroring are daemon invariants, not
+user-tunable.)
 
 ## Lifecycle & edge cases
 
@@ -389,10 +410,11 @@ wins; the mandatory flags (`--cd`, `--no-alt-screen`) are always enforced.
 - **Privacy (strict mock):** with a mock `ServerConnection` that **fails the test on any
   per-agent method call**, a `PrivateLocal` agent's full lifecycle (launch → run →
   heartbeat → exit/finalize → cleanup, incl. a simulated reconnect) triggers **none** of
-  them; the spawn env omits the hosted-agent vars
-  (`KCAP_AGENT_ID`/`KCAP_DAEMON_URL`/`KCAP_RENDERED_AGENT`) while `KCAP_URL` is present
-  (recording stays on). On share: registration + a one-time bounded buffer replay + live
-  streaming begin.
+  them. Spawn-env assertions: `KCAP_RENDERED_AGENT` and `KCAP_DAEMON_URL` **absent** (native
+  terminal permissions); `KCAP_URL` **and** `KCAP_AGENT_ID` **present** (recording on;
+  transcript tagged + link-ready). On share: registration with that same id + a one-time
+  bounded buffer replay + live streaming begin, and a recorded event's `agent_host_id`
+  matches the shared agent.
 - **Integration:** spawn a trivial PTY program (e.g. a tiny echo / `cat`) over the
   socket; assert stdin→stdout round-trip, resize, detach-leaves-running, and
   reattach-replays-buffer. TUnit + existing PTY test patterns.

--- a/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md
@@ -407,11 +407,9 @@ user-tunable.)
 - **Privacy (strict mock):** with a mock `ServerConnection` that **fails the test on any
   per-agent method call**, a `PrivateLocal` agent's full lifecycle (launch → run →
   heartbeat → exit/finalize → cleanup, incl. a simulated reconnect) triggers **none** of
-  them. Spawn-env assertions: `KCAP_RENDERED_AGENT` and `KCAP_DAEMON_URL` **absent** (native
-  terminal permissions); `KCAP_URL` **and** `KCAP_AGENT_ID` **present** (recording on;
-  transcript tagged + link-ready). On share: registration with that same id + a one-time
-  bounded buffer replay + live streaming begin, and a recorded event's `agent_host_id`
-  matches the shared agent.
+  them. Spawn-env assertions: `KCAP_RENDERED_AGENT`, `KCAP_DAEMON_URL`, **and**
+  `KCAP_AGENT_ID` are **absent** (native terminal permissions; records as a plain local
+  session with no `agent_host_id` tag), while `KCAP_URL` is **present** (recording on).
 - **Integration:** spawn a trivial PTY program (e.g. a tiny echo / `cat`) over the
   socket; assert stdin→stdout round-trip, resize, detach-leaves-running, and
   reattach-replays-buffer. TUnit + existing PTY test patterns.

--- a/src/Capacitor.Cli.Core/LocalIpc/DetachScanner.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/DetachScanner.cs
@@ -1,0 +1,44 @@
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// <summary>
+/// Scans the local terminal's raw stdin for the detach sequence — the prefix byte
+/// <c>Ctrl-Q</c> (<c>0x11</c>) followed by <c>d</c> — and strips it before the rest is
+/// forwarded to the agent. The prefix is held back until the next byte arrives (possibly
+/// in a later read), so the sequence is detected even when split across reads. A prefix
+/// not followed by <c>d</c> is forwarded as-is, so Ctrl-Q stays usable otherwise.
+/// </summary>
+public sealed class DetachScanner {
+    const byte Prefix = 0x11;        // Ctrl-Q
+    const byte Detach = (byte)'d';
+
+    bool _armed; // saw the prefix; the next byte decides detach-vs-forward
+
+    /// <summary>
+    /// Feeds a chunk of raw stdin. Returns the bytes to forward to the agent and whether a
+    /// detach was requested. When a detach is returned, any bytes after it in the same chunk
+    /// are intentionally dropped (the session is ending).
+    /// </summary>
+    public (byte[] Forward, bool Detach) Process(ReadOnlySpan<byte> input) {
+        var outBuf = new List<byte>(input.Length + 1);
+
+        foreach (var b in input) {
+            if (_armed) {
+                _armed = false;
+
+                if (b == Detach) return (outBuf.ToArray(), true); // strip prefix + 'd'
+
+                outBuf.Add(Prefix); // prefix was not a detach — forward it now
+
+                if (b == Prefix) { _armed = true; continue; } // a fresh prefix — re-arm
+
+                outBuf.Add(b);
+            } else if (b == Prefix) {
+                _armed = true; // hold; decide on the next byte
+            } else {
+                outBuf.Add(b);
+            }
+        }
+
+        return (outBuf.ToArray(), false);
+    }
+}

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
@@ -1,0 +1,111 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// Length-prefixed binary codec: [1B type][4B BE len][len payload]. No reflection /
+/// JSON — AOT-safe and allocation-light. Spawn/Attached have structured payloads
+/// (helpers below); other frames are trivial.
+public static class FrameCodec {
+    const int MaxPayload = 8 * 1024 * 1024; // hard cap; oversized => protocol error
+
+    public static async Task WriteAsync(Stream s, LocalFrame f, CancellationToken ct) {
+        var payload = Encode(f);
+        var head = new byte[5];
+        head[0] = (byte)f.Type;
+        BinaryPrimitives.WriteInt32BigEndian(head.AsSpan(1), payload.Length);
+        await s.WriteAsync(head, ct);
+        if (payload.Length > 0) await s.WriteAsync(payload, ct);
+        await s.FlushAsync(ct);
+    }
+
+    /// Returns null on clean EOF (peer closed between frames).
+    public static async Task<LocalFrame?> ReadAsync(Stream s, CancellationToken ct) {
+        var head = new byte[5];
+        if (!await ReadExactlyOrEof(s, head, ct)) return null;
+        var type = (FrameType)head[0];
+        var len  = BinaryPrimitives.ReadInt32BigEndian(head.AsSpan(1));
+        if (len is < 0 or > MaxPayload) throw new InvalidDataException($"frame len {len}");
+        var payload = len == 0 ? [] : new byte[len];
+        if (len > 0 && !await ReadExactlyOrEof(s, payload, ct))
+            throw new EndOfStreamException("truncated frame payload");
+        return Decode(type, payload);
+    }
+
+    static async Task<bool> ReadExactlyOrEof(Stream s, byte[] buf, CancellationToken ct) {
+        var off = 0;
+        while (off < buf.Length) {
+            var n = await s.ReadAsync(buf.AsMemory(off), ct);
+            if (n == 0) return off != 0 ? throw new EndOfStreamException("truncated frame header") : false;
+            off += n;
+        }
+        return true;
+    }
+
+    static byte[] Encode(LocalFrame f) => f.Type switch {
+        FrameType.Stdin or FrameType.Stdout => f.Bytes,
+        FrameType.Resize                    => Dims(f.Cols, f.Rows),
+        FrameType.Detach or FrameType.List  => [],
+        FrameType.Exited                    => BeInt(f.ExitCode),
+        FrameType.Error or FrameType.Attach or FrameType.AgentList => Encoding.UTF8.GetBytes(f.Text),
+        FrameType.Attached or FrameType.Spawn => f.Bytes, // pre-encoded by Attached(...)/Spawn(...)
+        _ => throw new InvalidDataException($"unencodable frame {f.Type}"),
+    };
+
+    static LocalFrame Decode(FrameType t, byte[] p) => t switch {
+        FrameType.Stdin or FrameType.Stdout => new(t) { Bytes = p },
+        FrameType.Resize  => new(t) { Cols = Be16(p, 0), Rows = Be16(p, 2) },
+        FrameType.Detach or FrameType.List => new(t),
+        FrameType.Exited  => new(t) { ExitCode = BinaryPrimitives.ReadInt32BigEndian(p) },
+        FrameType.Error or FrameType.Attach or FrameType.AgentList => new(t) { Text = Encoding.UTF8.GetString(p) },
+        FrameType.Attached or FrameType.Spawn => new(t) { Bytes = p },
+        _ => throw new InvalidDataException($"undecodable frame {t}"),
+    };
+
+    // --- Spawn structured payload ---
+    public static LocalFrame Spawn(string vendor, WorkLocation work, string cwd, IReadOnlyList<string> args, ushort cols, ushort rows) {
+        using var ms = new MemoryStream();
+        ms.WriteByte((byte)work);
+        WriteBe16(ms, cols); WriteBe16(ms, rows);
+        WriteLp(ms, vendor); WriteLp(ms, cwd);
+        WriteBe32(ms, args.Count);
+        foreach (var a in args) WriteLp(ms, a);
+        return new(FrameType.Spawn) { Bytes = ms.ToArray(), Text = vendor, Work = work, Cols = cols, Rows = rows };
+    }
+    public static string SpawnCwd(LocalFrame f) => ParseSpawn(f.Bytes).cwd;
+    public static string[] SpawnArgs(LocalFrame f) => ParseSpawn(f.Bytes).args;
+    public static (string vendor, WorkLocation work, string cwd, string[] args, ushort cols, ushort rows) Spawn(LocalFrame f)
+        => ParseSpawn(f.Bytes);
+
+    static (string vendor, WorkLocation work, string cwd, string[] args, ushort cols, ushort rows) ParseSpawn(byte[] p) {
+        var o = 0;
+        var work = (WorkLocation)p[o++];
+        var cols = Be16(p, o); o += 2; var rows = Be16(p, o); o += 2;
+        var vendor = ReadLp(p, ref o); var cwd = ReadLp(p, ref o);
+        var n = BinaryPrimitives.ReadInt32BigEndian(p.AsSpan(o)); o += 4;
+        var args = new string[n];
+        for (var i = 0; i < n; i++) args[i] = ReadLp(p, ref o);
+        return (vendor, work, cwd, args, cols, rows);
+    }
+
+    // --- Attached structured payload: [4B agentIdLen][agentId][snapshot...] ---
+    public static LocalFrame Attached(string agentId, byte[] snapshot) {
+        using var ms = new MemoryStream();
+        WriteLp(ms, agentId);
+        ms.Write(snapshot);
+        return new(FrameType.Attached) { Bytes = ms.ToArray(), Text = agentId };
+    }
+    public static (string agentId, byte[] snapshot) Attached(LocalFrame f) {
+        var o = 0; var id = ReadLp(f.Bytes, ref o);
+        return (id, f.Bytes[o..]);
+    }
+
+    // --- byte helpers ---
+    static byte[] Dims(ushort c, ushort r) { var b = new byte[4]; BinaryPrimitives.WriteUInt16BigEndian(b, c); BinaryPrimitives.WriteUInt16BigEndian(b.AsSpan(2), r); return b; }
+    static byte[] BeInt(int v) { var b = new byte[4]; BinaryPrimitives.WriteInt32BigEndian(b, v); return b; }
+    static ushort Be16(byte[] p, int o) => BinaryPrimitives.ReadUInt16BigEndian(p.AsSpan(o));
+    static void WriteBe16(Stream s, ushort v) { var b = new byte[2]; BinaryPrimitives.WriteUInt16BigEndian(b, v); s.Write(b); }
+    static void WriteBe32(Stream s, int v) { var b = new byte[4]; BinaryPrimitives.WriteInt32BigEndian(b, v); s.Write(b); }
+    static void WriteLp(Stream s, string v) { var u = Encoding.UTF8.GetBytes(v); WriteBe32(s, u.Length); s.Write(u); }
+    static string ReadLp(byte[] p, ref int o) { var n = BinaryPrimitives.ReadInt32BigEndian(p.AsSpan(o)); o += 4; var v = Encoding.UTF8.GetString(p, o, n); o += n; return v; }
+}

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
@@ -77,15 +77,32 @@ public static class FrameCodec {
     public static (string vendor, WorkLocation work, string cwd, string[] args, ushort cols, ushort rows) Spawn(LocalFrame f)
         => ParseSpawn(f.Bytes);
 
+    const int MaxSpawnArgs = 4096; // sane cap; the wire arg-count is untrusted (local 0600 socket, same-user)
+
     static (string vendor, WorkLocation work, string cwd, string[] args, ushort cols, ushort rows) ParseSpawn(byte[] p) {
         var o = 0;
+        Require(p, o, 5); // work(1) + cols(2) + rows(2)
         var work = (WorkLocation)p[o++];
         var cols = Be16(p, o); o += 2; var rows = Be16(p, o); o += 2;
         var vendor = ReadLp(p, ref o); var cwd = ReadLp(p, ref o);
+
+        Require(p, o, 4);
         var n = BinaryPrimitives.ReadInt32BigEndian(p.AsSpan(o)); o += 4;
+        // Validate the arg count against a cap AND remaining bytes before allocating, so a
+        // malformed/huge count can't force an OOM (each arg has at least a 4-byte prefix).
+        if (n is < 0 or > MaxSpawnArgs) throw new InvalidDataException($"Spawn arg count out of range: {n}");
+        if ((long)(p.Length - o) < (long)n * 4) throw new InvalidDataException("Spawn arg count exceeds payload");
+
         var args = new string[n];
         for (var i = 0; i < n; i++) args[i] = ReadLp(p, ref o);
         return (vendor, work, cwd, args, cols, rows);
+    }
+
+    /// <summary>Throws <see cref="InvalidDataException"/> unless <paramref name="count"/> bytes
+    /// remain at offset <paramref name="o"/> — keeps malformed frames a clean protocol error
+    /// rather than an <c>ArgumentOutOfRangeException</c> or oversized allocation.</summary>
+    static void Require(byte[] p, int o, int count) {
+        if (o < 0 || count < 0 || (long)o + count > p.Length) throw new InvalidDataException("Frame payload truncated");
     }
 
     // --- Attached structured payload: [4B agentIdLen][agentId][snapshot...] ---
@@ -107,5 +124,11 @@ public static class FrameCodec {
     static void WriteBe16(Stream s, ushort v) { var b = new byte[2]; BinaryPrimitives.WriteUInt16BigEndian(b, v); s.Write(b); }
     static void WriteBe32(Stream s, int v) { var b = new byte[4]; BinaryPrimitives.WriteInt32BigEndian(b, v); s.Write(b); }
     static void WriteLp(Stream s, string v) { var u = Encoding.UTF8.GetBytes(v); WriteBe32(s, u.Length); s.Write(u); }
-    static string ReadLp(byte[] p, ref int o) { var n = BinaryPrimitives.ReadInt32BigEndian(p.AsSpan(o)); o += 4; var v = Encoding.UTF8.GetString(p, o, n); o += n; return v; }
+    static string ReadLp(byte[] p, ref int o) {
+        Require(p, o, 4);
+        var n = BinaryPrimitives.ReadInt32BigEndian(p.AsSpan(o)); o += 4;
+        if (n < 0) throw new InvalidDataException($"Negative length-prefix: {n}");
+        Require(p, o, n);
+        var v = Encoding.UTF8.GetString(p, o, n); o += n; return v;
+    }
 }

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
@@ -1,0 +1,19 @@
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// Wire contract for the daemon↔local-client socket. Values are explicit and
+/// MUST be append-only — they are serialized as a single byte (see FrameCodec).
+public enum FrameType : byte {
+    // client → daemon
+    Spawn   = 1,
+    Attach  = 2,
+    Stdin   = 3,
+    Resize  = 4,
+    Detach  = 5,
+    List    = 6,   // request the daemon's agent list (for `kcap ls`)
+    // daemon → client
+    Attached  = 64,
+    Stdout    = 65,
+    Exited    = 66,
+    Error     = 67,
+    AgentList = 68, // UTF-8 table payload: one `id\tstatus\tcwd` line per agent
+}

--- a/src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs
@@ -1,0 +1,21 @@
+namespace Capacitor.Cli.Core.LocalIpc;
+
+public enum WorkLocation : byte { BorrowedCwd = 0, OwnedWorktree = 1 }
+
+/// A decoded frame. Exactly one of the payload properties is meaningful per Type;
+/// the codec owns which. Bytes are raw (Stdin/Stdout); strings are UTF-8.
+public sealed record LocalFrame(FrameType Type) {
+    public byte[]       Bytes    { get; init; } = [];
+    public string       Text     { get; init; } = "";
+    public ushort       Cols     { get; init; }
+    public ushort       Rows     { get; init; }
+    public WorkLocation Work     { get; init; }
+    public int          ExitCode { get; init; }
+
+    public static LocalFrame Stdin(byte[] b)            => new(FrameType.Stdin)  { Bytes = b };
+    public static LocalFrame Stdout(byte[] b)           => new(FrameType.Stdout) { Bytes = b };
+    public static LocalFrame Resize(ushort c, ushort r) => new(FrameType.Resize) { Cols = c, Rows = r };
+    public static LocalFrame Detach()                   => new(FrameType.Detach);
+    public static LocalFrame Exited(int code)           => new(FrameType.Exited) { ExitCode = code };
+    public static LocalFrame Error(string m)            => new(FrameType.Error)  { Text = m };
+}

--- a/src/Capacitor.Cli.Core/LocalIpc/LocalSocketPaths.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/LocalSocketPaths.cs
@@ -1,0 +1,7 @@
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// Per-daemon-name local control socket, colocated with the daemon's lock/pid files.
+public static class LocalSocketPaths {
+    public static string Socket(string daemonName)
+        => Path.Combine(DaemonLockPaths.Directory, $"{DaemonLockPaths.Sanitize(daemonName)}.sock");
+}

--- a/src/Capacitor.Cli.Core/RunAgentArgs.cs
+++ b/src/Capacitor.Cli.Core/RunAgentArgs.cs
@@ -1,0 +1,57 @@
+namespace Capacitor.Cli.Core;
+
+/// Parses `run-agent &lt;vendor&gt; [kcap flags] -- [agent args]`: kcap's own flags come
+/// before <c>--</c>; everything after <c>--</c> is forwarded to the agent CLI verbatim.
+public sealed class RunAgentArgs {
+    public string   Vendor      { get; private set; } = "";
+    public bool     Worktree    { get; private set; }
+    public string?  DaemonName  { get; private set; }
+    public bool     Detached    { get; private set; }
+    public string[] Passthrough { get; private set; } = [];
+    public string?  Error       { get; private set; }
+
+    public static RunAgentArgs Parse(string[] args) {
+        var r = new RunAgentArgs();
+
+        if (args.Length == 0) {
+            r.Error = "usage: kcap run-agent <vendor> [--worktree] [--name <id>] [--detached] [-- <agent args>]";
+
+            return r;
+        }
+
+        var dash = Array.IndexOf(args, "--");
+        var kcap = dash < 0 ? args : args[..dash];
+        r.Passthrough = dash < 0 ? [] : args[(dash + 1)..];
+
+        if (kcap.Length == 0) {
+            r.Error = "missing <vendor>";
+
+            return r;
+        }
+
+        r.Vendor = kcap[0];
+
+        for (var i = 1; i < kcap.Length; i++) {
+            switch (kcap[i]) {
+                case "--worktree": r.Worktree = true; break;
+                case "--detached": r.Detached = true; break;
+                case "--name":
+                    if (i + 1 >= kcap.Length) { r.Error = "--name requires a value"; return r; }
+
+                    r.DaemonName = kcap[++i];
+
+                    break;
+                case "--share":
+                    r.Error = "--share is Phase 2 and not yet supported";
+
+                    return r;
+                default:
+                    r.Error = $"unknown flag {kcap[i]} (agent args go after `--`)";
+
+                    return r;
+            }
+        }
+
+        return r;
+    }
+}

--- a/src/Capacitor.Cli.Core/RunAgentArgs.cs
+++ b/src/Capacitor.Cli.Core/RunAgentArgs.cs
@@ -41,10 +41,6 @@ public sealed class RunAgentArgs {
                     r.DaemonName = kcap[++i];
 
                     break;
-                case "--share":
-                    r.Error = "--share is Phase 2 and not yet supported";
-
-                    return r;
                 default:
                     r.Error = $"unknown flag {kcap[i]} (agent args go after `--`)";
 

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -183,6 +183,11 @@ public static partial class DaemonRunner {
         builder.Services.AddSingleton<EvalContextCache>();
         builder.Services.AddSingleton<EvalRunner>();
 
+        // Local control socket: lets `kcap run-agent`/`attach`/`ls` drive daemon-hosted
+        // agents from the user's own terminal (AI local-attach Phase 1).
+        builder.Services.AddSingleton<LocalControlServer>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<LocalControlServer>());
+
         var host   = builder.Build();
         var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("kcap.Daemon");
 

--- a/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
@@ -58,6 +58,13 @@ public sealed class UnixPtyProcess : IPtyProcess {
                 UnixPtyInterop.unsetenv("CLAUDECODE");
                 UnixPtyInterop.unsetenv("CLAUDE_CODE_ENTRYPOINT");
                 UnixPtyInterop.unsetenv("ANTHROPIC_API_KEY");
+                // Clear any hosted-agent identity/routing the daemon may have inherited (e.g.
+                // it was started from inside a kcap-tracked session) so the spawned agent gets
+                // ONLY what extraEnv sets: hosted launches re-add these below; private local
+                // launches deliberately leave them unset (no mis-tag, native permissions).
+                UnixPtyInterop.unsetenv("KCAP_AGENT_ID");
+                UnixPtyInterop.unsetenv("KCAP_RENDERED_AGENT");
+                UnixPtyInterop.unsetenv("KCAP_DAEMON_URL");
 
                 if (extraEnvKeys is not null) {
                     for (var i = 0; i < extraEnvKeys.Length; i++) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -47,12 +47,14 @@ internal partial class AgentOrchestrator {
             launcher.Prepare(ctx);
             var built = launcher.BuildPassthrough(ctx, args);
 
-            // PrivateLocal hook env: omit KCAP_RENDERED_AGENT / KCAP_DAEMON_URL so the agent
-            // isn't treated as headless and permissions prompt natively in the terminal.
-            // Keep KCAP_AGENT_ID (tags events for tag-and-link) and KCAP_URL (records the
-            // session). Re-add ANTHROPIC_API_KEY so the user's normal local auth survives
-            // UnixPtyProcess.Spawn's headless scrub (it applies extraEnv after unsetenv).
-            var env = new Dictionary<string, string> { ["KCAP_AGENT_ID"] = agentId };
+            // Phase 1 records as a plain local session. Keep KCAP_URL (records, under the
+            // user's default_visibility) and re-add ANTHROPIC_API_KEY so normal local auth
+            // survives UnixPtyProcess.Spawn's headless scrub (it applies extraEnv after
+            // unsetenv). Omit the hosted-agent vars: KCAP_AGENT_ID (the agent isn't a
+            // registered hosted agent yet, so no agent_host_id tag on events), and
+            // KCAP_RENDERED_AGENT / KCAP_DAEMON_URL (not headless → permissions prompt
+            // natively in the terminal). Phase 2 adds them when it registers like a UI agent.
+            var env = new Dictionary<string, string>();
             if (!string.IsNullOrEmpty(_config.ServerUrl)) env["KCAP_URL"] = _config.ServerUrl;
             var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
             if (!string.IsNullOrEmpty(apiKey)) env["ANTHROPIC_API_KEY"] = apiKey;

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -4,8 +4,12 @@ namespace Capacitor.Cli.Daemon.Services;
 
 /// Local-socket entry points invoked by <see cref="LocalControlServer"/>.
 internal partial class AgentOrchestrator {
-    // Filled in E4 (agent list).
-    public Task HandleLocalListAsync(Stream stream, CancellationToken ct) => Task.CompletedTask;
+    /// <summary>Reply to a <c>kcap ls</c> request with a tab-separated agent table.</summary>
+    public Task HandleLocalListAsync(Stream stream, CancellationToken ct) {
+        var lines = _agents.Values.Select(a => $"{a.Id}\t{a.Status}\t{a.RepoPath}");
+
+        return FrameCodec.WriteAsync(stream, new LocalFrame(FrameType.AgentList) { Text = string.Join('\n', lines) }, ct);
+    }
 
     /// <summary>
     /// Spawn a new agent from a local <c>run-agent</c> request, then attach the requesting

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -4,9 +4,71 @@ namespace Capacitor.Cli.Daemon.Services;
 
 /// Local-socket entry points invoked by <see cref="LocalControlServer"/>.
 internal partial class AgentOrchestrator {
-    // Filled in D5 (local spawn) and E4 (agent list).
-    public Task HandleLocalSpawnAsync(LocalFrame spawn, Stream stream, CancellationToken ct) => Task.CompletedTask;
+    // Filled in E4 (agent list).
     public Task HandleLocalListAsync(Stream stream, CancellationToken ct) => Task.CompletedTask;
+
+    /// <summary>
+    /// Spawn a new agent from a local <c>run-agent</c> request, then attach the requesting
+    /// client. The agent runs <b>PrivateLocal</b> (no per-agent server calls) in either an
+    /// owned worktree (<c>--worktree</c>) or the user's borrowed cwd (default in-place).
+    /// </summary>
+    public async Task HandleLocalSpawnAsync(LocalFrame spawn, Stream stream, CancellationToken ct) {
+        var (vendor, work, cwd, args, cols, rows) = FrameCodec.Spawn(spawn);
+
+        if (!_launchers.TryGetValue(vendor, out var launcher)) {
+            await FrameCodec.WriteAsync(stream, LocalFrame.Error($"Unknown vendor: {vendor}"), ct);
+            return;
+        }
+
+        if (!Directory.Exists(cwd)) {
+            await FrameCodec.WriteAsync(stream, LocalFrame.Error($"Directory does not exist: {cwd}"), ct);
+            return;
+        }
+
+        var           agentId = Guid.NewGuid().ToString("N");
+        AgentInstance agent;
+
+        try {
+            var worktree = work == WorkLocation.OwnedWorktree
+                ? await _worktreeManager.CreateAsync(cwd)
+                : WorktreeInfo.Borrowed(cwd);
+
+            var ctx = new LauncherContext(
+                agentId, cwd, worktree, Prompt: null, Model: "", Effort: null,
+                Tools: null, IsReview: false, Review: null, ReviewLaunch: null
+            ) {
+                Work = work
+            };
+
+            launcher.Prepare(ctx);
+            var built = launcher.BuildPassthrough(ctx, args);
+
+            // PrivateLocal hook env: omit KCAP_RENDERED_AGENT / KCAP_DAEMON_URL so the agent
+            // isn't treated as headless and permissions prompt natively in the terminal.
+            // Keep KCAP_AGENT_ID (tags events for tag-and-link) and KCAP_URL (records the
+            // session). Re-add ANTHROPIC_API_KEY so the user's normal local auth survives
+            // UnixPtyProcess.Spawn's headless scrub (it applies extraEnv after unsetenv).
+            var env = new Dictionary<string, string> { ["KCAP_AGENT_ID"] = agentId };
+            if (!string.IsNullOrEmpty(_config.ServerUrl)) env["KCAP_URL"] = _config.ServerUrl;
+            var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
+            if (!string.IsNullOrEmpty(apiKey)) env["ANTHROPIC_API_KEY"] = apiKey;
+
+            var proc = _ptyFactory.Spawn(launcher.CliPath, built.Args, worktree.Path, env, cols, rows);
+
+            agent = new AgentInstance(agentId, null, "", null, cwd, vendor, proc, worktree, new CancellationTokenSource()) {
+                IsPrivate     = true,
+                Work          = work,
+                McpConfigPath = built.McpConfigPath
+            };
+            _agents[agentId] = agent;
+        } catch (Exception ex) {
+            await FrameCodec.WriteAsync(stream, LocalFrame.Error($"Launch failed: {ex.Message}"), ct);
+            return;
+        }
+
+        _ = ReadAgentOutputAsync(agent);
+        await AttachClientLoopAsync(agent, stream, ct);
+    }
 
     /// <summary>Attach an existing agent to a local client (used by <c>kcap attach</c>).</summary>
     public Task HandleLocalAttachAsync(string agentId, Stream stream, CancellationToken ct) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -105,9 +105,15 @@ internal partial class AgentOrchestrator {
             await Send(FrameCodec.Attached(agent.Id, agent.OutputBuffer.Snapshot()));
             var pump = sink.RunAsync(ct);
 
+            // Wake this read loop when the agent exits on its own (CleanupAgentAsync trips
+            // ExitedCts), not only when the client sends input. Otherwise a self-exiting agent
+            // (e.g. typing /exit) leaves us blocked on the client read and we never flush the
+            // final output or send Exited — the client would just hang.
+            using var loopCts = CancellationTokenSource.CreateLinkedTokenSource(ct, agent.ExitedCts.Token);
+
             try {
-                while (!ct.IsCancellationRequested) {
-                    var f = await FrameCodec.ReadAsync(stream, ct);
+                while (!loopCts.Token.IsCancellationRequested) {
+                    var f = await FrameCodec.ReadAsync(stream, loopCts.Token);
                     if (f is null || f.Type == FrameType.Detach) break;
 
                     switch (f.Type) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -1,0 +1,12 @@
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// Local-socket entry points invoked by <see cref="LocalControlServer"/>. The bodies are
+/// filled in across the local-attach milestones (attach loop, spawn path, agent list);
+/// these stubs keep the listener compiling until then.
+internal partial class AgentOrchestrator {
+    public virtual Task HandleLocalSpawnAsync(LocalFrame spawn, Stream stream, CancellationToken ct) => Task.CompletedTask;
+    public virtual Task HandleLocalAttachAsync(string agentId, Stream stream, CancellationToken ct) => Task.CompletedTask;
+    public virtual Task HandleLocalListAsync(Stream stream, CancellationToken ct) => Task.CompletedTask;
+}

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -29,12 +29,13 @@ internal partial class AgentOrchestrator {
             return;
         }
 
-        var           agentId = Guid.NewGuid().ToString("N");
+        var           agentId       = Guid.NewGuid().ToString("N");
         AgentInstance agent;
+        WorktreeInfo? ownedWorktree = null; // tracked so a failure after creation cleans it up
 
         try {
             var worktree = work == WorkLocation.OwnedWorktree
-                ? await _worktreeManager.CreateAsync(cwd)
+                ? ownedWorktree = await _worktreeManager.CreateAsync(cwd)
                 : WorktreeInfo.Borrowed(cwd);
 
             var ctx = new LauncherContext(
@@ -68,6 +69,12 @@ internal partial class AgentOrchestrator {
             };
             _agents[agentId] = agent;
         } catch (Exception ex) {
+            // Don't leak a daemon-created worktree if Prepare / passthrough-arg building /
+            // spawn fails after the worktree was created (mirrors the server launch path).
+            if (ownedWorktree is { } leaked) {
+                try { await WorktreeManager.RemoveAsync(leaked); } catch { /* best-effort */ }
+            }
+
             await FrameCodec.WriteAsync(stream, LocalFrame.Error($"Launch failed: {ex.Message}"), ct);
             return;
         }
@@ -100,11 +107,19 @@ internal partial class AgentOrchestrator {
         }
 
         var sink = new LocalSocketSink(capacity: 4096, (chunk, _) => Send(LocalFrame.Stdout(chunk)));
-        lock (agent.SinksLock) agent.LocalSinks.Add(sink);
+
+        // Snapshot the replay buffer AND register the sink atomically under SinksLock (paired
+        // with the read loop's locked append+enqueue) so no chunk is both replayed and sent
+        // live, and none is dropped between the two.
+        byte[] snapshot;
+        lock (agent.SinksLock) {
+            snapshot = agent.OutputBuffer.Snapshot();
+            agent.LocalSinks.Add(sink);
+        }
 
         try {
             // Bounded replay BEFORE any live chunk so the client paints a coherent screen.
-            await Send(FrameCodec.Attached(agent.Id, agent.OutputBuffer.Snapshot()));
+            await Send(FrameCodec.Attached(agent.Id, snapshot));
             var pump = sink.RunAsync(ct);
 
             // Break this read loop when the agent exits on its own (CleanupAgentAsync trips
@@ -153,20 +168,29 @@ internal partial class AgentOrchestrator {
             lock (agent.SinksLock) {
                 agent.LocalSinks.Remove(sink);
                 agent.ClientDims.Remove(sink);
+                ClampPtyLocked(agent); // a departing (possibly smaller) client must not leave the rest clamped
             }
         }
     }
 
-    /// <summary>
-    /// Min-clamp the one PTY across all attached local clients (tmux semantics): size it
-    /// to the smallest cols × rows any client reports, so no client's redraw is corrupted.
-    /// </summary>
     void ApplyResizeClamp(AgentInstance agent, ITerminalSink sink, ushort cols, ushort rows) {
         lock (agent.SinksLock) {
             agent.ClientDims[sink] = new AgentInstance.Dim(cols, rows);
-            var c = agent.ClientDims.Values.Min(d => d.Cols);
-            var r = agent.ClientDims.Values.Min(d => d.Rows);
-            agent.Process.Resize(c == 0 ? cols : c, r == 0 ? rows : r);
+            ClampPtyLocked(agent);
         }
+    }
+
+    /// <summary>
+    /// Min-clamp the one PTY to the smallest cols × rows across the attached local clients
+    /// (tmux semantics), so no client's redraw is corrupted. Recomputed on attach/detach/
+    /// resize. Caller holds <see cref="AgentInstance.SinksLock"/>; no-op when no client has a
+    /// reported size.
+    /// </summary>
+    void ClampPtyLocked(AgentInstance agent) {
+        if (agent.ClientDims.Count == 0) return;
+
+        var c = agent.ClientDims.Values.Min(d => d.Cols);
+        var r = agent.ClientDims.Values.Min(d => d.Rows);
+        if (c > 0 && r > 0) agent.Process.Resize(c, r);
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -2,11 +2,81 @@ using Capacitor.Cli.Core.LocalIpc;
 
 namespace Capacitor.Cli.Daemon.Services;
 
-/// Local-socket entry points invoked by <see cref="LocalControlServer"/>. The bodies are
-/// filled in across the local-attach milestones (attach loop, spawn path, agent list);
-/// these stubs keep the listener compiling until then.
+/// Local-socket entry points invoked by <see cref="LocalControlServer"/>.
 internal partial class AgentOrchestrator {
-    public virtual Task HandleLocalSpawnAsync(LocalFrame spawn, Stream stream, CancellationToken ct) => Task.CompletedTask;
-    public virtual Task HandleLocalAttachAsync(string agentId, Stream stream, CancellationToken ct) => Task.CompletedTask;
-    public virtual Task HandleLocalListAsync(Stream stream, CancellationToken ct) => Task.CompletedTask;
+    // Filled in D5 (local spawn) and E4 (agent list).
+    public Task HandleLocalSpawnAsync(LocalFrame spawn, Stream stream, CancellationToken ct) => Task.CompletedTask;
+    public Task HandleLocalListAsync(Stream stream, CancellationToken ct) => Task.CompletedTask;
+
+    /// <summary>Attach an existing agent to a local client (used by <c>kcap attach</c>).</summary>
+    public Task HandleLocalAttachAsync(string agentId, Stream stream, CancellationToken ct) {
+        if (!_agents.TryGetValue(agentId, out var agent))
+            return FrameCodec.WriteAsync(stream, LocalFrame.Error($"no such agent {agentId}"), ct);
+
+        return AttachClientLoopAsync(agent, stream, ct);
+    }
+
+    /// <summary>
+    /// Registers a local sink, replays the agent's buffered output once, then pumps the
+    /// client's input (stdin/resize) until it detaches or disconnects. The agent keeps
+    /// running either way — the sink is just removed.
+    /// </summary>
+    internal async Task AttachClientLoopAsync(AgentInstance agent, Stream stream, CancellationToken ct) {
+        // One NetworkStream, two writers (the sink's Stdout frames + Attached/Exited here):
+        // serialise all writes through this lock. Reads (the input loop) are independent.
+        var writeLock = new SemaphoreSlim(1, 1);
+
+        async Task Send(LocalFrame f) {
+            await writeLock.WaitAsync(ct);
+            try { await FrameCodec.WriteAsync(stream, f, ct); } finally { writeLock.Release(); }
+        }
+
+        var sink = new LocalSocketSink(capacity: 4096, (chunk, _) => Send(LocalFrame.Stdout(chunk)));
+        lock (agent.SinksLock) agent.LocalSinks.Add(sink);
+
+        try {
+            // Bounded replay BEFORE any live chunk so the client paints a coherent screen.
+            await Send(FrameCodec.Attached(agent.Id, agent.OutputBuffer.Snapshot()));
+            var pump = sink.RunAsync(ct);
+
+            try {
+                while (!ct.IsCancellationRequested) {
+                    var f = await FrameCodec.ReadAsync(stream, ct);
+                    if (f is null || f.Type == FrameType.Detach) break;
+
+                    switch (f.Type) {
+                        case FrameType.Stdin:  await agent.Process.WriteAsync(f.Bytes); break;
+                        case FrameType.Resize: ApplyResizeClamp(agent, sink, f.Cols, f.Rows); break;
+                    }
+                }
+            } catch (Exception ex) when (ex is EndOfStreamException or IOException or OperationCanceledException) {
+                /* client gone */
+            } finally {
+                sink.Complete();
+                await pump.ConfigureAwait(false);
+            }
+
+            if (agent.Process.HasExited) {
+                try { await Send(LocalFrame.Exited(agent.Process.ExitCode ?? 0)); } catch { /* client already gone */ }
+            }
+        } finally {
+            lock (agent.SinksLock) {
+                agent.LocalSinks.Remove(sink);
+                agent.ClientDims.Remove(sink);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Min-clamp the one PTY across all attached local clients (tmux semantics): size it
+    /// to the smallest cols × rows any client reports, so no client's redraw is corrupted.
+    /// </summary>
+    void ApplyResizeClamp(AgentInstance agent, ITerminalSink sink, ushort cols, ushort rows) {
+        lock (agent.SinksLock) {
+            agent.ClientDims[sink] = new AgentInstance.Dim(cols, rows);
+            var c = agent.ClientDims.Values.Min(d => d.Cols);
+            var r = agent.ClientDims.Values.Min(d => d.Rows);
+            agent.Process.Resize(c == 0 ? cols : c, r == 0 ? rows : r);
+        }
+    }
 }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -107,11 +107,20 @@ internal partial class AgentOrchestrator {
             await Send(FrameCodec.Attached(agent.Id, agent.OutputBuffer.Snapshot()));
             var pump = sink.RunAsync(ct);
 
-            // Wake this read loop when the agent exits on its own (CleanupAgentAsync trips
-            // ExitedCts), not only when the client sends input. Otherwise a self-exiting agent
-            // (e.g. typing /exit) leaves us blocked on the client read and we never flush the
-            // final output or send Exited — the client would just hang.
+            // Break this read loop when the agent exits on its own (CleanupAgentAsync trips
+            // ExitedCts) — not only on client input — so a self-exiting agent (e.g. /exit)
+            // doesn't leave us blocked here and never flush the final output or send Exited.
             using var loopCts = CancellationTokenSource.CreateLinkedTokenSource(ct, agent.ExitedCts.Token);
+
+            // ...and break it when the sink force-detaches (overflow / send failure). The sink
+            // stops accepting output and completes its channel, so its pump finishes with
+            // Detached set; without this the client keeps typing into a dead output path
+            // (blind). Cancelling ends the loop so the client disconnects and reattaches for a
+            // fresh replay — the intended force-detach behaviour.
+            var detachMonitor = pump.ContinueWith(
+                _ => { if (sink.Detached) { try { loopCts.Cancel(); } catch (ObjectDisposedException) { } } },
+                TaskScheduler.Default
+            );
 
             try {
                 while (!loopCts.Token.IsCancellationRequested) {
@@ -124,10 +133,17 @@ internal partial class AgentOrchestrator {
                     }
                 }
             } catch (Exception ex) when (ex is EndOfStreamException or IOException or OperationCanceledException) {
-                /* client gone */
+                /* client gone or session ended */
             } finally {
                 sink.Complete();
                 await pump.ConfigureAwait(false);
+                await detachMonitor.ConfigureAwait(false); // ensure the cancel ran before loopCts disposes
+            }
+
+            if (sink.Detached && !agent.Process.HasExited) {
+                // We dropped this client because its output overflowed — tell it so the user
+                // reattaches (a fresh `kcap attach` replays the buffer from a clean frame).
+                try { await Send(LocalFrame.Error("terminal output overflowed — detached; reattach with `kcap attach`")); } catch { /* client already gone */ }
             }
 
             if (agent.Process.HasExited) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Capacitor.Cli.Daemon.Pty;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Commands;
 using Capacitor.Cli.Core.Config;
@@ -42,6 +43,26 @@ public record AgentInstance(
     /// finally-block call is the only one that lands.
     /// </summary>
     public string PendingEndReason { get; set; } = "agent_exited";
+
+    // ── Local terminal attach (Phase 1) ──────────────────────────────────
+    // Internal: these expose the daemon-internal ITerminalSink, so they can't be public
+    // on this public record (CS0053). They're only touched inside the daemon assembly.
+    /// <summary>Local-terminal clients attached over the control socket.</summary>
+    internal List<ITerminalSink> LocalSinks { get; } = [];
+    internal Lock                SinksLock  { get; } = new();
+    /// <summary>Each attached local client's last-reported size, for the resize min-clamp.</summary>
+    internal Dictionary<ITerminalSink, Dim> ClientDims { get; } = [];
+    public readonly record struct Dim(ushort Cols, ushort Rows);
+
+    /// <summary>
+    /// True for locally-launched agents: the orchestrator makes no per-agent server call
+    /// and does not attach the SignalR sink. An explicit share (Phase 2) clears this.
+    /// </summary>
+    public bool IsPrivate { get; init; }
+
+    /// <summary>Owned worktree (daemon-created — safe to remove on cleanup) vs borrowed cwd
+    /// (the user's own checkout — never removed).</summary>
+    public WorkLocation Work { get; init; } = WorkLocation.OwnedWorktree;
 }
 
 /// <summary>Ring buffer that keeps the last 2 MB of terminal output.</summary>
@@ -64,6 +85,17 @@ public class TerminalOutputBuffer {
 
     public List<byte[]> GetAll() {
         lock (_chunks) { return [.._chunks]; }
+    }
+
+    /// <summary>Flattens the retained ring into one buffer for a one-time replay to a
+    /// newly-attached client (bounded by <see cref="MaxBytes"/>).</summary>
+    public byte[] Snapshot() {
+        lock (_chunks) {
+            var ms = new MemoryStream(_totalBytes);
+            foreach (var c in _chunks) ms.Write(c);
+
+            return ms.ToArray();
+        }
     }
 }
 
@@ -451,16 +483,26 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
                 if (agent.Status == "Starting") {
                     agent.Status = "Running";
-                    _            = _server.AgentStatusChangedAsync(agent.Id, "Running", agent.SessionId);
+                    if (!agent.IsPrivate) _ = _server.AgentStatusChangedAsync(agent.Id, "Running", agent.SessionId);
                 }
 
                 agent.OutputBuffer.Append(data);
-                var base64 = Convert.ToBase64String(data);
-                // Await the enqueue: TerminalOutputSender back-pressures here when its
-                // queue is full (slow/down transport) so a chunk is never dropped to
-                // keep up — losing one byte garbles the whole redraw-TUI mirror (AI-844).
-                // sendCts releases this await on agent stop or daemon shutdown (AI-846).
-                await _server.SendTerminalOutputAsync(agent.Id, base64, sendCts.Token);
+
+                // Fan out to attached local-terminal clients (Phase 1). Non-blocking per
+                // sink: a slow client is force-detached inside TryEnqueue, never stalling
+                // this shared loop or the other clients.
+                ITerminalSink[] sinks;
+                lock (agent.SinksLock) sinks = [.. agent.LocalSinks];
+                foreach (var sink in sinks) sink.TryEnqueue(data);
+
+                if (!agent.IsPrivate) {
+                    var base64 = Convert.ToBase64String(data);
+                    // Await the enqueue: TerminalOutputSender back-pressures here when its
+                    // queue is full (slow/down transport) so a chunk is never dropped to
+                    // keep up — losing one byte garbles the whole redraw-TUI mirror (AI-844).
+                    // sendCts releases this await on agent stop or daemon shutdown (AI-846).
+                    await _server.SendTerminalOutputAsync(agent.Id, base64, sendCts.Token);
+                }
             }
         } catch (OperationCanceledException) {
             /* expected on stop */

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -54,6 +54,11 @@ public record AgentInstance(
     internal Dictionary<ITerminalSink, Dim> ClientDims { get; } = [];
     public readonly record struct Dim(ushort Cols, ushort Rows);
 
+    /// <summary>Tripped when the agent terminates (CleanupAgentAsync) so an attached local
+    /// client that's blocked waiting on the user's keystrokes wakes, flushes the last output,
+    /// and sends an Exited frame instead of hanging.</summary>
+    internal CancellationTokenSource ExitedCts { get; } = new();
+
     /// <summary>
     /// True for locally-launched agents: the orchestrator makes no per-agent server call
     /// and does not attach the SignalR sink. An explicit share (Phase 2) clears this.
@@ -971,6 +976,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         if (!_agents.TryRemove(agentId, out var agent)) {
             return;
         }
+
+        // Wake any attached local clients blocked on the user's stdin so they can flush the
+        // last output and send Exited (the agent is going away). The exit code is already
+        // captured on agent.Process, so disposing it below doesn't lose it.
+        try { await agent.ExitedCts.CancelAsync(); } catch { /* best-effort */ }
 
         // Each cleanup step is best-effort so later steps still run
         try { await agent.Process.DisposeAsync(); } catch (Exception ex) { LogCleanupStepFailed(ex, "disposing process", agentId); }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -968,7 +968,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             try { launcher.Cleanup(agent); } catch (Exception ex) { LogCleanupStepFailed(ex, "launcher.Cleanup", agentId); }
         }
 
-        try { await WorktreeManager.RemoveAsync(agent.Worktree); } catch (Exception ex) { LogCleanupStepFailed(ex, "removing worktree", agentId); }
+        // Owned worktrees are daemon-created and safe to remove. A borrowed cwd is the
+        // user's own checkout (local in-place launch) — NEVER delete it or its branch:
+        // RemoveAsync would Directory.Delete / `git worktree remove --force` + `branch -D`.
+        // This is the spec's top safety invariant.
+        if (agent.Work == WorkLocation.OwnedWorktree) {
+            try { await WorktreeManager.RemoveAsync(agent.Worktree); } catch (Exception ex) { LogCleanupStepFailed(ex, "removing worktree", agentId); }
+        }
 
         // Skip server unregister during shutdown — _ct is cancelled and the call
         // would throw TaskCanceledException. The server detects the daemon
@@ -1109,6 +1115,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// without going through SignalR. Keeps the private handler private to everyone else.
     /// </summary>
     internal Task HandleLaunchAgentForTest(LaunchAgentCommand cmd) => HandleLaunchAgent(cmd);
+
+    /// <summary>Test-only: register a pre-built agent so cleanup/lifecycle can be driven directly.</summary>
+    internal void RegisterAgentForTest(AgentInstance agent) => _agents[agent.Id] = agent;
+
+    /// <summary>Test-only entry point to the private cleanup path.</summary>
+    internal Task CleanupAgentForTest(string agentId) => CleanupAgentAsync(agentId);
 
     /// <summary>Test-only entry point to the private stop handler (mirrors <see cref="HandleLaunchAgentForTest"/>).</summary>
     internal Task HandleStopAgentForTest(string agentId) => HandleStopAgent(agentId);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -491,14 +491,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     if (!agent.IsPrivate) _ = _server.AgentStatusChangedAsync(agent.Id, "Running", agent.SessionId);
                 }
 
-                agent.OutputBuffer.Append(data);
-
-                // Fan out to attached local-terminal clients (Phase 1). Non-blocking per
-                // sink: a slow client is force-detached inside TryEnqueue, never stalling
-                // this shared loop or the other clients.
-                ITerminalSink[] sinks;
-                lock (agent.SinksLock) sinks = [.. agent.LocalSinks];
-                foreach (var sink in sinks) sink.TryEnqueue(data);
+                // Append to the replay buffer AND fan out to local sinks atomically under
+                // SinksLock — paired with attach taking its snapshot + subscribing under the
+                // same lock, so a chunk can't land in both a new client's replay and its live
+                // stream (duplication), nor in neither (gap). TryEnqueue is non-blocking so the
+                // lock is held only briefly; a slow client force-detaches inside TryEnqueue.
+                lock (agent.SinksLock) {
+                    agent.OutputBuffer.Append(data);
+                    foreach (var sink in agent.LocalSinks) sink.TryEnqueue(data);
+                }
 
                 if (!agent.IsPrivate) {
                     var base64 = Convert.ToBase64String(data);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -559,15 +559,19 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
                     LogStartupFailed(agent.Id, exitCode, reason);
 
-                    _ = _server.LaunchFailedAsync(agent.Id, reason);
+                    if (!agent.IsPrivate) _ = _server.LaunchFailedAsync(agent.Id, reason);
                 }
 
                 agent.Status = status;
-                await _server.AgentStatusChangedAsync(agent.Id, status, agent.SessionId);
 
-                var stopReason = status == "Completed" ? "exited" : "failed";
+                // PrivateLocal agents make no per-agent server calls (deny-all).
+                if (!agent.IsPrivate) {
+                    await _server.AgentStatusChangedAsync(agent.Id, status, agent.SessionId);
 
-                await _server.AppendAgentRunEventAsync(agent.Id, new AgentRunStopped(stopReason, exitCode));
+                    var stopReason = status == "Completed" ? "exited" : "failed";
+
+                    await _server.AppendAgentRunEventAsync(agent.Id, new AgentRunStopped(stopReason, exitCode));
+                }
             }
 
             LogAgentExited(agent.Id, exitCode);
@@ -585,27 +589,31 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // long we WAIT on it to EndAgentSessionBudget. The retry keeps running in the
             // background — a reconnect shortly after still lands the session-end — and a
             // genuinely long outage falls back to server-side daemon-disconnect reconcile.
-            var endTask = _server.EndAgentSessionAsync(agent.Id, agent.PendingEndReason);
+            //
+            // PrivateLocal agents have no server-side session to end (deny-all).
+            if (!agent.IsPrivate) {
+                var endTask = _server.EndAgentSessionAsync(agent.Id, agent.PendingEndReason);
 
-            try {
-                var result = await endTask.WaitAsync(EndAgentSessionBudget, _shutdownCts.Token);
+                try {
+                    var result = await endTask.WaitAsync(EndAgentSessionBudget, _shutdownCts.Token);
 
-                // The daemon doesn't track sessionId on its own (only agentId), so
-                // the server returns it in the result. Spawn what's-done locally
-                // when the server says yes.
-                if (result is { GenerateWhatsDone: true, SessionId: not null }) {
-                    SpawnWhatsDoneGenerator(result.SessionId);
+                    // The daemon doesn't track sessionId on its own (only agentId), so
+                    // the server returns it in the result. Spawn what's-done locally
+                    // when the server says yes.
+                    if (result is { GenerateWhatsDone: true, SessionId: not null }) {
+                        SpawnWhatsDoneGenerator(result.SessionId);
+                    }
+                } catch (TimeoutException) {
+                    // Outage outlasted the budget. Don't block cleanup; the retry continues
+                    // in the background (observed below so a later fault isn't unobserved).
+                    LogEndSessionTimedOut(agent.Id, EndAgentSessionBudget.TotalSeconds);
+                    ObserveEndSessionInBackground(endTask, agent.Id);
+                } catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) {
+                    // Shutdown fired mid-wait — connection is being torn down. Server
+                    // detects daemon disconnection independently. No warning needed.
+                } catch (Exception ex) {
+                    LogEndSessionFailed(ex, agent.Id);
                 }
-            } catch (TimeoutException) {
-                // Outage outlasted the budget. Don't block cleanup; the retry continues
-                // in the background (observed below so a later fault isn't unobserved).
-                LogEndSessionTimedOut(agent.Id, EndAgentSessionBudget.TotalSeconds);
-                ObserveEndSessionInBackground(endTask, agent.Id);
-            } catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) {
-                // Shutdown fired mid-wait — connection is being torn down. Server
-                // detects daemon disconnection independently. No warning needed.
-            } catch (Exception ex) {
-                LogEndSessionFailed(ex, agent.Id);
             }
 
             // Clean up worktree and unregister from server. Runs unconditionally — even
@@ -877,7 +885,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         return;
 
         async Task ReRegisterAgentsAsync() {
-            foreach (var agent in _agents.Values.Where(a => a.Status is "Starting" or "Running")) {
+            // PrivateLocal agents are never registered with the server, so never re-register them.
+            foreach (var agent in _agents.Values.Where(a => (a.Status is "Starting" or "Running") && !a.IsPrivate)) {
                 try {
                     await _server.AgentRegisteredAsync(agent.Id, agent.Prompt, agent.Model, agent.Effort, agent.RepoPath);
                     await _server.AgentStatusChangedAsync(agent.Id, agent.Status, agent.SessionId);
@@ -920,7 +929,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     async Task RunHeartbeatLoopAsync(CancellationToken ct) {
         while (await _heartbeatTimer.WaitForNextTickAsync(ct)) {
-            foreach (var agent in _agents.Values.Where(a => a.Status is "Starting" or "Running")) {
+            // PrivateLocal agents get no heartbeats and no stuck-Starting auto-stop (deny-all;
+            // the local user is present and drives them directly).
+            foreach (var agent in _agents.Values.Where(a => (a.Status is "Starting" or "Running") && !a.IsPrivate)) {
                 // Detect agents stuck in "Starting" with no output
                 if (agent.Status                         == "Starting" &&
                     DateTime.UtcNow - agent.LastOutputAt > StartupTimeout) {
@@ -980,7 +991,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // would throw TaskCanceledException. The server detects the daemon
         // disconnection through SignalR's transport-level signals. Filtered
         // catch covers the residual race where shutdown fires mid-call.
-        if (!_shutdownCts.IsCancellationRequested) {
+        // PrivateLocal agents were never registered, so never unregister them (deny-all).
+        if (!agent.IsPrivate && !_shutdownCts.IsCancellationRequested) {
             try { await _server.AgentUnregisteredAsync(agentId); } catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) { } catch (Exception ex) {
                 LogCleanupStepFailed(ex, "unregistering", agentId);
             }
@@ -1121,6 +1133,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     /// <summary>Test-only entry point to the private cleanup path.</summary>
     internal Task CleanupAgentForTest(string agentId) => CleanupAgentAsync(agentId);
+
+    /// <summary>Test-only: number of agents currently tracked (for awaiting cleanup).</summary>
+    internal int ActiveAgentCountForTest => _agents.Count;
 
     /// <summary>Test-only entry point to the private stop handler (mirrors <see cref="HandleLaunchAgentForTest"/>).</summary>
     internal Task HandleStopAgentForTest(string agentId) => HandleStopAgent(agentId);

--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
 using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Services;
@@ -19,6 +20,11 @@ internal sealed partial class ClaudeLauncher(
     static readonly JsonSerializerOptions IndentedJsonOpts = new() { WriteIndented = true };
 
     public void Prepare(LauncherContext ctx) {
+        // A borrowed cwd is the user's own, already-trusted, already-configured repo — do
+        // NOT overlay settings, write .mcp.json, edit settings.local.json, or write
+        // ~/.claude.json trust into it (local in-place launch). Touch nothing.
+        if (ctx.Work == WorkLocation.BorrowedCwd) return;
+
         // Overlay .claude/ local settings from source repo into worktree.
         try {
             var sourceClaudeDir = Path.Combine(ctx.SourceRepoPath, ".claude");
@@ -89,6 +95,11 @@ internal sealed partial class ClaudeLauncher(
 
         return new LaunchArgs(args.ToArray(), mcpConfigPath);
     }
+
+    /// Claude needs no mandatory daemon-level flags (cwd is set via forkpty chdir), so a
+    /// local launch forwards the user's post-`--` args verbatim.
+    public LaunchArgs BuildPassthrough(LauncherContext ctx, IReadOnlyList<string> userArgs)
+        => new([.. userArgs], McpConfigPath: null);
 
     public void Cleanup(AgentInstance agent) {
         try { RemoveClaudeProjectSymlink(agent.Worktree.Path); } catch (Exception ex) {

--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
 using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Services;
@@ -16,21 +17,27 @@ internal sealed partial class CodexLauncher(
     static readonly string[] CriticalHookEvents = ["SessionStart", "Stop", "PermissionRequest"];
 
     public void Prepare(LauncherContext ctx) {
-        // Step 1: overlay source/.codex into worktree FIRST so project-scope
-        // hooks (kcap plugin install --codex --project) become visible to
-        // the preflight in step 2. Best-effort.
-        try {
-            var sourceCodexDir = Path.Combine(ctx.SourceRepoPath, ".codex");
+        // A borrowed cwd is the user's own repo: skip the repo-mutating steps (overlay,
+        // ~/.codex trust write). Only the read-only hooks preflight runs for it.
+        var owned = ctx.Work == WorkLocation.OwnedWorktree;
 
-            if (Directory.Exists(sourceCodexDir)) {
-                FileSystemOverlay.OverlayDirectory(sourceCodexDir, Path.Combine(ctx.Worktree.Path, ".codex"));
+        if (owned) {
+            // Step 1: overlay source/.codex into worktree FIRST so project-scope
+            // hooks (kcap plugin install --codex --project) become visible to
+            // the preflight in step 2. Best-effort.
+            try {
+                var sourceCodexDir = Path.Combine(ctx.SourceRepoPath, ".codex");
+
+                if (Directory.Exists(sourceCodexDir)) {
+                    FileSystemOverlay.OverlayDirectory(sourceCodexDir, Path.Combine(ctx.Worktree.Path, ".codex"));
+                }
+            } catch (Exception ex) {
+                LogOverlayFailed(ex, ctx.AgentId);
             }
-        } catch (Exception ex) {
-            LogOverlayFailed(ex, ctx.AgentId);
         }
 
-        // Step 2: hook preflight (fail-fast). Either worktree-scope (after overlay)
-        // OR user-scope is sufficient.
+        // Step 2: hook preflight (fail-fast, read-only). Either worktree/cwd-scope OR
+        // user-scope is sufficient. Runs for borrowed cwd too — it only reads.
         var worktreeHooks = Path.Combine(ctx.Worktree.Path, ".codex", "hooks.json");
 
         if (!HooksInstalledIn(worktreeHooks) && !HooksInstalledIn(CodexPaths.UserHooksJson)) {
@@ -41,11 +48,13 @@ internal sealed partial class CodexLauncher(
             );
         }
 
-        // Step 3: pre-trust the worktree in ~/.codex/config.toml. Best-effort.
-        try {
-            CodexConfigWriter.TrustWorktree(ctx.Worktree.Path, logger);
-        } catch (Exception ex) {
-            LogTrustFailed(ex, ctx.AgentId);
+        if (owned) {
+            // Step 3: pre-trust the worktree in ~/.codex/config.toml. Best-effort.
+            try {
+                CodexConfigWriter.TrustWorktree(ctx.Worktree.Path, logger);
+            } catch (Exception ex) {
+                LogTrustFailed(ex, ctx.AgentId);
+            }
         }
 
         if (ctx.Tools is { Length: > 0 }) {
@@ -82,6 +91,31 @@ internal sealed partial class CodexLauncher(
             args.Add("--");
             args.Add(ctx.Prompt);
         }
+
+        return new([.. args], McpConfigPath: null);
+    }
+
+    /// Local launch: emit the mandatory daemon-level flags Codex always needs, then append
+    /// the user's verbatim post-`--` args. A user duplicate of a mandatory flag is rejected
+    /// outright (relying on Codex's arg precedence to make ours win is fragile).
+    public LaunchArgs BuildPassthrough(LauncherContext ctx, IReadOnlyList<string> userArgs) {
+        string[] mandatory = ["--cd", "--no-alt-screen"];
+
+        foreach (var m in mandatory) {
+            if (userArgs.Contains(m)) {
+                throw new ArgumentException($"{m} is set by kcap and cannot be overridden in `run-agent codex -- …`");
+            }
+        }
+
+        // --cd sets the working dir; --no-alt-screen keeps the mirror/replay on the primary
+        // screen. sandbox/approval defaults match the hosted path but stay user-overridable.
+        var args = new List<string> {
+            "--cd", ctx.Worktree.Path,
+            "--sandbox", "workspace-write",
+            "--ask-for-approval", "on-request",
+            "--no-alt-screen"
+        };
+        args.AddRange(userArgs);
 
         return new([.. args], McpConfigPath: null);
     }

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs
@@ -1,5 +1,6 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Commands;
+using Capacitor.Cli.Core.LocalIpc;
 
 namespace Capacitor.Cli.Daemon.Services;
 
@@ -40,8 +41,15 @@ internal interface IHostedAgentLauncher {
     /// </summary>
     void Prepare(LauncherContext ctx);
 
-    /// <summary>Build the argv array passed to the CLI.</summary>
+    /// <summary>Build the argv array passed to the CLI from structured server fields.</summary>
     LaunchArgs BuildArgs(LauncherContext ctx);
+
+    /// <summary>
+    /// Build argv for a local <c>run-agent</c> launch: emit only the mandatory daemon-level
+    /// flags this vendor must always set, then append the user's verbatim post-<c>--</c>
+    /// args. Used by the local-attach path instead of <see cref="BuildArgs"/>.
+    /// </summary>
+    LaunchArgs BuildPassthrough(LauncherContext ctx, IReadOnlyList<string> userArgs);
 
     /// <summary>Per-vendor cleanup AFTER the agent exits / is stopped.</summary>
     void Cleanup(AgentInstance agent);
@@ -58,6 +66,10 @@ internal sealed record LauncherContext(
         bool                              IsReview,
         ReviewLaunchInfo?                 Review,
         ReviewLaunchBuilder.ReviewLaunch? ReviewLaunch
-    );
+    ) {
+    /// <summary>Owned worktree (daemon-created) vs borrowed cwd (the user's own checkout).
+    /// Borrowed-cwd launches skip repo-mutating <c>Prepare()</c> steps.</summary>
+    public WorkLocation Work { get; init; } = WorkLocation.OwnedWorktree;
+}
 
 internal readonly record struct LaunchArgs(string[] Args, string? McpConfigPath);

--- a/src/Capacitor.Cli.Daemon/Services/ITerminalSink.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ITerminalSink.cs
@@ -1,0 +1,8 @@
+namespace Capacitor.Cli.Daemon.Services;
+
+/// One consumer of an agent's PTY output. The fan-out calls TryEnqueue (non-blocking);
+/// each sink drains itself on its own loop so one slow sink can't stall the others.
+internal interface ITerminalSink {
+    void TryEnqueue(byte[] chunk);
+    bool Detached { get; }
+}

--- a/src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs
@@ -1,0 +1,56 @@
+using System.Net.Sockets;
+using Capacitor.Cli.Core.LocalIpc;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// Accepts local (Unix-domain-socket / named-pipe) client connections and routes each
+/// opening frame to <see cref="AgentOrchestrator"/>. The socket file is owner-only (0600)
+/// — anything that can open it can spawn processes and stream a terminal, so it sits at
+/// the same trust boundary as the daemon PID/lock files.
+internal sealed partial class LocalControlServer(
+        DaemonConfig config, AgentOrchestrator orchestrator, ILogger<LocalControlServer> logger
+    ) : BackgroundService {
+    protected override async Task ExecuteAsync(CancellationToken ct) {
+        var path = LocalSocketPaths.Socket(config.Name);
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* stale; bind fails loudly below */ }
+
+        using var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        listener.Bind(new UnixDomainSocketEndPoint(path));
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite); // 0600
+        listener.Listen(16);
+        LogListening(path);
+
+        try {
+            while (!ct.IsCancellationRequested) {
+                var conn = await listener.AcceptAsync(ct);
+                _ = HandleConnectionAsync(conn, ct); // fire-and-forget; handler owns its lifetime
+            }
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) { /* shutdown */ }
+        finally { try { File.Delete(path); } catch { /* best-effort */ } }
+    }
+
+    async Task HandleConnectionAsync(Socket conn, CancellationToken ct) {
+        using var _ = conn;
+        await using var stream = new NetworkStream(conn, ownsSocket: false);
+        try {
+            var first = await FrameCodec.ReadAsync(stream, ct);
+            if (first is null) return;
+            switch (first.Type) {
+                case FrameType.Spawn:  await orchestrator.HandleLocalSpawnAsync(first, stream, ct); break;
+                case FrameType.Attach: await orchestrator.HandleLocalAttachAsync(first.Text, stream, ct); break;
+                case FrameType.List:   await orchestrator.HandleLocalListAsync(stream, ct); break;
+                default: await FrameCodec.WriteAsync(stream, LocalFrame.Error($"expected Spawn/Attach/List, got {first.Type}"), ct); break;
+            }
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            LogConnectionError(ex);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Local control socket listening at {Path}")]
+    partial void LogListening(string path);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Local control connection faulted")]
+    partial void LogConnectionError(Exception ex);
+}

--- a/src/Capacitor.Cli.Daemon/Services/LocalSocketSink.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalSocketSink.cs
@@ -1,0 +1,59 @@
+using System.Threading.Channels;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// A single local-client terminal output queue. The producer (the shared PTY read loop)
+/// calls <see cref="TryEnqueue"/>, which never blocks: if the bounded queue is full, the
+/// client is too slow, so we mark it <see cref="Detached"/> and drop it rather than (a)
+/// silently losing a chunk mid-stream — which desyncs Claude's cursor-addressing redraw
+/// (AI-844) — or (b) back-pressuring the shared loop and stalling every other client. A
+/// dropped client reattaches for a fresh <c>OutputBuffer</c> replay, recovering from a
+/// clean frame.
+internal sealed class LocalSocketSink : ITerminalSink {
+    readonly Channel<byte[]>                       _ch;
+    readonly Func<byte[], CancellationToken, Task> _send;
+
+    public bool Detached { get; private set; }
+
+    public LocalSocketSink(int capacity, Func<byte[], CancellationToken, Task> send) {
+        _send = send;
+        // Wait mode: TryWrite never blocks but returns false when the queue is full — that
+        // false is our overflow signal (force-detach). DropOldest/DropWrite would silently
+        // lose a chunk and always return true, reintroducing the AI-844 corruption.
+        _ch = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(capacity) {
+            FullMode     = BoundedChannelFullMode.Wait,
+            SingleReader = true
+        });
+    }
+
+    public void TryEnqueue(byte[] chunk) {
+        if (Detached) return;
+
+        if (!_ch.Writer.TryWrite(chunk)) {
+            Detached = true;
+            _ch.Writer.TryComplete();
+        }
+    }
+
+    public void Complete() => _ch.Writer.TryComplete();
+
+    public async Task RunAsync(CancellationToken ct) {
+        try {
+            await foreach (var chunk in _ch.Reader.ReadAllAsync(ct)) {
+                try {
+                    await _send(chunk, ct);
+                } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                    return;
+                } catch {
+                    // Socket write failed — the client is gone. Drop it; don't wedge the loop.
+                    Detached = true;
+                    _ch.Writer.TryComplete();
+
+                    return;
+                }
+            }
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            /* shutdown */
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -9,7 +9,11 @@ namespace Capacitor.Cli.Daemon.Services;
 /// Tracked so <see cref="WorktreeManager.RemoveAsync"/> can delete it on
 /// cleanup. Null for non-review launches.
 /// </summary>
-public record WorktreeInfo(string Path, string Branch, string SourceRepo, bool IsStandalone = false, string? FetchedRef = null);
+public record WorktreeInfo(string Path, string Branch, string SourceRepo, bool IsStandalone = false, string? FetchedRef = null) {
+    /// <summary>A borrowed cwd (local in-place launch) the daemon does NOT own. Cleanup
+    /// never removes it — the <see cref="AgentInstance.Work"/> guard enforces that.</summary>
+    public static WorktreeInfo Borrowed(string cwd) => new(cwd, "", cwd, IsStandalone: false);
+}
 
 public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManager> logger) {
     public async Task<WorktreeInfo> CreateAsync(string repoPath, string? name = null, string? baseRef = null) {

--- a/src/Capacitor.Cli/Commands/RunAgentCommand.cs
+++ b/src/Capacitor.Cli/Commands/RunAgentCommand.cs
@@ -1,0 +1,185 @@
+using System.Net.Sockets;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Local;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// `kcap run-agent` / `attach` / `ls` — drive a daemon-hosted agent from the local
+/// terminal over the daemon's local control socket (local-attach Phase 1).
+/// </summary>
+internal static class RunAgentCommand {
+    public static async Task<int> RunAsync(string[] args) {
+        if (NotSupportedOnWindows(out var rc)) return rc;
+
+        var parsed = RunAgentArgs.Parse(args);
+        if (parsed.Error is not null) {
+            await Console.Error.WriteLineAsync($"kcap run-agent: {parsed.Error}");
+
+            return 1;
+        }
+
+        var name = ResolveName(parsed.DaemonName);
+        if (!await EnsureDaemonAsync(name)) return 1;
+
+        var sock = LocalSocketPaths.Socket(name);
+        var work = parsed.Worktree ? WorkLocation.OwnedWorktree : WorkLocation.BorrowedCwd;
+        var (cols, rows) = TermSize();
+        var spawn = FrameCodec.Spawn(parsed.Vendor, work, Environment.CurrentDirectory, parsed.Passthrough, cols, rows);
+
+        return parsed.Detached
+            ? await SpawnDetachedAsync(sock, spawn)
+            : await LocalAgentClient.RunAsync(sock, spawn, CancellationToken.None);
+    }
+
+    public static async Task<int> AttachAsync(string[] args) {
+        if (NotSupportedOnWindows(out var rc)) return rc;
+
+        if (args.Length == 0 || args[0].StartsWith('-')) {
+            await Console.Error.WriteLineAsync("usage: kcap attach <agent-id> [--name <daemon>]");
+
+            return 1;
+        }
+
+        var agentId = args[0];
+        var sock    = LocalSocketPaths.Socket(ResolveName(NameFrom(args)));
+
+        if (!File.Exists(sock)) {
+            await Console.Error.WriteLineAsync($"kcap: no daemon socket at {sock}");
+
+            return 1;
+        }
+
+        return await LocalAgentClient.RunAsync(sock, new LocalFrame(FrameType.Attach) { Text = agentId }, CancellationToken.None);
+    }
+
+    public static async Task<int> ListAsync(string[] args) {
+        if (NotSupportedOnWindows(out var rc)) return rc;
+
+        var sock = LocalSocketPaths.Socket(ResolveName(NameFrom(args)));
+
+        if (!File.Exists(sock)) {
+            Console.WriteLine("No local daemon running.");
+
+            return 0;
+        }
+
+        try {
+            using var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            await socket.ConnectAsync(new UnixDomainSocketEndPoint(sock));
+            await using var stream = new NetworkStream(socket, ownsSocket: false);
+
+            await FrameCodec.WriteAsync(stream, new LocalFrame(FrameType.List), default);
+            var resp = await FrameCodec.ReadAsync(stream, default);
+
+            if (resp is null || resp.Type != FrameType.AgentList || resp.Text.Length == 0) {
+                Console.WriteLine("No agents.");
+
+                return 0;
+            }
+
+            Console.WriteLine($"{"AGENT",-34} {"STATUS",-10} REPO");
+            foreach (var line in resp.Text.Split('\n')) {
+                var parts = line.Split('\t');
+                if (parts.Length == 3) Console.WriteLine($"{parts[0],-34} {parts[1],-10} {parts[2]}");
+            }
+
+            return 0;
+        } catch (Exception ex) when (ex is SocketException or IOException) {
+            await Console.Error.WriteLineAsync($"kcap: cannot reach daemon: {ex.Message}");
+
+            return 1;
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    static async Task<int> SpawnDetachedAsync(string sock, LocalFrame spawn) {
+        using var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        await socket.ConnectAsync(new UnixDomainSocketEndPoint(sock));
+        await using var stream = new NetworkStream(socket, ownsSocket: false);
+
+        await FrameCodec.WriteAsync(stream, spawn, default);
+        var f = await FrameCodec.ReadAsync(stream, default);
+
+        switch (f?.Type) {
+            case FrameType.Attached:
+                var (id, _) = FrameCodec.Attached(f);
+                Console.WriteLine($"Started agent {id} (detached). Attach with: kcap attach {id}");
+
+                return 0;
+            case FrameType.Error:
+                await Console.Error.WriteLineAsync($"kcap: {f.Text}");
+
+                return 1;
+            default:
+                await Console.Error.WriteLineAsync("kcap: unexpected daemon response to spawn");
+
+                return 1;
+        }
+    }
+
+    /// <summary>Connects if a daemon is up; otherwise starts one detached and waits for the socket.</summary>
+    static async Task<bool> EnsureDaemonAsync(string name) {
+        var sock = LocalSocketPaths.Socket(name);
+        if (await CanConnectAsync(sock)) return true;
+
+        await Console.Error.WriteLineAsync($"kcap: starting daemon '{name}'…");
+        await DaemonCommands.HandleAsync(["daemon", "start", "-d", "--name", name]);
+
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline) {
+            if (await CanConnectAsync(sock)) return true;
+            await Task.Delay(250);
+        }
+
+        await Console.Error.WriteLineAsync("kcap: daemon did not come up in time (check `kcap daemon logs`).");
+
+        return false;
+    }
+
+    static async Task<bool> CanConnectAsync(string sock) {
+        if (!File.Exists(sock)) return false;
+
+        try {
+            using var s = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            await s.ConnectAsync(new UnixDomainSocketEndPoint(sock));
+
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    static string ResolveName(string? daemonName) {
+        string[] args = daemonName is null ? [] : ["--name", daemonName];
+
+        return DaemonNameResolver.Resolve(args, AppConfig.ResolvedProfile?.Profile?.Daemon?.Name);
+    }
+
+    static string? NameFrom(string[] args) {
+        var i = Array.IndexOf(args, "--name");
+
+        return i >= 0 && i + 1 < args.Length ? args[i + 1] : null;
+    }
+
+    static (ushort Cols, ushort Rows) TermSize() {
+        try { return ((ushort)Math.Max(1, Console.WindowWidth), (ushort)Math.Max(1, Console.WindowHeight)); }
+        catch { return (120, 40); }
+    }
+
+    static bool NotSupportedOnWindows(out int rc) {
+        if (OperatingSystem.IsWindows()) {
+            Console.Error.WriteLine("kcap run-agent/attach/ls is not supported on Windows yet.");
+            rc = 1;
+
+            return true;
+        }
+
+        rc = 0;
+
+        return false;
+    }
+}

--- a/src/Capacitor.Cli/Local/LocalAgentClient.cs
+++ b/src/Capacitor.Cli/Local/LocalAgentClient.cs
@@ -1,0 +1,126 @@
+using System.Net.Sockets;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Local;
+
+/// <summary>
+/// The dumb-pipe end of the local control socket: connects, sends an opening frame
+/// (Spawn or Attach), puts the terminal in raw mode, and pumps bytes both ways until the
+/// agent exits or the user detaches. Returns the agent's exit code (or 0 on detach).
+/// </summary>
+internal static class LocalAgentClient {
+    public static async Task<int> RunAsync(string socketPath, LocalFrame opening, CancellationToken outerCt) {
+        using var sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+
+        try {
+            await sock.ConnectAsync(new UnixDomainSocketEndPoint(socketPath), outerCt);
+        } catch (Exception ex) when (ex is SocketException or IOException) {
+            await Console.Error.WriteLineAsync($"kcap: cannot connect to daemon at {socketPath}: {ex.Message}");
+
+            return 1;
+        }
+
+        await using var stream = new NetworkStream(sock, ownsSocket: false);
+        using var       cts    = CancellationTokenSource.CreateLinkedTokenSource(outerCt);
+        var             ct     = cts.Token;
+
+        await FrameCodec.WriteAsync(stream, opening, ct);
+
+        using var raw      = TerminalRawMode.Enable();
+        var       stdout   = Console.OpenStandardOutput();
+        var       writeLock = new SemaphoreSlim(1, 1);
+        var       exitCode = 0;
+
+        async Task Send(LocalFrame f) {
+            await writeLock.WaitAsync(ct);
+            try { await FrameCodec.WriteAsync(stream, f, ct); } finally { writeLock.Release(); }
+        }
+
+        // daemon → client
+        var outPump = Task.Run(async () => {
+            try {
+                while (!ct.IsCancellationRequested) {
+                    var f = await FrameCodec.ReadAsync(stream, ct);
+                    if (f is null) break;
+
+                    switch (f.Type) {
+                        case FrameType.Stdout:
+                            await stdout.WriteAsync(f.Bytes, ct);
+                            await stdout.FlushAsync(ct);
+
+                            break;
+                        case FrameType.Attached:
+                            var (_, snapshot) = FrameCodec.Attached(f);
+                            if (snapshot.Length > 0) {
+                                await stdout.WriteAsync(snapshot, ct);
+                                await stdout.FlushAsync(ct);
+                            }
+
+                            await Send(SizeFrame()); // nudge a clean repaint at our size
+
+                            break;
+                        case FrameType.Exited:
+                            exitCode = f.ExitCode;
+
+                            return;
+                        case FrameType.Error:
+                            await Console.Error.WriteLineAsync($"\r\nkcap: {f.Text}");
+                            exitCode = 1;
+
+                            return;
+                    }
+                }
+            } catch (Exception ex) when (ex is OperationCanceledException or IOException or EndOfStreamException) {
+                /* connection closed */
+            }
+        }, ct);
+
+        // SIGWINCH isn't in .NET's PosixSignal enum, so poll the window size and send a
+        // Resize frame when it changes.
+        var resizePump = Task.Run(async () => {
+            var last = TrySize();
+            try {
+                while (!ct.IsCancellationRequested && !outPump.IsCompleted) {
+                    await Task.Delay(300, ct);
+                    var cur = TrySize();
+                    if (cur != last) { last = cur; await Send(SizeFrame()); }
+                }
+            } catch (Exception ex) when (ex is OperationCanceledException or IOException) {
+                /* shutting down */
+            }
+        }, ct);
+
+        // client → daemon (raw stdin), with detach-sequence interception
+        var stdinPump = Task.Run(async () => {
+            var scanner = new DetachScanner();
+            var stdin   = Console.OpenStandardInput();
+            var buf     = new byte[4096];
+            try {
+                while (!ct.IsCancellationRequested) {
+                    var n = await stdin.ReadAsync(buf, ct);
+                    if (n == 0) break;
+
+                    var (forward, detach) = scanner.Process(buf.AsSpan(0, n));
+                    if (forward.Length > 0) await Send(LocalFrame.Stdin(forward));
+                    if (detach) { await Send(LocalFrame.Detach()); break; }
+                }
+            } catch (Exception ex) when (ex is OperationCanceledException or IOException) {
+                /* shutting down */
+            }
+        }, ct);
+
+        // Return as soon as the agent exits (outPump) or the user detaches/EOFs (stdinPump).
+        await Task.WhenAny(outPump, stdinPump);
+        await cts.CancelAsync();
+
+        // raw mode is restored by `using raw` on return.
+        return exitCode;
+
+        LocalFrame SizeFrame() { var (c, r) = TrySize(); return LocalFrame.Resize(c, r); }
+    }
+
+    static (ushort Cols, ushort Rows) TrySize() {
+        try { return ((ushort)Math.Max(1, Console.WindowWidth), (ushort)Math.Max(1, Console.WindowHeight)); }
+        catch { return (80, 24); }
+    }
+}

--- a/src/Capacitor.Cli/Local/LocalAgentClient.cs
+++ b/src/Capacitor.Cli/Local/LocalAgentClient.cs
@@ -26,8 +26,12 @@ internal static class LocalAgentClient {
 
         await FrameCodec.WriteAsync(stream, opening, ct);
 
+        // Touch the Console size getter once BEFORE enabling raw mode, so .NET's lazy console
+        // init can't re-cook the terminal after we set raw. All real I/O bypasses Console and
+        // uses the raw fds directly (TerminalRawMode.ReadStdin/WriteStdout).
+        _ = TrySize();
+
         using var raw      = TerminalRawMode.Enable();
-        var       stdout   = Console.OpenStandardOutput();
         var       writeLock = new SemaphoreSlim(1, 1);
         var       exitCode = 0;
 
@@ -45,16 +49,12 @@ internal static class LocalAgentClient {
 
                     switch (f.Type) {
                         case FrameType.Stdout:
-                            await stdout.WriteAsync(f.Bytes, ct);
-                            await stdout.FlushAsync(ct);
+                            TerminalRawMode.WriteStdout(f.Bytes, f.Bytes.Length);
 
                             break;
                         case FrameType.Attached:
                             var (_, snapshot) = FrameCodec.Attached(f);
-                            if (snapshot.Length > 0) {
-                                await stdout.WriteAsync(snapshot, ct);
-                                await stdout.FlushAsync(ct);
-                            }
+                            if (snapshot.Length > 0) TerminalRawMode.WriteStdout(snapshot, snapshot.Length);
 
                             await Send(SizeFrame()); // nudge a clean repaint at our size
 
@@ -90,15 +90,16 @@ internal static class LocalAgentClient {
             }
         }, ct);
 
-        // client → daemon (raw stdin), with detach-sequence interception
+        // client → daemon (raw stdin via fd 0), with detach-sequence interception. read() is
+        // blocking and not cancellable; on detach we break, and on agent exit the process
+        // exits (Task.WhenAny below returns), abandoning this thread — which is fine.
         var stdinPump = Task.Run(async () => {
             var scanner = new DetachScanner();
-            var stdin   = Console.OpenStandardInput();
             var buf     = new byte[4096];
             try {
                 while (!ct.IsCancellationRequested) {
-                    var n = await stdin.ReadAsync(buf, ct);
-                    if (n == 0) break;
+                    var n = TerminalRawMode.ReadStdin(buf);
+                    if (n <= 0) break;
 
                     var (forward, detach) = scanner.Process(buf.AsSpan(0, n));
                     if (forward.Length > 0) await Send(LocalFrame.Stdin(forward));

--- a/src/Capacitor.Cli/Local/LocalAgentClient.cs
+++ b/src/Capacitor.Cli/Local/LocalAgentClient.cs
@@ -31,9 +31,13 @@ internal static class LocalAgentClient {
         // uses the raw fds directly (TerminalRawMode.ReadStdin/WriteStdout).
         _ = TrySize();
 
-        using var raw      = TerminalRawMode.Enable();
-        var       writeLock = new SemaphoreSlim(1, 1);
-        var       exitCode = 0;
+        using var raw       = TerminalRawMode.Enable();
+        var       writeLock  = new SemaphoreSlim(1, 1);
+        var       exitCode   = 0;
+        var       gotExited  = false; // daemon told us the agent exited
+        var       errored    = false; // daemon sent an Error frame (already printed)
+        var       detached   = false; // user pressed the detach sequence
+        var       inputClosed = false; // local stdin reached EOF
 
         async Task Send(LocalFrame f) {
             await writeLock.WaitAsync(ct);
@@ -60,12 +64,14 @@ internal static class LocalAgentClient {
 
                             break;
                         case FrameType.Exited:
-                            exitCode = f.ExitCode;
+                            exitCode  = f.ExitCode;
+                            gotExited = true;
 
                             return;
                         case FrameType.Error:
                             await Console.Error.WriteLineAsync($"\r\nkcap: {f.Text}");
                             exitCode = 1;
+                            errored  = true;
 
                             return;
                     }
@@ -99,11 +105,11 @@ internal static class LocalAgentClient {
             try {
                 while (!ct.IsCancellationRequested) {
                     var n = TerminalRawMode.ReadStdin(buf);
-                    if (n <= 0) break;
+                    if (n <= 0) { inputClosed = true; break; }
 
                     var (forward, detach) = scanner.Process(buf.AsSpan(0, n));
                     if (forward.Length > 0) await Send(LocalFrame.Stdin(forward));
-                    if (detach) { await Send(LocalFrame.Detach()); break; }
+                    if (detach) { detached = true; await Send(LocalFrame.Detach()); break; }
                 }
             } catch (Exception ex) when (ex is OperationCanceledException or IOException) {
                 /* shutting down */
@@ -113,6 +119,14 @@ internal static class LocalAgentClient {
         // Return as soon as the agent exits (outPump) or the user detaches/EOFs (stdinPump).
         await Task.WhenAny(outPump, stdinPump);
         await cts.CancelAsync();
+
+        // If the connection ended without an explicit detach, stdin EOF, an Exited frame, or a
+        // reported Error, the daemon dropped unexpectedly (crash / socket loss). Surface that
+        // as a failure rather than letting it look like a clean exit (code 0).
+        if (!detached && !inputClosed && !gotExited && !errored) {
+            await Console.Error.WriteLineAsync("\r\nkcap: lost connection to the daemon");
+            exitCode = 1;
+        }
 
         // raw mode is restored by `using raw` on return.
         return exitCode;

--- a/src/Capacitor.Cli/Local/TerminalRawMode.cs
+++ b/src/Capacitor.Cli/Local/TerminalRawMode.cs
@@ -16,6 +16,7 @@ namespace Capacitor.Cli.Local;
 /// </summary>
 internal static partial class TerminalRawMode {
     const int StdinFd         = 0;
+    const int StdoutFd        = 1;
     const int TCSANOW         = 0;
     const int TermiosBlobSize = 128; // > sizeof(struct termios) on Linux (~60) and macOS (~72)
 
@@ -30,6 +31,34 @@ internal static partial class TerminalRawMode {
     [LibraryImport("libc")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial void cfmakeraw(byte[] termios);
+
+    [LibraryImport("libc", SetLastError = true)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial nint read(int fd, byte[] buf, nint count);
+
+    [LibraryImport("libc", SetLastError = true)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial nint write(int fd, byte[] buf, nint count);
+
+    /// <summary>
+    /// Blocking raw read of stdin (fd 0). We deliberately bypass <see cref="Console"/>: on
+    /// Unix its stream layer re-cooks the terminal, which would defeat raw mode (double echo,
+    /// line buffering, LF-instead-of-CR on Enter). Returns bytes read, 0 on EOF.
+    /// </summary>
+    public static int ReadStdin(byte[] buf) => (int)read(StdinFd, buf, buf.Length);
+
+    /// <summary>Writes <paramref name="length"/> bytes of <paramref name="data"/> to stdout
+    /// (fd 1), looping over partial writes. Bypasses <see cref="Console"/> for the same reason.</summary>
+    public static void WriteStdout(byte[] data, int length) {
+        var off = 0;
+        while (off < length) {
+            var slice = off == 0 ? data : data[off..length];
+            var n     = (int)write(StdoutFd, slice, length - off);
+            if (n <= 0) break; // error/EOF — caller's read loop will notice the closed stream
+
+            off += n;
+        }
+    }
 
     /// <summary>
     /// Enables raw mode and returns a token whose <see cref="IDisposable.Dispose"/> restores

--- a/src/Capacitor.Cli/Local/TerminalRawMode.cs
+++ b/src/Capacitor.Cli/Local/TerminalRawMode.cs
@@ -1,0 +1,67 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Capacitor.Cli.Local;
+
+/// <summary>
+/// Puts the controlling terminal into raw mode so keystrokes — including Ctrl-C as the
+/// byte <c>0x03</c> — pass straight through to the attached agent's PTY (where the daemon's
+/// line discipline turns it into SIGINT for the agent), and restores the original mode on
+/// dispose.
+///
+/// <para>The platform <c>struct termios</c> layout differs between Linux and macOS (field
+/// widths, <c>NCCS</c>, presence of <c>c_line</c>), so we never interpret it: we treat it
+/// as an opaque, over-sized blob and let libc's <c>cfmakeraw</c> do the raw transform. We
+/// only ever round-trip the blob through <c>tcgetattr</c>/<c>tcsetattr</c>.</para>
+/// </summary>
+internal static partial class TerminalRawMode {
+    const int StdinFd         = 0;
+    const int TCSANOW         = 0;
+    const int TermiosBlobSize = 128; // > sizeof(struct termios) on Linux (~60) and macOS (~72)
+
+    [LibraryImport("libc", SetLastError = true)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial int tcgetattr(int fd, byte[] termios);
+
+    [LibraryImport("libc", SetLastError = true)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial int tcsetattr(int fd, int optionalActions, byte[] termios);
+
+    [LibraryImport("libc")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial void cfmakeraw(byte[] termios);
+
+    /// <summary>
+    /// Enables raw mode and returns a token whose <see cref="IDisposable.Dispose"/> restores
+    /// the original mode. If stdin is not a tty (e.g. piped), returns a no-op token so callers
+    /// can always wrap their session in a <c>using</c>.
+    /// </summary>
+    public static IDisposable Enable() {
+        if (OperatingSystem.IsWindows()) return new Noop();
+
+        var original = new byte[TermiosBlobSize];
+        if (tcgetattr(StdinFd, original) != 0) return new Noop(); // not a tty
+
+        var raw = (byte[])original.Clone();
+        cfmakeraw(raw);
+
+        return tcsetattr(StdinFd, TCSANOW, raw) != 0
+            ? new Noop()
+            : new Restore(original);
+    }
+
+    sealed class Restore(byte[] original) : IDisposable {
+        bool _done;
+
+        public void Dispose() {
+            if (_done) return;
+
+            _done = true;
+            tcsetattr(StdinFd, TCSANOW, original);
+        }
+    }
+
+    sealed class Noop : IDisposable {
+        public void Dispose() { }
+    }
+}

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -230,6 +230,12 @@ switch (command) {
     }
     case "daemon":
         return await DaemonCommands.HandleAsync(args);
+    case "run-agent":
+        return await RunAgentCommand.RunAsync(args[1..]);
+    case "attach":
+        return await RunAgentCommand.AttachAsync(args[1..]);
+    case "ls":
+        return await RunAgentCommand.ListAsync(args[1..]);
     case "setup":
         return await SetupCommand.HandleAsync(args);
     case "plugin":

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -138,9 +138,9 @@ public partial class AgentOrchestratorVendorTests {
             while (orch.ActiveAgentCountForTest > 0 && DateTime.UtcNow < deadline) await Task.Delay(20);
 
             await Assert.That(server.Calls.Count).IsEqualTo(0);
-            await Assert.That(pty.LastEnv!.ContainsKey("KCAP_AGENT_ID")).IsTrue();
-            await Assert.That(pty.LastEnv!.ContainsKey("KCAP_URL")).IsTrue();
-            await Assert.That(pty.LastEnv!.ContainsKey("KCAP_RENDERED_AGENT")).IsFalse();
+            await Assert.That(pty.LastEnv!.ContainsKey("KCAP_URL")).IsTrue();            // records as a plain local session
+            await Assert.That(pty.LastEnv!.ContainsKey("KCAP_AGENT_ID")).IsFalse();      // unregistered in Phase 1 → no agent_host_id tag
+            await Assert.That(pty.LastEnv!.ContainsKey("KCAP_RENDERED_AGENT")).IsFalse(); // native terminal permissions
             await Assert.That(pty.LastEnv!.ContainsKey("KCAP_DAEMON_URL")).IsFalse();
         } finally {
             Directory.Delete(dir.FullName, true);

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -1,0 +1,60 @@
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// Local-attach (Phase 1) behaviours on AgentOrchestrator. Partial of
+/// AgentOrchestratorVendorTests to reuse its BuildOrchestrator + test doubles.
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Borrowed_cwd_cleanup_does_not_delete_user_dir_or_branch() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server = new CaptureServerConnection();
+            await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+            // IsStandalone:true means RemoveAsync WOULD Directory.Delete this path —
+            // the Work=BorrowedCwd guard must prevent that.
+            var agent = new AgentInstance(
+                "local-1", null, "", null, repoPath, "claude",
+                new StubPtyProcess(), new WorktreeInfo(repoPath, "", repoPath, IsStandalone: true), new CancellationTokenSource()
+            ) {
+                IsPrivate = true,
+                Work      = WorkLocation.BorrowedCwd
+            };
+
+            orch.RegisterAgentForTest(agent);
+            await orch.CleanupAgentForTest("local-1");
+
+            await Assert.That(Directory.Exists(repoPath)).IsTrue();
+            await Assert.That(File.Exists(Path.Combine(repoPath, "README.md"))).IsTrue();
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test]
+    public async Task Owned_worktree_cleanup_still_removes_it() {
+        var dir = Directory.CreateTempSubdirectory("kcap-owned-");
+
+        try {
+            var server = new CaptureServerConnection();
+            await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+            var agent = new AgentInstance(
+                "owned-1", null, "", null, dir.FullName, "claude",
+                new StubPtyProcess(), new WorktreeInfo(dir.FullName, "", dir.FullName, IsStandalone: true), new CancellationTokenSource()
+            ) {
+                Work = WorkLocation.OwnedWorktree
+            };
+
+            orch.RegisterAgentForTest(agent);
+            await orch.CleanupAgentForTest("owned-1");
+
+            await Assert.That(Directory.Exists(dir.FullName)).IsFalse();
+        } finally {
+            try { Directory.Delete(dir.FullName, true); } catch { /* already gone — that's the assertion */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -1,11 +1,60 @@
 using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit;
 
 /// Local-attach (Phase 1) behaviours on AgentOrchestrator. Partial of
 /// AgentOrchestratorVendorTests to reuse its BuildOrchestrator + test doubles.
 public partial class AgentOrchestratorVendorTests {
+    static DaemonConfig LauncherCfg() => new() { Name = "t", ServerUrl = "http://127.0.0.1:1" };
+
+    static LauncherContext CtxFor(string path)
+        => new("a", path, new WorktreeInfo(path, "", path, IsStandalone: true), null, "", null, null, false, null, null) {
+            Work = WorkLocation.BorrowedCwd
+        };
+
+    [Test]
+    public async Task Claude_borrowed_cwd_prepare_writes_no_repo_files() {
+        var dir = Directory.CreateTempSubdirectory("kcap-inplace-");
+
+        try {
+            var launcher = new ClaudeLauncher(LauncherCfg(), NullLogger<ClaudeLauncher>.Instance);
+            launcher.Prepare(CtxFor(dir.FullName));
+
+            await Assert.That(File.Exists(Path.Combine(dir.FullName, ".mcp.json"))).IsFalse();
+            await Assert.That(File.Exists(Path.Combine(dir.FullName, ".claude", "settings.local.json"))).IsFalse();
+            await Assert.That(Directory.Exists(Path.Combine(dir.FullName, ".claude"))).IsFalse();
+        } finally {
+            Directory.Delete(dir.FullName, true);
+        }
+    }
+
+    [Test]
+    public async Task Claude_passthrough_forwards_user_args_verbatim() {
+        var launcher = new ClaudeLauncher(LauncherCfg(), NullLogger<ClaudeLauncher>.Instance);
+        var a = launcher.BuildPassthrough(CtxFor("/r"), ["--model", "opus", "fix it"]);
+        await Assert.That(a.Args).IsEquivalentTo(new[] { "--model", "opus", "fix it" });
+    }
+
+    [Test]
+    public async Task Codex_passthrough_injects_mandatory_flags_then_user_args() {
+        var launcher = new CodexLauncher(LauncherCfg(), NullLogger<CodexLauncher>.Instance);
+        var a = launcher.BuildPassthrough(CtxFor("/r"), ["-m", "gpt"]);
+        await Assert.That(a.Args).Contains("--cd");
+        await Assert.That(a.Args).Contains("--no-alt-screen");
+        await Assert.That(a.Args[^2]).IsEqualTo("-m");
+        await Assert.That(a.Args[^1]).IsEqualTo("gpt");
+    }
+
+    [Test]
+    public async Task Codex_passthrough_rejects_user_duplicate_of_mandatory_flag() {
+        var launcher = new CodexLauncher(LauncherCfg(), NullLogger<CodexLauncher>.Instance);
+        await Assert.That(() => launcher.BuildPassthrough(CtxFor("/r"), ["--cd", "/elsewhere"]))
+            .Throws<ArgumentException>();
+    }
+
     [Test]
     public async Task Borrowed_cwd_cleanup_does_not_delete_user_dir_or_branch() {
         var (repoPath, cleanup) = CreateGitRepo();

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Net.Sockets;
+using System.Text;
 using System.Text.Json;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
@@ -142,6 +144,53 @@ public partial class AgentOrchestratorVendorTests {
             await Assert.That(pty.LastEnv!.ContainsKey("KCAP_DAEMON_URL")).IsFalse();
         } finally {
             Directory.Delete(dir.FullName, true);
+        }
+    }
+
+    [Test]
+    public async Task Local_socket_list_round_trips_registered_agents_over_a_real_socket() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        var sockDir = Directory.CreateTempSubdirectory("kcap-sock-");
+        DaemonLockPaths.OverrideDirectoryForTesting(sockDir.FullName);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        LocalControlServer? listener = null;
+        AgentOrchestrator?  orch     = null;
+
+        try {
+            orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+            orch.RegisterAgentForTest(new AgentInstance(
+                "agent-xyz", null, "", null, "/tmp/repo", "claude",
+                new StubPtyProcess(), new WorktreeInfo("/tmp/repo", "", "/tmp/repo"), new CancellationTokenSource()
+            ) {
+                IsPrivate = true, Work = WorkLocation.BorrowedCwd, Status = "Running"
+            });
+
+            var config = new DaemonConfig { Name = "test", ServerUrl = "http://127.0.0.1:1" };
+            listener = new LocalControlServer(config, orch, NullLogger<LocalControlServer>.Instance);
+            await listener.StartAsync(cts.Token);
+
+            var sockPath = LocalSocketPaths.Socket("test");
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (!File.Exists(sockPath) && DateTime.UtcNow < deadline) await Task.Delay(20, cts.Token);
+            await Assert.That(File.Exists(sockPath)).IsTrue();
+
+            using var sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            await sock.ConnectAsync(new UnixDomainSocketEndPoint(sockPath), cts.Token);
+            await using var stream = new NetworkStream(sock, ownsSocket: false);
+
+            await FrameCodec.WriteAsync(stream, new LocalFrame(FrameType.List), cts.Token);
+            var resp = await FrameCodec.ReadAsync(stream, cts.Token);
+
+            await Assert.That(resp!.Type).IsEqualTo(FrameType.AgentList);
+            await Assert.That(resp.Text).Contains("agent-xyz");
+            await Assert.That(resp.Text).Contains("Running");
+        } finally {
+            if (orch is not null) await orch.DisposeAsync();
+            if (listener is not null) { await listener.StopAsync(CancellationToken.None); listener.Dispose(); }
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(sockDir.FullName, true); } catch { /* best-effort */ }
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -1,5 +1,9 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Pty;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -105,5 +109,92 @@ public partial class AgentOrchestratorVendorTests {
         } finally {
             try { Directory.Delete(dir.FullName, true); } catch { /* already gone — that's the assertion */ }
         }
+    }
+
+    [Test]
+    public async Task PrivateLocal_spawn_makes_no_server_calls_and_omits_hosted_agent_env() {
+        var dir = Directory.CreateTempSubdirectory("kcap-priv-");
+
+        try {
+            var server    = new TripwireServerConnection();
+            var pty       = new EnvCapturingPtyFactory();
+            var launchers = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = new SpyHostedAgentLauncher("claude", "spy-claude") };
+
+            await using var orch = BuildOrchestrator(server, pty, launchers);
+
+            // Client read side: one Detach frame so the attach loop returns promptly.
+            var readBuf = new MemoryStream();
+            await FrameCodec.WriteAsync(readBuf, LocalFrame.Detach(), default);
+            readBuf.Position = 0;
+            using var client = new DuplexTestStream(readBuf, new MemoryStream());
+
+            var spawn = FrameCodec.Spawn("claude", WorkLocation.BorrowedCwd, dir.FullName, ["--model", "opus"], 80, 24);
+            await orch.HandleLocalSpawnAsync(spawn, client, default);
+
+            // Let the fire-and-forget read loop + cleanup finish, then assert no server call landed.
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (orch.ActiveAgentCountForTest > 0 && DateTime.UtcNow < deadline) await Task.Delay(20);
+
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+            await Assert.That(pty.LastEnv!.ContainsKey("KCAP_AGENT_ID")).IsTrue();
+            await Assert.That(pty.LastEnv!.ContainsKey("KCAP_URL")).IsTrue();
+            await Assert.That(pty.LastEnv!.ContainsKey("KCAP_RENDERED_AGENT")).IsFalse();
+            await Assert.That(pty.LastEnv!.ContainsKey("KCAP_DAEMON_URL")).IsFalse();
+        } finally {
+            Directory.Delete(dir.FullName, true);
+        }
+    }
+
+    // ── Test doubles for the local-spawn lifecycle ──────────────────────
+
+    sealed class EnvCapturingPtyFactory : IPtyProcessFactory {
+        public Dictionary<string, string>? LastEnv { get; private set; }
+
+        public IPtyProcess Spawn(string command, string[] args, string cwd, Dictionary<string, string>? extraEnv = null, ushort cols = 120, ushort rows = 40) {
+            LastEnv = extraEnv;
+
+            return new StubPtyProcess();
+        }
+    }
+
+    /// Read and write go to separate underlying streams, so a test can preload client input
+    /// while the daemon's frames are captured/discarded independently (a MemoryStream can't
+    /// do both at once — it has a single position).
+    sealed class DuplexTestStream(Stream readSide, Stream writeSide) : Stream {
+        public override int Read(byte[] b, int o, int c) => readSide.Read(b, o, c);
+        public override ValueTask<int> ReadAsync(Memory<byte> b, CancellationToken ct = default) => readSide.ReadAsync(b, ct);
+        public override void Write(byte[] b, int o, int c) => writeSide.Write(b, o, c);
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> b, CancellationToken ct = default) => writeSide.WriteAsync(b, ct);
+        public override void Flush() => writeSide.Flush();
+        public override Task FlushAsync(CancellationToken ct) => writeSide.FlushAsync(ct);
+        public override bool CanRead => true; public override bool CanWrite => true; public override bool CanSeek => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => 0; set { } }
+        public override long Seek(long o, SeekOrigin s) => throw new NotSupportedException();
+        public override void SetLength(long v) => throw new NotSupportedException();
+        protected override void Dispose(bool disposing) { if (disposing) { readSide.Dispose(); writeSide.Dispose(); } }
+    }
+
+    /// Records the name of any per-agent server method invoked. A PrivateLocal agent must
+    /// invoke none of them — the test asserts Calls is empty.
+    sealed class TripwireServerConnection() : ServerConnection(
+        new() { Name = "test", ServerUrl = "http://127.0.0.1:1" },
+        NullLoggerFactory.Instance,
+        NullLogger<ServerConnection>.Instance
+    ) {
+        public ConcurrentBag<string> Calls { get; } = [];
+
+        public override Task LaunchFailedAsync(string agentId, string reason) { Calls.Add(nameof(LaunchFailedAsync)); return Task.CompletedTask; }
+        public override Task AgentRegisteredAsync(string agentId, string? prompt, string? model, string? effort, string? repoPath) { Calls.Add(nameof(AgentRegisteredAsync)); return Task.CompletedTask; }
+        public override Task AgentStatusChangedAsync(string agentId, string status, string? sessionId) { Calls.Add(nameof(AgentStatusChangedAsync)); return Task.CompletedTask; }
+        public override Task AgentUnregisteredAsync(string agentId) { Calls.Add(nameof(AgentUnregisteredAsync)); return Task.CompletedTask; }
+        public override Task UpdateRepoPathsAsync() { Calls.Add(nameof(UpdateRepoPathsAsync)); return Task.CompletedTask; }
+        public override Task SendTerminalOutputAsync(string agentId, string base64Data, CancellationToken ct = default) { Calls.Add(nameof(SendTerminalOutputAsync)); return Task.CompletedTask; }
+        public override Task AppendAgentRunEventAsync(string agentId, object evt) { Calls.Add(nameof(AppendAgentRunEventAsync)); return Task.CompletedTask; }
+        public override Task<EndAgentSessionResult> EndAgentSessionAsync(string agentId, string reason) { Calls.Add(nameof(EndAgentSessionAsync)); return Task.FromResult(new EndAgentSessionResult()); }
+
+        public override Task<PermissionDecision> RequestPermissionAsync(
+                string sessionId, string? toolName, JsonElement? toolInput, JsonElement? suggestions, CancellationToken ct = default
+            ) { Calls.Add(nameof(RequestPermissionAsync)); return Task.FromResult(new PermissionDecision("deny", null, null)); }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -19,7 +19,7 @@ namespace Capacitor.Cli.Tests.Unit;
 ///   • <see cref="CodexHooksNotInstalledException"/> from Prepare surfaces as a
 ///     LaunchFailed with the exception's message and no PTY ever spawns.
 /// </summary>
-public class AgentOrchestratorVendorTests {
+public partial class AgentOrchestratorVendorTests {
     static (string repoPath, Action cleanup) CreateGitRepo() {
         var repoPath = Path.Combine(Path.GetTempPath(), "kcap-orch-" + Guid.NewGuid().ToString("N")[..8]);
         Directory.CreateDirectory(repoPath);

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -53,7 +53,7 @@ public partial class AgentOrchestratorVendorTests {
     }
 
     static AgentOrchestrator BuildOrchestrator(
-            CaptureServerConnection                           server,
+            ServerConnection                                  server,
             IPtyProcessFactory                                ptyFactory,
             IReadOnlyDictionary<string, IHostedAgentLauncher> launchers,
             string?                                           allowedRepoPath = null

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -496,6 +496,12 @@ public partial class AgentOrchestratorVendorTests {
             return new LaunchArgs(Args: [], McpConfigPath: null);
         }
 
+        public LaunchArgs BuildPassthrough(LauncherContext ctx, IReadOnlyList<string> userArgs) {
+            BuildArgsCalls++;
+
+            return new LaunchArgs(Args: [.. userArgs], McpConfigPath: null);
+        }
+
         public void Cleanup(AgentInstance agent) {
             CleanupCalls++;
         }

--- a/test/Capacitor.Cli.Tests.Unit/DetachScannerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/DetachScannerTests.cs
@@ -1,0 +1,50 @@
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class DetachScannerTests {
+    [Test]
+    public async Task Forwards_normal_bytes_unchanged() {
+        var s = new DetachScanner();
+        var (forward, detach) = s.Process("hello"u8);
+        await Assert.That(detach).IsFalse();
+        await Assert.That(forward).IsEquivalentTo("hello"u8.ToArray());
+    }
+
+    [Test]
+    public async Task Detects_prefix_then_d_split_across_reads() {
+        var s = new DetachScanner();
+
+        var (f1, d1) = s.Process([0x11]); // prefix alone — held, nothing forwarded yet
+        await Assert.That(d1).IsFalse();
+        await Assert.That(f1).IsEmpty();
+
+        var (_, d2) = s.Process([(byte)'d']); // completes the sequence
+        await Assert.That(d2).IsTrue();
+    }
+
+    [Test]
+    public async Task Detects_prefix_then_d_in_one_read() {
+        var s = new DetachScanner();
+        var (_, detach) = s.Process([0x11, (byte)'d']);
+        await Assert.That(detach).IsTrue();
+    }
+
+    [Test]
+    public async Task Prefix_not_followed_by_d_is_forwarded() {
+        var s = new DetachScanner();
+        var (forward, detach) = s.Process([0x11, (byte)'x']);
+        await Assert.That(detach).IsFalse();
+        await Assert.That(forward).IsEquivalentTo(new byte[] { 0x11, (byte)'x' });
+    }
+
+    [Test]
+    public async Task Lone_prefix_then_normal_text_forwards_prefix_first() {
+        var s = new DetachScanner();
+        var (f1, _) = s.Process([0x11]);       // held
+        await Assert.That(f1).IsEmpty();
+        var (f2, d) = s.Process("a"u8);        // not 'd' → forward prefix then 'a'
+        await Assert.That(d).IsFalse();
+        await Assert.That(f2).IsEquivalentTo(new byte[] { 0x11, (byte)'a' });
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/FrameCodecTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FrameCodecTests.cs
@@ -65,6 +65,31 @@ public class FrameCodecTests {
         var r = await FrameCodec.ReadAsync(choppy, default);
         await Assert.That(r!.Bytes.Length).IsEqualTo(5000);
     }
+
+    [Test]
+    public async Task Spawn_with_bogus_arg_count_throws_protocol_error_not_oom() {
+        // work(1)=0, cols(2), rows(2), vendorLen(4)=0, cwdLen(4)=0, argCount(4)=int.MaxValue
+        using var ms = new MemoryStream();
+        ms.WriteByte(0);
+        ms.Write([0, 80]); ms.Write([0, 24]);           // cols, rows (BE)
+        ms.Write([0, 0, 0, 0]); ms.Write([0, 0, 0, 0]); // vendorLen=0, cwdLen=0
+        ms.Write([0x7f, 0xff, 0xff, 0xff]);             // argCount = int.MaxValue
+        var frame = new LocalFrame(FrameType.Spawn) { Bytes = ms.ToArray() };
+
+        await Assert.That(() => FrameCodec.Spawn(frame)).Throws<InvalidDataException>();
+    }
+
+    [Test]
+    public async Task Spawn_with_truncated_string_length_throws_protocol_error() {
+        // work(1)=0, cols(2), rows(2), vendorLen(4)=1000 but no bytes follow
+        using var ms = new MemoryStream();
+        ms.WriteByte(0);
+        ms.Write([0, 80]); ms.Write([0, 24]);
+        ms.Write([0, 0, 0x03, 0xe8]); // vendorLen = 1000, payload ends here
+        var frame = new LocalFrame(FrameType.Spawn) { Bytes = ms.ToArray() };
+
+        await Assert.That(() => FrameCodec.Spawn(frame)).Throws<InvalidDataException>();
+    }
 }
 
 /// Stream that returns at most `chunk` bytes per ReadAsync to simulate partial socket reads.

--- a/test/Capacitor.Cli.Tests.Unit/FrameCodecTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FrameCodecTests.cs
@@ -1,0 +1,87 @@
+using System.IO;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class FrameCodecTests {
+    static async Task<LocalFrame> RoundTrip(LocalFrame f) {
+        using var ms = new MemoryStream();
+        await FrameCodec.WriteAsync(ms, f, default);
+        ms.Position = 0;
+        var read = await FrameCodec.ReadAsync(ms, default);
+        return read!;
+    }
+
+    [Test]
+    public async Task Stdin_round_trips_raw_bytes() {
+        var f = LocalFrame.Stdin([0x00, 0x1b, 0x5b, 0x41, 0xff]);
+        var r = await RoundTrip(f);
+        await Assert.That(r.Type).IsEqualTo(FrameType.Stdin);
+        await Assert.That(r.Bytes).IsEquivalentTo(new byte[] { 0x00, 0x1b, 0x5b, 0x41, 0xff });
+    }
+
+    [Test]
+    public async Task Resize_round_trips_dimensions() {
+        var r = await RoundTrip(LocalFrame.Resize(203, 51));
+        await Assert.That(r.Cols).IsEqualTo((ushort)203);
+        await Assert.That(r.Rows).IsEqualTo((ushort)51);
+    }
+
+    [Test]
+    public async Task Spawn_round_trips_vendor_cwd_args_and_worklocation() {
+        var built = FrameCodec.Spawn("codex", WorkLocation.OwnedWorktree, "/repo", ["--model", "opus", "fix it"], 100, 30);
+        var r = await RoundTrip(built);
+        await Assert.That(r.Type).IsEqualTo(FrameType.Spawn);
+        var (vendor, work, cwd, args, cols, rows) = FrameCodec.Spawn(r);
+        await Assert.That(vendor).IsEqualTo("codex");
+        await Assert.That(work).IsEqualTo(WorkLocation.OwnedWorktree);
+        await Assert.That(cwd).IsEqualTo("/repo");
+        await Assert.That(args).IsEquivalentTo(new[] { "--model", "opus", "fix it" });
+        await Assert.That(cols).IsEqualTo((ushort)100);
+        await Assert.That(rows).IsEqualTo((ushort)30);
+    }
+
+    [Test]
+    public async Task Attached_round_trips_agent_id_and_snapshot() {
+        var built = FrameCodec.Attached("abc123", [9, 8, 7]);
+        var r = await RoundTrip(built);
+        var (id, snapshot) = FrameCodec.Attached(r);
+        await Assert.That(id).IsEqualTo("abc123");
+        await Assert.That(snapshot).IsEquivalentTo(new byte[] { 9, 8, 7 });
+    }
+
+    [Test]
+    public async Task ReadAsync_returns_null_on_clean_eof() {
+        using var ms = new MemoryStream();
+        await Assert.That(await FrameCodec.ReadAsync(ms, default)).IsNull();
+    }
+
+    [Test]
+    public async Task ReadAsync_reassembles_across_short_reads() {
+        var f = LocalFrame.Stdout(new byte[5000]); // > one socket read
+        using var ms = new MemoryStream();
+        await FrameCodec.WriteAsync(ms, f, default);
+        using var choppy = new ChoppyStream(ms.ToArray(), chunk: 7);
+        var r = await FrameCodec.ReadAsync(choppy, default);
+        await Assert.That(r!.Bytes.Length).IsEqualTo(5000);
+    }
+}
+
+/// Stream that returns at most `chunk` bytes per ReadAsync to simulate partial socket reads.
+sealed class ChoppyStream(byte[] data, int chunk) : Stream {
+    int _pos;
+    public override int Read(byte[] buffer, int offset, int count) {
+        if (_pos >= data.Length) return 0;
+        var n = Math.Min(Math.Min(chunk, count), data.Length - _pos);
+        Array.Copy(data, _pos, buffer, offset, n); _pos += n; return n;
+    }
+    public override ValueTask<int> ReadAsync(Memory<byte> b, CancellationToken ct = default) {
+        if (_pos >= data.Length) return ValueTask.FromResult(0);
+        var n = Math.Min(Math.Min(chunk, b.Length), data.Length - _pos);
+        data.AsSpan(_pos, n).CopyTo(b.Span); _pos += n; return ValueTask.FromResult(n);
+    }
+    public override bool CanRead => true; public override bool CanSeek => false; public override bool CanWrite => false;
+    public override long Length => data.Length; public override long Position { get => _pos; set => _pos = (int)value; }
+    public override void Flush() { } public override long Seek(long o, SeekOrigin s) => 0;
+    public override void SetLength(long v) { } public override void Write(byte[] b, int o, int c) { }
+}

--- a/test/Capacitor.Cli.Tests.Unit/LocalSocketPathsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalSocketPathsTests.cs
@@ -1,0 +1,13 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class LocalSocketPathsTests {
+    [Test]
+    public async Task Socket_path_is_under_daemon_dir_and_name_sanitized() {
+        var p = LocalSocketPaths.Socket("My Daemon!");
+        await Assert.That(p).EndsWith("my-daemon.sock");
+        await Assert.That(p).StartsWith(DaemonLockPaths.Directory);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/LocalSocketSinkTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalSocketSinkTests.cs
@@ -1,0 +1,32 @@
+using System.Text;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class LocalSocketSinkTests {
+    [Test]
+    public async Task Delivers_chunks_in_order() {
+        var got = new List<string>();
+        var sink = new LocalSocketSink(capacity: 8, (b, _) => { got.Add(Encoding.UTF8.GetString(b)); return Task.CompletedTask; });
+        var run = sink.RunAsync(default);
+        foreach (var s in new[] { "a", "b", "c" }) sink.TryEnqueue(Encoding.UTF8.GetBytes(s));
+        sink.Complete();
+        await run;
+        await Assert.That(got).IsEquivalentTo(new[] { "a", "b", "c" });
+    }
+
+    [Test]
+    public async Task Overflow_marks_detached_and_never_blocks_producer() {
+        // writer never drains until released; tiny capacity → overflow on the producer side
+        var tcs  = new TaskCompletionSource();
+        var sink = new LocalSocketSink(capacity: 2, async (_, c) => await tcs.Task.WaitAsync(c));
+        var run  = sink.RunAsync(default);
+
+        for (var i = 0; i < 1000; i++) sink.TryEnqueue([1]); // must not block
+
+        await Assert.That(sink.Detached).IsTrue();
+
+        tcs.SetResult();
+        sink.Complete();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/RunAgentArgsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RunAgentArgsTests.cs
@@ -34,7 +34,9 @@ public class RunAgentArgsTests {
     }
 
     [Test]
-    public async Task Share_flag_is_rejected_as_phase_2() {
+    public async Task Share_is_not_a_flag_sharing_is_a_ui_action() {
+        // Sharing is server/UI-authoritative (AI-861 tracks a future `kcap share` command),
+        // so --share is just an unknown run-agent flag and is rejected.
         await Assert.That(RunAgentArgs.Parse(["claude", "--share"]).Error).IsNotNull();
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/RunAgentArgsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RunAgentArgsTests.cs
@@ -1,0 +1,47 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class RunAgentArgsTests {
+    [Test]
+    public async Task Splits_kcap_flags_from_passthrough_at_double_dash() {
+        var a = RunAgentArgs.Parse(["claude", "--worktree", "--name", "dev", "--", "--model", "opus", "fix"]);
+        await Assert.That(a.Vendor).IsEqualTo("claude");
+        await Assert.That(a.Worktree).IsTrue();
+        await Assert.That(a.DaemonName).IsEqualTo("dev");
+        await Assert.That(a.Passthrough).IsEquivalentTo(new[] { "--model", "opus", "fix" });
+        await Assert.That(a.Error).IsNull();
+    }
+
+    [Test]
+    public async Task Default_is_in_place_with_no_passthrough() {
+        var a = RunAgentArgs.Parse(["codex"]);
+        await Assert.That(a.Vendor).IsEqualTo("codex");
+        await Assert.That(a.Worktree).IsFalse();
+        await Assert.That(a.Passthrough).IsEmpty();
+        await Assert.That(a.Error).IsNull();
+    }
+
+    [Test]
+    public async Task Empty_args_is_an_error() {
+        await Assert.That(RunAgentArgs.Parse([]).Error).IsNotNull();
+    }
+
+    [Test]
+    public async Task Unknown_kcap_flag_before_dash_is_an_error() {
+        var a = RunAgentArgs.Parse(["claude", "--model", "opus"]);
+        await Assert.That(a.Error).IsNotNull();
+    }
+
+    [Test]
+    public async Task Share_flag_is_rejected_as_phase_2() {
+        await Assert.That(RunAgentArgs.Parse(["claude", "--share"]).Error).IsNotNull();
+    }
+
+    [Test]
+    public async Task Empty_passthrough_after_dash_is_allowed() {
+        var a = RunAgentArgs.Parse(["claude", "--"]);
+        await Assert.That(a.Error).IsNull();
+        await Assert.That(a.Passthrough).IsEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of "local terminal attach" — start a daemon-hosted coding agent from your own terminal, drive it live, detach without killing it, and re-attach later ("tmux for your agent"). Entirely local; **no new server contract**. Web visibility (registering the agent so you can see/drive it from the web UI) is deferred to Phase 2.

Design + plan are on the branch:
- Spec: `docs/superpowers/specs/2026-06-13-local-attach-hosted-agent-design.md`
- Plan: `docs/superpowers/plans/2026-06-14-local-attach-phase1.md`

### What's new
- **`kcap run-agent <vendor> [kcap flags] -- [agent args]`** — auto-starts the daemon, spawns the agent, attaches your terminal. `--worktree` (default: in-place in your cwd), `--name`, `--detached`. Everything after `--` is forwarded to the `claude`/`codex` CLI verbatim (launcher-agnostic passthrough; Codex injects mandatory `--cd`/`--no-alt-screen` and rejects user duplicates).
- **`kcap attach <id>`** / **`kcap ls`** — re-attach to / list daemon-hosted agents. Detach with `Ctrl-Q d`.

### How it works
- New **local control socket** (Unix domain socket, `0600`) on the daemon; length-prefixed, AOT-safe frame codec shared by CLI + daemon (with bounds-checked parsing — a malformed frame is a clean protocol error, never an OOM).
- Daemon output fan-out generalized from **one client to N**, no silent partial-stream corruption (overflow force-detaches that one client, which then reattaches for a fresh replay — never `DropOldest`, which reintroduced AI-844 corruption; never stalls the shared PTY loop). Snapshot+subscribe is atomic with the read loop, so attach never duplicates live output.
- Local agents run **`PrivateLocal`**: a deny-all guard means **no per-agent server call** (register/status/events/repo-path/heartbeat/finalize/unregister/reconnect), enforced by a strict-tripwire test. They record as a **plain local session**: hook env keeps `KCAP_URL` and re-adds `ANTHROPIC_API_KEY`, and **omits the hosted-agent vars** (`KCAP_AGENT_ID`, `KCAP_RENDERED_AGENT`, `KCAP_DAEMON_URL`) — so the agent isn't tagged as a hosted agent and permissions prompt natively in the terminal. (`UnixPtyProcess` also unsets those in the PTY child so nothing leaks from the daemon's own env.)
- **Owned-worktree vs borrowed-cwd**: in-place launches never have their cwd/branch removed on cleanup and skip repo-mutating `Prepare()` (the catastrophic-`rm -rf`-your-repo path is the top safety invariant + has a dedicated test); a failed `--worktree` launch cleans up the worktree it created.
- Raw-mode CLI client over the socket; terminal I/O uses the raw fds directly (bypassing `System.Console`, which re-cooks the tty on Unix). Resize min-clamps the PTY across attached local clients (tmux semantics), recomputed on attach/detach/resize. Agent self-exit (e.g. `/exit`) cleanly tears the client down.

### Test plan
- [x] Unit: **1505 pass** (frame codec incl. bounds checks, sink overflow/force-detach, socket path, cleanup guard, Prepare skip, deny-all tripwire + env, passthrough/Codex flag rejection, run-agent arg parsing, detach scanner)
- [x] Integration: 30 pass (incl. real Unix-socket round-trip through `LocalControlServer`)
- [x] AOT publish clean (no IL2026/IL3050) — CLI and daemon
- [x] **Manual smoke**: real `claude` session — clean interactive I/O + cursor, `Ctrl-C` reaches the agent, `Ctrl-Q d` detaches (agent keeps running), `kcap attach` repaints, `/exit` quits cleanly.

### Review follow-ups (all addressed; see thread + commits)
- Qodo: frame-parse OOM bounds; sink-detach propagation (force-detach now ends the session so the client reattaches).
- Reviewer: PTY-child env isolation; failed-`--worktree` cleanup; atomic snapshot/subscribe; resize reclamp on detach; spec Scope/Phasing consistency.

### Notes / scope
- **Unix only** for now (`run-agent`/`attach`/`ls` no-op with a message on Windows).
- Not offline: the daemon still requires `ServerUrl` + SignalR as today.
- **Phase 2 (deferred):** register the local agent on spawn **like a UI-launched agent** → owner sees/drives it from their own web UI immediately; teammates via the **existing web UI "share"** (no kcap-specific share — a `kcap share` CLI convenience is tracked as AI-861). Web clients attach via the existing SignalR fan-out; first-web-subscribe one-time replay; web-client resize aggregation; Windows support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)