### PR TITLE
Mirror the requester's working tree into review-flow reviewer worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ args    = ["mcp", "flows"] # desktop app, which launches MCP servers without you
 
 It provides four tools:
 
-- **`start_review_flow`** — start a new review flow (`spec-review` or `code-review`). Provide `kind`, `target_kind`, `target_ref`, `target_title`, and `context`. Requester context (session ID, cwd, repo root, owner, name) is resolved automatically from the environment. Returns a `flow_run_id`.
+- **`start_review_flow`** — start a new review flow (`spec-review` or `code-review`). Provide `kind`, `target_kind`, `target_ref`, `target_title`, and `context`. Requester context (session ID, cwd, repo root, owner, name) is resolved automatically from the environment. Returns a `flow_run_id`. Optional `mode`: by default, when the daemon runs on the same machine, the reviewer works in a worktree mirrored from your working tree — **uncommitted and untracked changes included** — so it grounds the review in your actual in-progress source; pass `mode="context-only"` to opt out and have the reviewer treat only the submitted context as authoritative.
 - **`submit_review_round`** — submit a follow-up round to an existing flow with updated context or a response to the reviewer's findings. Returns the new round's findings.
 - **`get_review_flow_status`** — get the current status (running, waiting, completed, failed) and last result of a flow.
 - **`close_review_flow`** — mark a completed review flow as closed.

--- a/kcap/skills/review-flows/SKILL.md
+++ b/kcap/skills/review-flows/SKILL.md
@@ -68,7 +68,7 @@ if FINDINGS:
 
 | Tool | Required args | Optional args | When to call |
 |---|---|---|---|
-| `start_review_flow` | `kind` (`spec-review`\|`code-review`), `target_kind` (what is being reviewed: `spec`, `code`, `pr`, `branch`, `file`, etc.), `target_ref` (a path, branch name, or PR URL/number that identifies the target), `target_title` (short human-readable title, e.g. spec name or PR title), `context` (background context: what to focus on, constraints, definition of done) | `instructions`, `mode` (`context-only` — required for code-review unless the reviewer runs in your exact repo checkout) | Once, at the start of a review task. |
+| `start_review_flow` | `kind` (`spec-review`\|`code-review`), `target_kind` (what is being reviewed: `spec`, `code`, `pr`, `branch`, `file`, etc.), `target_ref` (a path, branch name, or PR URL/number that identifies the target), `target_title` (short human-readable title, e.g. spec name or PR title), `context` (background context: what to focus on, constraints, definition of done) | `instructions`, `mode` (`context-only` — optional; by default, on the same machine, the reviewer's worktree is mirrored from your working tree including uncommitted changes, so it reads the actual source. Pass `context-only` to opt out and treat the submitted context as authoritative) | Once, at the start of a review task. |
 | `submit_review_round` | `flow_run_id`, `context` | `instructions` | After addressing findings. Pass the same `flow_run_id` and the updated context. |
 | `get_review_flow_status` | `flow_run_id` | — | Poll or check the current status of a flow (running, waiting, completed, failed). |
 | `close_review_flow` | `flow_run_id` | — | Only after the reviewer returns `NO FINDINGS`. |
@@ -76,14 +76,14 @@ if FINDINGS:
 ## Example (code review)
 
 ```
-# Step 1 — start (all five required args must be provided; mode=context-only is required for code-review)
+# Step 1 — start (all five required args must be provided; on the same machine the reviewer sees
+# your working tree, uncommitted changes included — pass mode="context-only" to opt out)
 start_review_flow(
   kind="code-review",
   target_kind="branch",
   target_ref="feature/add-null-check",
   target_title="Add null check on user input",
-  context="Review the diff on this branch for correctness and adherence to project conventions.",
-  mode="context-only"
+  context="Review the diff on this branch for correctness and adherence to project conventions."
 )
 # → returns flow_run_id, e.g. "flow_abc123"
 # → reviewer returns FINDINGS: missing null check on line 42

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -804,9 +804,17 @@ public readonly record struct LaunchAgentCommand(
         string[]?         Tools,
         string[]?         AttachmentIds,
         string            Vendor,
-        LaunchKind        Kind    = LaunchKind.Default,
-        ReviewLaunchInfo? Review  = null,
-        string?           BaseRef = null
+        LaunchKind        Kind            = LaunchKind.Default,
+        ReviewLaunchInfo? Review          = null,
+        string?           BaseRef         = null,
+        // AI-1163: for a mirror-requester review flow, the requester's repo root. When set, the
+        // daemon syncs its working tree (uncommitted + untracked) into the freshly-created reviewer
+        // worktree BEFORE spawning, so round 1 sees in-progress code — not just committed HEAD. The
+        // daemon validates the source is a checkout of the same repo (origin match) before copying;
+        // a mismatch (e.g. a different machine, where the path doesn't resolve) skips the sync.
+        // Appended last as an optional field so the SignalR positional binding stays wire-compatible
+        // with older daemons/servers.
+        string?           SyncFromRepoRoot = null
     );
 
 /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -323,6 +323,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             worktree = await _worktreeManager.CreateAsync(repoPath, baseRef: baseRef);
 
+            // AI-1163: for a mirror-requester review flow the server sends the requester's repo root
+            // in SyncFromRepoRoot. Mirror its live working tree (uncommitted + untracked) into the
+            // fresh worktree BEFORE spawning, so round 1 sees in-progress code rather than committed
+            // HEAD. Daemon-validated + best-effort (see the helper); never fails the launch.
+            if (!string.IsNullOrEmpty(cmd.SyncFromRepoRoot)) {
+                await TrySyncWorktreeAtLaunchAsync(agentId, cmd.SyncFromRepoRoot, repoPath, worktree.Path);
+            }
+
             // Download attachments into worktree (best-effort)
             if (attachmentIds is { Length: > 0 }) {
                 try {
@@ -987,6 +995,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         if (agent.Work != WorkLocation.OwnedWorktree)
             return new RefreshAgentWorktreeResult(false, "not an owned worktree");
 
+        // AI-1163: daemon-validate that the source is a checkout of the SAME repo before copying.
+        // The server may now pass a requester repo root that is not the daemon's exact checkout path
+        // (e.g. a git worktree), so identity + locality are confirmed here (origin match) rather than
+        // by server-side path equality.
+        if (!await SourceMatchesRepoOriginAsync(cmd.SourceRepoRoot, agent.RepoPath))
+            return new RefreshAgentWorktreeResult(false, "source is not a checkout of the same repo");
+
         try {
             await _worktreeManager.SyncFromSourceAsync(
                 cmd.SourceRepoRoot,
@@ -1001,6 +1016,47 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             return new RefreshAgentWorktreeResult(false, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// AI-1163: launch-time worktree sync for a mirror-requester review flow. Mirrors the requester's
+    /// working-tree state (tracked + untracked, gitignore-respected) into the freshly-created reviewer
+    /// worktree before the reviewer process is spawned, so round 1 sees in-progress/uncommitted code.
+    /// Daemon-validated + best-effort: a source that doesn't resolve on this host or isn't the same
+    /// repo (origin mismatch) is skipped, leaving the worktree at its checked-out HEAD; any failure is
+    /// logged and swallowed so it never fails the launch.
+    /// </summary>
+    async Task TrySyncWorktreeAtLaunchAsync(string agentId, string sourceRepoRoot, string targetRepoPath, string worktreePath) {
+        try {
+            if (!await SourceMatchesRepoOriginAsync(sourceRepoRoot, targetRepoPath)) {
+                LogLaunchSyncSkipped(agentId, sourceRepoRoot, "source is not a checkout of the same repo (origin mismatch or path not found on this host)");
+
+                return;
+            }
+
+            await _worktreeManager.SyncFromSourceAsync(sourceRepoRoot, worktreePath, [], _shutdownCts.Token);
+        } catch (Exception ex) {
+            LogRefreshWorktreeFailed(ex, agentId, sourceRepoRoot, worktreePath);
+        }
+    }
+
+    /// <summary>
+    /// AI-1163: daemon-side check that <paramref name="sourceRepoRoot"/> is a checkout of the SAME
+    /// repository as <paramref name="targetRepoPath"/> — both resolve to a git checkout whose
+    /// <c>origin</c> remote matches. This is what lets the server pass the requester's repo root
+    /// (even a git worktree whose path differs from the daemon's checkout) and have the daemon
+    /// confirm locality + identity before copying files into the reviewer worktree.
+    /// </summary>
+    static async Task<bool> SourceMatchesRepoOriginAsync(string sourceRepoRoot, string targetRepoPath) {
+        if (string.IsNullOrEmpty(sourceRepoRoot) || !Directory.Exists(sourceRepoRoot))
+            return false;
+
+        var sourceOrigin = await GetOriginRemoteAsync(sourceRepoRoot);
+        var targetOrigin = await GetOriginRemoteAsync(targetRepoPath);
+
+        return sourceOrigin is not null &&
+               targetOrigin is not null &&
+               string.Equals(sourceOrigin, targetOrigin, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -1359,6 +1415,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to refresh worktree for agent {AgentId} (source={Source}, target={Target})")]
     partial void LogRefreshWorktreeFailed(Exception ex, string agentId, string source, string target);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Launch-time worktree sync skipped for agent {AgentId} (source={Source}): {Reason}")]
+    partial void LogLaunchSyncSkipped(string agentId, string source, string reason);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to persist repo path for agent {AgentId}")]
     partial void LogRepoPathPersistFailed(Exception ex, string agentId);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -999,8 +999,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // The server may now pass a requester repo root that is not the daemon's exact checkout path
         // (e.g. a git worktree), so identity + locality are confirmed here (origin match) rather than
         // by server-side path equality.
-        if (!await SourceMatchesRepoOriginAsync(cmd.SourceRepoRoot, agent.RepoPath))
-            return new RefreshAgentWorktreeResult(false, "source is not a checkout of the same repo");
+        if (!await IsAllowedSyncSourceAsync(cmd.SourceRepoRoot, agent.RepoPath))
+            return new RefreshAgentWorktreeResult(false, "source is not an allowed checkout of the same repo");
 
         try {
             await _worktreeManager.SyncFromSourceAsync(
@@ -1022,14 +1022,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// AI-1163: launch-time worktree sync for a mirror-requester review flow. Mirrors the requester's
     /// working-tree state (tracked + untracked, gitignore-respected) into the freshly-created reviewer
     /// worktree before the reviewer process is spawned, so round 1 sees in-progress/uncommitted code.
-    /// Daemon-validated + best-effort: a source that doesn't resolve on this host or isn't the same
-    /// repo (origin mismatch) is skipped, leaving the worktree at its checked-out HEAD; any failure is
-    /// logged and swallowed so it never fails the launch.
+    /// Daemon-validated + best-effort: a source that doesn't resolve on this host, is outside the
+    /// repo-path allowlist, or isn't the same repo (origin mismatch) is skipped, leaving the worktree
+    /// at its checked-out HEAD; any failure is logged and swallowed so it never fails the launch.
     /// </summary>
     async Task TrySyncWorktreeAtLaunchAsync(string agentId, string sourceRepoRoot, string targetRepoPath, string worktreePath) {
         try {
-            if (!await SourceMatchesRepoOriginAsync(sourceRepoRoot, targetRepoPath)) {
-                LogLaunchSyncSkipped(agentId, sourceRepoRoot, "source is not a checkout of the same repo (origin mismatch or path not found on this host)");
+            if (!await IsAllowedSyncSourceAsync(sourceRepoRoot, targetRepoPath)) {
+                LogLaunchSyncSkipped(agentId, sourceRepoRoot, "source not on the allowlist, not found on this host, or not a checkout of the same repo");
 
                 return;
             }
@@ -1041,14 +1041,25 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     }
 
     /// <summary>
-    /// AI-1163: daemon-side check that <paramref name="sourceRepoRoot"/> is a checkout of the SAME
-    /// repository as <paramref name="targetRepoPath"/> — both resolve to a git checkout whose
-    /// <c>origin</c> remote matches. This is what lets the server pass the requester's repo root
-    /// (even a git worktree whose path differs from the daemon's checkout) and have the daemon
-    /// confirm locality + identity before copying files into the reviewer worktree.
+    /// AI-1163: daemon-side check that <paramref name="sourceRepoRoot"/> is a safe, valid sync source
+    /// for the reviewer worktree built from <paramref name="targetRepoPath"/>. It must (1) resolve on
+    /// this host, (2) satisfy the daemon's repo-path allowlist — the same policy applied to the launch
+    /// repo, so a server-provided source can't read files from a checkout the operator disallowed
+    /// (no-op when no allowlist is configured), and (3) be a checkout of the SAME repository, which we
+    /// establish by matching the <c>origin</c> remote.
+    ///
+    /// Origin-match is the right identity check here (not a weaker path/`.git` check): review flows
+    /// are only ever discovered and launched for repos with a matching GitHub origin
+    /// (<c>DiscoverDaemonsAsync</c> resolves the daemon by owner/repo <i>from</i> origin, and the
+    /// server requires repo_owner/repo_name), so both sides always have an origin — a no-origin repo
+    /// can't be a flow target. Git worktrees inherit the clone's <c>origin</c>, so a requester working
+    /// in a worktree (whose path differs from the daemon's checkout) still matches.
     /// </summary>
-    static async Task<bool> SourceMatchesRepoOriginAsync(string sourceRepoRoot, string targetRepoPath) {
+    async Task<bool> IsAllowedSyncSourceAsync(string sourceRepoRoot, string targetRepoPath) {
         if (string.IsNullOrEmpty(sourceRepoRoot) || !Directory.Exists(sourceRepoRoot))
+            return false;
+
+        if (!_config.IsRepoAllowed(sourceRepoRoot))
             return false;
 
         var sourceOrigin = await GetOriginRemoteAsync(sourceRepoRoot);

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -552,7 +552,7 @@ static class McpFlowsServer {
                     ["target_title"] = new("string", "Human-readable title for the target (PR title, spec name, etc.)."),
                     ["context"]      = new("string", "Background context for the reviewer: what to focus on, constraints, definition of done."),
                     ["instructions"] = new("string", "Optional additional instructions for the reviewer agent."),
-                    ["mode"]         = new("string", "Optional. Pass 'context-only' to treat the submitted context/diff as authoritative. Required for code-review unless the reviewer runs in your exact repo checkout; omitting it will cause the server to reject the request with an error.")
+                    ["mode"]         = new("string", "Optional. Pass 'context-only' to have the reviewer treat the submitted context/diff as authoritative rather than reading the repository. By default the reviewer runs in a worktree mirrored from your working tree (uncommitted changes included) when it runs on the same machine, so it can ground the review in the actual source; passing 'context-only' opts out of that.")
                 },
                 ["kind", "target_kind", "target_ref", "target_title", "context"]
             )

--- a/test/Capacitor.Cli.Tests.Unit/LaunchAgentCommandWireFormatTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LaunchAgentCommandWireFormatTests.cs
@@ -89,6 +89,48 @@ public class LaunchAgentCommandWireFormatTests {
     }
 
     [Test]
+    public async Task DaemonDeserialises_SyncFromRepoRoot_WhenPresent() {
+        // AI-1163: a mirror-requester review-flow launch carries the requester's repo root so the
+        // daemon can sync its live working tree into the reviewer worktree before spawning.
+        var cmd = new LaunchAgentCommand(
+            AgentId:          "sync1234",
+            Prompt:           null,
+            Model:            "default",
+            Effort:           null,
+            RepoPath:         "/tmp/repo",
+            Tools:            null,
+            AttachmentIds:    null,
+            Vendor:           "codex",
+            Kind:             LaunchKind.ReviewFlow,
+            SyncFromRepoRoot: "/home/me/dev/kcap"
+        );
+
+        var wire   = JsonSerializer.Serialize(cmd, ServerWireOptions);
+        var parsed = JsonSerializer.Deserialize(wire, CapacitorJsonContext.Default.LaunchAgentCommand);
+
+        await Assert.That(wire).Contains("\"sync_from_repo_root\":\"/home/me/dev/kcap\"");
+        await Assert.That(parsed.SyncFromRepoRoot).IsEqualTo("/home/me/dev/kcap");
+        await Assert.That(parsed.Kind).IsEqualTo(LaunchKind.ReviewFlow);
+    }
+
+    [Test]
+    public async Task DaemonDeserialises_SyncFromRepoRoot_DefaultsToNull_WhenAbsent() {
+        // Version skew: an older server that predates AI-1163 omits the field entirely. The daemon
+        // must still bind the command (positional SignalR binding) and default the field to null —
+        // i.e. no launch-time sync — rather than failing to invoke LaunchAgent (cf. DEV-1665).
+        const string legacyWire =
+            """
+            {"agent_id":"legacy01","prompt":null,"model":"opus","effort":null,"repo_path":"/tmp/repo","tools":null,"attachment_ids":null,"vendor":"claude","kind":"reviewFlow"}
+            """;
+
+        var parsed = JsonSerializer.Deserialize(legacyWire, CapacitorJsonContext.Default.LaunchAgentCommand);
+
+        await Assert.That(parsed.SyncFromRepoRoot).IsNull();
+        await Assert.That(parsed.Kind).IsEqualTo(LaunchKind.ReviewFlow);
+        await Assert.That(parsed.RepoPath).IsEqualTo("/tmp/repo");
+    }
+
+    [Test]
     public async Task Vendor_field_round_trips_through_json_serializer() {
         var cmd = new LaunchAgentCommand(
             AgentId:       "agent-1",


### PR DESCRIPTION
## Problem

Hosted review-flow reviewers don't read the repository source — they review the submitted context (e.g. a spec) in isolation, even on the same machine as the requester. The reviewer's daemon-created worktree was only refreshed from the requester's working tree on **follow-up** rounds, and only when the requester's repo root **exactly** equalled the daemon's checkout path. So round 1 always ran against committed HEAD, and a review launched from a git worktree never mirrored the requester's changes.

## Change (daemon side)

- Add optional `LaunchAgentCommand.SyncFromRepoRoot` (appended field; SignalR positional binding stays wire-compatible — old daemon ignores it, old server → new daemon defaults it to null; covered by `LaunchAgentCommandWireFormatTests`).
- On launch, after creating the reviewer worktree and **before spawning**, mirror the requester's working tree (`SyncFromSourceAsync` — tracked + untracked, gitignore-respected) so round 1 grounds the review in in-progress/uncommitted code.
- **Daemon-validated source**: only sync when the source resolves on this host and is a checkout of the same repo (`origin` match). The same validation is added to the existing follow-up `RefreshAgentWorktree` handler, so the server can now relax its exact-path guard and let a worktree launch sync too; a different machine/repo is safely skipped (reviewer keeps HEAD).
- Docs: the `kcap mcp flows` `mode` tool description, the review-flows skill, and README now say the reviewer sees the working tree by default, with `mode=context-only` as the opt-out.

## Cross-repo

Server counterpart (flow definitions → `mirror-requester`, orchestrator, matching wire field, guard rework): kurrent-io/kcap-server#927. Deploy the server and CLI together; the optional wire field keeps either-order rollout safe.

## Tests

- `LaunchAgentCommandWireFormatTests`: new field round-trips over the server wire options and defaults to null on legacy (absent) JSON.
- `WorktreeManagerTests` already covers `SyncFromSourceAsync`.
- Full `Capacitor.Cli.Tests.Unit` suite green (2092); no IL2026/IL3050 AOT warnings on `dotnet publish -c Release` for both `kcap` and `kcap-daemon`.

Closes #245
Linear: AI-1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)
