### PR TITLE
Cover multi-provider PR-detection edge cases; harden GitLab iid parse

### DIFF
--- a/src/Capacitor.Cli/PrDetection/GitLabPrDetector.cs
+++ b/src/Capacitor.Cli/PrDetection/GitLabPrDetector.cs
@@ -31,13 +31,15 @@ internal static class GitLabPrDetector {
                 if (node is not JsonObject mr) continue;
                 // Defense in depth: only accept an exact source_branch match.
                 if (mr["source_branch"]?.GetValue<string>() != branch) continue;
-                var iid = mr["iid"]?.GetValue<int>();
-                if (iid is null) continue;
+                // Skip a record whose iid is missing or non-numeric rather than letting
+                // GetValue<int> throw — the outer catch would otherwise drop every match, not
+                // just the bad record.
+                if (mr["iid"] is not JsonValue iidVal || !iidVal.TryGetValue<int>(out var iid)) continue;
 
                 var updated = ParseTimestamp(mr["updated_at"]?.GetValue<string>());
                 if (best is null || updated > bestUpdated) {
                     bestUpdated = updated;
-                    best = new PrInfo(iid.Value, mr["title"]?.GetValue<string>(),
+                    best = new PrInfo(iid, mr["title"]?.GetValue<string>(),
                                       mr["web_url"]?.GetValue<string>(), mr["source_branch"]?.GetValue<string>());
                 }
             }

--- a/src/Capacitor.Cli/RepositoryDetection.cs
+++ b/src/Capacitor.Cli/RepositoryDetection.cs
@@ -244,8 +244,14 @@ static class RepositoryDetection {
         var kind  = await GitProviderRouter.ResolveAsync(host, cwd, providerCap, run);
 
         // The remainder after the probe — NOT the full providerCap. Passing providerCap here would
-        // let a slow probe + a full-length detector overrun the caller's deadline.
-        var detectCap = providerCap - Stopwatch.GetElapsedTime(start, getTs());
+        // let a slow probe + a full-length detector overrun the caller's deadline. Clamp the elapsed
+        // time to >= 0 so a non-monotonic timestamp seam can never inflate detectCap past providerCap
+        // (the invariant is "detector budget <= providerCap, always"). Production uses the monotonic
+        // Stopwatch.GetTimestamp, so this only hardens the injectable test seam.
+        var elapsed = Stopwatch.GetElapsedTime(start, getTs());
+        if (elapsed < TimeSpan.Zero) elapsed = TimeSpan.Zero;
+
+        var detectCap = providerCap - elapsed;
         if (detectCap <= TimeSpan.Zero) return null;
 
         return kind switch {

--- a/src/Capacitor.Cli/RepositoryDetection.cs
+++ b/src/Capacitor.Cli/RepositoryDetection.cs
@@ -192,24 +192,13 @@ static class RepositoryDetection {
             var providerCap = ghCap;
 
             if (providerCap > TimeSpan.Zero && host is not null) {
-                var provSw = Stopwatch.StartNew();
-                var kind   = await GitProviderRouter.ResolveAsync(host, cwd, providerCap, DefaultRunner);
-                var detectCap = providerCap - provSw.Elapsed; // combined ceiling: probe + detector
+                var pr = await ResolveAndDetectPrAsync(host, owner, repoName, branch, cwd, providerCap, DefaultRunner);
 
-                if (detectCap > TimeSpan.Zero) {
-                    var pr = kind switch {
-                        GitProviderKind.GitHub => await GitHubPrDetector.DetectAsync(cwd, detectCap, DefaultRunner),
-                        GitProviderKind.GitLab when owner is not null && repoName is not null
-                            => await GitLabPrDetector.DetectAsync(host, owner, repoName, branch, cwd, detectCap, DefaultRunner),
-                        _ => null
-                    };
-
-                    if (pr is not null) {
-                        prNumber  = pr.Number;
-                        prTitle   = pr.Title;
-                        prUrl     = pr.Url;
-                        prHeadRef = pr.HeadRef;
-                    }
+                if (pr is not null) {
+                    prNumber  = pr.Number;
+                    prTitle   = pr.Title;
+                    prUrl     = pr.Url;
+                    prHeadRef = pr.HeadRef;
                 }
             }
 
@@ -229,6 +218,42 @@ static class RepositoryDetection {
         } catch {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Resolves the git provider for <paramref name="host"/> and detects the current PR/MR within a
+    /// single <paramref name="providerCap"/> ceiling shared by the probe and the detector. The
+    /// detector is given only the budget the probe left behind — never the full cap — so probe +
+    /// detector together can't overrun the deadline. <paramref name="getTimestamp"/> is a seam for
+    /// tests (defaults to <see cref="Stopwatch.GetTimestamp"/>).
+    /// </summary>
+    internal static async Task<PrInfo?> ResolveAndDetectPrAsync(
+            string        host,
+            string?       owner,
+            string?       repoName,
+            string?       branch,
+            string        cwd,
+            TimeSpan      providerCap,
+            CommandRunner run,
+            Func<long>?   getTimestamp = null
+        ) {
+        if (providerCap <= TimeSpan.Zero) return null;
+
+        var getTs = getTimestamp ?? Stopwatch.GetTimestamp;
+        var start = getTs();
+        var kind  = await GitProviderRouter.ResolveAsync(host, cwd, providerCap, run);
+
+        // The remainder after the probe — NOT the full providerCap. Passing providerCap here would
+        // let a slow probe + a full-length detector overrun the caller's deadline.
+        var detectCap = providerCap - Stopwatch.GetElapsedTime(start, getTs());
+        if (detectCap <= TimeSpan.Zero) return null;
+
+        return kind switch {
+            GitProviderKind.GitHub => await GitHubPrDetector.DetectAsync(cwd, detectCap, run),
+            GitProviderKind.GitLab when owner is not null && repoName is not null
+                => await GitLabPrDetector.DetectAsync(host, owner, repoName, branch, cwd, detectCap, run),
+            _ => null
+        };
     }
 
     static async Task<string?> RunCommandAsync(string cmd, string arguments, string cwd, TimeSpan timeout) {

--- a/test/Capacitor.Cli.Tests.Unit/GitHubPrDetectorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GitHubPrDetectorTests.cs
@@ -29,4 +29,18 @@ public class GitHubPrDetectorTests {
         CommandRunner fake = (_, _, _, _) => Task.FromResult<string?>(null); // no PR / gh failed
         await Assert.That(await GitHubPrDetector.DetectAsync("/cwd", TimeSpan.FromSeconds(2), fake)).IsNull();
     }
+
+    [Test]
+    public async Task Malformed_json_yields_null() {
+        // gh emitted non-JSON → JsonNode.Parse throws → best-effort catch returns null.
+        CommandRunner fake = (_, _, _, _) => Task.FromResult<string?>("{not json");
+        await Assert.That(await GitHubPrDetector.DetectAsync("/cwd", TimeSpan.FromSeconds(2), fake)).IsNull();
+    }
+
+    [Test]
+    public async Task Non_numeric_number_yields_null() {
+        // A non-integer `number` makes GetValue<int> throw → caught → null (never a bogus PrInfo).
+        CommandRunner fake = (_, _, _, _) => Task.FromResult<string?>("""{"number":"oops","title":"t"}""");
+        await Assert.That(await GitHubPrDetector.DetectAsync("/cwd", TimeSpan.FromSeconds(2), fake)).IsNull();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/GitLabPrDetectorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GitLabPrDetectorTests.cs
@@ -54,4 +54,30 @@ public class GitLabPrDetectorTests {
             """[{"iid":5,"title":"x","web_url":"u","source_branch":"different","updated_at":"2026-06-01T00:00:00Z"}]""");
         await Assert.That(await GitLabPrDetector.DetectAsync("gitlab.com", "g", "p", "feat/x", "/cwd", TimeSpan.FromSeconds(2), fake)).IsNull();
     }
+
+    [Test]
+    public async Task Bad_iid_record_is_skipped_not_the_whole_result() {
+        // A non-numeric iid on one matching record must not drop the OTHER valid match — the bad
+        // record is skipped, not the whole detection (the per-record parse used to throw and the
+        // outer catch returned null for everything).
+        CommandRunner fake = (_, _, _, _) => Task.FromResult<string?>("""
+        [
+          {"iid":9,"title":"good","web_url":"https://gitlab.com/g/p/-/merge_requests/9","source_branch":"feat/x","updated_at":"2026-06-30T00:00:00Z"},
+          {"iid":"oops","title":"bad","web_url":"u","source_branch":"feat/x","updated_at":"2026-07-01T00:00:00Z"}
+        ]
+        """);
+        var pr = await GitLabPrDetector.DetectAsync("gitlab.com", "g", "p", "feat/x", "/cwd", TimeSpan.FromSeconds(2), fake);
+
+        await Assert.That(pr!.Number).IsEqualTo(9);
+    }
+
+    [Test]
+    public async Task Encodes_branch_with_plus() {
+        // '+' is a query-string metacharacter (space in x-www-form-urlencoded); it must be
+        // percent-encoded to %2B so the source_branch filter matches the real branch, not " ".
+        string seen = "";
+        CommandRunner fake = (_, args, _, _) => { seen = args; return Task.FromResult<string?>("[]"); };
+        await GitLabPrDetector.DetectAsync("gitlab.com", "g", "p", "feat+x", "/cwd", TimeSpan.FromSeconds(2), fake);
+        await Assert.That(seen).Contains("source_branch=feat%2Bx");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/GitProviderRouterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GitProviderRouterTests.cs
@@ -43,4 +43,19 @@ public class GitProviderRouterTests {
     public async Task Null_host_is_unknown() {
         await Assert.That(await GitProviderRouter.ResolveAsync(null, "/c", TimeSpan.FromSeconds(2), Never)).IsEqualTo(GitProviderKind.Unknown);
     }
+
+    [Test]
+    public async Task Malformed_gh_json_falls_back_to_gitlab() {
+        // `gh auth status --json hosts` returned junk → JsonNode.Parse throws → we can't confirm
+        // the host is a GitHub host, so best-effort GitLab (unique host avoids memo collisions).
+        CommandRunner fake = (_, _, _, _) => Task.FromResult<string?>("{not valid json");
+        await Assert.That(await GitProviderRouter.ResolveAsync("malformed-json.example.com", "/c", TimeSpan.FromSeconds(2), fake)).IsEqualTo(GitProviderKind.GitLab);
+    }
+
+    [Test]
+    public async Task Null_probe_result_falls_back_to_gitlab() {
+        // Probe failed / timed out (runner returned null) → best-effort GitLab.
+        CommandRunner fake = (_, _, _, _) => Task.FromResult<string?>(null);
+        await Assert.That(await GitProviderRouter.ResolveAsync("null-probe.example.com", "/c", TimeSpan.FromSeconds(2), fake)).IsEqualTo(GitProviderKind.GitLab);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ProviderBudgetSplitTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProviderBudgetSplitTests.cs
@@ -58,4 +58,27 @@ public class ProviderBudgetSplitTests {
         await Assert.That(detectorRan).IsFalse();
         await Assert.That(pr).IsNull();
     }
+
+    [Test]
+    public async Task Non_monotonic_timestamp_never_inflates_the_detector_budget() {
+        var providerCap = TimeSpan.FromSeconds(2);
+
+        // A misbehaving timestamp seam that goes BACKWARDS (end < start) would make GetElapsedTime
+        // negative and, unclamped, push detectCap above providerCap. The clamp must keep the
+        // detector budget within the shared ceiling.
+        var calls = 0;
+        long Timestamp() => calls++ == 0 ? Stopwatch.Frequency : 0L; // start high, end low → negative elapsed
+
+        TimeSpan? detectorCap = null;
+        CommandRunner run = (cmd, _, _, cap) => {
+            if (cmd == "glab") { detectorCap = cap; return Task.FromResult<string?>("[]"); }
+            return Task.FromResult<string?>("{}");
+        };
+
+        await RepositoryDetection.ResolveAndDetectPrAsync(
+            "git.example.com", "owner", "repo", "main", "/cwd", providerCap, run, Timestamp);
+
+        await Assert.That(detectorCap).IsNotNull();
+        await Assert.That(detectorCap!.Value).IsLessThanOrEqualTo(providerCap); // never exceeds the ceiling
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ProviderBudgetSplitTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProviderBudgetSplitTests.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+using Capacitor.Cli;
+using Capacitor.Cli.PrDetection;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Guards the effective-provider-budget split added in #229: the probe (GitProviderRouter) and the
+/// PR/MR detector share one ceiling, and the detector must run within the budget the probe LEFT
+/// BEHIND — not the full cap. This is timing-dependent in production; an injected timestamp makes
+/// it deterministic so a regression (handing the detector the full cap) is caught in CI (AI-1120).
+/// </summary>
+public class ProviderBudgetSplitTests {
+    [Before(Test)]
+    public void Reset() => GitProviderRouter.ResetMemoForTests();
+
+    [Test]
+    public async Task Detector_gets_the_budget_the_probe_left_behind() {
+        var providerCap = TimeSpan.FromSeconds(2);
+
+        // The probe "consumes" exactly half the cap: timestamp reads 0 at start, +1s afterwards.
+        var calls = 0;
+        long Timestamp() => calls++ == 0 ? 0L : Stopwatch.Frequency; // Frequency ticks == 1 second
+
+        TimeSpan? detectorCap = null;
+        CommandRunner run = (cmd, _, _, cap) => {
+            if (cmd == "glab") { detectorCap = cap; return Task.FromResult<string?>("[]"); }
+            return Task.FromResult<string?>("{}"); // gh auth status: custom host not a gh host → GitLab
+        };
+
+        // Custom host → the router probes (consuming the injected time); GitLab detector then runs.
+        await RepositoryDetection.ResolveAndDetectPrAsync(
+            "git.example.com", "owner", "repo", "main", "/cwd", providerCap, run, Timestamp);
+
+        await Assert.That(detectorCap).IsNotNull();
+        await Assert.That(detectorCap!.Value).IsLessThan(providerCap);                 // NOT the full cap
+        await Assert.That(detectorCap!.Value.TotalMilliseconds).IsGreaterThan(500);    // ≈ 1s remainder
+        await Assert.That(detectorCap!.Value.TotalMilliseconds).IsLessThan(1500);
+    }
+
+    [Test]
+    public async Task No_detection_when_probe_exhausts_the_budget() {
+        var providerCap = TimeSpan.FromSeconds(2);
+
+        // Probe consumes the whole cap (0 → 2s) → no budget left → detector must not run.
+        var calls = 0;
+        long Timestamp() => calls++ == 0 ? 0L : Stopwatch.Frequency * 2;
+
+        var detectorRan = false;
+        CommandRunner run = (cmd, _, _, _) => {
+            if (cmd == "glab") detectorRan = true;
+            return Task.FromResult<string?>(cmd == "glab" ? "[]" : "{}");
+        };
+
+        var pr = await RepositoryDetection.ResolveAndDetectPrAsync(
+            "git.example.com", "owner", "repo", "main", "/cwd", providerCap, run, Timestamp);
+
+        await Assert.That(detectorRan).IsFalse();
+        await Assert.That(pr).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/RemoteMatcherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RemoteMatcherTests.cs
@@ -136,7 +136,8 @@ public class RemoteMatcherTests {
     [Test]
     public async Task PathAfterHost_edge_inputs_return_null() {
         await Assert.That(RemoteMatcher.PathAfterHost("")).IsNull();            // empty
-        await Assert.That(RemoteMatcher.PathAfterHost("host/")).IsNull();       // lone trailing slash → no path
+        await Assert.That(RemoteMatcher.PathAfterHost("/")).IsNull();           // lone slash → no host, no path
+        await Assert.That(RemoteMatcher.PathAfterHost("host/")).IsNull();       // trailing slash → no path
         await Assert.That(RemoteMatcher.PathAfterHost("/owner/repo")).IsNull(); // leading slash → no host segment
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/RemoteMatcherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RemoteMatcherTests.cs
@@ -132,4 +132,11 @@ public class RemoteMatcherTests {
         await Assert.That(RemoteMatcher.PathAfterHost("gitlab.com/group/project")).IsEqualTo("group/project");
         await Assert.That(RemoteMatcher.PathAfterHost("nohostonly")).IsNull();
     }
+
+    [Test]
+    public async Task PathAfterHost_edge_inputs_return_null() {
+        await Assert.That(RemoteMatcher.PathAfterHost("")).IsNull();            // empty
+        await Assert.That(RemoteMatcher.PathAfterHost("host/")).IsNull();       // lone trailing slash → no path
+        await Assert.That(RemoteMatcher.PathAfterHost("/owner/repo")).IsNull(); // leading slash → no host segment
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs
@@ -65,9 +65,15 @@ public class RepositoryDetectionCacheTests {
             RedirectStandardError  = true
         };
         using var proc = Process.Start(psi)!;
+        // Drain BOTH pipes before WaitForExit. A child that fills its stdout buffer blocks on the
+        // write while we block on WaitForExit → deadlock. Harmless for init/remote add (near-empty
+        // output), but a footgun the moment this helper is reused for a chattier git subcommand.
+        var stdout = proc.StandardOutput.ReadToEndAsync();
+        var stderr = proc.StandardError.ReadToEndAsync();
         proc.WaitForExit();
         if (proc.ExitCode != 0) {
-            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {proc.StandardError.ReadToEnd()}");
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stderr.GetAwaiter().GetResult()}");
         }
+        _ = stdout.GetAwaiter().GetResult();
     }
 }


### PR DESCRIPTION
## What & why

Follow-up to #229 (multi-provider PR/MR detection). The provider-detection paths were correct by inspection but several negative/edge branches had no explicit tests. This adds that defense-in-depth coverage, and fixes two small issues the coverage surfaced.

## Production changes (small)

- **`GitLabPrDetector` — non-numeric `iid`.** `mr["iid"]?.GetValue<int>()` *throws* on a non-integer `iid`, and the method's outer best-effort `catch` then dropped **every** matching MR, not just the bad record. Now guarded with `JsonValue.TryGetValue<int>` so a malformed record is skipped (`continue`) and the other valid MRs still resolve.
- **`RepositoryDetection` — testable budget-split seam.** Extracted the probe + detector block into an internal `ResolveAndDetectPrAsync` (behaviour-preserving) with an injectable timestamp. The detector still receives only the budget the probe left behind — but now that split is covered by a deterministic test, so a regression (handing the detector the full cap) is caught in CI rather than being timing-only.

## Test-helper hygiene

- `RepositoryDetectionCacheTests.RunGit` now drains **both** stdout and stderr before `WaitForExit` — harmless for `init`/`remote add`, but a deadlock footgun the moment it's reused for a chattier git subcommand.

## New coverage

- **`GitProviderRouter`** — malformed `gh auth status --json hosts` JSON, and a null probe result → GitLab fallback.
- **`GitHubPrDetector`** — malformed JSON and a non-numeric `number` → null.
- **`GitLabPrDetector`** — bad-`iid` record skipped (not the whole result); `+` in a branch name → `%2B` (encoding was only tested with `&`).
- **`RemoteMatcher.PathAfterHost`** — empty / `"host/"` / `"/owner/repo"` → null.
- **Provider budget split** — detector gets the remainder; no detection when the probe exhausts the cap.

## Testing

- Full unit suite green (**2246** tests). AOT publish of the CLI clean — no IL3050/IL2026 warnings.

No README/CLI-surface change: tests + an internal robustness fix + an internal refactor.

Closes #230
Linear: AI-1120