### PR TITLE
[AI-686] ACP permission & elicitation bridge (daemon half)

### DIFF
--- a/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
+++ b/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
@@ -1,4 +1,5 @@
 // src/Capacitor.Cli.Core/Acp/AcpMessages.cs
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Capacitor.Cli.Core.Acp;
@@ -54,4 +55,83 @@ public sealed record PromptContentBlock(
 /// <summary><c>session/cancel</c> params — sent as a notification (no response expected).</summary>
 public sealed record SessionCancelParams(
     [property: JsonPropertyName("sessionId")] string SessionId
+);
+
+/// <summary>
+/// <c>session/request_permission</c> params sent BY THE AGENT (server-initiated request, handled
+/// via <see cref="Daemon.Acp.AcpConnection.OnServerRequest"/>) — AI-686. Spec-derived, NOT
+/// probe-confirmed: the AI-684 probe never observed a real <c>session/request_permission</c> frame
+/// (the probe account's turn ended before any tool call — see
+/// <c>docs/acp-probe-findings.md</c> §"Permission / elicitation requests"). Mirrors the shape
+/// <see cref="Capacitor.Cli.Tests.Unit.Acp.FakeAcpAgent.BuildRequestPermissionFrame"/> already
+/// builds for tests. <see cref="ToolCall"/> stays an opaque <see cref="JsonElement"/> — its exact
+/// schema is unconfirmed and it is never re-serialized, only forwarded to the server as
+/// <see cref="AcpInteractionRequest.ToolInput"/> best-effort (see <c>AcpInteractionBridge</c>).
+/// </summary>
+public sealed record SessionRequestPermissionParams(
+    [property: JsonPropertyName("sessionId")] string              SessionId,
+    [property: JsonPropertyName("toolCall")]  JsonElement          ToolCall,
+    [property: JsonPropertyName("options")]   PermissionOptionDto[] Options
+);
+
+/// <summary>One offered option in a <see cref="SessionRequestPermissionParams"/> — spec-derived, NOT probe-confirmed.</summary>
+public sealed record PermissionOptionDto(
+    [property: JsonPropertyName("optionId")] string OptionId,
+    [property: JsonPropertyName("name")]     string Name,
+    [property: JsonPropertyName("kind")]     string Kind
+);
+
+/// <summary>
+/// Client's JSON-RPC <c>result</c> for a <c>session/request_permission</c> request — spec-derived,
+/// NOT probe-confirmed. Mirrors <see cref="Capacitor.Cli.Tests.Unit.Acp.FakeAcpAgent.PermissionOutcomeSelected"/>/
+/// <see cref="Capacitor.Cli.Tests.Unit.Acp.FakeAcpAgent.PermissionOutcomeCancelled"/>.
+/// </summary>
+public sealed record PermissionOutcomeResult(
+    [property: JsonPropertyName("outcome")] PermissionOutcomeDto Outcome
+);
+
+/// <summary>
+/// <c>Outcome</c> is <c>"selected"</c> (with <see cref="OptionId"/> set to the chosen
+/// <see cref="PermissionOptionDto.OptionId"/>) or <c>"cancelled"</c> (denial/timeout/agent-exit) —
+/// spec-derived, NOT probe-confirmed.
+/// </summary>
+public sealed record PermissionOutcomeDto(
+    [property: JsonPropertyName("outcome")] string Outcome,
+    [property: JsonPropertyName("optionId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+                                             string? OptionId = null
+);
+
+/// <summary>
+/// Capability-gated, NOT part of the core ACP spec — modeled defensively on the same
+/// request/response shape as <see cref="SessionRequestPermissionParams"/> since no confirmed
+/// elicitation schema exists for Cursor (AI-682 R3's open question: "Does Cursor use the ACP
+/// elicitation RFD shape or a vendor extension?" is unanswered). The daemon never advertises
+/// support for this method in <c>initialize</c> (see <c>AcpHostedAgentRuntime.StartAsync</c>'s
+/// existing minimal-capabilities <c>ClientCapabilities</c>, unchanged by this plan) — if a real
+/// agent sends it anyway, <c>AcpInteractionBridge</c> still answers deterministically (see Task
+/// B2) rather than crashing or hanging, but this is explicitly a defensive best-effort path, not a
+/// negotiated capability.
+///
+/// <b>Spec-review Finding 1:</b> <see cref="RequestedSchema"/> is the JSON-Schema half of the
+/// roadmap spec's "options OR JSON Schema" elicitation shape — spec-derived field name
+/// (<c>requestedSchema</c> on the wire), following the MCP elicitation convention this
+/// ACP-capability-gated method is modeled after (there is no ACP-native precedent for it at all).
+/// <see cref="Options"/> and <see cref="RequestedSchema"/> are independent optional fields, not a
+/// discriminated union — a real agent could in principle send either, both, or neither;
+/// <see cref="Capacitor.Cli.Daemon.Acp.AcpInteractionBridge"/> (Task B3) forwards
+/// <see cref="RequestedSchema"/> to the server verbatim (capped server-side, Task A1/A3) and never
+/// attempts to render or validate it itself.
+/// </summary>
+public sealed record ElicitationCreateParams(
+    [property: JsonPropertyName("sessionId")] string SessionId,
+    [property: JsonPropertyName("message")]   string Message,
+    [property: JsonPropertyName("options"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+                                               PermissionOptionDto[]? Options = null,
+    [property: JsonPropertyName("requestedSchema"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+                                               JsonElement? RequestedSchema = null
+);
+
+/// <summary>Client's JSON-RPC <c>result</c> for a (capability-gated) <c>elicitation/create</c> request.</summary>
+public sealed record ElicitationCreateResult(
+    [property: JsonPropertyName("outcome")] PermissionOutcomeDto Outcome
 );

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -777,6 +777,16 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(Acp.SessionPromptParams))]
 [JsonSerializable(typeof(Acp.PromptContentBlock))]
 [JsonSerializable(typeof(Acp.SessionCancelParams))]
+[JsonSerializable(typeof(Acp.SessionRequestPermissionParams))]
+[JsonSerializable(typeof(Acp.PermissionOptionDto))]
+[JsonSerializable(typeof(Acp.PermissionOutcomeResult))]
+[JsonSerializable(typeof(Acp.PermissionOutcomeDto))]
+[JsonSerializable(typeof(Acp.ElicitationCreateParams))]
+[JsonSerializable(typeof(Acp.ElicitationCreateResult))]
+[JsonSerializable(typeof(AcpInteractionRequest))]
+[JsonSerializable(typeof(AcpInteractionOption))]
+[JsonSerializable(typeof(AcpInteractionDecision))]
+[JsonSerializable(typeof(AcpInteractionResolution))]
 // UseStringEnumConverter=true matches the server's SignalR JSON protocol, which
 // serialises enums (e.g. LaunchKind) as camelCase strings. Without it the
 // source-gen LaunchKind JsonTypeInfo defaults to numeric and silently drops the
@@ -823,6 +833,60 @@ public readonly record struct HostedPermissionRequest(
 public readonly record struct PermissionResolution(
         string             RequestId,
         PermissionDecision Decision
+    );
+
+/// <summary>
+/// Single-argument payload for the <c>AcpRequestInteraction</c> hub invocation (AI-686). Mirrors
+/// the server-side record of the same name in <c>Capacitor.Server.Core</c> (<c>src/Capacitor.Server.Core/AcpInteraction.cs</c>);
+/// property names must stay in sync (snake_case on the wire via this context's naming policy).
+/// <b>Spec-review Finding 1:</b> <see cref="RequestedSchema"/> is a new OPTIONAL trailing field,
+/// mirroring the server-side <c>AcpInteractionRequest.RequestedSchema</c> exactly (same name,
+/// position, and nullability) — kept in lockstep across the wire boundary the same way every other
+/// field on this type already is (see Task A2's Interfaces note for the "server `record` / daemon
+/// `readonly record struct`, same JSON shape" convention this type follows).
+/// </summary>
+public readonly record struct AcpInteractionRequest(
+        string                 AgentId,
+        string                 AcpSessionId,
+        string                 Kind,
+        string?                ToolName,
+        JsonElement?           ToolInput,
+        string?                ToolCallId,
+        string?                Prompt,
+        AcpInteractionOption[]? Options,
+        bool                   IsMultiSelect,
+        JsonElement?           RequestedSchema = null
+    );
+
+/// <summary>
+/// One selectable option for an ACP permission or elicitation interaction (AI-686). Spec-review
+/// Finding 6: <see cref="OptionId"/> is the stable resolution key (mirrors
+/// <c>Acp.PermissionOptionDto.OptionId</c>) — <see cref="Label"/> is display-only.
+/// </summary>
+public readonly record struct AcpInteractionOption(string OptionId, string Label, string? Description, string? Kind = null);
+
+/// <summary>
+/// Decision for an ACP interaction (AI-686), pushed from the server. Mirrors the server-side
+/// record of the same name. Spec-review Finding 6: <see cref="SelectedOptionId"/> is what
+/// <c>AcpInteractionBridge.MapPermissionDecision</c> (Task B3) matches against — never
+/// <see cref="SelectedOptionLabel"/>, which is retained for display/attribution only.
+/// </summary>
+public readonly record struct AcpInteractionDecision(
+        string       Outcome,
+        string?      SelectedOptionId,
+        string?      SelectedOptionLabel,
+        int?         SelectedIndex,
+        string?      FreeText,
+        JsonElement? UpdatedToolInput
+    );
+
+/// <summary>
+/// Payload of the <c>AcpInteractionResolved</c> server→client push (AI-686), correlated by
+/// <see cref="RequestId"/>. Mirrors the server-side record of the same name.
+/// </summary>
+public readonly record struct AcpInteractionResolution(
+        string             RequestId,
+        AcpInteractionDecision Decision
     );
 
 /// <summary>Commands sent from the server to daemon clients via SignalR.</summary>

--- a/src/Capacitor.Cli.Daemon/Acp/AcpConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpConnection.cs
@@ -309,19 +309,34 @@ internal sealed class AcpConnection : IAsyncDisposable {
         }
 
         try {
-            await WriteServerResponseAsync(idClone, result, error, ct).ConfigureAwait(false);
-        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            // AI-686: the final response write deliberately uses CancellationToken.None, not `ct` —
+            // this method's own doc comment guarantees exactly one response frame is written "no
+            // matter what happens", and `ct` is the SAME token AcpHostedAgentRuntime.DisposeAsync
+            // cancels to unblock a pending OnServerRequest handler (e.g. AcpInteractionBridge
+            // resolving to a well-formed `cancelled` result on disconnect — Task B3/B4). Gating the
+            // WRITE itself on that already-cancelled token would make WriteLineAsync's write-gate
+            // wait (`_writeGate.WaitAsync(ct)`) throw OperationCanceledException before a single byte
+            // goes out, silently violating the "always exactly one response frame" invariant (the
+            // exception propagates through this method's `when (ex is not OperationCanceledException)`
+            // guard, then DispatchLineAsync's identical guard, and is swallowed by RunAsync's
+            // "normal shutdown" catch) — the agent would see NO response at all instead of the
+            // well-formed cancelled/error result the handler already computed. The write is a single
+            // best-effort attempt against a stream that may itself be torn down (e.g. the process
+            // already exited) — that failure mode is unrelated to `ct` and is exactly what the
+            // fallback below still handles.
+            await WriteServerResponseAsync(idClone, result, error, CancellationToken.None).ConfigureAwait(false);
+        } catch (Exception ex) {
             // Serializing/writing the chosen response itself failed (e.g. a malformed JsonElement,
-            // or a transient write fault). The agent is still owed a response for this id — never
-            // leave it log-and-skipped by DispatchLineAsync's outer catch — so fall back to a
-            // minimal internal-error response. Best-effort: if even THIS write fails, there is
-            // nothing left to try (the wire itself is broken and the read loop will observe that
-            // via its own exception handling on the next read).
+            // or the underlying stream already closed). The agent is still owed a response for this
+            // id — never leave it log-and-skipped by DispatchLineAsync's outer catch — so fall back
+            // to a minimal internal-error response. Best-effort: if even THIS write fails, there is
+            // nothing left to try (the wire itself is broken and the read loop will observe that via
+            // its own exception handling on the next read).
             _logger.LogDebug(ex, "ACP: failed to write server-request response for method={Method}; sending internal-error fallback", method);
 
             try {
-                await WriteServerResponseAsync(idClone, null, new AcpError(-32603, "Internal error", null), ct).ConfigureAwait(false);
-            } catch (Exception fallbackEx) when (fallbackEx is not OperationCanceledException) {
+                await WriteServerResponseAsync(idClone, null, new AcpError(-32603, "Internal error", null), CancellationToken.None).ConfigureAwait(false);
+            } catch (Exception fallbackEx) {
                 _logger.LogDebug(fallbackEx, "ACP: internal-error fallback response also failed to write for method={Method}", method);
             }
         }

--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -36,16 +36,28 @@ internal sealed class AcpInteractionBridge(
     /// this bridge doesn't recognize (letting <see cref="AcpConnection.HandleServerRequestAsync"/>'s
     /// existing default-decline posture answer with a JSON-RPC "Method not found" error, unchanged
     /// from AI-684's behavior for every method except the two this bridge now claims).
+    ///
+    /// <b>Qodo daemon-review Q2:</b> takes NO caller-supplied session id — the ACP session id used to
+    /// correlate this interaction server-side comes ONLY from the request's OWN
+    /// <c>params.sessionId</c> (<see cref="SessionRequestPermissionParams.SessionId"/> /
+    /// <see cref="ElicitationCreateParams.SessionId"/>), never from a runtime field closed over at
+    /// wiring time. The prior shape took an <c>acpSessionId</c> parameter that
+    /// <see cref="Capacitor.Cli.Daemon.Services.AcpHostedAgentRuntime"/> supplied as
+    /// <c>_sessionId ?? ""</c> — a server→client request handled before <c>session/new</c>'s
+    /// response assigned <c>_sessionId</c> (the read loop can start before that completes) forwarded
+    /// an <see cref="AcpInteractionRequest"/> with <c>AcpSessionId == ""</c>, breaking server-side
+    /// correlation. Trusting the request's own params instead removes that whole class of bug: the
+    /// session id is authoritative and available at the exact moment the request itself exists.
     /// </summary>
-    public async Task<JsonElement?> HandleAsync(AcpRequest request, string acpSessionId, CancellationToken ct) {
+    public async Task<JsonElement?> HandleAsync(AcpRequest request, CancellationToken ct) {
         return request.Method switch {
-            "session/request_permission" => await HandlePermissionAsync(request, acpSessionId, ct).ConfigureAwait(false),
-            "elicitation/create"         => await HandleElicitationAsync(request, acpSessionId, ct).ConfigureAwait(false),
+            "session/request_permission" => await HandlePermissionAsync(request, ct).ConfigureAwait(false),
+            "elicitation/create"         => await HandleElicitationAsync(request, ct).ConfigureAwait(false),
             _                            => null
         };
     }
 
-    async Task<JsonElement?> HandlePermissionAsync(AcpRequest request, string acpSessionId, CancellationToken ct) {
+    async Task<JsonElement?> HandlePermissionAsync(AcpRequest request, CancellationToken ct) {
         SessionRequestPermissionParams parsed;
 
         try {
@@ -60,17 +72,45 @@ internal sealed class AcpInteractionBridge(
             return CancelledResult();
         }
 
+        // Qodo daemon-review Q2: the request's OWN params are the sole source of truth for
+        // correlation — no resolvable session id at all means the server has no way to correlate
+        // this interaction, so fail safe rather than forwarding an empty/placeholder id.
+        if (string.IsNullOrEmpty(parsed.SessionId)) {
+            logger.LogDebug("ACP: session/request_permission params carried no sessionId for agent {AgentId}; cannot correlate, defaulting to cancelled", agentId);
+
+            return CancelledResult();
+        }
+
+        // Qodo daemon-review Q1 (fail-safe hole): System.Text.Json does NOT enforce
+        // SessionRequestPermissionParams.Options' non-nullable C# annotation — an omitted OR
+        // explicit-null `options` field on the wire (this shape is spec-derived, NOT
+        // probe-confirmed; see docs/acp-probe-findings.md) deserializes to `parsed.Options == null`,
+        // which used to NRE inside `.Select(...)` below and propagate all the way out to
+        // AcpConnection.HandleServerRequestAsync's generic catch-all (-32603) instead of this
+        // bridge's well-formed `cancelled`. Normalize once, up front, filtering out any null
+        // element too (an options ARRAY with a null entry is equally unenforceable on the wire) —
+        // the normalized array is used for BOTH the forwarded AcpInteractionRequest.Options and the
+        // later MapPermissionDecision call, so there is exactly one empty-options code path
+        // (MapPermissionDecision's existing `options.Count == 0 → cancelled` branch) rather than two
+        // separate null-checks that could drift.
+        var options = parsed.Options?.Where(o => o is not null).ToArray() ?? [];
+
         var interactionRequest = new AcpInteractionRequest(
             AgentId: agentId,
-            AcpSessionId: acpSessionId,
+            AcpSessionId: parsed.SessionId,
             Kind: "permission",
             ToolName: TryGetToolTitle(parsed.ToolCall),
-            ToolInput: parsed.ToolCall,
+            // Qodo daemon-review Q1: a default/undefined JsonElement (e.g. `toolCall` itself omitted
+            // from the wire frame — ToolCall is non-nullable on SessionRequestPermissionParams, but
+            // again unenforced by System.Text.Json) must not be forwarded as a bare JsonElement,
+            // which can throw when the caller later tries to serialize/inspect it. Undefined maps to
+            // null; a genuine (even non-object) value forwards as-is, same as before.
+            ToolInput: parsed.ToolCall.ValueKind == JsonValueKind.Undefined ? null : parsed.ToolCall,
             ToolCallId: TryGetToolCallId(parsed.ToolCall),
             Prompt: null,
             // Spec-review Finding 6: carry OptionId through to the server-facing DTO so a UI
             // decision can round-trip it back — Options: o.Name (Label) is now display-only.
-            Options: parsed.Options.Select(o => new AcpInteractionOption(o.OptionId, o.Name, null, o.Kind)).ToArray(),
+            Options: options.Select(o => new AcpInteractionOption(o.OptionId, o.Name, null, o.Kind)).ToArray(),
             IsMultiSelect: false
         );
 
@@ -100,10 +140,10 @@ internal sealed class AcpInteractionBridge(
             return CancelledResult();
         }
 
-        return MapPermissionDecision(decision, parsed.Options);
+        return MapPermissionDecision(decision, options);
     }
 
-    async Task<JsonElement?> HandleElicitationAsync(AcpRequest request, string acpSessionId, CancellationToken ct) {
+    async Task<JsonElement?> HandleElicitationAsync(AcpRequest request, CancellationToken ct) {
         // Never advertised in `initialize` (see AcpHostedAgentRuntime.StartAsync's minimal
         // ClientCapabilities, unchanged by this plan) — handled defensively in case a real agent
         // sends it unprompted, per R3's open question on whether Cursor uses a vendor-specific
@@ -122,11 +162,21 @@ internal sealed class AcpInteractionBridge(
             return CancelledResult();
         }
 
-        var options = parsed.Options ?? [];
+        // Qodo daemon-review Q2 — same session-id-from-params contract as HandlePermissionAsync.
+        if (string.IsNullOrEmpty(parsed.SessionId)) {
+            logger.LogDebug("ACP: elicitation/create params carried no sessionId for agent {AgentId}; cannot correlate, defaulting to cancelled", agentId);
+
+            return CancelledResult();
+        }
+
+        // Qodo daemon-review Q1 — same null/omitted-array AND null-element normalization as
+        // HandlePermissionAsync above (this path was already null-coalescing the whole array, but
+        // not filtering individual null elements).
+        var options = parsed.Options?.Where(o => o is not null).ToArray() ?? [];
 
         var interactionRequest = new AcpInteractionRequest(
             AgentId: agentId,
-            AcpSessionId: acpSessionId,
+            AcpSessionId: parsed.SessionId,
             Kind: "elicitation",
             ToolName: null,
             ToolInput: null,

--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -1,0 +1,263 @@
+// src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Acp;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Acp;
+
+/// <summary>
+/// Bridges ACP server→client interaction requests (<c>session/request_permission</c>, and a
+/// capability-gated, defensive <c>elicitation/create</c>) to the Capacitor server's
+/// <c>AcpRequestInteraction</c> hub method (AI-686), and maps the returned decision back to the
+/// ACP JSON-RPC result shape. Wired as (a closure over) <see cref="AcpConnection.OnServerRequest"/>
+/// by <see cref="Capacitor.Cli.Daemon.Services.AcpHostedAgentRuntime"/> (Task B4).
+///
+/// <paramref name="requestInteraction"/> is injected as a plain delegate — matching the shape of
+/// <see cref="Capacitor.Cli.Daemon.Services.ServerConnection.RequestAcpInteractionAsync"/> — rather
+/// than taking a concrete <c>ServerConnection</c> dependency, so this class is unit-testable
+/// without a real SignalR connection (see <c>AcpInteractionBridgeTests</c>).
+///
+/// Defensive-by-construction: every code path that can fail (missing/malformed params, the
+/// server call throwing, a decision that doesn't map to any offered option) returns a
+/// <c>"cancelled"</c>/safest-available-option result rather than propagating an exception —
+/// <see cref="AcpConnection.HandleServerRequestAsync"/> already guarantees exactly one response
+/// frame is always written for a given request id, but this bridge additionally guarantees that
+/// response is always a well-formed ACP outcome, never a generic JSON-RPC "Internal error" that
+/// would tell the agent nothing about WHY the permission was denied.
+/// </summary>
+internal sealed class AcpInteractionBridge(
+        Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> requestInteraction,
+        string                                                                       agentId,
+        ILogger                                                                      logger
+    ) {
+    /// <summary>
+    /// Handles one inbound <see cref="AcpRequest"/>. Returns <see langword="null"/> for any method
+    /// this bridge doesn't recognize (letting <see cref="AcpConnection.HandleServerRequestAsync"/>'s
+    /// existing default-decline posture answer with a JSON-RPC "Method not found" error, unchanged
+    /// from AI-684's behavior for every method except the two this bridge now claims).
+    /// </summary>
+    public async Task<JsonElement?> HandleAsync(AcpRequest request, string acpSessionId, CancellationToken ct) {
+        return request.Method switch {
+            "session/request_permission" => await HandlePermissionAsync(request, acpSessionId, ct).ConfigureAwait(false),
+            "elicitation/create"         => await HandleElicitationAsync(request, acpSessionId, ct).ConfigureAwait(false),
+            _                            => null
+        };
+    }
+
+    async Task<JsonElement?> HandlePermissionAsync(AcpRequest request, string acpSessionId, CancellationToken ct) {
+        SessionRequestPermissionParams parsed;
+
+        try {
+            if (request.Params is not { } p)
+                return CancelledResult();
+
+            parsed = p.Deserialize(CapacitorJsonContext.Default.SessionRequestPermissionParams)
+                ?? throw new JsonException("null params");
+        } catch (JsonException ex) {
+            logger.LogDebug(ex, "ACP: malformed session/request_permission params for agent {AgentId}", agentId);
+
+            return CancelledResult();
+        }
+
+        var interactionRequest = new AcpInteractionRequest(
+            AgentId: agentId,
+            AcpSessionId: acpSessionId,
+            Kind: "permission",
+            ToolName: TryGetToolTitle(parsed.ToolCall),
+            ToolInput: parsed.ToolCall,
+            ToolCallId: TryGetToolCallId(parsed.ToolCall),
+            Prompt: null,
+            // Spec-review Finding 6: carry OptionId through to the server-facing DTO so a UI
+            // decision can round-trip it back — Options: o.Name (Label) is now display-only.
+            Options: parsed.Options.Select(o => new AcpInteractionOption(o.OptionId, o.Name, null, o.Kind)).ToArray(),
+            IsMultiSelect: false
+        );
+
+        AcpInteractionDecision decision;
+
+        try {
+            decision = await requestInteraction(interactionRequest, ct).ConfigureAwait(false);
+        } catch (OperationCanceledException) {
+            // Spec-review Finding 3(b): connection-closed / runtime-disposing / CT-cancelled while
+            // this interaction is pending (AcpHostedAgentRuntime.DisposeAsync cancels its _cts,
+            // which is the SAME token flowing through AcpConnection's read loop → HandleServerRequestAsync
+            // → this bridge → RequestAcpInteractionAsync → PendingAcpInteractionRegistry.AwaitDecisionAsync,
+            // whose own ct.Register callback removes the pending entry and TrySetCanceled()s it —
+            // see Task B2). PRE-FIX, this exception type was explicitly excluded from the catch
+            // below and propagated uncaught, so AcpConnection.HandleServerRequestAsync's own
+            // catch-all converted it to a generic JSON-RPC "Internal error" (-32603) instead of the
+            // well-formed ACP `cancelled` outcome every OTHER failure path in this bridge produces.
+            // Best-effort: WriteServerResponseAsync may itself fail if the wire is already torn
+            // down (AcpConnection's own catch around the write handles that silently) — this
+            // bridge's only job is to make the ATTEMPTED response well-formed.
+            logger.LogDebug("ACP: session/request_permission cancelled (connection closing) for agent {AgentId}; defaulting to cancelled", agentId);
+
+            return CancelledResult();
+        } catch (Exception ex) {
+            logger.LogDebug(ex, "ACP: RequestAcpInteractionAsync threw for agent {AgentId}; defaulting to cancelled", agentId);
+
+            return CancelledResult();
+        }
+
+        return MapPermissionDecision(decision, parsed.Options);
+    }
+
+    async Task<JsonElement?> HandleElicitationAsync(AcpRequest request, string acpSessionId, CancellationToken ct) {
+        // Never advertised in `initialize` (see AcpHostedAgentRuntime.StartAsync's minimal
+        // ClientCapabilities, unchanged by this plan) — handled defensively in case a real agent
+        // sends it unprompted, per R3's open question on whether Cursor uses a vendor-specific
+        // elicitation shape at all.
+        ElicitationCreateParams parsed;
+
+        try {
+            if (request.Params is not { } p)
+                return CancelledResult();
+
+            parsed = p.Deserialize(CapacitorJsonContext.Default.ElicitationCreateParams)
+                ?? throw new JsonException("null params");
+        } catch (JsonException ex) {
+            logger.LogDebug(ex, "ACP: malformed elicitation/create params for agent {AgentId}", agentId);
+
+            return CancelledResult();
+        }
+
+        var options = parsed.Options ?? [];
+
+        var interactionRequest = new AcpInteractionRequest(
+            AgentId: agentId,
+            AcpSessionId: acpSessionId,
+            Kind: "elicitation",
+            ToolName: null,
+            ToolInput: null,
+            ToolCallId: null,
+            Prompt: parsed.Message,
+            // Spec-review Finding 6: same OptionId carry-through as the permission path above.
+            Options: options.Select(o => new AcpInteractionOption(o.OptionId, o.Name, null, o.Kind)).ToArray(),
+            IsMultiSelect: false,
+            // Spec-review Finding 1: forward RequestedSchema verbatim — this bridge never validates,
+            // re-serializes, or renders it; the server (Task A1/A3) applies the actual 32KB/depth-8
+            // caps and decides the generic-card fallback. Forwarding an oversized/malformed schema
+            // here is safe: JsonElement.Deserialize already succeeded (it's syntactically valid JSON
+            // by the time we have a JsonElement at all — a genuinely malformed JSON payload for the
+            // whole params object was already caught by the JsonException handler above), and this
+            // bridge does zero further inspection of RequestedSchema's shape.
+            RequestedSchema: parsed.RequestedSchema
+        );
+
+        AcpInteractionDecision decision;
+
+        try {
+            decision = await requestInteraction(interactionRequest, ct).ConfigureAwait(false);
+        } catch (OperationCanceledException) {
+            // Spec-review Finding 3(b) — same disconnect handling as HandlePermissionAsync above.
+            logger.LogDebug("ACP: elicitation/create cancelled (connection closing) for agent {AgentId}; defaulting to cancelled", agentId);
+
+            return CancelledResult();
+        } catch (Exception ex) {
+            logger.LogDebug(ex, "ACP: RequestAcpInteractionAsync threw for elicitation on agent {AgentId}; defaulting to cancelled", agentId);
+
+            return CancelledResult();
+        }
+
+        return MapPermissionDecision(decision, options);
+    }
+
+    /// <summary>
+    /// Maps a resolved <see cref="AcpInteractionDecision"/> to the ACP outcome result shape.
+    ///
+    /// <b>Spec-review Finding 2 (security-critical, fail-safe-by-default):</b> this method uses
+    /// an EXPLICIT ALLOWLIST of recognized affirmative outcome strings (<c>"allow"</c>/
+    /// <c>"allow_once"</c>/<c>"allow_always"</c>/<c>"answered"</c> — the daemon does not reference
+    /// the server-only <c>InterruptOutcomes</c> type per this plan's AOT/trim Global Constraints, so
+    /// these are the literal string values of the SAME canonical vocabulary Task A2 documents, kept
+    /// in sync by the <c>AffirmativeOutcomes</c> constant below) rather than a denylist of recognized
+    /// negative outcomes with an "everything else selects" fallthrough. The PRIOR shape
+    /// (<c>decision.Outcome is "deny" or "cancel" ? cancelled : selected</c>) meant ANY unrecognized
+    /// outcome string — a typo (the canonical negative outcome is <c>"cancel"</c>, NOT
+    /// <c>"cancelled"</c> — see Task A2's Interfaces note for exactly this drift happening once
+    /// already in this plan), a future outcome vocabulary addition the daemon hasn't been updated
+    /// for, or a malformed/corrupted decision — fell through to <c>selected</c>/<c>options[0]</c>,
+    /// i.e. GRANTED permission for an outcome nobody explicitly asked to grant. Fail-safe now means:
+    /// not on the allowlist → always <see cref="CancelledResult"/>, full stop, regardless of how many
+    /// options were offered.
+    ///
+    /// <b>Fresh-review finding (this revision): a null <see cref="AcpInteractionDecision.SelectedOptionId"/>
+    /// used to STILL fall back to the first offered option even for a recognized affirmative
+    /// outcome</b> — an earlier draft of this fix treated "no id supplied" as "assume the human meant
+    /// the first option," which is exactly the same class of bug spec-review Finding 2 exists to
+    /// close: an ACP options request with two-or-more offered options (e.g. "Allow once" / "Deny")
+    /// resolved via a decision-submit path that (for whatever reason — a bug, a stale client, a
+    /// future code path that forgets to thread the id) omits <see cref="AcpInteractionDecision.SelectedOptionId"/>
+    /// would silently grant `options[0]` — often "Allow" — regardless of what the human actually
+    /// intended, or even whether the human ever saw the request. This method now FAILS CLOSED for
+    /// that case too: for an ACP interaction that offered ANY options, an affirmative outcome with
+    /// a null/unknown/unresolvable <see cref="AcpInteractionDecision.SelectedOptionId"/> ALWAYS maps
+    /// to <c>cancelled</c> — there is NO first-option fallback anywhere in this method, full stop.
+    /// The only way to get a <c>selected</c> result is an explicit, resolvable <c>SelectedOptionId</c>
+    /// matching one of the offered <see cref="PermissionOptionDto.OptionId"/>s.
+    ///
+    /// For a recognized affirmative outcome (spec-review Finding 6): selects the option whose
+    /// <see cref="PermissionOptionDto.OptionId"/> matches <see cref="AcpInteractionDecision.SelectedOptionId"/> —
+    /// NEVER by re-matching <see cref="PermissionOptionDto.Name"/>/<see cref="AcpInteractionDecision.SelectedOptionLabel"/>,
+    /// since duplicate or reordered option labels (which the ACP wire shape does not forbid) would
+    /// otherwise resolve to the wrong option. Two cases, both fail-closed: a
+    /// <see cref="AcpInteractionDecision.SelectedOptionId"/> that matches an offered
+    /// <see cref="PermissionOptionDto.OptionId"/> → that option, <c>selected</c>; ANYTHING else — no
+    /// id supplied at all (<see langword="null"/>), or an id that matches NONE of the offered
+    /// options — → <c>cancelled</c> (an absent or unresolvable id, whether from a decision-submit
+    /// path that forgot to echo one back or a correlation bug/stale/replayed decision, must never
+    /// silently grant an arbitrary option instead).
+    /// <c>"deny"</c>/<c>"cancel"</c>, no options offered at all, or ANY other outcome string not on
+    /// the allowlist above, map to <c>cancelled</c>.
+    /// </summary>
+    static readonly HashSet<string> AffirmativeOutcomes = ["allow", "allow_once", "allow_always", "answered"];
+
+    static JsonElement MapPermissionDecision(AcpInteractionDecision decision, IReadOnlyList<PermissionOptionDto> options) {
+        // Fail-safe allowlist: only a RECOGNIZED affirmative outcome can ever produce "selected".
+        // Everything else — deny, cancel, an unrecognized/typo'd string, or no options offered —
+        // maps to cancelled. There is deliberately no "default: selected" path anywhere below.
+        if (options.Count == 0 || !AffirmativeOutcomes.Contains(decision.Outcome))
+            return CancelledResult()!.Value;
+
+        // Fresh-review fix: resolve by OptionId ONLY, and FAIL CLOSED with no first-option
+        // fallback for either "no id supplied" or "id supplied but unresolvable" — both map to
+        // cancelled. There is deliberately no `options[0]` anywhere in this method:
+        //   1. No SelectedOptionId supplied at all (null) → cancelled. An affirmative outcome with
+        //      no specific option chosen is NOT treated as "assume the first option" — that was
+        //      precisely the bug this fix closes (see the doc comment above).
+        //   2. SelectedOptionId supplied and it matches an offered option's OptionId → that option.
+        //   3. SelectedOptionId supplied but does NOT match any offered OptionId → treat as
+        //      cancelled. An id that was explicitly set but doesn't resolve indicates a correlation
+        //      bug or a stale/replayed decision — silently granting an unrelated option in that
+        //      case would be worse than failing safe.
+        // Cases 1 and 3 are DELIBERATELY THE SAME "cancelled" outcome, handled by the same
+        // fallthrough below — there is no `options[0]`/first-option branch anywhere in this method.
+        if (decision.SelectedOptionId is not { } optionId)
+            return CancelledResult()!.Value;
+
+        var matched = options.FirstOrDefault(o => o.OptionId == optionId);
+
+        return matched is not null ? SelectedResult(matched) : CancelledResult()!.Value;
+    }
+
+    static JsonElement SelectedResult(PermissionOptionDto chosen) =>
+        JsonSerializer.SerializeToElement(
+            new PermissionOutcomeResult(new PermissionOutcomeDto("selected", chosen.OptionId)),
+            CapacitorJsonContext.Default.PermissionOutcomeResult);
+
+    static JsonElement? CancelledResult() =>
+        JsonSerializer.SerializeToElement(
+            new PermissionOutcomeResult(new PermissionOutcomeDto("cancelled")),
+            CapacitorJsonContext.Default.PermissionOutcomeResult);
+
+    static string? TryGetToolTitle(JsonElement toolCall) =>
+        toolCall.ValueKind == JsonValueKind.Object && toolCall.TryGetProperty("title", out var t) && t.ValueKind == JsonValueKind.String
+            ? t.GetString()
+            : null;
+
+    static string? TryGetToolCallId(JsonElement toolCall) =>
+        toolCall.ValueKind == JsonValueKind.Object && toolCall.TryGetProperty("toolCallId", out var id) && id.ValueKind == JsonValueKind.String
+            ? id.GetString()
+            : null;
+}

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -226,7 +226,11 @@ public static partial class DaemonRunner {
             )
         );
         builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
-            new AcpHostedAgentRuntimeFactory(sp.GetRequiredService<DaemonConfig>(), sp.GetRequiredService<ILoggerFactory>())
+            new AcpHostedAgentRuntimeFactory(
+                sp.GetRequiredService<DaemonConfig>(),
+                sp.GetRequiredService<ILoggerFactory>(),
+                sp.GetRequiredService<ServerConnection>() // spec-review Finding 4 — real production wiring
+            )
         );
 
         builder.Services.AddSingleton<IReadOnlyDictionary<string, IHostedAgentRuntimeFactory>>(sp =>

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -27,6 +27,7 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime {
     readonly AcpConnection _connection;
     readonly IAcpProcess   _process;
     readonly ILogger       _logger;
+    readonly AcpInteractionBridge? _interactionBridge;
     readonly CancellationTokenSource _cts = new();
     readonly Channel<AcpSessionUpdate> _updates = Channel.CreateUnbounded<AcpSessionUpdate>(
         new UnboundedChannelOptions { SingleReader = false, SingleWriter = true });
@@ -42,12 +43,34 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime {
     string? _sessionId;
     int     _disposed;
 
-    public AcpHostedAgentRuntime(AcpConnection connection, IAcpProcess process, ILogger logger) {
+    /// <summary>
+    /// <paramref name="requestInteraction"/> is optional (AI-686) — when null, matches AI-684's
+    /// original behavior exactly: <see cref="AcpConnection.OnServerRequest"/> stays unset, and any
+    /// <c>session/request_permission</c>/<c>elicitation/create</c> the agent sends gets the
+    /// connection's default JSON-RPC "Method not found" response. When provided, it is forwarded
+    /// into a new <see cref="AcpInteractionBridge"/> and wired as <see cref="AcpConnection.OnServerRequest"/>,
+    /// closing over this runtime's <see cref="_sessionId"/> at call time (not construction time —
+    /// the session id isn't known until <see cref="StartAsync"/>'s <c>session/new</c> resolves,
+    /// but a permission/elicitation request can only ever arrive AFTER that, during a
+    /// <c>session/prompt</c> turn).
+    /// </summary>
+    public AcpHostedAgentRuntime(
+            AcpConnection                                                                  connection,
+            IAcpProcess                                                                    process,
+            ILogger                                                                        logger,
+            string                                                                         agentId = "",
+            Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>>?   requestInteraction = null
+        ) {
         _connection = connection;
         _process    = process;
         _logger     = logger;
 
         _connection.OnNotification += HandleNotification;
+
+        if (requestInteraction is not null) {
+            _interactionBridge = new AcpInteractionBridge(requestInteraction, agentId, logger);
+            _connection.OnServerRequest = (request, ct) => _interactionBridge.HandleAsync(request, _sessionId ?? "", ct);
+        }
     }
 
     public string Vendor              => "cursor";
@@ -55,6 +78,9 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime {
     public bool   HasExited           => _process.HasExited;
     public int?   ExitCode            => _process.ExitCode;
     public bool   EmitsTerminalOutput => false;
+
+    /// <summary>The ACP <c>sessionId</c> once <see cref="StartAsync"/>'s <c>session/new</c> has resolved; null before that.</summary>
+    public string? SessionId => _sessionId;
 
     /// <summary>
     /// Reduced <c>session/update</c> notifications, in arrival order. Unbounded so a mapper that

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -48,11 +48,20 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime {
     /// original behavior exactly: <see cref="AcpConnection.OnServerRequest"/> stays unset, and any
     /// <c>session/request_permission</c>/<c>elicitation/create</c> the agent sends gets the
     /// connection's default JSON-RPC "Method not found" response. When provided, it is forwarded
-    /// into a new <see cref="AcpInteractionBridge"/> and wired as <see cref="AcpConnection.OnServerRequest"/>,
-    /// closing over this runtime's <see cref="_sessionId"/> at call time (not construction time —
-    /// the session id isn't known until <see cref="StartAsync"/>'s <c>session/new</c> resolves,
-    /// but a permission/elicitation request can only ever arrive AFTER that, during a
-    /// <c>session/prompt</c> turn).
+    /// into a new <see cref="AcpInteractionBridge"/> and wired as <see cref="AcpConnection.OnServerRequest"/>.
+    ///
+    /// <b>Qodo daemon-review Q2:</b> this wiring no longer closes over this runtime's
+    /// <see cref="_sessionId"/> — <see cref="AcpInteractionBridge.HandleAsync"/> now sources the ACP
+    /// session id solely from the inbound request's OWN params. The prior shape passed
+    /// <c>_sessionId ?? ""</c>, which was correct ONLY because a permission/elicitation request can
+    /// normally arrive no earlier than a <c>session/prompt</c> turn, by which point
+    /// <see cref="StartAsync"/>'s <c>session/new</c> has already resolved <see cref="_sessionId"/> —
+    /// but <see cref="AcpConnection"/>'s read loop is started (via <see cref="RunConnectionLoopAsync"/>)
+    /// BEFORE that handshake completes, so a server request arriving out of turn (a buggy or
+    /// malicious agent) would have forwarded an <see cref="AcpInteractionRequest"/> with
+    /// <c>AcpSessionId == ""</c>, silently breaking server-side correlation instead of failing loud
+    /// or safe. Trusting the request's own params removes this whole class of bug and this runtime
+    /// no longer needs to expose <see cref="_sessionId"/> to the bridge at all.
     /// </summary>
     public AcpHostedAgentRuntime(
             AcpConnection                                                                  connection,
@@ -69,7 +78,7 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime {
 
         if (requestInteraction is not null) {
             _interactionBridge = new AcpInteractionBridge(requestInteraction, agentId, logger);
-            _connection.OnServerRequest = (request, ct) => _interactionBridge.HandleAsync(request, _sessionId ?? "", ct);
+            _connection.OnServerRequest = (request, ct) => _interactionBridge.HandleAsync(request, ct);
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 using Capacitor.Cli.Daemon.Acp;
 using Microsoft.Extensions.Logging;
 
@@ -11,14 +12,71 @@ namespace Capacitor.Cli.Daemon.Services;
 /// <see cref="AcpHostedAgentRuntime.StartAsync"/>. Cursor has no unattended mode yet (no permission
 /// bridge until AI-686), so <see cref="SupportsUnattended"/> is <c>false</c> — the orchestrator's
 /// <c>UnattendedLaunchPolicy</c> refuses a review-flow launch for this vendor.
+///
+/// <b>Spec-review Finding 4 (AI-686):</b> gained a <see cref="ServerConnection"/> constructor
+/// dependency so every runtime this factory produces has the real permission/elicitation bridge
+/// wired — <see cref="StartAsync"/> passes <c>ctx.AgentId</c> and
+/// <see cref="ServerConnection.RequestAcpInteractionAsync"/> into <see cref="AcpHostedAgentRuntime"/>'s
+/// optional parameters instead of leaving them at their <c>""</c>/<see langword="null"/> defaults.
+///
+/// <b>Round-4 Finding 3:</b> process-spawning + stream construction is extracted into
+/// <paramref name="connectionSource"/> (defaulting to <see cref="StartRealProcess"/>) purely so
+/// <see cref="AcpHostedAgentRuntimeFactoryTests"/> can construct THIS class for real and drive its
+/// REAL <see cref="StartAsync"/> against an in-memory <c>FakeAcpAgent</c> peer instead of a real
+/// <c>cursor-agent acp</c> child process (unavailable and non-portable in CI) — the seam changes
+/// nothing about production behavior, since the default IS the real `Process.Start`-backed path.
 /// </summary>
-internal sealed class AcpHostedAgentRuntimeFactory(DaemonConfig config, ILoggerFactory loggerFactory) : IHostedAgentRuntimeFactory {
+internal sealed class AcpHostedAgentRuntimeFactory(
+        DaemonConfig      config,
+        ILoggerFactory    loggerFactory,
+        ServerConnection  connection,
+        Func<RuntimeStartContext, (Stream Input, Stream Output, IAcpProcess Process)>? connectionSource = null
+    ) : IHostedAgentRuntimeFactory {
+    readonly Func<RuntimeStartContext, (Stream Input, Stream Output, IAcpProcess Process)> _connectionSource =
+        connectionSource ?? (ctx => StartRealProcess(config, ctx, loggerFactory));
+
     public string Vendor             => "cursor";
     public bool   SupportsUnattended => false;
 
     public bool IsAvailable() => CliResolver.Exists(config.CursorPath);
 
     public async Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+        var runtimeLogger = loggerFactory.CreateLogger<AcpHostedAgentRuntime>();
+        var connLogger    = loggerFactory.CreateLogger<AcpConnection>();
+
+        var (input, output, acpProcess) = _connectionSource(ctx);
+        var acpConnection = new AcpConnection(input, output, connLogger);
+
+        // Spec-review Finding 4: real production wiring — every Cursor launch now gets the
+        // permission/elicitation bridge, not AI-684's default MethodNotFound/decline.
+        var runtime = new AcpHostedAgentRuntime(
+            acpConnection,
+            acpProcess,
+            runtimeLogger,
+            agentId: ctx.AgentId,
+            requestInteraction: connection.RequestAcpInteractionAsync
+        );
+
+        try {
+            await runtime.StartAsync(ctx.Worktree.Path, ctx.Prompt, ct).ConfigureAwait(false);
+        } catch {
+            // The runtime owns both the connection and the process; dispose on a failed handshake
+            // so a half-started cursor-agent child is never leaked.
+            await runtime.DisposeAsync().ConfigureAwait(false);
+
+            throw;
+        }
+
+        return new HostedRuntimeStart(runtime, McpConfigPath: null);
+    }
+
+    /// <summary>
+    /// The REAL, production process-spawning path — unchanged in behavior from the pre-round-4
+    /// shape of this factory, just extracted into a named method so <paramref name="connectionSource"/>
+    /// can default to it. Spawns <c>{config.CursorPath} acp</c> and returns its stdio streams plus
+    /// an <see cref="AcpChildProcess"/> lifecycle wrapper.
+    /// </summary>
+    static (Stream Input, Stream Output, IAcpProcess Process) StartRealProcess(DaemonConfig config, RuntimeStartContext ctx, ILoggerFactory loggerFactory) {
         var psi = new ProcessStartInfo(config.CursorPath, ["acp"]) {
             WorkingDirectory       = ctx.Worktree.Path,
             RedirectStandardInput  = true,
@@ -35,24 +93,9 @@ internal sealed class AcpHostedAgentRuntimeFactory(DaemonConfig config, ILoggerF
         var process = Process.Start(psi)
             ?? throw new InvalidOperationException($"Failed to start '{config.CursorPath} acp' (Process.Start returned null).");
 
-        var connLogger    = loggerFactory.CreateLogger<AcpConnection>();
-        var runtimeLogger = loggerFactory.CreateLogger<AcpHostedAgentRuntime>();
         var processLogger = loggerFactory.CreateLogger<AcpChildProcess>();
+        var acpProcess    = new AcpChildProcess(process, processLogger);
 
-        var connection = new AcpConnection(process.StandardInput.BaseStream, process.StandardOutput.BaseStream, connLogger);
-        var acpProcess = new AcpChildProcess(process, processLogger);
-        var runtime    = new AcpHostedAgentRuntime(connection, acpProcess, runtimeLogger);
-
-        try {
-            await runtime.StartAsync(ctx.Worktree.Path, ctx.Prompt, ct).ConfigureAwait(false);
-        } catch {
-            // The runtime owns both the connection and the process; dispose on a failed handshake
-            // so a half-started cursor-agent child is never leaked.
-            await runtime.DisposeAsync().ConfigureAwait(false);
-
-            throw;
-        }
-
-        return new HostedRuntimeStart(runtime, McpConfigPath: null);
+        return (process.StandardInput.BaseStream, process.StandardOutput.BaseStream, acpProcess);
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/PendingAcpInteractionRegistry.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PendingAcpInteractionRegistry.cs
@@ -1,0 +1,70 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Correlates an ACP interaction request (AI-686) with the server's later
+/// <c>AcpInteractionResolved</c> push. Copy-shape of <see cref="PendingPermissionRegistry"/>
+/// parameterized on <see cref="AcpInteractionDecision"/> instead of <see cref="PermissionDecision"/>
+/// — kept as a separate small class (matching this codebase's existing style of small,
+/// non-generic sibling classes rather than a shared generic base) rather than genericizing
+/// <see cref="PendingPermissionRegistry"/>, so the two registries can evolve independently (e.g.
+/// if ACP interactions later need multi-recipient fan-out that Claude Code permissions never
+/// will) without either one's tests coupling to the other's generic parameter.
+/// </summary>
+internal sealed class PendingAcpInteractionRegistry {
+    const int MaxBufferedDecisions = 1024;
+
+    readonly Lock                                                              _gate       = new();
+    readonly Dictionary<string, TaskCompletionSource<AcpInteractionDecision>>  _pending    = new();
+    readonly Dictionary<string, AcpInteractionDecision>                        _early      = new();
+    readonly Queue<string>                                                     _earlyOrder = new();
+
+    public Task<AcpInteractionDecision> AwaitDecisionAsync(string requestId, CancellationToken ct) {
+        TaskCompletionSource<AcpInteractionDecision> tcs;
+
+        lock (_gate) {
+            if (_early.Remove(requestId, out var early))
+                return Task.FromResult(early);
+
+            tcs = new TaskCompletionSource<AcpInteractionDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _pending[requestId] = tcs;
+        }
+
+        return AwaitWithCancellationAsync(requestId, tcs, ct);
+    }
+
+    async Task<AcpInteractionDecision> AwaitWithCancellationAsync(
+            string                                        requestId,
+            TaskCompletionSource<AcpInteractionDecision>   tcs,
+            CancellationToken                              ct
+        ) {
+        await using var _ = ct.Register(() => {
+            lock (_gate) _pending.Remove(requestId);
+
+            tcs.TrySetCanceled(ct);
+        }).ConfigureAwait(false);
+
+        return await tcs.Task.ConfigureAwait(false);
+    }
+
+    public void Resolve(string requestId, AcpInteractionDecision decision) {
+        TaskCompletionSource<AcpInteractionDecision>? tcs;
+
+        lock (_gate) {
+            if (!_pending.Remove(requestId, out tcs)) {
+                if (_early.TryAdd(requestId, decision))
+                    _earlyOrder.Enqueue(requestId);
+                else
+                    _early[requestId] = decision;
+
+                while (_early.Count > MaxBufferedDecisions && _earlyOrder.Count > 0)
+                    _early.Remove(_earlyOrder.Dequeue());
+
+                return;
+            }
+        }
+
+        tcs!.TrySetResult(decision);
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -19,6 +19,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     readonly ILogger<ServerConnection> _logger;
     readonly RegistrationGate          _gate                = new();
     readonly PendingPermissionRegistry _pendingPermissions  = new();
+    readonly PendingAcpInteractionRegistry _pendingAcpInteractions = new();
 
     static readonly TimeSpan PermissionRetryPollInterval = TimeSpan.FromMilliseconds(500);
     static readonly TimeSpan EndSessionRetryPollInterval  = TimeSpan.FromMilliseconds(500);
@@ -158,6 +159,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         // contract can evolve without breaking mixed-version daemons.
         _hub.On<PermissionResolution>("PermissionResolved",
             res => _pendingPermissions.Resolve(res.RequestId, res.Decision));
+
+        // Server→client push carrying the user's decision for an ACP permission/elicitation
+        // interaction (AI-686). Mirrors the PermissionResolved registration above — a separate
+        // registry (AcpInteractionDecision-typed) rather than reusing _pendingPermissions, since
+        // the decision payload shape differs (ACP interactions carry SelectedOptionLabel/
+        // SelectedIndex/FreeText that Claude Code's PermissionDecision has no equivalent for).
+        _hub.On<AcpInteractionResolution>("AcpInteractionResolved",
+            res => _pendingAcpInteractions.Resolve(res.RequestId, res.Decision));
 
         RegisterUiBroadcastSinks();
 
@@ -574,6 +583,30 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         );
 
         return await _pendingPermissions.AwaitDecisionAsync(requestId, ct);
+    }
+
+    /// <summary>
+    /// Forwards an ACP permission/elicitation interaction to the server's
+    /// <c>AcpRequestInteraction</c> hub method and returns the user's decision (AI-686). Mirrors
+    /// <see cref="RequestPermissionAsync"/>'s non-blocking-invoke-then-await-push pattern exactly —
+    /// see that method's remarks for why the invoke returns a requestId immediately rather than
+    /// blocking the connection's parallel-invocation slot for the whole interaction wait.
+    /// </summary>
+    public virtual async Task<AcpInteractionDecision> RequestAcpInteractionAsync(
+            AcpInteractionRequest request,
+            CancellationToken     ct = default
+        ) {
+        var requestId = await ConnectionRetry.InvokeWithConnectionRetryAsync(
+            () => _hub.InvokeAsync<string>("AcpRequestInteraction", request, ct),
+            () => IsReady,
+            PermissionRetryPollInterval,
+            attempt => LogPermissionRetry(request.AcpSessionId, attempt),
+            ct,
+            isRetriableServerError: IsOwnershipNotReady,
+            maxServerErrorRetries: OwnershipNotReadyMaxRetries
+        );
+
+        return await _pendingAcpInteractions.AwaitDecisionAsync(requestId, ct);
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimePermissionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimePermissionTests.cs
@@ -1,0 +1,241 @@
+// test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimePermissionTests.cs
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// AI-686 end-to-end: <see cref="FakeAcpAgent"/> sends a real
+/// <c>session/request_permission</c> server→client request mid-turn; the runtime's wired
+/// <see cref="AcpInteractionBridge"/> forwards it to an injected "ask the server" delegate and
+/// writes the JSON-RPC response back to the wire only once that delegate resolves — proving the
+/// agent's request genuinely blocks on the human decision rather than getting an immediate
+/// default-decline (AI-684's prior behavior, since <c>OnServerRequest</c> was unset).
+/// </summary>
+public class AcpHostedAgentRuntimePermissionTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    sealed class FakeAcpProcess : IAcpProcess {
+        readonly TaskCompletionSource _exited = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int  Pid       { get; init; } = 4242;
+        public bool HasExited { get; private set; }
+        public int? ExitCode  { get; private set; }
+        public void SignalExited(int exitCode = 0) { HasExited = true; ExitCode = exitCode; _exited.TrySetResult(); }
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => _exited.Task;
+        public Task TerminateAsync(TimeSpan? timeout = null) { SignalExited(); return Task.CompletedTask; }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    [Test]
+    public async Task PermissionRequest_BlocksResponseUntilInjectedDecisionResolves() {
+        var fake    = new FakeAcpAgent();
+        var conn    = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var process = new FakeAcpProcess();
+
+        var gate = new TaskCompletionSource<AcpInteractionDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var runtime = new AcpHostedAgentRuntime(
+            conn,
+            process,
+            NullLogger.Instance,
+            requestInteraction: (req, ct) => gate.Task);
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        await runtime.StartAsync("/abs/worktree", "", cts.Token).WaitAsync(HangGuard);
+
+        // Script the fake to send a session/request_permission mid-turn, then answer session/prompt
+        // normally afterward — the fake's new scripting mechanism (Step 3 below) lets a test drive
+        // this without hand-rolling raw JSON-RPC frames.
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Run ls"}""",
+            optionsJson: """[{"optionId":"allow-once","name":"Allow","kind":"allow_once"},{"optionId":"deny","name":"Deny","kind":"reject_once"}]""");
+
+        await runtime.SendUserInputAsync("run ls").WaitAsync(HangGuard);
+
+        // The fake recorded the outbound session/request_permission call, but hasn't received a
+        // response yet — the runtime's bridge is awaiting `gate.Task`, which we haven't resolved.
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!fake.ReceivedCalls.Any(c => c.Method == "session/request_permission" || fake.SentServerRequests.Any(r => r.Method == "session/request_permission")) && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        await Assert.That(fake.SentServerRequests.Any(r => r.Method == "session/request_permission")).IsTrue();
+        await Assert.That(fake.LastServerRequestResponse).IsNull(); // still pending — not yet answered
+
+        // Now resolve the human decision. Round-7 spec-review Finding 5: supply a REAL, matching
+        // SelectedOptionId ("allow-once", one of the two options offered above) rather than null —
+        // a null SelectedOptionId must map to `cancelled` (see AcpInteractionBridgeTests' fail-closed
+        // tests), never fall back to the first offered option, so this end-to-end test must not rely
+        // on that removed behavior either to observe a `selected` outcome below.
+        gate.TrySetResult(new AcpInteractionDecision("allow", "allow-once", "Allow", null, null, null));
+
+        var responseDeadline = DateTime.UtcNow + HangGuard;
+        while (fake.LastServerRequestResponse is null && DateTime.UtcNow < responseDeadline)
+            await Task.Delay(10);
+
+        await Assert.That(fake.LastServerRequestResponse).IsNotNull();
+        var outcome = fake.LastServerRequestResponse!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("selected");
+        await Assert.That(outcome.GetProperty("optionId").GetString()).IsEqualTo("allow-once");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    [Test]
+    public async Task PermissionRequest_NoInteractionDelegateWired_DefaultsToMethodNotFound() {
+        // Backward-compat: a runtime constructed WITHOUT the new optional delegate (matching every
+        // pre-AI-686 call site) keeps AI-684's exact default-decline posture — OnServerRequest
+        // stays effectively unset for permission requests, so AcpConnection answers with a
+        // JSON-RPC "Method not found" error, not a crash or hang.
+        var fake    = new FakeAcpAgent();
+        var conn    = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var process = new FakeAcpProcess();
+
+        var runtime = new AcpHostedAgentRuntime(conn, process, NullLogger.Instance); // no requestInteraction arg
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        await runtime.StartAsync("/abs/worktree", "", cts.Token).WaitAsync(HangGuard);
+
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Run ls"}""",
+            optionsJson: """[{"optionId":"allow-once","name":"Allow","kind":"allow_once"}]""");
+
+        await runtime.SendUserInputAsync("run ls").WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (fake.LastServerRequestError is null && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        await Assert.That(fake.LastServerRequestError).IsNotNull();
+        await Assert.That(fake.LastServerRequestError!.Value.GetProperty("code").GetInt32()).IsEqualTo(-32601);
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Spec-review Finding 2, end-to-end THROUGH the real <see cref="AcpInteractionBridge"/> (not a
+    /// direct <c>MapPermissionDecision</c> unit call — <see cref="AcpInteractionBridgeTests"/>
+    /// already covers that in isolation): a cancellation decision, delivered exactly the way a real
+    /// "human clicked Deny" or "session ended while pending" resolution would arrive (an
+    /// <see cref="AcpInteractionDecision"/> with <see cref="AcpInteractionDecision.Outcome"/> equal
+    /// to the canonical <c>"cancel"</c> string), must produce an ACP <c>cancelled</c> response on the
+    /// wire — NEVER <c>selected</c> — when routed through the runtime's wired
+    /// <see cref="AcpConnection.OnServerRequest"/> exactly as production traffic would be.
+    /// </summary>
+    [Test]
+    public async Task PermissionRequest_CancelledDecision_NeverProducesSelectedResponse() {
+        var fake    = new FakeAcpAgent();
+        var conn    = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var process = new FakeAcpProcess();
+
+        var runtime = new AcpHostedAgentRuntime(
+            conn,
+            process,
+            NullLogger.Instance,
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("cancel", null, null, null, null, null)));
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        await runtime.StartAsync("/abs/worktree", "", cts.Token).WaitAsync(HangGuard);
+
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Run rm -rf /"}""",
+            optionsJson: """[{"optionId":"allow-once","name":"Allow","kind":"allow_once"},{"optionId":"deny","name":"Deny","kind":"reject_once"}]""");
+
+        await runtime.SendUserInputAsync("run it").WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (fake.LastServerRequestResponse is null && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        await Assert.That(fake.LastServerRequestResponse).IsNotNull();
+        var outcome = fake.LastServerRequestResponse!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+        await Assert.That(outcome.TryGetProperty("optionId", out _)).IsFalse();
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Spec-review Finding 3(b): the runtime disposing (connection closing) WHILE a
+    /// <c>session/request_permission</c> is genuinely pending — <paramref name="requestInteraction"/>
+    /// never completes on its own — must resolve the pending request to the well-formed ACP
+    /// <c>cancelled</c> response exactly once, not hang forever and not surface as an unhandled
+    /// exception anywhere in the dispose path. <see cref="AcpHostedAgentRuntime.DisposeAsync"/>
+    /// cancels its own <c>_cts</c>, which is the SAME token threaded all the way through
+    /// <see cref="AcpConnection"/>'s read loop into this bridge's <c>ct</c> parameter — so the
+    /// injected delegate below observes that same cancellation and the bridge (Task B3's fix)
+    /// converts it to <c>cancelled</c> rather than letting it propagate as an unhandled
+    /// <see cref="OperationCanceledException"/> out of <c>AcpConnection.HandleServerRequestAsync</c>.
+    /// </summary>
+    [Test]
+    public async Task PermissionRequest_ConnectionDisposedWhilePending_ResolvesToCancelledExactlyOnce() {
+        var fake    = new FakeAcpAgent();
+        var conn    = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var process = new FakeAcpProcess();
+
+        var runtime = new AcpHostedAgentRuntime(
+            conn,
+            process,
+            NullLogger.Instance,
+            // Never resolves on its own — only cancellation (from DisposeAsync below) ends this.
+            requestInteraction: (req, ct) => Task.Delay(Timeout.Infinite, ct).ContinueWith(_ => default(AcpInteractionDecision), TaskScheduler.Default));
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        await runtime.StartAsync("/abs/worktree", "", cts.Token).WaitAsync(HangGuard);
+
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Run ls"}""",
+            optionsJson: """[{"optionId":"allow-once","name":"Allow","kind":"allow_once"}]""");
+
+        await runtime.SendUserInputAsync("run ls").WaitAsync(HangGuard);
+
+        // Confirm the request genuinely went out and is genuinely still pending before disposing.
+        var sentDeadline = DateTime.UtcNow + HangGuard;
+        while (!fake.SentServerRequests.Any(r => r.Method == "session/request_permission") && DateTime.UtcNow < sentDeadline)
+            await Task.Delay(10);
+        await Assert.That(fake.SentServerRequests.Any(r => r.Method == "session/request_permission")).IsTrue();
+        await Assert.That(fake.LastServerRequestResponse).IsNull();
+        await Assert.That(fake.LastServerRequestError).IsNull();
+
+        // Dispose while pending — this is the disconnect this finding covers.
+        await runtime.DisposeAsync().AsTask().WaitAsync(HangGuard);
+
+        // The bridge must have written back a well-formed `cancelled` response before/as part of
+        // teardown — never an unhandled exception, never a bare JSON-RPC "Internal error", and
+        // never left permanently unanswered. DisposeAsync awaiting the connection's own read loop
+        // only guarantees the response bytes were WRITTEN to the wire, not that the fake's separate
+        // RunAsync task has already read and processed them — so poll briefly rather than asserting
+        // immediately.
+        var writtenBackDeadline = DateTime.UtcNow + HangGuard;
+        while (fake.LastServerRequestResponse is null && DateTime.UtcNow < writtenBackDeadline)
+            await Task.Delay(10);
+
+        await Assert.That(fake.LastServerRequestResponse).IsNotNull();
+        var outcome = fake.LastServerRequestResponse!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+        await Assert.That(fake.LastServerRequestError).IsNull(); // NOT AcpConnection's generic -32603 fallback
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await fake.DisposeAsync();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimePermissionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimePermissionTests.cs
@@ -238,4 +238,56 @@ public class AcpHostedAgentRuntimePermissionTests {
         try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
         await fake.DisposeAsync();
     }
+
+    /// <summary>
+    /// Qodo daemon-review Q2, end-to-end through the real wiring: <see cref="AcpHostedAgentRuntime"/>
+    /// used to wire <c>OnServerRequest</c> as <c>(request, ct) =&gt; _interactionBridge.HandleAsync(request, _sessionId ?? "", ct)</c> —
+    /// closing over the runtime's own <c>_sessionId</c> field rather than trusting the inbound
+    /// request's OWN <c>sessionId</c> param. <c>FakeAcpAgent</c>'s scripted
+    /// <c>session/request_permission</c> frame always carries <see cref="FakeAcpAgent.FixedSessionId"/>
+    /// in its params (see <c>BuildRequestPermissionFrame</c>), which happens to equal the same value
+    /// <c>StartAsync</c>'s <c>session/new</c> response resolves into <c>_sessionId</c> — so the OLD
+    /// wiring and the NEW params-sourced wiring were indistinguishable via that path alone. This test
+    /// closes that gap by asserting directly that the forwarded <see cref="AcpInteractionRequest.AcpSessionId"/>
+    /// equals the fixed session id from the wire, proving the value is genuinely sourced from the
+    /// request rather than incidentally matching a runtime field of the same value.
+    /// </summary>
+    [Test]
+    public async Task PermissionRequest_ForwardedAcpSessionId_MatchesRequestParamsSessionId() {
+        var fake    = new FakeAcpAgent();
+        var conn    = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var process = new FakeAcpProcess();
+
+        AcpInteractionRequest? captured = null;
+
+        var runtime = new AcpHostedAgentRuntime(
+            conn,
+            process,
+            NullLogger.Instance,
+            requestInteraction: (req, ct) => { captured = req; return Task.FromResult(new AcpInteractionDecision("allow", "allow-once", "Allow", null, null, null)); });
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        await runtime.StartAsync("/abs/worktree", "", cts.Token).WaitAsync(HangGuard);
+
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Run ls"}""",
+            optionsJson: """[{"optionId":"allow-once","name":"Allow","kind":"allow_once"}]""");
+
+        await runtime.SendUserInputAsync("run ls").WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (captured is null && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        await Assert.That(captured).IsNotNull();
+        await Assert.That(captured!.Value.AcpSessionId).IsEqualTo(FakeAcpAgent.FixedSessionId);
+        await Assert.That(captured.Value.AcpSessionId).IsNotEmpty();
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
@@ -47,7 +47,7 @@ public class AcpInteractionBridgeTests {
 
         var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         await Assert.That(result).IsNotNull();
         var outcome = result!.Value.GetProperty("outcome");
@@ -64,7 +64,7 @@ public class AcpInteractionBridgeTests {
 
         var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         var outcome = result!.Value.GetProperty("outcome");
         await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
@@ -79,7 +79,7 @@ public class AcpInteractionBridgeTests {
 
         var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         var outcome = result!.Value.GetProperty("outcome");
         await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
@@ -94,7 +94,7 @@ public class AcpInteractionBridgeTests {
 
         var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         await Assert.That(result).IsNotNull();
         var outcome = result!.Value.GetProperty("outcome");
@@ -121,7 +121,7 @@ public class AcpInteractionBridgeTests {
 
         var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         await Assert.That(result).IsNotNull();
         var outcome = result!.Value.GetProperty("outcome");
@@ -138,9 +138,168 @@ public class AcpInteractionBridgeTests {
 
         var request = new AcpRequest(1, "session/request_permission", Params: null);
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         await Assert.That(called).IsFalse();
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>
+    /// Qodo daemon-review Q1 (fail-safe hole): <c>SessionRequestPermissionParams.Options</c> is
+    /// typed as a non-nullable <c>PermissionOptionDto[]</c>, but System.Text.Json does NOT enforce
+    /// non-nullable-reference annotations at deserialize time — an <c>options</c> field OMITTED
+    /// entirely from the wire frame (the ACP spec for this method is spec-derived, NOT
+    /// probe-confirmed; see <c>docs/acp-probe-findings.md</c>) yields <c>parsed.Options == null</c>.
+    /// PRE-FIX this NRE'd inside <c>.Select(...)</c>/<c>MapPermissionDecision</c>, which
+    /// <see cref="HandlePermissionAsync"/>'s own try/catch does NOT cover (it only wraps the
+    /// deserialize step and the <c>requestInteraction</c> call) — so the exception propagated all
+    /// the way out to <see cref="AcpConnection.HandleServerRequestAsync"/>'s generic catch-all,
+    /// which answers with a bare JSON-RPC "Internal error" (-32603) instead of the well-formed ACP
+    /// <c>cancelled</c> outcome every other malformed-input path in this bridge produces. This test
+    /// proves an omitted <c>options</c> field degrades to <c>cancelled</c> instead.
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_OptionsFieldOmitted_ReturnsCancelledResultNotThrow() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var json = $$"""{"sessionId":"{{AcpSessionId}}","toolCall":{"toolCallId":"call-1","title":"Run ls"} }""";
+        var request = new AcpRequest(1, "session/request_permission", JsonDocument.Parse(json).RootElement.Clone());
+
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>
+    /// Qodo daemon-review Q1: same fail-safe hole as above, but for an explicit JSON <c>null</c>
+    /// (rather than an omitted field) for <c>options</c> — also deserializes to
+    /// <c>parsed.Options == null</c> since <see cref="Capacitor.Cli.Core.Acp.PermissionOptionDto"/>[]
+    /// is a reference type and System.Text.Json happily assigns <c>null</c> to it regardless of the
+    /// record's non-nullable C# annotation.
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_OptionsFieldExplicitNull_ReturnsCancelledResultNotThrow() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var json = $$"""{"sessionId":"{{AcpSessionId}}","toolCall":{"toolCallId":"call-1","title":"Run ls"},"options":null}""";
+        var request = new AcpRequest(1, "session/request_permission", JsonDocument.Parse(json).RootElement.Clone());
+
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>
+    /// Qodo daemon-review Q1: an <c>options</c> array containing a JSON <c>null</c> ELEMENT (rather
+    /// than the whole array being absent/null) must also never throw — the fix's normalization
+    /// filters out null elements before building <see cref="AcpInteractionRequest.Options"/> and
+    /// before <c>MapPermissionDecision</c> ever sees them.
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_OptionsArrayContainsNullElement_ReturnsCancelledResultNotThrow() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var json = $$"""{"sessionId":"{{AcpSessionId}}","toolCall":{"toolCallId":"call-1","title":"Run ls"},"options":[null,{"optionId":"allow-once","name":"Allow","kind":"allow_once"}]}""";
+        var request = new AcpRequest(1, "session/request_permission", JsonDocument.Parse(json).RootElement.Clone());
+
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        var outcome = result!.Value.GetProperty("outcome");
+        // "allow" with no SelectedOptionId still fails closed per the existing fail-closed contract —
+        // the point of this test is only that the null element never throws.
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>
+    /// Qodo daemon-review Q1: the same omitted-<c>options</c> fail-safe hole exists on the
+    /// <c>elicitation/create</c> path too (<see cref="ElicitationCreateParams.Options"/> is already
+    /// nullable there, and <see cref="HandleElicitationAsync"/> already null-coalesces it — this
+    /// test pins that existing defensive behavior stays correct after the shared normalization
+    /// helper is introduced for Q1).
+    /// </summary>
+    [Test]
+    public async Task ElicitationCreate_OptionsFieldOmitted_ReturnsCancelledResultNotThrow() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("answered", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var json = $$"""{"sessionId":"{{AcpSessionId}}","message":"Proceed?"}""";
+        var request = new AcpRequest(1, "elicitation/create", JsonDocument.Parse(json).RootElement.Clone());
+
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>
+    /// Qodo daemon-review Q2: <see cref="AcpHostedAgentRuntime"/> used to wire
+    /// <c>OnServerRequest</c> with <c>_sessionId ?? ""</c> — a server→client request handled before
+    /// <c>session/new</c>'s response assigns <c>_sessionId</c> (the read loop can start before that
+    /// completes) forwarded an <see cref="AcpInteractionRequest"/> with <c>AcpSessionId == ""</c>,
+    /// breaking server-side correlation. The fix drops that runtime-level session id entirely and
+    /// has the bridge trust <see cref="SessionRequestPermissionParams.SessionId"/> — the request's
+    /// OWN params — as the sole source of truth. This test proves the forwarded
+    /// <see cref="AcpInteractionRequest.AcpSessionId"/> comes from the request params, not from any
+    /// caller-supplied value, by using a params <c>sessionId</c> distinct from any value the old API
+    /// shape would have injected.
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_ForwardsAcpSessionIdFromRequestParams() {
+        AcpInteractionRequest? captured = null;
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => { captured = req; return Task.FromResult(new AcpInteractionDecision("allow", null, null, null, null, null)); },
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        const string sessionIdFromParams = "session-from-params-only";
+        var json = $$"""{"sessionId":"{{sessionIdFromParams}}","toolCall":{"toolCallId":"call-1","title":"Run ls"},"options":[{"optionId":"allow-once","name":"Allow","kind":"allow_once"}]}""";
+        var request = new AcpRequest(1, "session/request_permission", JsonDocument.Parse(json).RootElement.Clone());
+
+        await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(captured).IsNotNull();
+        await Assert.That(captured!.Value.AcpSessionId).IsEqualTo(sessionIdFromParams);
+    }
+
+    /// <summary>
+    /// Qodo daemon-review Q2: a <c>session/request_permission</c> whose OWN params carry no
+    /// resolvable session id (missing/empty <c>sessionId</c>) can't be correlated server-side at
+    /// all — this must degrade to the well-formed ACP <c>cancelled</c> result (never a thrown
+    /// exception, and never forwarded to the server with an empty/placeholder session id).
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_EmptySessionIdInParams_ReturnsCancelledResultWithoutCallingServer() {
+        var called = false;
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => { called = true; return Task.FromResult(new AcpInteractionDecision("allow", null, null, null, null, null)); },
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var json = """{"sessionId":"","toolCall":{"toolCallId":"call-1","title":"Run ls"},"options":[{"optionId":"allow-once","name":"Allow","kind":"allow_once"}]}""";
+        var request = new AcpRequest(1, "session/request_permission", JsonDocument.Parse(json).RootElement.Clone());
+
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(called).IsFalse();
+        await Assert.That(result).IsNotNull();
         var outcome = result!.Value.GetProperty("outcome");
         await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
     }
@@ -168,7 +327,7 @@ public class AcpInteractionBridgeTests {
 
         var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         var outcome = result!.Value.GetProperty("outcome");
         // No SelectedOptionId was supplied — must be cancelled, NEVER "selected"/"allow-once".
@@ -191,7 +350,7 @@ public class AcpInteractionBridgeTests {
 
         var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once"]));
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         var outcome = result!.Value.GetProperty("outcome");
         await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
@@ -216,7 +375,7 @@ public class AcpInteractionBridgeTests {
         var json = $$"""{"sessionId":"{{AcpSessionId}}","toolCall":{"toolCallId":"call-1","title":"Run ls"},"options":[{"optionId":"allow-first","name":"Allow","kind":"allow_once"},{"optionId":"allow-second","name":"Allow","kind":"allow_always"},{"optionId":"deny","name":"Deny","kind":"reject_once"}]}""";
         var request = new AcpRequest(1, "session/request_permission", JsonDocument.Parse(json).RootElement.Clone());
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         var outcome = result!.Value.GetProperty("outcome");
         await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("selected");
@@ -241,7 +400,7 @@ public class AcpInteractionBridgeTests {
 
         var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         var outcome = result!.Value.GetProperty("outcome");
         await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
@@ -269,7 +428,7 @@ public class AcpInteractionBridgeTests {
 
         var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         var outcome = result!.Value.GetProperty("outcome");
         await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
@@ -285,7 +444,7 @@ public class AcpInteractionBridgeTests {
 
         var request = new AcpRequest(1, "fs/read_text_file", Params: JsonDocument.Parse("{}").RootElement.Clone());
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         await Assert.That(result).IsNull();
     }
@@ -304,7 +463,7 @@ public class AcpInteractionBridgeTests {
         var json = $$"""{"sessionId":"{{AcpSessionId}}","message":"Proceed?","options":[{"optionId":"yes","name":"Yes","kind":"allow_once"},{"optionId":"no","name":"No","kind":"reject_once"}]}""";
         var request = new AcpRequest(1, "elicitation/create", JsonDocument.Parse(json).RootElement.Clone());
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         await Assert.That(result).IsNotNull();
         var outcome = result!.Value.GetProperty("outcome");
@@ -339,7 +498,7 @@ public class AcpInteractionBridgeTests {
         var json = $$$$$"""{"sessionId":"{{{{{AcpSessionId}}}}}","message":"Describe the config","requestedSchema":{"type":"object","properties":{"name":{"type":"string"}}}}""";
         var request = new AcpRequest(1, "elicitation/create", JsonDocument.Parse(json).RootElement.Clone());
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         await Assert.That(result).IsNotNull();
         await Assert.That(captured).IsNotNull();
@@ -369,7 +528,7 @@ public class AcpInteractionBridgeTests {
         var json = $$"""{"sessionId":"{{AcpSessionId}}","message":"Proceed?","requestedSchema":"not-an-object"}""";
         var request = new AcpRequest(1, "elicitation/create", JsonDocument.Parse(json).RootElement.Clone());
 
-        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         await Assert.That(result).IsNotNull();
         var outcome = result!.Value.GetProperty("outcome");

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
@@ -1,0 +1,378 @@
+// test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// AI-686: <see cref="AcpInteractionBridge"/> parses an inbound <c>session/request_permission</c>
+/// (spec-derived shape, NOT probe-confirmed — see <c>docs/acp-probe-findings.md</c>) or capability-
+/// gated <c>elicitation/create</c> server request, forwards it to an injected
+/// "ask the server" delegate (standing in for <see cref="Capacitor.Cli.Daemon.Services.ServerConnection.RequestAcpInteractionAsync"/>),
+/// and maps the returned <see cref="AcpInteractionDecision"/> back to the ACP JSON-RPC result
+/// shape. Unit-tested against the delegate directly — no real SignalR connection involved.
+/// </summary>
+public class AcpInteractionBridgeTests {
+    const string AgentId      = "agent-1";
+    const string AcpSessionId = "fc2e09cf-f4b0-4463-9dc1-bda11268896b";
+
+    static JsonElement PermissionRequestParams(string[] optionIds) {
+        var optionsJson = string.Join(",", optionIds.Select(id => $$"""{"optionId":"{{id}}","name":"{{id}}","kind":"allow_once"}"""));
+        var json = $$"""{"sessionId":"{{AcpSessionId}}","toolCall":{"toolCallId":"call-1","title":"Run ls"},"options":[{{optionsJson}}]}""";
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    /// <summary>
+    /// Round-7 spec-review Finding 5 (test consistency): the "selected" case must supply a REAL,
+    /// matching <see cref="AcpInteractionDecision.SelectedOptionId"/> — asserting `selected(thatOptionId)`
+    /// — never a null <c>SelectedOptionId</c> that happens to map to the first offered option. An
+    /// earlier draft of this test resolved with `new AcpInteractionDecision("allow", null, ...)` and
+    /// still asserted `optionId == "allow-once"` (the first offered option), which contradicted this
+    /// same file's own fail-closed tests below (`RequestPermission_AffirmativeOutcomeButNoSelectedOptionId_MapsToCancelled_NeverFirstOption`,
+    /// `RequestPermission_SingleOptionOffered_NoSelectedOptionId_StillMapsToCancelled`) — a null
+    /// <c>SelectedOptionId</c> must map to <c>cancelled</c>, NEVER <c>selected</c>/first-option. This
+    /// test now supplies an explicit, resolvable `SelectedOptionId: "allow-once"` so it proves the
+    /// GENUINE "selected" path (an id that matches one of the offered options) without relying on
+    /// the removed first-option fallback.
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_SelectedOutcome_ReturnsSelectedResultWithMatchingOptionId() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", "allow-once", "Allow", null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("selected");
+        await Assert.That(outcome.GetProperty("optionId").GetString()).IsEqualTo("allow-once");
+    }
+
+    [Test]
+    public async Task RequestPermission_DenyOutcome_ReturnsCancelledResult() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("deny", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    [Test]
+    public async Task RequestPermission_CancelOutcome_ReturnsCancelledResult() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("cancel", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    [Test]
+    public async Task RequestPermission_ServerCallThrows_ReturnsCancelledResultDefensively() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => throw new InvalidOperationException("connection dropped"),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>
+    /// Spec-review Finding 3(b): connection-closed / runtime-disposing / CT-cancelled while this
+    /// interaction is pending — the SAME path <c>AcpHostedAgentRuntime.DisposeAsync</c> triggers by
+    /// cancelling its <c>_cts</c>, which flows through <c>AcpConnection</c>'s read loop into this
+    /// bridge's <c>ct</c> parameter and ultimately into <c>PendingAcpInteractionRegistry.AwaitDecisionAsync</c>'s
+    /// own cancellation registration (Task B2), which throws <see cref="OperationCanceledException"/>.
+    /// PRE-FIX, this exception type was excluded from the bridge's catch clause and propagated
+    /// uncaught, letting <c>AcpConnection.HandleServerRequestAsync</c>'s generic catch-all convert
+    /// it to a JSON-RPC "Internal error" (code -32603) instead of a well-formed ACP <c>cancelled</c>
+    /// outcome. This test proves the bridge itself now produces the well-formed shape.
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_ConnectionCancelled_ReturnsCancelledResultNotUnhandledException() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromException<AcpInteractionDecision>(new OperationCanceledException("connection closing")),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    [Test]
+    public async Task RequestPermission_MissingParams_ReturnsCancelledResultWithoutCallingServer() {
+        var called = false;
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => { called = true; return Task.FromResult(new AcpInteractionDecision("allow", null, null, null, null, null)); },
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", Params: null);
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        await Assert.That(called).IsFalse();
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>
+    /// Fresh-review finding (this revision, closing the last gap in spec-review Finding 2): an
+    /// earlier draft of this fix left a "no SelectedOptionId at all → fall back to the first
+    /// offered option" defensive path for a RECOGNIZED AFFIRMATIVE outcome — e.g. a UI/decision-submit
+    /// path that only knows "the user said yes" without echoing back a specific chosen option. That
+    /// is the SAME class of silent-grant bug spec-review Finding 2 targets: an ACP options request
+    /// with two-or-more offered options (here, "allow-once" and "deny") must NEVER resolve to
+    /// `options[0]` just because a caller forgot (or was unable) to supply which option was chosen.
+    /// This test proves the FIXED behavior: `allow_always` (a recognized affirmative outcome) with
+    /// `SelectedOptionId: null` maps to `cancelled`, NEVER `selected`. There is no code path left in
+    /// `MapPermissionDecision` that can produce a `selected` result without an explicit, resolvable
+    /// `SelectedOptionId` matching one of the offered options — see the next-but-one test for the
+    /// unresolvable-id half of the same fail-closed guarantee.
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_AffirmativeOutcomeButNoSelectedOptionId_MapsToCancelled_NeverFirstOption() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow_always", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        var outcome = result!.Value.GetProperty("outcome");
+        // No SelectedOptionId was supplied — must be cancelled, NEVER "selected"/"allow-once".
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+        await Assert.That(outcome.TryGetProperty("optionId", out _)).IsFalse();
+    }
+
+    /// <summary>
+    /// Same fail-closed guarantee as above, for a single-option permission prompt specifically —
+    /// proves the fix does not special-case "only one option was offered" as an implicit "assume
+    /// that one." A caller MUST echo back the single option's id explicitly; omitting it still maps
+    /// to cancelled even when there is only one option that COULD have been meant.
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_SingleOptionOffered_NoSelectedOptionId_StillMapsToCancelled() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once"]));
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>
+    /// Spec-review Finding 6: proves resolution is by <see cref="AcpInteractionDecision.SelectedOptionId"/>,
+    /// NEVER by re-matching <see cref="AcpInteractionDecision.SelectedOptionLabel"/> — duplicate
+    /// labels across two DIFFERENT offered options must resolve to the option whose
+    /// <c>optionId</c> was actually selected, not "whichever option happens to have this label
+    /// first" (the old label-matching behavior this finding replaces).
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_DuplicateLabels_ResolvesByOptionIdNotFirstLabelMatch() {
+        var bridge = new AcpInteractionBridge(
+            // Both offered options are labelled "Allow" — only OptionId disambiguates which one
+            // the human actually picked. Reordered relative to the wire order below on purpose.
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", "allow-second", "Allow", null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var json = $$"""{"sessionId":"{{AcpSessionId}}","toolCall":{"toolCallId":"call-1","title":"Run ls"},"options":[{"optionId":"allow-first","name":"Allow","kind":"allow_once"},{"optionId":"allow-second","name":"Allow","kind":"allow_always"},{"optionId":"deny","name":"Deny","kind":"reject_once"}]}""";
+        var request = new AcpRequest(1, "session/request_permission", JsonDocument.Parse(json).RootElement.Clone());
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("selected");
+        // Must be "allow-second" (matched by id) — a label-based (or first-match) mapper would
+        // have wrongly returned "allow-first", since that's the first option labelled "Allow".
+        await Assert.That(outcome.GetProperty("optionId").GetString()).IsEqualTo("allow-second");
+    }
+
+    /// <summary>
+    /// Spec-review Finding 6: an unresolvable <see cref="AcpInteractionDecision.SelectedOptionId"/>
+    /// (doesn't match any offered option's <c>optionId</c>) is treated as CANCELLED, not a silent
+    /// grant via a first-option fallback — an id that was explicitly supplied but doesn't match
+    /// anything offered indicates a correlation bug or a stale/replayed decision, and granting an
+    /// unrelated option in that case would be worse than failing safe.
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_UnresolvableSelectedOptionId_TreatedAsCancelled() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", "does-not-exist", "Allow", null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>
+    /// Spec-review Finding 2 (the security-critical fail-safe half): ANY outcome string that is
+    /// neither a recognized affirmative outcome (<c>allow</c>/<c>allow_once</c>/<c>allow_always</c>/
+    /// <c>answered</c>) NOR a recognized negative outcome (<c>deny</c>/<c>cancel</c>) must map to
+    /// <c>cancelled</c> — NEVER fall through to <c>selected</c>/<c>options[0]</c>. Before this fix,
+    /// <c>MapPermissionDecision</c> only special-cased the literal strings <c>"deny"</c>/<c>"cancel"</c>
+    /// and treated every other string (including a typo'd <c>"cancelled"</c>, or any future/unknown
+    /// outcome) as "select the first option" — i.e. an unrecognized outcome silently GRANTED
+    /// permission. This test uses the exact typo (<c>"cancelled"</c> instead of the canonical
+    /// <c>"cancel"</c>, per Task A2's Interfaces note) that a server-side regression would produce,
+    /// proving the daemon-side mapper is fail-safe even if the server ever sends a string outside
+    /// the documented vocabulary.
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_UnrecognizedOutcome_MapsToCancelled_NeverFallsThroughToSelected() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("cancelled", null, null, null, null, null)), // NOT the canonical "cancel"
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+        await Assert.That(outcome.TryGetProperty("optionId", out _)).IsFalse(); // never selects an option for an unmapped outcome
+    }
+
+    [Test]
+    public async Task UnrecognizedMethod_ReturnsNullResultSoConnectionSendsMethodNotFound() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "fs/read_text_file", Params: JsonDocument.Parse("{}").RootElement.Clone());
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task ElicitationCreate_NeverAdvertisedButHandledDefensivelyIfSent() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => {
+                // Spec-review Finding 6: resolution is by SelectedOptionId ("yes"), not by label —
+                // SelectedOptionLabel is passed too but is display-only from this point forward.
+                return Task.FromResult(new AcpInteractionDecision("answered", "yes", "Yes", 0, null, null));
+            },
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var json = $$"""{"sessionId":"{{AcpSessionId}}","message":"Proceed?","options":[{"optionId":"yes","name":"Yes","kind":"allow_once"},{"optionId":"no","name":"No","kind":"reject_once"}]}""";
+        var request = new AcpRequest(1, "elicitation/create", JsonDocument.Parse(json).RootElement.Clone());
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("selected");
+        await Assert.That(outcome.GetProperty("optionId").GetString()).IsEqualTo("yes");
+    }
+
+    /// <summary>
+    /// Spec-review Finding 1 (JSON-Schema elicitation): a schema-shaped <c>elicitation/create</c>
+    /// (<c>requestedSchema</c> present, no <c>options</c> at all) is forwarded to the server
+    /// verbatim via <see cref="AcpInteractionRequest.RequestedSchema"/> — this bridge does zero
+    /// schema validation/rendering of its own (no confirmed Cursor shape exists to render against;
+    /// the generic-card fallback lives server-side, Task A4/A6). This test also proves the request
+    /// never throws even though it has no options to offer a human — <see cref="MapPermissionDecision"/>'s
+    /// existing <c>options.Count == 0 → cancelled</c> branch (spec-review Finding 2) already handles
+    /// "no options were ever offered" safely, so a schema-only elicitation that somehow resolves
+    /// with an affirmative outcome still degrades to a well-formed <c>cancelled</c> result rather
+    /// than an unhandled exception or a bogus <c>selected</c> with no <c>optionId</c> to report.
+    /// </summary>
+    [Test]
+    public async Task ElicitationCreate_SchemaShaped_ForwardsRequestedSchemaVerbatim_NeverThrows() {
+        AcpInteractionRequest? captured = null;
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => {
+                captured = req;
+
+                return Task.FromResult(new AcpInteractionDecision("answered", null, null, null, "free text answer", null));
+            },
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var json = $$$$$"""{"sessionId":"{{{{{AcpSessionId}}}}}","message":"Describe the config","requestedSchema":{"type":"object","properties":{"name":{"type":"string"}}}}""";
+        var request = new AcpRequest(1, "elicitation/create", JsonDocument.Parse(json).RootElement.Clone());
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(captured).IsNotNull();
+        await Assert.That(captured!.Value.RequestedSchema).IsNotNull();
+        await Assert.That(captured.Value.RequestedSchema!.Value.GetProperty("type").GetString()).IsEqualTo("object");
+        await Assert.That(captured.Value.Options).IsEmpty(); // no flat options offered for a schema-shaped elicitation
+        // No options were offered, so even an "answered" decision safely degrades to cancelled
+        // (MapPermissionDecision's options.Count == 0 branch, spec-review Finding 2) — never throws.
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>
+    /// Spec-review Finding 1: a malformed <c>requestedSchema</c> value that still parses as valid
+    /// JSON (the whole <c>elicitation/create</c> params object is syntactically valid, so
+    /// <see cref="ElicitationCreateParams"/> deserializes successfully) never causes this bridge to
+    /// throw — it is forwarded to the server exactly as received, since schema hygiene/rejection is
+    /// entirely a server-side concern (Task A1's <c>CapAcpSchema</c>), not this bridge's.
+    /// </summary>
+    [Test]
+    public async Task ElicitationCreate_SchemaIsNotAnObject_StillForwardsWithoutThrowing() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("cancel", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var json = $$"""{"sessionId":"{{AcpSessionId}}","message":"Proceed?","requestedSchema":"not-an-object"}""";
+        var request = new AcpRequest(1, "elicitation/create", JsonDocument.Parse(json).RootElement.Clone());
+
+        var result = await bridge.HandleAsync(request, AcpSessionId, CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionMessagesTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionMessagesTests.cs
@@ -1,0 +1,166 @@
+// test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionMessagesTests.cs
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Acp;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// Round-trip / wire-shape tests for the AI-686 Task B1 ACP permission + elicitation DTOs — proves
+/// the source-gen <see cref="CapacitorJsonContext"/> registrations exist and serialize with the
+/// exact camelCase wire vocabulary (<see cref="Acp.PermissionOutcomeDto"/>'s <c>"selected"</c> /
+/// <c>"cancelled"</c> spellings, distinct from the server-internal <c>"cancel"</c>) and snake_case
+/// server-contract-mirror field names required for daemon&lt;-&gt;server lockstep (Task A2).
+/// </summary>
+public class AcpInteractionMessagesTests {
+    [Test]
+    public async Task SessionRequestPermissionParams_round_trips_with_camelCase_wire_shape() {
+        var toolCall = JsonDocument.Parse("""{"name":"bash","input":{"command":"ls"}}""").RootElement.Clone();
+        var src = new SessionRequestPermissionParams(
+            SessionId: "sess-1",
+            ToolCall:  toolCall,
+            Options: [
+                new PermissionOptionDto("opt-allow", "Allow", "allow_once"),
+                new PermissionOptionDto("opt-deny",  "Deny",  "reject_once")
+            ]
+        );
+
+        var json = JsonSerializer.Serialize(src, CapacitorJsonContext.Default.SessionRequestPermissionParams);
+
+        await Assert.That(json).Contains(@"""sessionId""");
+        await Assert.That(json).Contains(@"""toolCall""");
+        await Assert.That(json).Contains(@"""options""");
+        await Assert.That(json).Contains(@"""optionId""");
+        await Assert.That(json).Contains(@"""name""");
+        await Assert.That(json).Contains(@"""kind""");
+
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.SessionRequestPermissionParams)!;
+        await Assert.That(back.SessionId).IsEqualTo("sess-1");
+        await Assert.That(back.Options[0].OptionId).IsEqualTo("opt-allow");
+        await Assert.That(back.Options[1].Kind).IsEqualTo("reject_once");
+        await Assert.That(back.ToolCall.GetProperty("name").GetString()).IsEqualTo("bash");
+    }
+
+    [Test]
+    public async Task PermissionOutcomeDto_selected_serializes_optionId_and_omits_it_when_cancelled() {
+        var selected = new PermissionOutcomeDto("selected", "opt-allow");
+        var selectedJson = JsonSerializer.Serialize(selected, CapacitorJsonContext.Default.PermissionOutcomeDto);
+        await Assert.That(selectedJson).Contains(@"""outcome"":""selected""");
+        await Assert.That(selectedJson).Contains(@"""optionId"":""opt-allow""");
+
+        // Fail-safe cancellation vocabulary: the ACP wire spelling is "cancelled" (double-L),
+        // distinct from the server's internal InterruptOutcomes.Cancel = "cancel".
+        var cancelled = new PermissionOutcomeDto("cancelled");
+        var cancelledJson = JsonSerializer.Serialize(cancelled, CapacitorJsonContext.Default.PermissionOutcomeDto);
+        await Assert.That(cancelledJson).Contains(@"""outcome"":""cancelled""");
+        await Assert.That(cancelledJson).DoesNotContain(@"""optionId""");
+
+        var back = JsonSerializer.Deserialize(cancelledJson, CapacitorJsonContext.Default.PermissionOutcomeDto)!;
+        await Assert.That(back.Outcome).IsEqualTo("cancelled");
+        await Assert.That(back.OptionId).IsNull();
+    }
+
+    [Test]
+    public async Task PermissionOutcomeResult_round_trips_wrapping_outcome() {
+        var src  = new PermissionOutcomeResult(new PermissionOutcomeDto("selected", "opt-1"));
+        var json = JsonSerializer.Serialize(src, CapacitorJsonContext.Default.PermissionOutcomeResult);
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.PermissionOutcomeResult)!;
+
+        await Assert.That(back.Outcome.Outcome).IsEqualTo("selected");
+        await Assert.That(back.Outcome.OptionId).IsEqualTo("opt-1");
+    }
+
+    [Test]
+    public async Task ElicitationCreateParams_omits_optional_fields_when_null_and_round_trips_when_present() {
+        var minimal = new ElicitationCreateParams("sess-1", "Pick one");
+        var minimalJson = JsonSerializer.Serialize(minimal, CapacitorJsonContext.Default.ElicitationCreateParams);
+        await Assert.That(minimalJson).DoesNotContain(@"""options""");
+        await Assert.That(minimalJson).DoesNotContain(@"""requestedSchema""");
+
+        var schema = JsonDocument.Parse("""{"type":"string"}""").RootElement.Clone();
+        var full = new ElicitationCreateParams(
+            "sess-1", "Pick one",
+            Options: [new PermissionOptionDto("opt-a", "A", "allow_once")],
+            RequestedSchema: schema
+        );
+        var fullJson = JsonSerializer.Serialize(full, CapacitorJsonContext.Default.ElicitationCreateParams);
+        await Assert.That(fullJson).Contains(@"""requestedSchema""");
+        await Assert.That(fullJson).Contains(@"""options""");
+
+        var back = JsonSerializer.Deserialize(fullJson, CapacitorJsonContext.Default.ElicitationCreateParams)!;
+        await Assert.That(back.Message).IsEqualTo("Pick one");
+        await Assert.That(back.Options![0].OptionId).IsEqualTo("opt-a");
+        await Assert.That(back.RequestedSchema!.Value.GetProperty("type").GetString()).IsEqualTo("string");
+    }
+
+    [Test]
+    public async Task ElicitationCreateResult_round_trips() {
+        var src  = new ElicitationCreateResult(new PermissionOutcomeDto("cancelled"));
+        var json = JsonSerializer.Serialize(src, CapacitorJsonContext.Default.ElicitationCreateResult);
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.ElicitationCreateResult)!;
+
+        await Assert.That(back.Outcome.Outcome).IsEqualTo("cancelled");
+    }
+
+    [Test]
+    public async Task AcpInteractionRequest_round_trips_and_uses_snake_case_server_contract_wire_shape() {
+        var toolInput = JsonDocument.Parse("""{"command":"ls"}""").RootElement.Clone();
+        var schema    = JsonDocument.Parse("""{"type":"object"}""").RootElement.Clone();
+        var src = new AcpInteractionRequest(
+            AgentId:       "agent-1",
+            AcpSessionId:  "acp-sess-1",
+            Kind:          "permission",
+            ToolName:      "bash",
+            ToolInput:     toolInput,
+            ToolCallId:    "call-1",
+            Prompt:        null,
+            Options:       [new AcpInteractionOption("opt-1", "Allow", "Allow once", "allow_once")],
+            IsMultiSelect: false,
+            RequestedSchema: schema
+        );
+
+        var json = JsonSerializer.Serialize(src, CapacitorJsonContext.Default.AcpInteractionRequest);
+
+        // Server-contract mirror types use the context's default snake_case naming policy
+        // (matching HostedPermissionRequest/PermissionResolution precedent), NOT the explicit
+        // camelCase JsonPropertyName vocabulary used by the spec-derived Acp.* wire DTOs above.
+        await Assert.That(json).Contains(@"""agent_id""");
+        await Assert.That(json).Contains(@"""acp_session_id""");
+        await Assert.That(json).Contains(@"""tool_name""");
+        await Assert.That(json).Contains(@"""tool_input""");
+        await Assert.That(json).Contains(@"""tool_call_id""");
+        await Assert.That(json).Contains(@"""is_multi_select""");
+        await Assert.That(json).Contains(@"""requested_schema""");
+        await Assert.That(json).Contains(@"""option_id""");
+
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.AcpInteractionRequest)!;
+        await Assert.That(back.AgentId).IsEqualTo("agent-1");
+        await Assert.That(back.Options![0].OptionId).IsEqualTo("opt-1");
+        await Assert.That(back.RequestedSchema!.Value.GetProperty("type").GetString()).IsEqualTo("object");
+    }
+
+    [Test]
+    public async Task AcpInteractionDecision_and_resolution_round_trip() {
+        var updatedInput = JsonDocument.Parse("""{"command":"ls -la"}""").RootElement.Clone();
+        var decision = new AcpInteractionDecision(
+            Outcome:             "selected",
+            SelectedOptionId:    "opt-1",
+            SelectedOptionLabel: "Allow",
+            SelectedIndex:       0,
+            FreeText:            null,
+            UpdatedToolInput:    updatedInput
+        );
+        var resolution = new AcpInteractionResolution("req-1", decision);
+
+        var json = JsonSerializer.Serialize(resolution, CapacitorJsonContext.Default.AcpInteractionResolution);
+        await Assert.That(json).Contains(@"""request_id""");
+        await Assert.That(json).Contains(@"""selected_option_id""");
+        await Assert.That(json).Contains(@"""selected_option_label""");
+        await Assert.That(json).Contains(@"""updated_tool_input""");
+
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.AcpInteractionResolution)!;
+        await Assert.That(back.RequestId).IsEqualTo("req-1");
+        await Assert.That(back.Decision.SelectedOptionId).IsEqualTo("opt-1");
+        await Assert.That(back.Decision.UpdatedToolInput!.Value.GetProperty("command").GetString()).IsEqualTo("ls -la");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
@@ -1,6 +1,7 @@
 // test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
 using System.Collections.Concurrent;
 using System.IO.Pipelines;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.Json;
 
@@ -70,6 +71,23 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
 
     /// <summary>The connection's JSON-RPC <c>error</c> for the most recent server→client request this fake sent, or null if not answered with an error.</summary>
     public JsonElement? LastServerRequestError => _lastServerRequestError;
+
+    /// <summary>
+    /// Qodo daemon-review Q3: the FIRST exception thrown by a fire-and-forget
+    /// <c>DispatchLineAsync</c> dispatch (see <see cref="RunAsync"/>'s remarks on why dispatch must
+    /// stay untracked-by-the-loop rather than awaited in-line), or <see langword="null"/> if none has
+    /// faulted yet. PRE-FIX, a dispatch fault was only <c>Debug.WriteLine</c>'d — invisible to a test
+    /// assertion — so a faulted dispatch manifested as a hang/timeout on whatever the test was
+    /// awaiting from the connection, rather than a clear failure. Captured via
+    /// <see cref="ExceptionDispatchInfo"/> (not the bare <see cref="Exception"/>) so
+    /// <see cref="DisposeAsync"/> can rethrow it with its ORIGINAL stack trace preserved. Only the
+    /// first fault is kept — later ones are logged the same way the pre-fix code always did, since a
+    /// second fault on an already-faulted fake is rarely independently interesting and keeping "the
+    /// first thing that went wrong" is the more useful diagnostic.
+    /// </summary>
+    public Exception? DispatchFault => Volatile.Read(ref _dispatchFault)?.SourceException;
+
+    ExceptionDispatchInfo? _dispatchFault;
 
     /// <summary>
     /// Arranges the fake to send a real <c>session/request_permission</c> server→client request
@@ -182,8 +200,19 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
                 // in flight at once.
                 var dispatchTask = DispatchLineAsync(line, ct);
                 _ = dispatchTask.ContinueWith(t => {
-                    if (t.IsFaulted)
-                        System.Diagnostics.Debug.WriteLine($"FakeAcpAgent: DispatchLineAsync faulted: {t.Exception}");
+                    if (!t.IsFaulted)
+                        return;
+
+                    System.Diagnostics.Debug.WriteLine($"FakeAcpAgent: DispatchLineAsync faulted: {t.Exception}");
+
+                    // Qodo daemon-review Q3: capture the FIRST fault (thread-safe — multiple
+                    // dispatches can be in flight at once, see this method's own remarks above) so
+                    // it surfaces via DispatchFault / DisposeAsync instead of being visible only in
+                    // Debug output. t.Exception is an AggregateException; unwrap to the single inner
+                    // exception a faulted Task always carries here (DispatchLineAsync never throws
+                    // an AggregateException itself).
+                    var captured = ExceptionDispatchInfo.Capture(t.Exception!.InnerException ?? t.Exception);
+                    Interlocked.CompareExchange(ref _dispatchFault, captured, null);
                 }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
             }
         } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
@@ -546,10 +575,20 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
         await _agentWritesToConnection.FlushAsync(ct).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Qodo daemon-review Q3: disposes the fixture's streams as before, then — if a fire-and-forget
+    /// <c>DispatchLineAsync</c> dispatch ever faulted (see <see cref="DispatchFault"/>) — rethrows
+    /// that FIRST captured fault with its original stack trace, so a test that tore this fixture
+    /// down via <c>await using</c> without explicitly checking <see cref="DispatchFault"/> still
+    /// fails loudly instead of the fault being silently dropped. Stream disposal always runs first
+    /// (best-effort cleanup must not be skipped just because a fault will be rethrown after).
+    /// </summary>
     public async ValueTask DisposeAsync() {
         await _agentReadsFromConnection.DisposeAsync().ConfigureAwait(false);
         await _agentWritesToConnection.DisposeAsync().ConfigureAwait(false);
         await ClientWriteStream.DisposeAsync().ConfigureAwait(false);
         await ClientReadStream.DisposeAsync().ConfigureAwait(false);
+
+        Volatile.Read(ref _dispatchFault)?.Throw();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
@@ -46,6 +46,46 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     readonly List<(string Method, JsonElement? Params)> _receivedCalls = new();
     readonly object _receivedCallsLock = new();
 
+    string? _pendingServerRequestToolCallJson;
+    string? _pendingServerRequestOptionsJson;
+    long    _nextServerRequestId = 1000; // disjoint range from the connection's own outbound ids
+
+    readonly List<(string Method, JsonElement? Params)>          _sentServerRequests = new();
+    readonly object                                              _sentServerRequestsLock = new();
+    JsonElement?                                                 _lastServerRequestResponse;
+    JsonElement?                                                 _lastServerRequestError;
+
+    /// <summary>
+    /// Every server→client request (e.g. <c>session/request_permission</c>) this fake has SENT to
+    /// the connection under test, in send order. Populated by
+    /// <see cref="EnqueuePermissionRequestDuringNextPrompt"/>'s injection into
+    /// <see cref="RunPromptScriptAsync"/>.
+    /// </summary>
+    public IReadOnlyList<(string Method, JsonElement? Params)> SentServerRequests {
+        get { lock (_sentServerRequestsLock) return _sentServerRequests.ToArray(); }
+    }
+
+    /// <summary>The connection's JSON-RPC <c>result</c> for the most recent server→client request this fake sent, or null if not yet answered.</summary>
+    public JsonElement? LastServerRequestResponse => _lastServerRequestResponse;
+
+    /// <summary>The connection's JSON-RPC <c>error</c> for the most recent server→client request this fake sent, or null if not answered with an error.</summary>
+    public JsonElement? LastServerRequestError => _lastServerRequestError;
+
+    /// <summary>
+    /// Arranges the fake to send a real <c>session/request_permission</c> server→client request
+    /// (built via <see cref="BuildRequestPermissionFrame"/>) as part of the NEXT
+    /// <c>session/prompt</c> turn's response, awaiting and recording the connection's reply before
+    /// answering the prompt itself with the default <c>end_turn</c> result. This finally wires the
+    /// builder helpers <see cref="BuildRequestPermissionFrame"/>/<see cref="PermissionOutcomeSelected"/>/
+    /// <see cref="PermissionOutcomeCancelled"/> into the fake's active dispatch loop — AI-684 Task 8
+    /// built them but deliberately left them unwired (see this file's original remarks), since the
+    /// permission bridge itself was AI-686's job.
+    /// </summary>
+    public void EnqueuePermissionRequestDuringNextPrompt(string toolCallJson, string optionsJson) {
+        _pendingServerRequestToolCallJson = toolCallJson;
+        _pendingServerRequestOptionsJson  = optionsJson;
+    }
+
     /// <summary>
     /// The stream a NEW <see cref="Capacitor.Cli.Daemon.Acp.AcpConnection"/> under test should be
     /// constructed with as its <c>writeStream</c> — the connection's outbound frames land here, and
@@ -127,7 +167,24 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
                 if (string.IsNullOrWhiteSpace(line))
                     continue;
 
-                await DispatchLineAsync(line, ct).ConfigureAwait(false);
+                // AI-686: dispatched as untracked background work rather than awaited in-loop.
+                // EnqueuePermissionRequestDuringNextPrompt's session/request_permission send-and-await
+                // (SendServerRequestAndAwaitResponseAsync) is itself triggered from a session/prompt's
+                // dispatch — its TaskCompletionSource can only be completed by THIS SAME loop reading
+                // the connection's reply line. Awaiting the dispatch here would therefore deadlock:
+                // the loop would be blocked inside the prompt's dispatch waiting for a line that only
+                // the loop itself can read. Firing dispatch as background work keeps the loop free to
+                // read subsequent lines (including that reply) while a single dispatch is in flight.
+                // Record() (called synchronously at the top of DispatchLineAsync, before any await)
+                // still runs before this method returns to the loop for lines processed one at a
+                // time by ReadLineAsync, so ReceivedCalls order is unaffected for the existing tests
+                // that assert strict ordering (FakeAcpAgentTests) — those never have two lines
+                // in flight at once.
+                var dispatchTask = DispatchLineAsync(line, ct);
+                _ = dispatchTask.ContinueWith(t => {
+                    if (t.IsFaulted)
+                        System.Diagnostics.Debug.WriteLine($"FakeAcpAgent: DispatchLineAsync faulted: {t.Exception}");
+                }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
             }
         } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
             // normal shutdown
@@ -140,8 +197,24 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
 
         var hasId     = root.TryGetProperty("id", out var idElement);
         var hasMethod = root.TryGetProperty("method", out var methodElement);
-        if (!hasMethod)
+        if (!hasMethod) {
+            // A frame with no "method" is either the connection's reply to one of THIS fake's own
+            // session/request_permission sends (id in _pendingFakeRequests), or an unrelated
+            // response the fake doesn't care about — never expected in AI-684/686's scripts other
+            // than this new path, but guarded defensively.
+            if (hasId && idElement.TryGetInt64(out var replyId)) {
+                TaskCompletionSource<(JsonElement?, JsonElement?)>? pending;
+                lock (_sentServerRequestsLock) _pendingFakeRequests.Remove(replyId, out pending);
+
+                if (pending is not null) {
+                    var hasResult = root.TryGetProperty("result", out var resultEl);
+                    var hasError  = root.TryGetProperty("error", out var errorEl);
+                    pending.TrySetResult((hasResult ? resultEl.Clone() : null, hasError ? errorEl.Clone() : null));
+                }
+            }
+
             return;
+        }
 
         var method        = methodElement.GetString() ?? "";
         var paramsElement = root.TryGetProperty("params", out var p) ? p.Clone() : (JsonElement?) null;
@@ -177,6 +250,15 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     }
 
     async Task RunPromptScriptAsync(JsonElement id, CancellationToken ct) {
+        if (_pendingServerRequestToolCallJson is not null && _pendingServerRequestOptionsJson is not null) {
+            var toolCallJson = _pendingServerRequestToolCallJson;
+            var optionsJson  = _pendingServerRequestOptionsJson;
+            _pendingServerRequestToolCallJson = null;
+            _pendingServerRequestOptionsJson  = null;
+
+            await SendServerRequestAndAwaitResponseAsync("session/request_permission", toolCallJson, optionsJson, ct).ConfigureAwait(false);
+        }
+
         var (updates, result) = _promptScripts.TryDequeue(out var script)
             ? script
             : (new[] { DefaultAgentMessageChunkUpdate(FixedSessionId, "hello from FakeAcpAgent") }, DefaultPromptResult);
@@ -188,6 +270,36 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
             await gate.Task.ConfigureAwait(false);
 
         await WriteResponseAsync(id, result, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sends a server→client request frame (currently only <c>session/request_permission</c>) with
+    /// a fake-allocated id disjoint from the connection's own outbound id space, waits for the
+    /// connection's response frame, and records it on <see cref="LastServerRequestResponse"/>/
+    /// <see cref="LastServerRequestError"/>. This is a SEPARATE read loop concern from
+    /// <see cref="RunAsync"/>'s main dispatch (which handles requests ARRIVING from the connection
+    /// under test) — the fake's OWN read loop, already running via <see cref="RunAsync"/>, also
+    /// observes the connection's reply to THIS request as an ordinary incoming "response" frame
+    /// (has <c>id</c> + <c>result</c>/<c>error</c>, no <c>method</c>) and records it here via a
+    /// short-lived local completion source correlated by id.
+    /// </summary>
+    readonly Dictionary<long, TaskCompletionSource<(JsonElement? Result, JsonElement? Error)>> _pendingFakeRequests = new();
+
+    async Task SendServerRequestAndAwaitResponseAsync(string method, string toolCallJson, string optionsJson, CancellationToken ct) {
+        var id    = Interlocked.Increment(ref _nextServerRequestId);
+        var frame = BuildRequestPermissionFrame(id, FixedSessionId, toolCallJson, optionsJson);
+
+        var tcs = new TaskCompletionSource<(JsonElement?, JsonElement?)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (_sentServerRequestsLock) {
+            _pendingFakeRequests[id] = tcs;
+            _sentServerRequests.Add((method, frame.GetProperty("params")));
+        }
+
+        await WriteRawFrameAsync(frame, ct).ConfigureAwait(false);
+
+        var (result, error) = await tcs.Task.ConfigureAwait(false);
+        _lastServerRequestResponse = result;
+        _lastServerRequestError    = error;
     }
 
     void Record(string method, JsonElement? @params) {

--- a/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgentTests.cs
@@ -170,4 +170,72 @@ public class FakeAcpAgentTests {
             // expected shutdown path for this test's owned CTS
         }
     }
+
+    /// <summary>
+    /// Qodo daemon-review Q3: <see cref="FakeAcpAgent.RunAsync"/> dispatches each inbound line as
+    /// untracked background work (<c>DispatchLineAsync</c>, fire-and-forget — required to avoid the
+    /// self-deadlock documented on that method) and PRE-FIX only <c>Debug.WriteLine</c>'d a fault,
+    /// so a faulted dispatch manifested to a test as a silent hang/timeout (whatever the test was
+    /// awaiting from the connection never arrives) rather than a clear failure pointing at the fake.
+    /// This test forces a dispatch fault directly — malformed JSON written straight onto the fake's
+    /// simulated stdin (<see cref="FakeAcpAgent.ClientWriteStream"/>), which <c>DispatchLineAsync</c>'s
+    /// unguarded <c>JsonDocument.Parse(line)</c> throws on — and proves the fault is captured and
+    /// surfaced via <see cref="FakeAcpAgent.DispatchFault"/> rather than silently swallowed.
+    /// </summary>
+    [Test]
+    public async Task DispatchLineAsync_fault_is_captured_and_exposed_via_DispatchFault() {
+        var fake = new FakeAcpAgent();
+        using var cts = new CancellationTokenSource();
+
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var bytes = System.Text.Encoding.UTF8.GetBytes("not valid json\n");
+        await fake.ClientWriteStream.WriteAsync(bytes, CancellationToken.None).AsTask().WaitAsync(HangGuard);
+        await fake.ClientWriteStream.FlushAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (fake.DispatchFault is null && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        await Assert.That(fake.DispatchFault).IsNotNull();
+        await Assert.That(fake.DispatchFault).IsTypeOf<JsonException>();
+
+        cts.Cancel();
+        await SwallowCancellation(fakeRunTask);
+
+        // DisposeAsync rethrows the captured fault (proven by the next test) — this test's own
+        // focus is DispatchFault itself, so swallow the rethrow here rather than duplicating that
+        // assertion.
+        try { await fake.DisposeAsync(); } catch (JsonException) { }
+    }
+
+    /// <summary>
+    /// Qodo daemon-review Q3: <see cref="FakeAcpAgent.DisposeAsync"/> rethrows the FIRST captured
+    /// dispatch fault (via <see cref="System.Runtime.ExceptionServices.ExceptionDispatchInfo"/>, to
+    /// preserve the original stack trace) so a test that never explicitly inspects
+    /// <see cref="FakeAcpAgent.DispatchFault"/> — the common case, since most tests just
+    /// <c>await using var fake = new FakeAcpAgent();</c> — still fails loudly instead of the fault
+    /// being silently dropped when the fixture is torn down.
+    /// </summary>
+    [Test]
+    public async Task DisposeAsync_rethrows_captured_dispatch_fault() {
+        var fake = new FakeAcpAgent();
+        using var cts = new CancellationTokenSource();
+
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var bytes = System.Text.Encoding.UTF8.GetBytes("not valid json\n");
+        await fake.ClientWriteStream.WriteAsync(bytes, CancellationToken.None).AsTask().WaitAsync(HangGuard);
+        await fake.ClientWriteStream.FlushAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (fake.DispatchFault is null && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(fake.DispatchFault).IsNotNull();
+
+        cts.Cancel();
+        await SwallowCancellation(fakeRunTask);
+
+        await Assert.ThrowsAsync<JsonException>(async () => await fake.DisposeAsync());
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -1,0 +1,160 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Tests.Unit.Acp;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// AI-686 round-4, Finding 3: proves <see cref="AcpHostedAgentRuntimeFactory"/> — constructed for
+/// real, driven through its REAL <see cref="AcpHostedAgentRuntimeFactory.StartAsync"/> — actually
+/// wires the ACP interaction bridge into the runtime it produces, by observing an inbound
+/// <c>session/request_permission</c> genuinely dispatch to the injected <c>requestInteraction</c>
+/// delegate. Does NOT spawn a real <c>cursor-agent acp</c> process (unavailable/non-portable in
+/// CI, `.github/workflows/ci.yml`'s `ubuntu-latest`/`windows-latest` matrix) — the factory's
+/// process-spawning is swapped out via its <c>connectionSource</c> constructor seam for one backed
+/// by <see cref="FakeAcpAgent"/>'s existing in-memory pipe streams, the same fake this project
+/// already uses for <c>AcpHostedAgentRuntimeTests</c>/<c>AcpHostedAgentRuntimePermissionTests</c>.
+/// A regression that left <c>StartAsync</c> passing <c>requestInteraction: null</c> (AI-684's
+/// original default-decline posture) would make this test's <c>session/request_permission</c>
+/// resolve with a JSON-RPC "Method not found" error instead of the well-formed <c>cancelled</c>
+/// outcome asserted below — i.e. this test FAILS on that regression, unlike the pre-round-4 test it
+/// replaces.
+/// </summary>
+public class AcpHostedAgentRuntimeFactoryTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    sealed class FakeAcpProcess : IAcpProcess {
+        readonly TaskCompletionSource _exited = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int  Pid       { get; init; } = 4242;
+        public bool HasExited { get; private set; }
+        public int? ExitCode  { get; private set; }
+        public void SignalExited(int exitCode = 0) { HasExited = true; ExitCode = exitCode; _exited.TrySetResult(); }
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => _exited.Task;
+        public Task TerminateAsync(TimeSpan? timeout = null) { SignalExited(); return Task.CompletedTask; }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Records whether <see cref="ServerConnection.RequestAcpInteractionAsync"/> was actually
+    /// invoked BY THE RUNTIME THE FACTORY PRODUCED (not by the test calling it directly) — a real
+    /// (non-connecting) <see cref="ServerConnection"/> subclass, matching the established
+    /// <c>CaptureServerConnection</c>-style pattern used elsewhere in this test project (e.g.
+    /// <c>AgentOrchestratorVendorTests.cs</c>) rather than a mocking framework, since
+    /// <see cref="ServerConnection"/> is not an interface.
+    /// </summary>
+    sealed class CaptureServerConnection() : ServerConnection(
+            new() { Name = "test", ServerUrl = "http://127.0.0.1:1" },
+            NullLoggerFactory.Instance,
+            NullLogger<ServerConnection>.Instance
+        ) {
+        public bool RequestAcpInteractionAsyncCalled { get; private set; }
+        public AcpInteractionRequest? LastRequest     { get; private set; }
+
+        public override Task<AcpInteractionDecision> RequestAcpInteractionAsync(AcpInteractionRequest request, CancellationToken ct = default) {
+            RequestAcpInteractionAsyncCalled = true;
+            LastRequest                      = request;
+
+            return Task.FromResult(new AcpInteractionDecision("cancel", null, null, null, null, null));
+        }
+    }
+
+    static RuntimeStartContext MakeContext(string agentId) => new(
+        AgentId: agentId, Vendor: "cursor", SourceRepoPath: "/repo",
+        Worktree: new WorktreeInfo(Path: "/abs/worktree", Branch: "branch-name", SourceRepo: "/repo"), Prompt: "",
+        Model: "default", Effort: null, Tools: null,
+        IsReview: false, IsReviewFlow: false, Review: null,
+        Cols: 80, Rows: 24, ServerUrl: null, DaemonBridgeUrl: null, CapacitorPath: "/usr/local/bin/kcap");
+
+    [Test]
+    public async Task StartAsync_WiresRequestInteractionDelegate_DispatchesInboundPermissionRequestToTheBridge() {
+        var fake       = new FakeAcpAgent();
+        var connection = new CaptureServerConnection();
+
+        var factory = new AcpHostedAgentRuntimeFactory(
+            config: new DaemonConfig { CursorPath = "cursor-agent" }, // never actually spawned — connectionSource below bypasses Process.Start
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: connection,
+            connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, new FakeAcpProcess())
+        );
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var started = await factory.StartAsync(MakeContext("agent-1"), cts.Token).WaitAsync(HangGuard);
+
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Run ls"}""",
+            optionsJson: """[{"optionId":"allow-once","name":"Allow","kind":"allow_once"}]""");
+
+        await started.Runtime.SendUserInputAsync("run ls").WaitAsync(HangGuard);
+
+        // The factory-produced runtime dispatched the inbound session/request_permission to the
+        // bridge, which called connection.RequestAcpInteractionAsync — proving requestInteraction
+        // was genuinely wired (not left null) by StartAsync, observed through the REAL runtime the
+        // REAL factory produced, not a direct delegate invocation.
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!connection.RequestAcpInteractionAsyncCalled && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        await Assert.That(connection.RequestAcpInteractionAsyncCalled).IsTrue();
+        await Assert.That(connection.LastRequest?.AgentId).IsEqualTo("agent-1");
+        await Assert.That(connection.LastRequest?.Kind).IsEqualTo("permission");
+
+        var responseDeadline = DateTime.UtcNow + HangGuard;
+        while (fake.LastServerRequestResponse is null && DateTime.UtcNow < responseDeadline)
+            await Task.Delay(10);
+
+        // connection.RequestAcpInteractionAsync above returns a "cancel" decision — the bridge
+        // (Task B3) must map that to the well-formed ACP "cancelled" outcome, proving the FULL
+        // chain (factory → runtime → bridge → injected ServerConnection → back to the wire) works,
+        // not just that SOME delegate got called.
+        await Assert.That(fake.LastServerRequestResponse).IsNotNull();
+        await Assert.That(fake.LastServerRequestResponse!.Value.GetProperty("outcome").GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await started.Runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Negative control proving this test suite WOULD catch the round-4 regression it replaces: a
+    /// factory built with <c>connectionSource</c> returning a runtime whose <c>requestInteraction</c>
+    /// is deliberately left <see langword="null"/> (simulating the pre-Finding-4 defect) answers the
+    /// SAME inbound request with a JSON-RPC "Method not found" error, not a "cancelled" outcome —
+    /// demonstrating this test file's assertions are sensitive to the exact bug Finding 4 fixed and
+    /// Finding 3 makes verifiable end-to-end.
+    /// </summary>
+    [Test]
+    public async Task StartAsync_IfRequestInteractionWereNull_PermissionRequestWouldGetMethodNotFound() {
+        var fake = new FakeAcpAgent();
+        var conn = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var runtime = new AcpHostedAgentRuntime(conn, new FakeAcpProcess(), NullLogger.Instance); // no requestInteraction — AI-684 default
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        await runtime.StartAsync("/abs/worktree", "", cts.Token).WaitAsync(HangGuard);
+
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Run ls"}""",
+            optionsJson: """[{"optionId":"allow-once","name":"Allow","kind":"allow_once"}]""");
+
+        await runtime.SendUserInputAsync("run ls").WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (fake.LastServerRequestError is null && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        await Assert.That(fake.LastServerRequestError).IsNotNull();
+        await Assert.That(fake.LastServerRequestError!.Value.GetProperty("code").GetInt32()).IsEqualTo(-32601);
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/PendingAcpInteractionRegistryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PendingAcpInteractionRegistryTests.cs
@@ -1,0 +1,49 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// AI-686: <see cref="PendingAcpInteractionRegistry"/> is a straight copy-shape of the already-
+/// tested <see cref="PendingPermissionRegistry"/> parameterized on <see cref="AcpInteractionDecision"/>
+/// — these tests mirror that class's own test coverage for the early-arrival race and cancellation.
+/// </summary>
+public class PendingAcpInteractionRegistryTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    [Test]
+    public async Task Resolve_BeforeAwait_IsBufferedAndReturnedImmediately() {
+        var registry = new PendingAcpInteractionRegistry();
+        var decision = new AcpInteractionDecision("allow", null, null, null, null, null);
+
+        registry.Resolve("req-1", decision);
+
+        var result = await registry.AwaitDecisionAsync("req-1", CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(result.Outcome).IsEqualTo("allow");
+    }
+
+    [Test]
+    public async Task AwaitDecisionAsync_CompletesWhenResolveCalledAfter() {
+        var registry = new PendingAcpInteractionRegistry();
+        var decision = new AcpInteractionDecision("deny", null, null, null, null, null);
+
+        var awaitTask = registry.AwaitDecisionAsync("req-2", CancellationToken.None);
+        registry.Resolve("req-2", decision);
+
+        var result = await awaitTask.WaitAsync(HangGuard);
+
+        await Assert.That(result.Outcome).IsEqualTo("deny");
+    }
+
+    [Test]
+    public async Task AwaitDecisionAsync_CancellationTokenFires_ThrowsOperationCanceled() {
+        var registry = new PendingAcpInteractionRegistry();
+        using var cts = new CancellationTokenSource();
+
+        var awaitTask = registry.AwaitDecisionAsync("req-3", cts.Token);
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await awaitTask.WaitAsync(HangGuard));
+    }
+}


### PR DESCRIPTION
## What

**Daemon half of [AI-686](https://linear.app/kurrent/issue/AI-686) — ACP permission & elicitation bridge** (child of the AI-682 ACP epic). Wires ACP's blocking human-in-the-loop calls (`session/request_permission`, capability-gated `elicitation/create`) — which arrive **in-process** in the daemon ACP runtime — through to the server and back, so a hosted Cursor/ACP agent blocks until a human answers in the Capacitor UI.

Server half is a separate PR in kcap-server. This half is developed + tested entirely in kcap-cli; the only cross-repo step is a follow-up `src/cli` bump in kcap-server after this merges.

## Changes

- **`AcpInteractionBridge`** — parses an inbound ACP request, forwards it via `ServerConnection.RequestAcpInteractionAsync`, awaits the human decision, and **maps it back fail-safe**: `MapPermissionDecision` is an explicit affirmative allowlist (`allow`/`allow_once`/`allow_always`/`answered`) matched by `OptionId` **exclusively** — any unrecognized/deny/cancel/option-less/null-or-unresolvable-`OptionId` decision → the ACP `cancelled` response. No `default: selected`, no first-option fallback anywhere.
- **`PendingAcpInteractionRegistry`** — id-keyed await/resolve, early-buffer, idempotent, disconnect/cancel → defensive `cancelled` exactly once (mirrors the proven `PendingPermissionRegistry`).
- **`ServerConnection.RequestAcpInteractionAsync`** + the `AcpInteractionResolved` push handler.
- **Wire DTOs** (`SessionRequestPermissionParams`/`PermissionOptionDto`/`PermissionOutcomeDto`/…) in `AcpMessages.cs`, source-gen registered on `CapacitorJsonContext` — in lockstep with the server DTOs (ACP-wire outcome spelling `"cancelled"`, distinct from the server-internal `"cancel"`).
- **Production wiring**: `AcpHostedAgentRuntimeFactory` passes a non-null `requestInteraction` (real `ServerConnection.RequestAcpInteractionAsync`); `AcpHostedAgentRuntime` wires `AcpConnection.OnServerRequest`. Elicitation capability is **not advertised** (defensive if received). PTY/Claude/Codex runtimes untouched.
- Fixed a pre-existing bug: `AcpConnection.HandleServerRequestAsync` used a possibly-cancelled token for its final response write, dropping the disconnect-while-pending `cancelled` reply.

## Testing

`Capacitor.Cli.Tests.Unit` **2498/2498**; NativeAOT/trim publish gate clean (no IL2026/IL3050). Covers the full fail-safe mapping matrix, the registry lifecycle, `FakeAcpAgent`-driven end-to-end `session/request_permission`, and the real-factory wiring test (verified to fail if `requestInteraction` regresses to null). Spec-derived wire shapes are marked (the AI-684 probe never reached a permission turn).

## Review

Built via subagent-driven development: 4 tasks (B1–B4) each TDD'd + per-task-reviewed, then a **whole-branch opus review → READY TO MERGE** (no Critical/Important; 2 acceptable-follow-up Minors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
