### PR TITLE
Multi-provider PR/MR detection (GitHub + GitLab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ In `--no-prompt` mode, the wizard installs hooks for every detected agent by def
 
 > **Keep the daemon running:** `kcap daemon start -d` stops when the process dies (a crash, or an OS memory-pressure kill — macOS jetsam / Linux OOM). To auto-restart it and start it at login, install it as a per-user service: `kcap daemon service install`. See [Daemon](#daemon).
 
+> **PR/MR auto-tagging is best-effort:** sessions on a branch with an open pull/merge request are automatically tagged with it, using the provider's own CLI — `gh` for GitHub and GitHub Enterprise, `glab` for GitLab. Neither is required to use kcap; if the matching CLI isn't installed or authenticated for the repo's host, the session is simply left untagged (no error, no retry).
+
 ### 3. Import existing sessions (optional)
 
 ```bash
@@ -264,9 +266,11 @@ Expect ~1-3 minutes total depending on the model and session size — judges run
 kcap review <pr-url-or-owner/repo#number>
 ```
 
+Accepts a GitHub PR URL (`https://github.com/owner/repo/pull/123`, any host including GitHub Enterprise), a GitLab MR URL (`https://gitlab.com/owner/repo/-/merge_requests/123`), or the shorthand `owner/repo#123`. Only single-level `owner/repo` namespaces are supported — GitLab's nested groups (e.g. `group/subgroup/repo`) aren't recognized yet.
+
 Launches a Claude Code session equipped with MCP tools that query the implementation transcripts. Reviewers can ask *why* code was changed, understand design decisions, check what alternatives were considered, and verify test coverage — all grounded in what actually happened during development.
 
-The same MCP server (`kcap-review`) is also auto-registered by the Kurrent Capacitor plugin and available in any Claude Code session, not just ones launched via `kcap review`. Each PR-scoped tool (`get_pr_summary`, `list_pr_files`, `get_file_context`, `search_context`, `list_sessions`) accepts an optional `pr` argument — pass `"owner/repo#123"` or a GitHub PR URL to review any PR from any branch. When omitted, the server falls back to the PR passed at startup (set by `kcap review <pr>`) or to git auto-detection against the current branch. `get_transcript` keys off `session_id` and doesn't need a `pr` argument.
+The same MCP server (`kcap-review`) is also auto-registered by the Kurrent Capacitor plugin and available in any Claude Code session, not just ones launched via `kcap review`. Each PR-scoped tool (`get_pr_summary`, `list_pr_files`, `get_file_context`, `search_context`, `list_sessions`) accepts an optional `pr` argument — pass `"owner/repo#123"` or a GitHub/GitLab URL to review any PR from any branch. When omitted, the server falls back to the PR passed at startup (set by `kcap review <pr>`) or to git auto-detection against the current branch. `get_transcript` keys off `session_id` and doesn't need a `pr` argument.
 
 ### Sessions MCP server (for agents)
 

--- a/docs/superpowers/plans/2026-07-01-multi-provider-pr-detection.md
+++ b/docs/superpowers/plans/2026-07-01-multi-provider-pr-detection.md
@@ -1,0 +1,1008 @@
+# Multi-provider PR/MR detection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend kcap's PR detection beyond GitHub so that GitLab.com sessions are auto-tagged with their merge request and `kcap review <gitlab-url>` works, by delegating to the `gh`/`glab` CLIs — with no kcap-managed tokens and no server changes.
+
+**Architecture:** Resolution stays client-side. A remote's host selects a provider detector behind an `IPrDetector`-style seam: GitHub via the existing `gh pr view --json`, GitLab via `glab api` (raw JSON passthrough using glab's own auth). The PR/MR is only a grouping key (`owner/repo/number`) the server already accepts, so nothing server-side changes. Nested GitLab namespaces are out of scope for this pass (single-level `owner/repo` only).
+
+**Tech Stack:** .NET 10, NativeAOT, System.Text.Json (`JsonNode` for reflection-free parsing + source-gen `CapacitorJsonContext`), TUnit on Microsoft Testing Platform.
+
+**Design spec:** `docs/superpowers/specs/2026-07-01-multi-provider-pr-detection-design.md`
+
+## Global Constraints
+
+- **No kcap-managed provider tokens.** Only shell out to `gh`/`glab`, which own their own auth. Never read, store, or pass a provider token.
+- **Best-effort detection.** Missing/unauthenticated CLI, unknown host, non-git dir, malformed JSON, empty branch, or timeout → return without PR fields (untagged session), never throw. Preserve the `try/catch → return null` contract already in `DetectRepositoryAsync`.
+- **Single-level namespaces only.** `owner/repo` with no embedded slash. GitLab nested groups (`group/subgroup/project`) are explicitly deferred — such remotes/URLs must not parse or tag.
+- **AOT clean.** After changes, `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` must be empty. Parse JSON with `JsonNode` (reflection-free) or the source-generated `CapacitorJsonContext`; never build a `JsonArray` with a collection expression.
+- **TUnit run/filter.** Run unit tests with `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/<ClassName>/*"`. Never `--filter`; the bare `"*Class*"` glob matches zero tests.
+- **Commit trailer.** Every commit message ends with a blank line then:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- **README/help sync.** Any user-facing CLI surface change updates `README.md` in the same PR (see Task 9 for when GitLab docs land).
+
+---
+
+## File Structure
+
+**Phase 1 — dependency-free groundwork (no user-facing GitLab surface):**
+- `src/Capacitor.Cli.Core/Commands/PrRefParser.cs` — modify: generalize URL parsing to any host + GitLab MR URLs; keep shorthand single-level.
+- `src/Capacitor.Cli.Core/Config/RemoteMatcher.cs` — add `ExtractHost` / `PathAfterHost` pure helpers.
+- `src/Capacitor.Cli.Daemon/Services/RepoMatcher.cs` — modify: host-agnostic `owner/repo`-suffix match.
+- `src/Capacitor.Cli.Core/Models.cs` — modify: add `Host` to `RepositoryPayload` and `GitCacheEntry`; add `SchemaVersion` to `GitCacheEntry`.
+- `src/Capacitor.Cli/RepositoryDetection.cs` — modify: compute host; version-guard the cache; emit `host`.
+
+**Phase 2 — auto-detection (adds `glab` soft dep; user-visible):**
+- `src/Capacitor.Cli/PrDetection/PrDetector.cs` — create: `PrInfo`, `CommandRunner`, `GitHubPrDetector`.
+- `src/Capacitor.Cli/PrDetection/GitLabPrDetector.cs` — create: `glab api` MR detection + selection.
+- `src/Capacitor.Cli/PrDetection/GitProviderRouter.cs` — create: host → provider kind, custom-host probe, per-process memo.
+- `src/Capacitor.Cli/RepositoryDetection.cs` — modify: replace inline `gh` call with router + detectors; effective provider budget.
+- `README.md`, `src/Capacitor.Cli.Core/Resources/help-*.txt`, `src/Capacitor.Cli/Commands/ReviewCommand.cs` — GitLab docs/usage.
+
+**Tests:** all under `test/Capacitor.Cli.Tests.Unit/` (references all three assemblies with `InternalsVisibleTo`).
+
+---
+
+## Phase 1 — Groundwork
+
+### Task 1: Generalize `PrRefParser` to GitHub-any-host + GitLab MR URLs
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/Commands/PrRefParser.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/PrRefParserTests.cs`
+
+**Interfaces:**
+- Produces: `PrRefParser.TryParse(string input, out string owner, out string repo, out int prNumber) → bool` (signature unchanged). `owner`/`repo` remain single-segment.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `PrRefParserTests.cs`:
+
+```csharp
+[Test]
+public async Task Github_url_on_enterprise_host_parses() {
+    var ok = PrRefParser.TryParse("https://ghe.corp.com/team/app/pull/7", out var owner, out var repo, out var pr);
+    await Assert.That(ok).IsTrue();
+    await Assert.That(owner).IsEqualTo("team");
+    await Assert.That(repo).IsEqualTo("app");
+    await Assert.That(pr).IsEqualTo(7);
+}
+
+[Test]
+public async Task Gitlab_mr_url_parses() {
+    var ok = PrRefParser.TryParse("https://gitlab.com/group/project/-/merge_requests/42", out var owner, out var repo, out var pr);
+    await Assert.That(ok).IsTrue();
+    await Assert.That(owner).IsEqualTo("group");
+    await Assert.That(repo).IsEqualTo("project");
+    await Assert.That(pr).IsEqualTo(42);
+}
+
+[Test]
+public async Task Gitlab_mr_url_with_browser_suffix_parses() {
+    foreach (var suffix in new[] { "/diffs", "/commits", "?tab=1", "#note_9" }) {
+        var ok = PrRefParser.TryParse($"https://gitlab.com/group/project/-/merge_requests/42{suffix}", out _, out _, out var pr);
+        await Assert.That(ok).IsTrue();
+        await Assert.That(pr).IsEqualTo(42);
+    }
+}
+
+[Test]
+public async Task Gitlab_nested_group_mr_url_is_rejected_in_first_pass() {
+    // Multi-segment namespace deferred (§3/§6b): server routes are /{owner}/{repo}.
+    var ok = PrRefParser.TryParse("https://gitlab.com/group/sub/project/-/merge_requests/42", out _, out _, out _);
+    await Assert.That(ok).IsFalse();
+}
+```
+
+Also **replace** the existing `Garbage_input_rejected` test — its `gitlab.com/.../pull/1` line now parses (host-agnostic `/pull/`), so change that assertion:
+
+```csharp
+[Test]
+public async Task Garbage_input_rejected() {
+    await Assert.That(PrRefParser.TryParse("not-a-pr-ref", out _, out _, out _)).IsFalse();
+    // A GitHub-shaped /pull/ URL now parses on any host (see Github_url_on_enterprise_host_parses);
+    // reject genuinely malformed refs instead.
+    await Assert.That(PrRefParser.TryParse("https://gitlab.com/owner/repo/-/merge_requests/", out _, out _, out _)).IsFalse();
+    await Assert.That(PrRefParser.TryParse("https://gitlab.com/owner/repo/issues/3", out _, out _, out _)).IsFalse();
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/PrRefParserTests/*"`
+Expected: FAIL — new GitHub-enterprise/GitLab cases fail (regex still requires `github.com` and has no MR pattern).
+
+- [ ] **Step 3: Implement — drop the `github.com` literal and add a GitLab MR pattern**
+
+Replace the two GitHub-specific regexes and add a GitLab one. New body of `PrRefParser`:
+
+```csharp
+public static bool TryParse(string input, out string owner, out string repo, out int prNumber) {
+    owner = ""; repo = ""; prNumber = 0;
+    if (string.IsNullOrWhiteSpace(input)) return false;
+    input = input.Trim();
+
+    var gh = GitHubUrlPattern().Match(input);
+    if (gh.Success) {
+        owner = gh.Groups[1].Value; repo = gh.Groups[2].Value;
+        prNumber = int.Parse(gh.Groups[3].Value);
+        return true;
+    }
+
+    var gl = GitLabUrlPattern().Match(input);
+    if (gl.Success) {
+        owner = gl.Groups[1].Value; repo = gl.Groups[2].Value;
+        prNumber = int.Parse(gl.Groups[3].Value);
+        return true;
+    }
+
+    var shortMatch = ShorthandPattern().Match(input);
+    if (shortMatch.Success) {
+        owner = shortMatch.Groups[1].Value; repo = shortMatch.Groups[2].Value;
+        prNumber = int.Parse(shortMatch.Groups[3].Value);
+        return true;
+    }
+
+    return false;
+}
+
+// GitHub-style PR URL on ANY host (github.com or GitHub Enterprise). owner/repo are
+// single-segment; trailing path/query/fragment (browser copies) tolerated.
+[GeneratedRegex(@"^https?://[^/]+/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$")]
+private static partial Regex GitHubUrlPattern();
+
+// GitLab MR URL. Single-level owner/repo only (nested groups deferred, §3/§6b).
+// Same trailing-suffix tolerance so /diffs, /commits, ?query, #note parse.
+[GeneratedRegex(@"^https?://[^/]+/([^/]+)/([^/]+)/-/merge_requests/(\d+)(?:[/?#].*)?$")]
+private static partial Regex GitLabUrlPattern();
+
+// Shorthand owner/repo#123 — single-level, unchanged. Repo forbids '/'.
+[GeneratedRegex(@"^([^/]+)/([^/#]+)#(\d+)$")]
+private static partial Regex ShorthandPattern();
+```
+
+Update the class doc comment: replace "or github.com URL form" with "GitHub PR URL on any host, or GitLab MR URL".
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/PrRefParserTests/*"`
+Expected: PASS (all, including the updated `Garbage_input_rejected` and the nested-group rejection).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/Commands/PrRefParser.cs test/Capacitor.Cli.Tests.Unit/PrRefParserTests.cs
+git commit
+```
+Message: `feat(review): parse GitHub PR URLs on any host and GitLab MR URLs`
+
+---
+
+### Task 2: Add host helpers to `RemoteMatcher`
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/Config/RemoteMatcher.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/RemoteMatcherTests.cs`
+
+**Interfaces:**
+- Produces: `RemoteMatcher.ExtractHost(string url) → string?` (host from a raw remote URL, or null); `RemoteMatcher.PathAfterHost(string normalized) → string?` (the `owner/repo` part of a `host/owner/path` normalized string, or null).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `RemoteMatcherTests.cs`:
+
+```csharp
+[Test]
+public async Task ExtractHost_from_ssh_and_https() {
+    await Assert.That(RemoteMatcher.ExtractHost("git@github.com:kurrent-io/kcap.git")).IsEqualTo("github.com");
+    await Assert.That(RemoteMatcher.ExtractHost("https://gitlab.com/group/project.git")).IsEqualTo("gitlab.com");
+    await Assert.That(RemoteMatcher.ExtractHost("ssh://git@ghe.corp.com/team/app")).IsEqualTo("ghe.corp.com");
+    await Assert.That(RemoteMatcher.ExtractHost("not a url")).IsNull();
+}
+
+[Test]
+public async Task PathAfterHost_strips_leading_host_segment() {
+    await Assert.That(RemoteMatcher.PathAfterHost("github.com/kurrent-io/kcap")).IsEqualTo("kurrent-io/kcap");
+    await Assert.That(RemoteMatcher.PathAfterHost("gitlab.com/group/project")).IsEqualTo("group/project");
+    await Assert.That(RemoteMatcher.PathAfterHost("nohostonly")).IsNull();
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/RemoteMatcherTests/*"`
+Expected: FAIL — `ExtractHost`/`PathAfterHost` don't exist (compile error).
+
+- [ ] **Step 3: Implement the helpers**
+
+Add to `RemoteMatcher` (after `NormalizeRemoteUrl`):
+
+```csharp
+/// <summary>Host of a raw git remote URL (e.g. "github.com"), or null if unrecognized.</summary>
+public static string? ExtractHost(string url) {
+    var normalized = NormalizeRemoteUrl(url);
+    if (normalized is null) return null;
+    var slash = normalized.IndexOf('/');
+    return slash <= 0 ? null : normalized[..slash];
+}
+
+/// <summary>The "owner/repo" tail of a normalized "host/owner/path" string, or null.</summary>
+public static string? PathAfterHost(string normalized) {
+    if (string.IsNullOrEmpty(normalized)) return null;
+    var slash = normalized.IndexOf('/');
+    return slash <= 0 || slash == normalized.Length - 1 ? null : normalized[(slash + 1)..];
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/RemoteMatcherTests/*"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/Config/RemoteMatcher.cs test/Capacitor.Cli.Tests.Unit/RemoteMatcherTests.cs
+git commit
+```
+Message: `feat(core): add ExtractHost/PathAfterHost remote helpers`
+
+---
+
+### Task 3: Make daemon `RepoMatcher` host-agnostic
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/RepoMatcher.cs:30,57`
+- Test: `test/Capacitor.Cli.Tests.Unit/RepoMatcherTests.cs`
+
+**Interfaces:**
+- Consumes: `RemoteMatcher.PathAfterHost` (Task 2).
+- Produces: `RepoMatcher.FindAsync(string owner, string repo, string[] serverCandidates, CancellationToken)` — behavior change only (matches any host).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `RepoMatcherTests.cs` (follow the file's existing setup for creating a temp git repo with an origin remote — reuse its helper; if it seeds a `github.com` origin, add a variant that seeds a `gitlab.com` origin for the same `owner/repo`):
+
+```csharp
+[Test]
+public async Task Matches_gitlab_remote_for_same_owner_repo() {
+    using var tmp = new TempGitRepo(origin: "git@gitlab.com:group/project.git"); // mirror existing helper's shape
+    var matcher = new RepoMatcher(DaemonConfigForPath(tmp.Path), NullLogger<RepoMatcher>.Instance);
+
+    var matches = await matcher.FindAsync("group", "project", [tmp.Path], CancellationToken.None);
+
+    await Assert.That(matches).Contains(tmp.Path);
+}
+```
+
+> If `RepoMatcherTests.cs` has no reusable temp-repo helper with a settable origin, add a minimal one in this task (a private helper that `git init`s a temp dir and sets `origin`), then use it here and leave existing tests untouched.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/RepoMatcherTests/*"`
+Expected: FAIL — current `target = $"github.com/{owner}/{repo}"` never equals the normalized `gitlab.com/group/project`.
+
+- [ ] **Step 3: Implement host-agnostic matching**
+
+In `FindAsync`, replace the target line:
+
+```csharp
+// was: var target = $"github.com/{owner}/{repo}";
+var target = $"{owner}/{repo}";
+```
+
+And the comparison (line ~57):
+
+```csharp
+// was: if (string.Equals(remote, target, StringComparison.OrdinalIgnoreCase))
+if (RemoteMatcher.PathAfterHost(remote) is { } path
+    && string.Equals(path, target, StringComparison.OrdinalIgnoreCase)) {
+    matches.Add(root);
+}
+```
+
+Update the XML doc on the class: note matching is host-agnostic on `owner/repo` (consistent with the host-agnostic `repo_hash`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/RepoMatcherTests/*"`
+Expected: PASS (new GitLab test + all existing GitHub tests still pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/RepoMatcher.cs test/Capacitor.Cli.Tests.Unit/RepoMatcherTests.cs
+git commit
+```
+Message: `fix(daemon): match repos host-agnostically on owner/repo`
+
+---
+
+### Task 4: Add `Host` to payload/cache and version-invalidate the cache
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/Models.cs:52-102` (`RepositoryPayload`, `GitCacheEntry`)
+- Modify: `src/Capacitor.Cli/RepositoryDetection.cs` (compute host; version guard; emit `host`)
+- Test: `test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs` (create)
+
+**Interfaces:**
+- Consumes: `RemoteMatcher.ExtractHost` (Task 2).
+- Produces: `RepositoryPayload.Host` (`string?`, JSON `host`); `GitCacheEntry.Host` (`string?`) and `GitCacheEntry.SchemaVersion` (`int`, JSON `schema_version`); `RepositoryDetection` const `CacheSchemaVersion = 2`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs`:
+
+```csharp
+using System.Text.Json;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class RepositoryDetectionCacheTests {
+    [Test]
+    public async Task GitCacheEntry_without_schema_version_deserializes_as_stale() {
+        // A pre-upgrade entry (no schema_version, no host) must be treated as stale.
+        const string legacy = """{"owner":"o","repo_name":"r","cached_at":"2020-01-01T00:00:00+00:00"}""";
+        var entry = JsonSerializer.Deserialize(legacy, CapacitorJsonContext.Default.GitCacheEntry);
+        await Assert.That(entry!.SchemaVersion).IsEqualTo(0);        // absent → default 0
+        await Assert.That(entry.SchemaVersion == RepositoryDetection.CacheSchemaVersion).IsFalse();
+    }
+
+    [Test]
+    public async Task GitCacheEntry_roundtrips_host_and_version() {
+        var entry = new GitCacheEntry {
+            RemoteUrl = "git@gitlab.com:group/project.git",
+            Owner = "group", RepoName = "project", Host = "gitlab.com",
+            SchemaVersion = RepositoryDetection.CacheSchemaVersion, CachedAt = DateTimeOffset.UnixEpoch
+        };
+        var json = JsonSerializer.Serialize(entry, CapacitorJsonContext.Default.GitCacheEntry);
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.GitCacheEntry);
+        await Assert.That(back!.Host).IsEqualTo("gitlab.com");
+        await Assert.That(back.SchemaVersion).IsEqualTo(RepositoryDetection.CacheSchemaVersion);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/RepositoryDetectionCacheTests/*"`
+Expected: FAIL — `Host`/`SchemaVersion`/`CacheSchemaVersion` don't exist (compile error).
+
+- [ ] **Step 3: Add the fields**
+
+In `Models.cs`, add to `RepositoryPayload` (after `RemoteUrl`):
+
+```csharp
+[JsonPropertyName("host")]
+public string? Host { get; init; }
+```
+
+Add to `GitCacheEntry` (after `RemoteUrl`, and a version field):
+
+```csharp
+[JsonPropertyName("host")]
+public string? Host { get; init; }
+
+[JsonPropertyName("schema_version")]
+public int SchemaVersion { get; init; }
+```
+
+- [ ] **Step 4: Version-guard the cache and populate host in `RepositoryDetection.cs`**
+
+In `LoadCache` (the TTL check ~line 233), also reject on schema mismatch:
+
+```csharp
+if (entry is null || entry.SchemaVersion != CacheSchemaVersion) {
+    return null;
+}
+return DateTimeOffset.UtcNow - entry.CachedAt > TimeSpan.FromHours(1) ? null : entry;
+```
+
+Add the constant near the top of the class:
+
+```csharp
+// Bump whenever the cached shape/derivation changes so stale entries are ignored.
+// v2: added Host + provider-aware parsing.
+internal const int CacheSchemaVersion = 2;
+```
+
+In `DetectRepositoryAsync`, compute host and thread it through. In the cache-hit branch add `host = cache.Host;`; in the cache-miss branch after parsing owner/repo:
+
+```csharp
+(owner, repoName) = GitUrlParser.ParseRemoteUrl(remoteUrl);
+host = remoteUrl is null ? null : RemoteMatcher.ExtractHost(remoteUrl);
+
+SaveCache(cwd, new() {
+    UserName = userName, UserEmail = userEmail, RemoteUrl = remoteUrl,
+    Owner = owner, RepoName = repoName, Host = host,
+    SchemaVersion = CacheSchemaVersion, CachedAt = DateTimeOffset.UtcNow
+});
+```
+
+Declare `string? ... host;` alongside the other locals (line ~86). Add `Host = host` to the returned `RepositoryPayload`. In `EnrichWithRepositoryInfo`, emit it with the other fields:
+
+```csharp
+if (repo.Host is not null) repoNode["host"] = repo.Host;
+```
+
+> `host` is not consumed for routing yet — that lands in Phase 2. It is stored now so the cache is correct when routing arrives, and the version bump discards pre-upgrade entries. The emitted `host` field is ignored by the server (tolerant deserialization); no server change.
+
+- [ ] **Step 5: Run tests + full unit suite + AOT check**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/RepositoryDetectionCacheTests/*"
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj
+dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}' || echo "no AOT warnings"
+```
+Expected: cache tests PASS, full suite PASS, AOT grep prints "no AOT warnings".
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/Models.cs src/Capacitor.Cli/RepositoryDetection.cs test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs
+git commit
+```
+Message: `feat: carry repo host and version-invalidate the detection cache`
+
+---
+
+## Phase 2 — Auto-detection
+
+> The first user-visible GitLab release must include this phase (Open decision #3). Parse-only Phase 1 tags nothing, so `kcap review <gitlab-url>` would 404 until the detector lands.
+
+### Task 5: Provider seam + `GitHubPrDetector` (refactor the existing gh call)
+
+**Files:**
+- Create: `src/Capacitor.Cli/PrDetection/PrDetector.cs`
+- Modify: `src/Capacitor.Cli/RepositoryDetection.cs` (expose `RunCommandAsync` as a `CommandRunner`; route GitHub through the detector)
+- Test: `test/Capacitor.Cli.Tests.Unit/GitHubPrDetectorTests.cs` (create)
+
+**Interfaces:**
+- Produces:
+  - `internal delegate Task<string?> CommandRunner(string cmd, string arguments, string cwd, TimeSpan timeout);`
+  - `internal sealed record PrInfo(int Number, string? Title, string? Url, string? HeadRef);`
+  - `internal static Task<PrInfo?> GitHubPrDetector.DetectAsync(string cwd, TimeSpan cap, CommandRunner run);`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/Capacitor.Cli.Tests.Unit/GitHubPrDetectorTests.cs`:
+
+```csharp
+using Capacitor.Cli.PrDetection;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class GitHubPrDetectorTests {
+    [Test]
+    public async Task Parses_gh_pr_view_json() {
+        CommandRunner fake = (cmd, args, cwd, _) => {
+            Assert.That(cmd).IsEqualTo("gh");
+            Assert.That(args).Contains("pr view");
+            return Task.FromResult<string?>(
+                """{"number":12,"title":"Add thing","url":"https://github.com/o/r/pull/12","headRefName":"feat/x"}""");
+        };
+        var pr = await GitHubPrDetector.DetectAsync("/cwd", TimeSpan.FromSeconds(2), fake);
+        await Assert.That(pr!.Number).IsEqualTo(12);
+        await Assert.That(pr.Title).IsEqualTo("Add thing");
+        await Assert.That(pr.Url).IsEqualTo("https://github.com/o/r/pull/12");
+        await Assert.That(pr.HeadRef).IsEqualTo("feat/x");
+    }
+
+    [Test]
+    public async Task Null_output_yields_null() {
+        CommandRunner fake = (_, _, _, _) => Task.FromResult<string?>(null); // no PR / gh failed
+        await Assert.That(await GitHubPrDetector.DetectAsync("/cwd", TimeSpan.FromSeconds(2), fake)).IsNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/GitHubPrDetectorTests/*"`
+Expected: FAIL — namespace/types don't exist.
+
+- [ ] **Step 3: Create the seam and detector**
+
+Create `src/Capacitor.Cli/PrDetection/PrDetector.cs`:
+
+```csharp
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.PrDetection;
+
+/// <summary>Spawns a CLI and returns trimmed stdout, or null on failure/timeout.</summary>
+internal delegate Task<string?> CommandRunner(string cmd, string arguments, string cwd, TimeSpan timeout);
+
+internal sealed record PrInfo(int Number, string? Title, string? Url, string? HeadRef);
+
+/// <summary>GitHub / GitHub Enterprise detection via `gh` (auto-targets the remote's host).</summary>
+internal static class GitHubPrDetector {
+    public static async Task<PrInfo?> DetectAsync(string cwd, TimeSpan cap, CommandRunner run) {
+        var json = await run("gh", "pr view --json number,title,url,headRefName", cwd, cap);
+        if (json is null) return null;
+        try {
+            if (JsonNode.Parse(json) is not JsonObject o) return null;
+            var number = o["number"]?.GetValue<int>();
+            if (number is null) return null;
+            return new PrInfo(number.Value, o["title"]?.GetValue<string>(),
+                              o["url"]?.GetValue<string>(), o["headRefName"]?.GetValue<string>());
+        } catch {
+            return null; // best-effort
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Expose `RunCommandAsync` as a `CommandRunner` and route GitHub through the detector**
+
+In `RepositoryDetection.cs`, change `RunCommandAsync` from `static async Task<string?>` to keep the same body but ensure it is assignable to `CommandRunner` (same parameter types/order — it already is). Add a field the detection path can use:
+
+```csharp
+internal static CommandRunner DefaultRunner => RunCommandAsync;
+```
+
+Replace the inline `gh pr view` block (lines ~143-160) with:
+
+```csharp
+if (ghCap > TimeSpan.Zero) {
+    var pr = await PrDetection.GitHubPrDetector.DetectAsync(cwd, ghCap, DefaultRunner);
+    if (pr is not null) {
+        prNumber = pr.Number; prTitle = pr.Title; prUrl = pr.Url; prHeadRef = pr.HeadRef;
+    }
+}
+```
+
+> This is a pure refactor: GitHub behavior is unchanged. GitLab routing arrives in Task 8.
+
+- [ ] **Step 5: Run tests + full suite**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/GitHubPrDetectorTests/*"
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Capacitor.Cli/PrDetection/PrDetector.cs src/Capacitor.Cli/RepositoryDetection.cs test/Capacitor.Cli.Tests.Unit/GitHubPrDetectorTests.cs
+git commit
+```
+Message: `refactor: extract GitHubPrDetector behind a CommandRunner seam`
+
+---
+
+### Task 6: `GitLabPrDetector` (glab api + MR selection guards)
+
+**Files:**
+- Create: `src/Capacitor.Cli/PrDetection/GitLabPrDetector.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/GitLabPrDetectorTests.cs` (create)
+
+**Interfaces:**
+- Consumes: `CommandRunner`, `PrInfo` (Task 5).
+- Produces: `internal static Task<PrInfo?> GitLabPrDetector.DetectAsync(string host, string owner, string repo, string? branch, string cwd, TimeSpan cap, CommandRunner run);`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/Capacitor.Cli.Tests.Unit/GitLabPrDetectorTests.cs`:
+
+```csharp
+using Capacitor.Cli.PrDetection;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class GitLabPrDetectorTests {
+    const string TwoOpenMrs = """
+    [
+      {"iid":5,"title":"old","web_url":"https://gitlab.com/g/p/-/merge_requests/5","source_branch":"feat/x","updated_at":"2026-06-01T00:00:00Z"},
+      {"iid":9,"title":"new","web_url":"https://gitlab.com/g/p/-/merge_requests/9","source_branch":"feat/x","updated_at":"2026-06-30T00:00:00Z"},
+      {"iid":7,"title":"other","web_url":"https://gitlab.com/g/p/-/merge_requests/7","source_branch":"feat/other","updated_at":"2026-07-01T00:00:00Z"}
+    ]
+    """;
+
+    [Test]
+    public async Task Picks_matching_branch_most_recently_updated() {
+        CommandRunner fake = (cmd, args, _, _) => {
+            Assert.That(cmd).IsEqualTo("glab");
+            Assert.That(args).Contains("--hostname gitlab.com");
+            Assert.That(args).Contains("projects/g%2Fp/merge_requests");
+            Assert.That(args).Contains("source_branch=feat%2Fx");
+            return Task.FromResult<string?>(TwoOpenMrs);
+        };
+        var pr = await GitLabPrDetector.DetectAsync("gitlab.com", "g", "p", "feat/x", "/cwd", TimeSpan.FromSeconds(2), fake);
+        await Assert.That(pr!.Number).IsEqualTo(9);              // iid, newest updated_at, branch match
+        await Assert.That(pr.Url).IsEqualTo("https://gitlab.com/g/p/-/merge_requests/9");
+        await Assert.That(pr.HeadRef).IsEqualTo("feat/x");
+    }
+
+    [Test]
+    public async Task Empty_branch_never_calls_glab_and_returns_null() {
+        var called = false;
+        CommandRunner fake = (_, _, _, _) => { called = true; return Task.FromResult<string?>("[]"); };
+        var pr = await GitLabPrDetector.DetectAsync("gitlab.com", "g", "p", "", "/cwd", TimeSpan.FromSeconds(2), fake);
+        await Assert.That(pr).IsNull();
+        await Assert.That(called).IsFalse();                    // guard: no branch → no query (would return all MRs)
+    }
+
+    [Test]
+    public async Task Encodes_branch_with_ampersand() {
+        string seen = "";
+        CommandRunner fake = (_, args, _, _) => { seen = args; return Task.FromResult<string?>("[]"); };
+        await GitLabPrDetector.DetectAsync("gitlab.com", "g", "p", "feat/a&b", "/cwd", TimeSpan.FromSeconds(2), fake);
+        await Assert.That(seen).Contains("source_branch=feat%2Fa%26b");
+    }
+
+    [Test]
+    public async Task No_matching_branch_yields_null() {
+        CommandRunner fake = (_, _, _, _) => Task.FromResult<string?>(
+            """[{"iid":5,"title":"x","web_url":"u","source_branch":"different","updated_at":"2026-06-01T00:00:00Z"}]""");
+        await Assert.That(await GitLabPrDetector.DetectAsync("gitlab.com", "g", "p", "feat/x", "/cwd", TimeSpan.FromSeconds(2), fake)).IsNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/GitLabPrDetectorTests/*"`
+Expected: FAIL — type doesn't exist.
+
+- [ ] **Step 3: Implement the GitLab detector**
+
+Create `src/Capacitor.Cli/PrDetection/GitLabPrDetector.cs`:
+
+```csharp
+using System.Globalization;
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.PrDetection;
+
+/// <summary>
+/// GitLab MR detection via `glab api` (raw JSON passthrough using glab's own auth —
+/// kcap manages no token). Single-level owner/repo only.
+/// </summary>
+internal static class GitLabPrDetector {
+    public static async Task<PrInfo?> DetectAsync(
+            string host, string owner, string repo, string? branch, string cwd, TimeSpan cap, CommandRunner run) {
+        // Guard: GitLab ignores an empty source_branch filter and returns ALL open MRs,
+        // which would mis-tag the session (e.g. detached HEAD). No branch → no detection.
+        if (string.IsNullOrEmpty(branch)) return null;
+
+        var project = Uri.EscapeDataString($"{owner}/{repo}");
+        var branchEnc = Uri.EscapeDataString(branch);
+        var args = $"api --hostname {host} projects/{project}/merge_requests?source_branch={branchEnc}&state=opened";
+
+        var json = await run("glab", args, cwd, cap);
+        if (json is null) return null;
+
+        try {
+            if (JsonNode.Parse(json) is not JsonArray arr) return null;
+
+            PrInfo? best = null;
+            DateTimeOffset bestUpdated = DateTimeOffset.MinValue;
+
+            foreach (var node in arr) {
+                if (node is not JsonObject mr) continue;
+                // Defense in depth: only accept an exact source_branch match.
+                if (mr["source_branch"]?.GetValue<string>() != branch) continue;
+                var iid = mr["iid"]?.GetValue<int>();
+                if (iid is null) continue;
+
+                var updated = ParseTimestamp(mr["updated_at"]?.GetValue<string>());
+                if (best is null || updated > bestUpdated) {
+                    bestUpdated = updated;
+                    best = new PrInfo(iid.Value, mr["title"]?.GetValue<string>(),
+                                      mr["web_url"]?.GetValue<string>(), mr["source_branch"]?.GetValue<string>());
+                }
+            }
+            return best;
+        } catch {
+            return null; // best-effort
+        }
+    }
+
+    static DateTimeOffset ParseTimestamp(string? s) =>
+        DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var t)
+            ? t : DateTimeOffset.MinValue;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/GitLabPrDetectorTests/*"`
+Expected: PASS (branch guard, encoding, selection, no-match).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli/PrDetection/GitLabPrDetector.cs test/Capacitor.Cli.Tests.Unit/GitLabPrDetectorTests.cs
+git commit
+```
+Message: `feat: add GitLabPrDetector via glab api with MR selection guards`
+
+---
+
+### Task 7: `GitProviderRouter` (host routing + custom-host probe + memo)
+
+**Files:**
+- Create: `src/Capacitor.Cli/PrDetection/GitProviderRouter.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/GitProviderRouterTests.cs` (create)
+
+**Interfaces:**
+- Consumes: `CommandRunner` (Task 5).
+- Produces:
+  - `internal enum GitProviderKind { GitHub, GitLab, Unknown }`
+  - `internal static Task<GitProviderKind> GitProviderRouter.ResolveAsync(string? host, string cwd, TimeSpan cap, CommandRunner run);`
+  - `internal static void GitProviderRouter.ResetMemoForTests();`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/Capacitor.Cli.Tests.Unit/GitProviderRouterTests.cs`:
+
+```csharp
+using Capacitor.Cli.PrDetection;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class GitProviderRouterTests {
+    [Before(Test)]
+    public void Reset() => GitProviderRouter.ResetMemoForTests();
+
+    static CommandRunner Never => (_, _, _, _) => throw new InvalidOperationException("probe should not run for SaaS hosts");
+
+    [Test]
+    public async Task Saas_hosts_route_without_probing() {
+        await Assert.That(await GitProviderRouter.ResolveAsync("github.com", "/c", TimeSpan.FromSeconds(2), Never)).IsEqualTo(GitProviderKind.GitHub);
+        await Assert.That(await GitProviderRouter.ResolveAsync("gitlab.com", "/c", TimeSpan.FromSeconds(2), Never)).IsEqualTo(GitProviderKind.GitLab);
+    }
+
+    [Test]
+    public async Task Custom_host_in_gh_auth_status_is_github() {
+        CommandRunner fake = (cmd, args, _, _) => {
+            Assert.That(cmd).IsEqualTo("gh");
+            Assert.That(args).IsEqualTo("auth status --json hosts");
+            return Task.FromResult<string?>("""{"hosts":{"github.com":[],"ghe.corp.com":[]}}""");
+        };
+        await Assert.That(await GitProviderRouter.ResolveAsync("ghe.corp.com", "/c", TimeSpan.FromSeconds(2), fake)).IsEqualTo(GitProviderKind.GitHub);
+    }
+
+    [Test]
+    public async Task Custom_host_not_in_gh_falls_back_to_gitlab() {
+        CommandRunner fake = (_, _, _, _) => Task.FromResult<string?>("""{"hosts":{"github.com":[]}}""");
+        await Assert.That(await GitProviderRouter.ResolveAsync("gitlab.corp.com", "/c", TimeSpan.FromSeconds(2), fake)).IsEqualTo(GitProviderKind.GitLab);
+    }
+
+    [Test]
+    public async Task Probe_result_is_memoized_per_host() {
+        var calls = 0;
+        CommandRunner fake = (_, _, _, _) => { calls++; return Task.FromResult<string?>("""{"hosts":{"ghe.corp.com":[]}}"""); };
+        await GitProviderRouter.ResolveAsync("ghe.corp.com", "/c", TimeSpan.FromSeconds(2), fake);
+        await GitProviderRouter.ResolveAsync("ghe.corp.com", "/c", TimeSpan.FromSeconds(2), fake);
+        await Assert.That(calls).IsEqualTo(1); // memoized: bulk-import loop can't multiply the probe
+    }
+
+    [Test]
+    public async Task Null_host_is_unknown() {
+        await Assert.That(await GitProviderRouter.ResolveAsync(null, "/c", TimeSpan.FromSeconds(2), Never)).IsEqualTo(GitProviderKind.Unknown);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/GitProviderRouterTests/*"`
+Expected: FAIL — type doesn't exist.
+
+- [ ] **Step 3: Implement the router**
+
+Create `src/Capacitor.Cli/PrDetection/GitProviderRouter.cs`:
+
+```csharp
+using System.Collections.Concurrent;
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.PrDetection;
+
+internal enum GitProviderKind { GitHub, GitLab, Unknown }
+
+/// <summary>
+/// Maps a remote host to a provider. SaaS hosts route directly; a custom host is
+/// probed once via `gh auth status --json hosts` (GitHub if listed, else best-effort
+/// GitLab). The decision is memoized per host for the process lifetime so the
+/// ImportCommand bulk loop can't multiply the probe.
+/// </summary>
+internal static class GitProviderRouter {
+    static readonly ConcurrentDictionary<string, GitProviderKind> Memo = new(StringComparer.OrdinalIgnoreCase);
+
+    public static async Task<GitProviderKind> ResolveAsync(string? host, string cwd, TimeSpan cap, CommandRunner run) {
+        if (string.IsNullOrEmpty(host)) return GitProviderKind.Unknown;
+        if (host == "github.com") return GitProviderKind.GitHub;
+        if (host == "gitlab.com") return GitProviderKind.GitLab;
+
+        if (Memo.TryGetValue(host, out var cached)) return cached;
+
+        var kind = await ProbeAsync(host, cwd, cap, run);
+        Memo[host] = kind;
+        return kind;
+    }
+
+    static async Task<GitProviderKind> ProbeAsync(string host, string cwd, TimeSpan cap, CommandRunner run) {
+        // `gh auth status --json hosts` forces exit 0 even on auth failure, so decide
+        // from the JSON payload, not the exit code.
+        var json = await run("gh", "auth status --json hosts", cwd, cap);
+        if (json is not null) {
+            try {
+                if (JsonNode.Parse(json)?["hosts"] is JsonObject hosts && hosts.ContainsKey(host)) {
+                    return GitProviderKind.GitHub;
+                }
+            } catch { /* fall through */ }
+        }
+        // Not a known GitHub host → assume GitLab and let the detector no-op if unauthenticated.
+        return GitProviderKind.GitLab;
+    }
+
+    internal static void ResetMemoForTests() => Memo.Clear();
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/GitProviderRouterTests/*"`
+Expected: PASS (incl. memoization).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli/PrDetection/GitProviderRouter.cs test/Capacitor.Cli.Tests.Unit/GitProviderRouterTests.cs
+git commit
+```
+Message: `feat: add GitProviderRouter with custom-host probe and per-host memo`
+
+---
+
+### Task 8: Wire the router into `DetectRepositoryAsync` (effective provider budget)
+
+**Files:**
+- Modify: `src/Capacitor.Cli/RepositoryDetection.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs` (extend) — plus manual smoke.
+
+**Interfaces:**
+- Consumes: `GitProviderRouter.ResolveAsync`, `GitHubPrDetector.DetectAsync`, `GitLabPrDetector.DetectAsync`, and `host`/`owner`/`repo`/`branch` already computed in `DetectRepositoryAsync`.
+
+- [ ] **Step 1: Replace the GitHub-only block with router-driven dispatch**
+
+In `DetectRepositoryAsync`, the effective provider budget already exists as `ghCap` (post-git remainder when a budget is passed, else the fixed 2s cap). Rename intent in a comment and dispatch by provider:
+
+```csharp
+// Effective provider budget: the post-git remainder when the caller passed a budget
+// (only ClaudeHookCommand does), else the historical 2s cap. Covers probe + detector.
+var providerCap = ghCap;
+
+if (providerCap > TimeSpan.Zero && host is not null) {
+    var kind = await PrDetection.GitProviderRouter.ResolveAsync(host, cwd, providerCap, DefaultRunner);
+    var pr = kind switch {
+        PrDetection.GitProviderKind.GitHub => await PrDetection.GitHubPrDetector.DetectAsync(cwd, providerCap, DefaultRunner),
+        PrDetection.GitProviderKind.GitLab when owner is not null && repoName is not null
+            => await PrDetection.GitLabPrDetector.DetectAsync(host, owner, repoName, branch, cwd, providerCap, DefaultRunner),
+        _ => null
+    };
+    if (pr is not null) {
+        prNumber = pr.Number; prTitle = pr.Title; prUrl = pr.Url; prHeadRef = pr.HeadRef;
+    }
+}
+```
+
+Remove the now-dead direct `GitHubPrDetector.DetectAsync` block added in Task 5 (this supersedes it). Keep the whole thing inside the existing `try`/`catch` so any failure degrades to an untagged session.
+
+> The `gh auth status` probe only runs for non-SaaS hosts (the router returns early for `github.com`/`gitlab.com`) and shares `providerCap`. "No explicit budget" still yields the 2s default cap — detection runs on every surface; it is never silently skipped.
+
+- [ ] **Step 2: Add a routing smoke test**
+
+Extend `RepositoryDetectionCacheTests.cs` with a test that exercises `DetectRepositoryAsync` against a temp git repo whose origin is `gitlab.com` — assert it does not throw and returns owner/repo `group`/`project` even when `glab` is absent (PR fields null). Reuse the temp-repo helper from Task 3.
+
+```csharp
+[Test]
+public async Task Detects_gitlab_repo_base_info_without_glab() {
+    using var tmp = new TempGitRepo(origin: "git@gitlab.com:group/project.git");
+    var repo = await RepositoryDetection.DetectRepositoryAsync(tmp.Path);
+    await Assert.That(repo!.Owner).IsEqualTo("group");
+    await Assert.That(repo.RepoName).IsEqualTo("project");
+    await Assert.That(repo.Host).IsEqualTo("gitlab.com");
+    // No glab installed/authenticated in CI → PR fields stay null (best-effort).
+}
+```
+
+- [ ] **Step 3: Run the full unit suite + AOT check**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj
+dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}' || echo "no AOT warnings"
+```
+Expected: full suite PASS; AOT grep prints "no AOT warnings".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Capacitor.Cli/RepositoryDetection.cs test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs
+git commit
+```
+Message: `feat: route PR detection by provider (GitHub/GitLab) with effective budget`
+
+---
+
+### Task 9: Docs — announce GitLab support
+
+**Files:**
+- Modify: `README.md` (`## Getting started` prerequisites + the `kcap review` section under `## CLI commands`)
+- Modify: `src/Capacitor.Cli.Core/Resources/help-*.txt` (the `review` command help, if it enumerates URL formats)
+- Modify: `src/Capacitor.Cli/Commands/ReviewCommand.cs:13-14` (usage text)
+
+**Interfaces:** none (documentation).
+
+- [ ] **Step 1: Update `ReviewCommand` usage text**
+
+In `ReviewCommand.HandleReview`, extend the "Expected formats" block:
+
+```csharp
+await Console.Error.WriteLineAsync("Expected formats:");
+await Console.Error.WriteLineAsync("  GitHub URL:  https://github.com/owner/repo/pull/123");
+await Console.Error.WriteLineAsync("  GitLab URL:  https://gitlab.com/owner/repo/-/merge_requests/123");
+await Console.Error.WriteLineAsync("  Shorthand:   owner/repo#123");
+```
+
+- [ ] **Step 2: Update `README.md`**
+
+- In `## Getting started` prerequisites: note that PR/MR auto-tagging uses the provider CLI — `gh` for GitHub/GitHub Enterprise, `glab` for GitLab — and is best-effort (a session is simply untagged if the matching CLI isn't installed/authenticated).
+- In the `kcap review` section under `## CLI commands`: add the GitLab MR URL form alongside the GitHub URL and `owner/repo#123` shorthand, and mention nested GitLab groups are not yet supported.
+
+- [ ] **Step 3: Update `help-*.txt` if applicable**
+
+`grep -n "pull/" src/Capacitor.Cli.Core/Resources/help-*.txt` — if the review help lists the GitHub URL form, add the GitLab MR URL form the same way. If no help file mentions PR URL formats, skip (note it in the commit body).
+
+- [ ] **Step 4: Build + verify usage text renders**
+
+```bash
+dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj
+```
+Expected: builds clean. (Usage text is only printed on a parse failure; a manual `kcap review not-a-ref` would show the three formats.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md src/Capacitor.Cli/Commands/ReviewCommand.cs src/Capacitor.Cli.Core/Resources/
+git commit
+```
+Message: `docs: document GitLab MR support for kcap review and auto-detection`
+
+---
+
+## Self-Review
+
+**Spec coverage** (each spec section → task):
+- §1 provider routing → Tasks 5–8. §1 GitLab field mapping (`iid`→`pr_number`, etc.) → Task 6. §1 encoding of path+branch → Task 6.
+- §2 custom/self-hosted host probe (`gh auth status --json hosts`, read JSON not exit code) → Task 7.
+- §3 host extraction → Task 2 + Task 4; nested-group deferral → Task 1 (parser rejects) + Global Constraints; **Cache** requirement → Task 4.
+- §4 PrRefParser (GitHub any-host, GitLab MR URL + suffix tolerance, shorthand single-level) → Task 1.
+- §5 daemon `RepoMatcher` host-agnostic suffix match → Task 3.
+- §6a repo_hash kept host-agnostic → no code change (honored by Task 3's suffix match); §6b nested-group server routing → out of scope (deferred), enforced by Task 1 rejection.
+- §7 docs → Task 9.
+- Error handling / effective provider budget → Task 8; best-effort degradation → Global Constraints + every detector's `try/catch`.
+- Testing list → Tasks 1–8 test steps (parser incl. nested-group rejection & suffix; GitUrlParser via cache test host; router probe reads JSON; cache invalidation; encoded branch; MR selection/guards; field mapping).
+
+**Placeholder scan:** No TBD/TODO. The only conditional is Task 3/Task 9 step 3 ("if the file has no helper" / "if help lists URL formats") — both give the concrete action for each branch, not a deferral.
+
+**Type consistency:** `CommandRunner(string cmd, string arguments, string cwd, TimeSpan timeout)` matches `RepositoryDetection.RunCommandAsync`'s signature (Task 5 relies on this). `PrInfo(int Number, string? Title, string? Url, string? HeadRef)` is produced by both detectors and consumed identically in Task 8. `GitProviderKind { GitHub, GitLab, Unknown }` used consistently in Tasks 7–8. `GitCacheEntry.SchemaVersion` / `RepositoryDetection.CacheSchemaVersion` names match across Task 4 and the test. `RemoteMatcher.ExtractHost`/`PathAfterHost` defined in Task 2, consumed in Tasks 3–4.
+
+**Note on ordering:** Task 5 introduces a GitHub-only dispatch that Task 8 replaces. This is intentional (Task 5 is a behavior-preserving refactor mergeable on its own; Task 8 generalizes it). The plan calls out removing the Task-5 block in Task 8 Step 1.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-01-multi-provider-pr-detection.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-07-01-multi-provider-pr-detection-design.md
+++ b/docs/superpowers/specs/2026-07-01-multi-provider-pr-detection-design.md
@@ -1,0 +1,397 @@
+# Multi-provider PR/MR detection design
+
+**Date:** 2026-07-01
+**Status:** Draft for review
+**Linear:** (to be filed — GitHub issue too, per repo policy)
+
+## Problem
+
+kcap's session recording tags each session with the pull request it belongs to,
+so the review features can group sessions by PR. Today that PR is discovered by
+shelling out to the GitHub CLI (`gh pr view`) and the explicit `kcap review <ref>`
+path only understands `github.com` URLs. As a result, PR/MR detection only works
+for GitHub.
+
+The server has moved user authentication to WorkOS. Tenants can now be GitHub,
+GitHub Enterprise, GitLab.com, or self-hosted GitLab organizations. The PR
+detection surface has not kept up.
+
+## Key findings (why this is smaller than it looks)
+
+Investigated the CLI (`kcap-cli`) and the server (`../kcap-server`). The important
+facts:
+
+1. **The PR is only a grouping key.** The server derives the "PR view" (files,
+   transcripts, tests) from recorded kcap sessions grouped by `owner/repo/pr#`
+   (`session_file_changes` JOIN `session_prs`). It never fetches a real diff.
+   There are **zero** calls to a provider API for PR data anywhere in the server.
+
+2. **The server has no provider API access for tenants — by design.** WorkOS
+   supplies identity only. There is a global GitHub App, but it is used for
+   auth/installation checks, not to read repos or PRs. So resolving "branch → PR"
+   on the server would mean rebuilding the per-tenant provider integration that
+   the WorkOS migration deliberately removed. **Out of scope.**
+
+3. **The CLI supplies `pr_number`.** `RepositoryDetectedEvent` carries
+   `pr_number/pr_title/pr_url/pr_head_ref`; the server stores whatever the CLI
+   sends and never resolves a branch itself. So the *only* GitHub-locked piece is
+   the CLI's client-side discovery of the PR/MR number.
+
+4. **Account linking (AI-967) does not help.** It is "identity only, not auth" —
+   it captures the user's GitHub id/login/avatar, not a repo-scoped token, and is
+   GitHub-only. It cannot resolve PRs and is orthogonal to this work.
+
+5. **The grouping key is host-agnostic.**
+   `RepoHashHelper.ComputeRepoHash(owner, repo) = SHA256("{owner}/{repo}".ToLowerInvariant())[..16]`.
+   The host is not part of the hash, so `github.com/foo/bar` and
+   `gitlab.com/foo/bar` collide. **Correcting this is not a cheap re-projection:**
+   `repo_hash` is embedded in *event stream names* — `JudgeFacts-repo-{repoHash}-{category}`,
+   `JudgeFactEmbeddings-repo-{repoHash}-{category}`, `RepoSettings-{repoHash}`,
+   `RepoGuidelineSettings-{repoHash}`, `JudgeFactCuration-{repoHash}` (written via
+   `SessionWriter.Writes.cs` / `RepoSettingsService`) — and carried inside those
+   events' `ScopeId`/`RepoHash` fields. A read-model re-projection rebuilds SQLite
+   but does **not** rename streams, so changing the hash orphans all retained judge
+   facts, promotions, mutes, and per-repo settings. So this effort treats the
+   collision as a documented limitation, not something to fix here (see §6a).
+
+**Conclusion:** resolution stays **client-side**, and because the PR is just a
+label, the server endpoints and MCP review tools already work for any provider
+once the CLI sends a correct label.
+
+## Goals
+
+- `kcap` auto-detects the PR/MR for the current branch on **GitHub.com and
+  GitLab.com**, and `kcap review <url>` accepts both providers' URLs.
+- GitHub Enterprise keeps working (it already does — `gh pr view` auto-targets the
+  remote's host).
+- **No provider tokens are managed by kcap.** We delegate to the vendor CLIs
+  (`gh`, `glab`), which own their own auth exactly as `gh` does today.
+- Detection stays **best-effort**: a missing/unauthenticated CLI, unknown host, or
+  timeout results in an untagged session, never an error.
+
+## Non-goals
+
+- Server-side PR resolution or any per-tenant provider API integration.
+- Fetching real PR diffs from the provider (the review model is derived from
+  sessions, unchanged).
+- Explicit per-profile `host → provider` configuration. Self-hosted GitHub
+  Enterprise / GitLab work only opportunistically, when the vendor CLI is already
+  authenticated to that host (see "Custom / self-hosted hosts" below). Forcing a
+  provider for an unauthenticated custom host is left as a clean extension point.
+- Bitbucket or any provider beyond GitHub / GitLab.
+- Depending on AI-967 account linking.
+
+## Design
+
+### 1. Provider routing (which tool for which host)
+
+`RepositoryDetection.DetectRepositoryAsync` is the single detection engine and the
+only place `gh`/`glab` is spawned, so all detection changes live behind it. Note
+its blast radius is wide: besides hook enrichment (`EnrichWithRepositoryInfo`) and
+the MCP review server (`McpReviewServer.DetectPrFromGitAsync`), it is called by
+every vendor hook (Claude/Codex/Gemini/Copilot/Kiro/Pi/OpenCode), the sessions and
+flows MCP servers, `RecapCommand`, `CurateCommand`, `WatchCommand`, `RepoExclusion`,
+and `ImportCommand` (including a **per-session loop over a bulk import**). Only
+`ClaudeHookCommand` passes a time budget; the rest use the default caps. This
+matters for latency (see Error handling) — a slow provider probe multiplies across
+a bulk import.
+
+After parsing the remote into `(host, owner, repo)`, choose a detector by host:
+
+| Remote host        | Detector                    |
+|--------------------|-----------------------------|
+| `github.com`       | GitHub (`gh`)               |
+| `gitlab.com`       | GitLab (`glab`)             |
+| any other host     | probe (see §2)              |
+
+Introduce a small seam — an `IPrDetector` with `TryDetectAsync(host, owner, repo, branch, cwd, budget)` returning the
+`(prNumber, prTitle, prUrl, prHeadRef)` tuple or null — with two implementations:
+
+- **`GitHubCliPrDetector`** — runs the existing
+  `gh pr view --json number,title,url,headRefName` (unchanged). `gh` auto-targets
+  the remote's host, so GitHub Enterprise works with no extra code.
+- **`GitLabCliPrDetector`** — runs
+  `glab api --hostname <host> "projects/{Uri.EscapeDataString(owner/repo)}/merge_requests?source_branch={Uri.EscapeDataString(branch)}&state=opened"`,
+  parses the JSON **array**, and selects the MR per the rules below. Both the
+  project path **and** the branch must be `Uri.EscapeDataString`-encoded: git
+  branch names legally contain `/`, and can contain `&`/`+`/`%`, which would
+  otherwise corrupt the query and select the wrong MR (unit-test an encoded branch,
+  e.g. `feat/a&b`).
+
+**MR selection (critical correctness).** GitLab's `source_branch` filter is
+*ignored when empty*, returning **all** open MRs — so a naïve "take the first
+element" mis-tags the session on a detached HEAD or when `git branch --show-current`
+returns empty. The detector must therefore:
+
+1. **Abort if the branch is empty/unknown** — no branch, no GitLab detection
+   (`gh pr view` has no analogous failure because it takes no branch argument).
+2. **Filter the returned array to MRs whose `source_branch` exactly equals the
+   local branch** (defense in depth even though the query already filters).
+3. If more than one remains, pick the **most recently updated** (`updated_at`);
+   log nothing (best-effort). This mirrors `gh pr view`'s single-PR behavior.
+   `draft`/`work_in_progress` MRs are eligible (kcap tags them like any other).
+
+**External-tool surface (verified on installed tooling, gh 2.93.0 / current glab):**
+`gh auth status --json hosts` is a stable flag keyed by hostname; note `--json`
+forces exit 0 even on auth failure, so the custom-host probe must inspect the JSON
+payload, not the exit code. `glab api` is a real JSON passthrough (default
+`--output json`), `--hostname` exists, and MR objects carry `iid`/`id`/`title`/
+`web_url`/`source_branch`/`updated_at`/`draft`. We build the URL-encoded project
+path (`owner%2Frepo`) ourselves rather than using glab's `:fullpath` placeholder
+**because `:fullpath` is resolved from the current directory's repo and would not
+respect an explicit `--hostname`/owner** — hand-building keeps the two consistent.
+
+The process-spawn helper (`RunCommandAsync`) is factored so the detector can be
+unit-tested with a fake command runner instead of shelling out.
+
+#### GitLab field mapping
+
+| GitLab MR field           | → `RepositoryDetectedEvent` |
+|---------------------------|------------------------------|
+| `iid` (per-project MR #)  | `pr_number`                  |
+| `title`                   | `pr_title`                   |
+| `web_url`                 | `pr_url`                     |
+| `source_branch`           | `pr_head_ref`                |
+
+Use `iid` (the per-project number shown in MR URLs), **not** the global `id`.
+
+### 2. Custom / self-hosted hosts
+
+This routing branch **is** part of the first pass — it is cheap and, crucially,
+preserves today's GitHub Enterprise behavior (the current code runs `gh pr view`
+unconditionally, so a GHE host already works; host routing must not regress that).
+
+For a host that is neither `github.com` nor `gitlab.com`, detection probes rather
+than guesses:
+
+- If `gh auth status --json hosts` (inspect the JSON, not the exit code) lists the
+  host → it is GitHub → use the GitHub detector (`gh` targets it automatically).
+  This keeps GitHub Enterprise working with zero configuration for anyone whose
+  `gh` is authenticated to that host.
+- Otherwise, attempt the GitLab detector best-effort. On an unknown/unauthenticated
+  host `glab api` does not silently no-op — it prints an error and exits non-zero,
+  which `RunCommandAsync` already maps to `null` (untagged session). The caveat is
+  **latency**: the attempt may incur DNS/connect time before failing, so it must
+  run under the detection budget (see Error handling), and this probe path should
+  be skipped entirely for unbudgeted bulk callers (see below).
+- Otherwise, no detection (session untagged).
+
+No custom domains are hardcoded and no config map is required — self-hosted works
+opportunistically whenever the matching vendor CLI is already authenticated to
+that host. What is **out of scope** is an *explicit* per-profile `host → provider`
+map (for forcing a provider when the CLI is not authenticated); it can be layered
+on this same routing step later if ever wanted.
+
+### 3. Remote parsing — host extraction (first pass); nested groups deferred
+
+Detection needs the **host** to route, which the current parsing does not surface.
+**First pass:** extract the host by reusing `RemoteMatcher.NormalizeRemoteUrl`
+(which yields `host/owner/path`), so parsing stays in one place. Owner/repo
+continue to come from the existing single-level parse
+(`GitUrlParser.ParseRemoteUrl`), which already handles `gitlab.com/group/project`.
+
+`GitUrlParser.ParseRemoteUrl` captures exactly two path segments, so GitLab
+**nested groups** (`gitlab.com/group/subgroup/project`) fail to parse and yield no
+owner/repo — such repos are simply **not auto-detected in the first pass**
+(graceful: untagged session). Generalizing the parser to multi-segment namespaces
+is **deferred to the nested-group fast-follow** alongside the server route change
+(§6b); doing it earlier would tag sessions that `kcap review` cannot read (the
+routes are still `/{owner}/{repo}/pulls/{n}`). Until §6b lands, nested-group
+remotes are **consistently unsupported** across detection, `PrRefParser` (§4), and
+`RepoMatcher` (§5) — one scope, everywhere.
+
+**Cache.** `DetectRepositoryAsync` caches `RemoteUrl`/`Owner`/`RepoName` per cwd
+for 1 hour (`GitCacheEntry`) and reuses the cached `owner`/`repoName` *without
+reparsing* (`RepositoryDetection.cs:91`). Because host/provider routing is new,
+two changes are required: (1) the cache must also carry the **host** (routing needs
+it), and (2) pre-upgrade entries were produced by the old logic (no host; e.g. a
+nested-group repo cached with null owner), so **bump the `GitCacheEntry` schema
+version to invalidate stale entries on upgrade** — otherwise a repo can stay
+misparsed/unroutable for up to the TTL. **Requirement:** add `host` to
+`GitCacheEntry` and bump its schema version so pre-upgrade entries are discarded.
+This keeps today's cache-hit path untouched (no parsing on a hit). The alternative
+of caching only `RemoteUrl` and re-deriving on every load was rejected: it moves
+parsing (and the "not a git repo" / null-owner handling) onto the cache-**hit**
+path, where parsing never runs today, on every session across the wide
+unbudgeted-caller set (§1).
+
+### 4. Explicit PR/MR reference parsing (`PrRefParser`)
+
+`PrRefParser.TryParse` must accept, in addition to today's forms:
+
+- GitHub PR URL on any host: `https?://<host>/<owner>/<repo>/pull/<n>` (drop the
+  literal `github.com`), keeping the existing trailing-suffix tolerance
+  (`(?:[/?#].*)?$`).
+- GitLab MR URL: `https?://<host>/<owner>/<repo>/-/merge_requests/<n>` with the
+  **same trailing-suffix tolerance** as the GitHub pattern, so browser-copied URLs
+  ending in `/diffs`, `/commits`, `?query`, or `#note_…` fragments still parse
+  (GitLab users commonly copy these). **Single-level `owner/repo` only** in the
+  first pass — nested-group (multi-segment owner) MR URLs are rejected until §6b
+  lands, consistent with §3.
+- Shorthand `owner/repo#123` stays **single-level and unchanged**. The existing
+  regex deliberately forbids `/` in the repo group (a slash there would produce a
+  malformed API path segment); relaxing it reopens exactly that hazard.
+
+Because the URL now determines the provider implicitly and the server key is
+`owner/repo`, `TryParse` continues to return `(owner, repo, prNumber)` — all
+single-segment in the first pass.
+
+### 5. Daemon repo matching (`RepoMatcher`)
+
+`RepoMatcher.FindAsync` builds `target = $"github.com/{owner}/{repo}"` and compares
+against `RemoteMatcher.NormalizeRemoteUrl(origin)` (which is `host/owner/path`).
+The hardcoded `github.com` prefix must go.
+
+**Decision: match on the `owner/repo` suffix only** — strip the leading host
+segment from the normalized remote (`host/owner/path`) and compare the remaining
+`owner/repo` against the requested `owner/repo`, ignoring host. This is consistent
+with the host-agnostic `repo_hash` (§6a) the rest of the system already uses, and
+with the single-level scope of §3 (nested-group remotes simply won't match until
+that scope is lifted). Note this is *not* free: the normalizer emits the host, so
+it must be stripped before comparing.
+
+The "most correct" alternative — threading the real host through the match — is
+**out of scope and larger than it looks**: the daemon request
+(`FindRepoForRemoteRequest`) carries no host, the server builds it from owner/repo
+only, and the server's `repositories` table has **no host column**. Host-aware
+matching would require host on the event, host projected into `repositories`, a new
+request field, and daemon changes — the same chain that §6a's hash change would
+need. Deferred with the collision limitation.
+
+### 6. Server-side considerations (`../kcap-server` — separate repo/PR)
+
+These are dependencies, not CLI work, but block correct end-to-end GitLab support.
+
+**a. Host-agnostic `repo_hash` collision — accepted as a known limitation.**
+`ComputeRepoHash(owner, repo)` omits the host, so two repos with the same
+`owner/repo` on different providers share a `repo_hash` and therefore share review
+data. Fixing it properly means a **stream rekey**, not a re-projection: `repo_hash`
+names event streams (`JudgeFacts-repo-{repoHash}`, `RepoSettings-{repoHash}`, …),
+so rebuilding read models would leave those streams orphaned (see Key findings §5).
+The raw event does carry `remote_url` (host is derivable), so read models *could*
+be rebuilt host-aware — but the streams could not, without a dedicated rekey
+migration. The only existing rekey (`JudgeFactRekey`) is a *user-identity* re-key
+that re-projects columns while leaving repo-hash stream names intact — so there is
+**no precedent for renaming a `repo_hash`-keyed stream**, which underscores rather
+than eases the cost. **Decision:** do not change the hash in this
+effort; document the collision (realistically rare — it needs the identical
+`owner/repo` on two providers both recorded to the same tenant). Revisit only if a
+collision is actually hit.
+
+**b. Nested-group routing.** Review routes are
+`/api/review/{owner}/{repo}/pulls/{n}` — single path segments. A GitLab `owner`
+containing a slash cannot be a single segment. The CLI already URL-encodes
+owner/repo (`ReviewCommand`, `McpReviewServer`, via `Uri.EscapeDataString`), but
+whether an encoded `%2F` survives ASP.NET routing to this endpoint is **unverified
+and must be tested empirically against this server** (it is commonly rejected by
+default). The file-context route already uses a `{**filePath}` catch-all, so a
+catch-all or dedicated project-path parameter is a proven pattern if `%2F` fails.
+This is a server-side routing change — but note the daemon `RepoMatcher` (§5) is a
+separate client-side consumer of `owner/repo` that also needs the multi-segment
+handling, so the change is not purely server-side.
+
+**Scoping choice for the first pass:** to avoid the server routing change entirely,
+the initial release restricts GitLab auto-detection and `kcap review` to
+**single-level namespaces** (`owner/repo`), which fit the existing routes. Nested
+groups are a fast-follow once §6b is resolved. (See Open decision #2.)
+
+### 7. Docs
+
+- `README.md` — Getting started prerequisites and the `kcap review` command
+  section: document `glab` as a soft dependency for GitLab users (same shape as
+  `gh` for GitHub), and that `kcap review` accepts GitLab MR URLs. (Repo policy:
+  README must change in the same PR as any user-facing CLI surface change.)
+- `ReviewCommand` usage text (currently shows only the GitHub URL/shorthand) — add
+  the GitLab MR URL example.
+- `src/Capacitor.Cli.Core/Resources/help-*.txt` as applicable.
+
+These user-facing GitLab doc changes (README + help + `ReviewCommand` usage) land
+with the **auto-detector** PR, not the parser groundwork — so the docs never
+advertise GitLab review before it works end-to-end (see Open decision #3). The
+parser-only PR, if merged first, is internal groundwork and adds no user-facing
+GitLab surface, so it triggers no README change on its own.
+
+## Error handling / degradation
+
+Preserve the current best-effort contract in `DetectRepositoryAsync`:
+
+- Unknown host, missing `gh`/`glab`, unauthenticated CLI, non-git dir, malformed
+  JSON, or timeout → return without PR fields; the session is recorded untagged.
+
+**Budget is not "unchanged" — it must be re-sliced.** Today one `ghCap` is carved
+from the budget remaining after the git probes and spent on a single `gh pr view`.
+The new flow can spend up to three sub-steps — an optional `gh auth status` probe
+(custom hosts only), then the provider detector, and for GitLab a network round
+trip. The model is an **effective provider budget** that always exists:
+
+- Define an **effective provider budget** for all provider work (auth probe +
+  detector) combined, not per step. When the caller passes an explicit budget
+  (only `ClaudeHookCommand` does), it is the post-git remainder. When the caller
+  passes none — most surfaces: MCP servers, `RecapCommand`, `CurateCommand`,
+  `ImportCommand` — it defaults to the historical fixed cap (today's 2s `ghCap`).
+  So GHE probing and GitLab detection run on **every** surface; "no explicit
+  budget" means "use the default cap," **not** "skip detection." If the effective
+  budget is exhausted, skip the remaining provider work.
+- The `gh auth status` probe runs only for **non-SaaS hosts** (skipped for
+  `github.com`/`gitlab.com`, which route directly) and is charged against the same
+  effective budget.
+- **Sole exception — the `ImportCommand` bulk loop:** it must reuse a cached
+  host→provider decision per repo (or skip the custom-host probe) so a slow probe
+  cannot multiply across many sessions in one import.
+- Child processes are killed on timeout (existing behavior, extended to `glab`).
+
+## Testing
+
+Unit tests (pure, no network):
+
+- `PrRefParser` — GitHub PR URLs on `github.com` and other hosts; single-level
+  GitLab MR URLs, including browser-copy suffixes (`/diffs`, `/commits`, `?query`,
+  `#note_…`); shorthands; and rejections. **Nested-group MR URLs must be rejected**
+  in the first pass (asserts the deferred scope, §3/§6b).
+- `GitUrlParser` — single-level namespaces, SSH and HTTPS, `.git` suffix; and that
+  a nested-group remote yields no owner/repo (deferred). Host extraction via
+  `RemoteMatcher.NormalizeRemoteUrl`.
+- `RemoteMatcher` / `RepoMatcher` — host-agnostic `owner/repo`-suffix matching
+  (host stripped), GitLab remotes.
+- Provider routing — host → detector selection, including the custom-host probe
+  (assert it inspects the `gh auth status` JSON, not the exit code), via a fake
+  command runner (no real `gh`/`glab`).
+- Detection cache — a pre-upgrade `GitCacheEntry` (no host) is invalidated by the
+  version bump / re-derived from `RemoteUrl`, not served stale.
+- `GitLabCliPrDetector` request building — assert the project path and an
+  `&`-containing branch are `Uri.EscapeDataString`-encoded in the `glab api` args.
+- `GitLabCliPrDetector` field mapping — feed a captured GitLab MR JSON payload and
+  assert the `iid → pr_number` mapping.
+- `GitLabCliPrDetector` selection/guard cases (the Critical finding): empty/unknown
+  branch → no detection (must NOT tag from an all-MRs response); a payload of
+  multiple open MRs → the one matching `source_branch` is chosen, and the
+  most-recently-updated wins on ties; an MR whose `source_branch` ≠ local branch is
+  rejected.
+
+AOT: run `dotnet publish -c Release` and confirm no new IL3050/IL2026 warnings
+(new JSON parsing must use the source-generated `JsonSerializerContext`, and any
+`JsonArray` built by hand must use the constructor, not a collection expression).
+
+## Open decisions (resolve in planning)
+
+Each carries a recommended default so a plan can proceed if unchallenged.
+
+1. **`repo_hash` host inclusion.** Include host (a stream **rekey** migration, not a
+   cheap re-projection — see §6a) vs. keep host-agnostic and accept the
+   cross-provider collision. Drives §5 and §6a. *Recommendation:* keep it
+   host-agnostic and accept the (rare) collision; the rekey cost far outweighs the
+   risk. Match the daemon (§5) to this by comparing `owner/repo` suffix only.
+2. **GitLab nested groups.** Support now (needs §6b server routing) vs. single-level
+   `owner/repo` only in the first pass. *Recommendation:* single-level first to
+   avoid the Kestrel `%2F` routing change; add nested groups as a fast-follow.
+3. **Delivery sequencing.** The pure-string wins (`PrRefParser` + `RepoMatcher` +
+   `GitUrlParser`/host extraction) and the `GitLabCliPrDetector` auto-detector can
+   land in separate PRs. *Recommendation:* split for **engineering** reasons — the
+   pure-string PR is low-risk, dependency-free groundwork that can merge first — but
+   **the first user-visible GitLab release must include auto-detection.** Parse-only
+   is *preparatory, not shippable GitLab support*: with no auto-detector, no GitLab
+   session is ever tagged, so the server has no review context, and
+   `kcap review <gitlab-url>` parses the URL but then **404s** on `ReviewCommand`'s
+   existing review-context check (`GET /api/review/{owner}/{repo}/pulls/{n}`). Do
+   not announce GitLab support, or document the `kcap review` GitLab example (§7),
+   until the auto-detector ships.

--- a/src/Capacitor.Cli.Core/Commands/PrRefParser.cs
+++ b/src/Capacitor.Cli.Core/Commands/PrRefParser.cs
@@ -3,50 +3,51 @@ using System.Text.RegularExpressions;
 namespace Capacitor.Cli.Core.Commands;
 
 /// <summary>
-/// Parses a PR reference in either shorthand (<c>owner/repo#123</c>) or
-/// github.com URL form. Shared by the <c>kcap review</c> CLI command
-/// and the <c>kcap mcp review</c> server's per-tool PR argument.
+/// Parses a PR reference in either shorthand (<c>owner/repo#123</c>),
+/// GitHub PR URL on any host, or GitLab MR URL form. Shared by the <c>kcap review</c>
+/// CLI command and the <c>kcap mcp review</c> server's per-tool PR argument.
 /// </summary>
 public static partial class PrRefParser {
     public static bool TryParse(string input, out string owner, out string repo, out int prNumber) {
-        owner    = "";
-        repo     = "";
-        prNumber = 0;
-
+        owner = ""; repo = ""; prNumber = 0;
         if (string.IsNullOrWhiteSpace(input)) return false;
-
         input = input.Trim();
 
-        var urlMatch = UrlPattern().Match(input);
+        var gh = GitHubUrlPattern().Match(input);
+        if (gh.Success) {
+            owner = gh.Groups[1].Value; repo = gh.Groups[2].Value;
+            prNumber = int.Parse(gh.Groups[3].Value);
+            return true;
+        }
 
-        if (urlMatch.Success) {
-            owner    = urlMatch.Groups[1].Value;
-            repo     = urlMatch.Groups[2].Value;
-            prNumber = int.Parse(urlMatch.Groups[3].Value);
-
+        var gl = GitLabUrlPattern().Match(input);
+        if (gl.Success) {
+            owner = gl.Groups[1].Value; repo = gl.Groups[2].Value;
+            prNumber = int.Parse(gl.Groups[3].Value);
             return true;
         }
 
         var shortMatch = ShorthandPattern().Match(input);
-
         if (shortMatch.Success) {
-            owner    = shortMatch.Groups[1].Value;
-            repo     = shortMatch.Groups[2].Value;
+            owner = shortMatch.Groups[1].Value; repo = shortMatch.Groups[2].Value;
             prNumber = int.Parse(shortMatch.Groups[3].Value);
-
             return true;
         }
 
         return false;
     }
 
-    // Accept any of: trailing `/...`, `?query`, `#fragment` — browser-copied
-    // GitHub URLs commonly include these suffixes.
-    [GeneratedRegex(@"^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$")]
-    private static partial Regex UrlPattern();
+    // GitHub-style PR URL on ANY host (github.com or GitHub Enterprise). owner/repo are
+    // single-segment; trailing path/query/fragment (browser copies) tolerated.
+    [GeneratedRegex(@"^https?://[^/]+/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$")]
+    private static partial Regex GitHubUrlPattern();
 
-    // Repo group forbids `/` — GitHub repo names can't contain it, and allowing
-    // it would let `owner/foo/bar#42` parse into a malformed API URL segment.
+    // GitLab MR URL. Single-level owner/repo only (nested groups deferred, §3/§6b).
+    // Same trailing-suffix tolerance so /diffs, /commits, ?query, #note parse.
+    [GeneratedRegex(@"^https?://[^/]+/([^/]+)/([^/]+)/-/merge_requests/(\d+)(?:[/?#].*)?$")]
+    private static partial Regex GitLabUrlPattern();
+
+    // Shorthand owner/repo#123 — single-level, unchanged. Repo forbids '/'.
     [GeneratedRegex(@"^([^/]+)/([^/#]+)#(\d+)$")]
     private static partial Regex ShorthandPattern();
 }

--- a/src/Capacitor.Cli.Core/Config/RemoteMatcher.cs
+++ b/src/Capacitor.Cli.Core/Config/RemoteMatcher.cs
@@ -106,9 +106,9 @@ public static partial class RemoteMatcher {
     [GeneratedRegex(@"^git@(?<host>[\w.-]+):(?<path>.+)$")]
     private static partial Regex SshRemoteRegex();
 
-    [GeneratedRegex(@"^ssh://(?:[^@]+@)?(?<host>[\w.-]+)/(?<path>.+)$")]
+    [GeneratedRegex(@"^ssh://(?:[^@]+@)?(?<host>[\w.-]+)(?::\d+)?/(?<path>.+)$")]
     private static partial Regex SshProtoRemoteRegex();
 
-    [GeneratedRegex(@"^https?://(?:[^@]+@)?(?<host>[\w.-]+)/(?<path>.+)$")]
+    [GeneratedRegex(@"^https?://(?:[^@]+@)?(?<host>[\w.-]+)(?::\d+)?/(?<path>.+)$")]
     private static partial Regex HttpsRemoteRegex();
 }

--- a/src/Capacitor.Cli.Core/Config/RemoteMatcher.cs
+++ b/src/Capacitor.Cli.Core/Config/RemoteMatcher.cs
@@ -44,6 +44,21 @@ public static partial class RemoteMatcher {
         return null;
     }
 
+    /// <summary>Host of a raw git remote URL (e.g. "github.com"), or null if unrecognized.</summary>
+    public static string? ExtractHost(string url) {
+        var normalized = NormalizeRemoteUrl(url);
+        if (normalized is null) return null;
+        var slash = normalized.IndexOf('/');
+        return slash <= 0 ? null : normalized[..slash];
+    }
+
+    /// <summary>The "owner/repo" tail of a normalized "host/owner/path" string, or null.</summary>
+    public static string? PathAfterHost(string normalized) {
+        if (string.IsNullOrEmpty(normalized)) return null;
+        var slash = normalized.IndexOf('/');
+        return slash <= 0 || slash == normalized.Length - 1 ? null : normalized[(slash + 1)..];
+    }
+
     static string StripGitSuffix(string path) =>
         path.EndsWith(".git", StringComparison.OrdinalIgnoreCase)
             ? path[..^4]

--- a/src/Capacitor.Cli.Core/Config/RemoteMatcher.cs
+++ b/src/Capacitor.Cli.Core/Config/RemoteMatcher.cs
@@ -49,7 +49,7 @@ public static partial class RemoteMatcher {
         var normalized = NormalizeRemoteUrl(url);
         if (normalized is null) return null;
         var slash = normalized.IndexOf('/');
-        return slash <= 0 ? null : normalized[..slash];
+        return slash <= 0 ? null : normalized[..slash].ToLowerInvariant();
     }
 
     /// <summary>The "owner/repo" tail of a normalized "host/owner/path" string, or null.</summary>

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -609,6 +609,12 @@ static partial class GitUrlParser {
             return (sshMatch.Groups["owner"].Value, sshMatch.Groups["repo"].Value);
         }
 
+        var sshProtoMatch = SshProtoRegex().Match(url);
+
+        if (sshProtoMatch.Success) {
+            return (sshProtoMatch.Groups["owner"].Value, sshProtoMatch.Groups["repo"].Value);
+        }
+
         var httpsMatch = HttpsRegex().Match(url);
 
         return httpsMatch.Success
@@ -621,6 +627,9 @@ static partial class GitUrlParser {
 
     [GeneratedRegex(@"git@[\w.-]+:(?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?$")]
     internal static partial Regex SshRegex();
+
+    [GeneratedRegex(@"ssh://(?:[^@/]+@)?[^/]+/(?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?$")]
+    internal static partial Regex SshProtoRegex();
 }
 
 public record RepoEntry {

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -59,6 +59,9 @@ record RepositoryPayload {
     [JsonPropertyName("remote_url")]
     public string? RemoteUrl { get; init; }
 
+    [JsonPropertyName("host")]
+    public string? Host { get; init; }
+
     [JsonPropertyName("owner")]
     public string? Owner { get; init; }
 
@@ -90,6 +93,12 @@ record GitCacheEntry {
 
     [JsonPropertyName("remote_url")]
     public string? RemoteUrl { get; init; }
+
+    [JsonPropertyName("host")]
+    public string? Host { get; init; }
+
+    [JsonPropertyName("schema_version")]
+    public int SchemaVersion { get; init; }
 
     [JsonPropertyName("owner")]
     public string? Owner { get; init; }

--- a/src/Capacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-mcp.txt
@@ -19,8 +19,8 @@ Options for review:
 
 Per-tool PR override: each PR-scoped tool (`get_pr_summary`,
 `list_pr_files`, `get_file_context`, `search_context`, `list_sessions`)
-accepts an optional `pr` argument (`"owner/repo#123"` or a GitHub URL),
-so a single MCP server can answer about any PR from any branch.
+accepts an optional `pr` argument (`"owner/repo#123"` or a GitHub/GitLab
+URL), so a single MCP server can answer about any PR from any branch.
 
 Resolution order per tool call: tool `pr` arg → startup `--owner/--repo/--pr`
 → git auto-detect from current branch. `get_transcript` keys off

--- a/src/Capacitor.Cli.Core/Resources/help-review.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-review.txt
@@ -7,4 +7,5 @@ Arguments:
 
 Examples:
   kcap review https://github.com/owner/repo/pull/123
+  kcap review https://gitlab.com/owner/repo/-/merge_requests/123
   kcap review owner/repo#123

--- a/src/Capacitor.Cli.Daemon/Services/RepoMatcher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/RepoMatcher.cs
@@ -13,7 +13,10 @@ namespace Capacitor.Cli.Daemon.Services;
 ///      plus the <see cref="DaemonConfig.AllowedRepoPaths"/> allowlist — and dedupes.
 ///   3. For each candidate it verifies the path exists on disk, walks up to the
 ///      nearest <c>.git</c> root, reads <c>origin</c>, and matches against
-///      <c>owner/repo</c>.
+///      <c>owner/repo</c>. Matching is host-agnostic: only the trailing
+///      <c>owner/repo</c> segment of the normalized remote is compared, so a
+///      GitHub, GitLab, Bitbucket, etc. origin all match the same way it's
+///      done for the host-agnostic <c>repo_hash</c>.
 ///   4. All confirmed git roots are returned (the user picks which one to review on).
 ///
 /// Normalized origin URLs are cached for <see cref="CacheTtl"/> per path to avoid
@@ -27,7 +30,7 @@ internal partial class RepoMatcher(DaemonConfig config, ILogger<RepoMatcher> log
     readonly ConcurrentDictionary<string, CacheEntry> _cache = new();
 
     public async Task<string[]> FindAsync(string owner, string repo, string[] serverCandidates, CancellationToken ct) {
-        var target = $"github.com/{owner}/{repo}";
+        var target = $"{owner}/{repo}";
 
         var candidates = await MergeCandidatesAsync(serverCandidates);
         var matches    = new List<string>();
@@ -54,7 +57,8 @@ internal partial class RepoMatcher(DaemonConfig config, ILogger<RepoMatcher> log
                     continue;
                 }
 
-                if (string.Equals(remote, target, StringComparison.OrdinalIgnoreCase)) {
+                if (RemoteMatcher.PathAfterHost(remote) is { } path
+                    && string.Equals(path, target, StringComparison.OrdinalIgnoreCase)) {
                     matches.Add(root);
                 }
             } catch (OperationCanceledException) when (ct.IsCancellationRequested) {

--- a/src/Capacitor.Cli/Commands/ReviewCommand.cs
+++ b/src/Capacitor.Cli/Commands/ReviewCommand.cs
@@ -10,8 +10,9 @@ static class ReviewCommand {
         if (!PrRefParser.TryParse(prIdentifier, out var owner, out var repo, out var prNumber)) {
             await Console.Error.WriteLineAsync($"Could not parse PR identifier: {prIdentifier}");
             await Console.Error.WriteLineAsync("Expected formats:");
-            await Console.Error.WriteLineAsync("  URL:       https://github.com/owner/repo/pull/123");
-            await Console.Error.WriteLineAsync("  Shorthand: owner/repo#123");
+            await Console.Error.WriteLineAsync("  GitHub URL:  https://github.com/owner/repo/pull/123");
+            await Console.Error.WriteLineAsync("  GitLab URL:  https://gitlab.com/owner/repo/-/merge_requests/123");
+            await Console.Error.WriteLineAsync("  Shorthand:   owner/repo#123");
 
             return 1;
         }

--- a/src/Capacitor.Cli/PrDetection/GitLabPrDetector.cs
+++ b/src/Capacitor.Cli/PrDetection/GitLabPrDetector.cs
@@ -1,0 +1,53 @@
+using System.Globalization;
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.PrDetection;
+
+/// <summary>
+/// GitLab MR detection via `glab api` (raw JSON passthrough using glab's own auth —
+/// kcap manages no token). Single-level owner/repo only.
+/// </summary>
+internal static class GitLabPrDetector {
+    public static async Task<PrInfo?> DetectAsync(
+            string host, string owner, string repo, string? branch, string cwd, TimeSpan cap, CommandRunner run) {
+        // Guard: GitLab ignores an empty source_branch filter and returns ALL open MRs,
+        // which would mis-tag the session (e.g. detached HEAD). No branch → no detection.
+        if (string.IsNullOrEmpty(branch)) return null;
+
+        var project = Uri.EscapeDataString($"{owner}/{repo}");
+        var branchEnc = Uri.EscapeDataString(branch);
+        var args = $"api --hostname {host} projects/{project}/merge_requests?source_branch={branchEnc}&state=opened";
+
+        var json = await run("glab", args, cwd, cap);
+        if (json is null) return null;
+
+        try {
+            if (JsonNode.Parse(json) is not JsonArray arr) return null;
+
+            PrInfo? best = null;
+            DateTimeOffset bestUpdated = DateTimeOffset.MinValue;
+
+            foreach (var node in arr) {
+                if (node is not JsonObject mr) continue;
+                // Defense in depth: only accept an exact source_branch match.
+                if (mr["source_branch"]?.GetValue<string>() != branch) continue;
+                var iid = mr["iid"]?.GetValue<int>();
+                if (iid is null) continue;
+
+                var updated = ParseTimestamp(mr["updated_at"]?.GetValue<string>());
+                if (best is null || updated > bestUpdated) {
+                    bestUpdated = updated;
+                    best = new PrInfo(iid.Value, mr["title"]?.GetValue<string>(),
+                                      mr["web_url"]?.GetValue<string>(), mr["source_branch"]?.GetValue<string>());
+                }
+            }
+            return best;
+        } catch {
+            return null; // best-effort
+        }
+    }
+
+    static DateTimeOffset ParseTimestamp(string? s) =>
+        DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var t)
+            ? t : DateTimeOffset.MinValue;
+}

--- a/src/Capacitor.Cli/PrDetection/GitProviderRouter.cs
+++ b/src/Capacitor.Cli/PrDetection/GitProviderRouter.cs
@@ -1,0 +1,45 @@
+using System.Collections.Concurrent;
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.PrDetection;
+
+internal enum GitProviderKind { GitHub, GitLab, Unknown }
+
+/// <summary>
+/// Maps a remote host to a provider. SaaS hosts route directly; a custom host is
+/// probed once via `gh auth status --json hosts` (GitHub if listed, else best-effort
+/// GitLab). The decision is memoized per host for the process lifetime so the
+/// ImportCommand bulk loop can't multiply the probe.
+/// </summary>
+internal static class GitProviderRouter {
+    static readonly ConcurrentDictionary<string, GitProviderKind> Memo = new(StringComparer.OrdinalIgnoreCase);
+
+    public static async Task<GitProviderKind> ResolveAsync(string? host, string cwd, TimeSpan cap, CommandRunner run) {
+        if (string.IsNullOrEmpty(host)) return GitProviderKind.Unknown;
+        if (host == "github.com") return GitProviderKind.GitHub;
+        if (host == "gitlab.com") return GitProviderKind.GitLab;
+
+        if (Memo.TryGetValue(host, out var cached)) return cached;
+
+        var kind = await ProbeAsync(host, cwd, cap, run);
+        Memo[host] = kind;
+        return kind;
+    }
+
+    static async Task<GitProviderKind> ProbeAsync(string host, string cwd, TimeSpan cap, CommandRunner run) {
+        // `gh auth status --json hosts` forces exit 0 even on auth failure, so decide
+        // from the JSON payload, not the exit code.
+        var json = await run("gh", "auth status --json hosts", cwd, cap);
+        if (json is not null) {
+            try {
+                if (JsonNode.Parse(json)?["hosts"] is JsonObject hosts && hosts.ContainsKey(host)) {
+                    return GitProviderKind.GitHub;
+                }
+            } catch { /* fall through */ }
+        }
+        // Not a known GitHub host → assume GitLab and let the detector no-op if unauthenticated.
+        return GitProviderKind.GitLab;
+    }
+
+    internal static void ResetMemoForTests() => Memo.Clear();
+}

--- a/src/Capacitor.Cli/PrDetection/PrDetector.cs
+++ b/src/Capacitor.Cli/PrDetection/PrDetector.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.PrDetection;
+
+/// <summary>Spawns a CLI and returns trimmed stdout, or null on failure/timeout.</summary>
+internal delegate Task<string?> CommandRunner(string cmd, string arguments, string cwd, TimeSpan timeout);
+
+internal sealed record PrInfo(int Number, string? Title, string? Url, string? HeadRef);
+
+/// <summary>GitHub / GitHub Enterprise detection via `gh` (auto-targets the remote's host).</summary>
+internal static class GitHubPrDetector {
+    public static async Task<PrInfo?> DetectAsync(string cwd, TimeSpan cap, CommandRunner run) {
+        var json = await run("gh", "pr view --json number,title,url,headRefName", cwd, cap);
+        if (json is null) return null;
+        try {
+            if (JsonNode.Parse(json) is not JsonObject o) return null;
+            var number = o["number"]?.GetValue<int>();
+            if (number is null) return null;
+            return new PrInfo(number.Value, o["title"]?.GetValue<string>(),
+                              o["url"]?.GetValue<string>(), o["headRefName"]?.GetValue<string>());
+        } catch {
+            return null; // best-effort
+        }
+    }
+}

--- a/src/Capacitor.Cli/RepositoryDetection.cs
+++ b/src/Capacitor.Cli/RepositoryDetection.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.PrDetection;
 
 namespace Capacitor.Cli;
 
@@ -12,6 +13,8 @@ static class RepositoryDetection {
     // Bump whenever the cached shape/derivation changes so stale entries are ignored.
     // v2: added Host + provider-aware parsing.
     internal const int CacheSchemaVersion = 2;
+
+    internal static CommandRunner DefaultRunner => RunCommandAsync;
 
     public static async Task<string> EnrichWithRepositoryInfo(string json, TimeSpan? budget = null) {
         try {
@@ -151,21 +154,13 @@ static class RepositoryDetection {
             }
 
             if (ghCap > TimeSpan.Zero) {
-                try {
-                    var prJson = await RunCommandAsync("gh", "pr view --json number,title,url,headRefName", cwd, ghCap);
+                var pr = await GitHubPrDetector.DetectAsync(cwd, ghCap, DefaultRunner);
 
-                    if (prJson is not null) {
-                        var prNode = JsonNode.Parse(prJson);
-
-                        if (prNode is JsonObject prObj) {
-                            prNumber  = prObj["number"]?.GetValue<int>();
-                            prTitle   = prObj["title"]?.GetValue<string>();
-                            prUrl     = prObj["url"]?.GetValue<string>();
-                            prHeadRef = prObj["headRefName"]?.GetValue<string>();
-                        }
-                    }
-                } catch {
-                    // PR detection is best-effort
+                if (pr is not null) {
+                    prNumber  = pr.Number;
+                    prTitle   = pr.Title;
+                    prUrl     = pr.Url;
+                    prHeadRef = pr.HeadRef;
                 }
             }
 

--- a/src/Capacitor.Cli/RepositoryDetection.cs
+++ b/src/Capacitor.Cli/RepositoryDetection.cs
@@ -153,8 +153,18 @@ static class RepositoryDetection {
                 ghCap = TimeSpan.FromSeconds(Math.Min(2, Math.Max(0, remainingBudget.TotalSeconds)));
             }
 
-            if (ghCap > TimeSpan.Zero) {
-                var pr = await GitHubPrDetector.DetectAsync(cwd, ghCap, DefaultRunner);
+            // Effective provider budget: the post-git remainder when the caller passed a budget
+            // (only ClaudeHookCommand does), else the historical 2s cap. Covers probe + detector.
+            var providerCap = ghCap;
+
+            if (providerCap > TimeSpan.Zero && host is not null) {
+                var kind = await GitProviderRouter.ResolveAsync(host, cwd, providerCap, DefaultRunner);
+                var pr = kind switch {
+                    GitProviderKind.GitHub => await GitHubPrDetector.DetectAsync(cwd, providerCap, DefaultRunner),
+                    GitProviderKind.GitLab when owner is not null && repoName is not null
+                        => await GitLabPrDetector.DetectAsync(host, owner, repoName, branch, cwd, providerCap, DefaultRunner),
+                    _ => null
+                };
 
                 if (pr is not null) {
                     prNumber  = pr.Number;

--- a/src/Capacitor.Cli/RepositoryDetection.cs
+++ b/src/Capacitor.Cli/RepositoryDetection.cs
@@ -159,19 +159,24 @@ static class RepositoryDetection {
             var providerCap = ghCap;
 
             if (providerCap > TimeSpan.Zero && host is not null) {
-                var kind = await GitProviderRouter.ResolveAsync(host, cwd, providerCap, DefaultRunner);
-                var pr = kind switch {
-                    GitProviderKind.GitHub => await GitHubPrDetector.DetectAsync(cwd, providerCap, DefaultRunner),
-                    GitProviderKind.GitLab when owner is not null && repoName is not null
-                        => await GitLabPrDetector.DetectAsync(host, owner, repoName, branch, cwd, providerCap, DefaultRunner),
-                    _ => null
-                };
+                var provSw = Stopwatch.StartNew();
+                var kind   = await GitProviderRouter.ResolveAsync(host, cwd, providerCap, DefaultRunner);
+                var detectCap = providerCap - provSw.Elapsed; // combined ceiling: probe + detector
 
-                if (pr is not null) {
-                    prNumber  = pr.Number;
-                    prTitle   = pr.Title;
-                    prUrl     = pr.Url;
-                    prHeadRef = pr.HeadRef;
+                if (detectCap > TimeSpan.Zero) {
+                    var pr = kind switch {
+                        GitProviderKind.GitHub => await GitHubPrDetector.DetectAsync(cwd, detectCap, DefaultRunner),
+                        GitProviderKind.GitLab when owner is not null && repoName is not null
+                            => await GitLabPrDetector.DetectAsync(host, owner, repoName, branch, cwd, detectCap, DefaultRunner),
+                        _ => null
+                    };
+
+                    if (pr is not null) {
+                        prNumber  = pr.Number;
+                        prTitle   = pr.Title;
+                        prUrl     = pr.Url;
+                        prHeadRef = pr.HeadRef;
+                    }
                 }
             }
 

--- a/src/Capacitor.Cli/RepositoryDetection.cs
+++ b/src/Capacitor.Cli/RepositoryDetection.cs
@@ -4,10 +4,15 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.Cli;
 
 static class RepositoryDetection {
+    // Bump whenever the cached shape/derivation changes so stale entries are ignored.
+    // v2: added Host + provider-aware parsing.
+    internal const int CacheSchemaVersion = 2;
+
     public static async Task<string> EnrichWithRepositoryInfo(string json, TimeSpan? budget = null) {
         try {
             var node = JsonNode.Parse(json);
@@ -41,6 +46,7 @@ static class RepositoryDetection {
             if (repo.UserName is not null) repoNode["user_name"]    = repo.UserName;
             if (repo.UserEmail is not null) repoNode["user_email"]  = repo.UserEmail;
             if (repo.RemoteUrl is not null) repoNode["remote_url"]  = repo.RemoteUrl;
+            if (repo.Host is not null) repoNode["host"]             = repo.Host;
             if (repo.Owner is not null) repoNode["owner"]           = repo.Owner;
             if (repo.RepoName is not null) repoNode["repo_name"]    = repo.RepoName;
             if (repo.Branch is not null) repoNode["branch"]         = repo.Branch;
@@ -83,7 +89,7 @@ static class RepositoryDetection {
             // Try loading cached base info
             var cache = LoadCache(cwd);
 
-            string? userName, userEmail, remoteUrl, owner, repoName, branch;
+            string? userName, userEmail, remoteUrl, owner, repoName, branch, host;
 
             // Always detect branch fresh — it changes frequently during a session
             var branchTask = RunCommandAsync("git", "branch --show-current", cwd, gitCap);
@@ -94,6 +100,7 @@ static class RepositoryDetection {
                 remoteUrl = cache.RemoteUrl;
                 owner     = cache.Owner;
                 repoName  = cache.RepoName;
+                host      = cache.Host;
                 branch    = await branchTask;
             } else {
                 // Run git commands in parallel
@@ -114,17 +121,20 @@ static class RepositoryDetection {
                 }
 
                 (owner, repoName) = GitUrlParser.ParseRemoteUrl(remoteUrl);
+                host = remoteUrl is null ? null : RemoteMatcher.ExtractHost(remoteUrl);
 
                 // Save to cache (without branch — it's always detected fresh)
                 SaveCache(
                     cwd,
                     new() {
-                        UserName  = userName,
-                        UserEmail = userEmail,
-                        RemoteUrl = remoteUrl,
-                        Owner     = owner,
-                        RepoName  = repoName,
-                        CachedAt  = DateTimeOffset.UtcNow
+                        UserName      = userName,
+                        UserEmail     = userEmail,
+                        RemoteUrl     = remoteUrl,
+                        Owner         = owner,
+                        RepoName      = repoName,
+                        Host          = host,
+                        SchemaVersion = CacheSchemaVersion,
+                        CachedAt      = DateTimeOffset.UtcNow
                     }
                 );
             }
@@ -163,6 +173,7 @@ static class RepositoryDetection {
                 UserName  = userName,
                 UserEmail = userEmail,
                 RemoteUrl = remoteUrl,
+                Host      = host,
                 Owner     = owner,
                 RepoName  = repoName,
                 Branch    = branch,
@@ -225,7 +236,7 @@ static class RepositoryDetection {
             var json  = File.ReadAllText(path);
             var entry = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.GitCacheEntry);
 
-            if (entry is null) {
+            if (entry is null || entry.SchemaVersion != CacheSchemaVersion) {
                 return null;
             }
 

--- a/src/Capacitor.Cli/RepositoryDetection.cs
+++ b/src/Capacitor.Cli/RepositoryDetection.cs
@@ -72,6 +72,7 @@ static class RepositoryDetection {
     static bool RepoPayloadEquals(RepositoryPayload a, RepositoryPayload b) =>
         a.Owner     == b.Owner
      && a.RepoName  == b.RepoName
+     && a.Host      == b.Host
      && a.Branch    == b.Branch
      && a.PrNumber  == b.PrNumber
      && a.PrUrl     == b.PrUrl

--- a/test/Capacitor.Cli.Tests.Unit/GitHubPrDetectorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GitHubPrDetectorTests.cs
@@ -1,0 +1,32 @@
+using Capacitor.Cli.PrDetection;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class GitHubPrDetectorTests {
+    [Test]
+    public async Task Parses_gh_pr_view_json() {
+        string? capturedCmd = null, capturedArgs = null;
+
+        CommandRunner fake = (cmd, args, cwd, _) => {
+            capturedCmd  = cmd;
+            capturedArgs = args;
+            return Task.FromResult<string?>(
+                """{"number":12,"title":"Add thing","url":"https://github.com/o/r/pull/12","headRefName":"feat/x"}""");
+        };
+
+        var pr = await GitHubPrDetector.DetectAsync("/cwd", TimeSpan.FromSeconds(2), fake);
+
+        await Assert.That(capturedCmd).IsEqualTo("gh");
+        await Assert.That(capturedArgs).Contains("pr view");
+        await Assert.That(pr!.Number).IsEqualTo(12);
+        await Assert.That(pr.Title).IsEqualTo("Add thing");
+        await Assert.That(pr.Url).IsEqualTo("https://github.com/o/r/pull/12");
+        await Assert.That(pr.HeadRef).IsEqualTo("feat/x");
+    }
+
+    [Test]
+    public async Task Null_output_yields_null() {
+        CommandRunner fake = (_, _, _, _) => Task.FromResult<string?>(null); // no PR / gh failed
+        await Assert.That(await GitHubPrDetector.DetectAsync("/cwd", TimeSpan.FromSeconds(2), fake)).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/GitLabPrDetectorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GitLabPrDetectorTests.cs
@@ -1,0 +1,57 @@
+using Capacitor.Cli.PrDetection;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class GitLabPrDetectorTests {
+    const string TwoOpenMrs = """
+    [
+      {"iid":5,"title":"old","web_url":"https://gitlab.com/g/p/-/merge_requests/5","source_branch":"feat/x","updated_at":"2026-06-01T00:00:00Z"},
+      {"iid":9,"title":"new","web_url":"https://gitlab.com/g/p/-/merge_requests/9","source_branch":"feat/x","updated_at":"2026-06-30T00:00:00Z"},
+      {"iid":7,"title":"other","web_url":"https://gitlab.com/g/p/-/merge_requests/7","source_branch":"feat/other","updated_at":"2026-07-01T00:00:00Z"}
+    ]
+    """;
+
+    [Test]
+    public async Task Picks_matching_branch_most_recently_updated() {
+        string? capturedCmd = null, capturedArgs = null;
+
+        CommandRunner fake = (cmd, args, _, _) => {
+            capturedCmd  = cmd;
+            capturedArgs = args;
+            return Task.FromResult<string?>(TwoOpenMrs);
+        };
+        var pr = await GitLabPrDetector.DetectAsync("gitlab.com", "g", "p", "feat/x", "/cwd", TimeSpan.FromSeconds(2), fake);
+
+        await Assert.That(capturedCmd).IsEqualTo("glab");
+        await Assert.That(capturedArgs).Contains("--hostname gitlab.com");
+        await Assert.That(capturedArgs).Contains("projects/g%2Fp/merge_requests");
+        await Assert.That(capturedArgs).Contains("source_branch=feat%2Fx");
+        await Assert.That(pr!.Number).IsEqualTo(9);              // iid, newest updated_at, branch match
+        await Assert.That(pr.Url).IsEqualTo("https://gitlab.com/g/p/-/merge_requests/9");
+        await Assert.That(pr.HeadRef).IsEqualTo("feat/x");
+    }
+
+    [Test]
+    public async Task Empty_branch_never_calls_glab_and_returns_null() {
+        var called = false;
+        CommandRunner fake = (_, _, _, _) => { called = true; return Task.FromResult<string?>("[]"); };
+        var pr = await GitLabPrDetector.DetectAsync("gitlab.com", "g", "p", "", "/cwd", TimeSpan.FromSeconds(2), fake);
+        await Assert.That(pr).IsNull();
+        await Assert.That(called).IsFalse();                    // guard: no branch → no query (would return all MRs)
+    }
+
+    [Test]
+    public async Task Encodes_branch_with_ampersand() {
+        string seen = "";
+        CommandRunner fake = (_, args, _, _) => { seen = args; return Task.FromResult<string?>("[]"); };
+        await GitLabPrDetector.DetectAsync("gitlab.com", "g", "p", "feat/a&b", "/cwd", TimeSpan.FromSeconds(2), fake);
+        await Assert.That(seen).Contains("source_branch=feat%2Fa%26b");
+    }
+
+    [Test]
+    public async Task No_matching_branch_yields_null() {
+        CommandRunner fake = (_, _, _, _) => Task.FromResult<string?>(
+            """[{"iid":5,"title":"x","web_url":"u","source_branch":"different","updated_at":"2026-06-01T00:00:00Z"}]""");
+        await Assert.That(await GitLabPrDetector.DetectAsync("gitlab.com", "g", "p", "feat/x", "/cwd", TimeSpan.FromSeconds(2), fake)).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/GitProviderRouterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GitProviderRouterTests.cs
@@ -1,0 +1,46 @@
+using Capacitor.Cli.PrDetection;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class GitProviderRouterTests {
+    [Before(Test)]
+    public void Reset() => GitProviderRouter.ResetMemoForTests();
+
+    static CommandRunner Never => (_, _, _, _) => throw new InvalidOperationException("probe should not run for SaaS hosts");
+
+    [Test]
+    public async Task Saas_hosts_route_without_probing() {
+        await Assert.That(await GitProviderRouter.ResolveAsync("github.com", "/c", TimeSpan.FromSeconds(2), Never)).IsEqualTo(GitProviderKind.GitHub);
+        await Assert.That(await GitProviderRouter.ResolveAsync("gitlab.com", "/c", TimeSpan.FromSeconds(2), Never)).IsEqualTo(GitProviderKind.GitLab);
+    }
+
+    [Test]
+    public async Task Custom_host_in_gh_auth_status_is_github() {
+        CommandRunner fake = async (cmd, args, _, _) => {
+            await Assert.That(cmd).IsEqualTo("gh");
+            await Assert.That(args).IsEqualTo("auth status --json hosts");
+            return "{\"hosts\":{\"github.com\":[],\"ghe.corp.com\":[]}}";
+        };
+        await Assert.That(await GitProviderRouter.ResolveAsync("ghe.corp.com", "/c", TimeSpan.FromSeconds(2), fake)).IsEqualTo(GitProviderKind.GitHub);
+    }
+
+    [Test]
+    public async Task Custom_host_not_in_gh_falls_back_to_gitlab() {
+        CommandRunner fake = (_, _, _, _) => Task.FromResult<string?>("""{"hosts":{"github.com":[]}}""");
+        await Assert.That(await GitProviderRouter.ResolveAsync("gitlab.corp.com", "/c", TimeSpan.FromSeconds(2), fake)).IsEqualTo(GitProviderKind.GitLab);
+    }
+
+    [Test]
+    public async Task Probe_result_is_memoized_per_host() {
+        var calls = 0;
+        CommandRunner fake = (_, _, _, _) => { calls++; return Task.FromResult<string?>("""{"hosts":{"ghe.corp.com":[]}}"""); };
+        await GitProviderRouter.ResolveAsync("ghe.corp.com", "/c", TimeSpan.FromSeconds(2), fake);
+        await GitProviderRouter.ResolveAsync("ghe.corp.com", "/c", TimeSpan.FromSeconds(2), fake);
+        await Assert.That(calls).IsEqualTo(1); // memoized: bulk-import loop can't multiply the probe
+    }
+
+    [Test]
+    public async Task Null_host_is_unknown() {
+        await Assert.That(await GitProviderRouter.ResolveAsync(null, "/c", TimeSpan.FromSeconds(2), Never)).IsEqualTo(GitProviderKind.Unknown);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/GitUrlParserTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GitUrlParserTests.cs
@@ -43,6 +43,24 @@ public class GitUrlParserTests {
     }
 
     [Test]
+    [Arguments("ssh://git@gitlab.com/group/project.git", "group", "project")]
+    [Arguments("ssh://git@gitlab.corp.com:2222/org/repo.git", "org", "repo")]
+    public async Task ParseRemoteUrl_SshProtoUrls_ReturnsOwnerAndRepo(string url, string expectedOwner, string expectedRepo) {
+        var (owner, repoName) = GitUrlParser.ParseRemoteUrl(url);
+
+        await Assert.That(owner).IsEqualTo(expectedOwner);
+        await Assert.That(repoName).IsEqualTo(expectedRepo);
+    }
+
+    [Test]
+    public async Task ParseRemoteUrl_SshProtoUrl_NestedGroup_ReturnsBothNull() {
+        var (owner, repoName) = GitUrlParser.ParseRemoteUrl("ssh://git@gitlab.com/group/sub/project.git");
+
+        await Assert.That(owner).IsNull();
+        await Assert.That(repoName).IsNull();
+    }
+
+    [Test]
     public async Task ParseRemoteUrl_Null_ReturnsBothNull() {
         var (owner, repoName) = GitUrlParser.ParseRemoteUrl(null);
 

--- a/test/Capacitor.Cli.Tests.Unit/PrRefParserTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PrRefParserTests.cs
@@ -74,8 +74,45 @@ public class PrRefParserTests {
     }
 
     [Test]
+    public async Task Github_url_on_enterprise_host_parses() {
+        var ok = PrRefParser.TryParse("https://ghe.corp.com/team/app/pull/7", out var owner, out var repo, out var pr);
+        await Assert.That(ok).IsTrue();
+        await Assert.That(owner).IsEqualTo("team");
+        await Assert.That(repo).IsEqualTo("app");
+        await Assert.That(pr).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task Gitlab_mr_url_parses() {
+        var ok = PrRefParser.TryParse("https://gitlab.com/group/project/-/merge_requests/42", out var owner, out var repo, out var pr);
+        await Assert.That(ok).IsTrue();
+        await Assert.That(owner).IsEqualTo("group");
+        await Assert.That(repo).IsEqualTo("project");
+        await Assert.That(pr).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Gitlab_mr_url_with_browser_suffix_parses() {
+        foreach (var suffix in new[] { "/diffs", "/commits", "?tab=1", "#note_9" }) {
+            var ok = PrRefParser.TryParse($"https://gitlab.com/group/project/-/merge_requests/42{suffix}", out _, out _, out var pr);
+            await Assert.That(ok).IsTrue();
+            await Assert.That(pr).IsEqualTo(42);
+        }
+    }
+
+    [Test]
+    public async Task Gitlab_nested_group_mr_url_is_rejected_in_first_pass() {
+        // Multi-segment namespace deferred (§3/§6b): server routes are /{owner}/{repo}.
+        var ok = PrRefParser.TryParse("https://gitlab.com/group/sub/project/-/merge_requests/42", out _, out _, out _);
+        await Assert.That(ok).IsFalse();
+    }
+
+    [Test]
     public async Task Garbage_input_rejected() {
         await Assert.That(PrRefParser.TryParse("not-a-pr-ref", out _, out _, out _)).IsFalse();
-        await Assert.That(PrRefParser.TryParse("https://gitlab.com/owner/repo/pull/1", out _, out _, out _)).IsFalse();
+        // A GitHub-shaped /pull/ URL now parses on any host (see Github_url_on_enterprise_host_parses);
+        // reject genuinely malformed refs instead.
+        await Assert.That(PrRefParser.TryParse("https://gitlab.com/owner/repo/-/merge_requests/", out _, out _, out _)).IsFalse();
+        await Assert.That(PrRefParser.TryParse("https://gitlab.com/owner/repo/issues/3", out _, out _, out _)).IsFalse();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/RemoteMatcherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RemoteMatcherTests.cs
@@ -95,4 +95,19 @@ public class RemoteMatcherTests {
 
         await Assert.That(result).IsEqualTo("contoso");
     }
+
+    [Test]
+    public async Task ExtractHost_from_ssh_and_https() {
+        await Assert.That(RemoteMatcher.ExtractHost("git@github.com:kurrent-io/kcap.git")).IsEqualTo("github.com");
+        await Assert.That(RemoteMatcher.ExtractHost("https://gitlab.com/group/project.git")).IsEqualTo("gitlab.com");
+        await Assert.That(RemoteMatcher.ExtractHost("ssh://git@ghe.corp.com/team/app")).IsEqualTo("ghe.corp.com");
+        await Assert.That(RemoteMatcher.ExtractHost("not a url")).IsNull();
+    }
+
+    [Test]
+    public async Task PathAfterHost_strips_leading_host_segment() {
+        await Assert.That(RemoteMatcher.PathAfterHost("github.com/kurrent-io/kcap")).IsEqualTo("kurrent-io/kcap");
+        await Assert.That(RemoteMatcher.PathAfterHost("gitlab.com/group/project")).IsEqualTo("group/project");
+        await Assert.That(RemoteMatcher.PathAfterHost("nohostonly")).IsNull();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/RemoteMatcherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RemoteMatcherTests.cs
@@ -105,6 +105,13 @@ public class RemoteMatcherTests {
     }
 
     [Test]
+    public async Task ExtractHost_lowercases_mixed_case_host() {
+        // gh/glab auth host keys are lowercase, and GitProviderRouter compares hosts
+        // case-sensitively, so a mixed-case remote host must be canonicalized here.
+        await Assert.That(RemoteMatcher.ExtractHost("git@GitHub.com:o/r.git")).IsEqualTo("github.com");
+    }
+
+    [Test]
     public async Task PathAfterHost_strips_leading_host_segment() {
         await Assert.That(RemoteMatcher.PathAfterHost("github.com/kurrent-io/kcap")).IsEqualTo("kurrent-io/kcap");
         await Assert.That(RemoteMatcher.PathAfterHost("gitlab.com/group/project")).IsEqualTo("group/project");

--- a/test/Capacitor.Cli.Tests.Unit/RemoteMatcherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RemoteMatcherTests.cs
@@ -112,6 +112,21 @@ public class RemoteMatcherTests {
     }
 
     [Test]
+    public async Task ExtractHost_https_with_port_strips_port() {
+        await Assert.That(RemoteMatcher.ExtractHost("https://ghe.corp.com:8443/org/repo.git")).IsEqualTo("ghe.corp.com");
+    }
+
+    [Test]
+    public async Task ExtractHost_ssh_proto_with_port_strips_port() {
+        await Assert.That(RemoteMatcher.ExtractHost("ssh://git@gitlab.corp.com:2222/org/repo.git")).IsEqualTo("gitlab.corp.com");
+    }
+
+    [Test]
+    public async Task NormalizeRemoteUrl_https_with_port_drops_port() {
+        await Assert.That(RemoteMatcher.NormalizeRemoteUrl("https://ghe.corp.com:8443/org/repo.git")).IsEqualTo("ghe.corp.com/org/repo");
+    }
+
+    [Test]
     public async Task PathAfterHost_strips_leading_host_segment() {
         await Assert.That(RemoteMatcher.PathAfterHost("github.com/kurrent-io/kcap")).IsEqualTo("kurrent-io/kcap");
         await Assert.That(RemoteMatcher.PathAfterHost("gitlab.com/group/project")).IsEqualTo("group/project");

--- a/test/Capacitor.Cli.Tests.Unit/RepoMatcherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RepoMatcherTests.cs
@@ -144,6 +144,16 @@ public class RepoMatcherTests {
     }
 
     [Test]
+    public async Task FindAsync_MatchingGitlabOrigin_ReturnsRoot() {
+        var repo = MakeTempRepo("git@gitlab.com:group/project.git");
+        try {
+            var result = await NewMatcher().FindAsync("group", "project", [repo], CancellationToken.None);
+
+            await Assert.That(result).Contains(Path.GetFullPath(repo));
+        } finally { Directory.Delete(repo, true); }
+    }
+
+    [Test]
     public async Task FindAsync_AllowedRepoPathsContributesCandidates() {
         var repo = MakeTempRepo("https://github.com/contoso/widgets.git");
         try {

--- a/test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs
@@ -27,8 +27,11 @@ public class RepositoryDetectionCacheTests {
         await Assert.That(back.SchemaVersion).IsEqualTo(RepositoryDetection.CacheSchemaVersion);
     }
 
+    // Exercises the real best-effort detection path (calls DetectRepositoryAsync, which
+    // shells out to the real `glab` if present) and asserts only glab-independent base
+    // info. PR fields are intentionally not asserted because glab may be absent/unauthenticated.
     [Test]
-    public async Task Detects_gitlab_repo_base_info_without_glab() {
+    public async Task Detects_gitlab_repo_base_info() {
         var repo = MakeTempRepo("git@gitlab.com:group/project.git");
         try {
             var payload = await RepositoryDetection.DetectRepositoryAsync(repo);

--- a/test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using Capacitor.Cli.Core;
 
@@ -24,5 +25,46 @@ public class RepositoryDetectionCacheTests {
         var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.GitCacheEntry);
         await Assert.That(back!.Host).IsEqualTo("gitlab.com");
         await Assert.That(back.SchemaVersion).IsEqualTo(RepositoryDetection.CacheSchemaVersion);
+    }
+
+    [Test]
+    public async Task Detects_gitlab_repo_base_info_without_glab() {
+        var repo = MakeTempRepo("git@gitlab.com:group/project.git");
+        try {
+            var payload = await RepositoryDetection.DetectRepositoryAsync(repo);
+
+            await Assert.That(payload).IsNotNull();
+            await Assert.That(payload!.Owner).IsEqualTo("group");
+            await Assert.That(payload.RepoName).IsEqualTo("project");
+            await Assert.That(payload.Host).IsEqualTo("gitlab.com");
+            // No glab installed/authenticated in CI → PR fields stay null (best-effort).
+        } finally {
+            Directory.Delete(repo, true);
+        }
+    }
+
+    // Mirrors RepoMatcherTests.MakeTempRepo: creates a throwaway git repo with a
+    // controlled origin remote so router/detector dispatch can be exercised end-to-end.
+    static string MakeTempRepo(string originUrl) {
+        var root = Path.Combine(Path.GetTempPath(), "kcap-repo-detect-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(root);
+
+        RunGit(root, "init", "-q");
+        RunGit(root, "remote", "add", "origin", originUrl);
+
+        return root;
+    }
+
+    static void RunGit(string cwd, params string[] args) {
+        var psi = new ProcessStartInfo("git", args) {
+            WorkingDirectory       = cwd,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true
+        };
+        using var proc = Process.Start(psi)!;
+        proc.WaitForExit();
+        if (proc.ExitCode != 0) {
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {proc.StandardError.ReadToEnd()}");
+        }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class RepositoryDetectionCacheTests {
+    [Test]
+    public async Task GitCacheEntry_without_schema_version_deserializes_as_stale() {
+        // A pre-upgrade entry (no schema_version, no host) must be treated as stale.
+        const string legacy = """{"owner":"o","repo_name":"r","cached_at":"2020-01-01T00:00:00+00:00"}""";
+        var entry = JsonSerializer.Deserialize(legacy, CapacitorJsonContext.Default.GitCacheEntry);
+        await Assert.That(entry!.SchemaVersion).IsEqualTo(0);        // absent → default 0
+        await Assert.That(entry.SchemaVersion == RepositoryDetection.CacheSchemaVersion).IsFalse();
+    }
+
+    [Test]
+    public async Task GitCacheEntry_roundtrips_host_and_version() {
+        var entry = new GitCacheEntry {
+            RemoteUrl = "git@gitlab.com:group/project.git",
+            Owner = "group", RepoName = "project", Host = "gitlab.com",
+            SchemaVersion = RepositoryDetection.CacheSchemaVersion, CachedAt = DateTimeOffset.UnixEpoch
+        };
+        var json = JsonSerializer.Serialize(entry, CapacitorJsonContext.Default.GitCacheEntry);
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.GitCacheEntry);
+        await Assert.That(back!.Host).IsEqualTo("gitlab.com");
+        await Assert.That(back.SchemaVersion).IsEqualTo(RepositoryDetection.CacheSchemaVersion);
+    }
+}


### PR DESCRIPTION
## What & why

kcap's PR detection was GitHub-only: it shelled out to `gh pr view` and `kcap review` accepted only `github.com` URLs. Since the server moved auth to WorkOS, orgs can be on GitHub, GitHub Enterprise, or GitLab — but detection didn't follow.

This makes detection **multi-provider** while keeping it **client-side** with **no kcap-managed tokens**: we delegate to the provider CLIs (`gh` for GitHub/GitHub Enterprise, `glab` for GitLab), which own their own auth. The PR/MR is only a grouping key (`owner/repo/number`) the server already accepts, so **there is no server change**.

## What changed

**Groundwork (dependency-free):**
- `PrRefParser` — accepts GitHub PR URLs on any host + GitLab MR URLs (`/-/merge_requests/N`) with browser-copy suffix tolerance; shorthand stays single-level.
- `RemoteMatcher` — new `ExtractHost` / `PathAfterHost` helpers (host is normalized to lowercase).
- daemon `RepoMatcher` — matches host-agnostically on `owner/repo`.
- detection cache — carries `host` and bumps `GitCacheEntry` schema version to discard pre-upgrade entries.

**Auto-detection:**
- `CommandRunner`/`PrInfo` seam + `GitHubPrDetector` (refactor of the existing `gh pr view` call).
- `GitLabPrDetector` via `glab api` with correctness guards: aborts on empty branch (avoids GitLab returning *all* open MRs), filters to an exact `source_branch` match, picks the most-recently-updated MR, maps `iid`→PR number; both project path and branch are `Uri.EscapeDataString`-encoded.
- `GitProviderRouter` — routes by host (`github.com`→gh, `gitlab.com`→glab), probes `gh auth status --json hosts` for custom hosts (reads the JSON, not the exit code), and memoizes per host so a bulk import can't multiply the probe.
- wired into `DetectRepositoryAsync` with an effective provider budget; stays best-effort (missing/unauthenticated CLI → untagged session, never an error).

**Docs:** README (Getting started prerequisites + `kcap review` formats), `help-review.txt`, `help-mcp.txt`, and the `kcap review` usage text.

## Scope / limitations

- First pass targets **github.com + gitlab.com**; GitHub Enterprise keeps working via `gh` (which auto-targets the remote's host).
- **Single-level `owner/repo` only** — nested GitLab groups are deferred (they need a server route change; see design §6b).
- `repo_hash` stays host-agnostic (no server change; documented collision limitation in design §6a).
- `glab` is a soft dependency for GitLab users, same shape as `gh` for GitHub today.

## Testing

- Full unit suite: **1974/1974 passing**. New tests cover the parser (incl. nested-group rejection + suffix tolerance), host helpers, host-agnostic repo matching, cache invalidation, both detectors (incl. the empty-branch guard, exact-branch selection, newest-on-ties, and argument encoding), and the router (SaaS no-probe, custom-host probe reads JSON, per-host memoization).
- AOT: `dotnet publish -c Release` clean, no IL3050/IL2026 warnings (JSON parsed via `JsonNode` / source-gen).

## Design

- `docs/superpowers/specs/2026-07-01-multi-provider-pr-detection-design.md`
- `docs/superpowers/plans/2026-07-01-multi-provider-pr-detection.md`

Closes #228
AI-1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)
