### PR TITLE
[AI-1233] MCP server cross-harness readiness: protocol interop + repo-scope fail-closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ It provides four tools:
 - **`get_session_transcript`** — speaker-tagged events from a session. Pair `around_event` (and `agent_id` if the hit was in a subagent) with the values returned by `search_sessions` to fetch the exact decision context.
 - **`get_turn`** — the full event transcript for one turn (user prompt, tool calls + results, assistant text) by `session_id` + `turn_index`. A turn is one user message and the assistant's full response up to the next user message.
 
-The server is repo-aware — it resolves the current working directory to a repo hash at startup, and `search_sessions` defaults its `repo` filter to that hash unless you override it.
+The server is repo-aware — it resolves the current working directory to a repo hash at startup, and `search_sessions` defaults its `repo` filter to that hash unless you override it. **If the current repo can't be resolved** (run outside a git checkout, or a missing/unparseable `origin` remote), `search_sessions` returns an error asking you to pass `repo: "owner/name"` or `repo: "all"` — it will not silently search across all repos.
 
 ### Flows MCP server (for agents)
 

--- a/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
@@ -131,10 +131,11 @@ static class McpFlowResultServer {
                 if (id is null) continue;
 
                 var response = method switch {
-                    "initialize" => BuildInitializeResponse(id),
+                    "initialize" => BuildInitializeResponse(id, request),
                     "tools/list" => BuildToolsListResponse(id, tools),
                     "tools/call" => await DispatchToolCallAsync(id, request),
-                    _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
+                    _            => McpProtocol.TryHandleStandardMethod(method, id)
+                                    ?? BuildErrorResponse(id, -32601, $"Method not found: {method}")
                 };
 
                 await writer.WriteLineAsync(response);
@@ -305,10 +306,10 @@ static class McpFlowResultServer {
         return await send(client);
     }
 
-    static string BuildInitializeResponse(JsonNode id) =>
+    static string BuildInitializeResponse(JsonNode id, JsonObject request) =>
         ToResponse<McpInitResult>(
             id,
-            new("2024-11-05", new(new()), new("kcap-flow-result", "1.0.0")),
+            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-flow-result", "1.0.0")),
             McpJsonContext.Default.McpInitResult
         );
 

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -93,10 +93,11 @@ static class McpFlowsServer {
                 if (id is null) continue;
 
                 var response = method switch {
-                    "initialize" => BuildInitializeResponse(id),
+                    "initialize" => BuildInitializeResponse(id, request),
                     "tools/list" => BuildToolsListResponse(id, tools),
                     "tools/call" => await DispatchToolCallAsync(id, request),
-                    _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
+                    _            => McpProtocol.TryHandleStandardMethod(method, id)
+                                    ?? BuildErrorResponse(id, -32601, $"Method not found: {method}")
                 };
 
                 await writer.WriteLineAsync(response);
@@ -733,10 +734,10 @@ static class McpFlowsServer {
             _                                                 => throw new ArgumentException("Invalid argument: async must be a boolean")
         };
 
-    static string BuildInitializeResponse(JsonNode id) =>
+    static string BuildInitializeResponse(JsonNode id, JsonObject request) =>
         ToResponse<McpInitResult>(
             id,
-            new("2024-11-05", new(new()), new("kcap-flows", "1.0.0")),
+            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-flows", "1.0.0")),
             McpJsonContext.Default.McpInitResult
         );
 

--- a/src/Capacitor.Cli/Commands/McpJudgeServer.cs
+++ b/src/Capacitor.Cli/Commands/McpJudgeServer.cs
@@ -42,10 +42,11 @@ static class McpJudgeServer {
             if (id is null) continue;
 
             var response = method switch {
-                "initialize" => BuildInitializeResponse(id),
+                "initialize" => BuildInitializeResponse(id, request),
                 "tools/list" => BuildToolsListResponse(id, tools),
                 "tools/call" => await HandleToolCallAsync(id, request, client, baseUrl, expectedSessionId),
-                _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
+                _            => McpProtocol.TryHandleStandardMethod(method, id)
+                                ?? BuildErrorResponse(id, -32601, $"Method not found: {method}")
             };
 
             await writer.WriteLineAsync(response);
@@ -137,10 +138,10 @@ static class McpJudgeServer {
         }
     }
 
-    static string BuildInitializeResponse(JsonNode id) =>
+    static string BuildInitializeResponse(JsonNode id, JsonObject request) =>
         ToResponse<McpInitResult>(
             id,
-            new("2024-11-05", new(new()), new("kcap-judge", "1.0.0")),
+            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-judge", "1.0.0")),
             McpJsonContext.Default.McpInitResult
         );
 

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -77,10 +77,11 @@ static class McpMemoryServer {
                 if (id is null) continue;
 
                 var response = method switch {
-                    "initialize" => BuildInitializeResponse(id),
+                    "initialize" => BuildInitializeResponse(id, request),
                     "tools/list" => BuildToolsListResponse(id, tools),
                     "tools/call" => await DispatchToolCallAsync(id, request),
-                    _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
+                    _            => McpProtocol.TryHandleStandardMethod(method, id)
+                                    ?? BuildErrorResponse(id, -32601, $"Method not found: {method}")
                 };
 
                 await writer.WriteLineAsync(response);
@@ -113,10 +114,10 @@ static class McpMemoryServer {
         try { return await MachineIdProvider.GetOrCreateAsync(); } catch { return null; }
     }
 
-    static string BuildInitializeResponse(JsonNode id) =>
+    static string BuildInitializeResponse(JsonNode id, JsonObject request) =>
         ToResponse<McpInitResult>(
             id,
-            new("2024-11-05", new(new()), new("kcap-memory", "1.0.0")),
+            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-memory", "1.0.0")),
             McpJsonContext.Default.McpInitResult
         );
 

--- a/src/Capacitor.Cli/Commands/McpProtocol.cs
+++ b/src/Capacitor.Cli/Commands/McpProtocol.cs
@@ -1,0 +1,40 @@
+// src/Capacitor.Cli/Commands/McpProtocol.cs
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// Shared MCP protocol plumbing so every kcap MCP server answers the standard capability
+/// probes (<c>resources/list</c>, <c>prompts/list</c>, <c>ping</c>) and negotiates the
+/// protocol version — instead of returning <c>-32601</c>, which some clients treat as fatal
+/// and drop the server (the likely root of AI-1132). JsonNode DOM only → AOT-safe.
+/// </summary>
+static class McpProtocol {
+    /// The version we advertise when we don't recognise the client's request.
+    const string BaselineVersion = "2024-11-05";
+
+    /// Protocol versions this server is compatible with. We echo the client's requested
+    /// version when it's one of these, so newer clients negotiate up cleanly.
+    static readonly HashSet<string> Supported = ["2024-11-05", "2025-03-26", "2025-06-18"];
+
+    /// <summary>The protocolVersion to advertise: the client's requested version if we
+    /// support it, else our baseline. <paramref name="initializeRequest"/> is the full
+    /// JSON-RPC initialize request object.</summary>
+    public static string NegotiateVersion(JsonObject initializeRequest) {
+        var requested = initializeRequest["params"]?["protocolVersion"]?.GetValue<string>();
+        return requested is not null && Supported.Contains(requested) ? requested : BaselineVersion;
+    }
+
+    /// <summary>Answers the standard capability-probe methods a client may send regardless of
+    /// advertised capabilities. Returns a full JSON-RPC response string, or null if
+    /// <paramref name="method"/> isn't one of them (caller falls back to -32601).</summary>
+    public static string? TryHandleStandardMethod(string method, JsonNode id) => method switch {
+        "resources/list" => Result(id, new JsonObject { ["resources"] = new JsonArray() }),
+        "prompts/list"   => Result(id, new JsonObject { ["prompts"]   = new JsonArray() }),
+        "ping"           => Result(id, new JsonObject()),
+        _                => null
+    };
+
+    static string Result(JsonNode id, JsonObject result) =>
+        new JsonObject { ["jsonrpc"] = "2.0", ["id"] = id.DeepClone(), ["result"] = result }.ToJsonString();
+}

--- a/src/Capacitor.Cli/Commands/McpProtocol.cs
+++ b/src/Capacitor.Cli/Commands/McpProtocol.cs
@@ -28,7 +28,7 @@ static class McpProtocol {
     /// <summary>Answers the standard capability-probe methods a client may send regardless of
     /// advertised capabilities. Returns a full JSON-RPC response string, or null if
     /// <paramref name="method"/> isn't one of them (caller falls back to -32601).</summary>
-    public static string? TryHandleStandardMethod(string method, JsonNode id) => method switch {
+    public static string? TryHandleStandardMethod(string? method, JsonNode id) => method switch {
         "resources/list" => Result(id, new JsonObject { ["resources"] = new JsonArray() }),
         "prompts/list"   => Result(id, new JsonObject { ["prompts"]   = new JsonArray() }),
         "ping"           => Result(id, new JsonObject()),

--- a/src/Capacitor.Cli/Commands/McpProtocol.cs
+++ b/src/Capacitor.Cli/Commands/McpProtocol.cs
@@ -21,7 +21,11 @@ static class McpProtocol {
     /// support it, else our baseline. <paramref name="initializeRequest"/> is the full
     /// JSON-RPC initialize request object.</summary>
     public static string NegotiateVersion(JsonObject initializeRequest) {
-        var requested = initializeRequest["params"]?["protocolVersion"]?.GetValue<string>();
+        // Read params.protocolVersion DEFENSIVELY — a malformed initialize (non-object params, or a
+        // non-string protocolVersion) must fall back to baseline, never throw. The initialize dispatch
+        // arm has no try/catch, so a throw here would kill the stdio server.
+        var requested = (initializeRequest["params"] as JsonObject)?["protocolVersion"] is JsonValue v
+                        && v.TryGetValue(out string? s) ? s : null;
         return requested is not null && Supported.Contains(requested) ? requested : BaselineVersion;
     }
 

--- a/src/Capacitor.Cli/Commands/McpReviewServer.cs
+++ b/src/Capacitor.Cli/Commands/McpReviewServer.cs
@@ -92,10 +92,11 @@ static class McpReviewServer {
                 if (id is null) continue;
 
                 var response = method switch {
-                    "initialize" => BuildInitializeResponse(id),
+                    "initialize" => BuildInitializeResponse(id, request),
                     "tools/list" => BuildToolsListResponse(id, tools),
                     "tools/call" => await DispatchToolCallAsync(id, request),
-                    _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
+                    _            => McpProtocol.TryHandleStandardMethod(method, id)
+                                    ?? BuildErrorResponse(id, -32601, $"Method not found: {method}")
                 };
 
                 await writer.WriteLineAsync(response);
@@ -126,10 +127,10 @@ static class McpReviewServer {
         }
     }
 
-    static string BuildInitializeResponse(JsonNode id) =>
+    static string BuildInitializeResponse(JsonNode id, JsonObject request) =>
         ToResponse<McpInitResult>(
             id,
-            new("2024-11-05", new(new()), new("kcap-review", "1.0.0")),
+            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-review", "1.0.0")),
             McpJsonContext.Default.McpInitResult
         );
 

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -76,10 +76,11 @@ static class McpSessionsServer {
                 if (id is null) continue;
 
                 var response = method switch {
-                    "initialize" => BuildInitializeResponse(id),
+                    "initialize" => BuildInitializeResponse(id, request),
                     "tools/list" => BuildToolsListResponse(id, tools),
                     "tools/call" => await DispatchToolCallAsync(id, request),
-                    _            => BuildErrorResponse(id, -32601, $"Method not found: {method}")
+                    _            => McpProtocol.TryHandleStandardMethod(method, id)
+                                    ?? BuildErrorResponse(id, -32601, $"Method not found: {method}")
                 };
 
                 await writer.WriteLineAsync(response);
@@ -108,10 +109,10 @@ static class McpSessionsServer {
         }
     }
 
-    static string BuildInitializeResponse(JsonNode id) =>
+    static string BuildInitializeResponse(JsonNode id, JsonObject request) =>
         ToResponse<McpInitResult>(
             id,
-            new("2024-11-05", new(new()), new("kcap-sessions", "1.0.0")),
+            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-sessions", "1.0.0")),
             McpJsonContext.Default.McpInitResult
         );
 

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -206,14 +206,20 @@ static class McpSessionsServer {
             qs.Add($"author_github_id={aid}");
         }
 
-        // repo: explicit value > cwd-derived hash > omit. Sentinel "all" means cross-repo (omit param).
-        // Normalise empty/whitespace explicit repo to null so the cwd fallback runs — otherwise
-        // `repo: ""` produced `repo=` in the URL and silently broadened search to all visible repos.
+        // repo scope: explicit "all" → cross-repo; explicit value → that repo; else cwd repo.
+        // Fail closed rather than silently broadening: if we can't resolve the current repo
+        // and the caller didn't explicitly opt into cross-repo, error instead of searching everything.
         var explicitRepo                                          = args?["repo"]?.GetValue<string>();
         if (string.IsNullOrWhiteSpace(explicitRepo)) explicitRepo = null;
-        var repo                                                  = explicitRepo ?? cwdRepoHash;
 
-        if (repo is not null && !string.Equals(explicitRepo, "all", StringComparison.OrdinalIgnoreCase)) {
+        if (string.Equals(explicitRepo, "all", StringComparison.OrdinalIgnoreCase)) {
+            // cross-repo: omit the repo filter entirely.
+        } else {
+            var repo = explicitRepo ?? cwdRepoHash;
+            if (repo is null)
+                throw new ArgumentException(
+                    "Cannot resolve the current repository — run from a git checkout, or pass repo: \"<owner>/<name>\" " +
+                    "for a specific repo or repo: \"all\" to search across all visible repos.");
             qs.Add($"repo={Uri.EscapeDataString(repo)}");
         }
 

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -209,7 +209,15 @@ static class McpSessionsServer {
         // repo scope: explicit "all" → cross-repo; explicit value → that repo; else cwd repo.
         // Fail closed rather than silently broadening: if we can't resolve the current repo
         // and the caller didn't explicitly opt into cross-repo, error instead of searching everything.
-        var explicitRepo                                          = args?["repo"]?.GetValue<string>();
+        // Read `repo` defensively: a non-string JSON value must yield a clean validation error
+        // (caught as a tool error), not an unhandled InvalidOperationException that the outer
+        // guard turns into a generic "internal error".
+        string? explicitRepo = args?["repo"] switch {
+            null                                          => null,
+            JsonValue v when v.TryGetValue(out string? s) => s,
+            _                                             => throw new ArgumentException(
+                "`repo` must be a string — \"<owner>/<name>\", a 16-hex repo hash, or \"all\".")
+        };
         if (string.IsNullOrWhiteSpace(explicitRepo)) explicitRepo = null;
 
         if (string.Equals(explicitRepo, "all", StringComparison.OrdinalIgnoreCase)) {
@@ -218,8 +226,9 @@ static class McpSessionsServer {
             var repo = explicitRepo ?? cwdRepoHash;
             if (repo is null)
                 throw new ArgumentException(
-                    "Cannot resolve the current repository — run from a git checkout, or pass repo: \"<owner>/<name>\" " +
-                    "for a specific repo or repo: \"all\" to search across all visible repos.");
+                    "Cannot resolve the current repository owner/name from git metadata (e.g. a missing or " +
+                    "unparseable 'origin' remote). Pass repo: \"<owner>/<name>\" for a specific repo, or " +
+                    "repo: \"all\" to search across all visible repos.");
             qs.Add($"repo={Uri.EscapeDataString(repo)}");
         }
 

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -219,6 +219,51 @@ public class McpFlowsServerTests : IDisposable {
         }
     }
 
+    /// <summary>
+    /// Handshake probe (AI-1233): clients that send <c>resources/list</c> / <c>prompts/list</c> /
+    /// <c>ping</c> before treating the server as ready must get empty-but-successful responses,
+    /// not <c>-32601 Method not found</c> — and the negotiated protocolVersion must echo back a
+    /// client-requested version we support, not always the hardcoded baseline.
+    /// </summary>
+    [Test]
+    public async Task ResourcesList_and_PromptsList_return_empty_not_method_not_found() {
+        using var proc = SpawnMcpServer();
+        try {
+            var init = await SendRequest(proc, new JsonObject {
+                ["jsonrpc"] = "2.0",
+                ["id"]      = 1,
+                ["method"]  = "initialize",
+                ["params"]  = new JsonObject { ["protocolVersion"] = "2025-06-18" }
+            });
+            await Assert.That(init["result"]?["protocolVersion"]?.GetValue<string>()).IsEqualTo("2025-06-18");
+
+            var resources = await SendRequest(proc, new JsonObject {
+                ["jsonrpc"] = "2.0",
+                ["id"]      = 2,
+                ["method"]  = "resources/list"
+            });
+            await Assert.That(resources["error"]).IsNull();
+            await Assert.That(resources["result"]?["resources"]?.AsArray()?.Count).IsEqualTo(0);
+
+            var prompts = await SendRequest(proc, new JsonObject {
+                ["jsonrpc"] = "2.0",
+                ["id"]      = 3,
+                ["method"]  = "prompts/list"
+            });
+            await Assert.That(prompts["error"]).IsNull();
+            await Assert.That(prompts["result"]?["prompts"]?.AsArray()?.Count).IsEqualTo(0);
+
+            var ping = await SendRequest(proc, new JsonObject {
+                ["jsonrpc"] = "2.0",
+                ["id"]      = 4,
+                ["method"]  = "ping"
+            });
+            await Assert.That(ping["error"]).IsNull();
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
     [Test]
     public async Task Tools_list_returns_eight_flow_tools() {
         using var proc = SpawnMcpServer();

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -264,6 +264,35 @@ public class McpFlowsServerTests : IDisposable {
         }
     }
 
+    /// <summary>
+    /// Malformed-initialize survival probe (AI-1233): a client sending a non-string
+    /// <c>protocolVersion</c> (e.g. a bare JSON number) must not crash <c>McpProtocol.NegotiateVersion</c> —
+    /// the initialize dispatch arm has no try/catch, so an uncaught exception there would kill the
+    /// whole stdio server. The server must fall back to the baseline version and stay responsive.
+    /// </summary>
+    [Test]
+    public async Task Initialize_with_non_string_protocol_version_falls_back_and_server_survives() {
+        using var proc = SpawnMcpServer();
+        try {
+            var response = await SendRequest(proc, new JsonObject {
+                ["jsonrpc"] = "2.0",
+                ["id"]      = 1,
+                ["method"]  = "initialize",
+                ["params"]  = new JsonObject { ["protocolVersion"] = 2025 }
+            });
+
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["protocolVersion"]?.GetValue<string>()).IsEqualTo("2024-11-05");
+
+            // Server survived the malformed request — a follow-up still gets a response.
+            var again = await SendRequest(proc, ToolsListRequest(2));
+            await Assert.That(again["result"]?["tools"]).IsNotNull();
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
     [Test]
     public async Task Tools_list_returns_eight_flow_tools() {
         using var proc = SpawnMcpServer();

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpProtocolTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpProtocolTests.cs
@@ -1,0 +1,50 @@
+// test/Capacitor.Cli.Tests.Unit/Mcp/McpProtocolTests.cs
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit.Mcp;
+
+public class McpProtocolTests {
+    static JsonObject Init(string? version) {
+        var p = new JsonObject();
+        if (version is not null) p["protocolVersion"] = version;
+        return new JsonObject { ["params"] = p };
+    }
+    static JsonObject Parse(string s) => (JsonObject)JsonNode.Parse(s)!;
+
+    [Test]
+    public async Task NegotiateVersion_echoes_a_supported_client_version() {
+        await Assert.That(McpProtocol.NegotiateVersion(Init("2025-06-18"))).IsEqualTo("2025-06-18");
+    }
+
+    [Test]
+    public async Task NegotiateVersion_falls_back_to_baseline_for_unknown_or_missing() {
+        await Assert.That(McpProtocol.NegotiateVersion(Init("1999-01-01"))).IsEqualTo("2024-11-05");
+        await Assert.That(McpProtocol.NegotiateVersion(Init(null))).IsEqualTo("2024-11-05");
+    }
+
+    [Test]
+    public async Task ResourcesList_returns_empty_array_result() {
+        var r = Parse(McpProtocol.TryHandleStandardMethod("resources/list", 7)!);
+        await Assert.That((string)r["jsonrpc"]!).IsEqualTo("2.0");
+        await Assert.That((int)r["id"]!).IsEqualTo(7);
+        await Assert.That(r["result"]!["resources"]!.AsArray().Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task PromptsList_returns_empty_array_result() {
+        var r = Parse(McpProtocol.TryHandleStandardMethod("prompts/list", "abc")!);
+        await Assert.That(r["result"]!["prompts"]!.AsArray().Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Ping_returns_empty_object_result() {
+        var r = Parse(McpProtocol.TryHandleStandardMethod("ping", 1)!);
+        await Assert.That(r["result"] is JsonObject o && o.Count == 0).IsTrue();
+    }
+
+    [Test]
+    public async Task Unknown_method_returns_null() {
+        await Assert.That(McpProtocol.TryHandleStandardMethod("tools/call", 1)).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpProtocolTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpProtocolTests.cs
@@ -24,6 +24,17 @@ public class McpProtocolTests {
     }
 
     [Test]
+    public async Task NegotiateVersion_falls_back_when_params_is_not_an_object() {
+        await Assert.That(McpProtocol.NegotiateVersion(new JsonObject { ["params"] = "oops" })).IsEqualTo("2024-11-05");
+    }
+
+    [Test]
+    public async Task NegotiateVersion_falls_back_when_version_is_not_a_string() {
+        var req = new JsonObject { ["params"] = new JsonObject { ["protocolVersion"] = 2025 } };
+        await Assert.That(McpProtocol.NegotiateVersion(req)).IsEqualTo("2024-11-05");
+    }
+
+    [Test]
     public async Task ResourcesList_returns_empty_array_result() {
         var r = Parse(McpProtocol.TryHandleStandardMethod("resources/list", 7)!);
         await Assert.That((string)r["jsonrpc"]!).IsEqualTo("2.0");

--- a/test/Capacitor.Cli.Tests.Unit/McpSessionsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpSessionsServerTests.cs
@@ -6,10 +6,11 @@ namespace Capacitor.Cli.Tests.Unit;
 
 public class McpSessionsServerTests {
     [Test]
-    public async Task BuildSearchUrl_no_args_no_cwd_hash() {
-        var url = McpSessionsServer.BuildSearchUrl("http://srv", args: null, cwdRepoHash: null);
-
-        await Assert.That(url).IsEqualTo("http://srv/api/sessions/search");
+    public async Task BuildSearchUrl_no_args_no_cwd_hash_fails_closed() {
+        // Superseded fail-open expectation: with no repo resolvable and none requested, this now
+        // throws instead of silently searching cross-repo. See BuildSearchUrl_fails_closed_when_no_repo_resolves_and_none_requested.
+        await Assert.That(() => McpSessionsServer.BuildSearchUrl("http://srv", args: null, cwdRepoHash: null))
+            .Throws<ArgumentException>();
     }
 
     [Test]
@@ -17,10 +18,10 @@ public class McpSessionsServerTests {
         var url = McpSessionsServer.BuildSearchUrl(
             "http://srv",
             new JsonObject { ["query"] = "batch" },
-            cwdRepoHash: null
+            cwdRepoHash: "abc1234567890def"
         );
 
-        await Assert.That(url).IsEqualTo("http://srv/api/sessions/search?q=batch");
+        await Assert.That(url).IsEqualTo("http://srv/api/sessions/search?q=batch&repo=abc1234567890def");
     }
 
     [Test]
@@ -32,7 +33,7 @@ public class McpSessionsServerTests {
                 ["author"] = "alice",
                 ["limit"]  = 25
             },
-            cwdRepoHash: null
+            cwdRepoHash: "abc1234567890def"
         );
 
         await Assert.That(url).Contains("q=retry%20logic");
@@ -100,10 +101,10 @@ public class McpSessionsServerTests {
         var url = McpSessionsServer.BuildSearchUrl(
             "http://srv",
             new JsonObject { ["author_github_id"] = 12345 },
-            cwdRepoHash: null
+            cwdRepoHash: "abc1234567890def"
         );
 
-        await Assert.That(url).IsEqualTo("http://srv/api/sessions/search?author_github_id=12345");
+        await Assert.That(url).IsEqualTo("http://srv/api/sessions/search?author_github_id=12345&repo=abc1234567890def");
     }
 
     [Test]
@@ -229,7 +230,7 @@ public class McpSessionsServerTests {
         var url = McpSessionsServer.BuildSearchUrl(
             "http://srv",
             new JsonObject { ["author_github_id"] = 5_000_000_000L },
-            cwdRepoHash: null
+            cwdRepoHash: "abc1234567890def"
         );
 
         await Assert.That(url).Contains("author_github_id=5000000000");
@@ -258,6 +259,31 @@ public class McpSessionsServerTests {
         var ok = McpSessionsServer.TryReadInt(args, "limit", out _);
 
         await Assert.That(ok).IsFalse();
+    }
+
+    [Test]
+    public async Task BuildSearchUrl_fails_closed_when_no_repo_resolves_and_none_requested() {
+        var args = new JsonObject { ["query"] = "hi" }; // no repo arg, cwdRepoHash null
+        await Assert.That(() => McpSessionsServer.BuildSearchUrl("http://x", args, cwdRepoHash: null))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task BuildSearchUrl_allows_explicit_cross_repo_all() {
+        var url = McpSessionsServer.BuildSearchUrl("http://x", new JsonObject { ["query"] = "hi", ["repo"] = "all" }, cwdRepoHash: null);
+        await Assert.That(url).DoesNotContain("repo="); // cross-repo → repo param omitted, no throw
+    }
+
+    [Test]
+    public async Task BuildSearchUrl_uses_explicit_repo_when_cwd_absent() {
+        var url = McpSessionsServer.BuildSearchUrl("http://x", new JsonObject { ["query"] = "hi", ["repo"] = "owner/name" }, cwdRepoHash: null);
+        await Assert.That(url).Contains("repo=owner%2Fname");
+    }
+
+    [Test]
+    public async Task BuildSearchUrl_uses_cwd_repo_when_no_explicit() {
+        var url = McpSessionsServer.BuildSearchUrl("http://x", new JsonObject { ["query"] = "hi" }, cwdRepoHash: "abc123");
+        await Assert.That(url).Contains("repo=abc123");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/McpSessionsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpSessionsServerTests.cs
@@ -269,6 +269,13 @@ public class McpSessionsServerTests {
     }
 
     [Test]
+    public async Task BuildSearchUrl_rejects_nonstring_repo_with_clean_error() {
+        var args = new JsonObject { ["query"] = "hi", ["repo"] = 123 };
+        await Assert.That(() => McpSessionsServer.BuildSearchUrl("http://x", args, cwdRepoHash: "abc"))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
     public async Task BuildSearchUrl_allows_explicit_cross_repo_all() {
         var url = McpSessionsServer.BuildSearchUrl("http://x", new JsonObject { ["query"] = "hi", ["repo"] = "all" }, cwdRepoHash: null);
         await Assert.That(url).DoesNotContain("repo="); // cross-repo → repo param omitted, no throw


### PR DESCRIPTION
Second foundation of the MCP auto-config epic (AI-1224) — makes the `kcap mcp *` servers function correctly when launched by any harness. Independent of AI-1225 (kcap-cli#282); different files.

## What
- **`McpProtocol`** (new shared helper) — answers the standard MCP capability probes `resources/list` / `prompts/list` (empty results) and `ping`, and **negotiates the protocol version** (echoes a client's supported version, else baseline `2024-11-05`). Previously every server returned `-32601` for these, which some clients treat as fatal and drop the server (the likely root of AI-1132).
- **All 6 MCP servers** (`review`, `sessions`, `flows`, `memory`, `judge`, `flow-result`) now delegate their dispatch `default` to the helper and negotiate the version in `initialize`. Server names + happy-path (initialize/tools/list/tools/call) unchanged.
- **`sessions` fails closed** — `BuildSearchUrl` now errors (surfaced as an MCP tool error) when no repo resolves and neither an explicit repo nor `repo:"all"` was given, instead of silently searching cross-repo.

## ⚠️ Behavior change
`search_sessions` previously searched **cross-repo silently** when it couldn't resolve the cwd repo; it now returns a tool error asking for an explicit `repo` or `repo:"all"`. This is the approved fail-closed design (AI-1224 spec §5/§6, Codex-reviewed) — flagging because it changes an existing tool's default behavior.

## Repo-scope audit (the other servers need no change)
- `memory.save_memory` — already fails closed (`throw` when `!global && cwdRepoHash is null`).
- `review` — `PrResolution` already returns a tool **error** on unresolved PR; not silent.
- `flows` — passes nullable `RequestingRepoRoot`; the server disambiguates checkouts (AI-1112). Not a client-side silent mis-scope.
- `sessions` was the only silent-broadening case.

## Tests
- Unit **2479/2479** (incl. new `McpProtocolTests` 8, updated `McpSessionsServerTests`); integration `McpFlowsServerTests` **28/28** incl. a spawn-process handshake probe (negotiated version + `resources/list`/`prompts/list`/`ping`) and a **server-survival probe** (numeric `protocolVersion` → falls back to baseline, server stays alive). Build clean, 0 CS8604.
- Built via subagent-driven TDD; whole-branch review (opus) found + fixed a `NegotiateVersion` crash-on-malformed-`initialize` regression (now defensive + regression-tested).

Part of AI-1224; sibling to AI-1225 (kcap-cli#282). Both foundations block the per-harness registration issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
