### PR TITLE
[AI-1005] Durable subagent-stop via bounded POST + spool

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The `kcap mcp sessions` stdio server lets coding agents search and recall past C
 Once set up, Capacitor runs silently in the background. Every Claude Code (and Codex CLI, if you installed those hooks) session is captured automatically:
 
 - **Session lifecycle** — start, end, interruptions, context compaction
-- **Durable lifecycle delivery** — if the server is briefly unreachable when a `SessionStart`/`SessionEnd` hook fires (for example during a deploy), the event is spooled to `~/.config/kcap/spool/` and automatically re-sent on the next hook, so sessions don't get stuck "active" or lose their start record. No action needed; stale spool entries are reaped after 30 days.
+- **Durable lifecycle delivery** — if the server is briefly unreachable when a `SessionStart`/`SessionEnd` hook (or a per-subagent `SubagentStop` carrying an `agent_id`) fires (for example during a deploy), the event is spooled to `~/.config/kcap/spool/` and automatically re-sent on the next hook, so sessions don't get stuck "active", lose their start record, or leave subagents stuck "running". No action needed; stale spool entries are reaped after 30 days.
 - **Transcript data** — streamed in real time via a background watcher process over SignalR
 - **Subagent activity** — full tree of spawned subagents with their own transcripts
 - **Tool usage** — every tool call with timing and results

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -41,7 +41,7 @@ public static class ClaudeHookCommand {
         try { body = await stdin.ReadToEndAsync(); } catch { return 0; }
 
         // Minimal parse (no auth/git) so we can spool AND start the watcher even if client creation hangs.
-        string? command = null, sessionId = null, transcriptPath = null, cwd = null, source = null;
+        string? command = null, sessionId = null, transcriptPath = null, cwd = null, source = null, agentId = null;
         try {
             var node = JsonNode.Parse(body);
             var ev   = node?["hook_event_name"]?.GetValue<string>();
@@ -50,6 +50,7 @@ public static class ClaudeHookCommand {
             transcriptPath = node?["transcript_path"]?.GetValue<string>();
             cwd            = node?["cwd"]?.GetValue<string>();
             source         = node?["source"]?.GetValue<string>();
+            agentId        = node?["agent_id"]?.GetValue<string>();
         } catch { }
 
         var clientCap = HookBudget.Remaining(processStart, command ?? "stop");
@@ -71,6 +72,10 @@ public static class ClaudeHookCommand {
             if (command is "session-start" or "session-end" && sessionId is not null) {
                 spool.Append(sessionId, command, NormalizeForSpool(body, command));
                 await Console.Error.WriteLineAsync($"[kcap] {command} spooled (auth/client creation exceeded hook budget); will retry on the next kcap hook ({sessionId})");
+            }
+            else if (command == "subagent-stop" && sessionId is not null && agentId is not null) {
+                spool.Append(sessionId, "subagent-stop", NormalizeForSpool(body, command));
+                await Console.Error.WriteLineAsync($"[kcap] subagent-stop spooled (auth/client creation exceeded hook budget); will retry on the next kcap hook ({sessionId}/{agentId})");
             }
             return 0;
         }
@@ -587,6 +592,13 @@ public static class ClaudeHookCommand {
             } catch { }
 
             if (sessionId is not null && agentId is not null) {
+                // Ordering guard: if this session's backlog couldn't fully drain, spool the fresh
+                // subagent-stop so a stranded session-start reaches the server before it (AI-1005).
+                if (CurrentSessionHasBacklog(spool, sessionId)) {
+                    spool.Append(sessionId, "subagent-stop", body);
+                    await Console.Error.WriteLineAsync($"[kcap] subagent-stop spooled (ordering guard); will retry on the next kcap hook ({sessionId}/{agentId})");
+                    return 0;
+                }
                 var remaining = HookBudget.Remaining(processStart, command);
                 HttpResponseMessage? resp = null;
                 try {

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -336,6 +336,15 @@ public static class ClaudeHookCommand {
                     var transcriptPath = node?["transcript_path"]?.GetValue<string>();
 
                     if (sessionId is not null && agentId is not null) {
+                        // Clamp the pre-drain cap so it cannot consume the entire remaining budget
+                        // that the bounded POST needs (mirrors the session-end fix). Reserve at
+                        // least Safety (1.5s) for the bounded POST so a slow drain doesn't starve
+                        // it entirely. Use whichever is smallest (AI-1005).
+                        var remaining    = HookBudget.Remaining(processStart, "subagent-stop");
+                        var effectiveCap = TimeSpan.FromMilliseconds(
+                            Math.Max(0, Math.Min(PreHookDrainCap.TotalMilliseconds,
+                                remaining.TotalMilliseconds - HookBudget.Safety.TotalMilliseconds)));
+
                         var drained = await TimeBudget.RunCappedAsync(
                             async () => {
                                 await WatcherManager.KillWatcher($"{sessionId}-{agentId}");
@@ -346,12 +355,12 @@ public static class ClaudeHookCommand {
                                     await WatcherManager.InlineDrainAsync(baseUrl, sessionId, agentTranscriptPath, agentId);
                                 }
                             },
-                            PreHookDrainCap
+                            effectiveCap
                         );
 
                         if (!drained) {
                             await Console.Error.WriteLineAsync(
-                                $"[kcap] subagent-stop pre-drain cap ({PreHookDrainCap.TotalSeconds:0}s) elapsed; proceeding to POST"
+                                $"[kcap] subagent-stop pre-drain cap ({effectiveCap.TotalSeconds:0.#}s) elapsed; proceeding to POST"
                             );
                         }
                     }
@@ -563,6 +572,43 @@ public static class ClaudeHookCommand {
             } catch { }
             resp.Dispose();
             return 0;
+        }
+
+        // Dedicated bounded POST for the per-agent subagent-stop: a single attempt clamped to the
+        // remaining hook budget that spools on transient failure, so a dropped SubagentCompleted is
+        // replayed on the next hook (AI-1005). Only the stop carrying agent_id maps to a completion;
+        // without it, fall through to the shared best-effort path (behavior unchanged).
+        if (command == "subagent-stop") {
+            string? sessionId = null, agentId = null;
+            try {
+                var node  = JsonNode.Parse(body);
+                sessionId = node?["session_id"]?.GetValue<string>();
+                agentId   = node?["agent_id"]?.GetValue<string>();
+            } catch { }
+
+            if (sessionId is not null && agentId is not null) {
+                var remaining = HookBudget.Remaining(processStart, command);
+                HttpResponseMessage? resp = null;
+                try {
+                    if (remaining > TimeSpan.Zero) {
+                        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+                        resp = await client.PostOnceAsync($"{baseUrl}/hooks/subagent-stop", content, remaining, CancellationToken.None);
+                    }
+                } catch { resp = null; }
+
+                if (resp is null || !resp.IsSuccessStatusCode) {
+                    var permanent = resp is not null && (int)resp.StatusCode is < 500 and not 408 and not 429;
+                    resp?.Dispose();
+                    if (!permanent) {
+                        spool.Append(sessionId, "subagent-stop", body);
+                        await Console.Error.WriteLineAsync($"[kcap] subagent-stop spooled; will retry on the next kcap hook ({sessionId}/{agentId})");
+                    }
+                    return 0;
+                }
+
+                resp.Dispose();
+                return 0;
+            }
         }
 
         using var sharedContent = new StringContent(body, Encoding.UTF8, "application/json");

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
@@ -241,6 +241,24 @@ public class ClaudeHookCommandTests {
         await Assert.That(stopIdx).IsGreaterThan(startIdx);
     }
 
+    [Test]
+    public async Task subagent_stop_spooled_not_posted_when_current_session_backlog_remains() {
+        using var fx = new Fixture(HttpStatusCode.InternalServerError); // drain fails transiently → backlog remains
+        fx.Spool.Append(Sid, "session-start", $$"""{"session_id":"{{Sid}}"}""");
+
+        await fx.HandleAsync($$"""{"hook_event_name":"SubagentStop","session_id":"{{Sid}}","agent_id":"{{AgentId}}","transcript_path":"/none","cwd":"/tmp"}""");
+
+        // The drain attempted the stranded session-start (and failed transiently, leaving backlog).
+        await Assert.That(fx.RouteOrder).Contains("session-start");
+        // Ordering guard fired: the fresh subagent-stop was spooled, NOT posted — so it never
+        // appears in RouteOrder. (Without the guard it would be POSTed before this session's
+        // stranded session-start is delivered.)
+        await Assert.That(fx.RouteOrder).DoesNotContain("subagent-stop");
+        // ...and it is durably spooled.
+        var all = string.Concat(fx.SpoolFiles.Select(File.ReadAllText));
+        await Assert.That(all).Contains("\"route\":\"subagent-stop\"");
+    }
+
     sealed class Fixture : IDisposable {
         readonly string _tmpHome = Path.Combine(Path.GetTempPath(), $"kcap-claude-hook-{Guid.NewGuid():N}");
         readonly string _spoolPath;

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
@@ -208,6 +208,39 @@ public class ClaudeHookCommandTests {
         await Assert.That(fx.SpoolFiles.Any()).IsFalse();
     }
 
+    [Test]
+    public async Task subagent_stop_spooled_when_client_creation_exceeds_budget() {
+        using var fx = new Fixture();
+        Func<Task<(HttpClient, AuthStatus)>> slowFactory = () =>
+            Task.Delay(TimeSpan.FromSeconds(30)).ContinueWith(_ => (new HttpClient(), AuthStatus.Ok), TaskScheduler.Default);
+        // processStart ~3.4s in the past → subagent-stop remaining = 5 - 3.4 - 1.5 ≈ 0.1s cap.
+        var processStart = System.Diagnostics.Stopwatch.GetTimestamp()
+                         - (long)(3.4 * System.Diagnostics.Stopwatch.Frequency);
+        var sw   = System.Diagnostics.Stopwatch.StartNew();
+        var exit = await ClaudeHookCommand.HandleWithDeps(
+            fx.Spool, processStart, "http://localhost",
+            new StringReader($$"""{"hook_event_name":"SubagentStop","session_id":"{{Sid}}","agent_id":"{{AgentId}}","transcript_path":"/none","cwd":"/tmp"}"""),
+            updateCheckTask: null, clientFactory: slowFactory);
+        sw.Stop();
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
+        var files = fx.SpoolFiles.ToList();
+        await Assert.That(files.Count).IsEqualTo(1);
+        var content = await File.ReadAllTextAsync(files[0]);
+        await Assert.That(content).Contains("\"route\":\"subagent-stop\"");
+    }
+
+    [Test]
+    public async Task current_session_start_replays_before_subagent_stop() {
+        using var fx = new Fixture(); // server up
+        fx.Spool.Append(Sid, "session-start", $$"""{"session_id":"{{Sid}}"}""");
+        await fx.HandleAsync($$"""{"hook_event_name":"SubagentStop","session_id":"{{Sid}}","agent_id":"{{AgentId}}","transcript_path":"/none","cwd":"/tmp"}""");
+        var startIdx = fx.RouteOrder.IndexOf("session-start");
+        var stopIdx  = fx.RouteOrder.IndexOf("subagent-stop");
+        await Assert.That(startIdx).IsGreaterThanOrEqualTo(0);
+        await Assert.That(stopIdx).IsGreaterThan(startIdx);
+    }
+
     sealed class Fixture : IDisposable {
         readonly string _tmpHome = Path.Combine(Path.GetTempPath(), $"kcap-claude-hook-{Guid.NewGuid():N}");
         readonly string _spoolPath;

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
@@ -149,6 +149,55 @@ public class ClaudeHookCommandTests {
         result.Value.Client.Dispose();
     }
 
+    const string AgentId = "a1b2c3d4";
+
+    [Test]
+    public async Task subagent_stop_on_5xx_is_spooled_and_returns_zero() {
+        using var fx = new Fixture(HttpStatusCode.InternalServerError);
+        var exit = await fx.HandleAsync($$"""{"hook_event_name":"SubagentStop","session_id":"{{Sid}}","agent_id":"{{AgentId}}","transcript_path":"/none","cwd":"/tmp"}""");
+        await Assert.That(exit).IsEqualTo(0);
+        var files = fx.SpoolFiles.ToList();
+        await Assert.That(files.Count).IsEqualTo(1);
+        var content = await File.ReadAllTextAsync(files[0]);
+        await Assert.That(content).Contains("\"route\":\"subagent-stop\"");
+    }
+
+    [Test]
+    public async Task subagent_stop_against_hung_server_is_spooled_within_budget() {
+        using var fx = new Fixture();
+        fx.HoldOnPost = TimeSpan.FromSeconds(30); // server hangs past the bounded attempt
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var exit = await fx.HandleAsync($$"""{"hook_event_name":"SubagentStop","session_id":"{{Sid}}","agent_id":"{{AgentId}}","transcript_path":"/none","cwd":"/tmp"}""");
+        sw.Stop();
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5)); // did not wait the full 30s
+        await Assert.That(fx.SpoolFiles.Any()).IsTrue();
+    }
+
+    [Test]
+    public async Task subagent_stop_on_4xx_is_not_spooled() {
+        using var fx = new Fixture(HttpStatusCode.BadRequest);
+        await fx.HandleAsync($$"""{"hook_event_name":"SubagentStop","session_id":"{{Sid}}","agent_id":"{{AgentId}}","transcript_path":"/none","cwd":"/tmp"}""");
+        await Assert.That(fx.SpoolFiles.Any()).IsFalse();
+    }
+
+    [Test]
+    public async Task subagent_stop_without_agent_id_is_not_spooled() {
+        // No agent_id → no SubagentCompleted to deliver → unchanged shared-path behavior (no spool).
+        using var fx = new Fixture(); // OK
+        await fx.HandleAsync($$"""{"hook_event_name":"SubagentStop","session_id":"{{Sid}}","transcript_path":"/none","cwd":"/tmp"}""");
+        await Assert.That(fx.SpoolFiles.Any()).IsFalse();
+    }
+
+    [Test]
+    public async Task spooled_subagent_stop_is_replayed_on_next_hook() {
+        using var fx = new Fixture(); // server up
+        fx.Spool.Append(Sid, "subagent-stop", $$"""{"session_id":"{{Sid}}","agent_id":"{{AgentId}}"}""");
+        await fx.HandleAsync($$"""{"hook_event_name":"Stop","session_id":"{{Sid}}","transcript_path":"/none","cwd":"/tmp"}""");
+        await Assert.That(fx.RouteOrder).Contains("subagent-stop"); // drained + replayed
+        await Assert.That(fx.SpoolFiles.Any()).IsFalse();           // delivered + cleaned
+    }
+
     [Test]
     public async Task replayed_session_end_with_generate_whats_done_is_handled() {
         // Server returns generate_whats_done:false for the replayed session-end (set false to avoid process spawn).


### PR DESCRIPTION
## AI-1005 (CLI side): durable `subagent-stop`

Companion to the kcap-server fix ([kcap-server#829](https://github.com/kurrent-io/kcap-server/pull/829)). That PR makes the read model recover from a missing `SubagentCompleted` (cascade + reaper). This PR reduces the rate at which those completions are dropped in the first place.

### Problem
The merged `durable-hook-spool` work (#187) gave `session-start` and `session-end` dedicated bounded-POST + spool-on-transient paths, but **`subagent-stop` was left out** — it still fell through to the shared `PostWithRetryAsync` path, which on failure writes stderr and `return 1` with **no spool**. Under hook-budget pressure / fan-out, a dropped `subagent-stop` POST permanently loses that subagent's `SubagentCompleted`, leaving a stuck spinner in the UI.

### Fix
A dedicated `subagent-stop` branch in `ClaudeHookCommand.HandleCore` (mirrors the `session-end` block), gated on `agent_id` being present:
- single bounded `PostOnceAsync` clamped to `HookBudget.Remaining(processStart, "subagent-stop")` (5s ceiling);
- on transient failure (unreachable / timeout / 5xx / 408 / 429) → `spool.Append(sessionId, "subagent-stop", body)` and return 0;
- on permanent 4xx (≠ 408/429) → no spool;
- without `agent_id` → unchanged (falls through to the shared path).

The existing cross-session drainer replays spooled entries to `/hooks/subagent-stop`; server-side `SubagentCompleted` ids are deterministic (UUIDv5 over session+agent), so replay is idempotent — **no server changes required**.

### Pre-drain clamp (also fixed here)
`subagent-stop`'s pre-drain (`KillWatcher` + `InlineDrain`) was capped at `PreHookDrainCap` (8s) while the hook ceiling is only 5s — against a hung server the drain alone could blow the budget before the bounded POST, so the spool path was never reached before Claude's kill. It is now clamped to the remaining budget.

> ⚠️ **Do not "simplify" the clamp to match `session-end`.** The `subagent-stop` clamp is `Math.Max(0, Math.Min(PreHookDrainCap, remaining − HookBudget.Safety))`. The extra `− Safety` is **load-bearing** for the tight 5s ceiling (session-end's 15s ceiling doesn't need it): without it the drain can consume the whole ~3.5s budget, the POST is skipped, and a 4xx would spuriously spool. This is pinned by `subagent_stop_on_4xx_is_not_spooled`.

### Tests
TDD; mirrors the `session_end_*` tests. New: `subagent_stop_on_5xx_is_spooled_and_returns_zero`, `subagent_stop_against_hung_server_is_spooled_within_budget` (elapsed < 5s), `subagent_stop_on_4xx_is_not_spooled`, `subagent_stop_without_agent_id_is_not_spooled`, `spooled_subagent_stop_is_replayed_on_next_hook`. Full unit suite **1806/1806**, AOT-clean (no IL2026/IL3050).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
