### PR TITLE
kcap setup --codex: register kcap-memory in the config.toml allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The `kcap mcp flows` stdio server lets agents start and interact with AI-powered
 
 The `kcap mcp flow-result` stdio server is the reviewer-side counterpart: the daemon injects it into hosted review-flow reviewer sessions so they can submit their result. It is not meant to be registered or run manually — see [Flow-result MCP server](#flow-result-mcp-server-hosted-reviewers).
 
-The `kcap mcp memory` stdio server lets agents search, save, and update durable team memories — preferences, feedback, project facts, and references scoped to you, your team, or the org. The plugin **auto-registers it for Claude Code** (via `.mcp.json`) and for Codex's native plugin loader (via `.codex-mcp.json`). See the [Memory MCP server](#memory-mcp-server-for-agents) section for details.
+The `kcap mcp memory` stdio server lets agents search, save, and update durable team memories — preferences, feedback, project facts, and references scoped to you, your team, or the org. `kcap setup` **auto-registers it for both Claude Code** (via the plugin's `.mcp.json`) **and Codex CLI** (in `~/.codex/config.toml`, alongside `kcap-sessions` / `kcap-review`); Codex's native plugin loader also picks it up via `.codex-mcp.json`. See the [Memory MCP server](#memory-mcp-server-for-agents) section for details.
 
 ## What it records
 
@@ -303,7 +303,7 @@ kcap mcp flows
 
 Stdio MCP server that lets coding agents start and interact with AI-powered review flows directly from within a session. The Kurrent Capacitor plugin **auto-registers it for Claude Code** (via `.mcp.json`), so there's nothing to do after `kcap setup` — the flows server derives the target repo from its launch working directory, and Claude Code always runs inside the repo, so one registration works for every repo. It's registered even with no daemon connected; the tools simply stay inert (and `start_review_flow` returns an error) until a daemon with the repo is available.
 
-For Codex, `kcap-flows` stays manual — unlike the read-only `sessions` / `review` servers (which `kcap setup` registers in `config.toml`), it launches a paid hosted reviewer, so it isn't auto-registered. Add it to `~/.codex/config.toml`:
+For Codex, `kcap-flows` stays manual — unlike the `sessions` / `review` / `memory` servers (which `kcap setup` registers in `config.toml`), it launches a paid hosted reviewer, so it isn't auto-registered. Add it to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.kcap-flows]
@@ -334,7 +334,7 @@ Stdio MCP server the **daemon injects into hosted review-flow reviewer sessions*
 kcap mcp memory
 ```
 
-Stdio MCP server that lets coding agents search, save, and update durable "memories" — short, reusable notes (preferences, feedback, project facts, references) scoped to you, your team, or the whole org, so lessons learned in one session are available in the next. **Claude Code:** auto-registered via the plugin's `.mcp.json`. **Codex:** available via the plugin's `.codex-mcp.json` descriptor for Codex's native plugin loader.
+Stdio MCP server that lets coding agents search, save, and update durable "memories" — short, reusable notes (preferences, feedback, project facts, references) scoped to you, your team, or the whole org, so lessons learned in one session are available in the next. **Claude Code:** auto-registered via the plugin's `.mcp.json`. **Codex CLI:** `kcap setup` / `kcap plugin install --codex` register it in `~/.codex/config.toml` (alongside `kcap-sessions` / `kcap-review`), so there's nothing extra to do; enabling the plugin through Codex's native `codex plugin add` also provides it via the `.codex-mcp.json` descriptor.
 
 It provides six tools:
 

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -29,11 +29,14 @@ public static class CodexConfigToml {
     /// Codex reads MCP servers from the snake_case <c>[mcp_servers]</c> TOML table — note
     /// this is NOT the camelCase <c>mcpServers</c> key used by the Claude/Codex plugin
     /// *descriptor* JSON. <c>kcap-flows</c> is intentionally excluded: it launches a paid
-    /// hosted reviewer and stays Claude-only (AI-1056).
+    /// hosted reviewer and stays Claude-only (AI-1056). <c>kcap-memory</c> IS included
+    /// (AI-1146): it is a free, harness-agnostic team-memory server, so Codex users going
+    /// through <c>kcap setup</c> get it alongside review/sessions.
     /// </summary>
     static readonly (string Name, string[] Args)[] KcapMcpServers = [
         ("kcap-review",   ["mcp", "review"]),
-        ("kcap-sessions", ["mcp", "sessions"])
+        ("kcap-sessions", ["mcp", "sessions"]),
+        ("kcap-memory",   ["mcp", "memory"])
     ];
 
     const string McpServerCommand = "kcap";
@@ -87,7 +90,8 @@ public static class CodexConfigToml {
         Update(configPath ?? DefaultConfigPath, root => MutateTrust(root, worktreePath), out error);
 
     /// <summary>
-    /// Registers the kcap MCP servers (<c>kcap-review</c>, <c>kcap-sessions</c>) under the
+    /// Registers the kcap MCP servers (<c>kcap-review</c>, <c>kcap-sessions</c>,
+    /// <c>kcap-memory</c>) under the
     /// top-level <c>[mcp_servers]</c> table of <c>~/.codex/config.toml</c> (or
     /// <paramref name="configPath"/>) so Codex CLI picks them up with no manual TOML edit.
     /// Idempotent, and non-destructive: an entry that already exists (a prior registration
@@ -98,7 +102,8 @@ public static class CodexConfigToml {
         Update(configPath ?? DefaultConfigPath, MutateRegisterMcpServers, out _);
 
     /// <summary>
-    /// Removes the kcap-owned MCP server entries (<c>kcap-review</c>, <c>kcap-sessions</c>)
+    /// Removes the kcap-owned MCP server entries (<c>kcap-review</c>, <c>kcap-sessions</c>,
+    /// <c>kcap-memory</c>)
     /// from <c>~/.codex/config.toml</c> (or <paramref name="configPath"/>). Only those names
     /// are touched; user-defined servers are preserved. Drops the <c>[mcp_servers]</c> table
     /// entirely when removing them empties it, so uninstall leaves no bare table behind.

--- a/src/Capacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-mcp.txt
@@ -67,10 +67,24 @@ mcp memory:
   are scoped to user/team/org with optional repo and machine context. Agents
   should search before saving to avoid duplication. Requires `kcap login`.
 
+  `kcap setup` auto-registers `kcap-memory` for both Claude Code (plugin
+  `.mcp.json`) and Codex CLI (`~/.codex/config.toml`), same as sessions/review,
+  so no manual step is needed. To add it by hand instead:
+
+    Claude Code:
+      claude mcp add kcap-memory -- kcap mcp memory
+
+    Codex (CLI or desktop app) — add to ~/.codex/config.toml:
+      [mcp_servers.kcap-memory]
+      command = "kcap"
+      args    = ["mcp", "memory"]
+      # desktop app launches with no shell PATH, so command
+      # needs an absolute path (e.g. /opt/homebrew/bin/kcap)
+
 INSTALL
 
-  `kcap setup` registers `kcap-sessions` and `kcap-review` for both
-  Claude Code (via the plugin's `.mcp.json`) and Codex CLI (`kcap setup`
+  `kcap setup` registers `kcap-sessions`, `kcap-review`, and `kcap-memory`
+  for both Claude Code (via the plugin's `.mcp.json`) and Codex CLI (`kcap setup`
   / `kcap plugin install --codex` write them into `~/.codex/config.toml`),
   so no manual `claude mcp add` or TOML edit is needed. Enabling the kcap
   plugin through Codex's native `codex plugin add` also provides them via

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
@@ -208,21 +208,25 @@ public class CodexConfigTomlTests {
         ((TomlArray)server["args"]).Select(v => (string)v!).ToArray();
 
     [Test]
-    public async Task RegisterKcapMcpServers_on_missing_config_writes_both_servers() {
+    public async Task RegisterKcapMcpServers_on_missing_config_writes_all_servers() {
         var path = TempConfig();
 
         var change = CodexConfigToml.RegisterKcapMcpServers(path);
 
         await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
 
-        var servers = (TomlTable)ReadToml(path)["mcp_servers"];
-        var review  = (TomlTable)servers["kcap-review"];
+        var servers  = (TomlTable)ReadToml(path)["mcp_servers"];
+        var review   = (TomlTable)servers["kcap-review"];
         var sessions = (TomlTable)servers["kcap-sessions"];
+        var memory   = (TomlTable)servers["kcap-memory"];
 
         await Assert.That((string)review["command"]).IsEqualTo("kcap");
         await Assert.That(ArgsOf(review)).IsEquivalentTo(new[] { "mcp", "review" });
         await Assert.That((string)sessions["command"]).IsEqualTo("kcap");
         await Assert.That(ArgsOf(sessions)).IsEquivalentTo(new[] { "mcp", "sessions" });
+        // AI-1146: kcap-memory is now auto-registered for Codex too.
+        await Assert.That((string)memory["command"]).IsEqualTo("kcap");
+        await Assert.That(ArgsOf(memory)).IsEquivalentTo(new[] { "mcp", "memory" });
     }
 
     [Test]
@@ -236,6 +240,7 @@ public class CodexConfigTomlTests {
         var text = File.ReadAllText(path);
         await Assert.That(text).Contains("[mcp_servers.kcap-review]");
         await Assert.That(text).Contains("[mcp_servers.kcap-sessions]");
+        await Assert.That(text).Contains("[mcp_servers.kcap-memory]");
         await Assert.That(text).DoesNotContain("mcpServers");
     }
 
@@ -273,6 +278,7 @@ public class CodexConfigTomlTests {
         await Assert.That((string)((TomlTable)servers["my-tool"])["command"]).IsEqualTo("my-tool"); // user's preserved
         await Assert.That(servers.ContainsKey("kcap-review")).IsTrue();
         await Assert.That(servers.ContainsKey("kcap-sessions")).IsTrue();
+        await Assert.That(servers.ContainsKey("kcap-memory")).IsTrue();
     }
 
     [Test]
@@ -354,6 +360,7 @@ public class CodexConfigTomlTests {
         await Assert.That(servers.ContainsKey("my-tool")).IsTrue();
         await Assert.That(servers.ContainsKey("kcap-review")).IsFalse();
         await Assert.That(servers.ContainsKey("kcap-sessions")).IsFalse();
+        await Assert.That(servers.ContainsKey("kcap-memory")).IsFalse();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
@@ -606,6 +606,7 @@ public class PluginCommandCodexInstallIntegrationTests {
         var toml       = await File.ReadAllTextAsync(configPath);
         await Assert.That(toml).Contains("[mcp_servers.kcap-review]");
         await Assert.That(toml).Contains("[mcp_servers.kcap-sessions]");
+        await Assert.That(toml).Contains("[mcp_servers.kcap-memory]"); // AI-1146
     }
 
     [Test]
@@ -620,6 +621,7 @@ public class PluginCommandCodexInstallIntegrationTests {
         var toml = await File.ReadAllTextAsync(configPath);
         await Assert.That(toml).DoesNotContain("kcap-review");
         await Assert.That(toml).DoesNotContain("kcap-sessions");
+        await Assert.That(toml).DoesNotContain("kcap-memory"); // AI-1146
         await Assert.That(toml).Contains("my-tool"); // user's server preserved
     }
 
@@ -652,6 +654,10 @@ public class PluginCommandCodexInstallIntegrationTests {
             [mcp_servers.kcap-sessions]
             command = "kcap"
             args = ["mcp", "sessions"]
+
+            [mcp_servers.kcap-memory]
+            command = "kcap"
+            args = ["mcp", "memory"]
 
             [mcp_servers.my-tool]
             command = "my-tool"


### PR DESCRIPTION
Linear: AI-1146 (follow-up to AI-1134 Task 12; parent AI-1134). Created directly in Linear, so there's no GitHub issue to close.

## Problem
`kcap mcp memory` shipped registered for Claude Code (plugin `.mcp.json`) and for Codex's native plugin loader (`.codex-mcp.json`), but the `CodexConfigToml` allowlist used by `kcap setup` / `kcap plugin install --codex` only wrote `kcap-review` + `kcap-sessions`. So Codex users who onboard via `kcap setup` got sessions/review but **not** kcap-memory in `~/.codex/config.toml`.

## Change
- Add `("kcap-memory", ["mcp","memory"])` to `CodexConfigToml.KcapMcpServers`, so it's registered on setup/install and removed on uninstall via the existing non-destructive, idempotent paths. It's a free, harness-agnostic server — unlike the paid, Claude-only `kcap-flows`, which stays deliberately excluded.
- **Docs:** `help-mcp.txt` INSTALL now lists `kcap-memory` as auto-registered, and its `mcp memory` section carries the manual-Codex-TOML snippet its `mcp flows`/`mcp judge` siblings have. README's memory intro + "Memory MCP server" section + the flows contrast updated to match.

## Tests
- `CodexConfigTomlTests`: register writes `kcap-memory` (`["mcp","memory"]`); unregister removes it while preserving user servers; snake_case `[mcp_servers.kcap-memory]` emitted.
- `PluginCommandCodexTests`: `plugin install --codex` writes it; `plugin remove --codex` removes it (seed updated to include it).
- Full unit suite **2124/2124** green; Release AOT publish clean (no IL30xx/IL20xx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)