### PR TITLE
[AI-774] docs: fix Codex MCP config path for kcap mcp flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,10 +295,10 @@ Stdio MCP server that lets coding agents start and interact with AI-powered revi
 # Claude Code
 claude mcp add kcap-flows -- kcap mcp flows
 
-# Codex (~/.config/codex/mcp_servers.toml)
-# [kcap-flows]
-# command = "kcap"
-# args    = ["mcp", "flows"]
+# Codex (CLI or desktop app) — add to ~/.codex/config.toml:
+# [mcp_servers.kcap-flows]
+# command = "kcap"           # use an absolute path (e.g. /opt/homebrew/bin/kcap) for the
+# args    = ["mcp", "flows"] # desktop app, which launches MCP servers without your shell PATH
 ```
 
 It provides four tools:

--- a/kcap/README.md
+++ b/kcap/README.md
@@ -4,7 +4,7 @@ This plugin integrates [Kurrent Capacitor](../README.md) with Claude Code and Co
 
 ## What it does
 
-**MCP servers** — Two stdio servers, both auto-registered on plugin install (no manual `claude mcp add` or `~/.config/codex/mcp_servers.toml` edit):
+**MCP servers** — Two stdio servers, both auto-registered on plugin install (no manual `claude mcp add` or `~/.codex/config.toml` edit):
 
 ### `kcap-sessions`
 

--- a/src/Capacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-mcp.txt
@@ -53,10 +53,12 @@ mcp flows:
     Claude Code:
       claude mcp add kcap-flows -- kcap mcp flows
 
-    Codex (~/.config/codex/mcp_servers.toml):
-      [kcap-flows]
+    Codex (CLI or desktop app) — add to ~/.codex/config.toml:
+      [mcp_servers.kcap-flows]
       command = "kcap"
       args    = ["mcp", "flows"]
+      # desktop app launches with no shell PATH, so command
+      # needs an absolute path (e.g. /opt/homebrew/bin/kcap)
 
 INSTALL
 
@@ -72,7 +74,9 @@ INSTALL
     Claude Code:
       claude mcp add kcap-judge -- kcap mcp judge
 
-    Codex (~/.config/codex/mcp_servers.toml):
-      [kcap-judge]
+    Codex (CLI or desktop app) — add to ~/.codex/config.toml:
+      [mcp_servers.kcap-judge]
       command = "kcap"
       args    = ["mcp", "judge"]
+      # desktop app launches with no shell PATH, so command
+      # needs an absolute path (e.g. /opt/homebrew/bin/kcap)


### PR DESCRIPTION
## What

The `### Flows MCP server (for agents)` section told Codex users to add `kcap mcp flows` to `~/.config/codex/mcp_servers.toml` under a bare `[kcap-flows]` table. Both are wrong:

- The actual Codex config (CLI **and** the desktop app) is `~/.codex/config.toml` — `~/.config/codex/` does not exist.
- MCP servers must live under a `[mcp_servers.<name>]` table, not a bare `[kcap-flows]` table.

Verified against a real Codex desktop install (`/Applications/Codex.app`), whose `~/.codex/config.toml` already configures its own MCP servers via `[mcp_servers.node_repl]`.

## Change

Doc-only. Corrects the path/table and adds a note that the desktop app launches MCP servers without the user's shell `PATH`, so an absolute `command` path is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)