### PR TITLE
[AI-884] Report hosted-agent PTY dimensions to the server

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -116,6 +116,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     readonly IReadOnlyDictionary<string, IHostedAgentLauncher> _launchers;
     readonly ILogger<AgentOrchestrator>                        _logger;
 
+    // Hosted-agent PTYs are spawned at a fixed size and never resized. The daemon
+    // reports these dims to the server right after the agent registers so the
+    // read-only viewers (web/desktop xterm) lock to exactly the width Claude drew
+    // for — otherwise the viewer auto-fits its panel and the mismatched columns
+    // garble the TUI (AI-884). Keep in sync with IPtyProcessFactory.Spawn defaults.
+    const ushort HostedPtyCols = 120;
+    const ushort HostedPtyRows = 40;
+
     readonly PeriodicTimer _heartbeatTimer = new(TimeSpan.FromSeconds(30));
 
     // AI-79: heartbeat tightened from 60 s SendAsync to round-trip Ping.
@@ -357,7 +365,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 env["KCAP_REVIEW_PR"] = reviewEnv.PrNumber.ToString();
             }
 
-            var process = _ptyFactory.Spawn(launcher.CliPath, args, worktree.Path, env);
+            var process = _ptyFactory.Spawn(launcher.CliPath, args, worktree.Path, env, HostedPtyCols, HostedPtyRows);
 
             LogAgentSpawned(agentId, process.Pid, worktree.Path, launcher.CliPath);
 
@@ -370,6 +378,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             // Notify server
             await _server.AgentRegisteredAsync(agentId, prompt, model, effort, repoPath);
+
+            // Report the fixed PTY size so read-only viewers lock their xterm to it
+            // (see HostedPtyCols/Rows). Fire-and-forget — late delivery is harmless,
+            // the viewer reflows whenever the dims arrive.
+            _ = _server.SendTerminalDimensionsAsync(agentId, HostedPtyCols, HostedPtyRows);
 
             _ = _server.AppendAgentRunEventAsync(
                 agentId,

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -441,6 +441,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public virtual Task AgentRegisteredAsync(string agentId, string? prompt, string? model, string? effort, string? repoPath)
         => _hub.InvokeAsync("AgentRegistered", new AgentRegistered(agentId, prompt, model, effort, repoPath), cancellationToken: _ct);
 
+    /// <summary>
+    /// Reports the hosted agent's fixed PTY dimensions to the server, which stores
+    /// them and broadcasts to subscribed read-only viewers so their xterm locks to
+    /// the source size instead of auto-fitting its panel (which garbles the TUI).
+    /// </summary>
+    public virtual Task SendTerminalDimensionsAsync(string agentId, int cols, int rows)
+        => _hub.SendAsync("SendTerminalDimensions", agentId, cols, rows, cancellationToken: _ct);
+
     public virtual Task AgentStatusChangedAsync(string agentId, string status, string? sessionId)
         => _hub.InvokeAsync("AgentStatusChanged", new AgentStatusChanged(agentId, status, sessionId), cancellationToken: _ct);
 


### PR DESCRIPTION
Linear: [AI-884](https://linear.app/kurrent/issue/AI-884)

## Problem

The hosted-agent **Terminal** tab in the Capacitor UI shows garbled output — wrapped/overlapping text with truncated left edges. Classic PTY-width vs. display-width mismatch.

**Root cause:** hosted-agent PTYs spawn at a fixed **120×40** and never resize, but the daemon only streamed PTY *output* to the hub — it never reported the dimensions. So the server's `GetTerminalDimensions` returned `null`, the browser never received a `TerminalDimensions` event, and the read-only xterm stayed in **auto-fit mode** (~80 cols), rendering a 120-col TUI at the wrong width. Box-drawing and absolute cursor moves landed in the wrong cells.

The full dimension-sync machinery (`SetTerminalDimensions` → broadcast → `setFixedSizeReadOnly`) already existed — it was built for the MAUI rendered-agent path and was simply never wired for hosted daemon agents.

## Change

- Add `HostedPtyCols`/`HostedPtyRows` constants (120/40) and pass them explicitly to `Spawn`, kept in sync with the `IPtyProcessFactory` defaults.
- Fire `SendTerminalDimensionsAsync` right after the agent registers so read-only viewers lock their xterm to the source size. Fire-and-forget — late delivery is harmless, the viewer reflows when dims arrive.

The matching server/UI side (lock + font-scale the locked grid to fit the panel) ships in the kcap-server PR that bumps this submodule (#756).

This is the **interim lock** fix; a server-side virtual terminal is tracked as a separate follow-up (AI-885).

🤖 Generated with [Claude Code](https://claude.com/claude-code)