### PR TITLE
Defer kcap mcp review auth client until first tool call

### DIFF
--- a/src/Capacitor.Cli/Commands/McpReviewServer.cs
+++ b/src/Capacitor.Cli/Commands/McpReviewServer.cs
@@ -41,6 +41,26 @@ static class McpReviewServer {
         // McpSessionsServer / McpFlowsServer.
         var clientLazy = new Lazy<Task<HttpClient>>(() => HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl));
 
+        // Validate the server_url shape once, locally (pure string check — no network, token,
+        // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
+        var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
+
+        // Guarded tool dispatch: never let the stdio JSON-RPC loop die on one bad request.
+        // An unusable server_url would otherwise reach EnsureAbsolute inside the lazy
+        // auth-client factory, which hard-exits the process (Environment.Exit(2)) mid-request;
+        // and an unexpected client-creation/token failure would bubble out of the loop. Return
+        // a JSON-RPC tool error in both cases so the server keeps serving.
+        async Task<string> DispatchToolCallAsync(JsonNode callId, JsonObject callRequest) {
+            if (!urlOk)
+                return BuildToolResult(callId, HttpClientExtensions.SchemeMissingHint, isError: true);
+
+            try {
+                return await HandleToolCallAsync(callId, callRequest, await clientLazy.Value, baseUrl, sessionDefault);
+            } catch (Exception ex) {
+                return BuildToolResult(callId, $"Error: {ex.Message}", isError: true);
+            }
+        }
+
         await using var stdin  = Console.OpenStandardInput();
         await using var stdout = Console.OpenStandardOutput();
         using var       reader = new StreamReader(stdin, Encoding.UTF8);
@@ -70,7 +90,7 @@ static class McpReviewServer {
                 var response = method switch {
                     "initialize" => BuildInitializeResponse(id),
                     "tools/list" => BuildToolsListResponse(id, tools),
-                    "tools/call" => await HandleToolCallAsync(id, request, await clientLazy.Value, baseUrl, sessionDefault),
+                    "tools/call" => await DispatchToolCallAsync(id, request),
                     _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
                 };
 

--- a/src/Capacitor.Cli/Commands/McpReviewServer.cs
+++ b/src/Capacitor.Cli/Commands/McpReviewServer.cs
@@ -25,14 +25,21 @@ static class McpReviewServer {
     public static Task<int> RunAutoAsync(string baseUrl) => RunCoreAsync(baseUrl, null);
 
     static async Task<int> RunCoreAsync(string baseUrl, PrIdentity? startupDefault) {
-        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
-
         // Compute the session default once: explicit startup args win; otherwise
-        // try git auto-detect. Result is cached for the lifetime of the server
+        // try git auto-detect (local). Result is cached for the lifetime of the server
         // and used as the fallback when a tool call doesn't carry an explicit `pr`.
         var sessionDefault = startupDefault ?? await DetectPrFromGitAsync();
 
         var tools = BuildToolsList();
+
+        // Defer the authenticated-client creation until the first tools/call. kcap-review
+        // auto-registers via the plugin manifest, so Claude Code (and Codex) spawn
+        // `kcap mcp review` for every session; an eager CreateAuthenticatedClientAsync — which
+        // does a GET /auth/config round-trip + token load, and prints a re-auth hint to stderr
+        // when not logged in — would charge every session that work even when no review tool is
+        // invoked. initialize / tools/list need no auth, so startup stays local-only. Mirrors
+        // McpSessionsServer / McpFlowsServer.
+        var clientLazy = new Lazy<Task<HttpClient>>(() => HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl));
 
         await using var stdin  = Console.OpenStandardInput();
         await using var stdout = Console.OpenStandardOutput();
@@ -40,33 +47,41 @@ static class McpReviewServer {
         await using var writer = new StreamWriter(stdout, new UTF8Encoding(false));
         writer.AutoFlush = true;
 
-        while (await reader.ReadLineAsync() is { } line) {
-            if (string.IsNullOrWhiteSpace(line)) continue;
+        try {
+            while (await reader.ReadLineAsync() is { } line) {
+                if (string.IsNullOrWhiteSpace(line)) continue;
 
-            JsonObject? request;
+                JsonObject? request;
 
-            try {
-                request = JsonNode.Parse(line)?.AsObject();
-            } catch {
-                continue; // skip malformed JSON
+                try {
+                    request = JsonNode.Parse(line)?.AsObject();
+                } catch {
+                    continue; // skip malformed JSON
+                }
+
+                if (request is null) continue;
+
+                var id     = request["id"];
+                var method = request["method"]?.GetValue<string>();
+
+                // Notifications have no id — don't send a response
+                if (id is null) continue;
+
+                var response = method switch {
+                    "initialize" => BuildInitializeResponse(id),
+                    "tools/list" => BuildToolsListResponse(id, tools),
+                    "tools/call" => await HandleToolCallAsync(id, request, await clientLazy.Value, baseUrl, sessionDefault),
+                    _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
+                };
+
+                await writer.WriteLineAsync(response);
             }
-
-            if (request is null) continue;
-
-            var id     = request["id"];
-            var method = request["method"]?.GetValue<string>();
-
-            // Notifications have no id — don't send a response
-            if (id is null) continue;
-
-            var response = method switch {
-                "initialize" => BuildInitializeResponse(id),
-                "tools/list" => BuildToolsListResponse(id, tools),
-                "tools/call" => await HandleToolCallAsync(id, request, client, baseUrl, sessionDefault),
-                _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
-            };
-
-            await writer.WriteLineAsync(response);
+        } finally {
+            if (clientLazy.IsValueCreated) {
+                try { (await clientLazy.Value).Dispose(); } catch {
+                    /* swallow — best-effort cleanup */
+                }
+            }
         }
 
         return 0;

--- a/test/Capacitor.Cli.Tests.Integration/McpReviewServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpReviewServerTests.cs
@@ -1,0 +1,194 @@
+using System.Diagnostics;
+using System.Text.Json.Nodes;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// End-to-end stdio JSON-RPC tests for <c>kcap mcp review</c>. Spawns the freshly-built CLI
+/// binary against a WireMock-stubbed Capacitor server (via <c>KCAP_URL</c>) with an isolated
+/// config dir (<c>KCAP_CONFIG_DIR</c>). Mirrors the harness in
+/// <see cref="McpFlowsServerTests"/> / <see cref="McpSessionsServerTests"/>.
+/// </summary>
+public class McpReviewServerTests : IDisposable {
+    readonly WireMockServer _server           = WireMockServer.Start();
+    readonly string         _cfgDir           = Path.Combine(Path.GetTempPath(), $"kcap-review-cfg-{Guid.NewGuid():N}");
+    readonly string         _cwdDir           = Path.Combine(Path.GetTempPath(), $"kcap-review-cwd-{Guid.NewGuid():N}");
+    readonly List<Process>  _spawnedProcesses = [];
+
+    public McpReviewServerTests() {
+        Directory.CreateDirectory(_cfgDir);
+        Directory.CreateDirectory(_cwdDir);
+        InitGitRepo(_cwdDir);
+    }
+
+    public void Dispose() {
+        foreach (var p in _spawnedProcesses) {
+            try {
+                if (!p.HasExited) p.Kill(entireProcessTree: true);
+                p.Dispose();
+            } catch {
+                // best-effort cleanup
+            }
+        }
+
+        _server.Stop();
+        try { Directory.Delete(_cfgDir, recursive: true); } catch { /* best effort */ }
+        try { Directory.Delete(_cwdDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    static void InitGitRepo(string dir) {
+        RunGit(dir, "init");
+        RunGit(dir, "remote add origin https://github.com/test-owner/test-repo.git");
+    }
+
+    static void RunGit(string cwd, string args) {
+        using var p = Process.Start(new ProcessStartInfo("git", args) {
+            WorkingDirectory       = cwd,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false
+        })!;
+        p.WaitForExit(5000);
+    }
+
+    static string GetCliBinaryPath() {
+        var asmDir      = Path.GetDirectoryName(typeof(McpReviewServerTests).Assembly.Location)!;
+        var binDir      = Path.GetDirectoryName(asmDir)!;
+        var config      = Path.GetFileName(binDir);
+        var testBin     = Path.GetDirectoryName(binDir)!;
+        var testProjDir = Path.GetDirectoryName(testBin)!;
+        var testRoot    = Path.GetDirectoryName(testProjDir)!;
+        var repoRoot    = Path.GetDirectoryName(testRoot)!;
+        var binaryName  = OperatingSystem.IsWindows() ? "kcap.exe" : "kcap";
+        return Path.Combine(repoRoot, "src", "Capacitor.Cli", "bin", config, "net10.0", binaryName);
+    }
+
+    /// <summary>Spawns <c>kcap mcp review</c> (argless / auto PR-detection) against WireMock.</summary>
+    Process SpawnMcpServer(string provider = "None") {
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($$"""{"provider":"{{provider}}"}"""));
+
+        var binary = GetCliBinaryPath();
+
+        if (!File.Exists(binary)) {
+            throw new FileNotFoundException(
+                $"kcap binary not found at {binary}. Build it first: " +
+                "dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj",
+                binary
+            );
+        }
+
+        var psi = new ProcessStartInfo(binary, "mcp review") {
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+            CreateNoWindow         = true,
+            WorkingDirectory       = _cwdDir,
+            Environment = {
+                ["KCAP_URL"]        = _server.Url!,
+                ["KCAP_CONFIG_DIR"] = _cfgDir
+            }
+        };
+
+        var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start kcap process");
+        _spawnedProcesses.Add(process);
+        return process;
+    }
+
+    static async Task<JsonObject> SendRequest(Process proc, JsonObject request, TimeSpan? timeout = null) {
+        await proc.StandardInput.WriteLineAsync(request.ToJsonString());
+        await proc.StandardInput.FlushAsync();
+
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(15));
+        var line      = await proc.StandardOutput.ReadLineAsync(cts.Token);
+
+        if (line is null) {
+            var stderr = await proc.StandardError.ReadToEndAsync();
+            throw new InvalidOperationException($"MCP server closed stdout without responding. Stderr: {stderr}");
+        }
+
+        return JsonNode.Parse(line)?.AsObject()
+            ?? throw new InvalidOperationException($"Could not parse response as JSON object: {line}");
+    }
+
+    static async Task ShutdownAsync(Process proc) {
+        try { proc.StandardInput.Close(); } catch { /* already closed */ }
+        try {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await proc.WaitForExitAsync(cts.Token);
+        } catch {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
+        }
+    }
+
+    static JsonObject InitializeRequest(int id) => new() {
+        ["jsonrpc"] = "2.0",
+        ["id"]      = id,
+        ["method"]  = "initialize",
+        ["params"]  = new JsonObject()
+    };
+
+    static JsonObject ToolsListRequest(int id) => new() {
+        ["jsonrpc"] = "2.0",
+        ["id"]      = id,
+        ["method"]  = "tools/list",
+        ["params"]  = new JsonObject()
+    };
+
+    [Test]
+    public async Task Initialize_returns_kcap_review_server_info() {
+        using var proc = SpawnMcpServer();
+        try {
+            var response = await SendRequest(proc, InitializeRequest(1));
+
+            await Assert.That(response["id"]?.GetValue<int>()).IsEqualTo(1);
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["serverInfo"]?["name"]?.GetValue<string>()).IsEqualTo("kcap-review");
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    [Test]
+    public async Task Tools_list_returns_review_tools() {
+        using var proc = SpawnMcpServer();
+        try {
+            var response = await SendRequest(proc, ToolsListRequest(2));
+
+            var tools = response["result"]?["tools"]?.AsArray();
+            await Assert.That(tools).IsNotNull();
+
+            var names = tools!.Select(t => t?["name"]?.GetValue<string>()).ToHashSet();
+            await Assert.That(names.Contains("get_pr_summary")).IsTrue();
+            await Assert.That(names.Contains("get_transcript")).IsTrue();
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
+    /// Regression: kcap-review auto-registers via the plugin manifest, so Claude Code / Codex
+    /// spawn `kcap mcp review` for every session. initialize / tools/list must stay local-only —
+    /// the authenticated client (and its GET /auth/config round-trip + re-auth stderr hint) is
+    /// created lazily on the first tools/call, so sessions that never use a review tool pay
+    /// nothing. Mirrors McpSessionsServer / McpFlowsServer.
+    /// </summary>
+    [Test]
+    public async Task Initialize_and_tools_list_do_not_consult_auth() {
+        using var proc = SpawnMcpServer(provider: "GitHub");
+        try {
+            await SendRequest(proc, InitializeRequest(1));
+            await SendRequest(proc, ToolsListRequest(2));
+
+            var authHits = _server.FindLogEntries(Request.Create().WithPath("/auth/config").UsingGet());
+            await Assert.That(authHits.Count).IsEqualTo(0);
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Integration/McpReviewServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpReviewServerTests.cs
@@ -66,8 +66,12 @@ public class McpReviewServerTests : IDisposable {
         return Path.Combine(repoRoot, "src", "Capacitor.Cli", "bin", config, "net10.0", binaryName);
     }
 
-    /// <summary>Spawns <c>kcap mcp review</c> (argless / auto PR-detection) against WireMock.</summary>
-    Process SpawnMcpServer(string provider = "None") {
+    /// <summary>
+    /// Spawns <c>kcap mcp review</c> (argless / auto PR-detection) against WireMock.
+    /// <paramref name="urlOverride"/> replaces the WireMock URL (used to exercise the
+    /// invalid-server_url path).
+    /// </summary>
+    Process SpawnMcpServer(string provider = "None", string? urlOverride = null) {
         _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody($$"""{"provider":"{{provider}}"}"""));
 
@@ -89,7 +93,7 @@ public class McpReviewServerTests : IDisposable {
             CreateNoWindow         = true,
             WorkingDirectory       = _cwdDir,
             Environment = {
-                ["KCAP_URL"]        = _server.Url!,
+                ["KCAP_URL"]        = urlOverride ?? _server.Url!,
                 ["KCAP_CONFIG_DIR"] = _cfgDir
             }
         };
@@ -187,6 +191,39 @@ public class McpReviewServerTests : IDisposable {
 
             var authHits = _server.FindLogEntries(Request.Create().WithPath("/auth/config").UsingGet());
             await Assert.That(authHits.Count).IsEqualTo(0);
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
+    /// A scheme-less server_url would otherwise reach EnsureAbsolute inside the lazy auth-client
+    /// factory and hard-exit the process (Environment.Exit(2)) mid-request. The startup URL
+    /// guard turns it into a graceful JSON-RPC tool error, and the server keeps serving.
+    /// </summary>
+    [Test]
+    public async Task Tool_call_with_invalid_server_url_returns_error_and_server_survives() {
+        using var proc = SpawnMcpServer(urlOverride: "not-a-valid-url");
+        try {
+            await SendRequest(proc, InitializeRequest(1));
+
+            var call = new JsonObject {
+                ["jsonrpc"] = "2.0",
+                ["id"]      = 2,
+                ["method"]  = "tools/call",
+                ["params"]  = new JsonObject {
+                    ["name"]      = "get_pr_summary",
+                    ["arguments"] = new JsonObject()
+                }
+            };
+            var response = await SendRequest(proc, call);
+            var result   = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsTrue();
+
+            // Server survived the bad request — a follow-up still gets a response.
+            var again = await SendRequest(proc, ToolsListRequest(3));
+            await Assert.That(again["result"]?["tools"]).IsNotNull();
         } finally {
             await ShutdownAsync(proc);
         }


### PR DESCRIPTION
## Problem

`kcap-review` auto-registers via the plugin manifest (`.mcp.json` + `.codex-mcp.json`), so the host spawns `kcap mcp review` for **every** session. `McpReviewServer.RunCoreAsync` eagerly called `CreateAuthenticatedClientAsync` at startup — which does a `GET /auth/config` round-trip + token load, and prints a re-auth hint to **stderr** when not logged in. Every session paid that cost (and unauthenticated users saw stderr noise) even when no review tool was invoked. `initialize` / `tools/list` need no auth.

Same issue already solved for `kcap mcp sessions` (lazy client) and `kcap mcp flows` (#217). `review` predates both and was missed — this is a **pre-existing** issue, independent of #217/#220.

## Change

- Defer client creation to the first `tools/call` via `Lazy<Task<HttpClient>>`, mirroring `McpSessionsServer` / `McpFlowsServer`. `initialize` / `tools/list` stay local-only; PR auto-detection stays at startup (local git only); dispose in a `finally`.
- Add the review MCP server's **first integration tests** (it had none): `initialize`, `tools/list`, and a regression asserting `initialize` + `tools/list` make **zero** `GET /auth/config` calls.

## Verification

- Review integration suite: **3 passed** (incl. the regression, which would fail on the old eager code).
- `dotnet build` clean; `dotnet publish -c Release` — no IL3050/IL2026 AOT warnings.

## Issue references

Closes #223 (a Linear issue will auto-import from it). Same class of fix as #217 (flows) / the sessions lazy client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)