### PR TITLE
[AI-900] CLI: ingest Gemini subagents (import + live child watchers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,8 @@ kcap plugin remove --gemini                 # removes only kcap's entries
 
 Live sessions stream from the chat-recording JSONL Gemini names in each hook's `transcript_path` (`~/.gemini/tmp/<project>/chats/session-*.jsonl`); historical sessions import via `kcap import --gemini`. Sessions resumed with `gemini --resume` reattach to the same recorded session. (Historical import leaves working-directory / repo enrichment empty — Gemini doesn't record the cwd in a machine-readable header; live capture gets it from the hook payload.)
 
+Spawned subagents are captured too: Gemini records each in a nested `chats/<session>/<subId>.jsonl`, and both live capture (a child watcher per subagent) and `kcap import --gemini` discover and stream them, so they nest under the parent session in the trace.
+
 #### AWS Kiro CLI hooks
 
 AWS Kiro CLI (the rebranded Amazon Q Developer CLI) is detected via `~/.kiro/` or the `kiro` / `kiro-cli` binary on `PATH`. Kiro hooks fire only for the **active** agent — there is no global hook — so to capture every session transparently, `install --kiro` **clones your current default agent** into `~/.kiro/agents/kcap.json` (preserving its tools; a minimal agent would lose tool access), adds kcap's `agentSpawn` hook, and makes it your default agent (`chat.defaultAgent` in `~/.kiro/settings/cli.json`). This needs `kiro-cli` on `PATH` to perform the clone. Restart any running `kiro` session after installing. `remove --kiro` restores your previous default agent and deletes `kcap.json`.

--- a/src/Capacitor.Cli.Core/Gemini/GeminiPaths.cs
+++ b/src/Capacitor.Cli.Core/Gemini/GeminiPaths.cs
@@ -42,4 +42,15 @@ public static class GeminiPaths {
     /// <summary>Chat-recording directory for a project tmp dir: <c>&lt;tmp&gt;/&lt;project&gt;/chats</c>.</summary>
     public static string ChatsDir(string projectTmpDir)
         => Path.Combine(projectTmpDir, "chats");
+
+    /// <summary>
+    /// Nested subagent-recording directory for a parent session:
+    /// <c>&lt;chats&gt;/&lt;parentSessionId&gt;/</c>. Gemini records each subagent's transcript
+    /// here as <c>&lt;subId&gt;.jsonl</c> (subId = a fresh dashed UUID — the executor's agent
+    /// id; nested subagents at any depth stay flat under the top-level session).
+    /// <paramref name="parentSessionId"/> is the DASHED form from the parent transcript's
+    /// header, matching the on-disk directory name. AI-900.
+    /// </summary>
+    public static string SubagentDir(string chatsDir, string parentSessionId)
+        => Path.Combine(chatsDir, parentSessionId);
 }

--- a/src/Capacitor.Cli.Core/Gemini/GeminiSubagentDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Gemini/GeminiSubagentDiscovery.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core; // JsonElement Str/Obj/Arr extensions
+
+namespace Capacitor.Cli.Core.Gemini;
+
+/// <summary>
+/// Discovery + lifecycle-payload glue for Gemini's nested subagent transcripts (AI-900).
+/// Gemini records each subagent in <c>chats/&lt;parentSessionId&gt;/&lt;subId&gt;.jsonl</c>;
+/// the parent's <c>invoke_agent</c> tool call persists <c>agentId == subId</c> plus
+/// <c>args.agent_name</c>. Shared by the historical import path (<c>GeminiImportSource</c>)
+/// and the live watcher (<c>WatchCommand</c> / <c>GeminiHookCommand</c>) so both speak one
+/// wire contract.
+/// </summary>
+public static class GeminiSubagentDiscovery {
+    /// <summary>Dashed parent sessionId from a main transcript's header (first line), or null.</summary>
+    public static string? ReadParentSessionId(string transcriptPath) {
+        try {
+            foreach (var line in File.ReadLines(transcriptPath)) {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+
+                using var doc = JsonDocument.Parse(line);
+                return doc.RootElement.Str("sessionId");
+            }
+        } catch { /* unreadable / malformed → no subagents */ }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Nested subagent <c>*.jsonl</c> files recorded alongside a parent main transcript
+    /// (empty when the session spawned none). Path: <c>chats/&lt;dashedParent&gt;/*.jsonl</c>.
+    /// </summary>
+    public static IReadOnlyList<string> EnumerateSubagentFiles(string transcriptPath) {
+        if (ReadParentSessionId(transcriptPath) is not { } dashedParent) return [];
+        if (Path.GetDirectoryName(transcriptPath) is not { } chatsDir) return [];
+
+        var subDir = GeminiPaths.SubagentDir(chatsDir, dashedParent);
+        if (!Directory.Exists(subDir)) return [];
+
+        return Directory.EnumerateFiles(subDir, "*.jsonl").ToList();
+    }
+
+    /// <summary>
+    /// Maps each subagent id (DASHED, the nested filename stem) to the <c>agent_name</c>
+    /// from the parent's <c>invoke_agent</c> tool call — the subagent's only on-disk type
+    /// signal. Best-effort; unmatched ids are absent (callers fall back to "subagent").
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> ResolveAgentTypes(string parentTranscriptPath) {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        try {
+            foreach (var line in File.ReadLines(parentTranscriptPath)) {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+
+                using var doc  = JsonDocument.Parse(line);
+                var       root = doc.RootElement;
+
+                if (root.Str("type") != "gemini" || root.Arr("toolCalls") is not { } tcs) continue;
+
+                foreach (var tc in tcs.EnumerateArray()) {
+                    if (tc.Str("name") != "invoke_agent" || tc.Str("agentId") is not { } aid) continue;
+
+                    if (tc.Obj("args") is { } args && args.Str("agent_name") is { Length: > 0 } name)
+                        map[aid] = name;
+                }
+            }
+        } catch { /* best effort */ }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Canonical (dashless) agent id from a subagent filename stem (a dashed UUID). Matches
+    /// the dashless form the server routes/correlates on and canonicalizes defensively.
+    /// </summary>
+    public static string CanonicalAgentId(string dashedSubId) => dashedSubId.Replace("-", "");
+
+    // ── Hook payloads (the vendor-agnostic /hooks/subagent-start|stop wire shape) ──
+
+    /// <summary>
+    /// <c>/hooks/subagent-start</c> body. cwd is "" — Gemini carries no cwd for subagents
+    /// (same as the parent session); the server's HookBase requires the (non-null) field.
+    /// </summary>
+    public static JsonObject BuildStartPayload(string parentSessionId, string agentId, string agentType, string subagentTranscriptPath) =>
+        new() {
+            ["hook_event_name"] = "subagent_start",
+            ["session_id"]      = parentSessionId,
+            ["agent_id"]        = agentId,
+            ["agent_type"]      = agentType,
+            ["transcript_path"] = subagentTranscriptPath,
+            ["cwd"]             = "",
+        };
+
+    /// <summary><c>/hooks/subagent-stop</c> body.</summary>
+    public static JsonObject BuildStopPayload(string parentSessionId, string agentId, string agentType, string subagentTranscriptPath) =>
+        new() {
+            ["hook_event_name"]        = "subagent_stop",
+            ["session_id"]             = parentSessionId,
+            ["agent_id"]               = agentId,
+            ["agent_type"]             = agentType,
+            ["transcript_path"]        = subagentTranscriptPath,
+            ["cwd"]                    = "",
+            ["stop_hook_active"]       = false,
+            ["agent_transcript_path"]  = subagentTranscriptPath,
+            ["last_assistant_message"] = "",
+        };
+}

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.Gemini;
 
 namespace Capacitor.Cli.Commands;
 
@@ -147,6 +148,11 @@ static class GeminiHookCommand {
                     async () => {
                         await WatcherManager.KillWatcher(sessionId);
                         await WatcherManager.InlineDrainAsync(baseUrl, sessionId, transcriptPath, agentId: null, vendor: "gemini");
+                        // Gemini fires no subagent-stop hook, so the parent owns subagent
+                        // teardown: kill each live child watcher, drain its tail, and finalize
+                        // it (subagent-stop). Restart-safe — driven off the on-disk files,
+                        // not an in-memory set. Shares the same drain cap (AI-900).
+                        await DrainGeminiSubagentsAsync(baseUrl, sessionId, transcriptPath);
                     },
                     PreHookDrainCap
                 );
@@ -227,6 +233,43 @@ static class GeminiHookCommand {
             agentId: null, sessionIdOverride: null, cwd: cwd,
             skipTitle: skipTitle, vendor: "gemini"
         );
+    }
+
+    /// <summary>
+    /// Tears down any live Gemini subagent child watchers at session-end: for each nested
+    /// subagent transcript, kill its child watcher (no-op if not running), drain its tail
+    /// (resumes from the server watermark), and POST subagent-stop. Enumerates the on-disk
+    /// files rather than an in-memory set, so it recovers subagents even after a parent
+    /// watcher restart/crash. Best-effort per subagent (re-import recovers). AI-900.
+    /// </summary>
+    static async Task DrainGeminiSubagentsAsync(string baseUrl, string sessionId, string transcriptPath) {
+        var subFiles = GeminiSubagentDiscovery.EnumerateSubagentFiles(transcriptPath);
+        if (subFiles.Count == 0) return;
+
+        var types = GeminiSubagentDiscovery.ResolveAgentTypes(transcriptPath);
+
+        foreach (var subFile in subFiles) {
+            var subId = Path.GetFileNameWithoutExtension(subFile);
+            if (!Guid.TryParse(subId, out _)) continue;
+
+            var agentId   = GeminiSubagentDiscovery.CanonicalAgentId(subId);
+            var agentType = types.GetValueOrDefault(subId) ?? "subagent";
+
+            await WatcherManager.KillWatcher($"{sessionId}-{agentId}");
+            await WatcherManager.InlineDrainAsync(baseUrl, sessionId, subFile, agentId, vendor: "gemini");
+            await PostSubagentStopAsync(baseUrl, sessionId, agentId, agentType, subFile);
+        }
+    }
+
+    static async Task PostSubagentStopAsync(string baseUrl, string sessionId, string agentId, string agentType, string subFile) {
+        try {
+            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+            var       payload = GeminiSubagentDiscovery.BuildStopPayload(sessionId, agentId, agentType, subFile);
+            using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+            await client.PostWithRetryAsync($"{baseUrl}/hooks/subagent-stop", content);
+        } catch {
+            // Best effort — re-import (kcap import --gemini) recovers the subagent.
+        }
     }
 
     static async Task<int> PostHookAsync(string baseUrl, string endpoint, string body) {

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -151,8 +151,9 @@ static class GeminiHookCommand {
                         // Gemini fires no subagent-stop hook, so the parent owns subagent
                         // teardown: kill each live child watcher, drain its tail, and finalize
                         // it (subagent-stop). Restart-safe — driven off the on-disk files,
-                        // not an in-memory set. Shares the same drain cap (AI-900).
-                        await DrainGeminiSubagentsAsync(baseUrl, sessionId, transcriptPath);
+                        // not an in-memory set. Shared with the watcher's parent-exit fallback
+                        // so a crash that bypasses this hook still finalizes subagents (AI-900).
+                        await GeminiSubagentTeardown.DrainAsync(baseUrl, sessionId, transcriptPath);
                     },
                     PreHookDrainCap
                 );
@@ -233,43 +234,6 @@ static class GeminiHookCommand {
             agentId: null, sessionIdOverride: null, cwd: cwd,
             skipTitle: skipTitle, vendor: "gemini"
         );
-    }
-
-    /// <summary>
-    /// Tears down any live Gemini subagent child watchers at session-end: for each nested
-    /// subagent transcript, kill its child watcher (no-op if not running), drain its tail
-    /// (resumes from the server watermark), and POST subagent-stop. Enumerates the on-disk
-    /// files rather than an in-memory set, so it recovers subagents even after a parent
-    /// watcher restart/crash. Best-effort per subagent (re-import recovers). AI-900.
-    /// </summary>
-    static async Task DrainGeminiSubagentsAsync(string baseUrl, string sessionId, string transcriptPath) {
-        var subFiles = GeminiSubagentDiscovery.EnumerateSubagentFiles(transcriptPath);
-        if (subFiles.Count == 0) return;
-
-        var types = GeminiSubagentDiscovery.ResolveAgentTypes(transcriptPath);
-
-        foreach (var subFile in subFiles) {
-            var subId = Path.GetFileNameWithoutExtension(subFile);
-            if (!Guid.TryParse(subId, out _)) continue;
-
-            var agentId   = GeminiSubagentDiscovery.CanonicalAgentId(subId);
-            var agentType = types.GetValueOrDefault(subId) ?? "subagent";
-
-            await WatcherManager.KillWatcher($"{sessionId}-{agentId}");
-            await WatcherManager.InlineDrainAsync(baseUrl, sessionId, subFile, agentId, vendor: "gemini");
-            await PostSubagentStopAsync(baseUrl, sessionId, agentId, agentType, subFile);
-        }
-    }
-
-    static async Task PostSubagentStopAsync(string baseUrl, string sessionId, string agentId, string agentType, string subFile) {
-        try {
-            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
-            var       payload = GeminiSubagentDiscovery.BuildStopPayload(sessionId, agentId, agentType, subFile);
-            using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
-            await client.PostWithRetryAsync($"{baseUrl}/hooks/subagent-stop", content);
-        } catch {
-            // Best effort — re-import (kcap import --gemini) recovers the subagent.
-        }
     }
 
     static async Task<int> PostHookAsync(string baseUrl, string endpoint, string body) {

--- a/src/Capacitor.Cli/Commands/GeminiImportSource.cs
+++ b/src/Capacitor.Cli/Commands/GeminiImportSource.cs
@@ -226,6 +226,11 @@ internal sealed class GeminiImportSource : IImportSource {
             return ImportOutcome.Failed;
         }
 
+        // Import nested subagents (chats/<parentSessionId>/<subId>.jsonl) under the parent,
+        // BEFORE session-end so their SubagentStarted/Completed land in the parent stream
+        // ahead of SessionEnded. Subagent failures don't fail the (already-imported) parent.
+        await ImportSubagentsAsync(ctx.HttpClient, ctx.BaseUrl, classification.SessionId, transcriptPath, ct);
+
         var endOk = await PostSyntheticHookAsync(
             ctx.HttpClient, ctx.BaseUrl, "session-end/gemini",
             BuildSessionEndPayload(classification.SessionId, classification.Meta.LastTimestamp),
@@ -267,6 +272,112 @@ internal sealed class GeminiImportSource : IImportSource {
         } catch {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Imports any nested subagent transcripts (chats/&lt;parentSessionId&gt;/&lt;subId&gt;.jsonl)
+    /// recorded alongside the parent. Each is sent under the parent session id with the
+    /// subagent's canonical (dashless) id so the server routes it to AgentSubsession-*.
+    /// subagent-start is fail-closed (skip a subagent's content if start fails) so a subagent
+    /// stream never exists without the SubagentStarted that lets chat/trace nest it. Re-runs
+    /// are idempotent (deterministic server-side ids). AI-900.
+    /// </summary>
+    async Task ImportSubagentsAsync(
+        HttpClient client, string baseUrl, string parentSessionIdDashless, string transcriptPath, CancellationToken ct
+    ) {
+        var (dashedParent, _) = ReadHeader(transcriptPath);
+        if (dashedParent is null) return;
+
+        var chatsDir = Path.GetDirectoryName(transcriptPath);
+        if (chatsDir is null) return;
+
+        var subagentDir = GeminiPaths.SubagentDir(chatsDir, dashedParent);
+        if (!Directory.Exists(subagentDir)) return;
+
+        var typeMap = BuildSubagentTypeMap(transcriptPath);
+
+        foreach (var subFile in Directory.EnumerateFiles(subagentDir, "*.jsonl")) {
+            ct.ThrowIfCancellationRequested();
+
+            var subId = Path.GetFileNameWithoutExtension(subFile);
+            if (!Guid.TryParse(subId, out _)) continue; // only well-formed <subId>.jsonl
+
+            var agentId   = ImportCommand.NormalizeGuid(subId);             // dashless — matches server routing + correlation
+            var agentType = typeMap.GetValueOrDefault(subId) ?? "subagent"; // agent_name from the parent invoke_agent call
+
+            // Fail-closed: don't stream content unless the subagent registered first.
+            var startOk = await PostSyntheticHookAsync(
+                client, baseUrl, "subagent-start",
+                BuildSubagentStartPayload(parentSessionIdDashless, agentId, agentType, subFile), ct);
+            if (!startOk) continue;
+
+            try {
+                await SessionImporter.SendTranscriptBatches(
+                    httpClient: client, baseUrl: baseUrl,
+                    sessionId:  parentSessionIdDashless, filePath: subFile,
+                    agentId:    agentId, startLine: 0, vendor: Vendor);
+            } catch {
+                continue; // leave subagent-stop unsent; a re-import retries (idempotent)
+            }
+
+            await PostSyntheticHookAsync(
+                client, baseUrl, "subagent-stop",
+                BuildSubagentStopPayload(parentSessionIdDashless, agentId, agentType, subFile), ct);
+        }
+    }
+
+    static JsonObject BuildSubagentStartPayload(string parentSessionId, string agentId, string agentType, string subagentTranscriptPath) =>
+        new() {
+            ["hook_event_name"] = "subagent_start",
+            ["session_id"]      = parentSessionId,
+            ["agent_id"]        = agentId,
+            ["agent_type"]      = agentType,
+            ["transcript_path"] = subagentTranscriptPath,
+            ["cwd"]             = "", // Gemini import carries no cwd (same as the parent session)
+        };
+
+    static JsonObject BuildSubagentStopPayload(string parentSessionId, string agentId, string agentType, string subagentTranscriptPath) =>
+        new() {
+            ["hook_event_name"]        = "subagent_stop",
+            ["session_id"]             = parentSessionId,
+            ["agent_id"]               = agentId,
+            ["agent_type"]             = agentType,
+            ["transcript_path"]        = subagentTranscriptPath,
+            ["cwd"]                    = "",
+            ["stop_hook_active"]       = false,
+            ["agent_transcript_path"]  = subagentTranscriptPath,
+            ["last_assistant_message"] = "",
+        };
+
+    /// <summary>
+    /// Maps each subagent id (DASHED, as it appears in the nested filename) to the
+    /// <c>agent_name</c> from the parent's <c>invoke_agent</c> tool call, so the subagent
+    /// renders with a meaningful type. The parent invoke_agent toolCall persists
+    /// <c>agentId == subId</c>, and <c>args.agent_name</c> is its only on-disk type signal.
+    /// Best-effort — unmatched ids fall back to "subagent". AI-900.
+    /// </summary>
+    static Dictionary<string, string> BuildSubagentTypeMap(string transcriptPath) {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        try {
+            foreach (var line in File.ReadLines(transcriptPath)) {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+
+                using var doc  = JsonDocument.Parse(line);
+                var       root = doc.RootElement;
+
+                if (root.Str("type") != "gemini" || root.Arr("toolCalls") is not { } tcs) continue;
+
+                foreach (var tc in tcs.EnumerateArray()) {
+                    if (tc.Str("name") != "invoke_agent" || tc.Str("agentId") is not { } aid) continue;
+
+                    if (tc.Obj("args") is { } args && args.Str("agent_name") is { Length: > 0 } name)
+                        map[aid] = name;
+                }
+            }
+        } catch { /* best effort — type just falls back to "subagent" */ }
+
+        return map;
     }
 
     static DateTimeOffset? TryGetLastWriteUtc(string path) {

--- a/src/Capacitor.Cli/Commands/GeminiImportSource.cs
+++ b/src/Capacitor.Cli/Commands/GeminiImportSource.cs
@@ -285,30 +285,24 @@ internal sealed class GeminiImportSource : IImportSource {
     async Task ImportSubagentsAsync(
         HttpClient client, string baseUrl, string parentSessionIdDashless, string transcriptPath, CancellationToken ct
     ) {
-        var (dashedParent, _) = ReadHeader(transcriptPath);
-        if (dashedParent is null) return;
+        var subFiles = GeminiSubagentDiscovery.EnumerateSubagentFiles(transcriptPath);
+        if (subFiles.Count == 0) return;
 
-        var chatsDir = Path.GetDirectoryName(transcriptPath);
-        if (chatsDir is null) return;
+        var types = GeminiSubagentDiscovery.ResolveAgentTypes(transcriptPath);
 
-        var subagentDir = GeminiPaths.SubagentDir(chatsDir, dashedParent);
-        if (!Directory.Exists(subagentDir)) return;
-
-        var typeMap = BuildSubagentTypeMap(transcriptPath);
-
-        foreach (var subFile in Directory.EnumerateFiles(subagentDir, "*.jsonl")) {
+        foreach (var subFile in subFiles) {
             ct.ThrowIfCancellationRequested();
 
             var subId = Path.GetFileNameWithoutExtension(subFile);
             if (!Guid.TryParse(subId, out _)) continue; // only well-formed <subId>.jsonl
 
-            var agentId   = ImportCommand.NormalizeGuid(subId);             // dashless — matches server routing + correlation
-            var agentType = typeMap.GetValueOrDefault(subId) ?? "subagent"; // agent_name from the parent invoke_agent call
+            var agentId   = GeminiSubagentDiscovery.CanonicalAgentId(subId); // dashless — matches server routing + correlation
+            var agentType = types.GetValueOrDefault(subId) ?? "subagent";    // agent_name from the parent invoke_agent call
 
             // Fail-closed: don't stream content unless the subagent registered first.
             var startOk = await PostSyntheticHookAsync(
                 client, baseUrl, "subagent-start",
-                BuildSubagentStartPayload(parentSessionIdDashless, agentId, agentType, subFile), ct);
+                GeminiSubagentDiscovery.BuildStartPayload(parentSessionIdDashless, agentId, agentType, subFile), ct);
             if (!startOk) continue;
 
             try {
@@ -322,62 +316,8 @@ internal sealed class GeminiImportSource : IImportSource {
 
             await PostSyntheticHookAsync(
                 client, baseUrl, "subagent-stop",
-                BuildSubagentStopPayload(parentSessionIdDashless, agentId, agentType, subFile), ct);
+                GeminiSubagentDiscovery.BuildStopPayload(parentSessionIdDashless, agentId, agentType, subFile), ct);
         }
-    }
-
-    static JsonObject BuildSubagentStartPayload(string parentSessionId, string agentId, string agentType, string subagentTranscriptPath) =>
-        new() {
-            ["hook_event_name"] = "subagent_start",
-            ["session_id"]      = parentSessionId,
-            ["agent_id"]        = agentId,
-            ["agent_type"]      = agentType,
-            ["transcript_path"] = subagentTranscriptPath,
-            ["cwd"]             = "", // Gemini import carries no cwd (same as the parent session)
-        };
-
-    static JsonObject BuildSubagentStopPayload(string parentSessionId, string agentId, string agentType, string subagentTranscriptPath) =>
-        new() {
-            ["hook_event_name"]        = "subagent_stop",
-            ["session_id"]             = parentSessionId,
-            ["agent_id"]               = agentId,
-            ["agent_type"]             = agentType,
-            ["transcript_path"]        = subagentTranscriptPath,
-            ["cwd"]                    = "",
-            ["stop_hook_active"]       = false,
-            ["agent_transcript_path"]  = subagentTranscriptPath,
-            ["last_assistant_message"] = "",
-        };
-
-    /// <summary>
-    /// Maps each subagent id (DASHED, as it appears in the nested filename) to the
-    /// <c>agent_name</c> from the parent's <c>invoke_agent</c> tool call, so the subagent
-    /// renders with a meaningful type. The parent invoke_agent toolCall persists
-    /// <c>agentId == subId</c>, and <c>args.agent_name</c> is its only on-disk type signal.
-    /// Best-effort — unmatched ids fall back to "subagent". AI-900.
-    /// </summary>
-    static Dictionary<string, string> BuildSubagentTypeMap(string transcriptPath) {
-        var map = new Dictionary<string, string>(StringComparer.Ordinal);
-
-        try {
-            foreach (var line in File.ReadLines(transcriptPath)) {
-                if (string.IsNullOrWhiteSpace(line)) continue;
-
-                using var doc  = JsonDocument.Parse(line);
-                var       root = doc.RootElement;
-
-                if (root.Str("type") != "gemini" || root.Arr("toolCalls") is not { } tcs) continue;
-
-                foreach (var tc in tcs.EnumerateArray()) {
-                    if (tc.Str("name") != "invoke_agent" || tc.Str("agentId") is not { } aid) continue;
-
-                    if (tc.Obj("args") is { } args && args.Str("agent_name") is { Length: > 0 } name)
-                        map[aid] = name;
-                }
-            }
-        } catch { /* best effort — type just falls back to "subagent" */ }
-
-        return map;
     }
 
     static DateTimeOffset? TryGetLastWriteUtc(string path) {

--- a/src/Capacitor.Cli/Commands/GeminiSubagentTeardown.cs
+++ b/src/Capacitor.Cli/Commands/GeminiSubagentTeardown.cs
@@ -1,0 +1,63 @@
+using System.Text;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Gemini;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// Shared session-end teardown for live Gemini subagents (AI-900). Gemini fires no
+/// subagent-stop hook, and the child watchers the parent spawns carry no parent-pid
+/// watchdog, so the parent session-end is the ONLY thing that finalizes them: for each
+/// nested subagent transcript, kill its child watcher (no-op if already gone), drain its
+/// tail (resumes from the server watermark), and POST <c>/hooks/subagent-stop</c> so the
+/// server writes <c>SubagentCompleted</c> + the agent summary.
+///
+/// Enumerates the on-disk files rather than an in-memory set, so it recovers subagents
+/// even after a parent-watcher restart/crash. Invoked from BOTH session-end paths — the
+/// normal Gemini hook (<see cref="GeminiHookCommand"/>) and the watcher's parent-exit
+/// fallback (<see cref="WatchCommand.PostSessionEndOnParentExitAsync"/>) — so a crash that
+/// bypasses the hook still finalizes subagents instead of leaving them with
+/// <c>SubagentStarted</c> + content but no <c>SubagentCompleted</c>. Best-effort per step
+/// (a failure on one subagent — or one step — never skips the rest; re-import recovers).
+/// </summary>
+static class GeminiSubagentTeardown {
+    /// <summary>
+    /// Time budget for the teardown on a shutdown path (the parent-exit watchdog), so a slow
+    /// or retrying drain can't block process termination. Mirrors
+    /// <c>GeminiHookCommand.PreHookDrainCap</c>.
+    /// </summary>
+    internal static readonly TimeSpan DrainCap = TimeSpan.FromSeconds(8);
+
+    internal static async Task DrainAsync(string baseUrl, string sessionId, string transcriptPath) {
+        var subFiles = GeminiSubagentDiscovery.EnumerateSubagentFiles(transcriptPath);
+        if (subFiles.Count == 0) return;
+
+        var types = GeminiSubagentDiscovery.ResolveAgentTypes(transcriptPath);
+
+        foreach (var subFile in subFiles) {
+            var subId = Path.GetFileNameWithoutExtension(subFile);
+            if (!Guid.TryParse(subId, out _)) continue;
+
+            var agentId   = GeminiSubagentDiscovery.CanonicalAgentId(subId);
+            var agentType = types.GetValueOrDefault(subId) ?? "subagent";
+
+            // Each step best-effort + independent so subagent-stop (→ SubagentCompleted) is
+            // always attempted even if the kill or drain hiccups; re-import recovers the rest.
+            await SafeAsync(() => WatcherManager.KillWatcher($"{sessionId}-{agentId}"));
+            await SafeAsync(() => WatcherManager.InlineDrainAsync(baseUrl, sessionId, subFile, agentId, vendor: "gemini"));
+            await SafeAsync(() => PostStopAsync(baseUrl, sessionId, agentId, agentType, subFile));
+        }
+    }
+
+    static async Task PostStopAsync(string baseUrl, string sessionId, string agentId, string agentType, string subFile) {
+        using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+        var       payload = GeminiSubagentDiscovery.BuildStopPayload(sessionId, agentId, agentType, subFile);
+        using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+        await client.PostWithRetryAsync($"{baseUrl}/hooks/subagent-stop", content);
+    }
+
+    static async Task SafeAsync(Func<Task> op) {
+        try { await op(); } catch { /* best effort — kcap import --gemini recovers anything missed */ }
+    }
+}

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Gemini;
 using Capacitor.Cli.Core.Pi;
 using Capacitor.Cli.Core.Auth;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -268,6 +269,11 @@ static partial class WatchCommand {
         state.LinesProcessed = await hubConnection.InvokeAsync<int>("WatcherConnect", sessionId, agentId, cts.Token);
         Log($"Connected via SignalR, resuming from line {state.LinesProcessed}");
 
+        // Gemini fires no subagent hooks, so the parent watcher discovers nested subagent
+        // transcripts itself and spawns a child watcher per subagent (AI-900). Tracks the
+        // files already registered + spawned so each is handled exactly once across ticks.
+        var seenSubagents = new HashSet<string>(StringComparer.Ordinal);
+
         try {
             while (!cts.Token.IsCancellationRequested) {
                 // Skip work while disconnected — SignalR auto-reconnect handles recovery.
@@ -289,6 +295,12 @@ static partial class WatchCommand {
                 }
 
                 await DrainNewLines(hubConnection, sessionId, transcriptPath, agentId, state, vendor, cts.Token);
+
+                // Live Gemini subagent discovery: only the parent (agentId == null) watcher
+                // scans; child subagent watchers (agentId != null) just stream their file.
+                if (agentId is null && vendor == "gemini") {
+                    await ScanGeminiSubagents(baseUrl, sessionId, transcriptPath, seenSubagents, cts.Token);
+                }
 
                 try {
                     await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
@@ -346,6 +358,73 @@ static partial class WatchCommand {
         await logWriter.DisposeAsync();
 
         return 0;
+    }
+
+    /// <summary>
+    /// Gemini fires no subagent hooks, so the parent watcher discovers nested subagent
+    /// transcripts itself (<c>chats/&lt;parentSessionId&gt;/&lt;subId&gt;.jsonl</c>). On first
+    /// sight of a file it registers the subagent (<c>subagent-start</c>, fail-closed) then
+    /// spawns a detached child watcher that streams it with the subagent's canonical agentId
+    /// (→ <c>AgentSubsession-*</c>). Idempotent across ticks via <paramref name="seen"/>;
+    /// deterministic server-side lifecycle ids make re-registration safe. AI-900.
+    /// </summary>
+    static async Task ScanGeminiSubagents(
+            string          baseUrl,
+            string          sessionId,
+            string          transcriptPath,
+            HashSet<string> seen,
+            CancellationToken ct
+        ) {
+        IReadOnlyList<string> subFiles;
+        try {
+            subFiles = GeminiSubagentDiscovery.EnumerateSubagentFiles(transcriptPath);
+        } catch {
+            return; // discovery is best-effort — never break the main drain loop
+        }
+
+        if (subFiles.Count == 0) return;
+
+        IReadOnlyDictionary<string, string>? types = null;
+
+        foreach (var subFile in subFiles) {
+            if (ct.IsCancellationRequested) return;
+            if (!seen.Add(subFile)) continue; // already registered + spawned
+
+            var subId = Path.GetFileNameWithoutExtension(subFile);
+            if (!Guid.TryParse(subId, out _)) continue; // not a <subId>.jsonl
+
+            var agentId   = GeminiSubagentDiscovery.CanonicalAgentId(subId);
+            types       ??= GeminiSubagentDiscovery.ResolveAgentTypes(transcriptPath);
+            var agentType = types.GetValueOrDefault(subId) ?? "subagent";
+
+            // Fail-closed: register the subagent (→ SubagentStarted) before its child watcher
+            // streams content. On POST failure, drop from `seen` so the next tick retries.
+            if (!await PostSubagentStartAsync(baseUrl, sessionId, agentId, agentType, subFile, ct)) {
+                seen.Remove(subFile);
+                continue;
+            }
+
+            await WatcherManager.EnsureWatcherRunning(
+                baseUrl, key: $"{sessionId}-{agentId}", transcriptPath: subFile,
+                agentId: agentId, sessionIdOverride: sessionId, vendor: "gemini");
+
+            Log($"Gemini subagent {agentId} ({agentType}) registered + child watcher spawned");
+        }
+    }
+
+    static async Task<bool> PostSubagentStartAsync(
+        string baseUrl, string sessionId, string agentId, string agentType, string subFile, CancellationToken ct
+    ) {
+        try {
+            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, ct);
+            var       payload = GeminiSubagentDiscovery.BuildStartPayload(sessionId, agentId, agentType, subFile);
+            using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+            using var resp    = await client.PostWithRetryAsync($"{baseUrl}/hooks/subagent-start", content, ct: ct);
+
+            return resp.IsSuccessStatusCode;
+        } catch {
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -455,6 +455,27 @@ static partial class WatchCommand {
             return;
         }
 
+        // Gemini fires no subagent-stop hook and the child watchers spawned in ScanGeminiSubagents
+        // carry no parent-pid watchdog, so when the parent process dies WITHOUT the session-end
+        // hook this is the only place that finalizes live subagents. Mirror the hook path: kill
+        // each child watcher, drain its tail, POST subagent-stop — capped so a slow drain can't
+        // block the watchdog's self-termination, and run BEFORE the session-end POST so
+        // SubagentCompleted lands ahead of SessionEnded. No-op when none were spawned (AI-900).
+        if (vendor == "gemini") {
+            try {
+                var finalized = await TimeBudget.RunCappedAsync(
+                    () => GeminiSubagentTeardown.DrainAsync(baseUrl, sessionId, transcriptPath),
+                    GeminiSubagentTeardown.DrainCap);
+
+                if (!finalized) {
+                    Log("Parent-exit Gemini subagent teardown cap elapsed; "
+                      + "unfinalized subagents recover via: kcap import --gemini");
+                }
+            } catch (Exception ex) {
+                Log($"Parent-exit Gemini subagent teardown failed: {ex.Message}");
+            }
+        }
+
         using var budgetCts = new CancellationTokenSource(ParentExitPostBudget);
 
         try {

--- a/test/Capacitor.Cli.Tests.Integration/GeminiSubagentImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/GeminiSubagentImportTests.cs
@@ -1,0 +1,117 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// Wire-contract test for Gemini subagent import (AI-900). Gemini records subagents
+/// in nested files (<c>chats/&lt;parentSessionId&gt;/&lt;subId&gt;.jsonl</c>); the parent's
+/// <c>invoke_agent</c> tool call persists <c>agentId == subId</c> + <c>args.agent_name</c>.
+/// This drives the full discover → classify → import path and asserts the subagent
+/// lifecycle the server expects: <c>/hooks/subagent-start</c> and <c>/hooks/subagent-stop</c>
+/// carry the CANONICAL (dashless) <c>agent_id</c> and the <c>agent_type</c> resolved from
+/// the parent <c>agent_name</c>, and the subagent transcript batch is tagged
+/// <c>vendor=gemini</c> with that <c>agent_id</c> so the server routes it to
+/// <c>AgentSubsession-*</c>.
+/// </summary>
+public class GeminiSubagentImportTests : IDisposable {
+    readonly WireMockServer _server  = WireMockServer.Start();
+    readonly string         _tempDir = Directory.CreateTempSubdirectory("kcap-gemini-sub-it").FullName;
+
+    const string DashedParent   = "0a900000-0000-4000-8000-000000000903";
+    const string DashlessParent = "0a900000000040008000000000000903";
+    const string DashedSub      = "57d9b498-2705-4af5-b060-ebaba4878c96";
+    const string DashlessSub     = "57d9b49827054af5b060ebaba4878c96";
+
+    public void Dispose() {
+        _server.Stop();
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    // Writes a parent main session (with an invoke_agent call) + the nested subagent file,
+    // and returns the tmp-dir override (the dir that holds per-project subdirectories).
+    void WriteFixture() {
+        var chats = Path.Combine(_tempDir, "proj", "chats");
+        Directory.CreateDirectory(chats);
+
+        File.WriteAllLines(Path.Combine(chats, "session-2026-06-22T14-31-0a900000.jsonl"), new[] {
+            $$"""{"sessionId":"{{DashedParent}}","projectHash":"h","startTime":"2026-06-22T14:31:00.000Z","lastUpdated":"2026-06-22T14:31:00.000Z","kind":"main"}""",
+            """{"id":"u1","timestamp":"2026-06-22T14:31:01.000Z","type":"user","content":[{"text":"delegate it"}]}""",
+            $$"""{"id":"m1","timestamp":"2026-06-22T14:31:05.000Z","type":"gemini","content":"","tokens":{"input":5,"output":2,"total":7},"model":"gemini-3-flash-preview","toolCalls":[{"id":"invoke_agent__x","name":"invoke_agent","args":{"agent_name":"codebase_investigator","prompt":"list files"},"agentId":"{{DashedSub}}","status":"success"}]}"""
+        });
+
+        var subDir = Path.Combine(chats, DashedParent);
+        Directory.CreateDirectory(subDir);
+        File.WriteAllLines(Path.Combine(subDir, DashedSub + ".jsonl"), new[] {
+            $$"""{"sessionId":"{{DashedSub}}","projectHash":"h","startTime":"2026-06-22T14:31:06.000Z","lastUpdated":"2026-06-22T14:31:06.000Z","kind":"subagent","directories":[]}""",
+            """{"id":"s1","timestamp":"2026-06-22T14:31:07.000Z","type":"gemini","content":"calc.py, README.md","tokens":{"input":3,"output":4,"total":7},"model":"gemini-3-flash-preview"}"""
+        });
+    }
+
+    [Test]
+    public async Task ImportSession_imports_nested_subagent_with_canonical_id_and_resolved_type() {
+        WriteFixture();
+
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404));
+        foreach (var route in new[] {
+            "/hooks/session-start/gemini", "/hooks/transcript",
+            "/hooks/subagent-start", "/hooks/subagent-stop", "/hooks/session-end/gemini"
+        }) {
+            _server.Given(Request.Create().WithPath(route).UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200));
+        }
+
+        using var client = new HttpClient();
+        var source = new GeminiImportSource(tmpDirOverride: _tempDir);
+
+        var discovered = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+        // The nested subagent file must NOT be discovered as its own session.
+        await Assert.That(discovered.Count).IsEqualTo(1);
+        await Assert.That(discovered[0].SessionId).IsEqualTo(DashlessParent);
+
+        var classified = await source.ClassifyAsync(
+            discovered,
+            new ClassifyContext(client, _server.Url!, MinLines: 0, ExcludedRepos: null, ExcludedPaths: null),
+            CancellationToken.None);
+
+        var outcome = await source.ImportSessionAsync(
+            classified[0],
+            new ImportContext(client, _server.Url!, ForcePrivate: false),
+            CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(ImportOutcome.Loaded);
+
+        var posts = _server.LogEntries
+            .Where(e => e.RequestMessage.Method == "POST")
+            .Select(e => e.RequestMessage.Path)
+            .ToList();
+
+        // Main lifecycle + the subagent lifecycle + two transcript batches (main + subagent).
+        await Assert.That(posts).IsEquivalentTo(new[] {
+            "/hooks/session-start/gemini", "/hooks/transcript", "/hooks/subagent-start",
+            "/hooks/transcript", "/hooks/subagent-stop", "/hooks/session-end/gemini"
+        });
+        // subagent-start lands before subagent-stop (fail-closed lifecycle ordering).
+        await Assert.That(posts.IndexOf("/hooks/subagent-start"))
+            .IsLessThan(posts.IndexOf("/hooks/subagent-stop"));
+
+        // subagent-start carries the canonical (dashless) id + the agent_name-derived type.
+        var startBody = _server.LogEntries.Single(e => e.RequestMessage.Path == "/hooks/subagent-start").RequestMessage.Body!;
+        await Assert.That(startBody).Contains($"\"agent_id\":\"{DashlessSub}\"");
+        await Assert.That(startBody).Contains("\"agent_type\":\"codebase_investigator\"");
+
+        // The subagent transcript batch is tagged vendor=gemini and carries the agent_id.
+        var subTranscript = _server.LogEntries
+            .Where(e => e.RequestMessage.Path == "/hooks/transcript")
+            .Select(e => e.RequestMessage.Body!)
+            .Single(b => b.Contains(DashlessSub));
+        await Assert.That(subTranscript).Contains("\"vendor\":\"gemini\"");
+
+        var stopBody = _server.LogEntries.Single(e => e.RequestMessage.Path == "/hooks/subagent-stop").RequestMessage.Body!;
+        await Assert.That(stopBody).Contains($"\"agent_id\":\"{DashlessSub}\"");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Integration/WatcherParentExitPostTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/WatcherParentExitPostTests.cs
@@ -182,4 +182,71 @@ public class WatcherParentExitPostTests : IDisposable {
         var piHits = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-end/pi").UsingPost());
         await Assert.That(piHits.Count).IsEqualTo(1);
     }
+
+    [Test]
+    public async Task ParentExit_FinalizesGeminiSubagents_BeforeSessionEnd() {
+        // Regression (PR #170 review, BLOCKING): the watcher's parent-exit fallback must run
+        // the Gemini subagent teardown. Gemini fires no subagent-stop hook and its child
+        // watchers carry no parent-pid watchdog, so when the parent process dies WITHOUT the
+        // session-end hook this is the only thing that finalizes live subagents — otherwise
+        // the server keeps SubagentStarted + content but never SubagentCompleted until a
+        // manual re-import.
+        const string dashedParent = "0a900000-0000-4000-8000-000000000777";
+        const string dashedSub    = "57d9b498-2705-4af5-b060-ebaba4878c96";
+        const string dashlessSub  = "57d9b49827054af5b060ebaba4878c96";
+
+        var tmp = Directory.CreateTempSubdirectory("kcap-parentexit-sub").FullName;
+        try {
+            var chats = Path.Combine(tmp, "chats");
+            Directory.CreateDirectory(chats);
+
+            var parent = Path.Combine(chats, "session-2026-06-22T14-31-0a900000.jsonl");
+            File.WriteAllLines(parent, new[] {
+                $$"""{"sessionId":"{{dashedParent}}","projectHash":"h","kind":"main"}""",
+                $$"""{"id":"m1","type":"gemini","content":"","toolCalls":[{"id":"invoke_agent__x","name":"invoke_agent","args":{"agent_name":"codebase_investigator"},"agentId":"{{dashedSub}}","status":"success"}]}"""
+            });
+
+            var subDir = Path.Combine(chats, dashedParent);
+            Directory.CreateDirectory(subDir);
+            File.WriteAllLines(Path.Combine(subDir, dashedSub + ".jsonl"), new[] {
+                $$"""{"sessionId":"{{dashedSub}}","kind":"subagent","directories":[]}""",
+                """{"id":"s1","type":"gemini","content":"done"}"""
+            });
+
+            _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+                .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"provider":"None"}"""));
+            // 404 watermark → inline drain finds no new lines and posts no transcript batch;
+            // subagent-stop must still fire (that is the regression under test).
+            _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+                .RespondWith(Response.Create().WithStatusCode(404));
+            foreach (var route in new[] { "/hooks/transcript", "/hooks/subagent-stop", "/hooks/session-end/gemini" }) {
+                _server.Given(Request.Create().WithPath(route).UsingPost())
+                    .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"generate_whats_done":false}"""));
+            }
+
+            await WatchCommand.PostSessionEndOnParentExitAsync(
+                baseUrl:        _server.Url!,
+                sessionId:      "0a900000000040008000000000000777",
+                transcriptPath: parent,
+                cwd:            "/repo",
+                vendor:         "gemini",
+                repository:     null
+            );
+
+            // subagent-stop was posted, carrying the canonical (dashless) agent_id.
+            var stops = _server.FindLogEntries(Request.Create().WithPath("/hooks/subagent-stop").UsingPost());
+            await Assert.That(stops.Count).IsEqualTo(1);
+            await Assert.That(stops[0].RequestMessage.Body!).Contains($"\"agent_id\":\"{dashlessSub}\"");
+
+            // ... and it landed BEFORE session-end, so SubagentCompleted precedes SessionEnded.
+            var postPaths = _server.LogEntries
+                .Where(e => e.RequestMessage.Method == "POST")
+                .Select(e => e.RequestMessage.Path)
+                .ToList();
+            await Assert.That(postPaths.IndexOf("/hooks/subagent-stop"))
+                .IsLessThan(postPaths.IndexOf("/hooks/session-end/gemini"));
+        } finally {
+            Directory.Delete(tmp, recursive: true);
+        }
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/GeminiSubagentDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiSubagentDiscoveryTests.cs
@@ -1,0 +1,84 @@
+using Capacitor.Cli.Core.Gemini;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="GeminiSubagentDiscovery"/> (AI-900) — the shared discovery
+/// used by both the import path and the live watcher: locate nested subagent files under
+/// <c>chats/&lt;dashedParent&gt;/</c>, resolve each subagent's type from the parent's
+/// <c>invoke_agent</c> call, and canonicalize the (dashed) subId for the server.
+/// </summary>
+public class GeminiSubagentDiscoveryTests {
+    const string DashedParent = "0a900000-0000-4000-8000-000000000903";
+    const string DashedSub    = "57d9b498-2705-4af5-b060-ebaba4878c96";
+
+    static string WriteParentWithSubagent(string tmp, string agentName) {
+        var chats = Path.Combine(tmp, "chats");
+        Directory.CreateDirectory(chats);
+
+        var parent = Path.Combine(chats, "session-2026-06-22T14-31-0a900000.jsonl");
+        File.WriteAllLines(parent, new[] {
+            $$"""{"sessionId":"{{DashedParent}}","projectHash":"h","startTime":"2026-06-22T14:31:00.000Z","kind":"main"}""",
+            $$"""{"id":"m1","timestamp":"2026-06-22T14:31:05.000Z","type":"gemini","content":"","toolCalls":[{"id":"invoke_agent__x","name":"invoke_agent","args":{"agent_name":"{{agentName}}","prompt":"p"},"agentId":"{{DashedSub}}","status":"success"}]}"""
+        });
+
+        var subDir = Path.Combine(chats, DashedParent);
+        Directory.CreateDirectory(subDir);
+        File.WriteAllText(
+            Path.Combine(subDir, DashedSub + ".jsonl"),
+            $$"""{"sessionId":"{{DashedSub}}","projectHash":"h","kind":"subagent","directories":[]}""" + "\n");
+
+        return parent;
+    }
+
+    [Test]
+    public async Task EnumerateSubagentFiles_FindsNestedFile() {
+        var tmp = Directory.CreateTempSubdirectory("kcap-gsd").FullName;
+        try {
+            var parent = WriteParentWithSubagent(tmp, "codebase_investigator");
+
+            var files = GeminiSubagentDiscovery.EnumerateSubagentFiles(parent);
+
+            await Assert.That(files.Count).IsEqualTo(1);
+            await Assert.That(Path.GetFileNameWithoutExtension(files[0])).IsEqualTo(DashedSub);
+        } finally {
+            Directory.Delete(tmp, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task EnumerateSubagentFiles_EmptyWhenNoNestedDir() {
+        var tmp = Directory.CreateTempSubdirectory("kcap-gsd").FullName;
+        try {
+            var chats = Path.Combine(tmp, "chats");
+            Directory.CreateDirectory(chats);
+            var parent = Path.Combine(chats, "session-x.jsonl");
+            File.WriteAllText(parent, $$"""{"sessionId":"{{DashedParent}}","kind":"main"}""" + "\n");
+
+            await Assert.That(GeminiSubagentDiscovery.EnumerateSubagentFiles(parent).Count).IsEqualTo(0);
+        } finally {
+            Directory.Delete(tmp, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ResolveAgentTypes_MapsSubIdToParentAgentName() {
+        var tmp = Directory.CreateTempSubdirectory("kcap-gsd").FullName;
+        try {
+            var parent = WriteParentWithSubagent(tmp, "codebase_investigator");
+
+            var types = GeminiSubagentDiscovery.ResolveAgentTypes(parent);
+
+            await Assert.That(types.GetValueOrDefault(DashedSub)).IsEqualTo("codebase_investigator");
+        } finally {
+            Directory.Delete(tmp, recursive: true);
+        }
+    }
+
+    [Test]
+    [Arguments("57d9b498-2705-4af5-b060-ebaba4878c96", "57d9b49827054af5b060ebaba4878c96")]
+    [Arguments("alreadydashless", "alreadydashless")]
+    public async Task CanonicalAgentId_StripsDashes(string input, string expected) {
+        await Assert.That(GeminiSubagentDiscovery.CanonicalAgentId(input)).IsEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## What

Ingest **Gemini CLI subagents** — the nested transcripts Gemini records at
`~/.gemini/tmp/<project>/chats/<parentSessionId>/<subId>.jsonl` when a session
spawns a subagent via the `invoke_agent` tool. Previously the CLI captured the
main Gemini session only (the nested files were ignored). Now they're captured
both **on historical import** and **live**, and nest under the parent in the
trace.

Pairs with server PR kurrent-io/kcap-server#774 (correlation + idempotent
lifecycle). Closes the CLI half of **AI-900**.

## How

The parent's `invoke_agent` tool call persists `agentId == subId` plus
`args.agent_name`, which is the subagent's only on-disk type signal. A shared
`GeminiSubagentDiscovery` helper (`Capacitor.Cli.Core/Gemini/`) is the single
source of truth for both paths:

- **Discover** nested `chats/<dashedParent>/*.jsonl` files for a given main transcript.
- **Resolve** each subId → `agent_name` from the parent's `invoke_agent` call.
- **Canonicalize** the (dashed) subId to the dashless form the server routes/correlates on.
- **Build** the vendor-agnostic `/hooks/subagent-start|stop` payloads.

**Import** (`GeminiImportSource.ImportSubagentsAsync`): after the main batches and
before session-end, enumerate subagents → fail-closed `subagent-start` →
`/hooks/transcript` batches tagged `agent_id` + `vendor=gemini` → `subagent-stop`.

**Live** (`WatchCommand.ScanGeminiSubagents`): the parent watcher scans for new
nested files after each drain; for each unseen subagent it posts `subagent-start`
(fail-closed) and spawns a **child watcher** (`WatcherManager.EnsureWatcherRunning`,
key `{session}-{agentId}`) that streams the subagent transcript live.

**Teardown** (`GeminiHookCommand.DrainGeminiSubagentsAsync`): on `SessionEnd`, for
each subagent: kill the child watcher → inline-drain the tail → post `subagent-stop`.

All subagent lifecycle/content carries the **canonical (dashless) `agent_id`** and
`vendor=gemini`, so the server routes it to `AgentSubsession-*` and correlates the
`SubagentStarted`/`SubagentCompleted` lifecycle (deterministic ids → idempotent).

## Tests

- `GeminiSubagentDiscoveryTests` (unit) — enumerate / resolve-type / canonicalize.
- `GeminiSubagentImportTests` (integration) — full discover → classify → import;
  asserts the `subagent-start`/`-stop` ordering, canonical `agent_id`,
  `agent_type` from the parent `agent_name`, and `vendor=gemini` on the subagent batch.
- **Full Unit suite: 1650/1650.** AOT publish clean (0 IL2026/IL3050).

> Note: the Integration suite has one **pre-existing, unrelated** flake
> (`ClaudeHookStdoutTests.Emits_nudge_envelope_when_server_returns_newer_version_only`)
> — a process-global `Console.SetOut` capture race that fails identically on
> clean `main` without this branch, and passes in isolation. Not introduced here.

## Live E2E (real Gemini run)

Drove a real `gemini` session (API-key auth) that spawned a `codebase_investigator`
subagent against a fresh local server + KurrentDB:

- Parent watcher discovered the nested subagent file → posted `subagent-start`
  (`SubagentStarted` on the parent `AgentSession-` stream).
- Spawned child watcher streamed the subagent live (22 lines) → `AgentSubsession-`
  populated with the subagent's turns (thinking ×2, tool calls ×4, results ×4, user ×1).
- `SessionEnd` teardown killed the child watcher and posted `subagent-stop` →
  `SubagentCompleted` + `AgentSummaryComputed` on **both** streams, each exactly once
  (server idempotency holds).
