### PR TITLE
[AI-30] Submit hosted-agent input as a bracketed paste

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -857,8 +857,17 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             }
         }
 
-        // Split text and Enter with delay (Claude CLI needs separate writes)
-        await agent.Process.WriteAsync(message);
+        // Deliver the message as a bracketed paste (ESC[200~ … ESC[201~) so the agent's TUI
+        // treats it as one pasted block and the following Enter is an unambiguous submit
+        // keypress. Without the paste markers a large multi-line message is mis-handled (AI-30):
+        // Codex never submits it at all, and Claude only submits it ~50% of the time — the CR
+        // races the still-ingesting paste and is folded in as a literal newline, so the text
+        // sits in the composer until a later, isolated keystroke finishes it. Both hosted CLIs
+        // enable bracketed-paste mode, so the markers are consumed as paste delimiters (not
+        // echoed). Keep the text and the Enter as separate writes with a short delay so the CR
+        // lands as a distinct PTY read after the paste (Claude also needs the CR split out, or
+        // it treats the carriage return as part of the buffer rather than a submit).
+        await agent.Process.WriteAsync($"\x1b[200~{message}\x1b[201~");
         await Task.Delay(50);
         await agent.Process.WriteAsync("\r");
     }
@@ -1374,6 +1383,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     /// <summary>Test-only entry point to the private stop handler (mirrors <see cref="HandleLaunchAgentForTest"/>).</summary>
     internal Task HandleStopAgentForTest(string agentId) => HandleStopAgent(agentId);
+
+    /// <summary>Test-only entry point to the private send-input handler (AI-30 bracketed-paste submit).</summary>
+    internal Task HandleSendInputForTest(SendInputCommand cmd) => HandleSendInput(cmd);
 
     internal Task RegisterAgentForTestAsync(AgentInstance agent) => RegisterAgentAsync(agent);
     internal Task ReRegisterAgentsForTestAsync() => ReRegisterAgentsAsync();

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorBracketedPasteTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorBracketedPasteTests.cs
@@ -1,0 +1,83 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Pty;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-30: a pasted (large, multi-line) message written to a hosted agent's PTY as raw bytes
+/// followed by a carriage return often fails to submit — the CR races the still-ingesting
+/// paste and is folded into it as a literal newline, so the text sits in the composer until a
+/// later, isolated keystroke finishes it (Codex never submits at all; Claude ~50% of the time).
+/// The fix delivers the message as a bracketed paste (ESC[200~ … ESC[201~) so the TUI treats it
+/// as one block and the following Enter is an unambiguous submit. This test drives
+/// <see cref="AgentOrchestrator.HandleSendInput"/> and asserts the wire shape.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    const string PasteStart = "\x1b[200~";
+    const string PasteEnd   = "\x1b[201~";
+
+    [Test]
+    public async Task HandleSendInput_wraps_the_message_in_a_bracketed_paste_and_submits_with_a_separate_Enter() {
+        const string message = "line-1\nline-2\nline-3\nbig multi-line paste";
+
+        var server = new CaptureServerConnection();
+        var pty    = new RecordingPtyProcess();
+
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var agent = new AgentInstance(
+            "agent-paste", null, "", null, "/tmp", "codex",
+            pty, new WorktreeInfo("/tmp", "", "/tmp", IsStandalone: true), new CancellationTokenSource());
+        orch.RegisterAgentForTest(agent);
+
+        await orch.HandleSendInputForTest(new SendInputCommand("agent-paste", message, null));
+
+        // The message is delivered as one bracketed-paste block, then the submitting Enter as a
+        // separate write so it lands as a distinct keypress after the paste.
+        await Assert.That(pty.Writes.Count).IsEqualTo(2);
+        await Assert.That(pty.Writes[0]).IsEqualTo($"{PasteStart}{message}{PasteEnd}");
+        await Assert.That(pty.Writes[1]).IsEqualTo("\r");
+    }
+
+    /// <summary>PTY double that records the ordered sequence of writes and produces no output.</summary>
+    sealed class RecordingPtyProcess : IPtyProcess {
+        readonly List<string> _writes = [];
+        readonly Lock         _gate   = new();
+
+        public IReadOnlyList<string> Writes {
+            get { lock (_gate) { return [.. _writes]; } }
+        }
+
+        public int  Pid       => 5150;
+        public bool HasExited => false;
+        public int? ExitCode  => null;
+
+        public ValueTask DisposeAsync() => default;
+        public Task WaitForExitAsync(TimeSpan? _) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan?   _) => Task.CompletedTask;
+
+#pragma warning disable CS1998
+        public async IAsyncEnumerable<byte[]> ReadOutputAsync([EnumeratorCancellation] CancellationToken _ = default) {
+            yield break;
+        }
+#pragma warning restore CS1998
+
+        public Task WriteAsync(string input) {
+            lock (_gate) { _writes.Add(input); }
+
+            return Task.CompletedTask;
+        }
+
+        public Task WriteAsync(byte[] data) {
+            lock (_gate) { _writes.Add(Encoding.UTF8.GetString(data)); }
+
+            return Task.CompletedTask;
+        }
+
+        public void Resize(ushort _, ushort __) { }
+        public void SendInterrupt() { }
+    }
+}


### PR DESCRIPTION
## Problem (AI-30)

Follow-up input to a hosted agent (`SendInput` → `AgentOrchestrator.HandleSendInput`) was written to the PTY as raw bytes followed by a fixed **50 ms-delayed carriage return**. For a large multi-line paste the CR races the still-ingesting paste and is folded into it as a **literal newline instead of a submit**, so the message sits in the composer until a later, isolated keystroke finishes it.

- **Codex** never submits at all.
- **Claude** submits only ~50% of the time (the original AI-30 report, which predates Codex support).

This is also what caused a spec-review flow's **round 2 to hang for 11 minutes**: the ~17 KB re-submitted spec landed in the reviewer's composer but was never submitted until a manual keystroke flushed it. (Smaller rounds/messages settle within 50 ms, so their CR submits — which is why round 3 and typed messages worked.)

## Fix

Deliver the message wrapped in **bracketed-paste markers** (`ESC[200~ … ESC[201~`) so the TUI treats it as one pasted block and the trailing CR is an unambiguous submit keypress. Both hosted CLIs enable bracketed-paste mode, so the markers are consumed as delimiters (not echoed). The text/Enter split is kept so the CR lands as a distinct PTY read. As a bonus, bracketed paste also stops message content from being interpreted as slash-commands.

## Validation

Reproduced and fixed against the **real** CLIs (`codex 0.142.5`, `claude 2.1.198`) driving each in a PTY with the exact 17 KB paste that hung the flow round:

| Pattern | Codex | Claude |
|---|---|---|
| raw bytes + 50 ms + CR (before) | ✗ never submits | ✗ ~50% |
| raw + wait-for-quiet + CR | ✗ never submits | ✓ |
| **bracketed paste + 50 ms + CR (this PR)** | **✓ (3/3 runs)** | **✓** |

- New unit test `AgentOrchestratorBracketedPasteTests` asserts the bracketed wire shape + separate Enter.
- Full CLI unit suite: **2069/2069 pass**.

## Notes

- Not the same as AI-1142 (fire-and-forget `SendInput` over a connection blip): this hang was reproduced locally with no connection involved. AI-1142's no-delivery-ack weakness is real but separate/lower priority.
- `HandleStopAgent`'s `/exit` split is left unchanged (a 5-char command, unaffected by the paste race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)