### PR TITLE
[AI-815] Surface --cursor/--copilot in kcap --help Plugin section

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ kcap uninstall --keep-config    # remove integrations, keep ~/.config/kcap
 
 `--project` additionally cleans up `<repo>/.claude/settings.local.json` and `<repo>/.codex/hooks.json` in the current git working tree (errors if you're not inside one). Cursor only has a user-scope `hooks.json`, so `--project` does not affect it. Project-scope hooks in other repos are not touched — re-run from each repo that has them.
 
-Use `--keep-config` to preserve profiles, tokens, and ignore lists when you plan to reinstall. Per-agent selective cleanup is not exposed here — use `kcap plugin remove [--codex|--cursor|--skills]` for finer-grained removal.
+Use `--keep-config` to preserve profiles, tokens, and ignore lists when you plan to reinstall. Per-agent selective cleanup is not exposed here — use `kcap plugin remove [--codex|--cursor|--copilot|--skills]` for finer-grained removal.
 
 ### Other commands
 

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -54,8 +54,8 @@ MCP servers (stdio):
   mcp sessions                       Search/inspect past sessions from agents
 
 Plugin:
-  plugin install [--project] [--codex]   Register hooks (Claude or --codex for Codex)
-  plugin remove  [--project] [--codex]   Remove hooks (Claude or --codex for Codex)
+  plugin install [--project] [--codex|--cursor|--copilot|--skills]   Register hooks/skills (Claude default; flag picks the vendor)
+  plugin remove  [--project] [--codex|--cursor|--copilot|--skills]   Remove hooks/skills (Claude default; flag picks the vendor)
 
 Maintenance:
   update                           Check for and install updates

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -843,7 +843,7 @@ public static class PluginCommand {
 
     static int PrintUsage() {
         Console.Error.WriteLine(
-            "Usage: kcap plugin <install|remove> [--project] [--codex|--cursor|--skills] [--if-installed]"
+            "Usage: kcap plugin <install|remove> [--project] [--codex|--cursor|--copilot|--skills] [--if-installed]"
         );
 
         return 1;


### PR DESCRIPTION
## Problem

`kcap --help` (top-level usage) listed only `[--codex]` under **Plugin**, so a user reading the main help couldn't discover `plugin install --copilot` or `--cursor` — even though both have shipped (AI-731 Cursor, AI-815 Copilot) and `kcap plugin --help` documents them in full. Reported from the field: "looked at kcap --help and didn't see anything for Copilot."

The `import` line and the `Hooks` section already enumerate all four vendors; only this Plugin two-liner was stale.

## Fix

Bring the Plugin summary in sync with `PluginCommand`'s actual dispatch (`--codex|--cursor|--copilot|--skills`):

```
Plugin:
  plugin install [--project] [--codex|--cursor|--copilot|--skills]   Register hooks/skills (Claude default; flag picks the vendor)
  plugin remove  [--project] [--codex|--cursor|--copilot|--skills]   Remove hooks/skills (Claude default; flag picks the vendor)
```

Docs-only (embedded help resource). Verified by running `kcap --help` from a release build off current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)