### PR TITLE
Hosted Codex PR review support (AI-632)

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ The daemon starts Codex with `--sandbox workspace-write` and `--ask-for-approval
 >
 > npm 11+ blocks install scripts by default. Add `allow-scripts[]=@kurrent/kcap` to your `~/.npmrc` (or pass `--allow-scripts=@kurrent/kcap` on the install command line) to opt in to the auto-refresh; otherwise re-run the relevant `kcap plugin install ... --if-installed` commands manually after each upgrade. (`npm approve-scripts` does not work for global installs — that's a known npm UX bug.)
 
-PR review for hosted Codex agents is not yet supported (tracked in AI-632). The sandbox and approval-mode selectors in the launch dialog are also planned as a follow-up (AI-633).
+PR review is supported for hosted Codex agents as well as Claude — the same `kcap-review` MCP context is injected either way. The sandbox and approval-mode selectors in the launch dialog are planned as a follow-up (AI-633).
 
 #### Cursor IDE hooks
 

--- a/docs/superpowers/plans/2026-06-29-ai-632-codex-pr-review-support.md
+++ b/docs/superpowers/plans/2026-06-29-ai-632-codex-pr-review-support.md
@@ -1,0 +1,594 @@
+# Hosted Codex PR Review Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a hosted Codex agent review a PR with the same `kcap-review` MCP context the Claude path already gets.
+
+**Architecture:** Make the shared `ReviewLaunchBuilder` vendor-aware and take an explicit kcap-CLI path; build a vendor-neutral MCP-server descriptor. The Claude launcher keeps writing a temp `--mcp-config` JSON; the Codex launcher injects the same server via ephemeral `-c mcp_servers.kcap-review.*` overrides and passes the rendered review prompt as Codex's initial prompt. Lift the orchestrator's Codex-review rejection.
+
+**Tech Stack:** .NET 10 (NativeAOT), C#, TUnit on Microsoft Testing Platform, `System.Text.Json.Nodes`.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-ai-632-codex-pr-review-support-design.md`
+
+## Global Constraints
+
+- **NativeAOT-safe only.** No reflection-based serialization, no dynamic code. After code changes, verify zero IL3050/IL2026 warnings via `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` (must print nothing).
+- **JsonArray:** never use collection-expression `[a, b]` for `JsonArray` (lowers to `Add<T>()`, needs dynamic code). Build arrays with a loop using `JsonValue.Create(...)` or the `new JsonArray(node1, node2, …)` constructor.
+- **MCP server name is `kcap-review`** (hyphen). Valid as a Claude JSON key and a TOML bare key.
+- **Tests:** TUnit. Run a project as an executable: `dotnet run --project <test.csproj>`. Filter with `--treenode-filter '/*/*/<Class>/<Method>'` (glob), NOT `--filter`.
+- **README sync:** user-facing CLI/behavior changes must update `README.md` in the same PR (line 413 currently says Codex review is unsupported).
+- **Keep Claude review behavior byte-identical.** The Claude `--mcp-config`/`--system-prompt` argv and temp-file lifecycle must not change.
+
+---
+
+### Task 1: `ReviewLaunchBuilder` — vendor-aware, explicit CLI path, MCP descriptor
+
+Refactor the shared builder so it (a) takes the kcap-CLI path explicitly instead of `Environment.ProcessPath` (which is `kcap-daemon` inside the daemon and breaks `mcp review`), (b) exposes a vendor-neutral MCP descriptor, and (c) only writes the Claude temp JSON. Fix all callers so the solution compiles with Claude behavior unchanged.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/Commands/ReviewLaunchBuilder.cs`
+- Modify: `src/Capacitor.Cli/Commands/ReviewCommand.cs:48` (caller)
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs:341` (caller)
+- Modify: `src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs:71` (null-forgiving on now-nullable `McpConfigPath`)
+- Test (create): `test/Capacitor.Cli.Tests.Unit/ReviewLaunchBuilderTests.cs`
+
+**Interfaces:**
+- Produces (consumed by Tasks 2 & 3):
+  - `public record ReviewMcpServer(string Command, string[] Args, IReadOnlyDictionary<string, string> Env);` (nested in `ReviewLaunchBuilder`)
+  - `public record ReviewLaunch(string? McpConfigPath, string SystemPrompt, ReviewMcpServer Mcp);` (nested in `ReviewLaunchBuilder`)
+  - `public static Task<ReviewLaunch> BuildAsync(string vendor, string cliPath, string baseUrl, string owner, string repo, int prNumber)`
+- Consumes: `EmbeddedResources.Load("prompt-review.txt")` (existing).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/Capacitor.Cli.Tests.Unit/ReviewLaunchBuilderTests.cs`:
+
+```csharp
+using Capacitor.Cli.Core.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class ReviewLaunchBuilderTests {
+    [Test]
+    public async Task Claude_writes_mcp_config_file_and_populates_descriptor() {
+        var launch = await ReviewLaunchBuilder.BuildAsync(
+            vendor: "claude", cliPath: "/opt/kcap", baseUrl: "https://srv",
+            owner: "acme", repo: "widgets", prNumber: 42);
+
+        try {
+            await Assert.That(launch.McpConfigPath).IsNotNull();
+            await Assert.That(File.Exists(launch.McpConfigPath!)).IsTrue();
+            var json = await File.ReadAllTextAsync(launch.McpConfigPath!);
+            await Assert.That(json).Contains("kcap-review");
+            await Assert.That(json).Contains("/opt/kcap");
+
+            await Assert.That(launch.Mcp.Command).IsEqualTo("/opt/kcap");
+            await Assert.That(launch.Mcp.Args).Contains("--owner");
+            await Assert.That(launch.Mcp.Args).Contains("acme");
+            await Assert.That(launch.Mcp.Args).Contains("42");
+            await Assert.That(launch.Mcp.Env["KCAP_URL"]).IsEqualTo("https://srv");
+            await Assert.That(launch.SystemPrompt).Contains("acme");
+        } finally {
+            if (launch.McpConfigPath is not null) File.Delete(launch.McpConfigPath);
+        }
+    }
+
+    [Test]
+    public async Task Codex_writes_no_file_and_populates_descriptor() {
+        var launch = await ReviewLaunchBuilder.BuildAsync(
+            vendor: "codex", cliPath: "/opt/kcap", baseUrl: "https://srv",
+            owner: "acme", repo: "widgets", prNumber: 42);
+
+        await Assert.That(launch.McpConfigPath).IsNull();
+        await Assert.That(launch.Mcp.Command).IsEqualTo("/opt/kcap");
+        await Assert.That(launch.Mcp.Args).Contains("review");
+        await Assert.That(launch.Mcp.Args).Contains("widgets");
+        await Assert.That(launch.Mcp.Env["KCAP_URL"]).IsEqualTo("https://srv");
+        await Assert.That(launch.SystemPrompt).Contains("widgets");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail (compile error is the failure)**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter '/*/*/ReviewLaunchBuilderTests/*'`
+Expected: build FAILS — `BuildAsync` has no 6-arg overload, `ReviewMcpServer`/`Mcp` don't exist.
+
+- [ ] **Step 3: Rewrite `ReviewLaunchBuilder.cs`**
+
+Replace the body of `src/Capacitor.Cli.Core/Commands/ReviewLaunchBuilder.cs` with:
+
+```csharp
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Core.Commands;
+
+/// <summary>
+/// Shared helper that builds a PR-review launch for a given vendor: the rendered
+/// review system prompt (PR placeholders substituted) plus a vendor-neutral MCP
+/// server descriptor pointing at <c>kcap mcp review</c>. For Claude it also writes
+/// the temp <c>--mcp-config</c> JSON; Codex injects the same server via <c>-c</c>
+/// overrides and needs no file. The kcap CLI path is passed in because inside the
+/// daemon the running process is <c>kcap-daemon</c> (no <c>mcp review</c> subcommand).
+/// </summary>
+public static class ReviewLaunchBuilder {
+    public record ReviewMcpServer(string Command, string[] Args, IReadOnlyDictionary<string, string> Env);
+
+    public record ReviewLaunch(string? McpConfigPath, string SystemPrompt, ReviewMcpServer Mcp);
+
+    public static async Task<ReviewLaunch> BuildAsync(
+            string vendor, string cliPath, string baseUrl, string owner, string repo, int prNumber) {
+        // Render the system prompt first. EmbeddedResources.Load can throw; building
+        // the prompt before writing any temp file keeps the file's lifetime fully
+        // inside the caller's try/finally so a throw never leaks a path-less file.
+        var systemPrompt = EmbeddedResources.Load("prompt-review.txt")
+            .Replace("{prNumber}", prNumber.ToString())
+            .Replace("{owner}", owner)
+            .Replace("{repo}", repo);
+
+        var mcp = new ReviewMcpServer(
+            Command: cliPath,
+            Args: ["mcp", "review", "--owner", owner, "--repo", repo, "--pr", prNumber.ToString()],
+            Env: new Dictionary<string, string> { ["KCAP_URL"] = baseUrl });
+
+        string? configPath = null;
+
+        if (vendor == "claude") {
+            configPath = await WriteClaudeMcpConfigAsync(mcp);
+        }
+
+        return new ReviewLaunch(configPath, systemPrompt, mcp);
+    }
+
+    static async Task<string> WriteClaudeMcpConfigAsync(ReviewMcpServer mcp) {
+        // Use the implicit string -> JsonValue conversion (cast to JsonNode?) rather
+        // than JsonValue.Create / collection expressions, which lower to generic
+        // Add<T> and trip NativeAOT (IL3050). This matches the existing pattern.
+        var argsNode = new JsonArray();
+
+        foreach (var a in mcp.Args) {
+            argsNode.Add((JsonNode?)a);
+        }
+
+        var envNode = new JsonObject();
+
+        foreach (var kv in mcp.Env) {
+            envNode[kv.Key] = (JsonNode?)kv.Value;
+        }
+
+        var mcpConfig = new JsonObject {
+            ["mcpServers"] = new JsonObject {
+                ["kcap-review"] = new JsonObject {
+                    ["command"] = mcp.Command,
+                    ["args"]    = argsNode,
+                    ["env"]     = envNode
+                }
+            }
+        };
+
+        var configPath = Path.Combine(Path.GetTempPath(), $"kcap-review-{Guid.NewGuid():N}.json");
+        var json       = mcpConfig.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(configPath, json);
+
+        return configPath;
+    }
+}
+```
+
+- [ ] **Step 4: Fix the daemon caller**
+
+In `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs`, the `ReviewLaunch:` initializer (around line 340–342) currently reads:
+
+```csharp
+                ReviewLaunch: isReview && cmd.Review is { } reviewArgs
+                    ? await ReviewLaunchBuilder.BuildAsync(_config.ServerUrl ?? "", reviewArgs.Owner, reviewArgs.Repo, reviewArgs.PrNumber)
+                    : null
+```
+
+Change the `BuildAsync` call to pass vendor and the kcap-CLI path:
+
+```csharp
+                ReviewLaunch: isReview && cmd.Review is { } reviewArgs
+                    ? await ReviewLaunchBuilder.BuildAsync(cmd.Vendor, _config.CapacitorPath, _config.ServerUrl ?? "", reviewArgs.Owner, reviewArgs.Repo, reviewArgs.PrNumber)
+                    : null
+```
+
+- [ ] **Step 5: Fix the interactive CLI caller**
+
+In `src/Capacitor.Cli/Commands/ReviewCommand.cs`, line 48 currently reads:
+
+```csharp
+        var launch = await ReviewLaunchBuilder.BuildAsync(baseUrl, owner, repo, prNumber);
+```
+
+Replace with (interactive `kcap review` is Claude-only; the running process *is* `kcap`):
+
+```csharp
+        var launch = await ReviewLaunchBuilder.BuildAsync(
+            "claude", Environment.ProcessPath ?? "kcap", baseUrl, owner, repo, prNumber);
+```
+
+Then, on the line that adds the MCP config path (was line 59), the property is now `string?`; make it non-null-asserted since the Claude path always writes it:
+
+```csharp
+            psi.ArgumentList.Add(launch.McpConfigPath!);
+```
+
+- [ ] **Step 6: Fix the Claude launcher**
+
+In `src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs`, the review branch (around line 67–73) assigns and adds `launch.McpConfigPath`. `mcpConfigPath = launch.McpConfigPath;` is fine (both `string?`). On the `args.Add(launch.McpConfigPath)` line (was line 71), assert non-null because Claude reviews always write the file:
+
+```csharp
+            args.Add(launch.McpConfigPath!);
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter '/*/*/ReviewLaunchBuilderTests/*'`
+Expected: PASS (2 tests).
+
+- [ ] **Step 8: Run the existing vendor tests to confirm no Claude regression**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter '/*/*/AgentOrchestratorVendorTests/*'`
+Expected: PASS (all existing tests, including `Launch_review_kind_with_vendor_codex_emits_launch_failed`, still green — the gate is still in place at this point).
+
+- [ ] **Step 9: Commit**
+
+```bash
+WT=/Users/alexey/dev/eventstore/kcap-cli/.claude/worktrees/breezy-greeting-chipmunk
+git -C "$WT" add src/Capacitor.Cli.Core/Commands/ReviewLaunchBuilder.cs \
+  src/Capacitor.Cli/Commands/ReviewCommand.cs \
+  src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs \
+  src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs \
+  test/Capacitor.Cli.Tests.Unit/ReviewLaunchBuilderTests.cs
+git -C "$WT" commit -m "$(printf 'refactor(AI-632): vendor-aware ReviewLaunchBuilder with explicit CLI path\n\nThread the kcap CLI path (CapacitorPath in the daemon) through the\nbuilder instead of Environment.ProcessPath, which resolves to\nkcap-daemon in the daemon and has no mcp review subcommand. Expose a\nvendor-neutral MCP descriptor; write the temp JSON only for Claude.\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 2: `CodexLauncher` review branch + TOML `-c` injection
+
+Add a review branch to `CodexLauncher.BuildArgs` that injects the `kcap-review` MCP server via `-c` overrides and passes the rendered prompt as the initial prompt. No orchestrator change yet — the branch is unit-tested directly.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs` (add review branch + TOML helper)
+- Test: `test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs` (add review tests + a review-context helper)
+
+**Interfaces:**
+- Consumes: `ReviewLaunchBuilder.ReviewLaunch` / `ReviewMcpServer` from Task 1; `LauncherContext.IsReview`, `LauncherContext.ReviewLaunch` (existing).
+- Produces: argv where, for reviews, `McpConfigPath` is null and the args contain `-c mcp_servers.kcap-review.command=…`, `…args=[…]`, `…env={…}`, no `--system-prompt`, and a trailing `-- <prompt>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs`, add a review-context helper next to `NewCtxWith` and the tests below:
+
+```csharp
+    static LauncherContext NewReviewCtx(string prompt, string cliPath, string baseUrl) {
+        var mcp = new ReviewLaunchBuilder.ReviewMcpServer(
+            Command: cliPath,
+            Args: ["mcp", "review", "--owner", "acme", "--repo", "widgets", "--pr", "42"],
+            Env: new Dictionary<string, string> { ["KCAP_URL"] = baseUrl });
+
+        return new(
+            AgentId: "a-rev",
+            SourceRepoPath: "/tmp/repo",
+            Worktree: new WorktreeInfo(Path: "/tmp/wt", Branch: "wt-branch", SourceRepo: "/tmp/repo"),
+            Prompt: null,
+            Model: "gpt-5.3-codex",
+            Effort: null,
+            Tools: null,
+            IsReview: true,
+            Review: new ReviewLaunchInfo("acme", "widgets", 42),
+            ReviewLaunch: new ReviewLaunchBuilder.ReviewLaunch(McpConfigPath: null, SystemPrompt: prompt, Mcp: mcp));
+    }
+
+    [Test]
+    public async Task BuildArgs_review_injects_kcap_review_mcp_server_via_config_overrides() {
+        var result = NewLauncher().BuildArgs(NewReviewCtx("Review PR acme/widgets#42", "/opt/kcap", "https://srv"));
+        var joined = string.Join(' ', result.Args);
+
+        await Assert.That(joined).Contains("mcp_servers.kcap-review.command=\"/opt/kcap\"");
+        await Assert.That(joined).Contains("mcp_servers.kcap-review.args=[\"mcp\",\"review\",\"--owner\",\"acme\",\"--repo\",\"widgets\",\"--pr\",\"42\"]");
+        await Assert.That(joined).Contains("mcp_servers.kcap-review.env={KCAP_URL=\"https://srv\"}");
+    }
+
+    [Test]
+    public async Task BuildArgs_review_passes_prompt_after_double_dash_and_no_system_prompt() {
+        var result = NewLauncher().BuildArgs(NewReviewCtx("REVIEW PROMPT BODY", "/opt/kcap", "https://srv"));
+
+        var dashIdx = Array.IndexOf(result.Args, "--");
+        await Assert.That(dashIdx).IsGreaterThan(-1);
+        await Assert.That(result.Args[dashIdx + 1]).IsEqualTo("REVIEW PROMPT BODY");
+        await Assert.That(result.Args).DoesNotContain("--system-prompt");
+    }
+
+    [Test]
+    public async Task BuildArgs_review_returns_null_mcp_config_path() {
+        var result = NewLauncher().BuildArgs(NewReviewCtx("p", "/opt/kcap", "https://srv"));
+        await Assert.That(result.McpConfigPath).IsNull();
+    }
+
+    [Test]
+    public async Task BuildArgs_review_toml_escapes_quotes_and_backslashes_in_command() {
+        var ctx = NewReviewCtx("p", "C:\\Program Files\\kcap\\kcap.exe", "https://srv");
+        var joined = string.Join(' ', NewLauncher().BuildArgs(ctx).Args);
+        await Assert.That(joined).Contains("mcp_servers.kcap-review.command=\"C:\\\\Program Files\\\\kcap\\\\kcap.exe\"");
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter '/*/*/CodexLauncherTests/BuildArgs_review*'`
+Expected: tests FAIL — the review branch doesn't exist, so the `-c mcp_servers.*` overrides are absent (and `--system-prompt` assertion is vacuously fine but the others fail).
+
+- [ ] **Step 3: Add the review branch and TOML helper to `CodexLauncher.BuildArgs`**
+
+In `src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs`, change `BuildArgs` so the review case is handled first, then the existing logic runs for non-review. Replace the current `BuildArgs` method (lines ~65–96) with:
+
+```csharp
+    public LaunchArgs BuildArgs(LauncherContext ctx) {
+        if (ctx is { IsReview: true, ReviewLaunch: { } launch }) {
+            return BuildReviewArgs(ctx, launch);
+        }
+
+        var args = new List<string> {
+            "--cd",
+            ctx.Worktree.Path,
+            "--sandbox",
+            "workspace-write",
+            "--ask-for-approval",
+            "on-request"
+        };
+
+        if (!string.IsNullOrEmpty(ctx.Model)) {
+            args.Add("-m");
+            args.Add(ctx.Model);
+        }
+
+        var effort = ctx.Effort;
+
+        if (!string.IsNullOrEmpty(effort) && !string.Equals(effort, "auto", StringComparison.OrdinalIgnoreCase)) {
+            var mapped = string.Equals(effort, "max", StringComparison.OrdinalIgnoreCase) ? "xhigh" : effort;
+            args.Add("-c");
+            args.Add($"model_reasoning_effort=\"{mapped}\"");
+        }
+
+        args.Add("--no-alt-screen");
+
+        if (!string.IsNullOrEmpty(ctx.Prompt)) {
+            args.Add("--");
+            args.Add(ctx.Prompt);
+        }
+
+        return new([.. args], McpConfigPath: null);
+    }
+
+    /// Review launch: inject the same kcap-review MCP server Claude gets, but via
+    /// ephemeral `-c` overrides (no ~/.codex/config.toml mutation, nothing to clean
+    /// up), and pass the rendered review prompt as Codex's initial prompt (Codex has
+    /// no --system-prompt equivalent).
+    static LaunchArgs BuildReviewArgs(LauncherContext ctx, ReviewLaunchBuilder.ReviewLaunch launch) {
+        const string serverName = "kcap-review";
+        var          mcp        = launch.Mcp;
+
+        var args = new List<string> {
+            "--cd",
+            ctx.Worktree.Path,
+            "--sandbox",
+            "workspace-write",
+            "--ask-for-approval",
+            "on-request"
+        };
+
+        var argsList = string.Join(",", mcp.Args.Select(TomlString));
+        var envList  = string.Join(",", mcp.Env.Select(kv => $"{kv.Key}={TomlString(kv.Value)}"));
+
+        args.Add("-c");
+        args.Add($"mcp_servers.{serverName}.command={TomlString(mcp.Command)}");
+        args.Add("-c");
+        args.Add($"mcp_servers.{serverName}.args=[{argsList}]");
+        args.Add("-c");
+        args.Add($"mcp_servers.{serverName}.env={{{envList}}}");
+
+        if (!string.IsNullOrEmpty(ctx.Model)) {
+            args.Add("-m");
+            args.Add(ctx.Model);
+        }
+
+        args.Add("--no-alt-screen");
+        args.Add("--");
+        args.Add(launch.SystemPrompt);
+
+        return new([.. args], McpConfigPath: null);
+    }
+
+    /// Encode a value as a TOML basic string: wrap in double quotes and escape
+    /// backslashes and double quotes (covers Windows paths and arbitrary URLs).
+    static string TomlString(string value) =>
+        "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+```
+
+Add `using System.Linq;` at the top of the file if it is not already present (needed for `Select`).
+
+- [ ] **Step 4: Run the review tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter '/*/*/CodexLauncherTests/BuildArgs_review*'`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Run the full CodexLauncher suite to confirm no non-review regression**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter '/*/*/CodexLauncherTests/*'`
+Expected: PASS (all tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+WT=/Users/alexey/dev/eventstore/kcap-cli/.claude/worktrees/breezy-greeting-chipmunk
+git -C "$WT" add src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs \
+  test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+git -C "$WT" commit -m "$(printf 'feat(AI-632): CodexLauncher review branch with -c MCP injection\n\nInject the kcap-review MCP server via ephemeral -c mcp_servers.* TOML\noverrides and pass the rendered review prompt as Codex initial prompt.\nNo temp file, so nothing to clean up.\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 3: Lift the orchestrator Codex-review rejection
+
+Remove the hard gate so Codex review launches flow through the same validation and launcher path as Claude. Replace the rejection test with a gate-removal test (a fully offline happy-path orchestrator test is infeasible — see spec Testing section).
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs:239-243` (remove rejection)
+- Test: `test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs:234-267` (replace the rejection test)
+
+**Interfaces:**
+- Consumes: `CreateGitRepo()`, `BuildOrchestrator(...)`, `CaptureServerConnection`, `SpyHostedAgentLauncher`, `SpyPtyProcessFactory`, `orch.HandleLaunchAgentForTest(cmd)` (all existing in the test file).
+
+- [ ] **Step 1: Replace the rejection test with a gate-removal test**
+
+In `test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs`, replace the entire `Launch_review_kind_with_vendor_codex_emits_launch_failed` test (lines ~234–267) with:
+
+```csharp
+    [Test]
+    public async Task Launch_review_kind_with_vendor_codex_is_accepted_and_reaches_review_validation() {
+        // A git repo with NO origin remote: a Codex review now passes the vendor
+        // gate (which used to reject it) and fails later at origin validation —
+        // the SAME point a Claude review would. Proves the gate is lifted.
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new SpyPtyProcessFactory();
+            var codexSpy   = new SpyHostedAgentLauncher("codex", cliPath: "spy-codex");
+
+            var launchers = new Dictionary<string, IHostedAgentLauncher> { ["codex"] = codexSpy };
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
+
+            var cmd = new LaunchAgentCommand(
+                AgentId: "agent-r1",
+                Prompt: null,
+                Model: "gpt-5",
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "codex",
+                Kind: LaunchKind.Review,
+                Review: new ReviewLaunchInfo("acme", "widgets", 42)
+            );
+
+            await orch.HandleLaunchAgentForTest(cmd);
+
+            await Assert.That(server.LaunchFailedCalls.Count).IsEqualTo(1);
+            // The old Codex-specific rejection is gone...
+            await Assert.That(server.LaunchFailedCalls[0].Reason).DoesNotContain("PR review for Codex");
+            // ...and it failed at the shared origin check instead.
+            await Assert.That(server.LaunchFailedCalls[0].Reason).Contains("origin");
+            await Assert.That(ptyFactory.SpawnCalls).IsEqualTo(0);
+        } finally {
+            cleanup();
+        }
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter '/*/*/AgentOrchestratorVendorTests/Launch_review_kind_with_vendor_codex_is_accepted_and_reaches_review_validation'`
+Expected: FAIL — the rejection still fires, so `Reason` contains "PR review for Codex" (the `DoesNotContain` assertion fails).
+
+- [ ] **Step 3: Remove the rejection gate**
+
+In `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs`, delete these lines (around 239–243):
+
+```csharp
+        if (isReview && cmd.Vendor == "codex") {
+            await _server.LaunchFailedAsync(cmd.AgentId, "PR review for Codex is not yet supported");
+
+            return;
+        }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter '/*/*/AgentOrchestratorVendorTests/Launch_review_kind_with_vendor_codex_is_accepted_and_reaches_review_validation'`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full vendor suite to confirm no regression**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter '/*/*/AgentOrchestratorVendorTests/*'`
+Expected: PASS (all tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+WT=/Users/alexey/dev/eventstore/kcap-cli/.claude/worktrees/breezy-greeting-chipmunk
+git -C "$WT" add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs \
+  test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+git -C "$WT" commit -m "$(printf 'feat(AI-632): accept LaunchKind.Review for vendor codex\n\nRemove the hard rejection so Codex reviews flow through the same\nvalidation and launcher path as Claude.\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 4: README + full verification
+
+Update the public docs and run the whole-repo gates (full test suites + AOT warning scan).
+
+**Files:**
+- Modify: `README.md:413`
+
+- [ ] **Step 1: Update the README**
+
+In `README.md`, line 413 currently reads:
+
+```
+PR review for hosted Codex agents is not yet supported (tracked in AI-632). The sandbox and approval-mode selectors in the launch dialog are also planned as a follow-up (AI-633).
+```
+
+Replace it with:
+
+```
+PR review is supported for hosted Codex agents as well as Claude — the same `kcap-review` MCP context is injected either way. The sandbox and approval-mode selectors in the launch dialog are planned as a follow-up (AI-633).
+```
+
+Then check the `## CLI commands` / `### PR review with full context` section (around line 251–259) and remove any Claude-only phrasing if it now misstates Codex support; if it only describes `kcap review` (the interactive Claude command), leave it.
+
+- [ ] **Step 2: Run the full unit test suite**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj`
+Expected: all tests PASS.
+
+- [ ] **Step 3: Run the integration test suite**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Integration/Capacitor.Cli.Tests.Integration.csproj`
+Expected: all tests PASS.
+
+- [ ] **Step 4: Verify no AOT trimming warnings**
+
+Run: `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'`
+Expected: NO output (no IL3050/IL2026 warnings).
+
+- [ ] **Step 5: Commit**
+
+```bash
+WT=/Users/alexey/dev/eventstore/kcap-cli/.claude/worktrees/breezy-greeting-chipmunk
+git -C "$WT" add README.md
+git -C "$WT" commit -m "$(printf 'docs(AI-632): README — hosted Codex PR review is now supported\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Vendor-aware `ReviewLaunchBuilder` + MCP descriptor + CLI-path fix → Task 1. ✓
+- `CodexLauncher.BuildArgs` review branch (`-c` MCP injection, prompt as initial prompt, TOML encoding) → Task 2. ✓
+- Lift `AgentOrchestrator` Codex-review rejection → Task 3. ✓
+- Cleanup "free" (no temp file for Codex) → covered by Task 2 (`McpConfigPath: null`, no `Cleanup` change). ✓
+- README line 413 → Task 4. ✓
+- AOT-safety / no IL warnings → Task 4 Step 4 (and JsonArray loop in Task 1). ✓
+- Testing strategy (narrow unit tests + gate-removal, no infeasible happy-path) → Tasks 1–3 tests. ✓
+- Keep Claude behavior identical → Task 1 Steps 8, the temp-JSON shape preserved. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every run step has an exact command and expected result.
+
+**Type consistency:** `ReviewLaunchBuilder.ReviewLaunch(string? McpConfigPath, string SystemPrompt, ReviewMcpServer Mcp)` and `ReviewMcpServer(string Command, string[] Args, IReadOnlyDictionary<string,string> Env)` are used identically in Task 1 (definition + tests), Task 2 (`NewReviewCtx`, `BuildReviewArgs`), and consumed via `launch.Mcp` / `launch.SystemPrompt` / `launch.McpConfigPath`. `BuildAsync(string vendor, string cliPath, string baseUrl, string owner, string repo, int prNumber)` matches at both call sites and in tests. `TomlString` defined and used within `CodexLauncher`.

--- a/docs/superpowers/specs/2026-06-29-ai-632-codex-pr-review-support-design.md
+++ b/docs/superpowers/specs/2026-06-29-ai-632-codex-pr-review-support-design.md
@@ -1,0 +1,221 @@
+# AI-632 — Hosted Codex PR review support
+
+**Status:** Design approved (review feedback incorporated), pending final spec review
+**Issue:** [AI-632](https://linear.app/kurrent/issue/AI-632) (follow-up to AI-68; related: AI-72 Windows, AI-633 sandbox/approval selector, AI-774 persistent reviewer loop)
+**Date:** 2026-06-29
+
+## Problem
+
+The v1 hosted-Codex daemon path (AI-68) shipped with `LaunchKind.Review` explicitly
+rejected for `vendor: codex`. `AgentOrchestrator.HandleLaunchAgent` emits
+`"PR review for Codex is not yet supported"` before reaching `CodexLauncher`. Hosted PR
+reviews therefore only work with Claude. This issue lifts that restriction so a hosted
+Codex agent can review a PR with the same `kcap-review` MCP context the Claude path gets.
+
+## Spike outcome (resolves the issue's two unknowns)
+
+Verified against `codex-cli 0.142.3`. Both unknowns resolve in a way that makes the Codex
+path **simpler than the Claude path** — it needs no temp files at all.
+
+### MCP injection is ephemeral — no `config.toml` mutation
+Codex registers MCP servers passed purely as `-c` overrides; nothing is written to
+`~/.codex/config.toml`. Confirmed via `codex mcp list`:
+
+```
+codex mcp list \
+  -c 'mcp_servers.kcap-review.command="kcap"' \
+  -c 'mcp_servers.kcap-review.args=["mcp","review","--pr","42"]'
+# → kcap-review appears in the list, lives only for that invocation
+```
+
+This is the **same `kcap mcp review` stdio server** already used by Claude (Claude reaches
+it via a temp `--mcp-config` JSON file; Codex reaches it via `-c` overrides). The issue's
+worry about appending a transient `[mcp_servers.kapacitor-review]` table and cleaning it up
+on exit does not apply — the `-c` overrides exist only for that one process, so **there is
+nothing to clean up**. (`kcap-review` is a valid TOML bare key — hyphens are allowed —
+confirmed by the spike registering it.)
+
+Codex also supports streamable-HTTP MCP servers (`-c 'mcp_servers.x.url="…"'`), but we reuse
+the existing stdio server for parity and zero new server code.
+
+### No `--system-prompt` flag — instructions go in as the initial prompt
+Codex has no `--system-prompt` equivalent (the issue's guessed `system_prompt="…"` key does
+not exist). Candidate base-instruction keys `base_instructions` / `experimental_instructions_file`
+exist (accepted under `--strict-config`) and *replace* Codex's base system prompt, but
+replacing Codex's base instructions risks stripping its own harness/tool scaffolding.
+
+**Decision (approved):** pass the rendered `prompt-review.txt` as Codex's **initial prompt**
+(positional `--` arg, exactly like the existing non-review Codex launch), leaving Codex's
+base instructions intact. In interactive PTY mode `codex … -- "<prompt>"` starts the session
+and submits the prompt as the first turn, so the agent begins reviewing immediately and the
+human can attach and watch/intervene — matching how hosted Codex already launches.
+
+### Native `codex review` / `codex exec review` — set aside
+Codex 0.142 has native review subcommands, but they review *local git diffs*
+(`--base`, `--commit`, `--uncommitted`) and don't fit our model of injecting rich PR context
+(sessions, transcripts, file context) via the `kcap-review` MCP server. Not used here; noted
+as possibly relevant to AI-774.
+
+## Current architecture (touch-points)
+
+- `src/Capacitor.Cli.Core/Commands/ReviewLaunchBuilder.cs` — `BuildAsync` renders
+  `prompt-review.txt` (PR placeholders substituted) and writes a temp MCP JSON pointing at
+  `kcap mcp review`; returns `ReviewLaunch(McpConfigPath, SystemPrompt)`. The MCP command is
+  currently derived from `Environment.ProcessPath ?? "kcap"` — see the bug note below. Called
+  by the interactive `kcap review` command (`ReviewCommand.cs`) and the daemon orchestrator.
+- `src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs` — review branch in `BuildArgs`
+  emits `--mcp-config <path> --system-prompt <text>`; `Cleanup` deletes `agent.McpConfigPath`.
+- `src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs` — `BuildArgs` builds the interactive
+  launch (`--cd`, `--sandbox`, `--ask-for-approval`, `-m`, `-c model_reasoning_effort`,
+  `--no-alt-screen`, `-- <prompt>`); returns `McpConfigPath: null`; `Cleanup` is a no-op.
+- `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` — rejects Codex review
+  (lines ~239–243); for reviews bases the worktree on `refs/pull/{pr}/head` and re-validates
+  origin (lines ~267–292, ~454); calls `ReviewLaunchBuilder.BuildAsync` (line ~341).
+- `IHostedAgentLauncher` / `LauncherContext` carry `IsReview`, `Review`, `ReviewLaunch`.
+- `AgentInstance.McpConfigPath` is the cleanup handle; `CleanupAgentAsync` calls
+  `launcher.Cleanup(agent)`.
+- `DaemonConfig.CapacitorPath` (default `"kcap"`) — the daemon's path to the **kcap CLI**
+  binary, already used to spawn auxiliary kcap processes (`AgentOrchestrator.cs:757`).
+
+### Pre-existing bug surfaced during review (must fix here)
+`ReviewLaunchBuilder` derives the MCP server command from `Environment.ProcessPath ?? "kcap"`.
+That is correct for the interactive `kcap review` CLI (the running process *is* `kcap`), but
+**wrong inside the daemon**: the daemon is a separate binary (`Capacitor.Cli.Daemon.csproj`
+sets `AssemblyName = kcap-daemon`), and `mcp review` only exists in the `kcap` CLI
+(`Capacitor.Cli/Program.cs`). In the daemon, `Environment.ProcessPath` resolves to
+`…/kcap-daemon`, so the injected MCP command becomes `kcap-daemon mcp review …`, which has no
+such subcommand and cannot serve the review MCP server. This affects the **existing Claude
+hosted-review path** too. The fix (below) threads the correct CLI path through the builder.
+
+## Design
+
+### 1. `ReviewLaunchBuilder` — vendor-aware, explicit CLI path
+Surface the MCP server as a structured descriptor, take the CLI path explicitly (fixing the
+`Environment.ProcessPath` bug), and only write the temp JSON for Claude:
+
+```csharp
+public record ReviewMcpServer(
+    string Command,
+    string[] Args,
+    IReadOnlyDictionary<string, string> Env);
+
+public record ReviewLaunch(string? McpConfigPath, string SystemPrompt, ReviewMcpServer Mcp);
+
+public static async Task<ReviewLaunch> BuildAsync(
+    string vendor, string cliPath, string baseUrl, string owner, string repo, int prNumber)
+```
+
+- Render `prompt-review.txt` first (unchanged ordering — render before any file write so a
+  resource-load throw never leaks a temp file).
+- Build the `ReviewMcpServer` descriptor once: `Command = cliPath`,
+  `Args = ["mcp","review","--owner",owner,"--repo",repo,"--pr",pr]`, `Env = {KCAP_URL = baseUrl}`.
+- `vendor == "claude"` → serialize the descriptor to the temp JSON (`mcpServers.kcap-review`
+  shape, byte-identical to today), set `McpConfigPath`.
+- `vendor == "codex"` → `McpConfigPath = null`, descriptor only, no file written.
+- Callers pass the CLI path:
+  - daemon `AgentOrchestrator` → `_config.CapacitorPath` (the kcap CLI, **not** the daemon).
+  - interactive `ReviewCommand.cs` → `Environment.ProcessPath ?? "kcap"` (the running process
+    is `kcap` there, which is correct).
+
+### 2. `CodexLauncher.BuildArgs` — review branch
+Add an `IsReview`/`ReviewLaunch` branch mirroring the Claude branch shape:
+
+```
+--cd <worktree> --sandbox workspace-write --ask-for-approval on-request
+  -c mcp_servers.kcap-review.command="<cliPath>"
+  -c mcp_servers.kcap-review.args=["mcp","review","--owner","o","--repo","r","--pr","42"]
+  -c mcp_servers.kcap-review.env={KCAP_URL="…"}
+  [-m <model>] --no-alt-screen -- "<rendered prompt-review.txt>"
+```
+
+- Reads `launch.Mcp` (descriptor) and `launch.SystemPrompt` from `ctx.ReviewLaunch`.
+- Returns `McpConfigPath: null` (no temp file).
+- Build the three `-c` values via a small TOML-encoding helper:
+  - basic-string encoder (escape `"`, `\`, control chars) for `command`, env values, and each
+    `args` element;
+  - array literal `["a","b",…]` for `args`;
+  - inline-table literal `{KCAP_URL="…"}` for `env`.
+  Helper must be AOT-safe: plain string building, no reflection/serializer.
+- `Prepare`/`Cleanup` unchanged: the hooks preflight and `.codex` overlay still apply to
+  reviews (we want session capture), and there is nothing to clean up.
+
+### 3. `AgentOrchestrator.HandleLaunchAgent`
+- Delete the `isReview && cmd.Vendor == "codex"` rejection (lines ~239–243).
+- Pass `cmd.Vendor` and `_config.CapacitorPath` into `ReviewLaunchBuilder.BuildAsync`.
+- Worktree-on-PR-head-ref and origin re-validation already vendor-agnostic — no change.
+
+### 4. Cleanup — free
+Codex review produces no temp file, so `CodexLauncher.Cleanup` stays a no-op and
+`AgentInstance.McpConfigPath` stays null for Codex reviews. The acceptance criterion "temp
+injected config / file is cleaned up on agent exit" is satisfied by *not creating one*.
+
+### 5. README
+`README.md` line 413 currently states *"PR review for hosted Codex agents is not yet
+supported (tracked in AI-632)."* Update it in the same PR (per the CLAUDE.md doc-sync rule).
+The adjacent AI-633 note (sandbox/approval selectors) stays.
+
+## Smaller decisions (approved)
+
+- **Review sandbox/approval:** keep the existing hosted-Codex defaults
+  (`workspace-write` / `on-request`) for parity rather than forcing read-only — a reviewer may
+  want to run tests against the PR head. Read-only is a possible later refinement.
+- **Prompt reuse:** use the same `prompt-review.txt` for both vendors in v1. It reads slightly
+  like a system prompt delivered as a user turn, but the content is just instructions + tool
+  guidance. A Codex-tailored variant is a possible follow-up, not v1.
+
+## Testing
+
+The real new logic is pure argument/descriptor construction, so the bulk of coverage lives in
+**narrow unit tests that need no git fixture**:
+
+- `CodexLauncherTests` (`test/.../Codex/CodexLauncherTests.cs`, existing): review-branch
+  `BuildArgs` test — given a `LauncherContext` with `IsReview = true` and a `ReviewLaunch`
+  descriptor, assert it emits `-- <prompt>` plus the three `-c mcp_servers.kcap-review.*`
+  overrides, no `--system-prompt`, `McpConfigPath == null`, and correct TOML encoding of
+  `command`/`args`/`env` (including escaping).
+- `ReviewLaunchBuilder` tests (new): `vendor: claude` writes a temp file and populates the
+  descriptor with `Command == cliPath`; `vendor: codex` returns `McpConfigPath == null` with
+  the descriptor populated; `Args`/`Env`/`Command` correct for both. (Also pins the
+  `Environment.ProcessPath` → `cliPath` fix.)
+
+**Orchestrator level — replace the rejection test, don't "flip" it.** The existing
+`Launch_review_kind_with_vendor_codex_emits_launch_failed` uses `/tmp/whatever` and relies on
+the Codex gate firing *before* repo validation. Once the gate is removed, replace it with a
+test asserting the gate is **lifted**: a Codex review launch now fails at the *same* point a
+Claude review would (e.g. "Repo path does not exist" / origin mismatch) rather than emitting
+"PR review for Codex is not yet supported". This proves the routing change cheaply.
+
+A fully offline **happy-path** review launch through the orchestrator is **not feasible** and
+is intentionally not attempted: the review path both (a) validates `origin` is
+`github.com/{owner}/{repo}` (`GetOriginRemoteAsync`) and (b) fetches `refs/pull/{pr}/head`
+from `origin` (`WorktreeManager.CreateAsync`). A local fixture can satisfy one or the other
+but not both offline. This matches the current state — no happy-path review test exists at the
+orchestrator level for Claude either. End-to-end coverage is the manual smoke test below.
+
+Plus:
+- Existing wire-format test already covers `LaunchKind.Review`; vendor `codex` round-trips.
+- Verify no IL3050/IL2026 AOT warnings on `dotnet publish -c Release` (the TOML helper must be
+  reflection-free).
+- Manual smoke (acceptance): launch a hosted Codex PR review against a real PR; confirm the
+  agent sees PR context (calls `get_pr_summary` etc.) against the PR head ref, and that the
+  injected MCP command resolves to the real `kcap` CLI (not `kcap-daemon`).
+
+## Out of scope
+
+- Windows (AI-72).
+- Generic Codex sandbox / approval selector in the launch dialog (AI-633).
+- Persistent hosted Codex reviewer loop (AI-774).
+- Codex-tailored review prompt variant (possible follow-up).
+
+## Review feedback incorporated (2026-06-29)
+
+1. **CLI path bug (High).** MCP command was `Environment.ProcessPath ?? "kcap"`, which is
+   `kcap-daemon` inside the daemon (no `mcp review` subcommand) — also broken for the existing
+   Claude path. Resolved: thread `cliPath` into `BuildAsync`; daemon passes
+   `_config.CapacitorPath`, interactive CLI passes `Environment.ProcessPath ?? "kcap"`.
+2. **Test strategy (Medium).** "Flip the rejection test" is insufficient — launch then hits
+   repo/origin/PR-ref validation. Resolved: real coverage via narrow `CodexLauncher` /
+   `ReviewLaunchBuilder` unit tests; orchestrator test asserts gate removal; documented that a
+   fully offline happy-path orchestrator test isn't feasible (github-origin vs PR-ref fetch).
+3. **Spec on wrong branch (High).** The first commit landed on `main` by mistake; relocated to
+   `alexeyzimarev/ai-632-codex-hosted-codex-agents-pr-review-support` and `main` reset back.

--- a/src/Capacitor.Cli.Core/Commands/ReviewLaunchBuilder.cs
+++ b/src/Capacitor.Cli.Core/Commands/ReviewLaunchBuilder.cs
@@ -4,48 +4,64 @@ using System.Text.Json.Nodes;
 namespace Capacitor.Cli.Core.Commands;
 
 /// <summary>
-/// Shared helper that builds the <c>claude</c> invocation for a PR review:
-/// a temp MCP config pointing at <c>kcap mcp review</c> plus the embedded
-/// review system prompt with PR placeholders substituted. Used by both the
-/// interactive <c>kcap review</c> command and the daemon's hosted-review
-/// launch path so the review experience stays identical between them.
+/// Shared helper that builds a PR-review launch for a given vendor: the rendered
+/// review system prompt (PR placeholders substituted) plus a vendor-neutral MCP
+/// server descriptor pointing at <c>kcap mcp review</c>. For Claude it also writes
+/// the temp <c>--mcp-config</c> JSON; Codex injects the same server via <c>-c</c>
+/// overrides and needs no file. The kcap CLI path is passed in because inside the
+/// daemon the running process is <c>kcap-daemon</c> (no <c>mcp review</c> subcommand).
 /// </summary>
 public static class ReviewLaunchBuilder {
-    public record ReviewLaunch(string McpConfigPath, string SystemPrompt);
+    public record ReviewMcpServer(string Command, string[] Args, IReadOnlyDictionary<string, string> Env);
 
-    /// <summary>
-    /// Writes a temp MCP config and returns the path plus the rendered system
-    /// prompt. Caller is responsible for deleting the config file when the
-    /// claude process exits.
-    /// </summary>
-    public static async Task<ReviewLaunch> BuildAsync(string baseUrl, string owner, string repo, int prNumber) {
-        // Render the system prompt first. EmbeddedResources.Load can throw
-        // (e.g. resource missing under trimming), and if we wrote the temp
-        // file before that throw, the caller never sees a path to clean up
-        // and the file leaks. Building the prompt up front keeps the temp
-        // file's lifetime fully inside the caller's try/finally.
+    public record ReviewLaunch(string? McpConfigPath, string SystemPrompt, ReviewMcpServer Mcp);
+
+    public static async Task<ReviewLaunch> BuildAsync(
+            string vendor, string cliPath, string baseUrl, string owner, string repo, int prNumber) {
+        // Render the system prompt first. EmbeddedResources.Load can throw; building
+        // the prompt before writing any temp file keeps the file's lifetime fully
+        // inside the caller's try/finally so a throw never leaks a path-less file.
         var systemPrompt = EmbeddedResources.Load("prompt-review.txt")
             .Replace("{prNumber}", prNumber.ToString())
             .Replace("{owner}", owner)
             .Replace("{repo}", repo);
 
-        var kcapPath = Environment.ProcessPath ?? "kcap";
+        var mcp = new ReviewMcpServer(
+            Command: cliPath,
+            Args: ["mcp", "review", "--owner", owner, "--repo", repo, "--pr", prNumber.ToString()],
+            Env: new Dictionary<string, string> { ["KCAP_URL"] = baseUrl });
+
+        string? configPath = null;
+
+        if (vendor == "claude") {
+            configPath = await WriteClaudeMcpConfigAsync(mcp);
+        }
+
+        return new ReviewLaunch(configPath, systemPrompt, mcp);
+    }
+
+    static async Task<string> WriteClaudeMcpConfigAsync(ReviewMcpServer mcp) {
+        // Use the implicit string -> JsonValue conversion (cast to JsonNode?) rather
+        // than JsonValue.Create / collection expressions, which lower to generic
+        // Add<T> and trip NativeAOT (IL3050). This matches the existing pattern.
+        var argsNode = new JsonArray();
+
+        foreach (var a in mcp.Args) {
+            argsNode.Add((JsonNode?)a);
+        }
+
+        var envNode = new JsonObject();
+
+        foreach (var kv in mcp.Env) {
+            envNode[kv.Key] = (JsonNode?)kv.Value;
+        }
 
         var mcpConfig = new JsonObject {
             ["mcpServers"] = new JsonObject {
                 ["kcap-review"] = new JsonObject {
-                    ["command"] = kcapPath,
-                    ["args"] = new JsonArray(
-                        "mcp",
-                        "review",
-                        "--owner",
-                        owner,
-                        "--repo",
-                        repo,
-                        "--pr",
-                        prNumber.ToString()
-                    ),
-                    ["env"] = new JsonObject { ["KCAP_URL"] = baseUrl }
+                    ["command"] = mcp.Command,
+                    ["args"]    = argsNode,
+                    ["env"]     = envNode
                 }
             }
         };
@@ -54,6 +70,6 @@ public static class ReviewLaunchBuilder {
         var json       = mcpConfig.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
         await File.WriteAllTextAsync(configPath, json);
 
-        return new ReviewLaunch(configPath, systemPrompt);
+        return configPath;
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -243,12 +243,6 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             return;
         }
 
-        if (isReview && cmd.Vendor == "codex") {
-            await _server.LaunchFailedAsync(cmd.AgentId, "PR review for Codex is not yet supported");
-
-            return;
-        }
-
         WorktreeInfo? worktree      = null;
         string?       mcpConfigPath = null;
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -345,7 +345,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 IsReview: isReview,
                 Review: cmd.Review,
                 ReviewLaunch: isReview && cmd.Review is { } reviewArgs
-                    ? await ReviewLaunchBuilder.BuildAsync(_config.ServerUrl ?? "", reviewArgs.Owner, reviewArgs.Repo, reviewArgs.PrNumber)
+                    ? await ReviewLaunchBuilder.BuildAsync(cmd.Vendor, _config.CapacitorPath, _config.ServerUrl ?? "", reviewArgs.Owner, reviewArgs.Repo, reviewArgs.PrNumber)
                     : null
             );
 

--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -68,7 +68,7 @@ internal sealed partial class ClaudeLauncher(
             mcpConfigPath = launch.McpConfigPath;
 
             args.Add("--mcp-config");
-            args.Add(launch.McpConfigPath);
+            args.Add(launch.McpConfigPath!);
             args.Add("--system-prompt");
             args.Add(launch.SystemPrompt);
 

--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Commands;
 using Capacitor.Cli.Core.LocalIpc;
 using Microsoft.Extensions.Logging;
 
@@ -63,6 +64,10 @@ internal sealed partial class CodexLauncher(
     }
 
     public LaunchArgs BuildArgs(LauncherContext ctx) {
+        if (ctx is { IsReview: true, ReviewLaunch: { } launch }) {
+            return BuildReviewArgs(ctx, launch);
+        }
+
         var args = new List<string> {
             "--cd",
             ctx.Worktree.Path,
@@ -94,6 +99,50 @@ internal sealed partial class CodexLauncher(
 
         return new([.. args], McpConfigPath: null);
     }
+
+    /// Review launch: inject the same kcap-review MCP server Claude gets, but via
+    /// ephemeral `-c` overrides (no ~/.codex/config.toml mutation, nothing to clean
+    /// up), and pass the rendered review prompt as Codex's initial prompt (Codex has
+    /// no --system-prompt equivalent).
+    static LaunchArgs BuildReviewArgs(LauncherContext ctx, ReviewLaunchBuilder.ReviewLaunch launch) {
+        const string serverName = "kcap-review";
+        var          mcp        = launch.Mcp;
+
+        var args = new List<string> {
+            "--cd",
+            ctx.Worktree.Path,
+            "--sandbox",
+            "workspace-write",
+            "--ask-for-approval",
+            "on-request"
+        };
+
+        var argsList = string.Join(",", mcp.Args.Select(TomlString));
+        var envList  = string.Join(",", mcp.Env.Select(kv => $"{kv.Key}={TomlString(kv.Value)}"));
+
+        args.Add("-c");
+        args.Add($"mcp_servers.{serverName}.command={TomlString(mcp.Command)}");
+        args.Add("-c");
+        args.Add($"mcp_servers.{serverName}.args=[{argsList}]");
+        args.Add("-c");
+        args.Add($"mcp_servers.{serverName}.env={{{envList}}}");
+
+        if (!string.IsNullOrEmpty(ctx.Model)) {
+            args.Add("-m");
+            args.Add(ctx.Model);
+        }
+
+        args.Add("--no-alt-screen");
+        args.Add("--");
+        args.Add(launch.SystemPrompt);
+
+        return new([.. args], McpConfigPath: null);
+    }
+
+    /// Encode a value as a TOML basic string: wrap in double quotes and escape
+    /// backslashes and double quotes (covers Windows paths and arbitrary URLs).
+    static string TomlString(string value) =>
+        "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
 
     /// Local launch: emit the mandatory daemon-level flags Codex always needs, then append
     /// the user's verbatim post-`--` args. A user duplicate of a mandatory flag is rejected

--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Commands;
@@ -140,9 +141,38 @@ internal sealed partial class CodexLauncher(
     }
 
     /// Encode a value as a TOML basic string: wrap in double quotes and escape
-    /// backslashes and double quotes (covers Windows paths and arbitrary URLs).
-    static string TomlString(string value) =>
-        "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+    /// backslashes, double quotes, and control characters. TOML basic strings forbid
+    /// raw control chars, so an unescaped tab/newline/CR would yield invalid TOML and
+    /// fail the Codex `-c` config parse. Covers Windows paths and arbitrary URLs.
+    static string TomlString(string value) {
+        var sb = new StringBuilder(value.Length + 2);
+        sb.Append('"');
+
+        foreach (var c in value) {
+            switch (c) {
+                case '\\': sb.Append("\\\\"); break;
+                case '"':  sb.Append("\\\""); break;
+                case '\b': sb.Append("\\b");  break;
+                case '\t': sb.Append("\\t");  break;
+                case '\n': sb.Append("\\n");  break;
+                case '\f': sb.Append("\\f");  break;
+                case '\r': sb.Append("\\r");  break;
+                default:
+                    // Remaining C0 controls (and DEL) have no short escape — emit \uXXXX.
+                    if (c < ' ' || c == (char)0x7f) {
+                        sb.Append("\\u").Append(((int)c).ToString("X4"));
+                    } else {
+                        sb.Append(c);
+                    }
+
+                    break;
+            }
+        }
+
+        sb.Append('"');
+
+        return sb.ToString();
+    }
 
     /// Local launch: emit the mandatory daemon-level flags Codex always needs, then append
     /// the user's verbatim post-`--` args. A user duplicate of a mandatory flag is rejected

--- a/src/Capacitor.Cli/Commands/ReviewCommand.cs
+++ b/src/Capacitor.Cli/Commands/ReviewCommand.cs
@@ -45,7 +45,8 @@ static class ReviewCommand {
             return 1;
         }
 
-        var launch = await ReviewLaunchBuilder.BuildAsync(baseUrl, owner, repo, prNumber);
+        var launch = await ReviewLaunchBuilder.BuildAsync(
+            "claude", Environment.ProcessPath ?? "kcap", baseUrl, owner, repo, prNumber);
 
         try {
             await Console.Error.WriteLineAsync("Launching claude with review MCP server...");
@@ -56,7 +57,7 @@ static class ReviewCommand {
             };
 
             psi.ArgumentList.Add("--mcp-config");
-            psi.ArgumentList.Add(launch.McpConfigPath);
+            psi.ArgumentList.Add(launch.McpConfigPath!);
             psi.ArgumentList.Add("--system-prompt");
             psi.ArgumentList.Add(launch.SystemPrompt);
 
@@ -73,7 +74,7 @@ static class ReviewCommand {
             return process.ExitCode;
         } finally {
             try {
-                File.Delete(launch.McpConfigPath);
+                File.Delete(launch.McpConfigPath!);
             } catch {
                 // Best effort cleanup
             }

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -162,11 +162,19 @@ public partial class AgentOrchestratorVendorTests {
         await orch.RegisterAgentForTestAsync(pub);
         await Assert.That(server.Calls).Contains(nameof(ServerConnection.AgentRegisteredAsync));
 
-        server.Calls.Clear();
+        // Assert the private-agent skip on a fresh orchestrator + connection rather than
+        // clearing the public one's Calls. RegisterAgentAsync for a public agent kicks off
+        // fire-and-forget background work (the UpdateRepoPathsAsync Task.Run, gated behind
+        // RepoPathStore file I/O, and AppendAgentRunEventAsync) that can land in Calls AFTER
+        // a Clear() under slow I/O — a timing race that flaked CI. A pristine connection that
+        // only ever sees the private registration must see zero calls, since RegisterAgentAsync
+        // returns immediately for private agents without touching the server.
+        var privServer = new TripwireServerConnection();
+        await using var privOrch = BuildOrchestrator(privServer, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
         var priv = new AgentInstance("priv-1", null, "", null, "/r", "claude",
             new StubPtyProcess(), new WorktreeInfo("/r", "", "/r"), new CancellationTokenSource()) { IsPrivate = true };
-        await orch.RegisterAgentForTestAsync(priv);
-        await Assert.That(server.Calls.Count).IsEqualTo(0);
+        await privOrch.RegisterAgentForTestAsync(priv);
+        await Assert.That(privServer.Calls.Count).IsEqualTo(0);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -232,38 +232,45 @@ public partial class AgentOrchestratorVendorTests {
     }
 
     [Test]
-    public async Task Launch_review_kind_with_vendor_codex_emits_launch_failed() {
-        var server     = new CaptureServerConnection();
-        var ptyFactory = new SpyPtyProcessFactory();
-        var codexSpy   = new SpyHostedAgentLauncher("codex", cliPath: "spy-codex");
+    public async Task Launch_review_kind_with_vendor_codex_is_accepted_and_reaches_review_validation() {
+        // A git repo with NO origin remote: a Codex review now passes the vendor
+        // gate (which used to reject it) and fails later at origin validation —
+        // the SAME point a Claude review would. Proves the gate is lifted.
+        var (repoPath, cleanup) = CreateGitRepo();
 
-        var launchers = new Dictionary<string, IHostedAgentLauncher> {
-            ["codex"] = codexSpy
-        };
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new SpyPtyProcessFactory();
+            var codexSpy   = new SpyHostedAgentLauncher("codex", cliPath: "spy-codex");
 
-        await using var orch = BuildOrchestrator(server, ptyFactory, launchers);
+            var launchers = new Dictionary<string, IHostedAgentLauncher> { ["codex"] = codexSpy };
 
-        var cmd = new LaunchAgentCommand(
-            AgentId: "agent-r1",
-            Prompt: null,
-            Model: "gpt-5",
-            Effort: null,
-            RepoPath: "/tmp/whatever",
-            Tools: null,
-            AttachmentIds: null,
-            Vendor: "codex",
-            Kind: LaunchKind.Review,
-            Review: new ReviewLaunchInfo("acme", "widgets", 42)
-        );
+            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
 
-        await orch.HandleLaunchAgentForTest(cmd);
+            var cmd = new LaunchAgentCommand(
+                AgentId: "agent-r1",
+                Prompt: null,
+                Model: "gpt-5",
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "codex",
+                Kind: LaunchKind.Review,
+                Review: new ReviewLaunchInfo("acme", "widgets", 42)
+            );
 
-        await Assert.That(server.LaunchFailedCalls.Count).IsEqualTo(1);
-        await Assert.That(server.LaunchFailedCalls[0].AgentId).IsEqualTo("agent-r1");
-        await Assert.That(server.LaunchFailedCalls[0].Reason).Contains("PR review for Codex");
-        await Assert.That(codexSpy.BuildArgsCalls).IsEqualTo(0);
-        await Assert.That(codexSpy.PrepareCalls).IsEqualTo(0);
-        await Assert.That(ptyFactory.SpawnCalls).IsEqualTo(0);
+            await orch.HandleLaunchAgentForTest(cmd);
+
+            await Assert.That(server.LaunchFailedCalls.Count).IsEqualTo(1);
+            // The old Codex-specific rejection is gone...
+            await Assert.That(server.LaunchFailedCalls[0].Reason).DoesNotContain("PR review for Codex");
+            // ...and it failed at the shared origin check instead.
+            await Assert.That(server.LaunchFailedCalls[0].Reason).Contains("origin");
+            await Assert.That(ptyFactory.SpawnCalls).IsEqualTo(0);
+        } finally {
+            cleanup();
+        }
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -303,4 +303,33 @@ public class CodexLauncherTests {
         var joined = string.Join(' ', NewLauncher().BuildArgs(ctx).Args);
         await Assert.That(joined).Contains("mcp_servers.kcap-review.command=\"C:\\\\Program Files\\\\kcap\\\\kcap.exe\"");
     }
+
+    [Test]
+    public async Task BuildArgs_review_toml_escapes_control_chars_in_command_args_and_env() {
+        // TOML basic strings forbid raw control characters; an unescaped tab/newline/CR
+        // produces invalid TOML and fails the Codex launch at config-parse time. Exercise
+        // the encoder on all three injected surfaces: command, an args element, env value.
+        var mcp = new ReviewLaunchBuilder.ReviewMcpServer(
+            Command: "kcap\twith\tctrl",
+            Args: ["mcp", "review", "line1\nline2"],
+            Env: new Dictionary<string, string> { ["KCAP_URL"] = "https://srv\r/x" });
+
+        var ctx = new LauncherContext(
+            AgentId: "a-rev",
+            SourceRepoPath: "/tmp/repo",
+            Worktree: new WorktreeInfo(Path: "/tmp/wt", Branch: "wt-branch", SourceRepo: "/tmp/repo"),
+            Prompt: null,
+            Model: "gpt-5.3-codex",
+            Effort: null,
+            Tools: null,
+            IsReview: true,
+            Review: new ReviewLaunchInfo("acme", "widgets", 42),
+            ReviewLaunch: new ReviewLaunchBuilder.ReviewLaunch(McpConfigPath: null, SystemPrompt: "p", Mcp: mcp));
+
+        var joined = string.Join(' ', NewLauncher().BuildArgs(ctx).Args);
+
+        await Assert.That(joined).Contains("mcp_servers.kcap-review.command=\"kcap\\twith\\tctrl\"");
+        await Assert.That(joined).Contains("\"line1\\nline2\"");
+        await Assert.That(joined).Contains("mcp_servers.kcap-review.env={KCAP_URL=\"https://srv\\r/x\"}");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -1,3 +1,5 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Commands;
 using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -249,4 +251,56 @@ public class CodexLauncherTests {
         Review: null,
         ReviewLaunch: null
     );
+
+    static LauncherContext NewReviewCtx(string prompt, string cliPath, string baseUrl) {
+        var mcp = new ReviewLaunchBuilder.ReviewMcpServer(
+            Command: cliPath,
+            Args: ["mcp", "review", "--owner", "acme", "--repo", "widgets", "--pr", "42"],
+            Env: new Dictionary<string, string> { ["KCAP_URL"] = baseUrl });
+
+        return new(
+            AgentId: "a-rev",
+            SourceRepoPath: "/tmp/repo",
+            Worktree: new WorktreeInfo(Path: "/tmp/wt", Branch: "wt-branch", SourceRepo: "/tmp/repo"),
+            Prompt: null,
+            Model: "gpt-5.3-codex",
+            Effort: null,
+            Tools: null,
+            IsReview: true,
+            Review: new ReviewLaunchInfo("acme", "widgets", 42),
+            ReviewLaunch: new ReviewLaunchBuilder.ReviewLaunch(McpConfigPath: null, SystemPrompt: prompt, Mcp: mcp));
+    }
+
+    [Test]
+    public async Task BuildArgs_review_injects_kcap_review_mcp_server_via_config_overrides() {
+        var result = NewLauncher().BuildArgs(NewReviewCtx("Review PR acme/widgets#42", "/opt/kcap", "https://srv"));
+        var joined = string.Join(' ', result.Args);
+
+        await Assert.That(joined).Contains("mcp_servers.kcap-review.command=\"/opt/kcap\"");
+        await Assert.That(joined).Contains("mcp_servers.kcap-review.args=[\"mcp\",\"review\",\"--owner\",\"acme\",\"--repo\",\"widgets\",\"--pr\",\"42\"]");
+        await Assert.That(joined).Contains("mcp_servers.kcap-review.env={KCAP_URL=\"https://srv\"}");
+    }
+
+    [Test]
+    public async Task BuildArgs_review_passes_prompt_after_double_dash_and_no_system_prompt() {
+        var result = NewLauncher().BuildArgs(NewReviewCtx("REVIEW PROMPT BODY", "/opt/kcap", "https://srv"));
+
+        var dashIdx = Array.IndexOf(result.Args, "--");
+        await Assert.That(dashIdx).IsGreaterThan(-1);
+        await Assert.That(result.Args[dashIdx + 1]).IsEqualTo("REVIEW PROMPT BODY");
+        await Assert.That(result.Args).DoesNotContain("--system-prompt");
+    }
+
+    [Test]
+    public async Task BuildArgs_review_returns_null_mcp_config_path() {
+        var result = NewLauncher().BuildArgs(NewReviewCtx("p", "/opt/kcap", "https://srv"));
+        await Assert.That(result.McpConfigPath).IsNull();
+    }
+
+    [Test]
+    public async Task BuildArgs_review_toml_escapes_quotes_and_backslashes_in_command() {
+        var ctx = NewReviewCtx("p", "C:\\Program Files\\kcap\\kcap.exe", "https://srv");
+        var joined = string.Join(' ', NewLauncher().BuildArgs(ctx).Args);
+        await Assert.That(joined).Contains("mcp_servers.kcap-review.command=\"C:\\\\Program Files\\\\kcap\\\\kcap.exe\"");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ReviewLaunchBuilderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ReviewLaunchBuilderTests.cs
@@ -1,0 +1,43 @@
+using Capacitor.Cli.Core.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class ReviewLaunchBuilderTests {
+    [Test]
+    public async Task Claude_writes_mcp_config_file_and_populates_descriptor() {
+        var launch = await ReviewLaunchBuilder.BuildAsync(
+            vendor: "claude", cliPath: "/opt/kcap", baseUrl: "https://srv",
+            owner: "acme", repo: "widgets", prNumber: 42);
+
+        try {
+            await Assert.That(launch.McpConfigPath).IsNotNull();
+            await Assert.That(File.Exists(launch.McpConfigPath!)).IsTrue();
+            var json = await File.ReadAllTextAsync(launch.McpConfigPath!);
+            await Assert.That(json).Contains("kcap-review");
+            await Assert.That(json).Contains("/opt/kcap");
+
+            await Assert.That(launch.Mcp.Command).IsEqualTo("/opt/kcap");
+            await Assert.That(launch.Mcp.Args).Contains("--owner");
+            await Assert.That(launch.Mcp.Args).Contains("acme");
+            await Assert.That(launch.Mcp.Args).Contains("42");
+            await Assert.That(launch.Mcp.Env["KCAP_URL"]).IsEqualTo("https://srv");
+            await Assert.That(launch.SystemPrompt).Contains("acme");
+        } finally {
+            if (launch.McpConfigPath is not null) File.Delete(launch.McpConfigPath);
+        }
+    }
+
+    [Test]
+    public async Task Codex_writes_no_file_and_populates_descriptor() {
+        var launch = await ReviewLaunchBuilder.BuildAsync(
+            vendor: "codex", cliPath: "/opt/kcap", baseUrl: "https://srv",
+            owner: "acme", repo: "widgets", prNumber: 42);
+
+        await Assert.That(launch.McpConfigPath).IsNull();
+        await Assert.That(launch.Mcp.Command).IsEqualTo("/opt/kcap");
+        await Assert.That(launch.Mcp.Args).Contains("review");
+        await Assert.That(launch.Mcp.Args).Contains("widgets");
+        await Assert.That(launch.Mcp.Env["KCAP_URL"]).IsEqualTo("https://srv");
+        await Assert.That(launch.SystemPrompt).Contains("widgets");
+    }
+}


### PR DESCRIPTION
## What

Adds hosted **Codex** PR review support (AI-632). Previously the daemon hard-rejected `LaunchKind.Review` + `vendor: codex` with *"PR review for Codex is not yet supported."* A hosted Codex agent can now review a PR with the same `kcap-review` MCP context the Claude path gets.

## How (spike-grounded)

Verified against `codex-cli 0.142.3`. The Codex path turned out **simpler than Claude's** — it needs no temp files:

- **MCP injection is ephemeral.** The same `kcap mcp review` stdio server is registered via `-c mcp_servers.kcap-review.{command,args,env}` overrides — no `~/.codex/config.toml` mutation, so **nothing to clean up**. Confirmed all three forms (command, args array, env inline-table) register via `codex mcp get`.
- **No `--system-prompt` flag exists.** The rendered `prompt-review.txt` is passed as Codex's **initial prompt** (positional `--` arg), leaving Codex's base instructions intact.

### Changes
1. **`ReviewLaunchBuilder`** — now vendor-aware and takes an explicit kcap-CLI path; exposes a vendor-neutral `ReviewMcpServer` descriptor and writes the temp `--mcp-config` JSON only for Claude.
   - **Bug fix (also affected Claude):** the builder used `Environment.ProcessPath`, which inside the daemon resolves to the separate `kcap-daemon` binary (no `mcp review` subcommand). The daemon now passes `_config.CapacitorPath`; the interactive `kcap review` CLI passes `Environment.ProcessPath ?? "kcap"`.
2. **`CodexLauncher.BuildArgs`** — review branch injecting the `-c` MCP overrides + prompt, with an AOT-safe `TomlString` encoder. Returns `McpConfigPath: null`.
3. **`AgentOrchestrator`** — removed the Codex-review rejection; Codex reviews now flow through the same validation/launcher path as Claude.
4. **README** — documents hosted Codex review support.

The Claude review path is unchanged at runtime (only compile-time `!` null-forgiving edits); effort handling stays at parity (review branches pass `--model`/`-m` only, no `--effort`).

## Test plan

- New unit tests: `ReviewLaunchBuilderTests` (vendor split, descriptor, CLI-path), `CodexLauncherTests` review branch (the three `-c` overrides, prompt-after-`--`, no `--system-prompt`, null `McpConfigPath`, TOML escaping).
- Replaced the Codex-review rejection test with a gate-removal test (Codex review now reaches the shared origin validation, not the old rejection).
- Gates: unit **1860/1860**, integration **45/45**, `dotnet publish -c Release` clean (no IL3050/IL2026).
- CLI-level verification: `codex mcp get kcap-review` with the injected `-c` overrides resolves to `stdio` / `command=kcap` / `args=mcp review --owner … --pr …` / `env KCAP_URL`.

**Remaining manual acceptance** (needs a live server + PR, per the spec): launch a hosted Codex review against a real PR and confirm the agent calls `get_pr_summary` against the PR head ref.

## Out of scope
Windows (AI-72), the generic sandbox/approval selector (AI-633), the persistent reviewer loop (AI-774), and a Codex-tailored review prompt.

Design & plan: `docs/superpowers/specs/2026-06-29-ai-632-codex-pr-review-support-design.md`, `docs/superpowers/plans/2026-06-29-ai-632-codex-pr-review-support.md`.

Closes AI-632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
