### PR TITLE
[AI-866] feat: make `kcap update` perform the upgrade and refresh hooks/skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 bin/
+# The npm launcher sources live in a dir literally named bin/ — keep them
+# tracked (the platform-package bin/ dirs stay ignored: they hold build output).
+!npm/kcap/bin/
 obj/
 /packages/
 riderModule.iml

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ The CLI is compiled with NativeAOT — fast startup, no runtime dependency.
 > allow-scripts[]=@kurrent/kcap
 > ```
 >
-> Without either, re-run `kcap plugin install [--codex|--cursor|--copilot|--skills] --if-installed` manually after each upgrade.
+> Without either, upgrade with **`kcap update`** instead of `npm install -g` — it
+> runs the global npm upgrade and then refreshes your agent plugins itself, so it
+> works regardless of the install-script gate. (You can also re-run `kcap plugin
+> install [--codex|--cursor|--copilot|--skills] --if-installed` manually.)
 
 ### 2. Run setup
 
@@ -75,7 +78,7 @@ kcap setup --server-url https://my-tenant.kcap.ai --default-visibility org_publi
 In `--no-prompt` mode, the wizard installs hooks for every detected agent by default. Opt out per agent with `--skip-claude-hooks`, `--skip-codex-hooks`, `--skip-cursor-hooks`, and/or `--skip-copilot-hooks`.
 
 > **Need hooks for an agent installed after setup, or scoped to a single repo?**
-> Run `kcap plugin install [--codex|--cursor|--copilot]` (omit the flag for the Claude Code plugin), or pair Codex with `--project` for a per-repo install. Use `--skills` instead of `--codex` if you only want the agent skills without Codex hooks. Cursor uses user-scope only — `--project` has no effect with `--cursor`. After installing Codex hooks, the next `codex` launch prompts to trust the new hooks — accept once to trust them all (run `/hooks` inside Codex if you'd rather trust each entry individually). After a `--project` install, also run `codex` once in the repo and accept the workspace trust prompt. Re-running after a kcap upgrade is rarely needed for user-scope installs — the npm postinstall hook auto-refreshes them on every `npm install -g @kurrent/kcap` (npm 11+ blocks install scripts by default; add `allow-scripts[]=@kurrent/kcap` to `~/.npmrc` to opt in once).
+> Run `kcap plugin install [--codex|--cursor|--copilot]` (omit the flag for the Claude Code plugin), or pair Codex with `--project` for a per-repo install. Use `--skills` instead of `--codex` if you only want the agent skills without Codex hooks. Cursor uses user-scope only — `--project` has no effect with `--cursor`. After installing Codex hooks, the next `codex` launch prompts to trust the new hooks — accept once to trust them all (run `/hooks` inside Codex if you'd rather trust each entry individually). After a `--project` install, also run `codex` once in the repo and accept the workspace trust prompt. Re-running after a kcap upgrade is rarely needed for user-scope installs — the npm postinstall hook auto-refreshes them on every `npm install -g @kurrent/kcap`, and `kcap update` refreshes them too (npm 11+ blocks install scripts by default — `kcap update` works regardless, or add `allow-scripts[]=@kurrent/kcap` to `~/.npmrc` to opt the postinstall in once).
 
 > **Need at least one agent to capture sessions:** the setup wizard runs to completion without an agent CLI on `PATH` (it'll still configure your profile, auth, and daemon), but kcap only records work once Claude Code or Codex CLI is installed and the hooks are in place.
 
@@ -115,7 +118,7 @@ Once set up, Capacitor runs silently in the background. Every Claude Code (and C
 - **Tool usage** — every tool call with timing and results
 - **Token consumption** — input/output/cache token counts per interaction
 - **Repository context** — git repo, branch, and PR linkage
-- **In-agent upgrade prompts** — in Claude Code sessions, when the server is running a newer kcap release than the local CLI, additional context is injected into the session so the agent can offer the user an upgrade via `npm install -g @kurrent/kcap`. The stderr `kcap` update hint continues to fire for direct command-line use.
+- **In-agent upgrade prompts** — in Claude Code sessions, when the server is running a newer kcap release than the local CLI, additional context is injected into the session so the agent can offer the user an upgrade via `kcap update`. The stderr `kcap` update hint continues to fire for direct command-line use.
 - **SessionStart context injection** — at every session start the server injects top evaluation-derived fact clusters for the current repo into Claude's `additionalContext`. The injected block is split into two sections: `## Known patterns` (repo/project facts relevant to any reader) and `## Guidance from past sessions` (agent-targeted action items derived from prior eval suggestions with `audience: "agent"`). Opt out by setting `disable_session_guidelines: true` in `~/.config/kcap/config.json` or via `kcap config set disable_session_guidelines true`.
 
 ## CLI commands
@@ -367,7 +370,7 @@ All five auto-resolve the active session from `CODEX_THREAD_ID`; pass `<sessionI
 
 The daemon starts Codex with `--sandbox workspace-write` and `--ask-for-approval on-request`. This lets Codex edit files in the agent's worktree but escalates sensitive operations (e.g. network calls, shell commands outside the worktree) through the daemon's permission bridge to the dashboard.
 
-> **Upgrading from an earlier version of kcap?** The npm postinstall hook refreshes all user-scope kcap installations on every `npm install -g @kurrent/kcap`, so you always pick up the current CLI version's skills (`~/.agents/skills/kcap-*`), Codex hook commands (`~/.codex/hooks.json`), and Claude plugin registration (`~/.claude/settings.json`). Each refresh is gated on a marker file written by your previous setup — fresh systems that never opted in are left untouched. Project-scope installs (`--project`) are not auto-refreshed; re-run `kcap plugin install [--codex] --project` after upgrading if you want the latest config for a specific repo.
+> **Upgrading from an earlier version of kcap?** Run `kcap update` (or `npm install -g @kurrent/kcap`) — the npm postinstall hook, and `kcap update` itself, refresh all user-scope kcap installations, so you always pick up the current CLI version's skills (`~/.agents/skills/kcap-*`), Codex hook commands (`~/.codex/hooks.json`), and Claude plugin registration (`~/.claude/settings.json`). Each refresh is gated on a marker file written by your previous setup — fresh systems that never opted in are left untouched. Project-scope installs (`--project`) are not auto-refreshed; re-run `kcap plugin install [--codex] --project` after upgrading if you want the latest config for a specific repo.
 >
 > npm 11+ blocks install scripts by default. Add `allow-scripts[]=@kurrent/kcap` to your `~/.npmrc` (or pass `--allow-scripts=@kurrent/kcap` on the install command line) to opt in to the auto-refresh; otherwise re-run the relevant `kcap plugin install ... --if-installed` commands manually after each upgrade. (`npm approve-scripts` does not work for global installs — that's a known npm UX bug.)
 
@@ -594,11 +597,16 @@ kcap status         # server health check
 kcap whoami         # show current authenticated user
 kcap login          # authenticate via OAuth (browser flow by default)
 kcap login --device # force device-code flow (use in SSH / headless envs)
-kcap update         # check for CLI updates
+kcap update         # upgrade the CLI and refresh agent plugins (npm-global installs)
 kcap logout         # delete stored tokens
 ```
 
-## Upgrading from v1
+> `kcap update` is the one-step upgrade for npm-global installs: it checks the
+> registry, runs `npm install -g @kurrent/kcap@latest`, then refreshes your
+> opted-in agent plugins — so it picks up new skills/hooks even when your package
+> manager blocks install scripts. It exits early if you're already up to date,
+> and tells you what to run instead for non-npm installs (e.g. Homebrew). Use
+> `kcap update --check` for a machine-readable `{current, latest, newer}` probe.
 
 The v1 config format stored `server_url` as a bare host name without a
 scheme. If `kcap` crashes with `An invalid request URI was provided`

--- a/npm/kcap/README.md
+++ b/npm/kcap/README.md
@@ -24,7 +24,7 @@ kcap status                 Show server, auth, and daemon status
 kcap daemon start [-d]      Start the daemon
 kcap daemon stop            Stop the daemon
 kcap review <pr>            Launch Claude Code with PR review context
-kcap update                 Check for updates
+kcap update                 Upgrade the CLI and refresh agent plugins
 kcap --version              Show version
 kcap --help                 Show all commands
 ```

--- a/npm/kcap/bin/kcap.js
+++ b/npm/kcap/bin/kcap.js
@@ -2,7 +2,7 @@
 
 // Resolves and exec's the native kcap binary for the current platform.
 
-const { execFileSync } = require("child_process");
+const { execFileSync, spawnSync } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 
@@ -63,6 +63,21 @@ try {
   try { fs.chmodSync(binaryPath, 0o755); } catch {}
 }
 
+// `kcap update` for npm-global installs is driven HERE, in the Node launcher,
+// not by the native binary. The OS locks an executable image for the whole
+// process lifetime but a script only during load — so by driving the upgrade
+// from this script (with the native binary not running) npm can overwrite the
+// binary even on Windows, with no temp-file/rename/detached-helper dance.
+// `--check` (JSON probe) and `--help` fall through to the native binary.
+{
+  const updArgs   = process.argv.slice(3);
+  const checkOnly = updArgs.includes("--check");
+  const wantsHelp = updArgs.some((a) => a === "--help" || a === "-h");
+  if (process.argv[2] === "update" && !checkOnly && !wantsHelp) {
+    runUpdate(binaryPath); // never returns
+  }
+}
+
 // Exec the native binary, replacing this process
 try {
   execFileSync(binaryPath, process.argv.slice(2), {
@@ -75,4 +90,84 @@ try {
     process.exit(e.status);
   }
   process.exit(1);
+}
+
+// Performs `kcap update`: upgrade the global npm package, then refresh
+// user-scope skills/hooks. Always exits the process; never returns.
+function runUpdate(binaryPath) {
+  // On Windows, `npm` is a .cmd shim; Node refuses to spawn .cmd/.bat directly
+  // (2024 command-injection fix), so route npm through a shell there. Our npm
+  // args are static, so shell use is safe.
+  const npmOpts = process.platform === "win32" ? { shell: true } : {};
+
+  // Resolve npm's global root so we can (a) confirm this is a global install we
+  // own and (b) check we can write to it before starting.
+  let globalRoot = null;
+  try {
+    globalRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf8", ...npmOpts }).trim();
+  } catch {}
+
+  let isGlobalNpm = false;
+  try {
+    if (globalRoot) {
+      const root = fs.realpathSync(globalRoot) + path.sep;
+      isGlobalNpm = fs.realpathSync(__filename).startsWith(root);
+    }
+  } catch {}
+
+  if (!isGlobalNpm) {
+    console.error("kcap was not installed via a global npm install, so it can't");
+    console.error("self-update. Update it the way you installed it, e.g.:");
+    console.error("  npm install -g @kurrent/kcap@latest   (npm)");
+    console.error("  brew upgrade kcap                      (Homebrew)");
+    process.exit(1);
+  }
+
+  // Ask the native binary whether a newer version exists. This short-lived
+  // child fully EXITS before we run npm, so the binary file is unlocked when
+  // npm overwrites it (matters on Windows). `--no-update-check` keeps the
+  // background nudge from racing onto stderr.
+  try {
+    const out  = execFileSync(binaryPath, ["update", "--check", "--no-update-check"], { encoding: "utf8" });
+    // The probe prints one JSON line; take the last {...} line in case anything
+    // else (e.g. a git-remote warning) landed on stdout first.
+    const line = out.split(/\r?\n/).reverse().find((l) => l.trim().startsWith("{"));
+    const info = JSON.parse(line);
+    if (info && info.newer === false) {
+      console.log(`Already up to date: ${info.current}`);
+      process.exit(0);
+    }
+    if (info && info.newer) {
+      console.log(`Updating kcap: ${info.current} → ${info.latest}`);
+    }
+  } catch {
+    // Couldn't determine — fall through and let npm decide (it's idempotent).
+  }
+
+  // Fail clearly instead of half-installing under a root-owned prefix.
+  try {
+    fs.accessSync(globalRoot, fs.constants.W_OK);
+  } catch {
+    console.error(`Cannot write to the global npm directory (${globalRoot}).`);
+    console.error("Re-run with the permissions you installed kcap with, or reinstall");
+    console.error("to a user-owned prefix to avoid needing elevated rights on updates.");
+    process.exit(1);
+  }
+
+  const res = spawnSync("npm", ["install", "-g", "@kurrent/kcap@latest"], {
+    stdio: "inherit",
+    windowsHide: true,
+    ...npmOpts,
+  });
+  if (res.status !== 0) {
+    console.error("npm install failed; kcap was not updated.");
+    process.exit(res.status == null ? 1 : res.status);
+  }
+
+  // npm has now overwritten kcap.js, refresh.js, and the binary. require()
+  // reads the NEW refresh.js, which spawns the NEW launcher -> NEW binary.
+  console.log("Refreshing hooks and skills…");
+  require("./refresh").runRefreshes(fs.realpathSync(__filename));
+  console.log("kcap updated.");
+  process.exit(0);
 }

--- a/npm/kcap/bin/kcap.js
+++ b/npm/kcap/bin/kcap.js
@@ -133,7 +133,11 @@ function runUpdate(binaryPath) {
     // else (e.g. a git-remote warning) landed on stdout first.
     const line = out.split(/\r?\n/).reverse().find((l) => l.trim().startsWith("{"));
     const info = JSON.parse(line);
-    if (info && info.newer === false) {
+    // Only short-circuit when the probe is CONFIDENT we're up to date: `newer`
+    // explicitly false AND a known current version. `newer: null` (version
+    // unknown / check failed) falls through to the upgrade rather than stranding
+    // the user on a stale CLI.
+    if (info && info.newer === false && info.current) {
       console.log(`Already up to date: ${info.current}`);
       process.exit(0);
     }

--- a/npm/kcap/bin/postinstall.js
+++ b/npm/kcap/bin/postinstall.js
@@ -2,58 +2,30 @@
 
 // Runs after `npm install -g @kurrent/kcap` (including upgrades).
 //
-// Refreshes user-scope kcap agent installations so users pick up
-// new or updated skills, Codex hook commands, Cursor hook commands, and
-// Claude plugin registration without manually re-running `kcap setup`.
+// Refreshes user-scope kcap agent installations so users pick up new or updated
+// skills, hook commands, and Claude plugin registration without manually
+// re-running `kcap setup`. The actual refresh logic lives in refresh.js, shared
+// with the `kcap update` path.
 //
 // Contract:
-// - Only runs on global installs. Skipping non-global installs avoids
-//   touching ~/.agents/, ~/.codex/, ~/.cursor/, or ~/.claude/ during unrelated
+// - Only runs on global installs. Skipping non-global installs avoids touching
+//   ~/.agents/, ~/.codex/, ~/.cursor/, or ~/.claude/ during unrelated
 //   local/transitive installs on already-opted-in machines.
-// - Each refresh uses `--if-installed`, which no-ops unless the user
-//   has previously opted in (marker file present OR pre-marker install
-//   detected via existing kcap entries in the target file).
-// - Each refresh runs independently. A failure, timeout, or unexpected
-//   exit code from one does not prevent the others. The script always
-//   exits 0 — a failed refresh must never break `npm install`.
+// - Always exits 0 — a failed refresh must never break `npm install`.
+//
+// Note: modern package managers gate install scripts behind an "allowed
+// scripts" allowlist, so this hook may not run on upgrade. `kcap update` runs
+// the same refresh and is not subject to that gate (the user invokes it
+// explicitly).
 
-const { spawnSync } = require("child_process");
 const path = require("path");
 
 const isGlobal =
   process.env.npm_config_global === "true" ||
   process.env.npm_config_location === "global";
 
-if (!isGlobal) {
-  process.exit(0);
-}
-
-const launcher = path.join(__dirname, "kcap.js");
-
-// One entry per agent. Order is independent — each refresh is gated by
-// its own marker.
-const refreshes = [
-  ["plugin", "install", "--skills",  "--if-installed"],
-  ["plugin", "install", "--codex",   "--if-installed"],
-  ["plugin", "install", "--cursor",  "--if-installed"],
-  ["plugin", "install", "--copilot", "--if-installed"],
-  ["plugin", "install",              "--if-installed"], // Claude
-];
-
-for (const argv of refreshes) {
-  try {
-    spawnSync(process.execPath, [launcher, ...argv], {
-      stdio: "ignore",
-      env: process.env,
-      // Hard ceiling so a stalled child can never hang `npm install`.
-      // Each refresh is bounded independently.
-      timeout: 60_000,
-      killSignal: "SIGKILL",
-      windowsHide: true,
-    });
-  } catch {
-    // Never fail npm install.
-  }
+if (isGlobal) {
+  require("./refresh").runRefreshes(path.join(__dirname, "kcap.js"));
 }
 
 process.exit(0);

--- a/npm/kcap/bin/refresh.js
+++ b/npm/kcap/bin/refresh.js
@@ -1,0 +1,44 @@
+// Refreshes user-scope kcap agent installations so users pick up new or updated
+// skills, Codex/Cursor/Copilot hook commands, and Claude plugin registration.
+//
+// Shared by:
+// - postinstall.js — runs after `npm install -g @kurrent/kcap` (incl. upgrades),
+//   when the package manager allows install scripts to run.
+// - kcap.js `update` — runs after a user-initiated `kcap update`, which works
+//   even when the package manager blocks postinstall scripts.
+
+const { spawnSync } = require("child_process");
+
+// One entry per agent. Order is independent — each refresh is gated by its own
+// marker via `--if-installed`, which no-ops unless the user has previously
+// opted in (marker file present OR pre-marker install detected).
+const REFRESHES = [
+  ["plugin", "install", "--skills",  "--if-installed"],
+  ["plugin", "install", "--codex",   "--if-installed"],
+  ["plugin", "install", "--cursor",  "--if-installed"],
+  ["plugin", "install", "--copilot", "--if-installed"],
+  ["plugin", "install",              "--if-installed"], // Claude
+];
+
+// Runs each refresh via the given launcher (an absolute path to kcap.js).
+// Each refresh runs independently: a failure, timeout, or unexpected exit code
+// from one never prevents the others and never throws to the caller — a failed
+// refresh must never break `npm install` or report `kcap update` as failed.
+function runRefreshes(launcherPath) {
+  for (const argv of REFRESHES) {
+    try {
+      spawnSync(process.execPath, [launcherPath, ...argv], {
+        stdio: "ignore",
+        env: process.env,
+        // Hard ceiling so a stalled child can never hang the caller.
+        timeout: 60_000,
+        killSignal: "SIGKILL",
+        windowsHide: true,
+      });
+    } catch {
+      // Never fail the caller.
+    }
+  }
+}
+
+module.exports = { runRefreshes };

--- a/src/Capacitor.Cli.Core/Resources/help-update.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-update.txt
@@ -1,3 +1,14 @@
-kcap update — Check for and install updates
+kcap update — Upgrade the CLI and refresh agent plugins
 
-Usage: kcap update
+Usage: kcap update [--check]
+
+For npm-global installs, upgrades to the latest published version
+(npm install -g @kurrent/kcap@latest) and then refreshes your opted-in
+agent plugins (skills, Codex/Cursor/Copilot hooks, Claude plugin). This
+works even when your package manager blocks install scripts. Exits early
+if already up to date. For non-npm installs (e.g. Homebrew), prints the
+command to run instead.
+
+Options:
+  --check   Print a machine-readable {current, latest, newer} JSON line
+            and exit without upgrading.

--- a/src/Capacitor.Cli.Core/VersionNudgeEmitter.cs
+++ b/src/Capacitor.Cli.Core/VersionNudgeEmitter.cs
@@ -30,7 +30,7 @@ public static class VersionNudgeEmitter {
         // CLI (e.g. "0.6.3") rather than the MinVer commit-SHA form.
         return
             $"A newer kcap version is available: {StripBuildMetadata(currentCliVersion)} → {StripBuildMetadata(serverVersion)}.\n" +
-            "Offer the user to upgrade by running: npm install -g @kurrent/kcap";
+            "Offer the user to upgrade by running: kcap update";
     }
 
     static string StripBuildMetadata(string? v) {

--- a/src/Capacitor.Cli/Commands/UpdateCommand.cs
+++ b/src/Capacitor.Cli/Commands/UpdateCommand.cs
@@ -8,8 +8,26 @@ namespace Capacitor.Cli.Commands;
 public static class UpdateCommand {
     static readonly string CachePath = PathHelpers.ConfigPath("update-check.json");
 
-    public static async Task<int> HandleAsync() {
+    public static async Task<int> HandleAsync(string[] args) {
+        var checkOnly = args.Contains("--check");
+
         var (latest, current) = await CheckForUpdateAsync(forceCheck: true);
+
+        if (checkOnly) {
+            // Machine-readable probe consumed by the npm launcher (kcap.js).
+            // One JSON line on stdout; exit 1 only when the check itself failed.
+            var newer = latest is not null && current is not null && IsNewer(latest, current);
+
+            var obj = new JsonObject {
+                ["current"] = current,
+                ["latest"]  = latest,
+                ["newer"]   = newer,
+            };
+
+            await Console.Out.WriteLineAsync(obj.ToJsonString());
+
+            return latest is null ? 1 : 0;
+        }
 
         if (latest is null) {
             await Console.Error.WriteLineAsync("Could not check for updates.");
@@ -29,10 +47,13 @@ public static class UpdateCommand {
             return 0;
         }
 
+        // Reached only when the native binary is run WITHOUT the npm launcher
+        // (e.g. invoking the platform binary directly). For npm-global installs
+        // the launcher intercepts `update` and performs the upgrade itself.
         await Console.Out.WriteLineAsync($"Update available: {current} → {latest}");
         await Console.Out.WriteLineAsync();
-        await Console.Out.WriteLineAsync("Run:");
-        await Console.Out.WriteLineAsync("  npm update -g @kurrent/kcap");
+        await Console.Out.WriteLineAsync("Run `kcap update` to update, or upgrade directly:");
+        await Console.Out.WriteLineAsync("  npm install -g @kurrent/kcap@latest");
 
         return 0;
     }
@@ -52,7 +73,7 @@ public static class UpdateCommand {
             if (latest is not null && current is not null && IsNewer(latest, current)) {
                 await Console.Error.WriteLineAsync();
                 await Console.Error.WriteLineAsync($"Update available: {current} → {latest}");
-                await Console.Error.WriteLineAsync("Run `npm update -g @kurrent/kcap` to update");
+                await Console.Error.WriteLineAsync("Run `kcap update` to update");
             }
         } catch {
             // Best effort — never break the CLI for update checks

--- a/src/Capacitor.Cli/Commands/UpdateCommand.cs
+++ b/src/Capacitor.Cli/Commands/UpdateCommand.cs
@@ -16,7 +16,14 @@ public static class UpdateCommand {
         if (checkOnly) {
             // Machine-readable probe consumed by the npm launcher (kcap.js).
             // One JSON line on stdout; exit 1 only when the check itself failed.
-            var newer = latest is not null && current is not null && IsNewer(latest, current);
+            //
+            // `newer` is a tri-state: true => upgrade, false => confidently up to
+            // date, null => can't tell (current version unknown or registry check
+            // failed). The launcher must NOT skip on null — otherwise a binary
+            // that reports "unknown" would strand the user on a stale CLI.
+            bool? newer = string.IsNullOrEmpty(current) || latest is null
+                ? null
+                : IsNewer(latest, current);
 
             var obj = new JsonObject {
                 ["current"] = current,

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -255,7 +255,7 @@ switch (command) {
     case "repos":
         return await ReposCommand.HandleAsync(args);
     case "update":
-        return await UpdateCommand.HandleAsync();
+        return await UpdateCommand.HandleAsync(args);
     case "review": {
         if (args.Length < 2) {
             Console.Error.WriteLine("Usage: kcap review <pr-url-or-shorthand>");

--- a/test/Capacitor.Cli.Tests.Integration/ClaudeHookStdoutTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/ClaudeHookStdoutTests.cs
@@ -75,7 +75,7 @@ public class ClaudeHookStdoutTests : IDisposable {
 
         var ctx = json["hookSpecificOutput"]!["additionalContext"]!.GetValue<string>();
         await Assert.That(ctx).Contains("999.0.0");
-        await Assert.That(ctx).Contains("npm install -g @kurrent/kcap");
+        await Assert.That(ctx).Contains("kcap update");
         await Assert.That(ctx).DoesNotContain("## Known patterns");
         await Assert.That(ctx).DoesNotContain("## Guidance from past sessions");
     }
@@ -117,7 +117,7 @@ public class ClaudeHookStdoutTests : IDisposable {
         await Assert.That(ctx).Contains("## Known patterns");
         await Assert.That(ctx).Contains("- always close the writer");
         await Assert.That(ctx).Contains("999.0.0");
-        await Assert.That(ctx).Contains("npm install -g @kurrent/kcap");
+        await Assert.That(ctx).Contains("kcap update");
     }
 
     [Test, NotInParallel("Console_Out")]

--- a/test/Capacitor.Cli.Tests.Unit/VersionNudgeEmitterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/VersionNudgeEmitterTests.cs
@@ -95,9 +95,9 @@ public class VersionNudgeEmitterTests {
     }
 
     [Test]
-    public async Task Fragment_contains_npm_install_command() {
+    public async Task Fragment_contains_update_command() {
         var result = VersionNudgeEmitter.BuildFragment(ResponseWithVersion("0.6.5"), "0.6.3")!;
-        await Assert.That(result).Contains("npm install -g @kurrent/kcap");
+        await Assert.That(result).Contains("kcap update");
     }
 
     [Test]


### PR DESCRIPTION
## What

`kcap update` now performs a one-step upgrade and refreshes agent hooks/skills, instead of only printing `npm install -g …`.

Closes [AI-866](https://linear.app/kurrent/issue/AI-866).

## Why

The skills/hooks refresh lived only in the npm `postinstall` hook, which modern package managers gate behind an "allowed scripts" allowlist. When that gate blocks the postinstall, an upgraded CLI ships stale skills/hooks. A user-initiated `kcap update` runs the refresh regardless of that gate — the same pattern Claude Code / Codex use.

## How

The upgrade is driven from the **Node launcher** (`kcap.js`), never the native binary. The OS locks an executable image for the whole process lifetime, but a script only during load — so with the native binary not running, npm can overwrite it **even on Windows**, with no temp-file/rename/detached-helper dance.

`kcap update`:
1. Detects an npm-global install (launcher under `npm root -g`); otherwise prints install-method guidance (e.g. Homebrew) and exits.
2. Probes the native `update --check` (short-lived → binary unlocked before npm runs) to skip when already latest.
3. Pre-checks write access to the global root (clear message instead of a half-failed sudo install).
4. Runs `npm install -g @kurrent/kcap@latest`, then refreshes opted-in agent plugins via the new launcher. npm is routed through a shell on Windows (`.cmd`-spawn fix).

`update --check` / `update --help` fall through to the native binary.

## Changes
- **`npm/kcap/bin/refresh.js`** (new): shared per-agent `plugin install --if-installed` loop.
- **`postinstall.js`**: slimmed to call `refresh.runRefreshes()`.
- **`kcap.js`**: `update` intercept (above).
- **`UpdateCommand.cs`**: `--check` JSON probe (`{current, latest, newer}`); messages retargeted to `kcap update`.
- **`VersionNudgeEmitter.cs` / `Program.cs`**: in-agent nudge retargeted; pass args.
- **`.gitignore`**: track `npm/kcap/bin/` (the blanket `bin/` rule would silently drop `refresh.js`; platform binary dirs stay ignored).
- Docs (README, `help-update.txt`, npm README) + 3 test assertions updated.

## Verification
- ✅ All JS files pass `node --check`.
- ⚠️ **C# not built locally** (no .NET SDK on the dev machine) — relying on CI for build / AOT IL-warning check / unit + integration tests.

## Notes
- No automated test added for `--check`: `CheckForUpdateAsync` is network/cache-coupled (needs injection to test cleanly); the `newer` gating reuses already-tested `SemverCompare`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)