### PR TITLE
[AI-1134] kcap mcp memory — team memory MCP server + persisted machine id

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ The `kcap mcp sessions` stdio server lets coding agents search and recall past C
 
 The `kcap mcp flows` stdio server lets agents start and interact with AI-powered review flows. The plugin **auto-registers it for Claude Code** (Codex stays manual). See the [Flows MCP server](#flows-mcp-server-for-agents) section for details.
 
+The `kcap mcp memory` stdio server lets agents search, save, and update durable team memories — preferences, feedback, project facts, and references scoped to you, your team, or the org. The plugin **auto-registers it for Claude Code** (via `.mcp.json`) and for Codex's native plugin loader (via `.codex-mcp.json`). See the [Memory MCP server](#memory-mcp-server-for-agents) section for details.
+
 ## What it records
 
 Once set up, Capacitor runs silently in the background. Every Claude Code (and Codex CLI, if you installed those hooks) session is captured automatically:
@@ -315,6 +317,25 @@ It provides four tools:
 - **`close_review_flow`** — mark a completed review flow as closed.
 
 Requires `kcap login` **and a running daemon with this repo checked out** — the server discovers a connected daemon to launch the hosted reviewer (Codex for the built-in `spec-review`/`code-review` flows; the vendor is chosen by the flow definition), and `start_review_flow` errors if none (or more than one) matches. The server creates an authenticated HTTP client at startup and posts to the Capacitor server's `/api/flows/*` endpoints.
+
+### Memory MCP server (for agents)
+
+```bash
+kcap mcp memory
+```
+
+Stdio MCP server that lets coding agents search, save, and update durable "memories" — short, reusable notes (preferences, feedback, project facts, references) scoped to you, your team, or the whole org, so lessons learned in one session are available in the next. **Claude Code:** auto-registered via the plugin's `.mcp.json`. **Codex:** available via the plugin's `.codex-mcp.json` descriptor for Codex's native plugin loader.
+
+It provides six tools:
+
+- **`search_memories`** — hybrid semantic + keyword search over memories visible to you (your own, your teams', and org-wide). Agents are told to call this before saving a new memory.
+- **`get_memory`** — fetch a memory's full content by id or slug.
+- **`save_memory`** — save a new memory with an `audience` (`user`, `team`, or `org`), `slug`, `description`, `content`, and `kind`. Scoped to the current repo by default; pass `global: true` to save it repo-independent, or `machine_specific: true` (user audience only) to tag it to this machine.
+- **`update_memory`** — update an existing memory's description, content, and/or kind.
+- **`rescope_memory`** — change a memory's audience, e.g. promote a personal memory to the team or org.
+- **`archive_memory`** — soft-delete a memory.
+
+The server is repo- and machine-aware: it resolves the current working directory to a repo hash and the local persisted machine id at startup, and uses both to scope `save_memory` and to bias `search_memories` / `get_memory` results.
 
 ### Curate guidelines
 

--- a/kcap/.codex-mcp.json
+++ b/kcap/.codex-mcp.json
@@ -10,8 +10,7 @@
     },
     "kcap-memory": {
       "command": "kcap",
-      "args": ["mcp", "memory"],
-      "cwd": "${CLAUDE_PROJECT_DIR}"
+      "args": ["mcp", "memory"]
     }
   }
 }

--- a/kcap/.codex-mcp.json
+++ b/kcap/.codex-mcp.json
@@ -7,6 +7,11 @@
     "kcap-sessions": {
       "command": "kcap",
       "args": ["mcp", "sessions"]
+    },
+    "kcap-memory": {
+      "command": "kcap",
+      "args": ["mcp", "memory"],
+      "cwd": "${CLAUDE_PROJECT_DIR}"
     }
   }
 }

--- a/kcap/.mcp.json
+++ b/kcap/.mcp.json
@@ -15,6 +15,12 @@
       "args": ["mcp", "flows"],
       "cwd": "${CLAUDE_PROJECT_DIR}",
       "description": "Structured AI review flows — start_review_flow, submit_review_round, get_review_flow_status, close_review_flow. Launches a hosted reviewer agent through your daemon; requires `kcap login` and a running daemon with this repo checked out (the tools are inert otherwise)."
+    },
+    "kcap-memory": {
+      "command": "kcap",
+      "args": ["mcp", "memory"],
+      "cwd": "${CLAUDE_PROJECT_DIR}",
+      "description": "Team memory — search, read, and save durable learnings scoped to you, your team, or the org."
     }
   }
 }

--- a/kcap/README.md
+++ b/kcap/README.md
@@ -31,6 +31,21 @@ PR review context tools. Each PR-scoped tool accepts an optional `pr` argument (
 | `list_sessions` | Sessions that contributed to the PR | optional |
 | `get_transcript` | Full transcript of a specific session | n/a (keys off `session_id`) |
 
+### `kcap-memory`
+
+Search, save, and update durable team memories — preferences, feedback, project facts, and references scoped to you, your team, or the org.
+
+| Tool | Description |
+|------|-------------|
+| `search_memories` | Hybrid semantic + keyword search over memories visible to you |
+| `get_memory` | Fetch a memory's full content by id or slug |
+| `save_memory` | Save a new memory (`audience`, `slug`, `description`, `content`, `kind`); scoped to the cwd repo unless `global: true` |
+| `update_memory` | Update an existing memory's description/content/kind |
+| `rescope_memory` | Change a memory's audience (e.g. promote user → team/org) |
+| `archive_memory` | Soft-delete a memory |
+
+Repo- and machine-aware: it resolves the cwd to a repo hash and the local persisted machine id at startup to scope saves and bias search results.
+
 `kcap mcp judge` is intentionally not auto-registered. Add it with `claude mcp add kcap-judge -- kcap mcp judge` if you want it.
 
 **Hooks** — Automatically captures session activity and forwards it to the Kurrent Capacitor server:

--- a/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
@@ -25,6 +25,11 @@ public record ProfileConfig {
     /// </summary>
     [JsonPropertyName("cwd_remap")]
     public CwdRemap[] CwdRemap { get; init; } = [];
+
+    // AI-1134: stable machine identity for machine-tagged memories. Generated once by
+    // MachineIdProvider; never rotated (rotation orphans previously tagged memories).
+    [JsonPropertyName("machine_id")]
+    public string? MachineId { get; init; }
 }
 
 public record CwdRemap {

--- a/src/Capacitor.Cli.Core/MachineIdProvider.cs
+++ b/src/Capacitor.Cli.Core/MachineIdProvider.cs
@@ -1,0 +1,17 @@
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Core;
+
+public static class MachineIdProvider {
+    public static string Generate() => "mach-" + Guid.NewGuid().ToString("N")[..12];
+
+    /// <summary>Returns the persisted machine id, generating + saving one on first use.</summary>
+    public static async Task<string> GetOrCreateAsync() {
+        var config = await AppConfig.LoadProfileConfig();
+        if (!string.IsNullOrWhiteSpace(config.MachineId)) return config.MachineId;
+
+        var id = Generate();
+        await AppConfig.SaveProfileConfig(config with { MachineId = id });
+        return id;
+    }
+}

--- a/src/Capacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-mcp.txt
@@ -11,6 +11,8 @@ Subcommands:
                           inspect past Kurrent Capacitor sessions.
   flows                   Start the MCP flows server (stdio) — start and manage
                           review flows from within an agent session.
+  memory                  Start the MCP memory server (stdio) — team memory
+                          tools (search, get, save, update, rescope, archive).
 
 Options for review:
   --owner <owner>         Repository owner (session default)
@@ -58,6 +60,12 @@ mcp flows:
       args    = ["mcp", "flows"]
       # desktop app launches with no shell PATH, so command
       # needs an absolute path (e.g. /opt/homebrew/bin/kcap)
+
+mcp memory:
+  Exposes six tools — search_memories, get_memory, save_memory, update_memory,
+  rescope_memory, archive_memory — for agents to access team memories. Memories
+  are scoped to user/team/org with optional repo and machine context. Agents
+  should search before saving to avoid duplication. Requires `kcap login`.
 
 INSTALL
 

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -56,6 +56,7 @@ MCP servers (stdio):
   mcp judge --session <id>           Per-session judge tools
   mcp sessions                       Search/inspect past sessions from agents
   mcp flows                          Start and manage review flows from agents
+  mcp memory                         Team memory tools (search, get, save, update, rescope, archive)
 
 Plugin:
   plugin install [--project] [--codex|--cursor|--copilot|--gemini|--kiro|--pi|--opencode|--skills]   Register hooks/skills (Claude default; flag picks the vendor)

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -232,6 +232,16 @@ static class McpMemoryServer {
         var global          = args?["global"]?.GetValue<bool>() == true;
         var machineSpecific = args?["machine_specific"]?.GetValue<bool>() == true;
 
+        // Fail closed rather than silently broadening scope: a null cwdRepoHash with global not
+        // explicitly requested would otherwise be sent to the server as repo_hash: null, which the
+        // server treats as a GLOBAL (all-repos) memory. Likewise a null machineId with
+        // machine_specific: true would otherwise save an untagged (visible-to-everyone) memory.
+        if (!global && cwdRepoHash is null)
+            throw new ArgumentException("Cannot resolve the current repository — run from a git checkout or pass global: true for a repo-independent memory.");
+
+        if (machineSpecific && machineId is null)
+            throw new ArgumentException("Machine id unavailable — cannot save a machine-specific memory on this host.");
+
         return new JsonObject {
             ["audience"]          = Req("audience"),
             ["slug"]              = Req("slug"),
@@ -241,6 +251,7 @@ static class McpMemoryServer {
             ["team"]              = args?["team"]?.GetValue<string>(),
             ["repo_hash"]         = global ? null : cwdRepoHash,
             ["machine_tag"]       = machineSpecific ? machineId : null,
+            ["machine_context"]   = machineId,
             ["source_session_id"] = null,
             ["harness"]           = "mcp"
         };
@@ -340,7 +351,7 @@ static class McpMemoryServer {
                 ["id_or_slug"] = new("string", "Memory id (32 hex) or slug.")
             }, ["id_or_slug"])),
         new("save_memory",
-            "Save a durable learning to the server. audience: 'user' (private), 'team', or 'org' (everyone). Prefer update_memory when the result reports a nearDuplicate.",
+            "Save a durable learning to the server. audience: 'user' (private), 'team', or 'org' (everyone). Saves are repo-scoped by default (to the cwd's git checkout); if the current repo can't be resolved, pass global: true for a repo-independent memory, or the save fails. Prefer update_memory when the result reports a nearDuplicate.",
             new("object", new() {
                 ["audience"]         = new("string", "user | team | org"),
                 ["slug"]             = new("string", "kebab-case identifier, unique within the audience+repo pool"),
@@ -348,7 +359,7 @@ static class McpMemoryServer {
                 ["content"]          = new("string", "Full memory body (max 64 KiB)"),
                 ["kind"]             = new("string", "preference | feedback | project | reference"),
                 ["team"]             = new("string", "Team name or id — required for audience 'team' if you are in several teams"),
-                ["global"]           = new("boolean", "true = not tied to the current repo (default: scoped to cwd repo)"),
+                ["global"]           = new("boolean", "true = not tied to the current repo (required if not run from a git checkout; default: scoped to cwd repo)"),
                 ["machine_specific"] = new("boolean", "true = only relevant on this machine (user audience only)")
             }, ["audience", "slug", "description", "content", "kind"])),
         new("update_memory",

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -1,0 +1,373 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.Cli.Commands;
+
+static class McpMemoryServer {
+    internal const string NotLoggedInMessage = "Not logged in. Run 'kcap login' on the host shell.";
+
+    public static async Task<int> RunAsync(string baseUrl) {
+        var cwdRepoHash = await ResolveCwdRepoHashAsync();
+        var machineId   = await ResolveMachineIdAsync();
+        var tools       = BuildToolsList();
+
+        // Validate the server_url shape once, locally (pure string check — no network, token,
+        // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
+        var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
+
+        // The authenticated client is created on the first tools/call, not at startup:
+        // kcap-memory auto-registers, so Claude Code spawns `kcap mcp memory` for every
+        // session — deferring keeps startup local-only (no GET /auth/config, token load, or
+        // stderr) for sessions that never invoke a tool. Created on demand into a nullable field
+        // (rather than a Lazy<Task>) so a transient creation failure leaves it null and the next
+        // call retries, instead of a faulted task sticking for the rest of the session. Safe
+        // without locking: the stdio loop handles one request at a time.
+        HttpClient? client = null;
+
+        // Guarded tool dispatch: never let the stdio JSON-RPC loop die on one bad request. An
+        // unusable server_url would otherwise reach EnsureAbsolute inside the auth-client factory,
+        // which hard-exits the process (Environment.Exit(2)) mid-request; and an unexpected
+        // failure would bubble out of the loop. Return a JSON-RPC tool error in both cases so the
+        // server keeps serving.
+        async Task<string> DispatchToolCallAsync(JsonNode callId, JsonObject callRequest) {
+            if (!urlOk)
+                return BuildToolResult(callId, HttpClientExtensions.SchemeMissingHint, isError: true);
+
+            try {
+                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+                return await HandleToolCallAsync(callId, callRequest, client, baseUrl, cwdRepoHash, machineId);
+            } catch (Exception ex) {
+                // Unexpected: log the detail to stderr (not to the client, which could leak local
+                // paths from IO errors) and return a generic tool error, keeping the loop alive.
+                await Console.Error.WriteLineAsync($"kcap mcp memory: unexpected error handling tools/call: {ex}");
+                return BuildToolResult(callId, "Error: internal error handling the request.", isError: true);
+            }
+        }
+
+        await using var stdin  = Console.OpenStandardInput();
+        await using var stdout = Console.OpenStandardOutput();
+        using var       reader = new StreamReader(stdin, Encoding.UTF8);
+        await using var writer = new StreamWriter(stdout, new UTF8Encoding(false));
+        writer.AutoFlush = true;
+
+        try {
+            while (await reader.ReadLineAsync() is { } line) {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+
+                JsonObject? request;
+
+                try {
+                    request = JsonNode.Parse(line)?.AsObject();
+                } catch {
+                    continue; // skip malformed JSON
+                }
+
+                if (request is null) continue;
+
+                var id     = request["id"];
+                var method = request["method"]?.GetValue<string>();
+
+                // Notifications have no id — don't send a response
+                if (id is null) continue;
+
+                var response = method switch {
+                    "initialize" => BuildInitializeResponse(id),
+                    "tools/list" => BuildToolsListResponse(id, tools),
+                    "tools/call" => await DispatchToolCallAsync(id, request),
+                    _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
+                };
+
+                await writer.WriteLineAsync(response);
+            }
+        } finally {
+            if (client is not null) {
+                try { client.Dispose(); } catch {
+                    /* swallow — best-effort cleanup */
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    static async Task<string?> ResolveCwdRepoHashAsync() {
+        try {
+            var cwd      = Directory.GetCurrentDirectory();
+            var repoInfo = await RepositoryDetection.DetectRepositoryAsync(cwd);
+
+            if (repoInfo?.Owner is null || repoInfo.RepoName is null) return null;
+
+            return RepoHashHelper.ComputeRepoHash(repoInfo.Owner, repoInfo.RepoName);
+        } catch {
+            return null;
+        }
+    }
+
+    static async Task<string?> ResolveMachineIdAsync() {
+        try { return await MachineIdProvider.GetOrCreateAsync(); } catch { return null; }
+    }
+
+    static string BuildInitializeResponse(JsonNode id) =>
+        ToResponse<McpInitResult>(
+            id,
+            new("2024-11-05", new(new()), new("kcap-memory", "1.0.0")),
+            McpJsonContext.Default.McpInitResult
+        );
+
+    static string BuildToolsListResponse(JsonNode id, McpTool[] tools) =>
+        ToResponse(id, new McpToolsResult(tools), McpJsonContext.Default.McpToolsResult);
+
+    internal static async Task<string> HandleToolCallAsync(
+            JsonNode   id,
+            JsonObject request,
+            HttpClient client,
+            string     baseUrl,
+            string?    cwdRepoHash,
+            string?    machineId
+        ) {
+        var paramsNode = request["params"]?.AsObject();
+        var toolName   = paramsNode?["name"]?.GetValue<string>();
+        var arguments  = paramsNode?["arguments"]?.AsObject();
+
+        if (toolName is null) {
+            return BuildErrorResponse(id, -32602, "Missing params.name");
+        }
+
+        try {
+            using var httpResponse = toolName switch {
+                "search_memories" => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildSearchUrl(baseUrl, arguments, cwdRepoHash, machineId))),
+                "get_memory"      => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildGetUrl(baseUrl, arguments, cwdRepoHash, machineId))),
+                "save_memory"     => await SendWithRefreshRetryAsync(client, c => c.PostAsync($"{baseUrl}/api/memories", ToJsonContent(BuildSaveBody(arguments, cwdRepoHash, machineId)))),
+                "update_memory"   => await SendWithRefreshRetryAsync(client, c => c.PutAsync($"{baseUrl}/api/memories/{Uri.EscapeDataString(Id(arguments))}", ToJsonContent(BuildUpdateBody(arguments)))),
+                "rescope_memory"  => await SendWithRefreshRetryAsync(client, c => c.PostAsync($"{baseUrl}/api/memories/{Uri.EscapeDataString(Id(arguments))}/rescope", ToJsonContent(BuildRescopeBody(arguments)))),
+                "archive_memory"  => await SendWithRefreshRetryAsync(client, c => c.DeleteAsync($"{baseUrl}/api/memories/{Uri.EscapeDataString(Id(arguments))}")),
+                _                 => throw new ArgumentException($"Unknown tool: {toolName}")
+            };
+
+            var body = await httpResponse.Content.ReadAsStringAsync();
+
+            if (httpResponse.StatusCode == HttpStatusCode.Unauthorized) {
+                return BuildToolResult(id, NotLoggedInMessage, isError: true);
+            }
+
+            if (!httpResponse.IsSuccessStatusCode) {
+                return BuildToolResult(id, $"Error: HTTP {(int)httpResponse.StatusCode} — {body}", isError: true);
+            }
+
+            return BuildToolResult(id, body);
+        } catch (ArgumentException ex) {
+            return BuildToolResult(id, $"Error: {ex.Message}", isError: true);
+        } catch (HttpRequestException ex) {
+            return BuildToolResult(id, $"Error: {ex.Message}", isError: true);
+        }
+    }
+
+    /// <summary>
+    /// Sends an HTTP request with one-shot retry on 401. The MCP server reuses a single
+    /// <see cref="HttpClient"/> for the lifetime of the agent session, so a cached token
+    /// that was valid at startup may have expired by the time a tool call is made. On 401
+    /// we ask <see cref="TokenStore.GetValidTokensAsync"/> for a fresh token (which triggers
+    /// the refresh flow for WorkOS / GitHubApp), update the client's <c>Authorization</c>
+    /// header, and retry the same request once. If refresh fails (genuinely not logged in
+    /// or refresh-token expired), the original 401 is returned and the caller surfaces the
+    /// friendly "Not logged in" message.
+    /// </summary>
+    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, Func<HttpClient, Task<HttpResponseMessage>> send) {
+        var response = await send(client);
+
+        if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
+
+        var refreshed = await TokenStore.GetValidTokensAsync();
+
+        if (refreshed is null) return response; // genuinely not logged in; keep the original 401
+
+        response.Dispose();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", refreshed.AccessToken);
+
+        return await send(client);
+    }
+
+    static StringContent ToJsonContent(JsonObject body) => new(body.ToJsonString(), Encoding.UTF8, "application/json");
+
+    static string Id(JsonObject? args) =>
+        args?["id"]?.GetValue<string>() is { Length: > 0 } id ? id : throw new ArgumentException("id is required");
+
+    internal static string BuildSearchUrl(string baseUrl, JsonObject? args, string? cwdRepoHash, string? machineId) {
+        var q = args?["query"]?.GetValue<string>();
+        if (string.IsNullOrWhiteSpace(q)) throw new ArgumentException("query is required");
+
+        var qs = new List<string> { $"q={Uri.EscapeDataString(q)}" };
+        if (cwdRepoHash is not null) qs.Add($"repo={Uri.EscapeDataString(cwdRepoHash)}");
+        if (machineId is not null) qs.Add($"machine={Uri.EscapeDataString(machineId)}");
+        if (TryReadInt(args, "limit", out var limit)) qs.Add($"limit={limit}");
+
+        return $"{baseUrl}/api/memories/search?{string.Join("&", qs)}";
+    }
+
+    internal static string BuildGetUrl(string baseUrl, JsonObject? args, string? cwdRepoHash, string? machineId) {
+        var idOrSlug = args?["id_or_slug"]?.GetValue<string>();
+        if (string.IsNullOrWhiteSpace(idOrSlug)) throw new ArgumentException("id_or_slug is required");
+
+        var qs = new List<string>();
+        if (cwdRepoHash is not null) qs.Add($"repo={Uri.EscapeDataString(cwdRepoHash)}");
+        if (machineId is not null) qs.Add($"machine={Uri.EscapeDataString(machineId)}");
+
+        var url = $"{baseUrl}/api/memories/{Uri.EscapeDataString(idOrSlug)}";
+        return qs.Count == 0 ? url : $"{url}?{string.Join("&", qs)}";
+    }
+
+    // NOTE: request bodies use snake_case keys (repo_hash, machine_tag, source_session_id) —
+    // the server's global JSON policy is JsonNamingPolicy.SnakeCaseLower (see AI-1134 task 9).
+    // Responses are passed through as raw text, so only these request-body builders are affected.
+    internal static JsonObject BuildSaveBody(JsonObject? args, string? cwdRepoHash, string? machineId) {
+        string Req(string name) =>
+            args?[name]?.GetValue<string>() is { Length: > 0 } v ? v : throw new ArgumentException($"{name} is required");
+
+        var global          = args?["global"]?.GetValue<bool>() == true;
+        var machineSpecific = args?["machine_specific"]?.GetValue<bool>() == true;
+
+        return new JsonObject {
+            ["audience"]          = Req("audience"),
+            ["slug"]              = Req("slug"),
+            ["description"]       = Req("description"),
+            ["content"]           = Req("content"),
+            ["kind"]              = Req("kind"),
+            ["team"]              = args?["team"]?.GetValue<string>(),
+            ["repo_hash"]         = global ? null : cwdRepoHash,
+            ["machine_tag"]       = machineSpecific ? machineId : null,
+            ["source_session_id"] = null,
+            ["harness"]           = "mcp"
+        };
+    }
+
+    internal static JsonObject BuildUpdateBody(JsonObject? args) => new() {
+        ["description"] = args?["description"]?.GetValue<string>(),
+        ["content"]     = args?["content"]?.GetValue<string>(),
+        ["kind"]        = args?["kind"]?.GetValue<string>()
+    };
+
+    internal static JsonObject BuildRescopeBody(JsonObject? args) => new() {
+        ["audience"] = args?["audience"]?.GetValue<string>() is { Length: > 0 } a ? a : throw new ArgumentException("audience is required"),
+        ["team"]     = args?["team"]?.GetValue<string>()
+    };
+
+    /// <summary>
+    /// Reads a numeric field as int, tolerant of JsonValue holding any underlying numeric type
+    /// (int/long/double) — TryGetValue&lt;int&gt; on a JsonValue constructed from a long returns false.
+    /// Returns false when the key is missing or the value is the wrong shape (e.g., a string).
+    /// Throws <see cref="ArgumentException"/> when the value is numeric but out of range for int,
+    /// so the caller (via <see cref="HandleToolCallAsync"/>) surfaces it as a JSON-RPC validation error
+    /// rather than silently falling back to the default.
+    /// </summary>
+    internal static bool TryReadInt(JsonObject? args, string key, out int value) {
+        value = 0;
+        var node = args?[key];
+
+        if (node is null) return false;
+
+        JsonValue v;
+
+        try {
+            v = node.AsValue();
+        } catch {
+            return false; // wrong shape (object/array)
+        }
+
+        if (v.TryGetValue(out value)) return true;
+
+        if (v.TryGetValue<long>(out var lv)) {
+            if (lv is < int.MinValue or > int.MaxValue)
+                throw new ArgumentException($"'{key}' value {lv} is out of range for int.");
+
+            value = (int)lv;
+
+            return true;
+        }
+
+        if (v.TryGetValue<double>(out var dv)) {
+            var rounded = (long)dv;
+
+            if (rounded < int.MinValue || rounded > int.MaxValue || rounded != dv)
+                throw new ArgumentException($"'{key}' value {dv} is out of range or non-integer for int.");
+
+            value = (int)rounded;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    static string BuildToolResult(JsonNode id, string text, bool isError = false) =>
+        ToResponse<McpToolCallResult>(id, new([new("text", text)], isError ? true : null), McpJsonContext.Default.McpToolCallResult);
+
+    static string BuildErrorResponse(JsonNode id, int code, string message) {
+        var envelope = new JsonObject {
+            ["jsonrpc"] = "2.0",
+            ["id"]      = id.DeepClone(),
+            ["error"]   = JsonSerializer.SerializeToNode(new McpError(code, message), McpJsonContext.Default.McpError)
+        };
+
+        return envelope.ToJsonString();
+    }
+
+    static string ToResponse<T>(JsonNode id, T result, JsonTypeInfo<T> typeInfo) {
+        var envelope = new JsonObject {
+            ["jsonrpc"] = "2.0",
+            ["id"]      = id.DeepClone(),
+            ["result"]  = JsonSerializer.SerializeToNode(result, typeInfo)
+        };
+
+        return envelope.ToJsonString();
+    }
+
+    internal static McpTool[] BuildToolsList() => [
+        new("search_memories",
+            "Search the team's shared memories (hybrid semantic + keyword). Call this BEFORE saving a new memory and when starting work that might have prior learnings.",
+            new("object", new() {
+                ["query"] = new("string", "What to search for."),
+                ["limit"] = new("number", "Max results (default 10, max 50).")
+            }, ["query"])),
+        new("get_memory",
+            "Fetch a memory's full content by id or slug. Slug resolution precedence: your memories, then your teams', then org-wide; repo-scoped before global.",
+            new("object", new() {
+                ["id_or_slug"] = new("string", "Memory id (32 hex) or slug.")
+            }, ["id_or_slug"])),
+        new("save_memory",
+            "Save a durable learning to the server. audience: 'user' (private), 'team', or 'org' (everyone). Prefer update_memory when the result reports a nearDuplicate.",
+            new("object", new() {
+                ["audience"]         = new("string", "user | team | org"),
+                ["slug"]             = new("string", "kebab-case identifier, unique within the audience+repo pool"),
+                ["description"]      = new("string", "One-line summary (max 300 chars)"),
+                ["content"]          = new("string", "Full memory body (max 64 KiB)"),
+                ["kind"]             = new("string", "preference | feedback | project | reference"),
+                ["team"]             = new("string", "Team name or id — required for audience 'team' if you are in several teams"),
+                ["global"]           = new("boolean", "true = not tied to the current repo (default: scoped to cwd repo)"),
+                ["machine_specific"] = new("boolean", "true = only relevant on this machine (user audience only)")
+            }, ["audience", "slug", "description", "content", "kind"])),
+        new("update_memory",
+            "Update an existing memory's description/content/kind (any subset).",
+            new("object", new() {
+                ["id"]          = new("string", "Memory id"),
+                ["description"] = new("string", "New one-line summary"),
+                ["content"]     = new("string", "New body"),
+                ["kind"]        = new("string", "preference | feedback | project | reference")
+            }, ["id"])),
+        new("rescope_memory",
+            "Change a memory's audience (e.g. promote your user memory to team or org).",
+            new("object", new() {
+                ["id"]       = new("string", "Memory id"),
+                ["audience"] = new("string", "user | team | org"),
+                ["team"]     = new("string", "Target team when audience is 'team'")
+            }, ["id", "audience"])),
+        new("archive_memory",
+            "Archive (soft-delete) a memory.",
+            new("object", new() { ["id"] = new("string", "Memory id") }, ["id"]))
+    ];
+}

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -291,11 +291,12 @@ switch (command) {
     }
     case "mcp": {
         if (args.Length < 2) {
-            Console.Error.WriteLine("Usage: kcap mcp review|judge|sessions|flows …");
+            Console.Error.WriteLine("Usage: kcap mcp review|judge|sessions|flows|memory …");
             Console.Error.WriteLine("  kcap mcp review [--owner <owner> --repo <repo> --pr <number>]");
             Console.Error.WriteLine("  kcap mcp judge --session <sessionId>");
             Console.Error.WriteLine("  kcap mcp sessions");
             Console.Error.WriteLine("  kcap mcp flows");
+            Console.Error.WriteLine("  kcap mcp memory");
 
             return 1;
         }
@@ -329,6 +330,8 @@ switch (command) {
                 return await McpSessionsServer.RunAsync(baseUrl!);
             case "flows":
                 return await McpFlowsServer.RunAsync(baseUrl!);
+            case "memory":
+                return await McpMemoryServer.RunAsync(baseUrl!);
             default:
                 Console.Error.WriteLine($"Unknown mcp subcommand: {args[1]}");
 

--- a/test/Capacitor.Cli.Tests.Unit/MachineIdTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/MachineIdTests.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class MachineIdTests {
+    [Test]
+    public async Task Generated_id_has_stable_format() {
+        var id = MachineIdProvider.Generate();
+
+        await Assert.That(id).Matches("^mach-[0-9a-f]{12}$");
+    }
+
+    [Test]
+    public async Task Machine_id_round_trips_through_config_serialization() {
+        var config = new ProfileConfig { MachineId = "mach-abc123def456" };
+
+        var json     = JsonSerializer.Serialize(config, ProfileConfigJsonContext.Default.ProfileConfig);
+        var restored = JsonSerializer.Deserialize(json, ProfileConfigJsonContext.Default.ProfileConfig);
+
+        await Assert.That(json).Contains("\"machine_id\"");
+        await Assert.That(restored!.MachineId).IsEqualTo("mach-abc123def456");
+    }
+
+    [Test]
+    public async Task Missing_machine_id_deserializes_as_null() {
+        var restored = JsonSerializer.Deserialize("""{"version":2}""", ProfileConfigJsonContext.Default.ProfileConfig);
+
+        await Assert.That(restored!.MachineId).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/McpMemoryServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpMemoryServerTests.cs
@@ -42,6 +42,37 @@ public class McpMemoryServerTests {
     }
 
     [Test]
+    public async Task Save_body_throws_without_repo_context_unless_global() {
+        var argsWithoutGlobal = Args("""{"audience":"org","slug":"s","description":"d","content":"c","kind":"feedback"}""");
+
+        await Assert.That(() => McpMemoryServer.BuildSaveBody(argsWithoutGlobal, null, "mach-1"))
+            .Throws<ArgumentException>();
+
+        var argsWithGlobal = Args("""{"audience":"org","slug":"s","description":"d","content":"c","kind":"feedback","global":true}""");
+        var body           = McpMemoryServer.BuildSaveBody(argsWithGlobal, null, "mach-1");
+
+        await Assert.That(body["repo_hash"]).IsNull();
+    }
+
+    [Test]
+    public async Task Save_body_throws_for_machine_specific_without_machine_id() {
+        var args = Args("""{"audience":"user","slug":"s","description":"d","content":"c","kind":"preference","global":true,"machine_specific":true}""");
+
+        await Assert.That(() => McpMemoryServer.BuildSaveBody(args, "abc123", null))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Save_body_always_carries_machine_context() {
+        var body = McpMemoryServer.BuildSaveBody(
+            Args("""{"audience":"org","slug":"s","description":"d","content":"c","kind":"feedback"}"""),
+            "abc123", "mach-1");
+
+        await Assert.That(body["machine_context"]!.GetValue<string>()).IsEqualTo("mach-1");
+        await Assert.That(body["machine_tag"]).IsNull();
+    }
+
+    [Test]
     public async Task Get_url_escapes_slug_and_carries_context() {
         var url = McpMemoryServer.BuildGetUrl("http://x", Args("""{"id_or_slug":"my-slug"}"""), "abc123", "mach-1");
 

--- a/test/Capacitor.Cli.Tests.Unit/McpMemoryServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpMemoryServerTests.cs
@@ -1,0 +1,58 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class McpMemoryServerTests {
+    static JsonObject Args(string json) => JsonNode.Parse(json)!.AsObject();
+
+    [Test]
+    public async Task Search_url_includes_repo_machine_and_query() {
+        var url = McpMemoryServer.BuildSearchUrl("http://x", Args("""{"query":"utc clock","limit":5}"""), "abc123", "mach-1");
+
+        await Assert.That(url).IsEqualTo("http://x/api/memories/search?q=utc%20clock&repo=abc123&machine=mach-1&limit=5");
+    }
+
+    [Test]
+    public async Task Search_url_omits_missing_context() {
+        var url = McpMemoryServer.BuildSearchUrl("http://x", Args("""{"query":"a"}"""), null, null);
+
+        await Assert.That(url).IsEqualTo("http://x/api/memories/search?q=a");
+    }
+
+    [Test]
+    public async Task Save_body_defaults_to_cwd_repo_and_no_machine_tag() {
+        var body = McpMemoryServer.BuildSaveBody(
+            Args("""{"audience":"org","slug":"s","description":"d","content":"c","kind":"feedback"}"""),
+            "abc123", "mach-1");
+
+        await Assert.That(body["repo_hash"]!.GetValue<string>()).IsEqualTo("abc123");
+        await Assert.That(body["machine_tag"]).IsNull();
+        await Assert.That(body["harness"]!.GetValue<string>()).IsEqualTo("mcp");
+    }
+
+    [Test]
+    public async Task Save_body_honors_global_and_machine_specific() {
+        var body = McpMemoryServer.BuildSaveBody(
+            Args("""{"audience":"user","slug":"s","description":"d","content":"c","kind":"preference","global":true,"machine_specific":true}"""),
+            "abc123", "mach-1");
+
+        await Assert.That(body["repo_hash"]).IsNull();
+        await Assert.That(body["machine_tag"]!.GetValue<string>()).IsEqualTo("mach-1");
+    }
+
+    [Test]
+    public async Task Get_url_escapes_slug_and_carries_context() {
+        var url = McpMemoryServer.BuildGetUrl("http://x", Args("""{"id_or_slug":"my-slug"}"""), "abc123", "mach-1");
+
+        await Assert.That(url).IsEqualTo("http://x/api/memories/my-slug?repo=abc123&machine=mach-1");
+    }
+
+    [Test]
+    public async Task Tools_list_has_six_tools() {
+        var tools = McpMemoryServer.BuildToolsList();
+
+        await Assert.That(tools.Length).IsEqualTo(6);
+        await Assert.That(tools.Select(t => t.Name).ToArray()).Contains("save_memory");
+    }
+}


### PR DESCRIPTION
Adds the CLI side of Agent Memories ([AI-1134](https://linear.app/kurrent/issue/AI-1134/agent-memories-server-side-shared-memory-for-coding-agents)) — server-side shared memories for coding agents, scoped user/team/org with repo + machine context.

## What's in here

- **`kcap mcp memory`** — stdio MCP server (copy of the `McpSessionsServer` skeleton) with six tools: `search_memories`, `get_memory`, `save_memory`, `update_memory`, `rescope_memory`, `archive_memory`. Tool descriptions steer agents to search before saving and prefer `update_memory` on a reported near-duplicate.
- Request bodies are **snake_case** (`repo_hash`, `machine_tag`, …) matching the server's global `SnakeCaseLower` JSON policy; responses pass through as raw text. Bodies built with `JsonObject` — no `McpJsonContext` additions, AOT publish clean (no new IL3050/IL2026).
- **Persisted machine id** — `machine_id` (`mach-{12hex}`) on the top-level `ProfileConfig`, generated once by `MachineIdProvider`; stamps machine-specific memories so they never surface on other machines.
- Registration: `kcap/.mcp.json` (Claude, with `cwd`) and `kcap/.codex-mcp.json` (no `cwd` — matches that file's precedent); built-in help (`help-usage.txt`, `help-mcp.txt`) and both READMEs updated.

## Tests

`Capacitor.Cli.Tests.Unit`: 2077/2077 green (9 new: machine-id format/round-trip/back-compat + URL/body builders incl. snake_case, `global`, `machine_specific` rules).

## Notes

- Server counterpart: kcap-server branch `alexeyzimarev/ai-1134-agent-memories` (bump the submodule pointer to `origin/main` after this merges).
- Follow-up: [AI-1146](https://linear.app/kurrent/issue/AI-1146/kcap-setup-codex-register-kcap-memory-in-codexconfigtoml-allowlist) — wire `kcap-memory` into the `kcap setup --codex` allowlist + install docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)