### PR TITLE
[AI-887] List --gemini in the kcap --help Plugin section

### DIFF
--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -54,8 +54,8 @@ MCP servers (stdio):
   mcp sessions                       Search/inspect past sessions from agents
 
 Plugin:
-  plugin install [--project] [--codex|--cursor|--copilot|--skills]   Register hooks/skills (Claude default; flag picks the vendor)
-  plugin remove  [--project] [--codex|--cursor|--copilot|--skills]   Remove hooks/skills (Claude default; flag picks the vendor)
+  plugin install [--project] [--codex|--cursor|--copilot|--gemini|--skills]   Register hooks/skills (Claude default; flag picks the vendor)
+  plugin remove  [--project] [--codex|--cursor|--copilot|--gemini|--skills]   Remove hooks/skills (Claude default; flag picks the vendor)
 
 Maintenance:
   update                           Check for and install updates


### PR DESCRIPTION
Follow-up to kcap-cli#164. The `Plugin:` summary in `help-usage.txt` lists `--codex|--cursor|--copilot|--skills` but not `--gemini` — #163 rewrote that line after the #164 branch point, so the 3-way merge left Gemini off. The `import` line, the `Hooks` section, and the full `help-plugin.txt` already advertise Gemini; this aligns the one-line summary so `kcap --help` is consistent.

Resource-text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)