### PR TITLE
[AI-1219] Drop async from SessionStart hook so injected context reaches the model

### DIFF
--- a/kcap/hooks/hooks.json
+++ b/kcap/hooks/hooks.json
@@ -7,8 +7,7 @@
           {
             "type": "command",
             "command": "kcap hook --claude",
-            "timeout": 5,
-            "async": true
+            "timeout": 5
           }
         ]
       },


### PR DESCRIPTION
## Problem

The shipped SessionStart hook `kcap hook --claude` is marked `async: true`. Async SessionStart hooks are fire-and-forget — Claude Code does **not** parse their stdout for `hookSpecificOutput.additionalContext`, so everything the hook tries to inject at session start is silently dropped:

- the SessionStart guideline / eval-facts injection ("Prompted + top-weighted uncurated"), and
- the Phase 2 (AI-1165) `## Team memory` index.

Session **recording** still works (the background POST fires), so the breakage is invisible — capture looks fine, only injection is lost. Confirmed live: a synchronous SessionStart hook (superpowers) injected context while the async `kcap hook --claude` injected nothing.

## Fix

Remove `"async": true` from the SessionStart entry (keep the tight `timeout: 5`) so the hook runs synchronously and its `additionalContext` is injected. Worst case it blocks startup ≤5s; the CLI already fetches in parallel and is fail-open/budget-bounded.

`SubagentStart` / `SubagentStop` keep `async: true` — they only record and never inject, so non-blocking is correct there.

```diff
             "command": "kcap hook --claude",
-            "timeout": 5,
-            "async": true
+            "timeout": 5
```

## Impact

Affects every user on the current plugin (npm `@kurrent/kcap` v0.9.4). After this merges, bump the CLI / plugin version and republish so SessionStart injection reaches sessions again.

Fixes AI-1219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)