### PR TITLE
[AI-960] Adopt Duende.IdentityModel.OidcClient for CLI OAuth flows

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,8 @@
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include="IdentityModel.OidcClient" Version="6.0.0" />
+        <PackageVersion Include="Duende.IdentityModel.OidcClient" Version="7.1.0" />
+        <PackageVersion Include="Duende.IdentityModel" Version="8.1.0" />
         <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />
         <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
         <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />

--- a/docs/superpowers/plans/2026-06-25-ai-960-adopt-oidcclient.md
+++ b/docs/superpowers/plans/2026-06-25-ai-960-adopt-oidcclient.md
@@ -1,0 +1,788 @@
+# AI-960: Adopt Duende.IdentityModel.OidcClient — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hand-rolled OAuth machinery in `OAuthLoginFlow` with `Duende.IdentityModel.OidcClient` 7.1.0 for the WorkOS and GitHub-browser authorization-code-with-PKCE flows, keeping device flow + org-switch + the GitHub proxy exchange custom.
+
+**Architecture:** One shared `LoopbackBrowser : IBrowser` replaces both duplicated `HttpListener` loopbacks. WorkOS uses OidcClient's full `LoginAsync` (works because the code flow never requires an `id_token`); the WorkOS-specific response fields are recovered by deserializing the raw token response into the existing `WorkOSAuthResponse`. GitHub-browser uses OidcClient only for the front-channel (`PrepareLoginAsync` + `AuthorizeResponse`) and keeps the custom JSON proxy code-exchange. AI-958 is folded in: WorkOS authorize is always built on `api.workos.com`.
+
+**Tech Stack:** .NET 10, NativeAOT, `Duende.IdentityModel.OidcClient` 7.1.0 (+ `Duende.IdentityModel` 8.1.0), TUnit, WireMock.Net, NSubstitute.
+
+## Global Constraints
+
+- Target `net10.0`, NativeAOT — after any change, `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` MUST be empty. (AOT warnings only show on `publish`, not `build`.)
+- Central Package Management — package versions go in `Directory.Packages.props`; project files carry version-less `<PackageReference>`.
+- `JsonArray` collection expressions are banned (need `new JsonArray(...)`); not expected here, but stay AOT-safe — use the source-gen `CapacitorJsonContext` for all our DTO (de)serialization.
+- TUnit: filter with `--treenode-filter`, not `--filter`. Tests run as executables via `dotnet run --project <test csproj>`.
+- README sync: only required if user-facing CLI surface changes. This change is internal plumbing (same commands/flags/prereqs) — confirm no README edit is needed (Task 5), don't invent one.
+- Preserve the current `AcquireGitHubTokenAsync` contract: a `null` from the browser flow is a hard login failure (no device fallback); only a loopback **bind** exception (`HttpListenerException`/`PlatformNotSupportedException`) falls back to device flow.
+
+**Spec:** `docs/superpowers/specs/2026-06-24-ai-960-adopt-oidcclient-design.md`
+
+---
+
+### Task 1: Swap the package dependency
+
+Remove the unused, mis-located old `IdentityModel.OidcClient` 6.0.0 and add `Duende.IdentityModel.OidcClient` 7.1.0 (+ `Duende.IdentityModel` 8.1.0) to the project that actually owns the auth code (`Capacitor.Cli.Core`).
+
+**Files:**
+- Modify: `Directory.Packages.props:6`
+- Modify: `src/Capacitor.Cli/Capacitor.Cli.csproj:35`
+- Modify: `src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj` (add a `<PackageReference>` ItemGroup)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Duende.IdentityModel.OidcClient` + `Duende.IdentityModel` types available in `Capacitor.Cli.Core` (and transitively in `Capacitor.Cli`, which references Core).
+
+- [ ] **Step 1: Replace the package version pin**
+
+In `Directory.Packages.props`, replace the line:
+```xml
+        <PackageVersion Include="IdentityModel.OidcClient" Version="6.0.0" />
+```
+with:
+```xml
+        <PackageVersion Include="Duende.IdentityModel.OidcClient" Version="7.1.0" />
+        <PackageVersion Include="Duende.IdentityModel" Version="8.1.0" />
+```
+
+- [ ] **Step 2: Remove the stray reference from the CLI project**
+
+In `src/Capacitor.Cli/Capacitor.Cli.csproj`, delete the line:
+```xml
+        <PackageReference Include="IdentityModel.OidcClient" />
+```
+
+- [ ] **Step 3: Add the references to Core**
+
+In `src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj`, add a new ItemGroup after the existing `<ItemGroup>` blocks (before `</Project>`):
+```xml
+    <ItemGroup>
+        <PackageReference Include="Duende.IdentityModel.OidcClient" />
+        <PackageReference Include="Duende.IdentityModel" />
+    </ItemGroup>
+```
+
+- [ ] **Step 4: Restore and build**
+
+Run: `dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj`
+Expected: build succeeds, restore pulls `Duende.IdentityModel.OidcClient 7.1.0` + `Duende.IdentityModel 8.1.0`. No `IdentityModel.OidcClient` left:
+Run: `grep -rni "IdentityModel.OidcClient\b" Directory.Packages.props src/*/*.csproj` returns only the `Duende.` lines.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Directory.Packages.props src/Capacitor.Cli/Capacitor.Cli.csproj src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj
+git commit -m "[AI-960] Swap IdentityModel.OidcClient 6.0.0 -> Duende.IdentityModel.OidcClient 7.1.0"
+```
+
+---
+
+### Task 2: Shared `LoopbackBrowser : IBrowser`
+
+A single 127.0.0.1 loopback listener implementing OidcClient's `IBrowser`, replacing both duplicated `HttpListener` blocks. The browser-open action is injectable so it's unit-testable without launching a real browser. The bind exception is **not** caught — it must propagate so the GitHub device-flow fallback still triggers.
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs`
+- Modify: `src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs` (make `GetAvailablePort` `internal` so the browser/tests share it)
+- Test: `test/Capacitor.Cli.Tests.Unit/LoopbackBrowserTests.cs`
+
+**Interfaces:**
+- Consumes: `OAuthLoginFlow.GetAvailablePort()` (now `internal static int`).
+- Produces:
+  - `public sealed class LoopbackBrowser : IBrowser` with ctor `LoopbackBrowser(Action<string>? openBrowser = null)` and `Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken ct = default)`.
+  - `BrowserResult{ResultType = Success, Response = <raw callback query incl. leading '?'>}` on `/callback`; `{ResultType = Timeout}` on timeout; the port is parsed from `options.EndUrl`; `listener.Start()` exceptions propagate.
+
+- [ ] **Step 1: Make `GetAvailablePort` internal**
+
+In `src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs`, change:
+```csharp
+    static int GetAvailablePort() {
+```
+to:
+```csharp
+    internal static int GetAvailablePort() {
+```
+
+- [ ] **Step 2: Write the failing success + timeout tests**
+
+Create `test/Capacitor.Cli.Tests.Unit/LoopbackBrowserTests.cs`:
+```csharp
+using Capacitor.Cli.Core.Auth;
+using Duende.IdentityModel.OidcClient.Browser;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class LoopbackBrowserTests {
+    [Test]
+    public async Task Returns_success_with_raw_query_on_callback() {
+        var port     = OAuthLoginFlow.GetAvailablePort();
+        var redirect = $"http://127.0.0.1:{port}/callback";
+        var browser  = new LoopbackBrowser(openBrowser: _ => { }); // don't launch a real browser
+
+        var invoke = browser.InvokeAsync(new BrowserOptions("http://example.test/authorize", redirect));
+
+        using var http = new HttpClient();
+        // Listener is started synchronously before InvokeAsync's first await, so this connects.
+        _ = await http.GetAsync($"{redirect}?code=abc&state=xyz");
+
+        var result = await invoke;
+        await Assert.That(result.ResultType).IsEqualTo(BrowserResultType.Success);
+        await Assert.That(result.Response).Contains("code=abc");
+        await Assert.That(result.Response).Contains("state=xyz");
+    }
+
+    [Test]
+    public async Task Returns_timeout_when_no_callback_arrives() {
+        var port     = OAuthLoginFlow.GetAvailablePort();
+        var redirect = $"http://127.0.0.1:{port}/callback";
+        var browser  = new LoopbackBrowser(openBrowser: _ => { });
+
+        var result = await browser.InvokeAsync(
+            new BrowserOptions("http://example.test/authorize", redirect) { Timeout = TimeSpan.FromMilliseconds(200) });
+
+        await Assert.That(result.ResultType).IsEqualTo(BrowserResultType.Timeout);
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/LoopbackBrowserTests/*"`
+Expected: FAIL — `LoopbackBrowser` does not exist (compile error).
+
+- [ ] **Step 4: Implement `LoopbackBrowser`**
+
+Create `src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs`:
+```csharp
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+using Duende.IdentityModel.OidcClient.Browser;
+
+namespace Capacitor.Cli.Core.Auth;
+
+/// <summary>
+/// OidcClient <see cref="IBrowser"/> backed by a 127.0.0.1 loopback HttpListener.
+/// Opens the system browser to the authorize URL, waits for the redirect callback,
+/// and returns its raw query string. WorkOS documents the loopback exception as
+/// 127.0.0.1 (not localhost). The bind exception is intentionally NOT caught so the
+/// GitHub flow can fall back to device flow on a bind failure.
+/// </summary>
+public sealed class LoopbackBrowser(Action<string>? openBrowser = null) : IBrowser {
+    readonly Action<string> _openBrowser = openBrowser ?? OpenSystemBrowser;
+
+    public async Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken ct = default) {
+        var port = new Uri(options.EndUrl).Port;
+
+        using var listener = new HttpListener();
+        listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+        listener.Start(); // bind failure propagates (HttpListenerException / PlatformNotSupportedException)
+
+        await Console.Out.WriteLineAsync("Opening browser for authentication...");
+        await Console.Out.WriteLineAsync($"  If the browser doesn't open, visit: {options.StartUrl}");
+        _openBrowser(options.StartUrl);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(options.Timeout);
+
+        HttpListenerContext context;
+
+        while (true) {
+            var getContext = listener.GetContextAsync();
+
+            try {
+                context = await getContext.WaitAsync(cts.Token);
+            } catch (OperationCanceledException) {
+                listener.Stop();
+                _ = getContext.ContinueWith(t => _ = t.Exception, CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+
+                return new BrowserResult { ResultType = BrowserResultType.Timeout };
+            }
+
+            if (context.Request.Url?.AbsolutePath == "/callback") break;
+
+            // Ignore favicon and other browser-issued requests that aren't our callback.
+            context.Response.StatusCode = 404;
+            context.Response.Close();
+        }
+
+        var query = context.Request.Url?.Query ?? "";
+        await WriteClosingPageAsync(context, success: !query.Contains("error="));
+        listener.Stop();
+
+        return new BrowserResult { ResultType = BrowserResultType.Success, Response = query };
+    }
+
+    static void OpenSystemBrowser(string url) {
+        try {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        } catch {
+            // Best-effort — headless environments (devcontainers, SSH) have no browser.
+        }
+    }
+
+    static async Task WriteClosingPageAsync(HttpListenerContext ctx, bool success) {
+        var (title, message) = success
+            ? ("Authentication successful!", "You can close this window and return to the terminal.")
+            : ("Authentication failed", "Return to the terminal for details.");
+
+        var html = $"<html><body style='font-family:system-ui;max-width:480px;margin:80px auto;text-align:center'>"
+          + $"<h2>{WebUtility.HtmlEncode(title)}</h2><p>{WebUtility.HtmlEncode(message)}</p></body></html>";
+
+        var buffer = Encoding.UTF8.GetBytes(html);
+        ctx.Response.ContentType     = "text/html";
+        ctx.Response.ContentLength64 = buffer.Length;
+        await ctx.Response.OutputStream.WriteAsync(buffer);
+        ctx.Response.Close();
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/LoopbackBrowserTests/*"`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs test/Capacitor.Cli.Tests.Unit/LoopbackBrowserTests.cs
+git commit -m "[AI-960] Add shared LoopbackBrowser IBrowser implementation"
+```
+
+---
+
+### Task 3: WorkOS flow on OidcClient (+ AI-958 fold-in)
+
+Replace the WorkOS loopback + exchange with OidcClient's `LoginAsync`, always building authorize on `api.workos.com` (AI-958). Map the raw token response into the existing `WorkOSAuthResponse` via the source-gen context so omitted/nullable WorkOS fields don't throw. Rewire `WorkOSDiscovery` to the new no-`authorizeBase` helper and delete the bespoke WorkOS methods.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs`
+- Modify: `src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/FakeBrowser.cs` (new test helper)
+
+**Interfaces:**
+- Consumes: `LoopbackBrowser`, `OAuthLoginFlow.GetAvailablePort()`.
+- Produces:
+  - `internal static OidcClientOptions BuildWorkOSOptions(string clientId, string apiBase, string redirectUri)`
+  - `internal static Parameters WorkOSFrontChannel(string? organizationId)`
+  - `public static Task<WorkOSAuthResponse?> AuthenticateWorkOSAsync(string clientId, string? organizationId, IBrowser browser, string apiBase = "https://api.workos.com")`
+  - `WorkOSDiscovery.RunAsync(...)` `orglessLogin` param changes to `Func<Task<WorkOSAuthResponse?>>`.
+- Removes: `RunWorkOSLoopbackAsync`, `AuthenticateWorkOSCodeAsync`, `WorkOSLoopbackResult`, `LoginWorkOSAsync(string?, string, string?)`'s old body, the `WorkOSApiBase` duplicate in `WorkOSDiscovery`.
+
+- [ ] **Step 1: Add the `FakeBrowser` test helper**
+
+Create `test/Capacitor.Cli.Tests.Unit/FakeBrowser.cs`:
+```csharp
+using Duende.IdentityModel.OidcClient.Browser;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>Test IBrowser: returns a canned callback query, or a non-success result.</summary>
+public sealed class FakeBrowser(Func<string, BrowserResult> respond) : IBrowser {
+    public string? LastStartUrl { get; private set; }
+
+    public Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken ct = default) {
+        LastStartUrl = options.StartUrl;
+        return Task.FromResult(respond(options.StartUrl));
+    }
+
+    // Echo the state from the StartUrl so ProcessResponseAsync's state check passes.
+    public static FakeBrowser WithCode(string code) => new(startUrl => {
+        var query = new Uri(startUrl).Query.TrimStart('?');
+        var state = query.Split('&')
+            .First(p => p.StartsWith("state=", StringComparison.Ordinal))["state=".Length..];
+        return new BrowserResult { ResultType = BrowserResultType.Success, Response = $"?code={code}&state={state}" };
+    });
+
+    public static FakeBrowser WithRawQuery(string query) =>
+        new(_ => new BrowserResult { ResultType = BrowserResultType.Success, Response = query });
+
+    public static FakeBrowser NonSuccess(BrowserResultType type) =>
+        new(_ => new BrowserResult { ResultType = type });
+}
+```
+
+- [ ] **Step 2: Write the failing WorkOS authorize-URL test**
+
+In `test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs`, add `using Duende.IdentityModel.OidcClient;` at the top, and add:
+```csharp
+    [Test]
+    public async Task WorkOS_authorize_url_targets_api_domain_with_authkit_and_org() {
+        var options = OAuthLoginFlow.BuildWorkOSOptions("client_d", "https://api.workos.com", "http://127.0.0.1:5555/callback");
+        var oidc    = new OidcClient(options);
+
+        var state = await oidc.PrepareLoginAsync(OAuthLoginFlow.WorkOSFrontChannel("org_a"));
+
+        await Assert.That(state.StartUrl).StartsWith("https://api.workos.com/user_management/authorize");
+        await Assert.That(state.StartUrl).Contains("provider=authkit");
+        await Assert.That(state.StartUrl).Contains("organization_id=org_a");
+        await Assert.That(state.StartUrl).Contains("code_challenge_method=S256");
+        await Assert.That(options.LoadProfile).IsFalse();
+    }
+
+    [Test]
+    public async Task WorkOS_authorize_url_omits_org_when_null() {
+        var options = OAuthLoginFlow.BuildWorkOSOptions("client_d", "https://api.workos.com", "http://127.0.0.1:5555/callback");
+        var oidc    = new OidcClient(options);
+
+        var state = await oidc.PrepareLoginAsync(OAuthLoginFlow.WorkOSFrontChannel(null));
+
+        await Assert.That(state.StartUrl).DoesNotContain("organization_id");
+    }
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/OAuthFlowTests/WorkOS_authorize_url_*"`
+Expected: FAIL — `BuildWorkOSOptions`/`WorkOSFrontChannel` not defined.
+
+- [ ] **Step 4: Implement the WorkOS option/param builders**
+
+In `src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs`, add these usings at the top:
+```csharp
+using Duende.IdentityModel.Client;
+using Duende.IdentityModel.OidcClient;
+using Duende.IdentityModel.OidcClient.Browser;
+```
+Then add (near the WorkOS region):
+```csharp
+    internal static OidcClientOptions BuildWorkOSOptions(string clientId, string apiBase, string redirectUri) {
+        var options = new OidcClientOptions {
+            Authority   = apiBase,            // anonymous-principal issuer; discovery stays off (ProviderInformation set)
+            ClientId    = clientId,
+            Scope       = "",                 // preserve current no-scope behavior
+            RedirectUri = redirectUri,
+            LoadProfile = false,              // WorkOS has no userinfo endpoint
+            DisablePushedAuthorization = true,
+            ProviderInformation = new ProviderInformation {
+                IssuerName        = apiBase,
+                AuthorizeEndpoint = $"{apiBase}/user_management/authorize",     // AI-958: always the API domain
+                TokenEndpoint     = $"{apiBase}/user_management/authenticate",
+            },
+        };
+        options.Policy.Discovery.RequireKeySet = false;
+
+        return options;
+    }
+
+    internal static Parameters WorkOSFrontChannel(string? organizationId) {
+        var p = new Parameters { { "provider", "authkit" } };
+        if (!string.IsNullOrEmpty(organizationId)) p.Add("organization_id", organizationId);
+
+        return p;
+    }
+```
+
+- [ ] **Step 5: Run the URL tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/OAuthFlowTests/WorkOS_authorize_url_*"`
+Expected: PASS.
+
+(If `Scope=""` causes a `scope=` param to appear or any error — the spec's verify-at-impl #2 — set `Scope` to a single space or omit by leaving it null; re-run. Document the chosen value in the commit.)
+
+- [ ] **Step 6: Write the failing end-to-end mapping tests (org-scoped + org-less)**
+
+In `OAuthFlowTests.cs` add:
+```csharp
+    [Test]
+    public async Task AuthenticateWorkOS_maps_token_response_including_org_and_user() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(
+                """{"user":{"id":"user_x","first_name":"Ada"},"organization_id":"org_a","access_token":"acc","refresh_token":"rt"}"""));
+
+        var result = await OAuthLoginFlow.AuthenticateWorkOSAsync(
+            "client_d", "org_a", FakeBrowser.WithCode("the_code"), apiBase: server.Urls[0]);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.AccessToken).IsEqualTo("acc");
+        await Assert.That(result.RefreshToken).IsEqualTo("rt");
+        await Assert.That(result.OrganizationId).IsEqualTo("org_a");
+        await Assert.That(result.User!.FirstName).IsEqualTo("Ada");
+    }
+
+    [Test]
+    public async Task AuthenticateWorkOS_handles_orgless_response_without_throwing() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(
+                """{"access_token":"acc","refresh_token":"rt"}"""));   // no organization_id, no user
+
+        var result = await OAuthLoginFlow.AuthenticateWorkOSAsync(
+            "client_d", organizationId: null, FakeBrowser.WithCode("the_code"), apiBase: server.Urls[0]);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.OrganizationId).IsNull();
+        await Assert.That(result.User).IsNull();
+        await Assert.That(result.RefreshToken).IsEqualTo("rt");
+    }
+```
+
+- [ ] **Step 7: Run to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/OAuthFlowTests/AuthenticateWorkOS_*"`
+Expected: FAIL — `AuthenticateWorkOSAsync` not defined.
+
+- [ ] **Step 8: Implement `AuthenticateWorkOSAsync` and rewrite the WorkOS login path**
+
+In `OAuthLoginFlow.cs` add (using the builders from Step 4):
+```csharp
+    /// <summary>
+    /// WorkOS AuthKit authorization-code-with-PKCE login via OidcClient. Authorize + token both
+    /// on the API domain (AI-958), org-scoped when <paramref name="organizationId"/> is set.
+    /// Maps the raw token response (which carries WorkOS's non-standard organization_id/user and
+    /// no id_token) into <see cref="WorkOSAuthResponse"/> via the source-gen context.
+    /// </summary>
+    public static async Task<WorkOSAuthResponse?> AuthenticateWorkOSAsync(
+            string clientId, string? organizationId, IBrowser browser, string apiBase = WorkOSApiBase) {
+        var redirectUri = $"http://127.0.0.1:{GetAvailablePort()}/callback";
+        var options     = BuildWorkOSOptions(clientId, apiBase, redirectUri);
+        options.Browser = browser;
+
+        var oidc   = new OidcClient(options);
+        var result = await oidc.LoginAsync(new LoginRequest { FrontChannelExtraParameters = WorkOSFrontChannel(organizationId) });
+
+        if (result.IsError || result.TokenResponse?.Json is not { } json) return null;
+
+        return JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.WorkOSAuthResponse);
+    }
+```
+Replace the body of `HandleWorkOSLogin` + `LoginWorkOSAsync` so it no longer threads `authKitDomain`:
+```csharp
+    static Task<int> HandleWorkOSLogin(AuthDiscoveryResponse config) =>
+        LoginWorkOSAsync(config.ClientId!, config.OrganizationId);
+
+    static async Task<int> LoginWorkOSAsync(string clientId, string? organizationId) {
+        var json = await AuthenticateWorkOSAsync(clientId, organizationId, new LoopbackBrowser());
+        if (json is null) {
+            Console.Error.WriteLine("Error: WorkOS sign-in failed.");
+
+            return 1;
+        }
+
+        // Org gate: a multi-org user must not be "logged in" to the wrong org.
+        if (!string.IsNullOrEmpty(organizationId) && !string.Equals(json.OrganizationId, organizationId, StringComparison.Ordinal)) {
+            Console.Error.WriteLine($"Error: signed in to the wrong WorkOS organization (expected {organizationId}). Re-run `kcap login` and pick the correct organization.");
+
+            return 1;
+        }
+
+        var username = WorkOSDisplayName(json.User);
+
+        await TokenStore.SaveAsync(
+            new() {
+                AccessToken    = json.AccessToken,
+                RefreshToken   = json.RefreshToken,
+                ExpiresAt      = TokenStore.JwtExpiry(json.AccessToken),
+                GitHubUsername = username,
+                Provider       = AuthProvider.WorkOS,
+                ClientId       = clientId
+            });
+
+        await Console.Out.WriteLineAsync($"Logged in as {username}");
+
+        return 0;
+    }
+```
+Delete `RunWorkOSLoopbackAsync`, `AuthenticateWorkOSCodeAsync`, and the `WorkOSLoopbackResult` record entirely. Keep the `const string WorkOSApiBase = "https://api.workos.com";`.
+
+- [ ] **Step 9: Rewire `WorkOSDiscovery` to the no-`authorizeBase` helper**
+
+In `src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs`:
+
+Change `RunWithLiveAuthAsync` to drop the `authorizeBase` computation and pass the new helper:
+```csharp
+    public static Task<int> RunWithLiveAuthAsync(
+            string proxyUrl, ProxyConfigResponse proxyConfig, IAuthProxyClient proxy, ITenantPicker picker) {
+        var clientId = proxyConfig.WorkOSClientId ?? "";
+
+        return RunAsync(proxyUrl, proxyConfig, proxy, picker,
+            orglessLogin: () => OAuthLoginFlow.AuthenticateWorkOSAsync(clientId, organizationId: null, new LoopbackBrowser()),
+            orgSwitch: async (refreshToken, organizationId) => {
+                using var http = new HttpClient();
+                return await OAuthLoginFlow.SwitchWorkOSOrgAsync(http, WorkOSApiBase, clientId, refreshToken, organizationId);
+            });
+    }
+```
+Change the `RunAsync` signature delegate and its single call site:
+```csharp
+            Func<Task<WorkOSAuthResponse?>>                 orglessLogin,   // (was Func<string, ...>)
+```
+and:
+```csharp
+        var auth = await orglessLogin();
+```
+(Remove the now-unused `authorizeBase` local and the `WorkOSAuthKitDomain` read.)
+
+- [ ] **Step 10: Update `WorkOSDiscoveryTests` to the no-arg delegate**
+
+In `test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs`, change every `orglessLogin` lambda from `_ => Task.FromResult(...)` to `() => Task.FromResult(...)`. The four occurrences:
+```csharp
+            orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(orgless),
+```
+```csharp
+            _      => Task.FromResult<WorkOSAuthResponse?>(null),     // -> () => Task.FromResult<WorkOSAuthResponse?>(null),
+```
+```csharp
+            _      => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),   // -> () => ...
+```
+```csharp
+            _      => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),   // -> () => ...
+```
+(`orgSwitch` lambdas keep their two args.)
+
+- [ ] **Step 11: Run the WorkOS + discovery tests**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/OAuthFlowTests/AuthenticateWorkOS_*"`
+Then: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/WorkOSDiscoveryTests/*"`
+Expected: PASS. (If WorkOS rejects the extra `redirect_uri` OidcClient sends on the token POST — spec verify-at-impl #1 — the WireMock tests still pass; flag it for the live-WorkOS check in Task 5.)
+
+- [ ] **Step 12: AOT publish gate + commit**
+
+Run: `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'`
+Expected: empty output.
+```bash
+git add src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs test/Capacitor.Cli.Tests.Unit/FakeBrowser.cs
+git commit -m "[AI-960] WorkOS login via OidcClient; authorize on api.workos.com (AI-958)"
+```
+
+---
+
+### Task 4: GitHub browser flow on OidcClient front-channel
+
+Use OidcClient for PKCE + state + authorize-URL via `PrepareLoginAsync`, the shared `LoopbackBrowser`, and `AuthorizeResponse` to parse the callback; keep the custom JSON proxy code-exchange. Delete the bespoke GitHub URL/PKCE/callback helpers.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs`
+
+**Interfaces:**
+- Consumes: `LoopbackBrowser`, `GitHubCodeExchangeRequest`, `GitHubTokenResponse`, `OAuthLoginFlow.GetAvailablePort()`.
+- Produces: `public static Task<string?> RunGitHubBrowserFlowAsync(string clientId, string codeExchangeUrl, IBrowser? browser = null, TimeSpan? timeout = null)`.
+- Removes: `BuildGitHubAuthorizeUrl`, `ParseCallback`, `CallbackResult`, `RespondCallbackAsync`, `GenerateCodeVerifier`, `GenerateCodeChallenge`.
+
+- [ ] **Step 1: Delete the now-obsolete GitHub unit tests**
+
+In `OAuthFlowTests.cs`, delete `GitHub_authorize_url_includes_all_required_params` and all six `Callback_parser_*` tests (the methods they cover are being removed).
+
+- [ ] **Step 2: Write the failing GitHub browser-flow tests**
+
+In `OAuthFlowTests.cs` add:
+```csharp
+    [Test]
+    public async Task GitHubBrowser_exchanges_code_and_returns_access_token() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/code-exchange").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"access_token":"gho_abc"}"""));
+
+        var token = await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
+            "Iv1.abc", $"{server.Urls[0]}/code-exchange", FakeBrowser.WithCode("the_code"));
+
+        await Assert.That(token).IsEqualTo("gho_abc");
+    }
+
+    [Test]
+    public async Task GitHubBrowser_returns_null_on_state_mismatch_without_calling_proxy() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/code-exchange").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"access_token":"nope"}"""));
+
+        var token = await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
+            "Iv1.abc", $"{server.Urls[0]}/code-exchange",
+            FakeBrowser.WithRawQuery("?code=the_code&state=attacker"));
+
+        await Assert.That(token).IsNull();
+        // The proxy must never be hit when the CSRF state doesn't match.
+        await Assert.That(server.LogEntries.Any(e => e.RequestMessage.Path == "/code-exchange")).IsFalse();
+    }
+
+    [Test]
+    public async Task GitHubBrowser_returns_null_on_non_success_browser_result() {
+        var token = await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
+            "Iv1.abc", "http://unused.test/code-exchange", FakeBrowser.NonSuccess(BrowserResultType.Timeout));
+
+        await Assert.That(token).IsNull();
+    }
+```
+Add `using Duende.IdentityModel.OidcClient.Browser;` to the test file if not present.
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/OAuthFlowTests/GitHubBrowser_*"`
+Expected: FAIL — `RunGitHubBrowserFlowAsync` signature doesn't accept an `IBrowser` yet / state-mismatch path not implemented.
+
+- [ ] **Step 4: Rewrite `RunGitHubBrowserFlowAsync`**
+
+In `OAuthLoginFlow.cs` replace the whole `RunGitHubBrowserFlowAsync` method with:
+```csharp
+    /// <summary>
+    /// GitHub authorization-code-with-PKCE via OidcClient's front-channel (authorize URL + PKCE +
+    /// state) over a 127.0.0.1 loopback, then the proxy-mediated JSON code-exchange to the Capacitor
+    /// server (GitHub Apps need client_secret on the token POST, which the server adds). Returns the
+    /// GitHub access token, or <c>null</c> on cancel/timeout/state-mismatch/error — a null is a hard
+    /// failure (the caller does NOT fall back to device flow on null, only on a loopback bind exception).
+    /// </summary>
+    public static async Task<string?> RunGitHubBrowserFlowAsync(
+            string clientId, string codeExchangeUrl, IBrowser? browser = null, TimeSpan? timeout = null) {
+        browser ??= new LoopbackBrowser();
+        var redirectUri = $"http://127.0.0.1:{GetAvailablePort()}/callback";
+
+        var options = new OidcClientOptions {
+            Authority   = "https://github.com",
+            ClientId    = clientId,
+            Scope       = "read:user read:org",
+            RedirectUri = redirectUri,
+            LoadProfile = false,
+            DisablePushedAuthorization = true,
+            Browser     = browser,
+            ProviderInformation = new ProviderInformation {
+                IssuerName        = "https://github.com",
+                AuthorizeEndpoint = "https://github.com/login/oauth/authorize",
+                TokenEndpoint     = "https://github.com/login/oauth/access_token", // required non-empty; never called
+            },
+        };
+        options.Policy.Discovery.RequireKeySet = false;
+
+        var oidc  = new OidcClient(options);
+        var state = await oidc.PrepareLoginAsync();
+
+        var result = await browser.InvokeAsync(
+            new BrowserOptions(state.StartUrl, redirectUri) { Timeout = timeout ?? TimeSpan.FromMinutes(5) });
+
+        if (result.ResultType != BrowserResultType.Success) {
+            Console.Error.WriteLine(result.ResultType == BrowserResultType.Timeout
+                ? "Timed out waiting for authorization. Re-run `kcap login` to try again."
+                : $"Authorization failed: {result.Error ?? result.ResultType.ToString()}");
+
+            return null;
+        }
+
+        var resp = new AuthorizeResponse(result.Response);
+        if (resp.IsError) {
+            Console.Error.WriteLine($"Authorization failed: {resp.Error}");
+
+            return null;
+        }
+        if (!string.Equals(resp.State, state.State, StringComparison.Ordinal)) {
+            Console.Error.WriteLine("Error: state mismatch — possible CSRF. Aborting.");
+
+            return null;
+        }
+        if (string.IsNullOrEmpty(resp.Code)) {
+            Console.Error.WriteLine("Authorization failed: no authorization code received.");
+
+            return null;
+        }
+
+        using var http = new HttpClient();
+        http.DefaultRequestHeaders.Accept.Add(new("application/json"));
+
+        HttpResponseMessage tokenResponse;
+
+        try {
+            tokenResponse = await http.PostAsJsonAsync(
+                codeExchangeUrl,
+                new GitHubCodeExchangeRequest { Code = resp.Code, CodeVerifier = state.CodeVerifier, RedirectUri = redirectUri },
+                CapacitorJsonContext.Default.GitHubCodeExchangeRequest);
+        } catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or UriFormatException or InvalidOperationException) {
+            Console.Error.WriteLine($"Could not reach the code-exchange endpoint at {codeExchangeUrl}: {ex.Message}");
+
+            return null;
+        }
+
+        if (!tokenResponse.IsSuccessStatusCode) {
+            Console.Error.WriteLine($"Error exchanging code: {await tokenResponse.Content.ReadAsStringAsync()}");
+
+            return null;
+        }
+
+        GitHubTokenResponse? tokenResult;
+
+        try {
+            tokenResult = await tokenResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.GitHubTokenResponse);
+        } catch (JsonException ex) {
+            var raw = await tokenResponse.Content.ReadAsStringAsync();
+            Console.Error.WriteLine($"Code-exchange response was not valid JSON ({ex.Message}): {raw}");
+
+            return null;
+        }
+
+        if (tokenResult?.AccessToken is null) {
+            Console.Error.WriteLine($"Error: {tokenResult?.Error ?? "no access_token in response"}");
+
+            return null;
+        }
+
+        await Console.Out.WriteLineAsync("Authorization complete.");
+
+        return tokenResult.AccessToken;
+    }
+```
+Then delete `BuildGitHubAuthorizeUrl`, `ParseCallback`, the `CallbackResult` record, `RespondCallbackAsync`, `GenerateCodeVerifier`, and `GenerateCodeChallenge`. Remove now-unused usings (`System.Security.Cryptography`; keep `System.Net` only if still referenced — `HttpListener` now lives in `LoopbackBrowser`, so drop `System.Net` if nothing else uses it). Let the compiler guide the using cleanup.
+
+- [ ] **Step 5: Run the GitHub tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/OAuthFlowTests/GitHubBrowser_*"`
+Expected: PASS (all three).
+
+- [ ] **Step 6: AOT publish gate + commit**
+
+Run: `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'`
+Expected: empty.
+```bash
+git add src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
+git commit -m "[AI-960] GitHub browser flow via OidcClient front-channel; keep proxy exchange"
+```
+
+---
+
+### Task 5: Full verification sweep
+
+Confirm the whole suite passes, the AOT publish is clean, the macOS binary still signs, and no README change is owed.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full unit + integration test run**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj`
+Then: `dotnet run --project test/Capacitor.Cli.Tests.Integration/Capacitor.Cli.Tests.Integration.csproj`
+Expected: all pass.
+
+- [ ] **Step 2: AOT publish gate (authoritative)**
+
+Run: `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'`
+Expected: empty output. (If anything appears, it's almost certainly from a reflection-based JSON path — route it through `CapacitorJsonContext` / OidcClient's own source-gen; do not suppress.)
+
+- [ ] **Step 3: Re-sign the macOS AOT binary (if copied)**
+
+If the publish output binary was copied anywhere, run `codesign --force --sign - <path-to-binary>`. (No-op if not copied.)
+
+- [ ] **Step 4: Confirm no stray old references remain**
+
+Run: `grep -rni "RunWorkOSLoopbackAsync\|AuthenticateWorkOSCodeAsync\|BuildGitHubAuthorizeUrl\|ParseCallback\|GenerateCodeChallenge\|WorkOSLoopbackResult\|IdentityModel.OidcClient\b" src/ test/`
+Expected: no hits except the `Duende.IdentityModel.OidcClient` package/using lines.
+
+- [ ] **Step 5: README confirmation**
+
+Confirm `kcap login` / `kcap setup` commands, flags (`--github`, `--workos`, `--device`, `--discover`), and prerequisites are unchanged. No README edit required. (If any user-visible behavior shifted, update `README.md` quick-start + the per-command section in the same change.)
+
+- [ ] **Step 6: Live-WorkOS verify-at-impl checks (spec items 1 & 2)**
+
+Verify against a real WorkOS sign-in (or confirm via WorkOS docs) that: (1) the `redirect_uri` OidcClient adds to the `/user_management/authenticate` POST is accepted/ignored; (2) the `Scope` value chosen in Task 3 Step 5 produces a working authorize request. If either fails, fall WorkOS back to the manual `PrepareLoginAsync` + custom exchange pattern (mirroring GitHub) and note it.
+
+- [ ] **Step 7: Final commit (if Step 3/5 changed anything)**
+
+```bash
+git add -A && git commit -m "[AI-960] Verification sweep: tests, AOT, codesign, docs"
+```
+
+## Notes for the implementer
+
+- OidcClient parses a token response with **no `id_token`** fine — the code flow hardcodes `requireIdentityToken: false`. Don't add an `IdentityTokenValidator`; `LoadProfile=false` keeps it from hitting a userinfo endpoint.
+- `LoginResult.TokenResponse.Json` is a `JsonElement?`; the WorkOS extra fields (`organization_id`, `user`) come from deserializing it into `WorkOSAuthResponse`, NOT `JsonElement.GetProperty` (which throws on omitted fields).
+- The device flow (`RunDeviceFlowAsync`) and org-switch (`SwitchWorkOSOrgAsync`) are untouched — do not route them through OidcClient.

--- a/docs/superpowers/specs/2026-06-24-ai-960-adopt-oidcclient-design.md
+++ b/docs/superpowers/specs/2026-06-24-ai-960-adopt-oidcclient-design.md
@@ -1,0 +1,264 @@
+# AI-960: Adopt Duende.IdentityModel.OidcClient for CLI OAuth flows
+
+## Problem
+
+Every OAuth flow in the CLI is hand-rolled in
+`src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs`: PKCE generation
+(`GenerateCodeVerifier`/`GenerateCodeChallenge`), authorize-URL construction
+(`BuildGitHubAuthorizeUrl` and the inline WorkOS URL), the `HttpListener`
+loopback (duplicated between the GitHub and WorkOS browser flows), callback
+parsing (`ParseCallback`), and the code→token exchanges
+(`RunWorkOSLoopbackAsync` + `AuthenticateWorkOSCodeAsync`,
+`RunGitHubBrowserFlowAsync`).
+
+A dependency on `IdentityModel.OidcClient` 6.0.0 already exists — but it is
+**completely unused** (`grep` finds zero `OidcClient`/`IdentityModel` usages in
+`src/`), it is the **old pre-Duende** package, and the reference sits in the
+**wrong project** (`Capacitor.Cli.csproj`) while all the auth code lives in
+`Capacitor.Cli.Core` (which today has no package references at all). It was
+added and never wired in.
+
+Goal: replace the bespoke authorization-code-with-PKCE + loopback +
+code-exchange machinery with the audited
+**`Duende.IdentityModel.OidcClient` 7.1.0**, keeping the genuinely
+provider-specific bits custom.
+
+## Goals / non-goals
+
+**Goals**
+1. Adopt `Duende.IdentityModel.OidcClient` 7.1.0 for the WorkOS and GitHub
+   browser authorization-code-with-PKCE flows.
+2. Collapse the two duplicated `HttpListener` loopbacks into one
+   `IBrowser` implementation.
+3. Fold in AI-958 (CLI part): WorkOS authorize URL **always** on
+   `api.workos.com`, never `authKitDomain`.
+4. Stay IL2026/IL3050-clean under `dotnet publish -c Release`.
+
+**Non-goals**
+- GitHub **device flow** (`RunDeviceFlowAsync`) — OidcClient has no device
+  grant; stays custom.
+- WorkOS **org-switch** (`SwitchWorkOSOrgAsync`) — WorkOS-specific refresh
+  grant + `organization_id`; stays custom.
+- The GitHub App **proxy code-exchange** contract — proxy-mediated JSON to our
+  own server; stays custom (OidcClient owns only the front-channel for GitHub).
+- kcap-server WorkOS files named in AI-958 — out of scope for this repo.
+
+## Confirmed library facts (from DuendeSoftware/foss `main`)
+
+- **AOT**: `Duende.IdentityModel.OidcClient` 7.1.0 targets `net10.0` with
+  `IsTrimmable=true` / `IsAotCompatible=true`; deps are only
+  `Duende.IdentityModel 8.1.0` + `Microsoft.Extensions.Logging.Abstractions
+  10.0.4`. No `System.IdentityModel.Tokens.Jwt` reflection chain. It uses its
+  own `SourceGenerationContext` for `System.Text.Json`.
+- **No `id_token` required**: `ResponseProcessor.ProcessCodeFlowResponseAsync`
+  calls `ValidateTokenResponseAsync(..., requireIdentityToken: false, ...)`.
+  A token response carrying only `access_token`/`refresh_token` (WorkOS's exact
+  shape) validates fine; `User` becomes an anonymous `Principal`. The raw
+  `LoginResult.TokenResponse` is exposed ("additional custom response data that
+  clients need access to"), so WorkOS's extra `organization_id`/`user` fields
+  remain readable via `TokenResponse.Json` (a `JsonElement`, AOT-safe).
+- **Injectable seams**: `IBrowser` (loopback), `OidcClientOptions.Browser`,
+  `BackchannelHandler`/`HttpClientFactory` (point token endpoint at WireMock),
+  `PrepareLoginAsync`/`ProcessResponseAsync`, and `AuthorizeResponse(raw)`
+  (callback parser) are all public.
+- **Manual endpoints**: set `OidcClientOptions.ProviderInformation` with
+  `IssuerName` (required, non-empty), `AuthorizeEndpoint` (required),
+  `TokenEndpoint` (required); `KeySet` may be null when
+  `Policy.Discovery.RequireKeySet = false`. Setting `ProviderInformation`
+  disables discovery (no `.well-known` fetch).
+
+## Package changes
+
+In `Directory.Packages.props`:
+- Remove `PackageVersion Include="IdentityModel.OidcClient" Version="6.0.0"`.
+- Add `PackageVersion Include="Duende.IdentityModel.OidcClient" Version="7.1.0"`.
+- Add `PackageVersion Include="Duende.IdentityModel" Version="8.1.0"` (used
+  directly for `AuthorizeResponse`/`Parameters`; also the transitive dep).
+
+Project references:
+- Remove `PackageReference Include="IdentityModel.OidcClient"` from
+  `src/Capacitor.Cli/Capacitor.Cli.csproj`.
+- Add `Duende.IdentityModel.OidcClient` + `Duende.IdentityModel`
+  `PackageReference`s to **`src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj`**
+  (the project that owns the auth code; `Capacitor.Cli` already references it).
+
+## Component design
+
+### 1. `LoopbackBrowser : IBrowser` (new — `Core/Auth/LoopbackBrowser.cs`)
+
+Single implementation of the 127.0.0.1 loopback, replacing both inline
+`HttpListener` blocks.
+
+```csharp
+public sealed class LoopbackBrowser : IBrowser {
+    public Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken ct = default);
+}
+```
+
+Behavior (lifted from the existing flows, de-duplicated):
+- Parse the port from `options.EndUrl` (the redirect URI); bind
+  `http://127.0.0.1:{port}/`.
+- `Process.Start` the system browser to `options.StartUrl` (best-effort;
+  swallow failures — headless has no browser). Print the "if it didn't open,
+  visit: {StartUrl}" line.
+- Loop `GetContextAsync` with `options.Timeout`; ignore non-`/callback`
+  requests (favicon etc.) with 404; on cancellation return
+  `BrowserResult{ResultType = Timeout}`.
+- On `/callback`: write the success HTML, return
+  `BrowserResult{ResultType = Success, Response = <raw query string>}`.
+  (CSRF state validation is OidcClient's job in `ProcessResponseAsync`; for the
+  GitHub manual path we validate `AuthorizeResponse.State` ourselves.)
+
+Port allocation stays the caller's responsibility (keep `GetAvailablePort`) so
+`RedirectUri` is fixed before `LoginAsync`. Same brief alloc→bind TOCTOU window
+as today — no regression.
+
+### 2. WorkOS — full OidcClient `LoginAsync`
+
+Rewrite `LoginWorkOSAsync` and add a reusable
+`AuthenticateWorkOSAsync(clientId, organizationId, IBrowser, HttpMessageHandler?)`
+→ `WorkOSAuthResponse?` helper that builds:
+
+```csharp
+var options = new OidcClientOptions {
+    ClientId    = clientId,
+    Scope       = "",                          // preserve current no-scope behavior
+    RedirectUri = $"http://127.0.0.1:{port}/callback",
+    Browser     = loopback,
+    LoadProfile = false,                       // no userinfo endpoint
+    DisablePushedAuthorization = true,         // WorkOS has no PAR
+    ProviderInformation = new ProviderInformation {
+        IssuerName        = "https://api.workos.com",
+        AuthorizeEndpoint = "https://api.workos.com/user_management/authorize",   // AI-958
+        TokenEndpoint     = "https://api.workos.com/user_management/authenticate",
+    },
+};
+options.Policy.Discovery.RequireKeySet = false;
+if (backchannelHandler is not null) options.BackchannelHandler = backchannelHandler; // tests
+```
+
+Front-channel extra params via `LoginRequest.FrontChannelExtraParameters`:
+`provider=authkit` (+ `organization_id` when non-null).
+
+Map `LoginResult` → existing `WorkOSAuthResponse`:
+- `AccessToken` / `RefreshToken` from `LoginResult`.
+- `OrganizationId` and `User` read from `LoginResult.TokenResponse.Json`
+  (`GetProperty("organization_id")`, `GetProperty("user")`), so the existing
+  org-gate and `WorkOSDisplayName` logic is unchanged.
+
+`HandleWorkOSLogin` keeps the org-gate, token save, and "Logged in as …"
+output. **Deletes** `RunWorkOSLoopbackAsync`, `AuthenticateWorkOSCodeAsync`,
+and the WorkOS `WorkOSLoopbackResult` record.
+
+### 3. GitHub browser — OidcClient front-channel, custom proxy exchange
+
+`RunGitHubBrowserFlowAsync` becomes:
+1. Build `OidcClientOptions` with `AuthorizeEndpoint =
+   https://github.com/login/oauth/authorize`, `Scope = "read:user read:org"`,
+   `TokenEndpoint = https://github.com/login/oauth/access_token` (set but never
+   called — `ProviderInformation` requires it non-empty), `IssuerName =
+   "https://github.com"`, the shared `LoopbackBrowser`.
+2. `var state = await oidc.PrepareLoginAsync();` → `StartUrl`, `State`,
+   `CodeVerifier`, `RedirectUri`.
+3. `var result = await browser.InvokeAsync(new BrowserOptions(state.StartUrl,
+   state.RedirectUri){ Timeout = ... });`
+4. `var resp = new AuthorizeResponse(result.Response);` — check `resp.IsError`,
+   `resp.State == state.State` (CSRF), get `resp.Code`.
+5. Keep the existing JSON proxy exchange to `codeExchangeUrl`
+   (`GitHubCodeExchangeRequest{Code, CodeVerifier = state.CodeVerifier,
+   RedirectUri = state.RedirectUri}` → `GitHubTokenResponse`), unchanged.
+
+**Deletes** `BuildGitHubAuthorizeUrl`, `ParseCallback`, `CallbackResult`,
+`RespondCallbackAsync` (HTML now written by `LoopbackBrowser`),
+`GenerateCodeVerifier`, `GenerateCodeChallenge`, and the GitHub `HttpListener`
+block. `AcquireGitHubTokenAsync`'s browser→device fallback (catching loopback
+bind failures) is preserved; the bind now throws from inside
+`LoopbackBrowser.InvokeAsync`, so the `catch (HttpListenerException)` /
+`catch (PlatformNotSupportedException)` stays at the `AcquireGitHubTokenAsync`
+call site.
+
+### 4. AI-958 fold-in (plumbing removal)
+
+Because WorkOS authorize is now constant `api.workos.com`, the `authKitDomain`
+→ `authorizeBase` plumbing is dead:
+- `HandleWorkOSLogin`/`LoginWorkOSAsync` drop the `authKitDomain` parameter.
+- `WorkOSDiscovery.RunAsync` drops the `authorizeBase` computation, and its
+  `orglessLogin` delegate changes from `Func<string, Task<WorkOSAuthResponse?>>`
+  to `Func<Task<WorkOSAuthResponse?>>`.
+- `WorkOSDiscovery.RunWithLiveAuthAsync` calls the new
+  `AuthenticateWorkOSAsync` helper (no `authorizeBase`).
+
+`config.AuthKitDomain` / `proxyConfig.WorkOSAuthKitDomain` stay in the DTOs
+(server still sends them; logout may use them) but no longer drive authorize.
+
+### Stays custom (unchanged)
+
+`RunDeviceFlowAsync`, `SwitchWorkOSOrgAsync`, `ExchangeAndSaveAsync` (all
+overloads), `ChooseGitHubFlow`, `ChooseDiscoveryProvider`, `ShouldDiscoverLogin`,
+`IsValidExchangeUrl`, `WorkOSDisplayName`, `TryParseInstallationMessage`,
+`WriteExchangeError`, `GetAvailablePort`, the org-gate and `TokenStore` saves.
+
+## Error handling
+
+- WorkOS: a `LoginResult.IsError` maps to the existing
+  "WorkOS token exchange failed" / timeout / state-mismatch messaging
+  (OidcClient surfaces `"Invalid state."`, `"Missing authorization code."`,
+  `"Timeout"` from the browser result — translate to the current user-facing
+  strings).
+- GitHub: `resp.IsError` / state mismatch → existing "Authorization failed"
+  path; unreachable/invalid proxy exchange → existing messaging.
+- Loopback bind failure → `HttpListenerException`/`PlatformNotSupportedException`
+  propagates to `AcquireGitHubTokenAsync` → device-flow fallback (unchanged).
+
+## Testing strategy
+
+Delete (methods gone): `GitHub_authorize_url_includes_all_required_params`,
+all `Callback_parser_*` tests.
+
+Keep: `SwitchWorkOSOrg_*`, `IsValidExchangeUrl_*`, `ChooseGitHubFlow_*`,
+`ChooseDiscoveryProvider_*`, `ShouldDiscoverLogin_*`.
+
+Add:
+- WorkOS options builder test: asserts `AuthorizeEndpoint`/`TokenEndpoint` are
+  `api.workos.com`, `provider=authkit` present, `organization_id` present only
+  when supplied, `LoadProfile == false`. (Authorize URL is verified by driving
+  `PrepareLoginAsync` and inspecting `AuthorizeState.StartUrl`.)
+- WorkOS end-to-end mapping test: a fake `IBrowser` returns a canned
+  `?code=...&state=<state>` callback; a WireMock token endpoint returns
+  `{access_token, refresh_token, organization_id, user}` (no `id_token`);
+  assert the new helper yields a `WorkOSAuthResponse` with the right
+  `OrganizationId`/`RefreshToken`/`User`. Wire WireMock via
+  `OidcClientOptions.BackchannelHandler`.
+- `WorkOSDiscoveryTests`: update the `orglessLogin` fake to the no-arg delegate
+  signature.
+
+Plus the mandatory AOT gate:
+`dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'`
+must be empty.
+
+## Verify-at-implementation
+
+1. **`redirect_uri` on WorkOS token call**: our hand-rolled exchange omits it;
+   OidcClient always sends it. WorkOS `/user_management/authenticate` should
+   accept/ignore it, but confirm against a real WorkOS exchange (or docs)
+   before merge. If WorkOS rejects it, fall back to the manual
+   `PrepareLoginAsync` + custom exchange pattern (same as GitHub) for WorkOS.
+2. **Empty `Scope`**: confirm OidcClient omits `scope` from the authorize URL
+   when `Scope == ""` (preserving current behavior). If it emits `scope=`,
+   decide whether WorkOS tolerates it or set a minimal scope.
+
+## Files touched
+
+- `Directory.Packages.props` — swap package versions.
+- `src/Capacitor.Cli/Capacitor.Cli.csproj` — remove stray ref.
+- `src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj` — add OidcClient refs.
+- `src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs` — new.
+- `src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs` — rewrite WorkOS + GitHub
+  browser flows; delete bespoke helpers.
+- `src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs` — drop `authorizeBase`
+  plumbing; call the new WorkOS helper.
+- `test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs` — delete obsolete tests,
+  add option-builder + e2e-mapping tests.
+- `test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs` — delegate signature.
+- `README.md` — no user-facing CLI surface change expected (same commands,
+  flags, prerequisites); confirm no edit needed.

--- a/docs/superpowers/specs/2026-06-24-ai-960-adopt-oidcclient-design.md
+++ b/docs/superpowers/specs/2026-06-24-ai-960-adopt-oidcclient-design.md
@@ -116,7 +116,7 @@ as today — no regression.
 ### 2. WorkOS — full OidcClient `LoginAsync`
 
 Rewrite `LoginWorkOSAsync` and add a reusable
-`AuthenticateWorkOSAsync(clientId, organizationId, IBrowser, HttpMessageHandler?)`
+`AuthenticateWorkOSAsync(clientId, organizationId, IBrowser browser, string apiBase = "https://api.workos.com")`
 → `WorkOSAuthResponse?` helper that builds:
 
 ```csharp
@@ -124,27 +124,42 @@ var options = new OidcClientOptions {
     ClientId    = clientId,
     Scope       = "",                          // preserve current no-scope behavior
     RedirectUri = $"http://127.0.0.1:{port}/callback",
-    Browser     = loopback,
+    Browser     = browser,
     LoadProfile = false,                       // no userinfo endpoint
     DisablePushedAuthorization = true,         // WorkOS has no PAR
     ProviderInformation = new ProviderInformation {
-        IssuerName        = "https://api.workos.com",
-        AuthorizeEndpoint = "https://api.workos.com/user_management/authorize",   // AI-958
-        TokenEndpoint     = "https://api.workos.com/user_management/authenticate",
+        IssuerName        = apiBase,
+        AuthorizeEndpoint = $"{apiBase}/user_management/authorize",      // AI-958: always API domain
+        TokenEndpoint     = $"{apiBase}/user_management/authenticate",
     },
 };
 options.Policy.Discovery.RequireKeySet = false;
-if (backchannelHandler is not null) options.BackchannelHandler = backchannelHandler; // tests
 ```
+
+`apiBase` is the **test seam** (matching the existing `SwitchWorkOSOrgAsync`
+pattern of injecting `server.Urls[0]`); production passes the default
+`https://api.workos.com`. A `BackchannelHandler` alone is *not* enough — the
+hardcoded absolute `api.workos.com` token URL would never reach a WireMock
+server — so the base URL itself must be injectable. The shared
+`LoopbackBrowser` is the production `browser`; tests pass a fake `IBrowser`.
 
 Front-channel extra params via `LoginRequest.FrontChannelExtraParameters`:
 `provider=authkit` (+ `organization_id` when non-null).
 
-Map `LoginResult` → existing `WorkOSAuthResponse`:
-- `AccessToken` / `RefreshToken` from `LoginResult`.
-- `OrganizationId` and `User` read from `LoginResult.TokenResponse.Json`
-  (`GetProperty("organization_id")`, `GetProperty("user")`), so the existing
-  org-gate and `WorkOSDisplayName` logic is unchanged.
+Map `LoginResult` → existing `WorkOSAuthResponse`: WorkOS's extra fields
+(`organization_id`, `user`) are nullable and may be **omitted** (org-less
+discovery), so `JsonElement.GetProperty` is unsafe — it throws on a missing
+property. Instead, deserialize the **whole** raw token response through the
+existing source-gen context, which maps every nullable field natively and is
+AOT-safe:
+
+```csharp
+if (loginResult.IsError || loginResult.TokenResponse?.Json is not { } json) return null;
+return json.Deserialize(CapacitorJsonContext.Default.WorkOSAuthResponse);
+```
+
+(`TokenResponse.Raw` is the equivalent string fallback.) The existing org-gate
+and `WorkOSDisplayName` logic then consume the `WorkOSAuthResponse` unchanged.
 
 `HandleWorkOSLogin` keeps the org-gate, token save, and "Logged in as …"
 output. **Deletes** `RunWorkOSLoopbackAsync`, `AuthenticateWorkOSCodeAsync`,
@@ -152,19 +167,27 @@ and the WorkOS `WorkOSLoopbackResult` record.
 
 ### 3. GitHub browser — OidcClient front-channel, custom proxy exchange
 
-`RunGitHubBrowserFlowAsync` becomes:
+`RunGitHubBrowserFlowAsync(clientId, codeExchangeUrl, IBrowser? browser = null,
+TimeSpan? timeout = null)` becomes (the `IBrowser` parameter is the **test
+seam**; production passes `null` → `new LoopbackBrowser()`):
 1. Build `OidcClientOptions` with `AuthorizeEndpoint =
    https://github.com/login/oauth/authorize`, `Scope = "read:user read:org"`,
    `TokenEndpoint = https://github.com/login/oauth/access_token` (set but never
    called — `ProviderInformation` requires it non-empty), `IssuerName =
-   "https://github.com"`, the shared `LoopbackBrowser`.
+   "https://github.com"`, the injected/shared `LoopbackBrowser`.
 2. `var state = await oidc.PrepareLoginAsync();` → `StartUrl`, `State`,
    `CodeVerifier`, `RedirectUri`.
 3. `var result = await browser.InvokeAsync(new BrowserOptions(state.StartUrl,
    state.RedirectUri){ Timeout = ... });`
-4. `var resp = new AuthorizeResponse(result.Response);` — check `resp.IsError`,
+4. **Guard the browser result first:** if `result.ResultType !=
+   BrowserResultType.Success`, `result.Response` may be null/unset — map
+   `Timeout`/`UserCancel`/error to the existing "Timed out waiting for
+   authorization…" / failure messages and `return null` (so the
+   `AcquireGitHubTokenAsync` caller still falls back / reports). Only on
+   `Success` proceed.
+5. `var resp = new AuthorizeResponse(result.Response);` — check `resp.IsError`,
    `resp.State == state.State` (CSRF), get `resp.Code`.
-5. Keep the existing JSON proxy exchange to `codeExchangeUrl`
+6. Keep the existing JSON proxy exchange to `codeExchangeUrl`
    (`GitHubCodeExchangeRequest{Code, CodeVerifier = state.CodeVerifier,
    RedirectUri = state.RedirectUri}` → `GitHubTokenResponse`), unchanged.
 
@@ -218,17 +241,36 @@ all `Callback_parser_*` tests.
 Keep: `SwitchWorkOSOrg_*`, `IsValidExchangeUrl_*`, `ChooseGitHubFlow_*`,
 `ChooseDiscoveryProvider_*`, `ShouldDiscoverLogin_*`.
 
-Add:
-- WorkOS options builder test: asserts `AuthorizeEndpoint`/`TokenEndpoint` are
-  `api.workos.com`, `provider=authkit` present, `organization_id` present only
-  when supplied, `LoadProfile == false`. (Authorize URL is verified by driving
-  `PrepareLoginAsync` and inspecting `AuthorizeState.StartUrl`.)
-- WorkOS end-to-end mapping test: a fake `IBrowser` returns a canned
-  `?code=...&state=<state>` callback; a WireMock token endpoint returns
+All new flow tests use a **fake `IBrowser`** (returns a canned callback or a
+non-success result) plus a **WireMock server whose URL is injected** as the
+endpoint base — `apiBase` for WorkOS, `codeExchangeUrl` for GitHub — matching
+the existing `SwitchWorkOSOrg` test pattern. No reliance on
+`BackchannelHandler` rewriting an absolute URL.
+
+Add (WorkOS):
+- Authorize-URL builder test: drive `PrepareLoginAsync`, inspect
+  `AuthorizeState.StartUrl` — assert it targets `{apiBase}/user_management/
+  authorize`, carries `provider=authkit`, includes `organization_id` only when
+  supplied, and `LoadProfile == false`.
+- End-to-end mapping, **org-scoped**: fake `IBrowser` returns
+  `?code=...&state=<state>`; WireMock `/user_management/authenticate` returns
   `{access_token, refresh_token, organization_id, user}` (no `id_token`);
-  assert the new helper yields a `WorkOSAuthResponse` with the right
-  `OrganizationId`/`RefreshToken`/`User`. Wire WireMock via
-  `OidcClientOptions.BackchannelHandler`.
+  assert `WorkOSAuthResponse` has the right `OrganizationId`/`RefreshToken`/`User`.
+- End-to-end mapping, **org-less** (regression for the `GetProperty` bug):
+  WireMock response **omits** `organization_id` and `user`; assert the helper
+  returns a `WorkOSAuthResponse` with `OrganizationId == null` / `User == null`
+  and does **not** throw.
+
+Add (GitHub browser):
+- Success: fake `IBrowser` returns `?code=...&state=<state>`; WireMock
+  `codeExchangeUrl` returns `{access_token}`; assert the access token is
+  returned and the proxy got `code`/`code_verifier`/`redirect_uri`.
+- State mismatch: fake `IBrowser` returns a mismatched `state`; assert `null`
+  and that the proxy was **not** called.
+- Non-success browser result: fake `IBrowser` returns `Timeout`; assert `null`
+  (and no throw / no proxy call) so the caller's fallback path runs.
+
+Add (discovery):
 - `WorkOSDiscoveryTests`: update the `orglessLogin` fake to the no-arg delegate
   signature.
 

--- a/docs/superpowers/specs/2026-06-24-ai-960-adopt-oidcclient-design.md
+++ b/docs/superpowers/specs/2026-06-24-ai-960-adopt-oidcclient-design.md
@@ -58,9 +58,11 @@ provider-specific bits custom.
   clients need access to"), so WorkOS's extra `organization_id`/`user` fields
   remain readable via `TokenResponse.Json` (a `JsonElement`, AOT-safe).
 - **Injectable seams**: `IBrowser` (loopback), `OidcClientOptions.Browser`,
-  `BackchannelHandler`/`HttpClientFactory` (point token endpoint at WireMock),
   `PrepareLoginAsync`/`ProcessResponseAsync`, and `AuthorizeResponse(raw)`
-  (callback parser) are all public.
+  (callback parser) are all public. Note: `BackchannelHandler`/`HttpClientFactory`
+  only swap the HTTP *transport* — they do **not** redirect the absolute token
+  URL. The endpoint base is set via `ProviderInformation`, which is therefore
+  the test seam (point it at WireMock); see the WorkOS section.
 - **Manual endpoints**: set `OidcClientOptions.ProviderInformation` with
   `IssuerName` (required, non-empty), `AuthorizeEndpoint` (required),
   `TokenEndpoint` (required); `KeySet` may be null when
@@ -155,7 +157,7 @@ AOT-safe:
 
 ```csharp
 if (loginResult.IsError || loginResult.TokenResponse?.Json is not { } json) return null;
-return json.Deserialize(CapacitorJsonContext.Default.WorkOSAuthResponse);
+return JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.WorkOSAuthResponse);
 ```
 
 (`TokenResponse.Raw` is the equivalent string fallback.) The existing org-gate
@@ -182,9 +184,13 @@ seam**; production passes `null` → `new LoopbackBrowser()`):
 4. **Guard the browser result first:** if `result.ResultType !=
    BrowserResultType.Success`, `result.Response` may be null/unset — map
    `Timeout`/`UserCancel`/error to the existing "Timed out waiting for
-   authorization…" / failure messages and `return null` (so the
-   `AcquireGitHubTokenAsync` caller still falls back / reports). Only on
-   `Success` proceed.
+   authorization…" / failure messages and `return null`. Per the current
+   `AcquireGitHubTokenAsync` contract (`return token ?? null` with "don't
+   silently fall back"), a null here is a **hard login failure** — it does
+   **not** trigger device-flow fallback. Only a loopback **bind** exception
+   (`HttpListenerException`/`PlatformNotSupportedException`, thrown out of
+   `LoopbackBrowser.InvokeAsync`) triggers fallback. Preserve that split. Only
+   on `Success` proceed.
 5. `var resp = new AuthorizeResponse(result.Response);` — check `resp.IsError`,
    `resp.State == state.State` (CSRF), get `resp.Code`.
 6. Keep the existing JSON proxy exchange to `codeExchangeUrl`
@@ -268,7 +274,9 @@ Add (GitHub browser):
 - State mismatch: fake `IBrowser` returns a mismatched `state`; assert `null`
   and that the proxy was **not** called.
 - Non-success browser result: fake `IBrowser` returns `Timeout`; assert `null`
-  (and no throw / no proxy call) so the caller's fallback path runs.
+  (and no throw / no proxy call) — a reported hard login failure, **not** a
+  device-flow fallback (fallback is bind-exception-only; a separate test can
+  assert a throwing `IBrowser` still propagates to the caller's `catch`).
 
 Add (discovery):
 - `WorkOSDiscoveryTests`: update the `orglessLogin` fake to the no-arg delegate

--- a/src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs
+++ b/src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+using Duende.IdentityModel.OidcClient.Browser;
+
+namespace Capacitor.Cli.Core.Auth;
+
+/// <summary>
+/// OidcClient <see cref="IBrowser"/> backed by a 127.0.0.1 loopback HttpListener.
+/// Opens the system browser to the authorize URL, waits for the redirect callback,
+/// and returns its raw query string. WorkOS documents the loopback exception as
+/// 127.0.0.1 (not localhost). The bind exception is intentionally NOT caught so the
+/// GitHub flow can fall back to device flow on a bind failure.
+/// </summary>
+public sealed class LoopbackBrowser(Action<string>? openBrowser = null) : IBrowser {
+    readonly Action<string> _openBrowser = openBrowser ?? OpenSystemBrowser;
+
+    public async Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken ct = default) {
+        var port = new Uri(options.EndUrl).Port;
+
+        using var listener = new HttpListener();
+        listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+        listener.Start(); // bind failure propagates (HttpListenerException / PlatformNotSupportedException)
+
+        await Console.Out.WriteLineAsync("Opening browser for authentication...");
+        await Console.Out.WriteLineAsync($"  If the browser doesn't open, visit: {options.StartUrl}");
+        _openBrowser(options.StartUrl);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(options.Timeout);
+
+        HttpListenerContext context;
+
+        while (true) {
+            var getContext = listener.GetContextAsync();
+
+            try {
+                context = await getContext.WaitAsync(cts.Token);
+            } catch (OperationCanceledException) {
+                listener.Stop();
+                _ = getContext.ContinueWith(t => _ = t.Exception, CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+
+                return new BrowserResult { ResultType = BrowserResultType.Timeout };
+            }
+
+            if (context.Request.Url?.AbsolutePath == "/callback") break;
+
+            // Ignore favicon and other browser-issued requests that aren't our callback.
+            context.Response.StatusCode = 404;
+            context.Response.Close();
+        }
+
+        var query = context.Request.Url?.Query ?? "";
+        await WriteClosingPageAsync(context, success: !query.Contains("error="));
+        listener.Stop();
+
+        return new BrowserResult { ResultType = BrowserResultType.Success, Response = query };
+    }
+
+    static void OpenSystemBrowser(string url) {
+        try {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        } catch {
+            // Best-effort — headless environments (devcontainers, SSH) have no browser.
+        }
+    }
+
+    static async Task WriteClosingPageAsync(HttpListenerContext ctx, bool success) {
+        var (title, message) = success
+            ? ("Authentication successful!", "You can close this window and return to the terminal.")
+            : ("Authentication failed", "Return to the terminal for details.");
+
+        var html = $"<html><body style='font-family:system-ui;max-width:480px;margin:80px auto;text-align:center'>"
+          + $"<h2>{WebUtility.HtmlEncode(title)}</h2><p>{WebUtility.HtmlEncode(message)}</p></body></html>";
+
+        var buffer = Encoding.UTF8.GetBytes(html);
+        ctx.Response.ContentType     = "text/html";
+        ctx.Response.ContentLength64 = buffer.Length;
+        await ctx.Response.OutputStream.WriteAsync(buffer);
+        ctx.Response.Close();
+    }
+}

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -743,7 +743,7 @@ public static class OAuthLoginFlow {
         return Convert.ToBase64String(hash).TrimEnd('=').Replace('+', '-').Replace('/', '_');
     }
 
-    static int GetAvailablePort() {
+    internal static int GetAvailablePort() {
         var tcpListener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
         tcpListener.Start();
         var port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -1,8 +1,6 @@
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using Duende.IdentityModel.Client;
 using Duende.IdentityModel.OidcClient;
@@ -186,68 +184,61 @@ public static class OAuthLoginFlow {
     }
 
     /// <summary>
-    /// Runs GitHub authorization-code-with-PKCE flow against a localhost loopback
-    /// listener. Opens the system browser to GitHub's authorize page; on callback,
-    /// verifies CSRF state and POSTs the code+verifier to <paramref name="codeExchangeUrl"/>
-    /// on the Capacitor server. The server adds its GitHub App client_secret and forwards
-    /// to GitHub's token endpoint (which GitHub Apps require, even with PKCE).
-    /// Returns the token on success, or <c>null</c> on user cancel, state mismatch,
-    /// or upstream error. Throws if the loopback port can't be bound — the caller
-    /// uses that signal to fall back to device flow.
+    /// GitHub authorization-code-with-PKCE via OidcClient's front-channel (authorize URL + PKCE +
+    /// state) over a 127.0.0.1 loopback, then the proxy-mediated JSON code-exchange to the Capacitor
+    /// server (GitHub Apps need client_secret on the token POST, which the server adds). Returns the
+    /// GitHub access token, or <c>null</c> on cancel/timeout/state-mismatch/error — a null is a hard
+    /// failure (the caller does NOT fall back to device flow on null, only on a loopback bind exception
+    /// thrown out of <see cref="LoopbackBrowser"/>). <paramref name="browser"/> is the test seam.
     /// </summary>
-    public static async Task<string?> RunGitHubBrowserFlowAsync(string clientId, string codeExchangeUrl, TimeSpan? timeout = null) {
-        var verifier  = GenerateCodeVerifier();
-        var challenge = GenerateCodeChallenge(verifier);
-        var state     = GenerateCodeVerifier(); // reuse the random source — same entropy is fine
+    public static async Task<string?> RunGitHubBrowserFlowAsync(
+            string clientId, string codeExchangeUrl, IBrowser? browser = null, TimeSpan? timeout = null) {
+        browser ??= new LoopbackBrowser();
+        var redirectUri = $"http://127.0.0.1:{GetAvailablePort()}/callback";
 
-        var port        = GetAvailablePort();
-        var redirectUri = $"http://127.0.0.1:{port}/callback";
+        var options = new OidcClientOptions {
+            Authority   = "https://github.com",
+            ClientId    = clientId,
+            Scope       = "read:user read:org",
+            RedirectUri = redirectUri,
+            LoadProfile = false,
+            DisablePushedAuthorization = true,
+            Browser     = browser,
+            ProviderInformation = new ProviderInformation {
+                IssuerName        = "https://github.com",
+                AuthorizeEndpoint = "https://github.com/login/oauth/authorize",
+                TokenEndpoint     = "https://github.com/login/oauth/access_token", // required non-empty; never called
+            },
+        };
+        options.Policy.Discovery.RequireKeySet = false;
 
-        using var listener = new HttpListener();
-        listener.Prefixes.Add($"http://127.0.0.1:{port}/");
-        listener.Start();
+        var oidc  = new OidcClient(options);
+        var state = await oidc.PrepareLoginAsync();
 
-        var authUrl = BuildGitHubAuthorizeUrl(clientId, redirectUri, state, challenge);
+        var result = await browser.InvokeAsync(
+            new BrowserOptions(state.StartUrl, redirectUri) { Timeout = timeout ?? TimeSpan.FromMinutes(5) });
 
-        await Console.Out.WriteLineAsync("Opening browser for GitHub authentication...");
-        await Console.Out.WriteLineAsync($"  If the browser doesn't open, visit: {authUrl}");
+        if (result.ResultType != BrowserResultType.Success) {
+            Console.Error.WriteLine(result.ResultType == BrowserResultType.Timeout
+                ? "Timed out waiting for authorization. Re-run `kcap login` to try again."
+                : $"Authorization failed: {result.Error ?? result.ResultType.ToString()}");
 
-        try {
-            Process.Start(new ProcessStartInfo(authUrl) { UseShellExecute = true });
-        } catch {
-            /* Browser open is best-effort — user can still copy the URL */
+            return null;
         }
 
-        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(5));
+        var resp = new AuthorizeResponse(result.Response);
+        if (resp.IsError) {
+            Console.Error.WriteLine($"Authorization failed: {resp.Error}");
 
-        HttpListenerContext context;
-
-        while (true) {
-            var getContext = listener.GetContextAsync();
-
-            try {
-                context = await getContext.WaitAsync(cts.Token);
-            } catch (OperationCanceledException) {
-                listener.Stop();
-                _ = getContext.ContinueWith(t => _ = t.Exception, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
-                Console.Error.WriteLine("Timed out waiting for authorization. Re-run `kcap login` to try again.");
-
-                return null;
-            }
-
-            if (context.Request.Url?.AbsolutePath == "/callback") break;
-
-            // Ignore favicon and other browser-issued requests that aren't our callback.
-            context.Response.StatusCode = 404;
-            context.Response.Close();
+            return null;
         }
+        if (!string.Equals(resp.State, state.State, StringComparison.Ordinal)) {
+            Console.Error.WriteLine("Error: state mismatch — possible CSRF. Aborting.");
 
-        var callback = ParseCallback(context.Request.Url?.Query ?? "", state);
-        await RespondCallbackAsync(context, callback);
-        listener.Stop();
-
-        if (callback.Code is null) {
-            Console.Error.WriteLine($"Authorization failed: {callback.Error}");
+            return null;
+        }
+        if (string.IsNullOrEmpty(resp.Code)) {
+            Console.Error.WriteLine("Authorization failed: no authorization code received.");
 
             return null;
         }
@@ -255,20 +246,13 @@ public static class OAuthLoginFlow {
         using var http = new HttpClient();
         http.DefaultRequestHeaders.Accept.Add(new("application/json"));
 
-        var exchangeRequest = new GitHubCodeExchangeRequest {
-            Code         = callback.Code,
-            CodeVerifier = verifier,
-            RedirectUri  = redirectUri
-        };
-
         HttpResponseMessage tokenResponse;
 
         try {
             tokenResponse = await http.PostAsJsonAsync(
                 codeExchangeUrl,
-                exchangeRequest,
-                CapacitorJsonContext.Default.GitHubCodeExchangeRequest,
-                cancellationToken: cts.Token
+                new GitHubCodeExchangeRequest { Code = resp.Code, CodeVerifier = state.CodeVerifier, RedirectUri = redirectUri },
+                CapacitorJsonContext.Default.GitHubCodeExchangeRequest
             );
         } catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or UriFormatException or InvalidOperationException) {
             Console.Error.WriteLine($"Could not reach the code-exchange endpoint at {codeExchangeUrl}: {ex.Message}");
@@ -285,9 +269,9 @@ public static class OAuthLoginFlow {
         GitHubTokenResponse? tokenResult;
 
         try {
-            tokenResult = await tokenResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.GitHubTokenResponse, cancellationToken: cts.Token);
+            tokenResult = await tokenResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.GitHubTokenResponse);
         } catch (JsonException ex) {
-            var raw = await tokenResponse.Content.ReadAsStringAsync(cts.Token);
+            var raw = await tokenResponse.Content.ReadAsStringAsync();
             Console.Error.WriteLine($"Code-exchange response was not valid JSON ({ex.Message}): {raw}");
 
             return null;
@@ -302,22 +286,6 @@ public static class OAuthLoginFlow {
         await Console.Out.WriteLineAsync("Authorization complete.");
 
         return tokenResult.AccessToken;
-    }
-
-    static async Task RespondCallbackAsync(HttpListenerContext ctx, CallbackResult callback) {
-        var (status, message) = callback.Code is not null
-            ? ("Authentication successful!", "You can close this window and return to the terminal.")
-            : ($"Authentication failed: {callback.Error}", "Return to the terminal for details.");
-
-        var html = $"<html><body style='font-family:system-ui;max-width:480px;margin:80px auto;text-align:center'>"
-          + $"<h2>{WebUtility.HtmlEncode(status)}</h2>"
-          + $"<p>{WebUtility.HtmlEncode(message)}</p></body></html>";
-
-        var buffer = Encoding.UTF8.GetBytes(html);
-        ctx.Response.ContentType     = "text/html";
-        ctx.Response.ContentLength64 = buffer.Length;
-        await ctx.Response.OutputStream.WriteAsync(buffer);
-        ctx.Response.Close();
     }
 
     public static async Task<int> ExchangeAndSaveAsync(string serverUrl, string githubAccessToken, string provider) {
@@ -607,68 +575,12 @@ public static class OAuthLoginFlow {
         return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse);
     }
 
-    internal readonly record struct CallbackResult(string? Code, string? Error);
-
     // The server-supplied code-exchange URL must be a fully-qualified http(s) URI before
     // we trust it. An empty string, whitespace, relative path, or javascript:/file: URL
     // is treated as "no browser flow available" and the dispatcher falls back to device flow.
     internal static bool IsValidExchangeUrl(string? url) =>
         Uri.TryCreate(url, UriKind.Absolute, out var parsed)
      && (parsed.Scheme == Uri.UriSchemeHttp || parsed.Scheme == Uri.UriSchemeHttps);
-
-    internal static string BuildGitHubAuthorizeUrl(
-            string clientId,
-            string redirectUri,
-            string state,
-            string codeChallenge
-        ) =>
-        "https://github.com/login/oauth/authorize?"              +
-        $"client_id={Uri.EscapeDataString(clientId)}"            +
-        $"&redirect_uri={Uri.EscapeDataString(redirectUri)}"     +
-        $"&state={Uri.EscapeDataString(state)}"                  +
-        $"&scope={Uri.EscapeDataString("read:user read:org")}"   +
-        $"&code_challenge={Uri.EscapeDataString(codeChallenge)}" +
-        "&code_challenge_method=S256"                            +
-        "&response_type=code";
-
-    internal static CallbackResult ParseCallback(string queryString, string expectedState) {
-        var     qs    = queryString.TrimStart('?');
-        var     parts = qs.Split('&', StringSplitOptions.RemoveEmptyEntries);
-        string? code  = null, state = null, error = null;
-
-        foreach (var part in parts) {
-            var eq = part.IndexOf('=');
-
-            if (eq < 0) continue;
-
-            var key = part[..eq];
-            var val = Uri.UnescapeDataString(part[(eq + 1)..]);
-
-            switch (key) {
-                case "code":  code  = val; break;
-                case "state": state = val; break;
-                case "error": error = val; break;
-            }
-        }
-
-        if (state is null) return new(null, "missing_state");
-        if (state != expectedState) return new(null, "state_mismatch");
-        if (error is not null) return new(null, error);
-
-        return string.IsNullOrEmpty(code) ? new(null, "missing_code") : new(code, null);
-    }
-
-    static string GenerateCodeVerifier() {
-        var bytes = RandomNumberGenerator.GetBytes(32);
-
-        return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
-    }
-
-    static string GenerateCodeChallenge(string verifier) {
-        var hash = SHA256.HashData(Encoding.ASCII.GetBytes(verifier));
-
-        return Convert.ToBase64String(hash).TrimEnd('=').Replace('+', '-').Replace('/', '_');
-    }
 
     internal static int GetAvailablePort() {
         var tcpListener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -243,6 +243,9 @@ public static class OAuthLoginFlow {
             return null;
         }
 
+        // Bound the proxy exchange to the login timeout — a stalled endpoint must not hang the CLI.
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(5));
+
         using var http = new HttpClient();
         http.DefaultRequestHeaders.Accept.Add(new("application/json"));
 
@@ -252,7 +255,8 @@ public static class OAuthLoginFlow {
             tokenResponse = await http.PostAsJsonAsync(
                 codeExchangeUrl,
                 new GitHubCodeExchangeRequest { Code = resp.Code, CodeVerifier = state.CodeVerifier, RedirectUri = redirectUri },
-                CapacitorJsonContext.Default.GitHubCodeExchangeRequest
+                CapacitorJsonContext.Default.GitHubCodeExchangeRequest,
+                cancellationToken: cts.Token
             );
         } catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or UriFormatException or InvalidOperationException) {
             Console.Error.WriteLine($"Could not reach the code-exchange endpoint at {codeExchangeUrl}: {ex.Message}");
@@ -261,7 +265,7 @@ public static class OAuthLoginFlow {
         }
 
         if (!tokenResponse.IsSuccessStatusCode) {
-            Console.Error.WriteLine($"Error exchanging code: {await tokenResponse.Content.ReadAsStringAsync()}");
+            Console.Error.WriteLine($"Error exchanging code: {await tokenResponse.Content.ReadAsStringAsync(cts.Token)}");
 
             return null;
         }
@@ -269,9 +273,9 @@ public static class OAuthLoginFlow {
         GitHubTokenResponse? tokenResult;
 
         try {
-            tokenResult = await tokenResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.GitHubTokenResponse);
+            tokenResult = await tokenResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.GitHubTokenResponse, cancellationToken: cts.Token);
         } catch (JsonException ex) {
-            var raw = await tokenResponse.Content.ReadAsStringAsync();
+            var raw = await tokenResponse.Content.ReadAsStringAsync(cts.Token);
             Console.Error.WriteLine($"Code-exchange response was not valid JSON ({ex.Message}): {raw}");
 
             return null;
@@ -506,18 +510,35 @@ public static class OAuthLoginFlow {
         var oidc   = new OidcClient(options);
         var result = await oidc.LoginAsync(new LoginRequest { FrontChannelExtraParameters = WorkOSFrontChannel(organizationId) });
 
-        if (result.IsError || result.TokenResponse?.Json is not { } json) return null;
+        // Surface the actual reason (timeout / state mismatch / token-endpoint / upstream OIDC error)
+        // rather than collapsing every failure to a single opaque "sign-in failed".
+        if (result.IsError) {
+            Console.Error.WriteLine(WorkOSSignInError(result.Error, result.ErrorDescription));
+
+            return null;
+        }
+
+        if (result.TokenResponse?.Json is not { } json) {
+            Console.Error.WriteLine("WorkOS sign-in failed: empty token response.");
+
+            return null;
+        }
 
         return JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.WorkOSAuthResponse);
     }
 
-    static async Task<int> LoginWorkOSAsync(string clientId, string? organizationId) {
-        var json = await AuthenticateWorkOSAsync(clientId, organizationId, new LoopbackBrowser());
-        if (json is null) {
-            Console.Error.WriteLine("Error: WorkOS sign-in failed.");
+    /// <summary>Maps an OidcClient WorkOS failure to a user-facing message, preserving the actionable detail.</summary>
+    internal static string WorkOSSignInError(string? error, string? description) => error switch {
+        "Timeout"    => "Timed out waiting for authorization. Re-run `kcap login` to try again.",
+        "UserCancel" => "WorkOS sign-in was cancelled.",
+        _            => $"WorkOS sign-in failed: {error ?? "unknown error"}"
+                      + (string.IsNullOrEmpty(description) ? "" : $" — {description}")
+    };
 
-            return 1;
-        }
+    static async Task<int> LoginWorkOSAsync(string clientId, string? organizationId) {
+        // AuthenticateWorkOSAsync already reported the specific failure reason to stderr.
+        var json = await AuthenticateWorkOSAsync(clientId, organizationId, new LoopbackBrowser());
+        if (json is null) return 1;
 
         // Org gate: a multi-org user must not be "logged in" to the wrong org — every API
         // call would then fail the server's org check. Reject before saving tokens.

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -4,6 +4,9 @@ using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Duende.IdentityModel.Client;
+using Duende.IdentityModel.OidcClient;
+using Duende.IdentityModel.OidcClient.Browser;
 
 // ReSharper disable MethodHasAsyncOverload
 
@@ -483,35 +486,67 @@ public static class OAuthLoginFlow {
     }
 
     static Task<int> HandleWorkOSLogin(AuthDiscoveryResponse config) =>
-        LoginWorkOSAsync(config.AuthKitDomain, config.ClientId!, config.OrganizationId);
+        LoginWorkOSAsync(config.ClientId!, config.OrganizationId);
 
     const string WorkOSApiBase = "https://api.workos.com";
 
     /// <summary>
-    /// WorkOS AuthKit authorization-code-with-PKCE login on a 127.0.0.1 loopback listener
-    /// (WorkOS documents the HTTP loopback exception as 127.0.0.1, not localhost). Authorize
-    /// on the AuthKit domain (hosted UI; falls back to api.workos.com), org-scoped when known;
-    /// the token exchange always hits api.workos.com. Public client — no client secret.
+    /// Builds OidcClient options for the WorkOS AuthKit authorization-code-with-PKCE flow.
+    /// Authorize + token both on the API domain (AI-958 — never the AuthKit UI domain). WorkOS is a
+    /// public client (no secret) with non-standard endpoints, no discovery, and no id_token, so
+    /// discovery/keyset/userinfo are disabled and the response is mapped by hand.
     /// </summary>
-    static async Task<int> LoginWorkOSAsync(string? authKitDomain, string clientId, string? organizationId) {
-        var authorizeBase = string.IsNullOrEmpty(authKitDomain) ? WorkOSApiBase : $"https://{authKitDomain}";
+    internal static OidcClientOptions BuildWorkOSOptions(string clientId, string apiBase, string redirectUri) {
+        var options = new OidcClientOptions {
+            Authority   = apiBase,            // anonymous-principal issuer; discovery stays off (ProviderInformation set)
+            ClientId    = clientId,
+            Scope       = "",                 // preserve current no-scope behavior
+            RedirectUri = redirectUri,
+            LoadProfile = false,              // WorkOS has no userinfo endpoint
+            DisablePushedAuthorization = true,
+            ProviderInformation = new ProviderInformation {
+                IssuerName        = apiBase,
+                AuthorizeEndpoint = $"{apiBase}/user_management/authorize",     // AI-958: always the API domain
+                TokenEndpoint     = $"{apiBase}/user_management/authenticate",
+            },
+        };
+        options.Policy.Discovery.RequireKeySet = false;
 
-        var loop = await RunWorkOSLoopbackAsync(authorizeBase, clientId, organizationId);
-        if (loop.Code is null) {
-            Console.Error.WriteLine(loop.Error switch {
-                "state_mismatch" => "Error: state mismatch — possible CSRF. Aborting.",
-                "timeout"        => "Timed out waiting for authorization. Re-run `kcap login` to try again.",
-                _                => "Error: No authorization code received."
-            });
+        return options;
+    }
 
-            return 1;
-        }
+    /// <summary>WorkOS front-channel extras: <c>provider=authkit</c> (+ <c>organization_id</c> when org-scoped).</summary>
+    internal static Parameters WorkOSFrontChannel(string? organizationId) {
+        var p = new Parameters { { "provider", "authkit" } };
+        if (!string.IsNullOrEmpty(organizationId)) p.Add("organization_id", organizationId);
 
-        using var http = new HttpClient();
+        return p;
+    }
 
-        var json = await AuthenticateWorkOSCodeAsync(http, WorkOSApiBase, clientId, loop.Code, loop.Verifier);
+    /// <summary>
+    /// WorkOS AuthKit authorization-code-with-PKCE login via OidcClient. Org-scoped when
+    /// <paramref name="organizationId"/> is set. Maps the raw token response (which carries WorkOS's
+    /// non-standard organization_id/user and no id_token) into <see cref="WorkOSAuthResponse"/> via the
+    /// source-gen context — omitted/nullable fields don't throw. <paramref name="apiBase"/> is the test seam.
+    /// </summary>
+    public static async Task<WorkOSAuthResponse?> AuthenticateWorkOSAsync(
+            string clientId, string? organizationId, IBrowser browser, string apiBase = WorkOSApiBase) {
+        var redirectUri = $"http://127.0.0.1:{GetAvailablePort()}/callback";
+        var options     = BuildWorkOSOptions(clientId, apiBase, redirectUri);
+        options.Browser = browser;
+
+        var oidc   = new OidcClient(options);
+        var result = await oidc.LoginAsync(new LoginRequest { FrontChannelExtraParameters = WorkOSFrontChannel(organizationId) });
+
+        if (result.IsError || result.TokenResponse?.Json is not { } json) return null;
+
+        return JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.WorkOSAuthResponse);
+    }
+
+    static async Task<int> LoginWorkOSAsync(string clientId, string? organizationId) {
+        var json = await AuthenticateWorkOSAsync(clientId, organizationId, new LoopbackBrowser());
         if (json is null) {
-            Console.Error.WriteLine("Error: WorkOS token exchange failed.");
+            Console.Error.WriteLine("Error: WorkOS sign-in failed.");
 
             return 1;
         }
@@ -549,114 +584,6 @@ public static class OAuthLoginFlow {
         if (!string.IsNullOrEmpty(user?.LastName))  parts.Add(user!.LastName!);
 
         return parts.Count > 0 ? string.Join(' ', parts) : user?.Email ?? "unknown";
-    }
-
-    public sealed record WorkOSLoopbackResult(string? Code, string Verifier, string RedirectUri, string? Error);
-
-    /// <summary>
-    /// WorkOS AuthKit authorization-code-with-PKCE on a 127.0.0.1 loopback listener. Authorizes on
-    /// <paramref name="authorizeBase"/>, org-scoped only when <paramref name="organizationId"/> is set
-    /// (pass null for org-less discovery). Returns the authorization code + PKCE verifier, or an
-    /// <c>Error</c> ("timeout" / "state_mismatch" / "missing_code"). Public client — the separate token
-    /// exchange carries no secret.
-    /// </summary>
-    public static async Task<WorkOSLoopbackResult> RunWorkOSLoopbackAsync(
-            string authorizeBase, string clientId, string? organizationId, TimeSpan? timeout = null) {
-        var verifier    = GenerateCodeVerifier();
-        var challenge   = GenerateCodeChallenge(verifier);
-        var state       = GenerateCodeVerifier();
-        var port        = GetAvailablePort();
-        var redirectUri = $"http://127.0.0.1:{port}/callback";
-
-        using var listener = new HttpListener();
-        listener.Prefixes.Add($"http://127.0.0.1:{port}/");
-        listener.Start();
-
-        var authUrl = $"{authorizeBase}/user_management/authorize?"          +
-            $"response_type=code&client_id={Uri.EscapeDataString(clientId)}" +
-            $"&redirect_uri={Uri.EscapeDataString(redirectUri)}"             +
-            $"&provider=authkit"                                             +
-            (string.IsNullOrEmpty(organizationId) ? "" : $"&organization_id={Uri.EscapeDataString(organizationId)}") +
-            $"&state={Uri.EscapeDataString(state)}"                          +
-            $"&code_challenge={challenge}&code_challenge_method=S256";
-
-        await Console.Out.WriteLineAsync("Opening browser for authentication...");
-        await Console.Out.WriteLineAsync($"  If the browser doesn't open, visit: {authUrl}");
-
-        try {
-            Process.Start(new ProcessStartInfo(authUrl) { UseShellExecute = true });
-        } catch {
-            /* Browser open is best-effort — user can still copy the URL */
-        }
-
-        // Bounded wait + ignore non-callback requests (favicon etc.) — mirrors RunGitHubBrowserFlowAsync.
-        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(5));
-
-        HttpListenerContext context;
-
-        while (true) {
-            var getContext = listener.GetContextAsync();
-
-            try {
-                context = await getContext.WaitAsync(cts.Token);
-            } catch (OperationCanceledException) {
-                listener.Stop();
-                _ = getContext.ContinueWith(t => _ = t.Exception, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
-
-                return new(null, verifier, redirectUri, "timeout");
-            }
-
-            if (context.Request.Url?.AbsolutePath == "/callback") break;
-
-            // Ignore favicon and other browser-issued requests that aren't our callback.
-            context.Response.StatusCode = 404;
-            context.Response.Close();
-        }
-
-        var code          = context.Request.QueryString["code"];
-        var returnedState = context.Request.QueryString["state"];
-
-        if (returnedState != state) {
-            const string errHtml = "<html><body><h2>Authentication failed</h2><p>State mismatch — possible CSRF. Return to the terminal.</p></body></html>";
-            var          errBuf  = Encoding.UTF8.GetBytes(errHtml);
-            context.Response.ContentType     = "text/html";
-            context.Response.ContentLength64 = errBuf.Length;
-            await context.Response.OutputStream.WriteAsync(errBuf);
-            context.Response.Close();
-            listener.Stop();
-
-            return new(null, verifier, redirectUri, "state_mismatch");
-        }
-
-        const string html = "<html><body><h2>Authentication successful!</h2><p>You can close this window.</p></body></html>";
-
-        var buffer = Encoding.UTF8.GetBytes(html);
-        context.Response.ContentType     = "text/html";
-        context.Response.ContentLength64 = buffer.Length;
-        await context.Response.OutputStream.WriteAsync(buffer);
-        context.Response.Close();
-        listener.Stop();
-
-        return string.IsNullOrEmpty(code)
-            ? new(null, verifier, redirectUri, "missing_code")
-            : new(code, verifier, redirectUri, null);
-    }
-
-    /// <summary>Public-client WorkOS code→token exchange at <c>{apiBase}/user_management/authenticate</c>.</summary>
-    public static async Task<WorkOSAuthResponse?> AuthenticateWorkOSCodeAsync(
-            HttpClient http, string apiBase, string clientId, string code, string codeVerifier) {
-        var resp = await http.PostAsync(
-            $"{apiBase.TrimEnd('/')}/user_management/authenticate",
-            new FormUrlEncodedContent(new Dictionary<string, string> {
-                ["grant_type"]    = "authorization_code",
-                ["client_id"]     = clientId,
-                ["code"]          = code,
-                ["code_verifier"] = codeVerifier
-            }));
-
-        if (!resp.IsSuccessStatusCode) return null;
-
-        return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse);
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -23,12 +23,7 @@ public static class WorkOSDiscovery {
         var clientId = proxyConfig.WorkOSClientId ?? "";
 
         return RunAsync(proxyUrl, proxyConfig, proxy, picker,
-            orglessLogin: async authorizeBase => {
-                var loop = await OAuthLoginFlow.RunWorkOSLoopbackAsync(authorizeBase, clientId, organizationId: null);
-                if (loop.Code is null) return null;
-                using var http = new HttpClient();
-                return await OAuthLoginFlow.AuthenticateWorkOSCodeAsync(http, WorkOSApiBase, clientId, loop.Code, loop.Verifier);
-            },
+            orglessLogin: () => OAuthLoginFlow.AuthenticateWorkOSAsync(clientId, organizationId: null, new LoopbackBrowser()),
             orgSwitch: async (refreshToken, organizationId) => {
                 using var http = new HttpClient();
                 return await OAuthLoginFlow.SwitchWorkOSOrgAsync(http, WorkOSApiBase, clientId, refreshToken, organizationId);
@@ -40,7 +35,7 @@ public static class WorkOSDiscovery {
             ProxyConfigResponse                             proxyConfig,
             IAuthProxyClient                                proxy,
             ITenantPicker                                   picker,
-            Func<string, Task<WorkOSAuthResponse?>>         orglessLogin,   // arg: authorizeBase
+            Func<Task<WorkOSAuthResponse?>>                 orglessLogin,
             Func<string, string, Task<WorkOSAuthResponse?>> orgSwitch) {    // args: refreshToken, organizationId
         if (string.IsNullOrEmpty(proxyConfig.WorkOSClientId)) {
             await Console.Error.WriteLineAsync("This server isn't configured for WorkOS sign-in.");
@@ -48,11 +43,7 @@ public static class WorkOSDiscovery {
             return 1;
         }
 
-        var authorizeBase = string.IsNullOrEmpty(proxyConfig.WorkOSAuthKitDomain)
-            ? WorkOSApiBase
-            : $"https://{proxyConfig.WorkOSAuthKitDomain}";
-
-        var auth = await orglessLogin(authorizeBase);
+        var auth = await orglessLogin();
         if (auth is null || string.IsNullOrEmpty(auth.RefreshToken)) {
             await Console.Error.WriteLineAsync("WorkOS sign-in failed.");
 

--- a/src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj
+++ b/src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj
@@ -27,4 +27,8 @@
         <InternalsVisibleTo Include="Capacitor.Server.Tests.Read" />
         <InternalsVisibleTo Include="Capacitor.Server.Tests.UI" />
     </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Duende.IdentityModel.OidcClient" />
+        <PackageReference Include="Duende.IdentityModel" />
+    </ItemGroup>
 </Project>

--- a/src/Capacitor.Cli/Capacitor.Cli.csproj
+++ b/src/Capacitor.Cli/Capacitor.Cli.csproj
@@ -32,7 +32,6 @@
         <ProjectReference Include="..\Capacitor.Cli.Core\Capacitor.Cli.Core.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="IdentityModel.OidcClient" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
         <PackageReference Include="Microsoft.Extensions.Http" />
         <PackageReference Include="Spectre.Console" />

--- a/test/Capacitor.Cli.Tests.Unit/FakeBrowser.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FakeBrowser.cs
@@ -1,0 +1,27 @@
+using Duende.IdentityModel.OidcClient.Browser;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>Test IBrowser: returns a canned callback query, or a non-success result.</summary>
+public sealed class FakeBrowser(Func<string, BrowserResult> respond) : IBrowser {
+    public string? LastStartUrl { get; private set; }
+
+    public Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken ct = default) {
+        LastStartUrl = options.StartUrl;
+        return Task.FromResult(respond(options.StartUrl));
+    }
+
+    // Echo the state from the StartUrl so ProcessResponseAsync's state check passes.
+    public static FakeBrowser WithCode(string code) => new(startUrl => {
+        var query = new Uri(startUrl).Query.TrimStart('?');
+        var state = query.Split('&')
+            .First(p => p.StartsWith("state=", StringComparison.Ordinal))["state=".Length..];
+        return new BrowserResult { ResultType = BrowserResultType.Success, Response = $"?code={code}&state={state}" };
+    });
+
+    public static FakeBrowser WithRawQuery(string query) =>
+        new(_ => new BrowserResult { ResultType = BrowserResultType.Success, Response = query });
+
+    public static FakeBrowser NonSuccess(BrowserResultType type) =>
+        new(_ => new BrowserResult { ResultType = type });
+}

--- a/test/Capacitor.Cli.Tests.Unit/LoopbackBrowserTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LoopbackBrowserTests.cs
@@ -1,0 +1,36 @@
+using Capacitor.Cli.Core.Auth;
+using Duende.IdentityModel.OidcClient.Browser;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class LoopbackBrowserTests {
+    [Test]
+    public async Task Returns_success_with_raw_query_on_callback() {
+        var port     = OAuthLoginFlow.GetAvailablePort();
+        var redirect = $"http://127.0.0.1:{port}/callback";
+        var browser  = new LoopbackBrowser(openBrowser: _ => { }); // don't launch a real browser
+
+        var invoke = browser.InvokeAsync(new BrowserOptions("http://example.test/authorize", redirect));
+
+        using var http = new HttpClient();
+        // Listener is started synchronously before InvokeAsync's first await, so this connects.
+        _ = await http.GetAsync($"{redirect}?code=abc&state=xyz");
+
+        var result = await invoke;
+        await Assert.That(result.ResultType).IsEqualTo(BrowserResultType.Success);
+        await Assert.That(result.Response).Contains("code=abc");
+        await Assert.That(result.Response).Contains("state=xyz");
+    }
+
+    [Test]
+    public async Task Returns_timeout_when_no_callback_arrives() {
+        var port     = OAuthLoginFlow.GetAvailablePort();
+        var redirect = $"http://127.0.0.1:{port}/callback";
+        var browser  = new LoopbackBrowser(openBrowser: _ => { });
+
+        var result = await browser.InvokeAsync(
+            new BrowserOptions("http://example.test/authorize", redirect) { Timeout = TimeSpan.FromMilliseconds(200) });
+
+        await Assert.That(result.ResultType).IsEqualTo(BrowserResultType.Timeout);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/LoopbackBrowserTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LoopbackBrowserTests.cs
@@ -3,6 +3,11 @@ using Duende.IdentityModel.OidcClient.Browser;
 
 namespace Capacitor.Cli.Tests.Unit;
 
+// These tests bind real loopback HttpListeners on OS-assigned ports. Run fully exclusively
+// (no other test running) so the rest of the parallel suite can't grab the freed ephemeral
+// port in the alloc->bind window — the managed HttpListener on macOS/Linux throws
+// "Address already in use". (Production is single-use interactive, so the race is irrelevant there.)
+[NotInParallel]
 public class LoopbackBrowserTests {
     [Test]
     public async Task Returns_success_with_raw_query_on_callback() {

--- a/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
@@ -93,81 +93,38 @@ public class OAuthFlowTests {
     }
 
     [Test]
-    public async Task GitHub_authorize_url_includes_all_required_params() {
-        var url = OAuthLoginFlow.BuildGitHubAuthorizeUrl(
-            clientId:     "Iv1.abc",
-            redirectUri:  "http://127.0.0.1:54321/callback",
-            state:        "state-xyz",
-            codeChallenge:"challenge-123");
+    public async Task GitHubBrowser_exchanges_code_and_returns_access_token() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/code-exchange").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"access_token":"gho_abc"}"""));
 
-        await Assert.That(url).StartsWith("https://github.com/login/oauth/authorize?");
-        await Assert.That(url).Contains("client_id=Iv1.abc");
-        await Assert.That(url).Contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2Fcallback");
-        await Assert.That(url).Contains("state=state-xyz");
-        await Assert.That(url).Contains("scope=read%3Auser%20read%3Aorg");
-        await Assert.That(url).Contains("code_challenge=challenge-123");
-        await Assert.That(url).Contains("code_challenge_method=S256");
-        await Assert.That(url).Contains("response_type=code");
+        var token = await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
+            "Iv1.abc", $"{server.Urls[0]}/code-exchange", FakeBrowser.WithCode("the_code"));
+
+        await Assert.That(token).IsEqualTo("gho_abc");
     }
 
     [Test]
-    public async Task Callback_parser_returns_code_when_state_matches() {
-        var result = OAuthLoginFlow.ParseCallback(
-            queryString:  "?code=abc&state=expected",
-            expectedState:"expected");
+    public async Task GitHubBrowser_returns_null_on_state_mismatch_without_calling_proxy() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/code-exchange").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"access_token":"nope"}"""));
 
-        await Assert.That(result.Code).IsEqualTo("abc");
-        await Assert.That(result.Error).IsNull();
+        var token = await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
+            "Iv1.abc", $"{server.Urls[0]}/code-exchange",
+            FakeBrowser.WithRawQuery("?code=the_code&state=attacker"));
+
+        await Assert.That(token).IsNull();
+        // The proxy must never be hit when the CSRF state doesn't match.
+        await Assert.That(server.LogEntries.Any(e => e.RequestMessage.Path == "/code-exchange")).IsFalse();
     }
 
     [Test]
-    public async Task Callback_parser_rejects_state_mismatch() {
-        var result = OAuthLoginFlow.ParseCallback(
-            queryString:  "?code=abc&state=attacker",
-            expectedState:"expected");
+    public async Task GitHubBrowser_returns_null_on_non_success_browser_result() {
+        var token = await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
+            "Iv1.abc", "http://unused.test/code-exchange", FakeBrowser.NonSuccess(BrowserResultType.Timeout));
 
-        await Assert.That(result.Code).IsNull();
-        await Assert.That(result.Error).IsEqualTo("state_mismatch");
-    }
-
-    [Test]
-    public async Task Callback_parser_surfaces_provider_error() {
-        var result = OAuthLoginFlow.ParseCallback(
-            queryString:  "?error=access_denied&state=expected",
-            expectedState:"expected");
-
-        await Assert.That(result.Code).IsNull();
-        await Assert.That(result.Error).IsEqualTo("access_denied");
-    }
-
-    [Test]
-    public async Task Callback_parser_reports_missing_state_when_state_param_absent() {
-        var result = OAuthLoginFlow.ParseCallback(
-            queryString:  "?error=access_denied",
-            expectedState:"expected");
-
-        await Assert.That(result.Code).IsNull();
-        await Assert.That(result.Error).IsEqualTo("missing_state");
-    }
-
-    [Test]
-    public async Task Callback_parser_reports_state_mismatch_when_state_differs() {
-        var result = OAuthLoginFlow.ParseCallback(
-            queryString:  "?error=access_denied&state=attacker",
-            expectedState:"expected");
-
-        await Assert.That(result.Code).IsNull();
-        await Assert.That(result.Error).IsEqualTo("state_mismatch");
-    }
-
-    [Test]
-    public async Task Callback_parser_rejects_missing_code() {
-        var result = OAuthLoginFlow.ParseCallback(
-            queryString:  "?state=expected",
-            expectedState:"expected");
-
-        await Assert.That(result.Code).IsNull();
-        await Assert.That(result.Error).IsEqualTo("missing_code");
+        await Assert.That(token).IsNull();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
@@ -66,6 +66,27 @@ public class OAuthFlowTests {
     }
 
     [Test]
+    public async Task AuthenticateWorkOS_returns_null_on_token_endpoint_error() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(400).WithBody("""{"error":"invalid_grant"}"""));
+
+        var result = await OAuthLoginFlow.AuthenticateWorkOSAsync(
+            "client_d", "org_a", FakeBrowser.WithCode("the_code"), apiBase: server.Urls[0]);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task WorkOSSignInError_preserves_actionable_detail() {
+        await Assert.That(OAuthLoginFlow.WorkOSSignInError("Timeout", null)).Contains("Timed out");
+        await Assert.That(OAuthLoginFlow.WorkOSSignInError("Invalid state.", null))
+            .IsEqualTo("WorkOS sign-in failed: Invalid state.");
+        await Assert.That(OAuthLoginFlow.WorkOSSignInError("invalid_grant", "bad code"))
+            .IsEqualTo("WorkOS sign-in failed: invalid_grant — bad code");
+    }
+
+    [Test]
     public async Task SwitchWorkOSOrg_posts_refresh_grant_with_org_and_returns_token() {
         using var server = WireMockServer.Start();
         server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())

--- a/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
@@ -1,4 +1,6 @@
 using Capacitor.Cli.Core.Auth;
+using Duende.IdentityModel.OidcClient;
+using Duende.IdentityModel.OidcClient.Browser;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -6,6 +8,63 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Unit;
 
 public class OAuthFlowTests {
+    [Test]
+    public async Task WorkOS_authorize_url_targets_api_domain_with_authkit_and_org() {
+        var options = OAuthLoginFlow.BuildWorkOSOptions("client_d", "https://api.workos.com", "http://127.0.0.1:5555/callback");
+        var oidc    = new OidcClient(options);
+
+        var state = await oidc.PrepareLoginAsync(OAuthLoginFlow.WorkOSFrontChannel("org_a"));
+
+        await Assert.That(state.StartUrl).StartsWith("https://api.workos.com/user_management/authorize");
+        await Assert.That(state.StartUrl).Contains("provider=authkit");
+        await Assert.That(state.StartUrl).Contains("organization_id=org_a");
+        await Assert.That(state.StartUrl).Contains("code_challenge_method=S256");
+        await Assert.That(options.LoadProfile).IsFalse();
+    }
+
+    [Test]
+    public async Task WorkOS_authorize_url_omits_org_when_null() {
+        var options = OAuthLoginFlow.BuildWorkOSOptions("client_d", "https://api.workos.com", "http://127.0.0.1:5555/callback");
+        var oidc    = new OidcClient(options);
+
+        var state = await oidc.PrepareLoginAsync(OAuthLoginFlow.WorkOSFrontChannel(null));
+
+        await Assert.That(state.StartUrl).DoesNotContain("organization_id");
+    }
+
+    [Test]
+    public async Task AuthenticateWorkOS_maps_token_response_including_org_and_user() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(
+                """{"user":{"id":"user_x","first_name":"Ada"},"organization_id":"org_a","access_token":"acc","refresh_token":"rt"}"""));
+
+        var result = await OAuthLoginFlow.AuthenticateWorkOSAsync(
+            "client_d", "org_a", FakeBrowser.WithCode("the_code"), apiBase: server.Urls[0]);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.AccessToken).IsEqualTo("acc");
+        await Assert.That(result.RefreshToken).IsEqualTo("rt");
+        await Assert.That(result.OrganizationId).IsEqualTo("org_a");
+        await Assert.That(result.User!.FirstName).IsEqualTo("Ada");
+    }
+
+    [Test]
+    public async Task AuthenticateWorkOS_handles_orgless_response_without_throwing() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(
+                """{"access_token":"acc","refresh_token":"rt"}"""));   // no organization_id, no user
+
+        var result = await OAuthLoginFlow.AuthenticateWorkOSAsync(
+            "client_d", organizationId: null, FakeBrowser.WithCode("the_code"), apiBase: server.Urls[0]);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.OrganizationId).IsNull();
+        await Assert.That(result.User).IsNull();
+        await Assert.That(result.RefreshToken).IsEqualTo("rt");
+    }
+
     [Test]
     public async Task SwitchWorkOSOrg_posts_refresh_grant_with_org_and_returns_token() {
         using var server = WireMockServer.Start();

--- a/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
@@ -37,7 +37,7 @@ public class WorkOSDiscoveryTests {
 
         var exit = await WorkOSDiscovery.RunAsync(
             "https://auth.kcap.ai", proxyConfig, proxy, picker,
-            orglessLogin: _      => Task.FromResult<WorkOSAuthResponse?>(orgless),
+            orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(orgless),
             orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(switched));
 
         await Assert.That(exit).IsEqualTo(0);
@@ -57,7 +57,7 @@ public class WorkOSDiscoveryTests {
         var exit = await WorkOSDiscovery.RunAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "" },
             Substitute.For<IAuthProxyClient>(), Substitute.For<ITenantPicker>(),
-            _      => Task.FromResult<WorkOSAuthResponse?>(null),
+            ()     => Task.FromResult<WorkOSAuthResponse?>(null),
             (_, _) => Task.FromResult<WorkOSAuthResponse?>(null));
 
         await Assert.That(exit).IsEqualTo(1);
@@ -76,7 +76,7 @@ public class WorkOSDiscoveryTests {
         var exit = await WorkOSDiscovery.RunAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
             proxy, Substitute.For<ITenantPicker>(),
-            _      => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
+            ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => { switchCalled = true; return Task.FromResult<WorkOSAuthResponse?>(null); });
 
         await Assert.That(exit).IsEqualTo(1);
@@ -92,7 +92,7 @@ public class WorkOSDiscoveryTests {
         var exit = await WorkOSDiscovery.RunAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
             proxy, Substitute.For<ITenantPicker>(),
-            _      => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
+            ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => Task.FromResult<WorkOSAuthResponse?>(null));
 
         await Assert.That(exit).IsEqualTo(1);


### PR DESCRIPTION
## What & why

The CLI's OAuth was entirely hand-rolled in `OAuthLoginFlow`, while the referenced `IdentityModel.OidcClient` 6.0.0 package was **unused, deprecated (pre-Duende), and referenced from the wrong project** (`Capacitor.Cli` instead of `Capacitor.Cli.Core`, where the auth code lives). This replaces the bespoke PKCE/loopback/code-exchange machinery with the audited **`Duende.IdentityModel.OidcClient` 7.1.0** (net10, `IsAotCompatible`), keeping the genuinely provider-specific bits custom.

Closes AI-960. **Subsumes AI-958** (WorkOS authorize URL now always built on the API domain).

## Changes

- **Package**: drop `IdentityModel.OidcClient` 6.0.0; add `Duende.IdentityModel.OidcClient` 7.1.0 + `Duende.IdentityModel` 8.1.0, referenced in `Capacitor.Cli.Core`.
- **`LoopbackBrowser : IBrowser`** — one 127.0.0.1 loopback (injectable browser-opener) replacing the two duplicated `HttpListener` blocks. Bind exceptions intentionally propagate so the GitHub device-flow fallback still triggers.
- **WorkOS** → OidcClient `LoginAsync`. Works because the code flow never requires an `id_token`; WorkOS's non-standard `organization_id`/`user` are recovered by deserializing the raw token response into the existing `WorkOSAuthResponse` via the source-gen context (no `GetProperty` — safe on org-less responses).
- **AI-958 fold-in**: authorize + token always on `api.workos.com`; removed the `authKitDomain`/`authorizeBase` plumbing through `OAuthLoginFlow` + `WorkOSDiscovery`.
- **GitHub browser** → OidcClient owns the front-channel (`PrepareLoginAsync` + `AuthorizeResponse` CSRF check); the proxy-mediated JSON code-exchange stays custom.
- **Untouched (per the issue)**: GitHub device flow, WorkOS org-switch, the proxy exchange contract.
- Deleted: `RunWorkOSLoopbackAsync`, `AuthenticateWorkOSCodeAsync`, `WorkOSLoopbackResult`, `BuildGitHubAuthorizeUrl`, `ParseCallback`, `CallbackResult`, `RespondCallbackAsync`, `GenerateCodeVerifier/Challenge`.

## Tests

- New: `LoopbackBrowser` (success + timeout); WorkOS authorize-URL builder (API domain, `provider=authkit`, org omitted when null); WorkOS end-to-end mapping **org-scoped + org-less** (regression for the omitted-field case); GitHub browser **success / state-mismatch (no proxy call) / non-success result**.
- Removed the now-obsolete GitHub-URL and `Callback_parser_*` unit tests.
- **1693 unit tests + integration green; `dotnet publish -c Release` IL2026/IL3050-clean.**

## Docs

No README change: commands, flags (`--github`/`--workos`/`--device`/`--discover`), and default browser/device behavior are unchanged — this is internal plumbing.

## Pre-merge note

OidcClient sends `redirect_uri` on the WorkOS token POST; WorkOS docs list it on `/authorize` but not on `/user_management/authenticate`. OAuth2 (RFC 6749 §4.1.3) defines it as a valid token-request param and WorkOS is lenient (the old flow worked without it), so it's almost certainly ignored — worth one live `kcap login --workos` smoke test. Fallback if ever rejected: manual `PrepareLoginAsync` + custom exchange for WorkOS (same pattern as GitHub).

Spec: `docs/superpowers/specs/2026-06-24-ai-960-adopt-oidcclient-design.md` · Plan: `docs/superpowers/plans/2026-06-25-ai-960-adopt-oidcclient.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)