### PR TITLE
[AI-966] Size-gate eval judges onto the tools path on long sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Useful for post-session review: identify recurring mistakes, discover patterns t
 
 ### Session evaluation (LLM-as-judge)
 
-Score a recorded session against safety, plan adherence, quality, and efficiency criteria. Each of 13 questions (e.g. *"Did the agent run destructive commands?"*, *"Did it write tests when appropriate?"*, *"Were there repeated failed attempts at the same operation?"*) is answered by a separate headless Claude judge with **no tools** — the full compacted session trace is embedded in the prompt, so the judge reasons from evidence rather than hitting any external service.
+Score a recorded session against safety, plan adherence, quality, and efficiency criteria. Each of 13 questions (e.g. *"Did the agent run destructive commands?"*, *"Did it write tests when appropriate?"*, *"Were there repeated failed attempts at the same operation?"*) is answered by a separate headless Claude judge with **no filesystem or network tools**. Most judges reason from the compacted session trace embedded in the prompt; some questions — and any session whose trace is too large to embed — instead investigate the session on demand through a read-only, session-scoped MCP tool surface (summary, search, transcript, errors, recap, tool results). The embed-vs-tools threshold is tunable via `KCAP_EVAL_TRACE_TOKEN_BUDGET` (default ~200K estimated tokens).
 
 ```bash
 kcap eval <sessionId>                      # default: sonnet judge

--- a/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
+++ b/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
@@ -67,11 +67,15 @@ static class ClaudeCliRunner {
     /// pulls session details via <c>kcap mcp judge</c> instead of
     /// having the full trace embedded in its prompt). When
     /// <paramref name="mcpConfigJson"/> is supplied, the runner loads the
-    /// caller-supplied MCP config via <c>--mcp-config</c> and restricts the
-    /// model to exactly <paramref name="allowedTools"/> via
-    /// <c>--allowedTools</c>, dropping only the text-only tool lockdown
-    /// (empty <c>--tools</c> / <c>--disallowedTools LSP</c>).
-    /// <c>--strict-mcp-config</c> and <c>--disable-slash-commands</c> stay
+    /// caller-supplied MCP config via <c>--mcp-config</c> and permits exactly
+    /// <paramref name="allowedTools"/> via <c>--allowedTools</c> — layered on
+    /// top of the same built-in tool lockdown the text-only path uses (empty
+    /// <c>--tools</c> / <c>--disallowedTools LSP</c>), which stays on in BOTH
+    /// modes. The lockdown is required even with an allowlist because
+    /// <c>--allowedTools</c> alone does not stop claude exposing built-in tools
+    /// like <c>Agent</c> (subagents) to the model; the MCP tools are not part
+    /// of the built-in set, so <c>--tools ""</c> leaves them callable.
+    /// <c>--strict-mcp-config</c> and <c>--disable-slash-commands</c> also stay
     /// on in both modes — strict-mcp-config is what keeps the user's global
     /// or plugin MCP servers (e.g. <c>kcap-sessions</c> from the kcap Claude
     /// Code plugin) from leaking in and getting permission-blocked under
@@ -361,28 +365,33 @@ static class ClaudeCliRunner {
         //     investigate" (AI-803).
         args.Add("--strict-mcp-config");
 
-        if (mcpConfigJson is null) {
-            // Text-only mode (title generation, per-question judges): block
-            // all tools and the LSP probe on top of loading zero MCP servers.
-            //
-            // `--tools ""` is not enough for headless single-turn judge runs:
-            //   - The built-in `LSP` tool is attached regardless of `--tools`,
-            //     and Claude eagerly probes any file paths it sees in the
-            //     compacted trace, blowing past `--max-turns 1` with
-            //     `stop_reason=tool_use`. `--disallowedTools LSP` blocks it.
-            // Without these, real eval traces (which mention file paths)
-            // fail every question with `error_max_turns`.
-            args.Add("--tools");
-            args.Add("");
-            args.Add("--disallowedTools");
-            args.Add("LSP");
-        } else {
+        // Lock down the built-in tool surface in BOTH modes:
+        //   - `--tools ""` disables every built-in tool (Read/Bash/Agent/…).
+        //   - `--disallowedTools LSP` blocks the LSP probe, which is attached
+        //     regardless of `--tools` and otherwise eagerly probes file paths
+        //     it sees in the prompt, blowing past `--max-turns` with
+        //     `stop_reason=tool_use`. Without these, real eval prompts (which
+        //     mention file paths) fail with `error_max_turns`.
+        //
+        // The lockdown applies to MCP mode too: relying on `--allowedTools`
+        // alone to bound the tool surface is NOT enough — claude still exposes
+        // built-in tools (notably `Agent`, i.e. subagents) to the model even
+        // when they aren't allowlisted. A tools-enabled judge then reaches for
+        // `Agent` instead of the MCP tools, fanning out subagents that don't
+        // inherit the `--mcp-config`, burn the per-question budget
+        // (`error_max_budget_usd`), and return no verdict. The MCP tools the
+        // caller allowlists below are layered on top and are NOT part of the
+        // built-in set, so `--tools ""` leaves them callable.
+        args.Add("--tools");
+        args.Add("");
+        args.Add("--disallowedTools");
+        args.Add("LSP");
+
+        if (mcpConfigJson is not null) {
             // Tool-using mode (DEV-1484 retrospective + DEV-1486 per-question):
-            // load the caller-supplied MCP config and restrict the model to
-            // exactly the MCP tools the caller named. The `--tools ""` /
-            // `--disallowedTools LSP` lockdown from the text-only branch is
-            // dropped — the explicit `--allowedTools` allowlist is the only
-            // tool surface the model sees.
+            // load the caller-supplied session-scoped MCP server and permit
+            // exactly the MCP tools the caller named, on top of the built-in
+            // lockdown above.
             args.Add("--mcp-config");
             args.Add(mcpConfigJson);
             if (allowedTools is { Length: > 0 }) {

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -155,6 +155,37 @@ public static class EvalService {
         _                   => model
     };
 
+    // ── Embedded-trace size gate (size-gated hybrid) ───────────────────────
+    //
+    // The text-only judge path embeds the whole compacted trace as
+    // {TRACE_JSON}. That's cheap and high-fidelity for normal sessions, but
+    // very long sessions produce traces that overflow even the judge model's
+    // 1M-token context (observed: ~1.28M tokens → HTTP 400 "Prompt is too
+    // long", num_turns:1, no verdict). Above this budget PrepareAsync routes
+    // EVERY question for the session through the tools path
+    // (BuildToolsQuestionPrompt + the MCP judge surface) so the judge fetches
+    // only what it needs on demand instead of receiving the trace up front.
+    //
+    // The budget is a token estimate: the trace is JSON, so ~4 chars/token is
+    // a conservative approximation (the real ratio is usually higher, which
+    // keeps us on the safe side of the window). Overridable via
+    // KCAP_EVAL_TRACE_TOKEN_BUDGET for tuning without shipping a release.
+    const int DefaultTraceTokenBudget = 200_000;
+
+    internal static int TraceTokenBudget() =>
+        int.TryParse(Environment.GetEnvironmentVariable("KCAP_EVAL_TRACE_TOKEN_BUDGET"), out var v) && v > 0
+            ? v
+            : DefaultTraceTokenBudget;
+
+    /// <summary>
+    /// True when the embedded compacted trace is large enough that putting it
+    /// in front of the judge model risks overflowing the context window, in
+    /// which case the whole session is routed through the tools path. The
+    /// estimate is <paramref name="traceJsonLength"/> chars / 4 tokens.
+    /// </summary>
+    internal static bool ShouldForceTools(int traceJsonLength, int tokenBudget) =>
+        traceJsonLength / 4 >= tokenBudget;
+
     /// <summary>
     /// Output of <see cref="PrepareAsync"/> — the shared state threaded
     /// through every <see cref="RunQuestionAsync"/> and finally consumed by
@@ -169,7 +200,8 @@ public static class EvalService {
         string                                       PromptTemplate,
         string                                       ToolsPromptTemplate,
         IReadOnlyList<EvalQuestionDto>               Questions,
-        string                                       Model
+        string                                       Model,
+        bool                                         ForceTools
     );
 
     /// <summary>
@@ -315,6 +347,18 @@ public static class EvalService {
             context.Compaction.BytesSaved
         );
 
+        // Size-gated hybrid: if the compacted trace would overflow the judge
+        // model's context window when embedded, route every question for this
+        // session through the tools path (no embedded trace) instead of the
+        // text-only path. See ShouldForceTools / DefaultTraceTokenBudget.
+        var tokenBudget = TraceTokenBudget();
+        var forceTools  = ShouldForceTools(traceJson.Length, tokenBudget);
+        if (forceTools) {
+            observer.OnInfo(
+                $"trace ~{traceJson.Length / 4:N0} est. tokens exceeds budget ({tokenBudget:N0}) — "
+                + "routing all questions through the tools path (no embedded trace)");
+        }
+
         // Retained judge facts are no longer injected into per-question or
         // retrospective prompts — telling the judge "we already know about X"
         // suppresses re-reporting, which silently stops the cluster
@@ -335,7 +379,8 @@ public static class EvalService {
             PromptTemplate:      promptTemplate,
             ToolsPromptTemplate: toolsPromptTemplate,
             Questions:           questions,
-            Model:               model
+            Model:               model,
+            ForceTools:          forceTools
         );
     }
 
@@ -368,13 +413,15 @@ public static class EvalService {
         var              diagnostics = new List<string>();
         ClaudeCliResult? result;
 
-        if (question.NeedsTools) {
+        if (question.NeedsTools || ctx.ForceTools) {
             // DEV-1486 tools-enabled path. Session-scoped MCP tool surface
             // (same as retrospective) on a per-question budget: 15 turns,
             // 10-min timeout, $1.00 cap (raised from 10/$0.50 in DEV-1576
             // after real runs hit error_max_turns mid-tool-use). Prompt
             // omits the compacted trace — the judge fetches session details
-            // on demand.
+            // on demand. ctx.ForceTools additionally routes EVERY question
+            // here (not just the NeedsTools four) when the session's trace is
+            // too large to embed — see PrepareAsync's size gate.
             var prompt = BuildToolsQuestionPrompt(
                 ctx.ToolsPromptTemplate, ctx.SessionId, ctx.EvalRunId, question, patterns);
 
@@ -434,12 +481,14 @@ public static class EvalService {
             return null;
         }
 
-        // DEV-1486: record tool-call count for tools-enabled questions.
+        // DEV-1486: record tool-call count for tools-routed questions.
         // Derived as num_turns - 1 (the final StructuredOutput turn doesn't
         // count as investigation). Clamped at 0 for the defensive case
         // where the CLI reports 0 turns. Null for text-only questions so
         // the server can distinguish "didn't measure" from "measured zero".
-        if (question.NeedsTools) {
+        // Mirrors the branch condition above so size-gate-forced questions
+        // record their tool usage too.
+        if (question.NeedsTools || ctx.ForceTools) {
             verdict = verdict with { ToolsUsed = Math.Max(0, result.NumTurns - 1) };
         }
 

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -127,6 +127,38 @@ public static class EvalService {
         }.ToJsonString();
 
     /// <summary>
+    /// Resolves the path to the <c>kcap</c> executable used to launch the
+    /// session-scoped MCP judge subprocess (<c>kcap mcp judge</c>).
+    ///
+    /// <para>
+    /// The CLI host (<c>kcap eval</c>) is already the <c>kcap</c> binary, so
+    /// its <see cref="Environment.ProcessPath"/> is correct. The daemon host,
+    /// however, is a separate <c>kcap-daemon</c> binary that has no
+    /// <c>mcp judge</c> subcommand — invoking <c>kcap-daemon mcp judge</c>
+    /// just tries (and fails, "already running") to start a second daemon, so
+    /// the judge's MCP server never comes up and every tool call is dead. The
+    /// two binaries ship side-by-side in the same directory, so when the host
+    /// is <c>kcap-daemon</c> we remap to the sibling <c>kcap</c> (preserving any
+    /// executable extension, e.g. <c>.exe</c>), falling back to the original
+    /// path if the sibling isn't found.
+    /// </para>
+    /// </summary>
+    internal static string ResolveJudgeCommandPath(string? processPath, Func<string, bool> fileExists) {
+        if (string.IsNullOrEmpty(processPath)) return "kcap";
+
+        var dir = Path.GetDirectoryName(processPath);
+        if (dir is not null && Path.GetFileNameWithoutExtension(processPath) == "kcap-daemon") {
+            var sibling = Path.Combine(dir, "kcap" + Path.GetExtension(processPath));
+            if (fileExists(sibling)) return sibling;
+        }
+
+        return processPath;
+    }
+
+    static string ResolveJudgeCommandPath() =>
+        ResolveJudgeCommandPath(Environment.ProcessPath, File.Exists);
+
+    /// <summary>
     /// Resolves a caller-supplied model alias to the variant we actually
     /// want to dispatch to for a judge call. Today: force the 1M-context
     /// Sonnet variant for any plain <c>sonnet</c> request, because the
@@ -436,7 +468,7 @@ public static class EvalService {
             var prompt = BuildToolsQuestionPrompt(
                 ctx.ToolsPromptTemplate, ctx.SessionId, ctx.EvalRunId, question, patterns);
 
-            var commandPath = Environment.ProcessPath ?? "kcap";
+            var commandPath = ResolveJudgeCommandPath();
             var mcpConfig   = BuildJudgeMcpConfig(commandPath, ctx.SessionId, baseUrl);
 
             result = await ClaudeCliRunner.RunAsync(
@@ -1078,7 +1110,7 @@ public static class EvalService {
         // past Sonnet's 200K-token window on real sessions), launch a
         // per-session MCP judge server and let the judge pull recap /
         // errors / transcript slices on demand.
-        var commandPath = Environment.ProcessPath ?? "kcap";
+        var commandPath = ResolveJudgeCommandPath();
         var mcpConfig   = BuildJudgeMcpConfig(commandPath, sessionId, baseUrl);
 
         try {

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -351,6 +351,17 @@ public static class EvalService {
         // model's context window when embedded, route every question for this
         // session through the tools path (no embedded trace) instead of the
         // text-only path. See ShouldForceTools / DefaultTraceTokenBudget.
+        //
+        // Known limitation (AI-966 review): the judge MCP tools for
+        // summary/search/transcript/tool-result are single-session — only
+        // recap/errors follow the continuation chain (and the server endpoints
+        // they back have no chain support). So a chained eval (`--chain`) whose
+        // trace is large enough to force tools judges the nine formerly
+        // embedded-trace questions against the head session only, not the whole
+        // chain. Accepted here because the alternative for an oversized chained
+        // trace is the embed path's hard 400 (no verdict at all). Full
+        // chain-aware tools require server-side chain support on
+        // eval-summary/search/transcript — tracked in AI-968.
         var tokenBudget = TraceTokenBudget();
         var forceTools  = ShouldForceTools(traceJson.Length, tokenBudget);
         if (forceTools) {

--- a/src/Capacitor.Cli.Core/Resources/help-eval.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-eval.txt
@@ -3,10 +3,13 @@ Usage: kcap eval <sessionId> [options]
 
 Runs an LLM-as-judge evaluation over a stored session. 13 questions across 4
 categories (safety, plan adherence, quality, efficiency) are asked of Claude
-in sequence, each in its own headless invocation with no tools. The server's
-eval-context endpoint supplies the compacted session trace; results are
-aggregated into per-category + overall scores and persisted back to the
-session's stream as a SessionEvalCompleted event.
+in sequence, each in its own headless invocation. Most judges read the
+compacted session trace embedded in the prompt (supplied by the server's
+eval-context endpoint); some questions — and any session whose trace is too
+large to embed — instead investigate the session on demand via a read-only,
+session-scoped MCP tool surface (summary, search, transcript, errors, recap,
+tool results). Results are aggregated into per-category + overall scores and
+persisted back to the session's stream as a SessionEvalCompleted event.
 
 Options:
   --model <name>      Judge model (default: sonnet). haiku/sonnet/opus.
@@ -25,8 +28,12 @@ Options:
 Notes:
   - Judges run sequentially; expect ~1-3 minutes total depending on model and
     session size. Parallelization is tracked in DEV-1435.
-  - Each judge has no tools — Read, Bash, Grep, WebFetch, etc. are all blocked.
-    The full compacted trace is embedded in the prompt.
+  - Judges have no filesystem/network tools — Read, Bash, Grep, WebFetch, etc.
+    are blocked. They either reason from the compacted trace embedded in the
+    prompt, or — for tool-tagged questions and oversized sessions — pull session
+    details on demand through a read-only MCP tool surface scoped to the session.
+    Set KCAP_EVAL_TRACE_TOKEN_BUDGET to tune the embed-vs-tools threshold
+    (default ~200K estimated tokens).
   - If the session ID is omitted, the currently-recorded session is used —
     resolved from KCAP_SESSION_ID (Claude) or CODEX_THREAD_ID
     (Codex 0.81+).

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
@@ -124,12 +124,13 @@ public class ClaudeCliRunnerTests {
 
     // DEV-1484 contract: when a caller opts into MCP mode, they must name the
     // tools they want exposed. `--strict-mcp-config` already limits which MCP
-    // *servers* load to just the caller's inline config (AI-803), but without
-    // an allowlist the runner would drop the text-only `--tools ""` lockdown
-    // and expose every tool that inline config's servers offer. Requiring a
-    // non-empty allowlist keeps the callable-tool surface explicit. Guard at
-    // the entry point so the misuse surfaces as an ArgumentException instead
-    // of a silent broadening.
+    // *servers* load to just the caller's inline config (AI-803), and the
+    // built-in lockdown (`--tools ""` / `--disallowedTools LSP`) stays on, so
+    // an MCP config with no allowlist would load a server whose tools are never
+    // permitted — the judge can't call anything, which is a silent
+    // misconfiguration rather than a useful run. Requiring a non-empty
+    // allowlist keeps the callable-tool surface explicit. Guard at the entry
+    // point so the misuse surfaces as an ArgumentException.
     [Test]
     public async Task RunAsync_WithMcpConfigAndNullAllowedTools_Throws() =>
         await AssertAllowedToolsGuard(allowedTools: null);
@@ -192,10 +193,17 @@ public class ClaudeCliRunnerTests {
         await Assert.That(FlagValue(args, "--mcp-config")).IsEqualTo(mcpConfig);
         await Assert.That(FlagValue(args, "--allowedTools"))
             .IsEqualTo("mcp__kcap-judge__get_session_summary,mcp__kcap-judge__search_session");
-        // The text-only lockdown flags must NOT leak into MCP mode — the
-        // allowlist is the tool restriction there, not `--tools ""`.
-        await Assert.That(args).DoesNotContain("--tools");
-        await Assert.That(args).DoesNotContain("LSP");
+        // The built-in tool lockdown applies in MCP mode too. `--allowedTools`
+        // alone does NOT stop claude exposing built-in tools like `Agent`
+        // (subagents) to the model — a tools-judge will reach for `Agent`
+        // instead of the MCP tools, spawning subagents that blow the
+        // per-question budget and return no verdict. `--tools ""` disables the
+        // built-in set; `--disallowedTools LSP` blocks the LSP probe that is
+        // attached regardless of `--tools`. The allowlisted MCP tools are
+        // layered on top via `--mcp-config` + `--allowedTools` and are NOT part
+        // of the built-in set, so the lockdown does not remove them.
+        await Assert.That(FlagValue(args, "--tools")).IsEqualTo("");
+        await Assert.That(FlagValue(args, "--disallowedTools")).IsEqualTo("LSP");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
@@ -839,28 +839,34 @@ public class EvalServiceTests {
     // while leaving the `kcap eval` CLI host (ProcessPath already `kcap`)
     // untouched.
 
+    // Paths are built with Path.Combine so the separator matches the host
+    // (the resolver itself uses Path.Combine) — hardcoding "/" makes the
+    // sibling comparison fail on Windows, where Combine joins with "\".
+
     [Test]
     public async Task ResolveJudgeCommandPath_remaps_daemon_to_sibling_kcap() {
-        var resolved = EvalService.ResolveJudgeCommandPath(
-            "/opt/kcap/bin/kcap-daemon",
-            fileExists: p => p == "/opt/kcap/bin/kcap");
-        await Assert.That(resolved).IsEqualTo("/opt/kcap/bin/kcap");
+        var dir     = Path.Combine("opt", "kcap", "bin");
+        var daemon  = Path.Combine(dir, "kcap-daemon");
+        var sibling = Path.Combine(dir, "kcap");
+
+        var resolved = EvalService.ResolveJudgeCommandPath(daemon, fileExists: p => p == sibling);
+        await Assert.That(resolved).IsEqualTo(sibling);
     }
 
     [Test]
     public async Task ResolveJudgeCommandPath_keeps_daemon_path_when_sibling_missing() {
-        var resolved = EvalService.ResolveJudgeCommandPath(
-            "/opt/kcap/bin/kcap-daemon",
-            fileExists: _ => false);
-        await Assert.That(resolved).IsEqualTo("/opt/kcap/bin/kcap-daemon");
+        var daemon = Path.Combine("opt", "kcap", "bin", "kcap-daemon");
+
+        var resolved = EvalService.ResolveJudgeCommandPath(daemon, fileExists: _ => false);
+        await Assert.That(resolved).IsEqualTo(daemon);
     }
 
     [Test]
     public async Task ResolveJudgeCommandPath_leaves_cli_kcap_path_untouched() {
-        var resolved = EvalService.ResolveJudgeCommandPath(
-            "/usr/local/bin/kcap",
-            fileExists: _ => true);
-        await Assert.That(resolved).IsEqualTo("/usr/local/bin/kcap");
+        var cli = Path.Combine("usr", "local", "bin", "kcap");
+
+        var resolved = EvalService.ResolveJudgeCommandPath(cli, fileExists: _ => true);
+        await Assert.That(resolved).IsEqualTo(cli);
     }
 
     [Test]
@@ -872,11 +878,11 @@ public class EvalServiceTests {
     [Test]
     public async Task ResolveJudgeCommandPath_preserves_executable_extension_on_sibling() {
         // Windows host: kcap-daemon.exe → kcap.exe (extension carried over).
-        // Uses a synthetic extension so the assertion is independent of the
-        // test platform's path separator.
-        var resolved = EvalService.ResolveJudgeCommandPath(
-            "/opt/kcap/bin/kcap-daemon.exe",
-            fileExists: p => p == "/opt/kcap/bin/kcap.exe");
-        await Assert.That(resolved).IsEqualTo("/opt/kcap/bin/kcap.exe");
+        var dir     = Path.Combine("opt", "kcap", "bin");
+        var daemon  = Path.Combine(dir, "kcap-daemon.exe");
+        var sibling = Path.Combine(dir, "kcap.exe");
+
+        var resolved = EvalService.ResolveJudgeCommandPath(daemon, fileExists: p => p == sibling);
+        await Assert.That(resolved).IsEqualTo(sibling);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
@@ -828,4 +828,55 @@ public class EvalServiceTests {
             Environment.SetEnvironmentVariable("KCAP_EVAL_TRACE_TOKEN_BUDGET", previous);
         }
     }
+
+    // ── Judge command-path resolution ──────────────────────────────────────
+    //
+    // The session-scoped MCP judge subprocess is spawned from the path returned
+    // here. In the daemon the host process is `kcap-daemon`, which has no
+    // `mcp judge` subcommand — invoking it just tries (and fails) to start a
+    // second daemon, so the judge's MCP server never comes up. The fix remaps
+    // `kcap-daemon` to its sibling `kcap` binary (they ship in the same dir),
+    // while leaving the `kcap eval` CLI host (ProcessPath already `kcap`)
+    // untouched.
+
+    [Test]
+    public async Task ResolveJudgeCommandPath_remaps_daemon_to_sibling_kcap() {
+        var resolved = EvalService.ResolveJudgeCommandPath(
+            "/opt/kcap/bin/kcap-daemon",
+            fileExists: p => p == "/opt/kcap/bin/kcap");
+        await Assert.That(resolved).IsEqualTo("/opt/kcap/bin/kcap");
+    }
+
+    [Test]
+    public async Task ResolveJudgeCommandPath_keeps_daemon_path_when_sibling_missing() {
+        var resolved = EvalService.ResolveJudgeCommandPath(
+            "/opt/kcap/bin/kcap-daemon",
+            fileExists: _ => false);
+        await Assert.That(resolved).IsEqualTo("/opt/kcap/bin/kcap-daemon");
+    }
+
+    [Test]
+    public async Task ResolveJudgeCommandPath_leaves_cli_kcap_path_untouched() {
+        var resolved = EvalService.ResolveJudgeCommandPath(
+            "/usr/local/bin/kcap",
+            fileExists: _ => true);
+        await Assert.That(resolved).IsEqualTo("/usr/local/bin/kcap");
+    }
+
+    [Test]
+    public async Task ResolveJudgeCommandPath_falls_back_to_bare_kcap_when_path_null() {
+        var resolved = EvalService.ResolveJudgeCommandPath(null, fileExists: _ => false);
+        await Assert.That(resolved).IsEqualTo("kcap");
+    }
+
+    [Test]
+    public async Task ResolveJudgeCommandPath_preserves_executable_extension_on_sibling() {
+        // Windows host: kcap-daemon.exe → kcap.exe (extension carried over).
+        // Uses a synthetic extension so the assertion is independent of the
+        // test platform's path separator.
+        var resolved = EvalService.ResolveJudgeCommandPath(
+            "/opt/kcap/bin/kcap-daemon.exe",
+            fileExists: p => p == "/opt/kcap/bin/kcap.exe");
+        await Assert.That(resolved).IsEqualTo("/opt/kcap/bin/kcap.exe");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
@@ -757,4 +757,38 @@ public class EvalServiceTests {
         var snapshot = EvalService.BuildFactsUsedSnapshot(new Dictionary<string, List<JudgeFact>>());
         await Assert.That(snapshot.Count).IsEqualTo(0);
     }
+
+    // ── Size gate (size-gated hybrid) ──────────────────────────────────────
+    //
+    // When the compacted trace would overflow the judge model's context if
+    // embedded, PrepareAsync flips the whole session onto the tools path. The
+    // estimate is chars/4 tokens; the boundary triggers at >= budget.
+
+    [Test]
+    public async Task ShouldForceTools_false_when_trace_under_budget() {
+        // 100K chars ≈ 25K est. tokens, well under a 200K budget.
+        await Assert.That(EvalService.ShouldForceTools(100_000, 200_000)).IsFalse();
+    }
+
+    [Test]
+    public async Task ShouldForceTools_true_when_trace_at_or_over_budget() {
+        // 800K chars ≈ 200K est. tokens == budget → force.
+        await Assert.That(EvalService.ShouldForceTools(800_000, 200_000)).IsTrue();
+        // ~5M chars ≈ 1.25M est. tokens — the overflow case from the bug report.
+        await Assert.That(EvalService.ShouldForceTools(5_000_000, 200_000)).IsTrue();
+    }
+
+    [Test]
+    public async Task ShouldForceTools_uses_four_chars_per_token_estimate() {
+        // Exactly at the boundary: budget*4 chars → est tokens == budget → force.
+        await Assert.That(EvalService.ShouldForceTools(40_000, 10_000)).IsTrue();
+        // One token's worth of chars below the boundary → don't force.
+        await Assert.That(EvalService.ShouldForceTools(40_000 - 4, 10_000)).IsFalse();
+    }
+
+    [Test]
+    public async Task TraceTokenBudget_defaults_when_env_unset() {
+        // No KCAP_EVAL_TRACE_TOKEN_BUDGET override in the test process → default.
+        await Assert.That(EvalService.TraceTokenBudget()).IsEqualTo(200_000);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
@@ -786,9 +786,46 @@ public class EvalServiceTests {
         await Assert.That(EvalService.ShouldForceTools(40_000 - 4, 10_000)).IsFalse();
     }
 
+    // TraceTokenBudget reads the process environment directly, so these tests
+    // save → set → assert → restore the var and run NotInParallel with each
+    // other to avoid clobbering a value the host/CI may already have set.
+
     [Test]
+    [NotInParallel(nameof(EvalServiceTests))]
     public async Task TraceTokenBudget_defaults_when_env_unset() {
-        // No KCAP_EVAL_TRACE_TOKEN_BUDGET override in the test process → default.
-        await Assert.That(EvalService.TraceTokenBudget()).IsEqualTo(200_000);
+        var previous = Environment.GetEnvironmentVariable("KCAP_EVAL_TRACE_TOKEN_BUDGET");
+        Environment.SetEnvironmentVariable("KCAP_EVAL_TRACE_TOKEN_BUDGET", null);
+        try {
+            await Assert.That(EvalService.TraceTokenBudget()).IsEqualTo(200_000);
+        } finally {
+            Environment.SetEnvironmentVariable("KCAP_EVAL_TRACE_TOKEN_BUDGET", previous);
+        }
+    }
+
+    [Test]
+    [NotInParallel(nameof(EvalServiceTests))]
+    public async Task TraceTokenBudget_honours_valid_env_override() {
+        var previous = Environment.GetEnvironmentVariable("KCAP_EVAL_TRACE_TOKEN_BUDGET");
+        Environment.SetEnvironmentVariable("KCAP_EVAL_TRACE_TOKEN_BUDGET", "50000");
+        try {
+            await Assert.That(EvalService.TraceTokenBudget()).IsEqualTo(50_000);
+        } finally {
+            Environment.SetEnvironmentVariable("KCAP_EVAL_TRACE_TOKEN_BUDGET", previous);
+        }
+    }
+
+    [Test]
+    [NotInParallel(nameof(EvalServiceTests))]
+    public async Task TraceTokenBudget_falls_back_to_default_on_invalid_or_nonpositive_env() {
+        var previous = Environment.GetEnvironmentVariable("KCAP_EVAL_TRACE_TOKEN_BUDGET");
+        try {
+            Environment.SetEnvironmentVariable("KCAP_EVAL_TRACE_TOKEN_BUDGET", "not-a-number");
+            await Assert.That(EvalService.TraceTokenBudget()).IsEqualTo(200_000);
+
+            Environment.SetEnvironmentVariable("KCAP_EVAL_TRACE_TOKEN_BUDGET", "0");
+            await Assert.That(EvalService.TraceTokenBudget()).IsEqualTo(200_000);
+        } finally {
+            Environment.SetEnvironmentVariable("KCAP_EVAL_TRACE_TOKEN_BUDGET", previous);
+        }
     }
 }


### PR DESCRIPTION
## Problem

Running an eval on a long session fails. The text-only judge path (`prompt-eval-question.txt`) embeds the entire compacted session trace as `{TRACE_JSON}`. For one long session the trace was ~1.28M tokens, overflowing even the judge model's 1M-token context window. The judge `claude -p` call returns:

```
api_error_status: 400, num_turns: 1, "Prompt is too long · the request is ~1283904 tokens (limit ~1M)"
```

Because the call is pinned to `--json-schema`, the transcript fallback is (correctly) skipped, so the question (e.g. `sensitive_files`) surfaces as a failed verdict in the UI. 9 of 13 questions use this text-only path.

The text path also re-sends the full trace for **each** of the 13 questions (13 separate `claude -p` processes, no shared prompt cache), so even sessions that *fit* the window cost ~13× the trace in input tokens.

## Fix — size-gated hybrid

Reuse the existing tools-based judge path (MCP `kcap-judge` server: `get_session_summary`, `search_session`, `get_transcript`, `get_tool_result`, …) that 4 of 13 questions already use, and route the **whole session** through it when the trace is too large to embed:

- `ShouldForceTools(traceLen, budget)` + `TraceTokenBudget()` — default **200K tokens** (estimated as chars/4), overridable via `KCAP_EVAL_TRACE_TOKEN_BUDGET`.
- `PrepareAsync` computes the gate after fetching the trace and logs it via the observer when tripped.
- `EvalContext.ForceTools` flag; `RunQuestionAsync` routes via `question.NeedsTools || ctx.ForceTools` (and records `ToolsUsed` for forced questions too).

Small sessions keep the cheap single-shot embedded-trace path; oversized ones get a small prompt and fetch detail on demand — fixing both the overflow and the cost cliff. **No server-side change needed** (the MCP judge tools + `eval-context` endpoint already exist).

## Fix — make the tools path actually work (prerequisite for the size gate)

The size gate routes *more* questions onto the tools/MCP judge path, so that path has to be sound. Debugging a daemon-side eval that got "stuck on question 2" surfaced two bugs that broke the tools path. They already affected the 4 `NeedsTools` questions; the size gate would extend the blast radius to all 13 on oversized sessions, so both are fixed here:

1. **Headless judge spawned `Agent` subagents and blew the budget.** In MCP mode `ClaudeCliRunner` bounded the tool surface only with `--allowedTools`. Claude (2.1.x) still exposes built-in tools — notably `Agent` (subagents) — to the model regardless, so the judge delegated investigation to subagents that don't inherit `--mcp-config`, exhausted the $1 per-question budget (`error_max_budget_usd`) over ~6 min, and returned no verdict. The `--tools "" / --disallowedTools LSP` lockdown the text-only path already uses is now applied in MCP mode too; the allowlisted MCP tools layer on top via `--mcp-config`/`--allowedTools` and stay callable (they aren't part of the built-in set).

2. **Daemon's MCP judge server was dead on arrival.** The judge MCP config used `command = Environment.ProcessPath`, which on the daemon resolves to the `kcap-daemon` binary. `kcap-daemon` has no `mcp judge` subcommand — it just tries (and fails, "already running") to start a second daemon, so the judge's MCP server never came up and every tool call was dead. `ResolveJudgeCommandPath` now remaps `kcap-daemon` → its sibling `kcap` binary (preserving any `.exe` extension, falling back to the original path if the sibling is missing). The `kcap eval` CLI host (`ProcessPath` already `kcap`) is unaffected.

## Testing

- Full `Capacitor.Cli.Tests.Unit` suite — **1706/1706 pass**. New/updated: 4 `ShouldForceTools`/`TraceTokenBudget`, the MCP-mode `BuildClaudeArgs` arg test (now asserts the lockdown), and 5 `ResolveJudgeCommandPath` tests.
- `dotnet publish -c Release` for CLI and daemon — **no IL2026/IL3050 AOT warnings**.
- Live headless judge run with the exact production flag set (`--tools "" --disallowedTools LSP --mcp-config --allowedTools …`) against a freshly-built binary produces a **valid verdict with zero `Agent` subagents** ($0.24, under the $1 cap); the pre-fix control produced no verdict and burned the budget.

> Note: the daemon ships as a separate published `kcap-daemon` binary, so fix #2 takes effect only after a new release is installed and the daemon restarts.

Closes AI-966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
