### PR TITLE
[AI-1061] kcap mcp flows: infinite POST timeout + opt-in async poll loop

### DIFF
--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -15,6 +15,15 @@ static class McpFlowsServer {
     public static async Task<int> RunAsync(string baseUrl) {
         using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
 
+        // The review-flow endpoints are long-polls: start_review_flow / submit_review_round
+        // block server-side until the AI reviewer returns findings (FlowResultWaiter allows
+        // up to 10 minutes). The default HttpClient.Timeout (100s) would abort the POST first,
+        // which the server sees as a cancelled request and tears the reviewer down (~2 min) —
+        // so no real review could ever complete (AI-1061). Disable the client-side deadline and
+        // let the server's FlowResultWaiter and the harness MCP tool timeout bound the wait,
+        // mirroring the long-poll clients in PermissionRequestCommand / CodexHookCommand.
+        client.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
+
         var cwd      = Directory.GetCurrentDirectory();
         var repoRoot = GitRepository.FindRoot(cwd);
         var tools    = BuildToolsList();

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -93,9 +93,25 @@ static class McpFlowsServer {
         try {
             var apiRoot = baseUrl.TrimEnd('/');
 
+            // start_review_flow and submit_review_round may need async poll — handle separately.
+            if (toolName is "start_review_flow" or "submit_review_round") {
+                using var postResponse = toolName == "start_review_flow"
+                    ? await SendWithRefreshRetryAsync(client, c => StartReviewFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo))
+                    : await SendWithRefreshRetryAsync(client, c => SubmitReviewRoundAsync(c, apiRoot, arguments));
+
+                var postBody = await postResponse.Content.ReadAsStringAsync();
+
+                if (postResponse.StatusCode == HttpStatusCode.Unauthorized)
+                    return BuildToolResult(id, "Not logged in. Run 'kcap login' on the host shell.", isError: true);
+
+                if (!postResponse.IsSuccessStatusCode)
+                    return BuildToolResult(id, $"Error: HTTP {(int)postResponse.StatusCode} — {postBody}", isError: true);
+
+                var payload = await ResolveRoundResultAsync(client, apiRoot, postBody);
+                return BuildToolResult(id, payload);
+            }
+
             using var httpResponse = toolName switch {
-                "start_review_flow"      => await SendWithRefreshRetryAsync(client, c => StartReviewFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo)),
-                "submit_review_round"    => await SendWithRefreshRetryAsync(client, c => SubmitReviewRoundAsync(c, apiRoot, arguments)),
                 "get_review_flow_status" => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildFlowUrl(apiRoot, arguments))),
                 "close_review_flow"      => await SendWithRefreshRetryAsync(client, c => c.PostAsync(BuildFlowUrl(apiRoot, arguments) + "/close", null)),
                 _                        => throw new ArgumentException($"Unknown tool: {toolName}")
@@ -111,13 +127,13 @@ static class McpFlowsServer {
                 return BuildToolResult(id, $"Error: HTTP {(int)httpResponse.StatusCode} — {body}", isError: true);
             }
 
-            var payload = toolName switch {
+            var statusPayload = toolName switch {
                 "get_review_flow_status" => FormatStatusResponse(body),
                 "close_review_flow"      => FormatCloseResponse(body),
                 _                        => FormatRoundResponse(body)
             };
 
-            return BuildToolResult(id, payload);
+            return BuildToolResult(id, statusPayload);
         } catch (ArgumentException ex) {
             return BuildToolResult(id, $"Error: {ex.Message}", isError: true);
         } catch (HttpRequestException ex) {
@@ -182,7 +198,8 @@ static class McpFlowsServer {
             RepoName:             repoInfo?.RepoName,
             DaemonName:           null,
             RepoPath:             repoRoot,
-            Mode:                 mode
+            Mode:                 mode,
+            Async:                true
         );
 
         return await client.PostAsync(
@@ -207,7 +224,7 @@ static class McpFlowsServer {
             );
         }
 
-        var body = new SubmitReviewRoundDto(Context: context, Instructions: instructions);
+        var body = new SubmitReviewRoundDto(Context: context, Instructions: instructions, Async: true);
 
         return client.PostAsync(
             $"{apiRoot}/api/flows/{Uri.EscapeDataString(flowRunId)}/rounds",
@@ -220,6 +237,95 @@ static class McpFlowsServer {
             ?? throw new ArgumentException("Missing required argument: flow_run_id");
 
         return $"{apiRoot}/api/flows/{Uri.EscapeDataString(flowRunId)}";
+    }
+
+    static readonly TimeSpan PollInterval  = TimeSpan.FromSeconds(3);
+    static readonly TimeSpan PollCap       = TimeSpan.FromMinutes(8);   // safely below MCP_TOOL_TIMEOUT
+    static readonly TimeSpan PerGetTimeout = TimeSpan.FromSeconds(20);
+    static readonly TimeSpan NotFoundGrace = TimeSpan.FromSeconds(10);
+
+    static readonly HashSet<string> TerminalRoundStatuses =
+        new(StringComparer.Ordinal) { "findings", "clean", "waiting", "unclear", "failed", "cancelled" };
+
+    /// <summary>If the POST already carries a terminal result (old/blocking server), return it.
+    /// Otherwise poll GET /api/flows/{id} until the started round is terminal (AI-1061).</summary>
+    static async Task<string> ResolveRoundResultAsync(HttpClient client, string apiRoot, string postBody) {
+        var node      = JsonNode.Parse(postBody)?.AsObject();
+        var status    = node?["status"]?.GetValue<string>();
+        var flowRunId = node?["flow_run_id"]?.GetValue<string>();
+        var roundNum  = node?["round_number"]?.GetValue<int>();
+
+        if (status != "running" || flowRunId is null || roundNum is null)
+            return FormatRoundResponse(postBody); // terminal-in-POST (old server) or unparseable
+
+        return await PollUntilTerminalAsync(client, apiRoot, flowRunId, roundNum.Value);
+    }
+
+    static async Task<string> PollUntilTerminalAsync(HttpClient client, string apiRoot, string flowRunId, int roundNumber) {
+        var url      = $"{apiRoot}/api/flows/{Uri.EscapeDataString(flowRunId)}";
+        var deadline = DateTimeOffset.UtcNow + PollCap;
+        var firstSeenNotFound = (DateTimeOffset?)null;
+
+        while (DateTimeOffset.UtcNow < deadline) {
+            using var getCts = new CancellationTokenSource(PerGetTimeout);
+            HttpResponseMessage resp;
+            try {
+                resp = await SendWithRefreshRetryAsync(client, c => c.GetAsync(url, getCts.Token));
+            } catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException) {
+                await Task.Delay(PollInterval); continue; // transient — retry within cap
+            }
+
+            using (resp) {
+                if (resp.StatusCode == HttpStatusCode.NotFound) {
+                    firstSeenNotFound ??= DateTimeOffset.UtcNow;
+                    if (DateTimeOffset.UtcNow - firstSeenNotFound > NotFoundGrace)
+                        return $"Error: flow_run_id {flowRunId} not found.";
+                    await Task.Delay(PollInterval); continue;
+                }
+                if (resp.StatusCode == HttpStatusCode.Unauthorized)
+                    return "Not logged in. Run 'kcap login' on the host shell.";
+
+                var body = await resp.Content.ReadAsStringAsync();
+                if (!resp.IsSuccessStatusCode) { await Task.Delay(PollInterval); continue; }
+
+                var node     = JsonNode.Parse(body)?.AsObject();
+                var rn       = node?["round_number"]?.GetValue<int>();
+                var rs       = node?["round_status"]?.GetValue<string>();
+                var runStatus = node?["status"]?.GetValue<string>();
+
+                // If the run-level status is terminal, stop regardless of round status
+                // (guards against a run that failed with an in-flight round left at "running").
+                if (runStatus is "closed" or "failed") {
+                    if (rn == roundNumber && rs is not null)
+                        return FormatPolledRoundResult(node!, flowRunId);
+                    // Run terminal but round not matching yet — return what we have
+                    return FormatPolledRoundResult(node!, flowRunId);
+                }
+
+                // Only act on OUR round; an earlier projection may still show a prior round.
+                if (rn == roundNumber && rs is not null && TerminalRoundStatuses.Contains(rs))
+                    return FormatPolledRoundResult(node!, flowRunId);
+            }
+            await Task.Delay(PollInterval);
+        }
+
+        return $"Review still running for flow_run_id {flowRunId} (round {roundNumber}). " +
+               "Call get_review_flow_status to retrieve the result when ready.";
+    }
+
+    /// <summary>Formats the terminal GET /api/flows/{id} response into the same envelope+text as FormatRoundResponse.</summary>
+    static string FormatPolledRoundResult(JsonObject node, string flowRunId) {
+        var roundNumber = node["round_number"]?.GetValue<int>();
+        var resultKind  = node["round_result_kind"]?.GetValue<string>() ?? node["round_status"]?.GetValue<string>() ?? "";
+        var resultText  = node["round_result_text"]?.GetValue<string>();
+
+        var sb = new StringBuilder();
+        sb.Append("flow_run_id: "); AppendLine(sb, flowRunId);
+        if (roundNumber.HasValue) { sb.Append("round_number: "); sb.AppendLine(roundNumber.Value.ToString()); }
+        sb.Append("status: ");      AppendLine(sb, node["status"]?.GetValue<string>() ?? "");
+        sb.Append("result_kind: "); AppendLine(sb, resultKind);
+        if (!string.IsNullOrEmpty(resultText)) { sb.AppendLine(); sb.Append(resultText); }
+        return sb.ToString();
     }
 
     /// <summary>
@@ -356,7 +462,7 @@ static class McpFlowsServer {
     static McpTool[] BuildToolsList() => [
         new(
             "start_review_flow",
-            "Start a new review flow. The server starts an AI reviewer agent that will analyse the target and return findings. " +
+            "Start a new review flow. Returns findings (same UX); the server runs the reviewer asynchronously and the CLI polls internally. " +
             "Returns a flow_run_id that identifies this review session — save it to call submit_review_round or get_review_flow_status later.",
             new(
                 "object",
@@ -374,7 +480,7 @@ static class McpFlowsServer {
         ),
         new(
             "submit_review_round",
-            "Submit a follow-up round to an existing review flow. Use this to ask for clarifications, provide additional context, or request a re-review after addressing feedback. Returns the new round's findings.",
+            "Submit a follow-up round to an existing review flow. Returns findings (same UX); the server runs the reviewer asynchronously and the CLI polls internally. Use this to ask for clarifications, provide additional context, or request a re-review after addressing feedback.",
             new(
                 "object",
                 new() {
@@ -425,11 +531,13 @@ record StartReviewFlowDto(
     [property: JsonPropertyName("repo_name")]              string? RepoName,
     [property: JsonPropertyName("daemon_name")]            string? DaemonName,
     [property: JsonPropertyName("repo_path")]              string? RepoPath,
-    [property: JsonPropertyName("mode")]                   string? Mode
+    [property: JsonPropertyName("mode")]                   string? Mode,
+    [property: JsonPropertyName("async")]                  bool    Async
 );
 
 /// <summary>CLI-side DTO for POST /api/flows/{flowRunId}/rounds — mirrors the server's SubmitReviewRoundRequest.</summary>
 record SubmitReviewRoundDto(
     [property: JsonPropertyName("context")]      string  Context,
-    [property: JsonPropertyName("instructions")] string? Instructions
+    [property: JsonPropertyName("instructions")] string? Instructions,
+    [property: JsonPropertyName("async")]        bool    Async
 );

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -107,8 +107,8 @@ static class McpFlowsServer {
                 if (!postResponse.IsSuccessStatusCode)
                     return BuildToolResult(id, $"Error: HTTP {(int)postResponse.StatusCode} — {postBody}", isError: true);
 
-                var payload = await ResolveRoundResultAsync(client, apiRoot, postBody);
-                return BuildToolResult(id, payload);
+                var (payload, isError) = await ResolveRoundResultAsync(client, apiRoot, postBody);
+                return BuildToolResult(id, payload, isError);
             }
 
             using var httpResponse = toolName switch {
@@ -247,24 +247,34 @@ static class McpFlowsServer {
     static readonly HashSet<string> TerminalRoundStatuses =
         new(StringComparer.Ordinal) { "findings", "clean", "waiting", "unclear", "failed", "cancelled" };
 
+    // Structured result from the poll path so callers can propagate isError correctly.
+    record PollResult(string Payload, bool IsError);
+
+    // Maximum consecutive transient failures (5xx / network / TLS) before giving up.
+    const int MaxTransientRetries = 5;
+
     /// <summary>If the POST already carries a terminal result (old/blocking server), return it.
     /// Otherwise poll GET /api/flows/{id} until the started round is terminal (AI-1061).</summary>
-    static async Task<string> ResolveRoundResultAsync(HttpClient client, string apiRoot, string postBody) {
+    static async Task<PollResult> ResolveRoundResultAsync(HttpClient client, string apiRoot, string postBody) {
         var node      = JsonNode.Parse(postBody)?.AsObject();
         var status    = node?["status"]?.GetValue<string>();
         var flowRunId = node?["flow_run_id"]?.GetValue<string>();
         var roundNum  = node?["round_number"]?.GetValue<int>();
 
         if (status != "running" || flowRunId is null || roundNum is null)
-            return FormatRoundResponse(postBody); // terminal-in-POST (old server) or unparseable
+            return new(FormatRoundResponse(postBody), false); // terminal-in-POST (old server) or unparseable
 
         return await PollUntilTerminalAsync(client, apiRoot, flowRunId, roundNum.Value);
     }
 
-    static async Task<string> PollUntilTerminalAsync(HttpClient client, string apiRoot, string flowRunId, int roundNumber) {
-        var url      = $"{apiRoot}/api/flows/{Uri.EscapeDataString(flowRunId)}";
-        var deadline = DateTimeOffset.UtcNow + PollCap;
-        var firstSeenNotFound = (DateTimeOffset?)null;
+    static async Task<PollResult> PollUntilTerminalAsync(HttpClient client, string apiRoot, string flowRunId, int roundNumber) {
+        var url                   = $"{apiRoot}/api/flows/{Uri.EscapeDataString(flowRunId)}";
+        var pollStartedAt         = DateTimeOffset.UtcNow;
+        var deadline              = pollStartedAt + PollCap;
+        // Fix #3: anchor the 404 grace window to poll start, not to first-seen-404.
+        var notFoundGraceDeadline = pollStartedAt + NotFoundGrace;
+        var consecutiveTransient  = 0;
+        var lastTransientError    = (string?)null;
 
         while (DateTimeOffset.UtcNow < deadline) {
             using var getCts = new CancellationTokenSource(PerGetTimeout);
@@ -272,45 +282,73 @@ static class McpFlowsServer {
             try {
                 resp = await SendWithRefreshRetryAsync(client, c => c.GetAsync(url, getCts.Token));
             } catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException) {
-                await Task.Delay(PollInterval); continue; // transient — retry within cap
+                // Fix #4: count network/TLS/timeout as transient; stop after budget.
+                consecutiveTransient++;
+                lastTransientError = ex.Message;
+                if (consecutiveTransient > MaxTransientRetries)
+                    return new($"Error: poll failed after {MaxTransientRetries} consecutive network errors: {lastTransientError}", true);
+                await Task.Delay(PollInterval); continue;
             }
 
             using (resp) {
                 if (resp.StatusCode == HttpStatusCode.NotFound) {
-                    firstSeenNotFound ??= DateTimeOffset.UtcNow;
-                    if (DateTimeOffset.UtcNow - firstSeenNotFound > NotFoundGrace)
-                        return $"Error: flow_run_id {flowRunId} not found.";
+                    // Fix #3: 404 only gets the grace window anchored to poll start.
+                    if (DateTimeOffset.UtcNow > notFoundGraceDeadline)
+                        return new($"Error: flow_run_id {flowRunId} not found.", true);
                     await Task.Delay(PollInterval); continue;
                 }
+
                 if (resp.StatusCode == HttpStatusCode.Unauthorized)
-                    return "Not logged in. Run 'kcap login' on the host shell.";
+                    return new("Not logged in. Run 'kcap login' on the host shell.", true);
 
-                var body = await resp.Content.ReadAsStringAsync();
-                if (!resp.IsSuccessStatusCode) { await Task.Delay(PollInterval); continue; }
+                // Fix #4: non-transient 4xx (e.g. 400, 403) fail immediately.
+                var statusCode = (int)resp.StatusCode;
+                if (statusCode is >= 400 and < 500) {
+                    var errBody = await resp.Content.ReadAsStringAsync();
+                    return new($"Error: HTTP {statusCode} — {errBody}", true);
+                }
 
-                var node     = JsonNode.Parse(body)?.AsObject();
-                var rn       = node?["round_number"]?.GetValue<int>();
-                var rs       = node?["round_status"]?.GetValue<string>();
+                // Fix #4: 5xx / other non-success counts toward the transient budget.
+                if (!resp.IsSuccessStatusCode) {
+                    consecutiveTransient++;
+                    lastTransientError = $"HTTP {statusCode}";
+                    if (consecutiveTransient > MaxTransientRetries)
+                        return new($"Error: poll failed after {MaxTransientRetries} consecutive server errors: {lastTransientError}", true);
+                    await Task.Delay(PollInterval); continue;
+                }
+
+                // Successful response — reset transient counter.
+                consecutiveTransient = 0;
+                lastTransientError   = null;
+
+                var body      = await resp.Content.ReadAsStringAsync();
+                var node      = JsonNode.Parse(body)?.AsObject();
+                var rn        = node?["round_number"]?.GetValue<int>();
+                var rs        = node?["round_status"]?.GetValue<string>();
                 var runStatus = node?["status"]?.GetValue<string>();
 
-                // If the run-level status is terminal, stop regardless of round status
-                // (guards against a run that failed with an in-flight round left at "running").
+                // Fix #1: run-level terminal stops the loop, but only return round result
+                // when the projected round matches the one we submitted.
                 if (runStatus is "closed" or "failed") {
-                    if (rn == roundNumber && rs is not null)
-                        return FormatPolledRoundResult(node!, flowRunId);
-                    // Run terminal but round not matching yet — return what we have
-                    return FormatPolledRoundResult(node!, flowRunId);
+                    if (rn == roundNumber && rs is not null && TerminalRoundStatuses.Contains(rs))
+                        return new(FormatPolledRoundResult(node!, flowRunId), false);
+                    // Run became terminal before our round produced a result — explicit error.
+                    return new($"Error: review run {runStatus} before round {roundNumber} produced a result.", true);
                 }
 
                 // Only act on OUR round; an earlier projection may still show a prior round.
                 if (rn == roundNumber && rs is not null && TerminalRoundStatuses.Contains(rs))
-                    return FormatPolledRoundResult(node!, flowRunId);
+                    return new(FormatPolledRoundResult(node!, flowRunId), false);
             }
             await Task.Delay(PollInterval);
         }
 
-        return $"Review still running for flow_run_id {flowRunId} (round {roundNumber}). " +
-               "Call get_review_flow_status to retrieve the result when ready.";
+        // Genuine 8-min cap: round still legitimately running.
+        return new(
+            $"Review still running for flow_run_id {flowRunId} (round {roundNumber}). " +
+            "Call get_review_flow_status to retrieve the result when ready.",
+            false
+        );
     }
 
     /// <summary>Formats the terminal GET /api/flows/{id} response into the same envelope+text as FormatRoundResponse.</summary>

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -529,6 +529,63 @@ public class McpFlowsServerTests : IDisposable {
         }
     }
 
+    [Test]
+    public async Task Start_review_flow_async_polls_until_terminal_findings() {
+        const string flowRunId = "flow-poll-1";
+        const string scenario  = "poll";
+
+        // POST returns running + round_number 1.
+        _server.Given(Request.Create().WithPath("/api/flows/review/start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type","application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","round_id":"r1","round_number":1,"status":"running","result_kind":null,"result_text":null,"reviewer_agent_id":"a1","reviewer_session_id":"s1"}"""));
+
+        // GET #1: still running. GET #2: terminal findings.
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet())
+            .InScenario(scenario).WillSetStateTo("seen-once")
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type","application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","definition_id":"spec-review","status":"running","target_title":"t","round_count":1,"round_number":1,"round_status":"running","round_result_kind":null,"round_result_text":null}"""));
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet())
+            .InScenario(scenario).WhenStateIs("seen-once")
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type","application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","definition_id":"spec-review","status":"findings","target_title":"t","round_count":1,"round_number":1,"round_status":"findings","round_result_kind":"findings","round_result_text":"FINDINGS:\n- P1"}"""));
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["kind"]="spec-review", ["target_kind"]="spec", ["target_ref"]="r",
+                ["target_title"]="t", ["context"]="please review"
+            };
+            var response = await SendRequest(proc, ToolsCallRequest(20, "start_review_flow", args), TimeSpan.FromSeconds(30));
+            var text = response["result"]?["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text!.Contains("FINDINGS:")).IsTrue();
+            await Assert.That(text.Contains("result_kind: findings")).IsTrue();
+
+            // The POST carried async:true.
+            var postBody = JsonNode.Parse(_server.FindLogEntries(Request.Create().WithPath("/api/flows/review/start").UsingPost())[0].RequestMessage.Body ?? "")?.AsObject();
+            await Assert.That(postBody!["async"]?.GetValue<bool>()).IsTrue();
+            // At least 2 GETs (running then terminal).
+            await Assert.That(_server.FindLogEntries(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet()).Count >= 2).IsTrue();
+        } finally { await ShutdownAsync(proc); }
+    }
+
+    [Test]
+    public async Task Start_review_flow_uses_terminal_result_from_post_without_polling() {
+        const string flowRunId = "flow-old-server";
+        _server.Given(Request.Create().WithPath("/api/flows/review/start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type","application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","round_id":"r1","round_number":1,"status":"completed","result_kind":"FINDINGS","result_text":"## done","reviewer_agent_id":null,"reviewer_session_id":null}"""));
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject { ["kind"]="spec-review", ["target_kind"]="spec", ["target_ref"]="r", ["target_title"]="t", ["context"]="c" };
+            var response = await SendRequest(proc, ToolsCallRequest(21, "start_review_flow", args));
+            var text = response["result"]?["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text!.Contains("## done")).IsTrue();
+            // No GET polling happened (status was already terminal).
+            await Assert.That(_server.FindLogEntries(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet()).Count).IsEqualTo(0);
+        } finally { await ShutdownAsync(proc); }
+    }
+
     /// <summary>
     /// Writes a non-expired token to the per-test config dir's token store so the
     /// CLI's <c>HttpClientExtensions.CreateAuthenticatedClientAsync</c> attaches a

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -549,7 +549,7 @@ public class McpFlowsServerTests : IDisposable {
             await Assert.That(text.Contains("result_kind: findings")).IsTrue();
 
             // Exactly 2 GETs: the 500 and then the terminal 200.
-            await Assert.That(_server.FindLogEntries(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet()).Count >= 2).IsTrue();
+            await Assert.That(_server.FindLogEntries(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet()).Count).IsEqualTo(2);
         } finally { await ShutdownAsync(proc); }
     }
 
@@ -585,7 +585,12 @@ public class McpFlowsServerTests : IDisposable {
             var result = response["result"]?.AsObject();
             await Assert.That(result).IsNotNull();
             // The tool should return a result (not an MCP error) — we got a formatted envelope back.
-            await Assert.That(result!["content"]?[0]?["text"]?.GetValue<string>()).IsNotNull();
+            var text = result!["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            // Verify the response is the polled-round envelope (contains flow_run_id),
+            // not the graceful-cap message ("Review still running").
+            await Assert.That(text!.Contains("flow_run_id:")).IsTrue();
+            await Assert.That(text.Contains("Review still running")).IsFalse();
         } finally { await ShutdownAsync(proc); }
     }
 

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -508,6 +508,95 @@ public class McpFlowsServerTests : IDisposable {
         }
     }
 
+    /// <summary>
+    /// Transient-retry (a): if the GET for a running round returns HTTP 500 once
+    /// and then 200 with a terminal result, the poll should survive the transient
+    /// error and return the terminal result. Guards PollUntilTerminalAsync's
+    /// !IsSuccessStatusCode → continue branch.
+    /// </summary>
+    [Test]
+    public async Task Start_review_flow_async_survives_transient_500_on_poll() {
+        const string flowRunId = "flow-retry-500";
+        const string scenario  = "retry-500";
+
+        // POST returns running.
+        _server.Given(Request.Create().WithPath("/api/flows/review/start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type","application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","round_id":"r1","round_number":1,"status":"running","result_kind":null,"result_text":null,"reviewer_agent_id":"a1","reviewer_session_id":"s1"}"""));
+
+        // GET #1: 500 (transient). GET #2: terminal findings.
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet())
+            .InScenario(scenario).WillSetStateTo("after-500")
+            .RespondWith(Response.Create().WithStatusCode(500).WithBody("Internal Server Error"));
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet())
+            .InScenario(scenario).WhenStateIs("after-500")
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type","application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","definition_id":"spec-review","status":"findings","target_title":"t","round_count":1,"round_number":1,"round_status":"findings","round_result_kind":"findings","round_result_text":"FINDINGS:\n- P1"}"""));
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["kind"]="spec-review", ["target_kind"]="spec", ["target_ref"]="r",
+                ["target_title"]="t", ["context"]="please review"
+            };
+            var response = await SendRequest(proc, ToolsCallRequest(30, "start_review_flow", args), TimeSpan.FromSeconds(30));
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
+
+            var text = response["result"]?["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text!.Contains("FINDINGS:")).IsTrue();
+            await Assert.That(text.Contains("result_kind: findings")).IsTrue();
+
+            // Exactly 2 GETs: the 500 and then the terminal 200.
+            await Assert.That(_server.FindLogEntries(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet()).Count >= 2).IsTrue();
+        } finally { await ShutdownAsync(proc); }
+    }
+
+    /// <summary>
+    /// Run-terminal stop (c): if the GET returns a run-level <c>status: "failed"</c>
+    /// while <c>round_status</c> is still "running", the poll must stop immediately
+    /// (not hang until the 8-min cap) and return a result. Guards the run-terminal
+    /// early-exit branch in PollUntilTerminalAsync.
+    /// </summary>
+    [Test]
+    public async Task Start_review_flow_async_stops_when_run_level_fails() {
+        const string flowRunId = "flow-run-failed";
+
+        // POST returns running.
+        _server.Given(Request.Create().WithPath("/api/flows/review/start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type","application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","round_id":"r1","round_number":1,"status":"running","result_kind":null,"result_text":null,"reviewer_agent_id":"a1","reviewer_session_id":"s1"}"""));
+
+        // GET always returns run-level "failed" (round_status still "running").
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type","application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","definition_id":"spec-review","status":"failed","target_title":"t","round_count":1,"round_number":1,"round_status":"running","round_result_kind":null,"round_result_text":null}"""));
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["kind"]="spec-review", ["target_kind"]="spec", ["target_ref"]="r",
+                ["target_title"]="t", ["context"]="please review"
+            };
+            // This must resolve quickly (run-terminal path exits on first "failed" GET),
+            // well within 15 s (compared to the 8-min cap if we polled indefinitely).
+            var response = await SendRequest(proc, ToolsCallRequest(31, "start_review_flow", args), TimeSpan.FromSeconds(15));
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            // The tool should return a result (not an MCP error) — we got a formatted envelope back.
+            await Assert.That(result!["content"]?[0]?["text"]?.GetValue<string>()).IsNotNull();
+        } finally { await ShutdownAsync(proc); }
+    }
+
+    // NOTE: graceful-cap behaviour (poll exceeds 8-min PollCap → returns
+    // "Review still running … call get_review_flow_status" message) is exercised
+    // manually only. The 8-min cap has no injectable test seam in the current
+    // McpFlowsServer implementation, so a CI test would either run for 8 minutes
+    // (unacceptable) or require source changes out of scope for this task.
+    // Manual e2e: start a flow against a server that never completes the round,
+    // wait 8 min, assert the graceful-cap message appears in the MCP tool output.
+
     [Test]
     public async Task Submit_review_round_without_flow_run_id_returns_error() {
         using var proc = SpawnMcpServer();

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -555,9 +555,10 @@ public class McpFlowsServerTests : IDisposable {
 
     /// <summary>
     /// Run-terminal stop (c): if the GET returns a run-level <c>status: "failed"</c>
-    /// while <c>round_status</c> is still "running", the poll must stop immediately
-    /// (not hang until the 8-min cap) and return a result. Guards the run-terminal
-    /// early-exit branch in PollUntilTerminalAsync.
+    /// while <c>round_status</c> is still "running" (round didn't produce a result),
+    /// the poll must stop immediately (not hang until the 8-min cap) and return an
+    /// explicit isError:true result — NOT "Review still running" and NOT a partial envelope.
+    /// Guards the run-terminal early-exit + Finding #1 (no stale data) in PollUntilTerminalAsync.
     /// </summary>
     [Test]
     public async Task Start_review_flow_async_stops_when_run_level_fails() {
@@ -568,7 +569,7 @@ public class McpFlowsServerTests : IDisposable {
             .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type","application/json")
                 .WithBody($$"""{"flow_run_id":"{{flowRunId}}","round_id":"r1","round_number":1,"status":"running","result_kind":null,"result_text":null,"reviewer_agent_id":"a1","reviewer_session_id":"s1"}"""));
 
-        // GET always returns run-level "failed" (round_status still "running").
+        // GET always returns run-level "failed" (round_status still "running" — no terminal result).
         _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type","application/json")
                 .WithBody($$"""{"flow_run_id":"{{flowRunId}}","definition_id":"spec-review","status":"failed","target_title":"t","round_count":1,"round_number":1,"round_status":"running","round_result_kind":null,"round_result_text":null}"""));
@@ -584,13 +585,13 @@ public class McpFlowsServerTests : IDisposable {
             var response = await SendRequest(proc, ToolsCallRequest(31, "start_review_flow", args), TimeSpan.FromSeconds(15));
             var result = response["result"]?.AsObject();
             await Assert.That(result).IsNotNull();
-            // The tool should return a result (not an MCP error) — we got a formatted envelope back.
             var text = result!["content"]?[0]?["text"]?.GetValue<string>();
             await Assert.That(text).IsNotNull();
-            // Verify the response is the polled-round envelope (contains flow_run_id),
-            // not the graceful-cap message ("Review still running").
-            await Assert.That(text!.Contains("flow_run_id:")).IsTrue();
-            await Assert.That(text.Contains("Review still running")).IsFalse();
+            // Fix #1: run failed without producing a terminal round — must be isError:true,
+            // must NOT be the graceful-cap message, must mention "failed".
+            await Assert.That(result["isError"]?.GetValue<bool>()).IsTrue();
+            await Assert.That(text!.Contains("Review still running")).IsFalse();
+            await Assert.That(text.Contains("failed")).IsTrue();
         } finally { await ShutdownAsync(proc); }
     }
 
@@ -601,6 +602,188 @@ public class McpFlowsServerTests : IDisposable {
     // (unacceptable) or require source changes out of scope for this task.
     // Manual e2e: start a flow against a server that never completes the round,
     // wait 8 min, assert the graceful-cap message appears in the MCP tool output.
+
+    /// <summary>
+    /// Finding #1: when run-level status is "failed" but the projected round_number doesn't match
+    /// the round we submitted (e.g. projection still shows prior round 1 when we submitted round 2),
+    /// the result MUST be an explicit run-failed error (isError:true), NOT the prior round's findings.
+    /// </summary>
+    [Test]
+    public async Task Run_failed_before_requested_round_returns_explicit_error_not_stale_findings() {
+        const string flowRunId = "flow-run-failed-stale";
+
+        // POST submits round 2.
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}/rounds").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","round_id":"r2","round_number":2,"status":"running","result_kind":null,"result_text":null,"reviewer_agent_id":"a1","reviewer_session_id":"s1"}"""));
+
+        // GET returns run-level "failed" but still shows round 1's findings (stale projection).
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","definition_id":"spec-review","status":"failed","target_title":"t","round_count":2,"round_number":1,"round_status":"findings","round_result_kind":"findings","round_result_text":"FINDINGS:\n- Round 1 stale data"}"""));
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["flow_run_id"] = flowRunId,
+                ["context"]     = "Re-review after fixes."
+            };
+            var response = await SendRequest(proc, ToolsCallRequest(40, "submit_review_round", args), TimeSpan.FromSeconds(15));
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+
+            // Must be an error result (isError:true), NOT the prior round's findings.
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsTrue();
+
+            var text = result["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            // Must NOT contain the stale round 1 findings text.
+            await Assert.That(text!.Contains("Round 1 stale data")).IsFalse();
+            // Must contain an explicit failure message for round 2.
+            await Assert.That(text.Contains("failed")).IsTrue();
+            await Assert.That(text.Contains('2')).IsTrue(); // round number mentioned
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
+    /// Finding #2 + #4: persistent 500 on every GET exhausts the transient-retry budget and
+    /// returns isError:true well before the 8-min cap. The result must NOT be "Review still running"
+    /// (which is only for genuine running-at-cap). Budget is 5 consecutive transient failures.
+    /// </summary>
+    [Test]
+    public async Task Persistent_500_exhausts_retry_budget_and_returns_isError() {
+        const string flowRunId = "flow-persistent-500";
+
+        // POST returns running.
+        _server.Given(Request.Create().WithPath("/api/flows/review/start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","round_id":"r1","round_number":1,"status":"running","result_kind":null,"result_text":null,"reviewer_agent_id":"a1","reviewer_session_id":"s1"}"""));
+
+        // Every GET returns 500.
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(500).WithBody("Internal Server Error"));
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["kind"] = "spec-review", ["target_kind"] = "spec", ["target_ref"] = "r",
+                ["target_title"] = "t", ["context"] = "please review"
+            };
+            // Must complete well before 8 min (expect ~20-30s for 6 GETs at 3s poll + budget logic).
+            var response = await SendRequest(proc, ToolsCallRequest(41, "start_review_flow", args), TimeSpan.FromSeconds(60));
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+
+            // Must be an error (isError:true), NOT "Review still running" graceful cap.
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsTrue();
+
+            var text = result["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            await Assert.That(text!.Contains("Review still running")).IsFalse();
+            await Assert.That(text.Contains("Error:")).IsTrue();
+
+            // Should have hit exactly MaxTransientRetries + 1 GETs before giving up.
+            var getCount = _server.FindLogEntries(
+                Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet()
+            ).Count;
+            // Budget is 5; 6th failure (index 5) triggers the error return.
+            await Assert.That(getCount).IsEqualTo(6);
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
+    /// Finding #2 + #4: non-transient 403 on GET returns immediate isError:true with no retry.
+    /// Similarly for 400. These are non-transient 4xx errors that must fail immediately.
+    /// </summary>
+    [Test]
+    public async Task Non_transient_403_on_poll_returns_immediate_isError() {
+        const string flowRunId = "flow-403";
+
+        // POST returns running.
+        _server.Given(Request.Create().WithPath("/api/flows/review/start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","round_id":"r1","round_number":1,"status":"running","result_kind":null,"result_text":null,"reviewer_agent_id":"a1","reviewer_session_id":"s1"}"""));
+
+        // GET returns 403 (non-transient 4xx, not 401 which has refresh-retry logic).
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(403).WithBody("Forbidden"));
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["kind"] = "spec-review", ["target_kind"] = "spec", ["target_ref"] = "r",
+                ["target_title"] = "t", ["context"] = "please review"
+            };
+            // Must complete almost immediately (no retry, no delay loop for 4xx).
+            var response = await SendRequest(proc, ToolsCallRequest(42, "start_review_flow", args), TimeSpan.FromSeconds(15));
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsTrue();
+
+            var text = result["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            await Assert.That(text!.Contains("403")).IsTrue();
+
+            // Exactly 1 GET (immediate fail on first 403, no retry).
+            var getCount = _server.FindLogEntries(
+                Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet()
+            ).Count;
+            await Assert.That(getCount).IsEqualTo(1);
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
+    /// Finding #3: 404 that occurs after the grace deadline (anchored to poll start)
+    /// must return isError:true. The key invariant is that grace is relative to when
+    /// polling began, not when the first 404 was observed.
+    ///
+    /// Since NotFoundGrace = 10s and PollInterval = 3s, we stub every GET as 404
+    /// and wait long enough for the grace deadline to pass (> 10s). The poll must
+    /// give up before the 8-min cap.
+    /// </summary>
+    [Test]
+    public async Task NotFound_past_grace_deadline_returns_isError() {
+        const string flowRunId = "flow-404-grace";
+
+        // POST returns running.
+        _server.Given(Request.Create().WithPath("/api/flows/review/start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json")
+                .WithBody($$"""{"flow_run_id":"{{flowRunId}}","round_id":"r1","round_number":1,"status":"running","result_kind":null,"result_text":null,"reviewer_agent_id":"a1","reviewer_session_id":"s1"}"""));
+
+        // Every GET returns 404 indefinitely.
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404).WithBody("Not Found"));
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["kind"] = "spec-review", ["target_kind"] = "spec", ["target_ref"] = "r",
+                ["target_title"] = "t", ["context"] = "please review"
+            };
+            // NotFoundGrace = 10s, PollInterval = 3s → should fail within ~15s (grace + one more poll).
+            // Allow 30s to be safe.
+            var response = await SendRequest(proc, ToolsCallRequest(43, "start_review_flow", args), TimeSpan.FromSeconds(30));
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsTrue();
+
+            var text = result["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            await Assert.That(text!.Contains("not found")).IsTrue();
+            // Must NOT be the 8-min graceful cap message.
+            await Assert.That(text.Contains("Review still running")).IsFalse();
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
 
     [Test]
     public async Task Submit_review_round_without_flow_run_id_returns_error() {


### PR DESCRIPTION
## Problem
The `kcap mcp flows` MCP server called the long-blocking `/api/flows/review/start` with the default `HttpClient.Timeout` (**100s**), so any real review aborted at 100s and the server tore the reviewer down (~2 min). Even with that fixed, the server's synchronous long-poll hits **Cloudflare's ~100s 524** behind `kurrent.kcap.ai`. (See [AI-1061](https://linear.app/kurrent/issue/AI-1061).)

## Fix (CLI side)
1. **Infinite client timeout** on the flows client (so a blocking / self-hosted / non-Cloudflare server can complete) — mirrors `PermissionRequestCommand` / `CodexHookCommand`.
2. **Opt-in async + poll** (pairs with the server async rework in kcap-server #881): `start`/`submit` send `async:true`; if the POST returns a terminal result (old/blocking server) it's used directly (no poll); otherwise the CLI **polls `GET /api/flows/{id}`** keyed on `round_number` until the round is terminal, then returns the same findings text. Each poll GET uses its own **short timeout** (while the POST stays infinite), the **401-refresh** wrapper, bounded transient retry, a ~10s **404 grace**, an ~8-min **graceful cap** ("still running…"), and **stops on a terminal run status** (can't hang on a failed run).

MCP tool names/arguments and the `FINDINGS:`/`NO FINDINGS` UX are unchanged. The `async` flag makes this backward-compatible: old CLI ↔ new server keeps blocking behavior, so **deploy order is unconstrained**.

## Verification
`McpFlowsServerTests` 12/0 (incl. async-polls-until-findings, terminal-result-from-POST-no-poll, transient-500-retry, run-terminal-stop). AOT publish: **no IL2xxx/IL3xxx warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)