### PR TITLE
Harden kcap mcp sessions dispatch: guard invalid URL + catch per-request

### DIFF
--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -25,6 +25,26 @@ static class McpSessionsServer {
         // don't need auth, so we keep startup local-only.
         var clientLazy = new Lazy<Task<HttpClient>>(() => HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl));
 
+        // Validate the server_url shape once, locally (pure string check — no network, token,
+        // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
+        var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
+
+        // Guarded tool dispatch: never let the stdio JSON-RPC loop die on one bad request. An
+        // unusable server_url would otherwise reach EnsureAbsolute inside the lazy auth-client
+        // factory, which hard-exits the process (Environment.Exit(2)) mid-request; and an
+        // unexpected client-creation/token failure would bubble out of the loop. Return a
+        // JSON-RPC tool error in both cases so the server keeps serving.
+        async Task<string> DispatchToolCallAsync(JsonNode callId, JsonObject callRequest) {
+            if (!urlOk)
+                return BuildToolResult(callId, HttpClientExtensions.SchemeMissingHint, isError: true);
+
+            try {
+                return await HandleToolCallAsync(callId, callRequest, await clientLazy.Value, baseUrl, cwdRepoHash);
+            } catch (Exception ex) {
+                return BuildToolResult(callId, $"Error: {ex.Message}", isError: true);
+            }
+        }
+
         await using var stdin  = Console.OpenStandardInput();
         await using var stdout = Console.OpenStandardOutput();
         using var       reader = new StreamReader(stdin, Encoding.UTF8);
@@ -54,7 +74,7 @@ static class McpSessionsServer {
                 var response = method switch {
                     "initialize" => BuildInitializeResponse(id),
                     "tools/list" => BuildToolsListResponse(id, tools),
-                    "tools/call" => await HandleToolCallAsync(id, request, await clientLazy.Value, baseUrl, cwdRepoHash),
+                    "tools/call" => await DispatchToolCallAsync(id, request),
                     _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
                 };
 

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -16,32 +16,36 @@ static class McpSessionsServer {
         var cwdRepoHash = await ResolveCwdRepoHashAsync();
         var tools       = BuildToolsList();
 
-        // Defer the authenticated-client creation until the first tools/call.
-        // Under the plugin's auto-register manifest, Claude Code spawns
-        // `kcap mcp sessions` for every session, so an eager
-        // CreateAuthenticatedClientAsync (which does GET /auth/config + token
-        // load) would charge every session the network round-trip even when
-        // the agent never invokes a sessions tool. initialize / tools/list
-        // don't need auth, so we keep startup local-only.
-        var clientLazy = new Lazy<Task<HttpClient>>(() => HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl));
-
         // Validate the server_url shape once, locally (pure string check — no network, token,
         // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
         var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
 
+        // The authenticated client is created on the first tools/call, not at startup:
+        // kcap-sessions auto-registers, so Claude Code spawns `kcap mcp sessions` for every
+        // session — deferring keeps startup local-only (no GET /auth/config, token load, or
+        // stderr) for sessions that never invoke a tool. Created on demand into a nullable field
+        // (rather than a Lazy<Task>) so a transient creation failure leaves it null and the next
+        // call retries, instead of a faulted task sticking for the rest of the session. Safe
+        // without locking: the stdio loop handles one request at a time.
+        HttpClient? client = null;
+
         // Guarded tool dispatch: never let the stdio JSON-RPC loop die on one bad request. An
-        // unusable server_url would otherwise reach EnsureAbsolute inside the lazy auth-client
-        // factory, which hard-exits the process (Environment.Exit(2)) mid-request; and an
-        // unexpected client-creation/token failure would bubble out of the loop. Return a
-        // JSON-RPC tool error in both cases so the server keeps serving.
+        // unusable server_url would otherwise reach EnsureAbsolute inside the auth-client factory,
+        // which hard-exits the process (Environment.Exit(2)) mid-request; and an unexpected
+        // failure would bubble out of the loop. Return a JSON-RPC tool error in both cases so the
+        // server keeps serving.
         async Task<string> DispatchToolCallAsync(JsonNode callId, JsonObject callRequest) {
             if (!urlOk)
                 return BuildToolResult(callId, HttpClientExtensions.SchemeMissingHint, isError: true);
 
             try {
-                return await HandleToolCallAsync(callId, callRequest, await clientLazy.Value, baseUrl, cwdRepoHash);
+                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+                return await HandleToolCallAsync(callId, callRequest, client, baseUrl, cwdRepoHash);
             } catch (Exception ex) {
-                return BuildToolResult(callId, $"Error: {ex.Message}", isError: true);
+                // Unexpected: log the detail to stderr (not to the client, which could leak local
+                // paths from IO errors) and return a generic tool error, keeping the loop alive.
+                await Console.Error.WriteLineAsync($"kcap mcp sessions: unexpected error handling tools/call: {ex}");
+                return BuildToolResult(callId, "Error: internal error handling the request.", isError: true);
             }
         }
 
@@ -81,8 +85,8 @@ static class McpSessionsServer {
                 await writer.WriteLineAsync(response);
             }
         } finally {
-            if (clientLazy.IsValueCreated) {
-                try { (await clientLazy.Value).Dispose(); } catch {
+            if (client is not null) {
+                try { client.Dispose(); } catch {
                     /* swallow — best-effort cleanup */
                 }
             }

--- a/test/Capacitor.Cli.Tests.Integration/McpSessionsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpSessionsServerTests.cs
@@ -69,7 +69,7 @@ public class McpSessionsServerTests : IDisposable {
     /// resolution entirely; "GitHub" forces token-store consultation so the unauthenticated
     /// path can be exercised.
     /// </summary>
-    Process SpawnMcpServer(string provider = "None") {
+    Process SpawnMcpServer(string provider = "None", string? urlOverride = null) {
         // Auth discovery stub — primed before spawn so the child sees a response when it asks.
         _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody($$"""{"provider":"{{provider}}"}"""));
@@ -92,7 +92,7 @@ public class McpSessionsServerTests : IDisposable {
             CreateNoWindow         = true,
             WorkingDirectory       = _cwdDir,
             Environment = {
-                ["KCAP_URL"]        = _server.Url!,
+                ["KCAP_URL"]        = urlOverride ?? _server.Url!,
                 ["KCAP_CONFIG_DIR"] = _cfgDir
             }
         };
@@ -101,6 +101,30 @@ public class McpSessionsServerTests : IDisposable {
         _spawnedProcesses.Add(process);
 
         return process;
+    }
+
+    /// <summary>
+    /// A scheme-less server_url would otherwise reach EnsureAbsolute inside the lazy auth-client
+    /// factory and hard-exit the process (Environment.Exit(2)) mid-request. The startup URL
+    /// guard turns it into a graceful JSON-RPC tool error, and the server keeps serving.
+    /// </summary>
+    [Test]
+    public async Task Tool_call_with_invalid_server_url_returns_error_and_server_survives() {
+        using var proc = SpawnMcpServer(urlOverride: "not-a-valid-url");
+        try {
+            await SendRequest(proc, InitializeRequest(1));
+
+            var response = await SendRequest(proc, ToolsCallRequest(2, "search_sessions", new JsonObject { ["query"] = "x" }));
+            var result   = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsTrue();
+
+            // Server survived the bad request — a follow-up still gets a response.
+            var again = await SendRequest(proc, ToolsListRequest(3));
+            await Assert.That(again["result"]?["tools"]).IsNotNull();
+        } finally {
+            await ShutdownAsync(proc);
+        }
     }
 
     static async Task<JsonObject> SendRequest(Process proc, JsonObject request, TimeSpan? timeout = null) {


### PR DESCRIPTION
## Problem

The three auto-registered MCP servers now create the authenticated `HttpClient` lazily on first `tools/call`. Two dispatch-path gaps (raised by Qodo on #224):

1. **Invalid `server_url` hard-exits mid-request** — reaches `EnsureAbsolute` → `Environment.Exit(2)` inside the lazy auth-client factory (uncatchable), terminating the process on first `tools/call` instead of returning an error.
2. **Unexpected exceptions kill the stdio loop** — the `tools/call` arm has no surrounding `catch`, so an unexpected failure bubbles out and the server closes stdout without a JSON-RPC response.

## Change (sessions — the third server)

- Validate `server_url` once at startup via the pure, local `IsAcceptableUrl` (no network/token/stderr).
- Route `tools/call` through a guarded dispatcher returning a JSON-RPC tool error for an unusable URL or any unexpected exception; the server keeps serving. `initialize` / `tools/list` stay local-only.
- Test: `Tool_call_with_invalid_server_url_returns_error_and_server_survives`.

This is the same hardening applied to **flows (#217)** and **review (#224)** — landing per-server since each one's lazy-client change lives in a different place; sessions' lazy client is already on `main`, so this is standalone.

## Verification

- Sessions integration suite: **8 passed** (incl. the new graceful-failure test).
- `dotnet build` clean; `dotnet publish -c Release` — no IL3050/IL2026 AOT warnings.

Closes #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)