### PR TITLE
Restore flows + review MCP dispatch hardening + Qodo fixes lost in squash-merge

### DIFF
--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -24,26 +24,47 @@ static class McpFlowsServer {
             // best-effort; proceed with null
         }
 
-        // Defer the authenticated-client creation until the first tools/call. Under the
-        // plugin's auto-register manifest (AI-1056), Claude Code spawns `kcap mcp flows` for
-        // every session, so an eager CreateAuthenticatedClientAsync — which does a GET
-        // /auth/config round-trip + token load, and prints a re-auth hint to stderr when not
-        // logged in — would charge every session that work even when the agent never invokes a
-        // flows tool. initialize / tools/list need no auth, so startup stays local-only.
-        // Mirrors McpSessionsServer.
-        //
-        // The InfiniteTimeSpan timeout (AI-1061) is applied to the lazily-created client: the
-        // review-flow endpoints long-poll (start_review_flow / submit_review_round block
-        // server-side up to ~10 min while the reviewer runs). The default 100s timeout would
-        // abort the POST, which the server sees as a cancel and tears the reviewer down — so no
-        // review could complete. The server's FlowResultWaiter and the harness MCP tool timeout
-        // bound the wait instead, mirroring PermissionRequestCommand / CodexHookCommand.
-        var clientLazy = new Lazy<Task<HttpClient>>(async () => {
-            var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
-            client.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
+        // Validate the server_url shape once, locally (pure string check — no network, token,
+        // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
+        var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
 
-            return client;
-        });
+        // The authenticated client is created on the first tools/call, not at startup: kcap-flows
+        // auto-registers (AI-1056), so Claude Code spawns `kcap mcp flows` for every session —
+        // deferring keeps startup local-only (no GET /auth/config, token load, or stderr re-auth
+        // hint) for sessions that never invoke a flows tool. Created on demand into a nullable
+        // field (rather than a Lazy<Task>) so a transient creation failure leaves it null and the
+        // next call retries, instead of a faulted task sticking for the rest of the session. Safe
+        // without locking: the stdio loop handles one request at a time.
+        HttpClient? client = null;
+
+        // Guarded tool dispatch: never let the stdio JSON-RPC loop die on one bad request. An
+        // unusable server_url would otherwise reach EnsureAbsolute inside the auth-client factory,
+        // which hard-exits the process (Environment.Exit(2)) mid-request; and an unexpected
+        // failure would bubble out of the loop. Return a JSON-RPC tool error in both cases so the
+        // server keeps serving.
+        async Task<string> DispatchToolCallAsync(JsonNode callId, JsonObject callRequest) {
+            if (!urlOk)
+                return BuildToolResult(callId, HttpClientExtensions.SchemeMissingHint, isError: true);
+
+            try {
+                if (client is null) {
+                    client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+                    // AI-1061: the review-flow endpoints long-poll (start_review_flow /
+                    // submit_review_round block server-side up to ~10 min while the reviewer runs).
+                    // The default 100s timeout would abort the POST, which the server sees as a
+                    // cancel and tears the reviewer down — so disable the client-side deadline and
+                    // let the server's FlowResultWaiter + the harness MCP tool timeout bound it.
+                    client.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
+                }
+
+                return await HandleToolCallAsync(callId, callRequest, client, baseUrl, cwd, repoRoot, repoInfo);
+            } catch (Exception ex) {
+                // Unexpected: log the detail to stderr (not to the client, which could leak local
+                // paths from IO errors) and return a generic tool error, keeping the loop alive.
+                await Console.Error.WriteLineAsync($"kcap mcp flows: unexpected error handling tools/call: {ex}");
+                return BuildToolResult(callId, "Error: internal error handling the request.", isError: true);
+            }
+        }
 
         await using var stdin  = Console.OpenStandardInput();
         await using var stdout = Console.OpenStandardOutput();
@@ -74,15 +95,15 @@ static class McpFlowsServer {
                 var response = method switch {
                     "initialize" => BuildInitializeResponse(id),
                     "tools/list" => BuildToolsListResponse(id, tools),
-                    "tools/call" => await HandleToolCallAsync(id, request, await clientLazy.Value, baseUrl, cwd, repoRoot, repoInfo),
+                    "tools/call" => await DispatchToolCallAsync(id, request),
                     _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
                 };
 
                 await writer.WriteLineAsync(response);
             }
         } finally {
-            if (clientLazy.IsValueCreated) {
-                try { (await clientLazy.Value).Dispose(); } catch {
+            if (client is not null) {
+                try { client.Dispose(); } catch {
                     /* swallow — best-effort cleanup */
                 }
             }

--- a/src/Capacitor.Cli/Commands/McpReviewServer.cs
+++ b/src/Capacitor.Cli/Commands/McpReviewServer.cs
@@ -32,32 +32,36 @@ static class McpReviewServer {
 
         var tools = BuildToolsList();
 
-        // Defer the authenticated-client creation until the first tools/call. kcap-review
-        // auto-registers via the plugin manifest, so Claude Code (and Codex) spawn
-        // `kcap mcp review` for every session; an eager CreateAuthenticatedClientAsync — which
-        // does a GET /auth/config round-trip + token load, and prints a re-auth hint to stderr
-        // when not logged in — would charge every session that work even when no review tool is
-        // invoked. initialize / tools/list need no auth, so startup stays local-only. Mirrors
-        // McpSessionsServer / McpFlowsServer.
-        var clientLazy = new Lazy<Task<HttpClient>>(() => HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl));
-
         // Validate the server_url shape once, locally (pure string check — no network, token,
         // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
         var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
 
-        // Guarded tool dispatch: never let the stdio JSON-RPC loop die on one bad request.
-        // An unusable server_url would otherwise reach EnsureAbsolute inside the lazy
-        // auth-client factory, which hard-exits the process (Environment.Exit(2)) mid-request;
-        // and an unexpected client-creation/token failure would bubble out of the loop. Return
-        // a JSON-RPC tool error in both cases so the server keeps serving.
+        // The authenticated client is created on the first tools/call, not at startup:
+        // kcap-review auto-registers, so Claude Code (and Codex) spawn `kcap mcp review` for
+        // every session — deferring keeps startup local-only (no GET /auth/config, token load,
+        // or stderr re-auth hint) for sessions that never invoke a review tool. Created on demand
+        // into a nullable field (rather than a Lazy<Task>) so a transient creation failure leaves
+        // it null and the next call retries, instead of a faulted task sticking for the rest of
+        // the session. Safe without locking: the stdio loop handles one request at a time.
+        HttpClient? client = null;
+
+        // Guarded tool dispatch: never let the stdio JSON-RPC loop die on one bad request. An
+        // unusable server_url would otherwise reach EnsureAbsolute inside the auth-client factory,
+        // which hard-exits the process (Environment.Exit(2)) mid-request; and an unexpected
+        // failure would bubble out of the loop. Return a JSON-RPC tool error in both cases so the
+        // server keeps serving.
         async Task<string> DispatchToolCallAsync(JsonNode callId, JsonObject callRequest) {
             if (!urlOk)
                 return BuildToolResult(callId, HttpClientExtensions.SchemeMissingHint, isError: true);
 
             try {
-                return await HandleToolCallAsync(callId, callRequest, await clientLazy.Value, baseUrl, sessionDefault);
+                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+                return await HandleToolCallAsync(callId, callRequest, client, baseUrl, sessionDefault);
             } catch (Exception ex) {
-                return BuildToolResult(callId, $"Error: {ex.Message}", isError: true);
+                // Unexpected: log the detail to stderr (not to the client, which could leak local
+                // paths from IO errors) and return a generic tool error, keeping the loop alive.
+                await Console.Error.WriteLineAsync($"kcap mcp review: unexpected error handling tools/call: {ex}");
+                return BuildToolResult(callId, "Error: internal error handling the request.", isError: true);
             }
         }
 
@@ -97,8 +101,8 @@ static class McpReviewServer {
                 await writer.WriteLineAsync(response);
             }
         } finally {
-            if (clientLazy.IsValueCreated) {
-                try { (await clientLazy.Value).Dispose(); } catch {
+            if (client is not null) {
+                try { client.Dispose(); } catch {
                     /* swallow — best-effort cleanup */
                 }
             }

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -82,8 +82,10 @@ public class McpFlowsServerTests : IDisposable {
 
     /// <summary>
     /// Spawns <c>kcap mcp flows</c> as a child process with WireMock as the backend.
+    /// <paramref name="urlOverride"/> replaces the WireMock URL (used to exercise the
+    /// invalid-server_url path).
     /// </summary>
-    Process SpawnMcpServer(string provider = "None", string? workingDirectory = null) {
+    Process SpawnMcpServer(string provider = "None", string? workingDirectory = null, string? urlOverride = null) {
         _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody($$"""{"provider":"{{provider}}"}"""));
 
@@ -105,7 +107,7 @@ public class McpFlowsServerTests : IDisposable {
             CreateNoWindow         = true,
             WorkingDirectory       = workingDirectory ?? _cwdDir,
             Environment = {
-                ["KCAP_URL"]        = _server.Url!,
+                ["KCAP_URL"]        = urlOverride ?? _server.Url!,
                 ["KCAP_CONFIG_DIR"] = _cfgDir
             }
         };
@@ -253,6 +255,30 @@ public class McpFlowsServerTests : IDisposable {
 
             var authHits = _server.FindLogEntries(Request.Create().WithPath("/auth/config").UsingGet());
             await Assert.That(authHits.Count).IsEqualTo(0);
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
+    /// A scheme-less server_url would otherwise reach EnsureAbsolute inside the lazy auth-client
+    /// factory and hard-exit the process (Environment.Exit(2)) mid-request. The startup URL
+    /// guard turns it into a graceful JSON-RPC tool error, and the server keeps serving.
+    /// </summary>
+    [Test]
+    public async Task Tool_call_with_invalid_server_url_returns_error_and_server_survives() {
+        using var proc = SpawnMcpServer(urlOverride: "not-a-valid-url");
+        try {
+            await SendRequest(proc, InitializeRequest(1));
+
+            var response = await SendRequest(proc, ToolsCallRequest(2, "get_review_flow_status", new JsonObject()));
+            var result   = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsTrue();
+
+            // Server survived the bad request — a follow-up still gets a response.
+            var again = await SendRequest(proc, ToolsListRequest(3));
+            await Assert.That(again["result"]?["tools"]).IsNotNull();
         } finally {
             await ShutdownAsync(proc);
         }


### PR DESCRIPTION
## Problem

#217 (flows) and #224 (review) were **squash-merged at tips that predated their final commits**, so `main` is missing work that CI had already passed on those PRs. Only #226 (sessions) landed complete.

State on `main` right now:

| Server | On `main` | Missing |
|---|---|---|
| sessions (#226) | ✅ complete | — |
| flows (#217) | bare lazy client only | startup `server_url` guard, per-request `try/catch`, on-demand-client-with-retry, generic error message, invalid-URL integration test |
| review (#224) | guard, but `Lazy<Task>` + returns `ex.Message` | on-demand-client-with-retry, generic error message |

Nothing was lost — the final commits (`cd69ef308`, `d6b5a9e23`) still exist on their PR branches; they just weren't part of the squash.

## Change

Brings flows and review to the **same final dispatch pattern already merged for sessions**:
- **on-demand nullable client** — a transient creation failure leaves it null so the next `tools/call` retries, instead of a `Lazy<Task>` caching a faulted task for the session (Qodo #226 Bug 1);
- **catch-all logs to `stderr` + returns a generic tool error** rather than `ex.Message` (Qodo #226 Bug 2);
- **startup `server_url` validation** (`IsAcceptableUrl`) so a bad URL yields a JSON-RPC error instead of `Environment.Exit` mid-request;
- restores the flows invalid-URL integration test.

Restored `McpFlowsServer.cs` / `McpReviewServer.cs` (+ flows test) from the surviving commits so the dispatchers are byte-consistent with sessions.

## Verification

- flows integration: **18 passed**; review integration: **4 passed**; full unit: **2028 passed**.
- `dotnet publish -c Release`: no IL3050/IL2026 AOT warnings.

## Note

Root cause was squash-merging PRs while later commits were still being pushed. In future, hold the merge until the branch tip is final (or merge each PR only once its last commit is in).