### PR TITLE
Fix watcher self-kill: resolve agent PID by exec path, not process title

### DIFF
--- a/src/Capacitor.Cli/ProcessHelpers.cs
+++ b/src/Capacitor.Cli/ProcessHelpers.cs
@@ -32,12 +32,24 @@ static partial class ProcessHelpers {
     private static partial int setsid_native();
 
     // macOS: proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, sizeof(info)) fills a
-    // proc_bsdinfo struct. We read only pbi_ppid (offset 16) and pbi_name (offset
-    // 64, 32 bytes) out of the 136-byte struct, so no struct marshalling is needed.
+    // proc_bsdinfo struct. We read pbi_ppid (offset 16) for the parent PID and only
+    // FALL BACK to pbi_name (offset 64, 32 bytes) for the process name — the primary
+    // name source is the exec path from KERN_PROCARGS2 (see ReadExecPathMac), because
+    // both pbi_comm and pbi_name carry the mutable process *title*, which a node-based
+    // agent (Claude Code) sets to its version string ("2.1.196"), not "claude".
     [LibraryImport("libproc", EntryPoint = "proc_pidinfo")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static unsafe partial int proc_pidinfo(int pid, int flavor, ulong arg, byte* buffer, int buffersize);
 
+    // sysctl({CTL_KERN, KERN_PROCARGS2, pid}) returns argc + the kernel's recorded
+    // executable path + argv + env for a process. The exec path is immune to a process
+    // changing its title, so it is the reliable name source for the agent ancestry walk.
+    [LibraryImport("libc", EntryPoint = "sysctl", SetLastError = true)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static unsafe partial int sysctl(int* name, uint namelen, byte* oldp, nuint* oldlenp, byte* newp, nuint newlen);
+
+    const int CtlKern          = 1;
+    const int KernProcArgs2    = 49;
     const int ProcPidTBsdInfo  = 3;
     const int ProcBsdInfoSize  = 136;
     const int ProcBsdInfoPpid  = 16;
@@ -425,11 +437,73 @@ static partial class ProcessHelpers {
 
         var ppid = BitConverter.ToInt32(buf.Slice(ProcBsdInfoPpid, sizeof(int)));
 
-        var nameSpan = buf.Slice(ProcBsdInfoName, 32);
-        var nul      = nameSpan.IndexOf((byte)0);
-        var comm     = Encoding.UTF8.GetString(nul >= 0 ? nameSpan[..nul] : nameSpan);
+        // Take the name from the executable path, NOT proc_bsdinfo's name fields: a
+        // node-based agent (Claude Code) calls setproctitle with its version string,
+        // which overwrites BOTH pbi_comm and pbi_name (they read "2.1.196", never
+        // "claude"), so the ancestry walk would miss the durable agent and the
+        // parent-PID watchdog would fall back to the transient hook process-group
+        // leader — killing the watcher mid-session. The kernel's recorded exec path
+        // is unaffected by a title change. Fall back to pbi_name only when the exec
+        // path is unreadable (e.g. a zombie or a permission-restricted process).
+        var comm = ReadExecPathMac(pid);
+
+        if (string.IsNullOrEmpty(comm)) {
+            var nameSpan = buf.Slice(ProcBsdInfoName, 32);
+            var nul      = nameSpan.IndexOf((byte)0);
+            comm = Encoding.UTF8.GetString(nul >= 0 ? nameSpan[..nul] : nameSpan);
+        }
 
         return (ppid, comm);
+    }
+
+    /// <summary>
+    /// Returns the executable path of <paramref name="pid"/> via the
+    /// <c>KERN_PROCARGS2</c> sysctl — the same source <c>ps</c> uses — or null if it
+    /// can't be read. Unlike <c>proc_bsdinfo</c>'s name fields, the exec path is the
+    /// kernel's recorded image path and is not affected by a process changing its
+    /// title, so it reliably identifies the coding agent for the ancestry walk.
+    /// </summary>
+    static unsafe string? ReadExecPathMac(int pid) {
+        Span<int> mib = [CtlKern, KernProcArgs2, pid];
+        nuint     size = 0;
+
+        fixed (int* m = mib) {
+            // First call (oldp = null) reports the buffer size to allocate. The buffer
+            // holds argc + exec_path + argv + env, so it can't be guessed up front.
+            if (sysctl(m, 3, null, &size, null, 0) != 0 || size == 0) {
+                return null;
+            }
+
+            var buf = new byte[size];
+
+            fixed (byte* b = buf) {
+                // Reuse the same `size` as the buffer length; a short buffer would make
+                // sysctl fail with ENOMEM rather than truncate, so we'd just fall back.
+                if (sysctl(m, 3, b, &size, null, 0) != 0) {
+                    return null;
+                }
+            }
+
+            return ParseExecPath(buf.AsSpan(0, (int)size));
+        }
+    }
+
+    /// <summary>
+    /// Extracts the executable path from a <c>KERN_PROCARGS2</c> buffer: a 4-byte
+    /// <c>argc</c> followed by the NUL-terminated exec path string. Pure so the
+    /// parsing is unit-testable with a synthetic buffer. Returns null when the buffer
+    /// is too short to contain the path or the path is empty.
+    /// </summary>
+    internal static string? ParseExecPath(ReadOnlySpan<byte> procArgs2) {
+        if (procArgs2.Length <= sizeof(int)) {
+            return null;
+        }
+
+        var rest = procArgs2[sizeof(int)..]; // skip the leading argc
+        var nul  = rest.IndexOf((byte)0);
+        var path = nul >= 0 ? rest[..nul] : rest;
+
+        return path.IsEmpty ? null : Encoding.UTF8.GetString(path);
     }
 
     static (int ppid, string comm)? GetProcessInfoLinux(int pid) {
@@ -451,10 +525,33 @@ static partial class ProcessHelpers {
             return null;
         }
 
-        var comm = stat.Substring(open + 1, close - open - 1);
-        var rest = stat[(close + 1)..].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var statComm = stat.Substring(open + 1, close - open - 1);
+        var rest     = stat[(close + 1)..].Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
-        return rest.Length >= 2 && int.TryParse(rest[1], out var ppid) ? (ppid, comm) : null;
+        if (rest.Length < 2 || !int.TryParse(rest[1], out var ppid)) {
+            return null;
+        }
+
+        // Prefer the executable basename from /proc/<pid>/exe over the stat comm for the
+        // same reason as macOS (see GetProcessInfoMac): node's process.title support
+        // prctl(PR_SET_NAME)s the stat comm to the agent's version string, so a node-
+        // based agent's stat comm reads "2.1.196" rather than "claude". The /exe symlink
+        // is maintained by the kernel and a title change can't touch it. Falls back to
+        // the stat comm when the link is unreadable (kernel threads, permissions), so
+        // this can only improve resolution, never regress it. Note: when the agent is
+        // launched as `node <script>` (rather than a packaged binary) the link resolves
+        // to "node"; that case still relies on the legacy fallback.
+        string comm = statComm;
+
+        try {
+            if (File.ResolveLinkTarget($"/proc/{pid}/exe", returnFinalTarget: false)?.Name is { Length: > 0 } exeName) {
+                comm = exeName;
+            }
+        } catch {
+            // Best effort — keep the stat comm.
+        }
+
+        return (ppid, comm);
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/CodingAgentPidResolverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodingAgentPidResolverTests.cs
@@ -49,6 +49,28 @@ public class CodingAgentPidResolverTests {
     }
 
     [Test]
+    public async Task Skips_the_npm_node_shim_and_resolves_the_durable_claude() {
+        // The real macOS hook topology: `kcap hook` runs under the npm `node` shim
+        // (`node /opt/homebrew/bin/kcap`), which is the process-group leader and a
+        // direct child of the durable terminal claude. The walk must step over the
+        // "node" shim and resolve claude. This only works once GetProcessInfoMac reads
+        // the exec-path name ("claude") instead of proc_bsdinfo's title field, which a
+        // node agent sets to its version string ("2.1.196") — with the old field the
+        // walk found no claude and the watchdog latched onto the transient shim, which
+        // dies the moment the hook returns and took the watcher down with it.
+        // kcap(200) -> node-shim(150) -> claude(100) -> zsh(80)
+        var lookup = ProcTable.Of(
+            (150, 100, "node"),
+            (100, 80, "/Users/alexey/.local/bin/claude"),
+            (80, 1, "-zsh")
+        );
+
+        var pid = ProcessHelpers.ResolveCodingAgentPid(startPid: 150, vendor: "claude", lookup);
+
+        await Assert.That(pid).IsEqualTo(100);
+    }
+
+    [Test]
     public async Task Resolves_codex_by_name() {
         // codex(50) -> zsh(20). The ancestry walk must work uniformly for both vendors.
         var lookup = ProcTable.Of((50, 20, "codex"), (20, 1, "-zsh"));

--- a/test/Capacitor.Cli.Tests.Unit/ProcessHelpersTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProcessHelpersTests.cs
@@ -1,7 +1,29 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Builds a synthetic <c>KERN_PROCARGS2</c> payload (little-endian argc, then the
+/// NUL-terminated exec path, then argv) for <see cref="ProcessHelpers.ParseExecPath"/>
+/// tests. Kept out of the test class so the TUnit source generator only sees [Test]s.
+/// </summary>
+static class ProcArgs2 {
+    public static byte[] Of(int argc, string execPath, params string[] argv) {
+        var bytes = new List<byte>();
+        bytes.AddRange(BitConverter.GetBytes(argc));
+        bytes.AddRange(Encoding.UTF8.GetBytes(execPath));
+        bytes.Add(0);
+
+        foreach (var a in argv) {
+            bytes.AddRange(Encoding.UTF8.GetBytes(a));
+            bytes.Add(0);
+        }
+
+        return bytes.ToArray();
+    }
+}
 
 public class ProcessHelpersTests {
     [Test]
@@ -129,5 +151,29 @@ public class ProcessHelpersTests {
 
         await Assert.That(parent).IsNotNull();
         await Assert.That(ProcessHelpers.IsProcessAlive(self.Value.ppid)).IsTrue();
+    }
+
+    [Test]
+    public async Task ParseExecPath_extracts_the_exec_path_from_a_procargs2_buffer() {
+        // The exec path is the kernel's recorded image path and the only name source
+        // immune to a process changing its title (Claude Code sets its title to its
+        // version string, which clobbers proc_bsdinfo's name fields). Reading it is what
+        // lets the agent ancestry walk match "claude" rather than "2.1.196".
+        var buf = ProcArgs2.Of(2, "/Users/alexey/.local/bin/claude", "claude", "--resume");
+
+        await Assert.That(ProcessHelpers.ParseExecPath(buf)).IsEqualTo("/Users/alexey/.local/bin/claude");
+    }
+
+    [Test]
+    public async Task ParseExecPath_returns_null_for_a_buffer_too_short_for_a_path() {
+        // Just the 4-byte argc with no path, and a buffer shorter than argc itself.
+        await Assert.That(ProcessHelpers.ParseExecPath(new byte[] { 1, 0, 0, 0 })).IsNull();
+        await Assert.That(ProcessHelpers.ParseExecPath(new byte[] { 0, 0 })).IsNull();
+    }
+
+    [Test]
+    public async Task ParseExecPath_returns_null_when_the_exec_path_is_empty() {
+        // argc followed immediately by the NUL terminator — no path present.
+        await Assert.That(ProcessHelpers.ParseExecPath(ProcArgs2.Of(1, "", "claude"))).IsNull();
     }
 }


### PR DESCRIPTION
Closes #207

## Problem

The transcript watcher's parent-PID watchdog identifies the durable coding-agent process by walking the ppid chain and matching processes named `claude`/`codex`. On macOS the name came from `proc_bsdinfo`'s `pbi_name`/`pbi_comm` fields, which carry the **mutable process title** — and Claude Code (a node app) sets its title to its version string (`2.1.196`), so *neither field ever reads `claude`*.

As a result the walk never matched the durable agent, fell back to `getpgrp()`, and returned the **transient `node`-shim process-group leader** that spawns each hook. That shim dies the moment the hook returns, so:

- if it was still alive when the watcher booted → the watchdog armed, the shim exited ~5s later, and the watcher **self-terminated mid-session** (0 lines sent);
- if it was already dead at startup → the watchdog never armed and logged `parent already dead at watcher startup`.

Either way transcript capture stopped while hooks (which POST directly, independent of the watcher) kept flowing — so affected sessions showed **hooks but no chat**.

This was diagnosed live: the durable `claude` reported its name as `2.1.196` via `proc_pidinfo`, while `ps` (which reads the exec path) correctly showed `claude`.

## Fix

Read the process name from the kernel's recorded **executable path** — immune to title changes, and the same source `ps` uses:

- **macOS** — `GetProcessInfoMac` now derives the name from `KERN_PROCARGS2`'s exec path. New `sysctl` `LibraryImport` + a pure, unit-tested `ParseExecPath` parser. `proc_pidinfo` is still used for the ppid; `pbi_name` is kept only as a fallback when the exec path is unreadable (zombie / permission-restricted).
- **Linux** — same latent bug (`process.title` does `prctl(PR_SET_NAME)`, munging `/proc/<pid>/stat` comm), so it now prefers the `/proc/<pid>/exe` basename and falls back to the stat comm. Fallback-safe — can only improve resolution, never regress it. Marked by-analogy (not exercised on a Linux host); `node <script>` launches still rely on the fallback.

## Verification

- **End-to-end**: the fixed walk resolves the durable `claude` at the right hop in the real `claude → node-shim → kcap` topology, where the old logic returned `null`.
- **Unit tests**: full suite green (1897/1897), including new `ParseExecPath` parser tests and a resolver test documenting the `node`-shim topology.
- **AOT**: `dotnet publish -c Release` clean — no IL3050/IL2026 warnings.
- No README change — internal watchdog behavior, no CLI surface change.

## Rollout note

This fixes every future watcher once the binary that *hooks* invoke (the published `kcap`) is updated. After install, a fresh session's watcher log should read `Monitoring parent pid <durable claude pid>` and stay alive, and the recurring `parent already dead` warnings (same root cause) should disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)