### PR TITLE
[AI-822] Windows watcher self-reap: resolve durable agent PID via ppid walk

### DIFF
--- a/src/Capacitor.Cli/ProcessHelpers.cs
+++ b/src/Capacitor.Cli/ProcessHelpers.cs
@@ -56,6 +56,13 @@ static partial class ProcessHelpers {
     [LibraryImport("kernel32.dll", SetLastError = true)]
     private static partial nint GetCurrentProcess();
 
+    // Fills lpExeName with the full path of the process image (e.g. "C:\...\claude.exe").
+    // On input lpdwSize is the buffer size in chars; on success it's set to the number of
+    // chars written (excluding the terminating null). dwFlags 0 = Win32 path format.
+    [LibraryImport("kernel32.dll", EntryPoint = "QueryFullProcessImageNameW", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static unsafe partial bool QueryFullProcessImageName(nint hProcess, uint dwFlags, char* lpExeName, ref uint lpdwSize);
+
     [LibraryImport("kernel32.dll", SetLastError = true)]
     private static partial nint GetStdHandle(int nStdHandle);
 
@@ -84,6 +91,11 @@ static partial class ProcessHelpers {
 
     const uint SYNCHRONIZE   = 0x00100000;
     const uint WAIT_TIMEOUT  = 258;
+
+    // Minimal access right that still permits NtQueryInformationProcess(ProcessBasicInformation)
+    // and QueryFullProcessImageName on Vista+. Cheaper than PROCESS_QUERY_INFORMATION and
+    // succeeds for same-user processes even when they're protected/elevated-adjacent.
+    const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
 
     // GetStdHandle ids and the SetHandleInformation inherit flag.
     const int  STD_INPUT_HANDLE   = -10;
@@ -218,9 +230,10 @@ static partial class ProcessHelpers {
     /// the fallback is <c>getppid</c> — monitoring ourselves would let the
     /// watcher self-terminate immediately.
     ///
-    /// On Windows there's no process-group equivalent so we fall back to the
-    /// parent PID. Codex on Windows is uncommon and the Claude path is already
-    /// covered by Claude's own SessionEnd hook.
+    /// On Windows there's no process-group equivalent, so the vendor-aware overload
+    /// walks the parent-PID ancestry by process name instead (see
+    /// <see cref="GetCodingAgentPid(string?)"/>); this parameterless overload, with no
+    /// vendor to match, falls back to the immediate parent PID.
     /// </remarks>
     public static int? GetCodingAgentPid() => GetCodingAgentPid(vendor: null);
 
@@ -238,7 +251,23 @@ static partial class ProcessHelpers {
     /// </summary>
     public static int? GetCodingAgentPid(string? vendor) {
         if (OperatingSystem.IsWindows()) {
-            return GetParentPidWindows();
+            // Walk the ppid ancestry by process name to skip the transient per-hook
+            // executor. GetParentPidWindows() alone returns that executor, which has
+            // usually already exited by the time the watcher boots — so the parent-PID
+            // watchdog saw a dead PID at startup and silently never armed (AI-822).
+            // Falls back to the immediate parent when no agent is found on the chain
+            // (preserving prior behaviour for the no-vendor / unmatched cases). PID reuse
+            // is a known Windows hazard for ppid walks, but the by-name match means a
+            // recycled PID would have to *be* the agent's executable to falsely match.
+            var startPid = GetParentPidWindows();
+
+            if (!string.IsNullOrEmpty(vendor)
+             && startPid is { } sp
+             && ResolveCodingAgentPid(sp, vendor, GetProcessInfo) is { } winAgentPid) {
+                return winAgentPid;
+            }
+
+            return startPid;
         }
 
         // Walk the ancestry for any named vendor. The match is by the vendor's process
@@ -299,17 +328,55 @@ static partial class ProcessHelpers {
 
     /// <summary>
     /// Returns <c>(ppid, comm)</c> for an arbitrary live PID, or null if the process
-    /// can't be inspected (gone, or unsupported platform). Feeds the ancestry walk in
-    /// <see cref="ResolveCodingAgentPid"/>. Unix-only — Windows keeps the legacy
-    /// parent-PID path (codex/Windows is uncommon and claude has its own SessionEnd
-    /// hook there), so this returns null on Windows.
+    /// can't be inspected (gone, access denied, or unsupported platform). Feeds the
+    /// ancestry walk in <see cref="ResolveCodingAgentPid"/> on every platform — the
+    /// Windows implementation (AI-822) reads the parent PID via
+    /// <c>NtQueryInformationProcess</c> and the image name via
+    /// <c>QueryFullProcessImageName</c>.
     /// </summary>
     public static (int ppid, string comm)? GetProcessInfo(int pid) {
-        if (pid <= 0 || OperatingSystem.IsWindows()) {
+        if (pid <= 0) {
             return null;
         }
 
+        if (OperatingSystem.IsWindows()) {
+            return GetProcessInfoWindows(pid);
+        }
+
         return OperatingSystem.IsMacOS() ? GetProcessInfoMac(pid) : GetProcessInfoLinux(pid);
+    }
+
+    static unsafe (int ppid, string comm)? GetProcessInfoWindows(int pid) {
+        var handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, (uint)pid);
+
+        if (handle == 0) {
+            return null;
+        }
+
+        try {
+            var pbi    = default(ProcessBasicInformation);
+            var status = NtQueryInformationProcess(handle, 0, ref pbi, Unsafe.SizeOf<ProcessBasicInformation>(), out _);
+
+            if (status != 0) {
+                return null;
+            }
+
+            var ppid = (int)pbi.InheritedFromUniqueProcessId;
+
+            // Full image path → MatchesAgentName takes the basename. MAX_PATH is not a hard
+            // limit for long paths, but the agent executable lives well within 1024 chars.
+            const int max = 1024;
+            char*     buf = stackalloc char[max];
+            var       len = (uint)max;
+
+            var comm = QueryFullProcessImageName(handle, 0, buf, ref len)
+                ? new string(buf, 0, (int)len)
+                : "";
+
+            return (ppid, comm);
+        } finally {
+            CloseHandle(handle);
+        }
     }
 
     static unsafe (int ppid, string comm)? GetProcessInfoMac(int pid) {

--- a/src/Capacitor.Cli/ProcessHelpers.cs
+++ b/src/Capacitor.Cli/ProcessHelpers.cs
@@ -92,6 +92,9 @@ static partial class ProcessHelpers {
     const uint SYNCHRONIZE   = 0x00100000;
     const uint WAIT_TIMEOUT  = 258;
 
+    // QueryFullProcessImageName sets this when lpExeName is too small for the image path.
+    const int ERROR_INSUFFICIENT_BUFFER = 122;
+
     // Minimal access right that still permits NtQueryInformationProcess(ProcessBasicInformation)
     // and QueryFullProcessImageName on Vista+. Cheaper than PROCESS_QUERY_INFORMATION and
     // succeeds for same-user processes even when they're protected/elevated-adjacent.
@@ -363,19 +366,44 @@ static partial class ProcessHelpers {
 
             var ppid = (int)pbi.InheritedFromUniqueProcessId;
 
-            // Full image path → MatchesAgentName takes the basename. MAX_PATH is not a hard
-            // limit for long paths, but the agent executable lives well within 1024 chars.
-            const int max = 1024;
-            char*     buf = stackalloc char[max];
-            var       len = (uint)max;
-
-            var comm = QueryFullProcessImageName(handle, 0, buf, ref len)
-                ? new string(buf, 0, (int)len)
-                : "";
-
-            return (ppid, comm);
+            // comm is the full image path; MatchesAgentName takes the basename. An empty
+            // string on failure still lets the ancestry walk continue past this node (it
+            // just won't match here) — but if it's the agent's own path that fails to read,
+            // resolution falls back to the immediate parent and the watchdog can mis-arm,
+            // so QueryImageName grows the buffer rather than giving up on long paths.
+            return (ppid, QueryImageName(handle) ?? "");
         } finally {
             CloseHandle(handle);
+        }
+    }
+
+    /// <summary>
+    /// Reads a process's full image path via <c>QueryFullProcessImageName</c>, retrying on a
+    /// heap buffer if the path exceeds the initial stack buffer (Windows long paths can reach
+    /// ~32K chars). Returns null if the call fails for any reason other than buffer size.
+    /// </summary>
+    static unsafe string? QueryImageName(nint handle) {
+        const int stackCap = 1024;
+        char*     stackBuf = stackalloc char[stackCap];
+        var       len      = (uint)stackCap;
+
+        if (QueryFullProcessImageName(handle, 0, stackBuf, ref len)) {
+            return new string(stackBuf, 0, (int)len);
+        }
+
+        if (Marshal.GetLastPInvokeError() != ERROR_INSUFFICIENT_BUFFER) {
+            return null;
+        }
+
+        // Extended-length path maximum (\\?\-prefixed paths). One retry covers every
+        // realistic case; too large for stackalloc, so use a heap buffer.
+        const int maxCap   = 32768;
+        var       heapBuf  = new char[maxCap];
+
+        fixed (char* p = heapBuf) {
+            len = maxCap;
+
+            return QueryFullProcessImageName(handle, 0, p, ref len) ? new string(p, 0, (int)len) : null;
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/CodingAgentPidResolverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodingAgentPidResolverTests.cs
@@ -94,6 +94,24 @@ public class CodingAgentPidResolverTests {
     }
 
     [Test]
+    public async Task Matches_windows_exe_path_with_backslashes() {
+        // On Windows the per-PID lookup (GetProcessInfo) returns the full image path
+        // from QueryFullProcessImageNameW, e.g. "C:\...\claude.exe". The walk must match
+        // it by basename plus a single ".exe" extension so the Windows parent-PID
+        // watchdog can resolve the durable agent past the transient hook executor (AI-822).
+        // hook(100) -> cmd(90) -> claude.exe(50) -> explorer(20)
+        var lookup = ProcTable.Of(
+            (90, 50, @"C:\Windows\System32\cmd.exe"),
+            (50, 20, @"C:\Users\me\AppData\Local\Programs\claude\claude.exe"),
+            (20, 1, @"C:\Windows\explorer.exe")
+        );
+
+        var pid = ProcessHelpers.ResolveCodingAgentPid(startPid: 90, vendor: "claude", lookup);
+
+        await Assert.That(pid).IsEqualTo(50);
+    }
+
+    [Test]
     public async Task Returns_null_when_no_agent_in_chain() {
         // No claude/codex ancestor — caller falls back to the legacy heuristic.
         var lookup = ProcTable.Of((90, 20, "sh"), (20, 1, "-zsh"));

--- a/test/Capacitor.Cli.Tests.Unit/ProcessHelpersTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProcessHelpersTests.cs
@@ -104,10 +104,9 @@ public class ProcessHelpersTests {
     public async Task GetProcessInfo_returns_ppid_and_name_for_current_process() {
         // Backs the ancestry walk: it must report a process's real parent PID and a
         // non-empty executable name so the walk can match the coding agent by name.
-        if (OperatingSystem.IsWindows()) {
-            return; // Unix-only; Windows keeps the legacy parent-PID path.
-        }
-
+        // Runs on every platform now that Windows has a native implementation (AI-822):
+        // the Windows branch previously returned null, so the parent-PID watchdog had no
+        // way to resolve the durable coding-agent process and silently never armed.
         var info = ProcessHelpers.GetProcessInfo(Environment.ProcessId);
 
         await Assert.That(info).IsNotNull();


### PR DESCRIPTION
## Summary

Fixes the fragile self-reap path called out in AI-822: on Windows the transcript watcher's **parent-death watchdog silently never armed**, so a watcher could orphan whenever its kill hook was missed (crash, force-kill, IDE detach, hook failure/timeout) — leaving the session stuck "active".

`WatcherManager.SpawnWatcher` recorded `--parent-pid` from `GetCodingAgentPid`, which on Windows returned `GetParentPidWindows()` — the **transient per-hook executor**. That process has usually already exited by the time the spawned watcher initializes, so `DecideParentWatchdog` returned `ParentAlreadyDead` (`WatchCommand.cs:124`) and the monitor task never started. After AI-820 the happy-path kill hooks reap watchers fine, but this defense-in-depth layer was absent on Windows.

## Approach

The issue's preferred direction (#1). The cross-platform ancestry walker (`ResolveCodingAgentPid` + `MatchesAgentName`) already existed and was fully unit-tested — only two Windows gaps blocked reuse:

- **`GetProcessInfo` returned `null` on Windows.** Added `GetProcessInfoWindows`: parent PID via `NtQueryInformationProcess` (already P/Invoked), image path via a new `QueryFullProcessImageName` P/Invoke, opened with `PROCESS_QUERY_LIMITED_INFORMATION`.
- **`GetCodingAgentPid` short-circuited to the immediate parent on Windows.** Now routes through `ResolveCodingAgentPid`, falling back to the immediate parent when no agent is found on the chain — mirroring the Unix structure exactly.

Windows PID reuse is a known hazard for ppid walks; the by-name match means a recycled PID would have to *be* the agent's executable to falsely match. Documented inline.

## Tests

- `CodingAgentPidResolverTests`: new case proving the walker matches the Windows `C:\...\claude.exe` image-path format the native lookup produces.
- `ProcessHelpersTests`: un-skipped `GetProcessInfo_returns_ppid_and_name_for_current_process` so the native Windows implementation is exercised on the `windows-latest` CI runner (it returned `null` there before — that's the real red→green for the native code).

## Verification

- `dotnet build`: 0 warnings / 0 errors.
- AOT publish IL3050/IL2026 scan: clean (added P/Invoke + unsafe code).
- Full unit suite on macOS: same 11 pre-existing process-tree-kill failures as the clean base, +1 net-new passing test. No regression.
- **Note:** the native Windows paths can't run on a macOS dev box; the Unix path is unchanged and the Windows behavior is verified by the unit suite on the `windows-latest` CI runner.

Related: AI-820 (originating bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)