### PR TITLE
Isolate the unit suite's daemon lock/PID dir so it can't SIGKILL the developer's live daemon

### DIFF
--- a/src/Capacitor.Cli.Core/DaemonLockPaths.cs
+++ b/src/Capacitor.Cli.Core/DaemonLockPaths.cs
@@ -18,13 +18,29 @@ namespace Capacitor.Cli.Core;
 /// (<c>~/.config/kcap/daemons/</c>) regardless of <c>KCAP_CONFIG_DIR</c>,
 /// so cross-config-dir daemons under the same name now collide on the same
 /// <c>flock</c>. Sanitization is intentionally strict to keep filenames
-/// portable: only <c>[a-z0-9._-]</c> survives, anything else maps to <c>-</c>.</para>
+/// portable: only <c>[a-z0-9._-]</c> survives, anything else maps to <c>-</c>.
+/// The one exception is the opt-in <see cref="DaemonsDirEnvVar"/> test seam
+/// (never set in production) — see its remarks.</para>
 /// </summary>
 public static partial class DaemonLockPaths {
-    static readonly string DefaultDirectory = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        ".config", "kcap", "daemons"
-    );
+    /// <summary>
+    /// Opt-in override for the DEFAULT daemons directory, read lazily on every access so a test
+    /// assembly can redirect the whole process to a temp path before any daemon file is touched.
+    /// Production and the Aspire dev daemon never set this, so the deliberate cross-<c>KCAP_CONFIG_DIR</c>
+    /// collision on <c>~/.config/kcap/daemons/</c> is unchanged. It exists because this directory
+    /// ignores <c>KCAP_CONFIG_DIR</c> and the default daemon name is the OS username: a unit test
+    /// that reads this dir with <see cref="_overrideDir"/> cleared could otherwise resolve — and
+    /// <c>Process.Kill</c> — the developer's live daemon (its pid file lives here).
+    /// </summary>
+    public const string DaemonsDirEnvVar = "KCAP_DAEMONS_DIR";
+
+    static string DefaultDirectory =>
+        Environment.GetEnvironmentVariable(DaemonsDirEnvVar) is { Length: > 0 } dir
+            ? dir
+            : Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".config", "kcap", "daemons"
+            );
 
     static string? _overrideDir;
 

--- a/src/Capacitor.Cli.Core/DaemonLockPaths.cs
+++ b/src/Capacitor.Cli.Core/DaemonLockPaths.cs
@@ -34,13 +34,22 @@ public static partial class DaemonLockPaths {
     /// </summary>
     public const string DaemonsDirEnvVar = "KCAP_DAEMONS_DIR";
 
-    static string DefaultDirectory =>
-        Environment.GetEnvironmentVariable(DaemonsDirEnvVar) is { Length: > 0 } dir
-            ? dir
+    /// <summary>
+    /// Pure default-directory resolution: the supplied <see cref="DaemonsDirEnvVar"/> value when
+    /// non-empty, else the fixed <c>~/.config/kcap/daemons/</c> home location. Kept env-free so the
+    /// production fallback can be asserted with an explicit argument (see the test) without mutating
+    /// the process-global environment variable — clearing it at runtime would race any parallel test
+    /// that reads <see cref="Directory"/> and re-expose the real daemons dir this seam exists to hide.
+    /// </summary>
+    internal static string ResolveDefaultDir(string? envValue) =>
+        !string.IsNullOrEmpty(envValue)
+            ? envValue
             : Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                 ".config", "kcap", "daemons"
             );
+
+    static string DefaultDirectory => ResolveDefaultDir(Environment.GetEnvironmentVariable(DaemonsDirEnvVar));
 
     static string? _overrideDir;
 

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockPathsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockPathsTests.cs
@@ -40,23 +40,13 @@ public class DaemonLockPathsTests {
     }
 
     [Test]
-    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
     public async Task Directory_LivesUnderDaemonsFolder() {
-        // Verify the PRODUCTION fallback (no override, no KCAP_DAEMONS_DIR) uses the renamed
-        // ~/.config/kcap/daemons/ path, not the pre-AI-644 agents/ path. DaemonPathsGlobalSetup
-        // pins KCAP_DAEMONS_DIR to a temp path assembly-wide (so no test can reach the real
-        // daemon), so clear both here to observe the fallback — synchronously, with NO await
-        // between clear and restore, so the real dir is never visible to a parallel test.
-        var savedEnv = Environment.GetEnvironmentVariable(DaemonLockPaths.DaemonsDirEnvVar);
-        string resolved;
-        DaemonLockPaths.OverrideDirectoryForTesting(null);
-        Environment.SetEnvironmentVariable(DaemonLockPaths.DaemonsDirEnvVar, null);
-        try {
-            resolved = DaemonLockPaths.Directory;
-        } finally {
-            Environment.SetEnvironmentVariable(DaemonLockPaths.DaemonsDirEnvVar, savedEnv);
-        }
-
-        await Assert.That(resolved.Replace('\\', '/')).EndsWith("/.config/kcap/daemons");
+        // Verify the PRODUCTION fallback (no KCAP_DAEMONS_DIR set) uses the renamed
+        // ~/.config/kcap/daemons/ path, not the pre-AI-644 agents/ path. Asserted against the pure
+        // ResolveDefaultDir(null) rather than by clearing the process-global env var — clearing it
+        // would race any parallel test that reads DaemonLockPaths.Directory and briefly re-expose the
+        // real daemons dir (Qodo #289 finding 2/3). This is deterministic and touches no shared state.
+        await Assert.That(DaemonLockPaths.ResolveDefaultDir(null).Replace('\\', '/'))
+            .EndsWith("/.config/kcap/daemons");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockPathsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockPathsTests.cs
@@ -40,10 +40,23 @@ public class DaemonLockPathsTests {
     }
 
     [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
     public async Task Directory_LivesUnderDaemonsFolder() {
-        // Verify the production layout (no test override) uses the renamed
-        // ~/.config/kcap/daemons/ path, not the pre-AI-644 agents/ path.
-        await Assert.That(DaemonLockPaths.Directory.Replace('\\', '/'))
-            .EndsWith("/.config/kcap/daemons");
+        // Verify the PRODUCTION fallback (no override, no KCAP_DAEMONS_DIR) uses the renamed
+        // ~/.config/kcap/daemons/ path, not the pre-AI-644 agents/ path. DaemonPathsGlobalSetup
+        // pins KCAP_DAEMONS_DIR to a temp path assembly-wide (so no test can reach the real
+        // daemon), so clear both here to observe the fallback — synchronously, with NO await
+        // between clear and restore, so the real dir is never visible to a parallel test.
+        var savedEnv = Environment.GetEnvironmentVariable(DaemonLockPaths.DaemonsDirEnvVar);
+        string resolved;
+        DaemonLockPaths.OverrideDirectoryForTesting(null);
+        Environment.SetEnvironmentVariable(DaemonLockPaths.DaemonsDirEnvVar, null);
+        try {
+            resolved = DaemonLockPaths.Directory;
+        } finally {
+            Environment.SetEnvironmentVariable(DaemonLockPaths.DaemonsDirEnvVar, savedEnv);
+        }
+
+        await Assert.That(resolved.Replace('\\', '/')).EndsWith("/.config/kcap/daemons");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/DaemonPathsGlobalSetup.cs
+++ b/test/Capacitor.Cli.Tests.Unit/DaemonPathsGlobalSetup.cs
@@ -1,0 +1,38 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Assembly-level safety net for daemon lock/PID paths.
+///
+/// <para><see cref="DaemonLockPaths"/> deliberately ignores <c>KCAP_CONFIG_DIR</c> and pins its
+/// directory under the real home (<c>~/.config/kcap/daemons/</c>), and the default daemon name is the
+/// OS username — so the per-test <c>OverrideDirectoryForTesting</c> seam is not enough: any window
+/// where the process-wide override is <c>null</c> (a teardown reset, a test that never sets it, or a
+/// parallel test) exposes the developer's <b>real</b> daemon files. A daemon test that read them once
+/// <c>SIGKILL</c>ed the developer's live daemon (and its hosted agents).</para>
+///
+/// <para>Pinning <see cref="DaemonLockPaths.DaemonsDirEnvVar"/> to a throwaway temp dir for the whole
+/// process makes the real directory unreachable regardless of test order, parallelism, or a missing
+/// per-test override. Individual tests may still layer their own <c>OverrideDirectoryForTesting</c>
+/// on top; when they reset it to <c>null</c> the default now falls back here, never to the real dir.
+/// See <c>DaemonPathsIsolationTests</c> for the regression this guards.</para>
+/// </summary>
+public class DaemonPathsGlobalSetup {
+    internal static readonly string SharedDaemonsDir = Path.Combine(
+        Path.GetTempPath(),
+        "kcap-daemons-tests-" + Guid.NewGuid().ToString("N")[..8]
+    );
+
+    [Before(Assembly)]
+    public static void PinDaemonsDir() {
+        Directory.CreateDirectory(SharedDaemonsDir);
+        Environment.SetEnvironmentVariable(DaemonLockPaths.DaemonsDirEnvVar, SharedDaemonsDir);
+    }
+
+    [After(Assembly)]
+    public static void CleanupDaemonsDir() {
+        Environment.SetEnvironmentVariable(DaemonLockPaths.DaemonsDirEnvVar, null);
+        try { Directory.Delete(SharedDaemonsDir, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/DaemonPathsIsolationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/DaemonPathsIsolationTests.cs
@@ -1,0 +1,40 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Regression guard: a CLI unit-test run must NEVER be able to resolve the developer's REAL
+/// <c>~/.config/kcap/daemons/</c> directory.
+///
+/// <para><see cref="DaemonLockPaths"/> deliberately ignores <c>KCAP_CONFIG_DIR</c>, and the default
+/// daemon name is the OS username. Before this guard, a daemon test that read
+/// <see cref="DaemonLockPaths.Directory"/> while the process-wide override was <c>null</c> — a
+/// teardown reset, or a test that never set it — resolved the live launchd daemon's PID file
+/// (<c>~/.config/kcap/daemons/{username}.pid</c>) and <c>Process.Kill(entireProcessTree: true)</c>'d
+/// it, SIGKILLing the developer's running daemon and its hosted agents. <c>DaemonPathsGlobalSetup</c>
+/// pins the assembly's default daemons dir to a temp path (via <c>KCAP_DAEMONS_DIR</c>) so the real
+/// directory is unreachable no matter which test runs, in what order, or in parallel.</para>
+/// </summary>
+[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+public class DaemonPathsIsolationTests {
+    static string RealHomeDaemonsDir => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "kcap", "daemons");
+
+    [Test]
+    public async Task Directory_WithNoOverride_IsNotTheRealHomeDaemonsDir() {
+        // Reproduce the dangerous state a daemon test's teardown leaves behind.
+        DaemonLockPaths.OverrideDirectoryForTesting(null);
+
+        await Assert.That(DaemonLockPaths.Directory).IsNotEqualTo(RealHomeDaemonsDir);
+    }
+
+    [Test]
+    public async Task PidPath_ForUsernameDefaultName_IsNotUnderRealHomeDir() {
+        // The exact path the offending test read to find (and kill) the live daemon.
+        DaemonLockPaths.OverrideDirectoryForTesting(null);
+
+        var pidPath = DaemonLockPaths.PidPath(Environment.UserName);
+
+        await Assert.That(pidPath.StartsWith(RealHomeDaemonsDir, StringComparison.Ordinal)).IsFalse();
+    }
+}


### PR DESCRIPTION
## Problem

`DaemonLockPaths` deliberately ignores `KCAP_CONFIG_DIR` and pins daemon lock/PID files to the real `~/.config/kcap/daemons/`, and the default daemon name is the **OS username**. The unit suite's per-test `OverrideDirectoryForTesting` seam is a process-wide `static`, so any window where it's `null` — a teardown reset, a test that never sets it, or a parallel test — lets a daemon test resolve `~/.config/kcap/daemons/{username}.pid` and `Process.Kill(entireProcessTree: true)` it.

That is not hypothetical. It was caught in the act with `eslogger` (SIP-safe): the `Capacitor.Cli.Tests.Unit` binary sent `kill -0` → `SIGSTOP` → **`SIGKILL`** to the developer's live launchd daemon (and took its hosted agents down with the process tree). Because it's a SIGKILL, there's no death-rattle; because `daemon stop` wipes the PID markers, the unclean-exit breadcrumb never fires; and a userspace `kill` leaves no unified-log entry — so it was invisible and went undiagnosed for weeks (launchd's `KeepAlive` just relaunched the daemon each time).

## Fix

- **`DaemonLockPaths`** — `DefaultDirectory` now lazily honors an opt-in `KCAP_DAEMONS_DIR` env seam. Production and the Aspire dev daemon never set it, so the deliberate cross-`KCAP_CONFIG_DIR` collision on `~/.config/kcap/daemons/` is unchanged.
- **`DaemonPathsGlobalSetup`** (new) — an assembly-level `[Before(Assembly)]` pins `KCAP_DAEMONS_DIR` to a throwaway temp dir for the whole test process. So the real daemons dir is unreachable regardless of test order, parallelism, or a missing/`null` per-test override.
- **`DaemonPathsIsolationTests`** (new) — regression guard that reproduces the exact `PidPath(username)` path.
- **`DaemonLockPathsTests.Directory_LivesUnderDaemonsFolder`** — updated to observe the production fallback safely (clears the env synchronously, no `await` between clear and restore, so the real dir is never visible to a parallel test).

## Verification

- RED→GREEN on the new guard.
- **End-to-end: the full 2496-test unit suite now runs with the live daemon PID unchanged** (before, that same suite SIGKILL'd it). 2496/2496 pass, 0 failures.

## Notes

- **Land this before/with the AI-1207 daemon-suite work** — running that full suite without this isolation is hazardous to a developer's live daemon.
- Independent follow-ups worth filing: the OS-username default daemon name is a footgun, and the `daemon stop` service-guard should also cover the enumerate/`Process.Kill` path a test used to reach the real daemon.
- Please link the tracking GitHub issue (and Linear `AI-` id) here per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)