### PR TITLE
Add a beta-release runbook to RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,3 +16,50 @@ rollout, cut `vX.Y.Z-beta.N` instead — otherwise `@kurrent/kcap@latest` moves
 ahead of those users' servers and reintroduces version skew.
 
 Internal-tenant users opt into the beta CLI with `kcap update --beta`.
+
+## Cutting a beta release
+
+1. Confirm the matching server version is deployed to the internal tenant(s) you're testing.
+2. Pick a SemVer prerelease tag `vX.Y.Z-beta.N`, where `X.Y.Z` matches the server version
+   (consolidated bump). Start at `beta.1`; bump `N` for each iteration on the same `X.Y.Z`.
+3. Tag and push. The `Release` workflow triggers on the `v*` tag, waits for CI to pass,
+   builds every platform binary, and publishes all packages to the `beta` dist-tag
+   (`latest` is left untouched):
+
+   ```bash
+   git tag vX.Y.Z-beta.1
+   git push origin vX.Y.Z-beta.1
+   ```
+
+4. Verify the publish landed on `beta`, not `latest`:
+
+   ```bash
+   npm dist-tag ls @kurrent/kcap
+   # latest: <unchanged stable>   beta: X.Y.Z-beta.1
+   ```
+
+5. Internal testers opt in (only after the beta is published):
+
+   ```bash
+   kcap update --beta             # existing installs — persists the choice per profile
+   npm i -g @kurrent/kcap@beta    # fresh installs
+   ```
+
+   `kcap update --stable` switches back to the stable channel.
+
+## Promoting a beta to stable
+
+Once the matching server version is live for the `stable`/`micro` cohorts (see the
+invariant above), cut the plain release tag from the same — or a newer — commit. This
+publishes to `latest`, so everyone on `kcap update` / `npm i -g @kurrent/kcap` receives it:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+## How the dist-tag is chosen
+
+Only `v*` tags trigger a release. The tag's SemVer shape alone decides the dist-tag —
+a hyphenated prerelease (`-beta.N`, `-rc.N`, …) → `beta`; a bare `vX.Y.Z` → `latest` —
+via `scripts/npm-dist-tag.sh`. No manual dist-tag step is needed.


### PR DESCRIPTION
`RELEASING.md` (added in #267) documented the tag→dist-tag **policy** and the release invariant, but not the **operational steps** — so whoever cuts a beta had to reverse-engineer the tag format from `release.yml`.

This adds a runbook:
- **Cutting a beta release** — tag `vX.Y.Z-beta.N`, push, verify it landed on the `beta` dist-tag (not `latest`), and how internal testers opt in (`kcap update --beta` / `npm i -g @kurrent/kcap@beta`).
- **Promoting a beta to stable** — cut the plain `vX.Y.Z` tag once the matching server version is live for `stable`/`micro`.
- **How the dist-tag is chosen** — the tag's SemVer shape alone decides it (`scripts/npm-dist-tag.sh`); no manual dist-tag step.

Docs-only. Follow-up to #267 (version-skew Phase 1 / beta channel).

Closes #269
AI-1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)