### PR TITLE
[AI-1162] Fix sk- vendor-token regex over-redacting <task-notification>

### DIFF
--- a/src/Capacitor.Cli/SecretRedactor.cs
+++ b/src/Capacitor.Cli/SecretRedactor.cs
@@ -70,8 +70,14 @@ static partial class SecretRedactor {
     static readonly Regex AwsUniqueIdRegex = AwsUniqueIdRx();
 
     // Known vendor token prefixes followed by token characters
-    // Each prefix is specific enough to avoid false positives
-    [GeneratedRegex(@"(?:ghp_|gho_|ghs_|github_pat_|cfat_|sk-(?:proj-|live_|test_)?|sk_live_|sk_test_|xoxb-|xoxp-|xoxa-|pypi-|npm_|glpat-|dckr_pat_|dckr_oat_)[A-Za-z0-9\-_]{10,}", RegexOptions.None)]
+    // Each prefix is specific enough to avoid false positives — EXCEPT the bare `sk-` (OpenAI)
+    // prefix, which is short enough to appear mid-word: it matched the `sk-notification` substring
+    // inside "ta·sk-notification", redacting Claude Code's injected background-task blocks to
+    // `<ta[REDACTED]> … </ta[REDACTED]>` (AI-1162). Gate the `sk-` branch on a non-alphanumeric
+    // lookbehind so it only fires at a token boundary; real keys (`sk-proj-…`, `sk-live_…`,
+    // preceded by whitespace/quote/punctuation) still redact, while `disk-`, `task-`, `kiosk-` etc.
+    // pass through. The other prefixes carry `_`/distinctive spellings and don't collide mid-word.
+    [GeneratedRegex(@"(?:ghp_|gho_|ghs_|github_pat_|cfat_|(?<![A-Za-z0-9])sk-(?:proj-|live_|test_)?|sk_live_|sk_test_|xoxb-|xoxp-|xoxa-|pypi-|npm_|glpat-|dckr_pat_|dckr_oat_)[A-Za-z0-9\-_]{10,}", RegexOptions.None)]
     private static partial Regex VendorTokenRx();
 
     static readonly Regex VendorTokenRegex = VendorTokenRx();

--- a/test/Capacitor.Cli.Tests.Unit/SecretRedactorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SecretRedactorTests.cs
@@ -127,6 +127,55 @@ public class SecretRedactorTests {
     }
 
     [Test]
+    public async Task DoesNotRedact_TaskNotificationTag_MidWordSkMatch() {
+        // AI-1162: the OpenAI `sk-` vendor-token branch matched the `sk-notification` substring
+        // inside "ta·sk-notification", turning Claude Code's injected background-task blocks into
+        // `<ta[REDACTED]> … </ta[REDACTED]>`. The tag is not a secret and must survive verbatim.
+        var line = """
+            {"type":"user","message":{"role":"user","content":"<task-notification>\n<task-id>by9prly15</task-id> <tool-use-id>toolu_01BBj6kq3JaFfKHG93BEmqnj</tool-use-id> <status>completed</status> <summary>Background command \"Continue watching server CI\" completed (exit code 0)</summary>\n</task-notification>"}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).IsEqualTo(line);
+        await Assert.That(result).Contains("<task-notification>");
+        await Assert.That(result).Contains("</task-notification>");
+        await Assert.That(result).DoesNotContain("[REDACTED]");
+    }
+
+    [Test]
+    [Arguments("the disk-usage report shows 80% full")] // "sk-" inside "disk-"
+    [Arguments("run a task-notification handler on completion")]
+    [Arguments("brisk-walking is good; kiosk-mode too")]
+    public async Task DoesNotRedact_SkPrefix_MidWord(string prose) {
+        // The `sk-` prefix must only match at a token boundary, never mid-identifier.
+        var line = $$$"""
+            {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"{{{prose}}}"}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).IsEqualTo(line);
+    }
+
+    [Test]
+    [Arguments("space before: sk-proj-ABCDEFghijklmnop123", "sk-proj-ABCDEFghijklmnop123")]
+    [Arguments("(sk-live_00000000000FAKEFAKE00)", "sk-live_00000000000FAKEFAKE00")]
+    [Arguments("key=sk-test_00000000000FAKEFAKE00 end", "sk-test_00000000000FAKEFAKE00")]
+    public async Task RedactsLine_SkToken_AtBoundary_StillRedacts(string content, string token) {
+        // The boundary fix must NOT weaken redaction of genuine sk- keys preceded by a
+        // non-alphanumeric char (space, punctuation, `=`).
+        var line = $$$"""
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"{{{content}}}","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain(token);
+        await Assert.That(result).Contains("[REDACTED]");
+    }
+
+    [Test]
     public async Task RedactsLine_AwsAccessKey_InToolResult() {
         var line = """
             {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE","is_error":false}]}}


### PR DESCRIPTION
## Problem

`SecretRedactor.VendorTokenRegex`'s OpenAI `sk-` branch (`sk-[A-Za-z0-9\-_]{10,}`) matches the **`sk-notification`** substring inside "ta·sk-notification", so Claude Code's injected background-task blocks are mangled:

```
<task-notification>   -> <ta[REDACTED]>
</task-notification>  -> </ta[REDACTED]>
<task-id>by9prly15</task-id>   -> unchanged  (sk-id < 10 chars, so <task-id> survives)
```

This corrupts the recorded transcript content (surfaced in AI-1162, where the `<ta[REDACTED]>` blocks appeared in chat). It's cosmetic — the subagent-correlation `agent_id` travels out-of-band, so redaction doesn't affect matching — but it damages the stored content and any consumer that parses these blocks.

## Fix

Anchor the `sk-` branch with a `(?<![A-Za-z0-9])` lookbehind so it only fires at a token boundary. Genuine `sk-proj-…`/`sk-live_…` keys (preceded by whitespace, quote, `=`, punctuation) still redact; `task-`, `disk-`, `kiosk-` etc. pass through. Other vendor prefixes carry `_`/distinctive spellings and don't collide mid-word, so they're unchanged.

## Tests

`SecretRedactorTests` (82 pass), adds:
- `<task-notification>`/`</task-notification>` pass through untouched
- `disk-usage`, `task-notification`, `brisk-`/`kiosk-` prose not redacted
- boundary-preceded `sk-proj-`/`sk-live_`/`sk-test_` keys still redact

🤖 Generated with [Claude Code](https://claude.com/claude-code)