### PR TITLE
[AI-951] WorkOS tenant discovery — kcap login/setup without --server-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,15 @@ The CLI is compiled with NativeAOT — fast startup, no runtime dependency.
 ### 2. Run setup
 
 ```bash
-kcap setup
+kcap setup                      # discovers your tenant — no URL needed
+kcap setup <tenant>             # shorthand for a known tenant slug → https://<tenant>.kcap.ai
+kcap setup --server-url <url>   # explicit server (self-hosted, or a full URL)
 ```
 
 The setup wizard walks you through:
 
-1. **Server URL** — enter the URL your admin provided
-2. **Login** — authenticates via GitHub Device Flow (if the server requires auth)
+1. **Server** — with no `--server-url`/`<tenant>`, kcap **discovers** your tenant: pick how to sign in (**Continue** for email/SSO, or **Continue with GitHub**), authenticate once, then choose from the tenants you belong to. A bare `<tenant>` slug expands to `https://<tenant>.kcap.ai`; a full URL is used as-is.
+2. **Login** — authenticates via your tenant's provider (WorkOS or GitHub App); discovery completes the sign-in inline
 3. **Default visibility** — choose how your sessions are visible to others
 4. **Coding-agent hooks** — detects Claude Code and Codex CLI on `PATH`, Cursor by user-dir presence (`~/.cursor/`), GitHub Copilot CLI by `~/.copilot/` or `copilot` on `PATH`, Google Gemini CLI by `~/.gemini/` or `gemini` on `PATH`, AWS Kiro CLI by `~/.kiro/` or `kiro`/`kiro-cli` on `PATH`, Pi by `~/.pi/` or `pi` on `PATH`, and SST OpenCode by `~/.config/opencode/` (or `~/.local/share/opencode/`) or `opencode` on `PATH`, then offers to install hooks/skills (or, for Pi/OpenCode, the live-ingest plugin) for each (user-wide)
 5. **Daemon** — configure the daemon name for remote agent execution
@@ -133,9 +135,12 @@ Once set up, Capacitor runs silently in the background. Every Claude Code (and C
 ### Initial setup
 
 ```bash
-kcap setup                                   # interactive wizard
+kcap setup                                   # interactive wizard (discovers your tenant)
+kcap setup <tenant>                          # shorthand: https://<tenant>.kcap.ai
 kcap setup --server-url <url> --no-prompt    # CI / scripted
 ```
+
+With no server argument, setup (and `kcap login`) runs **tenant discovery**: you choose how to sign in — **Continue** (WorkOS email/SSO) or **Continue with GitHub** — then pick from the tenants you belong to. `--github`/`--workos` skip the provider prompt; `--discover` forces discovery even when a server is configured.
 
 The setup wizard detects every supported coding agent and offers to install hooks for each, then configures the daemon. Claude Code and Codex CLI are detected via `PATH`; Cursor is detected by user-dir presence (`~/.cursor/`), so IDE users without the `cursor` shell command are covered; GitHub Copilot CLI is detected via `~/.copilot/` or `copilot` on `PATH`; Google Gemini CLI via `~/.gemini/` or `gemini` on `PATH`; AWS Kiro CLI via `~/.kiro/` or `kiro`/`kiro-cli` on `PATH`; Pi via `~/.pi/agent/` or `pi` on `PATH` (and, because Pi has no shell hooks, the wizard installs a Pi extension rather than hook config). Re-run any time to update the configuration.
 

--- a/src/Capacitor.Cli.Core/Auth/AuthModels.cs
+++ b/src/Capacitor.Cli.Core/Auth/AuthModels.cs
@@ -153,7 +153,10 @@ public sealed record DiscoveredTenant {
     [JsonPropertyName("display_name")]    public string? DisplayName    { get; init; }
 
     // Profile key + picker label, provider-aware. WorkOS rows have no OrgLogin.
-    [JsonIgnore] public string ProfileName => Provider == AuthProvider.WorkOS ? (Slug ?? OrganizationId ?? "tenant") : OrgLogin;
+    // Compare provider case-insensitively: the proxy's /discover-tenants-workos emits "WorkOS"
+    // while AuthProvider.WorkOS is "workos" (the tenant /auth/config casing).
+    [JsonIgnore] public bool   IsWorkOS    => string.Equals(Provider, AuthProvider.WorkOS, StringComparison.OrdinalIgnoreCase);
+    [JsonIgnore] public string ProfileName => IsWorkOS ? (Slug ?? OrganizationId ?? "tenant") : OrgLogin;
     [JsonIgnore] public string Label       => !string.IsNullOrEmpty(DisplayName) ? DisplayName : OrgLogin;
 }
 

--- a/src/Capacitor.Cli.Core/Auth/AuthModels.cs
+++ b/src/Capacitor.Cli.Core/Auth/AuthModels.cs
@@ -135,11 +135,21 @@ public sealed record ProxyConfigResponse {
     [JsonPropertyName("github_code_exchange_url")] public string? GitHubCodeExchangeUrl { get; init; }
 }
 
-// Auth proxy: POST /discover-tenants response item
+// Auth proxy: POST /discover-tenants (GitHub) and /discover-tenants-workos (WorkOS) response item.
 public sealed record DiscoveredTenant {
     [JsonPropertyName("org_id")]    public long   OrgId    { get; init; }
     [JsonPropertyName("org_login")] public string OrgLogin { get; init; } = "";
     [JsonPropertyName("origin")]    public string Origin   { get; init; } = "";
+
+    // Provider-aware fields (additive; GitHub rows leave them defaulted).
+    [JsonPropertyName("provider")]        public string  Provider       { get; init; } = AuthProvider.GitHubApp;
+    [JsonPropertyName("organization_id")] public string? OrganizationId { get; init; }
+    [JsonPropertyName("slug")]            public string? Slug           { get; init; }
+    [JsonPropertyName("display_name")]    public string? DisplayName    { get; init; }
+
+    // Profile key + picker label, provider-aware. WorkOS rows have no OrgLogin.
+    [JsonIgnore] public string ProfileName => Provider == AuthProvider.WorkOS ? (Slug ?? OrganizationId ?? "tenant") : OrgLogin;
+    [JsonIgnore] public string Label       => !string.IsNullOrEmpty(DisplayName) ? DisplayName : OrgLogin;
 }
 
 public enum DiscoveryError {

--- a/src/Capacitor.Cli.Core/Auth/AuthModels.cs
+++ b/src/Capacitor.Cli.Core/Auth/AuthModels.cs
@@ -133,6 +133,11 @@ public sealed record ProxyConfigResponse {
     // to device flow because the CLI can't talk to GitHub's token endpoint directly
     // for a GitHub App without client_secret.
     [JsonPropertyName("github_code_exchange_url")] public string? GitHubCodeExchangeUrl { get; init; }
+
+    // WorkOS discovery: the shared AuthKit Application's public client id + (optional) custom
+    // AuthKit UI domain. Present (and client id non-empty) when the proxy serves WorkOS discovery.
+    [JsonPropertyName("workos_client_id")]      public string? WorkOSClientId      { get; init; }
+    [JsonPropertyName("workos_authkit_domain")] public string? WorkOSAuthKitDomain { get; init; }
 }
 
 // Auth proxy: POST /discover-tenants (GitHub) and /discover-tenants-workos (WorkOS) response item.

--- a/src/Capacitor.Cli.Core/Auth/AuthProxyClient.cs
+++ b/src/Capacitor.Cli.Core/Auth/AuthProxyClient.cs
@@ -6,6 +6,7 @@ namespace Capacitor.Cli.Core.Auth;
 public interface IAuthProxyClient {
     Task<ProxyConfigResponse?> GetConfigAsync(string proxyUrl);
     Task<DiscoveryResult>      DiscoverTenantsAsync(string proxyUrl, string githubAccessToken);
+    Task<DiscoveryResult>      DiscoverWorkOSTenantsAsync(string proxyUrl, string workosAccessToken);
 }
 
 public class AuthProxyClient(HttpClient http) : IAuthProxyClient {
@@ -23,6 +24,22 @@ public class AuthProxyClient(HttpClient http) : IAuthProxyClient {
         try {
             using var request = new HttpRequestMessage(HttpMethod.Post, $"{proxyUrl}/discover-tenants");
             request.Headers.Authorization = new("Bearer", githubAccessToken);
+            using var response = await http.SendAsync(request);
+
+            return response.StatusCode switch {
+                HttpStatusCode.OK                                       => new(await ReadTenants(response), DiscoveryError.None),
+                HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => new([], DiscoveryError.TokenRejected),
+                _                                                       => new([], DiscoveryError.UpstreamError)
+            };
+        } catch (Exception e) when (e is HttpRequestException or OperationCanceledException) {
+            return new([], DiscoveryError.ProxyUnreachable);
+        }
+    }
+
+    public async Task<DiscoveryResult> DiscoverWorkOSTenantsAsync(string proxyUrl, string workosAccessToken) {
+        try {
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{proxyUrl}/discover-tenants-workos");
+            request.Headers.Authorization = new("Bearer", workosAccessToken);
             using var response = await http.SendAsync(request);
 
             return response.StatusCode switch {

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -60,7 +60,10 @@ public static class OAuthLoginFlow {
         if (args.Contains("--github")) return AuthProvider.GitHubApp;
         if (args.Contains("--workos")) return AuthProvider.WorkOS;
 
-        return isInteractive ? null : AuthProvider.WorkOS;
+        // No flag: prompt when interactive. Headless can't run the WorkOS browser + 127.0.0.1
+        // loopback (it would hang until timeout), so fall back to GitHub, whose device flow works
+        // without a local browser. A headless WorkOS user must pass --workos explicitly.
+        return isInteractive ? null : AuthProvider.GitHubApp;
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -474,6 +474,72 @@ public static class OAuthLoginFlow {
     static async Task<int> LoginWorkOSAsync(string? authKitDomain, string clientId, string? organizationId) {
         var authorizeBase = string.IsNullOrEmpty(authKitDomain) ? WorkOSApiBase : $"https://{authKitDomain}";
 
+        var loop = await RunWorkOSLoopbackAsync(authorizeBase, clientId, organizationId);
+        if (loop.Code is null) {
+            Console.Error.WriteLine(loop.Error switch {
+                "state_mismatch" => "Error: state mismatch — possible CSRF. Aborting.",
+                "timeout"        => "Timed out waiting for authorization. Re-run `kcap login` to try again.",
+                _                => "Error: No authorization code received."
+            });
+
+            return 1;
+        }
+
+        using var http = new HttpClient();
+
+        var json = await AuthenticateWorkOSCodeAsync(http, WorkOSApiBase, clientId, loop.Code, loop.Verifier);
+        if (json is null) {
+            Console.Error.WriteLine("Error: WorkOS token exchange failed.");
+
+            return 1;
+        }
+
+        // Org gate: a multi-org user must not be "logged in" to the wrong org — every API
+        // call would then fail the server's org check. Reject before saving tokens.
+        if (!string.IsNullOrEmpty(organizationId) && !string.Equals(json.OrganizationId, organizationId, StringComparison.Ordinal)) {
+            Console.Error.WriteLine($"Error: signed in to the wrong WorkOS organization (expected {organizationId}). Re-run `kcap login` and pick the correct organization.");
+
+            return 1;
+        }
+
+        var username = WorkOSDisplayName(json.User);
+
+        await TokenStore.SaveAsync(
+            new() {
+                AccessToken    = json.AccessToken,
+                RefreshToken   = json.RefreshToken,
+                ExpiresAt      = TokenStore.JwtExpiry(json.AccessToken),
+                GitHubUsername = username,
+                Provider       = AuthProvider.WorkOS,
+                ClientId       = clientId
+            }
+        );
+
+        await Console.Out.WriteLineAsync($"Logged in as {username}");
+
+        return 0;
+    }
+
+    /// <summary>Human display name from a WorkOS user (first+last, else email, else "unknown").</summary>
+    internal static string WorkOSDisplayName(WorkOSUserInfo? user) {
+        var parts = new List<string>();
+        if (!string.IsNullOrEmpty(user?.FirstName)) parts.Add(user!.FirstName!);
+        if (!string.IsNullOrEmpty(user?.LastName))  parts.Add(user!.LastName!);
+
+        return parts.Count > 0 ? string.Join(' ', parts) : user?.Email ?? "unknown";
+    }
+
+    public sealed record WorkOSLoopbackResult(string? Code, string Verifier, string RedirectUri, string? Error);
+
+    /// <summary>
+    /// WorkOS AuthKit authorization-code-with-PKCE on a 127.0.0.1 loopback listener. Authorizes on
+    /// <paramref name="authorizeBase"/>, org-scoped only when <paramref name="organizationId"/> is set
+    /// (pass null for org-less discovery). Returns the authorization code + PKCE verifier, or an
+    /// <c>Error</c> ("timeout" / "state_mismatch" / "missing_code"). Public client — the separate token
+    /// exchange carries no secret.
+    /// </summary>
+    public static async Task<WorkOSLoopbackResult> RunWorkOSLoopbackAsync(
+            string authorizeBase, string clientId, string? organizationId, TimeSpan? timeout = null) {
         var verifier    = GenerateCodeVerifier();
         var challenge   = GenerateCodeChallenge(verifier);
         var state       = GenerateCodeVerifier();
@@ -502,7 +568,7 @@ public static class OAuthLoginFlow {
         }
 
         // Bounded wait + ignore non-callback requests (favicon etc.) — mirrors RunGitHubBrowserFlowAsync.
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(5));
 
         HttpListenerContext context;
 
@@ -514,9 +580,8 @@ public static class OAuthLoginFlow {
             } catch (OperationCanceledException) {
                 listener.Stop();
                 _ = getContext.ContinueWith(t => _ = t.Exception, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
-                Console.Error.WriteLine("Timed out waiting for authorization. Re-run `kcap login` to try again.");
 
-                return 1;
+                return new(null, verifier, redirectUri, "timeout");
             }
 
             if (context.Request.Url?.AbsolutePath == "/callback") break;
@@ -530,7 +595,6 @@ public static class OAuthLoginFlow {
         var returnedState = context.Request.QueryString["state"];
 
         if (returnedState != state) {
-            Console.Error.WriteLine("Error: state mismatch — possible CSRF. Aborting.");
             const string errHtml = "<html><body><h2>Authentication failed</h2><p>State mismatch — possible CSRF. Return to the terminal.</p></body></html>";
             var          errBuf  = Encoding.UTF8.GetBytes(errHtml);
             context.Response.ContentType     = "text/html";
@@ -539,7 +603,7 @@ public static class OAuthLoginFlow {
             context.Response.Close();
             listener.Stop();
 
-            return 1;
+            return new(null, verifier, redirectUri, "state_mismatch");
         }
 
         const string html = "<html><body><h2>Authentication successful!</h2><p>You can close this window.</p></body></html>";
@@ -551,61 +615,47 @@ public static class OAuthLoginFlow {
         context.Response.Close();
         listener.Stop();
 
-        if (string.IsNullOrEmpty(code)) {
-            Console.Error.WriteLine("Error: No authorization code received.");
+        return string.IsNullOrEmpty(code)
+            ? new(null, verifier, redirectUri, "missing_code")
+            : new(code, verifier, redirectUri, null);
+    }
 
-            return 1;
-        }
+    /// <summary>Public-client WorkOS code→token exchange at <c>{apiBase}/user_management/authenticate</c>.</summary>
+    public static async Task<WorkOSAuthResponse?> AuthenticateWorkOSCodeAsync(
+            HttpClient http, string apiBase, string clientId, string code, string codeVerifier) {
+        var resp = await http.PostAsync(
+            $"{apiBase.TrimEnd('/')}/user_management/authenticate",
+            new FormUrlEncodedContent(new Dictionary<string, string> {
+                ["grant_type"]    = "authorization_code",
+                ["client_id"]     = clientId,
+                ["code"]          = code,
+                ["code_verifier"] = codeVerifier
+            }));
 
-        using var http = new HttpClient();
+        if (!resp.IsSuccessStatusCode) return null;
 
-        var tokenResponse = await http.PostAsync(
-            $"{WorkOSApiBase}/user_management/authenticate",
-            new FormUrlEncodedContent(
-                new Dictionary<string, string> {
-                    ["grant_type"]    = "authorization_code",
-                    ["client_id"]     = clientId,
-                    ["code"]          = code,
-                    ["code_verifier"] = verifier
-                }
-            )
-        );
+        return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse);
+    }
 
-        if (!tokenResponse.IsSuccessStatusCode) {
-            Console.Error.WriteLine($"Error: {await tokenResponse.Content.ReadAsStringAsync()}");
+    /// <summary>
+    /// Public-client WorkOS org-switch: exchanges a refresh token for an org-scoped token. The spike
+    /// confirmed the resulting refresh token stays bound to the org, so subsequent refreshes need no
+    /// organization_id. No client secret.
+    /// </summary>
+    public static async Task<WorkOSAuthResponse?> SwitchWorkOSOrgAsync(
+            HttpClient http, string apiBase, string clientId, string refreshToken, string organizationId) {
+        var resp = await http.PostAsync(
+            $"{apiBase.TrimEnd('/')}/user_management/authenticate",
+            new FormUrlEncodedContent(new Dictionary<string, string> {
+                ["grant_type"]      = "refresh_token",
+                ["client_id"]       = clientId,
+                ["refresh_token"]   = refreshToken,
+                ["organization_id"] = organizationId
+            }));
 
-            return 1;
-        }
+        if (!resp.IsSuccessStatusCode) return null;
 
-        var json = (await tokenResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse))!;
-
-        // Org gate: a multi-org user must not be "logged in" to the wrong org — every API
-        // call would then fail the server's org check. Reject before saving tokens.
-        if (!string.IsNullOrEmpty(organizationId) && !string.Equals(json.OrganizationId, organizationId, StringComparison.Ordinal)) {
-            Console.Error.WriteLine($"Error: signed in to the wrong WorkOS organization (expected {organizationId}). Re-run `kcap login` and pick the correct organization.");
-
-            return 1;
-        }
-
-        var parts = new List<string>();
-        if (!string.IsNullOrEmpty(json.User?.FirstName)) parts.Add(json.User!.FirstName!);
-        if (!string.IsNullOrEmpty(json.User?.LastName)) parts.Add(json.User!.LastName!);
-        var username = parts.Count > 0 ? string.Join(' ', parts) : json.User?.Email ?? "unknown";
-
-        await TokenStore.SaveAsync(
-            new() {
-                AccessToken    = json.AccessToken,
-                RefreshToken   = json.RefreshToken,
-                ExpiresAt      = TokenStore.JwtExpiry(json.AccessToken),
-                GitHubUsername = username,
-                Provider       = AuthProvider.WorkOS,
-                ClientId       = clientId
-            }
-        );
-
-        await Console.Out.WriteLineAsync($"Logged in as {username}");
-
-        return 0;
+        return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse);
     }
 
     internal readonly record struct CallbackResult(string? Code, string? Error);

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -63,6 +63,13 @@ public static class OAuthLoginFlow {
         return isInteractive ? null : AuthProvider.WorkOS;
     }
 
+    /// <summary>
+    /// `kcap login` runs tenant discovery when there's no configured server (nothing to log into yet)
+    /// or the user explicitly asked with <c>--discover</c>; otherwise it logs into the configured server.
+    /// </summary>
+    internal static bool ShouldDiscoverLogin(string? baseUrl, string[] args)
+        => args.Contains("--discover") || baseUrl is null;
+
     static int HandleNoneLogin() {
         Console.Out.WriteLine("Server has no authentication configured — login not required.");
 

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -51,6 +51,18 @@ public static class OAuthLoginFlow {
     internal static GitHubFlow ChooseGitHubFlow(bool forceDevice, bool isHeadless, bool hasExchangeUrl)
         => forceDevice || isHeadless || !hasExchangeUrl ? GitHubFlow.Device : GitHubFlow.Browser;
 
+    /// <summary>
+    /// Picks the discovery provider before any auth runs: explicit <c>--github</c>/<c>--workos</c>
+    /// flags win; otherwise a non-interactive caller defaults to WorkOS, and an interactive caller
+    /// gets <c>null</c> (meaning "prompt the user").
+    /// </summary>
+    internal static string? ChooseDiscoveryProvider(string[] args, bool isInteractive) {
+        if (args.Contains("--github")) return AuthProvider.GitHubApp;
+        if (args.Contains("--workos")) return AuthProvider.WorkOS;
+
+        return isInteractive ? null : AuthProvider.WorkOS;
+    }
+
     static int HandleNoneLogin() {
         Console.Out.WriteLine("Server has no authentication configured — login not required.");
 

--- a/src/Capacitor.Cli.Core/Auth/TenantDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/TenantDiscovery.cs
@@ -53,7 +53,7 @@ public class TenantDiscovery(IAuthProxyClient proxy, ITenantPicker picker) {
                     ?? new Config_Profile();
 
         foreach (var t in discovered) {
-            var name = t.OrgLogin;
+            var name = t.ProfileName;
             profiles[name] = (profiles.GetValueOrDefault(name) ?? template) with {
                 ServerUrl = AppConfig.NormalizeUrl(t.Origin)
             };
@@ -61,7 +61,7 @@ public class TenantDiscovery(IAuthProxyClient proxy, ITenantPicker picker) {
 
         return existing with {
             Profiles      = profiles,
-            ActiveProfile = active.OrgLogin
+            ActiveProfile = active.ProfileName
         };
     }
 }

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -1,0 +1,94 @@
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Core.Auth;
+
+/// <summary>
+/// WorkOS tenant discovery: authenticate org-less against the proxy's shared AuthKit app,
+/// list the user's tenants via the proxy, let them pick, then org-switch into the chosen org
+/// and save an org-scoped profile. The two browser/HTTP effects (org-less login, org-switch)
+/// are injected so the orchestration (discover → pick → switch → save) is unit-testable;
+/// production wiring passes <see cref="OAuthLoginFlow"/>'s loopback + switch helpers.
+/// </summary>
+public static class WorkOSDiscovery {
+    const string WorkOSApiBase = "https://api.workos.com";
+
+    public static async Task<int> RunAsync(
+            string                                          proxyUrl,
+            ProxyConfigResponse                             proxyConfig,
+            IAuthProxyClient                                proxy,
+            ITenantPicker                                   picker,
+            Func<string, Task<WorkOSAuthResponse?>>         orglessLogin,   // arg: authorizeBase
+            Func<string, string, Task<WorkOSAuthResponse?>> orgSwitch) {    // args: refreshToken, organizationId
+        if (string.IsNullOrEmpty(proxyConfig.WorkOSClientId)) {
+            await Console.Error.WriteLineAsync("This server isn't configured for WorkOS sign-in.");
+
+            return 1;
+        }
+
+        var authorizeBase = string.IsNullOrEmpty(proxyConfig.WorkOSAuthKitDomain)
+            ? WorkOSApiBase
+            : $"https://{proxyConfig.WorkOSAuthKitDomain}";
+
+        var auth = await orglessLogin(authorizeBase);
+        if (auth is null || string.IsNullOrEmpty(auth.RefreshToken)) {
+            await Console.Error.WriteLineAsync("WorkOS sign-in failed.");
+
+            return 1;
+        }
+
+        var result = await proxy.DiscoverWorkOSTenantsAsync(proxyUrl, auth.AccessToken);
+        if (result.Error != DiscoveryError.None) {
+            await Console.Error.WriteLineAsync(result.Error switch {
+                DiscoveryError.ProxyUnreachable => "The Kurrent auth service is unreachable.",
+                DiscoveryError.TokenRejected    => "WorkOS rejected the authentication token. Please sign in again.",
+                DiscoveryError.UpstreamError    => "Kurrent auth service returned an error. Try again later.",
+                _                               => "Tenant discovery failed."
+            });
+
+            return 1;
+        }
+
+        if (result.Tenants.Length == 0) {
+            await Console.Error.WriteLineAsync("No Capacitor tenants are linked to your account. Ask your admin to invite you.");
+
+            return 1;
+        }
+
+        var picked = result.Tenants.Length == 1 ? result.Tenants[0] : picker.Pick(result.Tenants);
+        if (picked is null) {
+            await Console.Error.WriteLineAsync("No tenant selected.");
+
+            return 1;
+        }
+
+        // Org-switch once into the chosen org. The resulting refresh token stays org-bound
+        // (spike-confirmed), so later refreshes need no organization_id.
+        var switched = await orgSwitch(auth.RefreshToken!, picked.OrganizationId ?? "");
+        if (switched is null) {
+            await Console.Error.WriteLineAsync($"Could not switch to organization {picked.Label}.");
+
+            return 1;
+        }
+
+        var username = OAuthLoginFlow.WorkOSDisplayName(auth.User);
+
+        var cfg = await AppConfig.LoadProfileConfig();
+        cfg = TenantDiscovery.MergeProfiles(cfg, result.Tenants, picked);
+        await AppConfig.SaveProfileConfig(cfg);
+
+        await TokenStore.SaveAsync(
+            picked.ProfileName,
+            new StoredTokens {
+                AccessToken    = switched.AccessToken,
+                RefreshToken   = switched.RefreshToken,
+                ExpiresAt      = TokenStore.JwtExpiry(switched.AccessToken),
+                GitHubUsername = username,
+                Provider       = AuthProvider.WorkOS,
+                ClientId       = proxyConfig.WorkOSClientId
+            });
+
+        await Console.Out.WriteLineAsync($"Logged in as {username} → {picked.Label}");
+
+        return 0;
+    }
+}

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -84,9 +84,15 @@ public static class WorkOSDiscovery {
             return 1;
         }
 
+        if (string.IsNullOrEmpty(picked.OrganizationId)) {
+            await Console.Error.WriteLineAsync($"Tenant {picked.Label} is missing an organization id; cannot complete sign-in.");
+
+            return 1;
+        }
+
         // Org-switch once into the chosen org. The resulting refresh token stays org-bound
         // (spike-confirmed), so later refreshes need no organization_id.
-        var switched = await orgSwitch(auth.RefreshToken!, picked.OrganizationId ?? "");
+        var switched = await orgSwitch(auth.RefreshToken!, picked.OrganizationId);
         if (switched is null) {
             await Console.Error.WriteLineAsync($"Could not switch to organization {picked.Label}.");
 

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -12,6 +12,29 @@ namespace Capacitor.Cli.Core.Auth;
 public static class WorkOSDiscovery {
     const string WorkOSApiBase = "https://api.workos.com";
 
+    /// <summary>
+    /// <see cref="RunAsync"/> wired to the real WorkOS effects: an org-less loopback login on the
+    /// shared AuthKit app + a refresh-token org-switch (both public-client, no secret). The two call
+    /// sites (`kcap login --discover` and `kcap setup`) use this; tests call <see cref="RunAsync"/>
+    /// directly with fakes.
+    /// </summary>
+    public static Task<int> RunWithLiveAuthAsync(
+            string proxyUrl, ProxyConfigResponse proxyConfig, IAuthProxyClient proxy, ITenantPicker picker) {
+        var clientId = proxyConfig.WorkOSClientId ?? "";
+
+        return RunAsync(proxyUrl, proxyConfig, proxy, picker,
+            orglessLogin: async authorizeBase => {
+                var loop = await OAuthLoginFlow.RunWorkOSLoopbackAsync(authorizeBase, clientId, organizationId: null);
+                if (loop.Code is null) return null;
+                using var http = new HttpClient();
+                return await OAuthLoginFlow.AuthenticateWorkOSCodeAsync(http, WorkOSApiBase, clientId, loop.Code, loop.Verifier);
+            },
+            orgSwitch: async (refreshToken, organizationId) => {
+                using var http = new HttpClient();
+                return await OAuthLoginFlow.SwitchWorkOSOrgAsync(http, WorkOSApiBase, clientId, refreshToken, organizationId);
+            });
+    }
+
     public static async Task<int> RunAsync(
             string                                          proxyUrl,
             ProxyConfigResponse                             proxyConfig,

--- a/src/Capacitor.Cli.Core/Resources/help-login.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-login.txt
@@ -1,9 +1,15 @@
 kcap login — Authenticate via OAuth
 
-Usage: kcap login [--discover] [--device]
+Usage: kcap login [--discover] [--github | --workos] [--device]
 
-Opens the system browser for OAuth authentication. The auth method is
-auto-discovered from the server configuration (GitHub App or WorkOS).
+Opens the system browser for OAuth authentication.
+
+With no configured server (or with --discover), kcap runs tenant discovery:
+you choose how to sign in — "Continue" (email / SSO) or "Continue with
+GitHub" — authenticate once, then pick from the tenants you belong to. No
+--server-url and no existing profile are required. With a server already
+configured, kcap logs into it directly (the auth method — GitHub App or
+WorkOS — is auto-discovered from the server's /auth/config).
 
 For GitHub, the default flow uses a localhost callback with PKCE when the
 server advertises a code-exchange endpoint — the browser opens straight to
@@ -13,10 +19,12 @@ that endpoint, in headless environments (SSH, no DISPLAY), or when the
 loopback port can't be bound.
 
 Options:
-  --discover    Run tenant discovery across all your GitHub org memberships.
-                Exchanges tokens for each discovered Capacitor tenant and saves
-                them as named profiles, then sets the picked tenant as the
-                active profile. No existing profile configuration is required.
+  --discover    Force tenant discovery even when a server is configured.
+                Discovery picks a provider, authenticates, lists the tenants
+                you belong to, and saves the chosen one as the active profile.
+
+  --github      Skip the provider prompt and use GitHub for discovery.
+  --workos      Skip the provider prompt and use WorkOS for discovery.
 
   --device      Force GitHub Device Flow even when a browser is available.
                 Useful for SSH sessions, containers without a browser, or any

--- a/src/Capacitor.Cli/Commands/DiscoveryProviderPrompt.cs
+++ b/src/Capacitor.Cli/Commands/DiscoveryProviderPrompt.cs
@@ -1,0 +1,22 @@
+using Capacitor.Cli.Core.Auth;
+using Spectre.Console;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// Resolves which provider to use for tenant discovery: explicit --github/--workos flags or a
+/// non-interactive default win (<see cref="OAuthLoginFlow.ChooseDiscoveryProvider"/>); otherwise
+/// prompts. The WorkOS option is shown as the unbranded "Continue" (primary), GitHub as secondary.
+/// </summary>
+public static class DiscoveryProviderPrompt {
+    public static string Resolve(string[] args) {
+        var chosen = OAuthLoginFlow.ChooseDiscoveryProvider(args, isInteractive: !HeadlessEnvironment.IsHeadless());
+        if (chosen is not null) return chosen;
+
+        return AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("How would you like to sign in?")
+                .AddChoices(AuthProvider.WorkOS, AuthProvider.GitHubApp)
+                .UseConverter(p => p == AuthProvider.GitHubApp ? "Continue with GitHub" : "Continue"));
+    }
+}

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -584,6 +584,7 @@ public static class SetupCommand {
     /// </summary>
     internal static string ResolveTenantArg(string arg) =>
         arg.Contains("://") || arg.Contains('.') || arg.Contains(':')
+        || arg.Equals("localhost", StringComparison.OrdinalIgnoreCase) // bare loopback host, not a kcap.ai slug
             ? arg
             : $"https://{arg}.kcap.ai";
 

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -17,6 +17,11 @@ namespace Capacitor.Cli.Commands;
 public static class SetupCommand {
     public static async Task<int> HandleAsync(string[] args) {
         var serverUrlArg     = GetArg(args, "--server-url");
+
+        // `kcap setup <tenant>`: a leading positional arg (bare slug or full URL) is treated as the
+        // server, equivalent to --server-url. A bare single label expands to {slug}.kcap.ai.
+        if (serverUrlArg is null && args.Length > 1 && !args[1].StartsWith('-'))
+            serverUrlArg = ResolveTenantArg(args[1]);
         var noPrompt         = args.Contains("--no-prompt");
         var forceDevice      = args.Contains("--device");
         var skipClaudeFlag   = args.Contains("--skip-claude-hooks");
@@ -570,6 +575,17 @@ public static class SetupCommand {
 
         return idx >= 0 && idx + 1 < args.Length ? args[idx + 1] : null;
     }
+
+    /// <summary>
+    /// Resolves a `kcap setup &lt;tenant&gt;` positional: a bare single label (no scheme/dot/port)
+    /// expands to <c>https://{slug}.kcap.ai</c>; anything that already looks like a URL, FQDN, or
+    /// host:port is returned unchanged for the normal --server-url path. Self-hosted servers should
+    /// pass a full URL.
+    /// </summary>
+    internal static string ResolveTenantArg(string arg) =>
+        arg.Contains("://") || arg.Contains('.') || arg.Contains(':')
+            ? arg
+            : $"https://{arg}.kcap.ai";
 
     static readonly JsonSerializerOptions WriteOpts = new() { WriteIndented = true };
 

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -72,6 +72,7 @@ public static class SetupCommand {
         string serverUrl;
         string? preAuthToken = null;
         string  provider;
+        bool    loginComplete = false; // WorkOS discovery authenticates inline; skip the Step-2 login.
 
         if (serverUrlArg is not null) {
             var normalized = await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync("Checking server…",
@@ -102,9 +103,9 @@ public static class SetupCommand {
             await Console.Error.WriteLineAsync("  --server-url is required with --no-prompt");
             return 1;
         } else {
-            var discovered = await RunDiscoveryAsync(forceDevice);
+            var discovered = await RunDiscoveryAsync(args, forceDevice);
             if (discovered is null) return 1;
-            (serverUrl, preAuthToken, provider) = discovered.Value;
+            (serverUrl, preAuthToken, provider, loginComplete) = discovered.Value;
         }
 
         await Console.Out.WriteLineAsync();
@@ -112,7 +113,12 @@ public static class SetupCommand {
         // Step 2: Login
         AnsiConsole.Write(new Rule("[yellow]Step 2/5 — Login[/]").LeftJustified());
 
-        if (provider == AuthProvider.None) {
+        if (loginComplete) {
+            // WorkOS discovery already authenticated + saved the active (picked) profile.
+            var cfgAfter = await AppConfig.LoadProfileConfig();
+            var tokens   = await TokenStore.LoadAsync(cfgAfter.ActiveProfile);
+            AnsiConsole.MarkupLine($"  [green]✓[/] Logged in as [cyan]{Markup.Escape(tokens?.GitHubUsername ?? "?")}[/]");
+        } else if (provider == AuthProvider.None) {
             await Console.Out.WriteLineAsync("  Auth provider is None — no login required.");
         } else if (preAuthToken is not null) {
             var exchangeResult = await OAuthLoginFlow.ExchangeAndSaveAsync(serverUrl, preAuthToken, provider);
@@ -382,7 +388,8 @@ public static class SetupCommand {
         return 0;
     }
 
-    static async Task<(string ServerUrl, string PreAuthToken, string Provider)?> RunDiscoveryAsync(bool forceDevice) {
+    static async Task<(string ServerUrl, string? PreAuthToken, string Provider, bool LoginComplete)?> RunDiscoveryAsync(
+            string[] args, bool forceDevice) {
         AnsiConsole.MarkupLine($"  Proxy: [dim]{Markup.Escape(AuthProxyEndpoint.Url)}[/]");
 
         using var http  = new HttpClient();
@@ -390,7 +397,29 @@ public static class SetupCommand {
 
         var proxyConfig = await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync("Contacting auth service…",
             async _ => await proxyClient.GetConfigAsync(AuthProxyEndpoint.Url));
-        if (proxyConfig is null || string.IsNullOrEmpty(proxyConfig.GitHubClientId)) {
+        if (proxyConfig is null) {
+            AnsiConsole.MarkupLine("  [red]✗[/] Cannot reach the Kurrent auth service. Retry later, or pass --server-url <url>.");
+            return null;
+        }
+
+        var provider = DiscoveryProviderPrompt.Resolve(args);
+
+        if (provider == AuthProvider.WorkOS) {
+            var exit = await WorkOSDiscovery.RunWithLiveAuthAsync(
+                AuthProxyEndpoint.Url, proxyConfig, proxyClient, new SpectreTenantPicker());
+            if (exit != 0) return null;
+
+            // WorkOSDiscovery saved + activated the picked profile; continue setup against it.
+            var cfg    = await AppConfig.LoadProfileConfig();
+            var active = cfg.Profiles.GetValueOrDefault(cfg.ActiveProfile);
+            if (active?.ServerUrl is null) {
+                AnsiConsole.MarkupLine("  [red]✗[/] WorkOS sign-in did not set an active profile.");
+                return null;
+            }
+            return (active.ServerUrl, null, AuthProvider.WorkOS, true);
+        }
+
+        if (string.IsNullOrEmpty(proxyConfig.GitHubClientId)) {
             AnsiConsole.MarkupLine("  [red]✗[/] Cannot reach the Kurrent auth service. Retry later, or pass --server-url <url>.");
             return null;
         }
@@ -413,7 +442,7 @@ public static class SetupCommand {
 
         AnsiConsole.MarkupLine($"  [green]✓[/] Discovered {outcome.Tenants.Length} tenant(s). Active: [cyan]{Markup.Escape(outcome.Picked!.OrgLogin)}[/]");
 
-        return (AppConfig.NormalizeUrl(outcome.Picked.Origin), ghToken, AuthProvider.GitHubApp);
+        return (AppConfig.NormalizeUrl(outcome.Picked.Origin), ghToken, AuthProvider.GitHubApp, false);
     }
 
     internal static string? ResolvePluginPath(string? overrideDir = null) {

--- a/src/Capacitor.Cli/Commands/SpectreTenantPicker.cs
+++ b/src/Capacitor.Cli/Commands/SpectreTenantPicker.cs
@@ -7,7 +7,7 @@ public class SpectreTenantPicker : ITenantPicker {
     public DiscoveredTenant Pick(DiscoveredTenant[] tenants) {
         var prompt = new SelectionPrompt<DiscoveredTenant>()
             .Title("Which Capacitor tenant would you like to use as default?")
-            .UseConverter(t => $"{t.OrgLogin} · {t.Origin}")
+            .UseConverter(t => $"{t.Label} · {t.Origin}")
             .AddChoices(tenants);
 
         return AnsiConsole.Prompt(prompt);

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -661,7 +661,20 @@ async Task<int> HandleDiscoverLoginAsync(bool forceDevice) {
 
     var proxyConfig = await proxyClient.GetConfigAsync(AuthProxyEndpoint.Url);
 
-    if (proxyConfig is null || string.IsNullOrEmpty(proxyConfig.GitHubClientId)) {
+    if (proxyConfig is null) {
+        await Console.Error.WriteLineAsync("Cannot reach the Kurrent auth service.");
+
+        return 1;
+    }
+
+    var provider = DiscoveryProviderPrompt.Resolve(args);
+
+    if (provider == AuthProvider.WorkOS) {
+        return await WorkOSDiscovery.RunWithLiveAuthAsync(
+            AuthProxyEndpoint.Url, proxyConfig, proxyClient, new SpectreTenantPicker());
+    }
+
+    if (string.IsNullOrEmpty(proxyConfig.GitHubClientId)) {
         await Console.Error.WriteLineAsync("Cannot reach the Kurrent auth service.");
 
         return 1;

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -184,17 +184,13 @@ switch (command) {
     case "login": {
         var forceDevice = args.Contains("--device");
 
-        if (args.Contains("--discover")) {
+        // No configured server (or explicit --discover) → run tenant discovery (pick provider,
+        // then your tenants). Otherwise log into the configured server.
+        if (OAuthLoginFlow.ShouldDiscoverLogin(baseUrl, args)) {
             return await HandleDiscoverLoginAsync(forceDevice);
         }
 
-        if (baseUrl is null) {
-            Console.Error.WriteLine("No server configured. Run `kcap setup`, set KCAP_URL, or use `kcap login --discover`.");
-
-            return 1;
-        }
-
-        return await OAuthLoginFlow.LoginWithDiscoveryAsync(baseUrl, forceDevice);
+        return await OAuthLoginFlow.LoginWithDiscoveryAsync(baseUrl!, forceDevice);
     }
     case "logout": {
         await TokenStore.DeleteAsync();

--- a/test/Capacitor.Cli.Tests.Unit/AuthProxyClientTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthProxyClientTests.cs
@@ -161,4 +161,42 @@ public class AuthProxyClientTests {
 
         await Assert.That(result.Error).IsEqualTo(DiscoveryError.ProxyUnreachable);
     }
+
+    [Test]
+    public async Task DiscoverWorkOSTenantsAsync_parses_provider_aware_rows() {
+        using var server = WireMockServer.Start();
+
+        server.Given(Request.Create().WithPath("/discover-tenants-workos").UsingPost())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody("""[{"provider":"WorkOS","organization_id":"org_a","slug":"eventuous","display_name":"Eventuous","origin":"https://eventuous.kcap.ai"}]""")
+                    .WithHeader("Content-Type", "application/json")
+            );
+
+        using var http   = new HttpClient();
+        var       client = new AuthProxyClient(http);
+
+        var result = await client.DiscoverWorkOSTenantsAsync(server.Urls[0], "wos.tok.en");
+
+        await Assert.That(result.Error).IsEqualTo(DiscoveryError.None);
+        await Assert.That(result.Tenants[0].OrganizationId).IsEqualTo("org_a");
+        await Assert.That(result.Tenants[0].Slug).IsEqualTo("eventuous");
+        await Assert.That(result.Tenants[0].Origin).IsEqualTo("https://eventuous.kcap.ai");
+    }
+
+    [Test]
+    public async Task DiscoverWorkOSTenantsAsync_maps_401_to_TokenRejected() {
+        using var server = WireMockServer.Start();
+
+        server.Given(Request.Create().WithPath("/discover-tenants-workos").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(401));
+
+        using var http   = new HttpClient();
+        var       client = new AuthProxyClient(http);
+
+        var result = await client.DiscoverWorkOSTenantsAsync(server.Urls[0], "bad");
+
+        await Assert.That(result.Error).IsEqualTo(DiscoveryError.TokenRejected);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/AuthProxyClientTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthProxyClientTests.cs
@@ -51,6 +51,27 @@ public class AuthProxyClientTests {
     }
 
     [Test]
+    public async Task GetConfigAsync_reads_workos_fields() {
+        using var server = WireMockServer.Start();
+
+        server.Given(Request.Create().WithPath("/config").UsingGet())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody("""{"github_client_id":"gh","workos_client_id":"client_d","workos_authkit_domain":""}""")
+                    .WithHeader("Content-Type", "application/json")
+            );
+
+        using var http   = new HttpClient();
+        var       client = new AuthProxyClient(http);
+
+        var config = await client.GetConfigAsync(server.Urls[0]);
+
+        await Assert.That(config!.WorkOSClientId).IsEqualTo("client_d");
+        await Assert.That(config.WorkOSAuthKitDomain).IsEqualTo("");
+    }
+
+    [Test]
     public async Task GetConfigAsync_returns_null_on_proxy_unreachable() {
         using var http = new HttpClient();
         http.Timeout = TimeSpan.FromMilliseconds(200);

--- a/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
@@ -112,6 +112,14 @@ public class OAuthFlowTests {
     }
 
     [Test]
+    public async Task ChooseDiscoveryProvider_honors_flags_and_default() {
+        await Assert.That(OAuthLoginFlow.ChooseDiscoveryProvider(["--github"], isInteractive: true)).IsEqualTo(AuthProvider.GitHubApp);
+        await Assert.That(OAuthLoginFlow.ChooseDiscoveryProvider(["--workos"], isInteractive: true)).IsEqualTo(AuthProvider.WorkOS);
+        await Assert.That(OAuthLoginFlow.ChooseDiscoveryProvider([], isInteractive: false)).IsEqualTo(AuthProvider.WorkOS);
+        await Assert.That(OAuthLoginFlow.ChooseDiscoveryProvider([], isInteractive: true)).IsNull();
+    }
+
+    [Test]
     public async Task ChooseGitHubFlow_returns_device_when_forced() {
         var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: true, isHeadless: false, hasExchangeUrl: true);
         await Assert.That(choice).IsEqualTo(GitHubFlow.Device);

--- a/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
@@ -1,8 +1,38 @@
 using Capacitor.Cli.Core.Auth;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
 
 namespace Capacitor.Cli.Tests.Unit;
 
 public class OAuthFlowTests {
+    [Test]
+    public async Task SwitchWorkOSOrg_posts_refresh_grant_with_org_and_returns_token() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(
+                """{"user":{"id":"user_x"},"organization_id":"org_a","access_token":"acc","refresh_token":"rt2"}"""));
+        using var http = new HttpClient();
+
+        var auth = await OAuthLoginFlow.SwitchWorkOSOrgAsync(http, server.Urls[0], "client_d", "rt1", "org_a");
+
+        await Assert.That(auth!.OrganizationId).IsEqualTo("org_a");
+        await Assert.That(auth.RefreshToken).IsEqualTo("rt2");
+        await Assert.That(auth.AccessToken).IsEqualTo("acc");
+    }
+
+    [Test]
+    public async Task SwitchWorkOSOrg_returns_null_on_error() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(401));
+        using var http = new HttpClient();
+
+        var auth = await OAuthLoginFlow.SwitchWorkOSOrgAsync(http, server.Urls[0], "client_d", "rt1", "org_a");
+
+        await Assert.That(auth).IsNull();
+    }
+
     [Test]
     public async Task GitHub_authorize_url_includes_all_required_params() {
         var url = OAuthLoginFlow.BuildGitHubAuthorizeUrl(

--- a/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
@@ -115,7 +115,7 @@ public class OAuthFlowTests {
     public async Task ChooseDiscoveryProvider_honors_flags_and_default() {
         await Assert.That(OAuthLoginFlow.ChooseDiscoveryProvider(["--github"], isInteractive: true)).IsEqualTo(AuthProvider.GitHubApp);
         await Assert.That(OAuthLoginFlow.ChooseDiscoveryProvider(["--workos"], isInteractive: true)).IsEqualTo(AuthProvider.WorkOS);
-        await Assert.That(OAuthLoginFlow.ChooseDiscoveryProvider([], isInteractive: false)).IsEqualTo(AuthProvider.WorkOS);
+        await Assert.That(OAuthLoginFlow.ChooseDiscoveryProvider([], isInteractive: false)).IsEqualTo(AuthProvider.GitHubApp); // headless → GitHub device flow, not the WorkOS browser loopback
         await Assert.That(OAuthLoginFlow.ChooseDiscoveryProvider([], isInteractive: true)).IsNull();
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
@@ -120,6 +120,14 @@ public class OAuthFlowTests {
     }
 
     [Test]
+    public async Task ShouldDiscoverLogin_true_when_no_server_or_discover_flag() {
+        await Assert.That(OAuthLoginFlow.ShouldDiscoverLogin(null, [])).IsTrue();
+        await Assert.That(OAuthLoginFlow.ShouldDiscoverLogin(null, ["--device"])).IsTrue();
+        await Assert.That(OAuthLoginFlow.ShouldDiscoverLogin("https://x.example", ["--discover"])).IsTrue();
+        await Assert.That(OAuthLoginFlow.ShouldDiscoverLogin("https://x.example", [])).IsFalse();
+    }
+
+    [Test]
     public async Task ChooseGitHubFlow_returns_device_when_forced() {
         var choice = OAuthLoginFlow.ChooseGitHubFlow(forceDevice: true, isHeadless: false, hasExchangeUrl: true);
         await Assert.That(choice).IsEqualTo(GitHubFlow.Device);

--- a/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
@@ -200,6 +200,18 @@ public class SetupCommandTests {
         await Assert.That(SetupCommand.LiveRecordingRestartTip(result)).IsNull();
     }
 
+    [Test]
+    public async Task ResolveTenantArg_expands_bare_label_to_kcap_subdomain() {
+        await Assert.That(SetupCommand.ResolveTenantArg("eventuous")).IsEqualTo("https://eventuous.kcap.ai");
+    }
+
+    [Test]
+    public async Task ResolveTenantArg_leaves_urls_fqdns_and_hosts_untouched() {
+        await Assert.That(SetupCommand.ResolveTenantArg("https://x.example")).IsEqualTo("https://x.example");
+        await Assert.That(SetupCommand.ResolveTenantArg("self.hosted.example")).IsEqualTo("self.hosted.example");
+        await Assert.That(SetupCommand.ResolveTenantArg("localhost:5108")).IsEqualTo("localhost:5108");
+    }
+
     sealed class TempDir : IDisposable {
         public string Path { get; } = System.IO.Path.Combine(
             System.IO.Path.GetTempPath(),

--- a/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
@@ -210,6 +210,7 @@ public class SetupCommandTests {
         await Assert.That(SetupCommand.ResolveTenantArg("https://x.example")).IsEqualTo("https://x.example");
         await Assert.That(SetupCommand.ResolveTenantArg("self.hosted.example")).IsEqualTo("self.hosted.example");
         await Assert.That(SetupCommand.ResolveTenantArg("localhost:5108")).IsEqualTo("localhost:5108");
+        await Assert.That(SetupCommand.ResolveTenantArg("localhost")).IsEqualTo("localhost"); // bare loopback, not a slug
     }
 
     sealed class TempDir : IDisposable {

--- a/test/Capacitor.Cli.Tests.Unit/TenantDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TenantDiscoveryTests.cs
@@ -183,7 +183,7 @@ public class TenantDiscoveryTests {
         };
         DiscoveredTenant[] discovered = [
             new() {
-                Provider = "workos", OrganizationId = "org_a", Slug = "eventuous",
+                Provider = "WorkOS", OrganizationId = "org_a", Slug = "eventuous",
                 DisplayName = "Eventuous", Origin = "https://eventuous.kcap.ai"
             }
         ];

--- a/test/Capacitor.Cli.Tests.Unit/TenantDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TenantDiscoveryTests.cs
@@ -174,4 +174,23 @@ public class TenantDiscoveryTests {
         await Assert.That(merged.Profiles["acme"].ServerUrl).IsEqualTo("https://new.example");
         await Assert.That(merged.Profiles["acme"].DefaultVisibility).IsEqualTo("private");
     }
+
+    [Test]
+    public async Task MergeProfiles_uses_slug_for_workos_tenants() {
+        var existing = new ProfileConfig {
+            ActiveProfile = "default",
+            Profiles = new Dictionary<string, Profile> { ["default"] = new() { DefaultVisibility = "private" } }
+        };
+        DiscoveredTenant[] discovered = [
+            new() {
+                Provider = "workos", OrganizationId = "org_a", Slug = "eventuous",
+                DisplayName = "Eventuous", Origin = "https://eventuous.kcap.ai"
+            }
+        ];
+
+        var merged = TenantDiscovery.MergeProfiles(existing, discovered, discovered[0]);
+
+        await Assert.That(merged.ActiveProfile).IsEqualTo("eventuous");
+        await Assert.That(merged.Profiles["eventuous"].ServerUrl).IsEqualTo("https://eventuous.kcap.ai");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
@@ -23,8 +23,8 @@ public class WorkOSDiscoveryTests {
 
         var proxy = Substitute.For<IAuthProxyClient>();
         DiscoveredTenant[] tenants = [
-            new() { Provider = "workos", OrganizationId = "org_a", Slug = "eventuous", DisplayName = "Eventuous", Origin = "https://eventuous.kcap.ai" },
-            new() { Provider = "workos", OrganizationId = "org_b", Slug = "contoso",   DisplayName = "Contoso",   Origin = "https://contoso.kcap.ai" }
+            new() { Provider = "WorkOS", OrganizationId = "org_a", Slug = "eventuous", DisplayName = "Eventuous", Origin = "https://eventuous.kcap.ai" },
+            new() { Provider = "WorkOS", OrganizationId = "org_b", Slug = "contoso",   DisplayName = "Contoso",   Origin = "https://contoso.kcap.ai" }
         ];
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
              .Returns(Task.FromResult(new DiscoveryResult(tenants, DiscoveryError.None)));

--- a/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
@@ -64,6 +64,26 @@ public class WorkOSDiscoveryTests {
     }
 
     [Test]
+    public async Task RunAsync_errors_when_picked_tenant_has_no_org_id() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        DiscoveredTenant[] tenants = [
+            new() { Provider = "WorkOS", Slug = "eventuous", DisplayName = "Eventuous", Origin = "https://eventuous.kcap.ai" } // no OrganizationId
+        ];
+        proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult(tenants, DiscoveryError.None)));
+
+        var switchCalled = false;
+        var exit = await WorkOSDiscovery.RunAsync(
+            "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
+            proxy, Substitute.For<ITenantPicker>(),
+            _      => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
+            (_, _) => { switchCalled = true; return Task.FromResult<WorkOSAuthResponse?>(null); });
+
+        await Assert.That(exit).IsEqualTo(1);
+        await Assert.That(switchCalled).IsFalse(); // fail before the org-switch, not during it
+    }
+
+    [Test]
     public async Task RunAsync_errors_when_no_tenants() {
         var proxy = Substitute.For<IAuthProxyClient>();
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())

--- a/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
@@ -1,0 +1,80 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using NSubstitute;
+using DiscoveryResult = Capacitor.Cli.Core.Auth.DiscoveryResult;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+// Shares the TokenStoreProfileTests NotInParallel key so the shared KCAP_CONFIG_DIR
+// tokens directory isn't raced by other profile-writing tests.
+[NotInParallel(nameof(TokenStoreProfileTests))]
+public class WorkOSDiscoveryTests {
+    static string TokensDir => PathHelpers.ConfigPath("tokens");
+
+    [Before(Test)]
+    public void Cleanup() {
+        try { if (Directory.Exists(TokensDir)) Directory.Delete(TokensDir, recursive: true); } catch { }
+    }
+
+    [Test]
+    public async Task RunAsync_org_switches_picked_tenant_and_saves_workos_profile() {
+        var proxyConfig = new ProxyConfigResponse { WorkOSClientId = "client_d", WorkOSAuthKitDomain = "" };
+
+        var proxy = Substitute.For<IAuthProxyClient>();
+        DiscoveredTenant[] tenants = [
+            new() { Provider = "workos", OrganizationId = "org_a", Slug = "eventuous", DisplayName = "Eventuous", Origin = "https://eventuous.kcap.ai" },
+            new() { Provider = "workos", OrganizationId = "org_b", Slug = "contoso",   DisplayName = "Contoso",   Origin = "https://contoso.kcap.ai" }
+        ];
+        proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult(tenants, DiscoveryError.None)));
+
+        var picker = Substitute.For<ITenantPicker>();
+        picker.Pick(tenants).Returns(tenants[0]); // eventuous
+
+        var orgless  = new WorkOSAuthResponse { User = new() { Id = "user_x", FirstName = "Ada" }, AccessToken = "acc",  RefreshToken = "rt" };
+        var switched = new WorkOSAuthResponse { User = new() { Id = "user_x" }, OrganizationId = "org_a", AccessToken = "acc2", RefreshToken = "rt2" };
+
+        var exit = await WorkOSDiscovery.RunAsync(
+            "https://auth.kcap.ai", proxyConfig, proxy, picker,
+            orglessLogin: _      => Task.FromResult<WorkOSAuthResponse?>(orgless),
+            orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(switched));
+
+        await Assert.That(exit).IsEqualTo(0);
+
+        var stored = await TokenStore.LoadAsync("eventuous");
+        await Assert.That(stored).IsNotNull();
+        await Assert.That(stored!.AccessToken).IsEqualTo("acc2");
+        await Assert.That(stored.Provider).IsEqualTo(AuthProvider.WorkOS);
+
+        var cfg = await AppConfig.LoadProfileConfig();
+        await Assert.That(cfg.ActiveProfile).IsEqualTo("eventuous");
+        await Assert.That(cfg.Profiles["eventuous"].ServerUrl).IsEqualTo("https://eventuous.kcap.ai");
+    }
+
+    [Test]
+    public async Task RunAsync_errors_when_workos_not_configured() {
+        var exit = await WorkOSDiscovery.RunAsync(
+            "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "" },
+            Substitute.For<IAuthProxyClient>(), Substitute.For<ITenantPicker>(),
+            _      => Task.FromResult<WorkOSAuthResponse?>(null),
+            (_, _) => Task.FromResult<WorkOSAuthResponse?>(null));
+
+        await Assert.That(exit).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task RunAsync_errors_when_no_tenants() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
+
+        var exit = await WorkOSDiscovery.RunAsync(
+            "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
+            proxy, Substitute.For<ITenantPicker>(),
+            _      => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
+            (_, _) => Task.FromResult<WorkOSAuthResponse?>(null));
+
+        await Assert.That(exit).IsEqualTo(1);
+    }
+}


### PR DESCRIPTION
The CLI half of WorkOS tenant discovery (plan 2 of 2), against the now-live proxy contracts (`GET /config` WorkOS fields + `POST /discover-tenants-workos`, kcap-server #788, deployed).

`kcap login` / `kcap setup` with **no `--server-url`** now let a WorkOS user authenticate org-less against the shared AuthKit app, pick from the tenants they belong to, and land in one — same zero-friction flow GitHub-org users already had. Plus a `kcap setup <slug>` shorthand.

## What's here (9 commits)
- **Provider-aware `DiscoveredTenant`** — `provider`/`organization_id`/`slug`/`display_name` + `ProfileName`/`Label` (GitHub rows unchanged via defaults).
- **`ProxyConfigResponse`** reads `workos_client_id`/`workos_authkit_domain`.
- **`AuthProxyClient.DiscoverWorkOSTenantsAsync`** → `POST /discover-tenants-workos`.
- **`OAuthLoginFlow`** seams: org-less `RunWorkOSLoopbackAsync` + `AuthenticateWorkOSCodeAsync` (refactored out of the existing `LoginWorkOSAsync`, behavior preserved) + `SwitchWorkOSOrgAsync` (refresh + `organization_id`, public client).
- **`WorkOSDiscovery`** orchestration: org-less login → discover → picker → **org-switch once** at pick-time → save org-scoped profile. Spike-confirmed: the post-switch refresh stays org-bound, so **no `StoredTokens.OrganizationId`** / no per-refresh `organization_id`.
- **Provider choice** at the discovery entry (`Continue` / `Continue with GitHub`; `--github`/`--workos` skip the prompt); **`kcap login` defaults to discovery** when no server is configured; **`kcap setup <slug>`** → `https://<slug>.kcap.ai`.
- `help-login.txt` + `README` updated.

## Tests
`dotnet run --project test/Capacitor.Cli.Tests.Unit` → **1690 passed, 0 failed**; AOT publish clean (no IL2026/IL3050). New unit coverage: provider-aware DTO/MergeProfiles, proxy `/config` WorkOS fields, `DiscoverWorkOSTenantsAsync`, `SwitchWorkOSOrgAsync`, the discovery orchestration (fakes + temp `KCAP_CONFIG_DIR`), `ChooseDiscoveryProvider`, `ShouldDiscoverLogin`, `ResolveTenantArg`. The browser-loopback orchestration is manual-e2e (as the GitHub browser flow already is).

## Follow-up
After merge, bump the `src/cli` submodule pointer in `kcap-server` to this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)