### PR TITLE
[AI-1148] Turn-by-turn recap: default recap outline + list_turns MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ If you run `kcap setup` outside any git working tree, it still completes — hoo
 
 ### Session recap
 
-By default, shows a concise AI-generated summary — why the work was done, key decisions, and anything left unfinished. Use `--full` for the complete transcript with all prompts, responses, and file changes.
+By default, shows a concise AI-generated summary — why the work was done, key decisions, and anything left unfinished — followed by a per-turn outline (one prose line per turn) and a `--get-turn <N>` pointer for drilling into any turn. Use `--full` for the complete transcript with all prompts, responses, and file changes.
 
 ```bash
-kcap recap <sessionId>              # summary (default)
+kcap recap <sessionId>              # summary + per-turn outline (default)
 kcap recap --full <sessionId>       # full transcript
 kcap recap --chain <sessionId>      # summaries across continuation chain
 kcap recap --chain --full <sessionId>  # full transcript across chain

--- a/kcap/skills/recap/SKILL.md
+++ b/kcap/skills/recap/SKILL.md
@@ -15,7 +15,7 @@ description: >-
   kcap-sessions MCP tools.
 ---
 
-> **For agents:** When the `kcap-sessions` MCP server is available, prefer its tools (`search_sessions`, `get_session_summary`, `get_session_transcript`) for retrieving past sessions. This CLI-wrapped skill remains a fallback for shell use and when MCP isn't installed.
+> **For agents:** When the `kcap-sessions` MCP server is available, prefer its tools (`search_sessions`, `get_session_summary`, `list_turns`, `get_turn`, `get_session_transcript`) for retrieving past sessions. This CLI-wrapped skill remains a fallback for shell use and when MCP isn't installed.
 
 # Session Recap
 
@@ -26,7 +26,7 @@ Retrieve session history recorded by Kurrent Capacitor. Supports single-session 
 **IMPORTANT:** Always use the `kcap recap` CLI command. Do NOT call the HTTP API directly via `curl`, `WebFetch`, or `HttpClient` — the CLI handles formatting, error handling, and server URL resolution.
 
 ```bash
-# Current session summary (default — concise AI-generated overview)
+# Current session summary + per-turn outline (default)
 kcap recap
 
 # Full transcript (all prompts, responses, file changes)
@@ -41,10 +41,17 @@ kcap recap --chain --full
 # Recent session summaries for the current repository
 kcap recap --repo
 
+# Compact per-turn metadata index (no prose)
+kcap recap --per-turn
+
+# One turn's full transcript, drilling down from the outline
+kcap recap --get-turn <N>
+
 # Explicit session ID (overrides env var)
 kcap recap <sessionId>
 kcap recap --full <sessionId>
 kcap recap --chain <sessionId>
+kcap recap --get-turn <N> <sessionId>
 ```
 
 `kcap recap` resolves the current session id from the environment when the host agent CLI exposes one. If no session id is available, pass it explicitly: `kcap recap <sessionId>`.
@@ -61,14 +68,35 @@ Returns AI-generated summaries from the most recent ended sessions in the curren
 
 **Progressive disclosure:** Start with `--repo` for the overview. If a specific session's summary is relevant, drill into it with `kcap recap --full <sessionId>` to get the complete transcript. This avoids loading full transcripts for all sessions into context.
 
-## Default Output (Summary)
+## Default Output
 
-Shows the plan (if any) and an AI-generated summary with:
-- **Context** — why the work was done
-- **Key decisions** — trade-offs and design choices that matter for future work
-- **Unfinished/Risks** — anything deferred or left incomplete
+`kcap recap` (no flags) prints, in order:
 
-If no summary is available (e.g., active session), a hint is shown to use `--full`.
+1. **`## Plan`** — the plan captured for the session, if any.
+2. **`## Summary`** — an AI-generated narrative covering:
+   - **Context** — why the work was done
+   - **Key decisions** — trade-offs and design choices that matter for future work
+   - **Unfinished/Risks** — anything deferred or left incomplete
+3. **`## Turns`** — an outline with one line per turn:
+   - If the turn has a prose summary, that summary (1-3 sentences).
+   - Otherwise, a truncated user-prompt excerpt plus tool/file metadata (tool names, file count).
+4. A closing pointer: `→ kcap recap --get-turn <N> [sessionId]` for one turn's full detail.
+
+A session that has turns but no summary yet (generation hasn't run, or an ended session has no `whats_done`/`plan` entry) still shows the `## Turns` outline — only the plan/summary blocks are skipped. If there's neither a summary nor any turns (e.g. an active session with no recorded turns), recap prints a hint to use `--full` instead.
+
+With `--chain`, this same summary + outline is rendered per session under a `# Session <id>` header, oldest first.
+
+## Turn-by-turn drill-down
+
+Once you've read the `## Turns` outline, fetch one turn's complete transcript (user prompt, tool calls + results, assistant text):
+
+```bash
+kcap recap --get-turn <N> [sessionId]
+```
+
+For a plain metadata index instead of the outline (turn #, prompt excerpt, tool names, file count, token count, time range — no prose), use `kcap recap --per-turn [sessionId]`.
+
+**MCP agents:** call `list_turns` to get a session's full turn map (`turn_index`, `prose`, `user_prompt`, `tools`, `files`, token counts), then `get_turn(session_id, turn_index)` for one turn's full transcript. Use `get_session_summary` for the whole-session narrative instead of drilling into individual turns.
 
 ## Full Output (`--full`)
 
@@ -85,8 +113,10 @@ When using `--chain`, sessions are separated by `# Session <id>` headers, and ag
 ## When to Use Each Flag
 
 - **`--repo`** (`kcap recap --repo`) — recent session summaries across the repo (start here for "what did we do recently?")
-- **No flags** (`kcap recap`) — quick context on the current session
-- **`--full`** (`kcap recap --full`) — when you need exact prompts, responses, or file contents from a specific session
+- **No flags** (`kcap recap`) — summary + per-turn outline for the current session
+- **`--per-turn`** (`kcap recap --per-turn`) — compact metadata index per turn (prompt excerpt, tools, files, tokens, time), no prose
+- **`--get-turn <N>`** (`kcap recap --get-turn <N>`) — one turn's full transcript, drilling down from the outline or the per-turn index
+- **`--full`** (`kcap recap --full`) — whole transcript: exact prompts, responses, and file contents for a specific session
 - **`--chain`** (`kcap recap --chain`) — understanding the full history of a task that spanned multiple sessions
 - **`--chain --full`** — complete transcript across all continuations
 
@@ -97,7 +127,7 @@ The `KCAP_URL` environment variable overrides the default server URL (`http://lo
 ## Tips
 
 - **For "what have we been working on?"** — use `--repo` first, then drill into specific sessions.
-- Start with the default summary. Only use `--full` when you need specific details.
+- Start with the default summary + turn outline. Drill into a specific turn with `--get-turn <N>` before reaching for `--full`.
 - When continuing work from a previous session, use `--chain` to get summaries across continuations.
 - Summarize key decisions and changes for the user rather than echoing the full recap output verbatim.
 - The `kcap` CLI must be available on PATH (typically installed at `~/.local/bin/kcap`).

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -139,6 +139,7 @@ static class McpSessionsServer {
                 "get_session_summary"    => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildSummaryUrl(baseUrl, arguments))),
                 "get_session_transcript" => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildTranscriptUrl(baseUrl, arguments))),
                 "get_turn"               => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildTurnDetailUrl(baseUrl, arguments))),
+                "list_turns"             => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildTurnsUrl(baseUrl, arguments))),
                 _                        => throw new ArgumentException($"Unknown tool: {toolName}")
             };
 
@@ -242,6 +243,13 @@ static class McpSessionsServer {
         }
 
         return $"{baseUrl}/api/sessions/{Uri.EscapeDataString(id)}/turns/{turnIndex}";
+    }
+
+    internal static string BuildTurnsUrl(string baseUrl, JsonObject? args) {
+        var id = args?["session_id"]?.GetValue<string>()
+         ?? throw new ArgumentException("Missing required argument: session_id");
+
+        return $"{baseUrl}/api/sessions/{Uri.EscapeDataString(id)}/turns";
     }
 
     static string BuildTranscriptUrl(string baseUrl, JsonObject? args) {
@@ -518,6 +526,15 @@ static class McpSessionsServer {
                     ["turn_index"] = new("integer", "Zero-based turn index.")
                 },
                 ["session_id", "turn_index"]
+            )
+        ),
+        new(
+            "list_turns",
+            "List all turns of a past session with their prose summaries. A turn is one user message and the assistant's full response up to the next user message. Returns per turn: turn_index, prose (1-3 sentence summary; may be null for trivial/older turns), user_prompt, tools, files, and token counts. Use this to map a session turn by turn, then call get_turn(session_id, turn_index) for one turn's full transcript, or get_session_summary for the whole-session narrative.",
+            new(
+                "object",
+                new() { ["session_id"] = new("string", "Session ID (from search_sessions or get_session_summary).") },
+                ["session_id"]
             )
         )
     ];

--- a/src/Capacitor.Cli/Commands/RecapCommand.cs
+++ b/src/Capacitor.Cli/Commands/RecapCommand.cs
@@ -126,9 +126,7 @@ static class RecapCommand {
         var summaries = entries.Where(e => e.Type is "whats_done" or "plan").ToList();
 
         // Distinct session ids to render, in first-seen order. Non-chain: just the requested id.
-        var sessionIds = chain
-            ? entries.Select(e => e.SessionId).OfType<string>().Distinct().ToList()
-            : [sessionId];
+        var sessionIds = chain ? DistinctSessionIds(entries) : [sessionId];
 
         var printedAnything = false;
 
@@ -177,6 +175,10 @@ static class RecapCommand {
 
         return 0;
     }
+
+    /// <summary>Session ids present in recap entries, first-seen order, nulls dropped.</summary>
+    internal static List<string> DistinctSessionIds(List<RecapEntry> entries) =>
+        entries.Select(e => e.SessionId).OfType<string>().Distinct().ToList();
 
     /// <summary>GETs /turns for one session and renders the outline block, or "" on any non-success.</summary>
     static async Task<string> FetchTurnOutline(string baseUrl, HttpClient httpClient, string sessionId) {

--- a/src/Capacitor.Cli/Commands/RecapCommand.cs
+++ b/src/Capacitor.Cli/Commands/RecapCommand.cs
@@ -532,18 +532,9 @@ static class RecapCommand {
     /// Returns "" for a missing/empty/non-array payload so the caller can skip the section.
     /// </summary>
     internal static string FormatTurnOutline(string turnsJson) {
-        JsonDocument doc;
-
         try {
-            doc = JsonDocument.Parse(turnsJson);
-        } catch (JsonException) {
-            // Empty/truncated body, or a non-JSON page (e.g. a proxy 200 with an HTML error).
-            // The outline is best-effort enrichment, so treat unparseable input as "nothing to show"
-            // — same contract as the empty/non-array case below — rather than crashing recap.
-            return "";
-        }
+            using var doc = JsonDocument.Parse(turnsJson);
 
-        using (doc) {
             if (doc.RootElement.ValueKind != JsonValueKind.Array || doc.RootElement.GetArrayLength() == 0) {
                 return "";
             }
@@ -556,6 +547,15 @@ static class RecapCommand {
             }
 
             return sb.ToString();
+        } catch (JsonException) {
+            // Empty/truncated body, or a non-JSON page (e.g. a proxy 200 with an HTML error).
+            // The outline is best-effort enrichment, so treat unparseable input as "nothing to show"
+            // — same contract as the empty/non-array case above — rather than crashing recap.
+            return "";
+        } catch (InvalidOperationException) {
+            // Well-formed JSON array, but a field arrives as the wrong type (e.g. turn_index as a
+            // JSON string) so GetInt32()/GetString() throw. Degrade to summary-only, never crash.
+            return "";
         }
     }
 
@@ -564,10 +564,11 @@ static class RecapCommand {
         var prose = turn.TryGetProperty("prose", out var p) && p.ValueKind == JsonValueKind.String ? p.GetString() : null;
 
         if (!string.IsNullOrWhiteSpace(prose)) {
-            return $"{index,3}  {prose!.Trim()}";
+            return $"{index,3}  {CollapseWhitespace(prose!)}";
         }
 
-        var prompt  = turn.TryGetProperty("user_prompt", out var up) && up.ValueKind == JsonValueKind.String ? up.GetString() ?? "" : "";
+        var raw     = turn.TryGetProperty("user_prompt", out var up) && up.ValueKind == JsonValueKind.String ? up.GetString() ?? "" : "";
+        var prompt  = CollapseWhitespace(raw);
         var excerpt = prompt.Length == 0 ? "(no prompt)" : prompt.Length > 80 ? prompt[..80] + "…" : prompt;
 
         var toolNames = ExtractToolNames(turn);
@@ -580,4 +581,12 @@ static class RecapCommand {
 
         return $"{index,3}  {excerpt}{meta}";
     }
+
+    /// <summary>
+    /// Collapses all runs of internal whitespace (spaces, tabs, newlines) to single spaces and trims
+    /// the ends, so a multi-line prose/prompt stays on one outline line. AOT-safe (no runtime Regex):
+    /// splitting on null splits on all Unicode whitespace, RemoveEmptyEntries drops the gaps.
+    /// </summary>
+    static string CollapseWhitespace(string s) =>
+        string.Join(" ", s.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
 }

--- a/src/Capacitor.Cli/Commands/RecapCommand.cs
+++ b/src/Capacitor.Cli/Commands/RecapCommand.cs
@@ -125,19 +125,23 @@ static class RecapCommand {
         ) {
         var summaries = entries.Where(e => e.Type is "whats_done" or "plan").ToList();
 
-        // Distinct session ids to render, in first-seen order. Non-chain: just the requested id.
-        var sessionIds = chain ? DistinctSessionIds(entries) : [sessionId];
+        // Fetch outlines for the CONCRETE ids /recap resolved (a slug or chain maps to real session
+        // ids, tagged on the entries) — never the raw input. /turns doesn't resolve slugs, so using
+        // the slug would 404 and the outline would silently vanish. Fall back to the input only when
+        // /recap returned no entries at all. Headers appear whenever more than one session is shown.
+        var sessionIds  = OutlineSessionIds(entries, sessionId);
+        var showHeaders = chain || sessionIds.Count > 1;
 
         var printedAnything = false;
 
         foreach (var sid in sessionIds) {
-            if (chain) {
+            if (showHeaders) {
                 Console.Out.WriteLine($"# Session {sid}");
                 Console.Out.WriteLine();
             }
 
             // Summary section for this session (plan + whats_done), reusing the existing types.
-            foreach (var entry in summaries.Where(e => !chain || e.SessionId == sid)) {
+            foreach (var entry in summaries.Where(e => e.SessionId == sid)) {
                 switch (entry.Type) {
                     case "plan":
                         Console.Out.WriteLine("## Plan");
@@ -171,7 +175,7 @@ static class RecapCommand {
             return 0;
         }
 
-        Console.Out.WriteLine($"→ kcap recap --get-turn <N>{(chain ? " <sessionId>" : "")} for one turn's full detail");
+        Console.Out.WriteLine(DrillDownPointer(sessionIds));
 
         return 0;
     }
@@ -179,6 +183,28 @@ static class RecapCommand {
     /// <summary>Session ids present in recap entries, first-seen order, nulls dropped.</summary>
     internal static List<string> DistinctSessionIds(List<RecapEntry> entries) =>
         entries.Select(e => e.SessionId).OfType<string>().Distinct().ToList();
+
+    /// <summary>
+    /// Concrete session id(s) to fetch turn outlines for: the ids <c>/recap</c> resolved (a slug or
+    /// chain maps to real ids, tagged on the entries), or the raw input when <c>/recap</c> returned
+    /// no entries. Never the unresolved slug — <c>/turns</c> doesn't resolve slugs, so that would
+    /// silently drop the outline.
+    /// </summary>
+    internal static List<string> OutlineSessionIds(List<RecapEntry> entries, string inputSessionId) {
+        var resolved = DistinctSessionIds(entries);
+
+        return resolved.Count > 0 ? resolved : [inputSessionId];
+    }
+
+    /// <summary>
+    /// Drill-down hint. For a single resolved session, emit its concrete id so the command targets
+    /// THIS session (a bare <c>--get-turn</c> falls back to the current/env session); for multiple
+    /// sessions, a <c>&lt;sessionId&gt;</c> placeholder the caller substitutes per the # Session headers.
+    /// </summary>
+    internal static string DrillDownPointer(IReadOnlyList<string> sessionIds) =>
+        sessionIds.Count == 1
+            ? $"→ kcap recap --get-turn <N> {sessionIds[0]} for one turn's full detail"
+            : "→ kcap recap --get-turn <N> <sessionId> for one turn's full detail";
 
     /// <summary>GETs /turns for one session and renders the outline block, or "" on any non-success.</summary>
     static async Task<string> FetchTurnOutline(string baseUrl, HttpClient httpClient, string sessionId) {

--- a/src/Capacitor.Cli/Commands/RecapCommand.cs
+++ b/src/Capacitor.Cli/Commands/RecapCommand.cs
@@ -117,7 +117,7 @@ static class RecapCommand {
             return 0;
         }
 
-        return full ? PrintFull(entries, chain) : PrintSummary(entries, chain);
+        return full ? PrintFull(entries, chain) : await PrintSummaryWithOutline(baseUrl, httpClient, entries, chain, sessionId);
     }
 
     static int PrintSummary(List<RecapEntry> entries, bool chain) {
@@ -158,6 +158,78 @@ static class RecapCommand {
         Console.Error.WriteLine("Use `kcap recap --full` for the complete transcript.");
 
         return 0;
+    }
+
+    static async Task<int> PrintSummaryWithOutline(
+            string baseUrl, HttpClient httpClient, List<RecapEntry> entries, bool chain, string sessionId
+        ) {
+        var summaries = entries.Where(e => e.Type is "whats_done" or "plan").ToList();
+
+        // Distinct session ids to render, in first-seen order. Non-chain: just the requested id.
+        var sessionIds = chain
+            ? entries.Select(e => e.SessionId).OfType<string>().Distinct().ToList()
+            : [sessionId];
+
+        var printedAnything = false;
+
+        foreach (var sid in sessionIds) {
+            if (chain) {
+                Console.Out.WriteLine($"# Session {sid}");
+                Console.Out.WriteLine();
+            }
+
+            // Summary section for this session (plan + whats_done), reusing the existing types.
+            foreach (var entry in summaries.Where(e => !chain || e.SessionId == sid)) {
+                switch (entry.Type) {
+                    case "plan":
+                        Console.Out.WriteLine("## Plan");
+                        Console.Out.WriteLine(entry.Content);
+                        Console.Out.WriteLine();
+                        printedAnything = true;
+
+                        break;
+                    case "whats_done":
+                        Console.Out.WriteLine("## Summary");
+                        Console.Out.WriteLine(entry.Content);
+                        Console.Out.WriteLine();
+                        printedAnything = true;
+
+                        break;
+                }
+            }
+
+            // Turn outline for this session.
+            var outline = await FetchTurnOutline(baseUrl, httpClient, sid);
+
+            if (outline.Length > 0) {
+                Console.Out.WriteLine(outline);
+                printedAnything = true;
+            }
+        }
+
+        if (!printedAnything) {
+            Console.Out.WriteLine("No summary or turns available yet. Use `kcap recap --full` to see the raw transcript.");
+
+            return 0;
+        }
+
+        Console.Out.WriteLine($"→ kcap recap --get-turn <N>{(chain ? " <sessionId>" : "")} for one turn's full detail");
+
+        return 0;
+    }
+
+    /// <summary>GETs /turns for one session and renders the outline block, or "" on any non-success.</summary>
+    static async Task<string> FetchTurnOutline(string baseUrl, HttpClient httpClient, string sessionId) {
+        try {
+            var resp = await httpClient.GetWithRetryAsync($"{baseUrl}/api/sessions/{sessionId}/turns");
+
+            if (!resp.IsSuccessStatusCode) return "";
+
+            return FormatTurnOutline(await resp.Content.ReadAsStringAsync());
+        } catch (HttpRequestException) {
+            // Outline is best-effort enrichment on top of the summary — never fail recap on it.
+            return "";
+        }
     }
 
     static int PrintFull(List<RecapEntry> entries, bool chain) {
@@ -321,19 +393,8 @@ static class RecapCommand {
                 ? $"(turn {turnIndex})"
                 : userPrompt.Length > 80 ? userPrompt[..80] + "…" : userPrompt;
 
-            var tools = "—";
-
-            if (turn.TryGetProperty("tools", out var toolsEl) && toolsEl.ValueKind == JsonValueKind.Array) {
-                var names = new List<string>();
-
-                foreach (var t in toolsEl.EnumerateArray()) {
-                    if (t.TryGetProperty("name", out var n) && n.GetString() is { Length: > 0 } nm) {
-                        names.Add(nm);
-                    }
-                }
-
-                if (names.Count > 0) tools = string.Join(", ", names.Distinct());
-            }
+            var toolNames = ExtractToolNames(turn);
+            var tools     = toolNames.Count > 0 ? string.Join(", ", toolNames) : "—";
 
             var files  = turn.TryGetProperty("files", out var f) && f.ValueKind == JsonValueKind.Array ? f.GetArrayLength() : 0;
             var tokens = turn.TryGetProperty("total_tokens", out var tk) ? tk.GetInt64() : 0;
@@ -487,4 +548,63 @@ static class RecapCommand {
 
     static string GetTraceString(JsonElement el, string prop) =>
         el.TryGetProperty(prop, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() ?? "" : "";
+
+    /// <summary>Distinct tool names for a turn JSON object, in first-seen order.</summary>
+    internal static List<string> ExtractToolNames(JsonElement turn) {
+        var names = new List<string>();
+
+        if (turn.TryGetProperty("tools", out var toolsEl) && toolsEl.ValueKind == JsonValueKind.Array) {
+            foreach (var t in toolsEl.EnumerateArray()) {
+                if (t.TryGetProperty("name", out var n) && n.GetString() is { Length: > 0 } nm && !names.Contains(nm)) {
+                    names.Add(nm);
+                }
+            }
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// Renders the `## Turns` outline block for a session: one line per turn, using the turn's
+    /// prose summary when present, otherwise a truncated user-prompt excerpt + tool/file metadata.
+    /// Returns "" for a missing/empty/non-array payload so the caller can skip the section.
+    /// </summary>
+    internal static string FormatTurnOutline(string turnsJson) {
+        using var doc = JsonDocument.Parse(turnsJson);
+
+        if (doc.RootElement.ValueKind != JsonValueKind.Array || doc.RootElement.GetArrayLength() == 0) {
+            return "";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("## Turns");
+
+        foreach (var turn in doc.RootElement.EnumerateArray()) {
+            sb.AppendLine(FormatOutlineLine(turn));
+        }
+
+        return sb.ToString();
+    }
+
+    static string FormatOutlineLine(JsonElement turn) {
+        var index = turn.TryGetProperty("turn_index", out var ti) ? ti.GetInt32() : -1;
+        var prose = turn.TryGetProperty("prose", out var p) && p.ValueKind == JsonValueKind.String ? p.GetString() : null;
+
+        if (!string.IsNullOrWhiteSpace(prose)) {
+            return $"{index,3}  {prose!.Trim()}";
+        }
+
+        var prompt  = turn.TryGetProperty("user_prompt", out var up) && up.ValueKind == JsonValueKind.String ? up.GetString() ?? "" : "";
+        var excerpt = prompt.Length == 0 ? "(no prompt)" : prompt.Length > 80 ? prompt[..80] + "…" : prompt;
+
+        var toolNames = ExtractToolNames(turn);
+        var fileCount = turn.TryGetProperty("files", out var f) && f.ValueKind == JsonValueKind.Array ? f.GetArrayLength() : 0;
+
+        var parts = new List<string>();
+        if (toolNames.Count > 0) parts.Add(string.Join(", ", toolNames));
+        if (fileCount > 0) parts.Add($"{fileCount} files");
+        var meta = parts.Count > 0 ? $"  [{string.Join(" · ", parts)}]" : "";
+
+        return $"{index,3}  {excerpt}{meta}";
+    }
 }

--- a/src/Capacitor.Cli/Commands/RecapCommand.cs
+++ b/src/Capacitor.Cli/Commands/RecapCommand.cs
@@ -183,7 +183,9 @@ static class RecapCommand {
     /// <summary>GETs /turns for one session and renders the outline block, or "" on any non-success.</summary>
     static async Task<string> FetchTurnOutline(string baseUrl, HttpClient httpClient, string sessionId) {
         try {
-            var resp = await httpClient.GetWithRetryAsync($"{baseUrl}/api/sessions/{sessionId}/turns");
+            // Escape the id — session ids can be free-form slugs; matches the MCP BuildTurnsUrl path.
+            using var resp = await httpClient.GetWithRetryAsync(
+                $"{baseUrl}/api/sessions/{Uri.EscapeDataString(sessionId)}/turns");
 
             if (!resp.IsSuccessStatusCode) return "";
 

--- a/src/Capacitor.Cli/Commands/RecapCommand.cs
+++ b/src/Capacitor.Cli/Commands/RecapCommand.cs
@@ -120,46 +120,6 @@ static class RecapCommand {
         return full ? PrintFull(entries, chain) : await PrintSummaryWithOutline(baseUrl, httpClient, entries, chain, sessionId);
     }
 
-    static int PrintSummary(List<RecapEntry> entries, bool chain) {
-        var summaries = entries.Where(e => e.Type is "whats_done" or "plan").ToList();
-
-        if (summaries.Count == 0) {
-            Console.Out.WriteLine("No summary available yet. Use `kcap recap --full` to see the raw transcript.");
-
-            return 0;
-        }
-
-        string? currentSessionId = null;
-
-        foreach (var entry in summaries) {
-            if (chain && entry.SessionId != currentSessionId) {
-                currentSessionId = entry.SessionId;
-                Console.Out.WriteLine($"# Session {currentSessionId}");
-                Console.Out.WriteLine();
-            }
-
-            switch (entry.Type) {
-                case "plan":
-                    Console.Out.WriteLine("## Plan");
-                    Console.Out.WriteLine(entry.Content);
-                    Console.Out.WriteLine();
-
-                    break;
-
-                case "whats_done":
-                    Console.Out.WriteLine("## Summary");
-                    Console.Out.WriteLine(entry.Content);
-                    Console.Out.WriteLine();
-
-                    break;
-            }
-        }
-
-        Console.Error.WriteLine("Use `kcap recap --full` for the complete transcript.");
-
-        return 0;
-    }
-
     static async Task<int> PrintSummaryWithOutline(
             string baseUrl, HttpClient httpClient, List<RecapEntry> entries, bool chain, string sessionId
         ) {
@@ -570,20 +530,31 @@ static class RecapCommand {
     /// Returns "" for a missing/empty/non-array payload so the caller can skip the section.
     /// </summary>
     internal static string FormatTurnOutline(string turnsJson) {
-        using var doc = JsonDocument.Parse(turnsJson);
+        JsonDocument doc;
 
-        if (doc.RootElement.ValueKind != JsonValueKind.Array || doc.RootElement.GetArrayLength() == 0) {
+        try {
+            doc = JsonDocument.Parse(turnsJson);
+        } catch (JsonException) {
+            // Empty/truncated body, or a non-JSON page (e.g. a proxy 200 with an HTML error).
+            // The outline is best-effort enrichment, so treat unparseable input as "nothing to show"
+            // — same contract as the empty/non-array case below — rather than crashing recap.
             return "";
         }
 
-        var sb = new StringBuilder();
-        sb.AppendLine("## Turns");
+        using (doc) {
+            if (doc.RootElement.ValueKind != JsonValueKind.Array || doc.RootElement.GetArrayLength() == 0) {
+                return "";
+            }
 
-        foreach (var turn in doc.RootElement.EnumerateArray()) {
-            sb.AppendLine(FormatOutlineLine(turn));
+            var sb = new StringBuilder();
+            sb.AppendLine("## Turns");
+
+            foreach (var turn in doc.RootElement.EnumerateArray()) {
+                sb.AppendLine(FormatOutlineLine(turn));
+            }
+
+            return sb.ToString();
         }
-
-        return sb.ToString();
     }
 
     static string FormatOutlineLine(JsonElement turn) {

--- a/test/Capacitor.Cli.Tests.Integration/McpSessionsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpSessionsServerTests.cs
@@ -195,20 +195,21 @@ public class McpSessionsServerTests : IDisposable {
     }
 
     [Test]
-    public async Task Tools_list_returns_four_tools_with_correct_names() {
+    public async Task Tools_list_returns_five_tools_with_correct_names() {
         using var proc = SpawnMcpServer();
         try {
             var response = await SendRequest(proc, ToolsListRequest(2));
 
             var tools = response["result"]?["tools"]?.AsArray();
             await Assert.That(tools).IsNotNull();
-            await Assert.That(tools!.Count).IsEqualTo(4);
+            await Assert.That(tools!.Count).IsEqualTo(5);
 
             var names = tools.Select(t => t?["name"]?.GetValue<string>()).ToHashSet();
             await Assert.That(names.Contains("search_sessions")).IsTrue();
             await Assert.That(names.Contains("get_session_summary")).IsTrue();
             await Assert.That(names.Contains("get_session_transcript")).IsTrue();
             await Assert.That(names.Contains("get_turn")).IsTrue();
+            await Assert.That(names.Contains("list_turns")).IsTrue();
         } finally {
             await ShutdownAsync(proc);
         }

--- a/test/Capacitor.Cli.Tests.Unit/McpSessionsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpSessionsServerTests.cs
@@ -260,6 +260,33 @@ public class McpSessionsServerTests {
         await Assert.That(ok).IsFalse();
     }
 
+    [Test]
+    public async Task BuildTurnsUrl_builds_session_turns_url() {
+        var url = McpSessionsServer.BuildTurnsUrl(
+            "http://srv",
+            new JsonObject { ["session_id"] = "abc-123" }
+        );
+
+        await Assert.That(url).IsEqualTo("http://srv/api/sessions/abc-123/turns");
+    }
+
+    [Test]
+    public async Task BuildTurnsUrl_escapes_session_id() {
+        var url = McpSessionsServer.BuildTurnsUrl(
+            "http://srv",
+            new JsonObject { ["session_id"] = "a/b c" }
+        );
+
+        await Assert.That(url).IsEqualTo("http://srv/api/sessions/a%2Fb%20c/turns");
+    }
+
+    [Test]
+    public async Task BuildTurnsUrl_throws_when_session_id_missing() {
+        var ex = Assert.Throws<ArgumentException>(() => McpSessionsServer.BuildTurnsUrl("http://srv", new JsonObject()));
+
+        await Assert.That(ex!.Message).Contains("session_id");
+    }
+
     // BuildTranscriptUrl is private; reach it via the public test entry point HandleToolCallForTests
     // would round-trip through HTTP, so instead we use reflection for narrow per-builder coverage.
     static string InvokeBuildTranscriptUrl(string baseUrl, JsonObject args) {

--- a/test/Capacitor.Cli.Tests.Unit/RecapOutlineTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RecapOutlineTests.cs
@@ -61,6 +61,35 @@ public class RecapOutlineTests {
     }
 
     [Test]
+    public async Task FormatTurnOutline_collapses_internal_newlines_to_single_line() {
+        // prose carries a real newline (the \n is a JSON escape, decoded to U+000A by the parser).
+        const string turns = """
+            [ {"turn_index":7,"user_prompt":"p","prose":"first line\nsecond line","tools":[],"files":[]} ]
+            """;
+
+        var outline = RecapCommand.FormatTurnOutline(turns);
+
+        // The turn must render on exactly one line: the internal newline is collapsed, not passed
+        // through as a wrapped, unindented second line that breaks the outline's alignment.
+        var turnLine = outline.Split('\n', StringSplitOptions.RemoveEmptyEntries).Single(l => l.Contains("first line"));
+
+        await Assert.That(turnLine).DoesNotContain("\n");
+        await Assert.That(turnLine).Contains("second line");
+        await Assert.That(turnLine.TrimStart()).StartsWith("7");
+    }
+
+    [Test]
+    public async Task FormatTurnOutline_returns_empty_when_turn_index_is_wrong_type() {
+        // Well-formed JSON array, but turn_index is a string — GetInt32() throws
+        // InvalidOperationException, which must degrade to "" rather than crash recap.
+        const string turns = """
+            [ {"turn_index":"0","user_prompt":"p","prose":"x","tools":[],"files":[]} ]
+            """;
+
+        await Assert.That(RecapCommand.FormatTurnOutline(turns)).IsEqualTo("");
+    }
+
+    [Test]
     public async Task ExtractToolNames_dedupes_and_preserves_order() {
         using var doc = System.Text.Json.JsonDocument.Parse(
             """{"tools":[{"name":"Edit"},{"name":"Bash"},{"name":"Edit"}]}""");

--- a/test/Capacitor.Cli.Tests.Unit/RecapOutlineTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RecapOutlineTests.cs
@@ -49,6 +49,16 @@ public class RecapOutlineTests {
     }
 
     [Test]
+    public async Task FormatTurnOutline_returns_empty_for_non_json_body() {
+        await Assert.That(RecapCommand.FormatTurnOutline("not json")).IsEqualTo("");
+    }
+
+    [Test]
+    public async Task FormatTurnOutline_returns_empty_for_empty_body() {
+        await Assert.That(RecapCommand.FormatTurnOutline("")).IsEqualTo("");
+    }
+
+    [Test]
     public async Task ExtractToolNames_dedupes_and_preserves_order() {
         using var doc = System.Text.Json.JsonDocument.Parse(
             """{"tools":[{"name":"Edit"},{"name":"Bash"},{"name":"Edit"}]}""");

--- a/test/Capacitor.Cli.Tests.Unit/RecapOutlineTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RecapOutlineTests.cs
@@ -114,4 +114,40 @@ public class RecapOutlineTests {
 
         await Assert.That(ids).IsEquivalentTo(new List<string> { "A", "B" }, CollectionOrdering.Matching);
     }
+
+    [Test]
+    public async Task OutlineSessionIds_uses_resolved_ids_from_entries_not_input() {
+        var now     = DateTimeOffset.UtcNow;
+        var entries = new List<RecapEntry> {
+            new("whats_done", "concrete-guid", null, null, "s", null, now),
+            new("user_prompt", "concrete-guid", null, null, "hi", null, now),
+        };
+
+        // Input is a slug; /recap resolved it to the concrete id, so the outline must target that id.
+        var ids = RecapCommand.OutlineSessionIds(entries, "meta-session-slug");
+
+        await Assert.That(ids).IsEquivalentTo(new List<string> { "concrete-guid" }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task OutlineSessionIds_falls_back_to_input_when_no_entries() {
+        var ids = RecapCommand.OutlineSessionIds([], "the-input-id");
+
+        await Assert.That(ids).IsEquivalentTo(new List<string> { "the-input-id" }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task DrillDownPointer_includes_concrete_id_for_single_session() {
+        var hint = RecapCommand.DrillDownPointer(new List<string> { "abc-123" });
+
+        await Assert.That(hint).Contains("--get-turn <N> abc-123");
+        await Assert.That(hint).DoesNotContain("<sessionId>");
+    }
+
+    [Test]
+    public async Task DrillDownPointer_uses_placeholder_for_multiple_sessions() {
+        var hint = RecapCommand.DrillDownPointer(new List<string> { "a", "b" });
+
+        await Assert.That(hint).Contains("<sessionId>");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/RecapOutlineTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RecapOutlineTests.cs
@@ -1,0 +1,60 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class RecapOutlineTests {
+    [Test]
+    public async Task FormatTurnOutline_uses_prose_line_when_present() {
+        const string turns = """
+            [ {"turn_index":0,"user_prompt":"add feature","prose":"Added the feature and tests.","tools":[{"name":"Edit"}],"files":[{"path":"a.cs"}]} ]
+            """;
+
+        var outline = RecapCommand.FormatTurnOutline(turns);
+
+        await Assert.That(outline).Contains("## Turns");
+        await Assert.That(outline).Contains("Added the feature and tests.");
+        await Assert.That(outline).Contains("0");
+    }
+
+    [Test]
+    public async Task FormatTurnOutline_falls_back_to_prompt_and_metadata_when_prose_absent() {
+        const string turns = """
+            [ {"turn_index":2,"user_prompt":"investigate the failing build and fix it","prose":null,"tools":[{"name":"Bash"},{"name":"Edit"}],"files":[{"path":"a.cs"},{"path":"b.cs"}]} ]
+            """;
+
+        var outline = RecapCommand.FormatTurnOutline(turns);
+
+        await Assert.That(outline).Contains("investigate the failing build");
+        await Assert.That(outline).Contains("Bash");
+        await Assert.That(outline).Contains("Edit");
+        await Assert.That(outline).Contains("2 files");
+    }
+
+    [Test]
+    public async Task FormatTurnOutline_truncates_long_prompt_in_fallback() {
+        var longPrompt = new string('x', 200);
+        var turns      = $$"""
+            [ {"turn_index":0,"user_prompt":"{{longPrompt}}","prose":null,"tools":[],"files":[]} ]
+            """;
+
+        var outline = RecapCommand.FormatTurnOutline(turns);
+
+        await Assert.That(outline).Contains("…");
+        await Assert.That(outline.Length).IsLessThan(200);
+    }
+
+    [Test]
+    public async Task FormatTurnOutline_returns_empty_for_empty_array() {
+        await Assert.That(RecapCommand.FormatTurnOutline("[]")).IsEqualTo("");
+    }
+
+    [Test]
+    public async Task ExtractToolNames_dedupes_and_preserves_order() {
+        using var doc = System.Text.Json.JsonDocument.Parse(
+            """{"tools":[{"name":"Edit"},{"name":"Bash"},{"name":"Edit"}]}""");
+
+        var names = RecapCommand.ExtractToolNames(doc.RootElement);
+
+        await Assert.That(names).IsEquivalentTo(new List<string> { "Edit", "Bash" });
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/RecapOutlineTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RecapOutlineTests.cs
@@ -1,4 +1,6 @@
 using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using TUnit.Assertions.Enums;
 
 namespace Capacitor.Cli.Tests.Unit;
 
@@ -65,6 +67,22 @@ public class RecapOutlineTests {
 
         var names = RecapCommand.ExtractToolNames(doc.RootElement);
 
-        await Assert.That(names).IsEquivalentTo(new List<string> { "Edit", "Bash" });
+        await Assert.That(names).IsEquivalentTo(new List<string> { "Edit", "Bash" }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task DistinctSessionIds_preserves_first_seen_order_and_drops_nulls() {
+        var now     = DateTimeOffset.UtcNow;
+        var entries = new List<RecapEntry> {
+            new("whats_done", "A", null, null, "sa", null, now),
+            new("plan",       "A", null, null, "pa", null, now),
+            new("whats_done", null, null, null, "orphan", null, now),
+            new("whats_done", "B", null, null, "sb", null, now),
+            new("plan",       "A", null, null, "pa2", null, now),
+        };
+
+        var ids = RecapCommand.DistinctSessionIds(entries);
+
+        await Assert.That(ids).IsEquivalentTo(new List<string> { "A", "B" }, CollectionOrdering.Matching);
     }
 }


### PR DESCRIPTION
Part of the **Turn-by-turn session recap** feature ([AI-1148](https://linear.app/kurrent/issue/AI-1148/turn-by-turn-session-recap)). CLI half.

## What

- **Default `kcap recap`** now returns the session summary (plan + whats_done) followed by a `## Turns` outline — one line per turn using the turn's prose summary, or a truncated user-prompt excerpt + tool/file metadata when prose is absent — ending with a `→ kcap recap --get-turn <N>` pointer. A session with turns but no summary still shows the outline.
- **`--chain`** renders each chained session's summary + its own turn outline.
- **Robustness:** a bad/empty/malformed `/turns` body (or one with a wrong-typed field) degrades to summary-only and never crashes recap; outline lines collapse internal whitespace so each turn stays on one line.
- **New `list_turns` MCP tool** in the kcap-sessions server — lists a session's turns with prose; agents pair it with the existing `get_turn` (by `turn_index`) and `get_session_summary`.
- `--full` / `--per-turn` / `--get-turn` / `--repo` unchanged.
- Recap skill doc + README updated.

## Tests

`RecapOutlineTests` (10) cover the prose line, prompt/metadata fallback, truncation, whitespace collapse, malformed/empty/wrong-typed bodies, and `DistinctSessionIds` ordering; `BuildTurnsUrl` unit tests + updated tools-list integration test. Full unit suite 2081/2081 green.

## Delivery notes

Depends on the companion `kurrent-io/kcap-server` PR (adds the `prose` field to `/turns`). New CLI degrades gracefully against an older server (prose absent → fallback lines). Bump the `src/cli` submodule in kcap-server after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
