### PR TITLE
[AI-887] Google Gemini CLI ingest (CLI side)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The CLI is compiled with NativeAOT — fast startup, no runtime dependency.
 > **npm 11+ blocks install scripts by default.** You'll see a warning like
 > `1 package has install scripts not yet covered by allowScripts`. The `kcap`
 > binary works without the script; it only refreshes already-installed agent
-> plugins (Claude / Codex / Cursor / Copilot) on upgrade. The warning suggests
+> plugins (Claude / Codex / Cursor / Copilot / Gemini) on upgrade. The warning suggests
 > `npm approve-scripts @kurrent/kcap`, but that command rejects global installs
 > (`EGLOBAL`) — a known npm UX bug. Instead, opt in one of two ways:
 >
@@ -47,7 +47,7 @@ The CLI is compiled with NativeAOT — fast startup, no runtime dependency.
 > Without either, upgrade with **`kcap update`** instead of `npm install -g` — it
 > runs the global npm upgrade and then refreshes your agent plugins itself, so it
 > works regardless of the install-script gate. (You can also re-run `kcap plugin
-> install [--codex|--cursor|--copilot|--skills] --if-installed` manually.)
+> install [--codex|--cursor|--copilot|--gemini|--skills] --if-installed` manually.)
 
 ### 2. Run setup
 
@@ -60,7 +60,7 @@ The setup wizard walks you through:
 1. **Server URL** — enter the URL your admin provided
 2. **Login** — authenticates via GitHub Device Flow (if the server requires auth)
 3. **Default visibility** — choose how your sessions are visible to others
-4. **Coding-agent hooks** — detects Claude Code and Codex CLI on `PATH`, Cursor by user-dir presence (`~/.cursor/`), and GitHub Copilot CLI by `~/.copilot/` or `copilot` on `PATH`, then offers to install hooks/skills for each (user-wide)
+4. **Coding-agent hooks** — detects Claude Code and Codex CLI on `PATH`, Cursor by user-dir presence (`~/.cursor/`), GitHub Copilot CLI by `~/.copilot/` or `copilot` on `PATH`, and Google Gemini CLI by `~/.gemini/` or `gemini` on `PATH`, then offers to install hooks/skills for each (user-wide)
 5. **Daemon** — configure the daemon name for remote agent execution
 
 When setup finishes, `kcap` sends a best-effort POST to the server's `/api/users/me/cli-setup` endpoint so the dashboard can mark your CLI as registered and surface the import-past-sessions hint. The call is capped at 5 seconds and failures are silent — they do not affect setup completion.
@@ -75,10 +75,10 @@ For non-interactive environments:
 kcap setup --server-url https://my-tenant.kcap.ai --default-visibility org_public --no-prompt
 ```
 
-In `--no-prompt` mode, the wizard installs hooks for every detected agent by default. Opt out per agent with `--skip-claude-hooks`, `--skip-codex-hooks`, `--skip-cursor-hooks`, and/or `--skip-copilot-hooks`.
+In `--no-prompt` mode, the wizard installs hooks for every detected agent by default. Opt out per agent with `--skip-claude-hooks`, `--skip-codex-hooks`, `--skip-cursor-hooks`, `--skip-copilot-hooks`, and/or `--skip-gemini-hooks`.
 
 > **Need hooks for an agent installed after setup, or scoped to a single repo?**
-> Run `kcap plugin install [--codex|--cursor|--copilot]` (omit the flag for the Claude Code plugin), or pair Codex with `--project` for a per-repo install. Use `--skills` instead of `--codex` if you only want the agent skills without Codex hooks. Cursor uses user-scope only — `--project` has no effect with `--cursor`. After installing Codex hooks, the next `codex` launch prompts to trust the new hooks — accept once to trust them all (run `/hooks` inside Codex if you'd rather trust each entry individually). After a `--project` install, also run `codex` once in the repo and accept the workspace trust prompt. Re-running after a kcap upgrade is rarely needed for user-scope installs — the npm postinstall hook auto-refreshes them on every `npm install -g @kurrent/kcap`, and `kcap update` refreshes them too (npm 11+ blocks install scripts by default — `kcap update` works regardless, or add `allow-scripts[]=@kurrent/kcap` to `~/.npmrc` to opt the postinstall in once).
+> Run `kcap plugin install [--codex|--cursor|--copilot|--gemini]` (omit the flag for the Claude Code plugin), or pair Codex with `--project` for a per-repo install. Use `--skills` instead of `--codex` if you only want the agent skills without Codex hooks. Cursor uses user-scope only — `--project` has no effect with `--cursor`. After installing Codex hooks, the next `codex` launch prompts to trust the new hooks — accept once to trust them all (run `/hooks` inside Codex if you'd rather trust each entry individually). After a `--project` install, also run `codex` once in the repo and accept the workspace trust prompt. Re-running after a kcap upgrade is rarely needed for user-scope installs — the npm postinstall hook auto-refreshes them on every `npm install -g @kurrent/kcap`, and `kcap update` refreshes them too (npm 11+ blocks install scripts by default — `kcap update` works regardless, or add `allow-scripts[]=@kurrent/kcap` to `~/.npmrc` to opt the postinstall in once).
 
 > **Need at least one agent to capture sessions:** the setup wizard runs to completion without an agent CLI on `PATH` (it'll still configure your profile, auth, and daemon), but kcap only records work once Claude Code or Codex CLI is installed and the hooks are in place.
 
@@ -87,14 +87,15 @@ In `--no-prompt` mode, the wizard installs hooks for every detected agent by def
 ### 3. Import existing sessions (optional)
 
 ```bash
-kcap import                     # every detected agent (Claude, Codex, Cursor, Copilot)
+kcap import                     # every detected agent (Claude, Codex, Cursor, Copilot, Gemini)
 kcap import --org               # sessions for the org bound to your active profile
 kcap import --repo owner/repo   # sessions for one specific repo
 kcap import --cursor            # only Cursor
 kcap import --copilot           # only Copilot
+kcap import --gemini            # only Gemini
 ```
 
-This backfills your past sessions from `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex), `~/.cursor/projects/.../agent-transcripts/` (Cursor), and `~/.copilot/session-state/` (Copilot) so they appear in the dashboard. All agents are discovered automatically — pass `--claude`, `--codex`, `--cursor`, or `--copilot` (one or more) to narrow the run. All forms are idempotent — safe to run multiple times.
+This backfills your past sessions from `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex), `~/.cursor/projects/.../agent-transcripts/` (Cursor), `~/.copilot/session-state/` (Copilot), and `~/.gemini/tmp/<project>/chats/` (Gemini) so they appear in the dashboard. All agents are discovered automatically — pass `--claude`, `--codex`, `--cursor`, `--copilot`, or `--gemini` (one or more) to narrow the run. All forms are idempotent — safe to run multiple times.
 
 You must pick an explicit scope (`--all`, `--org`, or `--repo`) so personal/private repos aren't uploaded by accident. `--org` uses the active profile name as the GitHub org login — it works out of the box when the profile was created by `kcap setup` (which names it after the picked tenant), and errors otherwise. Run with no scope on an interactive terminal to get a picker. See [Loading historical sessions](#loading-historical-sessions) for the full set of flags.
 
@@ -130,7 +131,7 @@ kcap setup                                   # interactive wizard
 kcap setup --server-url <url> --no-prompt    # CI / scripted
 ```
 
-The setup wizard detects every supported coding agent and offers to install hooks for each, then configures the daemon. Claude Code and Codex CLI are detected via `PATH`; Cursor is detected by user-dir presence (`~/.cursor/`), so IDE users without the `cursor` shell command are covered; GitHub Copilot CLI is detected via `~/.copilot/` or `copilot` on `PATH`. Re-run any time to update the configuration.
+The setup wizard detects every supported coding agent and offers to install hooks for each, then configures the daemon. Claude Code and Codex CLI are detected via `PATH`; Cursor is detected by user-dir presence (`~/.cursor/`), so IDE users without the `cursor` shell command are covered; GitHub Copilot CLI is detected via `~/.copilot/` or `copilot` on `PATH`; Google Gemini CLI via `~/.gemini/` or `gemini` on `PATH`. Re-run any time to update the configuration.
 
 In `--no-prompt` mode, hooks install for every detected agent by default. Opt out per agent:
 
@@ -263,7 +264,7 @@ The server is repo-aware — it resolves the current working directory to a repo
 
 ### Loading historical sessions
 
-Backfill older sessions from every detected coding agent in a single run. All four agents ship per-session `.jsonl` transcripts (`~/.claude/projects/`, `~/.codex/sessions/`, `~/.cursor/projects/<sanitized-workspace>/agent-transcripts/`, `~/.copilot/session-state/`). They're discovered automatically and the command requires an explicit scope so personal/private repos aren't uploaded by accident:
+Backfill older sessions from every detected coding agent in a single run. All five agents ship per-session `.jsonl` transcripts (`~/.claude/projects/`, `~/.codex/sessions/`, `~/.cursor/projects/<sanitized-workspace>/agent-transcripts/`, `~/.copilot/session-state/`, `~/.gemini/tmp/<project>/chats/`). They're discovered automatically and the command requires an explicit scope so personal/private repos aren't uploaded by accident:
 
 ```bash
 kcap import --all                            # every discovered session from every agent
@@ -284,6 +285,7 @@ kcap import --codex --org                    # only Codex rollouts
 kcap import --cursor --all                   # only Cursor — every discovered transcript
 kcap import --cursor --cwd /path/to/proj     # only Cursor sessions whose workspace folder matches
 kcap import --copilot --all                  # only Copilot — every discovered transcript
+kcap import --gemini --all                   # only Gemini — every discovered transcript
 ```
 
 Cursor historical import walks every JSONL transcript under `~/.cursor/projects/*/agent-transcripts/*/*.jsonl` and posts each line through the same `POST /hooks/transcript` route the live hook path uses, so live and historical ingest converge on one canonical event stream. The walker resolves each session's working directory by matching its sanitized workspace name against `~/Library/Application Support/Cursor/User/workspaceStorage/*/workspace.json` (on Linux: `~/.config/Cursor/User/...`); sessions whose workspace can't be resolved are still imported, just without `cwd` and git owner/repo enrichment.
@@ -395,6 +397,17 @@ kcap plugin remove --copilot                # deletes ~/.copilot/hooks/kcap.json
 ```
 
 Live sessions stream from `~/.copilot/session-state/<session-id>/events.jsonl` (`$COPILOT_HOME` is honoured); historical sessions import via `kcap import --copilot`, which also forwards Copilot's auto-generated session names as titles. Sessions resumed with `copilot --continue` / `--resume` reattach to the same recorded session.
+
+#### Google Gemini CLI hooks
+
+Gemini CLI is detected via `~/.gemini/` (created on Gemini's first run) or the `gemini` binary on `PATH`. Gemini keeps its hooks in the shared `~/.gemini/settings.json`, so kcap **merges** its entries into the `hooks` block and preserves your other settings and any hand-authored hook entries. Gemini loads hook config at startup: restart any running `gemini` session after installing.
+
+```bash
+kcap plugin install --gemini                # merges kcap hooks into ~/.gemini/settings.json
+kcap plugin remove --gemini                 # removes only kcap's entries
+```
+
+Live sessions stream from the chat-recording JSONL Gemini names in each hook's `transcript_path` (`~/.gemini/tmp/<project>/chats/session-*.jsonl`); historical sessions import via `kcap import --gemini`. Sessions resumed with `gemini --resume` reattach to the same recorded session. (Historical import leaves working-directory / repo enrichment empty — Gemini doesn't record the cwd in a machine-readable header; live capture gets it from the hook payload.)
 
 Cursor uses a single user-scope `hooks.json`; there is no project-scope variant.
 

--- a/src/Capacitor.Cli.Core/Gemini/GeminiHooksInstaller.cs
+++ b/src/Capacitor.Cli.Core/Gemini/GeminiHooksInstaller.cs
@@ -1,0 +1,63 @@
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Core.Gemini;
+
+/// <summary>
+/// Marker + detection helpers for kcap's hooks inside Gemini CLI's shared
+/// <c>~/.gemini/settings.json</c>. Mirror of <c>CopilotHooksInstaller</c>, but
+/// the detection fallback inspects the merged <c>hooks</c> block rather than a
+/// kcap-owned file. The actual merge/unmerge lives in <c>PluginCommand</c>
+/// (it must preserve user-authored hook entries — see <see cref="GeminiHooksParser"/>).
+/// </summary>
+public static class GeminiHooksInstaller {
+    public const string MarkerFileName = ".kcap-hooks-version";
+
+    /// <summary>
+    /// True when kcap's Gemini hooks were previously installed. Marker file
+    /// presence OR an existing <c>kcap hook --gemini</c> entry in settings.json
+    /// (the latter covers pre-marker installs).
+    /// </summary>
+    public static bool IsInstalled(string settingsPath) {
+        var dir = Path.GetDirectoryName(settingsPath);
+        if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir)) return false;
+
+        if (File.Exists(Path.Combine(dir, MarkerFileName))) return true;
+        if (!File.Exists(settingsPath)) return false;
+
+        try {
+            if (JsonNode.Parse(File.ReadAllText(settingsPath)) is not JsonObject root) return false;
+            if (root["hooks"] is not JsonObject hooks) return false;
+
+            foreach (var (_, entries) in hooks) {
+                if (entries is JsonArray arr && arr.Any(GeminiHooksParser.EntryReferencesCapacitorGeminiHook)) {
+                    return true;
+                }
+            }
+        } catch { /* Malformed → treat as not installed. */ }
+        return false;
+    }
+
+    public static string? ReadMarker(string settingsPath) {
+        var dir = Path.GetDirectoryName(settingsPath);
+        if (string.IsNullOrEmpty(dir)) return null;
+        var marker = Path.Combine(dir, MarkerFileName);
+        try { return File.Exists(marker) ? File.ReadAllText(marker).Trim() : null; }
+        catch { return null; }
+    }
+
+    public static void WriteMarker(string settingsPath) {
+        var dir = Path.GetDirectoryName(settingsPath);
+        if (string.IsNullOrEmpty(dir)) return;
+        try {
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, MarkerFileName), CapacitorVersion.Current());
+        } catch { /* best effort */ }
+    }
+
+    public static void DeleteMarker(string settingsPath) {
+        var dir = Path.GetDirectoryName(settingsPath);
+        if (string.IsNullOrEmpty(dir)) return;
+        var marker = Path.Combine(dir, MarkerFileName);
+        try { if (File.Exists(marker)) File.Delete(marker); } catch { }
+    }
+}

--- a/src/Capacitor.Cli.Core/Gemini/GeminiHooksParser.cs
+++ b/src/Capacitor.Cli.Core/Gemini/GeminiHooksParser.cs
@@ -1,0 +1,81 @@
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Core.Gemini;
+
+/// <summary>
+/// Parsing + entry-building helpers for the <c>hooks</c> block in Gemini CLI's
+/// shared <c>~/.gemini/settings.json</c>. Gemini's schema nests one level
+/// deeper than Cursor's flat <c>{"command": "..."}</c>: each event maps to an
+/// array of <c>{ "matcher"?, "hooks": [ { "name", "type":"command", "command",
+/// "timeout" } ] }</c> objects. kcap registers ONE command hook per lifecycle
+/// event; the command (<see cref="HookCommand"/>) self-routes on the payload's
+/// <c>hook_event_name</c>, so every event shares the same command.
+/// </summary>
+public static class GeminiHooksParser {
+    /// <summary>The single dispatcher command kcap installs for every event.</summary>
+    public const string HookCommand = "kcap hook --gemini";
+
+    /// <summary>
+    /// Lifecycle events kcap subscribes to. SessionStart spawns the watcher +
+    /// records SessionStarted; SessionEnd drains + records SessionEnded;
+    /// Notification forwards to the Claude-shaped <c>/hooks/notification</c>.
+    /// Tool/model events are intentionally not hooked — content comes from the
+    /// transcript, not the hooks.
+    /// </summary>
+    public static readonly string[] GeminiHookEvents = [
+        "SessionStart",
+        "SessionEnd",
+        "Notification"
+    ];
+
+    /// <summary>
+    /// The event-array entry kcap installs: <c>{ "hooks": [ { kcap command } ] }</c>.
+    /// No <c>matcher</c> — lifecycle events ignore it. Uses the JsonArray/JsonObject
+    /// constructors (collection expressions trip AOT — see CLI CLAUDE.md).
+    /// </summary>
+    public static JsonObject BuildKcapEntry() =>
+        new() {
+            ["hooks"] = new JsonArray(
+                new JsonObject {
+                    ["name"]    = "kcap",
+                    ["type"]    = "command",
+                    ["command"] = HookCommand,
+                    ["timeout"] = 30000
+                }
+            )
+        };
+
+    /// <summary>
+    /// True if <paramref name="entry"/> (an event-array element) carries a kcap
+    /// command hook. Reads the nested <c>hooks[].command</c>; tolerates a flat
+    /// <c>{command}</c> shape defensively. Matches the current
+    /// <c>kcap hook --gemini</c> marker and the pre-rename
+    /// <c>kapacitor hook --gemini</c> so uninstall/refresh clean up older entries.
+    /// </summary>
+    public static bool EntryReferencesCapacitorGeminiHook(JsonNode? entry) {
+        if (entry?["hooks"] is JsonArray inner) {
+            return inner.Any(h => CommandReferencesKcap(h?["command"]));
+        }
+        return CommandReferencesKcap(entry?["command"]);
+    }
+
+    static bool CommandReferencesKcap(JsonNode? cmdNode) =>
+        cmdNode is JsonValue jv
+     && jv.TryGetValue<string>(out var cmd)
+     && (cmd.Contains("kcap hook --gemini",      StringComparison.Ordinal)
+      || cmd.Contains("kapacitor hook --gemini", StringComparison.Ordinal));
+
+    /// <summary>
+    /// True if every event in <paramref name="events"/> has at least one
+    /// settings.json entry referencing the kcap gemini command.
+    /// </summary>
+    public static bool HasCapacitorHooksFor(JsonObject root, IEnumerable<string> events) {
+        if (root["hooks"] is not JsonObject hooks) return false;
+
+        foreach (var evt in events) {
+            if (hooks[evt] is not JsonArray entries) return false;
+            if (!entries.Any(EntryReferencesCapacitorGeminiHook)) return false;
+        }
+        return true;
+    }
+}

--- a/src/Capacitor.Cli.Core/Gemini/GeminiPaths.cs
+++ b/src/Capacitor.Cli.Core/Gemini/GeminiPaths.cs
@@ -1,0 +1,45 @@
+namespace Capacitor.Cli.Core.Gemini;
+
+/// <summary>
+/// Filesystem layout for Google Gemini CLI state. Everything lives under a
+/// single root: <c>$GEMINI_HOME</c> when set, otherwise <c>~/.gemini</c> on
+/// every OS. Unlike Copilot's dedicated <c>hooks/kcap.json</c>, Gemini's hooks
+/// live in the SHARED <c>settings.json</c> under a <c>hooks</c> key, so the
+/// installer must MERGE (see <see cref="GeminiHooksParser"/>).
+/// </summary>
+public static class GeminiPaths {
+    public static string Root(string? home = null, string? geminiHome = null) {
+        geminiHome ??= Environment.GetEnvironmentVariable("GEMINI_HOME");
+        if (!string.IsNullOrEmpty(geminiHome)) return geminiHome;
+
+        home ??= Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".gemini");
+    }
+
+    /// <summary>
+    /// Detection by root-dir presence — Gemini CLI creates <c>~/.gemini</c> on
+    /// first run; the binary name <c>gemini</c> is too generic for a PATH probe
+    /// to be the only signal. Callers that also want the PATH probe OR this
+    /// with <c>AgentDetector.IsInstalled("gemini")</c>.
+    /// </summary>
+    public static bool IsInstalled(string? home = null, string? geminiHome = null)
+        => Directory.Exists(Root(home, geminiHome));
+
+    /// <summary>
+    /// Shared settings file (<c>~/.gemini/settings.json</c>) — holds user config
+    /// plus the <c>hooks</c> block kcap merges into. NEVER overwrite wholesale.
+    /// </summary>
+    public static string SettingsJson(string? home = null, string? geminiHome = null)
+        => Path.Combine(Root(home, geminiHome), "settings.json");
+
+    /// <summary>
+    /// Per-project temporary state root: <c>~/.gemini/tmp/&lt;project&gt;/</c>.
+    /// Chat recordings live under <c>chats/</c> within each project dir.
+    /// </summary>
+    public static string TmpDir(string? home = null, string? geminiHome = null)
+        => Path.Combine(Root(home, geminiHome), "tmp");
+
+    /// <summary>Chat-recording directory for a project tmp dir: <c>&lt;tmp&gt;/&lt;project&gt;/chats</c>.</summary>
+    public static string ChatsDir(string projectTmpDir)
+        => Path.Combine(projectTmpDir, "chats");
+}

--- a/src/Capacitor.Cli.Core/Resources/help-hook.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-hook.txt
@@ -9,8 +9,8 @@ Description:
   dispatcher; the event is taken from the payload.
 
   The command is registered via 'kcap setup' or
-  'kcap plugin install [--claude|--codex|--cursor|--copilot]', which writes
-  the appropriate hook configuration for the detected vendor.
+  'kcap plugin install [--claude|--codex|--cursor|--copilot|--gemini]', which
+  writes the appropriate hook configuration for the detected vendor.
 
 Options:
   --claude    Dispatch the event as a Claude Code hook.
@@ -19,6 +19,8 @@ Options:
   --copilot   Dispatch the event as a GitHub Copilot CLI hook. Copilot
               payloads carry no event-name field, so the installer embeds
               it in the registered command (--event <name>).
+  --gemini    Dispatch the event as a Gemini CLI hook. Self-routes on the
+              payload's hook_event_name (SessionStart/SessionEnd/Notification).
 
 Exit codes:
   0   Normal exit (including budget expiry, malformed payload, and

--- a/src/Capacitor.Cli.Core/Resources/help-import.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-import.txt
@@ -1,13 +1,14 @@
 kcap import — Import local sessions from every detected coding agent
 
-Discovers Claude, Codex, Cursor, and Copilot sessions on this machine and
-imports them in a single run. Each agent ships a per-session .jsonl transcript:
+Discovers Claude, Codex, Cursor, Copilot, and Gemini sessions on this machine
+and imports them in a single run. Each agent ships a per-session .jsonl transcript:
   Claude  — ~/.claude/projects/<encoded-cwd>/<sid>.jsonl
   Codex   — ~/.codex/sessions/.../rollout-<sid>.jsonl
   Cursor  — ~/.cursor/projects/<sanitized-workspace>/agent-transcripts/<sid>/<sid>.jsonl
   Copilot — ~/.copilot/session-state/<sid>/events.jsonl (plus the pre-GA
             history-session-state/ root; dirs without events.jsonl are skipped)
-kcap walks all four the same way.
+  Gemini  — ~/.gemini/tmp/<project>/chats/session-<ISO>-<shortId>.jsonl
+kcap walks all five the same way.
 
 Usage: kcap import [vendor-filters] [scope] [options]
 
@@ -20,6 +21,7 @@ Vendor filters (additive — pass one or more to restrict the run):
   --codex                 Import Codex rollouts
   --cursor                Import Cursor agent-session transcripts
   --copilot               Import GitHub Copilot CLI session transcripts
+  --gemini                Import Gemini CLI session transcripts
 
 Scope (one of, required for non-interactive use):
   --all                   Import every discovered session

--- a/src/Capacitor.Cli.Core/Resources/help-plugin.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-plugin.txt
@@ -1,4 +1,4 @@
-kcap plugin — Manage hooks and skills for Claude Code, Codex CLI, Cursor, Copilot CLI, and other agents
+kcap plugin — Manage hooks and skills for Claude Code, Codex CLI, Cursor, Copilot CLI, Gemini CLI, and other agents
 
 Usage: kcap plugin <subcommand> [options]
 
@@ -17,6 +17,11 @@ Options:
                       ~/.copilot/hooks/kcap.json (honours $COPILOT_HOME). Copilot
                       merges every *.json in that directory, so user-authored
                       hook files are never touched.
+  --gemini            Target Gemini CLI: merge kcap's hooks into the SHARED
+                      ~/.gemini/settings.json (honours $GEMINI_HOME). User-authored
+                      hook entries and every other settings key are preserved; if
+                      the file exists but isn't valid JSON the install fails closed
+                      and leaves it untouched.
   --skills            Install only the agent-agnostic skills to ~/.agents/skills/.
                       Use this if you only have Cursor (or another agent that
                       reads ~/.agents/skills/) and don't want Codex hooks.
@@ -49,6 +54,12 @@ Notes:
   so restart any running copilot session after install. Copilot has no
   project-scope hooks dir, so --project has no effect with --copilot.
 
+  --gemini merges SessionStart/SessionEnd/Notification entries into the shared
+  ~/.gemini/settings.json (like --cursor's shared hooks.json — your other Gemini
+  settings and hooks are kept). Gemini loads hook config at startup, so restart
+  any running gemini session after install. Gemini has no project-scope settings
+  dir, so --project has no effect with --gemini.
+
   --if-installed is scoped to user-wide installs only — the npm postinstall hook
   does not refresh --project installs.
 
@@ -59,10 +70,12 @@ Examples:
   kcap plugin install --project --codex     # Codex hooks in <repo>/.codex/hooks.json, skills user-wide
   kcap plugin install --cursor              # Install Cursor hooks (~/.cursor/hooks.json)
   kcap plugin install --copilot             # Install Copilot hooks (~/.copilot/hooks/kcap.json)
+  kcap plugin install --gemini              # Install Gemini hooks (merge into ~/.gemini/settings.json)
   kcap plugin install --skills --if-installed   # Refresh skills if previously installed (used by npm postinstall)
   kcap plugin install --codex --if-installed    # Refresh Codex hooks if previously installed (used by npm postinstall)
   kcap plugin install --if-installed            # Refresh Claude plugin registration if previously installed
   kcap plugin remove --codex                # Remove Codex hooks + agent skills + legacy ~/.codex/skills
   kcap plugin remove --cursor               # Remove Cursor hooks from ~/.cursor/hooks.json
   kcap plugin remove --copilot              # Delete ~/.copilot/hooks/kcap.json
+  kcap plugin remove --gemini               # Remove kcap hooks from ~/.gemini/settings.json
   kcap plugin remove --skills               # Remove agent skills + legacy ~/.codex/skills

--- a/src/Capacitor.Cli.Core/Resources/help-setup.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-setup.txt
@@ -17,6 +17,8 @@ Options:
                               user-dir is detected (~/.cursor/).
   --skip-copilot-hooks        Don't install Copilot CLI hooks even if Copilot
                               is detected (~/.copilot/ or copilot on PATH).
+  --skip-gemini-hooks         Don't install Gemini CLI hooks even if Gemini
+                              is detected (~/.gemini/ or gemini on PATH).
   --use-provider-api-key <v>  In --no-prompt mode, set whether kcap keeps
                               ANTHROPIC_API_KEY / OPENAI_API_KEY in headless
                               agent spawns. Accepts true/1/yes/on or
@@ -28,10 +30,11 @@ Options:
 The setup wizard detects every supported coding agent: Claude Code and Codex CLI
 via PATH; Cursor via user-dir presence (~/.cursor/) so IDE-only users without
 the cursor shell command are covered; Copilot CLI via ~/.copilot/ or the
-copilot binary on PATH. One yes/no prompt is shown per detected agent. Hooks
-are installed user-wide. For project-scope or post-setup re-installs, use:
+copilot binary on PATH; Gemini CLI via ~/.gemini/ or the gemini binary on PATH.
+One yes/no prompt is shown per detected agent. Hooks are installed user-wide.
+For project-scope or post-setup re-installs, use:
 
-  kcap plugin install [--codex] [--cursor] [--copilot] [--project]
+  kcap plugin install [--codex] [--cursor] [--copilot] [--gemini] [--project]
 
 Legacy:
   --plugin-scope <user|project|skip>

--- a/src/Capacitor.Cli.Core/Resources/help-uninstall.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-uninstall.txt
@@ -3,10 +3,10 @@ kcap uninstall — Remove kcap configuration from this machine
 Usage: kcap uninstall [options]
 
 Stops any running daemons and watcher processes, strips kcap entries from
-user-level Claude Code, Codex CLI, and Cursor hook files, deletes kcap's
-Copilot hooks file (~/.copilot/hooks/kcap.json), removes agent skills
-(and any legacy ~/.codex/skills/kcap-* folders), and deletes the kcap
-config directory.
+user-level Claude Code, Codex CLI, Cursor, and Gemini (~/.gemini/settings.json)
+hook files, deletes kcap's Copilot hooks file (~/.copilot/hooks/kcap.json),
+removes agent skills (and any legacy ~/.codex/skills/kcap-* folders), and
+deletes the kcap config directory.
 
 Non-kcap entries in shared files (settings.json, hooks.json) are preserved.
 
@@ -24,7 +24,7 @@ Options:
 
 Notes:
   Per-agent selective cleanup is not exposed here — uninstall always touches
-  all known agents. Use `kcap plugin remove [--codex|--cursor|--copilot|--skills]`
+  all known agents. Use `kcap plugin remove [--codex|--cursor|--copilot|--gemini|--skills]`
   for finer-grained removal.
 
   Project-scope hooks installed in a directory other than the cwd's git root

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -42,7 +42,7 @@ Session:
   validate-plan [id]               Validate plan completion for a session
   eval [--model N] [--chain] [id]  Run LLM-as-judge evaluation over a session
   generate-whats-done [--codex] <id>  Generate what's-done summary (--codex uses `codex exec`)
-  import [vendor-filters] [options]   Import local sessions (Claude, Codex, Cursor, Copilot)
+  import [vendor-filters] [options]   Import local sessions (Claude, Codex, Cursor, Copilot, Gemini)
   set-title <title>                Set session title
   disable                          Stop recording and delete session data
   hide                             Hide session (owner-only visibility)
@@ -64,11 +64,12 @@ Maintenance:
   --version                        Show version
   --help                           Show this help
 
-Hooks (internal — invoked by Claude Code / Codex / Cursor / Copilot):
+Hooks (internal — invoked by Claude Code / Codex / Cursor / Copilot / Gemini):
   hook --claude                    Dispatch a Claude Code hook event (reads payload from stdin)
   hook --codex                     Dispatch a Codex CLI hook event
   hook --cursor                    Dispatch a Cursor IDE hook event
   hook --copilot --event <name>    Dispatch a GitHub Copilot CLI hook event
+  hook --gemini                    Dispatch a Gemini CLI hook event
 
 Environment:
   KCAP_URL              Server URL (overrides config file)

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -8,9 +8,12 @@ namespace Capacitor.Cli.Commands;
 /// can drive every branch without touching ~/.claude, ~/.codex, or AnsiConsole.
 /// </summary>
 internal static class CodingAgentsStep {
-    internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool SkipCopilot, bool SkipGemini, bool NoPrompt);
+    // SkipGemini / Gemini / GeminiHooksInstalled default so existing call sites
+    // (and the broad CodingAgentsStep test suite) compile unchanged — Gemini was
+    // added (AI-887) after the other four vendors.
+    internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool SkipCopilot, bool NoPrompt, bool SkipGemini = false);
 
-    internal record DetectedAgents(bool Claude, bool Codex, bool Cursor, bool Copilot, bool Gemini);
+    internal record DetectedAgents(bool Claude, bool Codex, bool Cursor, bool Copilot, bool Gemini = false);
 
     internal record Paths(
             string  ClaudeSettingsPath,
@@ -41,7 +44,7 @@ internal static class CodingAgentsStep {
             bool CodexSkillsInstalled,
             bool CursorHooksInstalled,
             bool CopilotHooksInstalled,
-            bool GeminiHooksInstalled
+            bool GeminiHooksInstalled = false
         ) {
         /// <summary>
         /// True when at least one agent's hooks were installed — i.e. there's a

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -188,7 +188,7 @@ internal static class CodingAgentsStep {
         var ok = installers.InstallGeminiHooks(paths.GeminiSettingsPath);
 
         if (!ok) {
-            writeLine("  [yellow]⚠[/] Could not write Gemini settings file.");
+            writeLine("  [yellow]⚠[/] Could not install Gemini hooks — ensure settings.json is valid JSON (left untouched).");
 
             return false;
         }

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -8,9 +8,9 @@ namespace Capacitor.Cli.Commands;
 /// can drive every branch without touching ~/.claude, ~/.codex, or AnsiConsole.
 /// </summary>
 internal static class CodingAgentsStep {
-    internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool SkipCopilot, bool NoPrompt);
+    internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool SkipCopilot, bool SkipGemini, bool NoPrompt);
 
-    internal record DetectedAgents(bool Claude, bool Codex, bool Cursor, bool Copilot);
+    internal record DetectedAgents(bool Claude, bool Codex, bool Cursor, bool Copilot, bool Gemini);
 
     internal record Paths(
             string  ClaudeSettingsPath,
@@ -19,6 +19,7 @@ internal static class CodingAgentsStep {
             string  CodexHooksPath,
             string  CursorHooksPath,
             string  CopilotHooksPath,
+            string  GeminiSettingsPath,
             string  AgentsSkillsDir,
             string  LegacyCodexSkillsDir
         );
@@ -28,6 +29,7 @@ internal static class CodingAgentsStep {
             Func<string /*hooksPath*/, bool>                          InstallCodexHooks,
             Func<string /*hooksPath*/, bool>                          InstallCursorHooks,
             Func<string /*hooksPath*/, bool>                          InstallCopilotHooks,
+            Func<string /*settingsPath*/, bool>                       InstallGeminiHooks,
             Func<bool>                                                CapacitorOnPath,
             Func<string /*srcDir*/, string /*dstDir*/, bool>          InstallAgentSkills,
             Func<string /*legacyDir*/, bool>                          CleanLegacyCodexSkills
@@ -38,7 +40,8 @@ internal static class CodingAgentsStep {
             bool CodexHooksInstalled,
             bool CodexSkillsInstalled,
             bool CursorHooksInstalled,
-            bool CopilotHooksInstalled
+            bool CopilotHooksInstalled,
+            bool GeminiHooksInstalled
         ) {
         /// <summary>
         /// True when at least one agent's hooks were installed — i.e. there's a
@@ -48,7 +51,7 @@ internal static class CodingAgentsStep {
         /// as agents are added (consumers like SetupCommand's restart tip key off this).
         /// </summary>
         internal bool AnyHooksInstalled =>
-            ClaudeInstalled || CodexHooksInstalled || CursorHooksInstalled || CopilotHooksInstalled;
+            ClaudeInstalled || CodexHooksInstalled || CursorHooksInstalled || CopilotHooksInstalled || GeminiHooksInstalled;
     }
 
     /// <summary>
@@ -69,9 +72,10 @@ internal static class CodingAgentsStep {
         var codexSkillsInstalled  = codexHooksInstalled && HandleCodexSkills(paths, installers, writeLine);
         var cursorHooksInstalled  = HandleCursorHooks(options, detected, paths, installers, prompt, writeLine);
         var copilotHooksInstalled = HandleCopilotHooks(options, detected, paths, installers, prompt, writeLine);
+        var geminiHooksInstalled  = HandleGeminiHooks(options, detected, paths, installers, prompt, writeLine);
 
-        if (detected is { Claude: false, Codex: false, Cursor: false, Copilot: false }) {
-            writeLine("  [yellow]⚠ No supported agent CLI detected.[/] Install Claude Code, Codex CLI, Cursor, or Copilot CLI to start capturing sessions.");
+        if (detected is { Claude: false, Codex: false, Cursor: false, Copilot: false, Gemini: false }) {
+            writeLine("  [yellow]⚠ No supported agent CLI detected.[/] Install Claude Code, Codex CLI, Cursor, Copilot CLI, or Gemini CLI to start capturing sessions.");
         }
 
         return Task.FromResult(
@@ -80,7 +84,8 @@ internal static class CodingAgentsStep {
                 codexHooksInstalled,
                 codexSkillsInstalled,
                 cursorHooksInstalled,
-                copilotHooksInstalled
+                copilotHooksInstalled,
+                geminiHooksInstalled
             )
         );
     }
@@ -134,6 +139,59 @@ internal static class CodingAgentsStep {
 
         writeLine($"  [green]✓[/] Copilot hooks installed ({Markup.Escape(paths.CopilotHooksPath)})");
         writeLine("  [dim]  Note: Copilot loads hook config at startup — restart any running copilot session to pick them up.[/]");
+
+        return true;
+    }
+
+    static bool HandleGeminiHooks(
+            Options            options,
+            DetectedAgents     detected,
+            Paths              paths,
+            Installers         installers,
+            Func<string, bool> prompt,
+            Action<string>     writeLine
+        ) {
+        if (!detected.Gemini) {
+            writeLine("  [dim]· Gemini CLI not detected — skipping[/]");
+
+            return false;
+        }
+
+        writeLine("  [green]✓[/] Gemini CLI detected");
+
+        if (options.SkipGemini) {
+            writeLine("  [dim]· Gemini CLI hooks skipped by flag[/]");
+
+            return false;
+        }
+
+        var shouldInstall = options.NoPrompt || prompt("Install Gemini CLI hooks?");
+
+        if (!shouldInstall) {
+            writeLine("  [dim]· Gemini hooks not installed (you can run kcap plugin install --gemini later)[/]");
+
+            return false;
+        }
+
+        // settings.json writes the bare "kcap hook --gemini" command and relies
+        // on Gemini finding it on PATH — same precheck as the Cursor/Copilot branch.
+        if (!installers.CapacitorOnPath()) {
+            writeLine("  [yellow]⚠[/] Gemini hooks not installed — 'kcap' is not on PATH.");
+            writeLine("    [dim]Re-install via npm: [/][cyan]npm install -g @kurrent/kcap[/]");
+
+            return false;
+        }
+
+        var ok = installers.InstallGeminiHooks(paths.GeminiSettingsPath);
+
+        if (!ok) {
+            writeLine("  [yellow]⚠[/] Could not write Gemini settings file.");
+
+            return false;
+        }
+
+        writeLine($"  [green]✓[/] Gemini hooks installed ({Markup.Escape(paths.GeminiSettingsPath)})");
+        writeLine("  [dim]  Note: Gemini loads hook config at startup — restart any running gemini session to pick them up.[/]");
 
         return true;
     }

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -1,0 +1,268 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// Single-binary dispatcher for Google Gemini CLI hooks (AI-887). Unlike
+/// Copilot, Gemini's command-hook stdin payload carries a uniform
+/// <c>hook_event_name</c> (PascalCase: <c>SessionStart</c> / <c>SessionEnd</c> /
+/// <c>Notification</c>), so this dispatcher self-routes on it like Claude — the
+/// installer registers a single <c>kcap hook --gemini</c> command per event.
+/// </summary>
+/// <remarks>
+/// Wire contract (Gemini event → server route):
+///   SessionStart → POST /hooks/session-start/gemini, then spawn the watcher
+///                  tailing the payload's <c>transcript_path</c>
+///                  (<c>~/.gemini/tmp/&lt;project&gt;/chats/session-*.jsonl</c>)
+///                  with vendor=gemini. Gemini re-fires with source:"resume" on
+///                  the same session id and appends to the same transcript file,
+///                  so the server's deterministic lifecycle ids make the re-POST
+///                  idempotent and the watcher resumes from the server watermark.
+///   SessionEnd   → kill watcher + capped inline drain (mirror of the Copilot /
+///                  Claude AI-813 pre-drain cap), then POST /hooks/session-end/gemini.
+///   Notification → best-effort forward to the Claude-shaped /hooks/notification.
+/// Gemini treats hook stdout as a JSON decision channel; this dispatcher emits
+/// nothing (no stdout) so every action is allowed.
+/// </remarks>
+static class GeminiHookCommand {
+    // Mirror of CopilotHookCommand.PreHookDrainCap (AI-813): the drain must
+    // never starve the session-end POST, or the session sticks "Active".
+    static readonly TimeSpan PreHookDrainCap = TimeSpan.FromSeconds(8);
+
+    // Notification forwarding is telemetry — a stalled server must not block
+    // Gemini's turn loop.
+    static readonly TimeSpan NotificationPostBudget = TimeSpan.FromSeconds(2);
+
+    public static async Task<int> Handle(string baseUrl, TextReader stdin) {
+        var body = await stdin.ReadToEndAsync();
+
+        JsonNode? node;
+        try {
+            node = JsonNode.Parse(body);
+        } catch {
+            // Best effort — never crash the host CLI on a malformed payload.
+            return 0;
+        }
+
+        if (node is null) return 0;
+
+        var eventName = TryGetString(node, "hook_event_name");
+        if (string.IsNullOrEmpty(eventName)) return 0;
+
+        // Gemini session ids are dashed UUIDs; keep the dashless form for the
+        // server (AgentSession-{dashless} convention shared by every vendor).
+        var dashedSessionId = TryGetString(node, "session_id");
+        if (string.IsNullOrEmpty(dashedSessionId) || !Guid.TryParse(dashedSessionId, out _)) return 0;
+
+        var sessionId = dashedSessionId.Replace("-", "");
+
+        // Mirror the Claude/Codex/Copilot disabled-session fast path: `kcap
+        // disable` must stop every POST and watcher restart for the session.
+        if (DisabledSessions.IsDisabled(sessionId)) {
+            if (eventName == "SessionEnd") DisabledSessions.RemoveMarker(sessionId);
+            return 0;
+        }
+
+        var cwd           = TryGetString(node, "cwd");
+        var activeProfile = await AppConfig.GetActiveProfileAsync();
+
+        if (activeProfile?.ExcludedPaths is { Length: > 0 } excludedPaths
+         && PathExclusion.IsExcluded(cwd, excludedPaths)) {
+            return 0;
+        }
+
+        return eventName switch {
+            "SessionStart" => await HandleSessionStart(baseUrl, node, sessionId, cwd, activeProfile),
+            "SessionEnd"   => await HandleSessionEnd(baseUrl, node, sessionId, cwd),
+            "Notification" => await HandleNotification(baseUrl, node, sessionId, cwd),
+            _              => 0   // unknown / unsubscribed — fail-open like the other dispatchers
+        };
+    }
+
+    static async Task<int> HandleSessionStart(
+            string   baseUrl,
+            JsonNode node,
+            string   sessionId,
+            string?  cwd,
+            Profile? activeProfile
+        ) {
+        var source = TryGetString(node, "source") is { Length: > 0 } s ? s : "startup";
+
+        var forwarded = new JsonObject {
+            ["hook_event_name"] = "SessionStart",
+            ["session_id"]      = sessionId,
+            ["source"]          = source,
+            ["home_dir"]        = PathHelpers.HomeDirectory
+        };
+
+        if (cwd is not null) forwarded["cwd"] = cwd;
+
+        // Gemini stamps hook payloads with an ISO-8601 `timestamp`; forward it
+        // as started_at so canonical SessionStarted carries the real start time
+        // (the server falls back to UtcNow when absent).
+        if (TryGetIsoTimestamp(node, "timestamp") is { } startedAt) {
+            forwarded["started_at"] = startedAt.ToString("O");
+        }
+
+        if (Environment.GetEnvironmentVariable("KCAP_AGENT_ID") is { } agentHostId) {
+            forwarded["agent_host_id"] = agentHostId;
+        }
+
+        // Stamp default visibility BEFORE enrichment so it survives the
+        // JsonString round-trip (same rationale as the Codex/Copilot path).
+        if (activeProfile?.DefaultVisibility is { } visibility) {
+            forwarded["default_visibility"] = visibility;
+        }
+
+        var enriched = await RepositoryDetection.EnrichWithRepositoryInfo(forwarded.ToJsonString());
+
+        if (activeProfile?.ExcludedRepos is { Length: > 0 } excludedRepos
+         && await RepoExclusion.IsExcludedAsync(enriched, excludedRepos)) {
+            DisabledSessions.Mark(sessionId);
+            return 0;
+        }
+
+        var exit = await PostHookAsync(baseUrl, "session-start/gemini", enriched);
+        if (exit != 0) return exit;
+
+        EnsureWatcher(baseUrl, sessionId, node, cwd, source);
+        await Task.CompletedTask;
+        return 0;
+    }
+
+    static async Task<int> HandleSessionEnd(string baseUrl, JsonNode node, string sessionId, string? cwd) {
+        var transcriptPath = TryGetString(node, "transcript_path");
+
+        // Kill watcher + inline-drain BEFORE the POST so the server computes
+        // stats over the full transcript — capped so a slow drain can't starve
+        // the session-end POST. Only drain when Gemini gave us a transcript path
+        // (it always does today; defensive otherwise).
+        if (!string.IsNullOrEmpty(transcriptPath)) {
+            try {
+                var drained = await TimeBudget.RunCappedAsync(
+                    async () => {
+                        await WatcherManager.KillWatcher(sessionId);
+                        await WatcherManager.InlineDrainAsync(baseUrl, sessionId, transcriptPath, agentId: null, vendor: "gemini");
+                    },
+                    PreHookDrainCap
+                );
+
+                if (!drained) {
+                    await Console.Error.WriteLineAsync(
+                        $"[kcap] gemini session-end pre-drain cap ({PreHookDrainCap.TotalSeconds:0}s) elapsed; proceeding to POST. "
+                      + $"Transcript tail may be incomplete — recoverable via: kcap import --gemini --session {sessionId}"
+                    );
+                }
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"[kcap] gemini session-end pre-hook failed: {ex.Message}");
+            }
+        }
+
+        var forwarded = new JsonObject {
+            ["hook_event_name"] = "SessionEnd",
+            ["session_id"]      = sessionId,
+            ["reason"]          = TryGetString(node, "reason") ?? "exit",
+            ["home_dir"]        = PathHelpers.HomeDirectory
+        };
+
+        if (cwd is not null) forwarded["cwd"] = cwd;
+
+        if (TryGetIsoTimestamp(node, "timestamp") is { } endedAt) {
+            forwarded["ended_at"] = endedAt.ToString("O");
+        }
+
+        if (Environment.GetEnvironmentVariable("KCAP_AGENT_ID") is { } agentHostId) {
+            forwarded["agent_host_id"] = agentHostId;
+        }
+
+        return await PostHookAsync(baseUrl, "session-end/gemini", forwarded.ToJsonString());
+    }
+
+    static async Task<int> HandleNotification(string baseUrl, JsonNode node, string sessionId, string? cwd) {
+        // The server's NotificationHook requires message + notification_type.
+        var message          = TryGetString(node, "message");
+        var notificationType = TryGetString(node, "notification_type")
+                            ?? TryGetString(node, "notificationType");
+
+        if (message is null || notificationType is null) return 0;
+
+        var forwarded = new JsonObject {
+            ["hook_event_name"]   = "Notification",
+            ["session_id"]        = sessionId,
+            ["message"]           = message,
+            ["notification_type"] = notificationType,
+            ["home_dir"]          = PathHelpers.HomeDirectory
+        };
+
+        if (cwd is not null) forwarded["cwd"] = cwd;
+
+        using var cts = new CancellationTokenSource(NotificationPostBudget);
+        try {
+            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, cts.Token);
+            using var content = new StringContent(forwarded.ToJsonString(), Encoding.UTF8, "application/json");
+            using var _       = await client.PostAsync($"{baseUrl}/hooks/notification", content, cts.Token);
+        } catch {
+            // Recording must never fail the hook.
+        }
+
+        return 0;
+    }
+
+    static void EnsureWatcher(string baseUrl, string sessionId, JsonNode node, string? cwd, string source) {
+        // Gemini hands us the transcript path directly (no derivation needed,
+        // unlike Copilot). Empty/absent → skip (can't tail nothing).
+        var transcriptPath = TryGetString(node, "transcript_path");
+        if (string.IsNullOrEmpty(transcriptPath)) return;
+
+        // Skip title (re)generation on resume/clear — the session already has
+        // one and resume appends to the same transcript.
+        var skipTitle = source is "resume" or "clear";
+
+        _ = WatcherManager.EnsureWatcherRunning(
+            baseUrl, sessionId, transcriptPath,
+            agentId: null, sessionIdOverride: null, cwd: cwd,
+            skipTitle: skipTitle, vendor: "gemini"
+        );
+    }
+
+    static async Task<int> PostHookAsync(string baseUrl, string endpoint, string body) {
+        using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        try {
+            var resp = await client.PostWithRetryAsync($"{baseUrl}/hooks/{endpoint}", content);
+
+            if (!resp.IsSuccessStatusCode) {
+                Console.Error.WriteLine($"[kcap] gemini-hook {endpoint}: HTTP {(int)resp.StatusCode}");
+                return 1;
+            }
+
+            return 0;
+        } catch (HttpRequestException ex) {
+            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
+            return 1;
+        }
+    }
+
+    static DateTimeOffset? TryGetIsoTimestamp(JsonNode? node, string fieldName) {
+        if (node?[fieldName] is JsonValue v
+         && v.TryGetValue<string>(out var s)
+         && DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var ts)) {
+            return ts;
+        }
+
+        return null;
+    }
+
+    static string? TryGetString(JsonNode? node, string fieldName) {
+        if (node?[fieldName] is JsonValue v && v.TryGetValue<string>(out var s)) {
+            return s;
+        }
+
+        return null;
+    }
+}

--- a/src/Capacitor.Cli/Commands/GeminiImportSource.cs
+++ b/src/Capacitor.Cli/Commands/GeminiImportSource.cs
@@ -1,0 +1,399 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Gemini;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// Discover + classify + import historical Google Gemini CLI sessions from
+/// <c>~/.gemini/tmp/&lt;project&gt;/chats/session-&lt;ISO&gt;-&lt;shortId&gt;.jsonl</c>.
+/// Each file is one session in Gemini's native chat-recording format — the
+/// same lines the live watcher streams — so historical and live import
+/// converge on the server's <c>GeminiTranscriptNormalizer</c>.
+///
+/// <para>The full (dashed) session id lives in the file's header record
+/// (<c>sessionId</c>), not the filename (which carries only the 8-char shortId).
+/// Gemini does not record the workspace path in a machine-readable header, so
+/// import leaves <c>cwd</c> null (no repo enrichment / exclusion on historical
+/// import — a v1 limitation; live capture gets cwd from the hook payload). The
+/// <c>--cwd</c> filter is honoured best-effort against the project-dir basename.</para>
+/// </summary>
+internal sealed class GeminiImportSource : IImportSource {
+    readonly string _tmpDir;
+
+    public GeminiImportSource(string? tmpDirOverride = null) {
+        _tmpDir = tmpDirOverride ?? GeminiPaths.TmpDir();
+    }
+
+    static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+    public string Vendor => "gemini";
+
+    public bool IsAvailable => Directory.Exists(_tmpDir);
+
+    /// <summary>
+    /// False — Gemini doesn't name its sessions, so there's no CLI-side title
+    /// to forward; the server computes a fallback title from the first user
+    /// message at session-end (same as the Copilot routed path).
+    /// </summary>
+    public bool SupportsTitleGeneration => false;
+
+    public Task<IReadOnlyList<DiscoveredSession>> DiscoverAsync(DiscoveryFilters filters, CancellationToken ct) {
+        var sessionFilter = filters.FilterSession is { } sf ? ImportCommand.NormalizeGuid(sf) : null;
+        var cwdBasename   = filters.FilterCwd is { } fc ? Path.GetFileName(fc.TrimEnd('/', '\\')) : null;
+        var sinceUtc      = filters.Since is { } since
+            ? new DateTimeOffset(since.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc), TimeSpan.Zero)
+            : (DateTimeOffset?)null;
+
+        var result = new List<DiscoveredSession>();
+        var seen   = new HashSet<string>(StringComparer.Ordinal);
+
+        if (!Directory.Exists(_tmpDir)) {
+            return Task.FromResult<IReadOnlyList<DiscoveredSession>>(result);
+        }
+
+        foreach (var projectDir in Directory.EnumerateDirectories(_tmpDir)) {
+            ct.ThrowIfCancellationRequested();
+
+            if (cwdBasename is not null
+             && !string.Equals(Path.GetFileName(projectDir), cwdBasename, PathComparison)) {
+                continue;
+            }
+
+            var chatsDir = GeminiPaths.ChatsDir(projectDir);
+            if (!Directory.Exists(chatsDir)) continue;
+
+            foreach (var file in Directory.EnumerateFiles(chatsDir, "session-*.jsonl")) {
+                var (sessionId, startTime) = ReadHeader(file);
+
+                if (sessionId is null || !Guid.TryParse(sessionId, out _)) continue;
+
+                var dashless = sessionId.Replace("-", "");
+
+                if (!seen.Add(dashless)) continue;
+                if (sessionFilter is not null && !string.Equals(dashless, sessionFilter, StringComparison.Ordinal))
+                    continue;
+
+                var firstTimestamp = startTime;
+                if (firstTimestamp is null) {
+                    try { firstTimestamp = File.GetCreationTimeUtc(file); } catch { /* best effort */ }
+                }
+
+                if (sinceUtc is { } cutoff && firstTimestamp is { } ts && ts < cutoff) continue;
+
+                result.Add(new DiscoveredSession(
+                    SessionId:      dashless,
+                    Vendor:         Vendor,
+                    Cwd:            null,
+                    FirstTimestamp: firstTimestamp,
+                    SourceMeta:     new Dictionary<string, object?> {
+                        ["TranscriptPath"] = file,
+                    }));
+            }
+        }
+
+        return Task.FromResult<IReadOnlyList<DiscoveredSession>>(result);
+    }
+
+    public async Task<IReadOnlyList<ImportCommand.SessionClassification>> ClassifyAsync(
+            IReadOnlyList<DiscoveredSession> sessions,
+            ClassifyContext                  ctx,
+            CancellationToken                ct
+        ) {
+        var results = new List<ImportCommand.SessionClassification>(sessions.Count);
+
+        foreach (var s in sessions) {
+            var transcriptPath = (string)s.SourceMeta!["TranscriptPath"]!;
+
+            var meta = new SessionMetadata {
+                SessionId      = s.SessionId,
+                Cwd            = s.Cwd,
+                FirstTimestamp = s.FirstTimestamp,
+            };
+
+            int? lastNonBlankIndex;
+            int? lastRelevantIndex;
+            int  nonBlankCount;
+            try {
+                (lastNonBlankIndex, lastRelevantIndex, nonBlankCount) = await ReadTranscriptStatsAsync(transcriptPath, ct);
+            } catch {
+                results.Add(MakeClassification(s, meta, ImportCommand.ClassificationStatus.ProbeError, totalLines: 0,
+                                               probeErrorReason: "transcript read failed"));
+                continue;
+            }
+
+            if (lastNonBlankIndex is null) {
+                results.Add(MakeClassification(s, meta, ImportCommand.ClassificationStatus.ProbeError, totalLines: 0,
+                                               probeErrorReason: "empty transcript"));
+                continue;
+            }
+
+            if (nonBlankCount < ctx.MinLines) {
+                results.Add(MakeClassification(s, meta, ImportCommand.ClassificationStatus.TooShort, totalLines: nonBlankCount));
+                continue;
+            }
+
+            int? serverLastLine;
+            try {
+                serverLastLine = await FetchServerLastLineAsync(ctx.HttpClient, ctx.BaseUrl, s.SessionId, ct);
+            } catch {
+                results.Add(MakeClassification(s, meta, ImportCommand.ClassificationStatus.ProbeError, totalLines: nonBlankCount,
+                                               probeErrorReason: "watermark probe failed"));
+                continue;
+            }
+
+            meta.LastTimestamp = TryGetLastWriteUtc(transcriptPath);
+
+            var status       = ImportCommand.ClassificationStatus.New;
+            var resumeFromLn = 0;
+
+            // Compare the server watermark against the last IMPORT-RELEVANT line,
+            // not the last raw line: Gemini transcripts end with normalizer-skipped
+            // records ($set mutation ops, lastUpdated bumps), so a raw-tail compare
+            // would re-classify a complete session Partial forever.
+            var lastImportable = lastRelevantIndex ?? lastNonBlankIndex.Value;
+
+            if (serverLastLine is { } srv) {
+                if (srv >= lastImportable) {
+                    status = ImportCommand.ClassificationStatus.AlreadyLoaded;
+                } else {
+                    status       = ImportCommand.ClassificationStatus.Partial;
+                    resumeFromLn = srv + 1;
+                }
+            }
+
+            results.Add(new ImportCommand.SessionClassification {
+                SessionId       = s.SessionId,
+                // Empty FilePath keeps Gemini on the routed phase (ImportSessionAsync)
+                // instead of the Claude/Codex chain worker — same contract as Copilot.
+                FilePath        = "",
+                EncodedCwd      = "",
+                Meta            = meta,
+                Status          = status,
+                Vendor          = Vendor,
+                ResumeFromLine  = resumeFromLn,
+                TotalLines      = nonBlankCount,
+                SourceMeta      = s.SourceMeta,
+            });
+        }
+
+        return results;
+    }
+
+    public async Task<ImportOutcome> ImportSessionAsync(
+            ImportCommand.SessionClassification classification,
+            ImportContext                       ctx,
+            CancellationToken                   ct
+        ) {
+        var transcriptPath = (string)classification.SourceMeta!["TranscriptPath"]!;
+
+        if (!File.Exists(transcriptPath)) return ImportOutcome.Failed;
+
+        // Lifecycle-before-transcript ordering (see CopilotImportSource): a
+        // transcript that advances the watermark past a failed lifecycle POST
+        // would leave the session permanently lifecycle-less. Re-runs are
+        // idempotent server-side (deterministic lifecycle event ids).
+        var startOk = await PostSyntheticHookAsync(
+            ctx.HttpClient, ctx.BaseUrl, "session-start/gemini",
+            BuildSessionStartPayload(classification.SessionId, classification.Meta.FirstTimestamp),
+            ct);
+        if (!startOk) return ImportOutcome.Failed;
+
+        var startLine = classification.Status switch {
+            ImportCommand.ClassificationStatus.Partial       => classification.ResumeFromLine,
+            ImportCommand.ClassificationStatus.AlreadyLoaded => classification.TotalLines,
+            _                                                => 0,
+        };
+
+        int sent;
+        try {
+            sent = await SessionImporter.SendTranscriptBatches(
+                httpClient: ctx.HttpClient,
+                baseUrl:    ctx.BaseUrl,
+                sessionId:  classification.SessionId,
+                filePath:   transcriptPath,
+                agentId:    null,
+                startLine:  startLine,
+                vendor:     Vendor);
+        } catch {
+            return ImportOutcome.Failed;
+        }
+
+        var endOk = await PostSyntheticHookAsync(
+            ctx.HttpClient, ctx.BaseUrl, "session-end/gemini",
+            BuildSessionEndPayload(classification.SessionId, classification.Meta.LastTimestamp),
+            ct);
+        if (!endOk) return ImportOutcome.Failed;
+
+        if (sent == 0) return startLine > 0 ? ImportOutcome.Resumed : ImportOutcome.Skipped;
+
+        return startLine > 0 ? ImportOutcome.Resumed : ImportOutcome.Loaded;
+    }
+
+    static JsonObject BuildSessionStartPayload(string sessionId, DateTimeOffset? startedAt) {
+        var payload = new JsonObject {
+            ["hook_event_name"] = "SessionStart",
+            ["session_id"]      = sessionId,
+            ["source"]          = "startup",
+        };
+        if (startedAt is { } ts) payload["started_at"] = ts.ToString("O");
+        return payload;
+    }
+
+    static JsonObject BuildSessionEndPayload(string sessionId, DateTimeOffset? endedAt) {
+        var payload = new JsonObject {
+            ["hook_event_name"] = "SessionEnd",
+            ["session_id"]      = sessionId,
+            ["reason"]          = "gemini-import",
+        };
+        if (endedAt is { } ts) payload["ended_at"] = ts.ToString("O");
+        return payload;
+    }
+
+    static async Task<bool> PostSyntheticHookAsync(
+        HttpClient client, string baseUrl, string routeSegment, JsonObject payload, CancellationToken ct
+    ) {
+        try {
+            using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+            using var resp    = await client.PostWithRetryAsync($"{baseUrl}/hooks/{routeSegment}", content, ct: ct);
+            return resp.IsSuccessStatusCode;
+        } catch {
+            return false;
+        }
+    }
+
+    static DateTimeOffset? TryGetLastWriteUtc(string path) {
+        try { return File.GetLastWriteTimeUtc(path); } catch { return null; }
+    }
+
+    static ImportCommand.SessionClassification MakeClassification(
+        DiscoveredSession                  s,
+        SessionMetadata                    meta,
+        ImportCommand.ClassificationStatus status,
+        int                                totalLines,
+        string?                            probeErrorReason = null
+    ) => new() {
+        SessionId        = s.SessionId,
+        FilePath         = "",
+        EncodedCwd       = "",
+        Meta             = meta,
+        Status           = status,
+        Vendor           = "gemini",
+        ProbeErrorReason = probeErrorReason,
+        TotalLines       = totalLines,
+        SourceMeta       = s.SourceMeta,
+    };
+
+    /// <summary>
+    /// Reads the session's header record (first non-blank line) for the full
+    /// dashed <c>sessionId</c> and <c>startTime</c>. Gemini always writes the
+    /// header first; if the first line isn't one, bail rather than scan the
+    /// whole file.
+    /// </summary>
+    static (string? SessionId, DateTimeOffset? StartTime) ReadHeader(string path) {
+        try {
+            foreach (var line in File.ReadLines(path)) {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+
+                using var doc  = JsonDocument.Parse(line);
+                var       root = doc.RootElement;
+
+                if (root.Str("sessionId") is not { } sid) return (null, null);
+
+                DateTimeOffset? start = null;
+                if (root.Str("startTime") is { } s
+                 && DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var ts)) {
+                    start = ts;
+                }
+
+                return (sid, start);
+            }
+        } catch { /* unreadable / malformed → skip */ }
+
+        return (null, null);
+    }
+
+    static async Task<(int? LastNonBlankIndex, int? LastRelevantIndex, int NonBlankCount)> ReadTranscriptStatsAsync(
+        string transcriptPath, CancellationToken ct
+    ) {
+        await using var stream = new FileStream(transcriptPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var       reader = new StreamReader(stream);
+
+        int? lastIdx         = null;
+        int? lastRelevantIdx = null;
+        var  count           = 0;
+        var  lineIdx         = 0;
+
+        while (await reader.ReadLineAsync(ct) is { } line) {
+            if (!string.IsNullOrWhiteSpace(line)) {
+                lastIdx = lineIdx;
+                count++;
+
+                if (IsImportRelevantLine(line)) lastRelevantIdx = lineIdx;
+            }
+            lineIdx++;
+        }
+
+        return (lastIdx, lastRelevantIdx, count);
+    }
+
+    /// <summary>
+    /// True when the line maps to at least one canonical event under the
+    /// server's GeminiTranscriptNormalizer: a <c>gemini</c> message (always
+    /// emits thinking/text/tool events), or a <c>user</c> message carrying real
+    /// text (NOT the <c>&lt;session_context&gt;</c> bootstrap and NOT a
+    /// <c>functionResponse</c>-only tool-result echo). Header records and
+    /// <c>$set</c> mutation ops are skipped server-side and can never advance
+    /// the watermark — keep this in sync with the normalizer.
+    /// </summary>
+    internal static bool IsImportRelevantLine(string line) {
+        try {
+            using var doc  = JsonDocument.Parse(line);
+            var       root = doc.RootElement;
+
+            if (root.Obj("$set") is not null) return false;
+
+            var type = root.Str("type");
+            if (type == "gemini") return true;
+            if (type != "user") return false; // header (no type) or unknown
+
+            if (root.Str("content") is { } direct) {
+                return direct.Length > 0 && !direct.StartsWith("<session_context>", StringComparison.Ordinal);
+            }
+
+            if (root.Arr("content") is { } parts) {
+                foreach (var part in parts.EnumerateArray()) {
+                    if (part.Str("text") is { Length: > 0 } txt
+                     && !txt.StartsWith("<session_context>", StringComparison.Ordinal)) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        } catch {
+            return false;
+        }
+    }
+
+    static async Task<int?> FetchServerLastLineAsync(HttpClient http, string baseUrl, string sessionId, CancellationToken ct) {
+        using var resp = await http.GetWithRetryAsync($"{baseUrl}/api/sessions/{sessionId}/last-line", ct: ct);
+
+        if (resp.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.NoContent) return null;
+        if (!resp.IsSuccessStatusCode) throw new HttpRequestException($"watermark probe returned {(int)resp.StatusCode}");
+
+        var       body = await resp.Content.ReadAsStringAsync(ct);
+        using var doc  = JsonDocument.Parse(body);
+
+        return doc.RootElement.TryGetProperty("last_line_number", out var ln) && ln.ValueKind == JsonValueKind.Number
+            ? ln.GetInt32()
+            : null;
+    }
+}

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -943,7 +943,9 @@ public static class PluginCommand {
                     }
                 }
 
-                preserved.Add(GeminiHooksParser.BuildKcapEntry());
+                // Cast to JsonNode so this binds to JsonArray.Add(JsonNode?), not
+                // the generic Add<T>(T) — the generic trips IL2026/IL3050 under AOT.
+                preserved.Add((JsonNode)GeminiHooksParser.BuildKcapEntry());
                 hooks[evt] = preserved;
             }
 

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Copilot;
 using Capacitor.Cli.Core.Cursor;
+using Capacitor.Cli.Core.Gemini;
 
 namespace Capacitor.Cli.Commands;
 
@@ -35,7 +36,7 @@ public static class PluginCommand {
         };
     }
 
-    static readonly string[] ExclusiveTargetFlags = ["--codex", "--cursor", "--copilot", "--skills"];
+    static readonly string[] ExclusiveTargetFlags = ["--codex", "--cursor", "--copilot", "--gemini", "--skills"];
 
     static bool HasConflictingTargets(string[] args) =>
         ExclusiveTargetFlags.Count(args.Contains) > 1;
@@ -43,7 +44,7 @@ public static class PluginCommand {
     static async Task<int> Install(string[] args, PluginEnvironment env) {
         if (HasConflictingTargets(args)) {
             await env.Stderr.WriteLineAsync(
-                "--cursor, --codex, --copilot, and --skills are mutually exclusive."
+                "--cursor, --codex, --copilot, --gemini, and --skills are mutually exclusive."
             );
 
             return 1;
@@ -53,6 +54,7 @@ public static class PluginCommand {
         if (args.Contains("--codex")) return await InstallCodex(args, env);
         if (args.Contains("--cursor")) return await InstallCursor(args, env);
         if (args.Contains("--copilot")) return await InstallCopilot(args, env);
+        if (args.Contains("--gemini")) return await InstallGemini(args, env);
 
         return await InstallClaude(args, env);
     }
@@ -60,7 +62,7 @@ public static class PluginCommand {
     static async Task<int> Remove(string[] args, PluginEnvironment env) {
         if (HasConflictingTargets(args)) {
             await env.Stderr.WriteLineAsync(
-                "--cursor, --codex, --copilot, and --skills are mutually exclusive."
+                "--cursor, --codex, --copilot, --gemini, and --skills are mutually exclusive."
             );
 
             return 1;
@@ -70,6 +72,7 @@ public static class PluginCommand {
         if (args.Contains("--codex")) return await RemoveCodex(args, env);
         if (args.Contains("--cursor")) return await RemoveCursor(args, env);
         if (args.Contains("--copilot")) return await RemoveCopilot(args, env);
+        if (args.Contains("--gemini")) return await RemoveGemini(args, env);
 
         return await RemoveClaude(args, env);
     }
@@ -830,6 +833,156 @@ public static class PluginCommand {
         if (changed) {
             File.WriteAllText(hooksPath, root.ToJsonString(WriteOpts));
             CursorHooksInstaller.DeleteMarker(hooksPath);
+        }
+
+        return changed;
+    }
+
+    static async Task<int> InstallGemini(string[] args, PluginEnvironment env) {
+        var settingsPath = GetArg(args, "--gemini-settings-path") ?? env.GeminiSettingsJson;
+
+        var refreshOnly = args.Contains("--if-installed");
+
+        switch (refreshOnly) {
+            case true when !GeminiHooksInstaller.IsInstalled(settingsPath):
+            case true when GeminiHooksInstaller.ReadMarker(settingsPath) == CapacitorVersion.Current():
+                return 0;
+            // Gemini's settings.json writes the bare `kcap hook --gemini` command;
+            // verify Gemini will actually find kcap on PATH. Skip on the
+            // postinstall (--if-installed) refresh, same as the Cursor branch.
+            case false when !AgentDetector.IsInstalled("kcap"):
+                await env.Stderr.WriteLineAsync(
+                    "Cannot install Gemini hooks: 'kcap' is not on PATH. "
+                  + "Re-install kcap via npm: npm install -g @kurrent/kcap"
+                );
+
+                return 1;
+        }
+
+        if (!InstallGeminiHooks(settingsPath)) {
+            if (refreshOnly) return 0;
+
+            await env.Stderr.WriteLineAsync("Could not write Gemini settings file.");
+
+            return 1;
+        }
+
+        await env.Stdout.WriteLineAsync(
+            refreshOnly
+                ? $"Gemini hooks refreshed ({settingsPath})"
+                : $"Gemini hooks installed ({settingsPath})"
+        );
+
+        return 0;
+    }
+
+    static async Task<int> RemoveGemini(string[] args, PluginEnvironment env) {
+        var settingsPath = GetArg(args, "--gemini-settings-path") ?? env.GeminiSettingsJson;
+
+        if (!File.Exists(settingsPath)) {
+            await env.Stdout.WriteLineAsync("Nothing to remove — Gemini settings file not found.");
+
+            return 0;
+        }
+
+        try {
+            var removed = RemoveGeminiHooks(settingsPath);
+
+            await env.Stdout.WriteLineAsync(
+                removed
+                    ? $"Gemini hooks removed ({settingsPath})"
+                    : "Gemini hooks were not installed."
+            );
+
+            return 0;
+        } catch (Exception ex) {
+            await env.Stderr.WriteLineAsync($"Could not update Gemini hooks at {settingsPath}: {ex.Message}");
+
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// Merges kcap's command hooks into Gemini's shared
+    /// <c>~/.gemini/settings.json</c> for every event in
+    /// <see cref="GeminiHooksParser.GeminiHookEvents"/>. Touches ONLY the
+    /// <c>hooks</c> block (every other settings key is preserved) and keeps
+    /// user-authored hook entries; replaces existing kcap entries.
+    /// </summary>
+    public static bool InstallGeminiHooks(string settingsPath) {
+        try {
+            JsonObject root = [];
+
+            if (File.Exists(settingsPath)) {
+                try {
+                    if (JsonNode.Parse(File.ReadAllText(settingsPath)) is JsonObject obj) root = obj;
+                } catch {
+                    /* Malformed — start fresh */
+                }
+            }
+
+            if (root["hooks"] is not JsonObject hooks) {
+                hooks         = [];
+                root["hooks"] = hooks;
+            }
+
+            foreach (var evt in GeminiHooksParser.GeminiHookEvents) {
+                if (hooks[evt] is not JsonArray entries) {
+                    hooks[evt] = new JsonArray(GeminiHooksParser.BuildKcapEntry());
+
+                    continue;
+                }
+
+                var preserved = new JsonArray();
+
+                foreach (var entry in entries) {
+                    if (entry is null) continue;
+
+                    if (!GeminiHooksParser.EntryReferencesCapacitorGeminiHook(entry)) {
+                        preserved.Add(entry.DeepClone());
+                    }
+                }
+
+                preserved.Add(GeminiHooksParser.BuildKcapEntry());
+                hooks[evt] = preserved;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(settingsPath)!);
+            File.WriteAllText(settingsPath, root.ToJsonString(WriteOpts));
+            GeminiHooksInstaller.WriteMarker(settingsPath);
+
+            return true;
+        } catch { return false; }
+    }
+
+    public static bool RemoveGeminiHooks(string settingsPath) {
+        if (!File.Exists(settingsPath)) return false;
+        if (JsonNode.Parse(File.ReadAllText(settingsPath)) is not JsonObject root) return false;
+        if (root["hooks"] is not JsonObject hooks) return false;
+
+        var changed = false;
+
+        foreach (var evt in GeminiHooksParser.GeminiHookEvents) {
+            if (hooks[evt] is not JsonArray entries) continue;
+
+            var preserved = new JsonArray();
+
+            foreach (var entry in entries) {
+                if (entry is null) continue;
+
+                if (GeminiHooksParser.EntryReferencesCapacitorGeminiHook(entry)) {
+                    changed = true;
+                } else {
+                    preserved.Add(entry.DeepClone());
+                }
+            }
+
+            hooks[evt] = preserved;
+        }
+
+        if (changed) {
+            File.WriteAllText(settingsPath, root.ToJsonString(WriteOpts));
+            GeminiHooksInstaller.DeleteMarker(settingsPath);
         }
 
         return changed;

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -862,7 +862,11 @@ public static class PluginCommand {
         if (!InstallGeminiHooks(settingsPath)) {
             if (refreshOnly) return 0;
 
-            await env.Stderr.WriteLineAsync("Could not write Gemini settings file.");
+            await env.Stderr.WriteLineAsync(
+                $"Could not install Gemini hooks. If {settingsPath} exists, make sure it is valid JSON — "
+              + "kcap leaves an unparseable settings.json untouched rather than overwrite your settings. "
+              + "Fix or remove it, then re-run."
+            );
 
             return 1;
         }
@@ -914,11 +918,22 @@ public static class PluginCommand {
             JsonObject root = [];
 
             if (File.Exists(settingsPath)) {
+                // settings.json is SHARED user config, not a kcap-owned hook file.
+                // If it exists but won't parse into a JSON object (malformed, empty,
+                // or half-written), FAIL CLOSED and leave it untouched. Starting
+                // fresh here would have File.WriteAllText overwrite the whole file
+                // with only kcap hooks, silently dropping the user's unrelated Gemini
+                // settings. (Cursor/Copilot own their dedicated hooks file and may
+                // safely start fresh — this shared file must not.)
+                JsonNode? parsed;
                 try {
-                    if (JsonNode.Parse(File.ReadAllText(settingsPath)) is JsonObject obj) root = obj;
-                } catch {
-                    /* Malformed — start fresh */
+                    parsed = JsonNode.Parse(File.ReadAllText(settingsPath));
+                } catch (JsonException) {
+                    return false;
                 }
+
+                if (parsed is not JsonObject obj) return false;
+                root = obj;
             }
 
             if (root["hooks"] is not JsonObject hooks) {

--- a/src/Capacitor.Cli/Commands/PluginEnvironment.cs
+++ b/src/Capacitor.Cli/Commands/PluginEnvironment.cs
@@ -1,6 +1,7 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Copilot;
 using Capacitor.Cli.Core.Cursor;
+using Capacitor.Cli.Core.Gemini;
 
 namespace Capacitor.Cli.Commands;
 
@@ -27,6 +28,7 @@ public sealed record PluginEnvironment(
     public string CodexUserHooksJson  => Path.Combine(CodexHome, "hooks.json");
     public string CursorUserHooksJson => CursorPaths.UserHooksJson(HomeDirectory);
     public string CopilotKcapHooksJson => CopilotPaths.KcapHooksJson(HomeDirectory);
+    public string GeminiSettingsJson   => GeminiPaths.SettingsJson(HomeDirectory);
     public string AgentsSkillsDir     => Path.Combine(HomeDirectory, ".agents", "skills");
     public string LegacyCodexSkills   => Path.Combine(CodexHome, "skills");
 

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -5,6 +5,7 @@ using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Copilot;
 using Capacitor.Cli.Core.Cursor;
+using Capacitor.Cli.Core.Gemini;
 using Spectre.Console;
 using Profile = Capacitor.Cli.Core.Config.Profile;
 
@@ -19,6 +20,7 @@ public static class SetupCommand {
         var skipCodexFlag    = args.Contains("--skip-codex-hooks");
         var skipCursorFlag   = args.Contains("--skip-cursor-hooks");
         var skipCopilotFlag  = args.Contains("--skip-copilot-hooks");
+        var skipGeminiFlag   = args.Contains("--skip-gemini-hooks");
         var legacyPluginScope = GetArg(args, "--plugin-scope"); // "user" | "project" | "skip" | null
         var skipClaude       = skipClaudeFlag || legacyPluginScope == "skip";
         var legacyProjectScope = legacyPluginScope == "project";
@@ -175,7 +177,10 @@ public static class SetupCommand {
             // Dir presence covers users who launch Copilot through an IDE
             // wrapper; the PATH probe covers fresh installs that haven't run
             // yet (no ~/.copilot until first launch).
-            Copilot: CopilotPaths.IsInstalled() || AgentDetector.IsInstalled("copilot"));
+            Copilot: CopilotPaths.IsInstalled() || AgentDetector.IsInstalled("copilot"),
+            // Dir presence covers IDE-launched Gemini; the PATH probe covers a
+            // fresh install that hasn't created ~/.gemini yet.
+            Gemini:  GeminiPaths.IsInstalled()  || AgentDetector.IsInstalled("gemini"));
 
         // gitRoot is guaranteed non-null here when legacyProjectScope is true (the early
         // guard at the top of HandleAsync returns 1 otherwise).
@@ -188,6 +193,7 @@ public static class SetupCommand {
             SkipCodex:   skipCodexFlag,
             SkipCursor:  skipCursorFlag,
             SkipCopilot: skipCopilotFlag,
+            SkipGemini:  skipGeminiFlag,
             NoPrompt:    noPrompt);
 
         var stepPaths = new CodingAgentsStep.Paths(
@@ -197,6 +203,7 @@ public static class SetupCommand {
             CodexHooksPath:       CodexPaths.UserHooksJson,
             CursorHooksPath:      CursorPaths.UserHooksJson(),
             CopilotHooksPath:     CopilotPaths.KcapHooksJson(),
+            GeminiSettingsPath:   GeminiPaths.SettingsJson(),
             AgentsSkillsDir:      AgentsPaths.UserSkillsDir,
             LegacyCodexSkillsDir: Path.Combine(CodexPaths.Home, "skills"));
 
@@ -205,6 +212,7 @@ public static class SetupCommand {
             InstallCodexHooks:      PluginCommand.InstallCodexHooks,
             InstallCursorHooks:     PluginCommand.InstallCursorHooks,
             InstallCopilotHooks:    PluginCommand.InstallCopilotHooks,
+            InstallGeminiHooks:     PluginCommand.InstallGeminiHooks,
             CapacitorOnPath:        () => AgentDetector.IsInstalled("kcap"),
             InstallAgentSkills:     AgentsSkillsInstaller.Install,
             CleanLegacyCodexSkills: legacyDir => AgentsSkillsInstaller.CleanLegacyCodexSkills(legacyDir).RemovedAny);

--- a/src/Capacitor.Cli/Commands/UninstallCommand.cs
+++ b/src/Capacitor.Cli/Commands/UninstallCommand.cs
@@ -1,5 +1,6 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Cursor;
+using Capacitor.Cli.Core.Gemini;
 using Capacitor.Cli.Services;
 
 namespace Capacitor.Cli.Commands;
@@ -7,8 +8,9 @@ namespace Capacitor.Cli.Commands;
 /// <summary>
 /// Completely removes kcap from the local machine: stops daemons, kills
 /// watcher processes, strips kcap entries from user-level Claude / Codex /
-/// Cursor hook files, removes agent skills (and legacy Codex skills), and
-/// deletes the kcap config directory.
+/// Cursor / Gemini hook files, deletes the kcap-owned Copilot hooks file,
+/// removes agent skills (and legacy Codex skills), and deletes the kcap
+/// config directory.
 ///
 /// With <c>--project</c>, also strips kcap entries from the cwd's git-root
 /// <c>.claude/settings.local.json</c> and <c>.codex/hooks.json</c>. Project-scope
@@ -45,6 +47,7 @@ public static class UninstallCommand {
         await Console.Out.WriteLineAsync($"  • Remove kcap entries from {CodexPaths.UserHooksJson}");
         await Console.Out.WriteLineAsync($"  • Remove kcap entries from {CursorPaths.UserHooksJson()}");
         await Console.Out.WriteLineAsync($"  • Remove {Capacitor.Cli.Core.Copilot.CopilotPaths.KcapHooksJson()}");
+        await Console.Out.WriteLineAsync($"  • Remove kcap entries from {GeminiPaths.SettingsJson()}");
         await Console.Out.WriteLineAsync($"  • Remove agent skills under {AgentsPaths.UserSkillsDir}");
 
         if (projectRoot is not null) {
@@ -109,6 +112,7 @@ public static class UninstallCommand {
         if (await PluginCommand.HandleAsync(["plugin", "remove", "--codex"]) != 0) hadFailures = true; // Codex hooks + skills + legacy
         if (await PluginCommand.HandleAsync(["plugin", "remove", "--cursor"]) != 0) hadFailures = true;
         if (await PluginCommand.HandleAsync(["plugin", "remove", "--copilot"]) != 0) hadFailures = true;
+        if (await PluginCommand.HandleAsync(["plugin", "remove", "--gemini"]) != 0) hadFailures = true;  // shared ~/.gemini/settings.json
 
         // Skills are removed by --codex above, but call --skills explicitly in
         // case the user only ever installed Cursor / agent-agnostic skills and
@@ -126,6 +130,7 @@ public static class UninstallCommand {
         ClaudePluginInstaller.DeleteMarker(ClaudePaths.UserSettings);
         CodexHooksInstaller.DeleteMarker(CodexPaths.UserHooksJson);
         CursorHooksInstaller.DeleteMarker(CursorPaths.UserHooksJson());
+        GeminiHooksInstaller.DeleteMarker(GeminiPaths.SettingsJson());
 
         // Skill installer Remove uses the current SourceNames list, so any
         // kcap-* folder from an older release (renamed/retired skill)

--- a/src/Capacitor.Cli/Commands/VendorSelection.cs
+++ b/src/Capacitor.Cli/Commands/VendorSelection.cs
@@ -12,7 +12,7 @@ public static class VendorSelection {
         public bool HasError => Error is not null;
     }
 
-    static readonly string[] KnownVendorFlags = ["--claude", "--codex", "--cursor", "--copilot"];
+    static readonly string[] KnownVendorFlags = ["--claude", "--codex", "--cursor", "--copilot", "--gemini"];
 
     public static Result Parse(string[] args) {
         var vendors = new HashSet<string>(StringComparer.Ordinal);
@@ -23,6 +23,7 @@ public static class VendorSelection {
                 case "--codex":   vendors.Add("codex");   break;
                 case "--cursor":  vendors.Add("cursor");  break;
                 case "--copilot": vendors.Add("copilot"); break;
+                case "--gemini":  vendors.Add("gemini");  break;
             }
         }
 
@@ -34,7 +35,7 @@ public static class VendorSelection {
             if (!a.StartsWith("--")) continue;
             if (Array.IndexOf(KnownVendorFlags, a) >= 0) continue;
 
-            if (a.StartsWith("--cursor-") || a.StartsWith("--claude-") || a.StartsWith("--codex-") || a.StartsWith("--copilot-")) {
+            if (a.StartsWith("--cursor-") || a.StartsWith("--claude-") || a.StartsWith("--codex-") || a.StartsWith("--copilot-") || a.StartsWith("--gemini-")) {
                 return new(vendors, $"Unknown source option: {a}.");
             }
         }
@@ -43,7 +44,7 @@ public static class VendorSelection {
         foreach (var a in args) {
             if (!a.StartsWith("--")) continue;
             if (Array.IndexOf(KnownVendorFlags, a) >= 0) continue;
-            if (a.StartsWith("--cursor-") || a.StartsWith("--claude-") || a.StartsWith("--codex-") || a.StartsWith("--copilot-")) continue;
+            if (a.StartsWith("--cursor-") || a.StartsWith("--claude-") || a.StartsWith("--codex-") || a.StartsWith("--copilot-") || a.StartsWith("--gemini-")) continue;
 
             string? hint = null;
             var bestDist = int.MaxValue;

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -352,7 +352,7 @@ static partial class WatchCommand {
     /// Used to reject unexpected --vendor input before interpolating into the URL
     /// path (defence-in-depth against path traversal even though the CLI runs locally).
     /// </summary>
-    static readonly HashSet<string> KnownVendors = new(StringComparer.Ordinal) { "claude", "codex", "copilot" };
+    static readonly HashSet<string> KnownVendors = new(StringComparer.Ordinal) { "claude", "codex", "copilot", "gemini" };
 
     /// <summary>
     /// Total time budget for the parent-exit session-end POST. Covers /auth/config

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -465,6 +465,7 @@ switch (command) {
             new CodexImportSource(),
             new CursorImportSource(),
             new CopilotImportSource(),
+            new GeminiImportSource(),
         };
         IReadOnlyList<IImportSource> sources = explicitVendorSelection
             ? allSources.Where(s => vsel.Vendors.Contains(s.Vendor)).ToList()

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -38,7 +38,7 @@ var command = args[0];
 // nested headless invocation.
 if (Environment.GetEnvironmentVariable("KCAP_SKIP") is "1"
  && command == "hook"
- && (args.Contains("--claude") || args.Contains("--cursor") || args.Contains("--copilot"))) {
+ && (args.Contains("--claude") || args.Contains("--cursor") || args.Contains("--copilot") || args.Contains("--gemini"))) {
     return 0;
 }
 
@@ -604,8 +604,11 @@ switch (command) {
         if (args.Contains("--copilot")) {
             return await CopilotHookCommand.Handle(baseUrl!, Console.In, args);
         }
+        if (args.Contains("--gemini")) {
+            return await GeminiHookCommand.Handle(baseUrl!, Console.In);
+        }
         Console.Error.WriteLine("kcap hook requires a vendor flag (for example --claude)");
-        Console.Error.WriteLine("Supported vendors: --claude, --codex, --cursor, --copilot");
+        Console.Error.WriteLine("Supported vendors: --claude, --codex, --cursor, --copilot, --gemini");
         return 1;
     }
     case "cursor":

--- a/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
@@ -588,6 +588,7 @@ public class CodingAgentsStepTests {
         CodexHooksPath:       "/fake/.codex/hooks.json",
         CursorHooksPath:      "/fake/.cursor/hooks.json",
         CopilotHooksPath:     "/fake/.copilot/hooks/kcap.json",
+        GeminiSettingsPath:   "/fake/.gemini/settings.json",
         AgentsSkillsDir:      "/fake/.agents/skills",
         LegacyCodexSkillsDir: "/fake/.codex/skills"
     );
@@ -613,6 +614,10 @@ public class CodingAgentsStepTests {
         public bool    CopilotHooksCalled  { get; private set; }
         public string? CopilotHooksArg     { get; private set; }
         public bool    CopilotHooksReturns { get; set; } = true;
+
+        public bool    GeminiHooksCalled  { get; private set; }
+        public string? GeminiHooksArg     { get; private set; }
+        public bool    GeminiHooksReturns { get; set; } = true;
 
         public bool CapacitorOnPathCalled  { get; private set; }
         public bool CapacitorOnPathReturns { get; set; } = true;
@@ -649,6 +654,12 @@ public class CodingAgentsStepTests {
                 CopilotHooksArg    = h;
 
                 return CopilotHooksReturns;
+            },
+            InstallGeminiHooks: h => {
+                GeminiHooksCalled = true;
+                GeminiHooksArg    = h;
+
+                return GeminiHooksReturns;
             },
             CapacitorOnPath: () => {
                 CapacitorOnPathCalled = true;

--- a/test/Capacitor.Cli.Tests.Unit/GeminiHooksTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiHooksTests.cs
@@ -1,0 +1,99 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-887: kcap merges its command hooks into Gemini's SHARED
+/// <c>~/.gemini/settings.json</c> (nested <c>{hooks:[{command}]}</c> entries),
+/// so the merge must preserve user-authored hooks AND every other settings key.
+/// </summary>
+public class GeminiHooksTests {
+    const string KcapCommand = "kcap hook --gemini";
+
+    static bool HasKcap(JsonArray entries) =>
+        entries.Any(e => e?["hooks"] is JsonArray inner
+                      && inner.Any(h => h?["command"]?.GetValue<string>() == KcapCommand));
+
+    static bool HasCommand(JsonArray entries, string command) =>
+        entries.Any(e => e?["hooks"] is JsonArray inner
+                      && inner.Any(h => h?["command"]?.GetValue<string>() == command));
+
+    [Test]
+    public async Task fresh_install_merges_lifecycle_events() {
+        using var tmp = new TempDir();
+        var settingsPath = Path.Combine(tmp.Path, "settings.json");
+
+        var ok = PluginCommand.InstallGeminiHooks(settingsPath);
+        await Assert.That(ok).IsTrue();
+
+        var hooks = JsonNode.Parse(await File.ReadAllTextAsync(settingsPath))!.AsObject()["hooks"]!.AsObject();
+
+        foreach (var evt in new[] { "SessionStart", "SessionEnd", "Notification" }) {
+            await Assert.That(HasKcap(hooks[evt]!.AsArray())).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task install_preserves_user_hooks_and_other_settings() {
+        using var tmp = new TempDir();
+        var settingsPath = Path.Combine(tmp.Path, "settings.json");
+        await File.WriteAllTextAsync(settingsPath, """
+            {"security":{"auth":{"selectedType":"oauth-personal"}},"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo hi"}]}]}}
+            """);
+
+        await Assert.That(PluginCommand.InstallGeminiHooks(settingsPath)).IsTrue();
+
+        var root = JsonNode.Parse(await File.ReadAllTextAsync(settingsPath))!.AsObject();
+
+        // Unrelated settings keys survive the merge.
+        await Assert.That(root["security"]!["auth"]!["selectedType"]!.GetValue<string>()).IsEqualTo("oauth-personal");
+
+        var start = root["hooks"]!["SessionStart"]!.AsArray();
+        await Assert.That(HasCommand(start, "echo hi")).IsTrue();   // user hook preserved
+        await Assert.That(HasKcap(start)).IsTrue();                 // kcap hook added
+    }
+
+    [Test]
+    public async Task reinstall_does_not_duplicate_the_kcap_entry() {
+        using var tmp = new TempDir();
+        var settingsPath = Path.Combine(tmp.Path, "settings.json");
+
+        PluginCommand.InstallGeminiHooks(settingsPath);
+        PluginCommand.InstallGeminiHooks(settingsPath);
+
+        var start = JsonNode.Parse(await File.ReadAllTextAsync(settingsPath))!
+            .AsObject()["hooks"]!["SessionStart"]!.AsArray();
+
+        var kcapCount = start.Count(e => e?["hooks"] is JsonArray inner
+                                      && inner.Any(h => h?["command"]?.GetValue<string>() == KcapCommand));
+        await Assert.That(kcapCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task remove_deletes_only_kcap_hooks() {
+        using var tmp = new TempDir();
+        var settingsPath = Path.Combine(tmp.Path, "settings.json");
+        await File.WriteAllTextAsync(settingsPath, """
+            {"security":{"auth":{"selectedType":"oauth-personal"}},"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo hi"}]}]}}
+            """);
+
+        PluginCommand.InstallGeminiHooks(settingsPath);
+        await Assert.That(PluginCommand.RemoveGeminiHooks(settingsPath)).IsTrue();
+
+        var root  = JsonNode.Parse(await File.ReadAllTextAsync(settingsPath))!.AsObject();
+        var start = root["hooks"]!["SessionStart"]!.AsArray();
+
+        await Assert.That(HasKcap(start)).IsFalse();                                          // kcap gone
+        await Assert.That(HasCommand(start, "echo hi")).IsTrue();                             // user hook kept
+        await Assert.That(root["security"]!["auth"]!["selectedType"]!.GetValue<string>()).IsEqualTo("oauth-personal");
+    }
+
+    sealed class TempDir : IDisposable {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            $"kcap-gemini-hooks-test-{Guid.NewGuid().ToString("N")[..8]}");
+        public TempDir() => Directory.CreateDirectory(Path);
+        public void Dispose() { try { Directory.Delete(Path, true); } catch { } }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/GeminiHooksTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiHooksTests.cs
@@ -89,6 +89,35 @@ public class GeminiHooksTests {
         await Assert.That(root["security"]!["auth"]!["selectedType"]!.GetValue<string>()).IsEqualTo("oauth-personal");
     }
 
+    [Test]
+    public async Task install_leaves_malformed_settings_untouched() {
+        using var tmp = new TempDir();
+        var settingsPath = Path.Combine(tmp.Path, "settings.json");
+
+        // A shared settings.json that is half-written / not valid JSON, but carries
+        // user content we must never destroy by "starting fresh".
+        const string original = "{ \"theme\": \"dark\", \"hooks\": { \"SessionStart\": [ {{ broken";
+        await File.WriteAllTextAsync(settingsPath, original);
+
+        var ok = PluginCommand.InstallGeminiHooks(settingsPath);
+
+        await Assert.That(ok).IsFalse();                                            // fails closed
+        await Assert.That(await File.ReadAllTextAsync(settingsPath)).IsEqualTo(original); // untouched
+    }
+
+    [Test]
+    public async Task install_leaves_non_object_settings_untouched() {
+        using var tmp = new TempDir();
+        var settingsPath = Path.Combine(tmp.Path, "settings.json");
+
+        // Valid JSON, but not an object — still not something we can safely merge into.
+        const string original = "[1, 2, 3]";
+        await File.WriteAllTextAsync(settingsPath, original);
+
+        await Assert.That(PluginCommand.InstallGeminiHooks(settingsPath)).IsFalse();
+        await Assert.That(await File.ReadAllTextAsync(settingsPath)).IsEqualTo(original);
+    }
+
     sealed class TempDir : IDisposable {
         public string Path { get; } = System.IO.Path.Combine(
             System.IO.Path.GetTempPath(),

--- a/test/Capacitor.Cli.Tests.Unit/GeminiImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiImportSourceTests.cs
@@ -1,0 +1,79 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-887: discovery walks <c>~/.gemini/tmp/&lt;project&gt;/chats/session-*.jsonl</c>
+/// and reads the FULL dashed session id from the file's header record (the
+/// filename only carries the 8-char shortId). <see cref="GeminiImportSource.IsImportRelevantLine"/>
+/// must mirror the server normalizer's skip rules so the import watermark
+/// compares against the right line.
+/// </summary>
+public class GeminiImportSourceTests {
+    static void WriteSession(string tmpDir, string project, string fileName, string sessionId, params string[] extraLines) {
+        var chats = Path.Combine(tmpDir, project, "chats");
+        Directory.CreateDirectory(chats);
+
+        var header = $$"""{"sessionId":"{{sessionId}}","projectHash":"abc","startTime":"2026-06-17T14:10:03.447Z","kind":"main"}""";
+        File.WriteAllLines(Path.Combine(chats, fileName), new[] { header }.Concat(extraLines));
+    }
+
+    [Test]
+    public async Task discover_reads_full_session_id_from_header() {
+        using var tmp = new TempDir();
+        WriteSession(tmp.Path, "proj", "session-2026-06-17T14-10-11111111.jsonl",
+            "11111111-1111-1111-1111-111111111111",
+            """{"id":"u1","timestamp":"t","type":"user","content":[{"text":"hi"}]}""");
+
+        var source = new GeminiImportSource(tmpDirOverride: tmp.Path);
+        await Assert.That(source.IsAvailable).IsTrue();
+
+        var found = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 1), CancellationToken.None);
+
+        await Assert.That(found.Count).IsEqualTo(1);
+        await Assert.That(found[0].Vendor).IsEqualTo("gemini");
+        // Dashless FULL id from the header — not the 8-char filename shortId.
+        await Assert.That(found[0].SessionId).IsEqualTo("11111111111111111111111111111111");
+    }
+
+    [Test]
+    public async Task discover_filter_by_session_matches_dashless_id() {
+        using var tmp = new TempDir();
+        WriteSession(tmp.Path, "proj", "session-a-22222222.jsonl", "22222222-2222-2222-2222-222222222222");
+        WriteSession(tmp.Path, "proj", "session-b-33333333.jsonl", "33333333-3333-3333-3333-333333333333");
+
+        var source = new GeminiImportSource(tmpDirOverride: tmp.Path);
+        var found  = await source.DiscoverAsync(
+            new DiscoveryFilters(null, "22222222-2222-2222-2222-222222222222", null, 1), CancellationToken.None);
+
+        await Assert.That(found.Count).IsEqualTo(1);
+        await Assert.That(found[0].SessionId).IsEqualTo("22222222222222222222222222222222");
+    }
+
+    [Test]
+    public async Task unavailable_when_tmp_dir_missing() {
+        using var tmp = new TempDir();
+        var source = new GeminiImportSource(tmpDirOverride: Path.Combine(tmp.Path, "does-not-exist"));
+        await Assert.That(source.IsAvailable).IsFalse();
+    }
+
+    // Mirror of the GeminiTranscriptNormalizer skip rules.
+    [Test]
+    [Arguments("""{"sessionId":"s","projectHash":"h","kind":"main"}""", false)]                                                              // header
+    [Arguments("""{"$set":{"lastUpdated":"t"}}""", false)]                                                                                    // mutation op
+    [Arguments("""{"id":"u","type":"user","content":[{"text":"<session_context>x</session_context>"}]}""", false)]                            // bootstrap
+    [Arguments("""{"id":"u","type":"user","content":[{"functionResponse":{"id":"f","name":"read","response":{"output":"x"}}}]}""", false)]    // tool-result echo
+    [Arguments("""{"id":"u","type":"user","content":[{"text":"real prompt"}]}""", true)]                                                      // real user prompt
+    [Arguments("""{"id":"g","type":"gemini","content":"answer"}""", true)]                                                                    // gemini turn
+    public async Task import_relevant_line_mirrors_normalizer_skips(string line, bool expected) {
+        await Assert.That(GeminiImportSource.IsImportRelevantLine(line)).IsEqualTo(expected);
+    }
+
+    sealed class TempDir : IDisposable {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            $"kcap-gemini-import-test-{Guid.NewGuid().ToString("N")[..8]}");
+        public TempDir() => Directory.CreateDirectory(Path);
+        public void Dispose() { try { Directory.Delete(Path, true); } catch { } }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Gemini;
 
 namespace Capacitor.Cli.Tests.Unit;
 
@@ -64,6 +65,23 @@ public class UninstallCommandTests {
             }
             """);
 
+        // Gemini shared settings.json: kcap hook + user hook + unrelated setting, plus marker.
+        var geminiDir = Path.Combine(fixture.Home, ".gemini");
+        Directory.CreateDirectory(geminiDir);
+        var geminiSettings = Path.Combine(geminiDir, "settings.json");
+        await File.WriteAllTextAsync(geminiSettings, """
+            {
+              "theme": "keep-me",
+              "hooks": {
+                "SessionStart": [
+                  { "hooks": [{ "type": "command", "command": "user-script" }] },
+                  { "hooks": [{ "type": "command", "command": "kcap hook --gemini" }] }
+                ]
+              }
+            }
+            """);
+        GeminiHooksInstaller.WriteMarker(geminiSettings);
+
         // Skills present in ~/.agents/skills with marker.
         var skillsDir = Path.Combine(fixture.Home, ".agents", "skills");
         Directory.CreateDirectory(skillsDir);
@@ -100,6 +118,14 @@ public class UninstallCommandTests {
         var sessionStart2 = cursorRoot["hooks"]!["sessionStart"]!.AsArray();
         await Assert.That(sessionStart2.Count).IsEqualTo(1);
         await Assert.That(sessionStart2[0]!["command"]!.GetValue<string>()).IsEqualTo("user-script");
+
+        // Gemini: kcap hook gone, user hook + unrelated setting preserved, marker removed.
+        var geminiRoot  = JsonNode.Parse(await File.ReadAllTextAsync(geminiSettings))!.AsObject();
+        await Assert.That(geminiRoot["theme"]!.GetValue<string>()).IsEqualTo("keep-me");
+        var geminiStart = geminiRoot["hooks"]!["SessionStart"]!.AsArray();
+        await Assert.That(geminiStart.Count).IsEqualTo(1);
+        await Assert.That(geminiStart[0]!["hooks"]![0]!["command"]!.GetValue<string>()).IsEqualTo("user-script");
+        await Assert.That(GeminiHooksInstaller.IsInstalled(geminiSettings)).IsFalse();
 
         // Skills: kcap-* folders removed, user-authored folder intact.
         foreach (var name in AgentsSkillsInstaller.SourceNames) {


### PR DESCRIPTION
## [AI-887] Google Gemini CLI ingest — CLI side

Companion to the server PR (kurrent-io/kcap-server#759). Adds Google Gemini CLI as the 6th ingest vendor, mirroring the Copilot pattern. **Must merge after the server PR deploys** (this PR's hooks POST to `/hooks/session-{start,end}/gemini` + `/hooks/transcript?vendor=gemini`, which the server PR adds).

### Done in this PR (builds clean)
- `Core/Gemini/GeminiPaths` — `~/.gemini` layout (`$GEMINI_HOME` honoured; `settings.json`; `tmp/<project>/chats/`).
- `Core/Gemini/GeminiHooksParser` + `GeminiHooksInstaller` — helpers for the SHARED `~/.gemini/settings.json` `hooks` block (nested `{hooks:[{command}]}` shape; merge/detect/marker — must preserve user-authored hooks, like the Cursor installer).
- `Commands/GeminiHookCommand` — self-routes on `hook_event_name` (Gemini provides it, unlike Copilot); POSTs lifecycle to `/hooks/session-{start,end}/gemini`; spawns the watcher on the payload's `transcript_path` with `vendor=gemini`; capped inline drain on `SessionEnd`; `Notification` → `/hooks/notification`.
- Wiring: `kcap hook --gemini` dispatch + `KCAP_SKIP` gate + usage in `Program.cs`; `gemini` added to `WatchCommand.KnownVendors`.

### Follow-ups (this branch, before marking ready)
- `PluginCommand` `InstallGeminiHooks`/`RemoveGeminiHooks` (settings.json merge) + `--gemini` / `--skip-gemini-hooks` dispatch.
- `SetupCommand` / `CodingAgentsStep` Gemini detection + install offer.
- `GeminiImportSource : IImportSource` (`kcap import --gemini`, walking `~/.gemini/tmp/*/chats/*.jsonl`) + `VendorSelection` `--gemini`.
- Unit tests (hooks-merge + import discovery), AOT publish check, and `README.md` (new `--gemini` surface).

Spec + design: AI-887 (and server PR #759).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
