### PR TITLE
Refresh WorkOS token during kcap setup provisioning poll

### DIFF
--- a/src/Capacitor.Cli.Core/Auth/ITenantProvisioner.cs
+++ b/src/Capacitor.Cli.Core/Auth/ITenantProvisioner.cs
@@ -18,5 +18,9 @@ public sealed record ProvisionOffer(ProvisionOfferStatus Status, ProvisionedTena
 public interface ITenantProvisioner {
     // Interactive: prompt -> provision -> poll. Returns Created (with the tenant)
     // on success; Declined/InProgress/Failed otherwise.
-    Task<ProvisionOffer> OfferCreateAsync(string workosAccessToken, CancellationToken ct = default);
+    //
+    // Takes a token source rather than a bare access token: provisioning + polling can run
+    // for minutes, outliving WorkOS's ~5-minute access-token TTL, so each server call pulls a
+    // freshly-refreshed token via the source (see WorkOSTokenSource).
+    Task<ProvisionOffer> OfferCreateAsync(WorkOSTokenSource tokens, CancellationToken ct = default);
 }

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -593,6 +593,26 @@ public static class OAuthLoginFlow {
         return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse);
     }
 
+    /// <summary>
+    /// Public-client WorkOS token refresh (org-less): exchanges a refresh token for a fresh access
+    /// token without switching organization. Keeps the org-less token alive across the create-tenant
+    /// provisioning poll, which can outlive WorkOS's ~5-minute access-token TTL. No client secret.
+    /// </summary>
+    public static async Task<WorkOSAuthResponse?> RefreshWorkOSTokenAsync(
+            HttpClient http, string apiBase, string clientId, string refreshToken) {
+        var resp = await http.PostAsync(
+            $"{apiBase.TrimEnd('/')}/user_management/authenticate",
+            new FormUrlEncodedContent(new Dictionary<string, string> {
+                ["grant_type"]    = "refresh_token",
+                ["client_id"]     = clientId,
+                ["refresh_token"] = refreshToken
+            }));
+
+        if (!resp.IsSuccessStatusCode) return null;
+
+        return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse);
+    }
+
     // The server-supplied code-exchange URL must be a fully-qualified http(s) URI before
     // we trust it. An empty string, whitespace, relative path, or javascript:/file: URL
     // is treated as "no browser flow available" and the dispatcher falls back to device flow.

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -600,17 +600,24 @@ public static class OAuthLoginFlow {
     /// </summary>
     public static async Task<WorkOSAuthResponse?> RefreshWorkOSTokenAsync(
             HttpClient http, string apiBase, string clientId, string refreshToken) {
-        var resp = await http.PostAsync(
-            $"{apiBase.TrimEnd('/')}/user_management/authenticate",
-            new FormUrlEncodedContent(new Dictionary<string, string> {
-                ["grant_type"]    = "refresh_token",
-                ["client_id"]     = clientId,
-                ["refresh_token"] = refreshToken
-            }));
+        // Degrade transport/timeout/parse failures to null (mirrors TenantProvisioningClient): this
+        // fires automatically and repeatedly during the provisioning poll, so a blip must not throw
+        // and abort the flow — the token source keeps the current token and retries next tick.
+        try {
+            var resp = await http.PostAsync(
+                $"{apiBase.TrimEnd('/')}/user_management/authenticate",
+                new FormUrlEncodedContent(new Dictionary<string, string> {
+                    ["grant_type"]    = "refresh_token",
+                    ["client_id"]     = clientId,
+                    ["refresh_token"] = refreshToken
+                }));
 
-        if (!resp.IsSuccessStatusCode) return null;
+            if (!resp.IsSuccessStatusCode) return null;
 
-        return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse);
+            return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse);
+        } catch (Exception e) when (e is HttpRequestException or OperationCanceledException or JsonException or NotSupportedException) {
+            return null;
+        }
     }
 
     // The server-supplied code-exchange URL must be a fully-qualified http(s) URI before

--- a/src/Capacitor.Cli.Core/Auth/ProvisioningPoll.cs
+++ b/src/Capacitor.Cli.Core/Auth/ProvisioningPoll.cs
@@ -1,0 +1,25 @@
+namespace Capacitor.Cli.Core.Auth;
+
+// What the create-tenant poll should do with a single status-poll result.
+public enum PollVerdict {
+    Active,      // live and linked to an org — done
+    ActiveNoOrg, // live but no WorkOS org (can't org-switch) — terminal, needs support
+    Failed,      // server marked the row failed — terminal
+    Forbidden,   // 403 — email unverified — terminal
+    NotFound,    // 404 — slug isn't owned by this account — terminal
+    Wait         // still provisioning, or a transient/auth blip the next tick recovers from
+}
+
+// Pure decision for the interactive poll, extracted from the Spectre-coupled provisioner so
+// every branch is unit-tested. The old poll only reacted to active+orgId and failed; every
+// other response (reserved, 401/403/404, transport error) silently looped until timeout.
+public static class ProvisioningPoll {
+    public static PollVerdict Classify(int statusCode, string? state, string? workosOrgId) => statusCode switch {
+        200 when state == "active" => workosOrgId is { Length: > 0 } ? PollVerdict.Active : PollVerdict.ActiveNoOrg,
+        200 when state == "failed" => PollVerdict.Failed,
+        403                        => PollVerdict.Forbidden,
+        404                        => PollVerdict.NotFound,
+        // 200 provisioning/reserved, 401 (token source refreshes next tick), 0 transport, 5xx: keep waiting.
+        _                          => PollVerdict.Wait
+    };
+}

--- a/src/Capacitor.Cli.Core/Auth/TenantProvisioningClient.cs
+++ b/src/Capacitor.Cli.Core/Auth/TenantProvisioningClient.cs
@@ -10,6 +10,13 @@ namespace Capacitor.Cli.Core.Auth;
 // offer. Not serialized — no JSON context entry.
 public sealed record ProvisionOutcome(int StatusCode, ProvisionResponse? Body);
 
+// Result of a status GET: HTTP status + parsed body. Surfacing the status (rather than
+// collapsing everything to a nullable body) lets the poll distinguish "still provisioning"
+// (200) from auth/ownership failures (401/403/404) and transport blips (0), instead of
+// treating them all as "keep waiting" and spinning silently. StatusCode 0 = transport/parse
+// failure. Not serialized — no JSON context entry.
+public sealed record StatusOutcome(int StatusCode, StatusResponse? Body);
+
 // Talks to kcap-web /api/signup/* with a WorkOS bearer access token. All calls
 // are best-effort: transport / timeout / parse failures degrade to null
 // (availability/status) or StatusCode 0 (provision) rather than throwing, so a
@@ -50,15 +57,19 @@ public sealed class TenantProvisioningClient(HttpClient http) {
         }
     }
 
-    public async Task<StatusResponse?> GetStatusAsync(
+    public async Task<StatusOutcome> GetStatusAsync(
             string baseUrl, string token, string slug, CancellationToken ct) {
         try {
             using var req = Get($"{baseUrl}/api/signup/status?slug={Uri.EscapeDataString(slug)}", token);
             using var resp = await http.SendAsync(req, ct);
-            if (!resp.IsSuccessStatusCode) return null;
-            return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.StatusResponse, ct);
+            if (!resp.IsSuccessStatusCode) return new((int)resp.StatusCode, null);
+
+            StatusResponse? body = null;
+            try { body = await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.StatusResponse, ct); }
+            catch (Exception e) when (IsTransient(e)) { /* 2xx with empty/non-JSON body — leave null */ }
+            return new((int)resp.StatusCode, body);
         } catch (Exception e) when (IsTransient(e)) {
-            return null;
+            return new(0, null); // transport failure — caller treats as transient, keeps waiting
         }
     }
 

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -29,6 +29,10 @@ public static class WorkOSDiscovery {
                 using var http = new HttpClient();
                 return await OAuthLoginFlow.SwitchWorkOSOrgAsync(http, WorkOSApiBase, clientId, refreshToken, organizationId);
             },
+            orglessRefresh: async (refreshToken, _) => {
+                using var http = new HttpClient();
+                return await OAuthLoginFlow.RefreshWorkOSTokenAsync(http, WorkOSApiBase, clientId, refreshToken);
+            },
             provisioner: provisioner);
     }
 
@@ -39,6 +43,7 @@ public static class WorkOSDiscovery {
             ITenantPicker                                   picker,
             Func<Task<WorkOSAuthResponse?>>                 orglessLogin,
             Func<string, string, Task<WorkOSAuthResponse?>> orgSwitch,     // args: refreshToken, organizationId
+            Func<string, CancellationToken, Task<WorkOSAuthResponse?>>? orglessRefresh = null, // args: refreshToken, ct
             ITenantProvisioner?                             provisioner = null) {
         if (string.IsNullOrEmpty(proxyConfig.WorkOSClientId)) {
             await Console.Error.WriteLineAsync("This server isn't configured for WorkOS sign-in.");
@@ -72,7 +77,12 @@ public static class WorkOSDiscovery {
                 return 1;
             }
 
-            var offer = await provisioner.OfferCreateAsync(auth.AccessToken);
+            // Provisioning + polling can run for minutes, outliving WorkOS's ~5-minute access-token
+            // TTL, so hand the provisioner a refreshing token source rather than the login-time token.
+            var tokens = new WorkOSTokenSource(
+                auth.AccessToken, auth.RefreshToken,
+                orglessRefresh ?? ((_, _) => Task.FromResult<WorkOSAuthResponse?>(null)));
+            var offer = await provisioner.OfferCreateAsync(tokens);
             if (offer.Status != ProvisionOfferStatus.Created || offer.Tenant is null) {
                 // Declined / InProgress / Failed — the provisioner already printed the
                 // outcome-appropriate message; don't stack the legacy dead-end on top.
@@ -86,7 +96,10 @@ public static class WorkOSDiscovery {
                 DisplayName    = offer.Tenant.DisplayName,
                 Origin         = offer.Tenant.Origin
             };
-            return await SwitchAndSaveAsync(created, [created], auth, proxyConfig.WorkOSClientId!, orgSwitch);
+            // Polling may have rotated the org-less refresh token; the org-switch must use the
+            // current one (WorkOS invalidates the old on refresh) or the final switch would 401.
+            var authForSwitch = auth with { RefreshToken = tokens.CurrentRefreshToken ?? auth.RefreshToken };
+            return await SwitchAndSaveAsync(created, [created], authForSwitch, proxyConfig.WorkOSClientId!, orgSwitch);
         }
 
         var picked = result.Tenants.Length == 1 ? result.Tenants[0] : picker.Pick(result.Tenants);

--- a/src/Capacitor.Cli.Core/Auth/WorkOSTokenSource.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSTokenSource.cs
@@ -1,0 +1,57 @@
+namespace Capacitor.Cli.Core.Auth;
+
+// Keeps a valid WorkOS access token available across a long-running interactive flow.
+//
+// The create-a-tenant flow provisions, then polls for "active" for up to ~10 minutes — but a
+// WorkOS AuthKit access token lives only ~5 minutes. Reusing the login-time token for the whole
+// poll means it expires mid-wait; the server then 401s every status check, which the client
+// swallows to a null "still provisioning", so the CLI spins silently until timeout even though
+// the tenant went live. This refreshes the access token (public-client refresh_token grant, no
+// secret) before it lapses so every status call carries a live token.
+//
+// Not thread-safe: the provisioning flow calls GetAsync serially.
+public sealed class WorkOSTokenSource {
+    readonly Func<string, CancellationToken, Task<WorkOSAuthResponse?>> refresh;
+    readonly Func<DateTimeOffset>                                       now;
+    readonly TimeSpan                                                   margin;
+
+    string         accessToken;
+    string?        refreshToken;
+    DateTimeOffset expiresAt;
+
+    public WorkOSTokenSource(
+            string                                              accessToken,
+            string?                                             refreshToken,
+            Func<string, CancellationToken, Task<WorkOSAuthResponse?>> refresh,
+            Func<DateTimeOffset>?                               now    = null,
+            TimeSpan?                                           margin = null) {
+        this.accessToken  = accessToken;
+        this.refreshToken = refreshToken;
+        this.refresh      = refresh;
+        this.now          = now    ?? (() => DateTimeOffset.UtcNow);
+        this.margin       = margin ?? TimeSpan.FromSeconds(60);
+        expiresAt         = TokenStore.JwtExpiry(accessToken);
+    }
+
+    // The latest refresh token, rotated on each successful refresh. Callers that re-use the refresh
+    // token after polling (the final org-switch) must read this, not the login-time value — WorkOS
+    // rotates refresh tokens single-use, so the original is invalid once GetAsync has refreshed.
+    public string? CurrentRefreshToken => refreshToken;
+
+    // Returns a token expected to be valid for at least `margin`, refreshing first if the current
+    // one is that close to (or past) expiry. A failed refresh degrades to the existing token — the
+    // caller's HTTP call still surfaces the eventual 401 rather than this throwing mid-poll.
+    public async Task<string> GetAsync(CancellationToken ct) {
+        if (refreshToken is null) return accessToken;
+        if (now() < expiresAt - margin) return accessToken;
+
+        var refreshed = await refresh(refreshToken, ct);
+        if (refreshed is { AccessToken.Length: > 0 }) {
+            accessToken  = refreshed.AccessToken;
+            refreshToken = refreshed.RefreshToken ?? refreshToken;
+            expiresAt    = TokenStore.JwtExpiry(refreshed.AccessToken);
+        }
+
+        return accessToken;
+    }
+}

--- a/src/Capacitor.Cli.Core/Auth/WorkOSTokenSource.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSTokenSource.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Capacitor.Cli.Core.Auth;
 
 // Keeps a valid WorkOS access token available across a long-running interactive flow.
@@ -39,13 +41,21 @@ public sealed class WorkOSTokenSource {
     public string? CurrentRefreshToken => refreshToken;
 
     // Returns a token expected to be valid for at least `margin`, refreshing first if the current
-    // one is that close to (or past) expiry. A failed refresh degrades to the existing token — the
-    // caller's HTTP call still surfaces the eventual 401 rather than this throwing mid-poll.
+    // one is that close to (or past) expiry. A failed refresh — whether the delegate returns null or
+    // throws a transient network/JSON error — degrades to the existing token so a blip can't abort a
+    // long provisioning poll; the caller's HTTP call still surfaces the eventual 401, and the next
+    // tick retries. A genuine cancellation (via ct) is not swallowed.
     public async Task<string> GetAsync(CancellationToken ct) {
         if (refreshToken is null) return accessToken;
         if (now() < expiresAt - margin) return accessToken;
 
-        var refreshed = await refresh(refreshToken, ct);
+        WorkOSAuthResponse? refreshed;
+        try {
+            refreshed = await refresh(refreshToken, ct);
+        } catch (Exception e) when (IsTransient(e) && !ct.IsCancellationRequested) {
+            return accessToken;
+        }
+
         if (refreshed is { AccessToken.Length: > 0 }) {
             accessToken  = refreshed.AccessToken;
             refreshToken = refreshed.RefreshToken ?? refreshToken;
@@ -54,4 +64,10 @@ public sealed class WorkOSTokenSource {
 
         return accessToken;
     }
+
+    // Network / timeout / unreadable-body failures the refresh degrades on. OperationCanceledException
+    // is included as an HttpClient timeout; a real user/ct cancel is excluded by the caller's
+    // !ct.IsCancellationRequested guard so it still propagates. Mirrors TenantProvisioningClient.
+    static bool IsTransient(Exception e) =>
+        e is HttpRequestException or OperationCanceledException or JsonException or NotSupportedException;
 }

--- a/src/Capacitor.Cli/Commands/SpectreTenantProvisioner.cs
+++ b/src/Capacitor.Cli/Commands/SpectreTenantProvisioner.cs
@@ -10,7 +10,7 @@ public sealed class SpectreTenantProvisioner(TenantProvisioningClient client, st
     const int PollIntervalMs = 4000;
     const int MaxPolls       = 150; // ~10 minutes (server budget is 15)
 
-    public async Task<ProvisionOffer> OfferCreateAsync(string workosAccessToken, CancellationToken ct = default) {
+    public async Task<ProvisionOffer> OfferCreateAsync(WorkOSTokenSource tokens, CancellationToken ct = default) {
         AnsiConsole.MarkupLine("  [yellow]No Capacitor tenant is linked to your account.[/]");
         var create = AnsiConsole.Prompt(new ConfirmationPrompt("  Create one now?") { DefaultValue = true });
         if (!create) {
@@ -22,7 +22,7 @@ public sealed class SpectreTenantProvisioner(TenantProvisioningClient client, st
             new TextPrompt<string>("  Organization name:").Validate(n =>
                 string.IsNullOrWhiteSpace(n) ? ValidationResult.Error("Enter a name") : ValidationResult.Success()));
 
-        var slug = await PromptSlugAsync(orgName, workosAccessToken, ct);
+        var slug = await PromptSlugAsync(orgName, tokens, ct);
         if (slug is null) return ProvisionOffer.Declined;
 
         var origin = $"https://{slug}.kcap.ai";
@@ -33,12 +33,12 @@ public sealed class SpectreTenantProvisioner(TenantProvisioningClient client, st
             return ProvisionOffer.Declined;
         }
 
-        var outcome = await client.ProvisionAsync(baseUrl, workosAccessToken, orgName, slug, ct);
+        var outcome = await client.ProvisionAsync(baseUrl, await tokens.GetAsync(ct), orgName, slug, ct);
         switch (outcome.StatusCode) {
             case 200 when outcome.Body?.WorkosOrgId is { Length: > 0 } orgId:
                 return ProvisionOffer.Created(new ProvisionedTenant(orgId, slug, orgName, outcome.Body.Url ?? origin));
             case 202 or 200:
-                return await PollAsync(workosAccessToken, slug, orgName, origin, ct);
+                return await PollAsync(tokens, slug, orgName, origin, ct);
             case 400:
                 AnsiConsole.MarkupLine($"  [red]✗[/] {Reason400(outcome.Body?.Reason)}");
                 return ProvisionOffer.Failed;
@@ -54,7 +54,7 @@ public sealed class SpectreTenantProvisioner(TenantProvisioningClient client, st
         }
     }
 
-    async Task<string?> PromptSlugAsync(string orgName, string token, CancellationToken ct) {
+    async Task<string?> PromptSlugAsync(string orgName, WorkOSTokenSource tokens, CancellationToken ct) {
         var suggestion = SlugValidator.Derive(orgName);
         while (true) {
             var input = AnsiConsole.Prompt(
@@ -72,7 +72,7 @@ public sealed class SpectreTenantProvisioner(TenantProvisioningClient client, st
             }
 
             var avail = await AnsiConsole.Status().StartAsync($"Checking {slug}.kcap.ai…",
-                async _ => await client.CheckAvailabilityAsync(baseUrl, token, slug, ct));
+                async _ => await client.CheckAvailabilityAsync(baseUrl, await tokens.GetAsync(ct), slug, ct));
 
             if (avail is null) {
                 AnsiConsole.MarkupLine("  [yellow]![/] Couldn't check availability. Try again.");
@@ -89,20 +89,35 @@ public sealed class SpectreTenantProvisioner(TenantProvisioningClient client, st
         }
     }
 
-    async Task<ProvisionOffer> PollAsync(string token, string slug, string orgName, string origin, CancellationToken ct) {
-        return await AnsiConsole.Status().StartAsync($"Provisioning {slug}.kcap.ai — this can take a few minutes…", async _ => {
+    async Task<ProvisionOffer> PollAsync(WorkOSTokenSource tokens, string slug, string orgName, string origin, CancellationToken ct) {
+        var retry = $"Re-run [cyan]kcap setup {Markup.Escape(slug)}[/]";
+        return await AnsiConsole.Status().StartAsync($"Provisioning {slug}.kcap.ai — this can take a few minutes…", async ctx => {
             for (var i = 0; i < MaxPolls; i++) {
                 await Task.Delay(PollIntervalMs, ct);
-                var status = await client.GetStatusAsync(baseUrl, token, slug, ct);
-                switch (status?.State) {
-                    case "active" when status.WorkosOrgId is { Length: > 0 } orgId:
-                        return ProvisionOffer.Created(new ProvisionedTenant(orgId, slug, orgName, status.Url ?? origin));
-                    case "failed":
-                        AnsiConsole.MarkupLine("  [red]✗[/] Provisioning failed. Re-run [cyan]kcap setup " + Markup.Escape(slug) + "[/] to retry.");
+                var status = await client.GetStatusAsync(baseUrl, await tokens.GetAsync(ct), slug, ct);
+
+                switch (ProvisioningPoll.Classify(status.StatusCode, status.Body?.State, status.Body?.WorkosOrgId)) {
+                    case PollVerdict.Active:
+                        return ProvisionOffer.Created(new ProvisionedTenant(status.Body!.WorkosOrgId!, slug, orgName, status.Body.Url ?? origin));
+                    case PollVerdict.ActiveNoOrg:
+                        AnsiConsole.MarkupLine($"  [red]✗[/] {Markup.Escape(slug)}.kcap.ai is live but isn't linked to an organization. Contact support.");
                         return ProvisionOffer.Failed;
+                    case PollVerdict.Failed:
+                        AnsiConsole.MarkupLine($"  [red]✗[/] Provisioning failed. {retry} to retry.");
+                        return ProvisionOffer.Failed;
+                    case PollVerdict.Forbidden:
+                        AnsiConsole.MarkupLine($"  [red]✗[/] Verify your email address, then {retry.ToLowerInvariant()}.");
+                        return ProvisionOffer.Failed;
+                    case PollVerdict.NotFound:
+                        AnsiConsole.MarkupLine($"  [red]✗[/] '{Markup.Escape(slug)}' isn't linked to your account. {retry}.");
+                        return ProvisionOffer.Failed;
+                    case PollVerdict.Wait:
+                        // Surface liveness so an elapsed timer never reads as a frozen CLI.
+                        ctx.Status($"Provisioning {slug}.kcap.ai — waiting for it to come online… ({i + 1}/{MaxPolls})");
+                        break;
                 }
             }
-            AnsiConsole.MarkupLine($"  [yellow]![/] Still provisioning. Re-run [cyan]kcap setup {Markup.Escape(slug)}[/] once it's ready.");
+            AnsiConsole.MarkupLine($"  [yellow]![/] Still provisioning. {retry} once it's ready.");
             return ProvisionOffer.InProgress;
         });
     }

--- a/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
@@ -114,6 +114,39 @@ public class OAuthFlowTests {
     }
 
     [Test]
+    public async Task RefreshWorkOSToken_posts_org_less_refresh_grant_and_returns_token() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(
+                """{"user":{"id":"user_x"},"access_token":"acc","refresh_token":"rt2"}"""));
+        using var http = new HttpClient();
+
+        var auth = await OAuthLoginFlow.RefreshWorkOSTokenAsync(http, server.Urls[0], "client_d", "rt1");
+
+        await Assert.That(auth!.AccessToken).IsEqualTo("acc");
+        await Assert.That(auth.RefreshToken).IsEqualTo("rt2");
+
+        var body = server.FindLogEntries(Request.Create().WithPath("/user_management/authenticate").UsingPost())[0].RequestMessage.Body!;
+        await Assert.That(body).Contains("refresh_token=rt1");
+        await Assert.That(body).DoesNotContain("organization_id");
+    }
+
+    [Test]
+    public async Task RefreshWorkOSToken_returns_null_on_transport_failure() {
+        // A network/timeout blip during a mid-poll refresh must degrade to null, not throw and
+        // abort provisioning. Start then stop the server so the connection is refused.
+        var server = WireMockServer.Start();
+        var url = server.Urls[0];
+        server.Stop();
+
+        using var http = new HttpClient();
+
+        var auth = await OAuthLoginFlow.RefreshWorkOSTokenAsync(http, url, "client_d", "rt1");
+
+        await Assert.That(auth).IsNull();
+    }
+
+    [Test]
     public async Task GitHubBrowser_exchanges_code_and_returns_access_token() {
         using var server = WireMockServer.Start();
         server.Given(Request.Create().WithPath("/code-exchange").UsingPost())

--- a/test/Capacitor.Cli.Tests.Unit/ProvisioningPollTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProvisioningPollTests.cs
@@ -1,0 +1,54 @@
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+// Pure classification of a status-poll result into what the interactive poll should do next.
+// Kept out of SpectreTenantProvisioner (which is Spectre-coupled and untestable) so every
+// branch — including the silent-spin cases the old poll ignored — is covered.
+public class ProvisioningPollTests {
+    [Test]
+    public async Task Active_with_org_id_completes() =>
+        await Assert.That(ProvisioningPoll.Classify(200, "active", "org_1")).IsEqualTo(PollVerdict.Active);
+
+    [Test]
+    public async Task Active_without_org_id_is_a_distinct_terminal_verdict() =>
+        await Assert.That(ProvisioningPoll.Classify(200, "active", null)).IsEqualTo(PollVerdict.ActiveNoOrg);
+
+    [Test]
+    public async Task Active_with_empty_org_id_is_ActiveNoOrg() =>
+        await Assert.That(ProvisioningPoll.Classify(200, "active", "")).IsEqualTo(PollVerdict.ActiveNoOrg);
+
+    [Test]
+    public async Task Failed_state_is_terminal() =>
+        await Assert.That(ProvisioningPoll.Classify(200, "failed", null)).IsEqualTo(PollVerdict.Failed);
+
+    [Test]
+    public async Task Provisioning_state_keeps_waiting() =>
+        await Assert.That(ProvisioningPoll.Classify(200, "provisioning", null)).IsEqualTo(PollVerdict.Wait);
+
+    [Test]
+    public async Task Reserved_state_keeps_waiting() =>
+        await Assert.That(ProvisioningPoll.Classify(200, "reserved", null)).IsEqualTo(PollVerdict.Wait);
+
+    [Test]
+    public async Task Forbidden_is_terminal() =>
+        await Assert.That(ProvisioningPoll.Classify(403, null, null)).IsEqualTo(PollVerdict.Forbidden);
+
+    [Test]
+    public async Task NotFound_is_terminal() =>
+        await Assert.That(ProvisioningPoll.Classify(404, null, null)).IsEqualTo(PollVerdict.NotFound);
+
+    [Test]
+    // The token source refreshes proactively, so a lone 401 is tolerated — the next tick carries a
+    // fresh token rather than aborting a legitimate provisioning on a spurious/edge auth blip.
+    public async Task Unauthorized_keeps_waiting() =>
+        await Assert.That(ProvisioningPoll.Classify(401, null, null)).IsEqualTo(PollVerdict.Wait);
+
+    [Test]
+    public async Task Transport_failure_keeps_waiting() =>
+        await Assert.That(ProvisioningPoll.Classify(0, null, null)).IsEqualTo(PollVerdict.Wait);
+
+    [Test]
+    public async Task Server_error_keeps_waiting() =>
+        await Assert.That(ProvisioningPoll.Classify(503, null, null)).IsEqualTo(PollVerdict.Wait);
+}

--- a/test/Capacitor.Cli.Tests.Unit/TenantProvisioningClientTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TenantProvisioningClientTests.cs
@@ -76,8 +76,52 @@ public class TenantProvisioningClientTests {
         var client = new TenantProvisioningClient(http);
 
         var status = await client.GetStatusAsync(server.Urls[0], "tok", "acme", CancellationToken.None);
-        await Assert.That(status!.State).IsEqualTo("active");
-        await Assert.That(status.WorkosOrgId).IsEqualTo("org_live");
+        await Assert.That(status.StatusCode).IsEqualTo(200);
+        await Assert.That(status.Body!.State).IsEqualTo("active");
+        await Assert.That(status.Body.WorkosOrgId).IsEqualTo("org_live");
+    }
+
+    [Test]
+    public async Task GetStatusAsync_surfaces_401_so_the_poll_is_not_blind() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/api/signup/status").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(401)
+                .WithBody("""{"error":"unauthenticated"}""").WithHeader("Content-Type", "application/json"));
+
+        using var http = new HttpClient();
+        var client = new TenantProvisioningClient(http);
+
+        var status = await client.GetStatusAsync(server.Urls[0], "tok", "acme", CancellationToken.None);
+        await Assert.That(status.StatusCode).IsEqualTo(401);
+        await Assert.That(status.Body).IsNull();
+    }
+
+    [Test]
+    public async Task GetStatusAsync_surfaces_404_ownership_mismatch() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/api/signup/status").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404)
+                .WithBody("""{"error":"not_found"}""").WithHeader("Content-Type", "application/json"));
+
+        using var http = new HttpClient();
+        var client = new TenantProvisioningClient(http);
+
+        var status = await client.GetStatusAsync(server.Urls[0], "tok", "acme", CancellationToken.None);
+        await Assert.That(status.StatusCode).IsEqualTo(404);
+    }
+
+    [Test]
+    public async Task GetStatusAsync_returns_status_zero_on_transport_failure() {
+        var server = WireMockServer.Start();
+        var url = server.Urls[0];
+        server.Stop();
+
+        using var http = new HttpClient();
+        var client = new TenantProvisioningClient(http);
+
+        var status = await client.GetStatusAsync(url, "tok", "acme", CancellationToken.None);
+        await Assert.That(status.StatusCode).IsEqualTo(0);
+        await Assert.That(status.Body).IsNull();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
@@ -11,6 +12,13 @@ namespace Capacitor.Cli.Tests.Unit;
 [NotInParallel(nameof(TokenStoreProfileTests))]
 public class WorkOSDiscoveryTests {
     static string TokensDir => PathHelpers.ConfigPath("tokens");
+
+    static string JwtWithExp(DateTimeOffset exp) {
+        var json = $"{{\"exp\":{exp.ToUnixTimeSeconds()}}}";
+        var b64  = Convert.ToBase64String(Encoding.UTF8.GetBytes(json)).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        return $"header.{b64}.signature";
+    }
 
     [Before(Test)]
     public void Cleanup() {
@@ -105,10 +113,11 @@ public class WorkOSDiscoveryTests {
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
              .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
 
+        WorkOSTokenSource? handedTokens = null;
         var provisioner = Substitute.For<ITenantProvisioner>();
-        provisioner.OfferCreateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-                   .Returns(Task.FromResult(ProvisionOffer.Created(
-                       new ProvisionedTenant("org_new", "acme", "Acme Inc", "https://acme.kcap.ai"))));
+        provisioner.OfferCreateAsync(Arg.Any<WorkOSTokenSource>(), Arg.Any<CancellationToken>())
+                   .Returns(ci => { handedTokens = ci.Arg<WorkOSTokenSource>(); return Task.FromResult(ProvisionOffer.Created(
+                       new ProvisionedTenant("org_new", "acme", "Acme Inc", "https://acme.kcap.ai"))); });
 
         var orgless  = new WorkOSAuthResponse { User = new() { Id = "user_x", FirstName = "Ada" }, AccessToken = "acc", RefreshToken = "rt" };
         var switched = new WorkOSAuthResponse { User = new() { Id = "user_x" }, OrganizationId = "org_new", AccessToken = "acc2", RefreshToken = "rt2" };
@@ -128,6 +137,43 @@ public class WorkOSDiscoveryTests {
         var cfg = await AppConfig.LoadProfileConfig();
         await Assert.That(cfg.ActiveProfile).IsEqualTo("acme");
         await Assert.That(cfg.Profiles["acme"].ServerUrl).IsEqualTo("https://acme.kcap.ai");
+
+        // The provisioner is handed a refreshing token source seeded with the org-less login token.
+        await Assert.That(handedTokens).IsNotNull();
+        await Assert.That(await handedTokens!.GetAsync(CancellationToken.None)).IsEqualTo("acc");
+    }
+
+    [Test]
+    public async Task RunAsync_uses_rotated_refresh_token_for_org_switch_when_poll_refreshed() {
+        var proxyConfig = new ProxyConfigResponse { WorkOSClientId = "client_d" };
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
+
+        // Login-time access token is already near expiry, so the provisioner's first token pull
+        // forces a refresh — exactly the long-provisioning case that consumes the org-less token.
+        var nearExpiry = JwtWithExp(DateTimeOffset.UtcNow.AddSeconds(5));
+        var orgless    = new WorkOSAuthResponse { User = new() { Id = "u" }, AccessToken = nearExpiry, RefreshToken = "R0" };
+        var switched   = new WorkOSAuthResponse { User = new() { Id = "u" }, OrganizationId = "org_new", AccessToken = "acc2", RefreshToken = "R2" };
+
+        var provisioner = Substitute.For<ITenantProvisioner>();
+        provisioner.OfferCreateAsync(Arg.Any<WorkOSTokenSource>(), Arg.Any<CancellationToken>())
+                   .Returns(async ci => {
+                       await ci.Arg<WorkOSTokenSource>().GetAsync(CancellationToken.None); // rotates R0 -> R1
+                       return ProvisionOffer.Created(new ProvisionedTenant("org_new", "acme", "Acme Inc", "https://acme.kcap.ai"));
+                   });
+
+        string? switchRefreshToken = null;
+        var exit = await WorkOSDiscovery.RunAsync(
+            "https://auth.kcap.ai", proxyConfig, proxy, Substitute.For<ITenantPicker>(),
+            orglessLogin:   ()      => Task.FromResult<WorkOSAuthResponse?>(orgless),
+            orgSwitch:      (rt, _) => { switchRefreshToken = rt; return Task.FromResult<WorkOSAuthResponse?>(switched); },
+            orglessRefresh: (_, _)  => Task.FromResult<WorkOSAuthResponse?>(
+                new WorkOSAuthResponse { AccessToken = JwtWithExp(DateTimeOffset.UtcNow.AddMinutes(5)), RefreshToken = "R1" }),
+            provisioner:    provisioner);
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(switchRefreshToken).IsEqualTo("R1"); // rotated token, not the consumed login-time R0
     }
 
     [Test]
@@ -137,7 +183,7 @@ public class WorkOSDiscoveryTests {
              .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
 
         var provisioner = Substitute.For<ITenantProvisioner>();
-        provisioner.OfferCreateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        provisioner.OfferCreateAsync(Arg.Any<WorkOSTokenSource>(), Arg.Any<CancellationToken>())
                    .Returns(Task.FromResult(ProvisionOffer.Declined));
 
         var switchCalled = false;

--- a/test/Capacitor.Cli.Tests.Unit/WorkOSTokenSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorkOSTokenSourceTests.cs
@@ -1,0 +1,125 @@
+using System.Text;
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+// A provisioning poll can run up to ~10 minutes, but a WorkOS AuthKit access token lives
+// only ~5 minutes. WorkOSTokenSource keeps a valid access token across that window by
+// refreshing (public-client refresh_token grant) before the current token expires.
+public class WorkOSTokenSourceTests {
+    static string JwtWithExp(DateTimeOffset exp) {
+        var json = $"{{\"exp\":{exp.ToUnixTimeSeconds()}}}";
+        var b64  = Convert.ToBase64String(Encoding.UTF8.GetBytes(json)).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        return $"header.{b64}.signature";
+    }
+
+    [Test]
+    public async Task GetAsync_refreshes_when_within_expiry_margin_and_returns_new_token() {
+        var now      = DateTimeOffset.UnixEpoch.AddDays(1);
+        var expiring = JwtWithExp(now.AddSeconds(30)); // inside the 60s margin
+        var freshTok = JwtWithExp(now.AddMinutes(5));
+        var calls    = 0;
+
+        var src = new WorkOSTokenSource(expiring, "rt1",
+            refresh: (_, _) => { calls++; return Task.FromResult<WorkOSAuthResponse?>(
+                new WorkOSAuthResponse { AccessToken = freshTok, RefreshToken = "rt2" }); },
+            now: () => now, margin: TimeSpan.FromSeconds(60));
+
+        var token = await src.GetAsync(CancellationToken.None);
+
+        await Assert.That(calls).IsEqualTo(1);
+        await Assert.That(token).IsEqualTo(freshTok);
+    }
+
+    [Test]
+    public async Task GetAsync_does_not_refresh_when_token_still_valid() {
+        var now   = DateTimeOffset.UnixEpoch.AddDays(1);
+        var valid = JwtWithExp(now.AddMinutes(4)); // well outside the 60s margin
+        var calls = 0;
+
+        var src = new WorkOSTokenSource(valid, "rt1",
+            refresh: (_, _) => { calls++; return Task.FromResult<WorkOSAuthResponse?>(null); },
+            now: () => now, margin: TimeSpan.FromSeconds(60));
+
+        var token = await src.GetAsync(CancellationToken.None);
+
+        await Assert.That(calls).IsEqualTo(0);
+        await Assert.That(token).IsEqualTo(valid);
+    }
+
+    [Test]
+    public async Task GetAsync_returns_existing_token_when_refresh_fails() {
+        var now      = DateTimeOffset.UnixEpoch.AddDays(1);
+        var expiring = JwtWithExp(now.AddSeconds(10));
+
+        var src = new WorkOSTokenSource(expiring, "rt1",
+            refresh: (_, _) => Task.FromResult<WorkOSAuthResponse?>(null), // refresh failed
+            now: () => now, margin: TimeSpan.FromSeconds(60));
+
+        var token = await src.GetAsync(CancellationToken.None);
+
+        await Assert.That(token).IsEqualTo(expiring);
+    }
+
+    [Test]
+    public async Task GetAsync_rotates_the_refresh_token_across_successive_refreshes() {
+        var now  = DateTimeOffset.UnixEpoch.AddDays(1);
+        var t0   = JwtWithExp(now.AddSeconds(10));
+        var toks = new[] { JwtWithExp(now.AddSeconds(10)), JwtWithExp(now.AddMinutes(5)) };
+        var rts  = new[] { "rt2", "rt3" };
+        var seen = new List<string>();
+        var idx  = 0;
+
+        var src = new WorkOSTokenSource(t0, "rt1",
+            refresh: (rt, _) => {
+                seen.Add(rt);
+                var r = new WorkOSAuthResponse { AccessToken = toks[idx], RefreshToken = rts[idx] };
+                idx++;
+
+                return Task.FromResult<WorkOSAuthResponse?>(r);
+            },
+            now: () => now, margin: TimeSpan.FromSeconds(60));
+
+        await src.GetAsync(CancellationToken.None); // rt1 -> rt2 (token still near expiry)
+        await src.GetAsync(CancellationToken.None); // rt2 -> rt3
+
+        await Assert.That(seen.Count).IsEqualTo(2);
+        await Assert.That(seen[0]).IsEqualTo("rt1");
+        await Assert.That(seen[1]).IsEqualTo("rt2");
+    }
+
+    [Test]
+    public async Task CurrentRefreshToken_reflects_the_rotated_token_after_a_refresh() {
+        var now      = DateTimeOffset.UnixEpoch.AddDays(1);
+        var expiring = JwtWithExp(now.AddSeconds(10));
+        var fresh    = JwtWithExp(now.AddMinutes(5));
+
+        var src = new WorkOSTokenSource(expiring, "rt1",
+            refresh: (_, _) => Task.FromResult<WorkOSAuthResponse?>(
+                new WorkOSAuthResponse { AccessToken = fresh, RefreshToken = "rt2" }),
+            now: () => now, margin: TimeSpan.FromSeconds(60));
+
+        // WorkOS rotates refresh tokens (single-use), so callers that later re-use the refresh
+        // token (the final org-switch) must read the rotated value, not the login-time one.
+        await Assert.That(src.CurrentRefreshToken).IsEqualTo("rt1");
+        await src.GetAsync(CancellationToken.None);
+        await Assert.That(src.CurrentRefreshToken).IsEqualTo("rt2");
+    }
+
+    [Test]
+    public async Task GetAsync_without_refresh_token_returns_current_and_never_refreshes() {
+        var now      = DateTimeOffset.UnixEpoch.AddDays(1);
+        var expiring = JwtWithExp(now.AddSeconds(1));
+        var calls    = 0;
+
+        var src = new WorkOSTokenSource(expiring, refreshToken: null,
+            refresh: (_, _) => { calls++; return Task.FromResult<WorkOSAuthResponse?>(null); },
+            now: () => now, margin: TimeSpan.FromSeconds(60));
+
+        var token = await src.GetAsync(CancellationToken.None);
+
+        await Assert.That(calls).IsEqualTo(0);
+        await Assert.That(token).IsEqualTo(expiring);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/WorkOSTokenSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorkOSTokenSourceTests.cs
@@ -108,6 +108,40 @@ public class WorkOSTokenSourceTests {
     }
 
     [Test]
+    public async Task GetAsync_degrades_to_existing_token_when_refresh_throws() {
+        var now      = DateTimeOffset.UnixEpoch.AddDays(1);
+        var expiring = JwtWithExp(now.AddSeconds(10));
+
+        // A transient network/JSON failure inside the refresh must not abort the poll — the caller's
+        // next status call still carries this token (and surfaces the eventual 401) instead of crashing.
+        var src = new WorkOSTokenSource(expiring, "rt1",
+            refresh: (_, _) => Task.FromException<WorkOSAuthResponse?>(new HttpRequestException("network down")),
+            now: () => now, margin: TimeSpan.FromSeconds(60));
+
+        var token = await src.GetAsync(CancellationToken.None);
+
+        await Assert.That(token).IsEqualTo(expiring);
+    }
+
+    [Test]
+    public async Task GetAsync_propagates_genuine_cancellation_rather_than_swallowing_it() {
+        var now      = DateTimeOffset.UnixEpoch.AddDays(1);
+        var expiring = JwtWithExp(now.AddSeconds(10));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var src = new WorkOSTokenSource(expiring, "rt1",
+            refresh: (_, ct) => Task.FromException<WorkOSAuthResponse?>(new OperationCanceledException(ct)),
+            now: () => now, margin: TimeSpan.FromSeconds(60));
+
+        var cancelled = false;
+        try { await src.GetAsync(cts.Token); }
+        catch (OperationCanceledException) { cancelled = true; }
+
+        await Assert.That(cancelled).IsTrue();
+    }
+
+    [Test]
     public async Task GetAsync_without_refresh_token_returns_current_and_never_refreshes() {
         var now      = DateTimeOffset.UnixEpoch.AddDays(1);
         var expiring = JwtWithExp(now.AddSeconds(1));


### PR DESCRIPTION
## Problem

During `kcap setup` (WorkOS org SSO, no existing tenant) the CLI offers to create a tenant, provisions it, then polls `GET /api/signup/status` for it to go live. The poll **never completes even after the tenant is provisioned and live** — the spinner sits at "Provisioning {slug}.kcap.ai…" until it times out (~10 min) and no profile is saved.

## Root cause

The poll reused a **single org-less WorkOS access token for the entire ~10-minute wait**, but WorkOS AuthKit access tokens live only **~5 minutes**. Once it expired, the signup server returned 401 for every status check, and `GetStatusAsync` swallowed any non-2xx to a null "still provisioning" — so the CLI spun silently until timeout even though the tenant had gone live.

Same poll, contributing defects: `GetStatusAsync` collapsed 401/403/404/transport-error all to `null` (zero diagnostics), and an `active` row without `workosOrgId` (which the server contract explicitly allows) was treated as not-done — another infinite-spin path.

## Fix

- **`WorkOSTokenSource`** — refreshes the access token (public-client `refresh_token` grant, `OAuthLoginFlow.RefreshWorkOSTokenAsync`) before it lapses; every provision/poll call pulls a fresh token. WorkOS rotates refresh tokens single-use, so the final org-switch now uses `WorkOSTokenSource.CurrentRefreshToken`, not the login-time value (otherwise the switch would 401 after a long poll).
- **`GetStatusAsync` → `StatusOutcome`** surfaces the HTTP status; **`ProvisioningPoll.Classify`** turns each poll result into a verdict so 403/404/`failed`/`active`-without-org end with a clear message instead of a silent spin, and the spinner shows liveness per attempt.

## Tests

- `WorkOSTokenSourceTests` (6), `ProvisioningPollTests` (11), `GetStatusAsync` status-surfacing (TenantProvisioningClientTests), and a `WorkOSDiscoveryTests` guard proving the rotated refresh token is used for the org-switch. All written test-first (watched fail).
- Full unit suite green (2152/2152). `dotnet publish -c Release` clean — no IL3050/IL2026 AOT warnings.

No README change: internal bugfix, no user-facing CLI surface change (no new/renamed command, flag, default, or prerequisite).

Closes #258
AI-1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)