### PR TITLE
[AI-1126] Phase D-b: generic flow MCP tools (start_flow, send_to_participant, get_flow_status, close_flow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Open the server URL in your browser. The dashboard shows repositories, sessions,
 
 The `kcap mcp sessions` stdio server lets coding agents search and recall past Capacitor sessions without leaving the chat. `kcap setup` **registers it (with `kcap-review`) for both Claude Code and Codex CLI** — no manual `claude mcp add` or TOML edit. For Claude Code it's carried by the plugin's `.mcp.json`; for Codex CLI, `kcap setup` / `kcap plugin install --codex` write it into `~/.codex/config.toml`. The server is repo-aware: `cd` into a project before spawning your agent and `search_sessions` defaults to that repo's sessions.
 
-The `kcap mcp flows` stdio server lets agents start and interact with AI-powered review flows. The plugin **auto-registers it for Claude Code** (Codex stays manual). See the [Flows MCP server](#flows-mcp-server-for-agents) section for details.
+The `kcap mcp flows` stdio server lets agents start and interact with AI-powered agent flows — any flow-definition catalog entry, not just reviews. The plugin **auto-registers it for Claude Code** (Codex stays manual). See the [Flows MCP server](#flows-mcp-server-for-agents) section for details.
 
 The `kcap mcp flow-result` stdio server is the reviewer-side counterpart: the daemon injects it into hosted review-flow reviewer sessions so they can submit their result. It is not meant to be registered or run manually — see [Flow-result MCP server](#flow-result-mcp-server-hosted-reviewers).
 
@@ -301,9 +301,9 @@ The server is repo-aware — it resolves the current working directory to a repo
 kcap mcp flows
 ```
 
-Stdio MCP server that lets coding agents start and interact with AI-powered review flows directly from within a session. The Kurrent Capacitor plugin **auto-registers it for Claude Code** (via `.mcp.json`), so there's nothing to do after `kcap setup` — the flows server derives the target repo from its launch working directory, and Claude Code always runs inside the repo, so one registration works for every repo. It's registered even with no daemon connected; the tools simply stay inert (and `start_review_flow` returns an error) until a daemon with the repo is available.
+Stdio MCP server that lets coding agents start and interact with AI-powered agent flows — any entry in the server's flow-definition catalog, not just reviews — directly from within a session. The Kurrent Capacitor plugin **auto-registers it for Claude Code** (via `.mcp.json`), so there's nothing to do after `kcap setup` — the flows server derives the target repo from its launch working directory, and Claude Code always runs inside the repo, so one registration works for every repo. It's registered even with no daemon connected; the tools simply stay inert (and `start_flow` returns an error) until a daemon with the repo is available.
 
-For Codex, `kcap-flows` stays manual — unlike the `sessions` / `review` / `memory` servers (which `kcap setup` registers in `config.toml`), it launches a paid hosted reviewer, so it isn't auto-registered. Add it to `~/.codex/config.toml`:
+For Codex, `kcap-flows` stays manual — unlike the `sessions` / `review` / `memory` servers (which `kcap setup` registers in `config.toml`), it launches a paid hosted participant, so it isn't auto-registered. Add it to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.kcap-flows]
@@ -311,14 +311,16 @@ command = "kcap"           # use an absolute path (e.g. /opt/homebrew/bin/kcap) 
 args    = ["mcp", "flows"] # desktop app, which launches MCP servers without your shell PATH
 ```
 
-It provides four tools:
+It provides four generic tools:
 
-- **`start_review_flow`** — start a new review flow (`spec-review` or `code-review`). Provide `kind`, `target_kind`, `target_ref`, `target_title`, and `context`. Requester context (session ID, cwd, repo root, owner, name) is resolved automatically from the environment. Returns a `flow_run_id`. Optional `mode`: by default, when the daemon runs on the same machine, the reviewer works in a worktree mirrored from your working tree — **uncommitted and untracked changes included** — so it grounds the review in your actual in-progress source; pass `mode="context-only"` to opt out and have the reviewer treat only the submitted context as authoritative.
-- **`submit_review_round`** — submit a follow-up round to an existing flow with updated context or a response to the reviewer's findings. Returns the new round's findings.
-- **`get_review_flow_status`** — get the current status (running, waiting, completed, failed) and last result of a flow.
-- **`close_review_flow`** — mark a completed review flow as closed.
+- **`start_flow`** — start a new flow from the server's flow-definition catalog. Provide `definition_id` (e.g. `spec-review`, `code-review`, or a custom definition), `target_kind`, `target_ref`, `target_title`, and `context`. Requester context (session ID, cwd, repo root, owner, name) is resolved automatically from the environment. Returns a `flow_run_id`. Optional `mode`: by default, when the daemon runs on the same machine, the participant works in a worktree mirrored from your working tree — **uncommitted and untracked changes included** — so it grounds the work in your actual in-progress source; pass `mode="context-only"` to opt out and have the participant treat only the submitted context as authoritative.
+- **`send_to_participant`** — send a follow-up message to a participant (e.g. `"reviewer"`, the only participant Phase D definitions currently define) in an existing flow with updated context or a response to prior findings. Returns the new round's findings.
+- **`get_flow_status`** — get the current status (running, waiting, completed, failed) and last result of a flow run.
+- **`close_flow`** — mark a completed flow run as closed.
 
-Requires `kcap login` **and a running daemon with this repo checked out** — the server discovers a connected daemon to launch the hosted reviewer (Codex for the built-in `spec-review`/`code-review` flows; the vendor is chosen by the flow definition), and `start_review_flow` errors if none (or more than one) matches. The server creates an authenticated HTTP client at startup and posts to the Capacitor server's `/api/flows/*` endpoints.
+The four review tools — **`start_review_flow`**, **`submit_review_round`**, **`get_review_flow_status`**, **`close_review_flow`** — are aliases of the generic tools above, kept byte-compatible for existing callers: `start_review_flow`'s `kind` maps to `start_flow`'s `definition_id`, and `submit_review_round`'s `context` maps to `send_to_participant`'s `message` with no `participant` argument (the flow's single reviewer is targeted implicitly). New integrations should prefer the generic tools; the review tools stay best for a plain "review my PR" / "start a review flow" ask.
+
+Requires `kcap login` **and a running daemon with this repo checked out** — the server discovers a connected daemon to launch the hosted participant (Codex for the built-in `spec-review`/`code-review` flows; the vendor is chosen by the flow definition), and `start_flow` errors if none (or more than one) matches. The server creates an authenticated HTTP client at startup and posts to the Capacitor server's `/api/flows/*` endpoints.
 
 ### Flow-result MCP server (hosted reviewers)
 

--- a/docs/superpowers/plans/2026-07-03-ai1126-phase-d-b-generic-flow-mcp.md
+++ b/docs/superpowers/plans/2026-07-03-ai1126-phase-d-b-generic-flow-mcp.md
@@ -1,0 +1,162 @@
+# AI-1126 Phase D-b: Generic Flow MCP Tools — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the flow engine's already-generic API through generic MCP tools (`start_flow` / `send_to_participant` / `get_flow_status` / `close_flow`) in `kcap mcp flows`, keep the four review tools as thin aliases with byte-identical schemas, and ship an `agent-flows` skill — per the approved Phase D spec (kcap-server `docs/superpowers/specs/2026-07-02-ai1126-flows-phase-d-design.md`, review flow `a556d844`).
+
+**Architecture:** All tool changes live in `McpFlowsServer` (requester-side). Generic tools reuse the existing HTTP paths (`start_flow` → `POST /api/flows/review/start` with `kind = definition_id`; `send_to_participant` → `POST /api/flows/{id}/rounds` with the new optional `participant` passthrough — the server validates, the CLI holds no definition metadata). The reviewer-side `McpFlowResultServer` is a hard security boundary and is NOT touched.
+
+**Tech Stack:** .NET AOT CLI, source-generated System.Text.Json (`McpJsonContext`), TUnit on MTP, WireMock integration tests driving the real built binary over stdio JSON-RPC.
+
+## Global Constraints
+
+- **Alias schema stability:** the four review tools keep their EXACT existing MCP input schemas — same property names, descriptions, and required lists; `start_review_flow` keeps `kind`; no alias gains `definition_id`, `participant`, or any new parameter. A schema-pinning test locks this.
+- **Zero wire changes for existing callers:** `StartReviewFlowDto` unchanged; `SubmitReviewRoundDto` gains only the optional `[property: JsonPropertyName("participant")] string? Participant` (omitted when null — `McpJsonContext` uses `WhenWritingNull`); review-alias calls must serialize byte-identical request bodies to today.
+- **`McpFlowResultServer` (reviewer side) is out of bounds** — generic flow-starting tools must never leak into it (AI-1139 recursion boundary).
+- **Guardrail 400s surface verbatim:** the existing `Error: HTTP {code} — {body}` concatenation already does this; a test pins that a `max_rounds`/`budget_exceeded` ProblemDetails body reaches the tool result text.
+- kcap-server HTTP JSON is snake_case — all DTO fields and tool arg names stay snake_case.
+- AOT compatibility: no reflection-based serialization; DTOs already registered in `McpJsonContext` need no new `[JsonSerializable]` for added fields; any NEW DTO type must be registered in `McpReviewServer.cs`'s context.
+- Tests: TUnit on MTP (`dotnet run --project …`, never `dotnet test`). Integration tests build/spawn the real binary — run `test/Capacitor.Cli.Tests.Integration` and `test/Capacitor.Cli.Tests.Unit`.
+- Work in `/Users/alexey/dev/eventstore/kcap-cli-ai1126-db` on branch `alexeyzimarev/ai-1126-generic-flow-mcp`. Never edit the main kcap-cli checkout or the kcap-server submodule copy.
+
+## File Structure
+
+- Modify: `src/Capacitor.Cli/Commands/McpFlowsServer.cs` (tools, dispatch, DTO field)
+- Create: `kcap/skills/agent-flows/SKILL.md`
+- Modify: `kcap/.mcp.json` (kcap-flows description mentions generic tools)
+- Modify: `kcap/skills/review-flows/SKILL.md` (one pointer line)
+- Test: `test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs`
+
+**Read `McpFlowsServer.cs` and `McpFlowsServerTests.cs` fully before coding** — reuse the existing arg-parse/dispatch/HTTP helper patterns and the WireMock harness verbatim.
+
+---
+
+### Task 1: Generic tools + review aliases in `McpFlowsServer`
+
+**Files:**
+- Modify: `src/Capacitor.Cli/Commands/McpFlowsServer.cs`
+- Test: `test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs`
+
+**Interfaces:**
+- Produces: MCP tools `start_flow`, `send_to_participant`, `get_flow_status`, `close_flow`; `SubmitReviewRoundDto.Participant` (`string?`, snake_case `participant`, null-omitted). Task 2's skill documents exactly these tool names/args.
+
+- [ ] **Step 1: Failing tests.** Update/extend `McpFlowsServerTests.cs` (mirror its WireMock + stdio JSON-RPC harness):
+
+```csharp
+[Test]
+public async Task Tools_list_returns_eight_flow_tools() {
+    // was == 4 (line ~230): now assert count == 8 and names contain both the 4 review tools
+    // and: start_flow, send_to_participant, get_flow_status, close_flow
+}
+
+[Test]
+public async Task Review_tool_schemas_are_unchanged() {
+    // Pin the alias schemas byte-stably: for each of the 4 review tools assert the exact
+    // inputSchema property-name set and required list as they exist on main today
+    // (start_review_flow: kind, target_kind, target_ref, target_title, context, instructions?,
+    //  mode?, async? — copy the ACTUAL current sets from BuildToolsList before changing it).
+    // No participant/definition_id anywhere in the four review schemas.
+}
+
+[Test]
+public async Task Start_flow_posts_kind_from_definition_id() {
+    // call start_flow with definition_id="my-custom-flow" + target/context args
+    // → WireMock sees POST /api/flows/review/start with body kind=="my-custom-flow";
+    //   response terminal → tool result contains the result text
+}
+
+[Test]
+public async Task Send_to_participant_posts_participant_and_message_as_context() {
+    // start (stub) then send_to_participant(flow_run_id, participant="reviewer", message="ctx2")
+    // → POST /api/flows/{id}/rounds body has context=="ctx2" AND participant=="reviewer"
+}
+
+[Test]
+public async Task Submit_review_round_body_has_no_participant_key() {
+    // alias path: submit_review_round → POST body JSON does NOT contain "participant"
+    // (null-omitted — byte-compat with old servers)
+}
+
+[Test]
+public async Task Guardrail_400_body_surfaces_in_tool_error() {
+    // stub POST /rounds → 400 with ProblemDetails {"detail":"max_rounds (2) reached for this run — close the flow."}
+    // → send_to_participant tool result text contains "max_rounds (2)"
+}
+
+[Test]
+public async Task Get_flow_status_and_close_flow_hit_same_endpoints_as_review_tools() {
+    // get_flow_status → GET /api/flows/{id}; close_flow → POST /api/flows/{id}/close
+}
+```
+
+- [ ] **Step 2: Run the integration suite filter to verify the new tests fail** (`dotnet run --project test/Capacitor.Cli.Tests.Integration/Capacitor.Cli.Tests.Integration.csproj --treenode-filter "/*/*/McpFlowsServerTests/*"`). The pre-existing `Tools_list_returns_four_flow_tools` must be REPLACED by the new eight-count test (delete the old one in the same commit).
+
+- [ ] **Step 3: Implement in `McpFlowsServer.cs`.**
+
+1. `SubmitReviewRoundDto` gains the optional field (null-omitted by the existing `WhenWritingNull` context config):
+
+```csharp
+public sealed record SubmitReviewRoundDto(
+    [property: JsonPropertyName("context")]      string  Context,
+    [property: JsonPropertyName("instructions")] string? Instructions,
+    [property: JsonPropertyName("async")]        bool    Async,
+    [property: JsonPropertyName("participant")]  string? Participant = null
+);
+```
+(Match the record's ACTUAL current shape — copy it and append the defaulted param.)
+
+2. `BuildToolsList()` gains four generic `McpTool` entries (schemas mirror the review ones with these differences ONLY):
+   - `start_flow`: same properties as `start_review_flow` but `definition_id` (required, description: "Flow definition id from the catalog (e.g. 'code-review', or a custom definition).") replaces `kind`.
+   - `send_to_participant`: `flow_run_id` (required), `participant` (required, description: "The participant role to send to. Phase D flows have a single participant: 'reviewer'."), `message` (required — maps to the round context), `instructions` (optional), `async` (optional).
+   - `get_flow_status`: `flow_run_id` (required) — identical schema to `get_review_flow_status`.
+   - `close_flow`: `flow_run_id` (required) — identical schema to `close_review_flow`.
+   The four review-tool entries are NOT modified in any way.
+
+3. Dispatch (`HandleToolCallAsync`): generic names route to the SAME handlers —
+   - `"start_flow"` → the existing start path with `kind = args["definition_id"]` (extract a shared private method if the current code inlines it; the review alias keeps reading `kind`).
+   - `"send_to_participant"` → the existing submit path with `Context = args["message"]`, `Participant = args["participant"]`; `submit_review_round` calls the same path with `Participant = null` and `Context = args["context"]`.
+   - `"get_flow_status"` / `"close_flow"` → the same switch arms as the review equivalents (add the names to the existing cases).
+   Polling behavior (`PollUntilTerminalAsync`) is shared automatically by reusing the handlers.
+
+4. Update the server's self-description strings (the MCP `serverInfo`/instructions text, if any mentions "review") to mention both tool families — check `RunAsync`'s initialize response.
+
+- [ ] **Step 4: Run the McpFlowsServerTests filter → all green; then the FULL Integration + Unit suites** (the binary is shared across MCP server tests). Expected: all green, no schema drift elsewhere.
+
+- [ ] **Step 5: Commit** — `git add src/Capacitor.Cli/Commands/McpFlowsServer.cs test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs && git commit -m "[AI-1126] D-b: generic flow MCP tools (start_flow/send_to_participant/get_flow_status/close_flow) + review aliases"`
+
+---
+
+### Task 2: `agent-flows` skill + manifest description
+
+**Files:**
+- Create: `kcap/skills/agent-flows/SKILL.md`
+- Modify: `kcap/.mcp.json` (kcap-flows `description`)
+- Modify: `kcap/skills/review-flows/SKILL.md` (pointer line)
+
+**Interfaces:**
+- Consumes: the Task 1 tool names/args exactly.
+
+- [ ] **Step 1: Write `kcap/skills/agent-flows/SKILL.md`.** Mirror `review-flows/SKILL.md`'s structure (frontmatter with name + description trigger phrases; "if the tools are not loaded you are probably the hosted participant — do the work and end with the definition's result markers"; core rules; workflow; tool reference table; example). Content requirements:
+   - Triggers: "start a flow", "run the X flow", "agent flow", "use flow definition X", plus generic-review phrasing.
+   - The loop: `start_flow(definition_id, target_kind, target_ref, target_title, context)` → returns findings/clean per the definition's markers → address → `send_to_participant(flow_run_id, participant, message)` → repeat → `close_flow` only after the definition's clean marker.
+   - Definition discovery: definition ids come from the catalog (`/admin/flows`); the built-ins are `spec-review` and `code-review`; the review tools are aliases of the generic ones.
+   - **Guardrail errors section:** a `400` containing `max_rounds (N) reached` means address what you have and `close_flow` (the run stays open until you close it); a `budget_exceeded` error means the run is ALREADY failed and the participant stopped — report to the user, do not retry; a timed-out round surfaces as the round failing with `timeout`.
+   - Single-participant note: in Phase D every definition has exactly one participant, `reviewer`; `send_to_participant` with anything else is rejected by the server naming the valid participant.
+   - Same one-flow-per-task and no-nested-flows rules as review-flows.
+- [ ] **Step 2:** `kcap/.mcp.json`: extend the `kcap-flows` entry's `description` to name the generic tools alongside the review ones. `review-flows/SKILL.md`: add one line under the intro: "These four tools are aliases of the generic flow tools (`start_flow`, `send_to_participant`, `get_flow_status`, `close_flow`) — see the `agent-flows` skill for non-review flows."
+- [ ] **Step 3: Verify** the JSON is valid (`python3 -c "import json;json.load(open('kcap/.mcp.json'))"`) and the skill frontmatter matches the other skills' format (compare with `review-flows`).
+- [ ] **Step 4: Commit** — `[AI-1126] D-b: agent-flows skill + manifest description for generic flow tools`
+
+---
+
+### Task 3: Full verification
+
+- [ ] `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj` → green.
+- [ ] `dotnet run --project test/Capacitor.Cli.Tests.Integration/Capacitor.Cli.Tests.Integration.csproj` → green.
+- [ ] `git diff --stat origin/main` — only the five files above; `McpFlowResultServer.cs`, `McpReviewServer.cs` (except a new-DTO registration if one was truly needed — expected: none), launchers, and Models.cs untouched.
+
+## Notes / carry-overs
+
+- End-to-end `participant` validation needs a D-a-deployed server; an older server ignores the field (unknown JSON member) — graceful.
+- README flows-tool docs (README.md ~124/301-321/489) mention the review tools; a docs touch-up can ride the PR if trivial, otherwise follow-up.
+- `kcap/.codex-mcp.json` deliberately continues to omit kcap-flows (Codex drivers don't get flow-starting tools) — unchanged by design.

--- a/kcap/.mcp.json
+++ b/kcap/.mcp.json
@@ -14,7 +14,7 @@
       "command": "kcap",
       "args": ["mcp", "flows"],
       "cwd": "${CLAUDE_PROJECT_DIR}",
-      "description": "Structured AI review flows — start_review_flow, submit_review_round, get_review_flow_status, close_review_flow. Launches a SEPARATE hosted reviewer agent through your daemon and iterates to sign-off; requires `kcap login` and a running daemon with this repo checked out (the tools are inert otherwise). Use only when the user explicitly asks for a review flow / to submit for review — for an ordinary 'review my PR' or 'code review' request, review directly and do not call these tools."
+      "description": "Structured AI agent flows — start_review_flow, submit_review_round, get_review_flow_status, close_review_flow (review-specific) plus their generic equivalents start_flow, send_to_participant, get_flow_status, close_flow (any flow-definition catalog id). Launches a SEPARATE hosted participant agent through your daemon and iterates to sign-off; requires `kcap login` and a running daemon with this repo checked out (the tools are inert otherwise). Use only when the user explicitly asks for a review flow / agent flow / to submit for review — for an ordinary 'review my PR' or 'code review' request, review directly and do not call these tools."
     },
     "kcap-memory": {
       "command": "kcap",

--- a/kcap/skills/agent-flows/SKILL.md
+++ b/kcap/skills/agent-flows/SKILL.md
@@ -57,8 +57,8 @@ If `start_flow` / `send_to_participant` are not among the tools available in thi
 The server enforces per-run budgets; watch for these in tool error responses:
 
 - **`400` containing `max_rounds (N) reached for this run — close the flow.`** — the run is still **open**, it's just hit its round cap. Stop submitting further rounds, summarize what you have, and call `close_flow`.
-- **`400` containing `budget_exceeded: …`** — the run has **already failed** and the participant agent has stopped. Report this to the user; do NOT retry and do NOT call `close_flow` (closing a terminal run returns another `400`).
-- **A round that exceeds the definition's `round_timeout`** fails that round with `timeout`. The run itself stays open — you may submit another round or close the flow.
+- **`400` containing `budget_exceeded: …`** — the run has **already failed** and the participant agent has stopped. Report this to the user; do NOT retry and do NOT call `close_flow` — the run is already terminal and the participant already stopped, so closing is a no-op that only muddies the event stream.
+- **A round that exceeds the definition's `round_timeout`** lands as a terminal **`unclear`** round, with the timeout explained in its result text — if you check round status programmatically, look for `unclear` and read the text for the timeout reason. The run itself stays open — you may submit another round or close the flow.
 - **Idle runs are auto-reaped** after the definition's `idle_ttl` (server default 24h). Don't rely on this — always call `close_flow` yourself once you're done, whether the outcome was clean or you're abandoning the task.
 
 ## Workflow

--- a/kcap/skills/agent-flows/SKILL.md
+++ b/kcap/skills/agent-flows/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: agent-flows
+description: >-
+  This skill should be used ONLY when the user explicitly asks to run a
+  structured agent *flow* by name or definition id — e.g. "start a flow",
+  "run the code-review flow", "run the X flow", "use flow definition X",
+  "kick off an agent flow", or wants an iterative loop run by a separate
+  hosted participant agent that continues until sign-off. It covers the same
+  underlying tools as the `review-flows` skill (`start_review_flow` etc. are
+  aliases of the generic tools documented here) — use `review-flows` for the
+  two built-in review kinds (`spec-review`, `code-review`) and this skill for
+  any other flow definition, or when the user names a `definition_id`
+  explicitly. Do NOT use this skill (and do NOT call the flows MCP tools) for
+  an ordinary request such as "review my PR", "do X for me", or "check this
+  over" where the user just wants you to do the work yourself — perform that
+  work directly instead.
+---
+
+# Agent Flows
+
+Use the `kcap mcp flows` MCP tools (`start_flow`, `send_to_participant`, `get_flow_status`, `close_flow`) to run a structured agent **flow**: your work is handed to a **separate, hosted participant agent** driven by a flow definition from the server's catalog, which returns a result per that definition's markers (e.g. `FINDINGS:` / `NO FINDINGS` for the review-style built-ins); you address the result and keep iterating until the definition's clean/complete signal. This is a deliberate, heavier workflow — use it only when the user explicitly opts into it.
+
+## When NOT to use this skill / these tools
+
+These tools do **not** perform the work themselves — they hand it off to a separate hosted participant agent running a named flow definition. If the user simply asked *you* to do something in a normal session — e.g. "review my PR", "review this diff", "check this spec", "do X" — just do it yourself and report the result directly. Do **NOT** call `start_flow` / `send_to_participant` for an ordinary request; that would spin up a hosted agent the user did not ask for.
+
+Only start a flow when the user explicitly asks for a flow — e.g. "start a flow", "run the code-review flow", "use flow definition X", or "re-review after I address the findings" via a flow.
+
+## Choosing the flow definition
+
+Once the user has explicitly opted into a flow (see above), pick the `definition_id`:
+
+- Spec or design document → `definition_id: "spec-review"` (built-in; same as `review-flows`' `spec-review` kind)
+- Code changes or a pull request → `definition_id: "code-review"` (built-in; same as `review-flows`' `code-review` kind)
+- Anything else → the definition id the user named, or one you look up in the server's flow-definition catalog at `/admin/flows`. If you're unsure which definition applies, ask the user rather than guessing.
+
+## If the flows MCP tools are not loaded
+
+If `start_flow` / `send_to_participant` are not among the tools available in this session, do NOT try to obtain them:
+
+- Do NOT run `kcap mcp flows` from a shell, do NOT handshake it over stdio/JSON-RPC, and do NOT edit any MCP configuration.
+- The absence is deliberate: hosted flow participants run with all MCP servers stripped, so a participant cannot start a nested flow.
+- If you were asked to do work and these tools are absent, you are most likely the hosted participant inside an existing flow. This skill does not apply to you — skip the workflow below entirely. Perform the requested work directly and end your final message with the definition's result markers (for the review-style built-ins, that's a final message starting with `FINDINGS:` followed by your findings, or `NO FINDINGS`; check any instructions you were given for a custom definition's actual markers). Your final message is captured automatically; no tool call is needed to deliver it.
+
+## Core rules
+
+1. **Start exactly one flow per user task.** Call `start_flow` once and hold the returned `flow_run_id`. Do NOT start a new flow for follow-up rounds — reuse the same ID.
+2. **After receiving a non-clean result**, address it, then call `send_to_participant` with the same `flow_run_id` and the updated message.
+3. **Do NOT finish the user task while the flow has unresolved results.** Keep iterating until the definition's clean/complete signal.
+4. **Only call `close_flow` after the clean signal.** The run stays open until you explicitly close it — don't rely on it closing itself. Then report completion to the user.
+5. **If participant output is unclear or requires user input**, pause and ask the user before proceeding.
+6. **Never start a nested flow.** If you are the hosted participant (see above), do not call these tools yourself.
+7. **Single participant.** In Phase D every flow definition has exactly one participant, `reviewer`. `send_to_participant` with any other `participant` value is rejected by the server, which names the valid participant in its error.
+
+## Guardrail errors
+
+The server enforces per-run budgets; watch for these in tool error responses:
+
+- **`400` containing `max_rounds (N) reached for this run — close the flow.`** — the run is still **open**, it's just hit its round cap. Stop submitting further rounds, summarize what you have, and call `close_flow`.
+- **`400` containing `budget_exceeded: …`** — the run has **already failed** and the participant agent has stopped. Report this to the user; do NOT retry and do NOT call `close_flow` (closing a terminal run returns another `400`).
+- **A round that exceeds the definition's `round_timeout`** fails that round with `timeout`. The run itself stays open — you may submit another round or close the flow.
+- **Idle runs are auto-reaped** after the definition's `idle_ttl` (server default 24h). Don't rely on this — always call `close_flow` yourself once you're done, whether the outcome was clean or you're abandoning the task.
+
+## Workflow
+
+```
+start_flow(definition_id, target_kind, target_ref, target_title, context)
+  → participant returns a result per the definition's markers (e.g. FINDINGS: … | NO FINDINGS)
+
+if clean (e.g. NO FINDINGS):
+  close_flow(flow_run_id)
+  report completion to user
+  DONE
+
+if not clean (e.g. FINDINGS:):
+  address the result
+  send_to_participant(flow_run_id, participant="reviewer", message=…)
+    → repeat until clean
+  close_flow(flow_run_id)
+  report completion to user
+```
+
+## Tool reference
+
+| Tool | Required args | Optional args | When to call |
+|---|---|---|---|
+| `start_flow` | `definition_id` (e.g. `spec-review`, `code-review`, or a custom catalog id), `target_kind` (what is being worked on: `spec`, `code`, `pr`, `branch`, `file`, etc.), `target_ref` (a path, branch name, or PR URL/number that identifies the target), `target_title` (short human-readable title), `context` (background context: what to focus on, constraints, definition of done) | `instructions`, `mode` (`context-only` — optional; by default, on the same machine, the participant's worktree is mirrored from your working tree including uncommitted changes, so it reads the actual source. Pass `context-only` to opt out and treat the submitted context as authoritative) | Once, at the start of a flow task. |
+| `send_to_participant` | `flow_run_id`, `participant` (Phase D flows have a single participant: `reviewer`), `message` | `instructions`, `async` (defaults to `true`) | After addressing a non-clean result. Pass the same `flow_run_id` and the updated message. |
+| `get_flow_status` | `flow_run_id` | — | Poll or check the current status of a flow run (running, waiting, completed, failed). |
+| `close_flow` | `flow_run_id` | — | Only after the definition's clean signal — or when abandoning the task early; the run otherwise stays open until closed. |
+
+## Example (custom definition)
+
+```
+# Step 1 — start (all five required args must be provided; on the same machine the participant sees
+# your working tree, uncommitted changes included — pass mode="context-only" to opt out)
+start_flow(
+  definition_id="code-review",
+  target_kind="branch",
+  target_ref="feature/add-null-check",
+  target_title="Add null check on user input",
+  context="Review the diff on this branch for correctness and adherence to project conventions."
+)
+# → returns flow_run_id, e.g. "flow_abc123"
+# → participant returns FINDINGS: missing null check on line 42
+
+# Step 2 — address findings, then send a follow-up to the reviewer participant
+send_to_participant(
+  flow_run_id="flow_abc123",
+  participant="reviewer",
+  message="Fixed null check on line 42. Updated diff attached."
+)
+
+# Step 3 — participant returns NO FINDINGS
+close_flow(flow_run_id="flow_abc123")
+# Report to user: flow complete, all findings resolved
+```

--- a/kcap/skills/agent-flows/SKILL.md
+++ b/kcap/skills/agent-flows/SKILL.md
@@ -51,13 +51,14 @@ If `start_flow` / `send_to_participant` are not among the tools available in thi
 5. **If participant output is unclear or requires user input**, pause and ask the user before proceeding.
 6. **Never start a nested flow.** If you are the hosted participant (see above), do not call these tools yourself.
 7. **Single participant.** In Phase D every flow definition has exactly one participant, `reviewer`. `send_to_participant` with any other `participant` value is rejected by the server, which names the valid participant in its error.
+8. **For a code review flow (`definition_id: "code-review"`), do NOT ask the participant to run tests.** CI covers test execution; participant feedback is on correctness, design, and adherence to conventions.
 
 ## Guardrail errors
 
 The server enforces per-run budgets; watch for these in tool error responses:
 
 - **`400` containing `max_rounds (N) reached for this run — close the flow.`** — the run is still **open**, it's just hit its round cap. Stop submitting further rounds, summarize what you have, and call `close_flow`.
-- **`400` containing `budget_exceeded: …`** — the run has **already failed** and the participant agent has stopped. Report this to the user; do NOT retry and do NOT call `close_flow` — the run is already terminal and the participant already stopped, so closing is a no-op that only muddies the event stream.
+- **`400` containing `budget_exceeded: …`** — the run has **already failed** and the participant agent has stopped. Report this to the user; do NOT retry and do NOT call `close_flow` — closing a failed run overwrites the failure status in the read model (the projector flips `failed` → `closed`), hiding what went wrong.
 - **A round that exceeds the definition's `round_timeout`** lands as a terminal **`unclear`** round, with the timeout explained in its result text — if you check round status programmatically, look for `unclear` and read the text for the timeout reason. The run itself stays open — you may submit another round or close the flow.
 - **Idle runs are auto-reaped** after the definition's `idle_ttl` (server default 24h). Don't rely on this — always call `close_flow` yourself once you're done, whether the outcome was clean or you're abandoning the task.
 

--- a/kcap/skills/review-flows/SKILL.md
+++ b/kcap/skills/review-flows/SKILL.md
@@ -15,6 +15,8 @@ description: >-
 
 Use the `kcap mcp flows` MCP tools (`start_review_flow`, `submit_review_round`, …) to run a structured review **flow**: your work is submitted to a **separate, hosted reviewer** agent, which returns findings; you address them and keep iterating until the reviewer returns `NO FINDINGS`. This is a deliberate, heavier workflow — use it only when the user explicitly opts into it.
 
+These four tools are aliases of the generic flow tools (`start_flow`, `send_to_participant`, `get_flow_status`, `close_flow`) — see the `agent-flows` skill for non-review flows.
+
 ## When NOT to use this skill / these tools
 
 These tools do **not** perform a review — they hand the work off to a separate hosted reviewer. If the user simply asked *you* to review something in a normal session — e.g. "review my PR", "review this diff", "code review this", "look over this spec" — just perform the review yourself and report your findings directly. Do **NOT** call `start_review_flow` / `submit_review_round` for an ordinary review request; that would spin up a hosted reviewer the user did not ask for.

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -132,11 +132,14 @@ static class McpFlowsServer {
         try {
             var apiRoot = baseUrl.TrimEnd('/');
 
-            // start_review_flow and submit_review_round may need async poll — handle separately.
-            if (toolName is "start_review_flow" or "submit_review_round") {
-                using var postResponse = toolName == "start_review_flow"
-                    ? await SendWithRefreshRetryAsync(client, c => StartReviewFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo))
-                    : await SendWithRefreshRetryAsync(client, c => SubmitReviewRoundAsync(c, apiRoot, arguments));
+            // The start/submit tools (and their generic aliases) may need async poll — handle separately.
+            if (toolName is "start_review_flow" or "start_flow" or "submit_review_round" or "send_to_participant") {
+                using var postResponse = toolName switch {
+                    "start_review_flow"   => await SendWithRefreshRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind")),
+                    "start_flow"          => await SendWithRefreshRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id")),
+                    "submit_review_round" => await SendWithRefreshRetryAsync(client, c => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "context", participant: null, async: true)),
+                    _                     => await SendWithRefreshRetryAsync(client, c => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "message", participant: GetRequiredArg(arguments, "participant"), async: arguments?["async"]?.GetValue<bool>() ?? true))
+                };
 
                 var postBody = await postResponse.Content.ReadAsStringAsync();
 
@@ -151,9 +154,9 @@ static class McpFlowsServer {
             }
 
             using var httpResponse = toolName switch {
-                "get_review_flow_status" => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildFlowUrl(apiRoot, arguments))),
-                "close_review_flow"      => await SendWithRefreshRetryAsync(client, c => c.PostAsync(BuildFlowUrl(apiRoot, arguments) + "/close", null)),
-                _                        => throw new ArgumentException($"Unknown tool: {toolName}")
+                "get_review_flow_status" or "get_flow_status" => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildFlowUrl(apiRoot, arguments))),
+                "close_review_flow"      or "close_flow"      => await SendWithRefreshRetryAsync(client, c => c.PostAsync(BuildFlowUrl(apiRoot, arguments) + "/close", null)),
+                _                                             => throw new ArgumentException($"Unknown tool: {toolName}")
             };
 
             var body = await httpResponse.Content.ReadAsStringAsync();
@@ -167,9 +170,9 @@ static class McpFlowsServer {
             }
 
             var statusPayload = toolName switch {
-                "get_review_flow_status" => FormatStatusResponse(body),
-                "close_review_flow"      => FormatCloseResponse(body),
-                _                        => FormatRoundResponse(body)
+                "get_review_flow_status" or "get_flow_status" => FormatStatusResponse(body),
+                "close_review_flow"      or "close_flow"      => FormatCloseResponse(body),
+                _                                             => FormatRoundResponse(body)
             };
 
             return BuildToolResult(id, statusPayload);
@@ -205,15 +208,21 @@ static class McpFlowsServer {
         return await send(client);
     }
 
-    static async Task<System.Net.Http.HttpResponseMessage> StartReviewFlowAsync(
+    /// <summary>
+    /// Posts to POST /api/flows/review/start. Shared by start_review_flow (reads the flow
+    /// kind from the "kind" arg) and its generic alias start_flow (reads it from
+    /// "definition_id" — the server treats kind == definition id, AI-1126 phase C).
+    /// </summary>
+    static async Task<System.Net.Http.HttpResponseMessage> StartFlowAsync(
             HttpClient         client,
             string             apiRoot,
             JsonObject?        arguments,
             string             cwd,
             string?            repoRoot,
-            RepositoryPayload? repoInfo
+            RepositoryPayload? repoInfo,
+            string             kindArgName
         ) {
-        var kind         = GetRequiredArg(arguments, "kind");
+        var kind         = GetRequiredArg(arguments, kindArgName);
         var targetKind   = GetRequiredArg(arguments, "target_kind");
         var targetRef    = GetRequiredArg(arguments, "target_ref");
         var targetTitle  = GetRequiredArg(arguments, "target_title");
@@ -247,23 +256,32 @@ static class McpFlowsServer {
         );
     }
 
-    static Task<System.Net.Http.HttpResponseMessage> SubmitReviewRoundAsync(
+    /// <summary>
+    /// Posts to POST /api/flows/{id}/rounds. Shared by submit_review_round (reads the round
+    /// context from the "context" arg, never sends a participant) and its generic alias
+    /// send_to_participant (reads context from "message" and always sends a participant,
+    /// which the server validates against the flow definition).
+    /// </summary>
+    static Task<System.Net.Http.HttpResponseMessage> SubmitRoundAsync(
             HttpClient  client,
             string      apiRoot,
-            JsonObject? arguments
+            JsonObject? arguments,
+            string      contextArgName,
+            string?     participant,
+            bool        async
         ) {
         var flowRunId    = arguments?["flow_run_id"]?.GetValue<string>();
-        var context      = GetRequiredArg(arguments, "context");
+        var context      = GetRequiredArg(arguments, contextArgName);
         var instructions = arguments?["instructions"]?.GetValue<string>();
 
         if (string.IsNullOrWhiteSpace(flowRunId)) {
             throw new ArgumentException(
                 "Missing required argument: flow_run_id. " +
-                "Pass the flow_run_id returned by start_review_flow."
+                "Pass the flow_run_id returned by start_review_flow or start_flow."
             );
         }
 
-        var body = new SubmitReviewRoundDto(Context: context, Instructions: instructions, Async: true);
+        var body = new SubmitReviewRoundDto(Context: context, Instructions: instructions, Async: async, Participant: participant);
 
         return client.PostAsync(
             $"{apiRoot}/api/flows/{Uri.EscapeDataString(flowRunId)}/rounds",
@@ -591,6 +609,62 @@ static class McpFlowsServer {
                 },
                 ["flow_run_id"]
             )
+        ),
+        new(
+            "start_flow",
+            "Start a new agent flow from the server's flow-definition catalog. This hands the work to a SEPARATE hosted agent and iterates to sign-off — it is NOT how you do the work yourself. " +
+            "Returns findings (same UX); the server runs the flow asynchronously and the CLI polls internally. " +
+            "Returns a flow_run_id that identifies this flow run — save it to call send_to_participant or get_flow_status later.",
+            new(
+                "object",
+                new() {
+                    ["definition_id"] = new("string", "Flow definition id from the catalog (e.g. 'code-review', or a custom definition)."),
+                    ["target_kind"]    = new("string", "What is being reviewed: 'pr', 'branch', 'file', 'spec', 'plan', etc."),
+                    ["target_ref"]     = new("string", "A reference to the target (PR URL, branch name, file path, etc.)."),
+                    ["target_title"]   = new("string", "Human-readable title for the target (PR title, spec name, etc.)."),
+                    ["context"]        = new("string", "Background context for the agent: what to focus on, constraints, definition of done."),
+                    ["instructions"]   = new("string", "Optional additional instructions for the agent."),
+                    ["mode"]           = new("string", "Optional. Pass 'context-only' to have the agent treat the submitted context/diff as authoritative rather than reading the repository. By default the agent runs in a worktree mirrored from your working tree (uncommitted changes included) when it runs on the same machine, so it can ground the work in the actual source; passing 'context-only' opts out of that.")
+                },
+                ["definition_id", "target_kind", "target_ref", "target_title", "context"]
+            )
+        ),
+        new(
+            "send_to_participant",
+            "Send a follow-up message to a participant in an existing flow. Returns findings (same UX); the server runs the flow asynchronously and the CLI polls internally. Use this to ask for clarifications, provide additional context, or request a re-review after addressing feedback.",
+            new(
+                "object",
+                new() {
+                    ["flow_run_id"]  = new("string", "Flow run ID returned by start_flow."),
+                    ["participant"]  = new("string", "The participant role to send to. Phase D flows have a single participant: 'reviewer'."),
+                    ["message"]      = new("string", "Updated context or response to the participant's previous findings."),
+                    ["instructions"] = new("string", "Optional instructions for this round."),
+                    ["async"]        = new("boolean", "Optional. Defaults to true.")
+                },
+                ["flow_run_id", "participant", "message"]
+            )
+        ),
+        new(
+            "get_flow_status",
+            "Get the current status of a flow run: running, waiting, completed, or failed. Also surfaces the last result kind and result text.",
+            new(
+                "object",
+                new() {
+                    ["flow_run_id"] = new("string", "Flow run ID returned by start_flow.")
+                },
+                ["flow_run_id"]
+            )
+        ),
+        new(
+            "close_flow",
+            "Close a flow run, marking it as complete. Call this after the work is done and the findings have been addressed.",
+            new(
+                "object",
+                new() {
+                    ["flow_run_id"] = new("string", "Flow run ID returned by start_flow.")
+                },
+                ["flow_run_id"]
+            )
         )
     ];
 }
@@ -614,9 +688,16 @@ record StartReviewFlowDto(
     [property: JsonPropertyName("async")]                  bool    Async
 );
 
-/// <summary>CLI-side DTO for POST /api/flows/{flowRunId}/rounds — mirrors the server's SubmitReviewRoundRequest.</summary>
+/// <summary>
+/// CLI-side DTO for POST /api/flows/{flowRunId}/rounds — mirrors the server's SubmitReviewRoundRequest.
+/// Participant is optional (AI-1126 D-b): the review alias (submit_review_round) always leaves it
+/// null, which the WhenWritingNull context config omits from the wire entirely, keeping the alias
+/// byte-compatible with servers that predate the field. The generic alias (send_to_participant)
+/// always supplies it; the server validates it against the flow definition.
+/// </summary>
 record SubmitReviewRoundDto(
     [property: JsonPropertyName("context")]      string  Context,
     [property: JsonPropertyName("instructions")] string? Instructions,
-    [property: JsonPropertyName("async")]        bool    Async
+    [property: JsonPropertyName("async")]        bool    Async,
+    [property: JsonPropertyName("participant")]  string? Participant = null
 );

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -138,7 +138,7 @@ static class McpFlowsServer {
                     "start_review_flow"   => await SendWithRefreshRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind")),
                     "start_flow"          => await SendWithRefreshRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id")),
                     "submit_review_round" => await SendWithRefreshRetryAsync(client, c => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "context", participant: null, async: true)),
-                    _                     => await SendWithRefreshRetryAsync(client, c => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "message", participant: GetRequiredArg(arguments, "participant"), async: arguments?["async"]?.GetValue<bool>() ?? true))
+                    _                     => await SendWithRefreshRetryAsync(client, c => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "message", participant: GetRequiredArg(arguments, "participant"), async: ParseAsyncArg(arguments)))
                 };
 
                 var postBody = await postResponse.Content.ReadAsStringAsync();
@@ -149,7 +149,7 @@ static class McpFlowsServer {
                 if (!postResponse.IsSuccessStatusCode)
                     return BuildToolResult(id, $"Error: HTTP {(int)postResponse.StatusCode} — {postBody}", isError: true);
 
-                var (payload, isError) = await ResolveRoundResultAsync(client, apiRoot, postBody);
+                var (payload, isError) = await ResolveRoundResultAsync(client, apiRoot, postBody, toolName);
                 return BuildToolResult(id, payload, isError);
             }
 
@@ -311,8 +311,11 @@ static class McpFlowsServer {
     const int MaxTransientRetries = 5;
 
     /// <summary>If the POST already carries a terminal result (old/blocking server), return it.
-    /// Otherwise poll GET /api/flows/{id} until the started round is terminal (AI-1061).</summary>
-    static async Task<PollResult> ResolveRoundResultAsync(HttpClient client, string apiRoot, string postBody) {
+    /// Otherwise poll GET /api/flows/{id} until the started round is terminal (AI-1061).
+    /// <paramref name="toolName"/> is the tool that initiated the round (one of
+    /// start_review_flow/submit_review_round/start_flow/send_to_participant) — threaded through
+    /// so the graceful-cap timeout message can point back at the matching status tool.</summary>
+    static async Task<PollResult> ResolveRoundResultAsync(HttpClient client, string apiRoot, string postBody, string toolName) {
         var node      = JsonNode.Parse(postBody)?.AsObject();
         var status    = node?["status"]?.GetValue<string>();
         var flowRunId = node?["flow_run_id"]?.GetValue<string>();
@@ -321,10 +324,17 @@ static class McpFlowsServer {
         if (status != "running" || flowRunId is null || roundNum is null)
             return new(FormatRoundResponse(postBody), false); // terminal-in-POST (old server) or unparseable
 
-        return await PollUntilTerminalAsync(client, apiRoot, flowRunId, roundNum.Value);
+        return await PollUntilTerminalAsync(client, apiRoot, flowRunId, roundNum.Value, toolName);
     }
 
-    static async Task<PollResult> PollUntilTerminalAsync(HttpClient client, string apiRoot, string flowRunId, int roundNumber) {
+    /// <summary>Tool family that started the round determines which status tool the graceful-cap
+    /// message points callers back to: the review aliases (start_review_flow/submit_review_round)
+    /// suggest get_review_flow_status; the generic tools (start_flow/send_to_participant) suggest
+    /// get_flow_status. Both hit the exact same endpoint, so this only affects wording.</summary>
+    static string StatusToolNameFor(string toolName) =>
+        toolName is "start_review_flow" or "submit_review_round" ? "get_review_flow_status" : "get_flow_status";
+
+    static async Task<PollResult> PollUntilTerminalAsync(HttpClient client, string apiRoot, string flowRunId, int roundNumber, string toolName) {
         var url                   = $"{apiRoot}/api/flows/{Uri.EscapeDataString(flowRunId)}";
         var pollStartedAt         = DateTimeOffset.UtcNow;
         var deadline              = pollStartedAt + PollCap;
@@ -401,9 +411,10 @@ static class McpFlowsServer {
         }
 
         // Genuine 8-min cap: round still legitimately running.
+        var statusToolName = StatusToolNameFor(toolName);
         return new(
-            $"Review still running for flow_run_id {flowRunId} (round {roundNumber}). " +
-            "Call get_review_flow_status to retrieve the result when ready.",
+            $"Flow still running for flow_run_id {flowRunId} (round {roundNumber}). " +
+            $"Call {statusToolName} to retrieve the result when ready.",
             false
         );
     }
@@ -522,6 +533,21 @@ static class McpFlowsServer {
         var value = arguments?[name]?.GetValue<string>();
         return value ?? throw new ArgumentException($"Missing required argument: {name}");
     }
+
+    /// <summary>
+    /// Parses the optional "async" argument for send_to_participant. A missing key and an
+    /// explicit JSON null both surface as a null JsonNode from the indexer (JsonNode has no
+    /// "null" leaf type), so both default to true — matching submit_review_round's hardcoded
+    /// Async: true. A JSON boolean is used as-is. Anything else (e.g. an LLM caller passing the
+    /// string "yes") throws ArgumentException, which HandleToolCallAsync's catch turns into a
+    /// clean tool error instead of an uncaught GetValue&lt;bool&gt;() crash.
+    /// </summary>
+    static bool ParseAsyncArg(JsonObject? arguments) =>
+        arguments?["async"] switch {
+            null                                              => true,
+            JsonValue v when v.TryGetValue<bool>(out var b) => b,
+            _                                                 => throw new ArgumentException("Invalid argument: async must be a boolean")
+        };
 
     static string BuildInitializeResponse(JsonNode id) =>
         ToResponse<McpInitResult>(

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -220,20 +220,336 @@ public class McpFlowsServerTests : IDisposable {
     }
 
     [Test]
-    public async Task Tools_list_returns_four_flow_tools() {
+    public async Task Tools_list_returns_eight_flow_tools() {
         using var proc = SpawnMcpServer();
         try {
             var response = await SendRequest(proc, ToolsListRequest(2));
 
             var tools = response["result"]?["tools"]?.AsArray();
             await Assert.That(tools).IsNotNull();
-            await Assert.That(tools!.Count).IsEqualTo(4);
+            await Assert.That(tools!.Count).IsEqualTo(8);
 
             var names = tools.Select(t => t?["name"]?.GetValue<string>()).ToHashSet();
             await Assert.That(names.Contains("start_review_flow")).IsTrue();
             await Assert.That(names.Contains("submit_review_round")).IsTrue();
             await Assert.That(names.Contains("get_review_flow_status")).IsTrue();
             await Assert.That(names.Contains("close_review_flow")).IsTrue();
+            await Assert.That(names.Contains("start_flow")).IsTrue();
+            await Assert.That(names.Contains("send_to_participant")).IsTrue();
+            await Assert.That(names.Contains("get_flow_status")).IsTrue();
+            await Assert.That(names.Contains("close_flow")).IsTrue();
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
+    /// Pins the four review-tool schemas byte-stably: definition_id/participant/message must
+    /// NEVER leak into these schemas — old clients (and old skills) depend on the exact
+    /// property/required sets that shipped before the generic tools were added (AI-1126 D-b).
+    /// </summary>
+    [Test]
+    public async Task Review_tool_schemas_are_unchanged() {
+        using var proc = SpawnMcpServer();
+        try {
+            var response = await SendRequest(proc, ToolsListRequest(2));
+            var tools    = response["result"]?["tools"]?.AsArray();
+            await Assert.That(tools).IsNotNull();
+
+            var byName = tools!.ToDictionary(t => t!["name"]!.GetValue<string>(), t => t!);
+
+            await AssertSchema(
+                byName["start_review_flow"],
+                properties: ["kind", "target_kind", "target_ref", "target_title", "context", "instructions", "mode"],
+                required:   ["kind", "target_kind", "target_ref", "target_title", "context"]
+            );
+
+            await AssertSchema(
+                byName["submit_review_round"],
+                properties: ["flow_run_id", "context", "instructions"],
+                required:   ["flow_run_id", "context"]
+            );
+
+            await AssertSchema(
+                byName["get_review_flow_status"],
+                properties: ["flow_run_id"],
+                required:   ["flow_run_id"]
+            );
+
+            await AssertSchema(
+                byName["close_review_flow"],
+                properties: ["flow_run_id"],
+                required:   ["flow_run_id"]
+            );
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    static async Task AssertSchema(JsonNode tool, string[] properties, string[] required) {
+        var schema = tool["inputSchema"]?.AsObject();
+        await Assert.That(schema).IsNotNull();
+
+        var propNames = schema!["properties"]?.AsObject().Select(kv => kv.Key).ToHashSet() ?? [];
+        var reqNames  = schema["required"]?.AsArray().Select(n => n!.GetValue<string>()).ToHashSet() ?? [];
+
+        await Assert.That(propNames.SetEquals(properties)).IsTrue();
+        await Assert.That(reqNames.SetEquals(required)).IsTrue();
+    }
+
+    /// <summary>
+    /// Generic alias for start_review_flow: definition_id maps onto the wire "kind" field so the
+    /// server (which treats kind == definition id, AI-1126 phase C) doesn't need to know about
+    /// the generic tool name at all.
+    /// </summary>
+    [Test]
+    public async Task Start_flow_posts_kind_from_definition_id() {
+        const string flowRunId = "flow-generic-1";
+
+        var stubbedResponse = $$"""
+            {
+              "flow_run_id": "{{flowRunId}}",
+              "round_id": "round-1",
+              "round_number": 1,
+              "status": "completed",
+              "result_kind": "FINDINGS",
+              "result_text": "generic flow result",
+              "reviewer_agent_id": null,
+              "reviewer_session_id": null
+            }
+            """;
+
+        _server.Given(Request.Create().WithPath("/api/flows/review/start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(stubbedResponse));
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["definition_id"] = "my-custom-flow",
+                ["target_kind"]   = "pr",
+                ["target_ref"]    = "https://github.com/x/y/pull/1",
+                ["target_title"]  = "My PR",
+                ["context"]       = "please look at this"
+            };
+
+            var response = await SendRequest(proc, ToolsCallRequest(50, "start_flow", args));
+
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
+
+            var text = result["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            await Assert.That(text!.Contains($"flow_run_id: {flowRunId}")).IsTrue();
+            await Assert.That(text.Contains("generic flow result")).IsTrue();
+
+            var hits = _server.FindLogEntries(Request.Create().WithPath("/api/flows/review/start").UsingPost());
+            await Assert.That(hits.Count).IsEqualTo(1);
+
+            var bodyNode = JsonNode.Parse(hits[0].RequestMessage.Body ?? "")?.AsObject();
+            await Assert.That(bodyNode).IsNotNull();
+            await Assert.That(bodyNode!["kind"]?.GetValue<string>()).IsEqualTo("my-custom-flow");
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
+    /// send_to_participant is the generic alias for submit_review_round: "message" maps onto the
+    /// wire "context" field and "participant" is a new field the server validates against the
+    /// flow definition (Phase D flows have a single participant: "reviewer").
+    /// </summary>
+    [Test]
+    public async Task Send_to_participant_posts_participant_and_message_as_context() {
+        const string flowRunId = "flow-generic-2";
+
+        var stubbedResponse = $$"""
+            {
+              "flow_run_id": "{{flowRunId}}",
+              "round_id": "round-2",
+              "round_number": 2,
+              "status": "completed",
+              "result_kind": "FINDINGS",
+              "result_text": "round two",
+              "reviewer_agent_id": null,
+              "reviewer_session_id": null
+            }
+            """;
+
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}/rounds").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(stubbedResponse));
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["flow_run_id"] = flowRunId,
+                ["participant"] = "reviewer",
+                ["message"]     = "ctx2"
+            };
+
+            var response = await SendRequest(proc, ToolsCallRequest(51, "send_to_participant", args));
+
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
+
+            var hits = _server.FindLogEntries(Request.Create().WithPath($"/api/flows/{flowRunId}/rounds").UsingPost());
+            await Assert.That(hits.Count).IsEqualTo(1);
+
+            var bodyNode = JsonNode.Parse(hits[0].RequestMessage.Body ?? "")?.AsObject();
+            await Assert.That(bodyNode).IsNotNull();
+            await Assert.That(bodyNode!["context"]?.GetValue<string>()).IsEqualTo("ctx2");
+            await Assert.That(bodyNode["participant"]?.GetValue<string>()).IsEqualTo("reviewer");
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
+    /// The review alias must stay byte-compatible with old servers that don't know about
+    /// "participant" — the field is null-omitted, so the POST body must not carry the key at all.
+    /// </summary>
+    [Test]
+    public async Task Submit_review_round_body_has_no_participant_key() {
+        const string flowRunId = "flow-generic-3";
+
+        var stubbedResponse = $$"""
+            {
+              "flow_run_id": "{{flowRunId}}",
+              "round_id": "round-3",
+              "round_number": 1,
+              "status": "completed",
+              "result_kind": "FINDINGS",
+              "result_text": "ok",
+              "reviewer_agent_id": null,
+              "reviewer_session_id": null
+            }
+            """;
+
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}/rounds").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(stubbedResponse));
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["flow_run_id"] = flowRunId,
+                ["context"]     = "addressed all feedback"
+            };
+
+            var response = await SendRequest(proc, ToolsCallRequest(52, "submit_review_round", args));
+            var result   = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
+
+            var hits = _server.FindLogEntries(Request.Create().WithPath($"/api/flows/{flowRunId}/rounds").UsingPost());
+            await Assert.That(hits.Count).IsEqualTo(1);
+
+            var body     = hits[0].RequestMessage.Body ?? "";
+            var bodyNode = JsonNode.Parse(body)?.AsObject();
+            await Assert.That(bodyNode).IsNotNull();
+            await Assert.That(bodyNode!.ContainsKey("participant")).IsFalse();
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
+    /// Guardrail errors (max_rounds, wrong participant, etc.) come back from the server as a
+    /// ProblemDetails 400 body — it must surface verbatim in the tool's error text, same as the
+    /// review tools do (McpFlowsServer.cs:146-147/165-166/345-347).
+    /// </summary>
+    [Test]
+    public async Task Guardrail_400_body_surfaces_in_tool_error() {
+        const string flowRunId = "flow-generic-4";
+
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}/rounds").UsingPost())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(400)
+                    .WithHeader("Content-Type", "application/problem+json")
+                    .WithBody("""{"detail":"max_rounds (2) reached for this run — close the flow."}""")
+            );
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["flow_run_id"] = flowRunId,
+                ["participant"] = "reviewer",
+                ["message"]     = "one more please"
+            };
+
+            var response = await SendRequest(proc, ToolsCallRequest(53, "send_to_participant", args));
+            var result   = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsTrue();
+
+            var text = result["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            await Assert.That(text!.Contains("max_rounds (2)")).IsTrue();
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
+    /// get_flow_status / close_flow are pure aliases: they must hit the exact same endpoints as
+    /// get_review_flow_status / close_review_flow (McpFlowsServer.cs dispatch switch).
+    /// </summary>
+    [Test]
+    public async Task Get_flow_status_and_close_flow_hit_same_endpoints_as_review_tools() {
+        const string flowRunId = "flow-generic-5";
+
+        var stubbedStatus = $$"""
+            {
+              "flow_run_id": "{{flowRunId}}",
+              "definition_id": "my-custom-flow",
+              "status": "completed",
+              "target_title": "Generic target",
+              "round_count": 1,
+              "last_result_kind": "APPROVED",
+              "last_result_text": "Looks good."
+            }
+            """;
+
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(stubbedStatus));
+
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}/close").UsingPost())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody($$"""{"flow_run_id":"{{flowRunId}}","status":"closed"}""")
+            );
+
+        using var proc = SpawnMcpServer();
+        try {
+            var statusArgs     = new JsonObject { ["flow_run_id"] = flowRunId };
+            var statusResponse = await SendRequest(proc, ToolsCallRequest(54, "get_flow_status", statusArgs));
+            var statusResult   = statusResponse["result"]?.AsObject();
+            await Assert.That(statusResult).IsNotNull();
+            await Assert.That(statusResult!["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
+
+            var statusText = statusResult["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(statusText).IsNotNull();
+            await Assert.That(statusText!.Contains($"flow_run_id: {flowRunId}")).IsTrue();
+            await Assert.That(statusText.Contains("Looks good.")).IsTrue();
+
+            var getHits = _server.FindLogEntries(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet());
+            await Assert.That(getHits.Count).IsEqualTo(1);
+
+            var closeArgs     = new JsonObject { ["flow_run_id"] = flowRunId };
+            var closeResponse = await SendRequest(proc, ToolsCallRequest(55, "close_flow", closeArgs));
+            var closeResult   = closeResponse["result"]?.AsObject();
+            await Assert.That(closeResult).IsNotNull();
+            await Assert.That(closeResult!["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
+
+            var closeText = closeResult["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(closeText).IsNotNull();
+            await Assert.That(closeText!.Contains("status: closed")).IsTrue();
+
+            var closeHits = _server.FindLogEntries(Request.Create().WithPath($"/api/flows/{flowRunId}/close").UsingPost());
+            await Assert.That(closeHits.Count).IsEqualTo(1);
         } finally {
             await ShutdownAsync(proc);
         }

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -406,6 +406,64 @@ public class McpFlowsServerTests : IDisposable {
     }
 
     /// <summary>
+    /// send_to_participant declares an optional "async" arg (kept for symmetry with
+    /// submit_review_round's own Async field) — pin that it actually flows through onto the
+    /// wire. Stubs a terminal (non-"running") POST response so ResolveRoundResultAsync takes
+    /// the no-poll path and no GET calls happen.
+    /// </summary>
+    [Test]
+    public async Task Send_to_participant_async_false_posts_async_false() {
+        const string flowRunId = "flow-generic-async-false";
+
+        var stubbedResponse = $$"""
+            {
+              "flow_run_id": "{{flowRunId}}",
+              "round_id": "round-2",
+              "round_number": 2,
+              "status": "completed",
+              "result_kind": "FINDINGS",
+              "result_text": "sync round result",
+              "reviewer_agent_id": null,
+              "reviewer_session_id": null
+            }
+            """;
+
+        _server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}/rounds").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(stubbedResponse));
+
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["flow_run_id"] = flowRunId,
+                ["participant"] = "reviewer",
+                ["message"]     = "ctx2",
+                ["async"]       = false
+            };
+
+            var response = await SendRequest(proc, ToolsCallRequest(51, "send_to_participant", args));
+
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsNotEqualTo(true);
+
+            var hits = _server.FindLogEntries(Request.Create().WithPath($"/api/flows/{flowRunId}/rounds").UsingPost());
+            await Assert.That(hits.Count).IsEqualTo(1);
+
+            var bodyNode = JsonNode.Parse(hits[0].RequestMessage.Body ?? "")?.AsObject();
+            await Assert.That(bodyNode).IsNotNull();
+            await Assert.That(bodyNode!["async"]?.GetValue<bool>()).IsFalse();
+            await Assert.That(bodyNode["context"]?.GetValue<string>()).IsEqualTo("ctx2");
+            await Assert.That(bodyNode["participant"]?.GetValue<string>()).IsEqualTo("reviewer");
+
+            // No polling should have happened — the POST response was already terminal.
+            var getHits = _server.FindLogEntries(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet());
+            await Assert.That(getHits.Count).IsEqualTo(0);
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
     /// The review alias must stay byte-compatible with old servers that don't know about
     /// "participant" — the field is null-omitted, so the POST body must not carry the key at all.
     /// </summary>

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -464,6 +464,50 @@ public class McpFlowsServerTests : IDisposable {
     }
 
     /// <summary>
+    /// A non-boolean JSON "async" (e.g. an LLM caller passing the string "yes") must NOT crash
+    /// the request with an uncaught GetValue&lt;bool&gt;() exception — it must surface as a clean
+    /// isError:true tool result, and the stdio loop must stay alive for the next request (Qodo
+    /// finding, AI-1126 D-b). No WireMock stub is needed: the bad arg is rejected before any HTTP
+    /// call is made, mirroring Submit_review_round_without_flow_run_id_returns_error above.
+    /// </summary>
+    [Test]
+    public async Task Send_to_participant_non_boolean_async_returns_clean_error() {
+        using var proc = SpawnMcpServer();
+        try {
+            var args = new JsonObject {
+                ["flow_run_id"] = "flow-bad-async",
+                ["participant"] = "reviewer",
+                ["message"]     = "ctx",
+                ["async"]       = "yes"
+            };
+
+            var response = await SendRequest(proc, ToolsCallRequest(51, "send_to_participant", args));
+
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["isError"]?.GetValue<bool>()).IsTrue();
+
+            var text = result["content"]?[0]?["text"]?.GetValue<string>();
+            await Assert.That(text).IsNotNull();
+            await Assert.That(text!.Contains("async must be a boolean")).IsTrue();
+
+            // No POST should have fired — the bad arg is rejected before the HTTP call.
+            var hits = _server.FindLogEntries(Request.Create().WithPath("/api/flows/flow-bad-async/rounds").UsingPost());
+            await Assert.That(hits.Count).IsEqualTo(0);
+
+            // The stdio loop must still be alive: a follow-up request gets a normal response.
+            var followUp = await SendRequest(proc, ToolsCallRequest(52, "submit_review_round", new JsonObject {
+                ["context"] = "no flow id, expect a clean error too"
+            }));
+            var followUpResult = followUp["result"]?.AsObject();
+            await Assert.That(followUpResult).IsNotNull();
+            await Assert.That(followUpResult!["isError"]?.GetValue<bool>()).IsTrue();
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    /// <summary>
     /// The review alias must stay byte-compatible with old servers that don't know about
     /// "participant" — the field is null-omitted, so the POST body must not carry the key at all.
     /// </summary>


### PR DESCRIPTION
## Summary

Second Phase-D slice of AI-1119 (spec: kcap-server `docs/superpowers/specs/2026-07-02-ai1126-flows-phase-d-design.md`, approved via review flow `a556d844`). The flow engine and HTTP API have been generic since Phase C (`kind` IS the definition id); this exposes that through generic MCP tools in `kcap mcp flows`:

- **`start_flow(definition_id, …)`** → the existing `/api/flows/review/start` wire with `kind = definition_id` (no server change).
- **`send_to_participant(flow_run_id, participant, message, …)`** → the rounds endpoint; `participant` passes through verbatim on a new optional null-omitted `SubmitReviewRoundDto.Participant` — the server (Phase D-a, kcap-server #930) validates it against the pinned definition.
- **`get_flow_status` / `close_flow`** → 1:1 to the existing endpoints.
- **The four review tools are thin aliases** sharing the same handlers — schemas pinned **byte-identical** by a regression test; alias request bodies unchanged on the wire (`participant` omitted when null).
- **New `agent-flows` skill** teaching the generic driver loop, definition discovery, the single-participant rule, and the D-a guardrail semantics (max_rounds 400 → run open, summarize + close; budget_exceeded → run already failed + participant stopped, do NOT retry/close — closing would overwrite the failure status; round timeout → terminal `unclear` round, run open). `review-flows` gains a pointer; `kcap/.mcp.json` description updated.
- `McpFlowResultServer` (the reviewer-side recursion boundary) untouched.

## Test plan

- [x] McpFlowsServerTests 25/25: 8-tool list, review-alias schema pinning, `start_flow` posts `kind` from `definition_id`, participant + message wire bodies, `submit_review_round` body has NO participant key, `async:false` wire test, guardrail-400 ProblemDetails surfacing, status/close endpoint parity
- [x] Full Unit suite 2131/2131; Integration 81/82 (the one failure is the pre-existing `ServerUrlProbe` WireMock port flake, verified reproducing on clean baseline)

## Notes for the merger

- Against a pre-D-a server, `participant` is silently ignored (unmapped JSON member) — validation activates when kcap-server #930 deploys. Graceful in both directions.
- `kcap/.codex-mcp.json` deliberately still omits kcap-flows (Codex drivers don't get flow-starting tools).
- Deferred follow-ups (recorded in the plan): schema-pin descriptions too, README flows-tool docs, end-to-end participant validation test once a D-a server is deployable in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)