### PR TITLE
Auto-register kcap-flows MCP server via the Claude Code plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Open the server URL in your browser. The dashboard shows repositories, sessions,
 
 The `kcap mcp sessions` stdio server lets coding agents search and recall past Capacitor sessions without leaving the chat. The Kurrent Capacitor plugin (installed by `kcap setup`) **auto-registers it for both Claude Code and Codex CLI** — no manual `claude mcp add` or TOML edit. The server is repo-aware: `cd` into a project before spawning your agent and `search_sessions` defaults to that repo's sessions.
 
-The `kcap mcp flows` stdio server lets agents start and interact with AI-powered review flows. Add it manually via `claude mcp add kcap-flows -- kcap mcp flows`. See the [Flows MCP server](#flows-mcp-server-for-agents) section for details.
+The `kcap mcp flows` stdio server lets agents start and interact with AI-powered review flows. The plugin **auto-registers it for Claude Code** (Codex stays manual). See the [Flows MCP server](#flows-mcp-server-for-agents) section for details.
 
 ## What it records
 
@@ -291,16 +291,14 @@ The server is repo-aware — it resolves the current working directory to a repo
 kcap mcp flows
 ```
 
-Stdio MCP server that lets coding agents start and interact with AI-powered review flows directly from within a session. Add it explicitly to your agent setup:
+Stdio MCP server that lets coding agents start and interact with AI-powered review flows directly from within a session. The Kurrent Capacitor plugin **auto-registers it for Claude Code** (via `.mcp.json`), so there's nothing to do after `kcap setup` — the flows server derives the target repo from its launch working directory, and Claude Code always runs inside the repo, so one registration works for every repo. It's registered even with no daemon connected; the tools simply stay inert (and `start_review_flow` returns an error) until a daemon with the repo is available.
 
-```bash
-# Claude Code
-claude mcp add kcap-flows -- kcap mcp flows
+Codex CLI/desktop apps have no single repo working directory, so they stay manual — add it to `~/.codex/config.toml`:
 
-# Codex (CLI or desktop app) — add to ~/.codex/config.toml:
-# [mcp_servers.kcap-flows]
-# command = "kcap"           # use an absolute path (e.g. /opt/homebrew/bin/kcap) for the
-# args    = ["mcp", "flows"] # desktop app, which launches MCP servers without your shell PATH
+```toml
+[mcp_servers.kcap-flows]
+command = "kcap"           # use an absolute path (e.g. /opt/homebrew/bin/kcap) for the
+args    = ["mcp", "flows"] # desktop app, which launches MCP servers without your shell PATH
 ```
 
 It provides four tools:
@@ -310,7 +308,7 @@ It provides four tools:
 - **`get_review_flow_status`** — get the current status (running, waiting, completed, failed) and last result of a flow.
 - **`close_review_flow`** — mark a completed review flow as closed.
 
-Requires `kcap login`. The server creates an authenticated HTTP client at startup and posts to the Capacitor server's `/api/flows/*` endpoints.
+Requires `kcap login` **and a running daemon with this repo checked out** — the server discovers a connected daemon to launch the hosted Codex reviewer, and `start_review_flow` errors if none (or more than one) matches. The server creates an authenticated HTTP client at startup and posts to the Capacitor server's `/api/flows/*` endpoints.
 
 ### Curate guidelines
 

--- a/kcap/.claude-plugin/plugin.json
+++ b/kcap/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "kcap",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Records and visualizes Claude Code sessions via kcap CLI hooks"
 }

--- a/kcap/.mcp.json
+++ b/kcap/.mcp.json
@@ -9,6 +9,12 @@
       "command": "kcap",
       "args": ["mcp", "sessions"],
       "cwd": "${CLAUDE_PROJECT_DIR}"
+    },
+    "kcap-flows": {
+      "command": "kcap",
+      "args": ["mcp", "flows"],
+      "cwd": "${CLAUDE_PROJECT_DIR}",
+      "description": "Structured AI review flows — start_review_flow, submit_review_round, get_review_flow_status, close_review_flow. Launches a hosted reviewer agent through your daemon; requires `kcap login` and a running daemon with this repo checked out (the tools are inert otherwise)."
     }
   }
 }

--- a/src/Capacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-mcp.txt
@@ -48,10 +48,9 @@ mcp flows:
       get_review_flow_status Get the status and last result of a flow.
       close_review_flow      Close a completed review flow.
 
-  Add it explicitly if you want it:
-
-    Claude Code:
-      claude mcp add kcap-flows -- kcap mcp flows
+  Claude Code auto-registers `kcap-flows` via the plugin's `.mcp.json`
+  (installed by `kcap setup`), so no manual step is needed there. Add it
+  manually only for Codex:
 
     Codex (CLI or desktop app) — add to ~/.codex/config.toml:
       [mcp_servers.kcap-flows]
@@ -66,7 +65,9 @@ INSTALL
   `kcap-review` for both Claude Code (via the plugin's `.mcp.json`)
   and Codex CLI (via `.codex-plugin/plugin.json` -> `.codex-mcp.json`),
   so no manual `claude mcp add` or TOML edit is needed after
-  `kcap setup`.
+  `kcap setup`. `kcap-flows` is auto-registered for Claude Code only
+  (Codex has no single repo working directory, so it stays manual —
+  see `mcp flows` above).
 
   `kcap-judge` is not auto-registered. Add it explicitly if you
   want it:

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -13,17 +13,6 @@ namespace Capacitor.Cli.Commands;
 
 static class McpFlowsServer {
     public static async Task<int> RunAsync(string baseUrl) {
-        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
-
-        // The review-flow endpoints are long-polls: start_review_flow / submit_review_round
-        // block server-side until the AI reviewer returns findings (FlowResultWaiter allows
-        // up to 10 minutes). The default HttpClient.Timeout (100s) would abort the POST first,
-        // which the server sees as a cancelled request and tears the reviewer down (~2 min) —
-        // so no real review could ever complete (AI-1061). Disable the client-side deadline and
-        // let the server's FlowResultWaiter and the harness MCP tool timeout bound the wait,
-        // mirroring the long-poll clients in PermissionRequestCommand / CodexHookCommand.
-        client.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
-
         var cwd      = Directory.GetCurrentDirectory();
         var repoRoot = GitRepository.FindRoot(cwd);
         var tools    = BuildToolsList();
@@ -35,39 +24,68 @@ static class McpFlowsServer {
             // best-effort; proceed with null
         }
 
+        // Defer the authenticated-client creation until the first tools/call. Under the
+        // plugin's auto-register manifest (AI-1056), Claude Code spawns `kcap mcp flows` for
+        // every session, so an eager CreateAuthenticatedClientAsync — which does a GET
+        // /auth/config round-trip + token load, and prints a re-auth hint to stderr when not
+        // logged in — would charge every session that work even when the agent never invokes a
+        // flows tool. initialize / tools/list need no auth, so startup stays local-only.
+        // Mirrors McpSessionsServer.
+        //
+        // The InfiniteTimeSpan timeout (AI-1061) is applied to the lazily-created client: the
+        // review-flow endpoints long-poll (start_review_flow / submit_review_round block
+        // server-side up to ~10 min while the reviewer runs). The default 100s timeout would
+        // abort the POST, which the server sees as a cancel and tears the reviewer down — so no
+        // review could complete. The server's FlowResultWaiter and the harness MCP tool timeout
+        // bound the wait instead, mirroring PermissionRequestCommand / CodexHookCommand.
+        var clientLazy = new Lazy<Task<HttpClient>>(async () => {
+            var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+            client.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
+
+            return client;
+        });
+
         await using var stdin  = Console.OpenStandardInput();
         await using var stdout = Console.OpenStandardOutput();
         using var       reader = new StreamReader(stdin, Encoding.UTF8);
         await using var writer = new StreamWriter(stdout, new UTF8Encoding(false));
         writer.AutoFlush = true;
 
-        while (await reader.ReadLineAsync() is { } line) {
-            if (string.IsNullOrWhiteSpace(line)) continue;
+        try {
+            while (await reader.ReadLineAsync() is { } line) {
+                if (string.IsNullOrWhiteSpace(line)) continue;
 
-            JsonObject? request;
+                JsonObject? request;
 
-            try {
-                request = JsonNode.Parse(line)?.AsObject();
-            } catch {
-                continue;
+                try {
+                    request = JsonNode.Parse(line)?.AsObject();
+                } catch {
+                    continue;
+                }
+
+                if (request is null) continue;
+
+                var id     = request["id"];
+                var method = request["method"]?.GetValue<string>();
+
+                // Notifications have no id — don't send a response
+                if (id is null) continue;
+
+                var response = method switch {
+                    "initialize" => BuildInitializeResponse(id),
+                    "tools/list" => BuildToolsListResponse(id, tools),
+                    "tools/call" => await HandleToolCallAsync(id, request, await clientLazy.Value, baseUrl, cwd, repoRoot, repoInfo),
+                    _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
+                };
+
+                await writer.WriteLineAsync(response);
             }
-
-            if (request is null) continue;
-
-            var id     = request["id"];
-            var method = request["method"]?.GetValue<string>();
-
-            // Notifications have no id — don't send a response
-            if (id is null) continue;
-
-            var response = method switch {
-                "initialize" => BuildInitializeResponse(id),
-                "tools/list" => BuildToolsListResponse(id, tools),
-                "tools/call" => await HandleToolCallAsync(id, request, client, baseUrl, cwd, repoRoot, repoInfo),
-                _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
-            };
-
-            await writer.WriteLineAsync(response);
+        } finally {
+            if (clientLazy.IsValueCreated) {
+                try { (await clientLazy.Value).Dispose(); } catch {
+                    /* swallow — best-effort cleanup */
+                }
+            }
         }
 
         return 0;

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -238,6 +238,27 @@ public class McpFlowsServerTests : IDisposable {
     }
 
     /// <summary>
+    /// Regression (AI-1056): kcap-flows auto-registers via the Claude plugin, so Claude Code
+    /// spawns `kcap mcp flows` for every session. initialize / tools/list must stay local-only —
+    /// the authenticated client (and its GET /auth/config round-trip + re-auth stderr hint) is
+    /// created lazily on the first tools/call, so sessions that never use a flows tool pay
+    /// nothing. Mirrors McpSessionsServer.
+    /// </summary>
+    [Test]
+    public async Task Initialize_and_tools_list_do_not_consult_auth() {
+        using var proc = SpawnMcpServer(provider: "GitHub");
+        try {
+            await SendRequest(proc, InitializeRequest(1));
+            await SendRequest(proc, ToolsListRequest(2));
+
+            var authHits = _server.FindLogEntries(Request.Create().WithPath("/auth/config").UsingGet());
+            await Assert.That(authHits.Count).IsEqualTo(0);
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
     /// Core scenario: verifies that start_review_flow posts to /api/flows/review/start,
     /// that the POST body includes the resolved requester context (requesting_repo_root = git root,
     /// requesting_session_id from KCAP_SESSION_ID), and that the MCP tool response surfaces


### PR DESCRIPTION
## Problem

The review-flows feature (**AI-774**) shipped two things together in #190: the `kcap mcp flows` MCP server *and* the auto-installed `review-flows` skill. But the plugin never registered the server — `kcap/.mcp.json` only listed `kcap-review` and `kcap-sessions` (last touched by the rename PR #108, long before flows existed).

Result: the `review-flows` skill auto-installs and instructs the agent to call `start_review_flow`, but the tool was never connected. On a normal plugin install the review-flows MCP is unusable — exactly the symptom reported (only `kcap-review` / `kcap-sessions` show up, never `kcap-flows`).

## Change

Register `kcap-flows` in the Claude Code plugin manifest (`kcap/.mcp.json`), mirroring `kcap-sessions` with `cwd: ${CLAUDE_PROJECT_DIR}` — the flows server resolves the target repo from its launch working directory, and Claude Code always runs inside the repo, so a single registration works for every repo.

**On-by-default** (the decision AI-1056 flags): the tools are inert until a daemon with the repo is connected (`start_review_flow` returns an error otherwise), so auto-registering is safe. Codex CLI / GUI apps have no single repo cwd and stay manual — `.codex-mcp.json` is intentionally **unchanged**.

- `kcap/.mcp.json` — add `kcap-flows` (Claude Code only)
- `help-mcp.txt` — drop the manual `claude mcp add` for Claude Code; keep Codex manual; note it's auto-registered
- `README.md` — same doc update, plus document the `kcap login` + running-daemon prerequisites
- `plugin.json` — minor version bump (1.6.0 → 1.7.0) for the new capability

## Verification

- `dotnet build` — 0 errors, 0 warnings
- `dotnet publish -c Release` — no IL3050/IL2026 AOT warnings
- `kcap/.mcp.json` parses; now lists `kcap-review`, `kcap-sessions`, `kcap-flows`
- No test asserts the changed help-text strings or the manifest contents

## Issue references

Closes **AI-1056** (Auto-register `kcap mcp flows` via the Claude Code plugin). Follow-up to AI-774 (server #830, CLI #190).

_No GitHub issue: AI-1056 was created directly in Linear, so there's no imported GitHub issue to close with a `Closes #` keyword. Opening one now would re-import as a duplicate Linear issue._

🤖 Generated with [Claude Code](https://claude.com/claude-code)