### PR TITLE
[AI-884] Report hosted-agent PTY dimensions to the server

### DIFF
--- a/src/Capacitor.Cli.Daemon/Pty/IPtyProcessFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/IPtyProcessFactory.cs
@@ -1,7 +1,20 @@
 namespace Capacitor.Cli.Daemon.Pty;
 
+/// <summary>
+/// Single source of truth for the fixed size hosted-agent PTYs are spawned at.
+/// Hosted PTYs are never resized; the daemon reports these dims to the server so
+/// read-only viewers lock their xterm to exactly the width Claude drew for (AI-884).
+/// Referenced by both <see cref="IPtyProcessFactory.Spawn"/>'s defaults and the
+/// orchestrator's spawn + dimension-report calls so the two can never drift.
+/// </summary>
+public static class PtyDefaults
+{
+    public const ushort Cols = 120;
+    public const ushort Rows = 40;
+}
+
 public interface IPtyProcessFactory
 {
     IPtyProcess Spawn(string command, string[] args, string cwd,
-        Dictionary<string, string>? extraEnv = null, ushort cols = 120, ushort rows = 40);
+        Dictionary<string, string>? extraEnv = null, ushort cols = PtyDefaults.Cols, ushort rows = PtyDefaults.Rows);
 }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -117,12 +117,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     readonly ILogger<AgentOrchestrator>                        _logger;
 
     // Hosted-agent PTYs are spawned at a fixed size and never resized. The daemon
-    // reports these dims to the server right after the agent registers so the
-    // read-only viewers (web/desktop xterm) lock to exactly the width Claude drew
-    // for — otherwise the viewer auto-fits its panel and the mismatched columns
-    // garble the TUI (AI-884). Keep in sync with IPtyProcessFactory.Spawn defaults.
-    const ushort HostedPtyCols = 120;
-    const ushort HostedPtyRows = 40;
+    // reports these dims to the server right after the agent registers (and on
+    // reconnect) so the read-only viewers (web/desktop xterm) lock to exactly the
+    // width Claude drew for — otherwise the viewer auto-fits its panel and the
+    // mismatched columns garble the TUI (AI-884). PtyDefaults is the single source
+    // of truth, shared with IPtyProcessFactory.Spawn's defaults so they can't drift.
+    const ushort HostedPtyCols = PtyDefaults.Cols;
+    const ushort HostedPtyRows = PtyDefaults.Rows;
 
     readonly PeriodicTimer _heartbeatTimer = new(TimeSpan.FromSeconds(30));
 
@@ -380,9 +381,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             await _server.AgentRegisteredAsync(agentId, prompt, model, effort, repoPath);
 
             // Report the fixed PTY size so read-only viewers lock their xterm to it
-            // (see HostedPtyCols/Rows). Fire-and-forget — late delivery is harmless,
-            // the viewer reflows whenever the dims arrive.
-            _ = _server.SendTerminalDimensionsAsync(agentId, HostedPtyCols, HostedPtyRows);
+            // (see HostedPtyCols/Rows). Best-effort: a failed send must not fail the
+            // launch (late delivery is harmless — the viewer reflows when dims
+            // arrive), but observe the fault here with agent context rather than
+            // leaving it to the global unobserved-task handler.
+            try {
+                await _server.SendTerminalDimensionsAsync(agentId, HostedPtyCols, HostedPtyRows);
+            } catch (Exception ex) {
+                LogTerminalDimsSendFailed(ex, agentId);
+            }
 
             _ = _server.AppendAgentRunEventAsync(
                 agentId,
@@ -924,6 +931,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     await _server.AgentRegisteredAsync(agent.Id, agent.Prompt, agent.Model, agent.Effort, agent.RepoPath);
                     await _server.AgentStatusChangedAsync(agent.Id, agent.Status, agent.SessionId);
 
+                    // Re-send the fixed PTY dims. The server stores them in memory, so a
+                    // server restart (not just a daemon blip) wipes them — without this
+                    // resend the read-only viewers never re-lock and the TUI garbles
+                    // again exactly as before the fix (AI-884). Best-effort: its own
+                    // catch keeps a dims-send failure from escaping to the retry handler
+                    // (which would re-register the agent) or withholding readiness.
+                    try {
+                        await _server.SendTerminalDimensionsAsync(agent.Id, HostedPtyCols, HostedPtyRows);
+                    } catch (Exception ex) {
+                        LogTerminalDimsSendFailed(ex, agent.Id);
+                    }
+
                     // AI-842: do NOT replay the full output buffer here. The old
                     // replay re-sent the entire 2 MB ring on every reconnect, which
                     // the server appended to its own buffer and live-broadcast on
@@ -1126,6 +1145,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to re-register agent {AgentId}")]
     partial void LogReRegisterFailed(Exception ex, string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to send terminal dimensions for agent {AgentId} (read-only viewers may render garbled until the next reconnect)")]
+    partial void LogTerminalDimsSendFailed(Exception ex, string agentId);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Agent {AgentId} stuck in Starting for {Seconds:F1}s with no output (PID={Pid}, exited={Exited}), terminating")]
     partial void LogAgentStuck(string agentId, double seconds, int pid, bool exited);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -116,6 +116,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     readonly IReadOnlyDictionary<string, IHostedAgentLauncher> _launchers;
     readonly ILogger<AgentOrchestrator>                        _logger;
 
+    // Hosted-agent PTYs are spawned at a fixed size and never resized. The daemon
+    // reports these dims to the server right after the agent registers so the
+    // read-only viewers (web/desktop xterm) lock to exactly the width Claude drew
+    // for — otherwise the viewer auto-fits its panel and the mismatched columns
+    // garble the TUI (AI-884). Keep in sync with IPtyProcessFactory.Spawn defaults.
+    const ushort HostedPtyCols = 120;
+    const ushort HostedPtyRows = 40;
+
     readonly PeriodicTimer _heartbeatTimer = new(TimeSpan.FromSeconds(30));
 
     // AI-79: heartbeat tightened from 60 s SendAsync to round-trip Ping.
@@ -357,7 +365,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 env["KCAP_REVIEW_PR"] = reviewEnv.PrNumber.ToString();
             }
 
-            var process = _ptyFactory.Spawn(launcher.CliPath, args, worktree.Path, env);
+            var process = _ptyFactory.Spawn(launcher.CliPath, args, worktree.Path, env, HostedPtyCols, HostedPtyRows);
 
             LogAgentSpawned(agentId, process.Pid, worktree.Path, launcher.CliPath);
 
@@ -370,6 +378,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             // Notify server
             await _server.AgentRegisteredAsync(agentId, prompt, model, effort, repoPath);
+
+            // Report the fixed PTY size so read-only viewers lock their xterm to it
+            // (see HostedPtyCols/Rows). Fire-and-forget — late delivery is harmless,
+            // the viewer reflows whenever the dims arrive.
+            _ = _server.SendTerminalDimensionsAsync(agentId, HostedPtyCols, HostedPtyRows);
 
             _ = _server.AppendAgentRunEventAsync(
                 agentId,

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -441,6 +441,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public virtual Task AgentRegisteredAsync(string agentId, string? prompt, string? model, string? effort, string? repoPath)
         => _hub.InvokeAsync("AgentRegistered", new AgentRegistered(agentId, prompt, model, effort, repoPath), cancellationToken: _ct);
 
+    /// <summary>
+    /// Reports the hosted agent's fixed PTY dimensions to the server, which stores
+    /// them and broadcasts to subscribed read-only viewers so their xterm locks to
+    /// the source size instead of auto-fitting its panel (which garbles the TUI).
+    /// </summary>
+    public virtual Task SendTerminalDimensionsAsync(string agentId, int cols, int rows)
+        => _hub.SendAsync("SendTerminalDimensions", agentId, cols, rows, cancellationToken: _ct);
+
     public virtual Task AgentStatusChangedAsync(string agentId, string status, string? sessionId)
         => _hub.InvokeAsync("AgentStatusChanged", new AgentStatusChanged(agentId, status, sessionId), cancellationToken: _ct);
 


### PR DESCRIPTION
Linear: [AI-884](https://linear.app/kurrent/issue/AI-884)

_Supersedes #160 (closed by a branch rename)._

## Problem

The hosted-agent **Terminal** tab in the Capacitor UI shows garbled output — wrapped/overlapping text with truncated left edges. Classic PTY-width vs. display-width mismatch.

**Root cause:** hosted-agent PTYs spawn at a fixed **120×40** and never resize, but the daemon only streamed PTY *output* to the hub — it never reported the dimensions. So the server's `GetTerminalDimensions` returned `null`, the browser never received a `TerminalDimensions` event, and the read-only xterm stayed in **auto-fit mode** (~80 cols), rendering a 120-col TUI at the wrong width. Box-drawing and absolute cursor moves landed in the wrong cells.

The full dimension-sync machinery (`SetTerminalDimensions` → broadcast → `setFixedSizeReadOnly`) already existed — it was built for the MAUI rendered-agent path and was simply never wired for hosted daemon agents.

## Change

- Add `HostedPtyCols`/`HostedPtyRows` constants (120/40) and pass them explicitly to `Spawn`, kept in sync with the `IPtyProcessFactory` defaults.
- Fire `SendTerminalDimensionsAsync` right after the agent registers so read-only viewers lock their xterm to the source size. Fire-and-forget — late delivery is harmless, the viewer reflows when dims arrive.

The matching server/UI side (lock + font-scale the locked grid to fit the panel) ships in the kcap-server PR that bumps this submodule.

This is the **interim lock** fix; a server-side virtual terminal is tracked as a separate follow-up (AI-885).

🤖 Generated with [Claude Code](https://claude.com/claude-code)