### PR TITLE
docs(review-flows skill): daemon prerequisite, roles, and failure handling

### DIFF
--- a/kcap/skills/review-flows/SKILL.md
+++ b/kcap/skills/review-flows/SKILL.md
@@ -28,6 +28,18 @@ Once the user has explicitly opted into a flow (see above), pick the `kind`:
 - Spec or design document → `kind: "spec-review"`
 - Code changes or a pull request → `kind: "code-review"`
 
+## Prerequisites
+
+A flow hands your work to a **hosted reviewer** the daemon launches for you (its vendor and model come from the flow definition — you don't pick or configure the reviewer). For `start_review_flow` to succeed, two things must be true:
+
+1. You are logged in (`kcap login`).
+2. A `kcap` daemon is running with **this** repo checked out — that daemon hosts the reviewer.
+
+If `start_review_flow` errors, do **not** retry blindly — the two cases differ:
+
+- **No daemon** — tell the user to start one with the target repo checked out (`kcap daemon start -d`), then start the flow again.
+- **Ambiguous match** ("multiple daemons/checkouts match this repo") — retrying won't help: the tool exposes no `daemon_name`/`repo_path`, so it can't disambiguate when several checkouts of the repo are registered (e.g. multiple git worktrees). Surface this to the user rather than looping (tracked in AI-1112).
+
 ## If the flows MCP tools are not loaded
 
 If `start_review_flow` / `submit_review_round` are not among the tools available in this session, do NOT try to obtain them:


### PR DESCRIPTION
## What

Enhances the `review-flows` skill (`kcap/skills/review-flows/SKILL.md`) so the driving agent knows what has to be true for a flow to work, and what to do when it isn't.

- **Roles** — the driver calls these tools; the **reviewer is a separate hosted Codex agent** the server launches on a `kcap` daemon (never configured from the driver).
- **Prerequisites** — `start_review_flow` needs `kcap login` **and** a running daemon with *this* repo checked out, or it errors instead of returning a `flow_run_id`.
- **Failure handling** — on a no-daemon / ambiguous-daemon error, surface the fix (`kcap daemon start -d` with the target repo) rather than retrying blindly; don't start a flow (which spends real reviewer compute) unprompted.

## Why

Setting the feature up end-to-end surfaced that these prerequisites were undocumented on the agent-facing surface — the skill explained the loop mechanics but not the daemon dependency or the driver/reviewer split, so an agent hitting a no-daemon error had no guidance.

## Scope / relationship to other work

Doc-only; **no CLI surface change** (no new command/flag), so no README sync is required by the repo convention.

Complements **#217 (AI-1056)**, which auto-registers the flows MCP server for Claude Code and rewrites the README/registration guidance. This PR touches only `SKILL.md` (which #217 does not), so the two don't conflict.

Linear: **AI-774** (feature), **AI-1056** (auto-register follow-up).