### PR TITLE
[AI-774] Review flow MCP server + agent skill (kcap mcp flows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ claude mcp add kcap-flows -- kcap mcp flows
 
 It provides four tools:
 
-- **`start_review_flow`** — start a new review flow (spec-review, code-review, pr-review, etc.). Provide `kind`, `target_kind`, `target_ref`, `target_title`, and `context`. Requester context (session ID, cwd, repo root, owner, name) is resolved automatically from the environment. Returns a `flow_run_id`.
+- **`start_review_flow`** — start a new review flow (`spec-review` or `code-review`). Provide `kind`, `target_kind`, `target_ref`, `target_title`, and `context`. Requester context (session ID, cwd, repo root, owner, name) is resolved automatically from the environment. Returns a `flow_run_id`.
 - **`submit_review_round`** — submit a follow-up round to an existing flow with updated context or a response to the reviewer's findings. Returns the new round's findings.
 - **`get_review_flow_status`** — get the current status (running, waiting, completed, failed) and last result of a flow.
 - **`close_review_flow`** — mark a completed review flow as closed.

--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ If your repo directories have been renamed or deleted on disk, the import prints
 
 Open the server URL in your browser. The dashboard shows repositories, sessions, and agents. It updates in real time as Claude Code sessions are active.
 
-### Sessions MCP server for agents
+### Sessions and Flows MCP servers for agents
 
 The `kcap mcp sessions` stdio server lets coding agents search and recall past Capacitor sessions without leaving the chat. The Kurrent Capacitor plugin (installed by `kcap setup`) **auto-registers it for both Claude Code and Codex CLI** — no manual `claude mcp add` or TOML edit. The server is repo-aware: `cd` into a project before spawning your agent and `search_sessions` defaults to that repo's sessions.
+
+The `kcap mcp flows` stdio server lets agents start and interact with AI-powered review flows. Add it manually via `claude mcp add kcap-flows -- kcap mcp flows`. See the [Flows MCP server](#flows-mcp-server-for-agents) section for details.
 
 ## What it records
 
@@ -273,6 +275,33 @@ It provides three tools:
 - **`get_session_transcript`** — speaker-tagged events from a session. Pair `around_event` (and `agent_id` if the hit was in a subagent) with the values returned by `search_sessions` to fetch the exact decision context.
 
 The server is repo-aware — it resolves the current working directory to a repo hash at startup, and `search_sessions` defaults its `repo` filter to that hash unless you override it.
+
+### Flows MCP server (for agents)
+
+```bash
+kcap mcp flows
+```
+
+Stdio MCP server that lets coding agents start and interact with AI-powered review flows directly from within a session. Add it explicitly to your agent setup:
+
+```bash
+# Claude Code
+claude mcp add kcap-flows -- kcap mcp flows
+
+# Codex (~/.config/codex/mcp_servers.toml)
+# [kcap-flows]
+# command = "kcap"
+# args    = ["mcp", "flows"]
+```
+
+It provides four tools:
+
+- **`start_review_flow`** — start a new review flow (spec-review, code-review, pr-review, etc.). Provide `kind`, `target_kind`, `target_ref`, `target_title`, and `context`. Requester context (session ID, cwd, repo root, owner, name) is resolved automatically from the environment. Returns a `flow_run_id`.
+- **`submit_review_round`** — submit a follow-up round to an existing flow with updated context or a response to the reviewer's findings. Returns the new round's findings.
+- **`get_review_flow_status`** — get the current status (running, waiting, completed, failed) and last result of a flow.
+- **`close_review_flow`** — mark a completed review flow as closed.
+
+Requires `kcap login`. The server creates an authenticated HTTP client at startup and posts to the Capacitor server's `/api/flows/*` endpoints.
 
 ### Loading historical sessions
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ kcap plugin install --codex --if-installed           # refresh Codex hooks only 
 kcap plugin install --if-installed                   # refresh Claude plugin registration only if previously installed (used by npm postinstall)
 ```
 
-Installing with `--codex` (or `--skills`) writes five skills under `~/.agents/skills/`:
+Installing with `--codex` (or `--skills`) writes six skills under `~/.agents/skills/`:
 
 | Skill | Wraps | Purpose |
 |---|---|---|
@@ -417,8 +417,9 @@ Installing with `--codex` (or `--skills`) writes five skills under `~/.agents/sk
 | `kcap-hide` | `kcap hide` | Mark session owner-only |
 | `kcap-disable` | `kcap disable` | Stop recording + delete server data |
 | `kcap-validate-plan` | `kcap validate-plan` | Verify plan items were completed |
+| `kcap-review-flows` | `kcap mcp flows` | Structured iterative spec/code review loops |
 
-All five auto-resolve the active session from `CODEX_THREAD_ID`; pass `<sessionId>` explicitly to operate on a different session.
+All six auto-resolve the active session from `CODEX_THREAD_ID`; pass `<sessionId>` explicitly to operate on a different session.
 
 > **Codex sandbox network access (AI-794).** The skills shell out to `kcap …`, which talks to the Capacitor server — but Codex runs the agent's shell tool in a `workspace-write` sandbox that **blocks network by default**, so the skills fail (or demand escalation) until network access is allowed. Both `kcap setup` (one yes/no prompt after the Codex hooks step) and `kcap plugin install --codex` enable it for you. They write a constrained allowlist to `~/.codex/config.toml` rather than opening the network wholesale:
 >

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ Installing with `--codex` (or `--skills`) writes six skills under `~/.agents/ski
 | `kcap-validate-plan` | `kcap validate-plan` | Verify plan items were completed |
 | `kcap-review-flows` | `kcap mcp flows` | Structured iterative spec/code review loops |
 
-All six auto-resolve the active session from `CODEX_THREAD_ID`; pass `<sessionId>` explicitly to operate on a different session.
+The first five (`kcap-recap`, `kcap-errors`, `kcap-hide`, `kcap-disable`, `kcap-validate-plan`) auto-resolve the active session from `CODEX_THREAD_ID`; pass `<sessionId>` explicitly to operate on a different session. `kcap-review-flows` works differently — it operates via flow IDs through `kcap mcp flows` rather than session auto-resolution; see [Flows MCP server (for agents)](#flows-mcp-server-for-agents) for details.
 
 > **Codex sandbox network access (AI-794).** The skills shell out to `kcap …`, which talks to the Capacitor server — but Codex runs the agent's shell tool in a `workspace-write` sandbox that **blocks network by default**, so the skills fail (or demand escalation) until network access is allowed. Both `kcap setup` (one yes/no prompt after the Codex hooks step) and `kcap plugin install --codex` enable it for you. They write a constrained allowlist to `~/.codex/config.toml` rather than opening the network wholesale:
 >

--- a/kcap/skills/review-flows/SKILL.md
+++ b/kcap/skills/review-flows/SKILL.md
@@ -28,37 +28,52 @@ Use `kcap mcp flows` MCP tools to run structured review loops for specs/designs 
 ## Workflow
 
 ```
-start_review_flow(kind, context)
+start_review_flow(kind, target_kind, target_ref, target_title, context)
   → reviewer returns FINDINGS: … | NO FINDINGS
+
+if NO FINDINGS:
+  close_review_flow(flow_run_id)
+  report completion to user
+  DONE
 
 if FINDINGS:
   address each finding
   submit_review_round(flow_run_id, updated_context)
     → repeat until NO FINDINGS
-
-close_review_flow(flow_run_id)
-report completion to user
+  close_review_flow(flow_run_id)
+  report completion to user
 ```
 
 ## Tool reference
 
-| Tool | When to call |
-|---|---|
-| `start_review_flow` | Once, at the start of a review task. Pass `kind` (`spec-review` or `code-review`) and the content to review. |
-| `submit_review_round` | After addressing findings. Pass the same `flow_run_id` and the updated content. |
-| `close_review_flow` | Only after the reviewer returns `NO FINDINGS`. |
+| Tool | Required args | Optional args | When to call |
+|---|---|---|---|
+| `start_review_flow` | `kind` (`spec-review`\|`code-review`), `target_kind` (what is being reviewed: `spec`, `code`, `pr`, `branch`, `file`, etc.), `target_ref` (a path, branch name, or PR URL/number that identifies the target), `target_title` (short human-readable title, e.g. spec name or PR title), `context` (background context: what to focus on, constraints, definition of done) | `instructions`, `mode` | Once, at the start of a review task. |
+| `submit_review_round` | `flow_run_id`, `context` | `instructions` | After addressing findings. Pass the same `flow_run_id` and the updated context. |
+| `get_review_flow_status` | `flow_run_id` | — | Poll or check the current status of a flow (running, waiting, completed, failed). |
+| `close_review_flow` | `flow_run_id` | — | Only after the reviewer returns `NO FINDINGS`. |
 
 ## Example (code review)
 
 ```
-# Step 1 — start
-start_review_flow(kind="code-review", context="<diff or file contents>")
+# Step 1 — start (all five required args must be provided)
+start_review_flow(
+  kind="code-review",
+  target_kind="branch",
+  target_ref="feature/add-null-check",
+  target_title="Add null check on user input",
+  context="Review the diff on this branch for correctness and adherence to project conventions."
+)
+# → returns flow_run_id, e.g. "flow_abc123"
+# → reviewer returns FINDINGS: missing null check on line 42
 
-# Step 2 — reviewer returns FINDINGS: missing null check on line 42
-# Fix the code, then:
-submit_review_round(flow_run_id="<id>", context="<updated diff>")
+# Step 2 — address findings, then re-submit
+submit_review_round(
+  flow_run_id="flow_abc123",
+  context="Fixed null check on line 42. Updated diff attached."
+)
 
 # Step 3 — reviewer returns NO FINDINGS
-close_review_flow(flow_run_id="<id>")
+close_review_flow(flow_run_id="flow_abc123")
 # Report to user: review complete, all findings resolved
 ```

--- a/kcap/skills/review-flows/SKILL.md
+++ b/kcap/skills/review-flows/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: review-flows
+description: >-
+  This skill should be used when the user asks to "review this spec",
+  "review this design", "review my PR", "code review", "get this reviewed",
+  "re-review", "start a review flow", "review flow", "submit for review",
+  or wants structured iterative review with findings and sign-off.
+---
+
+# Review Flows
+
+Use `kcap mcp flows` MCP tools to run structured review loops for specs/designs and PR/code work. A review flow submits your work to a reviewer, collects findings, lets you address them, and keeps iterating until the reviewer returns `NO FINDINGS`.
+
+## When to use
+
+- Reviewing a spec or design document → use `kind: "spec-review"`
+- Reviewing code changes or a pull request → use `kind: "code-review"`
+
+## Core rules
+
+1. **Start exactly one flow per user task.** Call `start_review_flow` once and hold the returned `flow_run_id`. Do NOT start a new flow for follow-up rounds — reuse the same ID.
+2. **After receiving `FINDINGS:`**, address every finding, then call `submit_review_round` with the updated context and the same `flow_run_id`.
+3. **Do NOT finish the user task while the flow has unresolved findings.** Keep iterating until the reviewer returns `NO FINDINGS`.
+4. **Only call `close_review_flow` after `NO FINDINGS`.** Then report completion to the user.
+5. **If reviewer output is unclear or requires user input**, pause and ask the user before proceeding.
+6. **For code review, do NOT ask the reviewer to run tests.** CI covers test execution; reviewer feedback is on correctness, design, and adherence to conventions.
+
+## Workflow
+
+```
+start_review_flow(kind, context)
+  → reviewer returns FINDINGS: … | NO FINDINGS
+
+if FINDINGS:
+  address each finding
+  submit_review_round(flow_run_id, updated_context)
+    → repeat until NO FINDINGS
+
+close_review_flow(flow_run_id)
+report completion to user
+```
+
+## Tool reference
+
+| Tool | When to call |
+|---|---|
+| `start_review_flow` | Once, at the start of a review task. Pass `kind` (`spec-review` or `code-review`) and the content to review. |
+| `submit_review_round` | After addressing findings. Pass the same `flow_run_id` and the updated content. |
+| `close_review_flow` | Only after the reviewer returns `NO FINDINGS`. |
+
+## Example (code review)
+
+```
+# Step 1 — start
+start_review_flow(kind="code-review", context="<diff or file contents>")
+
+# Step 2 — reviewer returns FINDINGS: missing null check on line 42
+# Fix the code, then:
+submit_review_round(flow_run_id="<id>", context="<updated diff>")
+
+# Step 3 — reviewer returns NO FINDINGS
+close_review_flow(flow_run_id="<id>")
+# Report to user: review complete, all findings resolved
+```

--- a/kcap/skills/review-flows/SKILL.md
+++ b/kcap/skills/review-flows/SKILL.md
@@ -48,7 +48,7 @@ if FINDINGS:
 
 | Tool | Required args | Optional args | When to call |
 |---|---|---|---|
-| `start_review_flow` | `kind` (`spec-review`\|`code-review`), `target_kind` (what is being reviewed: `spec`, `code`, `pr`, `branch`, `file`, etc.), `target_ref` (a path, branch name, or PR URL/number that identifies the target), `target_title` (short human-readable title, e.g. spec name or PR title), `context` (background context: what to focus on, constraints, definition of done) | `instructions`, `mode` | Once, at the start of a review task. |
+| `start_review_flow` | `kind` (`spec-review`\|`code-review`), `target_kind` (what is being reviewed: `spec`, `code`, `pr`, `branch`, `file`, etc.), `target_ref` (a path, branch name, or PR URL/number that identifies the target), `target_title` (short human-readable title, e.g. spec name or PR title), `context` (background context: what to focus on, constraints, definition of done) | `instructions`, `mode` (`context-only` — required for code-review unless the reviewer runs in your exact repo checkout) | Once, at the start of a review task. |
 | `submit_review_round` | `flow_run_id`, `context` | `instructions` | After addressing findings. Pass the same `flow_run_id` and the updated context. |
 | `get_review_flow_status` | `flow_run_id` | — | Poll or check the current status of a flow (running, waiting, completed, failed). |
 | `close_review_flow` | `flow_run_id` | — | Only after the reviewer returns `NO FINDINGS`. |
@@ -56,13 +56,14 @@ if FINDINGS:
 ## Example (code review)
 
 ```
-# Step 1 — start (all five required args must be provided)
+# Step 1 — start (all five required args must be provided; mode=context-only is required for code-review)
 start_review_flow(
   kind="code-review",
   target_kind="branch",
   target_ref="feature/add-null-check",
   target_title="Add null check on user input",
-  context="Review the diff on this branch for correctness and adherence to project conventions."
+  context="Review the diff on this branch for correctness and adherence to project conventions.",
+  mode="context-only"
 )
 # → returns flow_run_id, e.g. "flow_abc123"
 # → reviewer returns FINDINGS: missing null check on line 42

--- a/src/Capacitor.Cli.Core/AgentsSkillsInstaller.cs
+++ b/src/Capacitor.Cli.Core/AgentsSkillsInstaller.cs
@@ -25,7 +25,8 @@ public static class AgentsSkillsInstaller {
         "errors",
         "hide",
         "disable",
-        "validate-plan"
+        "validate-plan",
+        "review-flows"
     ];
 
     /// <summary>

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -549,6 +549,8 @@ public record RepoEntry {
 [JsonSerializable(typeof(ReviewLaunchInfo))]
 [JsonSerializable(typeof(LaunchKind))]
 [JsonSerializable(typeof(FindRepoForRemoteRequest))]
+[JsonSerializable(typeof(RefreshAgentWorktreeCommand))]
+[JsonSerializable(typeof(RefreshAgentWorktreeResult))]
 [JsonSerializable(typeof(SendInputCommand))]
 [JsonSerializable(typeof(ResizeTerminalCommand))]
 [JsonSerializable(typeof(PrepareEvalCommand))]
@@ -673,6 +675,28 @@ public readonly record struct FindRepoForRemoteRequest(
         string   Owner,
         string   Repo,
         string[] CandidatePaths
+    );
+
+/// <summary>
+/// Server → daemon command to sync the source repo's current working-tree state (tracked +
+/// untracked non-ignored files) into the reviewer agent's daemon-created worktree, so the
+/// reviewer sees Claude's latest uncommitted changes before a code-review follow-up round.
+/// Wire keys (snake_case): <c>agent_id</c>, <c>source_repo_root</c>, <c>exclude_paths</c>.
+/// </summary>
+public readonly record struct RefreshAgentWorktreeCommand(
+        string   AgentId,
+        string   SourceRepoRoot,
+        string[] ExcludePaths
+    );
+
+/// <summary>
+/// Daemon reply to <see cref="RefreshAgentWorktreeCommand"/>. <see cref="Success"/> is
+/// <c>false</c> when a guard prevented the sync or the sync itself threw; <see cref="Error"/>
+/// carries the reason. Wire keys: <c>success</c>, <c>error</c>.
+/// </summary>
+public readonly record struct RefreshAgentWorktreeResult(
+        bool    Success,
+        string? Error
     );
 
 public readonly record struct SendInputCommand(

--- a/src/Capacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-mcp.txt
@@ -9,6 +9,8 @@ Subcommands:
                           and surface judge facts/clusters.
   sessions                Start the MCP sessions server (stdio) — search and
                           inspect past Kurrent Capacitor sessions.
+  flows                   Start the MCP flows server (stdio) — start and manage
+                          review flows from within an agent session.
 
 Options for review:
   --owner <owner>         Repository owner (session default)
@@ -32,6 +34,29 @@ mcp sessions:
   get_session_transcript — for agents to search and inspect past Kurrent
   Capacitor sessions. The active repo is resolved from cwd at startup;
   cd into your project before spawning. Requires `kcap login`.
+
+mcp flows:
+  Exposes four tools — start_review_flow, submit_review_round,
+  get_review_flow_status, close_review_flow — for agents to start and
+  interact with review flows. Requester context (session ID, cwd, repo
+  root, owner/name) is resolved automatically at startup. Requires
+  `kcap login`.
+
+    Tools:
+      start_review_flow      Start a new AI-powered review flow.
+      submit_review_round    Submit a follow-up round with updated context.
+      get_review_flow_status Get the status and last result of a flow.
+      close_review_flow      Close a completed review flow.
+
+  Add it explicitly if you want it:
+
+    Claude Code:
+      claude mcp add kcap-flows -- kcap mcp flows
+
+    Codex (~/.config/codex/mcp_servers.toml):
+      [kcap-flows]
+      command = "kcap"
+      args    = ["mcp", "flows"]
 
 INSTALL
 

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -52,6 +52,7 @@ MCP servers (stdio):
   mcp review [--owner --repo --pr]   PR review context for agents
   mcp judge --session <id>           Per-session judge tools
   mcp sessions                       Search/inspect past sessions from agents
+  mcp flows                          Start and manage review flows from agents
 
 Plugin:
   plugin install [--project] [--codex|--cursor|--copilot|--gemini|--kiro|--pi|--opencode|--skills]   Register hooks/skills (Claude default; flag picks the vendor)

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -204,8 +204,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _server.OnSendInput              += HandleSendInput;
         _server.OnSendSpecialKey         += HandleSendSpecialKey;
         _server.OnResizeTerminal         += HandleResizeTerminal;
-        _server.ReRegisterAgentsHook     =  ReRegisterAgentsAsync;
-        _server.FindRepoForRemoteHandler =  HandleFindRepoForRemote;
+        _server.ReRegisterAgentsHook          =  ReRegisterAgentsAsync;
+        _server.FindRepoForRemoteHandler      =  HandleFindRepoForRemote;
+        _server.RefreshAgentWorktreeHandler   =  HandleRefreshAgentWorktree;
 
         _server.GetLiveAgentIds = () => [
             .. _agents
@@ -913,6 +914,38 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         => _repoMatcher.FindAsync(req.Owner, req.Repo, req.CandidatePaths ?? [], _shutdownCts.Token);
 
     /// <summary>
+    /// Handles the server's <c>RefreshAgentWorktree</c> client-result invocation (AI-774).
+    /// Syncs the source repo's current working-tree state into the reviewer agent's daemon-created
+    /// worktree so the reviewer sees Claude's latest uncommitted changes before a follow-up round.
+    /// Guards: agent must exist, must not be private, and must be an OwnedWorktree (not borrowed cwd).
+    /// </summary>
+    async Task<RefreshAgentWorktreeResult> HandleRefreshAgentWorktree(RefreshAgentWorktreeCommand cmd) {
+        if (!_agents.TryGetValue(cmd.AgentId, out var agent))
+            return new RefreshAgentWorktreeResult(false, "agent not found");
+
+        if (agent.IsPrivate)
+            return new RefreshAgentWorktreeResult(false, "private agent");
+
+        if (agent.Work != WorkLocation.OwnedWorktree)
+            return new RefreshAgentWorktreeResult(false, "not an owned worktree");
+
+        try {
+            await _worktreeManager.SyncFromSourceAsync(
+                cmd.SourceRepoRoot,
+                agent.Worktree.Path,
+                cmd.ExcludePaths,
+                _shutdownCts.Token
+            );
+
+            return new RefreshAgentWorktreeResult(true, null);
+        } catch (Exception ex) {
+            LogRefreshWorktreeFailed(ex, cmd.AgentId, cmd.SourceRepoRoot, agent.Worktree.Path);
+
+            return new RefreshAgentWorktreeResult(false, ex.Message);
+        }
+    }
+
+    /// <summary>
     /// Registers an agent with the server exactly as a UI-launched agent: AgentRegistered +
     /// terminal dims + AgentRunStarted, then persists/announces the repo path. No-ops for a
     /// PrivateLocal agent. Shared by the hosted launch and the registered local launch so the
@@ -1262,6 +1295,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to spawn what's-done generator for session {SessionId}")]
     partial void LogWhatsDoneSpawnFailed(Exception? ex, string sessionId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to refresh worktree for agent {AgentId} (source={Source}, target={Target})")]
+    partial void LogRefreshWorktreeFailed(Exception ex, string agentId, string source, string target);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to persist repo path for agent {AgentId}")]
     partial void LogRepoPathPersistFailed(Exception ex, string agentId);

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -52,6 +52,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public Func<FindRepoForRemoteRequest, Task<string[]>>? FindRepoForRemoteHandler { get; set; }
 
     /// <summary>
+    /// Handler for the server's <c>RefreshAgentWorktree</c> client-result invocation (AI-774).
+    /// Receives the command and returns whether the sync succeeded. Set by
+    /// <see cref="AgentOrchestrator"/> at startup; when null, returns
+    /// <c>RefreshAgentWorktreeResult(false, "no handler")</c>.
+    /// </summary>
+    public Func<RefreshAgentWorktreeCommand, Task<RefreshAgentWorktreeResult>>? RefreshAgentWorktreeHandler { get; set; }
+
+    /// <summary>
     /// Callback invoked at <see cref="RegisterDaemon"/> time to snapshot the
     /// agent IDs currently hosted by this daemon. The server uses this to
     /// reconcile its registry against the daemon's view. Set by
@@ -131,6 +139,15 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         // startup) so the server treats this daemon as having no matches.
         _hub.On<FindRepoForRemoteRequest, string[]>("FindRepoForRemote",
             req => FindRepoForRemoteHandler?.Invoke(req) ?? Task.FromResult(Array.Empty<string>()));
+
+        // Client-result invocation: sync the source repo's working-tree state into a reviewer
+        // agent's daemon-created worktree before a code-review follow-up round (AI-774).
+        // Returns success/error so the server can decide whether to proceed normally or fall
+        // back to context-only. "no handler" is returned when the orchestrator hasn't wired
+        // the handler yet (e.g. early startup).
+        _hub.On<RefreshAgentWorktreeCommand, RefreshAgentWorktreeResult>("RefreshAgentWorktree",
+            cmd => RefreshAgentWorktreeHandler?.Invoke(cmd)
+                ?? Task.FromResult(new RefreshAgentWorktreeResult(false, "no handler")));
 
         // Server→client push carrying the user's decision for a hosted-agent permission request
         // (AI-864). Paired with the RequestPermission2 invocation in RequestPermissionAsync: that

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -75,6 +75,157 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         }
     }
 
+    /// <summary>
+    /// Syncs the source repo's current working-tree state (tracked + untracked non-ignored files)
+    /// into <paramref name="targetWorktreePath"/>, mirroring file additions, modifications, and
+    /// deletions so the reviewer agent sees Claude's latest uncommitted changes.
+    ///
+    /// Algorithm:
+    /// 1. Normalise and validate both paths; reject empty/equal, nonexistent, or source without .git.
+    /// 2. Run <c>git -C &lt;source&gt; ls-files -co --exclude-standard</c> to enumerate tracked +
+    ///    untracked non-ignored files.
+    /// 3. Copy each file source→target (create parent dirs, overwrite), skipping entries under
+    ///    <c>.git/</c>, <c>.capacitor/worktrees/</c>, any caller-supplied <paramref name="excludePaths"/>
+    ///    prefix, and directory-traversal segments.
+    /// 4. Delete target files whose relative path was NOT copied (i.e. deleted in source),
+    ///    excluding <c>.git/</c> and <c>.capacitor/worktrees/</c>.
+    /// </summary>
+    public async Task SyncFromSourceAsync(
+            string   sourceRepoRoot,
+            string   targetWorktreePath,
+            string[] excludePaths,
+            CancellationToken ct
+        ) {
+        if (string.IsNullOrEmpty(sourceRepoRoot))
+            throw new ArgumentException("Source repo root must not be empty.", nameof(sourceRepoRoot));
+
+        if (string.IsNullOrEmpty(targetWorktreePath))
+            throw new ArgumentException("Target worktree path must not be empty.", nameof(targetWorktreePath));
+
+        var source = Path.GetFullPath(sourceRepoRoot);
+        var target = Path.GetFullPath(targetWorktreePath);
+
+        if (string.Equals(source, target, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"Source and target paths are the same: {source}");
+
+        if (!Directory.Exists(source))
+            throw new InvalidOperationException(
+                $"Source repo root does not exist: {source}");
+
+        // Accept both a .git directory (normal clone) and a .git file (worktree link).
+        if (!File.Exists(Path.Combine(source, ".git")) && !Directory.Exists(Path.Combine(source, ".git")))
+            throw new InvalidOperationException(
+                $"Source path does not appear to be a git repo (no .git entry): {source}");
+
+        // Enumerate tracked + untracked non-ignored paths from the source repo.
+        List<string> relativePaths;
+
+        try {
+            var psi = NewGitPsi(source, ["ls-files", "-co", "--exclude-standard"]);
+            using var proc = Process.Start(psi)!;
+            using var cts  = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(GitTimeout);
+
+            string stdout;
+
+            try {
+                stdout = await proc.StandardOutput.ReadToEndAsync(cts.Token);
+                await proc.WaitForExitAsync(cts.Token);
+            } catch (OperationCanceledException) {
+                try { proc.Kill(true); } catch { /* best-effort */ }
+
+                throw;
+            }
+
+            if (proc.ExitCode != 0) {
+                var stderr = await proc.StandardError.ReadToEndAsync(ct);
+
+                throw new InvalidOperationException(
+                    $"git ls-files failed in {source}: {stderr}");
+            }
+
+            relativePaths = [..stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries)];
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            throw new InvalidOperationException(
+                $"SyncFromSourceAsync: failed to enumerate files in {source} → {target}: {ex.Message}", ex);
+        }
+
+        // Always-excluded path prefixes (normalised to use the platform separator).
+        var alwaysExcluded = new[] { ".git" + Path.DirectorySeparatorChar, ".git", ".capacitor" + Path.DirectorySeparatorChar + "worktrees" };
+
+        // Build caller-supplied excludes normalised the same way.
+        var callerExcluded = excludePaths
+            .Where(p => !string.IsNullOrEmpty(p))
+            .Select(p => p.Replace('/', Path.DirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar))
+            .ToArray();
+
+        var copied = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var rawPath in relativePaths) {
+            // Normalise separators (git always emits forward slashes).
+            var rel = rawPath.Replace('/', Path.DirectorySeparatorChar);
+
+            // Skip directory traversal.
+            if (rel.Contains(".." + Path.DirectorySeparatorChar) || rel == "..")
+                continue;
+
+            // Skip always-excluded prefixes.
+            if (IsUnderExcluded(rel, alwaysExcluded))
+                continue;
+
+            // Skip caller-supplied excludes.
+            if (callerExcluded.Length > 0 && IsUnderExcluded(rel, callerExcluded))
+                continue;
+
+            var srcFile = Path.Combine(source, rel);
+            var dstFile = Path.Combine(target, rel);
+
+            if (!File.Exists(srcFile))
+                continue;
+
+            var dstDir = Path.GetDirectoryName(dstFile);
+
+            if (dstDir is not null)
+                Directory.CreateDirectory(dstDir);
+
+            File.Copy(srcFile, dstFile, overwrite: true);
+            copied.Add(rel);
+        }
+
+        // Delete target files that no longer exist in the source (i.e. deleted).
+        foreach (var existingFile in Directory.EnumerateFiles(target, "*", SearchOption.AllDirectories)) {
+            var rel = Path.GetRelativePath(target, existingFile);
+
+            // Never touch .git/ or .capacitor/worktrees/ inside the target.
+            if (IsUnderExcluded(rel, alwaysExcluded))
+                continue;
+
+            // Also skip caller-excluded paths on the delete side — they are opaque to
+            // the sync and must be left exactly as they are in the target.
+            if (callerExcluded.Length > 0 && IsUnderExcluded(rel, callerExcluded))
+                continue;
+
+            if (!copied.Contains(rel))
+                File.Delete(existingFile);
+        }
+
+        LogSyncCompleted(source, target, copied.Count);
+    }
+
+    static bool IsUnderExcluded(string rel, string[] prefixes) {
+        foreach (var prefix in prefixes) {
+            // Exact match (e.g. ".git" as a file) or prefix match (e.g. ".git/foo").
+            if (rel.Equals(prefix, StringComparison.Ordinal))
+                return true;
+
+            if (rel.StartsWith(prefix + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+
     public Task CleanupOrphanedAsync(IEnumerable<string>? activeWorktreePaths = null) {
         // Legacy global root — clean up any leftover worktrees from before the per-repo change
         var worktreePaths = activeWorktreePaths as string[] ?? [..activeWorktreePaths ?? []];
@@ -178,6 +329,9 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
 
         return psi;
     }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Synced {FileCount} files from {Source} into worktree {Target}")]
+    partial void LogSyncCompleted(string source, string target, int fileCount);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Cleaning up orphaned worktree: {Path}")]
     partial void LogCleaningUp(string path);

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -100,9 +100,11 @@ static class McpFlowsServer {
                 return BuildToolResult(id, $"Error: HTTP {(int)httpResponse.StatusCode} — {body}", isError: true);
             }
 
-            var payload = toolName == "get_review_flow_status"
-                ? FormatStatusResponse(body)
-                : FormatRoundResponse(body);
+            var payload = toolName switch {
+                "get_review_flow_status" => FormatStatusResponse(body),
+                "close_review_flow"      => FormatCloseResponse(body),
+                _                        => FormatRoundResponse(body)
+            };
 
             return BuildToolResult(id, payload);
         } catch (ArgumentException ex) {
@@ -248,6 +250,28 @@ static class McpFlowsServer {
                 sb.AppendLine();
                 sb.Append(lastResultText);
             }
+
+            return sb.ToString();
+        } catch {
+            return body;
+        }
+    }
+
+    /// <summary>
+    /// Formats a CloseReviewFlowResponse into a compact envelope.
+    /// The server returns only <c>flow_run_id</c> and <c>status</c>.
+    /// </summary>
+    static string FormatCloseResponse(string body) {
+        try {
+            var node = JsonNode.Parse(body)?.AsObject();
+            if (node is null) return body;
+
+            var flowRunId = node["flow_run_id"]?.GetValue<string>() ?? "";
+            var status    = node["status"]?.GetValue<string>()      ?? "";
+
+            var sb = new StringBuilder();
+            sb.Append("flow_run_id: "); AppendLine(sb, flowRunId);
+            sb.Append("status: ");      AppendLine(sb, status);
 
             return sb.ToString();
         } catch {

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
@@ -6,6 +7,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
 
 namespace Capacitor.Cli.Commands;
 
@@ -83,10 +85,10 @@ static class McpFlowsServer {
             var apiRoot = baseUrl.TrimEnd('/');
 
             using var httpResponse = toolName switch {
-                "start_review_flow"      => await StartReviewFlowAsync(client, apiRoot, arguments, cwd, repoRoot, repoInfo),
-                "submit_review_round"    => await SubmitReviewRoundAsync(client, apiRoot, arguments),
-                "get_review_flow_status" => await client.GetAsync(BuildFlowUrl(apiRoot, arguments)),
-                "close_review_flow"      => await client.PostAsync(BuildFlowUrl(apiRoot, arguments) + "/close", null),
+                "start_review_flow"      => await SendWithRefreshRetryAsync(client, c => StartReviewFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo)),
+                "submit_review_round"    => await SendWithRefreshRetryAsync(client, c => SubmitReviewRoundAsync(c, apiRoot, arguments)),
+                "get_review_flow_status" => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildFlowUrl(apiRoot, arguments))),
+                "close_review_flow"      => await SendWithRefreshRetryAsync(client, c => c.PostAsync(BuildFlowUrl(apiRoot, arguments) + "/close", null)),
                 _                        => throw new ArgumentException($"Unknown tool: {toolName}")
             };
 
@@ -112,6 +114,31 @@ static class McpFlowsServer {
         } catch (HttpRequestException ex) {
             return BuildToolResult(id, $"Error: {ex.Message}", isError: true);
         }
+    }
+
+    /// <summary>
+    /// Sends an HTTP request with one-shot retry on 401. The MCP server reuses a single
+    /// <see cref="HttpClient"/> for the lifetime of the agent session, so a cached token
+    /// that was valid at startup may have expired by the time a tool call is made. On 401
+    /// we ask <see cref="TokenStore.GetValidTokensAsync"/> for a fresh token (which triggers
+    /// the refresh flow for WorkOS / GitHubApp), update the client's <c>Authorization</c>
+    /// header, and retry the same request once. If refresh fails (genuinely not logged in
+    /// or refresh-token expired), the original 401 is returned and the caller surfaces the
+    /// friendly "Not logged in" message.
+    /// </summary>
+    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, Func<HttpClient, Task<HttpResponseMessage>> send) {
+        var response = await send(client);
+
+        if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
+
+        var refreshed = await TokenStore.GetValidTokensAsync();
+
+        if (refreshed is null) return response; // genuinely not logged in; keep the original 401
+
+        response.Dispose();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", refreshed.AccessToken);
+
+        return await send(client);
     }
 
     static async Task<System.Net.Http.HttpResponseMessage> StartReviewFlowAsync(

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -301,13 +301,13 @@ static class McpFlowsServer {
             new(
                 "object",
                 new() {
-                    ["kind"]         = new("string", "Review flow kind, e.g. 'spec-review', 'code-review', 'pr-review'."),
+                    ["kind"]         = new("string", "Review flow kind. Valid values: 'spec-review' (for specs and design documents), 'code-review' (for code changes and PRs)."),
                     ["target_kind"]  = new("string", "What is being reviewed: 'pr', 'branch', 'file', 'spec', 'plan', etc."),
                     ["target_ref"]   = new("string", "A reference to the target (PR URL, branch name, file path, etc.)."),
                     ["target_title"] = new("string", "Human-readable title for the target (PR title, spec name, etc.)."),
                     ["context"]      = new("string", "Background context for the reviewer: what to focus on, constraints, definition of done."),
                     ["instructions"] = new("string", "Optional additional instructions for the reviewer agent."),
-                    ["mode"]         = new("string", "Optional mode hint, e.g. 'blocking' or 'async'.")
+                    ["mode"]         = new("string", "Optional. Pass 'context-only' to treat the submitted context/diff as authoritative. Required for code-review unless the reviewer runs in your exact repo checkout; omitting it will cause the server to reject the request with an error.")
                 },
                 ["kind", "target_kind", "target_ref", "target_title", "context"]
             )

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -1,0 +1,374 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Commands;
+
+static class McpFlowsServer {
+    public static async Task<int> RunAsync(string baseUrl) {
+        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+
+        var cwd      = Directory.GetCurrentDirectory();
+        var repoRoot = GitRepository.FindRoot(cwd);
+        var tools    = BuildToolsList();
+
+        RepositoryPayload? repoInfo = null;
+        try {
+            repoInfo = await RepositoryDetection.DetectRepositoryAsync(cwd);
+        } catch {
+            // best-effort; proceed with null
+        }
+
+        await using var stdin  = Console.OpenStandardInput();
+        await using var stdout = Console.OpenStandardOutput();
+        using var       reader = new StreamReader(stdin, Encoding.UTF8);
+        await using var writer = new StreamWriter(stdout, new UTF8Encoding(false));
+        writer.AutoFlush = true;
+
+        while (await reader.ReadLineAsync() is { } line) {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            JsonObject? request;
+
+            try {
+                request = JsonNode.Parse(line)?.AsObject();
+            } catch {
+                continue;
+            }
+
+            if (request is null) continue;
+
+            var id     = request["id"];
+            var method = request["method"]?.GetValue<string>();
+
+            // Notifications have no id — don't send a response
+            if (id is null) continue;
+
+            var response = method switch {
+                "initialize" => BuildInitializeResponse(id),
+                "tools/list" => BuildToolsListResponse(id, tools),
+                "tools/call" => await HandleToolCallAsync(id, request, client, baseUrl, cwd, repoRoot, repoInfo),
+                _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
+            };
+
+            await writer.WriteLineAsync(response);
+        }
+
+        return 0;
+    }
+
+    static async Task<string> HandleToolCallAsync(
+            JsonNode            id,
+            JsonObject          request,
+            HttpClient          client,
+            string              baseUrl,
+            string              cwd,
+            string?             repoRoot,
+            RepositoryPayload?  repoInfo
+        ) {
+        var paramsNode = request["params"]?.AsObject();
+        var toolName   = paramsNode?["name"]?.GetValue<string>();
+        var arguments  = paramsNode?["arguments"]?.AsObject();
+
+        if (toolName is null) {
+            return BuildErrorResponse(id, -32602, "Missing params.name");
+        }
+
+        try {
+            var apiRoot = baseUrl.TrimEnd('/');
+
+            using var httpResponse = toolName switch {
+                "start_review_flow"      => await StartReviewFlowAsync(client, apiRoot, arguments, cwd, repoRoot, repoInfo),
+                "submit_review_round"    => await SubmitReviewRoundAsync(client, apiRoot, arguments),
+                "get_review_flow_status" => await client.GetAsync(BuildFlowUrl(apiRoot, arguments, "get_review_flow_status")),
+                "close_review_flow"      => await client.PostAsync(BuildFlowUrl(apiRoot, arguments, "close_review_flow") + "/close", null),
+                _                        => throw new ArgumentException($"Unknown tool: {toolName}")
+            };
+
+            var body = await httpResponse.Content.ReadAsStringAsync();
+
+            if (httpResponse.StatusCode == HttpStatusCode.Unauthorized) {
+                return BuildToolResult(id, "Not logged in. Run 'kcap login' on the host shell.", isError: true);
+            }
+
+            if (!httpResponse.IsSuccessStatusCode) {
+                return BuildToolResult(id, $"Error: HTTP {(int)httpResponse.StatusCode} — {body}", isError: true);
+            }
+
+            var payload = toolName == "get_review_flow_status"
+                ? FormatStatusResponse(body)
+                : FormatRoundResponse(body);
+
+            return BuildToolResult(id, payload);
+        } catch (ArgumentException ex) {
+            return BuildToolResult(id, $"Error: {ex.Message}", isError: true);
+        } catch (HttpRequestException ex) {
+            return BuildToolResult(id, $"Error: {ex.Message}", isError: true);
+        }
+    }
+
+    static async Task<System.Net.Http.HttpResponseMessage> StartReviewFlowAsync(
+            HttpClient         client,
+            string             apiRoot,
+            JsonObject?        arguments,
+            string             cwd,
+            string?            repoRoot,
+            RepositoryPayload? repoInfo
+        ) {
+        var kind         = GetRequiredArg(arguments, "kind");
+        var targetKind   = GetRequiredArg(arguments, "target_kind");
+        var targetRef    = GetRequiredArg(arguments, "target_ref");
+        var targetTitle  = GetRequiredArg(arguments, "target_title");
+        var context      = GetRequiredArg(arguments, "context");
+        var instructions = arguments?["instructions"]?.GetValue<string>();
+        var mode         = arguments?["mode"]?.GetValue<string>();
+
+        var sessionId = ArgParsing.ResolveSessionIdFromEnv();
+
+        var body = new StartReviewFlowDto(
+            Kind:                 kind,
+            TargetKind:           targetKind,
+            TargetRef:            targetRef,
+            TargetTitle:          targetTitle,
+            Context:              context,
+            Instructions:         instructions,
+            RequestingSessionId:  sessionId,
+            RequestingCwd:        cwd,
+            RequestingRepoRoot:   repoRoot,
+            RepoOwner:            repoInfo?.Owner,
+            RepoName:             repoInfo?.RepoName,
+            DaemonName:           null,
+            RepoPath:             repoRoot,
+            Mode:                 mode
+        );
+
+        return await client.PostAsync(
+            $"{apiRoot}/api/flows/review/start",
+            JsonContent.Create(body, McpJsonContext.Default.StartReviewFlowDto)
+        );
+    }
+
+    static Task<System.Net.Http.HttpResponseMessage> SubmitReviewRoundAsync(
+            HttpClient  client,
+            string      apiRoot,
+            JsonObject? arguments
+        ) {
+        var flowRunId    = arguments?["flow_run_id"]?.GetValue<string>();
+        var context      = GetRequiredArg(arguments, "context");
+        var instructions = arguments?["instructions"]?.GetValue<string>();
+
+        if (string.IsNullOrWhiteSpace(flowRunId)) {
+            throw new ArgumentException(
+                "Missing required argument: flow_run_id. " +
+                "Pass the flow_run_id returned by start_review_flow."
+            );
+        }
+
+        var body = new SubmitReviewRoundDto(Context: context, Instructions: instructions);
+
+        return client.PostAsync(
+            $"{apiRoot}/api/flows/{Uri.EscapeDataString(flowRunId)}/rounds",
+            JsonContent.Create(body, McpJsonContext.Default.SubmitReviewRoundDto)
+        );
+    }
+
+    static string BuildFlowUrl(string apiRoot, JsonObject? arguments, string toolName) {
+        var flowRunId = arguments?["flow_run_id"]?.GetValue<string>()
+            ?? throw new ArgumentException("Missing required argument: flow_run_id");
+
+        return $"{apiRoot}/api/flows/{Uri.EscapeDataString(flowRunId)}";
+    }
+
+    /// <summary>
+    /// Formats a ReviewFlowRoundResponse or ReviewFlowStatusResponse (from start/submit) into a
+    /// compact envelope followed by the result text.
+    /// </summary>
+    static string FormatRoundResponse(string body) {
+        try {
+            var node = JsonNode.Parse(body)?.AsObject();
+            if (node is null) return body;
+
+            var flowRunId   = node["flowRunId"]?.GetValue<string>()   ?? "";
+            var roundId     = node["roundId"]?.GetValue<string>()     ?? "";
+            var status      = node["status"]?.GetValue<string>()      ?? "";
+            var resultKind  = node["resultKind"]?.GetValue<string>()  ?? "";
+            var resultText  = node["resultText"]?.GetValue<string>();
+
+            var sb = new StringBuilder();
+            sb.Append("flow_run_id: "); AppendLine(sb, flowRunId);
+            sb.Append("round_id: ");    AppendLine(sb, roundId);
+            sb.Append("status: ");      AppendLine(sb, status);
+            sb.Append("result_kind: "); AppendLine(sb, resultKind);
+
+            if (!string.IsNullOrEmpty(resultText)) {
+                sb.AppendLine();
+                sb.Append(resultText);
+            }
+
+            return sb.ToString();
+        } catch {
+            return body;
+        }
+    }
+
+    static string FormatStatusResponse(string body) {
+        try {
+            var node = JsonNode.Parse(body)?.AsObject();
+            if (node is null) return body;
+
+            var flowRunId      = node["flowRunId"]?.GetValue<string>()      ?? "";
+            var status         = node["status"]?.GetValue<string>()         ?? "";
+            var definitionId   = node["definitionId"]?.GetValue<string>()   ?? "";
+            var targetTitle    = node["targetTitle"]?.GetValue<string>()    ?? "";
+            var roundCount     = node["roundCount"]?.GetValue<int>();
+            var lastResultKind = node["lastResultKind"]?.GetValue<string>();
+            var lastResultText = node["lastResultText"]?.GetValue<string>();
+
+            var sb = new StringBuilder();
+            sb.Append("flow_run_id: ");   AppendLine(sb, flowRunId);
+            sb.Append("status: ");        AppendLine(sb, status);
+            sb.Append("definition_id: "); AppendLine(sb, definitionId);
+            sb.Append("target_title: ");  AppendLine(sb, targetTitle);
+
+            if (roundCount.HasValue) {
+                sb.Append("round_count: ");
+                sb.AppendLine(roundCount.Value.ToString());
+            }
+
+            if (!string.IsNullOrEmpty(lastResultKind)) {
+                sb.Append("result_kind: "); AppendLine(sb, lastResultKind);
+            }
+
+            if (!string.IsNullOrEmpty(lastResultText)) {
+                sb.AppendLine();
+                sb.Append(lastResultText);
+            }
+
+            return sb.ToString();
+        } catch {
+            return body;
+        }
+    }
+
+    static void AppendLine(StringBuilder sb, string value) => sb.AppendLine(value);
+
+    static string GetRequiredArg(JsonObject? arguments, string name) {
+        var value = arguments?[name]?.GetValue<string>();
+        return value ?? throw new ArgumentException($"Missing required argument: {name}");
+    }
+
+    static string BuildInitializeResponse(JsonNode id) =>
+        ToResponse<McpInitResult>(
+            id,
+            new("2024-11-05", new(new()), new("kcap-flows", "1.0.0")),
+            McpJsonContext.Default.McpInitResult
+        );
+
+    static string BuildToolsListResponse(JsonNode id, McpTool[] tools) =>
+        ToResponse(id, new McpToolsResult(tools), McpJsonContext.Default.McpToolsResult);
+
+    static string BuildToolResult(JsonNode id, string text, bool isError = false) =>
+        ToResponse<McpToolCallResult>(id, new([new("text", text)], isError ? true : null), McpJsonContext.Default.McpToolCallResult);
+
+    static string BuildErrorResponse(JsonNode id, int code, string message) {
+        var envelope = new JsonObject {
+            ["jsonrpc"] = "2.0",
+            ["id"]      = id.DeepClone(),
+            ["error"]   = JsonSerializer.SerializeToNode(new McpError(code, message), McpJsonContext.Default.McpError)
+        };
+        return envelope.ToJsonString();
+    }
+
+    static string ToResponse<T>(JsonNode id, T result, JsonTypeInfo<T> typeInfo) {
+        var envelope = new JsonObject {
+            ["jsonrpc"] = "2.0",
+            ["id"]      = id.DeepClone(),
+            ["result"]  = JsonSerializer.SerializeToNode(result, typeInfo)
+        };
+        return envelope.ToJsonString();
+    }
+
+    static McpTool[] BuildToolsList() => [
+        new(
+            "start_review_flow",
+            "Start a new review flow. The server starts an AI reviewer agent that will analyse the target and return findings. " +
+            "Returns a flow_run_id that identifies this review session — save it to call submit_review_round or get_review_flow_status later.",
+            new(
+                "object",
+                new() {
+                    ["kind"]         = new("string", "Review flow kind, e.g. 'spec-review', 'code-review', 'pr-review'."),
+                    ["target_kind"]  = new("string", "What is being reviewed: 'pr', 'branch', 'file', 'spec', 'plan', etc."),
+                    ["target_ref"]   = new("string", "A reference to the target (PR URL, branch name, file path, etc.)."),
+                    ["target_title"] = new("string", "Human-readable title for the target (PR title, spec name, etc.)."),
+                    ["context"]      = new("string", "Background context for the reviewer: what to focus on, constraints, definition of done."),
+                    ["instructions"] = new("string", "Optional additional instructions for the reviewer agent."),
+                    ["mode"]         = new("string", "Optional mode hint, e.g. 'blocking' or 'async'.")
+                },
+                ["kind", "target_kind", "target_ref", "target_title", "context"]
+            )
+        ),
+        new(
+            "submit_review_round",
+            "Submit a follow-up round to an existing review flow. Use this to ask for clarifications, provide additional context, or request a re-review after addressing feedback. Returns the new round's findings.",
+            new(
+                "object",
+                new() {
+                    ["flow_run_id"]  = new("string", "Flow run ID returned by start_review_flow."),
+                    ["context"]      = new("string", "Updated context or response to the reviewer's previous findings."),
+                    ["instructions"] = new("string", "Optional instructions for this round.")
+                },
+                ["flow_run_id", "context"]
+            )
+        ),
+        new(
+            "get_review_flow_status",
+            "Get the current status of a review flow: running, waiting, completed, or failed. Also surfaces the last result kind and result text.",
+            new(
+                "object",
+                new() {
+                    ["flow_run_id"] = new("string", "Flow run ID returned by start_review_flow.")
+                },
+                ["flow_run_id"]
+            )
+        ),
+        new(
+            "close_review_flow",
+            "Close a review flow, marking it as complete. Call this after the review is done and the findings have been addressed.",
+            new(
+                "object",
+                new() {
+                    ["flow_run_id"] = new("string", "Flow run ID returned by start_review_flow.")
+                },
+                ["flow_run_id"]
+            )
+        )
+    ];
+}
+
+/// <summary>CLI-side DTO for POST /api/flows/review/start — mirrors the server's StartReviewFlowRequest fields.</summary>
+record StartReviewFlowDto(
+    string  Kind,
+    string  TargetKind,
+    string  TargetRef,
+    string  TargetTitle,
+    string  Context,
+    string? Instructions,
+    string? RequestingSessionId,
+    string? RequestingCwd,
+    string? RequestingRepoRoot,
+    string? RepoOwner,
+    string? RepoName,
+    string? DaemonName,
+    string? RepoPath,
+    string? Mode
+);
+
+/// <summary>CLI-side DTO for POST /api/flows/{flowRunId}/rounds — mirrors the server's SubmitReviewRoundRequest.</summary>
+record SubmitReviewRoundDto(
+    string  Context,
+    string? Instructions
+);

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Capacitor.Cli.Core;
 
@@ -84,8 +85,8 @@ static class McpFlowsServer {
             using var httpResponse = toolName switch {
                 "start_review_flow"      => await StartReviewFlowAsync(client, apiRoot, arguments, cwd, repoRoot, repoInfo),
                 "submit_review_round"    => await SubmitReviewRoundAsync(client, apiRoot, arguments),
-                "get_review_flow_status" => await client.GetAsync(BuildFlowUrl(apiRoot, arguments, "get_review_flow_status")),
-                "close_review_flow"      => await client.PostAsync(BuildFlowUrl(apiRoot, arguments, "close_review_flow") + "/close", null),
+                "get_review_flow_status" => await client.GetAsync(BuildFlowUrl(apiRoot, arguments)),
+                "close_review_flow"      => await client.PostAsync(BuildFlowUrl(apiRoot, arguments) + "/close", null),
                 _                        => throw new ArgumentException($"Unknown tool: {toolName}")
             };
 
@@ -176,7 +177,7 @@ static class McpFlowsServer {
         );
     }
 
-    static string BuildFlowUrl(string apiRoot, JsonObject? arguments, string toolName) {
+    static string BuildFlowUrl(string apiRoot, JsonObject? arguments) {
         var flowRunId = arguments?["flow_run_id"]?.GetValue<string>()
             ?? throw new ArgumentException("Missing required argument: flow_run_id");
 
@@ -192,11 +193,11 @@ static class McpFlowsServer {
             var node = JsonNode.Parse(body)?.AsObject();
             if (node is null) return body;
 
-            var flowRunId   = node["flowRunId"]?.GetValue<string>()   ?? "";
-            var roundId     = node["roundId"]?.GetValue<string>()     ?? "";
+            var flowRunId   = node["flow_run_id"]?.GetValue<string>()   ?? "";
+            var roundId     = node["round_id"]?.GetValue<string>()     ?? "";
             var status      = node["status"]?.GetValue<string>()      ?? "";
-            var resultKind  = node["resultKind"]?.GetValue<string>()  ?? "";
-            var resultText  = node["resultText"]?.GetValue<string>();
+            var resultKind  = node["result_kind"]?.GetValue<string>()  ?? "";
+            var resultText  = node["result_text"]?.GetValue<string>();
 
             var sb = new StringBuilder();
             sb.Append("flow_run_id: "); AppendLine(sb, flowRunId);
@@ -220,13 +221,13 @@ static class McpFlowsServer {
             var node = JsonNode.Parse(body)?.AsObject();
             if (node is null) return body;
 
-            var flowRunId      = node["flowRunId"]?.GetValue<string>()      ?? "";
+            var flowRunId      = node["flow_run_id"]?.GetValue<string>()      ?? "";
             var status         = node["status"]?.GetValue<string>()         ?? "";
-            var definitionId   = node["definitionId"]?.GetValue<string>()   ?? "";
-            var targetTitle    = node["targetTitle"]?.GetValue<string>()    ?? "";
-            var roundCount     = node["roundCount"]?.GetValue<int>();
-            var lastResultKind = node["lastResultKind"]?.GetValue<string>();
-            var lastResultText = node["lastResultText"]?.GetValue<string>();
+            var definitionId   = node["definition_id"]?.GetValue<string>()   ?? "";
+            var targetTitle    = node["target_title"]?.GetValue<string>()    ?? "";
+            var roundCount     = node["round_count"]?.GetValue<int>();
+            var lastResultKind = node["last_result_kind"]?.GetValue<string>();
+            var lastResultText = node["last_result_text"]?.GetValue<string>();
 
             var sb = new StringBuilder();
             sb.Append("flow_run_id: ");   AppendLine(sb, flowRunId);
@@ -351,24 +352,24 @@ static class McpFlowsServer {
 
 /// <summary>CLI-side DTO for POST /api/flows/review/start — mirrors the server's StartReviewFlowRequest fields.</summary>
 record StartReviewFlowDto(
-    string  Kind,
-    string  TargetKind,
-    string  TargetRef,
-    string  TargetTitle,
-    string  Context,
-    string? Instructions,
-    string? RequestingSessionId,
-    string? RequestingCwd,
-    string? RequestingRepoRoot,
-    string? RepoOwner,
-    string? RepoName,
-    string? DaemonName,
-    string? RepoPath,
-    string? Mode
+    [property: JsonPropertyName("kind")]                   string  Kind,
+    [property: JsonPropertyName("target_kind")]            string  TargetKind,
+    [property: JsonPropertyName("target_ref")]             string  TargetRef,
+    [property: JsonPropertyName("target_title")]           string  TargetTitle,
+    [property: JsonPropertyName("context")]                string  Context,
+    [property: JsonPropertyName("instructions")]           string? Instructions,
+    [property: JsonPropertyName("requesting_session_id")] string? RequestingSessionId,
+    [property: JsonPropertyName("requesting_cwd")]         string? RequestingCwd,
+    [property: JsonPropertyName("requesting_repo_root")]   string? RequestingRepoRoot,
+    [property: JsonPropertyName("repo_owner")]             string? RepoOwner,
+    [property: JsonPropertyName("repo_name")]              string? RepoName,
+    [property: JsonPropertyName("daemon_name")]            string? DaemonName,
+    [property: JsonPropertyName("repo_path")]              string? RepoPath,
+    [property: JsonPropertyName("mode")]                   string? Mode
 );
 
 /// <summary>CLI-side DTO for POST /api/flows/{flowRunId}/rounds — mirrors the server's SubmitReviewRoundRequest.</summary>
 record SubmitReviewRoundDto(
-    string  Context,
-    string? Instructions
+    [property: JsonPropertyName("context")]      string  Context,
+    [property: JsonPropertyName("instructions")] string? Instructions
 );

--- a/src/Capacitor.Cli/Commands/McpReviewServer.cs
+++ b/src/Capacitor.Cli/Commands/McpReviewServer.cs
@@ -366,4 +366,6 @@ record SessionSearchQuery(string Query, int? Limit = null);
 [JsonSerializable(typeof(McpError))]
 [JsonSerializable(typeof(SearchQuery))]
 [JsonSerializable(typeof(SessionSearchQuery))]
+[JsonSerializable(typeof(StartReviewFlowDto))]
+[JsonSerializable(typeof(SubmitReviewRoundDto))]
 partial class McpJsonContext : JsonSerializerContext;

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -267,10 +267,11 @@ switch (command) {
     }
     case "mcp": {
         if (args.Length < 2) {
-            Console.Error.WriteLine("Usage: kcap mcp review|judge|sessions …");
+            Console.Error.WriteLine("Usage: kcap mcp review|judge|sessions|flows …");
             Console.Error.WriteLine("  kcap mcp review [--owner <owner> --repo <repo> --pr <number>]");
             Console.Error.WriteLine("  kcap mcp judge --session <sessionId>");
             Console.Error.WriteLine("  kcap mcp sessions");
+            Console.Error.WriteLine("  kcap mcp flows");
 
             return 1;
         }
@@ -302,6 +303,8 @@ switch (command) {
             }
             case "sessions":
                 return await McpSessionsServer.RunAsync(baseUrl!);
+            case "flows":
+                return await McpFlowsServer.RunAsync(baseUrl!);
             default:
                 Console.Error.WriteLine($"Unknown mcp subcommand: {args[1]}");
 

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -1,0 +1,523 @@
+using System.Diagnostics;
+using System.Text.Json.Nodes;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// End-to-end stdio JSON-RPC tests for <c>kcap mcp flows</c>.
+/// Spawns the freshly-built CLI binary, points it at a WireMock-stubbed
+/// Capacitor server (via <c>KCAP_URL</c>), seeds an isolated config
+/// directory (via <c>KCAP_CONFIG_DIR</c>) so token/profile state never
+/// leaks between tests, and asserts on the wire-level JSON-RPC envelopes
+/// the server emits plus the HTTP calls WireMock observed.
+/// </summary>
+public class McpFlowsServerTests : IDisposable {
+    readonly WireMockServer _server           = WireMockServer.Start();
+    readonly string         _cfgDir           = Path.Combine(Path.GetTempPath(), $"kcap-flows-cfg-{Guid.NewGuid():N}");
+    readonly string         _cwdDir           = Path.Combine(Path.GetTempPath(), $"kcap-flows-cwd-{Guid.NewGuid():N}");
+    readonly List<Process>  _spawnedProcesses = [];
+
+    public McpFlowsServerTests() {
+        Directory.CreateDirectory(_cfgDir);
+        Directory.CreateDirectory(_cwdDir);
+
+        // Initialize a git repo in _cwdDir so GitRepository.FindRoot returns a path,
+        // and create a subdirectory to verify requesting_cwd vs requesting_repo_root.
+        InitGitRepo(_cwdDir);
+    }
+
+    public void Dispose() {
+        foreach (var p in _spawnedProcesses) {
+            try {
+                if (!p.HasExited) p.Kill(entireProcessTree: true);
+                p.Dispose();
+            } catch {
+                // best-effort cleanup
+            }
+        }
+
+        _server.Stop();
+        try { Directory.Delete(_cfgDir, recursive: true); } catch { /* best effort */ }
+        try { Directory.Delete(_cwdDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Initialises a minimal git repo (git init + git remote add origin) so
+    /// <c>GitRepository.FindRoot</c> finds a root and <c>RepositoryDetection</c>
+    /// can parse an owner/name from the remote URL.
+    /// </summary>
+    static void InitGitRepo(string dir) {
+        RunGit(dir, "init");
+        RunGit(dir, "remote add origin https://github.com/test-owner/test-repo.git");
+    }
+
+    static void RunGit(string cwd, string args) {
+        using var p = Process.Start(new ProcessStartInfo("git", args) {
+            WorkingDirectory      = cwd,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false
+        })!;
+        p.WaitForExit(5000);
+    }
+
+    /// <summary>
+    /// Resolves the path of the built `kcap` CLI binary in the source tree.
+    /// Mirrors the approach in <see cref="McpSessionsServerTests"/>.
+    /// </summary>
+    static string GetCliBinaryPath() {
+        var asmDir      = Path.GetDirectoryName(typeof(McpFlowsServerTests).Assembly.Location)!;
+        var binDir      = Path.GetDirectoryName(asmDir)!;
+        var config      = Path.GetFileName(binDir);
+        var testBin     = Path.GetDirectoryName(binDir)!;
+        var testProjDir = Path.GetDirectoryName(testBin)!;
+        var testRoot    = Path.GetDirectoryName(testProjDir)!;
+        var repoRoot    = Path.GetDirectoryName(testRoot)!;
+        var binaryName  = OperatingSystem.IsWindows() ? "kcap.exe" : "kcap";
+        return Path.Combine(repoRoot, "src", "Capacitor.Cli", "bin", config, "net10.0", binaryName);
+    }
+
+    /// <summary>
+    /// Spawns <c>kcap mcp flows</c> as a child process with WireMock as the backend.
+    /// </summary>
+    Process SpawnMcpServer(string provider = "None", string? workingDirectory = null) {
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($$"""{"provider":"{{provider}}"}"""));
+
+        var binary = GetCliBinaryPath();
+
+        if (!File.Exists(binary)) {
+            throw new FileNotFoundException(
+                $"kcap binary not found at {binary}. Build it first: " +
+                "dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj",
+                binary
+            );
+        }
+
+        var psi = new ProcessStartInfo(binary, "mcp flows") {
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+            CreateNoWindow         = true,
+            WorkingDirectory       = workingDirectory ?? _cwdDir,
+            Environment = {
+                ["KCAP_URL"]        = _server.Url!,
+                ["KCAP_CONFIG_DIR"] = _cfgDir
+            }
+        };
+
+        var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start kcap process");
+        _spawnedProcesses.Add(process);
+        return process;
+    }
+
+    /// <summary>
+    /// Spawns the server with KCAP_SESSION_ID set so requester context includes a session ID.
+    /// </summary>
+    Process SpawnMcpServerWithSession(string sessionId, string provider = "None", string? workingDirectory = null) {
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($$"""{"provider":"{{provider}}"}"""));
+
+        var binary = GetCliBinaryPath();
+
+        if (!File.Exists(binary)) {
+            throw new FileNotFoundException(
+                $"kcap binary not found at {binary}. Build it first: " +
+                "dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj",
+                binary
+            );
+        }
+
+        var psi = new ProcessStartInfo(binary, "mcp flows") {
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+            CreateNoWindow         = true,
+            WorkingDirectory       = workingDirectory ?? _cwdDir,
+            Environment = {
+                ["KCAP_URL"]          = _server.Url!,
+                ["KCAP_CONFIG_DIR"]   = _cfgDir,
+                ["KCAP_SESSION_ID"]   = sessionId
+            }
+        };
+
+        var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start kcap process");
+        _spawnedProcesses.Add(process);
+        return process;
+    }
+
+    static async Task<JsonObject> SendRequest(Process proc, JsonObject request, TimeSpan? timeout = null) {
+        await proc.StandardInput.WriteLineAsync(request.ToJsonString());
+        await proc.StandardInput.FlushAsync();
+
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(15));
+        var line      = await proc.StandardOutput.ReadLineAsync(cts.Token);
+
+        if (line is null) {
+            var stderr = await proc.StandardError.ReadToEndAsync();
+            throw new InvalidOperationException($"MCP server closed stdout without responding. Stderr: {stderr}");
+        }
+
+        return JsonNode.Parse(line)?.AsObject()
+            ?? throw new InvalidOperationException($"Could not parse response as JSON object: {line}");
+    }
+
+    static async Task ShutdownAsync(Process proc) {
+        try { proc.StandardInput.Close(); } catch { /* already closed */ }
+        try {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await proc.WaitForExitAsync(cts.Token);
+        } catch {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
+        }
+    }
+
+    static JsonObject InitializeRequest(int id) => new() {
+        ["jsonrpc"] = "2.0",
+        ["id"]      = id,
+        ["method"]  = "initialize",
+        ["params"]  = new JsonObject()
+    };
+
+    static JsonObject ToolsListRequest(int id) => new() {
+        ["jsonrpc"] = "2.0",
+        ["id"]      = id,
+        ["method"]  = "tools/list",
+        ["params"]  = new JsonObject()
+    };
+
+    static JsonObject ToolsCallRequest(int id, string name, JsonObject arguments) => new() {
+        ["jsonrpc"] = "2.0",
+        ["id"]      = id,
+        ["method"]  = "tools/call",
+        ["params"]  = new JsonObject {
+            ["name"]      = name,
+            ["arguments"] = arguments
+        }
+    };
+
+    [Test]
+    public async Task Initialize_returns_kcap_flows_server_info() {
+        using var proc = SpawnMcpServer();
+        try {
+            var response = await SendRequest(proc, InitializeRequest(1));
+
+            await Assert.That(response["id"]?.GetValue<int>()).IsEqualTo(1);
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["serverInfo"]?["name"]?.GetValue<string>()).IsEqualTo("kcap-flows");
+            await Assert.That(result["protocolVersion"]?.GetValue<string>()).IsEqualTo("2024-11-05");
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    [Test]
+    public async Task Tools_list_returns_four_flow_tools() {
+        using var proc = SpawnMcpServer();
+        try {
+            var response = await SendRequest(proc, ToolsListRequest(2));
+
+            var tools = response["result"]?["tools"]?.AsArray();
+            await Assert.That(tools).IsNotNull();
+            await Assert.That(tools!.Count).IsEqualTo(4);
+
+            var names = tools.Select(t => t?["name"]?.GetValue<string>()).ToHashSet();
+            await Assert.That(names.Contains("start_review_flow")).IsTrue();
+            await Assert.That(names.Contains("submit_review_round")).IsTrue();
+            await Assert.That(names.Contains("get_review_flow_status")).IsTrue();
+            await Assert.That(names.Contains("close_review_flow")).IsTrue();
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
+    /// Core scenario: verifies that start_review_flow posts to /api/flows/review/start,
+    /// that the POST body includes the resolved requester context (requesting_repo_root = git root,
+    /// requesting_session_id from KCAP_SESSION_ID), and that the MCP tool response surfaces
+    /// both the flow_run_id/status envelope and the FINDINGS result text from the server.
+    /// </summary>
+    [Test]
+    public async Task Start_review_flow_posts_requester_context_and_returns_plain_text_result() {
+        const string flowRunId  = "flow-abc-123";
+        const string roundId    = "round-001";
+        const string sessionId  = "claude-session-aabbccdd";
+
+        var stubbedResponse = $$"""
+            {
+              "flowRunId": "{{flowRunId}}",
+              "roundId": "{{roundId}}",
+              "roundNumber": 1,
+              "status": "completed",
+              "resultKind": "FINDINGS",
+              "resultText": "## Review findings\n\nThe spec looks good.",
+              "reviewerAgentId": null,
+              "reviewerSessionId": null
+            }
+            """;
+
+        _server.Given(
+            Request.Create()
+                .WithPath("/api/flows/review/start")
+                .UsingPost()
+        ).RespondWith(
+            Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(stubbedResponse)
+        );
+
+        // Create a subdirectory inside _cwdDir so the server starts there — we can then
+        // verify requesting_repo_root points to _cwdDir (the git root) while requesting_cwd
+        // points to the subdirectory.
+        var subdir = Path.Combine(_cwdDir, "src", "feature");
+        Directory.CreateDirectory(subdir);
+
+        using var proc = SpawnMcpServerWithSession(sessionId, workingDirectory: subdir);
+        try {
+            var args = new JsonObject {
+                ["kind"]         = "spec-review",
+                ["target_kind"]  = "spec",
+                ["target_ref"]   = "docs/feature.md",
+                ["target_title"] = "Feature spec",
+                ["context"]      = "Please review this spec for completeness."
+            };
+
+            var response = await SendRequest(proc, ToolsCallRequest(3, "start_review_flow", args));
+
+            // Assert the MCP response is a success
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
+
+            // Assert the response text contains the envelope fields
+            var text = result["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            await Assert.That(text!.Contains($"flow_run_id: {flowRunId}")).IsTrue();
+            await Assert.That(text.Contains("status: completed")).IsTrue();
+            await Assert.That(text.Contains("result_kind: FINDINGS")).IsTrue();
+
+            // Assert the response text contains the result text from the server
+            await Assert.That(text.Contains("## Review findings")).IsTrue();
+            await Assert.That(text.Contains("The spec looks good.")).IsTrue();
+
+            // Assert the POST was made to the correct endpoint
+            var hits = _server.FindLogEntries(
+                Request.Create().WithPath("/api/flows/review/start").UsingPost()
+            );
+            await Assert.That(hits.Count).IsEqualTo(1);
+
+            // Verify the POST body includes the requester context fields
+            var body = hits[0].RequestMessage.Body ?? "";
+            var bodyNode = JsonNode.Parse(body)?.AsObject();
+            await Assert.That(bodyNode).IsNotNull();
+
+            // requesting_session_id: from KCAP_SESSION_ID (stripped of dashes)
+            var reqSessionId = bodyNode!["requestingSessionId"]?.GetValue<string>();
+            await Assert.That(reqSessionId).IsNotNull();
+            await Assert.That(reqSessionId!.Contains("claudesessionaabbccdd") || reqSessionId.Contains("claude-session-aabbccdd")).IsTrue();
+
+            // requesting_cwd: the subdirectory the server was started in
+            var reqCwd = bodyNode["requestingCwd"]?.GetValue<string>();
+            await Assert.That(reqCwd).IsNotNull();
+            // cwd should be either subdir or contain "src/feature"
+            await Assert.That(
+                reqCwd!.Contains(Path.Combine("src", "feature")) ||
+                reqCwd.Equals(subdir, StringComparison.OrdinalIgnoreCase)
+            ).IsTrue();
+
+            // requesting_repo_root: the git root (= _cwdDir, where git init was run).
+            // On macOS directory paths can differ between what the test creates
+            // (Path.GetTempPath() / Guid) and what the spawned process sees via
+            // Directory.GetCurrentDirectory() (which resolves symlinks on some platforms).
+            // We verify the invariant: the repo root is a parent of the subdir, and it
+            // contains the unique test-directory name so it can't be an arbitrary system dir.
+            var reqRepoRoot = bodyNode["requestingRepoRoot"]?.GetValue<string>();
+            await Assert.That(reqRepoRoot).IsNotNull();
+            // The unique GUID portion of _cwdDir must appear somewhere in the repo root path
+            // (both paths point to the same directory, just possibly via different symlink chains).
+            var cwdDirName = Path.GetFileName(_cwdDir.TrimEnd(Path.DirectorySeparatorChar));
+            await Assert.That(reqRepoRoot!.Contains(cwdDirName, StringComparison.OrdinalIgnoreCase)).IsTrue();
+
+            // kind: matches what we passed
+            await Assert.That(bodyNode["kind"]?.GetValue<string>()).IsEqualTo("spec-review");
+            await Assert.That(bodyNode["targetKind"]?.GetValue<string>()).IsEqualTo("spec");
+            await Assert.That(bodyNode["context"]?.GetValue<string>()).IsEqualTo("Please review this spec for completeness.");
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    [Test]
+    public async Task Get_review_flow_status_calls_correct_endpoint_and_surfaces_envelope() {
+        const string flowRunId = "flow-status-xyz";
+
+        var stubbedStatus = $$"""
+            {
+              "flowRunId": "{{flowRunId}}",
+              "definitionId": "spec-review",
+              "status": "completed",
+              "targetTitle": "My Spec",
+              "roundCount": 2,
+              "lastResultKind": "APPROVED",
+              "lastResultText": "Approved with minor comments."
+            }
+            """;
+
+        _server.Given(
+            Request.Create()
+                .WithPath($"/api/flows/{flowRunId}")
+                .UsingGet()
+        ).RespondWith(
+            Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(stubbedStatus)
+        );
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args     = new JsonObject { ["flow_run_id"] = flowRunId };
+            var response = await SendRequest(proc, ToolsCallRequest(4, "get_review_flow_status", args));
+
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
+
+            var text = result["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            await Assert.That(text!.Contains($"flow_run_id: {flowRunId}")).IsTrue();
+            await Assert.That(text.Contains("status: completed")).IsTrue();
+            await Assert.That(text.Contains("Approved with minor comments.")).IsTrue();
+
+            var hits = _server.FindLogEntries(
+                Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet()
+            );
+            await Assert.That(hits.Count).IsEqualTo(1);
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    [Test]
+    public async Task Submit_review_round_posts_to_rounds_endpoint() {
+        const string flowRunId = "flow-round-abc";
+        const string roundId   = "round-002";
+
+        var stubbedResponse = $$"""
+            {
+              "flowRunId": "{{flowRunId}}",
+              "roundId": "{{roundId}}",
+              "roundNumber": 2,
+              "status": "completed",
+              "resultKind": "APPROVED",
+              "resultText": "Changes look good now.",
+              "reviewerAgentId": null,
+              "reviewerSessionId": null
+            }
+            """;
+
+        _server.Given(
+            Request.Create()
+                .WithPath($"/api/flows/{flowRunId}/rounds")
+                .UsingPost()
+        ).RespondWith(
+            Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(stubbedResponse)
+        );
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["flow_run_id"] = flowRunId,
+                ["context"]     = "I have addressed all feedback."
+            };
+            var response = await SendRequest(proc, ToolsCallRequest(5, "submit_review_round", args));
+
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
+
+            var text = result["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            await Assert.That(text!.Contains($"flow_run_id: {flowRunId}")).IsTrue();
+            await Assert.That(text.Contains("round_id:")).IsTrue();
+            await Assert.That(text.Contains("Changes look good now.")).IsTrue();
+
+            var hits = _server.FindLogEntries(
+                Request.Create().WithPath($"/api/flows/{flowRunId}/rounds").UsingPost()
+            );
+            await Assert.That(hits.Count).IsEqualTo(1);
+
+            // Verify the POST body has context
+            var body     = hits[0].RequestMessage.Body ?? "";
+            var bodyNode = JsonNode.Parse(body)?.AsObject();
+            await Assert.That(bodyNode).IsNotNull();
+            await Assert.That(bodyNode!["context"]?.GetValue<string>()).IsEqualTo("I have addressed all feedback.");
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    [Test]
+    public async Task Close_review_flow_posts_to_close_endpoint() {
+        const string flowRunId = "flow-close-abc";
+
+        _server.Given(
+            Request.Create()
+                .WithPath($"/api/flows/{flowRunId}/close")
+                .UsingPost()
+        ).RespondWith(
+            Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""{"flowRunId":"{{flowRunId}}","status":"closed"}""")
+        );
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args     = new JsonObject { ["flow_run_id"] = flowRunId };
+            var response = await SendRequest(proc, ToolsCallRequest(6, "close_review_flow", args));
+
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
+
+            var hits = _server.FindLogEntries(
+                Request.Create().WithPath($"/api/flows/{flowRunId}/close").UsingPost()
+            );
+            await Assert.That(hits.Count).IsEqualTo(1);
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    [Test]
+    public async Task Submit_review_round_without_flow_run_id_returns_error() {
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["context"] = "Some context but no flow ID"
+            };
+            var response = await SendRequest(proc, ToolsCallRequest(7, "submit_review_round", args));
+
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsTrue();
+
+            var text = result["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            await Assert.That(text!.Contains("flow_run_id")).IsTrue();
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -528,4 +528,84 @@ public class McpFlowsServerTests : IDisposable {
             await ShutdownAsync(proc);
         }
     }
+
+    /// <summary>
+    /// Writes a non-expired token to the per-test config dir's token store so the
+    /// CLI's <c>HttpClientExtensions.CreateAuthenticatedClientAsync</c> attaches a
+    /// Bearer header. Exercises the long-lived-server path (the MCP server holds a
+    /// single HttpClient for the agent's whole session).
+    /// </summary>
+    void SeedToken(string accessToken = "seed-token") {
+        var tokensDir = Path.Combine(_cfgDir, "tokens");
+        Directory.CreateDirectory(tokensDir);
+        var tokenJson = $$"""
+            {
+              "access_token": "{{accessToken}}",
+              "expires_at": "{{DateTimeOffset.UtcNow.AddHours(1):O}}",
+              "github_username": "seed-user",
+              "provider": "GitHubApp"
+            }
+            """;
+        File.WriteAllText(Path.Combine(tokensDir, "default.json"), tokenJson);
+    }
+
+    /// <summary>
+    /// Regression for the "token refresh is never picked up after startup" bug.
+    /// The MCP server caches a single <c>HttpClient</c> for the whole agent session;
+    /// if the auth header expires mid-session, every tool call returned the friendly
+    /// 401 message until the server was restarted. The fix retries once on 401 after
+    /// calling <c>TokenStore.GetValidTokensAsync</c>.
+    ///
+    /// We seed a non-expired token in the per-test config dir and stub WireMock so
+    /// the first call returns 401 and the second returns 200. The retry re-reads
+    /// the token (which hasn't actually expired, so it's returned as-is) and resends —
+    /// proving the retry path runs at all. (Exercising the real refresh-token flow
+    /// would require stubbing the GitHub refresh endpoint as well, which is out of
+    /// scope for this regression.)
+    /// </summary>
+    [Test]
+    public async Task Refreshed_token_succeeds_after_401() {
+        const string flowRunId   = "flow-retry-abc";
+        const string stubbedBody = $$"""{"flow_run_id":"{{flowRunId}}","status":"closed"}""";
+        const string scenario    = "auth-retry";
+
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}/close").UsingPost())
+            .InScenario(scenario)
+            .WillSetStateTo("after-401")
+            .RespondWith(Response.Create().WithStatusCode(401).WithBody(""));
+
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}/close").UsingPost())
+            .InScenario(scenario)
+            .WhenStateIs("after-401")
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody(stubbedBody)
+            );
+
+        SeedToken();
+
+        using var proc = SpawnMcpServer(provider: "GitHubApp");
+        try {
+            var args     = new JsonObject { ["flow_run_id"] = flowRunId };
+            var response = await SendRequest(proc, ToolsCallRequest(8, "close_review_flow", args));
+
+            var result = response["result"]?.AsObject();
+            // Must be a success — the 401 was retried and the second call succeeded.
+            await Assert.That(result?["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
+
+            var text = result?["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            await Assert.That(text!.Contains($"flow_run_id: {flowRunId}")).IsTrue();
+            await Assert.That(text.Contains("status: closed")).IsTrue();
+
+            var hits = _server.FindLogEntries(
+                Request.Create().WithPath($"/api/flows/{flowRunId}/close").UsingPost()
+            );
+            await Assert.That(hits.Count).IsEqualTo(2);
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
 }

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -251,14 +251,14 @@ public class McpFlowsServerTests : IDisposable {
 
         var stubbedResponse = $$"""
             {
-              "flowRunId": "{{flowRunId}}",
-              "roundId": "{{roundId}}",
-              "roundNumber": 1,
+              "flow_run_id": "{{flowRunId}}",
+              "round_id": "{{roundId}}",
+              "round_number": 1,
               "status": "completed",
-              "resultKind": "FINDINGS",
-              "resultText": "## Review findings\n\nThe spec looks good.",
-              "reviewerAgentId": null,
-              "reviewerSessionId": null
+              "result_kind": "FINDINGS",
+              "result_text": "## Review findings\n\nThe spec looks good.",
+              "reviewer_agent_id": null,
+              "reviewer_session_id": null
             }
             """;
 
@@ -319,12 +319,12 @@ public class McpFlowsServerTests : IDisposable {
             await Assert.That(bodyNode).IsNotNull();
 
             // requesting_session_id: from KCAP_SESSION_ID (stripped of dashes)
-            var reqSessionId = bodyNode!["requestingSessionId"]?.GetValue<string>();
+            var reqSessionId = bodyNode!["requesting_session_id"]?.GetValue<string>();
             await Assert.That(reqSessionId).IsNotNull();
             await Assert.That(reqSessionId!.Contains("claudesessionaabbccdd") || reqSessionId.Contains("claude-session-aabbccdd")).IsTrue();
 
             // requesting_cwd: the subdirectory the server was started in
-            var reqCwd = bodyNode["requestingCwd"]?.GetValue<string>();
+            var reqCwd = bodyNode["requesting_cwd"]?.GetValue<string>();
             await Assert.That(reqCwd).IsNotNull();
             // cwd should be either subdir or contain "src/feature"
             await Assert.That(
@@ -338,7 +338,7 @@ public class McpFlowsServerTests : IDisposable {
             // Directory.GetCurrentDirectory() (which resolves symlinks on some platforms).
             // We verify the invariant: the repo root is a parent of the subdir, and it
             // contains the unique test-directory name so it can't be an arbitrary system dir.
-            var reqRepoRoot = bodyNode["requestingRepoRoot"]?.GetValue<string>();
+            var reqRepoRoot = bodyNode["requesting_repo_root"]?.GetValue<string>();
             await Assert.That(reqRepoRoot).IsNotNull();
             // The unique GUID portion of _cwdDir must appear somewhere in the repo root path
             // (both paths point to the same directory, just possibly via different symlink chains).
@@ -347,7 +347,7 @@ public class McpFlowsServerTests : IDisposable {
 
             // kind: matches what we passed
             await Assert.That(bodyNode["kind"]?.GetValue<string>()).IsEqualTo("spec-review");
-            await Assert.That(bodyNode["targetKind"]?.GetValue<string>()).IsEqualTo("spec");
+            await Assert.That(bodyNode["target_kind"]?.GetValue<string>()).IsEqualTo("spec");
             await Assert.That(bodyNode["context"]?.GetValue<string>()).IsEqualTo("Please review this spec for completeness.");
         } finally {
             await ShutdownAsync(proc);
@@ -360,13 +360,13 @@ public class McpFlowsServerTests : IDisposable {
 
         var stubbedStatus = $$"""
             {
-              "flowRunId": "{{flowRunId}}",
-              "definitionId": "spec-review",
+              "flow_run_id": "{{flowRunId}}",
+              "definition_id": "spec-review",
               "status": "completed",
-              "targetTitle": "My Spec",
-              "roundCount": 2,
-              "lastResultKind": "APPROVED",
-              "lastResultText": "Approved with minor comments."
+              "target_title": "My Spec",
+              "round_count": 2,
+              "last_result_kind": "APPROVED",
+              "last_result_text": "Approved with minor comments."
             }
             """;
 
@@ -412,14 +412,14 @@ public class McpFlowsServerTests : IDisposable {
 
         var stubbedResponse = $$"""
             {
-              "flowRunId": "{{flowRunId}}",
-              "roundId": "{{roundId}}",
-              "roundNumber": 2,
+              "flow_run_id": "{{flowRunId}}",
+              "round_id": "{{roundId}}",
+              "round_number": 2,
               "status": "completed",
-              "resultKind": "APPROVED",
-              "resultText": "Changes look good now.",
-              "reviewerAgentId": null,
-              "reviewerSessionId": null
+              "result_kind": "APPROVED",
+              "result_text": "Changes look good now.",
+              "reviewer_agent_id": null,
+              "reviewer_session_id": null
             }
             """;
 
@@ -479,7 +479,7 @@ public class McpFlowsServerTests : IDisposable {
             Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
-                .WithBody($$"""{"flowRunId":"{{flowRunId}}","status":"closed"}""")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","status":"closed"}""")
         );
 
         using var proc = SpawnMcpServer();

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -491,6 +491,14 @@ public class McpFlowsServerTests : IDisposable {
             await Assert.That(result).IsNotNull();
             await Assert.That(result!["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
 
+            var text = result["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            await Assert.That(text!.Contains($"flow_run_id: {flowRunId}")).IsTrue();
+            await Assert.That(text.Contains("status: closed")).IsTrue();
+            // FormatCloseResponse must NOT emit round_id or result_kind lines
+            await Assert.That(text.Contains("round_id:")).IsFalse();
+            await Assert.That(text.Contains("result_kind:")).IsFalse();
+
             var hits = _server.FindLogEntries(
                 Request.Create().WithPath($"/api/flows/{flowRunId}/close").UsingPost()
             );

--- a/test/Capacitor.Cli.Tests.Unit/AgentsSkillsInstallerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentsSkillsInstallerTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit;
 
 public class AgentsSkillsInstallerTests {
-    static readonly string[] SourceNames = ["recap", "errors", "disable", "hide", "validate-plan"];
+    static readonly string[] SourceNames = ["recap", "errors", "disable", "hide", "validate-plan", "review-flows"];
 
     [Test]
     public async Task Install_copies_each_source_to_kcap_prefixed_target() {

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
@@ -267,13 +267,14 @@ public class PluginCommandCodexTests {
     }
 
     [Test]
-    public async Task SourceNames_contains_expected_five() {
+    public async Task SourceNames_contains_expected_skills() {
         var expected = new[] {
             "recap",
             "errors",
             "hide",
             "disable",
-            "validate-plan"
+            "validate-plan",
+            "review-flows"
         };
 
         await Assert.That(AgentsSkillsInstaller.SourceNames).IsEquivalentTo(expected);

--- a/test/Capacitor.Cli.Tests.Unit/WorktreeManagerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorktreeManagerTests.cs
@@ -10,6 +10,11 @@ namespace Capacitor.Cli.Tests.Unit;
 /// We build a real local git repo with two commits on a side ref so we can
 /// fetch it back as if it were a PR head and assert the worktree HEAD lines up.
 /// </summary>
+/// <remarks>
+/// Also covers <see cref="WorktreeManager.SyncFromSourceAsync"/>: new/modified files are
+/// copied from source into the worktree, deleted source files are removed from the worktree,
+/// and special paths (<c>.git/</c>, excluded paths) are never touched.
+/// </remarks>
 public class WorktreeManagerTests {
     static (string upstream, string clone) MakeUpstreamWithSideRef(string sideRefName, out string sideCommitSha) {
         var upstream = Path.Combine(Path.GetTempPath(), "kcap-upstream-" + Guid.NewGuid().ToString("N")[..8]);
@@ -199,6 +204,145 @@ public class WorktreeManagerTests {
             try { Directory.Delete(clone, true); } catch {
                 /* best-effort */
             }
+        }
+    }
+
+    // ── SyncFromSourceAsync tests ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a minimal source git repo (no upstream) plus a pre-existing target worktree dir.
+    /// Returns (sourcePath, targetPath).
+    /// </summary>
+    static (string source, string target) MakeSourceAndTarget(out string sourceFile) {
+        var source = Path.Combine(Path.GetTempPath(), "kcap-src-" + Guid.NewGuid().ToString("N")[..8]);
+        var target = Path.Combine(Path.GetTempPath(), "kcap-tgt-" + Guid.NewGuid().ToString("N")[..8]);
+
+        Directory.CreateDirectory(source);
+        Directory.CreateDirectory(target);
+
+        Git(source, "init", "-q");
+        Git(source, "config", "user.email", "test@example.com");
+        Git(source, "config", "user.name", "Test");
+
+        sourceFile = Path.Combine(source, "hello.txt");
+        File.WriteAllText(sourceFile, "hello");
+        Git(source, "add", "-A");
+        Git(source, "commit", "-q", "-m", "initial");
+
+        // Also init target as a git repo so it looks like a real worktree.
+        Git(target, "init", "-q");
+        Git(target, "config", "user.email", "test@example.com");
+        Git(target, "config", "user.name", "Test");
+        File.WriteAllText(Path.Combine(target, "hello.txt"), "old-content");
+        Git(target, "add", "-A");
+        Git(target, "commit", "-q", "-m", "initial");
+
+        return (source, target);
+    }
+
+    /// <summary>
+    /// A new uncommitted file in the source is copied into the worktree, and a
+    /// pre-existing file whose content changed is overwritten.
+    /// </summary>
+    [Test]
+    public async Task SyncFromSourceAsync_CopiesNewAndModifiedFiles() {
+        var (source, target) = MakeSourceAndTarget(out var sourceHello);
+
+        try {
+            // Modify an existing tracked file (uncommitted change in source).
+            await File.WriteAllTextAsync(sourceHello, "updated-hello");
+
+            // Add a brand-new untracked file.
+            var newFile = Path.Combine(source, "new-untracked.txt");
+            await File.WriteAllTextAsync(newFile, "new content");
+
+            var manager = new WorktreeManager(new DaemonConfig(), NullLogger<WorktreeManager>.Instance);
+            await manager.SyncFromSourceAsync(source, target, [], CancellationToken.None);
+
+            // Modified tracked file must be overwritten.
+            var targetHello = Path.Combine(target, "hello.txt");
+            await Assert.That(File.Exists(targetHello)).IsTrue();
+            await Assert.That(await File.ReadAllTextAsync(targetHello)).IsEqualTo("updated-hello");
+
+            // Untracked file must be present in target.
+            var targetNew = Path.Combine(target, "new-untracked.txt");
+            await Assert.That(File.Exists(targetNew)).IsTrue();
+            await Assert.That(await File.ReadAllTextAsync(targetNew)).IsEqualTo("new content");
+        } finally {
+            try { Directory.Delete(source, true); } catch { /* best-effort */ }
+            try { Directory.Delete(target, true); } catch { /* best-effort */ }
+        }
+    }
+
+    /// <summary>
+    /// A file that exists in the target worktree but is absent from the source (simulating a
+    /// deletion in source) is removed from the target after sync.
+    /// </summary>
+    [Test]
+    public async Task SyncFromSourceAsync_DeletesFilesRemovedInSource() {
+        var (source, target) = MakeSourceAndTarget(out _);
+
+        try {
+            // Place an extra file in the target that does NOT exist in the source.
+            var staleFile = Path.Combine(target, "stale.txt");
+            await File.WriteAllTextAsync(staleFile, "should be deleted");
+
+            var manager = new WorktreeManager(new DaemonConfig(), NullLogger<WorktreeManager>.Instance);
+            await manager.SyncFromSourceAsync(source, target, [], CancellationToken.None);
+
+            // Stale file must have been deleted.
+            await Assert.That(File.Exists(staleFile)).IsFalse();
+
+            // The tracked source file must still be present.
+            await Assert.That(File.Exists(Path.Combine(target, "hello.txt"))).IsTrue();
+        } finally {
+            try { Directory.Delete(source, true); } catch { /* best-effort */ }
+            try { Directory.Delete(target, true); } catch { /* best-effort */ }
+        }
+    }
+
+    /// <summary>
+    /// Files under <c>.git/</c> in the target are never touched (the git plumbing must
+    /// remain intact), and paths matching the caller-supplied <paramref name="excludePaths"/>
+    /// are neither copied from source nor deleted from target.
+    /// </summary>
+    [Test]
+    public async Task SyncFromSourceAsync_SkipsGitDirAndExcludedPaths() {
+        var (source, target) = MakeSourceAndTarget(out _);
+
+        try {
+            // Write a sentinel into .git/ inside the target — it must survive the sync.
+            var gitSentinel = Path.Combine(target, ".git", "SENTINEL");
+            await File.WriteAllTextAsync(gitSentinel, "untouched");
+
+            // Write a file in an excluded directory inside the target — must survive.
+            var excludedDir = Path.Combine(target, ".excluded-dir");
+            Directory.CreateDirectory(excludedDir);
+            var excludedFile = Path.Combine(excludedDir, "keep.txt");
+            await File.WriteAllTextAsync(excludedFile, "kept");
+
+            // Also write the excluded dir name into source as an untracked file so the
+            // exclude logic is exercised on the copy side too.
+            var sourceExcludedDir = Path.Combine(source, ".excluded-dir");
+            Directory.CreateDirectory(sourceExcludedDir);
+            await File.WriteAllTextAsync(Path.Combine(sourceExcludedDir, "should-not-appear.txt"), "x");
+
+            var manager = new WorktreeManager(new DaemonConfig(), NullLogger<WorktreeManager>.Instance);
+            await manager.SyncFromSourceAsync(source, target, [".excluded-dir"], CancellationToken.None);
+
+            // .git sentinel must be intact.
+            await Assert.That(File.Exists(gitSentinel)).IsTrue();
+            await Assert.That(await File.ReadAllTextAsync(gitSentinel)).IsEqualTo("untouched");
+
+            // Excluded dir file must be intact.
+            await Assert.That(File.Exists(excludedFile)).IsTrue();
+            await Assert.That(await File.ReadAllTextAsync(excludedFile)).IsEqualTo("kept");
+
+            // The excluded-dir source file must NOT have been copied into target.
+            await Assert.That(File.Exists(Path.Combine(target, ".excluded-dir", "should-not-appear.txt"))).IsFalse();
+        } finally {
+            try { Directory.Delete(source, true); } catch { /* best-effort */ }
+            try { Directory.Delete(target, true); } catch { /* best-effort */ }
         }
     }
 


### PR DESCRIPTION
## Summary

The **CLI side** of AI-774 "Agent Review Flows": a `kcap mcp flows` MCP server and a checked-in `review-flows` agent skill. Pairs with the server slice in kurrent-io/kcap-server#830 (which adds the `/api/flows/*` endpoints this server calls).

A Claude Code session can now start one persistent hosted-Codex reviewer per task, submit repeated spec/code review rounds, and close only after `NO FINDINGS` — driven entirely through MCP tools instead of manual copy/paste.

## What's included

**`kcap mcp flows`** (`src/Capacitor.Cli/Commands/McpFlowsServer.cs`) — a raw JSON-RPC stdio MCP server (same pattern as `mcp sessions`/`review`), exposing 4 tools:
- `start_review_flow(kind, target_kind, target_ref, target_title, context, instructions?, mode?)`
- `submit_review_round(flow_run_id, context, instructions?)`
- `get_review_flow_status(flow_run_id)`
- `close_review_flow(flow_run_id)`

It resolves requester context (session id via `KCAP_SESSION_ID`/`CODEX_THREAD_ID`, cwd, git repo root, repo owner/name), authenticates via the shared token-store HTTP client, and maps the tools to `POST /api/flows/review/start`, `POST /api/flows/{id}/rounds`, `GET /api/flows/{id}`, `POST /api/flows/{id}/close`.

**`review-flows` skill** (`kcap/skills/review-flows/SKILL.md`, registered in `AgentsSkillsInstaller.SourceNames`) — teaches agents to start one flow per task, re-review until `NO FINDINGS`, close after clean, pass `mode=context-only` for code-review, and not ask the reviewer to run tests.

Docs (README quick-start + CLI commands + skills list, `help-mcp.txt`, `help-usage.txt`) updated for the new command.

## Contract note

The kcap-server's HTTP JSON is **snake_case** (`SnakeCaseLower`), while the shared `McpJsonContext` is camelCase for MCP protocol envelopes. The flow request DTOs therefore carry explicit `[JsonPropertyName]` snake_case keys, and responses are parsed by snake_case keys — verified end-to-end against the server's `StartReviewFlowRequest`/`ReviewFlowRoundResponse`/`ReviewFlowStatusResponse`. (WireMock tests can't catch a wire-casing mismatch, so the integration test explicitly asserts the captured request body uses snake_case.)

## Validation

- `McpFlowsServerTests` 7/7 (subprocess + WireMock: initialize, tools/list, requester-context POST body in snake_case, status, submit, close, missing-flow-run-id error).
- Full CLI **Unit suite 1801/1801**; `AgentsSkillsInstaller` tests updated for the new skill.
- `dotnet publish -c Release` **AOT-clean** (no IL2026/IL3050).
- Each task implemented TDD-first with independent review (the MCP server got an opus review that caught a critical camelCase/snake_case contract bug, since fixed).

## Daemon worktree refresh (Task 11 — daemon side)

Also includes the **daemon half** of worktree refresh: a `RefreshAgentWorktree` SignalR client-result handler + `WorktreeManager.SyncFromSourceAsync`, which syncs the requester's current working-tree files (tracked + staged + unstaged + untracked, excluding `.git`/`.capacitor/worktrees`) into the reviewer's worktree so it sees Claude's uncommitted changes. Guards: only owned (daemon-created) worktrees, never private agents, never the user's borrowed checkout. The matching server side ships in kcap-server#830. The destructive file-sync is structurally bounded inside the target worktree (reviewed). When the reviewer daemon is NOT on the requester's exact checkout, code-review falls back to `mode=context-only`.

## Follow-up

- After this merges, bump the `src/cli` submodule pointer in kcap-server to pick up `kcap mcp flows` + the daemon refresh handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
