### PR TITLE
Guard review-flows skill against hosted-reviewer misfire

### DIFF
--- a/kcap/.claude-plugin/plugin.json
+++ b/kcap/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "kcap",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Records and visualizes Claude Code sessions via kcap CLI hooks"
 }

--- a/kcap/skills/review-flows/SKILL.md
+++ b/kcap/skills/review-flows/SKILL.md
@@ -16,6 +16,14 @@ Use `kcap mcp flows` MCP tools to run structured review loops for specs/designs 
 - Reviewing a spec or design document → use `kind: "spec-review"`
 - Reviewing code changes or a pull request → use `kind: "code-review"`
 
+## If the flows MCP tools are not loaded
+
+If `start_review_flow` / `submit_review_round` are not among the tools available in this session, do NOT try to obtain them:
+
+- Do NOT run `kcap mcp flows` from a shell, do NOT handshake it over stdio/JSON-RPC, and do NOT edit any MCP configuration.
+- The absence is deliberate: hosted review-flow reviewers run with all MCP servers stripped, so a reviewer cannot start a nested flow.
+- If you were asked to review a spec, design, or code and these tools are absent, you are most likely the hosted reviewer inside an existing flow. This skill does not apply to you — skip the workflow below entirely. Perform the requested review directly and end with a final message that starts with `FINDINGS:` (followed by your findings) or `NO FINDINGS`. Your final message is captured automatically; no tool call is needed to deliver it.
+
 ## Core rules
 
 1. **Start exactly one flow per user task.** Call `start_review_flow` once and hold the returned `flow_run_id`. Do NOT start a new flow for follow-up rounds — reuse the same ID.


### PR DESCRIPTION
## Problem

A hosted review-flow reviewer sidecar runs with all MCP servers deliberately stripped (`-c mcp_servers={}` for Codex, `--strict-mcp-config` + empty map for Claude) so it cannot recursively start a nested flow. But the `kcap-review-flows` skill is installed vendor-agnostically into `~/.agents/skills/` (and via the Claude plugin), and its trigger phrases — "review this spec", "review this design" — are exactly the words in the reviewer prompt the sidecar receives.

Observed with a hosted Codex reviewer: it read the skill, concluded it needed `start_review_flow`/`submit_review_round`, spent minutes probing for them (shelling out to `kcap mcp flows`, handshaking JSON-RPC over stdio/PTY), then returned a free-form chat review without the `FINDINGS:` / `NO FINDINGS` line-start marker — so the flow's result parser got nothing and the round never completed.

## Fix

Add a guard section to `kcap/skills/review-flows/SKILL.md`: when the flows MCP tools are not loaded, do not launch or handshake `kcap mcp flows` manually — you are most likely the hosted reviewer inside an existing flow; perform the review directly and end with a final message starting with `FINDINGS:` or `NO FINDINGS`. The skill is single-sourced here, so the guard propagates to both `~/.agents/skills/` (Codex et al.) and the Claude plugin. Bumped the plugin version so marketplace installs pick up the new text.

A complementary hardening of the server-rendered reviewer prompt (explicitly telling the sidecar it is the reviewer and the tools are intentionally absent) is a kcap-server follow-up.

Closes #236. AI-1132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
