### PR TITLE
Add missing 'service' subcommand to daemon usage message

### DIFF
--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -760,13 +760,14 @@ public static class DaemonCommands {
         $"kcap-daemon binary not found next to {AppContext.BaseDirectory}. Reinstall the kcap package.";
 
     static int PrintUsage() {
-        Console.Error.WriteLine("Usage: kcap daemon <start|stop|status|logs|doctor>");
+        Console.Error.WriteLine("Usage: kcap daemon <start|stop|status|logs|doctor|service>");
         Console.Error.WriteLine();
         Console.Error.WriteLine("  start [-d] [--name <n>]    Start the daemon (foreground, or -d for background)");
         Console.Error.WriteLine("  stop [--name <n>] [--yes]  Stop a running daemon (prompts on multi unless --yes)");
         Console.Error.WriteLine("  status [--name <n>]        Show daemon status (lists all when --name omitted)");
         Console.Error.WriteLine("  logs                       Show recent daemon log output");
         Console.Error.WriteLine("  doctor [--clean]           Diagnose lock-file state, optionally clean stale entries");
+        Console.Error.WriteLine("  service <action>           Manage the OS service (launchd/systemd/Scheduled Task)");
         Console.Error.WriteLine();
         Console.Error.WriteLine("Options for start:");
         Console.Error.WriteLine("  --name <name>         Daemon name (defaults to OS username)");


### PR DESCRIPTION
## What

The `kcap daemon` wrong-command usage message (`PrintUsage()` in `DaemonCommands.cs`) listed `<start|stop|status|logs|doctor>` but omitted `service`, even though:

- `service` is dispatched at `DaemonCommands.cs:27`
- it is fully documented in `help-daemon.txt`
- it is documented in `README.md` (`kcap daemon service install`, etc.)

This brings the error text in sync with the actual, already-documented CLI surface.

## Changes

- Added `service` to the usage synopsis line
- Added a `service <action>` entry to the subcommand list

No README change needed — this only syncs the error text to the existing public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)