### PR TITLE
fix: stop YAML secret redactor from matching prose across a sentence

### DIFF
--- a/src/Capacitor.Cli/SecretRedactor.cs
+++ b/src/Capacitor.Cli/SecretRedactor.cs
@@ -97,7 +97,15 @@ static partial class SecretRedactor {
 
     // YAML-style: secret_name: value (key containing secret keyword followed by colon, space, and value)
     // Excludes " and \ to avoid crossing JSON string boundaries. Minimum 8 chars to reduce false positives.
-    [GeneratedRegex(@"((?:secret|token|password|passwd|pwd|api_key|apikey|private_key|credentials|client_secret|access_key|auth_token)[^:\n]*:[ \t]+)([^\s""\\]{8,})", RegexOptions.IgnoreCase)]
+    //
+    // The gap between the keyword and the colon is `[\w.\-]*` — only key-name characters — NOT the
+    // former `[^:\n]*`. `[^:\n]*` matched any run of non-colon chars, so a secret keyword appearing
+    // anywhere earlier in a prose sentence reached across to an unrelated prose colon and redacted
+    // whatever 8+-char word followed it: `"...access token. The one real risk: model-id matching"`
+    // had `model-id` (exactly 8 chars) replaced with [REDACTED]. Constraining the gap to identifier
+    // characters forces the keyword to actually be part of the `key:` token, while still allowing
+    // real keys like `client-secret:`, `aws.secret.access.key:`, and `auth_token:`.
+    [GeneratedRegex(@"((?:secret|token|password|passwd|pwd|api_key|apikey|private_key|credentials|client_secret|access_key|auth_token)[\w.\-]*:[ \t]+)([^\s""\\]{8,})", RegexOptions.IgnoreCase)]
     private static partial Regex YamlStyleSecretRx();
 
     static readonly Regex YamlStyleSecretRegex = YamlStyleSecretRx();

--- a/test/Capacitor.Cli.Tests.Unit/SecretRedactorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SecretRedactorTests.cs
@@ -211,6 +211,38 @@ public class SecretRedactorTests {
     }
 
     [Test]
+    [Arguments("client-secret: a8f3b2c91d4e7f0123456789abcdef01", "a8f3b2c91d4e7f0123456789abcdef01")] // hyphen in key
+    [Arguments("aws.secret.access.key: AKIAIOSFODNN7EXAMPLE99", "AKIAIOSFODNN7EXAMPLE99")]               // dots in key
+    public async Task RedactsLine_YamlStyleSecret_KeyWithSeparators_InToolResult(string kv, string secret) {
+        // The key gap is `[\w.\-]*`, so hyphen- and dot-separated key names still match.
+        var line = $$$"""
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"{{{kv}}}","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain(secret);
+        await Assert.That(result).Contains("[REDACTED]");
+    }
+
+    [Test]
+    public async Task DoesNotRedact_YamlStyleSecret_ProseColonAfterUpstreamKeyword() {
+        // Regression: a secret keyword anywhere earlier in a prose sentence used to reach across the
+        // old `[^:\n]*` gap to an unrelated prose colon, redacting the next 8+-char word. Here
+        // "access token" sits upstream and "model-id" (exactly 8 chars) followed "real risk:" — it
+        // was wrongly replaced with [REDACTED]. The `[\w.\-]*` gap requires the keyword to be part of
+        // the key token, so this prose now passes through untouched.
+        var line = """
+            {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"We send the access token. The one real risk: model-id matching is fragile here."}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).IsEqualTo(line);
+        await Assert.That(result).Contains("model-id matching");
+    }
+
+    [Test]
     public async Task RedactsLine_ConnectionStringPassword_InToolResult() {
         var line = """
             {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"Server=localhost;Database=mydb;Password=hunter2;User Id=sa","is_error":false}]}}


### PR DESCRIPTION
## Problem

A chat message rendered `The one real risk: [REDACTED] matching` while the terminal showed `The one real risk: model-id matching`. `model-id` is not a secret — it was swept up as the bogus *value* of a false `key: value` match.

## Root cause

`YamlStyleSecretRegex` (`src/Capacitor.Cli/SecretRedactor.cs`) used `[^:\n]*` for the gap between the secret keyword and the colon. That matches *any* run of non-colon characters, so a keyword (`token`, `secret`, `password`, …) appearing **anywhere earlier in a prose sentence** reached across to an unrelated prose colon (`risk:`) and redacted whatever 8+-char word followed. `model-id` is exactly 8 chars, so it cleared the `{8,}` value floor and was replaced.

Reproduced against the exact regex:

```
old MATCH(model-id) -> We send the access token. The one real risk: [REDACTED] matching
```

## Fix

Constrain the key gap from `[^:\n]*` to `[\w.\-]*` (key-name characters only). The secret keyword must now be part of the `key:` token rather than floating anywhere in the sentence — whitespace and sentence punctuation break the match.

Still redacts real keys: `client-secret:`, `aws.secret.access.key:`, `Access Token:`, `DB_PASSWORD:`, `api_key:`. No longer redacts prose.

## Tests

- `DoesNotRedact_YamlStyleSecret_ProseColonAfterUpstreamKeyword` — the exact reported case now passes through untouched.
- `RedactsLine_YamlStyleSecret_KeyWithSeparators_InToolResult` — proves hyphen/dot-separated real keys still redact.

All 75 SecretRedactor tests pass; `dotnet publish -c Release` shows no IL3050/IL2026 AOT warnings.

No user-facing CLI surface change, so no README update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)