### PR TITLE
Fix `import --org` after WorkOS migration; surface setup-completion ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ In `--no-prompt` mode, the wizard installs hooks for every detected agent by def
 
 ```bash
 kcap import                     # every detected agent (Claude, Codex, Cursor, Copilot, Gemini, Kiro, Pi, OpenCode)
-kcap import --org               # sessions for the org bound to your active profile
+kcap import --org EventStore    # sessions whose git-remote owner is EventStore
+kcap import --org               # pick an org from your discovered repos (and remember it)
 kcap import --repo owner/repo   # sessions for one specific repo
 kcap import --cursor            # only Cursor
 kcap import --copilot           # only Copilot
@@ -106,7 +107,7 @@ kcap import --opencode          # only OpenCode
 
 This backfills your past sessions from `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex), `~/.cursor/projects/.../agent-transcripts/` (Cursor), `~/.copilot/session-state/` (Copilot), `~/.gemini/tmp/<project>/chats/` (Gemini), `~/.kiro/sessions/cli/` (Kiro), `~/.pi/agent/sessions/` (Pi), and `~/.local/share/opencode/opencode.db` (OpenCode) so they appear in the dashboard. All agents are discovered automatically — pass `--claude`, `--codex`, `--cursor`, `--copilot`, `--gemini`, `--kiro`, `--pi`, or `--opencode` (one or more) to narrow the run. All forms are idempotent — safe to run multiple times.
 
-You must pick an explicit scope (`--all`, `--org`, or `--repo`) so personal/private repos aren't uploaded by accident. `--org` uses the active profile name as the GitHub org login — it works out of the box when the profile was created by `kcap setup` (which names it after the picked tenant), and errors otherwise. Run with no scope on an interactive terminal to get a picker. See [Loading historical sessions](#loading-historical-sessions) for the full set of flags.
+You must pick an explicit scope (`--all`, `--org`, or `--repo`) so personal/private repos aren't uploaded by accident. `--org <owner>` filters by the git-remote owner (GitHub org/user) detected on each session — independent of your profile name, so it behaves identically under GitHub and WorkOS sign-in. A bare `--org` lets you pick an owner from your discovered repos and remembers it for next time. Run with no scope on an interactive terminal to get a picker. See [Loading historical sessions](#loading-historical-sessions) for the full set of flags.
 
 If your repo directories have been renamed or deleted on disk, the import prints a list of unresolved cwds up front. See [Renamed repo directories (`kcap remap`)](#renamed-repo-directories-kcap-remap) to recover those sessions.
 
@@ -322,14 +323,15 @@ Backfill older sessions from every detected coding agent in a single run. All se
 
 ```bash
 kcap import --all                            # every discovered session from every agent
-kcap import --org                            # sessions whose repo owner matches your active profile name
+kcap import --org EventStore                 # sessions whose git-remote owner is EventStore
+kcap import --org                            # pick an owner from discovered repos, then remember it
 kcap import --repo owner/repo                # one specific repo
 kcap import --repo .                         # the repo at the current cwd (must be a git repo with an origin remote)
 ```
 
 Run `kcap import` with no scope on an interactive terminal to get a picker. Each run shows a confirmation summary (scope, matched count, repo samples, visibility) before uploading anything.
 
-`--org` is a shortcut: it takes the active profile *name* and uses it as a GitHub org login to filter on. `kcap setup` names the profile after the picked tenant, so `--org` works out of the box for tenant-bound profiles; on the `default` profile, or a manually-named profile like `work`, use `--repo <owner/name>` instead (or run `kcap setup` to bind a profile to your org).
+`--org` filters by the **git-remote owner** (GitHub org/user) detected on each session — not by your profile name. This makes it independent of how you signed in: under WorkOS the active profile is named after the tenant slug (which is not a GitHub org), so the owner to scope on is taken from the flag value or chosen from your discovered repos instead. Pass it explicitly as `--org <owner>`, or run a bare `kcap import --org` once on an interactive terminal to pick an owner from your discovered repos — the choice is saved to the active profile (`import_org`) and reused by later bare `--org` runs. Non-interactive runs (CI) must pass `--org <owner>` (or have a remembered org).
 
 By default every available agent is imported. Pass one or more vendor filters to restrict the run:
 
@@ -354,11 +356,11 @@ OpenCode historical import reads its SQLite database (`~/.local/share/opencode/o
 Additional flags:
 
 ```bash
-kcap import --org --yes                      # skip the confirmation prompt
-kcap import --org --private                  # mark every imported session as Only Visible to You
-kcap import --org --since 2026-01-01         # only sessions on or after this date
-kcap import --org --cwd /path/to/project     # filter by working directory
-kcap import --org --session abc123           # single session
+kcap import --org EventStore --yes           # skip the confirmation prompt
+kcap import --org EventStore --private        # mark every imported session as Only Visible to You
+kcap import --org EventStore --since 2026-01-01  # only sessions on or after this date
+kcap import --org EventStore --cwd /path/to/project  # filter by working directory
+kcap import --org EventStore --session abc123    # single session
 ```
 
 Non-interactive runs (no TTY, e.g. CI) must pass both a scope flag and `--yes`. The command is idempotent and resumable — re-running with the same scope only uploads what's missing or incomplete. A server-side tracker deduplicates events on `(stream, eventId)` so previously-imported turns don't get re-appended.

--- a/src/Capacitor.Cli.Core/Auth/TenantDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/TenantDiscovery.cs
@@ -54,7 +54,12 @@ public class TenantDiscovery(IAuthProxyClient proxy, ITenantPicker picker) {
 
         foreach (var t in discovered) {
             var name = t.ProfileName;
-            profiles[name] = (profiles.GetValueOrDefault(name) ?? template) with {
+            // Seed a brand-new tenant profile from the template, but never inherit the
+            // template's remembered import org — that GitHub owner belongs to a different
+            // tenant and would silently scope this tenant's `kcap import --org`. Existing
+            // profiles keep their own ImportOrg.
+            var basis = profiles.GetValueOrDefault(name) ?? template with { ImportOrg = null };
+            profiles[name] = basis with {
                 ServerUrl = AppConfig.NormalizeUrl(t.Origin)
             };
         }

--- a/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
@@ -69,6 +69,16 @@ public record Profile {
 
     [JsonPropertyName("remotes")]
     public string[] Remotes { get; init; } = [];
+
+    /// <summary>
+    /// GitHub org/owner used by <c>kcap import --org</c> to filter sessions by
+    /// their git-remote owner. Decoupled from the profile name: under WorkOS the
+    /// profile is named after the tenant slug, which is not a GitHub org, so the
+    /// org to scope on is chosen from discovered repos (or passed as
+    /// <c>--org &lt;owner&gt;</c>) and remembered here for subsequent bare <c>--org</c> runs.
+    /// </summary>
+    [JsonPropertyName("import_org")]
+    public string? ImportOrg { get; init; }
 }
 
 /// <summary>Repo-level .kcap.json committed to VCS.</summary>

--- a/src/Capacitor.Cli.Core/Resources/help-import.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-import.txt
@@ -30,9 +30,15 @@ Vendor filters (additive — pass one or more to restrict the run):
 
 Scope (one of, required for non-interactive use):
   --all                   Import every discovered session
-  --org                   Import only sessions from your active profile's org
+  --org <owner>           Import only sessions whose git-remote owner matches <owner>
+  --org                   Bare: pick an org from discovered repos (interactive) and
+                          remember it; reuses the remembered org on later runs
   --repo <owner/name>     Import only sessions from a specific repo
   --repo .                Import only sessions from the current cwd's repo
+
+The org is the git-remote owner (GitHub org/user), independent of your profile
+name — so `--org` works the same under GitHub and WorkOS sign-in. A bare `--org`
+with no remembered org needs an interactive terminal (or pass `--org <owner>`).
 
 Without a scope flag on an interactive terminal, an interactive picker is shown.
 

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -427,7 +427,9 @@ static class ImportCommand {
             bool                          skipConfirmation        = false,
             bool                          forcePrivate            = false,
             string                        activeProfile           = "default",
-            (string Owner, string Name)?  currentRepo             = null
+            (string Owner, string Name)?  currentRepo             = null,
+            bool                          needOrgPick             = false,
+            string?                       storedOrg               = null
         ) {
         using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
         var       display    = ImportDisplay.Create();
@@ -617,14 +619,29 @@ static class ImportCommand {
                 .Select(v => v!.Value)
                 .ToList();
 
-            scope = ImportScopePrompt.RunPicker(activeProfile, currentRepo, distinct);
+            if (needOrgPick) {
+                // Bare `--org` with no value/remembered org: pick the GitHub org to
+                // scope on from the owners seen across discovered sessions.
+                var owner = ImportScopePrompt.RunOrgPicker(distinct);
+                scope = owner is null ? null : new ImportScope.Org(owner);
+            } else {
+                scope = ImportScopePrompt.RunPicker(currentRepo, distinct);
+            }
 
             if (scope is null) {
-                // RunPicker has already printed the specific reason (e.g. "Active profile
-                // has no org" or "No repositories detected in discovered sessions") via
-                // AnsiConsole. Don't tack on a misleading "cancelled" message.
+                // The picker has already printed the specific reason (e.g. "No
+                // git-remote owners detected" or "No repositories detected in
+                // discovered sessions") via AnsiConsole. Don't tack on a
+                // misleading "cancelled" message.
                 return 1;
             }
+        }
+
+        // Remember an org chosen interactively or passed via `--org <owner>` so a
+        // later bare `kcap import --org` reuses it without re-prompting.
+        if (scope is ImportScope.Org chosenOrg &&
+            !string.Equals(chosenOrg.OrgLogin, storedOrg, StringComparison.OrdinalIgnoreCase)) {
+            await PersistImportOrgAsync(activeProfile, chosenOrg.OrgLogin);
         }
 
         // --- Per-source scope filtering ---
@@ -1700,6 +1717,28 @@ static class ImportCommand {
 
         var sessionWord = count == 1 ? "session" : "sessions";
         display.Line($"Attributed {count} {sessionWord} to a parent project via worktree path.");
+    }
+
+    /// <summary>
+    /// Persist the org chosen for <c>kcap import --org</c> onto the active profile so a
+    /// later bare <c>--org</c> reuses it. Best-effort: failing to remember the choice must
+    /// not abort the import. Creates the profile entry if it doesn't exist yet (e.g. the
+    /// <c>default</c> profile), so the org is remembered even without a tenant-bound profile.
+    /// </summary>
+    static async Task PersistImportOrgAsync(string profileName, string org) {
+        try {
+            var cfg     = await AppConfig.LoadProfileConfig();
+            var profile = cfg.Profiles.GetValueOrDefault(profileName) ?? new Core.Config.Profile();
+            var updated = cfg with {
+                Profiles = new Dictionary<string, Core.Config.Profile>(cfg.Profiles) {
+                    [profileName] = profile with { ImportOrg = org }
+                }
+            };
+
+            await AppConfig.SaveProfileConfig(updated);
+        } catch {
+            // Remembering the org is a convenience, not part of the import contract.
+        }
     }
 
     internal static void ReportMissingCwds(

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -1726,6 +1726,9 @@ static class ImportCommand {
     /// <c>default</c> profile), so the org is remembered even without a tenant-bound profile.
     /// </summary>
     static async Task PersistImportOrgAsync(string profileName, string org) {
+        if (string.IsNullOrWhiteSpace(org)) return;
+        org = org.Trim();
+
         try {
             var cfg     = await AppConfig.LoadProfileConfig();
             var profile = cfg.Profiles.GetValueOrDefault(profileName) ?? new Core.Config.Profile();

--- a/src/Capacitor.Cli/Commands/ImportScopeArgs.cs
+++ b/src/Capacitor.Cli/Commands/ImportScopeArgs.cs
@@ -92,8 +92,10 @@ public static class ImportScopeArgs {
         if (f.Org) {
             // Explicit `--org <owner>` wins. The owner is the GitHub org/owner to
             // match against each session's git-remote owner — NOT the profile name
-            // (which under WorkOS is a tenant slug, not a GitHub org).
-            var org = !string.IsNullOrEmpty(f.OrgArg) ? f.OrgArg : input.StoredOrg;
+            // (which under WorkOS is a tenant slug, not a GitHub org). Trim so a
+            // padded value (e.g. "EventStore ") can't produce a scope that never
+            // matches a detected owner.
+            var org = (!string.IsNullOrWhiteSpace(f.OrgArg) ? f.OrgArg : input.StoredOrg)?.Trim();
 
             if (!string.IsNullOrEmpty(org)) {
                 return new(new ImportScope.Org(org), f.Yes, f.Private, null);

--- a/src/Capacitor.Cli/Commands/ImportScopeArgs.cs
+++ b/src/Capacitor.Cli/Commands/ImportScopeArgs.cs
@@ -11,34 +11,44 @@ public static class ImportScopeArgs {
             bool    Org,
             string? RepoArg,
             bool    Yes,
-            bool    Private
+            bool    Private,
+            string? OrgArg = null // explicit owner after `--org`, or null for bare `--org`
         );
 
     public sealed record ResolveInput(
             ParsedFlags                  Flags,
             string                       ActiveProfile,
             bool                         IsInteractive,
-            (string Owner, string Name)? CurrentRepo
+            (string Owner, string Name)? CurrentRepo,
+            string?                      StoredOrg = null // org remembered on the active profile
         );
 
     public sealed record ResolveResult(
-            ImportScope? Scope, // null => either picker needed or error
+            ImportScope? Scope, // null => picker needed, org-pick needed, or error
             bool         Yes,
             bool         Private,
-            string?      Error
+            string?      Error,
+            bool         NeedOrgPick = false // bare `--org`, no value/stored org: pick from discovered repos
         );
 
     public static ParsedFlags ParseFlags(string[] args) {
         string? repo                                = null;
-        var     idx                                 = Array.IndexOf(args, "--repo");
-        if (idx >= 0 && idx + 1 < args.Length) repo = args[idx + 1];
+        var     repoIdx                             = Array.IndexOf(args, "--repo");
+        if (repoIdx >= 0 && repoIdx + 1 < args.Length) repo = args[repoIdx + 1];
+
+        // `--org` may be bare or take an explicit owner. Only treat the next token
+        // as the owner when it isn't another flag (so `--org --yes` stays bare).
+        string? org    = null;
+        var     orgIdx = Array.IndexOf(args, "--org");
+        if (orgIdx >= 0 && orgIdx + 1 < args.Length && !args[orgIdx + 1].StartsWith('-')) org = args[orgIdx + 1];
 
         return new(
             All: args.Contains("--all"),
             Org: args.Contains("--org"),
             RepoArg: repo,
             Yes: args.Contains("--yes") || args.Contains("-y"),
-            Private: args.Contains("--private")
+            Private: args.Contains("--private"),
+            OrgArg: org
         );
     }
 
@@ -80,16 +90,27 @@ public static class ImportScopeArgs {
         }
 
         if (f.Org) {
-            if (string.IsNullOrEmpty(input.ActiveProfile) || input.ActiveProfile == "default") {
-                return new(
-                    null,
-                    f.Yes,
-                    f.Private,
-                    "--org requires a tenant-bound profile. Run `kcap setup` first, or use --all / --repo <owner/name>."
-                );
+            // Explicit `--org <owner>` wins. The owner is the GitHub org/owner to
+            // match against each session's git-remote owner — NOT the profile name
+            // (which under WorkOS is a tenant slug, not a GitHub org).
+            var org = !string.IsNullOrEmpty(f.OrgArg) ? f.OrgArg : input.StoredOrg;
+
+            if (!string.IsNullOrEmpty(org)) {
+                return new(new ImportScope.Org(org), f.Yes, f.Private, null);
             }
 
-            return new(new ImportScope.Org(input.ActiveProfile), f.Yes, f.Private, null);
+            // Bare `--org` with nothing remembered: pick an org from discovered repos
+            // when interactive; otherwise we have no owner to scope on.
+            if (input.IsInteractive) {
+                return new(null, f.Yes, f.Private, Error: null, NeedOrgPick: true);
+            }
+
+            return new(
+                null,
+                f.Yes,
+                f.Private,
+                "--org needs an owner: pass `--org <owner>`, or run `kcap import --org` once interactively to choose and remember one."
+            );
         }
 
         // --repo <value>

--- a/src/Capacitor.Cli/Commands/ImportScopePrompt.cs
+++ b/src/Capacitor.Cli/Commands/ImportScopePrompt.cs
@@ -37,6 +37,23 @@ public static partial class ImportScopePrompt {
     }
 
     /// <summary>
+    /// Build the option strings for the "which org" picker: the distinct,
+    /// case-insensitively deduplicated, alphabetically sorted set of git-remote
+    /// owners across the discovered repos.
+    /// </summary>
+    public static string[] BuildOrgChoices(IReadOnlyList<(string Owner, string Name)> discoveredRepos) {
+        var owners = discoveredRepos
+            .Select(r => r.Owner)
+            .Where(o => !string.IsNullOrEmpty(o))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        owners.Sort(StringComparer.OrdinalIgnoreCase);
+
+        return [.. owners];
+    }
+
+    /// <summary>
     /// Build the confirmation summary block printed before the y/N prompt.
     /// The same text is printed in non-TTY runs (with --yes) so the imported
     /// scope is recorded in CI logs.
@@ -91,7 +108,6 @@ public static partial class ImportScopePrompt {
     /// options (no current repo + no detected repos).
     /// </summary>
     public static ImportScope? RunPicker(
-            string                                     activeProfile,
             (string Owner, string Name)?               currentRepo,
             IReadOnlyList<(string Owner, string Name)> discoveredRepos
         ) {
@@ -101,7 +117,7 @@ public static partial class ImportScopePrompt {
                 .AddChoices("all", "org", "repo")
                 .UseConverter(c => c switch {
                         "all"  => "Everything",
-                        "org"  => $"Org repos only ({activeProfile})",
+                        "org"  => "All repos in one org",
                         "repo" => "Specific repository",
                         _      => c,
                     }
@@ -111,12 +127,10 @@ public static partial class ImportScopePrompt {
         switch (choice) {
             case "all":
                 return new ImportScope.All();
-            case "org" when string.IsNullOrEmpty(activeProfile) || activeProfile == "default":
-                AnsiConsole.MarkupLine("[red]Active profile has no org. Run `kcap setup`.[/]");
-
-                return null;
             case "org":
-                return new ImportScope.Org(activeProfile);
+                var owner = RunOrgPicker(discoveredRepos);
+
+                return owner is null ? null : new ImportScope.Org(owner);
         }
 
         var repoChoices = BuildRepoChoices(currentRepo, discoveredRepos);
@@ -139,6 +153,28 @@ public static partial class ImportScopePrompt {
         var parts = clean.Split('/');
 
         return new ImportScope.Repo(parts[0], parts[1]);
+    }
+
+    /// <summary>
+    /// Prompt for which git-remote owner (GitHub org) to scope the import to,
+    /// choosing from the owners seen across discovered sessions. Returns the
+    /// chosen owner, or null when no owners were detected (a reason is printed).
+    /// </summary>
+    public static string? RunOrgPicker(IReadOnlyList<(string Owner, string Name)> discoveredRepos) {
+        var owners = BuildOrgChoices(discoveredRepos);
+
+        if (owners.Length == 0) {
+            AnsiConsole.MarkupLine("[red]No git-remote owners detected in discovered sessions. Use --repo <owner/name> or --all.[/]");
+
+            return null;
+        }
+
+        return AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("Which org? [dim](git-remote owner)[/]")
+                .PageSize(15)
+                .AddChoices(owners)
+        );
     }
 
     /// <summary>

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -518,9 +518,22 @@ public static class SetupCommand {
     //     internally. If the delay wins, HttpClient disposal on method-exit
     //     cancels the in-flight POST.
     static async Task PingCliSetupAsync(string serverUrl) {
+        // The ping is intentionally silent (see method-doc), which also hides why the
+        // dashboard welcome modal never flips when it fails — e.g. a token the server
+        // rejects or maps to a different identity. Set KCAP_DEBUG to surface the
+        // outcome on stderr without changing the best-effort, non-blocking contract.
+        var  debug = Environment.GetEnvironmentVariable("KCAP_DEBUG") is { Length: > 0 };
+        void Debug(string message) {
+            if (debug) Console.Error.WriteLine($"[kcap] cli-setup ping: {message}");
+        }
+
         try {
             var tokens = await TokenStore.LoadAsync();
-            if (tokens is null || tokens.IsExpired) return;
+            if (tokens is null || tokens.IsExpired) {
+                Debug(tokens is null ? "skipped — no stored token" : "skipped — token expired");
+
+                return;
+            }
 
             using var http = new HttpClient();
             http.DefaultRequestHeaders.Authorization = new("Bearer", tokens.AccessToken);
@@ -537,11 +550,13 @@ public static class SetupCommand {
             if (winner == pingTask) {
                 // Observe the result so any exception is consumed by the outer
                 // catch (instead of surfacing as UnobservedTaskException later).
-                (await pingTask).Dispose();
+                using var resp = await pingTask;
+                Debug($"{(int)resp.StatusCode} {resp.StatusCode} (provider={tokens.Provider})");
             } else {
                 // Wall-clock cap hit. HttpClient.Dispose() at method-exit
                 // cancels the in-flight POST; observe the orphan so its
                 // cancellation exception doesn't go unhandled.
+                Debug("timed out after 5s");
                 _ = pingTask.ContinueWith(
                     t => {
                         if (t.IsCompletedSuccessfully) t.Result.Dispose();
@@ -549,8 +564,9 @@ public static class SetupCommand {
                     },
                     TaskScheduler.Default);
             }
-        } catch {
-            // Swallow — see method-doc.
+        } catch (Exception e) {
+            // Swallow — see method-doc. KCAP_DEBUG surfaces the reason.
+            Debug($"failed — {e.GetType().Name}: {e.Message}");
         }
     }
 

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -495,6 +495,7 @@ switch (command) {
         // --- Scope resolution (AI-613) ---
         var profileConfig = await AppConfig.LoadProfileConfig();
         var activeProfile = string.IsNullOrEmpty(profileConfig.ActiveProfile) ? "default" : profileConfig.ActiveProfile;
+        var storedOrg     = profileConfig.Profiles.GetValueOrDefault(activeProfile)?.ImportOrg;
 
         var currentRepoDetected = await RepositoryDetection.DetectRepositoryAsync(Environment.CurrentDirectory);
         (string Owner, string Name)? currentRepo = currentRepoDetected is { Owner: { } o, RepoName: { } n }
@@ -506,7 +507,8 @@ switch (command) {
             Flags:         flags,
             ActiveProfile: activeProfile,
             IsInteractive: !Console.IsInputRedirected && !Console.IsOutputRedirected,
-            CurrentRepo:   currentRepo));
+            CurrentRepo:   currentRepo,
+            StoredOrg:     storedOrg));
 
         if (resolveResult.Error is not null) {
             Console.Error.WriteLine(resolveResult.Error);
@@ -526,7 +528,9 @@ switch (command) {
             skipConfirmation:        resolveResult.Yes,
             forcePrivate:            resolveResult.Private,
             activeProfile:           activeProfile,
-            currentRepo:             currentRepo);
+            currentRepo:             currentRepo,
+            needOrgPick:             resolveResult.NeedOrgPick,
+            storedOrg:               storedOrg);
     }
     case "watch" when args.Length < 3:
         Console.Error.WriteLine("Usage: kcap watch <sessionId> <transcriptPath> [--agent-id <agentId>] [--cwd <cwd>] [--skip-title] [--parent-pid <pid>] [--vendor claude|codex|copilot|gemini|kiro|pi|opencode]");

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportScopeArgsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportScopeArgsTests.cs
@@ -100,6 +100,33 @@ public class ImportScopeArgsTests {
     }
 
     [Test]
+    public async Task Resolve_trims_explicit_org_value() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false, OrgArg: "  EventStore  "),
+            ActiveProfile: "acme-tenant-slug",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(((ImportScope.Org)r.Scope!).OrgLogin).IsEqualTo("EventStore");
+    }
+
+    [Test]
+    public async Task Resolve_whitespace_only_org_value_falls_through_to_pick() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false, OrgArg: "   "),
+            ActiveProfile: "acme-tenant-slug",
+            IsInteractive: true,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.NeedOrgPick).IsTrue();
+    }
+
+    [Test]
     public async Task Resolve_bare_org_uses_remembered_stored_org() {
         var input = new ImportScopeArgs.ResolveInput(
             Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false),

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportScopeArgsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportScopeArgsTests.cs
@@ -20,6 +20,28 @@ public class ImportScopeArgsTests {
     }
 
     [Test]
+    public async Task ParseFlags_reads_org_value() {
+        var f = ImportScopeArgs.ParseFlags(["import", "--org", "EventStore"]);
+        await Assert.That(f.Org).IsTrue();
+        await Assert.That(f.OrgArg).IsEqualTo("EventStore");
+    }
+
+    [Test]
+    public async Task ParseFlags_bare_org_has_null_orgarg() {
+        var f = ImportScopeArgs.ParseFlags(["import", "--org"]);
+        await Assert.That(f.Org).IsTrue();
+        await Assert.That(f.OrgArg).IsNull();
+    }
+
+    [Test]
+    public async Task ParseFlags_org_followed_by_flag_stays_bare() {
+        var f = ImportScopeArgs.ParseFlags(["import", "--org", "--yes"]);
+        await Assert.That(f.Org).IsTrue();
+        await Assert.That(f.OrgArg).IsNull();
+        await Assert.That(f.Yes).IsTrue();
+    }
+
+    [Test]
     public async Task ParseFlags_reads_yes_short_form() {
         var f = ImportScopeArgs.ParseFlags(["import", "--all", "-y"]);
         await Assert.That(f.Yes).IsTrue();
@@ -61,10 +83,12 @@ public class ImportScopeArgsTests {
     }
 
     [Test]
-    public async Task Resolve_returns_Org_with_active_profile() {
+    public async Task Resolve_returns_Org_for_explicit_org_value() {
+        // The org comes from the flag value, NOT the profile name — so it works
+        // identically under GitHub and WorkOS sign-in.
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false),
-            ActiveProfile: "EventStore",
+            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false, OrgArg: "EventStore"),
+            ActiveProfile: "acme-tenant-slug",
             IsInteractive: true,
             CurrentRepo: null);
 
@@ -72,10 +96,40 @@ public class ImportScopeArgsTests {
 
         await Assert.That(r.Scope).IsTypeOf<ImportScope.Org>();
         await Assert.That(((ImportScope.Org)r.Scope!).OrgLogin).IsEqualTo("EventStore");
+        await Assert.That(r.NeedOrgPick).IsFalse();
     }
 
     [Test]
-    public async Task Resolve_errors_on_Org_when_profile_is_default() {
+    public async Task Resolve_bare_org_uses_remembered_stored_org() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false),
+            ActiveProfile: "acme-tenant-slug",
+            IsInteractive: true,
+            CurrentRepo: null,
+            StoredOrg: "EventStore");
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(((ImportScope.Org)r.Scope!).OrgLogin).IsEqualTo("EventStore");
+        await Assert.That(r.NeedOrgPick).IsFalse();
+    }
+
+    [Test]
+    public async Task Resolve_explicit_org_value_overrides_stored_org() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false, OrgArg: "kurrent"),
+            ActiveProfile: "acme-tenant-slug",
+            IsInteractive: true,
+            CurrentRepo: null,
+            StoredOrg: "EventStore");
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(((ImportScope.Org)r.Scope!).OrgLogin).IsEqualTo("kurrent");
+    }
+
+    [Test]
+    public async Task Resolve_bare_org_interactive_without_stored_org_needs_pick() {
         var input = new ImportScopeArgs.ResolveInput(
             Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false),
             ActiveProfile: "default",
@@ -85,7 +139,23 @@ public class ImportScopeArgsTests {
         var r = ImportScopeArgs.Resolve(input);
 
         await Assert.That(r.Scope).IsNull();
-        await Assert.That(r.Error!).Contains("tenant-bound profile");
+        await Assert.That(r.Error).IsNull();
+        await Assert.That(r.NeedOrgPick).IsTrue();
+    }
+
+    [Test]
+    public async Task Resolve_bare_org_non_interactive_without_stored_org_errors() {
+        var input = new ImportScopeArgs.ResolveInput(
+            Flags: new(All: false, Org: true, RepoArg: null, Yes: true, Private: false),
+            ActiveProfile: "default",
+            IsInteractive: false,
+            CurrentRepo: null);
+
+        var r = ImportScopeArgs.Resolve(input);
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.NeedOrgPick).IsFalse();
+        await Assert.That(r.Error!).Contains("--org <owner>");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportScopePromptTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportScopePromptTests.cs
@@ -46,6 +46,36 @@ public class ImportScopePromptTests {
         await Assert.That(choices).IsEquivalentTo(new[] { "A/x", "A/y" });
     }
 
+    // --- BuildOrgChoices ---
+
+    [Test]
+    public async Task BuildOrgChoices_distinct_owners_sorted() {
+        var owners = ImportScopePrompt.BuildOrgChoices(
+            [
+                ("EventStore", "kurrentdb"),
+                ("EventStore", "kcap"),       // same owner, different repo
+                ("alexeyzimarev", "scratchpad"),
+            ]
+        );
+
+        await Assert.That(owners).IsEquivalentTo(new[] { "alexeyzimarev", "EventStore" });
+    }
+
+    [Test]
+    public async Task BuildOrgChoices_deduplicates_case_insensitively() {
+        var owners = ImportScopePrompt.BuildOrgChoices(
+            [("EventStore", "a"), ("eventstore", "b")]
+        );
+
+        await Assert.That(owners.Length).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task BuildOrgChoices_empty_when_no_repos() {
+        var owners = ImportScopePrompt.BuildOrgChoices([]);
+        await Assert.That(owners).IsEmpty();
+    }
+
     // --- FormatSummary ---
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/TenantDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TenantDiscoveryTests.cs
@@ -159,6 +159,30 @@ public class TenantDiscoveryTests {
     }
 
     [Test]
+    public async Task MergeProfiles_does_not_leak_import_org_into_new_profiles() {
+        var existing = new ProfileConfig {
+            ActiveProfile = "acme",
+            Profiles = new Dictionary<string, Profile> {
+                ["acme"] = new() { ServerUrl = "https://a.example", DefaultVisibility = "private", ImportOrg = "AcmeOrg" }
+            }
+        };
+        DiscoveredTenant[] discovered = [
+            new() { OrgId = 1, OrgLogin = "acme",  Origin = "https://a.example" },
+            new() { OrgId = 2, OrgLogin = "newly", Origin = "https://n.example" }
+        ];
+
+        var merged = TenantDiscovery.MergeProfiles(existing, discovered, discovered[1]);
+
+        // The remembered import org belongs to "acme" — a brand-new tenant profile
+        // must not inherit it (it would silently scope a different tenant's import).
+        await Assert.That(merged.Profiles["newly"].ImportOrg).IsNull();
+        // Other template settings still flow through to the new profile.
+        await Assert.That(merged.Profiles["newly"].DefaultVisibility).IsEqualTo("private");
+        // The existing profile keeps its own remembered org.
+        await Assert.That(merged.Profiles["acme"].ImportOrg).IsEqualTo("AcmeOrg");
+    }
+
+    [Test]
     public async Task MergeProfiles_preserves_existing_profile_settings() {
         var existing = new ProfileConfig {
             Profiles = new Dictionary<string, Profile> {


### PR DESCRIPTION
Closes #194.

## Problem

After CLI sign-in moved from GitHub auth to WorkOS, `kcap import --org` stopped matching any sessions, and the dashboard "run `kcap setup`" welcome banner stopped clearing after setup. `--all` and `--repo owner/name` still work, so the WorkOS token is accepted by the server.

`--org` is a **client-side** filter: it compared each session's **git-remote owner** (from `RepositoryDetection`) against the **active profile name**. That coupling only held under GitHub auth, where the profile name was the GitHub org login:

```csharp
// AuthModels.cs — DiscoveredTenant
public string ProfileName => IsWorkOS ? (Slug ?? OrganizationId ?? "tenant") : OrgLogin;
```

Under WorkOS the profile is named after the tenant slug/org-id, which never equals a GitHub owner → every session filtered out. The WorkOS discovery payload has no `org_login`, so nothing on the profile records the GitHub org.

## Changes

**`import --org` (the real fix):**
- `kcap import --org <owner>` — explicit git-remote owner; identical behaviour under GitHub and WorkOS.
- `kcap import --org` (bare) — pick an owner from discovered repos and remember it on the active profile (`import_org`); later bare runs reuse it without prompting.
- The interactive scope menu's "org" choice now picks an owner from discovered repos instead of using the profile name.
- Non-interactive bare `--org` with no remembered org now errors with guidance instead of silently matching nothing.

**Setup-completion ping (diagnostic only):**
- `SetupCommand.PingCliSetupAsync` swallowed every error, hiding why the welcome banner never clears. Added `KCAP_DEBUG` to print the ping's HTTP status to stderr, without changing the best-effort, non-blocking contract. Import and live recording both work, so the token is accepted — this is **not** token rejection; the completion fix itself is **server-side** at `/api/users/me/cli-setup` (the status tells us whether it's a 2xx-not-honored or a non-2xx case).

## Files

- `ProfileConfig.cs` — new `import_org` profile field.
- `ImportScopeArgs.cs` — parse `--org <value>`; resolve from value → remembered → pick / error.
- `ImportScopePrompt.cs` — `BuildOrgChoices` + `RunOrgPicker`; menu "org" picks an owner.
- `ImportCommand.cs` — org-pick path + best-effort `PersistImportOrgAsync`.
- `Program.cs` — read/pass `import_org` and the org-pick signal.
- `SetupCommand.cs` — `KCAP_DEBUG` ping instrumentation.
- `help-import.txt`, `README.md` — `--org` docs (quick-start + per-command). `KCAP_DEBUG` is an internal diagnostic and is intentionally not documented in the public README.
- Tests — explicit/remembered/pick/error resolve paths + `BuildOrgChoices`.

## Testing

- Unit suite: **1890 passed / 0 failed**.
- AOT `dotnet publish -c Release`: clean (no IL2026/IL3050).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
