### PR TITLE
Fix Codex MCP registration: correct descriptor key + write config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Open the server URL in your browser. The dashboard shows repositories, sessions,
 
 ### Sessions and Flows MCP servers for agents
 
-The `kcap mcp sessions` stdio server lets coding agents search and recall past Capacitor sessions without leaving the chat. The Kurrent Capacitor plugin (installed by `kcap setup`) **auto-registers it for both Claude Code and Codex CLI** — no manual `claude mcp add` or TOML edit. The server is repo-aware: `cd` into a project before spawning your agent and `search_sessions` defaults to that repo's sessions.
+The `kcap mcp sessions` stdio server lets coding agents search and recall past Capacitor sessions without leaving the chat. `kcap setup` **registers it (with `kcap-review`) for both Claude Code and Codex CLI** — no manual `claude mcp add` or TOML edit. For Claude Code it's carried by the plugin's `.mcp.json`; for Codex CLI, `kcap setup` / `kcap plugin install --codex` write it into `~/.codex/config.toml`. The server is repo-aware: `cd` into a project before spawning your agent and `search_sessions` defaults to that repo's sessions.
 
 The `kcap mcp flows` stdio server lets agents start and interact with AI-powered review flows. Add it manually via `claude mcp add kcap-flows -- kcap mcp flows`. See the [Flows MCP server](#flows-mcp-server-for-agents) section for details.
 
@@ -276,9 +276,9 @@ The same MCP server (`kcap-review`) is also auto-registered by the Kurrent Capac
 kcap mcp sessions
 ```
 
-Stdio MCP server that exposes past Capacitor sessions to coding agents (Claude Code, Codex) so they can search and recall prior work without leaving the chat. The Kurrent Capacitor plugin auto-registers it for both Claude Code (via `.mcp.json`) and Codex CLI (via `.codex-plugin/plugin.json` → `.codex-mcp.json`), so there's nothing extra to do after `kcap setup`. If you installed the kcap plugin via Codex's native plugin manager (rather than `kcap setup` / `kcap plugin install --codex`), the MCP server is still auto-registered, but you'll also want to run `kcap plugin install --codex` to get hooks and agent skills.
+Stdio MCP server that exposes past Capacitor sessions to coding agents (Claude Code, Codex) so they can search and recall prior work without leaving the chat. **Claude Code:** auto-registered via the plugin's `.mcp.json`. **Codex CLI:** `kcap setup` / `kcap plugin install --codex` register it (alongside `kcap-review`) directly in `~/.codex/config.toml` under `[mcp_servers]`, so there's nothing extra to do — launch Codex from your repo directory so the server resolves the right repo. Enabling the kcap plugin through Codex's native plugin manager (`codex plugin add`) also provides them via the plugin's `.codex-mcp.json` descriptor.
 
-It provides three tools:
+It provides four tools:
 
 - **`search_sessions`** — free-text search over past sessions (and subagent transcripts) in the current repo. Pass `repo: "all"` to search across every repo you can see, or `repo: "owner/name"` for a different one. Filter by `author` / `author_github_id`. Returns ranked hits with `session_id`, snippet, and (for transcript hits) `hit_event_index` + `agent_id` for drilling in.
 - **`get_session_summary`** — concise `summary_text` + `plan` for a session. Use this to orient before reading the transcript.

--- a/kcap/.codex-mcp.json
+++ b/kcap/.codex-mcp.json
@@ -1,5 +1,5 @@
 {
-  "mcp_servers": {
+  "mcpServers": {
     "kcap-review": {
       "command": "kcap",
       "args": ["mcp", "review"]

--- a/kcap/README.md
+++ b/kcap/README.md
@@ -122,7 +122,7 @@ kcap/
   .codex-plugin/
     plugin.json          — Codex manifest (refs ./.codex-mcp.json)
   .mcp.json              — Claude MCP servers (camelCase mcpServers shape)
-  .codex-mcp.json        — Codex MCP servers (snake_case mcp_servers shape)
+  .codex-mcp.json        — Codex plugin MCP servers (also camelCase mcpServers shape)
   hooks/
     hooks.json           — Hook definitions for all Claude lifecycle events
   skills/

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -243,6 +243,15 @@ public static class CodexConfigToml {
     }
 
     static bool MutateRegisterMcpServers(TomlTable root) {
+        // If `mcp_servers` exists but isn't a table, refuse rather than let GetOrAddTable
+        // replace it — that would silently destroy the user's value and break the
+        // non-destructive contract. Update() turns this throw into Change.Failed, so the
+        // caller warns instead. (A non-table `mcp_servers` is an invalid Codex config, but
+        // we still won't clobber it.)
+        if (root.TryGetValue("mcp_servers", out var existing) && existing is not TomlTable)
+            throw new InvalidOperationException(
+                "~/.codex/config.toml has a non-table `mcp_servers` value; refusing to overwrite it.");
+
         var servers = GetOrAddTable(root, "mcp_servers");
         var changed = false;
 

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -25,6 +25,20 @@ public static class CodexConfigToml {
     static string DefaultConfigPath => Path.Combine(CodexPaths.Home(), "config.toml");
 
     /// <summary>
+    /// The kcap MCP servers auto-registered for Codex CLI in <c>~/.codex/config.toml</c>.
+    /// Codex reads MCP servers from the snake_case <c>[mcp_servers]</c> TOML table — note
+    /// this is NOT the camelCase <c>mcpServers</c> key used by the Claude/Codex plugin
+    /// *descriptor* JSON. <c>kcap-flows</c> is intentionally excluded: it launches a paid
+    /// hosted reviewer and stays Claude-only (AI-1056).
+    /// </summary>
+    static readonly (string Name, string[] Args)[] KcapMcpServers = [
+        ("kcap-review",   ["mcp", "review"]),
+        ("kcap-sessions", ["mcp", "sessions"])
+    ];
+
+    const string McpServerCommand = "kcap";
+
+    /// <summary>
     /// AI-794 — enable network access for Codex's <c>workspace-write</c> sandbox so
     /// kcap skills (which shell out to <c>kcap …</c>) can reach the Capacitor server.
     /// Codex blocks all sandbox network by default; a constrained
@@ -71,6 +85,26 @@ public static class CodexConfigToml {
     /// </summary>
     internal static Change TrustWorktree(string worktreePath, out Exception? error, string? configPath = null) =>
         Update(configPath ?? DefaultConfigPath, root => MutateTrust(root, worktreePath), out error);
+
+    /// <summary>
+    /// Registers the kcap MCP servers (<c>kcap-review</c>, <c>kcap-sessions</c>) under the
+    /// top-level <c>[mcp_servers]</c> table of <c>~/.codex/config.toml</c> (or
+    /// <paramref name="configPath"/>) so Codex CLI picks them up with no manual TOML edit.
+    /// Idempotent, and non-destructive: an entry that already exists (a prior registration
+    /// or a user customization such as an absolute-path <c>command</c>) is left untouched;
+    /// only missing servers are added. User-defined <c>mcp_servers</c> entries are preserved.
+    /// </summary>
+    public static Change RegisterKcapMcpServers(string? configPath = null) =>
+        Update(configPath ?? DefaultConfigPath, MutateRegisterMcpServers, out _);
+
+    /// <summary>
+    /// Removes the kcap-owned MCP server entries (<c>kcap-review</c>, <c>kcap-sessions</c>)
+    /// from <c>~/.codex/config.toml</c> (or <paramref name="configPath"/>). Only those names
+    /// are touched; user-defined servers are preserved. Drops the <c>[mcp_servers]</c> table
+    /// entirely when removing them empties it, so uninstall leaves no bare table behind.
+    /// </summary>
+    public static Change UnregisterKcapMcpServers(string? configPath = null) =>
+        Update(configPath ?? DefaultConfigPath, MutateUnregisterMcpServers, out _);
 
     /// <summary>
     /// Reads the top-level <c>model = "…"</c> key from <c>~/.codex/config.toml</c>
@@ -206,6 +240,48 @@ public static class CodexConfigToml {
         entry["trust_level"] = "trusted";
 
         return true;
+    }
+
+    static bool MutateRegisterMcpServers(TomlTable root) {
+        var servers = GetOrAddTable(root, "mcp_servers");
+        var changed = false;
+
+        foreach (var (name, args) in KcapMcpServers) {
+            // Never clobber an existing entry: a prior kcap registration is already
+            // correct, and a user may have customized it (e.g. an absolute-path command
+            // for a GUI host). Only create the server when it's missing entirely.
+            if (servers.ContainsKey(name)) continue;
+
+            var entry = new TomlTable {
+                ["command"] = McpServerCommand,
+                ["args"]    = ToTomlArray(args)
+            };
+            servers[name] = entry;
+            changed        = true;
+        }
+
+        return changed;
+    }
+
+    static bool MutateUnregisterMcpServers(TomlTable root) {
+        if (!root.TryGetValue("mcp_servers", out var sObj) || sObj is not TomlTable servers) return false;
+
+        var changed = false;
+
+        foreach (var (name, _) in KcapMcpServers)
+            if (servers.Remove(name)) changed = true;
+
+        // Don't leave a bare [mcp_servers] behind if we emptied it.
+        if (servers.Count == 0 && root.Remove("mcp_servers")) changed = true;
+
+        return changed;
+    }
+
+    static TomlArray ToTomlArray(string[] values) {
+        var arr = new TomlArray();
+        foreach (var v in values) arr.Add(v);
+
+        return arr;
     }
 
     static bool MutateNetworkAccess(TomlTable root, IReadOnlyCollection<string> allowDomains) {

--- a/src/Capacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-mcp.txt
@@ -30,9 +30,9 @@ Options for judge:
   --session <sessionId>   Bind the judge to a specific session
 
 mcp sessions:
-  Exposes three tools — search_sessions, get_session_summary,
-  get_session_transcript — for agents to search and inspect past Kurrent
-  Capacitor sessions. The active repo is resolved from cwd at startup;
+  Exposes four tools — search_sessions, get_session_summary,
+  get_session_transcript, get_turn — for agents to search and inspect past
+  Kurrent Capacitor sessions. The active repo is resolved from cwd at startup;
   cd into your project before spawning. Requires `kcap login`.
 
 mcp flows:
@@ -62,11 +62,12 @@ mcp flows:
 
 INSTALL
 
-  The Kurrent Capacitor plugin auto-registers `kcap-sessions` and
-  `kcap-review` for both Claude Code (via the plugin's `.mcp.json`)
-  and Codex CLI (via `.codex-plugin/plugin.json` -> `.codex-mcp.json`),
-  so no manual `claude mcp add` or TOML edit is needed after
-  `kcap setup`.
+  `kcap setup` registers `kcap-sessions` and `kcap-review` for both
+  Claude Code (via the plugin's `.mcp.json`) and Codex CLI (`kcap setup`
+  / `kcap plugin install --codex` write them into `~/.codex/config.toml`),
+  so no manual `claude mcp add` or TOML edit is needed. Enabling the kcap
+  plugin through Codex's native `codex plugin add` also provides them via
+  the plugin's `.codex-mcp.json` descriptor.
 
   `kcap-judge` is not auto-registered. Add it explicitly if you
   want it:

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -45,7 +45,8 @@ internal static class CodingAgentsStep {
             Func<string /*agentJsonPath*/, bool>?                     InstallKiroHooks = null,
             Func<string /*extensionPath*/, bool>?                     InstallPiExtension = null,
             Func<string /*pluginPath*/, bool>?                        InstallOpenCodeExtension = null,
-            Func<CodexConfigToml.Change>?                            EnableCodexNetworkAccess = null
+            Func<CodexConfigToml.Change>?                            EnableCodexNetworkAccess = null,
+            Func<CodexConfigToml.Change>?                            RegisterCodexMcp = null
         );
 
     internal record Result(
@@ -58,7 +59,8 @@ internal static class CodingAgentsStep {
             bool KiroHooksInstalled = false,
             bool PiExtensionInstalled = false,
             bool OpenCodeExtensionInstalled = false,
-            bool CodexNetworkAccessApplied = false
+            bool CodexNetworkAccessApplied = false,
+            bool CodexMcpRegistered = false
         ) {
         /// <summary>
         /// True when at least one agent's hooks were installed — i.e. there's a
@@ -88,6 +90,7 @@ internal static class CodingAgentsStep {
         var codexHooksInstalled   = HandleCodexHooks(options, detected, paths, installers, prompt, writeLine);
         var codexSkillsInstalled  = codexHooksInstalled && HandleCodexSkills(paths, installers, writeLine);
         var codexNetworkApplied   = HandleCodexNetworkAccess(options, paths, installers, prompt, writeLine, codexHooksInstalled);
+        var codexMcpRegistered    = HandleCodexMcp(paths, installers, writeLine, codexHooksInstalled);
         var cursorHooksInstalled  = HandleCursorHooks(options, detected, paths, installers, prompt, writeLine);
         var copilotHooksInstalled = HandleCopilotHooks(options, detected, paths, installers, prompt, writeLine);
         var geminiHooksInstalled  = HandleGeminiHooks(options, detected, paths, installers, prompt, writeLine);
@@ -110,7 +113,8 @@ internal static class CodingAgentsStep {
                 kiroHooksInstalled,
                 piExtensionInstalled,
                 openCodeExtensionInstalled,
-                codexNetworkApplied
+                codexNetworkApplied,
+                codexMcpRegistered
             )
         );
     }
@@ -505,6 +509,40 @@ internal static class CodingAgentsStep {
                 return false;
             default:
                 writeLine($"  [yellow]⚠[/] Could not update {configPath} — enable Codex sandbox network access manually (see README).");
+
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Registers the kcap MCP servers (kcap-review, kcap-sessions) in
+    /// <c>~/.codex/config.toml</c> via <see cref="Installers.RegisterCodexMcp"/> so Codex
+    /// CLI picks them up with no manual TOML edit. Gated on Codex hooks installing — the
+    /// same "full Codex integration" trigger as skills. No prompt: registration is
+    /// non-destructive (only adds missing kcap servers) and mirrors how the Claude plugin
+    /// auto-registers its MCP servers. <c>kcap-flows</c> stays Claude-only (AI-1056).
+    /// </summary>
+    static bool HandleCodexMcp(
+            Paths          paths,
+            Installers     installers,
+            Action<string> writeLine,
+            bool           codexHooksInstalled
+        ) {
+        if (!codexHooksInstalled || installers.RegisterCodexMcp is null) return false;
+
+        var configPath = Markup.Escape(paths.CodexConfigTomlPath);
+
+        switch (installers.RegisterCodexMcp()) {
+            case CodexConfigToml.Change.Updated:
+                writeLine($"  [green]✓[/] Codex MCP servers registered: kcap-review, kcap-sessions ([dim]{configPath}[/])");
+
+                return true;
+            case CodexConfigToml.Change.Unchanged:
+                writeLine("  [dim]· Codex MCP servers already registered — no change needed[/]");
+
+                return false;
+            default:
+                writeLine($"  [yellow]⚠[/] Could not register Codex MCP servers in {configPath} — see README to add them manually.");
 
                 return false;
         }

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -420,6 +420,13 @@ public static class PluginCommand {
         if (!args.Contains("--skip-codex-network-access"))
             await EnableCodexNetworkAccessAsync(env);
 
+        // Register the kcap MCP servers in ~/.codex/config.toml so Codex CLI picks them up
+        // with no manual TOML edit (the plugin descriptor path alone isn't enough — many
+        // users never run `codex plugin add`). Non-destructive + idempotent. `kcap-flows`
+        // stays Claude-only (AI-1056). The --if-installed refresh returns earlier, so npm
+        // postinstall never touches config.toml here.
+        await RegisterCodexMcpServersAsync(env);
+
         if (scope == "project") {
             await env.Stdout.WriteLineAsync(
                 "Note: Codex requires the project's .codex directory to be trusted. " +
@@ -460,6 +467,26 @@ public static class PluginCommand {
         }
     }
 
+    /// <summary>
+    /// Registers the kcap MCP servers (kcap-review, kcap-sessions) in
+    /// <c>~/.codex/config.toml</c> so Codex CLI loads them without a manual TOML edit.
+    /// Never fails the install: a write error is a warning, not an error code.
+    /// </summary>
+    static async Task RegisterCodexMcpServersAsync(PluginEnvironment env) {
+        switch (CodexConfigToml.RegisterKcapMcpServers(env.CodexConfigTomlPath)) {
+            case CodexConfigToml.Change.Updated:
+                await env.Stdout.WriteLineAsync($"Codex MCP servers registered: kcap-review, kcap-sessions ({env.CodexConfigTomlPath}).");
+                break;
+            case CodexConfigToml.Change.Unchanged:
+                await env.Stdout.WriteLineAsync("Codex MCP servers already registered — no change needed.");
+                break;
+            default:
+                await env.Stderr.WriteLineAsync(
+                    $"Warning: could not register Codex MCP servers in {env.CodexConfigTomlPath} — see README to add them manually.");
+                break;
+        }
+    }
+
     static async Task<int> RemoveCodex(string[] args, PluginEnvironment env) {
         var scope = args.Contains("--project") ? "project" : "user";
 
@@ -483,6 +510,18 @@ public static class PluginCommand {
             await env.Stdout.WriteLineAsync($"Codex hooks removed ({scope}: {hooksPath})");
         }
 
+        // Remove the kcap MCP server entries we wrote to config.toml. These are kcap-owned
+        // (unlike the sandbox network policy, which is the user's security posture and is
+        // deliberately left in place on uninstall).
+        var mcpChange = CodexConfigToml.UnregisterKcapMcpServers(env.CodexConfigTomlPath);
+        var mcpFailed = mcpChange == CodexConfigToml.Change.Failed;
+
+        if (mcpChange == CodexConfigToml.Change.Updated) {
+            await env.Stdout.WriteLineAsync($"Codex MCP servers removed ({env.CodexConfigTomlPath})");
+        } else if (mcpFailed) {
+            await env.Stderr.WriteLineAsync($"Could not update {env.CodexConfigTomlPath} to remove Codex MCP servers.");
+        }
+
         var agents = AgentsSkillsInstaller.Remove(env.AgentsSkillsDir);
 
         if (agents.RemovedAny) {
@@ -491,13 +530,13 @@ public static class PluginCommand {
 
         var legacy = AgentsSkillsInstaller.CleanLegacyCodexSkills(env.LegacyCodexSkills);
 
-        if (hooksFailed || agents.HadErrors || legacy.HadErrors) {
+        if (hooksFailed || mcpFailed || agents.HadErrors || legacy.HadErrors) {
             await env.Stdout.WriteLineAsync("Removal incomplete — see errors above.");
 
             return 1;
         }
 
-        if (!hooksRemoved && !agents.RemovedAny && !legacy.RemovedAny) {
+        if (!hooksRemoved && mcpChange != CodexConfigToml.Change.Updated && !agents.RemovedAny && !legacy.RemovedAny) {
             await env.Stdout.WriteLineAsync("Nothing to remove — hooks and skills were not installed.");
         }
 

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -510,10 +510,14 @@ public static class PluginCommand {
             await env.Stdout.WriteLineAsync($"Codex hooks removed ({scope}: {hooksPath})");
         }
 
-        // Remove the kcap MCP server entries we wrote to config.toml. These are kcap-owned
-        // (unlike the sandbox network policy, which is the user's security posture and is
-        // deliberately left in place on uninstall).
-        var mcpChange = CodexConfigToml.UnregisterKcapMcpServers(env.CodexConfigTomlPath);
+        // Remove the kcap MCP server entries we wrote to config.toml. These live in the
+        // user-scoped ~/.codex/config.toml, so ONLY a user-scope uninstall removes them — a
+        // project-scope remove must not nuke the user-global servers that every other repo
+        // relies on. (Mirrors the sandbox network policy, which is user-global and also
+        // deliberately left in place on remove.)
+        var mcpChange = scope == "user"
+            ? CodexConfigToml.UnregisterKcapMcpServers(env.CodexConfigTomlPath)
+            : CodexConfigToml.Change.Unchanged;
         var mcpFailed = mcpChange == CodexConfigToml.Change.Failed;
 
         if (mcpChange == CodexConfigToml.Change.Updated) {

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -263,7 +263,8 @@ public static class SetupCommand {
             InstallKiroHooks:       PluginCommand.InstallKiroHooks,
             InstallPiExtension:     PiExtensionInstaller.Install,
             InstallOpenCodeExtension: OpenCodeExtensionInstaller.Install,
-            EnableCodexNetworkAccess: () => CodexConfigToml.EnableNetworkAccess(codexAllowDomains));
+            EnableCodexNetworkAccess: () => CodexConfigToml.EnableNetworkAccess(codexAllowDomains),
+            RegisterCodexMcp:         () => CodexConfigToml.RegisterKcapMcpServers());
 
         bool PromptYesNo(string text) =>
             AnsiConsole.Prompt(new ConfirmationPrompt(text) { DefaultValue = true });

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
@@ -297,6 +297,20 @@ public class CodexConfigTomlTests {
     }
 
     [Test]
+    public async Task RegisterKcapMcpServers_non_table_mcp_servers_is_failure_not_clobber() {
+        // A non-table `mcp_servers` value must not be silently replaced (honours the
+        // non-destructive contract) — register fails and leaves the file untouched.
+        var path = TempConfig();
+        const string content = "mcp_servers = \"oops\"\n";
+        File.WriteAllText(path, content);
+
+        var change = CodexConfigToml.RegisterKcapMcpServers(path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Failed);
+        await Assert.That(File.ReadAllText(path)).IsEqualTo(content);
+    }
+
+    [Test]
     public async Task RegisterKcapMcpServers_malformed_config_is_not_overwritten() {
         var path = TempConfig();
         const string garbage = "{{{ not valid TOML";

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
@@ -201,4 +201,154 @@ public class CodexConfigTomlTests {
         await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Failed);
         await Assert.That(File.ReadAllText(path)).IsEqualTo(garbage);
     }
+
+    // ── RegisterKcapMcpServers ───────────────────────────────────────────────
+
+    static string[] ArgsOf(TomlTable server) =>
+        ((TomlArray)server["args"]).Select(v => (string)v!).ToArray();
+
+    [Test]
+    public async Task RegisterKcapMcpServers_on_missing_config_writes_both_servers() {
+        var path = TempConfig();
+
+        var change = CodexConfigToml.RegisterKcapMcpServers(path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
+
+        var servers = (TomlTable)ReadToml(path)["mcp_servers"];
+        var review  = (TomlTable)servers["kcap-review"];
+        var sessions = (TomlTable)servers["kcap-sessions"];
+
+        await Assert.That((string)review["command"]).IsEqualTo("kcap");
+        await Assert.That(ArgsOf(review)).IsEquivalentTo(new[] { "mcp", "review" });
+        await Assert.That((string)sessions["command"]).IsEqualTo("kcap");
+        await Assert.That(ArgsOf(sessions)).IsEquivalentTo(new[] { "mcp", "sessions" });
+    }
+
+    [Test]
+    public async Task RegisterKcapMcpServers_emits_snake_case_mcp_servers_table() {
+        // Codex config.toml uses the snake_case `mcp_servers` table — NOT the
+        // camelCase `mcpServers` key the plugin *descriptor* JSON requires.
+        var path = TempConfig();
+
+        CodexConfigToml.RegisterKcapMcpServers(path);
+
+        var text = File.ReadAllText(path);
+        await Assert.That(text).Contains("[mcp_servers.kcap-review]");
+        await Assert.That(text).Contains("[mcp_servers.kcap-sessions]");
+        await Assert.That(text).DoesNotContain("mcpServers");
+    }
+
+    [Test]
+    public async Task RegisterKcapMcpServers_is_idempotent() {
+        var path = TempConfig();
+
+        var first  = CodexConfigToml.RegisterKcapMcpServers(path);
+        var second = CodexConfigToml.RegisterKcapMcpServers(path);
+
+        await Assert.That(first).IsEqualTo(CodexConfigToml.Change.Updated);
+        await Assert.That(second).IsEqualTo(CodexConfigToml.Change.Unchanged);
+    }
+
+    [Test]
+    public async Task RegisterKcapMcpServers_preserves_user_config_and_servers() {
+        var path = TempConfig();
+        File.WriteAllText(path,
+            """
+            model = "gpt-5.5"
+
+            [mcp_servers.my-tool]
+            command = "my-tool"
+            args = ["serve"]
+            """);
+
+        var change = CodexConfigToml.RegisterKcapMcpServers(path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
+
+        var root    = ReadToml(path);
+        await Assert.That((string)root["model"]).IsEqualTo("gpt-5.5");
+
+        var servers = (TomlTable)root["mcp_servers"];
+        await Assert.That((string)((TomlTable)servers["my-tool"])["command"]).IsEqualTo("my-tool"); // user's preserved
+        await Assert.That(servers.ContainsKey("kcap-review")).IsTrue();
+        await Assert.That(servers.ContainsKey("kcap-sessions")).IsTrue();
+    }
+
+    [Test]
+    public async Task RegisterKcapMcpServers_does_not_clobber_existing_kcap_entry() {
+        // A user who set an absolute-path command (e.g. for a GUI host) must keep it.
+        var path = TempConfig();
+        File.WriteAllText(path,
+            """
+            [mcp_servers.kcap-sessions]
+            command = "/opt/homebrew/bin/kcap"
+            args = ["mcp", "sessions"]
+            """);
+
+        var change = CodexConfigToml.RegisterKcapMcpServers(path);
+
+        // kcap-review added; kcap-sessions left as-is → overall Updated.
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
+
+        var servers = (TomlTable)ReadToml(path)["mcp_servers"];
+        await Assert.That((string)((TomlTable)servers["kcap-sessions"])["command"]).IsEqualTo("/opt/homebrew/bin/kcap");
+        await Assert.That((string)((TomlTable)servers["kcap-review"])["command"]).IsEqualTo("kcap");
+    }
+
+    [Test]
+    public async Task RegisterKcapMcpServers_malformed_config_is_not_overwritten() {
+        var path = TempConfig();
+        const string garbage = "{{{ not valid TOML";
+        File.WriteAllText(path, garbage);
+
+        var change = CodexConfigToml.RegisterKcapMcpServers(path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Failed);
+        await Assert.That(File.ReadAllText(path)).IsEqualTo(garbage);
+    }
+
+    // ── UnregisterKcapMcpServers ─────────────────────────────────────────────
+
+    [Test]
+    public async Task UnregisterKcapMcpServers_removes_kcap_entries_and_drops_empty_table() {
+        var path = TempConfig();
+        CodexConfigToml.RegisterKcapMcpServers(path);
+
+        var change = CodexConfigToml.UnregisterKcapMcpServers(path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
+        await Assert.That(ReadToml(path).ContainsKey("mcp_servers")).IsFalse();
+    }
+
+    [Test]
+    public async Task UnregisterKcapMcpServers_preserves_user_servers() {
+        var path = TempConfig();
+        File.WriteAllText(path,
+            """
+            [mcp_servers.my-tool]
+            command = "my-tool"
+            args = ["serve"]
+            """);
+        CodexConfigToml.RegisterKcapMcpServers(path);
+
+        var change = CodexConfigToml.UnregisterKcapMcpServers(path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
+
+        var servers = (TomlTable)ReadToml(path)["mcp_servers"];
+        await Assert.That(servers.ContainsKey("my-tool")).IsTrue();
+        await Assert.That(servers.ContainsKey("kcap-review")).IsFalse();
+        await Assert.That(servers.ContainsKey("kcap-sessions")).IsFalse();
+    }
+
+    [Test]
+    public async Task UnregisterKcapMcpServers_is_noop_when_absent() {
+        var path = TempConfig();
+        File.WriteAllText(path, """model = "gpt-5.5" """);
+
+        var change = CodexConfigToml.UnregisterKcapMcpServers(path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Unchanged);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
@@ -331,6 +331,70 @@ public class CodingAgentsStepTests {
     }
 
     [Test]
+    public async Task Codex_mcp_registered_when_hooks_installed() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.CodexMcpRegistered).IsTrue();
+        await Assert.That(calls.RegisterCodexMcpCalled).IsTrue();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("MCP servers registered"));
+    }
+
+    [Test]
+    public async Task Codex_mcp_unchanged_when_already_registered() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { RegisterCodexMcpReturns = CodexConfigToml.Change.Unchanged };
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(calls.RegisterCodexMcpCalled).IsTrue();
+        await Assert.That(result.CodexMcpRegistered).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("already registered"));
+    }
+
+    [Test]
+    public async Task Codex_mcp_not_registered_when_hooks_fail() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { CodexHooksReturns = false };
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.CodexHooksInstalled).IsFalse();
+        await Assert.That(calls.RegisterCodexMcpCalled).IsFalse();
+        await Assert.That(result.CodexMcpRegistered).IsFalse();
+    }
+
+    [Test]
+    public async Task Codex_mcp_registration_failure_emits_warning() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { RegisterCodexMcpReturns = CodexConfigToml.Change.Failed };
+        var options  = new Options(SkipClaude: true, SkipCodex: false, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: true, Cursor: false, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(calls.RegisterCodexMcpCalled).IsTrue();
+        await Assert.That(result.CodexMcpRegistered).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("Could not register Codex MCP"));
+    }
+
+    [Test]
     public async Task Codex_network_access_not_attempted_when_hooks_fail() {
         var sink     = new Sink();
         var calls    = new InstallerCalls { CodexHooksReturns = false };
@@ -1046,6 +1110,9 @@ public class CodingAgentsStepTests {
         public bool                   EnableCodexNetworkCalled  { get; private set; }
         public CodexConfigToml.Change EnableCodexNetworkReturns { get; set; } = CodexConfigToml.Change.Updated;
 
+        public bool                   RegisterCodexMcpCalled  { get; private set; }
+        public CodexConfigToml.Change RegisterCodexMcpReturns { get; set; } = CodexConfigToml.Change.Updated;
+
         public Installers AsInstallers() => new(
             InstallClaudePlugin: (s, p) => {
                 ClaudeCalled = true;
@@ -1115,6 +1182,11 @@ public class CodingAgentsStepTests {
                 EnableCodexNetworkCalled = true;
 
                 return EnableCodexNetworkReturns;
+            },
+            RegisterCodexMcp: () => {
+                RegisterCodexMcpCalled = true;
+
+                return RegisterCodexMcpReturns;
             }
         );
     }

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
@@ -592,6 +592,74 @@ public class PluginCommandCodexInstallIntegrationTests {
         await Assert.That(stderr).Contains("Cannot install Codex plugin");
     }
 
+    [Test]
+    public async Task InstallCodex_registers_mcp_servers_in_config_toml() {
+        using var fakeHome   = new TempDir();
+        using var pluginRoot = new TempDir();
+        PlantFakePlugin(pluginRoot.Path);
+
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "install", "--codex"], TestEnv(fakeHome.Path, pluginRoot.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        var configPath = Path.Combine(fakeHome.Path, ".codex", "config.toml");
+        var toml       = await File.ReadAllTextAsync(configPath);
+        await Assert.That(toml).Contains("[mcp_servers.kcap-review]");
+        await Assert.That(toml).Contains("[mcp_servers.kcap-sessions]");
+    }
+
+    [Test]
+    public async Task RemoveCodex_user_scope_removes_mcp_servers_preserving_user_entries() {
+        using var fakeHome = new TempDir();
+        var configPath = SeedCodexConfigWithKcapServers(fakeHome.Path);
+
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "remove", "--codex"], TestEnv(fakeHome.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        var toml = await File.ReadAllTextAsync(configPath);
+        await Assert.That(toml).DoesNotContain("kcap-review");
+        await Assert.That(toml).DoesNotContain("kcap-sessions");
+        await Assert.That(toml).Contains("my-tool"); // user's server preserved
+    }
+
+    [Test]
+    public async Task RemoveCodex_project_scope_leaves_user_global_mcp_servers() {
+        // Regression: a project-scoped uninstall must NOT strip the user-global
+        // kcap MCP servers, which every other repo relies on.
+        using var fakeHome = new TempDir();
+        var configPath = SeedCodexConfigWithKcapServers(fakeHome.Path);
+        var before     = await File.ReadAllTextAsync(configPath);
+
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "remove", "--codex", "--project"], TestEnv(fakeHome.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        // config.toml is untouched — the user-global servers survive.
+        await Assert.That(await File.ReadAllTextAsync(configPath)).IsEqualTo(before);
+    }
+
+    static string SeedCodexConfigWithKcapServers(string fakeHome) {
+        var codexDir = Path.Combine(fakeHome, ".codex");
+        Directory.CreateDirectory(codexDir);
+        var configPath = Path.Combine(codexDir, "config.toml");
+        File.WriteAllText(configPath,
+            """
+            [mcp_servers.kcap-review]
+            command = "kcap"
+            args = ["mcp", "review"]
+
+            [mcp_servers.kcap-sessions]
+            command = "kcap"
+            args = ["mcp", "sessions"]
+
+            [mcp_servers.my-tool]
+            command = "my-tool"
+            args = ["serve"]
+            """);
+        return configPath;
+    }
+
     static void PlantFakePlugin(string pluginRoot) {
         var skillsSrc = Path.Combine(pluginRoot, "skills");
         Directory.CreateDirectory(skillsSrc);


### PR DESCRIPTION
## Problem

No kcap MCP server (`kcap-review`, `kcap-sessions`) has ever auto-registered for **Codex**, despite the docs claiming it works after `kcap setup`. Two independent, reproduced root causes:

1. **Wrong descriptor key.** `kcap/.codex-mcp.json` used the snake_case top-level key `mcp_servers`, but Codex's plugin loader requires camelCase `mcpServers` (like Claude's `.mcp.json`). An *enabled* kcap plugin surfaced zero servers:

   | `.codex-mcp.json` key | `codex mcp list` |
   |---|---|
   | `mcp_servers` (before) | *"No MCP servers configured yet."* |
   | `mcpServers` (after) | `kcap-review` + `kcap-sessions` → **enabled** |

2. **No registration during setup.** `PluginCommand.InstallCodex` and the setup wizard installed hooks + skills + sandbox network access, but never enabled the Codex plugin or wrote `mcp_servers` to `~/.codex/config.toml`. So even with the key fixed, registration was fully manual.

## Change

- **P1:** flip the descriptor key to `mcpServers` (fixes the native `codex plugin add` path — verified end-to-end with the real repo descriptor).
- **P2:** `CodexConfigToml.RegisterKcapMcpServers` / `UnregisterKcapMcpServers` write `[mcp_servers.kcap-review]` + `[mcp_servers.kcap-sessions]` (`command = "kcap"`) to `~/.codex/config.toml` via the existing RMW engine — idempotent, non-destructive (never clobbers a customized/absolute-path entry), preserves user servers, drops the table clean on uninstall.
- Wired into `kcap setup` (next to the network-access step) and `kcap plugin install --codex`; unregistered on `kcap plugin uninstall --codex`. **Not** run on the `--if-installed` npm refresh (keeps the "postinstall never touches `config.toml`" guarantee). Codex dedupes by name, so the config.toml + native-plugin paths coexist safely (verified).
- `kcap-flows` intentionally stays Codex-manual / Claude-only (AI-1056 — it launches a paid reviewer).
- Docs: fixed the false Codex auto-registration claims in `README.md`, `kcap/README.md`, and `help-mcp.txt`; corrected the stale sessions "three tools" count to four (`get_turn`).

## Verification

- Reproduced the descriptor-key bug and its fix in an isolated `CODEX_HOME` via `codex plugin add` + `codex mcp list`.
- Verified `config.toml` + native-plugin overlap dedupes without error.
- New tests: 9 `CodexConfigToml` register/unregister cases + 4 `CodingAgentsStep` MCP cases.
- Full unit suite: **2021 passed**. `dotnet publish -c Release`: no IL3050/IL2026 AOT warnings.

## Issue references

Closes #219 (a Linear issue will be auto-imported from it). Sibling to AI-1056 (Claude-side `kcap-flows` auto-registration, PR #217).

🤖 Generated with [Claude Code](https://claude.com/claude-code)