### PR TITLE
Self-heal the transcript watcher from the permission-request hook

### DIFF
--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -146,6 +146,30 @@ public static class ClaudeHookCommand {
         try { return await enrichment; } catch { return fallbackBody; }
     }
 
+    // Repo/path exclusion gate shared by the main command path and the permission-request
+    // watcher self-heal: true when the active profile excludes this session's repo or cwd
+    // (caller should skip capture). The fallback repo detection is budgeted so a slow git/gh
+    // probe can't blow the hook deadline; if it can't resolve in time we fail open to capturing
+    // (the per-cwd cache makes subsequent sessions in an excluded repo resolve and exclude promptly).
+    internal static async Task<bool> IsSessionExcludedAsync(Profile? profile, string body, long processStart, string command) {
+        if (profile?.ExcludedRepos is { Length: > 0 } repos
+         && await RepoExclusion.IsExcludedAsync(body, repos, HookBudget.Remaining(processStart, command))) {
+            return true;
+        }
+
+        if (profile?.ExcludedPaths is { Length: > 0 } paths) {
+            try {
+                var cwd = JsonNode.Parse(body)?["cwd"]?.GetValue<string>();
+
+                if (PathExclusion.IsExcluded(cwd, paths)) return true;
+            } catch {
+                // Best effort
+            }
+        }
+
+        return false;
+    }
+
     internal static async Task<int> HandleCore(HttpClient client, AuthStatus authStatus, HookSpool spool, long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask = null) {
         var body = await stdin.ReadToEndAsync();
 
@@ -197,9 +221,18 @@ public static class ClaudeHookCommand {
             // Best effort — don't fail if JSON parsing fails.
         }
 
-        // PermissionRequest has its own handler path (daemon bridge / fire-and-forget).
+        // PermissionRequest has its own handler path (daemon bridge / fire-and-forget). The
+        // repo/path exclusion gates run further below (AFTER this dispatch), so the watcher
+        // self-heal — which would start uploading the transcript — must apply them HERE first;
+        // otherwise a permission prompt in an excluded project spawns a watcher that
+        // session-start intentionally skipped (data leak). Disabled sessions already returned
+        // above. The permission record/long-poll itself is unaffected: hosted agents need the
+        // decision regardless of exclusion.
         if (command == "permission-request") {
-            return await PermissionRequestCommand.Handle(baseUrl, body);
+            var permProfile = await AppConfig.GetActiveProfileAsync();
+            var selfHeal    = !await IsSessionExcludedAsync(permProfile, body, processStart, command);
+
+            return await PermissionRequestCommand.Handle(baseUrl, body, selfHeal);
         }
 
         // On session-start, clear the last-emitted repo cache so this session always gets a
@@ -243,24 +276,9 @@ public static class ClaudeHookCommand {
         // visibility were being ignored.
         var activeProfile = await AppConfig.GetActiveProfileAsync();
 
-        // Check repo exclusion — silently exit for excluded repos. Budget the fallback repo
-        // detection so a slow git/gh probe can't delay the session-start watcher spawn below
-        // (if detection can't resolve the repo in time, we fail open to capturing — the per-cwd
-        // cache makes subsequent sessions in an excluded repo resolve and exclude promptly).
-        if (activeProfile?.ExcludedRepos is { Length: > 0 } repos
-         && await RepoExclusion.IsExcludedAsync(body, repos, HookBudget.Remaining(processStart, command))) {
+        // Silently exit for excluded repos/paths (see IsSessionExcludedAsync).
+        if (await IsSessionExcludedAsync(activeProfile, body, processStart, command)) {
             return 0;
-        }
-
-        // Check path exclusion against the V2 profile that applies to this process.
-        if (activeProfile?.ExcludedPaths is { Length: > 0 } paths) {
-            try {
-                var cwd = JsonNode.Parse(body)?["cwd"]?.GetValue<string>();
-
-                if (PathExclusion.IsExcluded(cwd, paths)) return 0;
-            } catch {
-                // Best effort
-            }
         }
 
         // Auth lapsed: do not POST (server would 401) and do not drain (a 401 would Drop the

--- a/src/Capacitor.Cli/Commands/PermissionRequestCommand.cs
+++ b/src/Capacitor.Cli/Commands/PermissionRequestCommand.cs
@@ -10,7 +10,10 @@ static class PermissionRequestCommand {
     public static Task<int> Handle(string baseUrl) =>
         Handle(baseUrl, body: null);
 
-    public static async Task<int> Handle(string baseUrl, string? body) {
+    // selfHealWatcher is false when the caller determined the session is excluded
+    // (excluded_repos/excluded_paths): we still handle the permission decision, but must NOT
+    // spawn a transcript-uploading watcher for a project the user opted out of recording.
+    public static async Task<int> Handle(string baseUrl, string? body, bool selfHealWatcher = true) {
         body ??= await Console.In.ReadToEndAsync();
 
         JsonNode? node;
@@ -37,8 +40,11 @@ static class PermissionRequestCommand {
         // Self-heal the transcript watcher (see TryEnsureWatcher). Done before the
         // rendered/non-rendered split so both the interactive path and the daemon-hosted
         // long-poll recover a dead or never-started watcher; idempotent, so a no-op when
-        // one is already running.
-        await TryEnsureWatcher(baseUrl, sessionId, node);
+        // one is already running. Skipped for excluded sessions (the caller passes
+        // selfHealWatcher: false) so exclusions are honored just like at session-start.
+        if (selfHealWatcher) {
+            await TryEnsureWatcher(baseUrl, sessionId, node);
+        }
 
         var isRenderedAgent = Environment.GetEnvironmentVariable("KCAP_RENDERED_AGENT") is "1";
 
@@ -90,23 +96,27 @@ static class PermissionRequestCommand {
     /// </summary>
     internal static async Task TryEnsureWatcher(string baseUrl, string sessionId, JsonNode node) {
         try {
-            if (node["agent_id"]?.GetValue<string>() is { Length: > 0 }) {
+            if (GetString(node, "agent_id") is { Length: > 0 }) {
                 return;
             }
 
-            var transcriptPath = node["transcript_path"]?.GetValue<string>();
+            var transcriptPath = GetString(node, "transcript_path");
 
             if (string.IsNullOrEmpty(transcriptPath)) {
                 return;
             }
 
-            var cwd = node["cwd"]?.GetValue<string>();
-
-            await WatcherManager.EnsureWatcherRunning(baseUrl, sessionId, transcriptPath, agentId: null, cwd: cwd);
+            await WatcherManager.EnsureWatcherRunning(
+                baseUrl, sessionId, transcriptPath, agentId: null, cwd: GetString(node, "cwd"));
         } catch (Exception ex) {
             await Console.Error.WriteLineAsync($"[kcap] permission-request watcher self-heal failed: {ex.Message}");
         }
     }
+
+    // Reads an optional string field, treating null / missing / non-string uniformly as
+    // absent — a frequently-firing hook should not throw + log on a variant payload.
+    static string? GetString(JsonNode node, string field) =>
+        node[field] is JsonValue v && v.TryGetValue<string>(out var s) ? s : null;
 
     internal static bool TryGetLoopbackDaemonUrl(out string daemonUrl) {
         daemonUrl = "";

--- a/src/Capacitor.Cli/Commands/PermissionRequestCommand.cs
+++ b/src/Capacitor.Cli/Commands/PermissionRequestCommand.cs
@@ -34,6 +34,12 @@ static class PermissionRequestCommand {
             return 0;
         }
 
+        // Self-heal the transcript watcher (see TryEnsureWatcher). Done before the
+        // rendered/non-rendered split so both the interactive path and the daemon-hosted
+        // long-poll recover a dead or never-started watcher; idempotent, so a no-op when
+        // one is already running.
+        await TryEnsureWatcher(baseUrl, sessionId, node);
+
         var isRenderedAgent = Environment.GetEnvironmentVariable("KCAP_RENDERED_AGENT") is "1";
 
         if (isRenderedAgent) {
@@ -70,6 +76,36 @@ static class PermissionRequestCommand {
         }
 
         return await PostAsync(baseUrl + "/hooks/permission-request", payload, authenticated: true);
+    }
+
+    /// <summary>
+    /// Self-heals the transcript watcher from a permission-request payload. Permission
+    /// requests fire frequently mid-session, so this is a cheap recovery point when the
+    /// watcher died or never started — an abruptly-killed agent orphans its watcher,
+    /// leaving the session stuck "active" because session-end is never POSTed.
+    /// Idempotent: <see cref="WatcherManager.EnsureWatcherRunning"/> is a no-op when the
+    /// watcher is already alive. Scoped to the MAIN session — a present <c>agent_id</c>
+    /// marks a subagent tool call, whose watcher uses a distinct key + transcript and is
+    /// ensured at subagent-start. Best-effort: never throws into the hook path.
+    /// </summary>
+    internal static async Task TryEnsureWatcher(string baseUrl, string sessionId, JsonNode node) {
+        try {
+            if (node["agent_id"]?.GetValue<string>() is { Length: > 0 }) {
+                return;
+            }
+
+            var transcriptPath = node["transcript_path"]?.GetValue<string>();
+
+            if (string.IsNullOrEmpty(transcriptPath)) {
+                return;
+            }
+
+            var cwd = node["cwd"]?.GetValue<string>();
+
+            await WatcherManager.EnsureWatcherRunning(baseUrl, sessionId, transcriptPath, agentId: null, cwd: cwd);
+        } catch (Exception ex) {
+            await Console.Error.WriteLineAsync($"[kcap] permission-request watcher self-heal failed: {ex.Message}");
+        }
     }
 
     internal static bool TryGetLoopbackDaemonUrl(out string daemonUrl) {

--- a/test/Capacitor.Cli.Tests.Integration/PermissionRequestWatcherSelfHealTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/PermissionRequestWatcherSelfHealTests.cs
@@ -1,0 +1,100 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// Verifies the permission-request hook self-heals the transcript watcher
+/// (<see cref="PermissionRequestCommand.TryEnsureWatcher"/>): a frequently-firing
+/// mid-session recovery point that re-spawns a dead/never-started watcher so the
+/// session does not stay stuck "active". Mirrors <see cref="WatcherLifecycleTests"/> —
+/// uses <c>KCAP_WATCHER_DIR</c> and deliberately does NOT capture Console, since
+/// spawning the watcher's child process corrupts TUnit's Console capture.
+/// </summary>
+[NotInParallel]
+public class PermissionRequestWatcherSelfHealTests {
+    static readonly string TempDir = Path.Combine(Path.GetTempPath(), "kcap-permreq-watcher-tests");
+
+    [Before(Class)]
+    public static void SetUp() {
+        Directory.CreateDirectory(TempDir);
+        Environment.SetEnvironmentVariable("KCAP_WATCHER_DIR", TempDir);
+    }
+
+    [After(Class)]
+    public static void TearDown() {
+        Environment.SetEnvironmentVariable("KCAP_WATCHER_DIR", null);
+
+        try { Directory.Delete(TempDir, recursive: true); } catch {
+            /* best effort */
+        }
+    }
+
+    static (string sessionId, string transcriptPath, string pidFile) NewSession() {
+        var sessionId      = $"permreq{Guid.NewGuid():N}";
+        var transcriptPath = Path.Combine(Path.GetTempPath(), $"{sessionId}.jsonl");
+        File.WriteAllText(transcriptPath, "");
+
+        return (sessionId, transcriptPath, Path.Combine(TempDir, $"{sessionId}.pid"));
+    }
+
+    [Test]
+    public async Task SpawnsWatcher_WhenMainSessionTranscriptPresent() {
+        var (sessionId, transcriptPath, pidFile) = NewSession();
+
+        var node = new JsonObject {
+            ["transcript_path"] = transcriptPath,
+            ["cwd"]             = "/tmp/test"
+        };
+
+        try {
+            await PermissionRequestCommand.TryEnsureWatcher("http://localhost:0", sessionId, node);
+
+            await Assert.That(File.Exists(pidFile)).IsTrue();
+            var pidText = await File.ReadAllTextAsync(pidFile);
+            await Assert.That(int.TryParse(pidText.Trim(), out _)).IsTrue();
+        } finally {
+            await Cli.WatcherManager.KillWatcher(sessionId);
+            File.Delete(transcriptPath);
+        }
+    }
+
+    [Test]
+    public async Task SkipsWatcher_WhenAgentIdPresent() {
+        // A present agent_id means a subagent tool call; its watcher uses a distinct
+        // key + transcript and is ensured at subagent-start, so self-heal must not spawn here.
+        var (sessionId, transcriptPath, pidFile) = NewSession();
+
+        var node = new JsonObject {
+            ["transcript_path"] = transcriptPath,
+            ["agent_id"]        = "agent-123"
+        };
+
+        try {
+            await PermissionRequestCommand.TryEnsureWatcher("http://localhost:0", sessionId, node);
+
+            await Assert.That(File.Exists(pidFile)).IsFalse();
+        } finally {
+            await Cli.WatcherManager.KillWatcher(sessionId);
+            File.Delete(transcriptPath);
+        }
+    }
+
+    [Test]
+    public async Task SkipsWatcher_WhenTranscriptPathMissing() {
+        var (sessionId, transcriptPath, pidFile) = NewSession();
+
+        var node = new JsonObject {
+            ["cwd"] = "/tmp/test"
+        };
+
+        try {
+            await PermissionRequestCommand.TryEnsureWatcher("http://localhost:0", sessionId, node);
+
+            await Assert.That(File.Exists(pidFile)).IsFalse();
+        } finally {
+            await Cli.WatcherManager.KillWatcher(sessionId);
+            File.Delete(transcriptPath);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Integration/PermissionRequestWatcherSelfHealTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/PermissionRequestWatcherSelfHealTests.cs
@@ -15,15 +15,20 @@ namespace Capacitor.Cli.Tests.Integration;
 public class PermissionRequestWatcherSelfHealTests {
     static readonly string TempDir = Path.Combine(Path.GetTempPath(), "kcap-permreq-watcher-tests");
 
+    static string? _previousWatcherDir;
+
     [Before(Class)]
     public static void SetUp() {
+        _previousWatcherDir = Environment.GetEnvironmentVariable("KCAP_WATCHER_DIR");
         Directory.CreateDirectory(TempDir);
         Environment.SetEnvironmentVariable("KCAP_WATCHER_DIR", TempDir);
     }
 
     [After(Class)]
     public static void TearDown() {
-        Environment.SetEnvironmentVariable("KCAP_WATCHER_DIR", null);
+        // Restore any preexisting value rather than clobbering to null, so a test process
+        // started with KCAP_WATCHER_DIR set isn't left altered for later test classes.
+        Environment.SetEnvironmentVariable("KCAP_WATCHER_DIR", _previousWatcherDir);
 
         try { Directory.Delete(TempDir, recursive: true); } catch {
             /* best effort */

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeHookExclusionGateTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeHookExclusionGateTests.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Covers the repo/path exclusion gate (<see cref="ClaudeHookCommand.IsSessionExcludedAsync"/>)
+/// that guards the permission-request watcher self-heal — so a permission prompt in an
+/// excluded project does not start a transcript-uploading watcher that session-start
+/// intentionally skipped.
+/// </summary>
+public class ClaudeHookExclusionGateTests {
+    static string Body(string cwd) => new JsonObject { ["cwd"] = cwd }.ToJsonString();
+
+    [Test]
+    public async Task ExcludedPath_ReturnsTrue() {
+        var excludedDir = Path.Combine(Path.GetTempPath(), $"kcap-excl-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(excludedDir);
+
+        try {
+            var profile  = new Profile { ExcludedPaths = [excludedDir] };
+            var body     = Body(Path.Combine(excludedDir, "project"));
+
+            var excluded = await ClaudeHookCommand.IsSessionExcludedAsync(
+                profile, body, Stopwatch.GetTimestamp(), "permission-request");
+
+            await Assert.That(excluded).IsTrue();
+        } finally {
+            Directory.Delete(excludedDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task NonExcludedPath_ReturnsFalse() {
+        var excludedDir = Path.Combine(Path.GetTempPath(), $"kcap-excl-{Guid.NewGuid():N}");
+        var otherDir    = Path.Combine(Path.GetTempPath(), $"kcap-other-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(excludedDir);
+        Directory.CreateDirectory(otherDir);
+
+        try {
+            var profile  = new Profile { ExcludedPaths = [excludedDir] };
+            var body     = Body(Path.Combine(otherDir, "project"));
+
+            var excluded = await ClaudeHookCommand.IsSessionExcludedAsync(
+                profile, body, Stopwatch.GetTimestamp(), "permission-request");
+
+            await Assert.That(excluded).IsFalse();
+        } finally {
+            Directory.Delete(excludedDir, recursive: true);
+            Directory.Delete(otherDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task NullProfile_ReturnsFalse() {
+        var excluded = await ClaudeHookCommand.IsSessionExcludedAsync(
+            profile: null, Body("/tmp/anything"), Stopwatch.GetTimestamp(), "permission-request");
+
+        await Assert.That(excluded).IsFalse();
+    }
+
+    [Test]
+    public async Task ProfileWithoutExclusions_ReturnsFalse() {
+        var excluded = await ClaudeHookCommand.IsSessionExcludedAsync(
+            new Profile(), Body("/tmp/anything"), Stopwatch.GetTimestamp(), "permission-request");
+
+        await Assert.That(excluded).IsFalse();
+    }
+}


### PR DESCRIPTION
## Summary

The PermissionRequest hook previously only recorded the permission event (or long-polled for the decision in rendered-agent mode) and never checked whether the transcript watcher was alive. Since permission requests fire frequently mid-session, this PR adds a best-effort, idempotent watcher self-heal there — the most frequent mid-session recovery point, complementing the existing `notification`/`stop` re-ensure.

This recovers sessions that get stuck `active` (because `session-end` is never POSTed) when an abruptly-killed agent orphans its watcher or the watcher self-kills.

## Changes

- `PermissionRequestCommand.TryEnsureWatcher(...)` calls the idempotent `WatcherManager.EnsureWatcherRunning` (PID-file liveness check, spawn only if dead). Wired into `Handle` **before** the rendered/non-rendered split so both the interactive and daemon-hosted long-poll paths benefit.
- **Main session only:** a present `agent_id` marks a subagent tool call, whose watcher uses a distinct key (`{sessionId}-{agentId}`) + transcript and is ensured at `subagent-start`. Mirrors how `notification`/`stop` only re-ensure the main watcher.
- **Best-effort:** wrapped in try/catch; never throws into the hook path and does not delay the permission decision (spawn is a sub-second `Process.Start`).

## Tests

New integration tests (mirror `WatcherLifecycleTests`: own `KCAP_WATCHER_DIR`, no Console capture):
- spawns the watcher when a main-session transcript is present
- skips when `agent_id` is present
- skips when `transcript_path` is missing

All pass; existing permission/watcher suites pass; AOT publish clean (no IL3050/IL2026 warnings).

No README change — internal self-heal, no user-facing CLI surface change.

Closes #209
AI-1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)