### PR TITLE
Fix Windows hosted-agent hang at trust dialog (empty terminal / "Waiting for session to start")

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -291,6 +291,17 @@ internal sealed partial class ClaudeLauncher(
         }
     }
 
+    /// <summary>
+    /// Matches Claude Code's <c>projects[]</c> key normalisation: absolute + collapsed, and
+    /// on Windows with forward slashes (Claude runs <c>path.normalize(p).replaceAll("\\","/")</c>).
+    /// Writing the raw Windows path instead makes our pre-trust write invisible to Claude.
+    /// </summary>
+    internal static string NormalizeClaudeProjectKey(string path) {
+        var full = Path.GetFullPath(path);
+
+        return OperatingSystem.IsWindows() ? full.Replace('\\', '/') : full;
+    }
+
     static void TrustWorktreeInClaudeConfig(string worktreePath) {
         // Serialize against concurrent agent launches. ~/.claude.json is shared
         // across the whole user and {worktree}/.claude/settings.local.json is
@@ -312,9 +323,19 @@ internal sealed partial class ClaudeLauncher(
                 root["projects"] = projects;
             }
 
-            if (projects[worktreePath] is not JsonObject entry) {
-                entry                  = [];
-                projects[worktreePath] = entry;
+            // Claude Code keys projects[] by a normalised path, and on Windows that
+            // normalisation converts backslashes to forward slashes (its `path.normalize`
+            // then `.replaceAll("\\","/")`). If we write the raw backslash path here, Claude
+            // looks up the forward-slash key, misses our entry, and shows the "Quick safety
+            // check" trust dialog — the hosted agent then hangs at the prompt forever, never
+            // starts a session, and the UI stays on "Waiting for session to start…" with an
+            // empty terminal (Windows-only; POSIX paths already match). Write under the same
+            // normalised key Claude reads.
+            var trustKey = NormalizeClaudeProjectKey(worktreePath);
+
+            if (projects[trustKey] is not JsonObject entry) {
+                entry              = [];
+                projects[trustKey] = entry;
             }
 
             var alreadyTrusted = entry["hasTrustDialogAccepted"] is JsonValue v && v.TryGetValue<bool>(out var b) && b;

--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -452,13 +452,20 @@ internal sealed partial class ClaudeLauncher(
         }
     }
 
-    static void WriteMcpConfig(string sourceRepoPath, string worktreePath) {
+    internal static void WriteMcpConfig(string sourceRepoPath, string worktreePath) {
         var claudeJsonPath = ClaudePaths.UserConfigJson();
 
         if (!File.Exists(claudeJsonPath)) return;
 
-        var root    = JsonNode.Parse(File.ReadAllText(claudeJsonPath));
-        var servers = root?["projects"]?[sourceRepoPath]?["mcpServers"]?.AsObject();
+        var root = JsonNode.Parse(File.ReadAllText(claudeJsonPath));
+
+        // Claude keys projects[] by the normalised path (forward slashes on Windows) —
+        // same reasoning as the trust write in TrustWorktreeInClaudeConfig. Fall back to
+        // the raw path for entries written by older kcap builds or by hand.
+        var sourceKey = NormalizeClaudeProjectKey(sourceRepoPath);
+
+        var servers = root?["projects"]?[sourceKey]?["mcpServers"]?.AsObject()
+         ?? root?["projects"]?[sourceRepoPath]?["mcpServers"]?.AsObject();
 
         if (servers is null || servers.Count == 0) return;
 

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherWriteMcpConfigTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherWriteMcpConfigTests.cs
@@ -1,0 +1,115 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Pins that <see cref="ClaudeLauncher.WriteMcpConfig"/> reads the source repo's
+/// MCP servers from <c>~/.claude.json</c> under Claude Code's normalised
+/// <c>projects[]</c> key (forward slashes on Windows — see
+/// <see cref="ClaudeLauncher.NormalizeClaudeProjectKey"/>), with a raw-path
+/// fallback for entries written by older builds or by hand. Before the fix the
+/// lookup used the raw Windows backslash path, missed the normalised entry, and
+/// silently skipped copying the user's MCP servers into the hosted worktree.
+/// </summary>
+[NotInParallel("HomeEnvVarMutation")]
+public class ClaudeLauncherWriteMcpConfigTests {
+
+    static async Task RunWithRelocatedConfigAsync(Func<string, string, string, Task> body) {
+        var original = Environment.GetEnvironmentVariable("CLAUDE_CONFIG_DIR");
+        var root     = Path.Combine(Path.GetTempPath(), "kcap-mcpcfg-" + Guid.NewGuid().ToString("N")[..8]);
+
+        var configDir  = Path.Combine(root, "claude-cfg");
+        var sourceRepo = Path.Combine(root, "source-repo");
+        var worktree   = Path.Combine(root, "worktree");
+
+        Directory.CreateDirectory(configDir);
+        Directory.CreateDirectory(sourceRepo);
+        Directory.CreateDirectory(worktree);
+
+        try {
+            Environment.SetEnvironmentVariable("CLAUDE_CONFIG_DIR", configDir);
+            await body(configDir, sourceRepo, worktree);
+        } finally {
+            Environment.SetEnvironmentVariable("CLAUDE_CONFIG_DIR", original);
+            try { Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    static void WriteClaudeJson(string configDir, string projectKey) {
+        var json = new JsonObject {
+            ["projects"] = new JsonObject {
+                [projectKey] = new JsonObject {
+                    ["mcpServers"] = new JsonObject {
+                        ["my-server"] = new JsonObject {
+                            ["command"] = "some-mcp",
+                            ["env"]     = new JsonObject { ["SECRET"] = "do-not-copy" }
+                        }
+                    }
+                }
+            }
+        };
+
+        File.WriteAllText(Path.Combine(configDir, ".claude.json"), json.ToJsonString());
+    }
+
+    static JsonObject? ReadWorktreeMcpServers(string worktree) {
+        var path = Path.Combine(worktree, ".mcp.json");
+
+        if (!File.Exists(path)) return null;
+
+        return JsonNode.Parse(File.ReadAllText(path))?["mcpServers"]?.AsObject();
+    }
+
+    /// <summary>
+    /// The entry Claude itself writes: keyed by the normalised path. On Windows
+    /// that differs from the raw path (forward vs. back slashes) — the lookup
+    /// must still find it. On POSIX both spellings coincide, so this documents
+    /// the invariant and guards the Windows behaviour where CI runs there.
+    /// </summary>
+    [Test]
+    public async Task Finds_servers_under_normalized_project_key() {
+        await RunWithRelocatedConfigAsync(async (configDir, sourceRepo, worktree) => {
+            WriteClaudeJson(configDir, ClaudeLauncher.NormalizeClaudeProjectKey(sourceRepo));
+
+            ClaudeLauncher.WriteMcpConfig(sourceRepo, worktree);
+
+            var servers = ReadWorktreeMcpServers(worktree);
+            await Assert.That(servers).IsNotNull();
+            await Assert.That(servers!.ContainsKey("my-server")).IsTrue();
+
+            // env must be stripped from the copied server definition.
+            await Assert.That(servers["my-server"]!.AsObject().ContainsKey("env")).IsFalse();
+        });
+    }
+
+    /// <summary>
+    /// Backward compatibility: an entry stored under the raw (unnormalised)
+    /// path — e.g. written by an older kcap build on Windows — is still found
+    /// via the fallback lookup.
+    /// </summary>
+    [Test]
+    public async Task Falls_back_to_raw_project_key() {
+        await RunWithRelocatedConfigAsync(async (configDir, sourceRepo, worktree) => {
+            WriteClaudeJson(configDir, sourceRepo);
+
+            ClaudeLauncher.WriteMcpConfig(sourceRepo, worktree);
+
+            var servers = ReadWorktreeMcpServers(worktree);
+            await Assert.That(servers).IsNotNull();
+            await Assert.That(servers!.ContainsKey("my-server")).IsTrue();
+        });
+    }
+
+    /// <summary>No project entry under either key → no .mcp.json written.</summary>
+    [Test]
+    public async Task No_matching_project_entry_writes_nothing() {
+        await RunWithRelocatedConfigAsync(async (configDir, sourceRepo, worktree) => {
+            WriteClaudeJson(configDir, Path.Combine(Path.GetTempPath(), "some-other-repo"));
+
+            ClaudeLauncher.WriteMcpConfig(sourceRepo, worktree);
+
+            await Assert.That(File.Exists(Path.Combine(worktree, ".mcp.json"))).IsFalse();
+        });
+    }
+}


### PR DESCRIPTION
## Problem

On **Windows**, a launched hosted agent shows **Active** in the web UI, but the **Terminal tab stays empty** and Chat is stuck on **"Waiting for session to start…"** forever. macOS/Linux are unaffected.

<img width="2559" height="1464" alt="Screenshot 2026-06-30 024239" src="https://github.com/user-attachments/assets/80f40784-ad0d-450f-978a-8244c5e9c9a6" />

<img width="2559" height="1391" alt="Screenshot 2026-06-30 020941" src="https://github.com/user-attachments/assets/17522de2-a99d-4247-a525-d2112d1b185d" />


## Root cause

The agent never starts a Claude session, so the SessionStart hook never fires and the agent's `SessionId` never links — and both the Terminal tab and the "Waiting for session to start" message are gated on that link.

The reason no session starts: the spawned `claude` hangs at the workspace-trust dialog (*"Quick safety check: Is this a project you created or one you trust?"*), waiting for input that never comes. Confirmed by reading the agent's terminal buffer off the server — Claude was parked at the trust prompt.

`ClaudeLauncher.TrustWorktreeInClaudeConfig` pre-accepts trust by writing `projects["<worktree>"].hasTrustDialogAccepted = true` into `~/.claude.json`. But Claude Code normalises the `projects[]` lookup key, and on Windows that normalisation converts backslashes to forward slashes:

```js
function normalizeKey(e){ let t = path.normalize(e); if (os === "windows") return t.replaceAll("\\","/"); return t }
```

So Claude looks up `C:/Users/.../agent-xxx` (forward slashes) while the daemon wrote `C:\Users\...\agent-xxx` (backslashes). The keys never match, the pre-trust write is invisible, and the trust dialog blocks. POSIX paths already use `/`, which is why this only reproduces on Windows. (Verified the daemon *did* write `hasTrustDialogAccepted: true` under the backslash key and Claude still prompted.)

## Fix

Write the `projects[]` trust key in Claude's normalised (forward-slash on Windows) form via a small `NormalizeClaudeProjectKey` helper. AOT-safe (`Path.GetFullPath` + `string.Replace` + `OperatingSystem.IsWindows`).

## Verification

Reproduced locally on Windows (empty terminal + "Waiting for session to start"; terminal buffer showed the trust prompt). After the fix, a freshly launched agent linked its session within ~10s:

```
Updated agent c7f43525 status to Running (session=257badde…)
Linked session 257badde… to daemon agent c7f43525
```

and the Terminal now renders the live Claude UI ("Claude Code v2.1.200 / Welcome back …"). Pre-fix agents stayed `session=null` indefinitely.

## Related (not fixed here)

The same key-mismatch pattern affects `WriteMcpConfig`, which reads `projects[sourceRepoPath]` with the raw path — so a user's interactively-configured MCP servers are not copied into hosted worktrees on Windows. Worth a follow-up with the same normalisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)