### PR TITLE
[AI-1167] Codex Stop hook: best-effort POST to /hooks/stop to clear idle spinner

### DIFF
--- a/src/Capacitor.Cli/Commands/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CodexHookCommand.cs
@@ -229,7 +229,7 @@ static class CodexHookCommand {
                 skipTitle: false, vendor: "codex"
             );
 
-            await PostStopBestEffortAsync(baseUrl, node);
+            await PostBestEffortAsync(baseUrl, "stop", node, TimeSpan.FromSeconds(2));
         }
 
         // AI-635: Codex's stop-hook output parser rejects empty stdout as
@@ -265,14 +265,9 @@ static class CodexHookCommand {
         // 30 s hook timeout. Passing baseUrl also keeps discovery targeted at
         // the server we're about to POST to, not the
         // AppConfig.ResolvedServerUrl / KCAP_URL / localhost:5108 fallback.
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-        try {
-            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, cts.Token);
-            using var content = new StringContent(node.ToJsonString(), Encoding.UTF8, "application/json");
-            using var _       = await client.PostAsync($"{baseUrl}/hooks/permission-record", content, cts.Token);
-        } catch {
-            // Best-effort — recording must never block Codex's approval prompt.
-        }
+        // Recording must never block Codex's approval prompt — see
+        // PostBestEffortAsync for the shared swallow-all/cap behavior.
+        await PostBestEffortAsync(baseUrl, "permission-record", node, TimeSpan.FromSeconds(2));
 
         // Empty hookSpecificOutput → Codex treats it as "no decision" and runs
         // its normal approval flow. See
@@ -341,23 +336,21 @@ static class CodexHookCommand {
     }
 
     /// <summary>
-    /// Best-effort POST of the Codex Stop payload to <c>/hooks/stop</c>. Codex
-    /// fires Stop at every turn end; the server marks the session waiting and,
-    /// after a short debounce, emits the idle-wait marker that clears the chat
-    /// "working" indicator. Capped at 2s and swallows every failure — a slow or
-    /// unreachable server must never hang the local Codex terminal or break the
-    /// hook's stdout contract. The single deadline covers both /auth/config
-    /// discovery inside CreateAuthenticatedClientAsync and the POST itself.
+    /// Best-effort POST of <paramref name="node"/> to <c>/hooks/{endpoint}</c>, capped at
+    /// <paramref name="cap"/> and swallowing every failure. The single deadline covers both
+    /// /auth/config discovery inside CreateAuthenticatedClientAsync and the POST itself, so a
+    /// slow or unreachable server can never hang the caller. Callers that must satisfy Codex's
+    /// stdout contract write their JSON output AFTER awaiting this.
     /// </summary>
-    static async Task PostStopBestEffortAsync(string baseUrl, JsonNode node) {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+    static async Task PostBestEffortAsync(string baseUrl, string endpoint, JsonNode node, TimeSpan cap) {
+        using var cts = new CancellationTokenSource(cap);
 
         try {
             using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, cts.Token);
             using var content = new StringContent(node.ToJsonString(), Encoding.UTF8, "application/json");
-            using var _       = await client.PostAsync($"{baseUrl}/hooks/stop", content, cts.Token);
+            using var _       = await client.PostAsync($"{baseUrl}/hooks/{endpoint}", content, cts.Token);
         } catch {
-            // Best-effort — the idle marker is nice-to-have; never block the hook.
+            // Best-effort — must never block or fail the caller.
         }
     }
 

--- a/src/Capacitor.Cli/Commands/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CodexHookCommand.cs
@@ -257,8 +257,8 @@ static class CodexHookCommand {
         // hosted-agent UI decision. With Codex's 30 s hook timeout, the hook
         // process is killed long before the server returns (AI-636).
         //
-        // Single 2 s deadline covers BOTH the /auth/config discovery inside
-        // CreateAuthenticatedClientAsync and the /hooks/permission-record POST.
+        // Single 2 s deadline covers BOTH the /auth/config discovery and the
+        // /hooks/permission-record POST inside PostBestEffortAsync.
         // Without bounding discovery too, a server that accepts the TCP
         // connection but stalls on /auth/config can burn the full HttpClient
         // default (100 s) before we even start the POST, blowing past Codex's
@@ -337,18 +337,34 @@ static class CodexHookCommand {
 
     /// <summary>
     /// Best-effort POST of <paramref name="node"/> to <c>/hooks/{endpoint}</c>, capped at
-    /// <paramref name="cap"/> and swallowing every failure. The single deadline covers both
-    /// /auth/config discovery inside CreateAuthenticatedClientAsync and the POST itself, so a
-    /// slow or unreachable server can never hang the caller. Callers that must satisfy Codex's
-    /// stdout contract write their JSON output AFTER awaiting this.
+    /// <paramref name="cap"/> and swallowing every failure — it must never block, throw, or
+    /// terminate the caller. The single deadline covers both /auth/config discovery and the POST.
+    /// Callers that must satisfy Codex's stdout contract write their JSON output AFTER awaiting this.
     /// </summary>
     static async Task PostBestEffortAsync(string baseUrl, string endpoint, JsonNode node, TimeSpan cap) {
+        // A blank or non-absolute baseUrl would trip EnsureAbsolute deep inside auth discovery,
+        // which calls Environment.Exit(2) — uncatchable, and would bypass the caller's stdout/exit
+        // contract. Bail silently before we can reach it.
+        if (string.IsNullOrWhiteSpace(baseUrl) || !HttpClientExtensions.IsAcceptableUrl(baseUrl)) {
+            return;
+        }
+
         using var cts = new CancellationTokenSource(cap);
 
         try {
-            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, cts.Token);
-            using var content = new StringContent(node.ToJsonString(), Encoding.UTF8, "application/json");
-            using var _       = await client.PostAsync($"{baseUrl}/hooks/{endpoint}", content, cts.Token);
+            // Use the status-returning variant, NOT CreateAuthenticatedClientAsync: the latter writes
+            // "Not authenticated" / "expired" to stderr, which a per-turn Stop would spam. Stay quiet
+            // and skip the POST when there's no usable auth (still swallow-all).
+            var (client, status) = await HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl, cts.Token);
+
+            using (client) {
+                if (status is not (AuthStatus.Ok or AuthStatus.NoAuthRequired)) {
+                    return;
+                }
+
+                using var content = new StringContent(node.ToJsonString(), Encoding.UTF8, "application/json");
+                using var _       = await client.PostAsync($"{baseUrl}/hooks/{endpoint}", content, cts.Token);
+            }
         } catch {
             // Best-effort — must never block or fail the caller.
         }

--- a/src/Capacitor.Cli/Commands/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CodexHookCommand.cs
@@ -15,12 +15,13 @@ namespace Capacitor.Cli.Commands;
 /// <remarks>
 /// Wire contract (Codex event → server route):
 ///   SessionStart      → POST /hooks/session-start/codex
-///   Stop              → no server POST. Codex fires Stop at every turn end,
-///                       not session end (AI-648). Session-end is owned by the
-///                       watcher's parent-PID monitor (AI-647 — see
-///                       WatchCommand.PostSessionEndOnParentExitAsync).
-///                       HandleStop only refreshes watcher liveness and emits
-///                       {"continue":true} so Codex's hook parser is satisfied.
+///   Stop              → POST /hooks/stop (best-effort, 2s cap, swallow-all).
+///                       Codex fires Stop at every turn end, not session end
+///                       (AI-648); session-end stays owned by the watcher's
+///                       parent-PID monitor (AI-647). The POST lets the server
+///                       emit the idle-wait marker that clears the chat
+///                       "working" indicator. HandleStop also refreshes watcher
+///                       liveness and emits {"continue":true} for Codex's parser.
 ///   PermissionRequest → in a daemon-launched hosted agent (KCAP_DAEMON_URL set), bounce
 ///                       through the daemon's LocalPermissionBridge and wait for the dashboard's
 ///                       decision (fail-closed on bridge errors: deny + exit nonzero). Otherwise:
@@ -213,8 +214,10 @@ static class CodexHookCommand {
         // the watcher after turn 1 and mismark multi-turn sessions as ended
         // before they actually finish.
         //
-        // Symmetric with Claude's stop/notification branch in Program.cs —
-        // we just keep the watcher alive in case it crashed mid-session.
+        // We keep the watcher alive (in case it crashed mid-session) AND
+        // best-effort POST /hooks/stop so the server can emit the idle-wait
+        // marker that clears the chat "working" indicator (symmetric with
+        // Claude's stop hook).
         var sessionId  = TryGetString(node, "session_id");
         var transcript = TryGetString(node, "transcript_path");
         var cwd        = TryGetString(node, "cwd");
@@ -225,6 +228,8 @@ static class CodexHookCommand {
                 agentId: null, sessionIdOverride: null, cwd: cwd,
                 skipTitle: false, vendor: "codex"
             );
+
+            await PostStopBestEffortAsync(baseUrl, node);
         }
 
         // AI-635: Codex's stop-hook output parser rejects empty stdout as
@@ -332,6 +337,27 @@ static class CodexHookCommand {
         } catch (HttpRequestException ex) {
             HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
             return 1;
+        }
+    }
+
+    /// <summary>
+    /// Best-effort POST of the Codex Stop payload to <c>/hooks/stop</c>. Codex
+    /// fires Stop at every turn end; the server marks the session waiting and,
+    /// after a short debounce, emits the idle-wait marker that clears the chat
+    /// "working" indicator. Capped at 2s and swallows every failure — a slow or
+    /// unreachable server must never hang the local Codex terminal or break the
+    /// hook's stdout contract. The single deadline covers both /auth/config
+    /// discovery inside CreateAuthenticatedClientAsync and the POST itself.
+    /// </summary>
+    static async Task PostStopBestEffortAsync(string baseUrl, JsonNode node) {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        try {
+            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, cts.Token);
+            using var content = new StringContent(node.ToJsonString(), Encoding.UTF8, "application/json");
+            using var _       = await client.PostAsync($"{baseUrl}/hooks/stop", content, cts.Token);
+        } catch {
+            // Best-effort — the idle marker is nice-to-have; never block the hook.
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs
@@ -184,6 +184,39 @@ public class CodexHookCommandTests : IDisposable {
         await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
     }
 
+    // Qodo #247: a malformed (scheme-less) server URL must NOT hard-exit via
+    // EnsureAbsolute's Environment.Exit(2) inside the best-effort POST — the hook
+    // must still emit {"continue":true} and return 0. The guard in
+    // PostBestEffortAsync bails before auth discovery (and thus EnsureAbsolute)
+    // is reached.
+    [Test, NotInParallel]
+    public async Task Stop_with_malformed_base_url_still_emits_continue_and_returns_zero() {
+        var payload = """
+                      {
+                        "hook_event_name": "Stop",
+                        "session_id": "abc",
+                        "transcript_path": "/tmp/rollout.jsonl",
+                        "cwd": "/tmp"
+                      }
+                      """;
+
+        var originalOut  = Console.Out;
+        var stdoutWriter = new StringWriter();
+
+        try {
+            Console.SetOut(stdoutWriter);
+            // Scheme-less URL → IsAcceptableUrl is false → PostBestEffortAsync returns
+            // before CreateClientWithAuthStatusAsync/EnsureAbsolute can Environment.Exit.
+            var exit = await CodexHookCommand.Handle("localhost:5108", new StringReader(payload));
+            await Assert.That(exit).IsEqualTo(0);
+
+            var doc = JsonDocument.Parse(stdoutWriter.ToString());
+            await Assert.That(doc.RootElement.GetProperty("continue").GetBoolean()).IsTrue();
+        } finally {
+            Console.SetOut(originalOut);
+        }
+    }
+
     // Globally sequential alongside Stop_is_turn_end_no_op_and_does_not_post_session_end —
     // see that test for why ConsoleSerialGroup alone has been observed to
     // interleave in suite runs and drop captured Console output.

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs
@@ -85,11 +85,14 @@ public class CodexHookCommandTests : IDisposable {
             var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
             await Assert.That(exit).IsEqualTo(0);
 
-            // Stop now POSTs /hooks/stop exactly once, carrying the session id.
+            // Stop now POSTs /hooks/stop exactly once, carrying the full payload.
             var stopRequests = _server.FindLogEntries(Request.Create().WithPath("/hooks/stop").UsingPost());
             await Assert.That(stopRequests.Count).IsEqualTo(1);
             var body = JsonDocument.Parse(stopRequests[0].RequestMessage.Body!).RootElement;
             await Assert.That(body.GetProperty("session_id").GetString()).IsEqualTo("abc");
+            await Assert.That(body.GetProperty("transcript_path").GetString()).IsEqualTo("/tmp/rollout.jsonl");
+            await Assert.That(body.GetProperty("cwd").GetString()).IsEqualTo("/tmp");
+            await Assert.That(body.GetProperty("hook_event_name").GetString()).IsEqualTo("Stop");
 
             // Must NOT POST session-end.
             var endRequests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-end/codex").UsingPost());
@@ -140,6 +143,44 @@ public class CodexHookCommandTests : IDisposable {
         }
 
         // 2s POST cap + slack for CI jitter.
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
+    }
+
+    // Symmetric with PermissionRequest_returns_quickly_when_auth_discovery_is_slow:
+    // the shared best-effort POST helper's single deadline must cover /auth/config
+    // discovery for the Stop path too, not just the POST itself.
+    [Test, NotInParallel]
+    public async Task Stop_still_emits_continue_json_when_auth_discovery_is_slow() {
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}").WithDelay(TimeSpan.FromSeconds(10)));
+        _server.Given(Request.Create().WithPath("/hooks/stop").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        var payload = """
+                      {
+                        "hook_event_name": "Stop",
+                        "session_id": "abc",
+                        "transcript_path": "/tmp/rollout.jsonl",
+                        "cwd": "/tmp"
+                      }
+                      """;
+
+        var originalOut  = Console.Out;
+        var stdoutWriter = new StringWriter();
+        var sw           = System.Diagnostics.Stopwatch.StartNew();
+
+        try {
+            Console.SetOut(stdoutWriter);
+            var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
+            sw.Stop();
+            await Assert.That(exit).IsEqualTo(0);
+
+            var doc = JsonDocument.Parse(stdoutWriter.ToString());
+            await Assert.That(doc.RootElement.GetProperty("continue").GetBoolean()).IsTrue();
+        } finally {
+            Console.SetOut(originalOut);
+        }
+
         await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs
@@ -53,18 +53,17 @@ public class CodexHookCommandTests : IDisposable {
         // the watcher spawn.
     }
 
-    // AI-648: Codex 'Stop' fires at turn end, not session end. The hook must
-    // NOT POST /hooks/session-end/codex (that path is reserved for the
-    // watcher's parent-exit fallback in WatchCommand.cs). It must still emit
-    // {"continue":true} on stdout to satisfy Codex's stop-hook JSON parser
-    // (AI-635 invariant) and must NOT leak WatcherManager chatter to stdout.
+    // Codex 'Stop' fires at turn end, not session end. The hook now best-effort
+    // POSTs to /hooks/stop so the server can emit the idle-wait marker that
+    // clears the chat "working" indicator — but it must NOT POST session-end
+    // (that path is reserved for the watcher's parent-exit fallback), and must
+    // still emit {"continue":true} on stdout (AI-635) with no watcher chatter.
     //
-    // Globally sequential: this test captures Console.Out for the duration.
-    // NotInParallel with no group key forces it to run on its own to avoid
-    // interleaving with other stdout-mutating tests under TUnit's scheduler.
+    // Globally sequential: captures Console.Out for the duration.
     [Test, NotInParallel]
-    public async Task Stop_is_turn_end_no_op_and_does_not_post_session_end() {
-        // Stub the route so any (incorrect) POST is recorded — we assert zero.
+    public async Task Stop_posts_to_hooks_stop_and_emits_continue_json() {
+        _server.Given(Request.Create().WithPath("/hooks/stop").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
         _server.Given(Request.Create().WithPath("/hooks/session-end/codex").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
 
@@ -86,26 +85,62 @@ public class CodexHookCommandTests : IDisposable {
             var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
             await Assert.That(exit).IsEqualTo(0);
 
-            // Core invariant: Stop must NOT POST session-end.
+            // Stop now POSTs /hooks/stop exactly once, carrying the session id.
+            var stopRequests = _server.FindLogEntries(Request.Create().WithPath("/hooks/stop").UsingPost());
+            await Assert.That(stopRequests.Count).IsEqualTo(1);
+            var body = JsonDocument.Parse(stopRequests[0].RequestMessage.Body!).RootElement;
+            await Assert.That(body.GetProperty("session_id").GetString()).IsEqualTo("abc");
+
+            // Must NOT POST session-end.
             var endRequests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-end/codex").UsingPost());
             await Assert.That(endRequests.Count).IsEqualTo(0);
-
-            // Defensive: also no other related routes.
-            var wrong1 = _server.FindLogEntries(Request.Create().WithPath("/hooks/stop").UsingPost());
-            var wrong2 = _server.FindLogEntries(Request.Create().WithPath("/hooks/codex/stop").UsingPost());
-            await Assert.That(wrong1.Count).IsEqualTo(0);
-            await Assert.That(wrong2.Count).IsEqualTo(0);
 
             // AI-635 invariant: valid JSON object on stdout, no chatter.
             var stdout = stdoutWriter.ToString();
             var doc    = JsonDocument.Parse(stdout);
             await Assert.That(doc.RootElement.GetProperty("continue").GetBoolean()).IsTrue();
             await Assert.That(stdout.Contains("Watcher ")).IsFalse();
-            await Assert.That(stdout.Contains("Inline drain")).IsFalse();
             await Assert.That(stdout.Contains("Spawned")).IsFalse();
         } finally {
             Console.SetOut(originalOut);
         }
+    }
+
+    // The POST is best-effort: a slow/unreachable server must never hang the hook
+    // or break its stdout contract. Cap at 2s and swallow — assert we still emit
+    // {"continue":true} and return under 5s even when /hooks/stop stalls 10s.
+    [Test, NotInParallel]
+    public async Task Stop_still_emits_continue_json_when_server_is_slow() {
+        _server.Given(Request.Create().WithPath("/hooks/stop").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}").WithDelay(TimeSpan.FromSeconds(10)));
+
+        var payload = """
+                      {
+                        "hook_event_name": "Stop",
+                        "session_id": "abc",
+                        "transcript_path": "/tmp/rollout.jsonl",
+                        "cwd": "/tmp"
+                      }
+                      """;
+
+        var originalOut  = Console.Out;
+        var stdoutWriter = new StringWriter();
+        var sw           = System.Diagnostics.Stopwatch.StartNew();
+
+        try {
+            Console.SetOut(stdoutWriter);
+            var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
+            sw.Stop();
+            await Assert.That(exit).IsEqualTo(0);
+
+            var doc = JsonDocument.Parse(stdoutWriter.ToString());
+            await Assert.That(doc.RootElement.GetProperty("continue").GetBoolean()).IsTrue();
+        } finally {
+            Console.SetOut(originalOut);
+        }
+
+        // 2s POST cap + slack for CI jitter.
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
     }
 
     // Globally sequential alongside Stop_is_turn_end_no_op_and_does_not_post_session_end —


### PR DESCRIPTION
## What

The Codex `Stop` hook fires at every turn end, but `kcap codex-hook` never contacted the server — so the server never emitted the idle-wait marker that clears the chat "working" spinner for Codex agents (Claude gets it via `/hooks/stop`).

This adds a **best-effort** POST of the Codex Stop payload to `/hooks/stop` (2s cap, swallow-all) via a shared `PostBestEffortAsync` helper (now also used by the existing permission-record path). The hook's stdout contract (`{"continue":true}`) and exit code (`0`) are preserved **unconditionally** — a slow or unreachable server can never hang the local terminal.

Session-end stays owned by the watcher's parent-PID monitor (AI-647); Stop still never POSTs session-end.

## Tests

`CodexHookCommandTests` 24/24 — new `Stop_posts_to_hooks_stop_and_emits_continue_json`, plus slow-server and slow-auth-discovery Stop tests; existing disabled-session / `KCAP_SKIP` / numeric-`session_id` regressions stay green.

## Pairs with

kcap-server PR kurrent-io/kcap-server#928 (non-blocking `HandleStop`). End-to-end works once both land and `kcap-server` bumps the `src/cli` submodule to include this commit.

Fixes AI-1167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)