### PR TITLE
[AI-907] Fix import progress stuck at 0% per session

### DIFF
--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -899,6 +899,7 @@ static class ImportCommand {
         var events = new ChainWorkerEvents {
             OnSessionStarted  = (_, _) => { },    // non-TTY: session start is silent; TTY overrides below
             OnSubagentStarted = (_, _, _) => { }, // non-TTY: subagent start is silent; TTY overrides below
+            OnSessionProgress = (_, _, _) => { }, // non-TTY: no live per-session bar; TTY overrides below
             OnSubagentFinished = (_, _, aid, lines) => display.Line(
                 $"  ↳ imported subagent {aid} ({lines} lines)",
                 $"  [dim]↳[/] imported subagent [cyan]{Markup.Escape(aid)}[/] ({lines} lines)"
@@ -1014,10 +1015,12 @@ static class ImportCommand {
                     .StartAsync(async ctx => {
                             var bar = ctx.AddTask("[green]Importing[/]", maxValue: chains.Sum(c => c.Count));
 
-                            // Four description-only progress tasks rendered as live "slot rows"
-                            // beneath the main bar. IsIndeterminate=true draws a stripe
-                            // animation while a worker is processing; setting it to false
-                            // and Description="idle" parks the slot.
+                            // Four progress tasks rendered as live "slot rows" beneath the
+                            // main bar — one per worker. Each fills as its session's transcript
+                            // lines are posted: MaxValue is the session's sendable-line count and
+                            // Value advances per flushed batch via OnSessionProgress. A slot that
+                            // has no batch yet (or whose total couldn't be counted) draws an
+                            // indeterminate stripe rather than a stuck 0% (AI-907).
                             var slots = new ProgressTask[ImportWorkerCount];
 
                             for (var i = 0; i < ImportWorkerCount; i++) {
@@ -1025,11 +1028,14 @@ static class ImportCommand {
                                 slots[i].IsIndeterminate = false;
                             }
 
-                            // currentSession[slot] holds the SessionId currently rendered on
-                            // the slot row, used to revert the description after a subagent
-                            // finishes (revert from "↳ subagent X" to "Loading <parent>").
+                            // Per-slot render state. currentSid/currentVerb let us revert the
+                            // description after a subagent finishes (from "↳ subagent X" back to
+                            // "Loading <parent>"); totalKnown tracks whether OnSessionProgress has
+                            // supplied a real denominator yet, so subagent⇄parent transitions
+                            // restore a determinate bar only when one exists.
                             var currentVerb = new string[ImportWorkerCount];
                             var currentSid  = new string[ImportWorkerCount];
+                            var totalKnown  = new bool[ImportWorkerCount];
 
                             var wrappedEvents = events with {
                                 OnSessionStarted = (slot, c) => {
@@ -1038,30 +1044,47 @@ static class ImportCommand {
                                         : "new";
                                     currentSid[slot]  = c.SessionId;
                                     currentVerb[slot] = verb;
-                                    SetSlot(slot, $"  [bold]Slot {slot + 1}[/] — Loading [cyan]{Markup.Escape(c.SessionId)}[/] ({verb})");
+                                    // Fresh bar; indeterminate stripe until the first batch reports
+                                    // the line total.
+                                    totalKnown[slot]            = false;
+                                    slots[slot].Value           = 0;
+                                    slots[slot].MaxValue        = 1;
+                                    slots[slot].IsIndeterminate = true;
+                                    slots[slot].Description     = LoadingDesc(slot, c.SessionId, verb);
+                                },
+                                OnSessionProgress = (slot, linesAdded, total) => {
+                                    if (total > 0) {
+                                        slots[slot].MaxValue        = total;
+                                        slots[slot].IsIndeterminate = false;
+                                        totalKnown[slot]            = true;
+                                    }
+
+                                    slots[slot].Increment(linesAdded);
                                 },
                                 OnSubagentStarted = (slot, sid, aid) => {
-                                    SetSlot(slot, $"  [bold]Slot {slot + 1}[/] — [dim]↳[/] subagent [cyan]{Markup.Escape(aid)}[/] (parent {Markup.Escape(sid)})");
+                                    // Subagent lines don't advance the parent bar; show a stripe
+                                    // and swap the description while the subagent streams.
+                                    slots[slot].IsIndeterminate = true;
+                                    slots[slot].Description     = $"  [bold]Slot {slot + 1}[/] — [dim]↳[/] subagent [cyan]{Markup.Escape(aid)}[/] (parent {Markup.Escape(sid)})";
                                 },
                                 OnSubagentFinished = (slot, _, _, _) => {
-                                    // Revert to the parent session's "Loading" description.
-                                    // No scrollback line in TTY mode — subagent activity was
-                                    // already visible on the slot row while it ran.
+                                    // Revert to the parent's "Loading" description and resume the
+                                    // determinate bar (only if a real total was reported; otherwise
+                                    // keep the stripe). No scrollback line in TTY mode — subagent
+                                    // activity was already visible on the slot row while it ran.
                                     if (!string.IsNullOrEmpty(currentSid[slot])) {
-                                        SetSlot(
-                                            slot,
-                                            $"  [bold]Slot {slot + 1}[/] — Loading [cyan]{Markup.Escape(currentSid[slot])}[/] ({currentVerb[slot]})"
-                                        );
+                                        slots[slot].IsIndeterminate = !totalKnown[slot];
+                                        slots[slot].Description     = LoadingDesc(slot, currentSid[slot], currentVerb[slot]);
                                     }
                                 },
                                 OnSessionEnded = (slot, c, _, _) => {
                                     importedSessionIds.Add(c.SessionId);
-                                    // Description stays on the just-finished session until
-                                    // the next OnSessionStarted swaps it. We only flip the
-                                    // stripe off here so a slot that drains (queue empty)
-                                    // looks calm.
+                                    // Snap the slot bar to 100% and park the stripe; the description
+                                    // stays on the just-finished session until the next
+                                    // OnSessionStarted swaps it.
                                     bar.Increment(1);
                                     slots[slot].IsIndeterminate = false;
+                                    slots[slot].Value           = slots[slot].MaxValue;
                                     // Suppress the legacy per-session log line in TTY mode
                                     // by NOT calling the base handler. Slot rows showed the
                                     // session while it ran; errors render via scrollback below.
@@ -1085,14 +1108,15 @@ static class ImportCommand {
                             void IdleSlot(int slot) {
                                 slots[slot].Description     = $"  Slot {slot + 1} — idle";
                                 slots[slot].IsIndeterminate = false;
+                                slots[slot].Value           = 0;
+                                slots[slot].MaxValue        = 1;
+                                totalKnown[slot]            = false;
                                 currentSid[slot]            = "";
                                 currentVerb[slot]           = "";
                             }
 
-                            void SetSlot(int slot, string markup) {
-                                slots[slot].Description     = markup;
-                                slots[slot].IsIndeterminate = true;
-                            }
+                            static string LoadingDesc(int slot, string sid, string verb) =>
+                                $"  [bold]Slot {slot + 1}[/] — Loading [cyan]{Markup.Escape(sid)}[/] ({verb})";
                         }
                     );
                 importResult = r!;
@@ -2017,6 +2041,16 @@ static class ImportCommand {
         public required Action<int, SessionClassification, SessionImportOutcome, int> OnSessionEnded { get; init; }
         // slot, classification, outcome (Loaded|Resumed), linesSent
 
+        /// <summary>
+        /// Fired after each parent-transcript batch is flushed, to advance the
+        /// per-slot progress bar. <c>linesAdded</c> is the size of the batch just
+        /// posted; <c>total</c> is the session's full sendable-line count (the
+        /// bar's denominator, or 0 when unknown). Subagent batches are excluded —
+        /// they're surfaced via <see cref="OnSubagentStarted"/> / <see cref="OnSubagentFinished"/>
+        /// and don't advance the parent bar.
+        /// </summary>
+        public required Action<int, int, int> OnSessionProgress { get; init; } // slot, linesAdded, total
+
         /// <summary>Fired when a successfully-imported session is ready for title generation.</summary>
         public required Action<(string SessionId, string FilePath, string? PreviousSessionId, string Vendor)> OnTitleTaskReady { get; init; }
 
@@ -2113,10 +2147,22 @@ static class ImportCommand {
             ChainWorkerEvents     events,
             CancellationToken     ct
         ) {
+        // Denominator for the per-slot progress bar: the number of parent-transcript
+        // lines this import will POST. For a resume, only the lines past the server's
+        // watermark are sent. 0 when the file is missing/unreadable — the slot then
+        // stays indeterminate instead of stuck at 0% (AI-907).
+        var sendableTotal = SessionImporter.CountSendableLines(
+            session.FilePath,
+            session.Status == ClassificationStatus.Partial ? session.ResumeFromLine : 0
+        );
+
         IProgress<ImportProgress> perSessionProgress = new CallbackProgress(ev => {
                 switch (ev) {
-                    case SubagentStarted ss:  events.OnSubagentStarted(slot, session.SessionId, ss.AgentId); break;
-                    case SubagentFinished sf: events.OnSubagentFinished(slot, session.SessionId, sf.AgentId, sf.LinesSent); break;
+                    // Only parent-transcript batches (AgentId == null) advance the
+                    // slot bar; subagent batches are surfaced via the subagent events.
+                    case BatchFlushed { AgentId: null } bf: events.OnSessionProgress(slot, bf.LinesAdded, sendableTotal); break;
+                    case SubagentStarted ss:               events.OnSubagentStarted(slot, session.SessionId, ss.AgentId); break;
+                    case SubagentFinished sf:              events.OnSubagentFinished(slot, session.SessionId, sf.AgentId, sf.LinesSent); break;
                 }
             }
         );

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -1038,6 +1038,9 @@ static class ImportCommand {
                             var totalKnown  = new bool[ImportWorkerCount];
 
                             var wrappedEvents = events with {
+                                // TTY renders live per-session bars, so opt into the
+                                // sendable-line pre-count that sets their denominator.
+                                TrackPerSessionProgress = true,
                                 OnSessionStarted = (slot, c) => {
                                     var verb = c.Status == ClassificationStatus.Partial
                                         ? $"resuming from line {c.ResumeFromLine}"
@@ -2051,6 +2054,15 @@ static class ImportCommand {
         /// </summary>
         public required Action<int, int, int> OnSessionProgress { get; init; } // slot, linesAdded, total
 
+        /// <summary>
+        /// Whether a live per-session bar consumes <see cref="OnSessionProgress"/>.
+        /// When false (non-TTY / redirected output), <see cref="ImportSingleSessionAsync"/>
+        /// skips the per-session line pre-count — a full transcript read whose
+        /// denominator nothing would render. Defaults to false; the TTY slot
+        /// renderer sets it true.
+        /// </summary>
+        public bool TrackPerSessionProgress { get; init; }
+
         /// <summary>Fired when a successfully-imported session is ready for title generation.</summary>
         public required Action<(string SessionId, string FilePath, string? PreviousSessionId, string Vendor)> OnTitleTaskReady { get; init; }
 
@@ -2150,11 +2162,14 @@ static class ImportCommand {
         // Denominator for the per-slot progress bar: the number of parent-transcript
         // lines this import will POST. For a resume, only the lines past the server's
         // watermark are sent. 0 when the file is missing/unreadable — the slot then
-        // stays indeterminate instead of stuck at 0% (AI-907).
-        var sendableTotal = SessionImporter.CountSendableLines(
-            session.FilePath,
-            session.Status == ClassificationStatus.Partial ? session.ResumeFromLine : 0
-        );
+        // stays indeterminate instead of stuck at 0% (AI-907). Skipped entirely when
+        // no live bar consumes it (non-TTY) so we don't pre-scan every transcript.
+        var sendableTotal = events.TrackPerSessionProgress
+            ? SessionImporter.CountSendableLines(
+                session.FilePath,
+                session.Status == ClassificationStatus.Partial ? session.ResumeFromLine : 0
+            )
+            : 0;
 
         IProgress<ImportProgress> perSessionProgress = new CallbackProgress(ev => {
                 switch (ev) {

--- a/src/Capacitor.Cli/Commands/SessionImporter.cs
+++ b/src/Capacitor.Cli/Commands/SessionImporter.cs
@@ -568,6 +568,37 @@ static class SessionImporter {
         return results;
     }
 
+    /// <summary>
+    /// Count the non-blank lines from <paramref name="startLine"/> (inclusive) to
+    /// EOF — i.e. the number of lines <see cref="SendTranscriptBatches"/> /
+    /// <see cref="ImportSessionAsync"/> will actually POST for the main transcript.
+    /// This is the denominator for the per-session import progress bar: the sum of
+    /// every <see cref="BatchFlushed"/> with a null <c>AgentId</c> equals this count.
+    /// Best-effort — returns 0 on a missing file or any I/O error, which callers
+    /// treat as "total unknown" (the bar stays indeterminate).
+    /// </summary>
+    internal static int CountSendableLines(string filePath, int startLine = 0) {
+        if (!File.Exists(filePath)) return 0;
+
+        try {
+            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream);
+
+            var count     = 0;
+            var lineIndex = 0;
+
+            while (reader.ReadLine() is { } line) {
+                if (lineIndex >= startLine && !string.IsNullOrWhiteSpace(line)) count++;
+
+                lineIndex++;
+            }
+
+            return count;
+        } catch {
+            return 0;
+        }
+    }
+
     internal static string? DecodeCwdFromDirName(string encodedCwd) {
         // Encoded cwd has / replaced with - (e.g., -Users-alexey-dev-myproject)
         // Reverse: replace leading - with /, then interior - with /

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportChainsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportChainsTests.cs
@@ -82,6 +82,7 @@ public class ImportChainsTests : IDisposable {
             OnSessionStarted      = (_, _) => { },
             OnSubagentStarted     = (_, _, _) => { },
             OnSubagentFinished    = (_, _, _, _) => { },
+            OnSessionProgress     = (_, _, _) => { },
             OnSessionErrored      = (_, _, _) => { },
             OnSessionEnded        = (_, c, _, _) => completedLines.Add($"Loading {c.SessionId}..."),
             OnTitleTaskReady      = _ => { },
@@ -94,6 +95,43 @@ public class ImportChainsTests : IDisposable {
         await Assert.That(result.Loaded).IsEqualTo(3);
         await Assert.That(result.Errored).IsEqualTo(0);
         await Assert.That(completedLines.Count).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task ImportChainsAsync_reports_per_session_progress() {
+        // Regression (AI-907): per-session slot rows always showed 0% because
+        // BatchFlushed events were never wired to the slot bar. OnSessionProgress
+        // must now fire once per flushed parent batch, carrying the batch size and
+        // the session's full sendable-line total.
+        StubAllHookEndpoints();
+
+        // 250 non-blank lines → batches of 100 → flushes of 100, 100, 50.
+        var chains = new List<List<ImportCommand.SessionClassification>> {
+            new() { MakeNew("prog-s1", 250) },
+        };
+
+        var progressLines  = new ConcurrentBag<int>();
+        var progressTotals = new ConcurrentBag<int>();
+
+        var events = new ImportCommand.ChainWorkerEvents {
+            OnSessionStarted      = (_, _) => { },
+            OnSubagentStarted     = (_, _, _) => { },
+            OnSubagentFinished    = (_, _, _, _) => { },
+            OnSessionProgress     = (_, lines, total) => { progressLines.Add(lines); progressTotals.Add(total); },
+            OnSessionErrored      = (_, _, _) => { },
+            OnSessionEnded        = (_, _, _, _) => { },
+            OnTitleTaskReady      = _ => { },
+            OnBackgroundWorkReady = _ => { },
+        };
+
+        using var client = new HttpClient();
+        await ImportCommand.ImportChainsAsync(client, _server.Url!, chains, events, CancellationToken.None);
+
+        // Three batches were flushed and the line counts sum to the whole transcript.
+        await Assert.That(progressLines.Count).IsEqualTo(3);
+        await Assert.That(progressLines.Sum()).IsEqualTo(250);
+        // Every report carries the same denominator: the session's sendable total.
+        await Assert.That(progressTotals.All(t => t == 250)).IsTrue();
     }
 
     [Test]
@@ -111,6 +149,7 @@ public class ImportChainsTests : IDisposable {
             OnSessionStarted      = (_, _) => { },
             OnSubagentStarted     = (_, _, _) => { },
             OnSubagentFinished    = (_, _, _, _) => { },
+            OnSessionProgress     = (_, _, _) => { },
             OnSessionErrored      = (_, _, _) => { },
             OnSessionEnded        = (_, c, _, _) => order.Enqueue($"Loading {c.SessionId}..."),
             OnTitleTaskReady      = _ => { },
@@ -141,6 +180,7 @@ public class ImportChainsTests : IDisposable {
             OnSessionStarted      = (_, _) => { },
             OnSubagentStarted     = (_, _, _) => { },
             OnSubagentFinished    = (_, _, _, _) => { },
+            OnSessionProgress     = (_, _, _) => { },
             OnSessionErrored      = (_, _, _) => { },
             OnSessionEnded        = (_, _, _, _) => { },
             OnTitleTaskReady      = _ => { },
@@ -191,6 +231,7 @@ public class ImportChainsTests : IDisposable {
             OnSessionStarted      = (_, _) => { },
             OnSubagentStarted     = (_, _, _) => { },
             OnSubagentFinished    = (_, _, _, _) => { },
+            OnSessionProgress     = (_, _, _) => { },
             OnSessionErrored      = (_, _, _) => { },
             OnSessionEnded        = (_, _, _, _) => { },
             OnTitleTaskReady      = _ => { },

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportChainsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportChainsTests.cs
@@ -114,6 +114,8 @@ public class ImportChainsTests : IDisposable {
         var progressTotals = new ConcurrentBag<int>();
 
         var events = new ImportCommand.ChainWorkerEvents {
+            // Opt into the sendable-line pre-count so OnSessionProgress carries a real total.
+            TrackPerSessionProgress = true,
             OnSessionStarted      = (_, _) => { },
             OnSubagentStarted     = (_, _, _) => { },
             OnSubagentFinished    = (_, _, _, _) => { },
@@ -132,6 +134,40 @@ public class ImportChainsTests : IDisposable {
         await Assert.That(progressLines.Sum()).IsEqualTo(250);
         // Every report carries the same denominator: the session's sendable total.
         await Assert.That(progressTotals.All(t => t == 250)).IsTrue();
+    }
+
+    [Test]
+    public async Task ImportChainsAsync_skips_line_precount_when_progress_disabled() {
+        // Perf gate (PR #186 review): when no live bar consumes the denominator
+        // (non-TTY, TrackPerSessionProgress defaults false), the per-session
+        // pre-count is skipped — OnSessionProgress still fires per batch but with
+        // total == 0, so we never read the whole transcript just to throw it away.
+        StubAllHookEndpoints();
+
+        var chains = new List<List<ImportCommand.SessionClassification>> {
+            new() { MakeNew("noprecount-s1", 250) },
+        };
+
+        var progressTotals = new ConcurrentBag<int>();
+
+        var events = new ImportCommand.ChainWorkerEvents {
+            // TrackPerSessionProgress omitted → defaults false (the non-TTY default).
+            OnSessionStarted      = (_, _) => { },
+            OnSubagentStarted     = (_, _, _) => { },
+            OnSubagentFinished    = (_, _, _, _) => { },
+            OnSessionProgress     = (_, _, total) => progressTotals.Add(total),
+            OnSessionErrored      = (_, _, _) => { },
+            OnSessionEnded        = (_, _, _, _) => { },
+            OnTitleTaskReady      = _ => { },
+            OnBackgroundWorkReady = _ => { },
+        };
+
+        using var client = new HttpClient();
+        await ImportCommand.ImportChainsAsync(client, _server.Url!, chains, events, CancellationToken.None);
+
+        // Batches still flowed, but the denominator was never computed.
+        await Assert.That(progressTotals.Count).IsEqualTo(3);
+        await Assert.That(progressTotals.All(t => t == 0)).IsTrue();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/SessionImporterProgressTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionImporterProgressTests.cs
@@ -57,6 +57,28 @@ public class SessionImporterProgressTests : IDisposable {
     }
 
     [Test]
+    public async Task CountSendableLines_counts_non_blank_lines_from_start() {
+        // The per-session progress denominator (AI-907): must equal the number of
+        // lines SendTranscriptBatches/ImportSessionAsync actually POST — non-blank
+        // lines from startLine to EOF.
+        var path = Path.GetTempFileName();
+        try {
+            await File.WriteAllLinesAsync(path, ["a", "", "b", "   ", "c"]);
+
+            // Whole file: 3 non-blank lines (a, b, c); the two blank lines don't count.
+            await Assert.That(SessionImporter.CountSendableLines(path)).IsEqualTo(3);
+
+            // From line index 2 onward: "b", "   ", "c" → 2 non-blank (b, c).
+            await Assert.That(SessionImporter.CountSendableLines(path, startLine: 2)).IsEqualTo(2);
+
+            // A missing file is best-effort 0 (slot stays indeterminate, never errors).
+            await Assert.That(SessionImporter.CountSendableLines(path + ".nope")).IsEqualTo(0);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
     public async Task ImportSessionAsync_fires_subagent_events_around_inline_import() {
         _server.Given(Request.Create().WithPath("/hooks/transcript").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200));


### PR DESCRIPTION
## Problem

During `kcap import`, the per-session progress in the TTY `Importing` phase always shows **0%** and never moves (AI-907).

## Root cause

The TTY `Importing` phase renders 4 worker "slot rows" as Spectre `ProgressTask`s created with `maxValue: 1`, but the code only ever toggled their `IsIndeterminate`/`Description` — **`.Value` was never set**. `PercentageColumn` renders `Value / MaxValue`, so every slot showed `0 / 1 = 0%` for the whole run.

The per-session data already existed: `SessionImporter` emits `BatchFlushed(AgentId, LinesAdded)` after each batch POST. But the `perSessionProgress` callback in `ImportSingleSessionAsync` only handled the subagent events and **ignored `BatchFlushed` entirely**, so nothing advanced the slot bar.

## Fix

- **`SessionImporter.CountSendableLines(path, startLine)`** — counts the non-blank lines that will actually be POSTed (the bar's denominator), honoring the resume watermark for `Partial` sessions. Best-effort: returns 0 on a missing/unreadable file.
- **`ChainWorkerEvents.OnSessionProgress(slot, linesAdded, total)`** — `ImportSingleSessionAsync` now forwards parent-transcript `BatchFlushed` (`AgentId == null`) to it.
- **TTY slot rows are now determinate bars**: `MaxValue` = sendable total, `Value` advances per flushed batch, snaps to 100% on session end. A slot whose total can't be counted falls back to the indeterminate stripe instead of a stuck 0%. Subagent streaming keeps its `↳ subagent` stripe and intentionally doesn't advance the parent bar.

**Caveat:** progress updates at batch granularity (every 100 lines), so sessions under 100 lines jump 0→100% in one step — correct, just coarse.

## Tests

- `ImportChainsAsync_reports_per_session_progress` — regression guard: `OnSessionProgress` fires per batch, line counts sum to the transcript, total denominator is correct.
- `CountSendableLines_counts_non_blank_lines_from_start`.
- Full unit suite **1781/1781 green**; `dotnet publish -c Release` clean (no IL3050/IL2026).

No README change — this is a display bug fix, not a change to any command/flag/default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)