### PR TITLE
[AI-1030] Codex rollout idle-timeout session-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,12 @@ KCAP_CLAUDE_PATH=/opt/claude/bin/claude kcap daemon
 KCAP_CODEX_PATH=/opt/codex/bin/codex  kcap daemon
 ```
 
+**Codex session-end tuning.** Because Codex has no session-end hook, the watcher owns session-end via two triggers: parent `codex` process exit, and rollout-file idle timeout. The idle trigger is particularly important for the Codex desktop app, whose shared `codex app-server` process never exits per-conversation.
+
+| Environment variable | Default | Description |
+|----------------------|---------|-------------|
+| `KCAP_CODEX_IDLE_MINUTES` | `60` | How long a Codex rollout file may be idle (no new lines) before the `kcap watch` background watcher ends the session (`reason: idle_timeout`). Increase for very long thinking/compute turns; decrease for faster cleanup of abandoned sessions. Invalid or non-positive values fall back to the 60-minute default. |
+
 #### Daemon log verbosity
 
 The daemon logs at `Information` by default. Raise the level for transport diagnostics — for example, per-tick `DaemonPing` round-trip times (logged at `Debug`) are useful for telling whether SignalR reconnects are caused by network/proxy latency. Set it either way:

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ KCAP_CODEX_PATH=/opt/codex/bin/codex  kcap daemon
 
 | Environment variable | Default | Description |
 |----------------------|---------|-------------|
-| `KCAP_CODEX_IDLE_MINUTES` | `60` | How long a Codex rollout file may be idle (no new lines) before the `kcap watch` background watcher ends the session (`reason: idle_timeout`). Increase for very long thinking/compute turns; decrease for faster cleanup of abandoned sessions. Invalid or non-positive values fall back to the 60-minute default. |
+| `KCAP_CODEX_IDLE_MINUTES` | `60` | How long a Codex rollout file may be idle (no new rollout lines and no Codex tool call in flight) before the `kcap watch` background watcher ends the session (`reason: idle_timeout`). Increase for very long thinking/compute turns; decrease for faster cleanup of abandoned sessions. Invalid or non-positive values fall back to the 60-minute default. |
 
 #### Daemon log verbosity
 

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -127,6 +127,16 @@ class WatchState {
     // Initialized when the watcher starts; updated in DrainNewLines on new lines.
     public DateTimeOffset LastActivityAt { get; set; } = DateTimeOffset.UtcNow;
 
+    // Tracks Codex tool-call call_ids that are currently in flight (started but
+    // not yet finished). A function_call/custom_tool_call response_item adds the
+    // call_id; its matching _output removes it. While this set is non-empty, the
+    // idle-end check is suppressed: a long-running shell command or custom tool can
+    // legitimately produce no new rollout lines for >60 min between its start and
+    // output lines (the tool is still running). No hard ceiling: if the tool hangs
+    // forever but the Codex process is still alive, the parent-exit watchdog will
+    // eventually fire and end the session — adding a ceiling here would be YAGNI.
+    public HashSet<string> PendingCodexToolCalls { get; } = new(StringComparer.Ordinal);
+
     public const int TranscriptThreshold = 10;
 }
 

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -122,6 +122,11 @@ class WatchState {
     public int          LinesReadAhead      { get; set; } // file position while buffering
     public bool         ThresholdReached    { get; set; }
 
+    // Last wall-clock time new transcript content was observed on the rollout file.
+    // Drives the Codex idle-timeout fallback (see WatchCommand.ShouldEndOnIdle).
+    // Initialized when the watcher starts; updated in DrainNewLines on new lines.
+    public DateTimeOffset LastActivityAt { get; set; } = DateTimeOffset.UtcNow;
+
     public const int TranscriptThreshold = 10;
 }
 

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -534,6 +534,28 @@ static partial class WatchCommand {
             ? TimeSpan.FromMinutes(minutes)
             : DefaultCodexIdleTimeout;
 
+    /// <summary>
+    /// Whether the watcher should self-terminate and POST session-end because the
+    /// Codex rollout file has gone idle. Pure so the policy is unit-testable.
+    /// Gated to: vendor codex (only vendor whose parent-exit watchdog can't fire
+    /// per-conversation — the desktop app's shared app-server never exits per
+    /// session), session watchers (not subagents), and threshold-reached sessions
+    /// (below-threshold short-lived sessions have no server session to end). Uses
+    /// strictly-greater-than so the boundary tick is not yet considered idle.
+    /// </summary>
+    internal static bool ShouldEndOnIdle(
+            string         vendor,
+            bool           isSessionWatcher,
+            bool           thresholdReached,
+            DateTimeOffset lastActivityAt,
+            DateTimeOffset now,
+            TimeSpan       idleTimeout
+        ) =>
+        vendor == "codex"
+        && isSessionWatcher
+        && thresholdReached
+        && now - lastActivityAt > idleTimeout;
+
     internal static async Task PostSessionEndOnParentExitAsync(
             string             baseUrl,
             string             sessionId,

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -512,6 +512,28 @@ static partial class WatchCommand {
     /// </summary>
     static readonly TimeSpan ParentExitPostBudget = TimeSpan.FromSeconds(10);
 
+    /// <summary>
+    /// Codex has no session-end hook and the desktop app's single long-lived
+    /// `codex app-server` process is the watchdog's parent PID for EVERY
+    /// conversation, so the parent-exit watchdog never fires per-conversation —
+    /// sessions stay "active" until the whole app quits. This idle window is the
+    /// fallback: if the rollout file gets no new lines for this long, the watcher
+    /// POSTs session-end (reason "idle_timeout"). Self-correcting — Codex fires a
+    /// Stop hook per turn that re-spawns the watcher and the read model
+    /// reactivates the session, so a resumed conversation comes back to life.
+    /// </summary>
+    internal static readonly TimeSpan DefaultCodexIdleTimeout = TimeSpan.FromMinutes(60);
+
+    /// <summary>
+    /// Resolves the Codex idle timeout from KCAP_CODEX_IDLE_MINUTES, falling back
+    /// to <see cref="DefaultCodexIdleTimeout"/> for unset/blank/non-numeric/
+    /// non-positive values. Pure so the parsing is unit-testable.
+    /// </summary>
+    internal static TimeSpan ResolveCodexIdleTimeout(string? envValue) =>
+        int.TryParse(envValue, out var minutes) && minutes > 0
+            ? TimeSpan.FromMinutes(minutes)
+            : DefaultCodexIdleTimeout;
+
     internal static async Task PostSessionEndOnParentExitAsync(
             string             baseUrl,
             string             sessionId,

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -156,6 +156,9 @@ static partial class WatchCommand {
         }
 
         var state = new WatchState();
+        state.LastActivityAt = DateTimeOffset.UtcNow;
+        var codexIdleTimeout = ResolveCodexIdleTimeout(Environment.GetEnvironmentVariable("KCAP_CODEX_IDLE_MINUTES"));
+        var idleExit = false;
 
         if (skipTitle) {
             state.TitleGenerated = true;
@@ -307,6 +310,20 @@ static partial class WatchCommand {
                     await ScanOpenCodeSubagents(baseUrl, sessionId, transcriptPath, seenSubagents, cts.Token);
                 }
 
+                if (ShouldEndOnIdle(
+                        vendor,
+                        isSessionWatcher: agentId is null,
+                        state.ThresholdReached,
+                        state.LastActivityAt,
+                        DateTimeOffset.UtcNow,
+                        codexIdleTimeout)) {
+                    Log($"Codex rollout idle for >{codexIdleTimeout.TotalMinutes:F0}m; ending session (idle_timeout)");
+                    idleExit = true;
+                    cts.Cancel();
+
+                    break;
+                }
+
                 try {
                     await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
                 } catch (OperationCanceledException) {
@@ -356,8 +373,12 @@ static partial class WatchCommand {
         //     server may not have a meaningful session to end.
         // Runs after SignalR dispose so the server's StopAndDrainAsync skips the
         // 10s drain wait (no live watcher connection to signal).
-        if (Volatile.Read(ref parentExited) == 1 && agentId is null && state.ThresholdReached) {
-            await PostSessionEndOnParentExitAsync(baseUrl, sessionId, transcriptPath, cwd, vendor, state.Repository);
+        var endReason = Volatile.Read(ref parentExited) == 1 ? "parent_exited"
+                      : idleExit                              ? "idle_timeout"
+                      :                                         null;
+
+        if (endReason is not null && agentId is null && state.ThresholdReached) {
+            await PostSessionEndOnParentExitAsync(baseUrl, sessionId, transcriptPath, cwd, vendor, state.Repository, endReason);
         }
 
         await logWriter.DisposeAsync();
@@ -562,7 +583,8 @@ static partial class WatchCommand {
             string             transcriptPath,
             string?            cwd,
             string             vendor,
-            RepositoryPayload? repository
+            RepositoryPayload? repository,
+            string             reason = "parent_exited"
         ) {
         if (!KnownVendors.Contains(vendor)) {
             Log($"Parent-exit session-end skipped: unknown vendor '{vendor}'");
@@ -621,7 +643,7 @@ static partial class WatchCommand {
                 ["transcript_path"] = transcriptPath,
                 ["cwd"]             = cwd ?? "",
                 ["hook_event_name"] = "session_end",
-                ["reason"]          = "parent_exited",
+                ["reason"]          = reason,
                 // Stamp the exit time so the server can scope the SessionEnded id
                 // per run. Vendors with no session-end hook (Kiro) end ONLY via this
                 // path, so without a timestamp a resumed session's second exit would
@@ -713,6 +735,10 @@ static partial class WatchCommand {
             }
 
             var linesRead = lineIndex;
+
+            if (newLines.Count > 0) {
+                state.LastActivityAt = DateTimeOffset.UtcNow;
+            }
 
             // Capture first user text (needed for title generation)
             if (state is { TitleGenerated: false, FirstUserText: null } && agentId is null) {

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -316,7 +316,8 @@ static partial class WatchCommand {
                         state.ThresholdReached,
                         state.LastActivityAt,
                         DateTimeOffset.UtcNow,
-                        codexIdleTimeout)) {
+                        codexIdleTimeout,
+                        toolInFlight: state.PendingCodexToolCalls.Count > 0)) {
                     Log($"Codex rollout idle for >{codexIdleTimeout.TotalMinutes:F0}m; ending session (idle_timeout)");
                     idleExit = true;
                     cts.Cancel();
@@ -563,6 +564,12 @@ static partial class WatchCommand {
     /// session), session watchers (not subagents), and threshold-reached sessions
     /// (below-threshold short-lived sessions have no server session to end). Uses
     /// strictly-greater-than so the boundary tick is not yet considered idle.
+    /// Also suppressed when a tool call is in flight (<paramref name="toolInFlight"/>
+    /// true): a long-running shell command / custom tool legitimately produces no
+    /// new rollout lines between its function_call start and its _output completion —
+    /// ending while it's running would falsely terminate an active session. No hard
+    /// ceiling on tool duration: if the process dies, the parent-exit watchdog takes
+    /// over; a hung-but-alive tool is a real in-flight turn (YAGNI — no ceiling).
     /// </summary>
     internal static bool ShouldEndOnIdle(
             string         vendor,
@@ -570,12 +577,52 @@ static partial class WatchCommand {
             bool           thresholdReached,
             DateTimeOffset lastActivityAt,
             DateTimeOffset now,
-            TimeSpan       idleTimeout
+            TimeSpan       idleTimeout,
+            bool           toolInFlight = false
         ) =>
         vendor == "codex"
         && isSessionWatcher
         && thresholdReached
-        && now - lastActivityAt > idleTimeout;
+        && now - lastActivityAt > idleTimeout
+        && !toolInFlight;
+
+    /// <summary>
+    /// Updates <paramref name="pending"/> based on a single Codex rollout line.
+    /// A <c>function_call</c> or <c>custom_tool_call</c> response_item adds its
+    /// <c>call_id</c> to the set; the matching <c>_output</c> variant removes it.
+    /// All other lines and malformed JSON are silently ignored so this is safe to
+    /// call unconditionally for every line of any vendor transcript.
+    /// </summary>
+    internal static void UpdateCodexPendingToolCalls(HashSet<string> pending, string line) {
+        try {
+            using var doc  = JsonDocument.Parse(line);
+            var       root = doc.RootElement;
+
+            if (root.Str("type") != "response_item") return;
+
+            var payload = root.Obj("payload");
+
+            if (payload is not { } p) return;
+
+            var callId = p.Str("call_id");
+
+            if (callId is null) return;
+
+            switch (p.Str("type")) {
+                case "function_call"
+                  or "custom_tool_call":
+                    pending.Add(callId);
+                    break;
+
+                case "function_call_output"
+                  or "custom_tool_call_output":
+                    pending.Remove(callId);
+                    break;
+            }
+        } catch {
+            // Ignore malformed / non-JSON lines — never break the drain loop
+        }
+    }
 
     internal static async Task PostSessionEndOnParentExitAsync(
             string             baseUrl,
@@ -738,6 +785,14 @@ static partial class WatchCommand {
 
             if (newLines.Count > 0) {
                 state.LastActivityAt = DateTimeOffset.UtcNow;
+            }
+
+            // Track Codex tool calls in flight across all new lines (Codex-only,
+            // but runs unconditionally so it is not gated on the title phase or
+            // threshold). Non-Codex lines have a different top-level shape (no
+            // response_item), so this is a cheap no-op for them.
+            foreach (var line in newLines) {
+                UpdateCodexPendingToolCalls(state.PendingCodexToolCalls, line);
             }
 
             // Capture first user text (needed for title generation)

--- a/test/Capacitor.Cli.Tests.Integration/WatcherParentExitPostTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/WatcherParentExitPostTests.cs
@@ -184,6 +184,43 @@ public class WatcherParentExitPostTests : IDisposable {
     }
 
     [Test]
+    public async Task IdleTimeout_PostsSessionEnd_WithIdleTimeoutReason() {
+        // When a Codex rollout file goes idle, the watcher calls PostSessionEndOnParentExitAsync
+        // with reason "idle_timeout". Validate the payload reaches /hooks/session-end/codex
+        // and the reason field is "idle_timeout" (not "parent_exited").
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"provider":"None"}"""));
+
+        _server.Given(Request.Create().WithPath("/hooks/session-end/codex").UsingPost())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody("""{"generate_whats_done":false}""")
+            );
+
+        var sessionId = $"test-{Guid.NewGuid():N}";
+
+        await WatchCommand.PostSessionEndOnParentExitAsync(
+            baseUrl:        _server.Url!,
+            sessionId:      sessionId,
+            transcriptPath: "/tmp/fake.jsonl",
+            cwd:            "/repo",
+            vendor:         "codex",
+            repository:     null,
+            reason:         "idle_timeout"
+        );
+
+        var requests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-end/codex").UsingPost());
+        await Assert.That(requests.Count).IsEqualTo(1);
+
+        var body = JsonDocument.Parse(requests[0].RequestMessage.Body!).RootElement;
+        await Assert.That(body.GetProperty("session_id").GetString()).IsEqualTo(sessionId);
+        await Assert.That(body.GetProperty("hook_event_name").GetString()).IsEqualTo("session_end");
+        await Assert.That(body.GetProperty("reason").GetString()).IsEqualTo("idle_timeout");
+    }
+
+    [Test]
     public async Task ParentExit_FinalizesGeminiSubagents_BeforeSessionEnd() {
         // Regression (PR #170 review, BLOCKING): the watcher's parent-exit fallback must run
         // the Gemini subagent teardown. Gemini fires no subagent-stop hook and its child

--- a/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
@@ -221,6 +221,69 @@ public class WatchCommandTests {
 
         await Assert.That(result).IsEqualTo(TimeSpan.FromMinutes(expectedMinutes));
     }
+
+    static readonly DateTimeOffset IdleNow    = new(2026, 6, 27, 12, 0, 0, TimeSpan.Zero);
+    static readonly TimeSpan       IdleWindow = TimeSpan.FromMinutes(60);
+
+    [Test]
+    public async Task ShouldEndOnIdle_true_for_idle_codex_session_watcher() {
+        var should = WatchCommand.ShouldEndOnIdle(
+            vendor: "codex", isSessionWatcher: true, thresholdReached: true,
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow);
+
+        await Assert.That(should).IsTrue();
+    }
+
+    [Test]
+    [Arguments("claude")]
+    [Arguments("gemini")]
+    [Arguments("pi")]
+    [Arguments("copilot")]
+    [Arguments("kiro")]
+    public async Task ShouldEndOnIdle_false_for_non_codex(string vendor) {
+        var should = WatchCommand.ShouldEndOnIdle(
+            vendor: vendor, isSessionWatcher: true, thresholdReached: true,
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow);
+
+        await Assert.That(should).IsFalse();
+    }
+
+    [Test]
+    public async Task ShouldEndOnIdle_false_when_not_yet_idle() {
+        var should = WatchCommand.ShouldEndOnIdle(
+            vendor: "codex", isSessionWatcher: true, thresholdReached: true,
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(59), now: IdleNow, idleTimeout: IdleWindow);
+
+        await Assert.That(should).IsFalse();
+    }
+
+    [Test]
+    public async Task ShouldEndOnIdle_false_for_subagent_watcher() {
+        var should = WatchCommand.ShouldEndOnIdle(
+            vendor: "codex", isSessionWatcher: false, thresholdReached: true,
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow);
+
+        await Assert.That(should).IsFalse();
+    }
+
+    [Test]
+    public async Task ShouldEndOnIdle_false_below_threshold() {
+        var should = WatchCommand.ShouldEndOnIdle(
+            vendor: "codex", isSessionWatcher: true, thresholdReached: false,
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow);
+
+        await Assert.That(should).IsFalse();
+    }
+
+    [Test]
+    public async Task ShouldEndOnIdle_false_exactly_at_timeout_boundary() {
+        // Strictly greater-than: exactly == idleTimeout is NOT yet idle.
+        var should = WatchCommand.ShouldEndOnIdle(
+            vendor: "codex", isSessionWatcher: true, thresholdReached: true,
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(60), now: IdleNow, idleTimeout: IdleWindow);
+
+        await Assert.That(should).IsFalse();
+    }
 }
 
 public class CodexTranscriptExtractionTests {

--- a/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
@@ -207,6 +207,20 @@ public class WatchCommandTests {
         await Assert.That(vendorParam!.HasDefaultValue).IsTrue();
         await Assert.That(vendorParam.DefaultValue).IsEqualTo("claude");
     }
+
+    [Test]
+    [Arguments(null, 60)]      // unset → default 60 min
+    [Arguments("", 60)]        // empty → default
+    [Arguments("abc", 60)]     // non-numeric → default
+    [Arguments("0", 60)]       // non-positive → default (clamped)
+    [Arguments("-5", 60)]      // negative → default
+    [Arguments("15", 15)]      // valid override
+    [Arguments("600", 600)]    // large but allowed
+    public async Task ResolveCodexIdleTimeout_parses_env_with_default(string? env, int expectedMinutes) {
+        var result = WatchCommand.ResolveCodexIdleTimeout(env);
+
+        await Assert.That(result).IsEqualTo(TimeSpan.FromMinutes(expectedMinutes));
+    }
 }
 
 public class CodexTranscriptExtractionTests {

--- a/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
@@ -229,7 +229,8 @@ public class WatchCommandTests {
     public async Task ShouldEndOnIdle_true_for_idle_codex_session_watcher() {
         var should = WatchCommand.ShouldEndOnIdle(
             vendor: "codex", isSessionWatcher: true, thresholdReached: true,
-            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow);
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow,
+            toolInFlight: false);
 
         await Assert.That(should).IsTrue();
     }
@@ -243,7 +244,8 @@ public class WatchCommandTests {
     public async Task ShouldEndOnIdle_false_for_non_codex(string vendor) {
         var should = WatchCommand.ShouldEndOnIdle(
             vendor: vendor, isSessionWatcher: true, thresholdReached: true,
-            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow);
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow,
+            toolInFlight: false);
 
         await Assert.That(should).IsFalse();
     }
@@ -252,7 +254,8 @@ public class WatchCommandTests {
     public async Task ShouldEndOnIdle_false_when_not_yet_idle() {
         var should = WatchCommand.ShouldEndOnIdle(
             vendor: "codex", isSessionWatcher: true, thresholdReached: true,
-            lastActivityAt: IdleNow - TimeSpan.FromMinutes(59), now: IdleNow, idleTimeout: IdleWindow);
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(59), now: IdleNow, idleTimeout: IdleWindow,
+            toolInFlight: false);
 
         await Assert.That(should).IsFalse();
     }
@@ -261,7 +264,8 @@ public class WatchCommandTests {
     public async Task ShouldEndOnIdle_false_for_subagent_watcher() {
         var should = WatchCommand.ShouldEndOnIdle(
             vendor: "codex", isSessionWatcher: false, thresholdReached: true,
-            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow);
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow,
+            toolInFlight: false);
 
         await Assert.That(should).IsFalse();
     }
@@ -270,7 +274,8 @@ public class WatchCommandTests {
     public async Task ShouldEndOnIdle_false_below_threshold() {
         var should = WatchCommand.ShouldEndOnIdle(
             vendor: "codex", isSessionWatcher: true, thresholdReached: false,
-            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow);
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow,
+            toolInFlight: false);
 
         await Assert.That(should).IsFalse();
     }
@@ -280,9 +285,86 @@ public class WatchCommandTests {
         // Strictly greater-than: exactly == idleTimeout is NOT yet idle.
         var should = WatchCommand.ShouldEndOnIdle(
             vendor: "codex", isSessionWatcher: true, thresholdReached: true,
-            lastActivityAt: IdleNow - TimeSpan.FromMinutes(60), now: IdleNow, idleTimeout: IdleWindow);
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(60), now: IdleNow, idleTimeout: IdleWindow,
+            toolInFlight: false);
 
         await Assert.That(should).IsFalse();
+    }
+
+    [Test]
+    public async Task ShouldEndOnIdle_false_when_tool_in_flight_even_if_idle() {
+        // A tool call is in progress — must NOT idle-end even after the timeout window.
+        var should = WatchCommand.ShouldEndOnIdle(
+            vendor: "codex", isSessionWatcher: true, thresholdReached: true,
+            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow,
+            toolInFlight: true);
+
+        await Assert.That(should).IsFalse();
+    }
+}
+
+public class UpdateCodexPendingToolCallsTests {
+    [Test]
+    public async Task FunctionCall_AddsCallId() {
+        var pending = new HashSet<string>(StringComparer.Ordinal);
+        const string line = """{"type":"response_item","payload":{"type":"function_call","call_id":"call_1","name":"shell","arguments":"{}"}}""";
+
+        WatchCommand.UpdateCodexPendingToolCalls(pending, line);
+
+        await Assert.That(pending.Contains("call_1")).IsTrue();
+    }
+
+    [Test]
+    public async Task CustomToolCall_AddsCallId() {
+        var pending = new HashSet<string>(StringComparer.Ordinal);
+        const string line = """{"type":"response_item","payload":{"type":"custom_tool_call","call_id":"call_2","name":"my_tool","arguments":"{}"}}""";
+
+        WatchCommand.UpdateCodexPendingToolCalls(pending, line);
+
+        await Assert.That(pending.Contains("call_2")).IsTrue();
+    }
+
+    [Test]
+    public async Task FunctionCallOutput_RemovesCallId() {
+        var pending = new HashSet<string>(StringComparer.Ordinal) { "call_1" };
+        const string line = """{"type":"response_item","payload":{"type":"function_call_output","call_id":"call_1","output":"done"}}""";
+
+        WatchCommand.UpdateCodexPendingToolCalls(pending, line);
+
+        await Assert.That(pending.Contains("call_1")).IsFalse();
+    }
+
+    [Test]
+    public async Task CustomToolCallOutput_RemovesCallId() {
+        var pending = new HashSet<string>(StringComparer.Ordinal) { "call_2" };
+        const string line = """{"type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_2","output":"done"}}""";
+
+        WatchCommand.UpdateCodexPendingToolCalls(pending, line);
+
+        await Assert.That(pending.Contains("call_2")).IsFalse();
+    }
+
+    [Test]
+    public async Task MessageResponseItem_LeavesSetUnchanged() {
+        var pending = new HashSet<string>(StringComparer.Ordinal) { "existing" };
+        const string line = """{"type":"response_item","payload":{"type":"message","role":"assistant","content":[]}}""";
+
+        WatchCommand.UpdateCodexPendingToolCalls(pending, line);
+
+        // Set unchanged — still contains "existing", nothing added
+        await Assert.That(pending.Count).IsEqualTo(1);
+        await Assert.That(pending.Contains("existing")).IsTrue();
+    }
+
+    [Test]
+    public async Task MalformedJson_LeavesSetUnchanged_NoThrow() {
+        var pending = new HashSet<string>(StringComparer.Ordinal) { "existing" };
+
+        // Must not throw; set must remain unchanged
+        WatchCommand.UpdateCodexPendingToolCalls(pending, "not json at all {{}}");
+
+        await Assert.That(pending.Count).IsEqualTo(1);
+        await Assert.That(pending.Contains("existing")).IsTrue();
     }
 }
 


### PR DESCRIPTION
## Summary

Codex has no session-end hook, so a Codex session ends only when the `kcap watch` parent-exit watchdog sees the parent `codex` process exit. The **Codex desktop app** runs one long-lived `codex app-server` process that is the `--parent-pid` for every conversation's watcher, so that PID never exits per-conversation and Codex sessions stay "active" forever.

This adds a **rollout-file idle-timeout fallback** to the watcher:

- `ResolveCodexIdleTimeout` reads `KCAP_CODEX_IDLE_MINUTES` (default **60**; invalid/non-positive → default).
- `WatchState.LastActivityAt` tracks the last time new lines were appended; updated in `DrainNewLines`.
- `ShouldEndOnIdle` (pure, unit-tested) — gated to **vendor codex, session watchers only, threshold-reached only**.
- The main watch loop ends the session on idle, reusing `PostSessionEndOnParentExitAsync` with a new `reason` parameter so it POSTs `/hooks/session-end/codex` with `reason: idle_timeout` (parent-exit path still posts `parent_exited`).

Self-correcting: Codex fires a `Stop` hook per turn that re-spawns the watcher (idempotent `EnsureWatcherRunning`), and the server reactivates a session when new transcript events arrive, so resuming a conversation brings it back.

**Pairs with kcap-server PR for AI-1030** (adds the `idle_timeout` `SessionEndReason` + a reactivation-aware session-end idempotency guard). Deploy **server before CLI**; older servers degrade the unknown reason to `Other` harmlessly.

## Test Plan

- [x] Unit: `ResolveCodexIdleTimeout` (env parsing incl. non-positive) + `ShouldEndOnIdle` (codex/non-codex, subagent, below-threshold, strict `>` boundary) — full unit suite 1850/1850.
- [x] Integration: `WatcherParentExitPostTests` asserts the POST to `/hooks/session-end/codex` carries `reason: idle_timeout` — 8/8.
- [x] AOT publish clean (no IL2026/IL3050).
- [ ] Real Codex desktop E2E (set `KCAP_CODEX_IDLE_MINUTES=2`: idle-end fires, then resume re-spawns watcher + reactivates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)