### PR TITLE
[AI-997] kcap recap --per-turn/--get-turn + MCP get_turn tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ kcap recap --full <sessionId>       # full transcript
 kcap recap --chain <sessionId>      # summaries across continuation chain
 kcap recap --chain --full <sessionId>  # full transcript across chain
 kcap recap --per-turn <sessionId>   # compact per-turn index (prompt, tools, files, tokens, time)
-kcap recap --get-turn <sessionId> <N>  # full event transcript for a single turn
+kcap recap --get-turn <N> <sessionId>  # full event transcript for a single turn
 ```
 
-`--per-turn` prints a one-block-per-turn index — useful for orienting in a long session before drilling into a specific turn with `--get-turn <N>` (the turn number shown in the `--per-turn` index).
+`--per-turn` prints a one-block-per-turn index — useful for orienting in a long session before drilling into a specific turn with `--get-turn <N>` (the turn number shown in the `--per-turn` index). `--get-turn` takes the turn number as its value; the session id is the usual positional (or comes from the current session), so `kcap recap <sessionId> --get-turn <N>` works too.
 
 The identifier can be a session GUID or a meta session slug. Find these from the dashboard or the current session's hook payloads. When run inside a Claude Code session with the kcap plugin, the session ID is set automatically.
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,11 @@ kcap recap <sessionId>              # summary (default)
 kcap recap --full <sessionId>       # full transcript
 kcap recap --chain <sessionId>      # summaries across continuation chain
 kcap recap --chain --full <sessionId>  # full transcript across chain
+kcap recap --per-turn <sessionId>   # compact per-turn index (prompt, tools, files, tokens, time)
+kcap recap --get-turn <sessionId> <N>  # full event transcript for a single turn
 ```
+
+`--per-turn` prints a one-block-per-turn index — useful for orienting in a long session before drilling into a specific turn with `--get-turn <N>` (the turn number shown in the `--per-turn` index).
 
 The identifier can be a session GUID or a meta session slug. Find these from the dashboard or the current session's hook payloads. When run inside a Claude Code session with the kcap plugin, the session ID is set automatically.
 
@@ -271,6 +275,7 @@ It provides three tools:
 - **`search_sessions`** — free-text search over past sessions (and subagent transcripts) in the current repo. Pass `repo: "all"` to search across every repo you can see, or `repo: "owner/name"` for a different one. Filter by `author` / `author_github_id`. Returns ranked hits with `session_id`, snippet, and (for transcript hits) `hit_event_index` + `agent_id` for drilling in.
 - **`get_session_summary`** — concise `summary_text` + `plan` for a session. Use this to orient before reading the transcript.
 - **`get_session_transcript`** — speaker-tagged events from a session. Pair `around_event` (and `agent_id` if the hit was in a subagent) with the values returned by `search_sessions` to fetch the exact decision context.
+- **`get_turn`** — the full event transcript for one turn (user prompt, tool calls + results, assistant text) by `session_id` + `turn_index`. A turn is one user message and the assistant's full response up to the next user message.
 
 The server is repo-aware — it resolves the current working directory to a repo hash at startup, and `search_sessions` defaults its `repo` filter to that hash unless you override it.
 

--- a/src/Capacitor.Cli.Core/Resources/help-recap.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-recap.txt
@@ -6,6 +6,10 @@ Options:
   --chain                 Include all sessions in the continuation chain
   --full                  Show raw transcript instead of summary
   --repo                  Show recent session summaries for the current repo
+  --per-turn              Show a compact per-turn index (prompt, tools,
+                          files, tokens, time) — one block per turn
+  --get-turn <N>          Show the full event transcript for turn N
+                          (use the turn number from --per-turn)
 
 Arguments:
   sessionId               Session ID (defaults to KCAP_SESSION_ID

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -114,6 +114,7 @@ static class McpSessionsServer {
                 "search_sessions"        => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildSearchUrl(baseUrl, arguments, cwdRepoHash))),
                 "get_session_summary"    => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildSummaryUrl(baseUrl, arguments))),
                 "get_session_transcript" => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildTranscriptUrl(baseUrl, arguments))),
+                "get_turn"               => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildTurnDetailUrl(baseUrl, arguments))),
                 _                        => throw new ArgumentException($"Unknown tool: {toolName}")
             };
 
@@ -206,6 +207,17 @@ static class McpSessionsServer {
          ?? throw new ArgumentException("Missing required argument: session_id");
 
         return $"{baseUrl}/api/sessions/{Uri.EscapeDataString(id)}/recap?chain=false";
+    }
+
+    static string BuildTurnDetailUrl(string baseUrl, JsonObject? args) {
+        var id = args?["session_id"]?.GetValue<string>()
+         ?? throw new ArgumentException("Missing required argument: session_id");
+
+        if (!TryReadInt(args, "turn_index", out var turnIndex)) {
+            throw new ArgumentException("Missing required argument: turn_index");
+        }
+
+        return $"{baseUrl}/api/sessions/{Uri.EscapeDataString(id)}/turns/{turnIndex}";
     }
 
     static string BuildTranscriptUrl(string baseUrl, JsonObject? args) {
@@ -470,6 +482,18 @@ static class McpSessionsServer {
                     ["include_thinking"] = new("boolean", "Include assistant thinking blocks. Default false.")
                 },
                 ["session_id"]
+            )
+        ),
+        new(
+            "get_turn",
+            "Get the full event transcript for one turn (user prompt, tool calls + results, assistant text) by session_id + turn_index. A turn is one user message and the assistant's full response up to the next user message. Use get_session_summary or search_sessions to find a session, then drill into specific turns by index.",
+            new(
+                "object",
+                new() {
+                    ["session_id"] = new("string",  "Session ID (from search_sessions or get_session_summary)."),
+                    ["turn_index"] = new("integer", "Zero-based turn index.")
+                },
+                ["session_id", "turn_index"]
             )
         )
     ];

--- a/src/Capacitor.Cli/Commands/RecapCommand.cs
+++ b/src/Capacitor.Cli/Commands/RecapCommand.cs
@@ -265,4 +265,196 @@ static class RecapCommand {
             _             => ""
         };
     }
+
+    /// <summary>
+    /// `kcap recap --per-turn &lt;sessionId&gt;` — prints a compact per-turn index
+    /// (turn #, prompt excerpt, tool names, file count, token count, time range),
+    /// one block per turn. Parses the server's snake_case JSON with JsonDocument
+    /// (the CLI has no TurnClosed DTO and JsonDocument is AOT-safe).
+    /// </summary>
+    public static async Task<int> HandlePerTurnRecap(string baseUrl, string sessionId) {
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+
+        HttpResponseMessage resp;
+
+        try {
+            resp = await httpClient.GetWithRetryAsync($"{baseUrl}/api/sessions/{sessionId}/turns");
+        } catch (HttpRequestException ex) {
+            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
+
+            return 1;
+        }
+
+        if (await HttpClientExtensions.HandleUnauthorizedAsync(resp)) {
+            return 1;
+        }
+
+        if (resp.StatusCode == System.Net.HttpStatusCode.NotFound) {
+            Console.Error.WriteLine($"Session not found: {sessionId}");
+
+            return 1;
+        }
+
+        if (!resp.IsSuccessStatusCode) {
+            Console.Error.WriteLine($"HTTP {(int)resp.StatusCode}");
+
+            return 1;
+        }
+
+        var json = await resp.Content.ReadAsStringAsync();
+
+        using var doc = JsonDocument.Parse(json);
+
+        if (doc.RootElement.ValueKind != JsonValueKind.Array || doc.RootElement.GetArrayLength() == 0) {
+            await Console.Out.WriteLineAsync("No turns found. The session may still be active or has no recorded turns.");
+
+            return 0;
+        }
+
+        await Console.Out.WriteLineAsync($"# Turns for session {sessionId}");
+        await Console.Out.WriteLineAsync();
+
+        foreach (var turn in doc.RootElement.EnumerateArray()) {
+            var turnIndex  = turn.TryGetProperty("turn_index", out var ti) ? ti.GetInt32() : -1;
+            var userPrompt = turn.TryGetProperty("user_prompt", out var up) ? up.GetString() ?? "" : "";
+            var prompt     = userPrompt.Length == 0
+                ? $"(turn {turnIndex})"
+                : userPrompt.Length > 80 ? userPrompt[..80] + "…" : userPrompt;
+
+            var tools = "—";
+
+            if (turn.TryGetProperty("tools", out var toolsEl) && toolsEl.ValueKind == JsonValueKind.Array) {
+                var names = new List<string>();
+
+                foreach (var t in toolsEl.EnumerateArray()) {
+                    if (t.TryGetProperty("name", out var n) && n.GetString() is { Length: > 0 } nm) {
+                        names.Add(nm);
+                    }
+                }
+
+                if (names.Count > 0) tools = string.Join(", ", names.Distinct());
+            }
+
+            var files  = turn.TryGetProperty("files", out var f) && f.ValueKind == JsonValueKind.Array ? f.GetArrayLength() : 0;
+            var tokens = turn.TryGetProperty("total_tokens", out var tk) ? tk.GetInt64() : 0;
+            var time   = $"{FormatTurnTime(turn, "first_event_at")}–{FormatTurnTime(turn, "last_event_at")}";
+
+            await Console.Out.WriteLineAsync($"Turn {turnIndex,3}: {prompt}");
+            await Console.Out.WriteLineAsync($"         tools={tools}  files={files}  tokens={tokens}  time={time}");
+            await Console.Out.WriteLineAsync();
+        }
+
+        Console.Error.WriteLine($"Use `kcap recap --get-turn {sessionId} <N>` for full turn detail.");
+
+        return 0;
+    }
+
+    /// <summary>
+    /// `kcap recap --get-turn &lt;sessionId&gt; &lt;turnIndex&gt;` — prints the formatted
+    /// event transcript for a single turn (user prompt, tool calls, assistant text).
+    /// </summary>
+    public static async Task<int> HandleGetTurn(string baseUrl, string sessionId, int turnIndex) {
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+
+        HttpResponseMessage resp;
+
+        try {
+            resp = await httpClient.GetWithRetryAsync($"{baseUrl}/api/sessions/{sessionId}/turns/{turnIndex}");
+        } catch (HttpRequestException ex) {
+            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
+
+            return 1;
+        }
+
+        if (await HttpClientExtensions.HandleUnauthorizedAsync(resp)) {
+            return 1;
+        }
+
+        if (resp.StatusCode == System.Net.HttpStatusCode.NotFound) {
+            Console.Error.WriteLine($"Turn {turnIndex} not found for session {sessionId}");
+
+            return 1;
+        }
+
+        if (!resp.IsSuccessStatusCode) {
+            Console.Error.WriteLine($"HTTP {(int)resp.StatusCode}");
+
+            return 1;
+        }
+
+        var json = await resp.Content.ReadAsStringAsync();
+
+        using var doc = JsonDocument.Parse(json);
+
+        if (!doc.RootElement.TryGetProperty("trace", out var trace) || trace.ValueKind != JsonValueKind.Array) {
+            await Console.Out.WriteLineAsync("No trace available for this turn.");
+
+            return 0;
+        }
+
+        await Console.Out.WriteLineAsync($"# Turn {turnIndex} — session {sessionId}");
+        await Console.Out.WriteLineAsync();
+
+        foreach (var entry in trace.EnumerateArray()) {
+            var kind = entry.TryGetProperty("kind", out var k) ? k.GetString() : null;
+
+            switch (kind) {
+                case "user_message":
+                    await Console.Out.WriteLineAsync("## User");
+                    await Console.Out.WriteLineAsync(GetTraceString(entry, "text"));
+                    await Console.Out.WriteLineAsync();
+
+                    break;
+
+                case "assistant_message":
+                    await Console.Out.WriteLineAsync("## Assistant");
+                    await Console.Out.WriteLineAsync(GetTraceString(entry, "text"));
+                    await Console.Out.WriteLineAsync();
+
+                    break;
+
+                case "tool_invocation":
+                    await Console.Out.WriteLineAsync($"## Tool: {GetTraceString(entry, "tool")}");
+
+                    if (entry.TryGetProperty("arguments", out var args) && args.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined) {
+                        await Console.Out.WriteLineAsync(args.ToString());
+                    }
+
+                    await Console.Out.WriteLineAsync();
+
+                    break;
+
+                case "tool_result":
+                    var isErr = entry.TryGetProperty("is_error", out var e) && e.ValueKind == JsonValueKind.True;
+                    await Console.Out.WriteLineAsync(isErr ? "### Error" : "### Result");
+                    await Console.Out.WriteLineAsync(GetTraceString(entry, "output"));
+                    await Console.Out.WriteLineAsync();
+
+                    break;
+
+                default:
+                    // assistant_thinking, plan, or any future kind that carries text — surface it
+                    // generically rather than silently dropping turn content.
+                    if (!string.IsNullOrEmpty(kind) && GetTraceString(entry, "text") is { Length: > 0 } text) {
+                        await Console.Out.WriteLineAsync($"## {kind}");
+                        await Console.Out.WriteLineAsync(text);
+                        await Console.Out.WriteLineAsync();
+                    }
+
+                    break;
+            }
+        }
+
+        return 0;
+    }
+
+    static string FormatTurnTime(JsonElement turn, string prop) =>
+        turn.TryGetProperty(prop, out var el)
+        && el.ValueKind == JsonValueKind.String
+        && DateTimeOffset.TryParse(el.GetString(), out var dto)
+            ? dto.ToLocalTime().ToString("HH:mm")
+            : "?";
+
+    static string GetTraceString(JsonElement el, string prop) =>
+        el.TryGetProperty(prop, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() ?? "" : "";
 }

--- a/src/Capacitor.Cli/Commands/RecapCommand.cs
+++ b/src/Capacitor.Cli/Commands/RecapCommand.cs
@@ -344,7 +344,7 @@ static class RecapCommand {
             await Console.Out.WriteLineAsync();
         }
 
-        Console.Error.WriteLine($"Use `kcap recap --get-turn {sessionId} <N>` for full turn detail.");
+        Console.Error.WriteLine($"Use `kcap recap --get-turn <N> {sessionId}` for full turn detail.");
 
         return 0;
     }
@@ -395,7 +395,36 @@ static class RecapCommand {
         await Console.Out.WriteLineAsync($"# Turn {turnIndex} — session {sessionId}");
         await Console.Out.WriteLineAsync();
 
+        // Trace entries from subagent streams carry agent_id (and agent_type); root entries don't.
+        // The builder interleaves them by timestamp, so emit an attribution header whenever the
+        // active agent changes — preserving the subagent grouping that `--full` recap shows.
+        string? currentAgentId = null;
+        var     sawAgentHeader = false;
+
         foreach (var entry in trace.EnumerateArray()) {
+            var entryAgentId = entry.TryGetProperty("agent_id", out var aidEl) && aidEl.ValueKind == JsonValueKind.String
+                ? aidEl.GetString()
+                : null;
+
+            if (entryAgentId != currentAgentId) {
+                currentAgentId = entryAgentId;
+
+                if (entryAgentId is { Length: > 0 }) {
+                    var agentType = entry.TryGetProperty("agent_type", out var atEl) && atEl.ValueKind == JsonValueKind.String
+                        ? atEl.GetString()
+                        : null;
+                    await Console.Out.WriteLineAsync(agentType is { Length: > 0 }
+                        ? $"### Subagent: {agentType} ({entryAgentId})"
+                        : $"### Subagent: {entryAgentId}");
+                    await Console.Out.WriteLineAsync();
+                    sawAgentHeader = true;
+                } else if (sawAgentHeader) {
+                    // Only note the return to the main session if we previously showed a subagent header.
+                    await Console.Out.WriteLineAsync("### (main session)");
+                    await Console.Out.WriteLineAsync();
+                }
+            }
+
             var kind = entry.TryGetProperty("kind", out var k) ? k.GetString() : null;
 
             switch (kind) {

--- a/src/Capacitor.Cli/Commands/RecapCommand.cs
+++ b/src/Capacitor.Cli/Commands/RecapCommand.cs
@@ -350,8 +350,9 @@ static class RecapCommand {
     }
 
     /// <summary>
-    /// `kcap recap --get-turn &lt;sessionId&gt; &lt;turnIndex&gt;` — prints the formatted
-    /// event transcript for a single turn (user prompt, tool calls, assistant text).
+    /// `kcap recap --get-turn &lt;N&gt; [sessionId]` — prints the formatted event transcript for a
+    /// single turn (user prompt, tool calls, assistant text). The turn number is the flag's value;
+    /// the session id is the usual positional (or comes from the current session).
     /// </summary>
     public static async Task<int> HandleGetTurn(string baseUrl, string sessionId, int turnIndex) {
         using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -101,22 +101,46 @@ switch (command) {
         return await ErrorsCommand.HandleErrors(baseUrl!, errSessionId, useChain);
     }
     case "recap": {
-        var useChain = args.Contains("--chain");
-        var useFull  = args.Contains("--full");
-        var useRepo  = args.Contains("--repo");
+        var useChain   = args.Contains("--chain");
+        var useFull    = args.Contains("--full");
+        var useRepo    = args.Contains("--repo");
+        var usePerTurn = args.Contains("--per-turn");
+        var useGetTurn = args.Contains("--get-turn");
 
         if (useRepo) {
             return await RecapCommand.HandleRepoRecap(baseUrl!);
         }
 
-        var recapSessionId = ResolveSessionId(args);
+        // --get-turn takes a value (the turn index), so declare it as a value flag
+        // or ResolveSessionId would mistake the index for the sessionId.
+        var recapSessionId = ResolveSessionId(args, valueFlags: ["--get-turn"]);
 
         if (recapSessionId is null) {
-            Console.Error.WriteLine("Usage: kcap recap [--chain] [--full] [--repo] [sessionId]");
+            Console.Error.WriteLine("Usage: kcap recap [--chain] [--full] [--repo] [--per-turn] [--get-turn <N>] [sessionId]");
             Console.Error.WriteLine("  No session ID provided. Pass one explicitly, or run inside Claude Code / Codex CLI 0.81+.");
             Console.Error.WriteLine("  Use --repo to see recent session summaries for the current repository.");
+            Console.Error.WriteLine("  Use --per-turn for a per-turn index, or --get-turn <N> for one turn's transcript.");
 
             return 1;
+        }
+
+        if (usePerTurn) {
+            return await RecapCommand.HandlePerTurnRecap(baseUrl!, recapSessionId);
+        }
+
+        if (useGetTurn) {
+            var getTurnIdx = args
+                .SkipWhile(a => a != "--get-turn")
+                .Skip(1)
+                .FirstOrDefault(a => !a.StartsWith('-'));
+
+            if (getTurnIdx is null || !int.TryParse(getTurnIdx, out var turnIndex)) {
+                Console.Error.WriteLine("Usage: kcap recap --get-turn <turnIndex> [sessionId]");
+
+                return 1;
+            }
+
+            return await RecapCommand.HandleGetTurn(baseUrl!, recapSessionId, turnIndex);
         }
 
         return await RecapCommand.HandleRecap(baseUrl!, recapSessionId, useChain, useFull);

--- a/test/Capacitor.Cli.Tests.Integration/McpSessionsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpSessionsServerTests.cs
@@ -171,19 +171,20 @@ public class McpSessionsServerTests : IDisposable {
     }
 
     [Test]
-    public async Task Tools_list_returns_three_tools_with_correct_names() {
+    public async Task Tools_list_returns_four_tools_with_correct_names() {
         using var proc = SpawnMcpServer();
         try {
             var response = await SendRequest(proc, ToolsListRequest(2));
 
             var tools = response["result"]?["tools"]?.AsArray();
             await Assert.That(tools).IsNotNull();
-            await Assert.That(tools!.Count).IsEqualTo(3);
+            await Assert.That(tools!.Count).IsEqualTo(4);
 
             var names = tools.Select(t => t?["name"]?.GetValue<string>()).ToHashSet();
             await Assert.That(names.Contains("search_sessions")).IsTrue();
             await Assert.That(names.Contains("get_session_summary")).IsTrue();
             await Assert.That(names.Contains("get_session_transcript")).IsTrue();
+            await Assert.That(names.Contains("get_turn")).IsTrue();
         } finally {
             await ShutdownAsync(proc);
         }


### PR DESCRIPTION
Part of **AI-995** (per-turn summaries), phase 2 (AI-997) — the CLI/MCP surface for the new server-side per-turn endpoints (`GET /api/sessions/{id}/turns` and `/turns/{index}`, added in the companion server PR).

## Changes
- **`kcap recap --per-turn <sessionId>`** — compact per-turn index (turn #, prompt excerpt, tool names, file count, tokens, time range), one block per turn.
- **`kcap recap --get-turn <sessionId> <N>`** — full event transcript for a single turn.
- **MCP `get_turn(session_id, turn_index)`** tool on the `kcap mcp sessions` server — lets eval judges / agents drill into one turn.
- README + `help-recap.txt` updated for both flags and the MCP tool.

## Notes for review
- Turn JSON is parsed with `JsonDocument` (not a typed DTO): the CLI has no `TurnClosed` type and `JsonDocument` is AOT-safe. The server serializes snake_case (`turn_index`, `total_tokens`, trace entries use `is_error`), and the parsing keys match.
- `--get-turn` is declared as a value-flag in `ResolveSessionId` so the turn index isn't mistaken for the session id.
- AOT publish verified: **0 IL2026/IL3050 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)