### PR TITLE
Fix review-flow hosted reviewer: re-mirror on each round + auto-approve submit_review_result

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -36,6 +36,16 @@ public record AgentInstance(
     public string? McpConfigPath { get; set; }
 
     /// <summary>
+    /// AI-1163 follow-up: the requester's repo root the launch-time worktree mirror copied from
+    /// (<see cref="LaunchAgentCommand.SyncFromRepoRoot"/>). Non-null only for a mirror-requester
+    /// review-flow reviewer. The reviewer process stays alive across rounds (to keep its context),
+    /// so its daemon-created worktree would otherwise stay frozen at the round-1 snapshot; keeping
+    /// the source here lets each subsequent round re-mirror the requester's <i>current</i> working
+    /// tree, so files created/edited while addressing findings reach the running reviewer.
+    /// </summary>
+    public string? SyncSourceRepoRoot { get; init; }
+
+    /// <summary>
     /// Reason string sent to the server when ending the AgentSession. Defaults to
     /// "agent_exited" (claude exited on its own); HandleStopAgent flips it to
     /// "agent_stopped" so a user-initiated stop is still attributed correctly even
@@ -408,9 +418,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             var cts = new CancellationTokenSource();
 
             var agent = new AgentInstance(agentId, prompt, model, effort, repoPath, cmd.Vendor, process, worktree, cts) {
-                McpConfigPath = mcpConfigPath,
-                CurrentCols   = HostedPtyCols,
-                CurrentRows   = HostedPtyRows
+                McpConfigPath      = mcpConfigPath,
+                SyncSourceRepoRoot = string.IsNullOrEmpty(cmd.SyncFromRepoRoot) ? null : cmd.SyncFromRepoRoot,
+                CurrentCols        = HostedPtyCols,
+                CurrentRows        = HostedPtyRows
             };
             _agents[agentId] = agent;
 
@@ -855,6 +866,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         if (agent.IsPrivate) return; // server-origin input ignored for private agents
 
+        // AI-1163 follow-up: for a mirror-requester review-flow reviewer, re-mirror the requester's
+        // current working tree into the (still-running) reviewer worktree BEFORE delivering this
+        // round, so it sees files created/edited since the previous round rather than the frozen
+        // round-1 snapshot. No-op for every other agent. See TryReSyncWorktreeForRoundAsync.
+        await TryReSyncWorktreeForRoundAsync(agent);
+
         var message = text;
 
         if (attachmentIds is { Length: > 0 }) {
@@ -1037,6 +1054,44 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             await _worktreeManager.SyncFromSourceAsync(sourceRepoRoot, worktreePath, [], _shutdownCts.Token);
         } catch (Exception ex) {
             LogRefreshWorktreeFailed(ex, agentId, sourceRepoRoot, worktreePath);
+        }
+    }
+
+    /// <summary>
+    /// Worktree paths the daemon writes at launch — downloaded attachments, the overlaid vendor
+    /// config, and the generated MCP config — that are NOT part of the requester's git working
+    /// tree. Excluded from the per-round re-mirror so <see cref="WorktreeManager.SyncFromSourceAsync"/>'s
+    /// delete phase (which removes anything not in the source's <c>git ls-files</c> enumeration)
+    /// can't wipe the reviewer's own setup. The launch-time mirror needs no such list because it
+    /// runs before these are written.
+    /// </summary>
+    static readonly string[] DaemonManagedWorktreeExcludes = [".attached", ".claude", ".codex", ".mcp.json"];
+
+    /// <summary>
+    /// AI-1163 follow-up: re-mirror the requester's current working tree into a review-flow
+    /// reviewer's worktree before a follow-up round is delivered. The reviewer process stays alive
+    /// across rounds (to keep its context), so its daemon-created worktree would otherwise stay
+    /// frozen at the round-1 snapshot and never pick up files the requester created/edited while
+    /// addressing findings. No-op unless the agent was launched with a mirror source
+    /// (<see cref="AgentInstance.SyncSourceRepoRoot"/>) and owns its worktree — a borrowed cwd is the
+    /// requester's own checkout and is never mutated. Daemon-validated (same origin, allowlisted,
+    /// resolves) + best-effort: any failure is logged and swallowed so it never blocks or fails
+    /// round delivery.
+    /// </summary>
+    async Task TryReSyncWorktreeForRoundAsync(AgentInstance agent) {
+        if (agent.SyncSourceRepoRoot is not { } source) return;
+        if (agent.Work != WorkLocation.OwnedWorktree)    return;
+
+        try {
+            if (!await IsAllowedSyncSourceAsync(source, agent.RepoPath)) {
+                LogRoundResyncSkipped(agent.Id, source, "source not on the allowlist, not found on this host, or not a checkout of the same repo");
+
+                return;
+            }
+
+            await _worktreeManager.SyncFromSourceAsync(source, agent.Worktree.Path, DaemonManagedWorktreeExcludes, _shutdownCts.Token);
+        } catch (Exception ex) {
+            LogRefreshWorktreeFailed(ex, agent.Id, source, agent.Worktree.Path);
         }
     }
 
@@ -1429,6 +1484,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Launch-time worktree sync skipped for agent {AgentId} (source={Source}): {Reason}")]
     partial void LogLaunchSyncSkipped(string agentId, string source, string reason);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Per-round worktree re-sync skipped for agent {AgentId} (source={Source}): {Reason}")]
+    partial void LogRoundResyncSkipped(string agentId, string source, string reason);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to persist repo path for agent {AgentId}")]
     partial void LogRepoPathPersistFailed(Exception ex, string agentId);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1068,15 +1068,30 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     static readonly string[] DaemonManagedWorktreeExcludes = [".attached", ".claude", ".codex", ".mcp.json"];
 
     /// <summary>
+    /// Upper bound on the per-round worktree re-mirror (<see cref="TryReSyncWorktreeForRoundAsync"/>).
+    /// The sync blocks round delivery by design (see there), so this caps a pathologically large or
+    /// slow sync: on expiry the round is delivered against a slightly stale mirror rather than
+    /// hanging. Only effective because <see cref="WorktreeManager.SyncFromSourceAsync"/> honours the
+    /// token in its copy/delete loops.
+    /// </summary>
+    static readonly TimeSpan RoundResyncTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     /// AI-1163 follow-up: re-mirror the requester's current working tree into a review-flow
     /// reviewer's worktree before a follow-up round is delivered. The reviewer process stays alive
     /// across rounds (to keep its context), so its daemon-created worktree would otherwise stay
     /// frozen at the round-1 snapshot and never pick up files the requester created/edited while
-    /// addressing findings. No-op unless the agent was launched with a mirror source
-    /// (<see cref="AgentInstance.SyncSourceRepoRoot"/>) and owns its worktree — a borrowed cwd is the
-    /// requester's own checkout and is never mutated. Daemon-validated (same origin, allowlisted,
-    /// resolves) + best-effort: any failure is logged and swallowed so it never blocks or fails
-    /// round delivery.
+    /// addressing findings.
+    ///
+    /// This runs on the round-delivery path and the caller awaits it on purpose: the reviewer must
+    /// see the updated tree before it starts the new round, so the sync cannot be fire-and-forget.
+    /// It is bounded, though — capped by <see cref="RoundResyncTimeout"/> and cancellable (the
+    /// underlying sync honours the token in its copy/delete loops) — so a stuck or huge sync
+    /// degrades to a slightly stale mirror instead of blocking round delivery indefinitely. No-op
+    /// unless the agent was launched with a mirror source (<see cref="AgentInstance.SyncSourceRepoRoot"/>)
+    /// and owns its worktree — a borrowed cwd is the requester's own checkout and is never mutated.
+    /// Daemon-validated (same origin, allowlisted, resolves); every timeout/validation-skip/error is
+    /// logged and swallowed so a sync problem never fails round delivery.
     /// </summary>
     async Task TryReSyncWorktreeForRoundAsync(AgentInstance agent) {
         if (agent.SyncSourceRepoRoot is not { } source) return;
@@ -1089,7 +1104,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 return;
             }
 
-            await _worktreeManager.SyncFromSourceAsync(source, agent.Worktree.Path, DaemonManagedWorktreeExcludes, _shutdownCts.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token);
+            cts.CancelAfter(RoundResyncTimeout);
+
+            await _worktreeManager.SyncFromSourceAsync(source, agent.Worktree.Path, DaemonManagedWorktreeExcludes, cts.Token);
+        } catch (OperationCanceledException) {
+            // Timed out, or the daemon is stopping: deliver the round against whatever synced rather
+            // than blocking on a stuck/huge sync. Best-effort staleness, logged for diagnosis.
+            LogRoundResyncSkipped(agent.Id, source, $"sync exceeded {RoundResyncTimeout.TotalSeconds:0}s or the daemon is stopping");
         } catch (Exception ex) {
             LogRefreshWorktreeFailed(ex, agent.Id, source, agent.Worktree.Path);
         }

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -208,11 +208,24 @@ internal sealed partial class LocalPermissionBridge(
             // would give us per-request cancellation; out of scope for this PR.
             PermissionDecision decision;
 
-            try {
-                decision = await server.RequestPermissionAsync(sessionId, toolName, toolInput, suggestions, ct);
-            } catch (Exception ex) {
-                LogRequestPermissionFailed(logger, ex, sessionId);
-                decision = new PermissionDecision("deny", null, null);
+            if (IsFlowResultSubmission(toolName)) {
+                // AI-1139 follow-up: a review-flow reviewer's own result-submission tool
+                // (kcap-flow-result → submit_review_result) is safe and expected — it only posts the
+                // reviewer's verdict back to the server. Auto-approve it here instead of surfacing a
+                // prompt: the reviewer is unattended (Codex fires a PermissionRequest for the MCP
+                // tool call even under `--ask-for-approval never`, and its hook bridges here), so a
+                // user decision it can't get would just block the flow. The tool name is unique to
+                // the kcap-flow-result server, which is only injected for review-flow reviewers, so
+                // matching it is sufficient and always safe — no server round-trip needed.
+                LogFlowResultAutoApproved(logger, sessionId, vendor);
+                decision = new PermissionDecision("allow", null, null);
+            } else {
+                try {
+                    decision = await server.RequestPermissionAsync(sessionId, toolName, toolInput, suggestions, ct);
+                } catch (Exception ex) {
+                    LogRequestPermissionFailed(logger, ex, sessionId);
+                    decision = new PermissionDecision("deny", null, null);
+                }
             }
 
             var responseJson = BuildHookResponseJson(decision, vendor);
@@ -247,6 +260,17 @@ internal sealed partial class LocalPermissionBridge(
 
         return doc.RootElement.Clone();
     }
+
+    /// <summary>
+    /// True when the permission request is for the review-flow reviewer's result-submission tool
+    /// (kcap-flow-result → <c>submit_review_result</c>). Matched by a substring so it holds across
+    /// vendors regardless of how each prefixes an MCP tool id (Claude sanitizes the server name to
+    /// <c>mcp__kcap_flow_result__submit_review_result</c>; Codex uses its own scheme). The name is
+    /// unique to the kcap-flow-result server — only injected for review-flow reviewers — so a
+    /// substring match cannot collide with an unrelated tool.
+    /// </summary>
+    static bool IsFlowResultSubmission(string? toolName) =>
+        toolName is not null && toolName.Contains("submit_review_result", StringComparison.Ordinal);
 
     static string BuildHookResponseJson(PermissionDecision decision, string vendor) =>
         vendor switch {
@@ -295,6 +319,9 @@ internal sealed partial class LocalPermissionBridge(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "RequestPermission via SignalR failed for session {SessionId}; falling back to deny")]
     static partial void LogRequestPermissionFailed(ILogger logger, Exception exception, string sessionId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Auto-approved review-flow result submission for session {SessionId} (vendor={Vendor}) without surfacing a prompt")]
+    static partial void LogFlowResultAutoApproved(ILogger logger, string sessionId, string vendor);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Permission bridge handler error")]
     static partial void LogBridgeHandlerError(ILogger logger, Exception exception);

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -263,14 +263,28 @@ internal sealed partial class LocalPermissionBridge(
 
     /// <summary>
     /// True when the permission request is for the review-flow reviewer's result-submission tool
-    /// (kcap-flow-result → <c>submit_review_result</c>). Matched by a substring so it holds across
-    /// vendors regardless of how each prefixes an MCP tool id (Claude sanitizes the server name to
-    /// <c>mcp__kcap_flow_result__submit_review_result</c>; Codex uses its own scheme). The name is
-    /// unique to the kcap-flow-result server — only injected for review-flow reviewers — so a
-    /// substring match cannot collide with an unrelated tool.
+    /// (the <c>kcap-flow-result</c> server's <c>submit_review_result</c>). This auto-approve bypasses
+    /// the server permission boundary, so the match is deliberately precise rather than a loose
+    /// substring: it accepts either the bare tool name (a vendor that passes the raw MCP tool name,
+    /// e.g. Codex) OR a vendor-prefixed id that both names the <c>kcap-flow-result</c> server AND ends
+    /// in the exact tool — e.g. Claude's <c>mcp__kcap_flow_result__submit_review_result</c> (Claude
+    /// sanitizes the hyphens to underscores). Requiring the server token means a coincidental
+    /// "…submit_review_result" exposed by some other MCP server on an interactive hosted agent can't
+    /// slip past the prompt.
     /// </summary>
-    static bool IsFlowResultSubmission(string? toolName) =>
-        toolName is not null && toolName.Contains("submit_review_result", StringComparison.Ordinal);
+    static bool IsFlowResultSubmission(string? toolName) {
+        if (string.IsNullOrEmpty(toolName)) return false;
+
+        // Bare tool name, no server prefix.
+        if (string.Equals(toolName, "submit_review_result", StringComparison.Ordinal)) return true;
+
+        // Vendor-prefixed MCP id: require the flow-result server identity AND the exact tool suffix.
+        var namesFlowResultServer =
+            toolName.Contains("kcap_flow_result", StringComparison.Ordinal) ||
+            toolName.Contains("kcap-flow-result", StringComparison.Ordinal);
+
+        return namesFlowResultServer && toolName.EndsWith("submit_review_result", StringComparison.Ordinal);
+    }
 
     static string BuildHookResponseJson(PermissionDecision decision, string vendor) =>
         vendor switch {

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -163,6 +163,10 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         var copied = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var rawPath in relativePaths) {
+            // Honour cancellation between files: on a large tree the copy loop is the bulk of the
+            // work, and callers (per-round resync timeout, daemon shutdown) rely on this to bound it.
+            ct.ThrowIfCancellationRequested();
+
             // Normalise separators (git always emits forward slashes).
             var rel = rawPath.Replace('/', Path.DirectorySeparatorChar);
 
@@ -195,6 +199,8 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
 
         // Delete target files that no longer exist in the source (i.e. deleted).
         foreach (var existingFile in Directory.EnumerateFiles(target, "*", SearchOption.AllDirectories)) {
+            ct.ThrowIfCancellationRequested();
+
             var rel = Path.GetRelativePath(target, existingFile);
 
             // Never touch .git/ or .capacitor/worktrees/ inside the target.

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorRoundResyncTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorRoundResyncTests.cs
@@ -1,0 +1,146 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-1163 follow-up: a mirror-requester review-flow reviewer stays alive across rounds to keep its
+/// context, so its daemon-created worktree must be re-mirrored from the requester's current working
+/// tree before EACH round is delivered — otherwise the reviewer keeps reviewing round 1's snapshot
+/// and never sees files the requester created/edited while addressing findings. These tests drive
+/// <see cref="AgentOrchestrator.HandleSendInput"/> and assert the re-mirror happens (and only for a
+/// mirror-source, daemon-owned worktree).
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    const string SameOrigin = "https://github.com/acme/widgets.git";
+
+    static (string repoPath, Action cleanup) CreateGitRepoWithOrigin(string originUrl) {
+        var (repoPath, cleanup) = CreateGitRepo();
+        Git(repoPath, "remote", "add", "origin", originUrl);
+
+        return (repoPath, cleanup);
+    }
+
+    static (string path, Action cleanup) CreateEmptyDir() {
+        var path = Path.Combine(Path.GetTempPath(), "kcap-reviewer-wt-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(path);
+
+        return (path, () => {
+            try { Directory.Delete(path, true); } catch {
+                /* best-effort */
+            }
+        });
+    }
+
+    [Test]
+    public async Task HandleSendInput_re_mirrors_requester_worktree_into_a_running_review_flow_reviewer() {
+        var (callerRepo, cleanupCaller) = CreateGitRepoWithOrigin(SameOrigin);
+        var (baseRepo, cleanupBase)     = CreateGitRepoWithOrigin(SameOrigin);
+        var (reviewerWorktree, cleanupWt) = CreateEmptyDir();
+
+        try {
+            // The requester creates a NEW untracked spec while addressing round-1 findings. It is
+            // enumerated by `git ls-files -co --exclude-standard`, so the re-mirror must copy it in.
+            Directory.CreateDirectory(Path.Combine(callerRepo, "docs"));
+            File.WriteAllText(Path.Combine(callerRepo, "docs", "spec.md"), "SPEC BODY");
+
+            var server = new CaptureServerConnection();
+            var pty    = new RecordingPtyProcess();
+
+            await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+            var agent = new AgentInstance(
+                "agent-flow", null, "", null, baseRepo, "codex",
+                pty, new WorktreeInfo(reviewerWorktree, "", baseRepo), new CancellationTokenSource()) {
+                SyncSourceRepoRoot = callerRepo,
+                Work               = WorkLocation.OwnedWorktree
+            };
+            orch.RegisterAgentForTest(agent);
+
+            await orch.HandleSendInputForTest(new SendInputCommand("agent-flow", "round 2 — please re-review", null));
+
+            // The freshly-created spec (untracked-not-ignored) is now mirrored into the reviewer's
+            // worktree, alongside the committed README — the reviewer sees the requester's live tree.
+            await Assert.That(File.Exists(Path.Combine(reviewerWorktree, "docs", "spec.md"))).IsTrue();
+            await Assert.That(File.Exists(Path.Combine(reviewerWorktree, "README.md"))).IsTrue();
+
+            // The round is still delivered as a bracketed paste + separate Enter.
+            await Assert.That(pty.Writes.Count).IsEqualTo(2);
+        } finally {
+            cleanupWt();
+            cleanupBase();
+            cleanupCaller();
+        }
+    }
+
+    [Test]
+    public async Task HandleSendInput_does_not_re_mirror_a_borrowed_cwd_reviewer() {
+        // A borrowed cwd is the requester's own checkout — never mutated. Even with a mirror source
+        // set, the OwnedWorktree guard must skip the sync (its delete phase would otherwise clobber
+        // files the user has locally).
+        var (callerRepo, cleanupCaller) = CreateGitRepoWithOrigin(SameOrigin);
+        var (borrowedCwd, cleanupCwd)   = CreateEmptyDir();
+
+        try {
+            File.WriteAllText(Path.Combine(callerRepo, "only-in-caller.txt"), "x");
+            var marker = Path.Combine(borrowedCwd, "local-only.txt");
+            File.WriteAllText(marker, "keep me");
+
+            var server = new CaptureServerConnection();
+            var pty    = new RecordingPtyProcess();
+
+            await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+            var agent = new AgentInstance(
+                "agent-borrowed", null, "", null, callerRepo, "codex",
+                pty, WorktreeInfo.Borrowed(borrowedCwd), new CancellationTokenSource()) {
+                SyncSourceRepoRoot = callerRepo,
+                Work               = WorkLocation.BorrowedCwd
+            };
+            orch.RegisterAgentForTest(agent);
+
+            await orch.HandleSendInputForTest(new SendInputCommand("agent-borrowed", "input", null));
+
+            // No sync ran: the local file survives and the caller's file was NOT copied in.
+            await Assert.That(File.Exists(marker)).IsTrue();
+            await Assert.That(File.Exists(Path.Combine(borrowedCwd, "only-in-caller.txt"))).IsFalse();
+            await Assert.That(pty.Writes.Count).IsEqualTo(2);
+        } finally {
+            cleanupCwd();
+            cleanupCaller();
+        }
+    }
+
+    [Test]
+    public async Task HandleSendInput_does_not_re_mirror_an_agent_launched_without_a_mirror_source() {
+        // A non-review-flow agent has no SyncSourceRepoRoot, so round delivery must not touch the
+        // worktree at all.
+        var (worktree, cleanupWt) = CreateEmptyDir();
+
+        try {
+            var marker = Path.Combine(worktree, "keep.txt");
+            File.WriteAllText(marker, "keep");
+
+            var server = new CaptureServerConnection();
+            var pty    = new RecordingPtyProcess();
+
+            await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+            var agent = new AgentInstance(
+                "agent-plain", null, "", null, "/tmp", "codex",
+                pty, new WorktreeInfo(worktree, "", "/tmp"), new CancellationTokenSource()) {
+                SyncSourceRepoRoot = null,
+                Work               = WorkLocation.OwnedWorktree
+            };
+            orch.RegisterAgentForTest(agent);
+
+            await orch.HandleSendInputForTest(new SendInputCommand("agent-plain", "input", null));
+
+            await Assert.That(File.Exists(marker)).IsTrue();
+            await Assert.That(pty.Writes.Count).IsEqualTo(2);
+        } finally {
+            cleanupWt();
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -430,6 +430,66 @@ public class LocalPermissionBridgeTests {
         }
     }
 
+    // AI-1139 follow-up: a review-flow reviewer's own result-submission tool must be auto-approved
+    // by the bridge WITHOUT surfacing a user prompt. Codex fires a PermissionRequest for the MCP
+    // tool call even under `--ask-for-approval never`, and its hook bridges here; without this the
+    // unattended reviewer blocks on a decision it can never get.
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Codex_flow_result_submission_is_auto_approved_without_a_server_round_trip() {
+        var (bridge, server) = CreateBridge((_, _, _, _, _) =>
+            // If the bridge ever consults the server for this tool the test should fail loudly:
+            // deny so an accidental round-trip can't masquerade as an allow.
+            Task.FromResult(new PermissionDecision("deny", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client = CreateClient();
+
+            var payload = new {
+                session_id = "abc",
+                tool_name  = "mcp__kcap_flow_result__submit_review_result",
+                tool_input = new { kind = "clean" }
+            };
+            using var response = await client.PostAsync($"{bridge.BaseUrl}/codex/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)response.StatusCode).IsEqualTo(200);
+
+            // Short-circuited entirely — the server hub was never asked.
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+
+            var       body     = await response.Content.ReadAsStringAsync();
+            using var doc      = JsonDocument.Parse(body);
+            var       decision = doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("decision");
+            await Assert.That(decision.GetProperty("behavior").GetString()).IsEqualTo("allow");
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    // Regression guard: an ordinary tool still goes through the server (no over-broad auto-approve).
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Non_flow_result_tool_still_consults_the_server() {
+        var (bridge, server) = CreateBridge((_, _, _, _, _) =>
+            Task.FromResult(new PermissionDecision("allow", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client = CreateClient();
+
+            var payload = new { session_id = "abc", tool_name = "Bash", tool_input = new { command = "ls" } };
+            using var response = await client.PostAsync($"{bridge.BaseUrl}/codex/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)response.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(1);
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
     public async Task Claude_cli_hook_post_target_lands_at_new_url() {
         // Verify that the bridge accepts POSTs at the /{token}/claude/permission-request URL

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -490,6 +490,59 @@ public class LocalPermissionBridgeTests {
         }
     }
 
+    // Qodo #255: the auto-approve must be precise. A tool from a DIFFERENT server whose id merely
+    // ends in "submit_review_result" must NOT be short-circuited — it goes to the server like any
+    // other tool, so the auto-approve can't be used to slip an unrelated tool past the prompt.
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Same_named_tool_from_a_different_server_is_not_auto_approved() {
+        var (bridge, server) = CreateBridge((_, _, _, _, _) =>
+            Task.FromResult(new PermissionDecision("allow", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client = CreateClient();
+
+            // Ends with the tool name but names some other server — must be treated as untrusted.
+            var payload = new { session_id = "abc", tool_name = "mcp__evil_server__submit_review_result" };
+            using var response = await client.PostAsync($"{bridge.BaseUrl}/codex/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)response.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(1);
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    // The bare tool name (a vendor that passes the raw MCP tool name with no server prefix) is the
+    // flow-result tool and is auto-approved without a server round-trip.
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Bare_flow_result_tool_name_is_auto_approved() {
+        var (bridge, server) = CreateBridge((_, _, _, _, _) =>
+            Task.FromResult(new PermissionDecision("deny", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client = CreateClient();
+
+            var payload = new { session_id = "abc", tool_name = "submit_review_result" };
+            using var response = await client.PostAsync($"{bridge.BaseUrl}/codex/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)response.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+
+            var       body     = await response.Content.ReadAsStringAsync();
+            using var doc      = JsonDocument.Parse(body);
+            var       decision = doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("decision");
+            await Assert.That(decision.GetProperty("behavior").GetString()).IsEqualTo("allow");
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
     public async Task Claude_cli_hook_post_target_lands_at_new_url() {
         // Verify that the bridge accepts POSTs at the /{token}/claude/permission-request URL


### PR DESCRIPTION
Two independent fixes for the review-flow hosted reviewer, both observed against a hosted **Codex** reviewer.

## 1. Re-mirror the requester’s working tree on every round

The reviewer process stays alive across rounds (to keep its context), but its daemon-created worktree was mirrored from the requester’s working tree **only once, at launch**. Follow-up rounds copied nothing, so the reviewer kept reviewing round 1’s snapshot and never saw files the requester created/edited while addressing findings (e.g. a newly created, untracked spec showed as absent on round 2).

- Persist the launch mirror source (`LaunchAgentCommand.SyncFromRepoRoot`) on `AgentInstance.SyncSourceRepoRoot`.
- Before delivering each round (`HandleSendInput` → new `TryReSyncWorktreeForRoundAsync`), re-mirror the requester’s **current** working tree into the running reviewer’s worktree.
- Gated to mirror-source + `OwnedWorktree` agents (a borrowed cwd is never mutated), daemon-validated (same origin, allowlisted, resolves), best-effort (never blocks/fails round delivery), and excludes daemon-managed worktree paths (`.attached`/`.claude`/`.codex`/`.mcp.json`) so the sync’s delete phase can’t wipe the reviewer’s own setup.

## 2. Auto-approve `submit_review_result` at the permission bridge

AI-1139 injected the `kcap-flow-result` MCP server into the reviewer but added no approval handling for its tool. Codex fires a `PermissionRequest` for the MCP tool call (even under `--ask-for-approval never`); its hook bridges it to the user via the daemon `LocalPermissionBridge`, and nothing auto-approved it — so the reviewer’s own result submission blocked on a user prompt.

- `LocalPermissionBridge.HandleAsync` now short-circuits to `allow` (no server round-trip) when the tool is `submit_review_result` — a name unique to the safe flow-result server, which is only injected for review-flow reviewers.
- The Claude reviewer already sidesteps this via `--permission-mode bypassPermissions` (its hook is suppressed), which is why the prompt was Codex-only.

## Tests
- New: 3 tests for the per-round re-mirror (incl. borrowed-cwd and no-mirror-source safety) and 2 for the bridge (auto-approve short-circuit + non-flow regression). Confirmed the re-mirror test fails without the fix and passes with it.
- Full unit suite: 2159 passed, 0 failed. Daemon `dotnet publish -c Release`: no IL3050/IL2026 warnings.

## Docs
No README/skill change: the docs already promise "the reviewer works in a worktree mirrored from your working tree" — this makes that hold on rounds 2+.

Closes #254

Linear: auto-imported from #254 (AI-… will be assigned on import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)