### PR TITLE
Gate review flows behind explicit opt-in (skip in regular review sessions)

### DIFF
--- a/kcap/.claude-plugin/plugin.json
+++ b/kcap/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "kcap",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Records and visualizes Claude Code sessions via kcap CLI hooks"
 }

--- a/kcap/.mcp.json
+++ b/kcap/.mcp.json
@@ -14,7 +14,7 @@
       "command": "kcap",
       "args": ["mcp", "flows"],
       "cwd": "${CLAUDE_PROJECT_DIR}",
-      "description": "Structured AI review flows — start_review_flow, submit_review_round, get_review_flow_status, close_review_flow. Launches a hosted reviewer agent through your daemon; requires `kcap login` and a running daemon with this repo checked out (the tools are inert otherwise)."
+      "description": "Structured AI review flows — start_review_flow, submit_review_round, get_review_flow_status, close_review_flow. Launches a SEPARATE hosted reviewer agent through your daemon and iterates to sign-off; requires `kcap login` and a running daemon with this repo checked out (the tools are inert otherwise). Use only when the user explicitly asks for a review flow / to submit for review — for an ordinary 'review my PR' or 'code review' request, review directly and do not call these tools."
     }
   }
 }

--- a/kcap/skills/review-flows/SKILL.md
+++ b/kcap/skills/review-flows/SKILL.md
@@ -1,20 +1,32 @@
 ---
 name: review-flows
 description: >-
-  This skill should be used when the user asks to "review this spec",
-  "review this design", "review my PR", "code review", "get this reviewed",
-  "re-review", "start a review flow", "review flow", "submit for review",
-  or wants structured iterative review with findings and sign-off.
+  This skill should be used ONLY when the user explicitly asks to run a
+  structured review *flow* — e.g. "start a review flow", "submit this for
+  review", "re-review after I address findings", or wants an iterative review
+  loop run by a separate reviewer that continues until sign-off. Do NOT use
+  this skill (and do NOT call the flows MCP tools) for an ordinary review
+  request such as "review my PR", "review this diff/spec/design", or "code
+  review" where the user just wants you to review it yourself — perform that
+  review directly instead.
 ---
 
 # Review Flows
 
-Use `kcap mcp flows` MCP tools to run structured review loops for specs/designs and PR/code work. A review flow submits your work to a reviewer, collects findings, lets you address them, and keeps iterating until the reviewer returns `NO FINDINGS`.
+Use the `kcap mcp flows` MCP tools (`start_review_flow`, `submit_review_round`, …) to run a structured review **flow**: your work is submitted to a **separate, hosted reviewer** agent, which returns findings; you address them and keep iterating until the reviewer returns `NO FINDINGS`. This is a deliberate, heavier workflow — use it only when the user explicitly opts into it.
 
-## When to use
+## When NOT to use this skill / these tools
 
-- Reviewing a spec or design document → use `kind: "spec-review"`
-- Reviewing code changes or a pull request → use `kind: "code-review"`
+These tools do **not** perform a review — they hand the work off to a separate hosted reviewer. If the user simply asked *you* to review something in a normal session — e.g. "review my PR", "review this diff", "code review this", "look over this spec" — just perform the review yourself and report your findings directly. Do **NOT** call `start_review_flow` / `submit_review_round` for an ordinary review request; that would spin up a hosted reviewer the user did not ask for.
+
+Only start a flow when the user explicitly asks for a review *flow* — e.g. "start a review flow", "submit this for review", "get an independent review", or "re-review after I address the findings".
+
+## Choosing the flow kind
+
+Once the user has explicitly opted into a flow (see above), pick the `kind`:
+
+- Spec or design document → `kind: "spec-review"`
+- Code changes or a pull request → `kind: "code-review"`
 
 ## If the flows MCP tools are not loaded
 

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -539,7 +539,9 @@ static class McpFlowsServer {
     static McpTool[] BuildToolsList() => [
         new(
             "start_review_flow",
-            "Start a new review flow. Returns findings (same UX); the server runs the reviewer asynchronously and the CLI polls internally. " +
+            "Start a new review flow. This hands the work to a SEPARATE hosted reviewer agent and iterates to sign-off — it is NOT how you review something yourself. " +
+            "Only call this when the user explicitly asked for a review *flow* / to submit for review; for an ordinary 'review my PR' or 'code review' request, review directly and do NOT call this tool. " +
+            "Returns findings (same UX); the server runs the reviewer asynchronously and the CLI polls internally. " +
             "Returns a flow_run_id that identifies this review session — save it to call submit_review_round or get_review_flow_status later.",
             new(
                 "object",


### PR DESCRIPTION
## Problem

When the flows MCP tools are registered in a **regular** interactive Codex/Claude session, a plain review request (`"review my PR"`, `"code review"`, `"review this spec"`) triggered the `kcap-review-flows` skill and pushed the agent to call `start_review_flow` — which launches a **separate hosted reviewer** through the daemon and drives a multi-round loop the user never asked for. Observed in the wild as Codex announcing *"…using kcap-review-flows as the review workflow guide"* for an ordinary review.

## Fix

Gate the flow behind **explicit opt-in**, consistently across the three places an agent sees flows guidance:

- **`kcap/skills/review-flows/SKILL.md`** — narrow the `description` to explicit-flow intent only (`"start a review flow"`, `"submit for review"`, `"re-review after I address findings"`) and explicitly exclude ordinary review verbs; add a prominent **"When NOT to use"** guard (ordinary review → review directly, don't call the tools); retitle `## When to use` → `## Choosing the flow kind` so the spec-review/code-review split isn't misread as "any review → use the flow".
- **`src/Capacitor.Cli/Commands/McpFlowsServer.cs`** — prepend the same gate to the `start_review_flow` tool description. This is the cross-agent lever: Codex reads tool descriptions from `tools/list` because `config.toml` carries no server description.
- **`kcap/.mcp.json`** — same gate on the Claude Code `kcap-flows` server description.
- **`kcap/.claude-plugin/plugin.json`** — bump `1.7.1` → `1.7.2` so marketplace installs refresh the new skill text (matching how #235 handled it).

Net effect: a plain review request → the agent reviews directly and reports findings; the hosted-reviewer flow runs only when the user explicitly asks for a review *flow* / to *submit for review*.

## Relationship to #235

Follow-up to #235, which guarded the **opposite** case (flows tools *absent* → you're likely the hosted reviewer, review directly). This PR covers tools *present* in a regular session where the user just wants a direct review.

## Notes

- No dedicated Linear/GitHub issue tracked for this; happy to link one if there is/should be.
- Agent-facing guidance + version bump only — no user-facing CLI surface change, so no README sync required.
- `dotnet build` clean (0 warnings); no tests assert on the touched descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)