### PR TITLE
Inject team-memory index at SessionStart (Claude Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Once set up, Capacitor runs silently in the background. Every Claude Code (and C
 - **Repository context** — git repo, branch, and PR linkage
 - **In-agent upgrade prompts** — in Claude Code sessions, when the server is running a newer kcap release than the local CLI, additional context is injected into the session so the agent can offer the user an upgrade via `kcap update`. The stderr `kcap` update hint continues to fire for direct command-line use.
 - **SessionStart context injection** — at every session start the server injects top evaluation-derived fact clusters for the current repo into Claude's `additionalContext`. The injected block is split into two sections: `## Known patterns` (repo/project facts relevant to any reader) and `## Guidance from past sessions` (agent-targeted action items derived from prior eval suggestions with `audience: "agent"`). Opt out by setting `disable_session_guidelines: true` in `~/.config/kcap/config.json` or via `kcap config set disable_session_guidelines true`.
+- **SessionStart team-memory index** — at every session start (Claude Code) `kcap` also fetches a compact index of durable [team memories](#memory-mcp-server-for-agents) visible for the current repo/machine and appends a `## Team memory` block to `additionalContext`: one `slug: description` line per memory, grouped **Org / Team / Yours**, with a nudge to call `get_memory` / `search_memories` for full content. Only the index is injected — never the bodies — so the cost stays roughly flat as the pool grows (mirrors a local `MEMORY.md`). Best-effort and fail-open (a slow or failed fetch injects nothing, never blocking the hook). Opt out with `disable_memory_index: true` in `~/.config/kcap/config.json` or `kcap config set disable_memory_index true`.
 
 ## CLI commands
 
@@ -346,6 +347,8 @@ It provides six tools:
 - **`archive_memory`** — soft-delete a memory.
 
 The server is repo- and machine-aware: it resolves the current working directory to a repo hash and the local persisted machine id at startup, and uses both to scope `save_memory` and to bias `search_memories` / `get_memory` results.
+
+At SessionStart (Claude Code), `kcap` also injects a compact **index** of the memories visible for the current repo/machine into the session context, so the agent starts each session aware of what's saved without a search — see [SessionStart team-memory index](#what-it-records) above. Opt out with `kcap config set disable_memory_index true`.
 
 ### Curate guidelines
 

--- a/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
@@ -54,6 +54,14 @@ public record Profile {
     public bool? DisableSessionGuidelines { get; init; }
 
     /// <summary>
+    /// AI-1165 — when true, kcap skips injecting the team-memory index at SessionStart.
+    /// Independent of <see cref="DisableSessionGuidelines"/> so the recurring-lessons and
+    /// memory-index injections can be toggled separately.
+    /// </summary>
+    [JsonPropertyName("disable_memory_index")]
+    public bool? DisableMemoryIndex { get; init; }
+
+    /// <summary>
     /// When true, kcap keeps <c>ANTHROPIC_API_KEY</c> / <c>OPENAI_API_KEY</c>
     /// in the spawn environment for headless agent CLIs (title generation,
     /// summaries, judges). Default <c>false</c> scrubs them so subscription

--- a/src/Capacitor.Cli.Core/Resources/help-config.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-config.txt
@@ -12,5 +12,6 @@ Config keys:
   daemon.max_agents           Max concurrent hosted coding agents
   default_visibility          Default session visibility (private, org_public, public)
   disable_session_guidelines  Skip injecting recurring-lessons context at SessionStart (true/false)
+  disable_memory_index        Skip injecting the team-memory index at SessionStart (true/false)
   excluded_repos              Excluded repos, comma-separated (owner/repo,owner/repo)
   update_check                Enable update check (true/false)

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -759,8 +759,14 @@ public static class ClaudeHookCommand {
     // ── AI-1165: SessionStart team-memory index injection ────────────────────────
     //
     // Best-effort fetch of GET /api/memories/index for the current repo + machine.
-    // Everything here is fail-open: a failure, non-2xx, timeout, or unresolved repo/
-    // machine yields null, and MemoryIndexEmitter.BuildFragment(null, …) emits nothing.
+    // Fail-open on a failure / non-2xx / timeout → null, and
+    // MemoryIndexEmitter.BuildFragment(null, …) emits nothing.
+    //
+    // Unresolved repo/machine is NOT an error: the query params are simply omitted, which the
+    // server's scope predicate (`repo_hash IS NULL OR repo_hash = @repo`, likewise machine_tag)
+    // narrows to the caller's GLOBAL, machine-agnostic memories — exactly the repo-independent
+    // subset that should surface everywhere (e.g. a session outside any git repo). It never
+    // returns another repo's repo-scoped memories, so the result stays correctly scoped.
 
     static async Task<JsonNode?> TryFetchMemoryIndexAsync(HttpClient client, string baseUrl, string? sessionCwd, long processStart) {
         try {

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -470,6 +470,16 @@ public static class ClaudeHookCommand {
                 return 0;
             }
 
+            // AI-1165 — kick off the team-memory index fetch in PARALLEL with the hook POST so
+            // it adds no latency to the critical path. Fully best-effort / fail-open: any failure,
+            // a 401, or a budget overrun yields a null fragment and nothing is injected. Started
+            // after the ordering-guard / backlog returns above so a spooled session-start doesn't
+            // pay for a fetch it won't use.
+            var memoryDisabled  = AppConfig.ResolvedProfile?.Profile?.DisableMemoryIndex is true;
+            var memoryIndexTask = memoryDisabled
+                ? Task.FromResult<JsonNode?>(null)
+                : TryFetchMemoryIndexAsync(client, baseUrl, sessionCwd, processStart);
+
             // 2. Single bounded POST — keep resp alive to read the response body for the
             //    context-envelope emission and plan-content POST on success.
             var remaining = HookBudget.Remaining(processStart, "session-start");
@@ -520,8 +530,12 @@ public static class ClaudeHookCommand {
                     var disabled        = AppConfig.ResolvedProfile?.Profile?.DisableSessionGuidelines is true;
                     var lessonsFragment = SessionGuidelinesEmitter.BuildFragment(responseNode, disabled);
                     var nudgeFragment   = VersionNudgeEmitter.BuildFragment(responseNode, CapacitorVersion.CurrentDisplay());
+                    // AI-1165 — join the parallel memory-index fetch, bounded by the remaining
+                    // hook budget so a slow fetch can't delay the hook (fail-open → null).
+                    var memoryFragment  = MemoryIndexEmitter.BuildFragment(
+                        await AwaitMemoryIndexAsync(memoryIndexTask, processStart), memoryDisabled);
 
-                    var envelope = SessionStartAdditionalContext.BuildEnvelope(lessonsFragment, nudgeFragment);
+                    var envelope = SessionStartAdditionalContext.BuildEnvelope(lessonsFragment, nudgeFragment, memoryFragment);
 
                     if (envelope is not null) {
                         Console.WriteLine(envelope);
@@ -740,6 +754,67 @@ public static class ClaudeHookCommand {
         if (value is not null && value.Contains('-')) {
             node[fieldName] = value.Replace("-", "");
         }
+    }
+
+    // ── AI-1165: SessionStart team-memory index injection ────────────────────────
+    //
+    // Best-effort fetch of GET /api/memories/index for the current repo + machine.
+    // Everything here is fail-open: a failure, non-2xx, timeout, or unresolved repo/
+    // machine yields null, and MemoryIndexEmitter.BuildFragment(null, …) emits nothing.
+
+    static async Task<JsonNode?> TryFetchMemoryIndexAsync(HttpClient client, string baseUrl, string? sessionCwd, long processStart) {
+        try {
+            var budget = HookBudget.Remaining(processStart, "session-start");
+            if (budget <= TimeSpan.Zero) return null;
+
+            var repoHash  = await TryResolveRepoHashAsync(sessionCwd);
+            var machineId = await TryResolveMachineIdAsync();
+
+            using var cts  = new CancellationTokenSource(HookBudget.Remaining(processStart, "session-start"));
+            using var resp = await client.GetAsync(BuildMemoryIndexUrl(baseUrl, repoHash, machineId), cts.Token);
+            if (!resp.IsSuccessStatusCode) return null;
+
+            return JsonNode.Parse(await resp.Content.ReadAsStringAsync(cts.Token));
+        } catch {
+            return null; // fail-open — memory injection never breaks the hook
+        }
+    }
+
+    // Bound the join on the parallel fetch by the remaining hook budget so a slow index
+    // fetch can never delay session capture. Timeout or fault → null (nothing injected).
+    static async Task<JsonNode?> AwaitMemoryIndexAsync(Task<JsonNode?> task, long processStart) {
+        try {
+            var budget = HookBudget.Remaining(processStart, "session-start");
+            if (budget <= TimeSpan.Zero) return task.IsCompletedSuccessfully ? task.Result : null;
+
+            return await task.WaitAsync(budget);
+        } catch {
+            return null;
+        }
+    }
+
+    internal static string BuildMemoryIndexUrl(string baseUrl, string? repoHash, string? machineId) {
+        var qs = new List<string>();
+        if (repoHash is not null)  qs.Add($"repo={Uri.EscapeDataString(repoHash)}");
+        if (machineId is not null) qs.Add($"machine={Uri.EscapeDataString(machineId)}");
+
+        return qs.Count > 0 ? $"{baseUrl}/api/memories/index?{string.Join('&', qs)}" : $"{baseUrl}/api/memories/index";
+    }
+
+    static async Task<string?> TryResolveRepoHashAsync(string? sessionCwd) {
+        try {
+            var cwd      = string.IsNullOrWhiteSpace(sessionCwd) ? Directory.GetCurrentDirectory() : sessionCwd;
+            var repoInfo = await RepositoryDetection.DetectRepositoryAsync(cwd);
+            if (repoInfo?.Owner is null || repoInfo.RepoName is null) return null;
+
+            return RepoHashHelper.ComputeRepoHash(repoInfo.Owner, repoInfo.RepoName);
+        } catch {
+            return null;
+        }
+    }
+
+    static async Task<string?> TryResolveMachineIdAsync() {
+        try { return await MachineIdProvider.GetOrCreateAsync(); } catch { return null; }
     }
 
     static string? ReadPlanFile(string slug) {

--- a/src/Capacitor.Cli/Commands/ConfigCommand.cs
+++ b/src/Capacitor.Cli/Commands/ConfigCommand.cs
@@ -76,6 +76,8 @@ public static class ConfigCommand {
             "update_check" => throw new ArgumentException($"Invalid value for update_check: '{value}'. Must be true or false."),
             "disable_session_guidelines" when bool.TryParse(value, out var b) => profile with { DisableSessionGuidelines = b },
             "disable_session_guidelines" => throw new ArgumentException($"Invalid value for disable_session_guidelines: '{value}'. Must be true or false."),
+            "disable_memory_index" when bool.TryParse(value, out var b) => profile with { DisableMemoryIndex = b },
+            "disable_memory_index" => throw new ArgumentException($"Invalid value for disable_memory_index: '{value}'. Must be true or false."),
             "use_provider_api_key" when bool.TryParse(value, out var b) => profile with { UseProviderApiKey = b },
             "use_provider_api_key" => throw new ArgumentException($"Invalid value for use_provider_api_key: '{value}'. Must be true or false."),
             "default_visibility" when value is "private" or "org_public" or "public" => profile with { DefaultVisibility = value },

--- a/src/Capacitor.Cli/MemoryIndexEmitter.cs
+++ b/src/Capacitor.Cli/MemoryIndexEmitter.cs
@@ -48,7 +48,11 @@ static class MemoryIndexEmitter {
 
             if (string.IsNullOrWhiteSpace(slug) || string.IsNullOrWhiteSpace(description)) continue;
 
-            var line = $"- {slug}: {description}";
+            // Collapse any internal whitespace — including newlines — to single spaces so a
+            // description keeps to one bullet. The server validates descriptions as single-line,
+            // but the injected block feeds an LLM's context, so the CLI must not depend on that:
+            // a stray '\n' would otherwise split one memory across lines and distort the grouping.
+            var line = $"- {OneLine(slug)}: {OneLine(description)}";
             switch (audience) {
                 case "org":  org.Add(line);  break;
                 case "team": team.Add(line); break;
@@ -78,4 +82,8 @@ static class MemoryIndexEmitter {
         sb.AppendLine($"### {heading}");
         foreach (var l in lines) sb.AppendLine(l);
     }
+
+    // Collapse all whitespace runs (spaces, tabs, CR/LF) to single spaces and trim, so any
+    // value renders as one line. Splitting on null splits on Unicode whitespace.
+    static string OneLine(string s) => string.Join(' ', s.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
 }

--- a/src/Capacitor.Cli/MemoryIndexEmitter.cs
+++ b/src/Capacitor.Cli/MemoryIndexEmitter.cs
@@ -1,0 +1,81 @@
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli;
+
+/// <summary>
+/// AI-1165 (Agent Memories Phase 2) — builds the SessionStart "team memory" index
+/// fragment from the <c>GET /api/memories/index</c> response body: a JSON array of
+/// <c>{memory_id, slug, audience, description, kind}</c>, already capped and
+/// most-recently-updated first by the server.
+/// <para>
+/// Entries are grouped by <c>audience</c> (org → team → user), preserving the
+/// server's order within each group, and rendered as <c>slug: description</c> — one
+/// line per memory — under a lead-in that tells the agent to call
+/// <c>get_memory</c> / <c>search_memories</c> for full content. Bodies are NEVER
+/// injected: this mirrors a local <c>MEMORY.md</c> index so the injected token cost
+/// stays roughly flat as the pool grows.
+/// </para>
+/// <para>
+/// Returns <c>null</c> when disabled, empty, or malformed — the caller
+/// (<c>SessionStartAdditionalContext</c>) drops null fragments, so a failed or empty
+/// fetch emits nothing (fail-open, same as guideline injection).
+/// </para>
+/// </summary>
+static class MemoryIndexEmitter {
+    /// <param name="indexNode">The <c>/api/memories/index</c> response body parsed as a <see cref="JsonNode"/> (expected: a JSON array).</param>
+    /// <param name="disabled">True when the user set <c>disable_memory_index</c> on their active profile.</param>
+    public static string? BuildFragment(JsonNode? indexNode, bool disabled) {
+        if (disabled) return null;
+        if (indexNode is not JsonArray entries || entries.Count == 0) return null;
+
+        // Preserve server order (updated_at DESC) within each audience bucket.
+        var org  = new List<string>();
+        var team = new List<string>();
+        var user = new List<string>();
+
+        foreach (var node in entries) {
+            if (node is not JsonObject o) continue;
+
+            string? slug, description, audience;
+            try {
+                slug        = o["slug"]?.GetValue<string>();
+                description = o["description"]?.GetValue<string>();
+                audience    = o["audience"]?.GetValue<string>();
+            } catch {
+                continue; // skip a malformed entry rather than dropping the whole block
+            }
+
+            if (string.IsNullOrWhiteSpace(slug) || string.IsNullOrWhiteSpace(description)) continue;
+
+            var line = $"- {slug}: {description}";
+            switch (audience) {
+                case "org":  org.Add(line);  break;
+                case "team": team.Add(line); break;
+                case "user": user.Add(line); break;
+                // Unknown/missing audience: skip — we only render the three known buckets,
+                // and grouping on an unrecognized key would be misleading.
+            }
+        }
+
+        if (org.Count == 0 && team.Count == 0 && user.Count == 0) return null;
+
+        var sb = new StringBuilder();
+        sb.AppendLine("## Team memory");
+        sb.AppendLine("Durable memories for this repo/context. Call `get_memory <slug>` for the full content of any entry, or `search_memories` to find more.");
+
+        AppendGroup(sb, "Org", org);
+        AppendGroup(sb, "Team", team);
+        AppendGroup(sb, "Yours", user);
+
+        return sb.ToString().TrimEnd();
+    }
+
+    static void AppendGroup(StringBuilder sb, string heading, List<string> lines) {
+        if (lines.Count == 0) return;
+
+        sb.AppendLine();
+        sb.AppendLine($"### {heading}");
+        foreach (var l in lines) sb.AppendLine(l);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Integration/ClaudeHookStdoutTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/ClaudeHookStdoutTests.cs
@@ -25,6 +25,13 @@ namespace Capacitor.Cli.Tests.Integration;
 /// <c>excluded_paths</c> entry covering the test <c>cwd</c> would silently
 /// short-circuit <c>ClaudeHookCommand</c> and make these tests pass for
 /// the wrong reason.
+///
+/// Each test is <c>[NotInParallel]</c> with NO group key — i.e. globally
+/// sequential — because it redirects the process-global <c>Console.Out</c>.
+/// A group key is insufficient: another file's test whose SUT writes to
+/// <c>Console.Out</c> (e.g. <c>CodexHookCommand</c> emitting
+/// <c>{"continue":true}</c>) can run under a DIFFERENT key and leak into the
+/// capture (AI-737). Do not re-add a group key here.
 /// </summary>
 public class ClaudeHookStdoutTests : IDisposable {
     readonly WireMockServer _server = WireMockServer.Start();
@@ -54,7 +61,7 @@ public class ClaudeHookStdoutTests : IDisposable {
         return sw.ToString();
     }
 
-    [Test, NotInParallel("Console_Out")]
+    [Test, NotInParallel]
     public async Task Emits_nudge_envelope_when_server_returns_newer_version_only() {
         _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
             .RespondWith(
@@ -80,7 +87,7 @@ public class ClaudeHookStdoutTests : IDisposable {
         await Assert.That(ctx).DoesNotContain("## Guidance from past sessions");
     }
 
-    [Test, NotInParallel("Console_Out")]
+    [Test, NotInParallel]
     public async Task Emits_combined_envelope_when_server_returns_top_clusters_and_newer_version() {
         _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
             .RespondWith(
@@ -120,7 +127,7 @@ public class ClaudeHookStdoutTests : IDisposable {
         await Assert.That(ctx).Contains("kcap update");
     }
 
-    [Test, NotInParallel("Console_Out")]
+    [Test, NotInParallel]
     public async Task Emits_nothing_when_server_returns_empty_object() {
         _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));

--- a/test/Capacitor.Cli.Tests.Unit/MemoryIndexEmitterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/MemoryIndexEmitterTests.cs
@@ -162,6 +162,21 @@ public class MemoryIndexEmitterTests {
     }
 
     [Test]
+    public async Task Collapses_newlines_in_description_to_keep_one_line_per_memory() {
+        // The server validates descriptions single-line, but the CLI must not depend on that:
+        // a stray newline would otherwise split one memory across bullets and distort grouping.
+        var index = new JsonArray(
+            new JsonObject { ["slug"] = "multi", ["audience"] = "org", ["description"] = "line one\nline two\r\n\tline three" }
+        );
+
+        var fragment = MemoryIndexEmitter.BuildFragment(index, disabled: false)!;
+
+        await Assert.That(fragment).Contains("- multi: line one line two line three");
+        // Exactly one bullet — the description did not spill onto extra lines.
+        await Assert.That(fragment.Split('\n').Count(l => l.StartsWith("- ", StringComparison.Ordinal))).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Fragment_is_not_a_json_envelope() {
         var fragment = MemoryIndexEmitter.BuildFragment(Index(("x", "org", "y")), disabled: false)!;
 

--- a/test/Capacitor.Cli.Tests.Unit/MemoryIndexEmitterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/MemoryIndexEmitterTests.cs
@@ -1,0 +1,171 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class MemoryIndexUrlTests {
+    [Test]
+    public async Task No_repo_or_machine_omits_query() {
+        var url = ClaudeHookCommand.BuildMemoryIndexUrl("http://srv", repoHash: null, machineId: null);
+        await Assert.That(url).IsEqualTo("http://srv/api/memories/index");
+    }
+
+    [Test]
+    public async Task Includes_repo_and_machine_when_present() {
+        var url = ClaudeHookCommand.BuildMemoryIndexUrl("http://srv", "abcd1234", "mach-01");
+        await Assert.That(url).IsEqualTo("http://srv/api/memories/index?repo=abcd1234&machine=mach-01");
+    }
+
+    [Test]
+    public async Task Repo_only_omits_machine_param() {
+        var url = ClaudeHookCommand.BuildMemoryIndexUrl("http://srv", "abcd1234", machineId: null);
+        await Assert.That(url).IsEqualTo("http://srv/api/memories/index?repo=abcd1234");
+    }
+
+    [Test]
+    public async Task Url_encodes_parameter_values() {
+        var url = ClaudeHookCommand.BuildMemoryIndexUrl("http://srv", "a b", "m/1");
+        await Assert.That(url).Contains("repo=a%20b");
+        await Assert.That(url).Contains("machine=m%2F1");
+    }
+}
+
+public class MemoryIndexEmitterTests {
+    static JsonArray Index(params (string slug, string audience, string description)[] items) {
+        var arr = new JsonArray();
+        foreach (var (slug, audience, description) in items) {
+            arr.Add(new JsonObject {
+                ["memory_id"]   = $"id-{slug}",
+                ["slug"]        = slug,
+                ["audience"]    = audience,
+                ["description"] = description,
+                ["kind"]        = "feedback"
+            });
+        }
+        return arr;
+    }
+
+    [Test]
+    public async Task Groups_by_audience_with_headers_and_instruction() {
+        var index = Index(
+            ("org-rule",  "org",  "org fact"),
+            ("team-rule", "team", "team fact"),
+            ("my-rule",   "user", "my fact")
+        );
+
+        var fragment = MemoryIndexEmitter.BuildFragment(index, disabled: false);
+
+        await Assert.That(fragment).IsNotNull();
+        await Assert.That(fragment!).Contains("## Team memory");
+        await Assert.That(fragment!).Contains("get_memory");
+        await Assert.That(fragment!).Contains("search_memories");
+        await Assert.That(fragment!).Contains("### Org");
+        await Assert.That(fragment!).Contains("- org-rule: org fact");
+        await Assert.That(fragment!).Contains("### Team");
+        await Assert.That(fragment!).Contains("- team-rule: team fact");
+        await Assert.That(fragment!).Contains("### Yours");
+        await Assert.That(fragment!).Contains("- my-rule: my fact");
+    }
+
+    [Test]
+    public async Task Groups_render_in_org_then_team_then_user_order_regardless_of_input_order() {
+        // Deliberately feed user → team → org; output must still be Org, Team, Yours.
+        var index = Index(
+            ("my-rule",   "user", "my fact"),
+            ("team-rule", "team", "team fact"),
+            ("org-rule",  "org",  "org fact")
+        );
+
+        var fragment = MemoryIndexEmitter.BuildFragment(index, disabled: false)!;
+
+        var org  = fragment.IndexOf("### Org", StringComparison.Ordinal);
+        var team = fragment.IndexOf("### Team", StringComparison.Ordinal);
+        var user = fragment.IndexOf("### Yours", StringComparison.Ordinal);
+
+        await Assert.That(org).IsGreaterThanOrEqualTo(0);
+        await Assert.That(org).IsLessThan(team);
+        await Assert.That(team).IsLessThan(user);
+    }
+
+    [Test]
+    public async Task Preserves_server_order_within_a_group() {
+        // Server returns most-recently-updated first; the emitter must not reorder within a bucket.
+        var index = Index(
+            ("newest", "org", "a"),
+            ("middle", "org", "b"),
+            ("oldest", "org", "c")
+        );
+
+        var fragment = MemoryIndexEmitter.BuildFragment(index, disabled: false)!;
+
+        var newest = fragment.IndexOf("- newest:", StringComparison.Ordinal);
+        var middle = fragment.IndexOf("- middle:", StringComparison.Ordinal);
+        var oldest = fragment.IndexOf("- oldest:", StringComparison.Ordinal);
+
+        await Assert.That(newest).IsLessThan(middle);
+        await Assert.That(middle).IsLessThan(oldest);
+    }
+
+    [Test]
+    public async Task Renders_only_the_groups_that_have_entries() {
+        var fragment = MemoryIndexEmitter.BuildFragment(Index(("my-rule", "user", "my fact")), disabled: false)!;
+
+        await Assert.That(fragment).Contains("### Yours");
+        await Assert.That(fragment).DoesNotContain("### Org");
+        await Assert.That(fragment).DoesNotContain("### Team");
+    }
+
+    [Test]
+    public async Task Returns_null_when_disabled() =>
+        await Assert.That(MemoryIndexEmitter.BuildFragment(Index(("x", "org", "y")), disabled: true)).IsNull();
+
+    [Test]
+    public async Task Returns_null_when_index_is_empty_array() =>
+        await Assert.That(MemoryIndexEmitter.BuildFragment(new JsonArray(), disabled: false)).IsNull();
+
+    [Test]
+    public async Task Returns_null_when_index_is_null() =>
+        await Assert.That(MemoryIndexEmitter.BuildFragment(null, disabled: false)).IsNull();
+
+    [Test]
+    public async Task Returns_null_when_index_is_object_not_array() {
+        var body = JsonNode.Parse("""{ "slug": "x", "audience": "org", "description": "y" }""");
+        await Assert.That(MemoryIndexEmitter.BuildFragment(body, disabled: false)).IsNull();
+    }
+
+    [Test]
+    public async Task Skips_entries_missing_slug_or_description() {
+        var index = new JsonArray(
+            new JsonObject { ["slug"] = "good", ["audience"] = "org", ["description"] = "ok" },
+            new JsonObject {                     ["audience"] = "org", ["description"] = "no slug" },
+            new JsonObject { ["slug"] = "blank", ["audience"] = "org", ["description"] = "   " },
+            new JsonObject { ["slug"] = "nodesc",["audience"] = "org" }
+        );
+
+        var fragment = MemoryIndexEmitter.BuildFragment(index, disabled: false)!;
+
+        await Assert.That(fragment).Contains("- good: ok");
+        await Assert.That(fragment.Split('\n').Count(l => l.StartsWith("- ", StringComparison.Ordinal))).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Skips_entries_with_unknown_or_missing_audience() {
+        // Denial branch: only the three known buckets render. An unknown audience must be
+        // dropped, not grouped under a made-up heading — and if ALL entries are unknown the
+        // whole block collapses to null.
+        var index = new JsonArray(
+            new JsonObject { ["slug"] = "weird", ["audience"] = "everyone", ["description"] = "d" },
+            new JsonObject { ["slug"] = "none",                            ["description"] = "d" }
+        );
+
+        await Assert.That(MemoryIndexEmitter.BuildFragment(index, disabled: false)).IsNull();
+    }
+
+    [Test]
+    public async Task Fragment_is_not_a_json_envelope() {
+        var fragment = MemoryIndexEmitter.BuildFragment(Index(("x", "org", "y")), disabled: false)!;
+
+        await Assert.That(fragment.TrimStart().StartsWith('{')).IsFalse();
+        await Assert.That(fragment).DoesNotContain("hookSpecificOutput");
+    }
+}


### PR DESCRIPTION
Linear: AI-1165 (Agent Memories Phase 2; parent AI-1134). Created in Linear, so there's no GitHub issue to close.

Depends on server-side memory (AI-1134, shipped) — no server change here. Sibling hardening: AI-1144/AI-1145 (server #929), AI-1146 (this repo, #249).

## What
At SessionStart, `kcap` now fetches a compact index of the memories visible for the current repo/machine (`GET /api/memories/index?repo=&machine=`) and appends a `## Team memory` block to Claude Code's `additionalContext` — one `slug: description` line per memory, grouped **Org / Team / Yours**, with a nudge to call `get_memory` / `search_memories` for the full content. Only the index is injected, never the bodies, so token cost stays roughly flat as the pool grows (mirrors a local `MEMORY.md`).

## How
- **`MemoryIndexEmitter`** — pure, unit-tested formatter. Groups by audience (org→team→user), preserves the server's most-recently-updated-first order within a group, skips malformed / unknown-audience entries, returns `null` when empty/disabled/malformed.
- **`ClaudeHookCommand`** — fires the index GET **in parallel** with the hook POST and joins it **bounded by the remaining hook budget**, so it adds no latency and can't block the hook. Fully **fail-open**: failure / non-2xx / timeout / unresolved repo → nothing injected (same contract as guideline injection). Reuses `RepositoryDetection` + `RepoHashHelper` + `MachineIdProvider` for repo/machine scope, identical to `kcap mcp memory`.
- **Opt-out** — new `disable_memory_index` profile flag, independent of `disable_session_guidelines`, plus a `kcap config set` case.

## Design decisions (asked the human; proceeded on spec-aligned defaults while away — easy to change)
- **Grouping in the emitter, not SQL** (AI-1165's open question): the `/api/memories/index` endpoint already returns capped, audience-tagged, recency-ordered rows, so grouping is a presentation concern → **no server change**, and the endpoint stays a simple list reusable by any client.
- **Separate `disable_memory_index` opt-out** (vs. reusing `disable_session_guidelines` or none) for independent control.
- **Format:** grouped Org/Team/Yours, `slug: description` per line (spec's "compact index"). Not the kind-tagged or flat variants.
- **Scope:** Claude Code only this increment (spec: "Claude Code first"); other hook-bearing harnesses + Pi/OpenCode plugins follow later. MCP already covers pull-based access everywhere.

## Tests
- `MemoryIndexEmitterTests` — grouping + headers + instruction; group order (org→team→user) regardless of input order; server order preserved within a group; only-present groups render; disabled/empty/null/object→null; malformed entries skipped; unknown/missing audience skipped (block collapses to null); not a JSON envelope.
- `MemoryIndexUrlTests` — repo/machine query-param assembly + URL-encoding.
- Full unit suite **2139/2139**; Release AOT publish clean (no IL30xx/IL20xx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)