### PR TITLE
docs: document GitHub issue + Linear auto-import PR workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,13 @@ Always verify no IL3050/IL2026 AOT warnings after changes:
 dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
 ```
 
+## Issues and pull requests
+
+This is a public repository — we develop in the open.
+
+- **Open issues in GitHub Issues**, not Linear. Linear auto-imports GitHub issues, so there is no need to create the issue in Linear by hand.
+- **PRs must reference both the Linear issue and the GitHub issue.** Put these references in the PR *description*, not the title (the title stays clean and human-readable). Reference the GitHub issue with a closing keyword (e.g. `Closes #123`) and include the Linear issue (e.g. `AI-774`) so Linear links the PR back to the imported issue.
+
 ## Common mistakes to avoid
 
 - **AOT warnings only show on publish** — `dotnet build` does NOT surface IL3050/IL2026 trimming warnings. Run `dotnet publish -c Release` after changes.


### PR DESCRIPTION
## Summary

Adds an **Issues and pull requests** section to `CLAUDE.md` to document how we manage issues and PRs now that this is a public repo we develop in the open:

- Open issues in **GitHub Issues** — Linear auto-imports them, so there's no need to create the issue in Linear by hand.
- PRs reference **both** the Linear issue and the GitHub issue in the **description** (not the title), so the title stays clean and Linear links the PR back to the imported issue.

Documentation-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)