### PR TITLE
Reap orphaned interactive commands when the console detaches mid-prompt

### DIFF
--- a/src/Capacitor.Cli/InteractiveLifetime.cs
+++ b/src/Capacitor.Cli/InteractiveLifetime.cs
@@ -1,0 +1,129 @@
+using System.Runtime.InteropServices;
+
+namespace Capacitor.Cli;
+
+/// <summary>
+/// Interrupt / abandonment safety net for interactive commands.
+///
+/// Commands such as <c>setup</c>, <c>login</c>, <c>profile</c>, <c>use</c>,
+/// <c>import</c>, and <c>uninstall</c> block on synchronous Spectre.Console
+/// prompts (<c>ConfirmationPrompt</c>, <c>SelectionPrompt</c>, <c>TextPrompt</c>).
+/// A blocking console read has no timeout and observes neither Ctrl+C nor a
+/// detached/closed console, so when the controlling terminal or the launching
+/// agent goes away mid-prompt the read never returns and the process is
+/// orphaned alive — the reported stray <c>kcap.exe</c> processes left behind
+/// after a user abandons <c>kcap setup</c> partway through.
+///
+/// Redirected/piped stdin is already safe: the prompt read throws
+/// "Failed to read input in non-interactive mode" and the process exits. This
+/// closes the two gaps that piped stdin doesn't cover:
+///   1. Ctrl+C / SIGTERM / SIGHUP while blocked in a prompt.
+///   2. The launching parent (shell or coding agent) exiting while we wait for
+///      input — a detached pseudo-console delivers no signal at all, so a
+///      liveness watchdog is the only thing that reaps it.
+///
+/// This mirrors what <see cref="Commands.WatchCommand"/> already does for the
+/// long-lived watcher; every other interactive command previously had no such
+/// protection. Idempotent — safe to call once per process.
+/// </summary>
+static class InteractiveLifetime {
+    // Exit code for an interrupted interactive command (128 + SIGINT).
+    const int InterruptExitCode = 130;
+
+    // How often the parent-liveness watchdog polls. Short enough to reap a
+    // stray promptly, long enough to be negligible overhead.
+    static readonly TimeSpan ParentPollInterval = TimeSpan.FromSeconds(3);
+
+    // PosixSignalRegistration.Create returns an IDisposable that owns the
+    // underlying handler slot; if it isn't rooted for the process lifetime the
+    // finalizer silently unregisters the handler (see WatchCommand). Hold the
+    // registrations in static fields so they live until the process exits.
+    static IDisposable? _sigterm;
+    static IDisposable? _sighup;
+    static int          _installed;
+
+    /// <summary>
+    /// Commands that drive interactive Spectre.Console prompts and therefore
+    /// need the safety net. Kept as an explicit allow-list so non-interactive
+    /// commands (hooks, mcp servers) and commands that manage their own
+    /// lifetime (<c>watch</c>, <c>daemon</c>) are never affected.
+    /// </summary>
+    public static bool IsInteractiveCommand(string command) => command is
+        "setup" or "login" or "profile" or "use" or "import" or "uninstall";
+
+    /// <summary>
+    /// Installs the interrupt handlers and the parent-liveness watchdog. Best
+    /// effort throughout: a failure to register any single guard must never
+    /// break the command it is meant to protect.
+    /// </summary>
+    public static void Install() {
+        if (Interlocked.Exchange(ref _installed, 1) != 0) {
+            return;
+        }
+
+        // Ctrl+C: exit deterministically instead of relying on the default
+        // terminate action, which a blocking prompt read can swallow.
+        try {
+            Console.CancelKeyPress += static (_, e) => {
+                e.Cancel = true; // we own termination below
+                Environment.Exit(InterruptExitCode);
+            };
+        } catch {
+            // Some hosts don't support CancelKeyPress; the watchdog still covers us.
+        }
+
+        // SIGTERM / SIGHUP (Unix): a closed terminal or `kill` should reap us.
+        // No-ops on platforms where the signal isn't delivered.
+        try {
+            _sigterm = PosixSignalRegistration.Create(PosixSignal.SIGTERM, static ctx => {
+                ctx.Cancel = true;
+                Environment.Exit(InterruptExitCode);
+            });
+        } catch {
+            // best effort
+        }
+
+        try {
+            _sighup = PosixSignalRegistration.Create(PosixSignal.SIGHUP, static ctx => {
+                ctx.Cancel = true;
+                Environment.Exit(InterruptExitCode);
+            });
+        } catch {
+            // best effort
+        }
+
+        // Parent-liveness watchdog. On Windows, closing the console window or
+        // force-killing the launching agent delivers no signal we can catch
+        // from inside a blocking prompt read, so poll the parent instead: once
+        // the process that launched us is gone there is no one left to answer
+        // the prompt, so self-terminate rather than orphan.
+        try {
+            StartParentWatchdog(ProcessHelpers.GetParentPid());
+        } catch {
+            // best effort
+        }
+    }
+
+    static void StartParentWatchdog(int? parentPid) {
+        // pid <= 1 means no real parent (init / detached) — nothing sane to
+        // monitor, so skip rather than risk self-terminating immediately.
+        if (parentPid is not { } ppid || ppid <= 1 || !ProcessHelpers.IsProcessAlive(ppid)) {
+            return;
+        }
+
+        var thread = new Thread(() => {
+            while (true) {
+                Thread.Sleep(ParentPollInterval);
+
+                if (!ProcessHelpers.IsProcessAlive(ppid)) {
+                    Environment.Exit(InterruptExitCode);
+                }
+            }
+        }) {
+            IsBackground = true,
+            Name         = "kcap-interactive-parent-watchdog"
+        };
+
+        thread.Start();
+    }
+}

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -68,6 +68,14 @@ if (args.Skip(1).Any(a => a is "--help" or "-h")) {
     return await PrintCommandHelp(command);
 }
 
+// Interactive commands block on synchronous Spectre.Console prompts. Install a
+// signal + parent-liveness safety net so an abandoned prompt (closed terminal,
+// killed launching agent, detached pseudo-console) can't orphan this process
+// alive — the reported stray `kcap.exe` after `kcap setup` is exited partway.
+if (InteractiveLifetime.IsInteractiveCommand(command)) {
+    InteractiveLifetime.Install();
+}
+
 // Commands that don't need a server URL
 string[] offlineCommands = ["--help", "-h", "help", "--version", "-v", "logout", "cleanup", "config", "daemon", "setup", "status", "update", "plugin", "profile", "use", "repos", "login", "ignore", "remap", "uninstall"];
 

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -17,6 +17,20 @@ if (args.Length < 1) {
 
 var command = args[0];
 
+// Interactive commands block on synchronous Spectre.Console prompts. Install a
+// signal + parent-liveness safety net so an abandoned prompt (closed terminal,
+// killed launching agent, detached pseudo-console) can't orphan this process
+// alive — the reported stray `kcap.exe` after `kcap setup` is exited partway.
+//
+// Armed here, before ResolveServerUrl/update-check, on purpose: those can block
+// for seconds (git remote lookup, npm registry), and StartParentWatchdog refuses
+// to arm if the parent is already gone. Installing later leaves a window where
+// the launching agent can exit during that startup work — the watchdog then
+// never starts and the very first prompt still orphans us.
+if (InteractiveLifetime.IsInteractiveCommand(command)) {
+    InteractiveLifetime.Install();
+}
+
 // Hook short-circuit: when spawned inside a kcap-launched headless agent
 // invocation (e.g., title generation, the eval judge) we don't forward the
 // nested session's hook events back into kcap. Scoped to `hook` because
@@ -66,14 +80,6 @@ if (command is "--help" or "-h" or "help") {
 // Per-command help: kcap <command> --help / -h
 if (args.Skip(1).Any(a => a is "--help" or "-h")) {
     return await PrintCommandHelp(command);
-}
-
-// Interactive commands block on synchronous Spectre.Console prompts. Install a
-// signal + parent-liveness safety net so an abandoned prompt (closed terminal,
-// killed launching agent, detached pseudo-console) can't orphan this process
-// alive — the reported stray `kcap.exe` after `kcap setup` is exited partway.
-if (InteractiveLifetime.IsInteractiveCommand(command)) {
-    InteractiveLifetime.Install();
 }
 
 // Commands that don't need a server URL

--- a/test/Capacitor.Cli.Tests.Unit/InteractiveLifetimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/InteractiveLifetimeTests.cs
@@ -1,0 +1,27 @@
+namespace Capacitor.Cli.Tests.Unit;
+
+public class InteractiveLifetimeTests {
+    [Test]
+    [Arguments("setup")]
+    [Arguments("login")]
+    [Arguments("profile")]
+    [Arguments("use")]
+    [Arguments("import")]
+    [Arguments("uninstall")]
+    public async Task IsInteractiveCommand_true_for_prompting_commands(string command) {
+        await Assert.That(InteractiveLifetime.IsInteractiveCommand(command)).IsTrue();
+    }
+
+    [Test]
+    // watch/daemon manage their own lifetime; hook/mcp are non-interactive.
+    [Arguments("watch")]
+    [Arguments("daemon")]
+    [Arguments("hook")]
+    [Arguments("mcp")]
+    [Arguments("recap")]
+    [Arguments("status")]
+    [Arguments("")]
+    public async Task IsInteractiveCommand_false_for_non_prompting_commands(string command) {
+        await Assert.That(InteractiveLifetime.IsInteractiveCommand(command)).IsFalse();
+    }
+}


### PR DESCRIPTION
## Problem
On Windows 11 (and any platform), `kcap setup` can leave a stray `kcap.exe` running indefinitely after the user abandons it partway through — e.g. exits before confirming the visibility step. Confirmed with a live stray `kcap setup` process whose launching parent had already exited, all threads parked in a blocking console read.

## Root cause
`setup` and other interactive commands drive synchronous Spectre.Console prompts (`ConfirmationPrompt`, `SelectionPrompt`, `TextPrompt`) that do a **blocking console read with no timeout or cancellation**. Only `WatchCommand` registers `Console.CancelKeyPress` + `PosixSignalRegistration` and a parent-exit watchdog; interactive commands had **no** interrupt handling.

- Piped/redirected stdin is already safe: the read throws `Failed to read input in non-interactive mode` and the process exits.
- A real TTY that later **detaches** (terminal closed, launching coding-agent killed, detached pseudo-console) delivers neither EOF nor a signal, so the blocking read never returns and the process is orphaned alive.

Reproducible at any prompt, including the very first `ConfirmationPrompt` (so it can happen "before step 1"). Affects `setup`, `login`, `profile`, `use`, `import`, `uninstall`.

## Fix
Add `InteractiveLifetime`, a shared safety net installed only for interactive commands (explicit allow-list, so hooks/mcp/`watch`/`daemon` are untouched). It mirrors what `WatchCommand` already does for the watcher:
1. `Console.CancelKeyPress` + POSIX `SIGTERM`/`SIGHUP` handlers that exit deterministically (`130`).
2. A parent-process-liveness watchdog (reusing `ProcessHelpers.GetParentPid`/`IsProcessAlive`) that self-terminates once the launching process is gone — the only thing that reaps the detached-TTY case on Windows, which delivers no catchable signal from inside a blocking prompt read.

Redirected-stdin behaviour is unchanged (still fails fast via the existing thrown exception).

## Testing
- `dotnet build` clean.
- New `InteractiveLifetimeTests` cover the interactive-command allow-list (prompting commands guarded; `watch`/`daemon`/`hook`/`mcp`/non-prompting commands not). All unit tests pass.
- ⚠️ Could not run `dotnet publish -c Release` to check IL2026/IL3050 AOT warnings — the native toolchain (`vswhere`/MSVC linker) isn't available on this dev box. The new code uses only patterns already present and AOT-safe in `WatchCommand`/`ProcessHelpers` (`PosixSignalRegistration`, `Thread`, `Environment.Exit`, `Interlocked`), so no new AOT warnings are expected, but a publish check should be run in CI.

## Notes
Filing an accompanying GitHub issue was blocked in this environment; the problem statement above stands in for it. This same "no interrupt handling" fragility also explains stuck auth-retry hook processes seen elsewhere — a candidate follow-up to extend the same guard to relevant hook paths.