### PR TITLE
[AI-1241] kcap projects + project default visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,17 @@ kcap repos remove ~/dev/old   # remove a path
 
 Known repos are persisted to `~/.config/kcap/repos.json` and reported to the server when the daemon connects, so the launch dialog always shows previously-used repos even after restarts.
 
+### Projects
+
+List and inspect projects — a Team/Enterprise-plan grouping of repos and members that sessions can be scoped to (see `default_visibility project` below).
+
+```bash
+kcap projects            # table: slug, name, repos, members, your role
+kcap project <slug>      # metadata, repo list, member list, and (owner/admin) pending join requests
+```
+
+Requires the Team or Enterprise plan — the server 403s on Free with a message telling you so.
+
 ### Profiles
 
 Profiles let you work with multiple Capacitor servers — for example, a company server for work repos and a separate one for open-source projects. Each profile stores its own server URL, visibility settings, and daemon configuration.
@@ -731,6 +742,7 @@ kcap config set <key> <value>
 
 ```bash
 kcap config set default_visibility private      # only you can see your sessions
+kcap config set default_visibility project      # visible to the repo's project members (see `kcap projects`)
 kcap config set default_visibility org_public   # org repos visible, others private (default)
 kcap config set default_visibility public       # all sessions visible to others in your account
 ```

--- a/src/Capacitor.Cli.Core/Config/AppConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/AppConfig.cs
@@ -224,7 +224,12 @@ public static class AppConfig {
     /// </summary>
     public static string NormalizeUrl(string url) => url.TrimEnd('/');
 
-    static readonly string[] ValidVisibilities = ["private", "project", "org_public", "public"];
+    /// <summary>The full set of accepted <c>default_visibility</c> values, server-agnostic
+    /// (a server that gates Projects off simply treats <c>project</c> as owner-only — see
+    /// AI-1206). Internal (not private) so other CLI-side surfaces that validate or offer this
+    /// value — e.g. <c>SetupCommand</c>'s <c>--default-visibility</c> flag and interactive
+    /// wizard choice list — can't drift out of sync with what config actually accepts.</summary>
+    internal static readonly string[] ValidVisibilities = ["private", "project", "org_public", "public"];
 
     public static async Task<ProfileConfig> LoadProfileConfig() {
         if (!File.Exists(ConfigPath))

--- a/src/Capacitor.Cli.Core/Config/AppConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/AppConfig.cs
@@ -224,7 +224,7 @@ public static class AppConfig {
     /// </summary>
     public static string NormalizeUrl(string url) => url.TrimEnd('/');
 
-    static readonly string[] ValidVisibilities = ["private", "org_public", "public"];
+    static readonly string[] ValidVisibilities = ["private", "project", "org_public", "public"];
 
     public static async Task<ProfileConfig> LoadProfileConfig() {
         if (!File.Exists(ConfigPath))

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -668,6 +668,123 @@ public record RepoEntry {
     public required DateTimeOffset LastUsed { get; init; }
 }
 
+// ── Projects (`kcap projects` / `kcap project <slug>`) — mirrors the server's
+// ProjectSummaryDto / ProjectDetailDto (src/Capacitor.Server.Core/Projects/ProjectContracts.cs) ──
+
+/// <summary>A single row from <c>GET /api/projects</c>.</summary>
+public sealed record CliProjectSummary {
+    [JsonPropertyName("project_id")]
+    public required string ProjectId { get; init; }
+
+    [JsonPropertyName("slug")]
+    public required string Slug { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("owner_user_id")]
+    public required string OwnerUserId { get; init; }
+
+    [JsonPropertyName("repo_count")]
+    public int RepoCount { get; init; }
+
+    [JsonPropertyName("member_count")]
+    public int MemberCount { get; init; }
+
+    /// <summary>"owner" | "member" | "none".</summary>
+    [JsonPropertyName("viewer_membership")]
+    public required string ViewerMembership { get; init; }
+
+    /// <summary>"request" | "invite" | null.</summary>
+    [JsonPropertyName("viewer_pending")]
+    public string? ViewerPending { get; init; }
+
+    [JsonPropertyName("pending_request_count")]
+    public int PendingRequestCount { get; init; }
+
+    [JsonPropertyName("repo_hashes")]
+    public List<string> RepoHashes { get; init; } = [];
+}
+
+/// <summary>A repo entry inside <see cref="CliProjectDetail"/>.</summary>
+public sealed record CliProjectRepo {
+    [JsonPropertyName("repo_hash")]
+    public required string RepoHash { get; init; }
+
+    [JsonPropertyName("repo_slug")]
+    public required string RepoSlug { get; init; }
+}
+
+/// <summary>A member entry inside <see cref="CliProjectDetail"/>.</summary>
+public sealed record CliProjectMember {
+    [JsonPropertyName("member_kind")]
+    public required string MemberKind { get; init; }
+
+    [JsonPropertyName("member_id")]
+    public required string MemberId { get; init; }
+
+    [JsonPropertyName("display_name")]
+    public required string DisplayName { get; init; }
+}
+
+/// <summary>A pending join request/invite inside <see cref="CliProjectDetail"/>. Empty unless the viewer is owner/admin.</summary>
+public sealed record CliProjectJoinRequest {
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; init; }
+
+    /// <summary>"request" | "invite".</summary>
+    [JsonPropertyName("direction")]
+    public required string Direction { get; init; }
+
+    [JsonPropertyName("requested_at")]
+    public DateTimeOffset RequestedAt { get; init; }
+}
+
+/// <summary>The body of <c>GET /api/projects/{slug}</c>.</summary>
+public sealed record CliProjectDetail {
+    [JsonPropertyName("project_id")]
+    public required string ProjectId { get; init; }
+
+    [JsonPropertyName("slug")]
+    public required string Slug { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("owner_user_id")]
+    public required string OwnerUserId { get; init; }
+
+    [JsonPropertyName("viewer_membership")]
+    public required string ViewerMembership { get; init; }
+
+    [JsonPropertyName("viewer_pending")]
+    public string? ViewerPending { get; init; }
+
+    [JsonPropertyName("repos")]
+    public List<CliProjectRepo> Repos { get; init; } = [];
+
+    [JsonPropertyName("members")]
+    public List<CliProjectMember> Members { get; init; } = [];
+
+    [JsonPropertyName("join_requests")]
+    public List<CliProjectJoinRequest> JoinRequests { get; init; } = [];
+}
+
+/// <summary>Error body shared by every <c>/api/projects*</c> route on failure (e.g. <c>projects_not_in_plan</c>).</summary>
+public sealed record CliProjectError {
+    [JsonPropertyName("error")]
+    public required string Error { get; init; }
+
+    [JsonPropertyName("message")]
+    public required string Message { get; init; }
+}
+
 public sealed record CurationApplyItem {
     [JsonPropertyName("category")]      public string?               Category     { get; init; }
     [JsonPropertyName("cluster_id")]    public string?               ClusterId    { get; init; }
@@ -701,6 +818,9 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(EvalCatalogQuestionDto))]
 [JsonSerializable(typeof(SessionEvalCompletedPayloadV3))]
 [JsonSerializable(typeof(List<ErrorEntry>))]
+[JsonSerializable(typeof(List<CliProjectSummary>))]
+[JsonSerializable(typeof(CliProjectDetail))]
+[JsonSerializable(typeof(CliProjectError))]
 [JsonSerializable(typeof(RepositoryPayload))]
 [JsonSerializable(typeof(GitCacheEntry))]
 [JsonSerializable(typeof(TranscriptBatch))]

--- a/src/Capacitor.Cli.Core/Resources/help-config.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-config.txt
@@ -10,7 +10,7 @@ Config keys:
   server_url              Server URL
   daemon.name                 Daemon name
   daemon.max_agents           Max concurrent hosted coding agents
-  default_visibility          Default session visibility (private, org_public, public)
+  default_visibility          Default session visibility (private, project, org_public, public)
   disable_session_guidelines  Skip injecting recurring-lessons context at SessionStart (true/false)
   disable_memory_index        Skip injecting the team-memory index at SessionStart (true/false)
   excluded_repos              Excluded repos, comma-separated (owner/repo,owner/repo)

--- a/src/Capacitor.Cli.Core/Resources/help-project.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-project.txt
@@ -1,0 +1,8 @@
+kcap project — Show project detail
+
+Usage: kcap project <slug>
+
+Prints project metadata, the repo list, the member list, and (owners/admins
+only) pending join requests and invites.
+
+Requires the Team or Enterprise plan; the server returns a 403 on Free.

--- a/src/Capacitor.Cli.Core/Resources/help-projects.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-projects.txt
@@ -1,0 +1,8 @@
+kcap projects — List projects you can see
+
+Usage: kcap projects
+
+Prints a table with slug, name, repo count, member count, and your role
+(owner / member / pending invite / pending request / —).
+
+Requires the Team or Enterprise plan; the server returns a 403 on Free.

--- a/src/Capacitor.Cli.Core/Resources/help-setup.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-setup.txt
@@ -5,7 +5,7 @@ Usage: kcap setup [options]
 Options:
   --server-url <url>          Server URL (skip prompt)
   --daemon-name <name>        Daemon name (skip prompt)
-  --default-visibility <vis>  Default visibility: private, org_public, public
+  --default-visibility <vis>  Default visibility: private, project, org_public, public
   --no-prompt                 Non-interactive mode (requires --server-url)
   --github                    Sign in with GitHub instead of org SSO during
                               the login step (default is org SSO when a

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -35,6 +35,10 @@ Daemon:
   repos add <path>                 Add a repo path (supports "." for cwd)
   repos remove <path>              Remove a repo path
 
+Projects:
+  projects                         List projects you can see (repos, members, your role)
+  project <slug>                   Show project detail (repos, members, join requests)
+
 Session:
   errors [--chain] [id]            List tool call errors for a session
   recap [--chain] [--full] [id]    Session summary (--full for raw transcript)

--- a/src/Capacitor.Cli/Commands/ConfigCommand.cs
+++ b/src/Capacitor.Cli/Commands/ConfigCommand.cs
@@ -80,8 +80,8 @@ public static class ConfigCommand {
             "disable_memory_index" => throw new ArgumentException($"Invalid value for disable_memory_index: '{value}'. Must be true or false."),
             "use_provider_api_key" when bool.TryParse(value, out var b) => profile with { UseProviderApiKey = b },
             "use_provider_api_key" => throw new ArgumentException($"Invalid value for use_provider_api_key: '{value}'. Must be true or false."),
-            "default_visibility" when value is "private" or "org_public" or "public" => profile with { DefaultVisibility = value },
-            "default_visibility" => throw new ArgumentException("Invalid value. Must be: private, org_public, or public"),
+            "default_visibility" when value is "private" or "project" or "org_public" or "public" => profile with { DefaultVisibility = value },
+            "default_visibility" => throw new ArgumentException("Invalid value. Must be: private, project, org_public, or public"),
             "excluded_repos" => profile with { ExcludedRepos = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) },
             _ => throw new ArgumentException($"Unknown config key: {key}")
         };
@@ -96,7 +96,7 @@ public static class ConfigCommand {
         Console.Error.WriteLine("  daemon.claude_path          Path to claude binary (default: claude)");
         Console.Error.WriteLine("  daemon.codex_path           Path to codex binary (default: codex)");
         Console.Error.WriteLine("  update_check                Enable update check (true/false)");
-        Console.Error.WriteLine("  default_visibility          Default session visibility (private, org_public, public)");
+        Console.Error.WriteLine("  default_visibility          Default session visibility (private, project, org_public, public)");
         Console.Error.WriteLine("  disable_session_guidelines  Skip injecting recurring-lessons context at SessionStart (true/false)");
         Console.Error.WriteLine("  use_provider_api_key        Keep ANTHROPIC_API_KEY/OPENAI_API_KEY in headless agent spawns (true/false)");
         Console.Error.WriteLine("  excluded_repos              Excluded repos, comma-separated (owner/repo,owner/repo)");

--- a/src/Capacitor.Cli/Commands/ProjectsCommand.cs
+++ b/src/Capacitor.Cli/Commands/ProjectsCommand.cs
@@ -1,0 +1,190 @@
+using System.Net;
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Spectre.Console;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// <c>kcap projects</c> / <c>kcap project &lt;slug&gt;</c> — read-only views over the server's
+/// <c>/api/projects</c> endpoints. Follows <see cref="ErrorsCommand"/> for client/auth/error handling.
+/// Every route 403s with <c>projects_not_in_plan</c> on the Free plan (see <see cref="CliProjectError"/>).
+/// </summary>
+static class ProjectsCommand {
+    public static async Task<int> HandleList(string baseUrl) {
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+
+        HttpResponseMessage resp;
+
+        try {
+            resp = await httpClient.GetWithRetryAsync($"{baseUrl}/api/projects");
+        } catch (HttpRequestException ex) {
+            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
+
+            return 1;
+        }
+
+        if (await HttpClientExtensions.HandleUnauthorizedAsync(resp)) {
+            return 1;
+        }
+
+        if (resp.StatusCode == HttpStatusCode.Forbidden) {
+            return await ReportForbidden(resp);
+        }
+
+        if (!resp.IsSuccessStatusCode) {
+            await Console.Error.WriteLineAsync($"HTTP {(int)resp.StatusCode}");
+
+            return 1;
+        }
+
+        var json     = await resp.Content.ReadAsStringAsync();
+        var projects = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.ListCliProjectSummary);
+
+        if (projects is null || projects.Count == 0) {
+            await Console.Out.WriteLineAsync("No projects found.");
+
+            return 0;
+        }
+
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("Slug");
+        table.AddColumn("Name");
+        table.AddColumn("Repos");
+        table.AddColumn("Members");
+        table.AddColumn("Your role");
+
+        foreach (var project in projects) {
+            table.AddRow(
+                Markup.Escape(project.Slug),
+                Markup.Escape(project.Name),
+                project.RepoCount.ToString(),
+                project.MemberCount.ToString(),
+                Markup.Escape(FormatRole(project.ViewerMembership, project.ViewerPending))
+            );
+        }
+
+        AnsiConsole.Write(table);
+
+        return 0;
+    }
+
+    public static async Task<int> HandleDetail(string baseUrl, string slug) {
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+
+        HttpResponseMessage resp;
+
+        try {
+            resp = await httpClient.GetWithRetryAsync($"{baseUrl}/api/projects/{Uri.EscapeDataString(slug)}");
+        } catch (HttpRequestException ex) {
+            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
+
+            return 1;
+        }
+
+        if (await HttpClientExtensions.HandleUnauthorizedAsync(resp)) {
+            return 1;
+        }
+
+        if (resp.StatusCode == HttpStatusCode.Forbidden) {
+            return await ReportForbidden(resp);
+        }
+
+        if (resp.StatusCode == HttpStatusCode.NotFound) {
+            await Console.Error.WriteLineAsync("Project not found.");
+
+            return 1;
+        }
+
+        if (!resp.IsSuccessStatusCode) {
+            await Console.Error.WriteLineAsync($"HTTP {(int)resp.StatusCode}");
+
+            return 1;
+        }
+
+        var json    = await resp.Content.ReadAsStringAsync();
+        var project = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.CliProjectDetail);
+
+        if (project is null) {
+            await Console.Error.WriteLineAsync("Project not found.");
+
+            return 1;
+        }
+
+        await Console.Out.WriteLineAsync($"{project.Name} ({project.Slug})");
+
+        if (!string.IsNullOrWhiteSpace(project.Description)) {
+            await Console.Out.WriteLineAsync(project.Description);
+        }
+
+        await Console.Out.WriteLineAsync($"  Owner:     {project.OwnerUserId}");
+        await Console.Out.WriteLineAsync($"  Your role: {FormatRole(project.ViewerMembership, project.ViewerPending)}");
+
+        await Console.Out.WriteLineAsync();
+        await Console.Out.WriteLineAsync($"Repos ({project.Repos.Count}):");
+
+        if (project.Repos.Count == 0) {
+            await Console.Out.WriteLineAsync("  (none)");
+        } else {
+            foreach (var repo in project.Repos) {
+                await Console.Out.WriteLineAsync($"  {repo.RepoSlug}");
+            }
+        }
+
+        await Console.Out.WriteLineAsync();
+        await Console.Out.WriteLineAsync($"Members ({project.Members.Count}):");
+
+        if (project.Members.Count == 0) {
+            await Console.Out.WriteLineAsync("  (none)");
+        } else {
+            foreach (var member in project.Members) {
+                await Console.Out.WriteLineAsync($"  {member.DisplayName} ({member.MemberKind})");
+            }
+        }
+
+        if (project.JoinRequests.Count > 0) {
+            await Console.Out.WriteLineAsync();
+            await Console.Out.WriteLineAsync($"Join requests ({project.JoinRequests.Count}):");
+
+            foreach (var request in project.JoinRequests) {
+                await Console.Out.WriteLineAsync($"  {request.UserId} — {request.Direction} ({request.RequestedAt:u})");
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Every <c>/api/projects*</c> route 403s identically when the tenant plan doesn't include
+    /// projects (Free). Falls back to a generic message for any other 403 shape.
+    /// </summary>
+    static async Task<int> ReportForbidden(HttpResponseMessage resp) {
+        var body = await resp.Content.ReadAsStringAsync();
+
+        try {
+            using var doc = JsonDocument.Parse(body);
+
+            if (doc.RootElement.Str("error") == "projects_not_in_plan") {
+                await Console.Error.WriteLineAsync("Projects require the Team or Enterprise plan.");
+
+                return 1;
+            }
+        } catch (JsonException) {
+            /* fall through to generic message */
+        }
+
+        await Console.Error.WriteLineAsync("Forbidden.");
+
+        return 1;
+    }
+
+    static string FormatRole(string viewerMembership, string? viewerPending) => viewerMembership switch {
+        "owner"  => "owner",
+        "member" => "member",
+        _ => viewerPending switch {
+            "invite"  => "pending invite",
+            "request" => "pending request",
+            _         => "—"
+        }
+    };
+}

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -160,8 +160,8 @@ public static class SetupCommand {
         if (noPrompt) {
             defaultVisibility = (GetArg(args, "--default-visibility") ?? "org_public").ToLowerInvariant();
 
-            if (defaultVisibility is not "private" and not "org_public" and not "public") {
-                await Console.Error.WriteLineAsync($"  Invalid default-visibility: {defaultVisibility}. Must be: private, org_public, or public");
+            if (!AppConfig.ValidVisibilities.Contains(defaultVisibility)) {
+                await Console.Error.WriteLineAsync($"  Invalid default-visibility: {defaultVisibility}. Must be: {string.Join(", ", AppConfig.ValidVisibilities)}");
 
                 return 1;
             }
@@ -171,9 +171,10 @@ public static class SetupCommand {
             defaultVisibility = AnsiConsole.Prompt(
                 new SelectionPrompt<string>()
                     .Title("Which of your sessions should be readable by other users in the same Kurrent Capacitor account by default?")
-                    .AddChoices("org_public", "private", "public")
+                    .AddChoices(AppConfig.ValidVisibilities)
                     .UseConverter(v => v switch {
                         "private"    => "All private — only you can see your sessions",
+                        "project"    => "Project repos public to fellow project members, others private",
                         "org_public" => "Org repos public, others private (default)",
                         "public"     => "All public — others can see all your sessions",
                         _            => v

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -282,6 +282,17 @@ switch (command) {
         return await RemapCommand.HandleAsync(args);
     case "repos":
         return await ReposCommand.HandleAsync(args);
+    case "projects":
+        return await ProjectsCommand.HandleList(baseUrl!);
+    case "project": {
+        if (args.Length < 2) {
+            Console.Error.WriteLine("Usage: kcap project <slug>");
+
+            return 1;
+        }
+
+        return await ProjectsCommand.HandleDetail(baseUrl!, args[1]);
+    }
     case "update":
         return await UpdateCommand.HandleAsync(args);
     case "review": {

--- a/test/Capacitor.Cli.Tests.Unit/ConfigCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ConfigCommandTests.cs
@@ -168,4 +168,27 @@ public class ConfigCommandTests {
 
         await Assert.That(updated.ServerUrl).IsEqualTo("https://example.com");
     }
+
+    // ── default_visibility (AI-1206: "project" added to the ladder) ────────────
+
+    [Test]
+    [Arguments("private")]
+    [Arguments("project")]
+    [Arguments("org_public")]
+    [Arguments("public")]
+    public async Task ApplySet_DefaultVisibility_AcceptsEachValidValue(string value) {
+        var profile = new Profile();
+
+        var updated = ConfigCommand.ApplySet(profile, "default_visibility", value);
+
+        await Assert.That(updated.DefaultVisibility).IsEqualTo(value);
+    }
+
+    [Test]
+    public async Task ApplySet_DefaultVisibility_InvalidValue_Throws() {
+        var profile = new Profile();
+
+        await Assert.That(() => ConfigCommand.ApplySet(profile, "default_visibility", "team"))
+            .Throws<ArgumentException>();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ProjectsCommandDtoTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProjectsCommandDtoTests.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Deserialization tests for the <c>kcap projects</c> / <c>kcap project &lt;slug&gt;</c> DTOs
+/// against sample payloads mirroring the server's <c>ProjectSummaryDto</c> / <c>ProjectDetailDto</c>
+/// (src/Capacitor.Server.Core/Projects/ProjectContracts.cs) — snake_case wire, no client-side
+/// [JsonPropertyName] typos possible without a test catching it.
+/// </summary>
+public class ProjectsCommandDtoTests {
+    [Test]
+    public async Task CliProjectSummary_DeserializesFromServerShape() {
+        const string json = """
+            [
+              {
+                "project_id": "proj-1",
+                "slug": "payments",
+                "name": "Payments",
+                "description": "Payments squad repos",
+                "owner_user_id": "github:42",
+                "repo_count": 3,
+                "member_count": 5,
+                "viewer_membership": "owner",
+                "viewer_pending": null,
+                "pending_request_count": 2,
+                "repo_hashes": ["abc123", "def456"]
+              },
+              {
+                "project_id": "proj-2",
+                "slug": "growth",
+                "name": "Growth",
+                "description": null,
+                "owner_user_id": "github:7",
+                "repo_count": 1,
+                "member_count": 1,
+                "viewer_membership": "none",
+                "viewer_pending": "invite",
+                "pending_request_count": 0,
+                "repo_hashes": []
+              }
+            ]
+            """;
+
+        var projects = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.ListCliProjectSummary);
+
+        await Assert.That(projects).IsNotNull();
+        await Assert.That(projects!.Count).IsEqualTo(2);
+
+        var payments = projects[0];
+        await Assert.That(payments.ProjectId).IsEqualTo("proj-1");
+        await Assert.That(payments.Slug).IsEqualTo("payments");
+        await Assert.That(payments.Name).IsEqualTo("Payments");
+        await Assert.That(payments.Description).IsEqualTo("Payments squad repos");
+        await Assert.That(payments.OwnerUserId).IsEqualTo("github:42");
+        await Assert.That(payments.RepoCount).IsEqualTo(3);
+        await Assert.That(payments.MemberCount).IsEqualTo(5);
+        await Assert.That(payments.ViewerMembership).IsEqualTo("owner");
+        await Assert.That(payments.ViewerPending).IsNull();
+        await Assert.That(payments.PendingRequestCount).IsEqualTo(2);
+        await Assert.That(payments.RepoHashes).IsEquivalentTo(["abc123", "def456"]);
+
+        var growth = projects[1];
+        await Assert.That(growth.Description).IsNull();
+        await Assert.That(growth.ViewerMembership).IsEqualTo("none");
+        await Assert.That(growth.ViewerPending).IsEqualTo("invite");
+        await Assert.That(growth.RepoHashes).IsEmpty();
+    }
+
+    [Test]
+    public async Task CliProjectDetail_DeserializesFromServerShape() {
+        const string json = """
+            {
+              "project_id": "proj-1",
+              "slug": "payments",
+              "name": "Payments",
+              "description": "Payments squad repos",
+              "owner_user_id": "github:42",
+              "viewer_membership": "owner",
+              "viewer_pending": null,
+              "repos": [
+                { "repo_hash": "abc123", "repo_slug": "kurrent-io/payments-api" }
+              ],
+              "members": [
+                { "member_kind": "user", "member_id": "github:7", "display_name": "Alice" }
+              ],
+              "join_requests": [
+                { "user_id": "github:99", "direction": "request", "requested_at": "2026-07-01T12:00:00Z" }
+              ]
+            }
+            """;
+
+        var project = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.CliProjectDetail);
+
+        await Assert.That(project).IsNotNull();
+        await Assert.That(project!.ProjectId).IsEqualTo("proj-1");
+        await Assert.That(project.ViewerMembership).IsEqualTo("owner");
+
+        await Assert.That(project.Repos).Count().IsEqualTo(1);
+        await Assert.That(project.Repos[0].RepoHash).IsEqualTo("abc123");
+        await Assert.That(project.Repos[0].RepoSlug).IsEqualTo("kurrent-io/payments-api");
+
+        await Assert.That(project.Members).Count().IsEqualTo(1);
+        await Assert.That(project.Members[0].MemberKind).IsEqualTo("user");
+        await Assert.That(project.Members[0].DisplayName).IsEqualTo("Alice");
+
+        await Assert.That(project.JoinRequests).Count().IsEqualTo(1);
+        await Assert.That(project.JoinRequests[0].UserId).IsEqualTo("github:99");
+        await Assert.That(project.JoinRequests[0].Direction).IsEqualTo("request");
+    }
+
+    [Test]
+    public async Task CliProjectDetail_DeserializesWithEmptyCollections() {
+        const string json = """
+            {
+              "project_id": "proj-3",
+              "slug": "solo",
+              "name": "Solo",
+              "description": null,
+              "owner_user_id": "github:1",
+              "viewer_membership": "member",
+              "viewer_pending": null,
+              "repos": [],
+              "members": [],
+              "join_requests": []
+            }
+            """;
+
+        var project = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.CliProjectDetail);
+
+        await Assert.That(project).IsNotNull();
+        await Assert.That(project!.Repos).IsEmpty();
+        await Assert.That(project.Members).IsEmpty();
+        await Assert.That(project.JoinRequests).IsEmpty();
+    }
+
+    [Test]
+    public async Task CliProjectError_DeserializesProjectsNotInPlanBody() {
+        const string json = """
+            { "error": "projects_not_in_plan", "message": "Projects require the Team or Enterprise plan." }
+            """;
+
+        var error = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.CliProjectError);
+
+        await Assert.That(error).IsNotNull();
+        await Assert.That(error!.Error).IsEqualTo("projects_not_in_plan");
+        await Assert.That(error.Message).IsEqualTo("Projects require the Team or Enterprise plan.");
+    }
+}


### PR DESCRIPTION
## What

CLI side of the Projects feature ([kcap-server PR #975](https://github.com/kurrent-io/kcap-server/pull/975), spec in kcap-server PR #956):

- **`kcap projects`** — lists the server's projects (Spectre table: slug, name, repos, members, your role incl. pending invite/request states).
- **`kcap project <slug>`** — detail view (metadata, repo list, member list, join requests where visible).
- Both use the shared authenticated-client/retry/unauthorized helpers; a 403 with `projects_not_in_plan` prints "Projects require the Team or Enterprise plan." (exit 1); 404 → "Project not found."; DTOs registered in `CapacitorJsonContext` (AOT-safe, snake_case parity with the server contracts).
- **`default_visibility` gains `project`** (ladder: private < project < org_public < public): accepted by `kcap config set`, the setup wizard, and `--default-visibility`; `NormalizeProfileVisibilities` keeps it across config round-trips. Hook forwarding is value-agnostic — no hook changes needed; the server resolves project context from `repo_hash`.

## Testing

Unit suite 2439/2439; integration suite green (one unrelated network-probe timing flake passed in isolation); full solution builds with 0 errors, no AOT/trim warnings on the new DTOs. Command paths (table render, detail render, 403 plan-gate message, 404, usage errors) verified live against a mock server.

## Sequencing

The kcap-server PR's `src/cli` submodule pointer references this branch's head (`30e391c`) — merge this before (or alongside) kcap-server #975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)