### PR TITLE
[AI-973] Fold web viewer dims into the daemon resize min-clamp

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -208,8 +208,8 @@ internal partial class AgentOrchestrator {
     /// <summary>
     /// Min-clamp the one PTY to the smallest cols × rows across every attached viewer — the local
     /// clients (<see cref="AgentInstance.ClientDims"/>) <b>and</b> the server-aggregated web viewers
-    /// (<see cref="AgentInstance.WebDims"/>) — so no surface's redraw is corrupted (tmux semantics,
-    /// AI-973). Recomputed on local attach/detach/resize and on a server-origin web resize. Caller
+    /// (<see cref="AgentInstance.WebDims"/>) — so no surface's redraw is corrupted (tmux semantics).
+    /// Recomputed on local attach/detach/resize and on a server-origin web resize. Caller
     /// holds <see cref="AgentInstance.SinksLock"/>; no-op when no viewer has a reported size.
     /// </summary>
     void ClampPtyLocked(AgentInstance agent) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -206,16 +206,24 @@ internal partial class AgentOrchestrator {
     }
 
     /// <summary>
-    /// Min-clamp the one PTY to the smallest cols × rows across the attached local clients
-    /// (tmux semantics), so no client's redraw is corrupted. Recomputed on attach/detach/
-    /// resize. Caller holds <see cref="AgentInstance.SinksLock"/>; no-op when no client has a
-    /// reported size.
+    /// Min-clamp the one PTY to the smallest cols × rows across every attached viewer — the local
+    /// clients (<see cref="AgentInstance.ClientDims"/>) <b>and</b> the server-aggregated web viewers
+    /// (<see cref="AgentInstance.WebDims"/>) — so no surface's redraw is corrupted (tmux semantics,
+    /// AI-973). Recomputed on local attach/detach/resize and on a server-origin web resize. Caller
+    /// holds <see cref="AgentInstance.SinksLock"/>; no-op when no viewer has a reported size.
     /// </summary>
     void ClampPtyLocked(AgentInstance agent) {
-        if (agent.ClientDims.Count == 0) return;
+        ushort c = 0, r = 0;
 
-        var c = agent.ClientDims.Values.Min(d => d.Cols);
-        var r = agent.ClientDims.Values.Min(d => d.Rows);
+        foreach (var d in agent.ClientDims.Values) {
+            if (c == 0 || d.Cols < c) c = d.Cols;
+            if (r == 0 || d.Rows < r) r = d.Rows;
+        }
+        if (agent.WebDims is { } w) {
+            if (c == 0 || w.Cols < c) c = w.Cols;
+            if (r == 0 || w.Rows < r) r = w.Rows;
+        }
+
         if (c > 0 && r > 0) {
             agent.Process.Resize(c, r);
             agent.CurrentCols = c;

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -54,6 +54,13 @@ public record AgentInstance(
     internal Dictionary<ITerminalSink, Dim> ClientDims { get; } = [];
     public readonly record struct Dim(ushort Cols, ushort Rows);
 
+    /// <summary>The server-aggregated min size across all web viewers (one value per agent,
+    /// computed server-side from per-connection web dims), folded into the same min-clamp as the
+    /// local clients so a small web viewer and a large local terminal share the one PTY at the
+    /// smallest size — tmux semantics across surfaces (AI-973). <c>null</c> when no web viewer is
+    /// attached, so the clamp grows back to the local-only size. Guarded by <see cref="SinksLock"/>.</summary>
+    internal Dim? WebDims { get; set; }
+
     /// <summary>Tripped when the agent terminates (CleanupAgentAsync) so an attached local
     /// client that's blocked waiting on the user's keystrokes wakes, flushes the last output,
     /// and sends an Exited frame instead of hanging.</summary>
@@ -944,10 +951,21 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     Task HandleResizeTerminal(ResizeTerminalCommand cmd) {
         // Ignore server-origin resize for private agents (defence-in-depth; see HandleStopAgent).
         if (_agents.TryGetValue(cmd.AgentId, out var agent) && !agent.IsPrivate) {
-            agent.Process.Resize((ushort)cmd.Cols, (ushort)cmd.Rows);
-            // Keep the stored dims current so a later reconnect resends the real size, not stale ones.
-            agent.CurrentCols = (ushort)cmd.Cols;
-            agent.CurrentRows = (ushort)cmd.Rows;
+            // The server sends the min aggregate across all web viewers (AI-973), or (0,0) when the
+            // last web viewer left. Fold it into the same min-clamp as the local clients rather than
+            // resizing the PTY directly — a small web viewer must not corrupt a large local terminal
+            // (or vice-versa), and a departing web viewer must let the PTY grow back to the local size.
+            lock (agent.SinksLock) {
+                agent.WebDims = cmd is { Cols: > 0, Rows: > 0 }
+                    ? new AgentInstance.Dim((ushort)cmd.Cols, (ushort)cmd.Rows)
+                    : null;
+                ClampPtyLocked(agent);
+            }
+
+            // Announce the clamped size so every web viewer re-locks (and reconnect resends the real
+            // size, not stale ones). Outside the lock, best-effort, fire-and-forget — same as the
+            // local resize path in ApplyResizeClamp.
+            _ = SafeSendDimsAsync(agent);
         }
 
         return Task.CompletedTask;

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -57,7 +57,7 @@ public record AgentInstance(
     /// <summary>The server-aggregated min size across all web viewers (one value per agent,
     /// computed server-side from per-connection web dims), folded into the same min-clamp as the
     /// local clients so a small web viewer and a large local terminal share the one PTY at the
-    /// smallest size — tmux semantics across surfaces (AI-973). <c>null</c> when no web viewer is
+    /// smallest size — tmux semantics across surfaces. <c>null</c> when no web viewer is
     /// attached, so the clamp grows back to the local-only size. Guarded by <see cref="SinksLock"/>.</summary>
     internal Dim? WebDims { get; set; }
 
@@ -951,7 +951,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     Task HandleResizeTerminal(ResizeTerminalCommand cmd) {
         // Ignore server-origin resize for private agents (defence-in-depth; see HandleStopAgent).
         if (_agents.TryGetValue(cmd.AgentId, out var agent) && !agent.IsPrivate) {
-            // The server sends the min aggregate across all web viewers (AI-973), or (0,0) when the
+            // The server sends the min aggregate across all web viewers, or (0,0) when the
             // last web viewer left. Fold it into the same min-clamp as the local clients rather than
             // resizing the PTY directly — a small web viewer must not corrupt a large local terminal
             // (or vice-versa), and a departing web viewer must let the PTY grow back to the local size.

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -955,17 +955,26 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // last web viewer left. Fold it into the same min-clamp as the local clients rather than
             // resizing the PTY directly — a small web viewer must not corrupt a large local terminal
             // (or vice-versa), and a departing web viewer must let the PTY grow back to the local size.
-            lock (agent.SinksLock) {
-                agent.WebDims = cmd is { Cols: > 0, Rows: > 0 }
-                    ? new AgentInstance.Dim((ushort)cmd.Cols, (ushort)cmd.Rows)
-                    : null;
-                ClampPtyLocked(agent);
-            }
+            //
+            // (0,0) clears WebDims. Accept other dims only when they're positive AND fit the PTY's
+            // ushort winsize — ignore anything else (negative, or > ushort.MaxValue) so a bad value
+            // can't wrap on the cast and poison the shared clamp (e.g. a wrapped 0 would block all
+            // resizing). The server already bounds-checks; this is defence-in-depth — the daemon must
+            // not trust the wire.
+            var clear = cmd is { Cols: 0, Rows: 0 };
+            var valid = cmd is { Cols: > 0 and <= ushort.MaxValue, Rows: > 0 and <= ushort.MaxValue };
 
-            // Announce the clamped size so every web viewer re-locks (and reconnect resends the real
-            // size, not stale ones). Outside the lock, best-effort, fire-and-forget — same as the
-            // local resize path in ApplyResizeClamp.
-            _ = SafeSendDimsAsync(agent);
+            if (clear || valid) {
+                lock (agent.SinksLock) {
+                    agent.WebDims = clear ? null : new AgentInstance.Dim((ushort)cmd.Cols, (ushort)cmd.Rows);
+                    ClampPtyLocked(agent);
+                }
+
+                // Announce the clamped size so every web viewer re-locks (and reconnect resends the
+                // real size, not stale ones). Outside the lock, best-effort, fire-and-forget — same
+                // as the local resize path in ApplyResizeClamp.
+                _ = SafeSendDimsAsync(agent);
+            }
         }
 
         return Task.CompletedTask;

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -101,7 +101,13 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         _hub.On<string>("StopAgent", agentId => SafeInvoke("StopAgent", () => OnStopAgent?.Invoke(agentId)));
         _hub.On<SendInputCommand>("SendInput", cmd => SafeInvoke("SendInput", () => OnSendInput?.Invoke(cmd)));
         _hub.On<string, string>("SendSpecialKey", (agentId, key) => SafeInvoke("SendSpecialKey", () => OnSendSpecialKey?.Invoke(agentId, key)));
-        _hub.On<ResizeTerminalCommand>("ResizeTerminal", cmd => SafeInvoke("ResizeTerminal", () => OnResizeTerminal?.Invoke(cmd)));
+        // "ResizeTerminalAggregate", not the legacy "ResizeTerminal": the payload is now the
+        // server-aggregated min terminal size across web viewers, with (0,0) meaning "clear web
+        // dims". A daemon predating web/local resize aggregation only registered "ResizeTerminal",
+        // so a newer server's aggregate (including the (0,0) clear) is silently ignored by it
+        // instead of resizing the PTY to 0×0 — graceful degradation during a non-atomic CLI/server
+        // rollout.
+        _hub.On<ResizeTerminalCommand>("ResizeTerminalAggregate", cmd => SafeInvoke("ResizeTerminalAggregate", () => OnResizeTerminal?.Invoke(cmd)));
 
         // Client-result invocations for per-phase eval dispatch.
         _hub.On<PrepareEvalCommand, PrepareResult>("PrepareEval",

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -235,6 +235,70 @@ public partial class AgentOrchestratorVendorTests {
     }
 
     [Test]
+    public async Task Web_resize_min_clamps_per_dimension_with_local_client() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var agent = new AgentInstance("reg-3", null, "", null, "/r", "claude",
+            new StubPtyProcess(), new WorktreeInfo("/r", "", "/r"), new CancellationTokenSource()) {
+            IsPrivate = false, Status = "Running", CurrentCols = 80, CurrentRows = 24
+        };
+        // A local client reports 80×24; the web viewer wants 120×40.
+        agent.ClientDims[new FakeTerminalSink()] = new AgentInstance.Dim(80, 24);
+        orch.RegisterAgentForTest(agent);
+
+        orch.HandleResizeTerminalForTest(new ResizeTerminalCommand("reg-3", 120, 40));
+
+        // Per-dimension min across local ∪ web: cols min(80,120)=80, rows min(24,40)=24.
+        await Assert.That(agent.CurrentCols).IsEqualTo((ushort)80);
+        await Assert.That(agent.CurrentRows).IsEqualTo((ushort)24);
+        await Assert.That(server.LastDims).IsEqualTo((80, 24)); // clamped size announced back to web
+    }
+
+    [Test]
+    public async Task Web_resize_shrinks_pty_below_a_larger_local_client() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var agent = new AgentInstance("reg-4", null, "", null, "/r", "claude",
+            new StubPtyProcess(), new WorktreeInfo("/r", "", "/r"), new CancellationTokenSource()) {
+            IsPrivate = false, Status = "Running", CurrentCols = 200, CurrentRows = 50
+        };
+        agent.ClientDims[new FakeTerminalSink()] = new AgentInstance.Dim(200, 50);
+        orch.RegisterAgentForTest(agent);
+
+        orch.HandleResizeTerminalForTest(new ResizeTerminalCommand("reg-4", 100, 30));
+
+        // The smaller web viewer wins both dimensions.
+        await Assert.That(agent.CurrentCols).IsEqualTo((ushort)100);
+        await Assert.That(agent.CurrentRows).IsEqualTo((ushort)30);
+    }
+
+    [Test]
+    public async Task Web_resize_zero_dims_clears_web_and_grows_back_to_local() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var agent = new AgentInstance("reg-5", null, "", null, "/r", "claude",
+            new StubPtyProcess(), new WorktreeInfo("/r", "", "/r"), new CancellationTokenSource()) {
+            IsPrivate = false, Status = "Running", CurrentCols = 150, CurrentRows = 40
+        };
+        agent.ClientDims[new FakeTerminalSink()] = new AgentInstance.Dim(150, 40);
+        orch.RegisterAgentForTest(agent);
+
+        // A small web viewer attaches and clamps the PTY down.
+        orch.HandleResizeTerminalForTest(new ResizeTerminalCommand("reg-5", 80, 20));
+        await Assert.That(agent.CurrentCols).IsEqualTo((ushort)80);
+        await Assert.That(agent.CurrentRows).IsEqualTo((ushort)20);
+
+        // Last web viewer leaves: the server sends (0,0); the PTY grows back to the local size.
+        orch.HandleResizeTerminalForTest(new ResizeTerminalCommand("reg-5", 0, 0));
+        await Assert.That(agent.WebDims).IsNull();
+        await Assert.That(agent.CurrentCols).IsEqualTo((ushort)150);
+        await Assert.That(agent.CurrentRows).IsEqualTo((ushort)40);
+    }
+
+    [Test]
     public async Task Private_agent_ignores_server_origin_resize_and_stop() {
         var server = new CaptureServerConnection();
         await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
@@ -381,6 +445,13 @@ public partial class AgentOrchestratorVendorTests {
         public override long Seek(long o, SeekOrigin s) => throw new NotSupportedException();
         public override void SetLength(long v) => throw new NotSupportedException();
         protected override void Dispose(bool disposing) { if (disposing) { readSide.Dispose(); writeSide.Dispose(); } }
+    }
+
+    /// A no-op local sink used only as a stable key to seed AgentInstance.ClientDims in resize
+    /// tests (the real socket attach loop isn't needed to exercise the min-clamp).
+    sealed class FakeTerminalSink : ITerminalSink {
+        public void TryEnqueue(byte[] chunk) { }
+        public bool Detached => false;
     }
 
     /// Records the name of any per-agent server method invoked. A PrivateLocal agent must

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -299,6 +299,27 @@ public partial class AgentOrchestratorVendorTests {
     }
 
     [Test]
+    public async Task Web_resize_out_of_ushort_range_is_ignored() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var agent = new AgentInstance("reg-6", null, "", null, "/r", "claude",
+            new StubPtyProcess(), new WorktreeInfo("/r", "", "/r"), new CancellationTokenSource()) {
+            IsPrivate = false, Status = "Running", CurrentCols = 120, CurrentRows = 40
+        };
+        agent.ClientDims[new FakeTerminalSink()] = new AgentInstance.Dim(120, 40);
+        orch.RegisterAgentForTest(agent);
+
+        // 70000 > ushort.MaxValue — would wrap to 4464 on a raw (ushort) cast. The guard ignores it
+        // so WebDims stays null and the clamp is untouched (no poisoned web entry).
+        orch.HandleResizeTerminalForTest(new ResizeTerminalCommand("reg-6", 70000, 40));
+
+        await Assert.That(agent.WebDims).IsNull();
+        await Assert.That(agent.CurrentCols).IsEqualTo((ushort)120);
+        await Assert.That(agent.CurrentRows).IsEqualTo((ushort)40);
+    }
+
+    [Test]
     public async Task Private_agent_ignores_server_origin_resize_and_stop() {
         var server = new CaptureServerConnection();
         await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());


### PR DESCRIPTION
## What & why

Phase 2 / Slice 2 of local terminal attach (AI-973), **daemon half**. Extends the Phase 1 resize min-clamp to include web viewers so a local terminal and one or more browsers can drive the same agent without corrupting each other's redraw (tmux semantics).

Previously `HandleResizeTerminal` resized the PTY **directly** from the server-sent dims, bypassing the local-client min-clamp — a web resize would stomp a local terminal's size, and a local resize would ignore the web.

## Change

- `AgentInstance.WebDims` — the server-aggregated min size across all web viewers, guarded by the existing `SinksLock`.
- `ClampPtyLocked` now takes the per-dimension min over **local `ClientDims` ∪ `WebDims`** (was local-only). For a web-only agent the result equals the web dims, so existing behavior is preserved.
- `HandleResizeTerminal` records `WebDims` and re-clamps instead of resizing directly, then announces the clamped size back via `SafeSendDimsAsync` so every viewer re-locks. `(0,0)` clears `WebDims` and grows the PTY back to the local-only size when the last web viewer leaves.

The `ResizeTerminalCommand` wire contract is **unchanged in shape** — only its meaning changes from "one web client's desired size" to "server-aggregated min across web viewers." The server half (per-connection aggregation + web UI viewport reporting) is in the **kcap-server** PR (kurrent-io/kcap-server#825) and must land together.

## Tests

3 new clamp-aggregation tests (per-dimension min with a local client; web shrinks below a larger local; `(0,0)` clears web dims and grows back). Full suite: **1782/1782** pass. No IL30xx/IL20xx/IL31xx AOT warnings on `dotnet publish -c Release`.

No user-facing CLI surface change (no command/flag), so no README change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
