### PR TITLE
Scrub inherited Claude Code session vars from hosted-agent PTY env

### DIFF
--- a/src/Capacitor.Cli.Daemon/Pty/PtyEnvScrub.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/PtyEnvScrub.cs
@@ -1,0 +1,26 @@
+namespace Capacitor.Cli.Daemon.Pty;
+
+internal static class PtyEnvScrub {
+    public static readonly string[] ClaudeSessionVars = [
+        "CLAUDECODE",
+        "CLAUDE_CODE_ENTRYPOINT",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_CHILD_SESSION",
+        "CLAUDE_CODE_SESSION_ID",
+        "CLAUDE_ENV_FILE",
+        "ANTHROPIC_API_KEY_CLAUDE_CODE_BACKUP"
+    ];
+
+    public static readonly string[] DaemonSupervisionVars = [
+        "KCAP_DAEMON_SUPERVISED",
+        "XPC_SERVICE_NAME",
+        "INVOCATION_ID",
+        "SYSTEMD_EXEC_PID"
+    ];
+
+    public static readonly string[] HostedAgentVars = [
+        "KCAP_AGENT_ID",
+        "KCAP_RENDERED_AGENT",
+        "KCAP_DAEMON_URL"
+    ];
+}

--- a/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
@@ -58,13 +58,6 @@ public sealed class UnixPtyProcess : IPtyProcess {
                 UnixPtyInterop.unsetenv("CLAUDECODE");
                 UnixPtyInterop.unsetenv("CLAUDE_CODE_ENTRYPOINT");
                 UnixPtyInterop.unsetenv("ANTHROPIC_API_KEY");
-                // A daemon started from inside a Claude Code session inherits that
-                // session's identity vars. CLAUDE_CODE_CHILD_SESSION=1 makes the spawned
-                // interactive claude behave as a child session and never write its own
-                // transcript .jsonl, so `kcap watch` has nothing to stream and the hosted
-                // agent's web chat stays empty forever ("Waiting for conversation
-                // data...") while the PTY works fine. Scrub the whole inherited-session
-                // surface — parity with ConPtyProcess.BuildEnvironmentBlock.
                 UnixPtyInterop.unsetenv("CLAUDE_CODE_CHILD_SESSION");
                 UnixPtyInterop.unsetenv("CLAUDE_CODE_SESSION_ID");
                 UnixPtyInterop.unsetenv("CLAUDE_ENV_FILE");

--- a/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
@@ -58,6 +58,17 @@ public sealed class UnixPtyProcess : IPtyProcess {
                 UnixPtyInterop.unsetenv("CLAUDECODE");
                 UnixPtyInterop.unsetenv("CLAUDE_CODE_ENTRYPOINT");
                 UnixPtyInterop.unsetenv("ANTHROPIC_API_KEY");
+                // A daemon started from inside a Claude Code session inherits that
+                // session's identity vars. CLAUDE_CODE_CHILD_SESSION=1 makes the spawned
+                // interactive claude behave as a child session and never write its own
+                // transcript .jsonl, so `kcap watch` has nothing to stream and the hosted
+                // agent's web chat stays empty forever ("Waiting for conversation
+                // data...") while the PTY works fine. Scrub the whole inherited-session
+                // surface — parity with ConPtyProcess.BuildEnvironmentBlock.
+                UnixPtyInterop.unsetenv("CLAUDE_CODE_CHILD_SESSION");
+                UnixPtyInterop.unsetenv("CLAUDE_CODE_SESSION_ID");
+                UnixPtyInterop.unsetenv("CLAUDE_ENV_FILE");
+                UnixPtyInterop.unsetenv("ANTHROPIC_API_KEY_CLAUDE_CODE_BACKUP");
                 // Clear any hosted-agent identity/routing the daemon may have inherited (e.g.
                 // it was started from inside a kcap-tracked session) so the spawned agent gets
                 // ONLY what extraEnv sets: hosted launches re-add these below; private local

--- a/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using Capacitor.Cli.Daemon.Pty;
 
 namespace Capacitor.Cli.Daemon.Pty.Unix;
 
@@ -43,6 +44,12 @@ public sealed class UnixPtyProcess : IPtyProcess {
             extraEnvValues = extraEnv.Values.ToArray();
         }
 
+        // Touch shared scrub lists before fork; the child then only iterates
+        // prebuilt arrays before exec.
+        var claudeSessionVars     = PtyEnvScrub.ClaudeSessionVars;
+        var hostedAgentVars       = PtyEnvScrub.HostedAgentVars;
+        var daemonSupervisionVars = PtyEnvScrub.DaemonSupervisionVars;
+
         var ws  = new UnixPtyInterop.WinSize { ws_row = rows, ws_col = cols };
         var pid = UnixPtyInterop.forkpty(out var masterFd, IntPtr.Zero, IntPtr.Zero, ref ws);
 
@@ -55,27 +62,22 @@ public sealed class UnixPtyProcess : IPtyProcess {
                 UnixPtyInterop.setenv("LANG", "en_US.UTF-8", 1);
                 UnixPtyInterop.setenv("COLUMNS", colsStr, 1);
                 UnixPtyInterop.setenv("LINES", rowsStr, 1);
-                UnixPtyInterop.unsetenv("CLAUDECODE");
-                UnixPtyInterop.unsetenv("CLAUDE_CODE_ENTRYPOINT");
-                UnixPtyInterop.unsetenv("ANTHROPIC_API_KEY");
-                UnixPtyInterop.unsetenv("CLAUDE_CODE_CHILD_SESSION");
-                UnixPtyInterop.unsetenv("CLAUDE_CODE_SESSION_ID");
-                UnixPtyInterop.unsetenv("CLAUDE_ENV_FILE");
-                UnixPtyInterop.unsetenv("ANTHROPIC_API_KEY_CLAUDE_CODE_BACKUP");
+                foreach (var key in claudeSessionVars) {
+                    UnixPtyInterop.unsetenv(key);
+                }
                 // Clear any hosted-agent identity/routing the daemon may have inherited (e.g.
                 // it was started from inside a kcap-tracked session) so the spawned agent gets
                 // ONLY what extraEnv sets: hosted launches re-add these below; private local
                 // launches deliberately leave them unset (no mis-tag, native permissions).
-                UnixPtyInterop.unsetenv("KCAP_AGENT_ID");
-                UnixPtyInterop.unsetenv("KCAP_RENDERED_AGENT");
-                UnixPtyInterop.unsetenv("KCAP_DAEMON_URL");
+                foreach (var key in hostedAgentVars) {
+                    UnixPtyInterop.unsetenv(key);
+                }
                 // Never leak daemon supervision state into hosted agents — otherwise a
                 // `kcap daemon start` run from inside an agent could inherit a supervised
                 // classification and later take the exit-for-relaunch path with no supervisor.
-                UnixPtyInterop.unsetenv("KCAP_DAEMON_SUPERVISED");
-                UnixPtyInterop.unsetenv("XPC_SERVICE_NAME");
-                UnixPtyInterop.unsetenv("INVOCATION_ID");
-                UnixPtyInterop.unsetenv("SYSTEMD_EXEC_PID");
+                foreach (var key in daemonSupervisionVars) {
+                    UnixPtyInterop.unsetenv(key);
+                }
 
                 if (extraEnvKeys is not null) {
                     for (var i = 0; i < extraEnvKeys.Length; i++) {

--- a/src/Capacitor.Cli.Daemon/Pty/Windows/ConPtyProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Windows/ConPtyProcess.cs
@@ -80,6 +80,18 @@ public sealed class ConPtyProcess : IPtyProcess {
         env.Remove("CLAUDECODE");
         env.Remove("CLAUDE_CODE_ENTRYPOINT");
         env.Remove("ANTHROPIC_API_KEY");
+        // A daemon started from inside a Claude Code session inherits that session's
+        // identity vars. CLAUDE_CODE_CHILD_SESSION=1 makes the spawned interactive
+        // claude behave as a child session and never write its own transcript .jsonl,
+        // so `kcap watch` has nothing to stream and the hosted agent's web chat stays
+        // empty forever ("Waiting for conversation data...") while the PTY works fine.
+        // Scrub the whole inherited-session surface: the child marker, the outer
+        // session id, the outer session's env file, and the backup API key Claude
+        // Code stashes for its own children.
+        env.Remove("CLAUDE_CODE_CHILD_SESSION");
+        env.Remove("CLAUDE_CODE_SESSION_ID");
+        env.Remove("CLAUDE_ENV_FILE");
+        env.Remove("ANTHROPIC_API_KEY_CLAUDE_CODE_BACKUP");
         // Parity with UnixPtyProcess: never leak daemon supervision state into spawned
         // children. Auto-restart is out of scope on Windows, but keep the two PTY paths
         // in lockstep so the scrub doesn't drift.

--- a/src/Capacitor.Cli.Daemon/Pty/Windows/ConPtyProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Windows/ConPtyProcess.cs
@@ -80,14 +80,6 @@ public sealed class ConPtyProcess : IPtyProcess {
         env.Remove("CLAUDECODE");
         env.Remove("CLAUDE_CODE_ENTRYPOINT");
         env.Remove("ANTHROPIC_API_KEY");
-        // A daemon started from inside a Claude Code session inherits that session's
-        // identity vars. CLAUDE_CODE_CHILD_SESSION=1 makes the spawned interactive
-        // claude behave as a child session and never write its own transcript .jsonl,
-        // so `kcap watch` has nothing to stream and the hosted agent's web chat stays
-        // empty forever ("Waiting for conversation data...") while the PTY works fine.
-        // Scrub the whole inherited-session surface: the child marker, the outer
-        // session id, the outer session's env file, and the backup API key Claude
-        // Code stashes for its own children.
         env.Remove("CLAUDE_CODE_CHILD_SESSION");
         env.Remove("CLAUDE_CODE_SESSION_ID");
         env.Remove("CLAUDE_ENV_FILE");

--- a/src/Capacitor.Cli.Daemon/Pty/Windows/ConPtyProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Windows/ConPtyProcess.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using Capacitor.Cli.Daemon.Pty;
 using Microsoft.Win32.SafeHandles;
 using static Capacitor.Cli.Daemon.Pty.Windows.ConPtyInterop;
 
@@ -77,20 +78,24 @@ public sealed class ConPtyProcess : IPtyProcess {
         }
 
         env["TERM"] = "xterm-256color";
-        env.Remove("CLAUDECODE");
-        env.Remove("CLAUDE_CODE_ENTRYPOINT");
-        env.Remove("ANTHROPIC_API_KEY");
-        env.Remove("CLAUDE_CODE_CHILD_SESSION");
-        env.Remove("CLAUDE_CODE_SESSION_ID");
-        env.Remove("CLAUDE_ENV_FILE");
-        env.Remove("ANTHROPIC_API_KEY_CLAUDE_CODE_BACKUP");
+
+        foreach (var key in PtyEnvScrub.ClaudeSessionVars) {
+            env.Remove(key);
+        }
+
+        // Clear any hosted-agent identity/routing the daemon may have inherited (e.g.
+        // it was started from inside a kcap-tracked session) so the spawned agent gets
+        // ONLY what extraEnv sets: hosted launches re-add these below; private local
+        // launches deliberately leave them unset (no mis-tag, native permissions).
+        foreach (var key in PtyEnvScrub.HostedAgentVars) {
+            env.Remove(key);
+        }
+
         // Parity with UnixPtyProcess: never leak daemon supervision state into spawned
-        // children. Auto-restart is out of scope on Windows, but keep the two PTY paths
-        // in lockstep so the scrub doesn't drift.
-        env.Remove("KCAP_DAEMON_SUPERVISED");
-        env.Remove("XPC_SERVICE_NAME");
-        env.Remove("INVOCATION_ID");
-        env.Remove("SYSTEMD_EXEC_PID");
+        // children. Auto-restart is out of scope on Windows.
+        foreach (var key in PtyEnvScrub.DaemonSupervisionVars) {
+            env.Remove(key);
+        }
 
         if (extraEnv is not null) {
             foreach (var (key, value) in extraEnv) {

--- a/test/Capacitor.Cli.Tests.Unit/PtyEnvScrubTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PtyEnvScrubTests.cs
@@ -1,0 +1,38 @@
+using Capacitor.Cli.Daemon.Pty;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class PtyEnvScrubTests {
+    [Test]
+    public async Task Claude_session_vars_are_shared_by_pty_implementations() {
+        await Assert.That(PtyEnvScrub.ClaudeSessionVars).IsEquivalentTo(new[] {
+            "CLAUDECODE",
+            "CLAUDE_CODE_ENTRYPOINT",
+            "ANTHROPIC_API_KEY",
+            "CLAUDE_CODE_CHILD_SESSION",
+            "CLAUDE_CODE_SESSION_ID",
+            "CLAUDE_ENV_FILE",
+            "ANTHROPIC_API_KEY_CLAUDE_CODE_BACKUP"
+        }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Daemon_supervision_vars_are_shared_by_pty_implementations() {
+        await Assert.That(PtyEnvScrub.DaemonSupervisionVars).IsEquivalentTo(new[] {
+            "KCAP_DAEMON_SUPERVISED",
+            "XPC_SERVICE_NAME",
+            "INVOCATION_ID",
+            "SYSTEMD_EXEC_PID"
+        }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Hosted_agent_vars_are_shared_by_pty_implementations() {
+        await Assert.That(PtyEnvScrub.HostedAgentVars).IsEquivalentTo(new[] {
+            "KCAP_AGENT_ID",
+            "KCAP_RENDERED_AGENT",
+            "KCAP_DAEMON_URL"
+        }, CollectionOrdering.Matching);
+    }
+}


### PR DESCRIPTION
## Problem

A hosted agent's web **Chat tab shows nothing** ("Waiting for conversation data...") while the agent is demonstrably alive — the Terminal tab / local PTY carries a full conversation. Reported against production (kurrent tenant) and reproduced locally end-to-end.

## Root cause

When the daemon is started **from inside a Claude Code session** (e.g. `kcap agent start` or `kcap setup` run in a Claude conversation), it inherits that session's identity env vars and passes them into every hosted agent it spawns. The PTY scrub removes `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, and `ANTHROPIC_API_KEY` — but not `CLAUDE_CODE_CHILD_SESSION` / `CLAUDE_CODE_SESSION_ID`.

The spawned interactive claude sees `CLAUDE_CODE_CHILD_SESSION=1` and behaves as a child session: it runs, chats on the PTY, and even fires its SessionStart hook (session links, transcript path is declared in the hook payload) — **but never writes its transcript `.jsonl`**. `kcap watch` connects, tails the declared path, and waits forever. No transcript events → no chat sections → the web chat is empty for the session's whole life.

## Evidence (A/B differential, same daemon build, same repo, same prompt)

| Daemon env | Transcript on disk | Web chat |
|---|---|---|
| inherited from an outer Claude Code session | **never created** (answer text found in no file on disk) | "Waiting for conversation data..." forever |
| identical, with `CLAUDE_CODE_CHILD_SESSION` / `CLAUDE_CODE_SESSION_ID` (+2 related) removed | written, watcher streams (`Sent 13 line(s) via SignalR`) | renders fully (prompt, answer, token chips) |

The exact single-var culprit was not isolated (the differential scrubbed the set); `CLAUDE_CODE_CHILD_SESSION` is the prime suspect. The fix scrubs the whole inherited-session surface regardless.

## Fix

Add to the spawn-env scrub in **both** PTY paths (`ConPtyProcess.BuildEnvironmentBlock`, `UnixPtyProcess.Spawn` child branch), kept in lockstep per the existing parity convention:

- `CLAUDE_CODE_CHILD_SESSION` — the child-session marker that suppresses transcript writing
- `CLAUDE_CODE_SESSION_ID` — the *outer* session's id; meaningless (at best) and misattributing (at worst) inside the hosted agent
- `CLAUDE_ENV_FILE` — points at the outer session's env file
- `ANTHROPIC_API_KEY_CLAUDE_CODE_BACKUP` — credential stashed by the outer Claude for its own children; should never reach a hosted agent

## Testing

- `dotnet build` clean; full unit suite passes (2305/2305).
- No unit test added: both scrub sites are inside P/Invoke spawn paths (private static env-block builder; post-`forkpty` child branch) with no seam to assert through. Happy to extract a shared scrub-list constant + test if reviewers prefer — it would also mechanically enforce the "keep the two PTY paths in lockstep" comment.
- ⚠️ `dotnet publish -c Release` (AOT IL-warning check) could not run on the authoring machine (MSVC toolchain missing) — needs CI confirmation. The change is `Dictionary.Remove`/`unsetenv` calls only, matching existing patterns.

## Notes for reviewers

- `CLAUDE_EFFORT` and `AI_AGENT` also leak but were left alone: effort is already governed by the explicit `--effort` launch arg, and scrubbing them felt like scope creep. Opinions welcome.
- Related but separate issues found in the same investigation (not addressed here): an expired kcap token 401s the session-start hook and permanently unlinks the hosted agent's session (server-side, no fallback path — the chat then shows "Waiting for session to start..."); and the server could surface "watcher connected but zero transcript lines" instead of an eternal spinner. Server-side follow-ups tracked in kcap-server.
- No GitHub/Linear issue exists yet for this; the problem statement above is self-contained. Can file one if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)