### PR TITLE
Improve auth-expiry experience: retry refresh + non-nagging hooks

### DIFF
--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -216,6 +216,14 @@ public static class TokenStore {
         return DateTimeOffset.UtcNow.AddMinutes(5);
     }
 
+    // Short retry budget for the refresh HTTP call. A bare single-shot POST turned any
+    // transient blip (DNS stutter, connection reset, brief server slowness) into a hard
+    // "token expired — run kcap login", even though the refresh credential was still valid.
+    // PostWithRetryAsync retries only transport failures, never non-success responses — so a
+    // genuinely-expired refresh token still returns fast (400/401 → null, no pointless retries).
+    // Kept short so a hook never blocks for the default 30s budget when the server is down.
+    static readonly TimeSpan RefreshRetryBudget = TimeSpan.FromSeconds(5);
+
     static async Task<StoredTokens?> RefreshGitHubAsync(StoredTokens tokens) {
         var       baseUrl = AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KCAP_URL") ?? "http://localhost:5108";
         using var http    = new HttpClient();
@@ -227,7 +235,7 @@ public static class TokenStore {
         var payload = new StringContent(requestBody, System.Text.Encoding.UTF8, "application/json");
 
         try {
-            var response = await http.PostAsync($"{baseUrl}/auth/refresh", payload);
+            var response = await http.PostWithRetryAsync($"{baseUrl}/auth/refresh", payload, RefreshRetryBudget);
 
             if (!response.IsSuccessStatusCode) {
                 return null;
@@ -258,7 +266,13 @@ public static class TokenStore {
         try {
             using var http = new HttpClient();
 
-            using var response = await http.PostAsync(
+            // Retries only transport failures. WorkOS rotates the refresh token on each
+            // successful use, so a retry after the server already rotated (response lost in
+            // transit) would re-send the now-consumed token. That reuse window already exists
+            // without retry — the next refresh call re-reads the same unrotated token from disk
+            // and re-sends it — so the short retry doesn't add a new failure mode; it just rides
+            // out the common case where the request never reached WorkOS.
+            using var response = await http.PostWithRetryAsync(
                 "https://api.workos.com/user_management/authenticate",
                 new FormUrlEncodedContent(
                     new Dictionary<string, string> {
@@ -266,7 +280,8 @@ public static class TokenStore {
                         ["client_id"]     = tokens.ClientId!,
                         ["refresh_token"] = tokens.RefreshToken!
                     }
-                )
+                ),
+                RefreshRetryBudget
             );
 
             if (!response.IsSuccessStatusCode) {

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -225,8 +225,19 @@ public static class TokenStore {
     static readonly TimeSpan RefreshRetryBudget = TimeSpan.FromSeconds(5);
 
     static async Task<StoredTokens?> RefreshGitHubAsync(StoredTokens tokens) {
-        var       baseUrl = AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KCAP_URL") ?? "http://localhost:5108";
-        using var http    = new HttpClient();
+        var baseUrl = AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KCAP_URL") ?? "http://localhost:5108";
+        var url     = $"{baseUrl}/auth/refresh";
+
+        // PostWithRetryAsync runs EnsureAbsolute, which Environment.Exit(2)s on a scheme-less URL.
+        // Refresh is reached from daemon/background callers via GetValidTokensAsync and must fail
+        // gracefully (return null), never terminate the process — so validate here instead of
+        // letting the retry helper exit. The hook *entry* paths still EnsureAbsolute-and-exit by
+        // design; this guard only covers the refresh call.
+        if (!HttpClientExtensions.IsAcceptableUrl(url)) {
+            return null;
+        }
+
+        using var http = new HttpClient();
 
         var requestBody = JsonSerializer.Serialize(
             new() { AccessToken = tokens.AccessToken },
@@ -235,7 +246,7 @@ public static class TokenStore {
         var payload = new StringContent(requestBody, System.Text.Encoding.UTF8, "application/json");
 
         try {
-            var response = await http.PostWithRetryAsync($"{baseUrl}/auth/refresh", payload, RefreshRetryBudget);
+            var response = await http.PostWithRetryAsync(url, payload, RefreshRetryBudget);
 
             if (!response.IsSuccessStatusCode) {
                 return null;

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -7,35 +7,74 @@ using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.Cli.Core;
 
+/// <summary>
+/// Outcome of building an authenticated client. Lets hook callers decide whether a POST is even
+/// worth attempting and whether to surface a re-auth prompt, instead of blindly POSTing a request
+/// the server will reject with 401.
+/// </summary>
+public enum AuthStatus {
+    /// <summary>A valid Bearer token is attached to the client.</summary>
+    Ok,
+
+    /// <summary>The server requires no auth ("None" provider) — the client is usable as-is.</summary>
+    NoAuthRequired,
+
+    /// <summary>A token is stored but expired and could not be refreshed — re-login required.</summary>
+    Expired,
+
+    /// <summary>No token is stored at all — login required.</summary>
+    NotAuthenticated,
+}
+
 public static class HttpClientExtensions {
     /// <summary>
-    /// Creates an HttpClient with a Bearer token from the local token store.
-    /// Checks auth discovery first — if the server uses "None" provider, skips auth entirely.
-    /// All CLI commands that call the Capacitor server should use this
-    /// instead of <c>new HttpClient()</c>.
+    /// Builds an <see cref="HttpClient"/> and reports the auth outcome. Attaches a Bearer token when
+    /// one is valid (refreshing transparently if needed); otherwise leaves the client unauthenticated
+    /// and returns the reason. Does NOT write to stderr — the caller chooses how, and whether, to
+    /// surface it. Hook callers should prefer this over <see cref="CreateAuthenticatedClientAsync"/>
+    /// so they can stay quiet on high-frequency events and exit cleanly instead of erroring per-turn.
     /// </summary>
-    public static async Task<HttpClient> CreateAuthenticatedClientAsync(string? baseUrl = null, CancellationToken ct = default) {
+    public static async Task<(HttpClient Client, AuthStatus Status)> CreateClientWithAuthStatusAsync(string? baseUrl = null, CancellationToken ct = default) {
         var client = new HttpClient();
 
         baseUrl ??= AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KCAP_URL") ?? "http://localhost:5108";
         var provider = await DiscoverProviderAsync(baseUrl, ct);
 
         if (provider == "None") {
-            return client; // No auth needed
+            return (client, AuthStatus.NoAuthRequired); // No auth needed
         }
 
         var tokens = await TokenStore.GetValidTokensAsync();
 
         if (tokens is not null) {
             client.DefaultRequestHeaders.Authorization = new("Bearer", tokens.AccessToken);
-        } else {
-            var stored = await TokenStore.LoadAsync();
 
-            if (stored is not null) {
+            return (client, AuthStatus.Ok);
+        }
+
+        var stored = await TokenStore.LoadAsync();
+
+        return (client, stored is not null ? AuthStatus.Expired : AuthStatus.NotAuthenticated);
+    }
+
+    /// <summary>
+    /// Creates an HttpClient with a Bearer token from the local token store, printing an actionable
+    /// re-auth hint to stderr when no valid token is available. Checks auth discovery first — if the
+    /// server uses "None" provider, skips auth entirely. Interactive CLI commands use this; hook
+    /// callers should prefer <see cref="CreateClientWithAuthStatusAsync"/> so they control messaging.
+    /// </summary>
+    public static async Task<HttpClient> CreateAuthenticatedClientAsync(string? baseUrl = null, CancellationToken ct = default) {
+        var (client, status) = await CreateClientWithAuthStatusAsync(baseUrl, ct);
+
+        switch (status) {
+            case AuthStatus.Expired:
                 await Console.Error.WriteLineAsync("Authentication token has expired. Run 'kcap login' to re-authenticate.");
-            } else {
+
+                break;
+            case AuthStatus.NotAuthenticated:
                 await Console.Error.WriteLineAsync("Not authenticated. Run 'kcap login' to authenticate.");
-            }
+
+                break;
         }
 
         return client;

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -238,7 +238,32 @@ public static class ClaudeHookCommand {
             }
         }
 
-        using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+        var       authResult = await HttpClientExtensions.CreateClientWithAuthStatusAsync();
+        using var client     = authResult.Client;
+        var       authStatus = authResult.Status;
+
+        // Recording is best-effort. When auth has lapsed there's no point POSTing a request the
+        // server will reject with 401 — and a non-zero exit makes Claude Code render a red
+        // "Stop hook error" banner on *every* turn until the user re-authenticates. Exit cleanly
+        // (0) so there's no banner, and nudge the user to re-login only on session-start (once per
+        // session) rather than on the high-frequency stop/notification/subagent events. The nudge
+        // is a `systemMessage` JSON object: Claude Code shows it to the user but — unlike plain
+        // session-start stdout — does NOT inject it into the model's context. (On exit 0 stderr is
+        // hidden entirely, so it can't carry a user-visible notice.)
+        if (authStatus is AuthStatus.Expired or AuthStatus.NotAuthenticated) {
+            if (command == "session-start") {
+                var notice = new JsonObject {
+                    ["systemMessage"] = authStatus == AuthStatus.Expired
+                        ? "[kcap] Authentication expired — session recording is paused. Run 'kcap login' to resume."
+                        : "[kcap] Not authenticated — session recording is off. Run 'kcap login' to start recording."
+                };
+
+                Console.WriteLine(notice.ToJsonString());
+            }
+
+            return 0;
+        }
+
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
 
         HttpResponseMessage response;


### PR DESCRIPTION
## Why

A user hit this on a Stop hook after their auth lapsed:

```
Stop hook error: Failed with non-blocking status code: Authentication token has expired. Run 'kcap login' to re-authenticate.
HTTP 401
```

Two separate problems were behind it, addressed in two commits.

## 1. Retry token refresh on transient failures

`TokenStore` refreshes tokens silently before every authenticated call, but the two refresh HTTP calls used a bare single-shot `PostAsync` and swallowed every exception to `null`. So a momentary transport blip (DNS stutter, connection reset, brief server slowness) degraded **instantly** to "Authentication token has expired. Run 'kcap login'" — even when the refresh credential was still perfectly valid.

Both calls now go through the existing `PostWithRetryAsync` helper with a short **5s** budget:
- `RefreshGitHubAsync` → `/auth/refresh`
- `RefreshWorkOSAsync` → WorkOS `/user_management/authenticate`

`PostWithRetryAsync` retries **only transport failures, never non-success HTTP responses**, so a genuinely-expired refresh token still returns fast (`400`/`401` → `null`, no pointless retries). The short budget keeps a hook from blocking on the default 30s when the server is truly down. Adding retry introduces no new failure mode for WorkOS's rotate-on-use refresh tokens — that reuse window already existed across separate refresh calls, and the cross-process lock + re-read-under-lock remains the mitigation.

## 2. Make hook auth-expiry non-nagging and non-alarming

When auth has genuinely lapsed (refresh credential dead → re-login truly required), the Claude hook used to POST a request it knew would `401`, print `HTTP 401`, and exit `1` — which Claude Code renders as a red **"Stop hook error"** banner **on every turn** until the user re-authenticates.

Recording is best-effort, so this now:
- **Skips the POST** when auth is expired/missing (no point — it would 401).
- **Exits 0** — no red banner.
- **Nudges the user to re-login only on `session-start`** (once per session), staying silent on the high-frequency `stop` / `notification` / `subagent-*` events.

Mechanism: `HttpClientExtensions.CreateClientWithAuthStatusAsync` now reports an `AuthStatus` (`Ok` / `NoAuthRequired` / `Expired` / `NotAuthenticated`) instead of swallowing it. The existing `CreateAuthenticatedClientAsync` is preserved as a thin wrapper (same stderr behaviour for interactive commands), so non-hook callers are unaffected.

The session-start nudge is emitted as a **`systemMessage` JSON object** on stdout, not stderr. This matters: on exit 0 Claude Code hides hook stderr entirely, and plain `session-start` stdout is injected into the *model's* context — `systemMessage` is the one channel that shows the notice to the **user** without leaking into context. (Verified against the Claude Code hooks docs.)

## Scope

Hook change applied to the **Claude Code** path (the one reported). The other agent hooks (Codex, Cursor, Gemini, …) share the same `CreateAuthenticatedClientAsync` shape and can adopt `CreateClientWithAuthStatusAsync` as a fast follow-up.

## Follow-up

Proactive background token refresh in the daemon is tracked separately in #182.

## Testing

- `dotnet build` — clean.
- AOT publish — no IL3050/IL2026 warnings.
- Unit tests — pass.
- README: no change (no user-facing CLI surface change — internal behaviour only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
