### PR TITLE
[AI-794] Enable Codex sandbox network access for kcap skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The setup wizard walks you through:
 1. **Server** — with no `--server-url`/`<tenant>`, kcap **discovers** your tenant: it signs you in with your organization's single sign-on (pass `--github` to use GitHub instead), then lets you choose from the tenants you belong to. A bare `<tenant>` slug expands to `https://<tenant>.kcap.ai`; a full URL is used as-is.
 2. **Login** — authenticates via your tenant's configured sign-in method; discovery completes the sign-in inline
 3. **Default visibility** — choose how your sessions are visible to others
-4. **Coding-agent hooks** — detects Claude Code and Codex CLI on `PATH`, Cursor by user-dir presence (`~/.cursor/`), GitHub Copilot CLI by `~/.copilot/` or `copilot` on `PATH`, Google Gemini CLI by `~/.gemini/` or `gemini` on `PATH`, AWS Kiro CLI by `~/.kiro/` or `kiro`/`kiro-cli` on `PATH`, Pi by `~/.pi/` or `pi` on `PATH`, and SST OpenCode by `~/.config/opencode/` (or `~/.local/share/opencode/`) or `opencode` on `PATH`, then offers to install hooks/skills (or, for Pi/OpenCode, the live-ingest plugin) for each (user-wide)
+4. **Coding-agent hooks** — detects Claude Code and Codex CLI on `PATH`, Cursor by user-dir presence (`~/.cursor/`), GitHub Copilot CLI by `~/.copilot/` or `copilot` on `PATH`, Google Gemini CLI by `~/.gemini/` or `gemini` on `PATH`, AWS Kiro CLI by `~/.kiro/` or `kiro`/`kiro-cli` on `PATH`, Pi by `~/.pi/` or `pi` on `PATH`, and SST OpenCode by `~/.config/opencode/` (or `~/.local/share/opencode/`) or `opencode` on `PATH`, then offers to install hooks/skills (or, for Pi/OpenCode, the live-ingest plugin) for each (user-wide). For Codex it also offers to enable **sandbox network access** for kcap (see below) — Codex blocks sandbox network by default, so the kcap skills can't reach the server without it.
 5. **Daemon** — configure the daemon name for remote agent execution
 
 When setup finishes, `kcap` sends a best-effort POST to the server's `/api/users/me/cli-setup` endpoint so the dashboard can mark your CLI as registered and surface the import-past-sessions hint. The call is capped at 5 seconds and failures are silent — they do not affect setup completion.
@@ -77,7 +77,7 @@ For non-interactive environments:
 kcap setup --server-url https://my-tenant.kcap.ai --default-visibility org_public --no-prompt
 ```
 
-In `--no-prompt` mode, the wizard installs hooks for every detected agent by default. Opt out per agent with `--skip-claude-hooks`, `--skip-codex-hooks`, `--skip-cursor-hooks`, `--skip-copilot-hooks`, `--skip-gemini-hooks`, `--skip-kiro-hooks`, `--skip-pi-hooks`, and/or `--skip-opencode-hooks`.
+In `--no-prompt` mode, the wizard installs hooks for every detected agent by default. Opt out per agent with `--skip-claude-hooks`, `--skip-codex-hooks`, `--skip-cursor-hooks`, `--skip-copilot-hooks`, `--skip-gemini-hooks`, `--skip-kiro-hooks`, `--skip-pi-hooks`, and/or `--skip-opencode-hooks`. When Codex hooks are installed, the wizard also enables Codex sandbox network access for your server(s) by default; pass `--skip-codex-network-access` to leave `~/.codex/config.toml` untouched.
 
 > **Need hooks for an agent installed after setup, or scoped to a single repo?**
 > Run `kcap plugin install [--codex|--cursor|--copilot|--gemini|--kiro|--pi|--opencode]` (omit the flag for the Claude Code plugin), or pair Codex with `--project` for a per-repo install. Use `--skills` instead of `--codex` if you only want the agent skills without Codex hooks. Cursor uses user-scope only — `--project` has no effect with `--cursor`. After installing Codex hooks, the next `codex` launch prompts to trust the new hooks — accept once to trust them all (run `/hooks` inside Codex if you'd rather trust each entry individually). After a `--project` install, also run `codex` once in the repo and accept the workspace trust prompt. Re-running after a kcap upgrade is rarely needed for user-scope installs — the npm postinstall hook auto-refreshes them on every `npm install -g @kurrent/kcap`, and `kcap update` refreshes them too (npm 11+ blocks install scripts by default — `kcap update` works regardless, or add `allow-scripts[]=@kurrent/kcap` to `~/.npmrc` to opt the postinstall in once).
@@ -389,6 +389,19 @@ Installing with `--codex` (or `--skills`) writes five skills under `~/.agents/sk
 | `kcap-validate-plan` | `kcap validate-plan` | Verify plan items were completed |
 
 All five auto-resolve the active session from `CODEX_THREAD_ID`; pass `<sessionId>` explicitly to operate on a different session.
+
+> **Codex sandbox network access (AI-794).** The skills shell out to `kcap …`, which talks to the Capacitor server — but Codex runs the agent's shell tool in a `workspace-write` sandbox that **blocks network by default**, so the skills fail (or demand escalation) until network access is allowed. Both `kcap setup` (one yes/no prompt after the Codex hooks step) and `kcap plugin install --codex` enable it for you. They write a constrained allowlist to `~/.codex/config.toml` rather than opening the network wholesale:
+>
+> ```toml
+> [sandbox_workspace_write]
+> network_access = true          # required — the proxy only enforces; it doesn't grant
+>
+> [features.network_proxy]
+> enabled = true
+> domains = { "**.kcap.ai" = "allow" }
+> ```
+>
+> The `**.kcap.ai` wildcard covers every SaaS tenant — current and future — plus `auth.kcap.ai`, so switching profiles and adding tenants just work with no per-tenant edits. **Self-hosted** servers are added as exact-host entries, derived from every configured profile's `server_url` and refreshed on each `kcap setup`. Existing config is respected: if you already run a `network_proxy` policy, kcap's hosts are merged into your `domains` (yours preserved); if you've already opened the network (`network_access = true` with no proxy), nothing changes. Opt out with `--skip-codex-network-access` on either command (and the npm-postinstall `--if-installed` refresh never touches `config.toml`). A localhost dev server additionally needs `allow_local_binding = true`, which kcap does not set. Uninstall leaves these keys in place — they're your security posture, not kcap state.
 
 The daemon starts Codex with `--sandbox workspace-write` and `--ask-for-approval on-request`. This lets Codex edit files in the agent's worktree but escalates sensitive operations (e.g. network calls, shell commands outside the worktree) through the daemon's permission bridge to the dashboard.
 

--- a/src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj
+++ b/src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj
@@ -30,5 +30,6 @@
     <ItemGroup>
         <PackageReference Include="Duende.IdentityModel.OidcClient" />
         <PackageReference Include="Duende.IdentityModel" />
+        <PackageReference Include="Tomlyn" />
     </ItemGroup>
 </Project>

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -50,7 +50,7 @@ public static class CodexConfigToml {
     public static Change EnableNetworkAccess(IReadOnlyCollection<string> allowDomains, string? configPath = null) =>
         allowDomains.Count == 0
             ? Change.Unchanged
-            : Update(configPath ?? DefaultConfigPath, root => MutateNetworkAccess(root, allowDomains));
+            : Update(configPath ?? DefaultConfigPath, root => MutateNetworkAccess(root, allowDomains), out _);
 
     /// <summary>
     /// Writes the per-worktree pre-trust entry:
@@ -60,7 +60,17 @@ public static class CodexConfigToml {
     /// </code>
     /// </summary>
     public static Change TrustWorktree(string worktreePath, string? configPath = null) =>
-        Update(configPath ?? DefaultConfigPath, root => MutateTrust(root, worktreePath));
+        TrustWorktree(worktreePath, out _, configPath);
+
+    /// <summary>
+    /// As <see cref="TrustWorktree(string,string?)"/>, but surfaces the underlying
+    /// exception on <see cref="Change.Failed"/> so the daemon can log the root cause
+    /// (parse vs permissions vs IO) it would otherwise lose to the swallowing
+    /// <see cref="Update"/>. <paramref name="error"/> is null unless the result is
+    /// <see cref="Change.Failed"/>.
+    /// </summary>
+    internal static Change TrustWorktree(string worktreePath, out Exception? error, string? configPath = null) =>
+        Update(configPath ?? DefaultConfigPath, root => MutateTrust(root, worktreePath), out error);
 
     /// <summary>
     /// Builds the Codex proxy allowlist from a set of Capacitor server URLs (the
@@ -112,16 +122,21 @@ public static class CodexConfigToml {
     /// changed <paramref name="root"/>. Returns <see cref="Change.Failed"/> on a
     /// parse error (we never clobber a config we can't read) or a write error,
     /// <see cref="Change.Unchanged"/> when nothing changed, otherwise
-    /// <see cref="Change.Updated"/>.
+    /// <see cref="Change.Updated"/>. <paramref name="error"/> carries the captured
+    /// exception on <see cref="Change.Failed"/> (null otherwise) so callers can log it.
     /// </summary>
-    static Change Update(string configPath, Func<TomlTable, bool> mutate) {
+    static Change Update(string configPath, Func<TomlTable, bool> mutate, out Exception? error) {
+        error = null;
+
         lock (_writeLock) {
             TomlTable root;
 
             if (File.Exists(configPath)) {
                 try {
                     root = TomlSerializer.Deserialize(File.ReadAllText(configPath), _tomlTypeInfo.TableInfo) ?? new TomlTable();
-                } catch {
+                } catch (Exception ex) {
+                    error = ex;
+
                     return Change.Failed;
                 }
             } else {
@@ -132,7 +147,9 @@ public static class CodexConfigToml {
 
             try {
                 changed = mutate(root);
-            } catch {
+            } catch (Exception ex) {
+                error = ex;
+
                 return Change.Failed;
             }
 
@@ -140,11 +157,16 @@ public static class CodexConfigToml {
 
             try {
                 // First-time users have no ~/.codex; create it before the atomic rename.
-                Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+                // GetDirectoryName is null/empty for a directory-less path — skip the
+                // create in that case (the file lands in the current directory).
+                var dir = Path.GetDirectoryName(configPath);
+                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
                 WriteTomlAtomic(configPath, root);
 
                 return Change.Updated;
-            } catch {
+            } catch (Exception ex) {
+                error = ex;
+
                 return Change.Failed;
             }
         }

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -1,0 +1,253 @@
+using Tomlyn;
+using Tomlyn.Model;
+using Tomlyn.Serialization;
+
+namespace Capacitor.Cli.Core;
+
+/// <summary>
+/// Read-modify-write engine for <c>~/.codex/config.toml</c>. Owns the AOT-safe
+/// Tomlyn plumbing (load, atomic write, untyped-model type info) so both the
+/// daemon's per-worktree pre-trust (<see cref="TrustWorktree"/>) and the setup
+/// wizard's sandbox network-access opt-in (<see cref="EnableNetworkAccess"/>)
+/// share one code path.
+///
+/// Tomlyn's TomlTable mode round-trips preserve all other top-level tables
+/// (model, mcp_servers, plugins, marketplaces, ad-hoc user keys) but DO NOT
+/// preserve comments or original formatting. Acceptable because the file is
+/// largely tool-managed and human edits are expected to be sparse.
+/// </summary>
+public static class CodexConfigToml {
+    static readonly Lock              _writeLock    = new();
+    static readonly TomlTableTypeInfo _tomlTypeInfo = new();
+
+    public enum Change { Unchanged, Updated, Failed }
+
+    static string DefaultConfigPath => Path.Combine(CodexPaths.Home, "config.toml");
+
+    /// <summary>
+    /// AI-794 — enable network access for Codex's <c>workspace-write</c> sandbox so
+    /// kcap skills (which shell out to <c>kcap …</c>) can reach the Capacitor server.
+    /// Codex blocks all sandbox network by default; a constrained
+    /// <c>network_proxy</c> allowlist keeps everything else closed.
+    ///
+    /// The change respects what the user already has (see the truth table below).
+    /// <paramref name="allowDomains"/> is the host allowlist to permit, e.g.
+    /// <c>["**.kcap.ai"]</c> for SaaS plus any self-hosted hosts — build it with
+    /// <see cref="BuildAllowDomains"/>. An empty allowlist is a no-op (enabling the
+    /// proxy with no <c>allow</c> rule would deny everything, breaking kcap too).
+    ///
+    /// <list type="bullet">
+    /// <item>Default config (no network) → set <c>network_access=true</c> +
+    ///   <c>network_proxy.enabled=true</c> + the allowlist. Only the allowlisted
+    ///   hosts become reachable; everything else stays blocked as before.</item>
+    /// <item><c>network_proxy.enabled=true</c> already → merge the allow entries into
+    ///   the user's <c>domains</c> (theirs preserved) and ensure
+    ///   <c>network_access=true</c>.</item>
+    /// <item><c>network_access=true</c>, no active proxy (fully open) → no-op; kcap
+    ///   already works and pinning a proxy would only narrow their access.</item>
+    /// </list>
+    /// </summary>
+    public static Change EnableNetworkAccess(IReadOnlyCollection<string> allowDomains, string? configPath = null) =>
+        allowDomains.Count == 0
+            ? Change.Unchanged
+            : Update(configPath ?? DefaultConfigPath, root => MutateNetworkAccess(root, allowDomains));
+
+    /// <summary>
+    /// Writes the per-worktree pre-trust entry:
+    /// <code>
+    /// [projects."/abs/worktree/path"]
+    /// trust_level = "trusted"
+    /// </code>
+    /// </summary>
+    public static Change TrustWorktree(string worktreePath, string? configPath = null) =>
+        Update(configPath ?? DefaultConfigPath, root => MutateTrust(root, worktreePath));
+
+    /// <summary>
+    /// Builds the Codex proxy allowlist from a set of Capacitor server URLs (the
+    /// active one plus every configured profile). Any host under <c>kcap.ai</c>
+    /// collapses to a single <c>**.kcap.ai</c> wildcard — it matches the apex and
+    /// every subdomain, so all SaaS tenants (current and future) and the auth proxy
+    /// (<c>auth.kcap.ai</c>) are covered without per-tenant maintenance. Self-hosted
+    /// hosts are added as exact entries. Output is deterministic (wildcard first,
+    /// then hosts sorted) so repeated writes are idempotent.
+    /// </summary>
+    public static IReadOnlyList<string> BuildAllowDomains(IEnumerable<string?> serverUrls) {
+        var hosts              = new List<string>();
+        var seen               = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var includeKcapWildcard = false;
+
+        foreach (var url in serverUrls) {
+            var host = TryGetHost(url);
+            if (host is null) continue;
+
+            if (host.Equals("kcap.ai", StringComparison.OrdinalIgnoreCase) ||
+                host.EndsWith(".kcap.ai", StringComparison.OrdinalIgnoreCase)) {
+                includeKcapWildcard = true;
+            } else if (seen.Add(host)) {
+                hosts.Add(host);
+            }
+        }
+
+        hosts.Sort(StringComparer.Ordinal);
+
+        if (includeKcapWildcard) hosts.Insert(0, "**.kcap.ai");
+
+        return hosts;
+    }
+
+    static string? TryGetHost(string? url) {
+        if (string.IsNullOrWhiteSpace(url)) return null;
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var abs) && !string.IsNullOrEmpty(abs.Host))
+            return abs.Host;
+
+        // Bare host[:port] without a scheme (self-hosted shorthand).
+        return Uri.TryCreate("https://" + url, UriKind.Absolute, out var withScheme) && !string.IsNullOrEmpty(withScheme.Host)
+            ? withScheme.Host
+            : null;
+    }
+
+    /// <summary>
+    /// Load → mutate → atomic-write. <paramref name="mutate"/> returns true when it
+    /// changed <paramref name="root"/>. Returns <see cref="Change.Failed"/> on a
+    /// parse error (we never clobber a config we can't read) or a write error,
+    /// <see cref="Change.Unchanged"/> when nothing changed, otherwise
+    /// <see cref="Change.Updated"/>.
+    /// </summary>
+    static Change Update(string configPath, Func<TomlTable, bool> mutate) {
+        lock (_writeLock) {
+            TomlTable root;
+
+            if (File.Exists(configPath)) {
+                try {
+                    root = TomlSerializer.Deserialize(File.ReadAllText(configPath), _tomlTypeInfo.TableInfo) ?? new TomlTable();
+                } catch {
+                    return Change.Failed;
+                }
+            } else {
+                root = new TomlTable();
+            }
+
+            bool changed;
+
+            try {
+                changed = mutate(root);
+            } catch {
+                return Change.Failed;
+            }
+
+            if (!changed) return Change.Unchanged;
+
+            try {
+                // First-time users have no ~/.codex; create it before the atomic rename.
+                Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+                WriteTomlAtomic(configPath, root);
+
+                return Change.Updated;
+            } catch {
+                return Change.Failed;
+            }
+        }
+    }
+
+    static bool MutateTrust(TomlTable root, string worktreePath) {
+        var projects = GetOrAddTable(root, "projects");
+        var entry    = GetOrAddTable(projects, worktreePath);
+
+        if (entry.TryGetValue("trust_level", out var existing) &&
+            existing is string s && string.Equals(s, "trusted", StringComparison.Ordinal))
+            return false;
+
+        entry["trust_level"] = "trusted";
+
+        return true;
+    }
+
+    static bool MutateNetworkAccess(TomlTable root, IReadOnlyCollection<string> allowDomains) {
+        // Inspect current state WITHOUT mutating, so the "fully open" branch can
+        // bail out without having created empty tables.
+        var sandbox   = root.TryGetValue("sandbox_workspace_write", out var sObj) ? sObj as TomlTable : null;
+        var networkOn = sandbox is not null && sandbox.TryGetValue("network_access", out var na) && na is true;
+
+        var features     = root.TryGetValue("features", out var fObj) ? fObj as TomlTable : null;
+        var proxy        = features is not null && features.TryGetValue("network_proxy", out var pObj) ? pObj as TomlTable : null;
+        var proxyEnabled = proxy is not null && proxy.TryGetValue("enabled", out var pe) && pe is true;
+
+        if (proxyEnabled) {
+            // The user runs an allowlist policy — extend it with our hosts and make
+            // sure network access is granted, preserving their existing entries.
+            var changed = MergeAllowDomains(GetOrAddTable(proxy!, "domains"), allowDomains);
+
+            if (!networkOn) {
+                GetOrAddTable(root, "sandbox_workspace_write")["network_access"] = true;
+                changed = true;
+            }
+
+            return changed;
+        }
+
+        // Fully open (network on, no active proxy): kcap already works; don't narrow it.
+        if (networkOn) return false;
+
+        // Default (network off, no active proxy): enable + tight kcap-only allowlist.
+        GetOrAddTable(root, "sandbox_workspace_write")["network_access"] = true;
+
+        var networkProxy = GetOrAddTable(GetOrAddTable(root, "features"), "network_proxy");
+        networkProxy["enabled"] = true;
+        MergeAllowDomains(GetOrAddTable(networkProxy, "domains"), allowDomains);
+
+        return true;
+    }
+
+    static bool MergeAllowDomains(TomlTable domains, IReadOnlyCollection<string> allowDomains) {
+        var changed = false;
+
+        foreach (var domain in allowDomains) {
+            if (domains.TryGetValue(domain, out var v) && v is string s && string.Equals(s, "allow", StringComparison.Ordinal))
+                continue;
+
+            domains[domain] = "allow";
+            changed         = true;
+        }
+
+        return changed;
+    }
+
+    static TomlTable GetOrAddTable(TomlTable parent, string key) {
+        if (parent.TryGetValue(key, out var existing) && existing is TomlTable table) return table;
+
+        var created = new TomlTable();
+        parent[key] = created;
+
+        return created;
+    }
+
+    static void WriteTomlAtomic(string path, TomlTable root) {
+        var tmp = path + ".tmp-" + Environment.ProcessId + "-" + Guid.NewGuid().ToString("N");
+        File.WriteAllText(tmp, TomlSerializer.Serialize(root, _tomlTypeInfo.TableInfo));
+
+        try {
+            File.Move(tmp, path, overwrite: true);
+        } catch {
+            try { File.Delete(tmp); } catch {
+                /* best-effort */
+            }
+
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// AOT-safe accessor for <see cref="TomlTypeInfo{T}"/> of <see cref="TomlTable"/>.
+    /// <see cref="TomlSerializerContext.GetBuiltInTypeInfo{T}"/> is protected, so a thin
+    /// subclass surfaces the built-in untyped-model metadata without reflection.
+    /// </summary>
+    sealed class TomlTableTypeInfo : TomlSerializerContext {
+        static readonly TomlSerializerOptions DefaultOptions = new();
+
+        public readonly TomlTypeInfo<TomlTable> TableInfo = GetBuiltInTypeInfo<TomlTable>(DefaultOptions)!;
+
+        public override TomlTypeInfo? GetTypeInfo(Type type, TomlSerializerOptions options) =>
+            type == typeof(TomlTable) ? TableInfo : null;
+    }
+}

--- a/src/Capacitor.Cli.Core/Resources/help-plugin.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-plugin.txt
@@ -40,6 +40,14 @@ Options:
   --skills            Install only the agent-agnostic skills to ~/.agents/skills/.
                       Use this if you only have Cursor (or another agent that
                       reads ~/.agents/skills/) and don't want Codex hooks.
+  --skip-codex-network-access
+                      With --codex: skip enabling Codex sandbox network access.
+                      By default `install --codex` also allows Codex's
+                      workspace-write sandbox to reach your configured Capacitor
+                      server(s) (a network_proxy allowlist in
+                      ~/.codex/config.toml) so kcap skills work. The
+                      --if-installed refresh path never touches this, so the npm
+                      postinstall hook leaves config.toml alone.
   --if-installed      Refresh-only mode: no-op unless the user has previously
                       installed the target (marker file or pre-marker entry
                       detected). Used by the npm postinstall hook to refresh

--- a/src/Capacitor.Cli.Core/Resources/help-setup.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-setup.txt
@@ -16,6 +16,15 @@ Options:
                               the claude CLI is detected on PATH.
   --skip-codex-hooks          Don't install Codex CLI hooks/skills even if
                               the codex CLI is detected on PATH.
+  --skip-codex-network-access Don't enable Codex sandbox network access. By
+                              default, after installing Codex hooks the wizard
+                              also allows Codex's workspace-write sandbox to
+                              reach your Capacitor server(s) so kcap skills
+                              (recap, errors, …) work — Codex blocks sandbox
+                              network by default. Writes a network_proxy
+                              allowlist to ~/.codex/config.toml limited to your
+                              server(s) (**.kcap.ai for SaaS). Use this flag to
+                              leave ~/.codex/config.toml untouched.
   --skip-cursor-hooks         Don't install Cursor hooks even if the Cursor
                               user-dir is detected (~/.cursor/).
   --skip-copilot-hooks        Don't install Copilot CLI hooks even if Copilot

--- a/src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj
+++ b/src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj
@@ -35,7 +35,6 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="Microsoft.Extensions.Http" />
-        <PackageReference Include="Tomlyn" />
     </ItemGroup>
 
     <!-- NativeAOT on macOS needs Homebrew library paths for keg-only packages (openssl, brotli) -->

--- a/src/Capacitor.Cli.Daemon/Services/CodexConfigWriter.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexConfigWriter.cs
@@ -1,98 +1,19 @@
 using Capacitor.Cli.Core;
 using Microsoft.Extensions.Logging;
-using Tomlyn;
-using Tomlyn.Model;
-using Tomlyn.Serialization;
 
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// Writes the per-worktree pre-trust entry into <c>~/.codex/config.toml</c>:
-/// <code>
-/// [projects."/abs/worktree/path"]
-/// trust_level = "trusted"
-/// </code>
-/// Tomlyn's TomlTable mode round-trips preserve all other top-level tables
-/// (model, mcp_servers, plugins, marketplaces, ad-hoc user keys) but DO NOT
-/// preserve user comments or original formatting. This is acceptable because
-/// the file is daemon-managed and human edits are expected to be sparse.
+/// Daemon-facing wrapper around <see cref="CodexConfigToml.TrustWorktree"/> that
+/// pre-trusts a worktree in <c>~/.codex/config.toml</c> so Codex doesn't prompt on
+/// every hook execution. The read-modify-write plumbing lives in Core; this layer
+/// only adds the daemon's structured logging on failure.
 /// </summary>
 internal static class CodexConfigWriter {
-    static readonly Lock              _writeLock    = new();
-    static readonly TomlTableTypeInfo _tomlTypeInfo = new();
-
     public static void TrustWorktree(string worktreePath, ILogger logger) {
-        lock (_writeLock) {
-            var configPath = Path.Combine(CodexPaths.Home, "config.toml");
-
-            TomlTable root;
-
-            if (File.Exists(configPath)) {
-                try {
-                    root = TomlSerializer.Deserialize(File.ReadAllText(configPath), _tomlTypeInfo.TableInfo) ?? [];
-                } catch (Exception ex) {
-                    logger.LogWarning(ex, "Failed to parse {Path}; aborting pre-trust", configPath);
-
-                    return;
-                }
-            } else {
-                root = new TomlTable();
-            }
-
-            if (!root.TryGetValue("projects", out var projectsObj) || projectsObj is not TomlTable projects) {
-                projects         = new TomlTable();
-                root["projects"] = projects;
-            }
-
-            if (!projects.TryGetValue(worktreePath, out var entryObj) || entryObj is not TomlTable entry) {
-                entry                  = new TomlTable();
-                projects[worktreePath] = entry;
-            }
-
-            var alreadyTrusted = entry.TryGetValue("trust_level", out var existing) &&
-                existing is string s                                                &&
-                string.Equals(s, "trusted", StringComparison.Ordinal);
-
-            if (alreadyTrusted) return;
-
-            entry["trust_level"] = "trusted";
-
-            try {
-                // First-time users have no ~/.codex; create it before the atomic rename.
-                Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
-                WriteTomlAtomic(configPath, root);
-            } catch (Exception ex) {
-                logger.LogWarning(ex, "Failed to write {Path}; pre-trust not persisted", configPath);
-            }
-        }
-    }
-
-    static void WriteTomlAtomic(string path, TomlTable root) {
-        var tmp = path + ".tmp-" + Environment.ProcessId + "-" + Guid.NewGuid().ToString("N");
-        File.WriteAllText(tmp, TomlSerializer.Serialize(root, _tomlTypeInfo.TableInfo));
-
-        try {
-            File.Move(tmp, path, overwrite: true);
-        } catch {
-            try { File.Delete(tmp); } catch {
-                /* best-effort */
-            }
-
-            throw;
-        }
-    }
-
-    /// <summary>
-    /// AOT-safe accessor for <see cref="TomlTypeInfo{T}"/> of <see cref="TomlTable"/>.
-    /// <see cref="TomlSerializerContext.GetBuiltInTypeInfo{T}"/> is protected, so a thin
-    /// subclass is used to surface the built-in untyped-model metadata without reflection.
-    /// </summary>
-    sealed class TomlTableTypeInfo : TomlSerializerContext {
-        static readonly TomlSerializerOptions DefaultOptions = new();
-
-        public readonly TomlTypeInfo<TomlTable> TableInfo = GetBuiltInTypeInfo<TomlTable>(DefaultOptions)!;
-
-        public override TomlTypeInfo? GetTypeInfo(Type type, TomlSerializerOptions options) =>
-            type == typeof(TomlTable) ? TableInfo : null;
+        if (CodexConfigToml.TrustWorktree(worktreePath) == CodexConfigToml.Change.Failed)
+            logger.LogWarning(
+                "Failed to read/write {Path}; Codex worktree pre-trust not persisted",
+                Path.Combine(CodexPaths.Home, "config.toml"));
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/CodexConfigWriter.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexConfigWriter.cs
@@ -11,8 +11,9 @@ namespace Capacitor.Cli.Daemon.Services;
 /// </summary>
 internal static class CodexConfigWriter {
     public static void TrustWorktree(string worktreePath, ILogger logger) {
-        if (CodexConfigToml.TrustWorktree(worktreePath) == CodexConfigToml.Change.Failed)
+        if (CodexConfigToml.TrustWorktree(worktreePath, out var error) == CodexConfigToml.Change.Failed)
             logger.LogWarning(
+                error,
                 "Failed to read/write {Path}; Codex worktree pre-trust not persisted",
                 Path.Combine(CodexPaths.Home, "config.toml"));
     }

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -29,7 +29,8 @@ internal static class CodingAgentsStep {
             string  LegacyCodexSkillsDir,
             string  KiroHooksPath = "",
             string  PiExtensionPath = "",
-            string  OpenCodeExtensionPath = ""
+            string  OpenCodeExtensionPath = "",
+            string  CodexConfigTomlPath = ""
         );
 
     internal record Installers(
@@ -86,7 +87,7 @@ internal static class CodingAgentsStep {
         var claudeInstalled       = HandleClaude(options, detected, paths, installers, prompt, writeLine);
         var codexHooksInstalled   = HandleCodexHooks(options, detected, paths, installers, prompt, writeLine);
         var codexSkillsInstalled  = codexHooksInstalled && HandleCodexSkills(paths, installers, writeLine);
-        var codexNetworkApplied   = HandleCodexNetworkAccess(options, installers, prompt, writeLine, codexHooksInstalled);
+        var codexNetworkApplied   = HandleCodexNetworkAccess(options, paths, installers, prompt, writeLine, codexHooksInstalled);
         var cursorHooksInstalled  = HandleCursorHooks(options, detected, paths, installers, prompt, writeLine);
         var copilotHooksInstalled = HandleCopilotHooks(options, detected, paths, installers, prompt, writeLine);
         var geminiHooksInstalled  = HandleGeminiHooks(options, detected, paths, installers, prompt, writeLine);
@@ -466,6 +467,7 @@ internal static class CodingAgentsStep {
     /// </summary>
     static bool HandleCodexNetworkAccess(
             Options            options,
+            Paths              paths,
             Installers         installers,
             Func<string, bool> prompt,
             Action<string>     writeLine,
@@ -490,9 +492,11 @@ internal static class CodingAgentsStep {
             return false;
         }
 
+        var configPath = Markup.Escape(paths.CodexConfigTomlPath);
+
         switch (installers.EnableCodexNetworkAccess()) {
             case CodexConfigToml.Change.Updated:
-                writeLine("  [green]✓[/] Codex sandbox network access enabled for kcap ([dim]~/.codex/config.toml[/])");
+                writeLine($"  [green]✓[/] Codex sandbox network access enabled for kcap ([dim]{configPath}[/])");
 
                 return true;
             case CodexConfigToml.Change.Unchanged:
@@ -500,7 +504,7 @@ internal static class CodingAgentsStep {
 
                 return false;
             default:
-                writeLine("  [yellow]⚠[/] Could not update ~/.codex/config.toml — enable Codex sandbox network access manually (see README).");
+                writeLine($"  [yellow]⚠[/] Could not update {configPath} — enable Codex sandbox network access manually (see README).");
 
                 return false;
         }

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core;
 using Spectre.Console;
 
 namespace Capacitor.Cli.Commands;
@@ -12,7 +13,7 @@ internal static class CodingAgentsStep {
     // sites and the broad CodingAgentsStep test suite compile unchanged. Gemini
     // (AI-887), Kiro (AI-888), and Pi (AI-886) were all added after the original
     // four vendors.
-    internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool SkipCopilot, bool NoPrompt, bool SkipGemini = false, bool SkipKiro = false, bool SkipPi = false, bool SkipOpenCode = false);
+    internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool SkipCopilot, bool NoPrompt, bool SkipGemini = false, bool SkipKiro = false, bool SkipPi = false, bool SkipOpenCode = false, bool SkipCodexNetworkAccess = false);
 
     internal record DetectedAgents(bool Claude, bool Codex, bool Cursor, bool Copilot, bool Gemini = false, bool Kiro = false, bool Pi = false, bool OpenCode = false);
 
@@ -42,7 +43,8 @@ internal static class CodingAgentsStep {
             Func<string /*legacyDir*/, bool>                          CleanLegacyCodexSkills,
             Func<string /*agentJsonPath*/, bool>?                     InstallKiroHooks = null,
             Func<string /*extensionPath*/, bool>?                     InstallPiExtension = null,
-            Func<string /*pluginPath*/, bool>?                        InstallOpenCodeExtension = null
+            Func<string /*pluginPath*/, bool>?                        InstallOpenCodeExtension = null,
+            Func<CodexConfigToml.Change>?                            EnableCodexNetworkAccess = null
         );
 
     internal record Result(
@@ -54,7 +56,8 @@ internal static class CodingAgentsStep {
             bool GeminiHooksInstalled = false,
             bool KiroHooksInstalled = false,
             bool PiExtensionInstalled = false,
-            bool OpenCodeExtensionInstalled = false
+            bool OpenCodeExtensionInstalled = false,
+            bool CodexNetworkAccessApplied = false
         ) {
         /// <summary>
         /// True when at least one agent's hooks were installed — i.e. there's a
@@ -83,6 +86,7 @@ internal static class CodingAgentsStep {
         var claudeInstalled       = HandleClaude(options, detected, paths, installers, prompt, writeLine);
         var codexHooksInstalled   = HandleCodexHooks(options, detected, paths, installers, prompt, writeLine);
         var codexSkillsInstalled  = codexHooksInstalled && HandleCodexSkills(paths, installers, writeLine);
+        var codexNetworkApplied   = HandleCodexNetworkAccess(options, installers, prompt, writeLine, codexHooksInstalled);
         var cursorHooksInstalled  = HandleCursorHooks(options, detected, paths, installers, prompt, writeLine);
         var copilotHooksInstalled = HandleCopilotHooks(options, detected, paths, installers, prompt, writeLine);
         var geminiHooksInstalled  = HandleGeminiHooks(options, detected, paths, installers, prompt, writeLine);
@@ -104,7 +108,8 @@ internal static class CodingAgentsStep {
                 geminiHooksInstalled,
                 kiroHooksInstalled,
                 piExtensionInstalled,
-                openCodeExtensionInstalled
+                openCodeExtensionInstalled,
+                codexNetworkApplied
             )
         );
     }
@@ -450,6 +455,55 @@ internal static class CodingAgentsStep {
         writeLine("  [dim]  accept once to trust them all (or run /hooks inside Codex to trust them individually).[/]");
 
         return true;
+    }
+
+    /// <summary>
+    /// AI-794 — Codex runs the agent's shell tool in a network-blocked sandbox, so kcap
+    /// skills (which shell out to <c>kcap …</c>) can't reach the Capacitor server. After
+    /// Codex hooks install, offer to enable sandbox network access for the configured
+    /// server(s) via <see cref="Installers.EnableCodexNetworkAccess"/>. Gated on hooks
+    /// actually installing — there's nothing to fix if the Codex integration is off.
+    /// </summary>
+    static bool HandleCodexNetworkAccess(
+            Options            options,
+            Installers         installers,
+            Func<string, bool> prompt,
+            Action<string>     writeLine,
+            bool               codexHooksInstalled
+        ) {
+        if (!codexHooksInstalled || installers.EnableCodexNetworkAccess is null) return false;
+
+        if (options.SkipCodexNetworkAccess) {
+            writeLine("  [dim]· Codex sandbox network access left unchanged (--skip-codex-network-access)[/]");
+
+            return false;
+        }
+
+        writeLine("  [dim]  kcap skills (recap, errors, …) run in Codex's sandbox, which blocks network by default.[/]");
+
+        var shouldApply = options.NoPrompt
+            || prompt("Allow Codex's sandbox to reach your Capacitor server(s) so kcap skills work?");
+
+        if (!shouldApply) {
+            writeLine("  [dim]· Codex sandbox network access not changed — kcap skills may prompt for escalation (see README)[/]");
+
+            return false;
+        }
+
+        switch (installers.EnableCodexNetworkAccess()) {
+            case CodexConfigToml.Change.Updated:
+                writeLine("  [green]✓[/] Codex sandbox network access enabled for kcap ([dim]~/.codex/config.toml[/])");
+
+                return true;
+            case CodexConfigToml.Change.Unchanged:
+                writeLine("  [dim]· Codex sandbox already allows network access — no change needed[/]");
+
+                return false;
+            default:
+                writeLine("  [yellow]⚠[/] Could not update ~/.codex/config.toml — enable Codex sandbox network access manually (see README).");
+
+                return false;
+        }
     }
 
     static bool HandleCursorHooks(

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -448,14 +448,14 @@ public static class PluginCommand {
 
         switch (CodexConfigToml.EnableNetworkAccess(domains, env.CodexConfigTomlPath)) {
             case CodexConfigToml.Change.Updated:
-                await env.Stdout.WriteLineAsync("Codex sandbox network access enabled for kcap (~/.codex/config.toml).");
+                await env.Stdout.WriteLineAsync($"Codex sandbox network access enabled for kcap ({env.CodexConfigTomlPath}).");
                 break;
             case CodexConfigToml.Change.Unchanged:
                 await env.Stdout.WriteLineAsync("Codex sandbox already allows network access — no change needed.");
                 break;
             default:
                 await env.Stderr.WriteLineAsync(
-                    "Warning: could not update ~/.codex/config.toml — enable Codex sandbox network access manually (see README).");
+                    $"Warning: could not update {env.CodexConfigTomlPath} — enable Codex sandbox network access manually (see README).");
                 break;
         }
     }

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Copilot;
 using Capacitor.Cli.Core.Cursor;
 using Capacitor.Cli.Core.Gemini;
@@ -413,6 +414,12 @@ public static class PluginCommand {
 
         AgentsSkillsInstaller.CleanLegacyCodexSkills(env.LegacyCodexSkills);
 
+        // AI-794 — enable Codex sandbox network access so the skills just installed can
+        // reach the Capacitor server. Opt out with --skip-codex-network-access. The
+        // --if-installed refresh path returns earlier, so npm postinstall never flips this.
+        if (!args.Contains("--skip-codex-network-access"))
+            await EnableCodexNetworkAccessAsync(env);
+
         if (scope == "project") {
             await env.Stdout.WriteLineAsync(
                 "Note: Codex requires the project's .codex directory to be trusted. " +
@@ -421,6 +428,36 @@ public static class PluginCommand {
         }
 
         return 0;
+    }
+
+    /// <summary>
+    /// AI-794 — turn on Codex's <c>workspace-write</c> sandbox network access, constrained
+    /// to the Capacitor server(s) of every configured profile, so kcap skills can reach the
+    /// server. Never fails the install: a write error is a warning, not an error code.
+    /// </summary>
+    static async Task EnableCodexNetworkAccessAsync(PluginEnvironment env) {
+        var profiles = await AppConfig.LoadProfileConfig();
+        var domains  = CodexConfigToml.BuildAllowDomains(profiles.Profiles.Values.Select(p => p.ServerUrl));
+
+        if (domains.Count == 0) {
+            await env.Stdout.WriteLineAsync(
+                "No Capacitor server configured yet — run `kcap setup` to allow Codex network access for kcap skills.");
+
+            return;
+        }
+
+        switch (CodexConfigToml.EnableNetworkAccess(domains, env.CodexConfigTomlPath)) {
+            case CodexConfigToml.Change.Updated:
+                await env.Stdout.WriteLineAsync("Codex sandbox network access enabled for kcap (~/.codex/config.toml).");
+                break;
+            case CodexConfigToml.Change.Unchanged:
+                await env.Stdout.WriteLineAsync("Codex sandbox already allows network access — no change needed.");
+                break;
+            default:
+                await env.Stderr.WriteLineAsync(
+                    "Warning: could not update ~/.codex/config.toml — enable Codex sandbox network access manually (see README).");
+                break;
+        }
     }
 
     static async Task<int> RemoveCodex(string[] args, PluginEnvironment env) {

--- a/src/Capacitor.Cli/Commands/PluginEnvironment.cs
+++ b/src/Capacitor.Cli/Commands/PluginEnvironment.cs
@@ -29,6 +29,7 @@ public sealed record PluginEnvironment(
     public string ClaudeUserSettings  => Path.Combine(ClaudeHome, "settings.json");
     public string CodexHome           => Path.Combine(HomeDirectory, ".codex");
     public string CodexUserHooksJson  => Path.Combine(CodexHome, "hooks.json");
+    public string CodexConfigTomlPath => Path.Combine(CodexHome, "config.toml");
     public string CursorUserHooksJson => CursorPaths.UserHooksJson(HomeDirectory);
     public string CopilotKcapHooksJson => CopilotPaths.KcapHooksJson(HomeDirectory);
     public string GeminiSettingsJson   => GeminiPaths.SettingsJson(HomeDirectory);

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -26,6 +26,7 @@ public static class SetupCommand {
         var forceDevice      = args.Contains("--device");
         var skipClaudeFlag   = args.Contains("--skip-claude-hooks");
         var skipCodexFlag    = args.Contains("--skip-codex-hooks");
+        var skipCodexNetworkFlag = args.Contains("--skip-codex-network-access");
         var skipCursorFlag   = args.Contains("--skip-cursor-hooks");
         var skipCopilotFlag  = args.Contains("--skip-copilot-hooks");
         var skipGeminiFlag   = args.Contains("--skip-gemini-hooks");
@@ -224,7 +225,16 @@ public static class SetupCommand {
             SkipKiro:    skipKiroFlag,
             SkipPi:      skipPiFlag,
             SkipOpenCode: skipOpenCodeFlag,
-            NoPrompt:    noPrompt);
+            NoPrompt:    noPrompt,
+            SkipCodexNetworkAccess: skipCodexNetworkFlag);
+
+        // AI-794 — allowlist the Capacitor server(s) Codex skills need to reach. A single
+        // **.kcap.ai wildcard covers every SaaS tenant (current + future) and the auth
+        // proxy; self-hosted servers are added as exact hosts. Derived from the active
+        // server URL plus every configured profile so switching profiles still works.
+        var profilesForDomains = await AppConfig.LoadProfileConfig();
+        var codexAllowDomains  = CodexConfigToml.BuildAllowDomains(
+            new[] { serverUrl }.Concat(profilesForDomains.Profiles.Values.Select(p => p.ServerUrl)));
 
         var stepPaths = new CodingAgentsStep.Paths(
             ClaudeSettingsPath:   claudeSettingsPath,
@@ -251,7 +261,8 @@ public static class SetupCommand {
             CleanLegacyCodexSkills: legacyDir => AgentsSkillsInstaller.CleanLegacyCodexSkills(legacyDir).RemovedAny,
             InstallKiroHooks:       PluginCommand.InstallKiroHooks,
             InstallPiExtension:     PiExtensionInstaller.Install,
-            InstallOpenCodeExtension: OpenCodeExtensionInstaller.Install);
+            InstallOpenCodeExtension: OpenCodeExtensionInstaller.Install,
+            EnableCodexNetworkAccess: () => CodexConfigToml.EnableNetworkAccess(codexAllowDomains));
 
         bool PromptYesNo(string text) =>
             AnsiConsole.Prompt(new ConfirmationPrompt(text) { DefaultValue = true });

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -248,7 +248,8 @@ public static class SetupCommand {
             LegacyCodexSkillsDir: Path.Combine(CodexPaths.Home, "skills"),
             KiroHooksPath:        KiroPaths.KcapAgentJson(),
             PiExtensionPath:      PiPaths.KcapExtension(),
-            OpenCodeExtensionPath: OpenCodePaths.KcapPlugin());
+            OpenCodeExtensionPath: OpenCodePaths.KcapPlugin(),
+            CodexConfigTomlPath:  Path.Combine(CodexPaths.Home, "config.toml"));
 
         var stepInstallers = new CodingAgentsStep.Installers(
             InstallClaudePlugin:    InstallPlugin,

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
@@ -1,0 +1,183 @@
+using Capacitor.Cli.Core;
+using Tomlyn;
+using Tomlyn.Model;
+
+namespace Capacitor.Cli.Tests.Unit.Codex;
+
+// EnableNetworkAccess/TrustWorktree take an explicit config path, so these tests
+// use a temp file and never touch HOME — safe to run in parallel.
+public class CodexConfigTomlTests {
+    static string TempConfig() =>
+        Path.Combine(Directory.CreateTempSubdirectory("kcap-codextoml-").FullName, "config.toml");
+
+    static TomlTable ReadToml(string path) =>
+        TomlSerializer.Deserialize<TomlTable>(File.ReadAllText(path))!;
+
+    // ── BuildAllowDomains ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task BuildAllowDomains_collapses_kcap_ai_tenants_to_one_wildcard() {
+        var domains = CodexConfigToml.BuildAllowDomains([
+            "https://acme.kcap.ai", "https://globex.kcap.ai"
+        ]);
+
+        await Assert.That(domains).IsEquivalentTo(new[] { "**.kcap.ai" });
+    }
+
+    [Test]
+    public async Task BuildAllowDomains_keeps_self_hosted_hosts_exact_and_sorted_after_wildcard() {
+        var domains = CodexConfigToml.BuildAllowDomains([
+            "https://team.kcap.ai", "https://kcap.internal.corp", "https://capacitor.example.com"
+        ]);
+
+        // Wildcard first (kcap.ai tenant present), then self-hosted hosts sorted.
+        await Assert.That(domains).IsEquivalentTo(new[] {
+            "**.kcap.ai", "capacitor.example.com", "kcap.internal.corp"
+        });
+    }
+
+    [Test]
+    public async Task BuildAllowDomains_pure_self_hosted_has_no_kcap_wildcard() {
+        var domains = CodexConfigToml.BuildAllowDomains([
+            "https://capacitor.example.com:8443"
+        ]);
+
+        await Assert.That(domains).IsEquivalentTo(new[] { "capacitor.example.com" });
+    }
+
+    [Test]
+    public async Task BuildAllowDomains_skips_null_blank_and_dedupes() {
+        var domains = CodexConfigToml.BuildAllowDomains([
+            null, "", "  ", "https://capacitor.example.com", "https://capacitor.example.com"
+        ]);
+
+        await Assert.That(domains).IsEquivalentTo(new[] { "capacitor.example.com" });
+    }
+
+    [Test]
+    public async Task BuildAllowDomains_accepts_bare_host_without_scheme() {
+        var domains = CodexConfigToml.BuildAllowDomains(["my-tenant.kcap.ai", "self.example.com"]);
+
+        await Assert.That(domains).IsEquivalentTo(new[] { "**.kcap.ai", "self.example.com" });
+    }
+
+    // ── EnableNetworkAccess: default config ──────────────────────────────────
+
+    [Test]
+    public async Task EnableNetworkAccess_on_missing_config_writes_access_and_proxy_allowlist() {
+        var path = TempConfig();
+
+        var change = CodexConfigToml.EnableNetworkAccess(["**.kcap.ai"], path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
+
+        var root  = ReadToml(path);
+        var sww   = (TomlTable)root["sandbox_workspace_write"];
+        await Assert.That((bool)sww["network_access"]).IsTrue();
+
+        var proxy = (TomlTable)((TomlTable)root["features"])["network_proxy"];
+        await Assert.That((bool)proxy["enabled"]).IsTrue();
+        await Assert.That((string)((TomlTable)proxy["domains"])["**.kcap.ai"]).IsEqualTo("allow");
+    }
+
+    [Test]
+    public async Task EnableNetworkAccess_is_idempotent() {
+        var path = TempConfig();
+
+        var first  = CodexConfigToml.EnableNetworkAccess(["**.kcap.ai"], path);
+        var second = CodexConfigToml.EnableNetworkAccess(["**.kcap.ai"], path);
+
+        await Assert.That(first).IsEqualTo(CodexConfigToml.Change.Updated);
+        await Assert.That(second).IsEqualTo(CodexConfigToml.Change.Unchanged);
+    }
+
+    [Test]
+    public async Task EnableNetworkAccess_empty_allowlist_is_noop() {
+        var path = TempConfig();
+
+        var change = CodexConfigToml.EnableNetworkAccess([], path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Unchanged);
+        await Assert.That(File.Exists(path)).IsFalse();
+    }
+
+    // ── EnableNetworkAccess: respect existing config ─────────────────────────
+
+    [Test]
+    public async Task EnableNetworkAccess_fully_open_no_proxy_is_left_untouched() {
+        var path = TempConfig();
+        File.WriteAllText(path,
+            """
+            [sandbox_workspace_write]
+            network_access = true
+            """);
+        var before = File.ReadAllText(path);
+
+        var change = CodexConfigToml.EnableNetworkAccess(["**.kcap.ai"], path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Unchanged);
+        await Assert.That(File.ReadAllText(path)).IsEqualTo(before);
+    }
+
+    [Test]
+    public async Task EnableNetworkAccess_merges_into_existing_proxy_preserving_user_entries() {
+        var path = TempConfig();
+        File.WriteAllText(path,
+            """
+            model = "gpt-5.5"
+
+            [sandbox_workspace_write]
+            network_access = true
+
+            [features.network_proxy]
+            enabled = true
+
+            [features.network_proxy.domains]
+            "github.com" = "allow"
+            """);
+
+        var change = CodexConfigToml.EnableNetworkAccess(["**.kcap.ai", "self.example.com"], path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
+
+        var root    = ReadToml(path);
+        await Assert.That((string)root["model"]).IsEqualTo("gpt-5.5");
+
+        var domains = (TomlTable)((TomlTable)((TomlTable)root["features"])["network_proxy"])["domains"];
+        await Assert.That((string)domains["github.com"]).IsEqualTo("allow");     // user's preserved
+        await Assert.That((string)domains["**.kcap.ai"]).IsEqualTo("allow");     // ours added
+        await Assert.That((string)domains["self.example.com"]).IsEqualTo("allow");
+    }
+
+    [Test]
+    public async Task EnableNetworkAccess_existing_proxy_without_network_access_turns_it_on() {
+        var path = TempConfig();
+        File.WriteAllText(path,
+            """
+            [features.network_proxy]
+            enabled = true
+
+            [features.network_proxy.domains]
+            "github.com" = "allow"
+            """);
+
+        var change = CodexConfigToml.EnableNetworkAccess(["**.kcap.ai"], path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
+
+        var root = ReadToml(path);
+        await Assert.That((bool)((TomlTable)root["sandbox_workspace_write"])["network_access"]).IsTrue();
+    }
+
+    [Test]
+    public async Task EnableNetworkAccess_malformed_config_is_not_overwritten() {
+        var path = TempConfig();
+        const string garbage = "{{{ not valid TOML";
+        File.WriteAllText(path, garbage);
+
+        var change = CodexConfigToml.EnableNetworkAccess(["**.kcap.ai"], path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Failed);
+        await Assert.That(File.ReadAllText(path)).IsEqualTo(garbage);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
@@ -92,6 +92,27 @@ public class CodexConfigTomlTests {
     }
 
     [Test]
+    [NotInParallel("CwdMutation")]
+    public async Task EnableNetworkAccess_writes_when_config_path_has_no_directory_component() {
+        // GetDirectoryName("config.toml") is empty; CreateDirectory("") would throw and
+        // silently turn the write into Change.Failed without the guard.
+        var dir         = Directory.CreateTempSubdirectory("kcap-codextoml-cwd-").FullName;
+        var originalCwd = Environment.CurrentDirectory;
+
+        try {
+            Environment.CurrentDirectory = dir;
+
+            var change = CodexConfigToml.EnableNetworkAccess(["**.kcap.ai"], "config.toml");
+
+            await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
+            await Assert.That(File.Exists(Path.Combine(dir, "config.toml"))).IsTrue();
+        } finally {
+            Environment.CurrentDirectory = originalCwd;
+            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Test]
     public async Task EnableNetworkAccess_empty_allowlist_is_noop() {
         var path = TempConfig();
 

--- a/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core;
 using static Capacitor.Cli.Commands.CodingAgentsStep;
 
 namespace Capacitor.Cli.Tests.Unit;
@@ -241,6 +242,124 @@ public class CodingAgentsStepTests {
         await Assert.That(result.CodexSkillsInstalled).IsFalse();
         await Assert.That(sink.Lines).Contains(l => l.Contains("Codex hooks installed but agent skills"));
         await Assert.That(sink.Lines).Contains(l => l.Contains("/hooks") && l.Contains("trust"));
+    }
+
+    // ── Codex sandbox network access (AI-794) ────────────────────────────────
+
+    [Test]
+    public async Task Codex_network_access_enabled_when_hooks_installed_and_accepted() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.CodexNetworkAccessApplied).IsTrue();
+        await Assert.That(calls.EnableCodexNetworkCalled).IsTrue();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("network access enabled"));
+    }
+
+    [Test]
+    public async Task Codex_network_access_declined_is_not_applied() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
+
+        // Accept the hooks prompt, decline only the network prompt (which is the
+        // one asking to "reach your Capacitor" server).
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: text => !text.Contains("reach your Capacitor"), writeLine: sink.Write);
+
+        await Assert.That(result.CodexHooksInstalled).IsTrue();
+        await Assert.That(result.CodexNetworkAccessApplied).IsFalse();
+        await Assert.That(calls.EnableCodexNetworkCalled).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("network access not changed"));
+    }
+
+    [Test]
+    public async Task Codex_network_access_skipped_by_flag() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false, SkipCodexNetworkAccess: true);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.CodexHooksInstalled).IsTrue();
+        await Assert.That(result.CodexNetworkAccessApplied).IsFalse();
+        await Assert.That(calls.EnableCodexNetworkCalled).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("--skip-codex-network-access"));
+    }
+
+    [Test]
+    public async Task Codex_network_access_unchanged_when_already_enabled() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { EnableCodexNetworkReturns = CodexConfigToml.Change.Unchanged };
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(calls.EnableCodexNetworkCalled).IsTrue();
+        await Assert.That(result.CodexNetworkAccessApplied).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("already allows network access"));
+    }
+
+    [Test]
+    public async Task Codex_network_access_failure_emits_warning() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { EnableCodexNetworkReturns = CodexConfigToml.Change.Failed };
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(calls.EnableCodexNetworkCalled).IsTrue();
+        await Assert.That(result.CodexNetworkAccessApplied).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("Could not update") && l.Contains("config.toml"));
+    }
+
+    [Test]
+    public async Task Codex_network_access_not_attempted_when_hooks_fail() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { CodexHooksReturns = false };
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: false);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.CodexHooksInstalled).IsFalse();
+        await Assert.That(calls.EnableCodexNetworkCalled).IsFalse();
+    }
+
+    [Test]
+    public async Task Codex_network_access_auto_applied_in_no_prompt() {
+        var sink         = new Sink();
+        var calls        = new InstallerCalls();
+        var options      = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected     = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
+        var promptCalled = false;
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => { promptCalled = true; return false; }, writeLine: sink.Write);
+
+        await Assert.That(result.CodexNetworkAccessApplied).IsTrue();
+        await Assert.That(calls.EnableCodexNetworkCalled).IsTrue();
+        await Assert.That(promptCalled).IsFalse();
     }
 
     [Test]
@@ -923,6 +1042,9 @@ public class CodingAgentsStepTests {
         public string? LegacyCleanupArg     { get; private set; }
         public bool    LegacyCleanupReturns { get; set; } = true;
 
+        public bool                   EnableCodexNetworkCalled  { get; private set; }
+        public CodexConfigToml.Change EnableCodexNetworkReturns { get; set; } = CodexConfigToml.Change.Updated;
+
         public Installers AsInstallers() => new(
             InstallClaudePlugin: (s, p) => {
                 ClaudeCalled = true;
@@ -987,6 +1109,11 @@ public class CodingAgentsStepTests {
                 LegacyCleanupArg    = d;
 
                 return LegacyCleanupReturns;
+            },
+            EnableCodexNetworkAccess: () => {
+                EnableCodexNetworkCalled = true;
+
+                return EnableCodexNetworkReturns;
             }
         );
     }

--- a/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
@@ -990,7 +990,8 @@ public class CodingAgentsStepTests {
         LegacyCodexSkillsDir: "/fake/.codex/skills",
         KiroHooksPath:        "/fake/.kiro/agents/kcap.json",
         PiExtensionPath:      "/fake/.pi/agent/extensions/kcap.ts",
-        OpenCodeExtensionPath: "/fake/.config/opencode/plugins/kcap.ts"
+        OpenCodeExtensionPath: "/fake/.config/opencode/plugins/kcap.ts",
+        CodexConfigTomlPath:  "/fake/.codex/config.toml"
     );
 
     sealed class Sink {


### PR DESCRIPTION
## Problem (AI-794)

Codex runs the agent's shell tool in a `workspace-write` sandbox with **network blocked by default**. kcap skills (`kcap-recap`, `kcap-errors`, …) shell out to `kcap …`, which must reach the Capacitor server — so they failed or demanded escalation. (Hooks like `kcap hook --codex` run *outside* the sandbox, which is why recording worked but skills didn't.)

## Fix

`kcap setup` (one prompt after the Codex hooks step) and `kcap plugin install --codex` now write a **constrained** `network_proxy` allowlist to `~/.codex/config.toml` rather than opening the network wholesale:

```toml
[sandbox_workspace_write]
network_access = true          # required — the proxy only enforces, doesn't grant
[features.network_proxy]
enabled = true
[features.network_proxy.domains]
"**.kcap.ai" = "allow"
```

### Multi-tenant
The `**.kcap.ai` wildcard matches the apex + all subdomains, so it covers every SaaS tenant (current **and future**) plus `auth.kcap.ai` in one entry — switching profiles / adding tenants needs no edits. **Self-hosted** servers are added as exact-host entries, derived from every configured profile's `server_url` and refreshed on each `kcap setup`.

### Respecting existing config (the agreed merge table)
| Existing `~/.codex/config.toml` | Action |
|---|---|
| Default (no network) | set `network_access` + proxy + allowlist (tight: only kcap reachable) |
| `network_proxy.enabled` already | merge our `allow` entries into `domains` (user's preserved), ensure `network_access` |
| `network_access=true`, no proxy (fully open) | no-op (kcap already works; pinning a proxy would only narrow access) |

### Behavior
- `--no-prompt` auto-applies when Codex hooks install; `--skip-codex-network-access` opts out (on both `setup` and `plugin install --codex`).
- The npm-postinstall `--if-installed` refresh **never** touches `config.toml`.
- Uninstall leaves these keys in place — they're the user's security posture, not kcap state.
- A localhost dev server additionally needs `allow_local_binding = true`, which kcap does not set (documented).

## Changes
- **New** `Capacitor.Cli.Core/CodexConfigToml.cs` — AOT-safe TOML engine: `EnableNetworkAccess` (merge table), `BuildAllowDomains` (wildcard + self-hosted), `TrustWorktree`. The daemon's `CodexConfigWriter` now delegates to it, removing the duplicated Tomlyn plumbing (daemon's explicit Tomlyn ref dropped; Core provides it).
- Wired into `CodingAgentsStep`/`SetupCommand` and `PluginCommand`; new `--skip-codex-network-access` flag; help-setup/help-plugin + README updated.

## Testing
- 13 new `CodexConfigToml` tests + 7 `CodingAgentsStep` tests. Full unit suite **1778/1778 green**; daemon's 8 trust tests still pass.
- `dotnet publish -c Release` for **both** CLI and daemon: **no IL3050/IL2026 AOT warnings**.
- End-to-end with the AOT binary against a 2-profile (SaaS + self-hosted) config produced exactly the TOML above with both `"**.kcap.ai"` and `"capacitor.example.com"` allowed; a second run was idempotent — confirming Tomlyn serialize works at runtime under AOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)