### PR TITLE
Treat Pi branch summaries as import-relevant

### DIFF
--- a/src/Capacitor.Cli/Commands/PiImportSource.cs
+++ b/src/Capacitor.Cli/Commands/PiImportSource.cs
@@ -368,11 +368,13 @@ internal sealed class PiImportSource : IImportSource {
     /// True when the line maps to at least one canonical event under the
     /// server's <c>PiTranscriptNormalizer</c>: the <c>session</c> header always
     /// emits; <c>compaction</c> emits a <c>ContextCompacted</c> (AI-892);
+    /// <c>branch_summary</c> emits an <c>AssistantTextGenerated</c> with Pi metadata
+    /// (AI-892);
     /// <c>message</c> emits for roles user/assistant (non-empty content),
     /// toolResult (has toolCallId), bashExecution (has command). Everything else
-    /// (model_change / thinking_level_change / branch_summary / label /
-    /// session_info / custom*) is skipped server-side and can never advance the
-    /// watermark. Keep in sync with the normalizer.
+    /// (model_change / thinking_level_change / label / session_info / custom*) is
+    /// skipped server-side and can never advance the watermark. Keep in sync with
+    /// the normalizer.
     /// </summary>
     internal static bool IsImportRelevantLine(string line) {
         try {
@@ -380,8 +382,9 @@ internal sealed class PiImportSource : IImportSource {
             var       root = doc.RootElement;
 
             switch (root.Str("type")) {
-                case "session":    return true;
-                case "compaction": return true;
+                case "session":        return true;
+                case "compaction":     return true;
+                case "branch_summary": return root.Str("summary") is { Length: > 0 };
                 case "message":
                     if (root.Obj("message") is not { } msg) return false;
                     return msg.Str("role") switch {

--- a/src/Capacitor.Cli/Commands/PiImportSource.cs
+++ b/src/Capacitor.Cli/Commands/PiImportSource.cs
@@ -384,7 +384,7 @@ internal sealed class PiImportSource : IImportSource {
             switch (root.Str("type")) {
                 case "session":        return true;
                 case "compaction":     return true;
-                case "branch_summary": return root.Str("summary") is { Length: > 0 };
+                case "branch_summary": return !string.IsNullOrWhiteSpace(root.Str("summary"));
                 case "message":
                     if (root.Obj("message") is not { } msg) return false;
                     return msg.Str("role") switch {

--- a/test/Capacitor.Cli.Tests.Integration/PiImportSourceImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/PiImportSourceImportTests.cs
@@ -33,7 +33,6 @@ public class PiImportSourceImportTests : IDisposable {
         File.WriteAllLines(path, new[] {
             $$"""{"type":"session","version":3,"id":"{{DashedSid}}","timestamp":"2026-06-12T10:00:00.000Z","cwd":"/work/a"}""",
             """{"type":"message","id":"a1","parentId":null,"timestamp":"2026-06-12T10:00:01.000Z","message":{"role":"user","content":"hello"}}""",
-            """{"type":"branch_summary","id":"b1","parentId":"a1","timestamp":"2026-06-12T10:00:01.500Z","fromId":"a1","summary":"branch summary kept for import"}""",
             """{"type":"message","id":"a2","parentId":"a1","timestamp":"2026-06-12T10:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"hi there"}],"model":"gpt-5","usage":{"input":10,"output":3}}}"""
         });
         return sessionsDir;

--- a/test/Capacitor.Cli.Tests.Integration/PiImportSourceImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/PiImportSourceImportTests.cs
@@ -33,6 +33,7 @@ public class PiImportSourceImportTests : IDisposable {
         File.WriteAllLines(path, new[] {
             $$"""{"type":"session","version":3,"id":"{{DashedSid}}","timestamp":"2026-06-12T10:00:00.000Z","cwd":"/work/a"}""",
             """{"type":"message","id":"a1","parentId":null,"timestamp":"2026-06-12T10:00:01.000Z","message":{"role":"user","content":"hello"}}""",
+            """{"type":"branch_summary","id":"b1","parentId":"a1","timestamp":"2026-06-12T10:00:01.500Z","fromId":"a1","summary":"branch summary kept for import"}""",
             """{"type":"message","id":"a2","parentId":"a1","timestamp":"2026-06-12T10:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"hi there"}],"model":"gpt-5","usage":{"input":10,"output":3}}}"""
         });
         return sessionsDir;
@@ -96,6 +97,8 @@ public class PiImportSourceImportTests : IDisposable {
             .Single(e => e.RequestMessage.Path == "/hooks/transcript")
             .RequestMessage.Body;
         await Assert.That(transcriptBody!).Contains("\"vendor\":\"pi\"");
+        await Assert.That(transcriptBody!).Contains("branch_summary");
+        await Assert.That(transcriptBody!).Contains("branch summary kept for import");
 
         // The synthesized session-end marks itself as an import (reason pi-import).
         var endBody = _server.LogEntries

--- a/test/Capacitor.Cli.Tests.Integration/PiImportSourceImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/PiImportSourceImportTests.cs
@@ -39,6 +39,18 @@ public class PiImportSourceImportTests : IDisposable {
         return sessionsDir;
     }
 
+    string WriteSessionFileEndingWithBranchSummary() {
+        var sessionsDir = Path.Combine(_tempDir, "sessions-tail");
+        Directory.CreateDirectory(sessionsDir);
+        var path = Path.Combine(sessionsDir, DashedSid + ".jsonl");
+        File.WriteAllLines(path, new[] {
+            $$"""{"type":"session","version":3,"id":"{{DashedSid}}","timestamp":"2026-06-12T10:00:00.000Z","cwd":"/work/a"}""",
+            """{"type":"message","id":"a1","parentId":null,"timestamp":"2026-06-12T10:00:01.000Z","message":{"role":"user","content":"hello"}}""",
+            """{"type":"branch_summary","id":"b1","parentId":"a1","timestamp":"2026-06-12T10:00:01.500Z","fromId":"a1","summary":"branch summary kept for import"}"""
+        });
+        return sessionsDir;
+    }
+
     [Test]
     public async Task ImportSession_posts_lifecycle_and_transcript_with_pi_vendor() {
         var sessionsDir = WriteSessionFile();
@@ -97,8 +109,6 @@ public class PiImportSourceImportTests : IDisposable {
             .Single(e => e.RequestMessage.Path == "/hooks/transcript")
             .RequestMessage.Body;
         await Assert.That(transcriptBody!).Contains("\"vendor\":\"pi\"");
-        await Assert.That(transcriptBody!).Contains("branch_summary");
-        await Assert.That(transcriptBody!).Contains("branch summary kept for import");
 
         // The synthesized session-end marks itself as an import (reason pi-import).
         var endBody = _server.LogEntries
@@ -143,5 +153,32 @@ public class PiImportSourceImportTests : IDisposable {
             CancellationToken.None);
 
         await Assert.That(outcome).IsEqualTo(ImportOutcome.Resumed);
+    }
+
+    [Test]
+    public async Task Classify_treats_trailing_branch_summary_as_import_relevant_when_resuming() {
+        var sessionsDir = WriteSessionFileEndingWithBranchSummary();
+
+        // Server already has the user turn on line 1. The only remaining relevant
+        // line is a Pi branch_summary, so classification must resume from line 2
+        // rather than deciding the transcript is already loaded.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"last_line_number":1}"""));
+
+        using var client = new HttpClient();
+
+        var source = new PiImportSource(
+            sessionsDir,
+            repoDetector: _ => Task.FromResult<RepositoryPayload?>(null));
+
+        var discovered = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+        var classified = await source.ClassifyAsync(
+            discovered,
+            new ClassifyContext(client, _server.Url!, MinLines: 0, ExcludedRepos: null, ExcludedPaths: null),
+            CancellationToken.None);
+
+        await Assert.That(classified.Count).IsEqualTo(1);
+        await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.Partial);
+        await Assert.That(classified[0].ResumeFromLine).IsEqualTo(2);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/PiImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PiImportSourceTests.cs
@@ -142,6 +142,7 @@ public class PiImportSourceTests {
     [Arguments("""{"type":"compaction","id":"a","summary":"x"}""", true)]  // AI-892: compaction → ContextCompacted
     [Arguments("""{"type":"branch_summary","id":"a","summary":"branch","fromId":"b"}""", true)] // AI-892: branch_summary → AssistantTextGenerated
     [Arguments("""{"type":"branch_summary","id":"a","summary":""}""", false)]
+    [Arguments("""{"type":"branch_summary","id":"a","summary":"   "}""", false)]
     [Arguments("""{"type":"label","id":"a","label":"x"}""", false)]
     [Arguments("""{"type":"session_info","id":"a","name":"x"}""", false)]
     [Arguments("""{"type":"message","id":"a","message":{"role":"toolResult","content":[]}}""", false)]

--- a/test/Capacitor.Cli.Tests.Unit/PiImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PiImportSourceTests.cs
@@ -140,6 +140,8 @@ public class PiImportSourceTests {
     [Arguments("""{"type":"message","id":"a","message":{"role":"bashExecution","command":"ls"}}""", true)]
     [Arguments("""{"type":"model_change","id":"a","modelId":"gpt-5"}""", false)]
     [Arguments("""{"type":"compaction","id":"a","summary":"x"}""", true)]  // AI-892: compaction → ContextCompacted
+    [Arguments("""{"type":"branch_summary","id":"a","summary":"branch","fromId":"b"}""", true)] // AI-892: branch_summary → AssistantTextGenerated
+    [Arguments("""{"type":"branch_summary","id":"a","summary":""}""", false)]
     [Arguments("""{"type":"label","id":"a","label":"x"}""", false)]
     [Arguments("""{"type":"session_info","id":"a","name":"x"}""", false)]
     [Arguments("""{"type":"message","id":"a","message":{"role":"toolResult","content":[]}}""", false)]


### PR DESCRIPTION
## Summary
- Treat non-empty Pi `branch_summary` entries as import-relevant so partial imports resume them instead of leaving sessions stuck behind the watermark.
- Keep empty branch summaries ignored.
- Extend Pi import unit and routed import integration tests.

## Tests
- `/Users/tony/.dotnet/dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/PiImportSourceTests/*"`
- `/Users/tony/.dotnet/dotnet run --project test/Capacitor.Cli.Tests.Integration/Capacitor.Cli.Tests.Integration.csproj -- --treenode-filter "/*/*/PiImportSourceImportTests/*"`
