### PR TITLE
Proactively refresh auth tokens in the daemon ahead of expiry

### DIFF
--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -305,9 +305,9 @@ public static class TokenStore {
     // parse failures (return null → Failed); a genuine IO fault reading the token or config
     // can still propagate and is caught by the daemon's total tick.
     public static async Task<ProactiveRefreshOutcome> RefreshIfExpiringAsync(TimeSpan window) {
-        // Resolve the active profile once and thread it through both the read and the lock, so
-        // a profile switch mid-call can't make us refresh one profile's token under another's
-        // lock (GetValidTokensAsync re-resolves; this is deliberately tighter).
+        // Resolve the active profile once and thread it through the read and the lock; the lock
+        // helper also persists under this same profile, so a profile switch mid-call can't make us
+        // refresh — or write — one profile's token under another profile's lock.
         var profile = await ResolveActiveProfileAsync();
         var tokens  = await LoadAsync(profile);
 
@@ -331,7 +331,7 @@ public static class TokenStore {
     // may have just rotated it), refresh only if it is still due per `needsRefresh`, persist,
     // release. If the lock can't be acquired within the deadline, fall back to whatever a peer
     // persisted.
-    static async Task<StoredTokens?> RefreshWithCrossProcessLockAsync(
+    internal static async Task<StoredTokens?> RefreshWithCrossProcessLockAsync(
             string                                  profile,
             StoredTokens                            current,
             Func<StoredTokens, Task<StoredTokens?>> refresh,
@@ -369,7 +369,31 @@ public static class TokenStore {
         try {
             var latest = await LoadAsync(profile) ?? current;
 
-            return needsRefresh(latest) ? await refresh(latest) : latest;
+            // A peer refreshed while we waited for the lock (the persisted token changed) and its
+            // result is still valid → don't refresh again, even if the fresh token is still inside
+            // the proactive window. A short-lived / JwtExpiry-fallback token would otherwise be
+            // double-rotated (and double the endpoint traffic) right after a peer just rotated it.
+            // The reactive path is unaffected: its needsRefresh is IsExpired, already false here.
+            if (latest.AccessToken != current.AccessToken && !latest.IsExpired) {
+                return latest;
+            }
+
+            if (!needsRefresh(latest)) {
+                return latest;
+            }
+
+            var refreshed = await refresh(latest);
+
+            // Persist under THIS profile's lock. The refresh delegates deliberately do NOT persist
+            // themselves — they used the active-profile-resolving SaveAsync(StoredTokens) overload,
+            // so an active-profile switch mid-refresh could write this profile's rotated token into
+            // a different profile's file (without that profile's lock). Saving here, under the lock,
+            // with the profile we locked, closes that hole for both callers.
+            if (refreshed is not null) {
+                await SaveAsync(profile, refreshed);
+            }
+
+            return refreshed;
         } finally {
             // Close the stream to release the OS lock, but DON'T delete the file: on Unix a
             // waiter can acquire the old inode between dispose and delete, then the unlink lets
@@ -444,14 +468,13 @@ public static class TokenStore {
                 return null;
             }
 
-            var refreshed = tokens with {
+            // Persistence is the caller's responsibility (RefreshWithCrossProcessLockAsync saves
+            // under the locked profile). Returning without saving keeps a rotated token from being
+            // written to the wrong profile if the active profile changes mid-refresh.
+            return tokens with {
                 AccessToken = json.AccessToken,
                 ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(json.ExpiresIn)
             };
-
-            await SaveAsync(refreshed);
-
-            return refreshed;
         } catch {
             return null;
         }
@@ -491,15 +514,14 @@ public static class TokenStore {
                 return null;
             }
 
-            var refreshed = tokens with {
+            // Persistence is the caller's responsibility (RefreshWithCrossProcessLockAsync saves
+            // under the locked profile) — see RefreshGitHubAsync. WorkOS rotates the refresh token
+            // on use, so writing under the wrong profile would be especially damaging.
+            return tokens with {
                 AccessToken = json.AccessToken,
                 ExpiresAt = JwtExpiry(json.AccessToken),
                 RefreshToken = json.RefreshToken ?? tokens.RefreshToken
             };
-
-            await SaveAsync(refreshed);
-
-            return refreshed;
         } catch {
             return null;
         }

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -31,9 +31,11 @@ public record StoredTokens {
 // NotDue = no-op (no tokens, the None provider, or the token still comfortably valid);
 // Refreshed = a valid token is now persisted (we refreshed, a peer did, or it was already
 // fresh under the lock); Failed = a refresh was attempted but failed (network / 4xx) and the
-// token is unchanged. The daemon loop rate-limits on both Refreshed and Failed so it never
-// re-hits the refresh endpoint every tick.
-public enum ProactiveRefreshOutcome { NotDue, Refreshed, Failed }
+// token is unchanged; Contended = we couldn't acquire the cross-process lock before its
+// deadline (a peer holds it, presumably refreshing) — no endpoint call was made, so it is NOT a
+// failure. The daemon loop rate-limits on Refreshed and Failed (to bound endpoint traffic) but
+// treats Contended quietly — no warning, no backoff.
+public enum ProactiveRefreshOutcome { NotDue, Refreshed, Failed, Contended }
 
 public static class TokenStore {
     static string LegacyTokenPath => PathHelpers.ConfigPath("tokens.json");
@@ -184,15 +186,21 @@ public static class TokenStore {
     // ── Legacy (profile-resolving) overloads ────────────────────────────────
 
     public static async Task<StoredTokens?> LoadAsync() {
-        var profile           = await ResolveActiveProfileAsync();
-        var (state, tokens)   = await ReadTokenFileAsync(ProfileTokenPath(profile));
+        var profile = await ResolveActiveProfileAsync();
+
+        return await LoadWithLegacyFallbackAsync(profile);
+    }
+
+    // Read a profile's token file, falling back to the legacy single-file tokens.json ONLY when the
+    // per-profile file is genuinely absent (a pre-upgrade install). A present-but-corrupt active
+    // file is "not authenticated" — do NOT resurrect stale credentials from a legacy file whose
+    // best-effort deletion previously failed. Shared by LoadAsync() and RefreshIfExpiringAsync so
+    // both get the legacy fallback without re-resolving the active profile.
+    static async Task<StoredTokens?> LoadWithLegacyFallbackAsync(string profile) {
+        var (state, tokens) = await ReadTokenFileAsync(ProfileTokenPath(profile));
 
         if (state == TokenFileState.Loaded) return tokens;
 
-        // Only a genuinely-absent per-profile file means "pre-upgrade install" and
-        // warrants the legacy single-file fallback. A present-but-corrupt active file is
-        // "not authenticated" — do NOT resurrect stale credentials from a legacy file
-        // whose best-effort deletion previously failed.
         if (state == TokenFileState.Missing) {
             var (_, legacy) = await ReadTokenFileAsync(LegacyTokenPath);
             return legacy;
@@ -307,35 +315,49 @@ public static class TokenStore {
     public static async Task<ProactiveRefreshOutcome> RefreshIfExpiringAsync(TimeSpan window) {
         // Resolve the active profile once and thread it through the read and the lock; the lock
         // helper also persists under this same profile, so a profile switch mid-call can't make us
-        // refresh — or write — one profile's token under another profile's lock.
+        // refresh — or write — one profile's token under another profile's lock. Use the
+        // legacy-fallback loader so a pre-upgrade install (only tokens.json, no per-profile file)
+        // is still refreshed (and migrated into the per-profile store when the refresh persists).
         var profile = await ResolveActiveProfileAsync();
-        var tokens  = await LoadAsync(profile);
+        var tokens  = await LoadWithLegacyFallbackAsync(profile);
+
+        var decision = DecideProactiveRefresh(tokens, DateTimeOffset.UtcNow, window);
+
+        if (decision is not (RefreshDecision.RefreshWorkOS or RefreshDecision.RefreshGitHub)) {
+            return ProactiveRefreshOutcome.NotDue;
+        }
 
         // Re-evaluate the window under the lock too (via this predicate): a peer may refresh
         // between our read here and our acquiring the lock, leaving the re-read token fresh.
         bool ExpiringWithinWindow(StoredTokens t) => DateTimeOffset.UtcNow >= t.ExpiresAt - window;
 
-        return DecideProactiveRefresh(tokens, DateTimeOffset.UtcNow, window) switch {
-            RefreshDecision.RefreshWorkOS => ToOutcome(await RefreshWithCrossProcessLockAsync(profile, tokens!, RefreshWorkOSAsync, ExpiringWithinWindow)),
-            RefreshDecision.RefreshGitHub => ToOutcome(await RefreshWithCrossProcessLockAsync(profile, tokens!, RefreshGitHubAsync, ExpiringWithinWindow)),
-            _                             => ProactiveRefreshOutcome.NotDue
-        };
+        var refresh = decision == RefreshDecision.RefreshWorkOS
+            ? (Func<StoredTokens, Task<StoredTokens?>>)RefreshWorkOSAsync
+            : RefreshGitHubAsync;
 
-        // Non-null = a valid token is now persisted; null = the refresh call failed and left
-        // the token unchanged (so the loop should back off rather than retry every tick).
-        static ProactiveRefreshOutcome ToOutcome(StoredTokens? result)
-            => result is not null ? ProactiveRefreshOutcome.Refreshed : ProactiveRefreshOutcome.Failed;
+        var contended = false;
+        var result    = await RefreshWithCrossProcessLockAsync(
+            profile, tokens!, refresh, ExpiringWithinWindow, onLockContended: () => contended = true);
+
+        // Lock contention (a peer holds the lock, likely mid-refresh) is not a refresh failure —
+        // don't let the daemon warn/back off as though the endpoint rejected us. Otherwise:
+        // non-null = a valid token is now persisted; null = the refresh call actually failed.
+        if (contended) return ProactiveRefreshOutcome.Contended;
+
+        return result is not null ? ProactiveRefreshOutcome.Refreshed : ProactiveRefreshOutcome.Failed;
     }
 
     // Profile-scoped cross-process lock. Acquire it, re-read the token under it (a peer
     // may have just rotated it), refresh only if it is still due per `needsRefresh`, persist,
     // release. If the lock can't be acquired within the deadline, fall back to whatever a peer
-    // persisted.
+    // persisted; `onLockContended` (proactive path only) is invoked when we give up still-due so
+    // the caller can distinguish lock contention from an actual refresh failure.
     internal static async Task<StoredTokens?> RefreshWithCrossProcessLockAsync(
             string                                  profile,
             StoredTokens                            current,
             Func<StoredTokens, Task<StoredTokens?>> refresh,
-            Func<StoredTokens, bool>?               needsRefresh = null
+            Func<StoredTokens, bool>?               needsRefresh    = null,
+            Action?                                 onLockContended = null
         ) {
         // Default predicate: refresh a token GetValidTokensAsync already found expired. The
         // proactive path (RefreshIfExpiringAsync) passes a wider "within N minutes of expiry"
@@ -359,7 +381,16 @@ public static class TokenStore {
                 if (DateTime.UtcNow >= deadline) {
                     var latest = await LoadAsync(profile);
 
-                    return latest is not null && !needsRefresh(latest) ? latest : null;
+                    // A peer refreshed while we waited → return their fresh token.
+                    if (latest is not null && !needsRefresh(latest)) {
+                        return latest;
+                    }
+
+                    // Gave up still-due: a peer holds the lock (likely mid-refresh). Signal
+                    // contention so the proactive caller doesn't report this as a refresh failure.
+                    onLockContended?.Invoke();
+
+                    return null;
                 }
 
                 await Task.Delay(100);

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -27,6 +27,14 @@ public record StoredTokens {
     public bool IsExpired => DateTimeOffset.UtcNow >= ExpiresAt - TimeSpan.FromSeconds(30);
 }
 
+// Outcome of a proactive-refresh tick (<see cref="TokenStore.RefreshIfExpiringAsync"/>).
+// NotDue = no-op (no tokens, the None provider, or the token still comfortably valid);
+// Refreshed = a valid token is now persisted (we refreshed, a peer did, or it was already
+// fresh under the lock); Failed = a refresh was attempted but failed (network / 4xx) and the
+// token is unchanged. The daemon loop rate-limits on both Refreshed and Failed so it never
+// re-hits the refresh endpoint every tick.
+public enum ProactiveRefreshOutcome { NotDue, Refreshed, Failed }
+
 public static class TokenStore {
     static string LegacyTokenPath => PathHelpers.ConfigPath("tokens.json");
     static string TokenDir         => PathHelpers.ConfigPath("tokens");
@@ -251,14 +259,90 @@ public static class TokenStore {
         return null;
     }
 
+    // The decision the daemon's proactive-refresh tick makes each time it wakes. Kept a
+    // pure function (no IO) so every branch is unit-testable in isolation;
+    // RefreshIfExpiringAsync turns the decision into action.
+    internal enum RefreshDecision { NoTokens, NotDueYet, RefreshWorkOS, RefreshGitHub, Unsupported }
+
+    // Should the active profile's token be refreshed ahead of expiry, and via which provider
+    // path? Refresh only once the token is within `window` of `ExpiresAt` — outside it we leave
+    // the refresh credential untouched so proactive refresh adds no measurable traffic. Provider
+    // gating mirrors GetValidTokensAsync: WorkOS needs its rotating refresh_token + client_id;
+    // GitHub re-mints via the server. Anything else — the None provider, or a WorkOS token
+    // missing its credentials — is a no-op.
+    internal static RefreshDecision DecideProactiveRefresh(StoredTokens? tokens, DateTimeOffset now, TimeSpan window) {
+        if (tokens is null) {
+            return RefreshDecision.NoTokens;
+        }
+
+        if (now < tokens.ExpiresAt - window) {
+            return RefreshDecision.NotDueYet;
+        }
+
+        if (tokens is { Provider: AuthProvider.WorkOS, RefreshToken: not null, ClientId: not null }) {
+            return RefreshDecision.RefreshWorkOS;
+        }
+
+        if (tokens.Provider is AuthProvider.GitHubApp) {
+            return RefreshDecision.RefreshGitHub;
+        }
+
+        return RefreshDecision.Unsupported;
+    }
+
+    // Proactively refresh the active profile's token when it is within `window` of expiry —
+    // even though it isn't expired yet. The daemon calls this on a low-frequency timer so a
+    // continuously-running daemon keeps a WorkOS sliding-inactivity session alive (up to its
+    // absolute lifetime) instead of the user hitting a 401 on the next hook after an idle
+    // period and being forced to re-run `kcap login`.
+    //
+    // Goes through the same profile-scoped cross-process lock as GetValidTokensAsync, so it
+    // never races a hook/watcher/MCP refresh and clobbers a rotated WorkOS refresh token, and
+    // refreshes only inside the window. The daemon loop rate-limits attempts, so refresh
+    // traffic stays bounded even when a token keeps landing back inside the window.
+    //
+    // Returns a ProactiveRefreshOutcome (see that enum). The refresh calls swallow network /
+    // parse failures (return null → Failed); a genuine IO fault reading the token or config
+    // can still propagate and is caught by the daemon's total tick.
+    public static async Task<ProactiveRefreshOutcome> RefreshIfExpiringAsync(TimeSpan window) {
+        // Resolve the active profile once and thread it through both the read and the lock, so
+        // a profile switch mid-call can't make us refresh one profile's token under another's
+        // lock (GetValidTokensAsync re-resolves; this is deliberately tighter).
+        var profile = await ResolveActiveProfileAsync();
+        var tokens  = await LoadAsync(profile);
+
+        // Re-evaluate the window under the lock too (via this predicate): a peer may refresh
+        // between our read here and our acquiring the lock, leaving the re-read token fresh.
+        bool ExpiringWithinWindow(StoredTokens t) => DateTimeOffset.UtcNow >= t.ExpiresAt - window;
+
+        return DecideProactiveRefresh(tokens, DateTimeOffset.UtcNow, window) switch {
+            RefreshDecision.RefreshWorkOS => ToOutcome(await RefreshWithCrossProcessLockAsync(profile, tokens!, RefreshWorkOSAsync, ExpiringWithinWindow)),
+            RefreshDecision.RefreshGitHub => ToOutcome(await RefreshWithCrossProcessLockAsync(profile, tokens!, RefreshGitHubAsync, ExpiringWithinWindow)),
+            _                             => ProactiveRefreshOutcome.NotDue
+        };
+
+        // Non-null = a valid token is now persisted; null = the refresh call failed and left
+        // the token unchanged (so the loop should back off rather than retry every tick).
+        static ProactiveRefreshOutcome ToOutcome(StoredTokens? result)
+            => result is not null ? ProactiveRefreshOutcome.Refreshed : ProactiveRefreshOutcome.Failed;
+    }
+
     // Profile-scoped cross-process lock. Acquire it, re-read the token under it (a peer
-    // may have just rotated it), refresh only if still expired, persist, release. If the
-    // lock can't be acquired within the deadline, fall back to whatever a peer persisted.
+    // may have just rotated it), refresh only if it is still due per `needsRefresh`, persist,
+    // release. If the lock can't be acquired within the deadline, fall back to whatever a peer
+    // persisted.
     static async Task<StoredTokens?> RefreshWithCrossProcessLockAsync(
             string                                  profile,
             StoredTokens                            current,
-            Func<StoredTokens, Task<StoredTokens?>> refresh
+            Func<StoredTokens, Task<StoredTokens?>> refresh,
+            Func<StoredTokens, bool>?               needsRefresh = null
         ) {
+        // Default predicate: refresh a token GetValidTokensAsync already found expired. The
+        // proactive path (RefreshIfExpiringAsync) passes a wider "within N minutes of expiry"
+        // predicate so it can refresh ahead of expiry — under this same lock, re-checked after
+        // the re-read, so it can't race a peer's refresh or double-spend a rotated token.
+        needsRefresh ??= static t => t.IsExpired;
+
         // Validate before building the lock path — a profile name with path separators
         // must not let the lock file escape TokenDir (matches ProfileTokenPath's guard).
         ValidateProfileName(profile);
@@ -275,7 +359,7 @@ public static class TokenStore {
                 if (DateTime.UtcNow >= deadline) {
                     var latest = await LoadAsync(profile);
 
-                    return latest is { IsExpired: false } ? latest : null;
+                    return latest is not null && !needsRefresh(latest) ? latest : null;
                 }
 
                 await Task.Delay(100);
@@ -285,7 +369,7 @@ public static class TokenStore {
         try {
             var latest = await LoadAsync(profile) ?? current;
 
-            return latest.IsExpired ? await refresh(latest) : latest;
+            return needsRefresh(latest) ? await refresh(latest) : latest;
         } finally {
             // Close the stream to release the OS lock, but DON'T delete the file: on Unix a
             // waiter can acquire the old inode between dispose and delete, then the unlink lets

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -160,6 +160,25 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     static readonly TimeSpan PingDeadline = TimeSpan.FromSeconds(5);
 
+    // AI-992: proactively refresh the active profile's auth token ahead of expiry so a
+    // continuously-running daemon keeps a WorkOS sliding-inactivity session alive (up to its
+    // absolute lifetime) rather than forcing a `kcap login` after an idle period. The tick is
+    // cheap (a token-file read + expiry compare) and only calls the refresh endpoint when the
+    // token is within ProactiveRefreshWindow of expiry; TokenRefreshLoop further rate-limits
+    // attempts to at most one per ProactiveRefreshMinInterval, so refresh traffic stays bounded
+    // even for a failing refresh or a short-lived token that keeps re-entering the window.
+    readonly PeriodicTimer _tokenRefresh = new(TimeSpan.FromSeconds(60));
+
+    // Refresh once the token is within this much of its expiry. Comfortably above the 60 s tick
+    // so the window is never stepped over.
+    static readonly TimeSpan ProactiveRefreshWindow = TimeSpan.FromMinutes(5);
+
+    // Hit the refresh endpoint at most once per this interval (see TokenRefreshLoop). Small
+    // enough that a healthy token issued with a short lifetime is still renewed before it
+    // lapses during idle; large enough that a dead/rotated refresh token isn't re-hit every
+    // tick.
+    static readonly TimeSpan ProactiveRefreshMinInterval = TimeSpan.FromMinutes(5);
+
     /// <summary>
     /// How long <see cref="FinalizeAgentRunAsync"/> waits on the (reconnect-retrying)
     /// EndAgentSession call before proceeding with local cleanup regardless. Covers a
@@ -217,6 +236,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // Start heartbeat loops
         _ = RunHeartbeatLoopAsync(_shutdownCts.Token);
         _ = RunDaemonHeartbeatLoopAsync(_shutdownCts.Token);
+        _ = RunTokenRefreshLoopAsync(_shutdownCts.Token);
     }
 
     internal int ActiveCount => _agents.Count(a => a.Value.Status is "Starting" or "Running");
@@ -1194,6 +1214,23 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         }
     }
 
+    async Task RunTokenRefreshLoopAsync(CancellationToken ct) {
+        var loop = new TokenRefreshLoop(new TokenStoreRefreshPort(ProactiveRefreshWindow), _logger, ProactiveRefreshMinInterval);
+
+        while (await _tokenRefresh.WaitForNextTickAsync(ct)) {
+            // Defence in depth: TickAsync is intentionally total, but this runs as an
+            // unobserved background Task — guard here so the loop survives even if a
+            // future change lets an exception escape the tick.
+            try {
+                await loop.TickAsync(ct);
+            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                return;
+            } catch (Exception ex) {
+                _logger.LogWarning(ex, "Token refresh tick faulted — continuing loop");
+            }
+        }
+    }
+
     async Task CleanupAgentAsync(string agentId) {
         if (!_agents.TryRemove(agentId, out var agent)) {
             return;
@@ -1249,6 +1286,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         _heartbeatTimer.Dispose();
         _daemonHeartbeat.Dispose();
+        _tokenRefresh.Dispose();
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/TokenRefreshLoop.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TokenRefreshLoop.cs
@@ -1,0 +1,110 @@
+using Capacitor.Cli.Core.Auth;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Abstracts the one action the proactive token-refresh tick performs, so the loop can be
+/// unit-tested without a real token store or network. Implemented in production by
+/// <see cref="TokenStoreRefreshPort"/>.
+/// </summary>
+internal interface IProactiveTokenRefreshPort {
+    /// <summary>
+    /// Refresh the active profile's token if it is within the expiry window. See
+    /// <see cref="ProactiveRefreshOutcome"/> for the meaning of each result.
+    /// </summary>
+    Task<ProactiveRefreshOutcome> RefreshIfExpiringAsync();
+}
+
+/// <summary>
+/// Production port — proactively refreshes the active profile's token through the shared,
+/// cross-process-locked <see cref="TokenStore"/> when it is within <paramref name="window"/>
+/// of expiry.
+/// </summary>
+internal sealed class TokenStoreRefreshPort(TimeSpan window) : IProactiveTokenRefreshPort {
+    public Task<ProactiveRefreshOutcome> RefreshIfExpiringAsync() => TokenStore.RefreshIfExpiringAsync(window);
+}
+
+/// <summary>
+/// Daemon-driven proactive auth-token refresh (AI-992). Auth tokens are otherwise refreshed
+/// lazily — only once a hook hits an expired access token — so after an idle period the user
+/// sees a 401 and must re-run <c>kcap login</c>. This loop keeps the active profile's token
+/// warm by refreshing it <em>ahead</em> of expiry while the daemon runs, which for WorkOS's
+/// sliding inactivity window pushes forced re-logins out to the absolute session lifetime.
+///
+/// The heavy lifting (window check, provider gating, cross-process lock, rotation-safe
+/// re-read) lives in <see cref="TokenStore.RefreshIfExpiringAsync"/>; this class drives it,
+/// reports the outcome, and rate-limits attempts.
+///
+/// <para><b>Rate limiting.</b> A refresh ATTEMPT (success or failure) arms a
+/// <c>minAttemptInterval</c> gate; ticks inside that gate are skipped without touching the
+/// endpoint. This bounds refresh traffic in the cases where the token keeps landing back
+/// inside the window every tick — a refresh that fails (dead / rotated refresh token, server
+/// down) leaves the expiry unchanged, and a provider that issues a token whose whole lifetime
+/// is shorter than the window (or <see cref="TokenStore.JwtExpiry"/>'s parse-failure fallback)
+/// puts the freshly-refreshed token right back inside it. A no-op (NotDue) tick is not an
+/// attempt and never arms the gate, so a healthy long-lived token is still refreshed promptly
+/// the moment it enters the window.</para>
+/// </summary>
+internal sealed class TokenRefreshLoop {
+    readonly IProactiveTokenRefreshPort _port;
+    readonly ILogger                    _logger;
+    readonly TimeSpan                   _minAttemptInterval;
+    readonly Func<DateTimeOffset>       _utcNow;
+
+    // Earliest time at which the next refresh ATTEMPT may run; advanced after every attempt.
+    DateTimeOffset _nextAttemptAllowedAt = DateTimeOffset.MinValue;
+
+    public TokenRefreshLoop(
+            IProactiveTokenRefreshPort port,
+            ILogger                    logger,
+            TimeSpan                   minAttemptInterval,
+            Func<DateTimeOffset>?      utcNow = null
+        ) {
+        _port               = port;
+        _logger             = logger;
+        _minAttemptInterval = minAttemptInterval;
+        _utcNow             = utcNow ?? (static () => DateTimeOffset.UtcNow);
+    }
+
+    /// <summary>
+    /// Total — never throws (modulo outer cancellation, which is expected at shutdown). The
+    /// loop in <c>AgentOrchestrator.RunTokenRefreshLoopAsync</c> runs as an unobserved
+    /// background Task; if a tick faulted the loop would die silently and proactive refresh
+    /// would stop, letting the session lapse after the next idle gap.
+    /// </summary>
+    public async Task TickAsync(CancellationToken ct) {
+        try {
+            // Skip without hitting the endpoint while the post-attempt gate is still closed.
+            if (_utcNow() < _nextAttemptAllowedAt) {
+                return;
+            }
+
+            switch (await _port.RefreshIfExpiringAsync()) {
+                case ProactiveRefreshOutcome.Refreshed:
+                    _nextAttemptAllowedAt = _utcNow() + _minAttemptInterval;
+                    _logger.LogDebug("Proactive token refresh: token inside the expiry window — refreshed ahead of expiry");
+
+                    break;
+
+                case ProactiveRefreshOutcome.Failed:
+                    _nextAttemptAllowedAt = _utcNow() + _minAttemptInterval;
+                    _logger.LogWarning(
+                        "Proactive token refresh failed — backing off for {BackoffSeconds:F0}s; run `kcap login` if this persists",
+                        _minAttemptInterval.TotalSeconds
+                    );
+
+                    break;
+
+                case ProactiveRefreshOutcome.NotDue:
+                    _logger.LogTrace("Proactive token refresh: token still valid — nothing to do");
+
+                    break;
+            }
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            // Outer cancellation (process shutting down) — let the loop exit.
+        } catch (Exception ex) {
+            _logger.LogWarning(ex, "Proactive token refresh tick faulted — continuing loop");
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/TokenRefreshLoop.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TokenRefreshLoop.cs
@@ -96,6 +96,14 @@ internal sealed class TokenRefreshLoop {
 
                     break;
 
+                case ProactiveRefreshOutcome.Contended:
+                    // A peer (hook/watcher/MCP) held the cross-process refresh lock — it is
+                    // presumably refreshing. No endpoint call was made, so this is not a failure:
+                    // stay quiet and retry on the next tick (no warning, no backoff).
+                    _logger.LogDebug("Proactive token refresh: another process holds the refresh lock — retrying next tick");
+
+                    break;
+
                 case ProactiveRefreshOutcome.NotDue:
                     _logger.LogTrace("Proactive token refresh: token still valid — nothing to do");
 

--- a/test/Capacitor.Cli.Tests.Unit/CrossProcessRefreshTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CrossProcessRefreshTests.cs
@@ -1,0 +1,125 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Tests for TokenStore.RefreshWithCrossProcessLockAsync — the profile-scoped lock that both the
+/// reactive (GetValidTokensAsync) and proactive (RefreshIfExpiringAsync) paths refresh through.
+///
+/// Covers two review findings on the proactive-refresh PR (#257 / AI-992):
+///   1. The refreshed token must be persisted under the SAME profile the lock was taken on, not
+///      the (possibly since-switched) active profile — the refresh delegates no longer self-save.
+///   2. A refresh that a peer already performed while we waited for the lock must NOT be repeated,
+///      even if the freshly-rotated token is still inside the proactive window (short-lived token).
+///
+/// A fake refresh delegate is injected so no network or real provider endpoint is touched. Shares
+/// the KCAP_CONFIG_DIR token store, so it cleans up and runs non-parallel like TokenStoreProfileTests.
+/// </summary>
+[NotInParallel(nameof(TokenStoreProfileTests))]
+public class CrossProcessRefreshTests {
+    static readonly TimeSpan Window = TimeSpan.FromMinutes(5);
+
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+    static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
+
+    [Before(Test)]
+    public void Cleanup() {
+        if (File.Exists(LegacyPath)) File.Delete(LegacyPath);
+        if (Directory.Exists(TokensDir)) Directory.Delete(TokensDir, recursive: true);
+        var cfg = Capacitor.Cli.Core.Config.AppConfig.GetConfigPath();
+        if (File.Exists(cfg)) File.Delete(cfg);
+    }
+
+    static StoredTokens Token(string accessToken, DateTimeOffset expiresAt) => new() {
+        AccessToken    = accessToken,
+        RefreshToken   = "rt",
+        ClientId       = "cid",
+        ExpiresAt      = expiresAt,
+        GitHubUsername = "alice",
+        Provider       = AuthProvider.WorkOS
+    };
+
+    static bool WithinWindow(StoredTokens t) => DateTimeOffset.UtcNow >= t.ExpiresAt - Window;
+
+    [Test]
+    [NotInParallel(nameof(TokenStoreProfileTests))]
+    public async Task Persists_refreshed_token_under_the_locked_profile() {
+        // Lock a NON-default profile ("alpha"); the active profile resolves to "default". The
+        // refreshed token must land in alpha.json — a persist path that re-resolved the active
+        // profile would write it to default.json and leave alpha.json stale.
+        var current = Token("old", DateTimeOffset.UtcNow.AddMinutes(-10)); // expired → default predicate refreshes
+        await TokenStore.SaveAsync("alpha", current);
+
+        var refreshed = Token("new-alpha", DateTimeOffset.UtcNow.AddHours(1));
+
+        var result = await TokenStore.RefreshWithCrossProcessLockAsync(
+            "alpha", current, _ => Task.FromResult<StoredTokens?>(refreshed));
+
+        await Assert.That(result!.AccessToken).IsEqualTo("new-alpha");
+        await Assert.That((await TokenStore.LoadAsync("alpha"))!.AccessToken).IsEqualTo("new-alpha");
+        await Assert.That(File.Exists(Path.Combine(TokensDir, "default.json"))).IsFalse();
+    }
+
+    [Test]
+    [NotInParallel(nameof(TokenStoreProfileTests))]
+    public async Task Refreshes_and_persists_when_no_peer_changed_the_token() {
+        // On-disk token equals `current` (no peer refresh) and is inside the proactive window →
+        // refresh, and the result is persisted under the lock.
+        var current = Token("same", DateTimeOffset.UtcNow.AddMinutes(3));
+        await TokenStore.SaveAsync("alpha", current);
+
+        var refreshed     = Token("refreshed", DateTimeOffset.UtcNow.AddHours(1));
+        var refreshCalled = false;
+
+        var result = await TokenStore.RefreshWithCrossProcessLockAsync(
+            "alpha", current,
+            _ => { refreshCalled = true; return Task.FromResult<StoredTokens?>(refreshed); },
+            WithinWindow);
+
+        await Assert.That(refreshCalled).IsTrue();
+        await Assert.That(result!.AccessToken).IsEqualTo("refreshed");
+        await Assert.That((await TokenStore.LoadAsync("alpha"))!.AccessToken).IsEqualTo("refreshed");
+    }
+
+    [Test]
+    [NotInParallel(nameof(TokenStoreProfileTests))]
+    public async Task Does_not_re_refresh_a_token_a_peer_already_refreshed() {
+        // We read `current` before the lock; under the lock the on-disk token has CHANGED to a
+        // peer-refreshed one that is still valid but ALSO still inside the window (short lifetime).
+        // The within-window predicate alone would re-refresh it — the peer-refresh guard must not.
+        var current       = Token("old",  DateTimeOffset.UtcNow.AddMinutes(3));
+        var peerRefreshed = Token("peer", DateTimeOffset.UtcNow.AddMinutes(3)); // changed, valid, still within window
+        await TokenStore.SaveAsync("alpha", peerRefreshed);
+
+        var refreshCalled = false;
+
+        var result = await TokenStore.RefreshWithCrossProcessLockAsync(
+            "alpha", current,
+            _ => { refreshCalled = true; return Task.FromResult<StoredTokens?>(current); },
+            WithinWindow);
+
+        await Assert.That(refreshCalled).IsFalse();            // suppressed — peer already refreshed
+        await Assert.That(result!.AccessToken).IsEqualTo("peer");
+    }
+
+    [Test]
+    [NotInParallel(nameof(TokenStoreProfileTests))]
+    public async Task Reactive_default_predicate_still_refreshes_expired_token() {
+        // Guard: the default (reactive) predicate is unchanged — an expired token still refreshes
+        // and persists, even though the on-disk token changed (peer wrote an expired token).
+        var current       = Token("old",     DateTimeOffset.UtcNow.AddMinutes(-10));
+        var peerButExpired = Token("peer-x", DateTimeOffset.UtcNow.AddMinutes(-5)); // changed but still expired
+        await TokenStore.SaveAsync("alpha", peerButExpired);
+
+        var refreshed     = Token("fresh", DateTimeOffset.UtcNow.AddHours(1));
+        var refreshCalled = false;
+
+        var result = await TokenStore.RefreshWithCrossProcessLockAsync(
+            "alpha", current,
+            _ => { refreshCalled = true; return Task.FromResult<StoredTokens?>(refreshed); });
+
+        await Assert.That(refreshCalled).IsTrue();
+        await Assert.That((await TokenStore.LoadAsync("alpha"))!.AccessToken).IsEqualTo("fresh");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/TokenRefreshLoopTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/TokenRefreshLoopTests.cs
@@ -95,6 +95,24 @@ public class TokenRefreshLoopTests {
     }
 
     [Test]
+    public async Task Tick_Contended_IsQuietAndDoesNotBackOff() {
+        // Lock contention (a peer holds the refresh lock) is not a refresh failure: no warning,
+        // and the next tick is NOT rate-limited — contention is transient, so we retry promptly.
+        var now    = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var logger = new CaptureLogger();
+        var port   = new FakePort { Handler = () => Task.FromResult(ProactiveRefreshOutcome.Contended) };
+        var loop   = new TokenRefreshLoop(port, logger, Interval, () => now);
+
+        await loop.TickAsync(CancellationToken.None);
+        await Assert.That(port.Calls).IsEqualTo(1);
+        await Assert.That(logger.Entries).DoesNotContain(e => e.Level == LogLevel.Warning);
+
+        now = now.AddMinutes(1);                            // well within the rate-limit interval
+        await loop.TickAsync(CancellationToken.None);
+        await Assert.That(port.Calls).IsEqualTo(2);         // not suppressed — contention doesn't arm the gate
+    }
+
+    [Test]
     public async Task Tick_OuterCancellation_DoesNotLogWarning() {
         // Outer cancellation = process shutdown. A cancellation surfacing from the refresh
         // during teardown must be treated as a clean exit, not a fault to warn about.

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/TokenRefreshLoopTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/TokenRefreshLoopTests.cs
@@ -1,0 +1,172 @@
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// Unit tests for the daemon-side proactive token-refresh tick (AI-992). The loop wakes on a
+/// low-frequency timer and asks the port to refresh the active profile's token if it is inside
+/// the expiry window. Like the daemon heartbeat loop, it runs as an unobserved background Task,
+/// so <see cref="TokenRefreshLoop.TickAsync"/> must be total — a throwing refresh must not kill
+/// the loop, or proactive refresh silently stops and the session lapses after the next idle gap.
+///
+/// The loop also rate-limits refresh ATTEMPTS to at most one per configured interval, so a
+/// token that stays inside the window every tick (a failing refresh, or a token whose lifetime
+/// is shorter than the window) can't hammer the refresh endpoint once per tick.
+///
+/// Exercised through a fake <see cref="IProactiveTokenRefreshPort"/> and an injected clock so
+/// no network, token store, or wall-clock delay is touched.
+/// </summary>
+public class TokenRefreshLoopTests {
+    static readonly TimeSpan Interval = TimeSpan.FromMinutes(5);
+
+    sealed class FakePort : IProactiveTokenRefreshPort {
+        public Func<Task<ProactiveRefreshOutcome>>? Handler { get; set; }
+        public int                                  Calls;
+
+        public Task<ProactiveRefreshOutcome> RefreshIfExpiringAsync() {
+            Calls++;
+
+            return Handler is null ? Task.FromResult(ProactiveRefreshOutcome.NotDue) : Handler();
+        }
+    }
+
+    /// <summary>Minimal <see cref="ILogger"/> that records the rendered message and level of every entry.</summary>
+    sealed class CaptureLogger : ILogger {
+        public readonly List<(LogLevel Level, string Message)> Entries = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool         IsEnabled(LogLevel logLevel)                            => true;
+
+        public void Log<TState>(LogLevel level, EventId id, TState state, Exception? ex, Func<TState, Exception?, string> formatter)
+            => Entries.Add((level, formatter(state, ex)));
+    }
+
+    [Test]
+    public async Task Tick_TokenInsideWindow_RefreshesAndLogsAtDebug() {
+        var logger = new CaptureLogger();
+        var port   = new FakePort { Handler = () => Task.FromResult(ProactiveRefreshOutcome.Refreshed) };
+        var loop   = new TokenRefreshLoop(port, logger, Interval);
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.Calls).IsEqualTo(1);
+        await Assert.That(logger.Entries).Contains(e => e.Level == LogLevel.Debug && e.Message.Contains("refreshed"));
+        await Assert.That(logger.Entries).DoesNotContain(e => e.Level == LogLevel.Warning);
+    }
+
+    [Test]
+    public async Task Tick_TokenStillValid_IsQuietNoWarning() {
+        var logger = new CaptureLogger();
+        var port   = new FakePort { Handler = () => Task.FromResult(ProactiveRefreshOutcome.NotDue) };
+        var loop   = new TokenRefreshLoop(port, logger, Interval);
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.Calls).IsEqualTo(1);
+        await Assert.That(logger.Entries).DoesNotContain(e => e.Level == LogLevel.Warning);
+    }
+
+    [Test]
+    public async Task Tick_RefreshFailed_LogsWarning() {
+        var logger = new CaptureLogger();
+        var port   = new FakePort { Handler = () => Task.FromResult(ProactiveRefreshOutcome.Failed) };
+        var loop   = new TokenRefreshLoop(port, logger, Interval);
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.Calls).IsEqualTo(1);
+        await Assert.That(logger.Entries).Contains(e => e.Level == LogLevel.Warning && e.Message.Contains("failed"));
+    }
+
+    [Test]
+    public async Task Tick_PortThrows_DoesNotRethrowAndLogsWarning() {
+        // The unobserved background loop must survive a faulting refresh (e.g. a genuine IO
+        // fault reading the token file that TokenStore lets propagate).
+        var logger = new CaptureLogger();
+        var port   = new FakePort { Handler = () => Task.FromException<ProactiveRefreshOutcome>(new InvalidOperationException("disk gone")) };
+        var loop   = new TokenRefreshLoop(port, logger, Interval);
+
+        await loop.TickAsync(CancellationToken.None);
+
+        await Assert.That(port.Calls).IsEqualTo(1);
+        await Assert.That(logger.Entries).Contains(e => e.Level == LogLevel.Warning && e.Message.Contains("faulted"));
+    }
+
+    [Test]
+    public async Task Tick_OuterCancellation_DoesNotLogWarning() {
+        // Outer cancellation = process shutdown. A cancellation surfacing from the refresh
+        // during teardown must be treated as a clean exit, not a fault to warn about.
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var logger = new CaptureLogger();
+        var port   = new FakePort { Handler = () => Task.FromException<ProactiveRefreshOutcome>(new OperationCanceledException()) };
+        var loop   = new TokenRefreshLoop(port, logger, Interval);
+
+        await loop.TickAsync(cts.Token);
+
+        await Assert.That(logger.Entries).DoesNotContain(e => e.Level == LogLevel.Warning);
+    }
+
+    [Test]
+    public async Task Tick_AfterFailedRefresh_SuppressesAttemptsUntilIntervalElapses() {
+        // A failed refresh leaves the token inside the window, so without rate-limiting the
+        // next tick would re-hit the (dead/rotated) refresh endpoint 60s later — and every 60s
+        // forever. The loop must back off for the interval before attempting again.
+        var now    = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var logger = new CaptureLogger();
+        var port   = new FakePort { Handler = () => Task.FromResult(ProactiveRefreshOutcome.Failed) };
+        var loop   = new TokenRefreshLoop(port, logger, Interval, () => now);
+
+        await loop.TickAsync(CancellationToken.None);      // attempt #1
+        await Assert.That(port.Calls).IsEqualTo(1);
+
+        now = now.AddMinutes(2);                           // still inside the 5-minute interval
+        await loop.TickAsync(CancellationToken.None);
+        await Assert.That(port.Calls).IsEqualTo(1);         // suppressed — no second endpoint hit
+
+        now = now.AddMinutes(3);                           // interval (5 min total) has elapsed
+        await loop.TickAsync(CancellationToken.None);
+        await Assert.That(port.Calls).IsEqualTo(2);         // allowed to retry now
+    }
+
+    [Test]
+    public async Task Tick_AfterSuccessfulRefresh_AlsoSuppressesNextAttempt() {
+        // Guards the short-token / JwtExpiry-fallback storm: even a SUCCESSFUL refresh can leave
+        // the new token back inside the window (lifetime <= window), so a success must also arm
+        // the rate limiter — otherwise we'd refresh (and rotate the WorkOS refresh token) every
+        // tick.
+        var now    = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var logger = new CaptureLogger();
+        var port   = new FakePort { Handler = () => Task.FromResult(ProactiveRefreshOutcome.Refreshed) };
+        var loop   = new TokenRefreshLoop(port, logger, Interval, () => now);
+
+        await loop.TickAsync(CancellationToken.None);
+        await Assert.That(port.Calls).IsEqualTo(1);
+
+        now = now.AddMinutes(2);
+        await loop.TickAsync(CancellationToken.None);
+        await Assert.That(port.Calls).IsEqualTo(1);         // suppressed within the interval
+    }
+
+    [Test]
+    public async Task Tick_NotDue_DoesNotArmRateLimiter() {
+        // A no-op tick isn't an attempt, so it must not gate the next tick — a healthy token
+        // that later enters the window must be refreshed promptly, not held off by an interval.
+        var now    = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var logger = new CaptureLogger();
+        var outcome = ProactiveRefreshOutcome.NotDue;
+        var port   = new FakePort { Handler = () => Task.FromResult(outcome) };
+        var loop   = new TokenRefreshLoop(port, logger, Interval, () => now);
+
+        await loop.TickAsync(CancellationToken.None);       // NotDue
+        await Assert.That(port.Calls).IsEqualTo(1);
+
+        outcome = ProactiveRefreshOutcome.Refreshed;
+        now = now.AddMinutes(1);                            // token just entered the window
+        await loop.TickAsync(CancellationToken.None);
+        await Assert.That(port.Calls).IsEqualTo(2);         // not suppressed — attempted immediately
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/ProactiveTokenRefreshDecisionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProactiveTokenRefreshDecisionTests.cs
@@ -1,0 +1,101 @@
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="TokenStore.DecideProactiveRefresh"/> — the pure decision the
+/// daemon's proactive-refresh tick makes each time it wakes. It answers "should we
+/// refresh the active profile's token ahead of expiry, and via which provider path?"
+/// without touching the network or the filesystem, so every branch is unit-testable
+/// in isolation (AI-992).
+/// </summary>
+public class ProactiveTokenRefreshDecisionTests {
+    static readonly TimeSpan Window = TimeSpan.FromMinutes(5);
+    static readonly DateTimeOffset Now = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    static StoredTokens Tokens(string provider, DateTimeOffset expiresAt, string? refreshToken = "rt", string? clientId = "cid") => new() {
+        AccessToken    = "at",
+        RefreshToken   = refreshToken,
+        ClientId       = clientId,
+        ExpiresAt      = expiresAt,
+        GitHubUsername = "alice",
+        Provider       = provider
+    };
+
+    [Test]
+    public async Task No_stored_tokens_is_a_no_op() {
+        var decision = TokenStore.DecideProactiveRefresh(null, Now, Window);
+
+        await Assert.That(decision).IsEqualTo(TokenStore.RefreshDecision.NoTokens);
+    }
+
+    [Test]
+    public async Task Token_comfortably_valid_is_not_due() {
+        // Expires well beyond the window — nothing to do yet.
+        var tokens   = Tokens(AuthProvider.WorkOS, Now.AddMinutes(30));
+        var decision = TokenStore.DecideProactiveRefresh(tokens, Now, Window);
+
+        await Assert.That(decision).IsEqualTo(TokenStore.RefreshDecision.NotDueYet);
+    }
+
+    [Test]
+    public async Task WorkOS_token_inside_window_refreshes_via_workos() {
+        var tokens   = Tokens(AuthProvider.WorkOS, Now.AddMinutes(4));
+        var decision = TokenStore.DecideProactiveRefresh(tokens, Now, Window);
+
+        await Assert.That(decision).IsEqualTo(TokenStore.RefreshDecision.RefreshWorkOS);
+    }
+
+    [Test]
+    public async Task GitHub_token_inside_window_refreshes_via_github() {
+        var tokens   = Tokens(AuthProvider.GitHubApp, Now.AddMinutes(4));
+        var decision = TokenStore.DecideProactiveRefresh(tokens, Now, Window);
+
+        await Assert.That(decision).IsEqualTo(TokenStore.RefreshDecision.RefreshGitHub);
+    }
+
+    [Test]
+    public async Task Token_exactly_at_window_boundary_refreshes() {
+        // now == ExpiresAt - window: inclusive, so we refresh rather than wait a tick.
+        var tokens   = Tokens(AuthProvider.WorkOS, Now.Add(Window));
+        var decision = TokenStore.DecideProactiveRefresh(tokens, Now, Window);
+
+        await Assert.That(decision).IsEqualTo(TokenStore.RefreshDecision.RefreshWorkOS);
+    }
+
+    [Test]
+    public async Task Already_expired_workos_token_still_refreshes() {
+        var tokens   = Tokens(AuthProvider.WorkOS, Now.AddMinutes(-10));
+        var decision = TokenStore.DecideProactiveRefresh(tokens, Now, Window);
+
+        await Assert.That(decision).IsEqualTo(TokenStore.RefreshDecision.RefreshWorkOS);
+    }
+
+    [Test]
+    public async Task WorkOS_token_without_refresh_token_is_unsupported() {
+        // WorkOS refresh needs the rotating refresh_token; without it there's nothing
+        // to present, so the tick must not attempt a (doomed) refresh.
+        var tokens   = Tokens(AuthProvider.WorkOS, Now.AddMinutes(1), refreshToken: null);
+        var decision = TokenStore.DecideProactiveRefresh(tokens, Now, Window);
+
+        await Assert.That(decision).IsEqualTo(TokenStore.RefreshDecision.Unsupported);
+    }
+
+    [Test]
+    public async Task WorkOS_token_without_client_id_is_unsupported() {
+        var tokens   = Tokens(AuthProvider.WorkOS, Now.AddMinutes(1), clientId: null);
+        var decision = TokenStore.DecideProactiveRefresh(tokens, Now, Window);
+
+        await Assert.That(decision).IsEqualTo(TokenStore.RefreshDecision.Unsupported);
+    }
+
+    [Test]
+    public async Task None_provider_token_is_unsupported() {
+        // A None-auth server stores no tokens, but even if a stray file surfaced with
+        // Provider=None the tick must be a no-op (acceptance criterion).
+        var tokens   = Tokens(AuthProvider.None, Now.AddMinutes(1));
+        var decision = TokenStore.DecideProactiveRefresh(tokens, Now, Window);
+
+        await Assert.That(decision).IsEqualTo(TokenStore.RefreshDecision.Unsupported);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/RefreshIfExpiringTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RefreshIfExpiringTests.cs
@@ -1,0 +1,69 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// No-op behaviour of <see cref="TokenStore.RefreshIfExpiringAsync"/> — the paths that
+/// must NOT touch the network. These are the daemon acceptance criteria: proactive refresh
+/// is a no-op when no tokens are stored, for the None provider, and while the token is still
+/// comfortably valid (refresh only inside the expiry window). The provider paths that DO hit
+/// the WorkOS / server refresh endpoints are exercised by DecideProactiveRefresh's unit tests
+/// and integration coverage, never here, so this suite stays offline and fast.
+///
+/// Shares the KCAP_CONFIG_DIR token store with the other path-based tests, so it cleans up
+/// and runs non-parallel exactly like <see cref="TokenStoreProfileTests"/>.
+/// </summary>
+[NotInParallel(nameof(TokenStoreProfileTests))]
+public class RefreshIfExpiringTests {
+    static readonly TimeSpan Window = TimeSpan.FromMinutes(5);
+
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+    static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
+
+    [Before(Test)]
+    public void Cleanup() {
+        if (File.Exists(LegacyPath)) File.Delete(LegacyPath);
+        if (Directory.Exists(TokensDir)) Directory.Delete(TokensDir, recursive: true);
+
+        var cfg = Capacitor.Cli.Core.Config.AppConfig.GetConfigPath();
+        if (File.Exists(cfg)) File.Delete(cfg);
+    }
+
+    [Test]
+    public async Task NotDue_when_no_tokens_stored() {
+        await Assert.That(await TokenStore.RefreshIfExpiringAsync(Window)).IsEqualTo(ProactiveRefreshOutcome.NotDue);
+    }
+
+    [Test]
+    public async Task NotDue_and_leaves_token_untouched_when_comfortably_valid() {
+        var original = new StoredTokens {
+            AccessToken    = "at",
+            RefreshToken   = "rt",
+            ClientId       = "cid",
+            ExpiresAt      = DateTimeOffset.UtcNow.AddHours(1), // well outside the 5-minute window
+            GitHubUsername = "alice",
+            Provider       = AuthProvider.WorkOS
+        };
+        await TokenStore.SaveAsync("default", original);
+
+        await Assert.That(await TokenStore.RefreshIfExpiringAsync(Window)).IsEqualTo(ProactiveRefreshOutcome.NotDue);
+
+        // Untouched — no refresh attempted, so the persisted access token is unchanged.
+        var after = await TokenStore.LoadAsync("default");
+        await Assert.That(after!.AccessToken).IsEqualTo("at");
+    }
+
+    [Test]
+    public async Task NotDue_for_none_provider_even_inside_window() {
+        // A None-auth server stores no tokens; a stray Provider=None file must still be a no-op.
+        await TokenStore.SaveAsync("default", new StoredTokens {
+            AccessToken    = "at",
+            ExpiresAt      = DateTimeOffset.UtcNow.AddMinutes(1), // inside the window
+            GitHubUsername = "alice",
+            Provider       = AuthProvider.None
+        });
+
+        await Assert.That(await TokenStore.RefreshIfExpiringAsync(Window)).IsEqualTo(ProactiveRefreshOutcome.NotDue);
+    }
+}


### PR DESCRIPTION
## What & why

Auth tokens were refreshed only **lazily** — `TokenStore.GetValidTokensAsync()` refreshes only once the access token is already expired, on the next call that needs it. Nothing kept the refresh credential warm ahead of time, so after an idle period the next hook hit a 401 and the user was forced to re-run `kcap login`.

The daemon now runs a low-frequency loop that refreshes the active profile's token **ahead** of expiry. For WorkOS's sliding inactivity window, periodic refresh keeps the session alive for as long as the daemon runs, pushing forced re-logins out to the absolute session max instead of the shorter inactivity timeout.

## How

- **`TokenStore.RefreshIfExpiringAsync(window)`** (Core) — refreshes the active profile's token when it's within `window` of expiry, through the **same profile-scoped cross-process lock** as `GetValidTokensAsync` (rotation-safe re-read under the lock, so it can't race a hook/watcher/MCP refresh or double-spend a rotated WorkOS refresh token). No-op for the `None` provider and when no tokens are stored. The decision is factored into a pure, fully unit-tested `DecideProactiveRefresh`. Resolves the active profile once and threads it through the read + lock (tighter than the reactive path).
- **`TokenRefreshLoop`** (Daemon) — mirrors `DaemonHeartbeatLoop`: a total (never-throwing) tick behind an `IProactiveTokenRefreshPort`. It **rate-limits attempts to at most one per interval**, so a failing refresh (dead/rotated token, server down) or a token whose lifetime is shorter than the window can't hammer the refresh endpoint every tick.
- Wired into `AgentOrchestrator` alongside the existing heartbeat loops (60s tick, 5-min window, 5-min min attempt interval), disposed on shutdown.

## Acceptance criteria

- [x] Daemon refreshes the active profile's token ahead of expiry on a timer, via the cross-process lock.
- [x] No measurable increase in refresh-endpoint traffic — refresh fires only inside the window, and the loop rate-limits attempts so a failing/short-lived token can't retry-storm.
- [x] A continuously-running daemon keeps a WorkOS session alive up to its absolute lifetime without a manual `kcap login`.
- [x] No-op for the `None` auth provider and when no tokens are stored.

## Testing

- New unit tests: `ProactiveTokenRefreshDecisionTests` (all decision branches), `RefreshIfExpiringTests` (offline no-op paths), `TokenRefreshLoopTests` (outcome logging, totality, and rate-limiting on failed/successful/short-lived refresh).
- Full unit suite green (2089 tests). `dotnet publish -c Release` clean — no IL3050/IL2026 AOT warnings on CLI or daemon.

No README/CLI-surface change: this is internal daemon behavior (no new command, flag, default, or prerequisite).

Closes #182
Linear: AI-992