### PR TITLE
fix(codex): don't pass model sentinel "default" to Codex

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -78,10 +78,7 @@ internal sealed partial class CodexLauncher(
             "on-request"
         };
 
-        if (!string.IsNullOrEmpty(ctx.Model)) {
-            args.Add("-m");
-            args.Add(ctx.Model);
-        }
+        AppendModel(args, ctx.Model);
 
         var effort = ctx.Effort;
 
@@ -128,16 +125,28 @@ internal sealed partial class CodexLauncher(
         args.Add("-c");
         args.Add($"mcp_servers.{serverName}.env={{{envList}}}");
 
-        if (!string.IsNullOrEmpty(ctx.Model)) {
-            args.Add("-m");
-            args.Add(ctx.Model);
-        }
+        AppendModel(args, ctx.Model);
 
         args.Add("--no-alt-screen");
         args.Add("--");
         args.Add(launch.SystemPrompt);
 
         return new([.. args], McpConfigPath: null);
+    }
+
+    /// Append `-m <model>` unless the model is empty or the vendor-neutral sentinel
+    /// "default". The server sends "default" to mean "use the vendor's own default
+    /// model"; Claude accepts `--model default` but Codex has no such model and rejects
+    /// `-m default` on ChatGPT/subscription accounts (HTTP 400, AI-1114). Omitting -m
+    /// lets Codex fall back to its configured/account default — mirroring how the
+    /// "auto" effort sentinel is dropped so the CLI picks its own default.
+    static void AppendModel(List<string> args, string? model) {
+        if (string.IsNullOrEmpty(model) || string.Equals(model, "default", StringComparison.OrdinalIgnoreCase)) {
+            return;
+        }
+
+        args.Add("-m");
+        args.Add(model);
     }
 
     /// Encode a value as a TOML basic string: wrap in double quotes and escape

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -92,6 +92,27 @@ public class CodexLauncherTests {
     }
 
     [Test]
+    [Arguments("default")]
+    [Arguments("Default")]
+    [Arguments("DEFAULT")]
+    public async Task BuildArgs_omits_model_when_default_sentinel(string model) {
+        // "default" is a vendor-neutral sentinel meaning "use the vendor's own default
+        // model". Codex has no such model — `-m default` fails on ChatGPT accounts
+        // (AI-1114). Omit -m so Codex falls back to its configured default.
+        var args = NewLauncher().BuildArgs(NewCtx(model: model)).Args;
+        await Assert.That(args).DoesNotContain("-m");
+        await Assert.That(args).DoesNotContain(model);
+    }
+
+    [Test]
+    public async Task BuildArgs_review_omits_model_when_default_sentinel() {
+        var ctx  = NewReviewCtx("Review PR acme/widgets#42", "/opt/kcap", "https://srv", model: "default");
+        var args = NewLauncher().BuildArgs(ctx).Args;
+        await Assert.That(args).DoesNotContain("-m");
+        await Assert.That(args).DoesNotContain("default");
+    }
+
+    [Test]
     public async Task Prepare_overlays_codex_settings_dir_from_source_repo() {
         var sourceRepo = Directory.CreateTempSubdirectory("kcap-codexlauncher-src-").FullName;
         var worktree = Directory.CreateTempSubdirectory("kcap-codexlauncher-wt-").FullName;
@@ -252,7 +273,7 @@ public class CodexLauncherTests {
         ReviewLaunch: null
     );
 
-    static LauncherContext NewReviewCtx(string prompt, string cliPath, string baseUrl) {
+    static LauncherContext NewReviewCtx(string prompt, string cliPath, string baseUrl, string model = "gpt-5.3-codex") {
         var mcp = new ReviewLaunchBuilder.ReviewMcpServer(
             Command: cliPath,
             Args: ["mcp", "review", "--owner", "acme", "--repo", "widgets", "--pr", "42"],
@@ -263,7 +284,7 @@ public class CodexLauncherTests {
             SourceRepoPath: "/tmp/repo",
             Worktree: new WorktreeInfo(Path: "/tmp/wt", Branch: "wt-branch", SourceRepo: "/tmp/repo"),
             Prompt: null,
-            Model: "gpt-5.3-codex",
+            Model: model,
             Effort: null,
             Tools: null,
             IsReview: true,


### PR DESCRIPTION
## Problem

Requesting a plan/spec review through the review flow (`kcap-flows` MCP) with a **Codex** reviewer failed immediately. The hosted Codex agent launched with `model: default xhigh` and died before producing findings:

```
⚠ Model metadata for `default` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.
■ {"type":"error","status":400,"error":{"type":"invalid_request_error",
   "message":"The 'default' model is not supported when using Codex with a ChatGPT account."}}
```

## Root cause

The server sends the daemon a **vendor-neutral model sentinel** `"default"` in `LaunchAgentCommand.Model`, meaning "use the vendor's own default model". The daemon translates it per-vendor:

- `ClaudeLauncher` → `--model default` — Claude Code accepts `default` as a valid alias, so it works.
- `CodexLauncher` (`BuildArgs` + `BuildReviewArgs`) → `-m default` — Codex has no `default` model and rejects it (HTTP 400) on ChatGPT/subscription accounts.

The launcher only skipped `-m` for null/empty models, so the sentinel `"default"` slipped through.

## Fix

Add an `AppendModel` helper in `CodexLauncher` that omits `-m` when the model is empty **or** the `"default"` sentinel (case-insensitive), letting Codex fall back to its configured/account default. This mirrors how the `"auto"` effort sentinel is already dropped. Fixed at the vendor-specific translation layer, so Claude's working `--model default` behaviour is untouched.

## Tests

- New unit tests (TDD, watched fail first): `default`/`Default`/`DEFAULT` and the review path all omit `-m`.
- Full unit suite: 1968 passed, 0 failed.
- `dotnet publish -c Release`: no IL3050/IL2026 AOT warnings.

Closes #221

Linear: AI-1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
