### PR TITLE
Apply auth-expiry hook handling to the non-Claude agent hooks

### DIFF
--- a/src/Capacitor.Cli/Commands/AgentHookPoster.cs
+++ b/src/Capacitor.Cli/Commands/AgentHookPoster.cs
@@ -1,0 +1,90 @@
+using System.Text;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// Outcome of an agent-hook recording POST (<see cref="AgentHookPoster.PostAsync(string,string,string,string)"/>).
+/// </summary>
+internal enum HookPostOutcome {
+    /// <summary>Auth was usable and the POST completed successfully.</summary>
+    Posted,
+
+    /// <summary>
+    /// Auth has lapsed (expired refresh credential, or never logged in) — the POST was SKIPPED
+    /// because the server would 401. No request was sent and nothing was written to stderr. The
+    /// caller should skip follow-on work that also needs auth (e.g. spawning the transcript
+    /// watcher) and exit cleanly, so a lapsed session produces no per-turn error banner.
+    /// </summary>
+    AuthLapsed,
+
+    /// <summary>
+    /// Auth was usable but the POST failed (non-success status or the server was unreachable).
+    /// An error was already written to stderr; the caller keeps its existing failure handling.
+    /// </summary>
+    Failed
+}
+
+/// <summary>
+/// Shared recording-hook POST for the non-Claude agent hooks (Codex, Gemini, Copilot, Pi, Kiro,
+/// OpenCode), which all otherwise built their client with <c>CreateAuthenticatedClientAsync</c>
+/// and POSTed blindly. When auth has lapsed that meant a guaranteed-to-401 POST plus a
+/// misleading per-turn <c>HTTP 401</c> stderr line; this helper instead reports
+/// <see cref="HookPostOutcome.AuthLapsed"/> so the caller can skip the doomed work and exit
+/// cleanly — carrying the Claude hook's #183 behaviour to the other hooks (AI-993).
+///
+/// These agents have no user-facing stdout notice channel (stdout is either unused or a JSON
+/// decision/context channel), so no re-login nudge is surfaced here — the expired state is
+/// visible via <c>kcap status</c> and the interactive CLI. A no-op for the <c>None</c> provider
+/// (posts normally, unauthenticated) and unchanged when authenticated.
+/// </summary>
+internal static class AgentHookPoster {
+    /// <summary>Auth has genuinely lapsed → any POST would 401. <c>Ok</c> and <c>NoAuthRequired</c> are usable.</summary>
+    public static bool IsAuthLapsed(AuthStatus status) => status is AuthStatus.Expired or AuthStatus.NotAuthenticated;
+
+    /// <summary>
+    /// Builds an auth-aware client for <paramref name="baseUrl"/> and POSTs <paramref name="body"/>
+    /// to <c>{baseUrl}/hooks/{endpoint}</c>, skipping the POST when auth has lapsed.
+    /// <paramref name="agentTag"/> is the stderr prefix on a real failure, e.g. <c>"codex-hook"</c>.
+    /// </summary>
+    public static Task<HookPostOutcome> PostAsync(string baseUrl, string endpoint, string body, string agentTag)
+        => PostAsync(() => HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl), baseUrl, endpoint, body, agentTag);
+
+    /// <summary>
+    /// Core with an injectable <paramref name="clientFactory"/> (test seam — lets tests control the
+    /// auth outcome without a token store or /auth/config discovery).
+    /// </summary>
+    internal static async Task<HookPostOutcome> PostAsync(
+            Func<Task<(HttpClient Client, AuthStatus Status)>> clientFactory,
+            string                                             baseUrl,
+            string                                             endpoint,
+            string                                             body,
+            string                                             agentTag
+        ) {
+        var (client, status) = await clientFactory();
+
+        using (client) {
+            // Auth lapsed: the POST would 401. Skip it and report so the caller exits cleanly
+            // (no per-turn stderr line / error banner); kcap status reports the expired state.
+            if (IsAuthLapsed(status)) {
+                return HookPostOutcome.AuthLapsed;
+            }
+
+            using var content = new StringContent(body, Encoding.UTF8, "application/json");
+
+            try {
+                var resp = await client.PostWithRetryAsync($"{baseUrl}/hooks/{endpoint}", content);
+
+                if (!resp.IsSuccessStatusCode) {
+                    Console.Error.WriteLine($"[kcap] {agentTag} {endpoint}: HTTP {(int)resp.StatusCode}");
+                    return HookPostOutcome.Failed;
+                }
+
+                return HookPostOutcome.Posted;
+            } catch (HttpRequestException ex) {
+                HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
+                return HookPostOutcome.Failed;
+            }
+        }
+    }
+}

--- a/src/Capacitor.Cli/Commands/AgentHookPoster.cs
+++ b/src/Capacitor.Cli/Commands/AgentHookPoster.cs
@@ -73,7 +73,7 @@ internal static class AgentHookPoster {
             using var content = new StringContent(body, Encoding.UTF8, "application/json");
 
             try {
-                var resp = await client.PostWithRetryAsync($"{baseUrl}/hooks/{endpoint}", content);
+                using var resp = await client.PostWithRetryAsync($"{baseUrl}/hooks/{endpoint}", content);
 
                 if (!resp.IsSuccessStatusCode) {
                     Console.Error.WriteLine($"[kcap] {agentTag} {endpoint}: HTTP {(int)resp.StatusCode}");

--- a/src/Capacitor.Cli/Commands/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CodexHookCommand.cs
@@ -198,14 +198,18 @@ static class CodexHookCommand {
             return 0;
         }
 
-        var exit = await PostHookAsync(baseUrl, "session-start/codex", enriched);
-        if (exit != 0) return exit;
+        var outcome = await PostHookAsync(baseUrl, "session-start/codex", enriched);
+        if (outcome == HookPostOutcome.Failed) return 1;
 
         // Emit Codex's required JSON output BEFORE spawning the watcher. The
         // watcher is best-effort and may take time to start; the parent (Codex)
         // is waiting on stdout, and there's nothing the watcher can contribute
         // to this response.
         Console.Write(SessionScopedOutputJson);
+
+        // Auth lapsed: recording is paused until the user re-runs `kcap login`. We've satisfied
+        // Codex's stdout contract and exit cleanly; skip the watcher — its POSTs would 401 too.
+        if (outcome == HookPostOutcome.AuthLapsed) return 0;
 
         var enrichedNode = JsonNode.Parse(enriched);
         var sessionId    = TryGetString(enrichedNode, "session_id");
@@ -335,23 +339,11 @@ static class CodexHookCommand {
         return 1;
     }
 
-    static async Task<int> PostHookAsync(string baseUrl, string endpoint, string body) {
-        using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
-        using var content = new StringContent(body, Encoding.UTF8, "application/json");
-
-        try {
-            var resp = await client.PostWithRetryAsync($"{baseUrl}/hooks/{endpoint}", content);
-            if (!resp.IsSuccessStatusCode) {
-                Console.Error.WriteLine($"[kcap] codex-hook {endpoint}: HTTP {(int)resp.StatusCode}");
-                return 1;
-            }
-
-            return 0;
-        } catch (HttpRequestException ex) {
-            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
-            return 1;
-        }
-    }
+    // Shared auth-aware recording POST: skips the doomed POST (and the misleading per-turn
+    // "HTTP 401" stderr line) when auth has lapsed, reporting AuthLapsed so the caller exits
+    // cleanly instead of erroring. See AgentHookPoster.
+    static Task<HookPostOutcome> PostHookAsync(string baseUrl, string endpoint, string body)
+        => AgentHookPoster.PostAsync(baseUrl, endpoint, body, "codex-hook");
 
     /// <summary>
     /// Best-effort POST of <paramref name="node"/> to <c>/hooks/{endpoint}</c>, capped at

--- a/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
@@ -168,8 +168,11 @@ static class CopilotHookCommand {
             return 0;
         }
 
-        var exit = await PostHookAsync(baseUrl, "session-start/copilot", enriched);
-        if (exit != 0) return exit;
+        var outcome = await PostHookAsync(baseUrl, "session-start/copilot", enriched);
+
+        // Failed keeps the prior non-zero exit; AuthLapsed exits cleanly (no error banner). Either
+        // way skip the watcher — on a lapse its POSTs would 401 too.
+        if (outcome != HookPostOutcome.Posted) return outcome == HookPostOutcome.Failed ? 1 : 0;
 
         await EnsureWatcherAsync(baseUrl, dashedSessionId, sessionId, node, cwd);
         return 0;
@@ -237,7 +240,8 @@ static class CopilotHookCommand {
             forwarded["agent_host_id"] = agentHostId;
         }
 
-        return await PostHookAsync(baseUrl, "session-end/copilot", forwarded.ToJsonString());
+        // AuthLapsed / Posted → clean exit (0); a real failure keeps the prior non-zero exit.
+        return await PostHookAsync(baseUrl, "session-end/copilot", forwarded.ToJsonString()) == HookPostOutcome.Failed ? 1 : 0;
     }
 
     static async Task<int> HandleAgentStop(string baseUrl, JsonNode node, string dashedSessionId, string sessionId, string? cwd) {
@@ -278,9 +282,14 @@ static class CopilotHookCommand {
         // path so a stalled server can't block Copilot's loop.
         using var cts = new CancellationTokenSource(NotificationPostBudget);
         try {
-            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, cts.Token);
-            using var content = new StringContent(forwarded.ToJsonString(), Encoding.UTF8, "application/json");
-            using var _       = await client.PostAsync($"{baseUrl}/hooks/notification", content, cts.Token);
+            // Status-returning variant (not CreateAuthenticatedClientAsync, which writes a
+            // per-turn "expired" line to stderr): on a lapse, stay quiet and skip the doomed POST.
+            var (client, status) = await HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl, cts.Token);
+            using (client) {
+                if (AgentHookPoster.IsAuthLapsed(status)) return 0;
+                using var content = new StringContent(forwarded.ToJsonString(), Encoding.UTF8, "application/json");
+                using var _       = await client.PostAsync($"{baseUrl}/hooks/notification", content, cts.Token);
+            }
         } catch {
             // Recording must never fail the hook.
         }
@@ -322,24 +331,11 @@ static class CopilotHookCommand {
         return File.Exists(legacy) ? legacy : current;
     }
 
-    static async Task<int> PostHookAsync(string baseUrl, string endpoint, string body) {
-        using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
-        using var content = new StringContent(body, Encoding.UTF8, "application/json");
-
-        try {
-            var resp = await client.PostWithRetryAsync($"{baseUrl}/hooks/{endpoint}", content);
-
-            if (!resp.IsSuccessStatusCode) {
-                Console.Error.WriteLine($"[kcap] copilot-hook {endpoint}: HTTP {(int)resp.StatusCode}");
-                return 1;
-            }
-
-            return 0;
-        } catch (HttpRequestException ex) {
-            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
-            return 1;
-        }
-    }
+    // Shared auth-aware recording POST: skips the doomed POST (and the misleading per-turn
+    // "HTTP 401" stderr line) when auth has lapsed, reporting AuthLapsed so the caller exits
+    // cleanly instead of erroring. See AgentHookPoster.
+    static Task<HookPostOutcome> PostHookAsync(string baseUrl, string endpoint, string body)
+        => AgentHookPoster.PostAsync(baseUrl, endpoint, body, "copilot-hook");
 
     static string? GetArg(string[] args, string flag) {
         var idx = Array.IndexOf(args, flag);

--- a/src/Capacitor.Cli/Commands/CursorHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CursorHookCommand.cs
@@ -52,7 +52,16 @@ public static class CursorHookCommand {
         using var cts = new CancellationTokenSource(DispatcherBudget);
         HttpClient? client = null;
         try {
-            client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, cts.Token);
+            // Status-returning variant so a lapse doesn't write the per-turn "expired" stderr
+            // line CreateAuthenticatedClientAsync would. On a lapse, skip HandleCore entirely:
+            // every POST would 401, and draining the spool would turn its 401s into Drops that
+            // discard the backlog — so leave it intact for replay after the user re-runs
+            // `kcap login`, and exit cleanly. Mirrors the Claude hook (#183); kcap status
+            // surfaces the expired state. Cursor has no user-facing notice channel.
+            var (c, status) = await HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl, cts.Token);
+            client = c;
+            if (AgentHookPoster.IsAuthLapsed(status)) return 0;
+
             var spool = new HookSpool(PathHelpers.ConfigPath("spool"));
             MigrateLegacyCursorSpool(spool, CursorPaths.SpoolDir());
             spool.ReapOlderThan(TimeSpan.FromDays(30));

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -127,8 +127,11 @@ static class GeminiHookCommand {
             return 0;
         }
 
-        var exit = await PostHookAsync(baseUrl, "session-start/gemini", enriched);
-        if (exit != 0) return exit;
+        var outcome = await PostHookAsync(baseUrl, "session-start/gemini", enriched);
+
+        // Failed keeps the prior non-zero exit; AuthLapsed exits cleanly (no error banner). Either
+        // way skip the watcher — on a lapse its POSTs would 401 too.
+        if (outcome != HookPostOutcome.Posted) return outcome == HookPostOutcome.Failed ? 1 : 0;
 
         EnsureWatcher(baseUrl, sessionId, node, cwd, source);
         await Task.CompletedTask;
@@ -186,7 +189,8 @@ static class GeminiHookCommand {
             forwarded["agent_host_id"] = agentHostId;
         }
 
-        return await PostHookAsync(baseUrl, "session-end/gemini", forwarded.ToJsonString());
+        // AuthLapsed / Posted → clean exit (0); a real failure keeps the prior non-zero exit.
+        return await PostHookAsync(baseUrl, "session-end/gemini", forwarded.ToJsonString()) == HookPostOutcome.Failed ? 1 : 0;
     }
 
     static async Task<int> HandleNotification(string baseUrl, JsonNode node, string sessionId, string? cwd) {
@@ -209,9 +213,14 @@ static class GeminiHookCommand {
 
         using var cts = new CancellationTokenSource(NotificationPostBudget);
         try {
-            using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, cts.Token);
-            using var content = new StringContent(forwarded.ToJsonString(), Encoding.UTF8, "application/json");
-            using var _       = await client.PostAsync($"{baseUrl}/hooks/notification", content, cts.Token);
+            // Status-returning variant (not CreateAuthenticatedClientAsync, which writes a
+            // per-turn "expired" line to stderr): on a lapse, stay quiet and skip the doomed POST.
+            var (client, status) = await HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl, cts.Token);
+            using (client) {
+                if (AgentHookPoster.IsAuthLapsed(status)) return 0;
+                using var content = new StringContent(forwarded.ToJsonString(), Encoding.UTF8, "application/json");
+                using var _       = await client.PostAsync($"{baseUrl}/hooks/notification", content, cts.Token);
+            }
         } catch {
             // Recording must never fail the hook.
         }
@@ -236,24 +245,11 @@ static class GeminiHookCommand {
         );
     }
 
-    static async Task<int> PostHookAsync(string baseUrl, string endpoint, string body) {
-        using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
-        using var content = new StringContent(body, Encoding.UTF8, "application/json");
-
-        try {
-            var resp = await client.PostWithRetryAsync($"{baseUrl}/hooks/{endpoint}", content);
-
-            if (!resp.IsSuccessStatusCode) {
-                Console.Error.WriteLine($"[kcap] gemini-hook {endpoint}: HTTP {(int)resp.StatusCode}");
-                return 1;
-            }
-
-            return 0;
-        } catch (HttpRequestException ex) {
-            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
-            return 1;
-        }
-    }
+    // Shared auth-aware recording POST: skips the doomed POST (and the misleading per-turn
+    // "HTTP 401" stderr line) when auth has lapsed, reporting AuthLapsed so the caller exits
+    // cleanly instead of erroring. See AgentHookPoster.
+    static Task<HookPostOutcome> PostHookAsync(string baseUrl, string endpoint, string body)
+        => AgentHookPoster.PostAsync(baseUrl, endpoint, body, "gemini-hook");
 
     static DateTimeOffset? TryGetIsoTimestamp(JsonNode? node, string fieldName) {
         if (node?[fieldName] is JsonValue v

--- a/src/Capacitor.Cli/Commands/KiroHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/KiroHookCommand.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
@@ -130,11 +129,11 @@ static class KiroHookCommand {
 
         // Fail-open: a non-zero exit surfaces as a FAILED agentSpawn hook inside
         // kiro-cli, which is exactly what this vendor wrapper must avoid on a
-        // transient server/auth blip. PostHookAsync already logged the failure to
-        // stderr; swallow it and skip the watcher this firing. agentSpawn fires
-        // again on the next prompt and retries both the POST and the watcher.
-        var exit = await PostHookAsync(baseUrl, "session-start/kiro", enriched);
-        if (exit != 0) return 0;
+        // transient server/auth blip. On a real failure PostHookAsync already logged to
+        // stderr; on an auth lapse it stayed silent (no doomed POST). Either way skip the
+        // watcher this firing and exit 0 — agentSpawn fires again next prompt and retries.
+        var outcome = await PostHookAsync(baseUrl, "session-start/kiro", enriched);
+        if (outcome != HookPostOutcome.Posted) return 0;
 
         // The watcher tails Kiro's own append-only session log
         // ~/.kiro/sessions/cli/{id}.jsonl (the file is named with the dashed id).
@@ -152,24 +151,11 @@ static class KiroHookCommand {
         return 0;
     }
 
-    static async Task<int> PostHookAsync(string baseUrl, string endpoint, string body) {
-        using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
-        using var content = new StringContent(body, Encoding.UTF8, "application/json");
-
-        try {
-            var resp = await client.PostWithRetryAsync($"{baseUrl}/hooks/{endpoint}", content);
-
-            if (!resp.IsSuccessStatusCode) {
-                Console.Error.WriteLine($"[kcap] kiro-hook {endpoint}: HTTP {(int)resp.StatusCode}");
-                return 1;
-            }
-
-            return 0;
-        } catch (HttpRequestException ex) {
-            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
-            return 1;
-        }
-    }
+    // Shared auth-aware recording POST: skips the doomed POST (and the misleading per-turn
+    // "HTTP 401" stderr line) when auth has lapsed, reporting AuthLapsed so the caller exits
+    // cleanly instead of erroring. See AgentHookPoster.
+    static Task<HookPostOutcome> PostHookAsync(string baseUrl, string endpoint, string body)
+        => AgentHookPoster.PostAsync(baseUrl, endpoint, body, "kiro-hook");
 
     /// <summary>
     /// Reads the session model from the sibling <c>{id}.json</c>

--- a/src/Capacitor.Cli/Commands/OpenCodeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/OpenCodeHookCommand.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
@@ -101,10 +100,11 @@ static class OpenCodeHookCommand {
             return 0;
         }
 
-        // Fail-open like Kiro: a non-zero exit would surface as a failed plugin
-        // call; skip the watcher this firing and let the next session.idle retry.
-        var exit = await PostHookAsync(baseUrl, "session-start/opencode", enriched);
-        if (exit != 0) return 0;
+        // Fail-open like Kiro: a non-zero exit would surface as a failed plugin call. On a real
+        // failure PostHookAsync logged to stderr; on an auth lapse it stayed silent (no doomed
+        // POST). Either way skip the watcher this firing and exit 0; the next session.idle retries.
+        var outcome = await PostHookAsync(baseUrl, "session-start/opencode", enriched);
+        if (outcome != HookPostOutcome.Posted) return 0;
 
         await WatcherManager.EnsureWatcherRunning(
             baseUrl, sessionId, file,
@@ -115,24 +115,11 @@ static class OpenCodeHookCommand {
         return 0;
     }
 
-    static async Task<int> PostHookAsync(string baseUrl, string endpoint, string body) {
-        using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
-        using var content = new StringContent(body, Encoding.UTF8, "application/json");
-
-        try {
-            var resp = await client.PostWithRetryAsync($"{baseUrl}/hooks/{endpoint}", content);
-
-            if (!resp.IsSuccessStatusCode) {
-                Console.Error.WriteLine($"[kcap] opencode-hook {endpoint}: HTTP {(int)resp.StatusCode}");
-                return 1;
-            }
-
-            return 0;
-        } catch (HttpRequestException ex) {
-            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
-            return 1;
-        }
-    }
+    // Shared auth-aware recording POST: skips the doomed POST (and the misleading per-turn
+    // "HTTP 401" stderr line) when auth has lapsed, reporting AuthLapsed so the caller exits
+    // cleanly instead of erroring. See AgentHookPoster.
+    static Task<HookPostOutcome> PostHookAsync(string baseUrl, string endpoint, string body)
+        => AgentHookPoster.PostAsync(baseUrl, endpoint, body, "opencode-hook");
 
     static string? GetArg(string[] args, string flag) {
         var idx = Array.IndexOf(args, flag);

--- a/src/Capacitor.Cli/Commands/PiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/PiHookCommand.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
@@ -112,8 +111,11 @@ static class PiHookCommand {
             return 0;
         }
 
-        var exit = await PostHookAsync(baseUrl, "session-start/pi", enriched);
-        if (exit != 0) return exit;
+        var outcome = await PostHookAsync(baseUrl, "session-start/pi", enriched);
+
+        // Failed keeps the prior non-zero exit; AuthLapsed exits cleanly (no error banner). Either
+        // way skip the watcher — on a lapse its POSTs would 401 too.
+        if (outcome != HookPostOutcome.Posted) return outcome == HookPostOutcome.Failed ? 1 : 0;
 
         await WatcherManager.EnsureWatcherRunning(
             baseUrl, sessionId, file,
@@ -156,7 +158,8 @@ static class PiHookCommand {
         if (cwd is not null) forwarded["cwd"] = cwd;
         if (Environment.GetEnvironmentVariable("KCAP_AGENT_ID") is { } agentHostId) forwarded["agent_host_id"] = agentHostId;
 
-        return await PostHookAsync(baseUrl, "session-end/pi", forwarded.ToJsonString());
+        // AuthLapsed / Posted → clean exit (0); a real failure keeps the prior non-zero exit.
+        return await PostHookAsync(baseUrl, "session-end/pi", forwarded.ToJsonString()) == HookPostOutcome.Failed ? 1 : 0;
     }
 
     // ── helpers ─────────────────────────────────────────────────────────────
@@ -204,24 +207,11 @@ static class PiHookCommand {
         return null;
     }
 
-    static async Task<int> PostHookAsync(string baseUrl, string endpoint, string body) {
-        using var client  = await HttpClientExtensions.CreateAuthenticatedClientAsync();
-        using var content = new StringContent(body, Encoding.UTF8, "application/json");
-
-        try {
-            var resp = await client.PostWithRetryAsync($"{baseUrl}/hooks/{endpoint}", content);
-
-            if (!resp.IsSuccessStatusCode) {
-                Console.Error.WriteLine($"[kcap] pi-hook {endpoint}: HTTP {(int)resp.StatusCode}");
-                return 1;
-            }
-
-            return 0;
-        } catch (HttpRequestException ex) {
-            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
-            return 1;
-        }
-    }
+    // Shared auth-aware recording POST: skips the doomed POST (and the misleading per-turn
+    // "HTTP 401" stderr line) when auth has lapsed, reporting AuthLapsed so the caller exits
+    // cleanly instead of erroring. See AgentHookPoster.
+    static Task<HookPostOutcome> PostHookAsync(string baseUrl, string endpoint, string body)
+        => AgentHookPoster.PostAsync(baseUrl, endpoint, body, "pi-hook");
 
     static string? GetArg(string[] args, string flag) {
         var idx = Array.IndexOf(args, flag);

--- a/test/Capacitor.Cli.Tests.Unit/AgentHookPosterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentHookPosterTests.cs
@@ -1,0 +1,104 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Tests for the shared agent-hook recording POST (AI-993). This is the seam the non-Claude
+/// hooks (Codex, Gemini, Copilot, Pi, Kiro, OpenCode) delegate to. Its job is to SKIP a POST
+/// that would 401 because auth has lapsed — reporting <see cref="HookPostOutcome.AuthLapsed"/>
+/// without touching stderr or the server — while leaving the authenticated success path and
+/// the real-failure path (stderr + <see cref="HookPostOutcome.Failed"/>) unchanged.
+///
+/// The (client, status) factory is injected so the auth outcome is controlled directly and no
+/// token store or /auth/config discovery is needed; the POST itself goes to a WireMock server.
+/// </summary>
+public class AgentHookPosterTests : IDisposable {
+    readonly WireMockServer _server = WireMockServer.Start();
+
+    public void Dispose() => _server.Stop();
+
+    static Func<Task<(HttpClient, AuthStatus)>> Factory(AuthStatus status)
+        => () => Task.FromResult((new HttpClient(), status));
+
+    [Test]
+    public async Task Expired_auth_skips_the_post_and_reports_AuthLapsed() {
+        _server.Given(Request.Create().WithPath("/hooks/session-start/codex").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        var outcome = await AgentHookPoster.PostAsync(
+            Factory(AuthStatus.Expired), _server.Url!, "session-start/codex", "{}", "codex-hook");
+
+        await Assert.That(outcome).IsEqualTo(HookPostOutcome.AuthLapsed);
+
+        // The doomed POST must never be sent.
+        var hits = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-start/codex").UsingPost());
+        await Assert.That(hits.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task NotAuthenticated_skips_the_post_and_reports_AuthLapsed() {
+        _server.Given(Request.Create().WithPath("/hooks/session-start/gemini").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var outcome = await AgentHookPoster.PostAsync(
+            Factory(AuthStatus.NotAuthenticated), _server.Url!, "session-start/gemini", "{}", "gemini-hook");
+
+        await Assert.That(outcome).IsEqualTo(HookPostOutcome.AuthLapsed);
+
+        var hits = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-start/gemini").UsingPost());
+        await Assert.That(hits.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Ok_auth_posts_the_body_and_reports_Posted() {
+        _server.Given(Request.Create().WithPath("/hooks/session-start/pi").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        var outcome = await AgentHookPoster.PostAsync(
+            Factory(AuthStatus.Ok), _server.Url!, "session-start/pi", """{"hello":"world"}""", "pi-hook");
+
+        await Assert.That(outcome).IsEqualTo(HookPostOutcome.Posted);
+
+        var hits = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-start/pi").UsingPost());
+        await Assert.That(hits.Count).IsEqualTo(1);
+        await Assert.That(hits[0].RequestMessage.Body).IsEqualTo("""{"hello":"world"}""");
+    }
+
+    [Test]
+    public async Task NoAuthRequired_posts_normally() {
+        // "None" provider → the client is usable as-is; behave exactly like authenticated.
+        _server.Given(Request.Create().WithPath("/hooks/session-start/opencode").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var outcome = await AgentHookPoster.PostAsync(
+            Factory(AuthStatus.NoAuthRequired), _server.Url!, "session-start/opencode", "{}", "opencode-hook");
+
+        await Assert.That(outcome).IsEqualTo(HookPostOutcome.Posted);
+
+        var hits = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-start/opencode").UsingPost());
+        await Assert.That(hits.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Server_error_reports_Failed() {
+        _server.Given(Request.Create().WithPath("/hooks/session-start/kiro").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(500));
+
+        var outcome = await AgentHookPoster.PostAsync(
+            Factory(AuthStatus.Ok), _server.Url!, "session-start/kiro", "{}", "kiro-hook");
+
+        await Assert.That(outcome).IsEqualTo(HookPostOutcome.Failed);
+    }
+
+    [Test]
+    public async Task IsAuthLapsed_is_true_only_for_expired_or_unauthenticated() {
+        await Assert.That(AgentHookPoster.IsAuthLapsed(AuthStatus.Expired)).IsTrue();
+        await Assert.That(AgentHookPoster.IsAuthLapsed(AuthStatus.NotAuthenticated)).IsTrue();
+        await Assert.That(AgentHookPoster.IsAuthLapsed(AuthStatus.Ok)).IsFalse();
+        await Assert.That(AgentHookPoster.IsAuthLapsed(AuthStatus.NoAuthRequired)).IsFalse();
+    }
+}


### PR DESCRIPTION
## What & why

Follow-up to #183. That PR taught the **Claude** hook to skip the doomed POST and stop nagging when auth has lapsed (expired refresh credential, or never logged in). The other **7 agent hooks** all still built their client with `CreateAuthenticatedClientAsync` and POSTed blindly, so an expired/absent token meant (a) a guaranteed-to-401 POST, and (b) a misleading per-turn `[kcap] <agent>-hook <endpoint>: HTTP 401` stderr line — for the fail-open agents it also drained the Cursor spool into 401→Drop, discarding the backlog.

## How

- **New `AgentHookPoster` shared helper** — builds the client via `CreateClientWithAuthStatusAsync` and returns `HookPostOutcome { Posted, AuthLapsed, Failed }`. On `AuthLapsed` it skips the POST entirely (no request, no stderr); `Failed` keeps the prior stderr line + exit code; `Posted` is unchanged. Single tested seam for the "skip the doomed POST" decision.
- **Codex, Gemini, Copilot, Pi, Kiro, OpenCode** — `PostHookAsync` delegates to the helper. Session-start handlers **skip the watcher and exit cleanly on `AuthLapsed`** (would only 401 too); Codex still emits its required `{"continue":true}` stdout. `Failed`/`Posted` behaviour is unchanged (real failures keep their exit codes; Kiro/OpenCode keep their fail-open `0`).
- **Gemini/Copilot per-turn `Notification`** and **Cursor's `HandleInternal`** use `AgentHookPoster.IsAuthLapsed` to skip. Cursor additionally skips the spool drain on a lapse, so a 401 can't `Drop` the backlog — it replays after `kcap login`.
- **No re-login nudge:** none of these agents has a safe user-facing stdout channel (all emit nothing or a JSON decision/context channel), so per the issue's caveat we soft-exit silently; `kcap status` already reports `✗ token expired (run: kcap login)`.

## Acceptance criteria

- [x] No agent hook sends a POST it knows will 401 due to expired/missing auth.
- [x] No agent hook produces a misleading per-turn `HTTP 401` stderr line (or error banner) solely because auth lapsed.
- [x] Re-login nudge surfaced only where a real user-facing channel exists — N/A for these agents (documented), so silent soft-exit.
- [x] No-op for the `None` auth provider and unchanged when authenticated.
- [x] `dotnet publish -c Release` shows no IL3050/IL2026 warnings; unit tests pass.

## Testing

- New `AgentHookPosterTests` (WireMock + injected `(client, status)` factory): auth-lapse skips the POST (server sees 0 requests), `Ok`/`NoAuthRequired` post the body, server error → `Failed`.
- Full unit suite green (2180 tests). AOT publish clean (no IL30xx/20xx) for the CLI.

## Known follow-up (out of scope, pre-existing)

On **session-end during a lapse**, the pre-POST drain path (`InlineDrainAsync`, `GeminiSubagentTeardown.DrainAsync`, `SpawnCopilotFinalizeDrain`) still uses `CreateAuthenticatedClientAsync` internally, so it emits the "expired" stderr line and fires a doomed drain POST. This lives in the watcher/drain layer (not the hooks), is unchanged by this PR, and fires once per session (not per-turn). Worth gating on auth status in a follow-up.

No README/CLI-surface change: internal hook behaviour only (no new command, flag, default, or prerequisite).

Closes #184
Linear: AI-993