### PR TITLE
Cursor: attribute sessions to their repo + nest subagents under the parent

### DIFF
--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -27,6 +27,14 @@ record TranscriptBatch {
     [JsonPropertyName("vendor")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Vendor { get; init; }
+
+    // When true, the server returns non-2xx if any line in the batch fails to normalize
+    // (HandleTranscript → 500 on batch.Strict && Failed>0), so a fail-closed importer aborts
+    // instead of proceeding over a partially-ingested transcript. Omitted on the wire when
+    // false so older servers keep deserialising unchanged.
+    [JsonPropertyName("strict")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool Strict { get; init; }
 }
 
 record ErrorEntry(

--- a/src/Capacitor.Cli/Commands/CursorHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CursorHookCommand.cs
@@ -111,6 +111,25 @@ public static class CursorHookCommand {
 
             if (sessionId is not null && DisabledSessions.IsDisabled(sessionId)) return 0;
 
+            // AI-1152: attach a `repository` node on sessionStart so the session groups
+            // under its repo in the sidebar. Cursor payloads carry `workspace_roots`
+            // rather than `cwd`, so the generic EnrichWithRepositoryInfo (which reads
+            // `cwd`) can't be used — detect from workspace_roots[0] instead. Bounded by
+            // the remaining dispatcher budget; fail-open (git detection is cached).
+            if (eventName == "sessionStart") {
+                var workspaceRoot = node["workspace_roots"] is JsonArray roots && roots.Count > 0
+                    ? roots[0]?.GetValue<string>()
+                    : null;
+                if (!string.IsNullOrEmpty(workspaceRoot)) {
+                    var remaining = budgetTotal - sw.Elapsed;
+                    if (remaining > TimeSpan.Zero) {
+                        node = JsonNode.Parse(
+                            await RepositoryDetection.EnrichWithRepositoryInfoFromCwd(node.ToJsonString(), workspaceRoot, remaining)
+                        ) ?? node;
+                    }
+                }
+            }
+
             var normalized = node.ToJsonString();
 
             if (sessionId is not null) {

--- a/src/Capacitor.Cli/Commands/CursorHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CursorHookCommand.cs
@@ -117,9 +117,12 @@ public static class CursorHookCommand {
             // `cwd`) can't be used — detect from workspace_roots[0] instead. Bounded by
             // the remaining dispatcher budget; fail-open (git detection is cached).
             if (eventName == "sessionStart") {
-                var workspaceRoot = node["workspace_roots"] is JsonArray roots && roots.Count > 0
-                    ? roots[0]?.GetValue<string>()
-                    : null;
+                // Safe extract: workspace_roots[0] may be absent or a non-string; GetValue<string>
+                // would throw and (via the outer catch) drop the whole sessionStart hook.
+                string? workspaceRoot = null;
+                if (node["workspace_roots"] is JsonArray roots && roots.Count > 0
+                 && roots[0] is JsonValue wv && wv.TryGetValue<string>(out var wr))
+                    workspaceRoot = wr;
                 if (!string.IsNullOrEmpty(workspaceRoot)) {
                     var remaining = budgetTotal - sw.Elapsed;
                     if (remaining > TimeSpan.Zero) {

--- a/src/Capacitor.Cli/Commands/CursorImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CursorImportSource.cs
@@ -196,6 +196,16 @@ internal sealed class CursorImportSource : IImportSource {
         var repoCache    = new Dictionary<string, string?>(StringComparer.Ordinal); // cwd → "owner/repo" or null
         var hasExcludes  = ctx.ExcludedRepos is { Count: > 0 };
 
+        // AI-1153: correlate subagent (child) sessions to their parent by prompt-hash across
+        // all discovered transcripts. A child is then ingested under the parent's
+        // AgentSubsession stream (subagent-start → transcript-with-agent_id → subagent-stop)
+        // rather than as a separate top-level session.
+        var subagentLinks = CursorSubagentCorrelator.Correlate(
+            sessions.Select(s => (
+                s.SessionId,
+                s.SourceMeta!.TryGetValue("TranscriptPath", out var tp) && tp is string p ? p : ""
+            )));
+
         foreach (var s in sessions) {
             var transcriptPath = (string)s.SourceMeta!["TranscriptPath"]!;
 
@@ -287,7 +297,12 @@ internal sealed class CursorImportSource : IImportSource {
                 ExcludedRepoKey = excludedRepoKey,
                 ExcludedPathKey = excludedPathKey,
                 TotalLines      = nonBlankCount,
-                SourceMeta      = s.SourceMeta,
+                SourceMeta      = subagentLinks.TryGetValue(s.SessionId, out var link)
+                    ? new Dictionary<string, object?>(s.SourceMeta!) {
+                        ["ParentSessionId"] = link.ParentSessionId,
+                        ["SubagentType"]    = link.SubagentType,
+                    }
+                    : s.SourceMeta,
             });
         }
 
@@ -299,6 +314,13 @@ internal sealed class CursorImportSource : IImportSource {
             ImportContext                       ctx,
             CancellationToken                   ct
         ) {
+        // AI-1153: a correlated subagent child is ingested under its parent's
+        // AgentSubsession stream instead of as a standalone top-level session.
+        if (classification.SourceMeta!.TryGetValue("ParentSessionId", out var parentObj)
+         && parentObj is string parentSessionId && !string.IsNullOrEmpty(parentSessionId)) {
+            return await ImportSubagentAsync(classification, parentSessionId, ctx, ct);
+        }
+
         var transcriptPath = (string)classification.SourceMeta!["TranscriptPath"]!;
 
         if (!File.Exists(transcriptPath)) return ImportOutcome.Failed;
@@ -309,6 +331,20 @@ internal sealed class CursorImportSource : IImportSource {
 
         var (createdUtc, modifiedUtc) = TryGetTranscriptTimes(transcriptPath);
 
+        // AI-1152: detect the repo from the workspace folder so the synthetic
+        // sessionStart carries a `repository` node → server emits RepositoryDetected
+        // and the (historical/backfilled) session groups under its repo. Fail-open:
+        // a non-git workspace or detection error leaves it null and unattributed.
+        JsonObject? repositoryNode = null;
+        if (workspaceFolder is not null) {
+            try {
+                var repo = await _repoDetector(workspaceFolder);
+                if (repo is not null) repositoryNode = RepositoryDetection.BuildRepositoryNode(repo);
+            } catch {
+                repositoryNode = null;
+            }
+        }
+
         // sessionStart MUST succeed before transcript advances the server
         // watermark — otherwise a transient lifecycle failure plus a successful
         // transcript would leave the session permanently lifecycle-less
@@ -318,7 +354,7 @@ internal sealed class CursorImportSource : IImportSource {
         // (canonical event ids are deterministic — AI-731).
         var startOk = await PostSyntheticHookAsync(
             ctx.HttpClient, ctx.BaseUrl, "session-start/cursor",
-            BuildSessionStartPayload(classification.SessionId, workspaceFolder, transcriptPath, createdUtc),
+            BuildSessionStartPayload(classification.SessionId, workspaceFolder, transcriptPath, createdUtc, repositoryNode),
             ct);
         if (!startOk) return ImportOutcome.Failed;
 
@@ -363,8 +399,67 @@ internal sealed class CursorImportSource : IImportSource {
         return startLine > 0 ? ImportOutcome.Resumed : ImportOutcome.Loaded;
     }
 
-    static JsonObject BuildSessionStartPayload(
-        string sessionId, string? workspaceFolder, string transcriptPath, DateTimeOffset? startedAt
+    /// <summary>
+    /// AI-1153: ingest a Cursor subagent child under its parent's <c>AgentSubsession</c>
+    /// stream. Mirrors <c>SessionImporter.SendAgentLifecycle</c>: <c>subagent-start</c>
+    /// (session_id=parent, agent_id=child) → transcript batches routed with
+    /// <c>agent_id</c>=child → <c>subagent-stop</c>. No standalone session-start/-end is
+    /// emitted for the child, so it never becomes a top-level session card. Sends from
+    /// line 0 — idempotent via deterministic ids + server dedup.
+    /// </summary>
+    async Task<ImportOutcome> ImportSubagentAsync(
+            ImportCommand.SessionClassification classification,
+            string                              parentSessionId,
+            ImportContext                       ctx,
+            CancellationToken                   ct
+        ) {
+        var transcriptPath = (string)classification.SourceMeta!["TranscriptPath"]!;
+        if (!File.Exists(transcriptPath)) return ImportOutcome.Failed;
+
+        var agentId      = classification.SessionId; // the child session id doubles as the subagent id
+        var subagentType = classification.SourceMeta.TryGetValue("SubagentType", out var stObj)
+                        && stObj is string st && !string.IsNullOrEmpty(st)
+            ? st
+            : "task";
+
+        // subagent-start on the parent stream (creates AgentSubsession-{parent}-{child}).
+        var startOk = await PostSyntheticHookAsync(ctx.HttpClient, ctx.BaseUrl, "subagent-start", new JsonObject {
+            ["hook_event_name"] = "subagent_start",
+            ["session_id"]      = parentSessionId,
+            ["agent_id"]        = agentId,
+            ["agent_type"]      = subagentType,
+            ["transcript_path"] = transcriptPath,
+        }, ct);
+        if (!startOk) return ImportOutcome.Failed;
+
+        int sent;
+        try {
+            sent = await SessionImporter.SendTranscriptBatches(
+                httpClient: ctx.HttpClient,
+                baseUrl:    ctx.BaseUrl,
+                sessionId:  parentSessionId,
+                filePath:   transcriptPath,
+                agentId:    agentId,
+                startLine:  0,
+                vendor:     Vendor);
+        } catch {
+            return ImportOutcome.Failed;
+        }
+
+        var stopOk = await PostSyntheticHookAsync(ctx.HttpClient, ctx.BaseUrl, "subagent-stop", new JsonObject {
+            ["hook_event_name"] = "subagent_stop",
+            ["session_id"]      = parentSessionId,
+            ["agent_id"]        = agentId,
+            ["agent_type"]      = subagentType,
+        }, ct);
+        if (!stopOk) return ImportOutcome.Failed;
+
+        return sent > 0 ? ImportOutcome.Loaded : ImportOutcome.Skipped;
+    }
+
+    internal static JsonObject BuildSessionStartPayload(
+        string sessionId, string? workspaceFolder, string transcriptPath, DateTimeOffset? startedAt,
+        JsonObject? repository = null
     ) {
         var payload = new JsonObject {
             ["hook_event_name"]     = "sessionStart",
@@ -374,6 +469,11 @@ internal sealed class CursorImportSource : IImportSource {
         };
         if (workspaceFolder is not null) {
             payload["workspace_roots"] = new JsonArray(workspaceFolder);
+        }
+        // AI-1152: git-detected repo (owner/repo/branch/...) so the server emits
+        // RepositoryDetected for historical/backfilled Cursor sessions.
+        if (repository is not null) {
+            payload["repository"] = repository;
         }
         // AI-739: server prefers started_at over UtcNow when present, so
         // historical sessions surface with their real start time. Use an

--- a/src/Capacitor.Cli/Commands/CursorImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CursorImportSource.cs
@@ -197,14 +197,25 @@ internal sealed class CursorImportSource : IImportSource {
         var hasExcludes  = ctx.ExcludedRepos is { Count: > 0 };
 
         // AI-1153: correlate subagent (child) sessions to their parent by prompt-hash across
-        // all discovered transcripts. A child is then ingested under the parent's
-        // AgentSubsession stream (subagent-start → transcript-with-agent_id → subagent-stop)
-        // rather than as a separate top-level session.
-        var subagentLinks = CursorSubagentCorrelator.Correlate(
-            sessions.Select(s => (
-                s.SessionId,
-                s.SourceMeta!.TryGetValue("TranscriptPath", out var tp) && tp is string p ? p : ""
-            )));
+        // all discovered transcripts. A child is ingested under the parent's AgentSubsession
+        // stream *by the parent's own import* (subagent-start → transcript-with-agent_id →
+        // subagent-stop, before the parent's session-end) rather than as a separate top-level
+        // session. Doing it inside the parent import guarantees the parent's SessionEnded stays
+        // the last event on its stream — a subagent-start posted after a parallel parent's
+        // session-end would reactivate the ended parent (SubagentStarted is a reactivation event).
+        var pathBySession = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var s in sessions)
+            pathBySession[s.SessionId] = s.SourceMeta!.TryGetValue("TranscriptPath", out var tp) && tp is string p ? p : "";
+
+        var subagentLinks    = CursorSubagentCorrelator.Correlate(pathBySession.Select(kv => (kv.Key, kv.Value)));
+        var childrenByParent = new Dictionary<string, List<CursorSubagentChild>>(StringComparer.Ordinal);
+        foreach (var (childId, lnk) in subagentLinks) {
+            if (!childrenByParent.TryGetValue(lnk.ParentSessionId, out var kids)) {
+                kids = [];
+                childrenByParent[lnk.ParentSessionId] = kids;
+            }
+            kids.Add(new CursorSubagentChild(childId, pathBySession.GetValueOrDefault(childId, ""), lnk.SubagentType));
+        }
 
         foreach (var s in sessions) {
             var transcriptPath = (string)s.SourceMeta!["TranscriptPath"]!;
@@ -297,12 +308,7 @@ internal sealed class CursorImportSource : IImportSource {
                 ExcludedRepoKey = excludedRepoKey,
                 ExcludedPathKey = excludedPathKey,
                 TotalLines      = nonBlankCount,
-                SourceMeta      = subagentLinks.TryGetValue(s.SessionId, out var link)
-                    ? new Dictionary<string, object?>(s.SourceMeta!) {
-                        ["ParentSessionId"] = link.ParentSessionId,
-                        ["SubagentType"]    = link.SubagentType,
-                    }
-                    : s.SourceMeta,
+                SourceMeta      = StampSubagentMeta(s.SourceMeta!, s.SessionId, subagentLinks, childrenByParent),
             });
         }
 
@@ -314,11 +320,10 @@ internal sealed class CursorImportSource : IImportSource {
             ImportContext                       ctx,
             CancellationToken                   ct
         ) {
-        // AI-1153: a correlated subagent child is ingested under its parent's
-        // AgentSubsession stream instead of as a standalone top-level session.
-        if (classification.SourceMeta!.TryGetValue("ParentSessionId", out var parentObj)
-         && parentObj is string parentSessionId && !string.IsNullOrEmpty(parentSessionId)) {
-            return await ImportSubagentAsync(classification, parentSessionId, ctx, ct);
+        // AI-1153: a correlated subagent child is imported by its parent (below), under the
+        // parent's AgentSubsession stream — never as a standalone top-level session.
+        if (classification.SourceMeta!.TryGetValue("IsSubagentChild", out var scObj) && scObj is true) {
+            return ImportOutcome.Skipped;
         }
 
         var transcriptPath = (string)classification.SourceMeta!["TranscriptPath"]!;
@@ -383,6 +388,19 @@ internal sealed class CursorImportSource : IImportSource {
             return ImportOutcome.Failed;
         }
 
+        // AI-1153: import this parent's subagent children BEFORE its session-end, so the
+        // parent's SessionEnded remains the last event on its stream. A subagent-start
+        // (reactivation event) appended after the parent's SessionEnded would flip the
+        // ended parent back to Active. Hard-fail on child failure (same contract as the
+        // parent lifecycle) so a re-run — idempotent via deterministic ids — repairs it.
+        if (classification.SourceMeta!.TryGetValue("SubagentChildren", out var kidsObj)
+         && kidsObj is List<CursorSubagentChild> children) {
+            foreach (var child in children) {
+                if (!await SendSubagentLifecycleAsync(classification.SessionId, child, ctx, ct))
+                    return ImportOutcome.Failed;
+            }
+        }
+
         // sessionEnd: same hard-fail contract — if it can't be appended, the
         // session would otherwise look perpetually "active" in the read-model.
         var durationMs = createdUtc is { } c && modifiedUtc is { } m && m >= c
@@ -399,28 +417,52 @@ internal sealed class CursorImportSource : IImportSource {
         return startLine > 0 ? ImportOutcome.Resumed : ImportOutcome.Loaded;
     }
 
-    /// <summary>
-    /// AI-1153: ingest a Cursor subagent child under its parent's <c>AgentSubsession</c>
-    /// stream. Mirrors <c>SessionImporter.SendAgentLifecycle</c>: <c>subagent-start</c>
-    /// (session_id=parent, agent_id=child) → transcript batches routed with
-    /// <c>agent_id</c>=child → <c>subagent-stop</c>. No standalone session-start/-end is
-    /// emitted for the child, so it never becomes a top-level session card. Sends from
-    /// line 0 — idempotent via deterministic ids + server dedup.
-    /// </summary>
-    async Task<ImportOutcome> ImportSubagentAsync(
-            ImportCommand.SessionClassification classification,
-            string                              parentSessionId,
-            ImportContext                       ctx,
-            CancellationToken                   ct
-        ) {
-        var transcriptPath = (string)classification.SourceMeta!["TranscriptPath"]!;
-        if (!File.Exists(transcriptPath)) return ImportOutcome.Failed;
+    /// <summary>A Cursor subagent child correlated to a parent: its own session id (used as the
+    /// AgentSubsession agent id), its transcript path, and the parent's declared subagent_type.</summary>
+    internal sealed record CursorSubagentChild(string SessionId, string TranscriptPath, string? SubagentType);
 
-        var agentId      = classification.SessionId; // the child session id doubles as the subagent id
-        var subagentType = classification.SourceMeta.TryGetValue("SubagentType", out var stObj)
-                        && stObj is string st && !string.IsNullOrEmpty(st)
-            ? st
-            : "task";
+    /// <summary>
+    /// Stamps subagent correlation onto a session's SourceMeta (SourceMeta is read-only, so a
+    /// child/parent gets a fresh copy). Children carry <c>IsSubagentChild</c> so their own
+    /// import no-ops; parents carry <c>SubagentChildren</c> so they import them inline.
+    /// </summary>
+    static IReadOnlyDictionary<string, object?> StampSubagentMeta(
+        IReadOnlyDictionary<string, object?>                       src,
+        string                                                     sessionId,
+        Dictionary<string, CursorSubagentCorrelator.SubagentLink>  links,
+        Dictionary<string, List<CursorSubagentChild>>              childrenByParent
+    ) {
+        var isChild = links.ContainsKey(sessionId);
+        var hasKids = childrenByParent.TryGetValue(sessionId, out var kids);
+        if (!isChild && !hasKids) return src;
+
+        var d = new Dictionary<string, object?>(src);
+        if (isChild) d["IsSubagentChild"]  = true;
+        if (hasKids) d["SubagentChildren"] = kids;
+        return d;
+    }
+
+    /// <summary>
+    /// AI-1153: ingest one Cursor subagent child under its parent's <c>AgentSubsession</c>
+    /// stream. Mirrors <c>SessionImporter.SendAgentLifecycle</c>: <c>subagent-start</c>
+    /// (session_id=parent, agent_id=child) → transcript batches routed with <c>agent_id</c>=child
+    /// (resumed from the subsession watermark so re-imports don't repost the whole child) →
+    /// <c>subagent-stop</c>. Called from the parent's <see cref="ImportSessionAsync"/> BEFORE the
+    /// parent's session-end. Returns false on a hard failure (start/transcript/stop POST failed);
+    /// a missing child transcript is skipped non-fatally. No standalone session lifecycle is
+    /// emitted for the child, so it never becomes a top-level session card.
+    /// </summary>
+    async Task<bool> SendSubagentLifecycleAsync(
+            string            parentSessionId,
+            CursorSubagentChild child,
+            ImportContext     ctx,
+            CancellationToken ct
+        ) {
+        if (string.IsNullOrEmpty(child.TranscriptPath) || !File.Exists(child.TranscriptPath))
+            return true; // missing child transcript — skip, non-fatal
+
+        var agentId      = child.SessionId; // the child session id doubles as the subagent id
+        var subagentType = string.IsNullOrEmpty(child.SubagentType) ? "task" : child.SubagentType!;
 
         // subagent-start on the parent stream (creates AgentSubsession-{parent}-{child}).
         var startOk = await PostSyntheticHookAsync(ctx.HttpClient, ctx.BaseUrl, "subagent-start", new JsonObject {
@@ -428,33 +470,39 @@ internal sealed class CursorImportSource : IImportSource {
             ["session_id"]      = parentSessionId,
             ["agent_id"]        = agentId,
             ["agent_type"]      = subagentType,
-            ["transcript_path"] = transcriptPath,
+            ["transcript_path"] = child.TranscriptPath,
         }, ct);
-        if (!startOk) return ImportOutcome.Failed;
+        if (!startOk) return false;
 
-        int sent;
+        // Resume from the subsession watermark (AgentSubsession-{parent}-{child}) so a re-import
+        // doesn't repost the full child transcript every time. Fail-open to a full send.
+        var startLine = 0;
         try {
-            sent = await SessionImporter.SendTranscriptBatches(
+            if (await FetchServerLastLineAsync(ctx.HttpClient, ctx.BaseUrl, parentSessionId, ct, agentId) is { } last)
+                startLine = last + 1;
+        } catch {
+            startLine = 0;
+        }
+
+        try {
+            await SessionImporter.SendTranscriptBatches(
                 httpClient: ctx.HttpClient,
                 baseUrl:    ctx.BaseUrl,
                 sessionId:  parentSessionId,
-                filePath:   transcriptPath,
+                filePath:   child.TranscriptPath,
                 agentId:    agentId,
-                startLine:  0,
+                startLine:  startLine,
                 vendor:     Vendor);
         } catch {
-            return ImportOutcome.Failed;
+            return false;
         }
 
-        var stopOk = await PostSyntheticHookAsync(ctx.HttpClient, ctx.BaseUrl, "subagent-stop", new JsonObject {
+        return await PostSyntheticHookAsync(ctx.HttpClient, ctx.BaseUrl, "subagent-stop", new JsonObject {
             ["hook_event_name"] = "subagent_stop",
             ["session_id"]      = parentSessionId,
             ["agent_id"]        = agentId,
             ["agent_type"]      = subagentType,
         }, ct);
-        if (!stopOk) return ImportOutcome.Failed;
-
-        return sent > 0 ? ImportOutcome.Loaded : ImportOutcome.Skipped;
     }
 
     internal static JsonObject BuildSessionStartPayload(
@@ -569,8 +617,12 @@ internal sealed class CursorImportSource : IImportSource {
         return (lastIdx, count);
     }
 
-    static async Task<int?> FetchServerLastLineAsync(HttpClient http, string baseUrl, string sessionId, CancellationToken ct) {
-        using var resp = await http.GetWithRetryAsync($"{baseUrl}/api/sessions/{sessionId}/last-line", ct: ct);
+    static async Task<int?> FetchServerLastLineAsync(HttpClient http, string baseUrl, string sessionId, CancellationToken ct, string? agentId = null) {
+        // agentId set → probe the AgentSubsession-{sessionId}-{agentId} watermark (AI-1153).
+        var url = string.IsNullOrEmpty(agentId)
+            ? $"{baseUrl}/api/sessions/{sessionId}/last-line"
+            : $"{baseUrl}/api/sessions/{sessionId}/last-line?agentId={Uri.EscapeDataString(agentId)}";
+        using var resp = await http.GetWithRetryAsync(url, ct: ct);
 
         if (resp.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.NoContent) return null;
         if (!resp.IsSuccessStatusCode) throw new HttpRequestException($"watermark probe returned {(int)resp.StatusCode}");

--- a/src/Capacitor.Cli/Commands/CursorImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CursorImportSource.cs
@@ -485,23 +485,32 @@ internal sealed class CursorImportSource : IImportSource {
         }
 
         try {
+            // failOnError: fail-closed like the parent lifecycle — a rejected/failed child
+            // transcript POST must abort so the parent import fails and a re-run repairs it,
+            // rather than leaving an empty completed subagent while reporting success.
             await SessionImporter.SendTranscriptBatches(
-                httpClient: ctx.HttpClient,
-                baseUrl:    ctx.BaseUrl,
-                sessionId:  parentSessionId,
-                filePath:   child.TranscriptPath,
-                agentId:    agentId,
-                startLine:  startLine,
-                vendor:     Vendor);
+                httpClient:  ctx.HttpClient,
+                baseUrl:     ctx.BaseUrl,
+                sessionId:   parentSessionId,
+                filePath:    child.TranscriptPath,
+                agentId:     agentId,
+                startLine:   startLine,
+                vendor:      Vendor,
+                failOnError: true);
         } catch {
             return false;
         }
 
+        // Full SubagentStopHook shape (mirrors the Gemini/OpenCode builders) — the server
+        // binds all fields, so an incomplete body can be rejected before HandleSubagentStop.
         return await PostSyntheticHookAsync(ctx.HttpClient, ctx.BaseUrl, "subagent-stop", new JsonObject {
-            ["hook_event_name"] = "subagent_stop",
-            ["session_id"]      = parentSessionId,
-            ["agent_id"]        = agentId,
-            ["agent_type"]      = subagentType,
+            ["hook_event_name"]        = "subagent_stop",
+            ["session_id"]             = parentSessionId,
+            ["agent_id"]               = agentId,
+            ["agent_type"]             = subagentType,
+            ["stop_hook_active"]       = false,
+            ["agent_transcript_path"]  = child.TranscriptPath,
+            ["last_assistant_message"] = "",
         }, ct);
     }
 

--- a/src/Capacitor.Cli/Commands/CursorImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CursorImportSource.cs
@@ -470,8 +470,9 @@ internal sealed class CursorImportSource : IImportSource {
             ["session_id"]      = parentSessionId,
             ["agent_id"]        = agentId,
             ["agent_type"]      = subagentType,
-            ["transcript_path"] = child.TranscriptPath,
-            ["cwd"]             = "", // wire-shape parity with SendAgentLifecycle / other vendors
+            ["transcript_path"] = child.TranscriptPath, // required by HookBase
+            ["cwd"]             = "",                    // required by HookBase
+            ["strict"]          = true,                  // fail-closed: 500 if SubagentStarted isn't persisted
         }, ct);
         if (!startOk) return false;
 
@@ -509,11 +510,12 @@ internal sealed class CursorImportSource : IImportSource {
             ["session_id"]             = parentSessionId,
             ["agent_id"]               = agentId,
             ["agent_type"]             = subagentType,
-            ["transcript_path"]        = child.TranscriptPath,
-            ["cwd"]                    = "", // wire-shape parity with SendAgentLifecycle / other vendors
+            ["transcript_path"]        = child.TranscriptPath, // required by HookBase
+            ["cwd"]                    = "",                   // required by HookBase
             ["stop_hook_active"]       = false,
             ["agent_transcript_path"]  = child.TranscriptPath,
             ["last_assistant_message"] = "",
+            ["strict"]                 = true,                 // fail-closed: 500 if SubagentCompleted isn't persisted
         }, ct);
     }
 

--- a/src/Capacitor.Cli/Commands/CursorImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CursorImportSource.cs
@@ -471,6 +471,7 @@ internal sealed class CursorImportSource : IImportSource {
             ["agent_id"]        = agentId,
             ["agent_type"]      = subagentType,
             ["transcript_path"] = child.TranscriptPath,
+            ["cwd"]             = "", // wire-shape parity with SendAgentLifecycle / other vendors
         }, ct);
         if (!startOk) return false;
 
@@ -508,6 +509,8 @@ internal sealed class CursorImportSource : IImportSource {
             ["session_id"]             = parentSessionId,
             ["agent_id"]               = agentId,
             ["agent_type"]             = subagentType,
+            ["transcript_path"]        = child.TranscriptPath,
+            ["cwd"]                    = "", // wire-shape parity with SendAgentLifecycle / other vendors
             ["stop_hook_active"]       = false,
             ["agent_transcript_path"]  = child.TranscriptPath,
             ["last_assistant_message"] = "",

--- a/src/Capacitor.Cli/Commands/CursorSubagentCorrelator.cs
+++ b/src/Capacitor.Cli/Commands/CursorSubagentCorrelator.cs
@@ -33,10 +33,9 @@ public static class CursorSubagentCorrelator {
     ) {
         var scanned = new List<(string Sid, string? FirstUserHash, List<(string Hash, string? SubType)> Tasks)>();
 
-        // Order by session id so "first writer wins" (below) is deterministic — the caller
-        // feeds us filesystem-discovery order, which is not stable across runs; without a
-        // stable tie-break, a duplicate Task prompt could route the same child under a
-        // different parent on re-run and defeat idempotency.
+        // Deterministic iteration order — the caller feeds filesystem-discovery order, which
+        // isn't stable across runs. (Cross-parent prompt collisions are handled explicitly as
+        // "ambiguous" below rather than by picking a first writer.)
         foreach (var (sid, path) in sessions.OrderBy(s => s.SessionId, StringComparer.Ordinal)) {
             if (string.IsNullOrEmpty(path) || !File.Exists(path)) continue;
             try {
@@ -48,16 +47,25 @@ public static class CursorSubagentCorrelator {
             }
         }
 
-        // promptHash → (parentSessionId, subagentType). First writer wins on the (rare)
-        // case of two parents Tasking an identical prompt.
+        // promptHash → parent. If the SAME prompt is Tasked by two DISTINCT parents the linkage
+        // is genuinely ambiguous (the data can't tell which parent owns a matching child), so we
+        // record the collision and drop the link rather than misattribute the child to a guessed
+        // parent. A single parent Tasking the same prompt more than once is NOT ambiguous.
         var parentByPrompt = new Dictionary<string, (string Parent, string? SubType)>(StringComparer.Ordinal);
+        var ambiguous      = new HashSet<string>(StringComparer.Ordinal);
         foreach (var s in scanned)
-            foreach (var (hash, subType) in s.Tasks)
-                parentByPrompt.TryAdd(hash, (s.Sid, subType));
+            foreach (var (hash, subType) in s.Tasks) {
+                if (parentByPrompt.TryGetValue(hash, out var existing)) {
+                    if (!string.Equals(existing.Parent, s.Sid, StringComparison.Ordinal))
+                        ambiguous.Add(hash);
+                } else {
+                    parentByPrompt[hash] = (s.Sid, subType);
+                }
+            }
 
         var links = new Dictionary<string, SubagentLink>(StringComparer.Ordinal);
         foreach (var s in scanned) {
-            if (s.FirstUserHash is null) continue;
+            if (s.FirstUserHash is null || ambiguous.Contains(s.FirstUserHash)) continue;
             if (parentByPrompt.TryGetValue(s.FirstUserHash, out var p)
              && !string.Equals(p.Parent, s.Sid, StringComparison.Ordinal)) {
                 links[s.Sid] = new SubagentLink(p.Parent, p.SubType);

--- a/src/Capacitor.Cli/Commands/CursorSubagentCorrelator.cs
+++ b/src/Capacitor.Cli/Commands/CursorSubagentCorrelator.cs
@@ -33,9 +33,19 @@ public static class CursorSubagentCorrelator {
     ) {
         var scanned = new List<(string Sid, string? FirstUserHash, List<(string Hash, string? SubType)> Tasks)>();
 
-        foreach (var (sid, path) in sessions) {
+        // Order by session id so "first writer wins" (below) is deterministic — the caller
+        // feeds us filesystem-discovery order, which is not stable across runs; without a
+        // stable tie-break, a duplicate Task prompt could route the same child under a
+        // different parent on re-run and defeat idempotency.
+        foreach (var (sid, path) in sessions.OrderBy(s => s.SessionId, StringComparer.Ordinal)) {
             if (string.IsNullOrEmpty(path) || !File.Exists(path)) continue;
-            scanned.Add((sid, ScanFirstUserHash(path, out var tasks), tasks));
+            try {
+                var firstHash = ScanFirstUserHash(path, out var tasks);
+                scanned.Add((sid, firstHash, tasks));
+            } catch {
+                // A single unreadable/locked transcript must not abort correlation (which would
+                // abort ClassifyAsync for the whole import) — skip it and correlate the rest.
+            }
         }
 
         // promptHash → (parentSessionId, subagentType). First writer wins on the (rare)

--- a/src/Capacitor.Cli/Commands/CursorSubagentCorrelator.cs
+++ b/src/Capacitor.Cli/Commands/CursorSubagentCorrelator.cs
@@ -1,0 +1,122 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// Correlates Cursor subagent sessions to their parent (AI-1153).
+///
+/// Cursor runs a subagent (a <c>Task</c>/<c>Agent</c> tool call) as its OWN
+/// top-level session with its own transcript — and provides NO explicit
+/// parent→child id anywhere in the transcript. The only reliable in-data link
+/// is that the child session's first <c>user_query</c> (minus Cursor's
+/// <c>&lt;user_query&gt;…&lt;/user_query&gt;</c> wrapper) is byte-identical to the
+/// parent's <c>Task</c>/<c>Agent</c> tool_use <c>input.prompt</c>.
+///
+/// This recovers that link (keyed by a SHA-256 of the trimmed prompt) so the
+/// importer can ingest the child under the parent's <c>AgentSubsession</c> stream
+/// (via <c>/hooks/subagent-start</c> + transcript-with-agent_id) instead of as a
+/// separate top-level session. Pure over the on-disk transcripts — no server or
+/// read-model state.
+/// </summary>
+public static class CursorSubagentCorrelator {
+    public readonly record struct SubagentLink(string ParentSessionId, string? SubagentType);
+
+    /// <summary>
+    /// Returns a map of <c>childSessionId → (parentSessionId, subagentType)</c> for every
+    /// discovered session whose first user prompt matches another session's Task prompt.
+    /// Sessions with no match are absent from the map. A session is never linked to itself.
+    /// </summary>
+    public static Dictionary<string, SubagentLink> Correlate(
+        IEnumerable<(string SessionId, string TranscriptPath)> sessions
+    ) {
+        var scanned = new List<(string Sid, string? FirstUserHash, List<(string Hash, string? SubType)> Tasks)>();
+
+        foreach (var (sid, path) in sessions) {
+            if (string.IsNullOrEmpty(path) || !File.Exists(path)) continue;
+            scanned.Add((sid, ScanFirstUserHash(path, out var tasks), tasks));
+        }
+
+        // promptHash → (parentSessionId, subagentType). First writer wins on the (rare)
+        // case of two parents Tasking an identical prompt.
+        var parentByPrompt = new Dictionary<string, (string Parent, string? SubType)>(StringComparer.Ordinal);
+        foreach (var s in scanned)
+            foreach (var (hash, subType) in s.Tasks)
+                parentByPrompt.TryAdd(hash, (s.Sid, subType));
+
+        var links = new Dictionary<string, SubagentLink>(StringComparer.Ordinal);
+        foreach (var s in scanned) {
+            if (s.FirstUserHash is null) continue;
+            if (parentByPrompt.TryGetValue(s.FirstUserHash, out var p)
+             && !string.Equals(p.Parent, s.Sid, StringComparison.Ordinal)) {
+                links[s.Sid] = new SubagentLink(p.Parent, p.SubType);
+            }
+        }
+
+        return links;
+    }
+
+    /// <summary>
+    /// Scans one transcript: returns the hash of its first user prompt (wrapper-stripped)
+    /// and collects the hashes of every <c>Task</c>/<c>Agent</c> tool_use prompt it issues.
+    /// </summary>
+    static string? ScanFirstUserHash(string path, out List<(string Hash, string? SubType)> tasks) {
+        tasks = [];
+        string? firstUserHash = null;
+
+        foreach (var line in File.ReadLines(path)) {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            JsonDocument doc;
+            try { doc = JsonDocument.Parse(line); } catch { continue; }
+
+            using (doc) {
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object) continue;
+                if (!root.TryGetProperty("role", out var roleEl)) continue;
+                var role = roleEl.GetString();
+                if (!root.TryGetProperty("message", out var msg)
+                 || !msg.TryGetProperty("content", out var content)
+                 || content.ValueKind != JsonValueKind.Array) continue;
+
+                if (role == "user" && firstUserHash is null) {
+                    foreach (var b in content.EnumerateArray()) {
+                        if (b.ValueKind == JsonValueKind.Object
+                         && b.TryGetProperty("type", out var ty) && ty.GetString() == "text"
+                         && b.TryGetProperty("text", out var tx) && tx.ValueKind == JsonValueKind.String) {
+                            firstUserHash = Hash(StripUserQueryWrapper(tx.GetString() ?? ""));
+                            break;
+                        }
+                    }
+                } else if (role == "assistant") {
+                    foreach (var b in content.EnumerateArray()) {
+                        if (b.ValueKind != JsonValueKind.Object) continue;
+                        if (!b.TryGetProperty("type", out var ty) || ty.GetString() != "tool_use") continue;
+                        var name = b.TryGetProperty("name", out var n) ? n.GetString() : null;
+                        if (name is not ("Task" or "Agent")) continue;
+                        if (!b.TryGetProperty("input", out var inp) || inp.ValueKind != JsonValueKind.Object) continue;
+                        if (!inp.TryGetProperty("prompt", out var pr) || pr.ValueKind != JsonValueKind.String) continue;
+                        var prompt = pr.GetString();
+                        if (string.IsNullOrWhiteSpace(prompt)) continue;
+                        var subType = inp.TryGetProperty("subagent_type", out var st) ? st.GetString() : null;
+                        tasks.Add((Hash(prompt), subType));
+                    }
+                }
+            }
+        }
+
+        return firstUserHash;
+    }
+
+    static string StripUserQueryWrapper(string text) {
+        var t = text.Trim();
+        const string open = "<user_query>", close = "</user_query>";
+        return t.StartsWith(open, StringComparison.Ordinal) && t.EndsWith(close, StringComparison.Ordinal)
+            ? t[open.Length..^close.Length].Trim()
+            : t;
+    }
+
+    static string Hash(string s) =>
+        Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(s.Trim())));
+}

--- a/src/Capacitor.Cli/Commands/SessionImporter.cs
+++ b/src/Capacitor.Cli/Commands/SessionImporter.cs
@@ -535,7 +535,10 @@ static class SessionImporter {
             LineNumbers = [.. lineNumbers],
             // Default vendor "claude" stays absent on the wire to match older servers; the
             // explicit "codex" tag is what flips the server to CodexNormalizer.
-            Vendor = vendor == "claude" ? null : vendor
+            Vendor = vendor == "claude" ? null : vendor,
+            // Fail-closed callers (failOnError) also want server-side normalization failures to
+            // surface as non-2xx (server only does so when Strict), not just transport/HTTP errors.
+            Strict = failOnError
         };
 
         var       json    = JsonSerializer.Serialize(batch, CapacitorJsonContext.Default.TranscriptBatch);

--- a/src/Capacitor.Cli/RepositoryDetection.cs
+++ b/src/Capacitor.Cli/RepositoryDetection.cs
@@ -43,23 +43,7 @@ static class RepositoryDetection {
                 return json;
             }
 
-            var repoNode = new JsonObject();
-
-#pragma warning disable IDE0011
-            if (repo.UserName is not null) repoNode["user_name"]    = repo.UserName;
-            if (repo.UserEmail is not null) repoNode["user_email"]  = repo.UserEmail;
-            if (repo.RemoteUrl is not null) repoNode["remote_url"]  = repo.RemoteUrl;
-            if (repo.Host is not null) repoNode["host"]             = repo.Host;
-            if (repo.Owner is not null) repoNode["owner"]           = repo.Owner;
-            if (repo.RepoName is not null) repoNode["repo_name"]    = repo.RepoName;
-            if (repo.Branch is not null) repoNode["branch"]         = repo.Branch;
-            if (repo.PrNumber is not null) repoNode["pr_number"]    = repo.PrNumber;
-            if (repo.PrTitle is not null) repoNode["pr_title"]      = repo.PrTitle;
-            if (repo.PrUrl is not null) repoNode["pr_url"]          = repo.PrUrl;
-            if (repo.PrHeadRef is not null) repoNode["pr_head_ref"] = repo.PrHeadRef;
-#pragma warning restore IDE0011
-
-            obj["repository"] = repoNode;
+            obj["repository"] = BuildRepositoryNode(repo);
 
             SaveLastEmitted(cwd, repo);
 
@@ -67,6 +51,55 @@ static class RepositoryDetection {
         } catch {
             return json; // on any error, forward original payload
         }
+    }
+
+    /// <summary>
+    /// cwd-explicit enrichment (AI-1152). Same as <see cref="EnrichWithRepositoryInfo"/> but the
+    /// working directory is supplied by the caller rather than read from a <c>cwd</c> field —
+    /// used by the Cursor hook path, whose payloads carry <c>workspace_roots</c> instead of
+    /// <c>cwd</c>. Always attaches when a repo is detected (no last-emitted dedup): callers use
+    /// this for session-start, where each session needs its own RepositoryDetected event.
+    /// Fail-open: forwards the original payload unchanged on any error or non-git dir.
+    /// </summary>
+    public static async Task<string> EnrichWithRepositoryInfoFromCwd(string json, string cwd, TimeSpan? budget = null) {
+        try {
+            if (string.IsNullOrEmpty(cwd)) return json;
+            if (JsonNode.Parse(json) is not JsonObject obj) return json;
+
+            var repo = await DetectRepositoryAsync(cwd, budget);
+            if (repo is null) return json;
+
+            obj["repository"] = BuildRepositoryNode(repo);
+            return obj.ToJsonString();
+        } catch {
+            return json;
+        }
+    }
+
+    /// <summary>
+    /// Builds the <c>repository</c> JSON node from a detected payload. Only non-null fields are
+    /// emitted so the server-side <c>RepositoryInfoPayload</c> deserialises cleanly. Shared by
+    /// <see cref="EnrichWithRepositoryInfo"/> and <see cref="EnrichWithRepositoryInfoFromCwd"/>,
+    /// and reused by the Cursor import path.
+    /// </summary>
+    public static JsonObject BuildRepositoryNode(RepositoryPayload repo) {
+        var repoNode = new JsonObject();
+
+#pragma warning disable IDE0011
+        if (repo.UserName is not null) repoNode["user_name"]    = repo.UserName;
+        if (repo.UserEmail is not null) repoNode["user_email"]  = repo.UserEmail;
+        if (repo.RemoteUrl is not null) repoNode["remote_url"]  = repo.RemoteUrl;
+        if (repo.Host is not null) repoNode["host"]             = repo.Host;
+        if (repo.Owner is not null) repoNode["owner"]           = repo.Owner;
+        if (repo.RepoName is not null) repoNode["repo_name"]    = repo.RepoName;
+        if (repo.Branch is not null) repoNode["branch"]         = repo.Branch;
+        if (repo.PrNumber is not null) repoNode["pr_number"]    = repo.PrNumber;
+        if (repo.PrTitle is not null) repoNode["pr_title"]      = repo.PrTitle;
+        if (repo.PrUrl is not null) repoNode["pr_url"]          = repo.PrUrl;
+        if (repo.PrHeadRef is not null) repoNode["pr_head_ref"] = repo.PrHeadRef;
+#pragma warning restore IDE0011
+
+        return repoNode;
     }
 
     static bool RepoPayloadEquals(RepositoryPayload a, RepositoryPayload b) =>

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
@@ -615,15 +615,9 @@ public class CursorImportSourceTests {
         await Assert.That(startNode["repository"]).IsNull();
     }
 
-    [Test]
-    public async Task subagent_child_is_imported_under_parent_agentsubsession_not_as_standalone() {
-        // AI-1153: a Cursor subagent runs as its own session/transcript. When its first
-        // user_query matches a parent's Task prompt, the importer must route it under the
-        // parent's AgentSubsession stream (subagent-start + transcript-with-agent_id +
-        // subagent-stop) and NOT emit a standalone session-start (which would create a
-        // separate top-level session card).
-        using var fx = new ProjectsDirFixture();
-
+    // Builds a parent (Task prompt) + child (first user_query == prompt) session pair in the
+    // same workspace and returns their (parentId, childId, discovered, classified).
+    async Task<(string ParentId, string ChildId, IReadOnlyList<ImportCommand.SessionClassification> Classified, CursorImportSource Src)> SetupParentChildAsync(ProjectsDirFixture fx) {
         const string prompt = "EXPLORE the repo and report back";
         var childUserText = System.Text.Json.JsonSerializer.Serialize("<user_query>\n" + prompt + "\n</user_query>");
         var taskPrompt    = System.Text.Json.JsonSerializer.Serialize(prompt);
@@ -636,45 +630,80 @@ public class CursorImportSourceTests {
             "{\"role\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n");
 
         var src = new CursorImportSource(fx.ProjectsDir, fx.WorkspaceStorageDir);
-
         using var getHandler = new StubHandler(getResponse: _ => new HttpResponseMessage(HttpStatusCode.NotFound));
         using var getClient  = new HttpClient(getHandler);
+        var discovered = await src.DiscoverAsync(Filters(), CancellationToken.None);
+        var classified = await src.ClassifyAsync(discovered, Ctx(getClient, minLines: 1), CancellationToken.None);
+        return ("11111111111111111111111111111111", "22222222222222222222222222222222", classified, src);
+    }
 
-        var discovered  = await src.DiscoverAsync(Filters(), CancellationToken.None);
-        var classified  = await src.ClassifyAsync(discovered, Ctx(getClient, minLines: 1), CancellationToken.None);
+    [Test]
+    public async Task parent_import_nests_subagent_child_before_its_own_session_end() {
+        // AI-1153: the PARENT's import ingests its subagent child under the parent's
+        // AgentSubsession stream (subagent-start + transcript-with-agent_id + subagent-stop),
+        // and — critically — BEFORE the parent's own session-end, so a late subagent-start
+        // can't reactivate the ended parent (review finding on ordering).
+        using var fx = new ProjectsDirFixture();
+        var (parentId, childId, classified, src) = await SetupParentChildAsync(fx);
 
-        const string parentId = "11111111111111111111111111111111";
-        const string childId  = "22222222222222222222222222222222";
+        var parentClass = classified.Single(c => c.SessionId == parentId);
+        // Parent classification carries its children; parent is not itself a child.
+        await Assert.That(parentClass.SourceMeta!.ContainsKey("SubagentChildren")).IsTrue();
+        await Assert.That(parentClass.SourceMeta!.ContainsKey("IsSubagentChild")).IsFalse();
 
-        var childClass = classified.Single(c => c.SessionId == childId);
-        // Correlator stamped the parent link onto the child classification.
-        await Assert.That((string)childClass.SourceMeta!["ParentSessionId"]!).IsEqualTo(parentId);
-
-        var posted = new List<(string Path, string Body)>();
-        using var postHandler = new StubHandler(postCapture: (req, body) => {
-            posted.Add((req.RequestUri!.AbsolutePath, body));
-            return new HttpResponseMessage(HttpStatusCode.OK);
-        });
+        var posted = new List<string>();
+        var bodies = new List<(string Path, string Body)>();
+        using var postHandler = new StubHandler(
+            getResponse: _ => new HttpResponseMessage(HttpStatusCode.NotFound), // subsession watermark → New
+            postCapture: (req, body) => { posted.Add(req.RequestUri!.AbsolutePath); bodies.Add((req.RequestUri!.AbsolutePath, body)); return new HttpResponseMessage(HttpStatusCode.OK); });
         using var postClient = new HttpClient(postHandler);
 
-        var outcome = await src.ImportSessionAsync(childClass, new ImportContext(postClient, "http://localhost", ForcePrivate: false), CancellationToken.None);
-
+        var outcome = await src.ImportSessionAsync(parentClass, new ImportContext(postClient, "http://localhost", ForcePrivate: false), CancellationToken.None);
         await Assert.That(outcome).IsEqualTo(ImportOutcome.Loaded);
-        // Routed as a subagent: no standalone session-start/-end for the child.
-        await Assert.That(posted.Select(p => p.Path)).DoesNotContain("/hooks/session-start/cursor");
-        await Assert.That(posted.Select(p => p.Path)).DoesNotContain("/hooks/session-end/cursor");
-        await Assert.That(posted.Select(p => p.Path)).Contains("/hooks/subagent-start");
-        await Assert.That(posted.Select(p => p.Path)).Contains("/hooks/subagent-stop");
-        await Assert.That(posted.Select(p => p.Path)).Contains("/hooks/transcript");
 
-        var startNode = JsonNode.Parse(posted.First(p => p.Path == "/hooks/subagent-start").Body)!;
+        // Parent lifecycle + the child's subagent lifecycle are all present.
+        await Assert.That(posted).Contains("/hooks/session-start/cursor");
+        await Assert.That(posted).Contains("/hooks/session-end/cursor");
+        await Assert.That(posted).Contains("/hooks/subagent-start");
+        await Assert.That(posted).Contains("/hooks/subagent-stop");
+
+        // Ordering guard (the review finding): subagent-start/-stop must precede the parent's session-end.
+        var endIdx        = posted.IndexOf("/hooks/session-end/cursor");
+        var subStartIdx   = posted.IndexOf("/hooks/subagent-start");
+        var subStopIdx    = posted.LastIndexOf("/hooks/subagent-stop");
+        await Assert.That(subStartIdx >= 0 && subStartIdx < endIdx).IsTrue();
+        await Assert.That(subStopIdx  >= 0 && subStopIdx  < endIdx).IsTrue();
+
+        var startNode = JsonNode.Parse(bodies.First(b => b.Path == "/hooks/subagent-start").Body)!;
         await Assert.That(startNode["session_id"]!.GetValue<string>()).IsEqualTo(parentId);
         await Assert.That(startNode["agent_id"]!.GetValue<string>()).IsEqualTo(childId);
         await Assert.That(startNode["agent_type"]!.GetValue<string>()).IsEqualTo("generalPurpose");
 
-        var transcriptNode = JsonNode.Parse(posted.First(p => p.Path == "/hooks/transcript").Body)!;
-        await Assert.That(transcriptNode["session_id"]!.GetValue<string>()).IsEqualTo(parentId);
-        await Assert.That(transcriptNode["agent_id"]!.GetValue<string>()).IsEqualTo(childId);
+        var subTranscript = bodies.First(b => b.Path == "/hooks/transcript" && JsonNode.Parse(b.Body)!["agent_id"] is not null);
+        var tNode = JsonNode.Parse(subTranscript.Body)!;
+        await Assert.That(tNode["session_id"]!.GetValue<string>()).IsEqualTo(parentId);
+        await Assert.That(tNode["agent_id"]!.GetValue<string>()).IsEqualTo(childId);
+    }
+
+    [Test]
+    public async Task subagent_child_import_is_a_noop_handled_by_the_parent() {
+        // A child's own routed import must no-op (Skipped) — the parent imports it. Otherwise
+        // the child would create a standalone top-level session AND post subagent lifecycle
+        // out of order with the parent.
+        using var fx = new ProjectsDirFixture();
+        var (parentId, childId, classified, src) = await SetupParentChildAsync(fx);
+
+        var childClass = classified.Single(c => c.SessionId == childId);
+        await Assert.That(childClass.SourceMeta!.ContainsKey("IsSubagentChild")).IsTrue();
+
+        var posted = new List<string>();
+        using var postHandler = new StubHandler(postCapture: (req, body) => { posted.Add(req.RequestUri!.AbsolutePath); return new HttpResponseMessage(HttpStatusCode.OK); });
+        using var postClient = new HttpClient(postHandler);
+
+        var outcome = await src.ImportSessionAsync(childClass, new ImportContext(postClient, "http://localhost", ForcePrivate: false), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(ImportOutcome.Skipped);
+        await Assert.That(posted.Count).IsEqualTo(0); // nothing posted — the parent owns this child
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
@@ -683,6 +683,43 @@ public class CursorImportSourceTests {
         var tNode = JsonNode.Parse(subTranscript.Body)!;
         await Assert.That(tNode["session_id"]!.GetValue<string>()).IsEqualTo(parentId);
         await Assert.That(tNode["agent_id"]!.GetValue<string>()).IsEqualTo(childId);
+
+        // Full SubagentStopHook shape (review finding): the server binds all fields.
+        var stopNode = JsonNode.Parse(bodies.First(b => b.Path == "/hooks/subagent-stop").Body)!;
+        await Assert.That(stopNode["session_id"]!.GetValue<string>()).IsEqualTo(parentId);
+        await Assert.That(stopNode["agent_id"]!.GetValue<string>()).IsEqualTo(childId);
+        await Assert.That(stopNode["stop_hook_active"]).IsNotNull();
+        await Assert.That(stopNode["agent_transcript_path"]!.GetValue<string>().EndsWith(".jsonl")).IsTrue();
+        await Assert.That(stopNode["last_assistant_message"]).IsNotNull();
+    }
+
+    [Test]
+    public async Task parent_import_fails_when_a_subagent_transcript_post_is_rejected() {
+        // Review finding (fail-closed): a rejected child transcript POST must abort the parent
+        // import (return Failed) BEFORE the parent session-end, so a re-run repairs it — rather
+        // than posting subagent-stop + session-end over a child whose transcript wasn't accepted.
+        using var fx = new ProjectsDirFixture();
+        var (parentId, childId, classified, src) = await SetupParentChildAsync(fx);
+        var parentClass = classified.Single(c => c.SessionId == parentId);
+
+        var posted = new List<string>();
+        using var handler = new StubHandler(
+            getResponse: _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+            postCapture: (req, body) => {
+                var path = req.RequestUri!.AbsolutePath;
+                posted.Add(path);
+                // Reject only the subagent transcript (agent_id present).
+                if (path == "/hooks/transcript" && JsonNode.Parse(body)!["agent_id"] is not null)
+                    return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+        using var client = new HttpClient(handler);
+
+        var outcome = await src.ImportSessionAsync(parentClass, new ImportContext(client, "http://localhost", ForcePrivate: false), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(ImportOutcome.Failed);
+        // The parent's session-end must NOT be posted after a failed child transcript.
+        await Assert.That(posted).DoesNotContain("/hooks/session-end/cursor");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
@@ -520,6 +520,164 @@ public class CursorImportSourceTests {
     }
 
     [Test]
+    public async Task import_session_attaches_repository_from_detected_workspace_repo() {
+        // AI-1152: the import/backfill path must attach a `repository` node to the
+        // synthetic sessionStart so historical Cursor sessions emit RepositoryDetected
+        // server-side and group under their repo (not just "All repos"). Detected from
+        // the workspace folder via the repo detector (git remote parse).
+        using var fx    = new ProjectsDirFixture();
+        var       jsonl = fx.AddSession("Users-me-proj", "11111111-1111-1111-1111-111111111111", "{}\n{}\n");
+
+        var src = new CursorImportSource(
+            fx.ProjectsDir,
+            fx.WorkspaceStorageDir,
+            repoDetector: _ => Task.FromResult<RepositoryPayload?>(
+                new RepositoryPayload {
+                    Owner     = "kurrent-io",
+                    RepoName  = "kcap-server",
+                    Branch    = "main",
+                    RemoteUrl = "git@github.com:kurrent-io/kcap-server.git",
+                }
+            )
+        );
+
+        var posted = new List<(string Path, string Body)>();
+        using var handler = new StubHandler(
+            postCapture: (req, body) => {
+                posted.Add((req.RequestUri!.AbsolutePath, body));
+
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+        );
+        using var client = new HttpClient(handler);
+
+        var classification = new ImportCommand.SessionClassification {
+            SessionId  = "11111111111111111111111111111111",
+            FilePath   = "",
+            EncodedCwd = "",
+            Meta       = new SessionMetadata(),
+            Status     = ImportCommand.ClassificationStatus.New,
+            Vendor     = "cursor",
+            SourceMeta = new Dictionary<string, object?> {
+                ["TranscriptPath"]  = jsonl,
+                ["WorkspaceFolder"] = "/Users/me/dev/proj",
+            },
+        };
+
+        await src.ImportSessionAsync(classification, new ImportContext(client, "http://localhost", ForcePrivate: false), CancellationToken.None);
+
+        var startNode = JsonNode.Parse(posted.First(p => p.Path == "/hooks/session-start/cursor").Body)!;
+        var repo      = startNode["repository"];
+        await Assert.That(repo).IsNotNull();
+        await Assert.That(repo!["owner"]!.GetValue<string>()).IsEqualTo("kurrent-io");
+        await Assert.That(repo!["repo_name"]!.GetValue<string>()).IsEqualTo("kcap-server");
+    }
+
+    [Test]
+    public async Task import_session_omits_repository_when_workspace_repo_undetected() {
+        // Fail-open: non-git workspace (detector returns null) → no repository node,
+        // session stays unattributed rather than erroring.
+        using var fx    = new ProjectsDirFixture();
+        var       jsonl = fx.AddSession("Users-me-proj", "11111111-1111-1111-1111-111111111111", "{}\n");
+
+        var src = new CursorImportSource(
+            fx.ProjectsDir,
+            fx.WorkspaceStorageDir,
+            repoDetector: _ => Task.FromResult<RepositoryPayload?>(null)
+        );
+
+        var posted = new List<(string Path, string Body)>();
+        using var handler = new StubHandler(
+            postCapture: (req, body) => {
+                posted.Add((req.RequestUri!.AbsolutePath, body));
+
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+        );
+        using var client = new HttpClient(handler);
+
+        var classification = new ImportCommand.SessionClassification {
+            SessionId  = "11111111111111111111111111111111",
+            FilePath   = "",
+            EncodedCwd = "",
+            Meta       = new SessionMetadata(),
+            Status     = ImportCommand.ClassificationStatus.New,
+            Vendor     = "cursor",
+            SourceMeta = new Dictionary<string, object?> {
+                ["TranscriptPath"]  = jsonl,
+                ["WorkspaceFolder"] = "/Users/me/dev/proj",
+            },
+        };
+
+        await src.ImportSessionAsync(classification, new ImportContext(client, "http://localhost", ForcePrivate: false), CancellationToken.None);
+
+        var startNode = JsonNode.Parse(posted.First(p => p.Path == "/hooks/session-start/cursor").Body)!;
+        await Assert.That(startNode["repository"]).IsNull();
+    }
+
+    [Test]
+    public async Task subagent_child_is_imported_under_parent_agentsubsession_not_as_standalone() {
+        // AI-1153: a Cursor subagent runs as its own session/transcript. When its first
+        // user_query matches a parent's Task prompt, the importer must route it under the
+        // parent's AgentSubsession stream (subagent-start + transcript-with-agent_id +
+        // subagent-stop) and NOT emit a standalone session-start (which would create a
+        // separate top-level session card).
+        using var fx = new ProjectsDirFixture();
+
+        const string prompt = "EXPLORE the repo and report back";
+        var childUserText = System.Text.Json.JsonSerializer.Serialize("<user_query>\n" + prompt + "\n</user_query>");
+        var taskPrompt    = System.Text.Json.JsonSerializer.Serialize(prompt);
+
+        fx.AddSession("Users-me-proj", "11111111-1111-1111-1111-111111111111",
+            "{\"role\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"go\"}]}}\n" +
+            "{\"role\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Task\",\"input\":{\"description\":\"d\",\"prompt\":" + taskPrompt + ",\"subagent_type\":\"generalPurpose\"}}]}}\n");
+        fx.AddSession("Users-me-proj", "22222222-2222-2222-2222-222222222222",
+            "{\"role\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":" + childUserText + "}]}}\n" +
+            "{\"role\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n");
+
+        var src = new CursorImportSource(fx.ProjectsDir, fx.WorkspaceStorageDir);
+
+        using var getHandler = new StubHandler(getResponse: _ => new HttpResponseMessage(HttpStatusCode.NotFound));
+        using var getClient  = new HttpClient(getHandler);
+
+        var discovered  = await src.DiscoverAsync(Filters(), CancellationToken.None);
+        var classified  = await src.ClassifyAsync(discovered, Ctx(getClient, minLines: 1), CancellationToken.None);
+
+        const string parentId = "11111111111111111111111111111111";
+        const string childId  = "22222222222222222222222222222222";
+
+        var childClass = classified.Single(c => c.SessionId == childId);
+        // Correlator stamped the parent link onto the child classification.
+        await Assert.That((string)childClass.SourceMeta!["ParentSessionId"]!).IsEqualTo(parentId);
+
+        var posted = new List<(string Path, string Body)>();
+        using var postHandler = new StubHandler(postCapture: (req, body) => {
+            posted.Add((req.RequestUri!.AbsolutePath, body));
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        using var postClient = new HttpClient(postHandler);
+
+        var outcome = await src.ImportSessionAsync(childClass, new ImportContext(postClient, "http://localhost", ForcePrivate: false), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(ImportOutcome.Loaded);
+        // Routed as a subagent: no standalone session-start/-end for the child.
+        await Assert.That(posted.Select(p => p.Path)).DoesNotContain("/hooks/session-start/cursor");
+        await Assert.That(posted.Select(p => p.Path)).DoesNotContain("/hooks/session-end/cursor");
+        await Assert.That(posted.Select(p => p.Path)).Contains("/hooks/subagent-start");
+        await Assert.That(posted.Select(p => p.Path)).Contains("/hooks/subagent-stop");
+        await Assert.That(posted.Select(p => p.Path)).Contains("/hooks/transcript");
+
+        var startNode = JsonNode.Parse(posted.First(p => p.Path == "/hooks/subagent-start").Body)!;
+        await Assert.That(startNode["session_id"]!.GetValue<string>()).IsEqualTo(parentId);
+        await Assert.That(startNode["agent_id"]!.GetValue<string>()).IsEqualTo(childId);
+        await Assert.That(startNode["agent_type"]!.GetValue<string>()).IsEqualTo("generalPurpose");
+
+        var transcriptNode = JsonNode.Parse(posted.First(p => p.Path == "/hooks/transcript").Body)!;
+        await Assert.That(transcriptNode["session_id"]!.GetValue<string>()).IsEqualTo(parentId);
+        await Assert.That(transcriptNode["agent_id"]!.GetValue<string>()).IsEqualTo(childId);
+    }
+
+    [Test]
     public async Task import_session_omits_workspace_roots_when_cwd_unresolved() {
         using var fx    = new ProjectsDirFixture();
         var       jsonl = fx.AddSession("unknown-workspace", "11111111-1111-1111-1111-111111111111", "{}\n");

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
@@ -678,19 +678,28 @@ public class CursorImportSourceTests {
         await Assert.That(startNode["session_id"]!.GetValue<string>()).IsEqualTo(parentId);
         await Assert.That(startNode["agent_id"]!.GetValue<string>()).IsEqualTo(childId);
         await Assert.That(startNode["agent_type"]!.GetValue<string>()).IsEqualTo("generalPurpose");
+        // HookBase-required fields (server binding rejects the hook without them) + fail-closed.
+        await Assert.That(startNode["cwd"]).IsNotNull();
+        await Assert.That(startNode["transcript_path"]).IsNotNull();
+        await Assert.That(startNode["strict"]!.GetValue<bool>()).IsTrue();
 
         var subTranscript = bodies.First(b => b.Path == "/hooks/transcript" && JsonNode.Parse(b.Body)!["agent_id"] is not null);
         var tNode = JsonNode.Parse(subTranscript.Body)!;
         await Assert.That(tNode["session_id"]!.GetValue<string>()).IsEqualTo(parentId);
         await Assert.That(tNode["agent_id"]!.GetValue<string>()).IsEqualTo(childId);
+        // Strict so server-side normalization failures fail the import, not just HTTP errors.
+        await Assert.That(tNode["strict"]!.GetValue<bool>()).IsTrue();
 
-        // Full SubagentStopHook shape (review finding): the server binds all fields.
+        // Full SubagentStopHook + HookBase shape (review finding): the server binds all fields.
         var stopNode = JsonNode.Parse(bodies.First(b => b.Path == "/hooks/subagent-stop").Body)!;
         await Assert.That(stopNode["session_id"]!.GetValue<string>()).IsEqualTo(parentId);
         await Assert.That(stopNode["agent_id"]!.GetValue<string>()).IsEqualTo(childId);
+        await Assert.That(stopNode["cwd"]).IsNotNull();
+        await Assert.That(stopNode["transcript_path"]).IsNotNull();
         await Assert.That(stopNode["stop_hook_active"]).IsNotNull();
         await Assert.That(stopNode["agent_transcript_path"]!.GetValue<string>().EndsWith(".jsonl")).IsTrue();
         await Assert.That(stopNode["last_assistant_message"]).IsNotNull();
+        await Assert.That(stopNode["strict"]!.GetValue<bool>()).IsTrue();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorSubagentCorrelatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorSubagentCorrelatorTests.cs
@@ -77,6 +77,55 @@ public class CursorSubagentCorrelatorTests {
         await Assert.That(links.ContainsKey("cccccccccccccccccccccccccccccccc")).IsFalse();
     }
 
+    [Test]
+    public async Task duplicate_task_prompt_resolves_to_a_stable_parent_regardless_of_input_order() {
+        // Review finding: two parents issuing the same Task prompt must resolve to the SAME
+        // parent across runs (input arrives in filesystem-discovery order, which isn't stable).
+        // The correlator orders by session id, so the lowest id wins deterministically.
+        using var fx = new CorrelatorFixture();
+        const string prompt = "shared prompt";
+        var p1    = fx.Add("11111111111111111111111111111111", ParentTranscript(prompt, "typeA"));
+        var p2    = fx.Add("99999999999999999999999999999999", ParentTranscript(prompt, "typeB"));
+        var child = fx.Add("22222222222222222222222222222222", ChildTranscript(prompt));
+
+        var forward = CursorSubagentCorrelator.Correlate([
+            ("11111111111111111111111111111111", p1),
+            ("99999999999999999999999999999999", p2),
+            ("22222222222222222222222222222222", child),
+        ]);
+        var reversed = CursorSubagentCorrelator.Correlate([
+            ("22222222222222222222222222222222", child),
+            ("99999999999999999999999999999999", p2),
+            ("11111111111111111111111111111111", p1),
+        ]);
+
+        // Same parent (the lowest session id) both ways.
+        await Assert.That(forward["22222222222222222222222222222222"].ParentSessionId).IsEqualTo("11111111111111111111111111111111");
+        await Assert.That(reversed["22222222222222222222222222222222"].ParentSessionId).IsEqualTo("11111111111111111111111111111111");
+    }
+
+    [Test]
+    public async Task a_bad_transcript_entry_is_skipped_without_aborting_correlation() {
+        // Review finding: a bad transcript entry must not break correlation (which would abort
+        // ClassifyAsync for the whole import). A non-file path is skipped by the File.Exists
+        // guard; genuine read errors are additionally swallowed by the per-session try/catch.
+        using var fx = new CorrelatorFixture();
+        const string prompt = "explore it";
+        var parent = fx.Add("11111111111111111111111111111111", ParentTranscript(prompt));
+        var child  = fx.Add("22222222222222222222222222222222", ChildTranscript(prompt));
+        var badDir = Path.Combine(fx.Root, "not-a-file.jsonl");
+        Directory.CreateDirectory(badDir); // a directory, not a readable transcript file
+
+        var links = CursorSubagentCorrelator.Correlate([
+            ("33333333333333333333333333333333", badDir),
+            ("11111111111111111111111111111111", parent),
+            ("22222222222222222222222222222222", child),
+        ]);
+
+        // Valid pair still correlated; no throw.
+        await Assert.That(links["22222222222222222222222222222222"].ParentSessionId).IsEqualTo("11111111111111111111111111111111");
+    }
+
     sealed class CorrelatorFixture : IDisposable {
         public string Root { get; } = Path.Combine(Path.GetTempPath(), $"kcap-correlator-{Guid.NewGuid():N}");
 

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorSubagentCorrelatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorSubagentCorrelatorTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit.Import;
+
+public class CursorSubagentCorrelatorTests {
+    // Cursor runs a subagent as its OWN session/transcript. The only in-data link is that
+    // the child's first user_query (minus the <user_query> wrapper) is byte-identical to the
+    // parent's `Task`/`Agent` tool_use `prompt`. The correlator recovers that link (AI-1153).
+
+    static string Line(object o) => JsonSerializer.Serialize(o);
+
+    static string ParentTranscript(string prompt, string subagentType = "generalPurpose") => string.Join("\n",
+        Line(new { role = "user", message = new { content = new object[] { new { type = "text", text = "do the thing" } } } }),
+        Line(new {
+            role    = "assistant",
+            message = new {
+                content = new object[] {
+                    new { type = "tool_use", name = "Task", input = new { description = "explore", prompt, subagent_type = subagentType } }
+                }
+            }
+        })
+    );
+
+    static string ChildTranscript(string prompt) => string.Join("\n",
+        Line(new { role = "user", message = new { content = new object[] { new { type = "text", text = "<user_query>\n" + prompt + "\n</user_query>" } } } }),
+        Line(new { role = "assistant", message = new { content = new object[] { new { type = "text", text = "exploring" } } } })
+    );
+
+    static string TaskLine(string prompt, string subagentType) => Line(new {
+        role    = "assistant",
+        message = new { content = new object[] { new { type = "tool_use", name = "Task", input = new { prompt, subagent_type = subagentType } } } }
+    });
+
+    [Test]
+    public async Task links_child_to_parent_when_first_user_query_matches_task_prompt() {
+        using var fx = new CorrelatorFixture();
+        const string prompt = "You are exploring the LoanApplicationDemo project. Return an overview.";
+        var parent = fx.Add("11111111111111111111111111111111", ParentTranscript(prompt));
+        var child  = fx.Add("22222222222222222222222222222222", ChildTranscript(prompt));
+
+        var links = CursorSubagentCorrelator.Correlate([
+            ("11111111111111111111111111111111", parent),
+            ("22222222222222222222222222222222", child),
+        ]);
+
+        await Assert.That(links.ContainsKey("22222222222222222222222222222222")).IsTrue();
+        await Assert.That(links["22222222222222222222222222222222"].ParentSessionId).IsEqualTo("11111111111111111111111111111111");
+        await Assert.That(links["22222222222222222222222222222222"].SubagentType).IsEqualTo("generalPurpose");
+        // The parent itself is not a child of anyone.
+        await Assert.That(links.ContainsKey("11111111111111111111111111111111")).IsFalse();
+    }
+
+    [Test]
+    public async Task no_link_when_no_prompt_matches() {
+        using var fx = new CorrelatorFixture();
+        var a = fx.Add("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ParentTranscript("prompt A"));
+        var b = fx.Add("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", ChildTranscript("a totally different prompt"));
+
+        var links = CursorSubagentCorrelator.Correlate([
+            ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", a),
+            ("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", b),
+        ]);
+
+        await Assert.That(links.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task does_not_self_link_when_a_session_tasks_with_its_own_first_prompt() {
+        // Degenerate guard: a session must never be classified as its own subagent.
+        using var fx = new CorrelatorFixture();
+        const string prompt = "explore repo";
+        var self = fx.Add("cccccccccccccccccccccccccccccccc", ChildTranscript(prompt) + "\n" + TaskLine(prompt, "x"));
+
+        var links = CursorSubagentCorrelator.Correlate([("cccccccccccccccccccccccccccccccc", self)]);
+
+        await Assert.That(links.ContainsKey("cccccccccccccccccccccccccccccccc")).IsFalse();
+    }
+
+    sealed class CorrelatorFixture : IDisposable {
+        public string Root { get; } = Path.Combine(Path.GetTempPath(), $"kcap-correlator-{Guid.NewGuid():N}");
+
+        public CorrelatorFixture() => Directory.CreateDirectory(Root);
+
+        public string Add(string sessionId, string jsonl) {
+            var path = Path.Combine(Root, sessionId + ".jsonl");
+            File.WriteAllText(path, jsonl.ReplaceLineEndings("\n") + "\n");
+            return path;
+        }
+
+        public void Dispose() {
+            try { Directory.Delete(Root, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorSubagentCorrelatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorSubagentCorrelatorTests.cs
@@ -78,10 +78,10 @@ public class CursorSubagentCorrelatorTests {
     }
 
     [Test]
-    public async Task duplicate_task_prompt_resolves_to_a_stable_parent_regardless_of_input_order() {
-        // Review finding: two parents issuing the same Task prompt must resolve to the SAME
-        // parent across runs (input arrives in filesystem-discovery order, which isn't stable).
-        // The correlator orders by session id, so the lowest id wins deterministically.
+    public async Task ambiguous_prompt_across_two_parents_yields_no_link_regardless_of_input_order() {
+        // Review finding: if two DISTINCT parents issue the same Task prompt, the linkage is
+        // genuinely ambiguous — the correlator must NOT guess a parent (which could misattribute
+        // the child). It drops the link entirely, deterministically, in any input order.
         using var fx = new CorrelatorFixture();
         const string prompt = "shared prompt";
         var p1    = fx.Add("11111111111111111111111111111111", ParentTranscript(prompt, "typeA"));
@@ -99,9 +99,27 @@ public class CursorSubagentCorrelatorTests {
             ("11111111111111111111111111111111", p1),
         ]);
 
-        // Same parent (the lowest session id) both ways.
-        await Assert.That(forward["22222222222222222222222222222222"].ParentSessionId).IsEqualTo("11111111111111111111111111111111");
-        await Assert.That(reversed["22222222222222222222222222222222"].ParentSessionId).IsEqualTo("11111111111111111111111111111111");
+        // No link either way — ambiguous prompt is not attributed to a guessed parent.
+        await Assert.That(forward.ContainsKey("22222222222222222222222222222222")).IsFalse();
+        await Assert.That(reversed.ContainsKey("22222222222222222222222222222222")).IsFalse();
+    }
+
+    [Test]
+    public async Task same_parent_tasking_a_prompt_twice_is_not_ambiguous() {
+        // A single parent issuing the same Task prompt more than once must still link its child —
+        // only DISTINCT parents make a prompt ambiguous.
+        using var fx = new CorrelatorFixture();
+        const string prompt = "explore twice";
+        var parent = fx.Add("11111111111111111111111111111111",
+            ParentTranscript(prompt) + "\n" + TaskLine(prompt, "generalPurpose"));
+        var child  = fx.Add("22222222222222222222222222222222", ChildTranscript(prompt));
+
+        var links = CursorSubagentCorrelator.Correlate([
+            ("11111111111111111111111111111111", parent),
+            ("22222222222222222222222222222222", child),
+        ]);
+
+        await Assert.That(links["22222222222222222222222222222222"].ParentSessionId).IsEqualTo("11111111111111111111111111111111");
     }
 
     [Test]


### PR DESCRIPTION
Fixes two Cursor ingest gaps. Pairs with the **kcap-server** PR (shared repo recorder + Cursor normalizer id-scoping for subsessions) — both halves ship together. Tracks Linear **AI-1152** (repo attribution), **AI-1153** (subagent nesting), and the subagent half of **AI-1154** (backfill).

## AI-1152 — repo attribution
Cursor sessions never grouped under a repository (only "All repos") because the sidebar keys on `repo_hash`, set only by a `RepositoryDetected` event, which needs a git-detected `owner`/`repo_name`. Every other vendor's hook path attaches a `repository` node via `RepositoryDetection.EnrichWithRepositoryInfo` — but that reads `cwd`, and Cursor payloads carry `workspace_roots` instead, and `CursorHookCommand` never called it.

- Add `RepositoryDetection.EnrichWithRepositoryInfoFromCwd` + extract `BuildRepositoryNode` (shared).
- `CursorHookCommand` enriches `sessionStart` from `workspace_roots[0]` (budget-bounded, fail-open).
- `CursorImportSource` detects the repo from the workspace folder and attaches it to the synthetic `sessionStart` (also fixes historical import/backfill).

## AI-1153 — nest subagents under the parent
A Cursor subagent (`Task`/`Agent`) runs as its **own** session/transcript with **no explicit parent link** — the only in-data signal is that the child's first `user_query` (minus the `<user_query>` wrapper) is byte-identical to the parent's `Task` `input.prompt`.

- New pure `CursorSubagentCorrelator.Correlate` recovers the link by SHA-256 prompt hash (self-link guarded).
- `CursorImportSource.ClassifyAsync` builds the map and stamps `ParentSessionId`/`SubagentType`; `ImportSessionAsync` routes a detected child through `ImportSubagentAsync` — `/hooks/subagent-start` (session_id=parent, agent_id=child) + transcript batches with `agent_id`=child (→ `AgentSubsession-{parent}-{child}`) + `/hooks/subagent-stop` — and emits **no** standalone session lifecycle. This mirrors how Gemini/OpenCode subagents nest, so no server read-model change is needed; the child never creates a top-level card.

## Tests
`CursorSubagentCorrelatorTests` (3), `CursorImportSourceTests` incl. repo-attach + subagent-routing (34 total). AOT publish clean (no IL2026/IL3050).

🤖 Generated with [Claude Code](https://claude.com/claude-code)