### PR TITLE
Make kcap update work on Windows while sessions and the daemon are running

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,15 @@ kcap logout         # delete stored tokens
 > and tells you what to run instead for non-npm installs (e.g. Homebrew). Use
 > `kcap update --check` for a machine-readable `{current, latest, newer}` probe.
 >
+> **Windows:** the update works even while Claude Code sessions (whose kcap MCP
+> servers keep the binary locked) or the daemon are running — the old executable
+> is moved aside so npm can replace it, and the leftover is cleaned up
+> automatically later. Running processes keep the old version until they
+> restart; a running daemon reports this and applies the new version on
+> `kcap daemon restart`. A plain `npm install -g` / `npm update -g` does **not**
+> do this and fails with `EBUSY` while any kcap process is running — prefer
+> `kcap update`.
+>
 > **Beta channel (opt-in):** `kcap update --beta` switches the active profile to
 > the beta release channel (npm dist-tag `beta`) and updates to the latest beta
 > immediately. The choice is **persisted per profile**, so subsequent `kcap

--- a/npm/kcap/bin/kcap.js
+++ b/npm/kcap/bin/kcap.js
@@ -48,6 +48,144 @@ function probeArgs(updArgs) {
   return ["update", "--check", "--no-update-check", ...channelFlags];
 }
 
+// ── Windows binary-lock handling ────────────────────────────────────────────
+//
+// Windows locks an executing image against overwrite/delete for the process
+// lifetime, and kcap has long-lived native processes: MCP servers (four per
+// open Claude Code session) and the daemon. A plain `npm install -g` therefore
+// dies with EBUSY whenever any agent session is open. But Windows DOES allow
+// renaming/moving a running image within a volume — so `kcap update` moves the
+// exes into a trash directory first (rename-aside), lets npm lay down fresh
+// files at the real path, and sweeps the trash on later launcher runs once the
+// old processes have exited. Running processes keep executing the moved image
+// untouched and pick up the new binary on their next start.
+
+const TRASH_DIR_NAME = ".kcap-trash";
+
+// Trash lives next to node_modules (e.g. %APPDATA%\npm\.kcap-trash): renaming
+// a running image requires the destination to be on the same volume, and a
+// sibling of the install tree guarantees that.
+function trashDirFor(globalRoot) {
+  return path.join(globalRoot, "..", TRASH_DIR_NAME);
+}
+
+// Trash dir as seen from this launcher file, without shelling out to
+// `npm root -g` (too slow for the hook hot path). Returns null when the
+// launcher isn't laid out as a node_modules install.
+function trashDirFromLauncher(launcherDir) {
+  // <root>\node_modules\@kurrent\kcap\bin → <root>\.kcap-trash
+  const nodeModules = path.resolve(launcherDir, "..", "..", "..");
+  if (path.basename(nodeModules) !== "node_modules") return null;
+  return path.join(path.dirname(nodeModules), TRASH_DIR_NAME);
+}
+
+// Best-effort reclaim of exes parked by earlier updates. Deleting a file whose
+// process is still running fails; it just stays for a later sweep.
+function sweepTrash(trashDir) {
+  if (!trashDir) return;
+  let entries;
+  try { entries = fs.readdirSync(trashDir); } catch { return; }
+  for (const f of entries) {
+    try { fs.unlinkSync(path.join(trashDir, f)); } catch {}
+  }
+}
+
+// Move the native exes out of the install tree so npm can replace them.
+// Returns the performed moves so a failed install can restore them. Throws if
+// even a rename is refused (something holds the file exclusively) — after
+// first undoing any move it already made, so a partial failure never leaves
+// the install half-emptied.
+function renameAsideBinaries(binDir, trashDir) {
+  const moved = [];
+  for (const name of ["kcap.exe", "kcap-daemon.exe"]) {
+    const src = path.join(binDir, name);
+    if (!fs.existsSync(src)) continue;
+    try {
+      fs.mkdirSync(trashDir, { recursive: true });
+      const dest = path.join(trashDir, `${name}.${process.pid}.${Date.now()}`);
+      fs.renameSync(src, dest);
+      moved.push({ from: src, to: dest });
+    } catch (e) {
+      restoreMoved(moved);
+      throw e;
+    }
+  }
+  return moved;
+}
+
+// Undo rename-aside after a failed install, so the user isn't left without a
+// binary. Skips any path npm already managed to replace.
+function restoreMoved(moved) {
+  for (const m of moved) {
+    try {
+      if (!fs.existsSync(m.from)) fs.renameSync(m.to, m.from);
+    } catch {}
+  }
+}
+
+// Pure helper (unit-tested): shape a Win32_Process JSON payload into the kcap
+// processes running from the given install root. ConvertTo-Json unwraps
+// single-element arrays, so `parsed` may be a bare object.
+function filterKcapProcesses(parsed, installRoot) {
+  const list = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
+  const root = installRoot.toLowerCase();
+  return list
+    .filter((p) => p && typeof p.ExecutablePath === "string"
+      && p.ExecutablePath.toLowerCase().startsWith(root))
+    .map((p) => ({
+      pid: p.ProcessId,
+      name: path.basename(p.ExecutablePath),
+      role: describeRole(p.CommandLine || p.ExecutablePath || ""),
+    }));
+}
+
+// Pure helper (unit-tested): human label for what a kcap process is, from its
+// command line. MCP servers are the common locker — one per MCP entry in the
+// kcap Claude Code plugin, so four per open session.
+function describeRole(commandLine) {
+  if (/kcap-daemon/i.test(commandLine)) return "daemon";
+  if (/\bmcp\b/i.test(commandLine)) return "MCP server — open Claude Code/agent session";
+  if (/\bdaemon\b/i.test(commandLine)) return "daemon";
+  return "kcap process";
+}
+
+// Enumerate running kcap processes under the install tree (Windows only).
+// Returns null when enumeration itself fails, so callers can degrade to a
+// generic message.
+function listKcapProcesses(installRoot) {
+  try {
+    const script =
+      "Get-CimInstance Win32_Process -Filter \"Name='kcap.exe' OR Name='kcap-daemon.exe'\" | " +
+      "Select-Object ProcessId,ExecutablePath,CommandLine | ConvertTo-Json -Compress";
+    const out = execFileSync("powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command", script],
+      { encoding: "utf8", windowsHide: true });
+    return filterKcapProcesses(out.trim() ? JSON.parse(out) : [], installRoot);
+  } catch {
+    return null;
+  }
+}
+
+// Actionable diagnosis for a locked binary: name the processes holding it and
+// say what to do, instead of leaving the user with npm's raw EBUSY. With
+// `onlyIfFound` (the npm-failure path, where the cause may be unrelated —
+// network, registry) it stays silent unless lockers are actually found.
+function printLockedBinaryHelp(globalRoot, onlyIfFound = false) {
+  const procs = listKcapProcesses(path.join(globalRoot, "@kurrent"));
+  if (procs && procs.length) {
+    console.error("The kcap binary is locked by running kcap processes:");
+    for (const p of procs) {
+      console.error(`  PID ${String(p.pid).padEnd(6)} ${p.name}  (${p.role})`);
+    }
+    console.error("MCP servers belong to open Claude Code / agent sessions. Close those");
+    console.error("sessions (and stop the daemon, if running), then re-run `kcap update`.");
+  } else if (!onlyIfFound) {
+    console.error("The kcap binary appears to be locked by a running process (open");
+    console.error("Claude Code sessions run kcap MCP servers; the daemon also counts).");
+    console.error("Close agent sessions and stop the daemon, then re-run `kcap update`.");
+  }
+}
+
 // Everything below actually DOES something (resolves the binary, execs it,
 // runs the update flow), so it's guarded to only run when this file is
 // executed directly — not when `require()`d (e.g. by the test).
@@ -87,11 +225,18 @@ if (require.main === module) {
     try { fs.chmodSync(binaryPath, 0o755); } catch {}
   }
 
+  // Reclaim exes parked by a previous rename-aside update, now that their
+  // processes may have exited. Cheap when there's nothing to do (one stat).
+  if (process.platform === "win32") {
+    sweepTrash(trashDirFromLauncher(__dirname));
+  }
+
   // `kcap update` for npm-global installs is driven HERE, in the Node launcher,
   // not by the native binary. The OS locks an executable image for the whole
-  // process lifetime but a script only during load — so by driving the upgrade
-  // from this script (with the native binary not running) npm can overwrite the
-  // binary even on Windows, with no temp-file/rename/detached-helper dance.
+  // process lifetime but a script only during load — so with the short-lived
+  // probe exited, npm can overwrite the binary in place on macOS/Linux; on
+  // Windows the long-lived MCP/daemon processes are handled by rename-aside
+  // (see the binary-lock section above).
   // `--check` (JSON probe) and `--help` fall through to the native binary.
   {
     const updArgs   = process.argv.slice(3);
@@ -174,23 +319,16 @@ function runUpdate(binaryPath, updArgs) {
     // Couldn't determine — fall through and let npm decide (it's idempotent).
   }
 
-  // Windows preflight: a running kcap-daemon.exe locks the binary, so `npm install`
-  // would FAIL to overwrite it. Detect a running daemon and abort with instructions
-  // BEFORE attempting the (doomed) install. macOS/Linux can replace the file in place,
-  // so this guard is Windows-only.
-  if (process.platform === "win32") {
-    try {
-      const status = execFileSync(binaryPath, ["daemon", "status"], { encoding: "utf8" });
-      if (/running \(PID/i.test(status)) {
-        console.error("A kcap daemon is running and locks the binary, so the update can't");
-        console.error("replace it. Stop it first, then re-run `kcap update`:");
-        console.error("  kcap daemon service stop   (if installed as a service)");
-        console.error("  kcap daemon stop           (otherwise)");
-        process.exit(1);
-      }
-    } catch {
-      // status probe failed (no daemon / old binary) — fall through to the normal install.
-    }
+  // Detect a running daemon up front (short-lived child; it exits before npm
+  // runs). Used only for the post-update notice — the update itself no longer
+  // needs the daemon stopped on any platform. `--no-update-check` keeps this
+  // child's "update available" nudge from landing mid-update.
+  let daemonRunning = false;
+  try {
+    const status = execFileSync(binaryPath, ["daemon", "status", "--no-update-check"], { encoding: "utf8" });
+    daemonRunning = /running \(PID/i.test(status);
+  } catch {
+    // status probe failed (no daemon / old binary) — treat as not running.
   }
 
   // Fail clearly instead of half-installing under a root-owned prefix.
@@ -203,13 +341,31 @@ function runUpdate(binaryPath, updArgs) {
     process.exit(1);
   }
 
+  // Windows: move the (possibly executing) exes out of npm's way. See the
+  // binary-lock section above for why rename works when overwrite doesn't.
+  let moved = [];
+  if (process.platform === "win32") {
+    try {
+      moved = renameAsideBinaries(path.dirname(binaryPath), trashDirFor(globalRoot));
+    } catch (e) {
+      // Even a rename was refused — something holds the file exclusively
+      // (AV scan, exclusive open). renameAsideBinaries already rolled back its
+      // partial moves; diagnose instead of letting npm EBUSY.
+      console.error(`Could not move the current kcap binary aside: ${e.message}`);
+      printLockedBinaryHelp(globalRoot);
+      process.exit(1);
+    }
+  }
+
   const res = spawnSync("npm", ["install", "-g", resolveInstallSpec(info)], {
     stdio: "inherit",
     windowsHide: true,
     ...npmOpts,
   });
   if (res.status !== 0) {
+    restoreMoved(moved);
     console.error("npm install failed; kcap was not updated.");
+    if (process.platform === "win32") printLockedBinaryHelp(globalRoot, /* onlyIfFound */ true);
     process.exit(res.status == null ? 1 : res.status);
   }
 
@@ -219,23 +375,29 @@ function runUpdate(binaryPath, updArgs) {
   require("./refresh").runRefreshes(fs.realpathSync(__filename));
   console.log("kcap updated.");
 
-  // macOS/Linux: a running daemon self-detects the new binary and restarts when idle.
-  // Just inform the user (best-effort; never fail the update for this). On Windows the
-  // doomed install was already aborted by the preflight above, so this only runs on Unix.
-  if (process.platform !== "win32") {
-    try {
-      const status = execFileSync(binaryPath, ["daemon", "status"], { encoding: "utf8" });
-      if (/running \(PID/i.test(status)) {
-        console.log("A kcap daemon is running; it will restart automatically when idle to");
-        console.log("pick up the new version. Check with `kcap daemon status`, or apply now");
-        console.log("with `kcap daemon restart --force`.");
-      }
-    } catch {
-      // best-effort notice only
+  // A running daemon keeps executing the old image until restarted. On
+  // macOS/Linux it self-detects the new binary and restarts when idle; on
+  // Windows self-detection is off (the running image was moved, not replaced),
+  // so the user applies it explicitly.
+  if (daemonRunning) {
+    if (process.platform === "win32") {
+      console.log("A kcap daemon is running and still uses the old version. Apply the");
+      console.log("update with `kcap daemon restart` (add --force if agents are running).");
+    } else {
+      console.log("A kcap daemon is running; it will restart automatically when idle to");
+      console.log("pick up the new version. Check with `kcap daemon status`, or apply now");
+      console.log("with `kcap daemon restart --force`.");
     }
   }
 
   process.exit(0);
 }
 
-module.exports = { resolveInstallSpec, probeArgs };
+module.exports = {
+  resolveInstallSpec,
+  probeArgs,
+  trashDirFor,
+  trashDirFromLauncher,
+  filterKcapProcesses,
+  describeRole,
+};

--- a/npm/kcap/bin/kcap.js
+++ b/npm/kcap/bin/kcap.js
@@ -116,11 +116,24 @@ function renameAsideBinaries(binDir, trashDir) {
 // Undo rename-aside after a failed install, so the user isn't left without a
 // binary. Skips any path npm already managed to replace.
 function restoreMoved(moved) {
+  const failures = [];
   for (const m of moved) {
     try {
       if (!fs.existsSync(m.from)) fs.renameSync(m.to, m.from);
-    } catch {}
+    } catch (e) {
+      failures.push({ ...m, error: e });
+    }
   }
+
+  if (failures.length) {
+    console.error("Could not restore one or more kcap binaries after a failed update:");
+    for (const f of failures) {
+      console.error(`  ${f.to} -> ${f.from}: ${f.error.message}`);
+    }
+    console.error("You may need to move the files back manually from the .kcap-trash directory.");
+  }
+
+  return failures;
 }
 
 // Pure helper (unit-tested): shape a Win32_Process JSON payload into the kcap
@@ -277,10 +290,12 @@ function runUpdate(binaryPath, updArgs) {
     globalRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf8", ...npmOpts }).trim();
   } catch {}
 
+  let realGlobalRoot = null;
   let isGlobalNpm = false;
   try {
     if (globalRoot) {
-      const root = fs.realpathSync(globalRoot) + path.sep;
+      realGlobalRoot = fs.realpathSync(globalRoot);
+      const root = realGlobalRoot + path.sep;
       isGlobalNpm = fs.realpathSync(__filename).startsWith(root);
     }
   } catch {}
@@ -333,7 +348,7 @@ function runUpdate(binaryPath, updArgs) {
 
   // Fail clearly instead of half-installing under a root-owned prefix.
   try {
-    fs.accessSync(globalRoot, fs.constants.W_OK);
+    fs.accessSync(realGlobalRoot, fs.constants.W_OK);
   } catch {
     console.error(`Cannot write to the global npm directory (${globalRoot}).`);
     console.error("Re-run with the permissions you installed kcap with, or reinstall");
@@ -346,13 +361,13 @@ function runUpdate(binaryPath, updArgs) {
   let moved = [];
   if (process.platform === "win32") {
     try {
-      moved = renameAsideBinaries(path.dirname(binaryPath), trashDirFor(globalRoot));
+      moved = renameAsideBinaries(path.dirname(binaryPath), trashDirFor(realGlobalRoot));
     } catch (e) {
       // Even a rename was refused — something holds the file exclusively
       // (AV scan, exclusive open). renameAsideBinaries already rolled back its
       // partial moves; diagnose instead of letting npm EBUSY.
       console.error(`Could not move the current kcap binary aside: ${e.message}`);
-      printLockedBinaryHelp(globalRoot);
+      printLockedBinaryHelp(realGlobalRoot);
       process.exit(1);
     }
   }
@@ -365,7 +380,7 @@ function runUpdate(binaryPath, updArgs) {
   if (res.status !== 0) {
     restoreMoved(moved);
     console.error("npm install failed; kcap was not updated.");
-    if (process.platform === "win32") printLockedBinaryHelp(globalRoot, /* onlyIfFound */ true);
+    if (process.platform === "win32") printLockedBinaryHelp(realGlobalRoot, /* onlyIfFound */ true);
     process.exit(res.status == null ? 1 : res.status);
   }
 
@@ -400,4 +415,5 @@ module.exports = {
   trashDirFromLauncher,
   filterKcapProcesses,
   describeRole,
+  restoreMoved,
 };

--- a/npm/kcap/bin/kcap.test.js
+++ b/npm/kcap/bin/kcap.test.js
@@ -1,5 +1,13 @@
 const assert = require("node:assert");
-const { resolveInstallSpec, probeArgs } = require("./kcap.js");
+const path = require("node:path");
+const {
+  resolveInstallSpec,
+  probeArgs,
+  trashDirFor,
+  trashDirFromLauncher,
+  filterKcapProcesses,
+  describeRole,
+} = require("./kcap.js");
 
 assert.strictEqual(resolveInstallSpec({ install_tag: "beta" }), "@kurrent/kcap@beta");
 assert.strictEqual(resolveInstallSpec({ install_tag: "latest" }), "@kurrent/kcap@latest");
@@ -12,5 +20,49 @@ assert.deepStrictEqual(probeArgs(["--beta"]), ["update", "--check", "--no-update
 assert.deepStrictEqual(probeArgs(["--stable"]), ["update", "--check", "--no-update-check", "--stable"]);
 assert.deepStrictEqual(probeArgs(["--foo", "--beta", "-x"]), ["update", "--check", "--no-update-check", "--beta"]); // only channel flags forwarded
 assert.deepStrictEqual(probeArgs(undefined), ["update", "--check", "--no-update-check"]); // defensive
+
+// trashDirFor: sibling of node_modules (same volume as the install tree).
+assert.strictEqual(
+  trashDirFor(path.join("C:", "npm", "node_modules")),
+  path.join("C:", "npm", ".kcap-trash"),
+);
+
+// trashDirFromLauncher: derives the same dir from the launcher's location…
+assert.strictEqual(
+  trashDirFromLauncher(path.join("C:", "npm", "node_modules", "@kurrent", "kcap", "bin")),
+  path.join("C:", "npm", ".kcap-trash"),
+);
+// …and refuses non-node_modules layouts (dev checkout, packed tarball).
+assert.strictEqual(trashDirFromLauncher(path.join("C:", "git", "kcap", "npm", "kcap", "bin")), null);
+
+// filterKcapProcesses: keeps only processes under the install root
+// (case-insensitive), tolerates a bare object (ConvertTo-Json unwraps
+// single-element arrays), null entries, and missing ExecutablePath.
+const installRoot = "C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@kurrent";
+const exePath = `${installRoot}\\kcap\\node_modules\\@kurrent\\kcap-win-x64\\bin\\kcap.exe`;
+assert.deepStrictEqual(
+  filterKcapProcesses(
+    [
+      { ProcessId: 11, ExecutablePath: exePath.toUpperCase(), CommandLine: `"${exePath}" mcp sessions` },
+      { ProcessId: 22, ExecutablePath: "C:\\other\\kcap.exe", CommandLine: "kcap.exe mcp review" }, // foreign install
+      { ProcessId: 33 },       // no path (access denied)
+      null,                    // defensive
+    ],
+    installRoot,
+  ),
+  [{ pid: 11, name: "KCAP.EXE", role: "MCP server — open Claude Code/agent session" }],
+);
+assert.deepStrictEqual(
+  filterKcapProcesses({ ProcessId: 7, ExecutablePath: exePath, CommandLine: `"${exePath}" hook --claude` }, installRoot),
+  [{ pid: 7, name: "kcap.exe", role: "kcap process" }],
+);
+assert.deepStrictEqual(filterKcapProcesses(null, installRoot), []);
+
+// describeRole: daemon beats mcp (the daemon exe name matches first), mcp
+// detected as a word, everything else generic.
+assert.strictEqual(describeRole("C:\\x\\kcap-daemon.exe run --name main"), "daemon");
+assert.strictEqual(describeRole("kcap.exe daemon status"), "daemon");
+assert.strictEqual(describeRole("kcap.exe mcp memory"), "MCP server — open Claude Code/agent session");
+assert.strictEqual(describeRole("kcap.exe watch"), "kcap process");
 
 console.log("ok");

--- a/npm/kcap/bin/kcap.test.js
+++ b/npm/kcap/bin/kcap.test.js
@@ -1,4 +1,6 @@
 const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const {
   resolveInstallSpec,
@@ -7,6 +9,7 @@ const {
   trashDirFromLauncher,
   filterKcapProcesses,
   describeRole,
+  restoreMoved,
 } = require("./kcap.js");
 
 assert.strictEqual(resolveInstallSpec({ install_tag: "beta" }), "@kurrent/kcap@beta");
@@ -64,5 +67,37 @@ assert.strictEqual(describeRole("C:\\x\\kcap-daemon.exe run --name main"), "daem
 assert.strictEqual(describeRole("kcap.exe daemon status"), "daemon");
 assert.strictEqual(describeRole("kcap.exe mcp memory"), "MCP server — open Claude Code/agent session");
 assert.strictEqual(describeRole("kcap.exe watch"), "kcap process");
+
+// restoreMoved: successful restores are reported as no failures; restore
+// failures are surfaced so users can recover files left in trash manually.
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kcap-restore-test-"));
+  try {
+    const from = path.join(dir, "bin", "kcap.exe");
+    const to = path.join(dir, ".kcap-trash", "kcap.exe.1");
+    fs.mkdirSync(path.dirname(from), { recursive: true });
+    fs.mkdirSync(path.dirname(to), { recursive: true });
+    fs.writeFileSync(to, "exe");
+
+    assert.deepStrictEqual(restoreMoved([{ from, to }]), []);
+    assert.strictEqual(fs.readFileSync(from, "utf8"), "exe");
+    assert.strictEqual(fs.existsSync(to), false);
+
+    const missing = path.join(dir, ".kcap-trash", "missing.exe");
+    const errors = [];
+    const originalError = console.error;
+    console.error = (message) => errors.push(String(message));
+    try {
+      const failures = restoreMoved([{ from: path.join(dir, "bin", "missing.exe"), to: missing }]);
+      assert.strictEqual(failures.length, 1);
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.some((m) => m.includes("Could not restore one or more kcap binaries")));
+    assert(errors.some((m) => m.includes(".kcap-trash")));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 console.log("ok");

--- a/src/Capacitor.Cli.Core/Resources/help-update.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-update.txt
@@ -9,6 +9,11 @@ Claude plugin). This works even when your package manager blocks install
 scripts. Exits early if already up to date. For non-npm installs (e.g.
 Homebrew), prints the command to run instead.
 
+On Windows the update also works while agent sessions or the daemon keep
+the binary locked: the old executable is moved aside and cleaned up later.
+Running processes keep the old version until they restart (for a running
+daemon: kcap daemon restart).
+
 Options:
   --check    Print a machine-readable {current, latest, newer} JSON line
              and exit without upgrading.

--- a/src/Capacitor.Cli/Commands/UpdateCommand.cs
+++ b/src/Capacitor.Cli/Commands/UpdateCommand.cs
@@ -16,6 +16,12 @@ public static class UpdateCommand {
     static readonly string[] KnownChannels = ["latest", "beta"];
 
     /// <summary>
+    /// Version-transition arrow. ASCII on Windows: legacy console codepages
+    /// (cp437/cp850) can't encode `→` and render it as `␦`/`?`.
+    /// </summary>
+    static readonly string Arrow = OperatingSystem.IsWindows() ? "->" : "→";
+
+    /// <summary>
     /// Resolves the effective update channel (npm dist-tag): an explicit
     /// <c>--beta</c>/<c>--stable</c> flag wins, otherwise the configured channel
     /// is used. The result is validated against <see cref="KnownChannels"/> and
@@ -109,7 +115,7 @@ public static class UpdateCommand {
         // Reached only when the native binary is run WITHOUT the npm launcher
         // (e.g. invoking the platform binary directly). For npm-global installs
         // the launcher intercepts `update` and performs the upgrade itself.
-        await Console.Out.WriteLineAsync($"Update available: {current} → {latest}");
+        await Console.Out.WriteLineAsync($"Update available: {current} {Arrow} {latest}");
         await Console.Out.WriteLineAsync();
         await Console.Out.WriteLineAsync("Run `kcap update` to update, or upgrade directly:");
         await Console.Out.WriteLineAsync("  npm install -g @kurrent/kcap@latest");
@@ -130,7 +136,7 @@ public static class UpdateCommand {
 
             if (latest is not null && current is not null && IsNewer(latest, current)) {
                 await Console.Error.WriteLineAsync();
-                await Console.Error.WriteLineAsync($"Update available: {current} → {latest}");
+                await Console.Error.WriteLineAsync($"Update available: {current} {Arrow} {latest}");
                 await Console.Error.WriteLineAsync("Run `kcap update` to update");
             }
         } catch {

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -50,7 +50,9 @@ var baseUrl = await AppConfig.ResolveServerUrl(args, gitTimeoutMs: isHook ? 1000
 // Skipped for `uninstall` — the check writes ~/.config/kcap/update-check-{channel}.json
 // (e.g. update-check-latest.json), which would race with uninstall's `rm -rf`
 // of the config dir and recreate it after the command has reported success.
-var   noUpdateCheck   = args.Contains("--no-update-check") || command == "uninstall";
+// Skipped for `update` — nudging "run `kcap update`" from inside `kcap update`
+// is noise at best and lands mid-upgrade at worst.
+var   noUpdateCheck   = args.Contains("--no-update-check") || command is "uninstall" or "update";
 Task? updateCheckTask = null;
 
 if (!noUpdateCheck) {


### PR DESCRIPTION
## What & why

On Windows, `kcap update` (and plain `npm install/update -g`) died with npm's raw `EBUSY`: Windows locks an executing image against overwrite/delete, and kcap has long-lived native processes — the Claude Code plugin runs **four MCP servers per open session** (`kcap mcp review/sessions/flows/memory`), plus the daemon. Since a kcap user essentially always has an agent session open, the binary was effectively always locked (the reporting machine had 20 running `kcap.exe` processes). The launcher's existing Windows preflight only checked the *daemon*, so it happily proceeded into the doomed install.

Windows **does** allow renaming a running image, so the launcher now uses the standard self-update pattern (rustup/VS Code): move the exes aside, install, clean up later.

Closes #279
AI-1223

## What's in it

**Launcher (`npm/kcap/bin/kcap.js`)**
- **Rename-aside update (Windows)**: before `npm install`, move `kcap.exe`/`kcap-daemon.exe` into `%APPDATA%\npm\.kcap-trash` (sibling of `node_modules` ⇒ same volume, which rename of a running image requires). npm lays down fresh files; running processes keep executing the moved image and pick up the new binary on their next start. A failed install **restores the moves** (including on partial rename failure), so the user is never left without a binary.
- **Trash sweep**: every launcher run best-effort deletes parked exes once their processes have exited (no `npm root -g` spawn — the trash path is derived from the launcher's own location, so the hook hot path stays cheap).
- **Daemon preflight no longer aborts**: it only drives a post-update notice — Windows: "still uses the old version, run `kcap daemon restart`"; Unix keeps the existing restart-when-idle message.
- **Actionable lock diagnosis**: if even a rename is refused, or npm still fails with lockers present, enumerate the locking kcap processes via `Get-CimInstance` and print PID + role (e.g. "MCP server — open Claude Code/agent session") instead of raw EBUSY. On npm failure the diagnosis only prints when lockers are actually found (npm can fail for unrelated reasons).

**Native CLI**
- The preflight `daemon status` child gets `--no-update-check`, and `kcap update` suppresses its own background nudge (`Program.cs`) — this is what caused the stray "Update available" line printing *mid-update*.
- Version arrow prints as ASCII `->` on Windows: legacy console codepages render `→` as `␦` (`Update available: 0.9.2 ␦ 0.9.5`).

**Docs**: README `kcap update` section + `help-update.txt` document the Windows behavior and warn that plain `npm install -g` still EBUSYs while kcap processes run.

## Testing

- Launcher unit tests extended (`kcap.test.js`): trash-dir derivation (incl. refusing non-`node_modules` layouts), `filterKcapProcesses` (case-insensitivity, bare-object `ConvertTo-Json` payloads, foreign installs, missing paths), role labeling.
- All 2401 .NET unit tests pass; ILC compilation clean of IL3050/IL2026 AOT warnings.
- **Live validation on an affected Windows machine**: renamed the actual locked, executing `kcap.exe` aside and back with running MCP/daemon processes — rename succeeded, processes unaffected, restored binary runs; process enumeration correctly identified and labeled the running daemon.

## Notes for review

- Daemon self-detection of new binaries stays disabled on Windows (`RestartCoordinator.StatProcessBinary`): after rename-aside the running daemon's image was *moved*, not replaced, so the post-update notice + explicit `kcap daemon restart` is the Windows path. Enabling idle self-restart on Windows is a possible follow-up.
- There is a small window during the install where `bin\kcap.exe` doesn't exist; a hook firing in it fails best-effort. That replaces the previous behavior of the whole update failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)