### PR TITLE
Report the running daemon's version in `kcap daemon status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ kcap daemon start                   # start in foreground (defaults --name to yo
 kcap daemon start -d                # start in background (daemonize)
 kcap daemon start --name laptop -d  # run multiple daemons on the same machine by giving each a unique name
 kcap daemon status                  # list all running daemons
-kcap daemon status --name laptop    # show status of a specific daemon
+kcap daemon status --name laptop    # show status of a specific daemon (incl. its running version)
 kcap daemon stop --name laptop      # stop just that one
 kcap daemon stop --yes              # stop all running daemons unattended (otherwise prompts on multi)
 kcap daemon restart --name laptop              # restart now if idle; refuses while agents/evals run
@@ -397,7 +397,14 @@ kcap daemon doctor --clean          # also remove stale lock/pid files (held ent
 
 `KCAP_DAEMON_NAME` overrides the active profile's daemon name (superseded by an explicit `--name` flag).
 
-**Updating:** after `kcap update`, a running daemon on macOS/Linux detects the new binary and restarts itself once it's **idle** (no running hosted agents and no in-flight eval) — service-managed daemons exit so the supervisor relaunches the new binary; background (`-d`) daemons re-spawn themselves. `kcap daemon status` shows a pending restart; `kcap daemon restart --force` applies it now. On **Windows**, stop the daemon (`kcap daemon stop` / `kcap daemon service stop`) before `kcap update` — a running daemon locks its binary, so the update can't replace it (the launcher detects this and aborts with instructions).
+For a running daemon, `kcap daemon status` reports the **version the daemon process is actually running** (read from a marker the daemon writes at startup, not the CLI's own version) — so you can confirm whether a self-update has taken effect:
+
+```
+Daemon 'laptop': running (PID 12345)
+  version: 0.8.12
+```
+
+**Updating:** after `kcap update`, a running daemon on macOS/Linux detects the new binary and restarts itself once it's **idle** (no running hosted agents and no in-flight eval) — service-managed daemons exit so the supervisor relaunches the new binary; background (`-d`) daemons re-spawn themselves. `kcap daemon status` shows the running version (above) plus any pending restart, so you can tell the update apart from an as-yet-unrestarted daemon; `kcap daemon restart --force` applies it now. On **Windows**, stop the daemon (`kcap daemon stop` / `kcap daemon service stop`) before `kcap update` — a running daemon locks its binary, so the update can't replace it (the launcher detects this and aborts with instructions).
 
 #### Run it as a service (auto-restart)
 

--- a/src/Capacitor.Cli.Core/CapacitorVersion.cs
+++ b/src/Capacitor.Cli.Core/CapacitorVersion.cs
@@ -23,9 +23,16 @@ public static class CapacitorVersion {
     /// markers and other machine-consumed identifiers that must match across
     /// installers exactly.
     /// </summary>
-    public static string CurrentDisplay() {
-        var v    = Current();
-        var plus = v.IndexOf('+');
-        return plus >= 0 ? v[..plus] : v;
+    public static string CurrentDisplay() => Display(Current());
+
+    /// <summary>
+    /// Strips the <c>+buildmetadata</c> suffix from an arbitrary version string
+    /// so the raw commit SHA from MinVer's semver doesn't leak into user-facing
+    /// output. Used for <see cref="CurrentDisplay"/> and to render another
+    /// process's reported version (e.g. the daemon's, on <c>kcap daemon status</c>).
+    /// </summary>
+    public static string Display(string version) {
+        var plus = version.IndexOf('+');
+        return plus >= 0 ? version[..plus] : version;
     }
 }

--- a/src/Capacitor.Cli.Core/DaemonLockPaths.cs
+++ b/src/Capacitor.Cli.Core/DaemonLockPaths.cs
@@ -79,17 +79,27 @@ public static partial class DaemonLockPaths {
     public static string RestartPendingPath(string daemonName) =>
         Path.Combine(Directory, $"{Sanitize(daemonName)}.restart-pending");
 
+    /// <summary>
+    /// Path to the daemon's version marker — a freely-readable file (unlike the
+    /// exclusively-flocked <see cref="LockPath"/>) holding the running daemon's
+    /// version so <c>kcap daemon status</c> can report it without a socket
+    /// round-trip. Same on-disk-marker pattern as <see cref="RestartPendingPath"/>.
+    /// </summary>
+    public static string VersionPath(string daemonName) =>
+        Path.Combine(Directory, $"{Sanitize(daemonName)}.version");
+
     /// <summary>Ensures the parent directory exists. Safe to call repeatedly.</summary>
     public static void EnsureDirectory() => System.IO.Directory.CreateDirectory(Directory);
 
     /// <summary>
     /// Returns the daemon names visible on disk — the union of names
-    /// derived from <c>*.lock</c>, <c>*.pid</c>, and <c>*.restart-pending</c>
-    /// files. Used by <c>daemon doctor</c> to classify held vs stale entries;
-    /// covers orphan PID files that have no matching lock (e.g. a pre-AI-630
-    /// daemon whose migration ran for the PID file but not the start lock, or
-    /// a stop that removed the lock but left the PID behind) and marker-only
-    /// leftovers (a crash between queueing a restart and applying it).
+    /// derived from <c>*.lock</c>, <c>*.pid</c>, <c>*.restart-pending</c>, and
+    /// <c>*.version</c> files. Used by <c>daemon doctor</c> to classify held vs
+    /// stale entries; covers orphan PID files that have no matching lock (e.g. a
+    /// pre-AI-630 daemon whose migration ran for the PID file but not the start
+    /// lock, or a stop that removed the lock but left the PID behind) and
+    /// marker-only leftovers (a crash between queueing a restart and applying it,
+    /// or a version marker left after an unclean exit).
     /// </summary>
     public static IReadOnlyList<string> EnumerateNames() {
         if (!System.IO.Directory.Exists(Directory)) return [];
@@ -100,9 +110,11 @@ public static partial class DaemonLockPaths {
             .Select(Path.GetFileNameWithoutExtension);
         var fromMarkers = System.IO.Directory.EnumerateFiles(Directory, "*.restart-pending")
             .Select(Path.GetFileNameWithoutExtension);
+        var fromVersions = System.IO.Directory.EnumerateFiles(Directory, "*.version")
+            .Select(Path.GetFileNameWithoutExtension);
 
         return [
-            .. fromLocks.Concat(fromPids).Concat(fromMarkers)
+            .. fromLocks.Concat(fromPids).Concat(fromMarkers).Concat(fromVersions)
                 .Where(n => !string.IsNullOrEmpty(n))
                 .Select(n => n!)
                 .Distinct()

--- a/src/Capacitor.Cli.Core/DaemonVersionMarker.cs
+++ b/src/Capacitor.Cli.Core/DaemonVersionMarker.cs
@@ -1,0 +1,41 @@
+namespace Capacitor.Cli.Core;
+
+/// <summary>
+/// The <c>&lt;name&gt;.version</c> marker the daemon writes at startup (holding its
+/// own version) and clears on clean exit. Read by <c>kcap daemon status</c> so it
+/// can report the <b>running</b> daemon's version — letting a user confirm a
+/// self-update actually took effect — without a socket round-trip.
+///
+/// <para>A separate, freely-readable file rather than a line in the
+/// <c>&lt;name&gt;.lock</c>: the lock is held with <c>FileShare.None</c> (exclusive
+/// flock), so on Windows the CLI couldn't read it at all while the daemon is live.
+/// Same on-disk-marker rationale as <see cref="DaemonRestartMarker"/>.</para>
+///
+/// <para>A single-line plain-text file (just the version string) — no JSON, so
+/// nothing to trip the NativeAOT reflection serializer.</para>
+/// </summary>
+public static class DaemonVersionMarker {
+    public static void Write(string daemonName, string version) {
+        DaemonLockPaths.EnsureDirectory();
+        var path = DaemonLockPaths.VersionPath(daemonName);
+        var tmp  = $"{path}.tmp";
+        File.WriteAllText(tmp, version);
+        File.Move(tmp, path, overwrite: true);
+    }
+
+    /// <summary>The recorded version, or <c>null</c> if the marker is absent, blank, or unreadable.</summary>
+    public static string? TryRead(string daemonName) {
+        var path = DaemonLockPaths.VersionPath(daemonName);
+        if (!File.Exists(path)) return null;
+        try {
+            var version = File.ReadAllText(path).Trim();
+            return string.IsNullOrEmpty(version) ? null : version;
+        } catch {
+            return null; // unreadable — treat as absent
+        }
+    }
+
+    public static void Delete(string daemonName) {
+        try { File.Delete(DaemonLockPaths.VersionPath(daemonName)); } catch { /* best-effort */ }
+    }
+}

--- a/src/Capacitor.Cli.Core/Resources/help-daemon.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-daemon.txt
@@ -7,7 +7,8 @@ Subcommands:
   stop [--name N] [--yes] Stop a running daemon (prompts on multi unless --yes)
   restart [--name N]      Restart the daemon (now if idle; --when-idle queues;
                           --force overrides while busy)
-  status [--name N]       Show daemon status (lists all when --name omitted)
+  status [--name N]       Show daemon status, incl. the running daemon's
+                          version (lists all when --name omitted)
   logs                    Show recent daemon log output
   doctor [--clean]        Diagnose lock-file state, optionally clean stale entries
   service <action>        Manage the OS service (launchd/systemd/Scheduled Task)
@@ -36,8 +37,10 @@ Options for restart:
   --force                 Restart now even if busy (running agents are torn down).
 
 Updating: after `kcap update`, a running daemon on macOS/Linux detects the new
-binary and restarts itself when idle. `kcap daemon status` shows a pending restart.
-On Windows, stop the daemon before `kcap update` (a running daemon locks its binary).
+binary and restarts itself when idle. `kcap daemon status` reports the running
+daemon's version plus any pending restart, so you can confirm a self-update took
+effect. On Windows, stop the daemon before `kcap update` (a running daemon locks
+its binary).
 
 Options for doctor:
   --clean                 Remove stale entries (lock files whose holder is

--- a/src/Capacitor.Cli.Daemon/DaemonLock.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonLock.cs
@@ -26,27 +26,34 @@ internal sealed class DaemonLock : IDisposable {
     readonly FileStream _stream;
     readonly string     _pidPath;
     readonly string     _lockPath;
+    readonly string     _versionPath;
     bool                _disposed;
 
     public string InstanceId { get; }
 
-    DaemonLock(FileStream stream, string lockPath, string pidPath, string instanceId) {
-        _stream    = stream;
-        _lockPath  = lockPath;
-        _pidPath   = pidPath;
-        InstanceId = instanceId;
+    DaemonLock(FileStream stream, string lockPath, string pidPath, string versionPath, string instanceId) {
+        _stream      = stream;
+        _lockPath    = lockPath;
+        _pidPath     = pidPath;
+        _versionPath = versionPath;
+        InstanceId   = instanceId;
     }
 
     /// <summary>
     /// Try to acquire the per-name lock for <paramref name="daemonName"/>.
     /// Returns null when another live daemon already holds the lock — the
     /// caller should print a "name in use" message and exit with code 2.
+    ///
+    /// <para>When <paramref name="version"/> is supplied, also writes the
+    /// freely-readable <c>&lt;name&gt;.version</c> marker so <c>kcap daemon
+    /// status</c> can report the running daemon's version.</para>
     /// </summary>
-    public static DaemonLock? TryAcquire(string daemonName) {
+    public static DaemonLock? TryAcquire(string daemonName, string? version = null) {
         DaemonLockPaths.EnsureDirectory();
 
-        var lockPath = DaemonLockPaths.LockPath(daemonName);
-        var pidPath  = DaemonLockPaths.PidPath(daemonName);
+        var lockPath    = DaemonLockPaths.LockPath(daemonName);
+        var pidPath     = DaemonLockPaths.PidPath(daemonName);
+        var versionPath = DaemonLockPaths.VersionPath(daemonName);
 
         FileStream stream;
 
@@ -73,24 +80,29 @@ internal sealed class DaemonLock : IDisposable {
             stream.Flush();
 
             WritePidFile(pidPath);
+
+            // Overwrite (atomically) any stale version marker with ours. A
+            // successor of a restart-after-update lands here and refreshes it
+            // to the new binary's version.
+            if (version is not null) DaemonVersionMarker.Write(daemonName, version);
         } catch {
             stream.Dispose();
             throw;
         }
 
-        return new DaemonLock(stream, lockPath, pidPath, instanceId);
+        return new DaemonLock(stream, lockPath, pidPath, versionPath, instanceId);
     }
 
     /// <summary>
-    /// Like <see cref="TryAcquire(string)"/> but retries until <paramref name="awaitTimeout"/>
+    /// Like <see cref="TryAcquire(string, string?)"/> but retries until <paramref name="awaitTimeout"/>
     /// elapses — used by a self-respawned successor (<c>--await-lock</c>) to wait out the
     /// outgoing daemon's flock instead of exiting with code 2 on the first contended attempt.
     /// </summary>
-    public static DaemonLock? TryAcquire(string daemonName, TimeSpan awaitTimeout) {
+    public static DaemonLock? TryAcquire(string daemonName, TimeSpan awaitTimeout, string? version = null) {
         var deadline = DateTime.UtcNow + awaitTimeout;
 
         while (true) {
-            if (TryAcquire(daemonName) is { } locked) return locked;
+            if (TryAcquire(daemonName, version) is { } locked) return locked;
             if (DateTime.UtcNow >= deadline) return null;
             Thread.Sleep(100);
         }
@@ -128,10 +140,17 @@ internal sealed class DaemonLock : IDisposable {
         // Delete the PID file only if it still points to our own PID. A
         // legitimate successor daemon that ran while we were disposing
         // would have already rewritten the file to its own PID, and an
-        // unconditional Delete here would orphan their entry.
-        try {
-            if (PidFileMatchesCurrentProcess(_pidPath)) File.Delete(_pidPath);
-        } catch { /* best-effort */ }
+        // unconditional Delete here would orphan their entry. The version
+        // marker follows the SAME ownership guard: if a successor has taken
+        // over the name it has already written its own version marker, so
+        // deleting here would clobber the successor's fresh value.
+        bool ours;
+        try { ours = PidFileMatchesCurrentProcess(_pidPath); } catch { ours = false; }
+
+        if (ours) {
+            try { File.Delete(_pidPath); } catch { /* best-effort */ }
+            try { File.Delete(_versionPath); } catch { /* best-effort */ }
+        }
     }
 
     static bool PidFileMatchesCurrentProcess(string pidPath) {

--- a/src/Capacitor.Cli.Daemon/DaemonLock.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonLock.cs
@@ -80,14 +80,18 @@ internal sealed class DaemonLock : IDisposable {
             stream.Flush();
 
             WritePidFile(pidPath);
-
-            // Overwrite (atomically) any stale version marker with ours. A
-            // successor of a restart-after-update lands here and refreshes it
-            // to the new binary's version.
-            if (version is not null) DaemonVersionMarker.Write(daemonName, version);
         } catch {
             stream.Dispose();
             throw;
+        }
+
+        // Overwrite (atomically) any stale version marker with ours. A successor
+        // of a restart-after-update lands here and refreshes it to the new
+        // binary's version. Best-effort and OUTSIDE the fatal try above: the
+        // marker is observability-only (`kcap daemon status`), so an IO failure
+        // writing it must never abort acquisition the way a lock/pid failure does.
+        if (version is not null) {
+            try { DaemonVersionMarker.Write(daemonName, version); } catch { /* best-effort */ }
         }
 
         return new DaemonLock(stream, lockPath, pidPath, versionPath, instanceId);

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -136,14 +136,19 @@ public static partial class DaemonRunner {
             return 1;
         }
 
+        // Resolve our version before acquiring the lock so DaemonLock can stamp
+        // it into the freely-readable <name>.version marker that `kcap daemon
+        // status` reads to report the running daemon's version.
+        config.Version = ResolveDaemonVersion();
+
         // Acquire the per-name flock that prevents another daemon from
         // running under the same name on this machine. The lock content is
         // a fresh instance id that we'll also send over DaemonConnect so
         // the server can refuse a second daemon claiming the same
         // (owner, name) slot (AI-630).
         var daemonLock = awaitLock
-            ? DaemonLock.TryAcquire(config.Name, TimeSpan.FromSeconds(5))
-            : DaemonLock.TryAcquire(config.Name);
+            ? DaemonLock.TryAcquire(config.Name, TimeSpan.FromSeconds(5), config.Version)
+            : DaemonLock.TryAcquire(config.Name, config.Version);
 
         if (daemonLock is null) {
             await Console.Error.WriteLineAsync(
@@ -155,7 +160,6 @@ public static partial class DaemonRunner {
         }
 
         config.InstanceId = daemonLock.InstanceId;
-        config.Version    = ResolveDaemonVersion();
 
         builder.Services.AddSingleton(config);
         builder.Services.AddSingleton(daemonLock);

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -504,7 +504,6 @@ public static class DaemonCommands {
             var pidPath  = DaemonLockPaths.PidPath(name);
 
             var hasLock = File.Exists(lockPath);
-            File.Exists(pidPath);
 
             string? instanceId = null;
 
@@ -550,9 +549,13 @@ public static class DaemonCommands {
                     break;
                 }
                 case null: {
-                    // No .lock file at all but a .pid is present — orphan.
+                    // No .lock file at all — leftover pid and/or marker files
+                    // with no live daemon. Describe what's actually present
+                    // (a version-marker-only orphan is common now that every
+                    // start writes one) rather than always blaming the pid file.
                     staleCount++;
-                    await Console.Out.WriteLineAsync($"  {name,-20}  STALE    instance=(none)   (orphan pid file, no lock)");
+                    var leftovers = File.Exists(pidPath) ? "orphan pid file, no lock" : "marker-only, no lock/pid";
+                    await Console.Out.WriteLineAsync($"  {name,-20}  STALE    instance=(none)   ({leftovers})");
 
                     if (clean) {
                         try { File.Delete(pidPath); } catch {

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -314,6 +314,7 @@ public static class DaemonCommands {
             if (!IsOurDaemon(entry.Pid, entry.StartToken)) {
                 Console.Out.WriteLine($"Daemon '{name}' was not running (stale PID file).");
                 File.Delete(DaemonLockPaths.PidPath(name));
+                DaemonVersionMarker.Delete(name);
 
                 return 0;
             }
@@ -325,9 +326,15 @@ public static class DaemonCommands {
             Console.Out.WriteLine($"Daemon '{name}' was not running.");
         }
 
+        // Clean up the daemon's on-disk markers. The kill above is a SIGKILL, so
+        // the daemon's own Dispose cleanup never runs — the CLI must remove the
+        // PID file and the version marker itself (they were written together at
+        // startup and track the same "live under this name" fact).
         try { File.Delete(DaemonLockPaths.PidPath(name)); } catch {
             /* best-effort */
         }
+
+        DaemonVersionMarker.Delete(name);
 
         return 0;
     }
@@ -437,6 +444,11 @@ public static class DaemonCommands {
             } else if (IsOurDaemon(entry.Pid, entry.StartToken)) {
                 await Console.Out.WriteLineAsync($"Daemon '{name}': running (PID {entry.Pid})");
 
+                // Version of the *running* daemon (from the marker it wrote at
+                // startup), so the user can confirm a self-update took effect.
+                if (DaemonVersionMarker.TryRead(name) is { } version)
+                    await Console.Out.WriteLineAsync($"  version: {CapacitorVersion.Display(version)}");
+
                 if (DaemonRestartMarker.TryRead(name) is { } marker)
                     await Console.Out.WriteLineAsync($"  {marker.Describe()}");
             } else {
@@ -445,6 +457,8 @@ public static class DaemonCommands {
                 try { File.Delete(DaemonLockPaths.PidPath(name)); } catch {
                     /* best-effort */
                 }
+
+                DaemonVersionMarker.Delete(name);
             }
 
             if (manager is not null) {
@@ -548,6 +562,8 @@ public static class DaemonCommands {
                         try { File.Delete(DaemonLockPaths.RestartPendingPath(name)); } catch {
                             /* best-effort */
                         }
+
+                        DaemonVersionMarker.Delete(name);
                     }
 
                     break;
@@ -569,6 +585,8 @@ public static class DaemonCommands {
                         try { File.Delete(DaemonLockPaths.RestartPendingPath(name)); } catch {
                             /* best-effort */
                         }
+
+                        DaemonVersionMarker.Delete(name);
                     }
 
                     break;

--- a/test/Capacitor.Cli.Tests.Unit/CapacitorVersionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CapacitorVersionTests.cs
@@ -18,4 +18,13 @@ public class CapacitorVersionTests {
         await Assert.That(CapacitorVersion.Current())
             .IsEqualTo(AgentsSkillsInstaller.CurrentVersion());
     }
+
+    [Test]
+    [Arguments("0.4.11+sha.abc1234", "0.4.11")]
+    [Arguments("0.4.11", "0.4.11")]
+    [Arguments("unknown", "unknown")]
+    [Arguments("1.2.3-preview.4+build.5", "1.2.3-preview.4")]
+    public async Task Display_strips_build_metadata(string input, string expected) {
+        await Assert.That(CapacitorVersion.Display(input)).IsEqualTo(expected);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockTests.cs
@@ -216,6 +216,30 @@ public class DaemonLockTests {
         }
     }
 
+    /// <summary>
+    /// The version marker is observability-only (for <c>kcap daemon status</c>),
+    /// so a failure to write it must never abort lock acquisition / daemon startup
+    /// — unlike the correctness-critical flock and PID file.
+    /// </summary>
+    [Test]
+    public async Task TryAcquire_StillSucceeds_WhenVersionMarkerWriteFails() {
+        var dir = CreateScratchDir();
+
+        try {
+            // Plant a directory where the marker file would go, so the atomic
+            // move in DaemonVersionMarker.Write throws.
+            System.IO.Directory.CreateDirectory(DaemonLockPaths.VersionPath("alpha"));
+
+            using var l = DaemonLock.TryAcquire("alpha", "0.4.11");
+
+            await Assert.That(l).IsNotNull();
+            await Assert.That(l!.InstanceId).IsNotEmpty();
+        } finally {
+            Restore();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     [Test]
     public async Task Dispose_DeletesVersionMarker_WhenPidStillOurs() {
         var dir = CreateScratchDir();

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockTests.cs
@@ -196,6 +196,69 @@ public class DaemonLockTests {
         }
     }
 
+    /// <summary>
+    /// The daemon writes its version to a freely-readable <c>&lt;name&gt;.version</c>
+    /// marker at acquisition so <c>kcap daemon status</c> (a separate process) can
+    /// report the running daemon's version without contending with the exclusive flock.
+    /// </summary>
+    [Test]
+    public async Task TryAcquire_WritesVersionMarker() {
+        var dir = CreateScratchDir();
+
+        try {
+            using var l = DaemonLock.TryAcquire("alpha", "0.4.11+sha.abc1234");
+            await Assert.That(l).IsNotNull();
+
+            await Assert.That(DaemonVersionMarker.TryRead("alpha")).IsEqualTo("0.4.11+sha.abc1234");
+        } finally {
+            Restore();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Dispose_DeletesVersionMarker_WhenPidStillOurs() {
+        var dir = CreateScratchDir();
+
+        try {
+            var l = DaemonLock.TryAcquire("alpha", "0.4.11")!;
+            await Assert.That(File.Exists(DaemonLockPaths.VersionPath("alpha"))).IsTrue();
+
+            l.Dispose();
+
+            await Assert.That(File.Exists(DaemonLockPaths.VersionPath("alpha"))).IsFalse();
+        } finally {
+            Restore();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Detached-respawn race: once a successor has rewritten the PID file with its
+    /// own PID (and its own version marker), the disposing daemon must not delete
+    /// the marker — same ownership guard as the PID file — or the successor's fresh
+    /// version would be clobbered.
+    /// </summary>
+    [Test]
+    public async Task Dispose_DoesNotDeleteVersionMarker_IfPidPointsToSomeoneElse() {
+        var dir = CreateScratchDir();
+
+        try {
+            var l = DaemonLock.TryAcquire("alpha", "0.4.10")!;
+
+            // Simulate the successor: it rewrote both the PID file and the version marker.
+            File.WriteAllText(DaemonLockPaths.PidPath("alpha"), "99999\n637999999999999999");
+            DaemonVersionMarker.Write("alpha", "0.4.11");
+
+            l.Dispose();
+
+            await Assert.That(DaemonVersionMarker.TryRead("alpha")).IsEqualTo("0.4.11");
+        } finally {
+            Restore();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     [Test]
     public async Task TryAcquire_AfterStaleLockFileLeftBehind_StillAcquires() {
         var dir = CreateScratchDir();

--- a/test/Capacitor.Cli.Tests.Unit/DaemonVersionMarkerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/DaemonVersionMarkerTests.cs
@@ -1,0 +1,75 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+public class DaemonVersionMarkerTests {
+    [Test]
+    public async Task Write_then_read_round_trips() {
+        var dir = Directory.CreateTempSubdirectory("kcap-ver-");
+        DaemonLockPaths.OverrideDirectoryForTesting(dir.FullName);
+        try {
+            DaemonVersionMarker.Write("laptop", "0.4.11+sha.abc1234");
+
+            await Assert.That(DaemonVersionMarker.TryRead("laptop")).IsEqualTo("0.4.11+sha.abc1234");
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            dir.Delete(true);
+        }
+    }
+
+    [Test]
+    public async Task TryRead_returns_null_when_absent() {
+        var dir = Directory.CreateTempSubdirectory("kcap-ver-");
+        DaemonLockPaths.OverrideDirectoryForTesting(dir.FullName);
+        try {
+            await Assert.That(DaemonVersionMarker.TryRead("nope")).IsNull();
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            dir.Delete(true);
+        }
+    }
+
+    [Test]
+    public async Task TryRead_returns_null_for_blank_marker() {
+        var dir = Directory.CreateTempSubdirectory("kcap-ver-");
+        DaemonLockPaths.OverrideDirectoryForTesting(dir.FullName);
+        try {
+            File.WriteAllText(DaemonLockPaths.VersionPath("laptop"), "   \n");
+
+            await Assert.That(DaemonVersionMarker.TryRead("laptop")).IsNull();
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            dir.Delete(true);
+        }
+    }
+
+    [Test]
+    public async Task Delete_removes_marker() {
+        var dir = Directory.CreateTempSubdirectory("kcap-ver-");
+        DaemonLockPaths.OverrideDirectoryForTesting(dir.FullName);
+        try {
+            DaemonVersionMarker.Write("laptop", "0.4.11");
+            DaemonVersionMarker.Delete("laptop");
+
+            await Assert.That(File.Exists(DaemonLockPaths.VersionPath("laptop"))).IsFalse();
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            dir.Delete(true);
+        }
+    }
+
+    [Test]
+    public async Task EnumerateNames_includes_marker_only_entry() {
+        var dir = Directory.CreateTempSubdirectory("kcap-ver-");
+        DaemonLockPaths.OverrideDirectoryForTesting(dir.FullName);
+        try {
+            DaemonVersionMarker.Write("orphan", "0.4.11");
+
+            await Assert.That(DaemonLockPaths.EnumerateNames()).Contains("orphan");
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            dir.Delete(true);
+        }
+    }
+}


### PR DESCRIPTION
## What

`kcap daemon status` now reports the version the daemon process is **actually running**, so you can confirm whether a self-update has taken effect:

```
Daemon 'laptop': running (PID 12345)
  version: 0.8.12
```

## Why

The daemon knows its own version (`DaemonRunner.ResolveDaemonVersion()`) but only sent it to the server on `DaemonConnect` — nothing wrote it where the CLI (a separate process) could read it locally. After a self-update-while-idle restart, there was no easy way to tell whether the running daemon was on the new version yet.

## How

Mirrors the existing on-disk `DaemonRestartMarker` pattern (no socket round-trip):

- **New `DaemonVersionMarker`** — a freely-readable `<name>.version` file. Deliberately *not* a line in the `.lock`: the lock is held with `FileShare.None`, so on Windows the CLI couldn't read it while the daemon is live.
- **`DaemonLock`** writes the marker at acquisition (`TryAcquire` gains a `version` param) and deletes it in `Dispose` **under the same PID-ownership guard the PID file already uses** — so a detached-respawn successor's fresh marker is never clobbered. A self-update successor overwrites it atomically at its own startup.
- **`daemon status`** reads the marker and prints the clean semver (`+buildmetadata` stripped via a new `CapacitorVersion.Display` helper, extracted from `CurrentDisplay`). `stop` / stale-`status` / `doctor --clean` clean it alongside the PID file; `EnumerateNames` includes `.version` so `doctor` sees orphans.

Missing/old-format marker (daemon started by a pre-this-change binary) → the `version:` line is simply omitted, no error.

## Testing

- New unit tests: `DaemonVersionMarker` round-trip, `CapacitorVersion.Display` trimming, `DaemonLock` writing the marker, and the detached-respawn race guard (`Dispose_DoesNotDeleteVersionMarker_IfPidPointsToSomeoneElse`). Full suite: **1964 passed, 0 failed**.
- **0 IL3050/IL2026 AOT warnings** on both CLI and daemon publishes.
- Live smoke test with the real AOT binaries: a running daemon reported `version: 0.8.12-alpha.0.1`, and the marker was cleaned on `stop`.

## Docs

`README.md` and `help-daemon.txt` updated for the new output.

Closes #213
AI-1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)