### PR TITLE
Daemon: borrow the requester's cwd for hosted flow reviewers — AI-1207 Phase A

### DIFF
--- a/src/Capacitor.Cli.Core/MachineId.cs
+++ b/src/Capacitor.Cli.Core/MachineId.cs
@@ -60,7 +60,29 @@ public static class MachineId {
         } catch (IOException) {
             // Lost the race: a peer created machine.json between our ReadPersisted() check
             // (inside Get()) and this create. Adopt whichever id won.
-            return ReadPersisted() ?? id;
+            return ReadPeerIdWithRetry() ?? id;
+        }
+    }
+
+    // Fallback read on the lost-race path. The winner holds the file exclusively (FileShare.None)
+    // between its FileStream construction and disposal; a plain ReadPersisted() (File.ReadAllText
+    // opens FileShare.Read) landing inside that sub-ms window throws an uncaught IOException that
+    // would otherwise propagate out of Get() and fail daemon registration. Retry a few times with
+    // a tiny backoff so the write completes and the id becomes readable; only return null (→ the
+    // caller keeps its locally-generated id) if it stays genuinely unreadable past the budget.
+    const int  PeerReadMaxAttempts = 10;
+    const int  PeerReadDelayMs     = 5;
+
+    static string? ReadPeerIdWithRetry() {
+        for (var attempt = 1; ; attempt++) {
+            try {
+                var peer = ReadPersisted();
+                if (peer is not null || attempt >= PeerReadMaxAttempts) return peer;
+            } catch (IOException) {
+                if (attempt >= PeerReadMaxAttempts) return null;
+            }
+
+            Thread.Sleep(PeerReadDelayMs);
         }
     }
 }

--- a/src/Capacitor.Cli.Core/MachineId.cs
+++ b/src/Capacitor.Cli.Core/MachineId.cs
@@ -37,7 +37,9 @@ public static class MachineId {
             var json = File.ReadAllText(MachinePath);
             var file = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.MachineIdFile);
             return string.IsNullOrWhiteSpace(file.Id) ? null : file.Id;
-        } catch (JsonException) {
+        } catch (Exception e) when (e is JsonException or IOException or UnauthorizedAccessException) {
+            // Corrupt/partial JSON, or a transient read error while a peer holds the file exclusively
+            // mid-write — treat all as "no readable id right now"; never throw out of Get() (Qodo #290 #1).
             return null;
         }
     }
@@ -53,35 +55,42 @@ public static class MachineId {
         Directory.CreateDirectory(dir);
 
         try {
-            using var stream = new FileStream(MachinePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
-            using var writer = new StreamWriter(stream);
-            writer.Write(JsonSerializer.Serialize(new MachineIdFile(id), CapacitorJsonContext.Default.MachineIdFile));
+            WriteId(FileMode.CreateNew, id);   // exclusive create — the brand-new-machine case
             return id;
         } catch (IOException) {
-            // Lost the race: a peer created machine.json between our ReadPersisted() check
-            // (inside Get()) and this create. Adopt whichever id won.
-            return ReadPeerIdWithRetry() ?? id;
+            // machine.json already exists: adopt a peer's valid id if we can read one (the
+            // lost-the-race case — a peer created it between our ReadPersisted() check inside Get()
+            // and this create).
+            var peer = ReadPeerIdWithRetry();
+            if (peer is not null) return peer;
+            // ...else it's persistently unreadable (corrupt / stuck partial write). HEAL by overwriting
+            // once so Get() returns a STABLE persisted id instead of churning a new GUID each call
+            // (Qodo #290 #2). Best-effort: on a heal race we still return our id; the next Get() reads
+            // whichever heal won.
+            try { WriteId(FileMode.Create, id); } catch (IOException) { /* best effort */ }
+            return id;
         }
+    }
+
+    static void WriteId(FileMode mode, string id) {
+        using var stream = new FileStream(MachinePath, mode, FileAccess.Write, FileShare.None);
+        using var writer = new StreamWriter(stream);
+        writer.Write(JsonSerializer.Serialize(new MachineIdFile(id), CapacitorJsonContext.Default.MachineIdFile));
     }
 
     // Fallback read on the lost-race path. The winner holds the file exclusively (FileShare.None)
     // between its FileStream construction and disposal; a plain ReadPersisted() (File.ReadAllText
-    // opens FileShare.Read) landing inside that sub-ms window throws an uncaught IOException that
-    // would otherwise propagate out of Get() and fail daemon registration. Retry a few times with
-    // a tiny backoff so the write completes and the id becomes readable; only return null (→ the
-    // caller keeps its locally-generated id) if it stays genuinely unreadable past the budget.
+    // opens FileShare.Read) landing inside that sub-ms window fails to read and returns null (the
+    // IOException is now swallowed there — Qodo #290 #1). Retry a few times with a tiny backoff so
+    // the write completes and the id becomes readable; only return null (→ the caller heals with its
+    // own generated id) if it stays genuinely unreadable past the budget.
     const int  PeerReadMaxAttempts = 10;
     const int  PeerReadDelayMs     = 5;
 
     static string? ReadPeerIdWithRetry() {
         for (var attempt = 1; ; attempt++) {
-            try {
-                var peer = ReadPersisted();
-                if (peer is not null || attempt >= PeerReadMaxAttempts) return peer;
-            } catch (IOException) {
-                if (attempt >= PeerReadMaxAttempts) return null;
-            }
-
+            var peer = ReadPersisted();
+            if (peer is not null || attempt >= PeerReadMaxAttempts) return peer;
             Thread.Sleep(PeerReadDelayMs);
         }
     }

--- a/src/Capacitor.Cli.Core/MachineId.cs
+++ b/src/Capacitor.Cli.Core/MachineId.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+
+namespace Capacitor.Cli.Core;
+
+/// <summary>
+/// Stable per-machine identifier (AI-1207): lets the server prove that a daemon reconnecting
+/// under a given repo path is actually running on the machine it claims, rather than trusting a
+/// path string alone. Persisted once to <c>machine.json</c> in the CLI's config directory
+/// (<see cref="PathHelpers.ConfigPath"/> — the same resolution <c>Auth.TokenStore</c> uses,
+/// honouring <c>KCAP_CONFIG_DIR</c>) so every process on this machine — hooks, watcher, daemon,
+/// MCP — resolves the same file and reports the same id.
+///
+/// Distinct from <see cref="MachineIdProvider"/> (AI-1134), which tags memories with a
+/// separately-generated id stored inside the profile config (<c>config.json</c>'s
+/// <c>machine_id</c>); the two are not reconciled. This one is a standalone file so reading/
+/// writing it can never race a concurrent <c>ProfileConfig</c> save.
+/// </summary>
+public static class MachineId {
+    static readonly string MachinePath = PathHelpers.ConfigPath("machine.json");
+
+    /// <summary>
+    /// Returns this machine's stable id, generating and persisting one on first call. Later
+    /// calls — in this process or a new one — read the same persisted value back.
+    /// </summary>
+    public static string Get() => ReadPersisted() ?? Create();
+
+    /// <summary>
+    /// Reads the persisted id straight off disk — what a fresh process (or a fresh call after a
+    /// peer process wrote it) would see. Returns null if machine.json doesn't exist yet or is
+    /// corrupt (never resurrects a partial/garbled write; the next <see cref="Get"/> just
+    /// regenerates).
+    /// </summary>
+    public static string? ReadPersisted() {
+        if (!File.Exists(MachinePath)) return null;
+
+        try {
+            var json = File.ReadAllText(MachinePath);
+            var file = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.MachineIdFile);
+            return string.IsNullOrWhiteSpace(file.Id) ? null : file.Id;
+        } catch (JsonException) {
+            return null;
+        }
+    }
+
+    // Two processes can race to create machine.json on a brand-new machine (e.g. the watcher and
+    // the daemon starting at once). FileMode.CreateNew is an exclusive OS-level create — exactly
+    // one writer succeeds; the loser's create throws IOException and re-reads the file the
+    // winner just wrote instead of keeping its own generated id, so both converge on one value
+    // with no separate lock file needed.
+    static string Create() {
+        var id  = Guid.NewGuid().ToString("N");
+        var dir = Path.GetDirectoryName(MachinePath)!;
+        Directory.CreateDirectory(dir);
+
+        try {
+            using var stream = new FileStream(MachinePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            using var writer = new StreamWriter(stream);
+            writer.Write(JsonSerializer.Serialize(new MachineIdFile(id), CapacitorJsonContext.Default.MachineIdFile));
+            return id;
+        } catch (IOException) {
+            // Lost the race: a peer created machine.json between our ReadPersisted() check
+            // (inside Get()) and this create. Adopt whichever id won.
+            return ReadPersisted() ?? id;
+        }
+    }
+}
+
+/// <summary>On-disk shape of <c>machine.json</c> (see <see cref="MachineId"/>).</summary>
+public readonly record struct MachineIdFile(string Id);

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -725,6 +725,7 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(FindRepoForRemoteRequest))]
 [JsonSerializable(typeof(RefreshAgentWorktreeCommand))]
 [JsonSerializable(typeof(RefreshAgentWorktreeResult))]
+[JsonSerializable(typeof(BorrowProbeResult))]
 [JsonSerializable(typeof(SendInputCommand))]
 [JsonSerializable(typeof(ResizeTerminalCommand))]
 [JsonSerializable(typeof(PrepareEvalCommand))]
@@ -906,6 +907,21 @@ public readonly record struct RefreshAgentWorktreeCommand(
 public readonly record struct RefreshAgentWorktreeResult(
         bool    Success,
         string? Error
+    );
+
+/// <summary>
+/// Daemon reply to the server's <c>ProbeBorrowSource</c> client-result invocation (AI-1207 Phase A,
+/// task A3): "can you borrow this path?". <see cref="CanBorrow"/> mirrors
+/// <c>BorrowAuthResult.Allowed</c>; <see cref="CanonicalCwd"/>/<see cref="CanonicalGitRoot"/> are the
+/// daemon-computed canonical paths (non-null only when the path exists), and <see cref="Reason"/>
+/// carries the rejection reason (<c>path_absent</c> / <c>not_allowed</c>) when not borrowable. Wire
+/// keys (snake_case): <c>can_borrow</c>, <c>canonical_cwd</c>, <c>canonical_git_root</c>, <c>reason</c>.
+/// </summary>
+public record BorrowProbeResult(
+        bool    CanBorrow,
+        string? CanonicalCwd,
+        string? CanonicalGitRoot,
+        string? Reason
     );
 
 public readonly record struct SendInputCommand(

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -756,6 +756,7 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(HostedPermissionRequest))]
 [JsonSerializable(typeof(PermissionResolution))]
 [JsonSerializable(typeof(EndAgentSessionResult))]
+[JsonSerializable(typeof(MachineIdFile))]
 [JsonSerializable(typeof(int))]
 [JsonSerializable(typeof(string))]
 [JsonSerializable(typeof(string[]))]
@@ -934,6 +935,12 @@ public readonly record struct ResizeTerminalCommand(
 /// <c>AssemblyInformationalVersion</c>. Logged on connect and surfaced on
 /// the server's <c>DaemonInfo</c> so the dashboard can show what version
 /// each connected daemon is running.</para>
+///
+/// <para><c>MachineId</c> (AI-1207) is this machine's stable id (see
+/// <see cref="MachineId"/>), reported so the server can later prove a daemon
+/// claiming a given repo path is actually running on the requester's
+/// machine. Trailing/optional so an older daemon that doesn't send it (or a
+/// newer daemon talking to an older server that ignores it) never breaks.</para>
 /// </summary>
 public readonly record struct DaemonConnect(
         string    Name,
@@ -943,7 +950,8 @@ public readonly record struct DaemonConnect(
         string[]  LiveAgentIds,
         string?   InstanceId       = null,
         string?   Version          = null,
-        string[]? SupportedVendors = null
+        string[]? SupportedVendors = null,
+        string?   MachineId        = null
     );
 
 public readonly record struct AgentRegistered(

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -852,7 +852,15 @@ public readonly record struct LaunchAgentCommand(
         // names the daemon resolves against the kcap-owned KcapMcpRegistry and materializes into the
         // launcher's MCP config (flow-starting servers are stripped regardless of listing). Appended
         // last, same wire-compat rule as SyncFromRepoRoot above.
-        string[]?         McpAllowlist = null
+        string[]?         McpAllowlist = null,
+        // AI-1207 Phase A: launch against the user's own checkout instead of a fresh daemon-owned
+        // worktree. A bool on the wire (not the WorkLocation enum) — WorkLocation's numeric values
+        // are BorrowedCwd=0/OwnedWorktree=1, the reverse of what you'd guess, so a raw enum int
+        // would be a footgun; the daemon maps Borrowed -> WorkLocation internally. BorrowCwd is the
+        // absolute path to borrow when Borrowed is true. Appended last, same wire-compat rule as the
+        // fields above.
+        bool               Borrowed = false,
+        string?            BorrowCwd = null
     );
 
 /// <summary>

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -87,14 +87,20 @@ public class DaemonConfig {
             return true;
         }
 
-        return AllowedRepoPaths.Any(pattern => {
+        // Compare with forward slashes so an operator's "/*" wildcard and prefix matching work
+        // regardless of the host's native separator (Windows canonical paths use '\'). No-op on POSIX.
+        var path = repoPath.Replace('\\', '/');
+
+        return AllowedRepoPaths.Any(raw => {
+                var pattern = raw.Replace('\\', '/');
+
                 if (pattern.EndsWith("/*")) {
                     var prefix = pattern[..^1]; // keep trailing slash: "/allowed/"
 
-                    return repoPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) || string.Equals(repoPath, pattern[..^2], StringComparison.OrdinalIgnoreCase);
+                    return path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) || string.Equals(path, pattern[..^2], StringComparison.OrdinalIgnoreCase);
                 }
 
-                return string.Equals(repoPath, pattern, StringComparison.OrdinalIgnoreCase);
+                return string.Equals(path, pattern, StringComparison.OrdinalIgnoreCase);
             }
         );
     }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -290,6 +290,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         WorktreeInfo? worktree      = null;
         string?       mcpConfigPath = null;
 
+        // Declared OUTSIDE the try so it is in scope in the catch blocks below: the failed-launch
+        // cleanup must consult it to decide whether the worktree is ours to remove. A borrowed cwd
+        // is the user's real checkout — never removed on any path (spec's top safety invariant).
+        var work = cmd.Borrowed ? WorkLocation.BorrowedCwd : WorkLocation.OwnedWorktree;
+
         try {
             if (ActiveCount >= _config.MaxConcurrentAgents) {
                 await _server.LaunchFailedAsync(agentId, $"At max capacity ({_config.MaxConcurrentAgents} agents)");
@@ -356,34 +361,46 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 ? $"refs/pull/{reviewInfo.PrNumber}/head"
                 : cmd.BaseRef;
 
-            worktree = await _worktreeManager.CreateAsync(repoPath, baseRef: baseRef);
+            if (cmd.Borrowed) {
+                // Defense-in-depth re-authorization: the server already probed this cwd, but the
+                // daemon NEVER borrows a path just because the server said so (TOCTOU-safe). The
+                // reason is surfaced verbatim to the server via the catch → LaunchFailedAsync below;
+                // Phase B (server) keys off the `borrow_auth_failed:` prefix.
+                var auth = await new BorrowAuthorizer(_config).AuthorizeBorrowAsync(cmd.BorrowCwd ?? "");
 
-            // AI-1163: for a mirror-requester review flow the server sends the requester's repo root
-            // in SyncFromRepoRoot. Mirror its live working tree (uncommitted + untracked) into the
-            // fresh worktree BEFORE spawning, so round 1 sees in-progress code rather than committed
-            // HEAD. Daemon-validated + best-effort (see the helper); never fails the launch.
-            if (!string.IsNullOrEmpty(cmd.SyncFromRepoRoot)) {
-                await TrySyncWorktreeAtLaunchAsync(agentId, cmd.SyncFromRepoRoot, repoPath, worktree.Path);
-            }
+                if (!auth.Allowed) {
+                    throw new InvalidOperationException($"borrow_auth_failed: {auth.Reason}");
+                }
 
-            // Download attachments into worktree (best-effort)
-            if (attachmentIds is { Length: > 0 }) {
-                try {
-                    var paths = await DownloadAttachmentsAsync(worktree.Path, attachmentIds);
+                // Run IN the user's real (canonicalized) checkout. Deliberately SKIP CreateAsync, any
+                // base fetch / `git worktree add`, the launch-time mirror, and the attachment
+                // download-into-cwd — every one of those would mutate the user's own tree.
+                worktree = WorktreeInfo.Borrowed(auth.CanonicalCwd!);
+            } else {
+                worktree = await _worktreeManager.CreateAsync(repoPath, baseRef: baseRef);
 
-                    if (paths.Count > 0) {
-                        var suffix = $"\n\n[Attached files: {string.Join(", ", paths)}]";
-                        prompt = string.IsNullOrEmpty(prompt) ? suffix.TrimStart() : prompt + suffix;
+                // AI-1163: for a mirror-requester review flow the server sends the requester's repo root
+                // in SyncFromRepoRoot. Mirror its live working tree (uncommitted + untracked) into the
+                // fresh worktree BEFORE spawning, so round 1 sees in-progress code rather than committed
+                // HEAD. Daemon-validated + best-effort (see the helper); never fails the launch.
+                if (!string.IsNullOrEmpty(cmd.SyncFromRepoRoot)) {
+                    await TrySyncWorktreeAtLaunchAsync(agentId, cmd.SyncFromRepoRoot, repoPath, worktree.Path);
+                }
+
+                // Download attachments into worktree (best-effort)
+                if (attachmentIds is { Length: > 0 }) {
+                    try {
+                        var paths = await DownloadAttachmentsAsync(worktree.Path, attachmentIds);
+
+                        if (paths.Count > 0) {
+                            var suffix = $"\n\n[Attached files: {string.Join(", ", paths)}]";
+                            prompt = string.IsNullOrEmpty(prompt) ? suffix.TrimStart() : prompt + suffix;
+                        }
+                    } catch (Exception ex) {
+                        LogAttachmentDownloadFailed(ex, agentId);
                     }
-                } catch (Exception ex) {
-                    LogAttachmentDownloadFailed(ex, agentId);
                 }
             }
-
-            // AI-1207 Phase A: pure plumbing — Borrowed=false (the only case exercised today)
-            // resolves to the same OwnedWorktree the pipeline always used. The borrowed launch
-            // branch (skip worktree creation) is a follow-up task.
-            var work = cmd.Borrowed ? WorkLocation.BorrowedCwd : WorkLocation.OwnedWorktree;
 
             var runtimeCtx = new RuntimeStartContext(
                 AgentId: agentId,
@@ -413,9 +430,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             } catch (CodexHooksNotInstalledException ex) {
                 await _server.LaunchFailedAsync(agentId, ex.Message);
 
-                // Still need to clean up the worktree before returning
-                try { await WorktreeManager.RemoveAsync(worktree); } catch {
-                    /* best-effort */
+                // Still need to clean up the worktree before returning — but ONLY if we own it.
+                // A borrowed cwd is the user's real checkout; removing it here would `git worktree
+                // remove` the user's tree (spec's top safety invariant; mirrors CleanupAgentAsync).
+                if (work == WorkLocation.OwnedWorktree) {
+                    try { await WorktreeManager.RemoveAsync(worktree); } catch {
+                        /* best-effort */
+                    }
                 }
 
                 return;
@@ -468,7 +489,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         } catch (Exception ex) {
             LogLaunchFailed(ex, agentId);
 
-            if (worktree != null) {
+            // Only tear down a worktree we OWN. A borrowed cwd is the user's real checkout — never
+            // remove it, its branch, or its Claude project symlink on a failed launch (spec's top
+            // safety invariant; mirrors the normal-stop guard in CleanupAgentAsync). For a borrowed
+            // launch there is nothing daemon-created to clean up anyway (no CreateAsync, no mirror,
+            // no attachments), and StartAsync throwing means mcpConfigPath was never assigned.
+            if (worktree != null && work == WorkLocation.OwnedWorktree) {
                 if (_launchers.TryGetValue(cmd.Vendor, out var launcherForCleanup)) {
                     try {
                         // Build a transient AgentInstance with a no-op PTY just so launcher.Cleanup
@@ -1572,6 +1598,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     /// <summary>Test-only: register a pre-built agent so cleanup/lifecycle can be driven directly.</summary>
     internal void RegisterAgentForTest(AgentInstance agent) => _agents[agent.Id] = agent;
+
+    /// <summary>Test-only: look up a tracked agent by id (null if absent), so a launch test can
+    /// assert the resolved <see cref="AgentInstance.Work"/> / <see cref="AgentInstance.Worktree"/>.</summary>
+    internal AgentInstance? GetAgentForTest(string agentId) => _agents.GetValueOrDefault(agentId);
 
     /// <summary>Test-only entry point to the private cleanup path.</summary>
     internal Task CleanupAgentForTest(string agentId) => CleanupAgentAsync(agentId);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -380,6 +380,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 }
             }
 
+            // AI-1207 Phase A: pure plumbing — Borrowed=false (the only case exercised today)
+            // resolves to the same OwnedWorktree the pipeline always used. The borrowed launch
+            // branch (skip worktree creation) is a follow-up task.
+            var work = cmd.Borrowed ? WorkLocation.BorrowedCwd : WorkLocation.OwnedWorktree;
+
             var runtimeCtx = new RuntimeStartContext(
                 AgentId: agentId,
                 Vendor: cmd.Vendor,
@@ -397,7 +402,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 ServerUrl: _config.ServerUrl,
                 DaemonBridgeUrl: _permissionBridge.BaseUrl,
                 CapacitorPath: _config.CapacitorPath,
-                McpAllowlist: cmd.McpAllowlist
+                McpAllowlist: cmd.McpAllowlist,
+                Work: work
             );
 
             HostedRuntimeStart start;
@@ -426,7 +432,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 McpConfigPath      = mcpConfigPath,
                 SyncSourceRepoRoot = string.IsNullOrEmpty(cmd.SyncFromRepoRoot) ? null : cmd.SyncFromRepoRoot,
                 CurrentCols        = HostedPtyCols,
-                CurrentRows        = HostedPtyRows
+                CurrentRows        = HostedPtyRows,
+                Work               = work
             };
             _agents[agentId] = agent;
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -239,6 +239,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _server.ReRegisterAgentsHook          =  ReRegisterAgentsAsync;
         _server.FindRepoForRemoteHandler      =  HandleFindRepoForRemote;
         _server.RefreshAgentWorktreeHandler   =  HandleRefreshAgentWorktree;
+        _server.ProbeBorrowSourceHandler      =  HandleProbeBorrowSource;
 
         _server.GetLiveAgentIds = () => [
             .. _agents
@@ -1048,6 +1049,19 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     }
 
     /// <summary>
+    /// Handles the server's <c>ProbeBorrowSource</c> client-result invocation (AI-1207 Phase A, task
+    /// A3): "can you borrow this path?". Delegates the actual policy (allowlist, git-root resolution,
+    /// symlink canonicalization) to <see cref="BorrowAuthorizer"/> — constructed fresh over the
+    /// daemon's current <see cref="DaemonConfig"/> so a config reload is picked up on the next probe —
+    /// and maps its <see cref="BorrowAuthResult"/> onto the wire-facing <see cref="BorrowProbeResult"/>.
+    /// </summary>
+    async Task<BorrowProbeResult> HandleProbeBorrowSource(string path) {
+        var result = await new BorrowAuthorizer(_config).AuthorizeBorrowAsync(path);
+
+        return new BorrowProbeResult(result.Allowed, result.CanonicalCwd, result.CanonicalGitRoot, result.Reason);
+    }
+
+    /// <summary>
     /// AI-1163: launch-time worktree sync for a mirror-requester review flow. Mirrors the requester's
     /// working-tree state (tracked + untracked, gitignore-respected) into the freshly-created reviewer
     /// worktree before the reviewer process is spawned, so round 1 sees in-progress/uncommitted code.
@@ -1563,6 +1577,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     /// <summary>Test-only entry point to the private send-input handler (AI-30 bracketed-paste submit).</summary>
     internal Task HandleSendInputForTest(SendInputCommand cmd) => HandleSendInput(cmd);
+
+    /// <summary>Test-only entry point to the private probe-borrow-source handler (AI-1207 task A3).</summary>
+    internal Task<BorrowProbeResult> HandleProbeBorrowSourceForTest(string path) => HandleProbeBorrowSource(path);
 
     internal Task RegisterAgentForTestAsync(AgentInstance agent) => RegisterAgentAsync(agent);
     internal Task ReRegisterAgentsForTestAsync() => ReRegisterAgentsAsync();

--- a/src/Capacitor.Cli.Daemon/Services/BorrowAuthorizer.cs
+++ b/src/Capacitor.Cli.Daemon/Services/BorrowAuthorizer.cs
@@ -29,7 +29,15 @@ public class BorrowAuthorizer(DaemonConfig config) {
             return Task.FromResult(new BorrowAuthResult(false, null, null, "path_absent"));
         }
 
-        var canonicalCwd    = Canonicalize(path);
+        string canonicalCwd;
+        try {
+            canonicalCwd = Canonicalize(path);
+        } catch {
+            // realpath resolution failed (permission on an ancestor, transient FS error, …). Fail
+            // CLOSED — never authorize against an unresolved path on this security boundary (Qodo #290 #3).
+            return Task.FromResult(new BorrowAuthResult(false, null, null, "not_allowed"));
+        }
+
         var canonicalGitRoot = GitRepository.FindRoot(canonicalCwd);
 
         var allowed = canonicalGitRoot is not null
@@ -52,16 +60,7 @@ public class BorrowAuthorizer(DaemonConfig config) {
     /// Also called by <c>WorktreeInfo.Borrowed</c> (Task A5) so both sides of a borrow compare
     /// canonical paths.
     /// </summary>
-    public static string Canonicalize(string path) {
-        var fullPath = Path.GetFullPath(path);
-
-        try {
-            return RealPath(fullPath);
-        } catch {
-            // Any I/O error during resolution — fall back to the lexical full path.
-            return fullPath;
-        }
-    }
+    public static string Canonicalize(string path) => RealPath(Path.GetFullPath(path));
 
     /// <summary>
     /// Walks the path root-first, resolving each accumulated prefix a single hop at a time: when a

--- a/src/Capacitor.Cli.Daemon/Services/BorrowAuthorizer.cs
+++ b/src/Capacitor.Cli.Daemon/Services/BorrowAuthorizer.cs
@@ -1,0 +1,59 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>Outcome of <see cref="BorrowAuthorizer.AuthorizeBorrowAsync"/>.</summary>
+public readonly record struct BorrowAuthResult(bool Allowed, string? CanonicalCwd, string? CanonicalGitRoot, string? Reason);
+
+/// <summary>
+/// Decides whether a given cwd may be <i>borrowed</i> — a read-only reviewer run in it on
+/// this daemon. This repurposes the intent of <c>AgentOrchestrator.IsAllowedSyncSourceAsync</c>
+/// (the mirror-sync guard) but is deliberately a new, standalone type: unlike that guard, borrow
+/// authorization has no same-origin check, since cross-repo borrowing is expected.
+///
+/// Depends only on <see cref="DaemonConfig.IsRepoAllowed"/> and <see cref="GitRepository.FindRoot"/>,
+/// both cheap/local, so this is unit-testable without a running daemon.
+/// </summary>
+public class BorrowAuthorizer(DaemonConfig config) {
+    /// <summary>
+    /// 1. Rejects a missing/non-existent path outright.
+    /// 2. Canonicalizes the path (resolves symlinks + normalizes).
+    /// 3. Finds the git root at or above the canonical path, if any.
+    /// 4. Authorizes git-rooted cwds under the normal repo allowlist (empty allowlist = allow
+    ///    all local repos); a non-repo cwd is authorized ONLY against a non-empty allowlist —
+    ///    an empty allowlist never authorizes a non-repo directory, since "allow all local
+    ///    repos" means repos, not arbitrary directories.
+    /// </summary>
+    public Task<BorrowAuthResult> AuthorizeBorrowAsync(string path) {
+        if (string.IsNullOrEmpty(path) || !Directory.Exists(path)) {
+            return Task.FromResult(new BorrowAuthResult(false, null, null, "path_absent"));
+        }
+
+        var canonicalCwd    = Canonicalize(path);
+        var canonicalGitRoot = GitRepository.FindRoot(canonicalCwd);
+
+        var allowed = canonicalGitRoot is not null
+            ? config.IsRepoAllowed(canonicalCwd) || config.IsRepoAllowed(canonicalGitRoot)
+            : config.AllowedRepoPaths.Length > 0 && config.IsRepoAllowed(canonicalCwd);
+
+        return Task.FromResult(new BorrowAuthResult(allowed, canonicalCwd, canonicalGitRoot, allowed ? null : "not_allowed"));
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="path"/> to its real, symlink-free, host-normalized form.
+    /// Also called by <c>WorktreeInfo.Borrowed</c> (Task A5) so both sides of a borrow compare
+    /// canonical paths.
+    /// </summary>
+    public static string Canonicalize(string path) {
+        var fullPath = Path.GetFullPath(path);
+
+        try {
+            var finalTarget = new DirectoryInfo(fullPath).ResolveLinkTarget(returnFinalTarget: true);
+
+            return finalTarget is null ? fullPath : Path.GetFullPath(finalTarget.FullName);
+        } catch {
+            // Not a link (or resolution failed for some other I/O reason) — use the normalized path as-is.
+            return fullPath;
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/BorrowAuthorizer.cs
+++ b/src/Capacitor.Cli.Daemon/Services/BorrowAuthorizer.cs
@@ -39,8 +39,16 @@ public class BorrowAuthorizer(DaemonConfig config) {
         return Task.FromResult(new BorrowAuthResult(allowed, canonicalCwd, canonicalGitRoot, allowed ? null : "not_allowed"));
     }
 
+    // A symlink cycle can't loop forever: cap total resolution steps and return the best-resolved
+    // path on hitting the cap. 40 mirrors the common OS-level MAXSYMLINKS limit.
+    const int MaxResolveSteps = 40;
+
     /// <summary>
-    /// Resolves <paramref name="path"/> to its real, symlink-free, host-normalized form.
+    /// Resolves <paramref name="path"/> to its real, symlink-free, host-normalized form — a true
+    /// <c>realpath</c> that resolves symlinks in EVERY path component, not just the leaf. This is a
+    /// security boundary: an <i>ancestor</i> symlink must not let a directory that physically lives
+    /// outside the operator's allowlisted tree textually match <see cref="DaemonConfig.IsRepoAllowed"/>
+    /// (e.g. an allowlisted <c>/repos/*</c> containing a symlink <c>proj/linkdir</c> → <c>~/.ssh</c>).
     /// Also called by <c>WorktreeInfo.Borrowed</c> (Task A5) so both sides of a borrow compare
     /// canonical paths.
     /// </summary>
@@ -48,12 +56,61 @@ public class BorrowAuthorizer(DaemonConfig config) {
         var fullPath = Path.GetFullPath(path);
 
         try {
-            var finalTarget = new DirectoryInfo(fullPath).ResolveLinkTarget(returnFinalTarget: true);
-
-            return finalTarget is null ? fullPath : Path.GetFullPath(finalTarget.FullName);
+            return RealPath(fullPath);
         } catch {
-            // Not a link (or resolution failed for some other I/O reason) — use the normalized path as-is.
+            // Any I/O error during resolution — fall back to the lexical full path.
             return fullPath;
         }
     }
+
+    /// <summary>
+    /// Walks the path root-first, resolving each accumulated prefix a single hop at a time: when a
+    /// prefix is a symlink, its target replaces the prefix (an absolute target restarts from its own
+    /// root; a relative one resolves against the already-canonical parent) and resolution continues
+    /// against it, so symlink chains and ancestor symlinks are all followed. Bounded by
+    /// <see cref="MaxResolveSteps"/> so a symlink cycle terminates at the best-resolved path.
+    /// </summary>
+    static string RealPath(string fullPath) {
+        var root      = Path.GetPathRoot(fullPath) ?? "";
+        var segments  = SplitSegments(fullPath[root.Length..]);
+        var resolved  = root;
+        var steps     = 0;
+
+        while (segments.Count > 0) {
+            if (steps++ >= MaxResolveSteps) {
+                // Cycle guard: stitch the unresolved remainder back on and stop.
+                return Path.GetFullPath(Path.Combine([resolved, ..segments]));
+            }
+
+            var next   = Path.Combine(resolved, segments.Dequeue());
+            var target = new DirectoryInfo(next).ResolveLinkTarget(returnFinalTarget: false);
+
+            if (target is null) {
+                resolved = next; // real directory component
+                continue;
+            }
+
+            // One symlink hop. Resolve a relative target against the link's (canonical) parent.
+            var linkPath = target.FullName;
+
+            if (!Path.IsPathRooted(linkPath)) {
+                linkPath = Path.GetFullPath(Path.Combine(resolved, linkPath));
+            }
+
+            var linkRoot = Path.GetPathRoot(linkPath) ?? "";
+
+            // Re-queue the target's own segments (so ancestor symlinks inside it get resolved too)
+            // ahead of the segments we hadn't reached yet.
+            segments = new Queue<string>(SplitSegments(linkPath[linkRoot.Length..]).Concat(segments));
+            resolved = linkRoot;
+        }
+
+        return resolved;
+    }
+
+    static Queue<string> SplitSegments(string pathRemainder) => new(
+        pathRemainder
+            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Where(s => s.Length > 0)
+    );
 }

--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -89,8 +89,17 @@ internal sealed partial class ClaudeLauncher(
             // MCP servers, so the reviewer can't recursively start a nested review flow.
             // Interactive (Default) agents keep prompts + their configured MCP servers.
             if (ctx.IsReviewFlow) {
-                args.Add("--permission-mode");
-                args.Add("bypassPermissions");
+                // A borrowed reviewer runs in the user's REAL checkout (not a daemon-owned,
+                // throwaway worktree) — bypassPermissions would auto-approve writes there.
+                // Skip it for BorrowedCwd; the --disallowedTools deny-list below removes the
+                // write/execute surface instead. Deliberately NOT --permission-mode plan —
+                // that reshapes tool use more broadly and can block/reshape the injected
+                // flow-result MCP tool too (AI-1207).
+                if (ctx.Work != WorkLocation.BorrowedCwd) {
+                    args.Add("--permission-mode");
+                    args.Add("bypassPermissions");
+                }
+
                 args.Add("--strict-mcp-config");
                 args.Add("--mcp-config");
                 // AI-1139: the strict config now whitelists exactly the kcap-flow-result
@@ -103,8 +112,16 @@ internal sealed partial class ClaudeLauncher(
                 // the user-scoped kcap-flows server — and could recursively start a nested
                 // flow, escaping the empty-MCP boundary above. The reviewer keeps Read/Grep/
                 // Bash etc.; it just can't fan out subagents.
+                //
+                // For a borrowed reviewer, additionally deny the write/execute surface — Edit/
+                // Write/MultiEdit/NotebookEdit/Bash — composed into the SAME --disallowedTools
+                // value: the Claude CLI takes one comma-or-space-separated list per flag, not
+                // repeated flags, so both denials must be merged into a single argument
+                // (AI-1207). Read/Grep/Glob and the flow-result MCP tool stay available.
                 args.Add("--disallowedTools");
-                args.Add("Agent");
+                args.Add(ctx.Work == WorkLocation.BorrowedCwd
+                    ? "Agent,Edit,Write,MultiEdit,NotebookEdit,Bash"
+                    : "Agent");
             }
 
             if (!string.IsNullOrEmpty(ctx.Effort)) {

--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -74,7 +74,11 @@ internal sealed partial class CodexLauncher(
             "--cd",
             ctx.Worktree.Path,
             "--sandbox",
-            "workspace-write",
+            // A borrowed reviewer runs in the user's REAL checkout (not a daemon-owned,
+            // throwaway worktree) — workspace-write would let it mutate that real repo.
+            // read-only is already proven in the headless runner (CodexCliRunner), including
+            // with MCP injection, so the flow-result MCP tool still works (AI-1207).
+            ctx.Work == WorkLocation.BorrowedCwd ? "read-only" : "workspace-write",
             // Review-flow reviewers (LaunchKind.ReviewFlow) run unattended → never pause for
             // approval (writes stay confined by the workspace-write sandbox). Interactive rendered
             // agents keep the default on-request approval so the user stays in the loop.

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -79,5 +79,9 @@ internal sealed record RuntimeStartContext(
         // LaunchAgentCommand.McpAllowlist through to LauncherContext.McpAllowlist for the PTY
         // launchers to materialize. Unused by the ACP factory (Cursor has no MCP-allowlist
         // materialization yet).
-        string[]?         McpAllowlist = null
+        string[]?         McpAllowlist = null,
+        // AI-1207 Phase A: owned worktree (daemon-created) vs borrowed cwd (the user's own
+        // checkout), carried from LaunchAgentCommand.Borrowed through to LauncherContext.Work.
+        // Defaults to OwnedWorktree — today's only exercised path — unchanged.
+        WorkLocation       Work = WorkLocation.OwnedWorktree
     );

--- a/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
@@ -57,7 +57,8 @@ internal sealed partial class PtyHostedAgentRuntimeFactory(
                 ? await ReviewLaunchBuilder.BuildAsync(ctx.Vendor, ctx.CapacitorPath, ctx.ServerUrl ?? "", reviewArgs.Owner, reviewArgs.Repo, reviewArgs.PrNumber)
                 : null
         ) {
-            McpAllowlist = ctx.McpAllowlist
+            McpAllowlist = ctx.McpAllowlist,
+            Work         = ctx.Work
         };
 
         try {

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -339,7 +339,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                 "DaemonConnect",
                 new DaemonConnect(
                     _config.Name, platform, repoPaths, _config.MaxConcurrentAgents, liveIds,
-                    _config.InstanceId, _config.Version, _config.SupportedVendors
+                    _config.InstanceId, _config.Version, _config.SupportedVendors, MachineId.Get()
                 ),
                 cancellationToken: _ct
             );

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -60,6 +60,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public Func<RefreshAgentWorktreeCommand, Task<RefreshAgentWorktreeResult>>? RefreshAgentWorktreeHandler { get; set; }
 
     /// <summary>
+    /// Handler for the server's <c>ProbeBorrowSource</c> client-result invocation (AI-1207 Phase A,
+    /// task A3): "can you borrow this path?". Receives a filesystem path and returns the
+    /// daemon-computed authorization + canonical paths. Set by <see cref="AgentOrchestrator"/> at
+    /// startup; when null, returns <c>BorrowProbeResult(false, null, null, "no handler")</c>.
+    /// </summary>
+    public Func<string, Task<BorrowProbeResult>>? ProbeBorrowSourceHandler { get; set; }
+
+    /// <summary>
     /// Callback invoked at <see cref="RegisterDaemon"/> time to snapshot the
     /// agent IDs currently hosted by this daemon. The server uses this to
     /// reconcile its registry against the daemon's view. Set by
@@ -148,6 +156,13 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         _hub.On<RefreshAgentWorktreeCommand, RefreshAgentWorktreeResult>("RefreshAgentWorktree",
             cmd => RefreshAgentWorktreeHandler?.Invoke(cmd)
                 ?? Task.FromResult(new RefreshAgentWorktreeResult(false, "no handler")));
+
+        // Client-result invocation: "can you borrow this path?" (AI-1207 Phase A, task A3). Lets the
+        // server prove co-location before offering a borrow-cwd launch target. "no handler" is
+        // returned when the orchestrator hasn't wired the handler yet (e.g. early startup).
+        _hub.On<string, BorrowProbeResult>("ProbeBorrowSource",
+            path => ProbeBorrowSourceHandler?.Invoke(path)
+                ?? Task.FromResult(new BorrowProbeResult(false, null, null, "no handler")));
 
         // Server→client push carrying the user's decision for a hosted-agent permission request
         // (AI-864). Paired with the RequestPermission2 invocation in RequestPermissionAsync: that

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorBorrowLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorBorrowLaunchTests.cs
@@ -1,0 +1,275 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-1207 Phase A (tasks A5 + A6): the borrowed-launch branch in
+/// <see cref="AgentOrchestrator.HandleLaunchAgent"/> and — the reason A5 and A6 ship together —
+/// the failed-launch cleanup guard.
+///
+/// THE TOP SAFETY INVARIANT: a borrowed cwd is the user's REAL checkout. It must NEVER be
+/// removed / <c>git worktree remove</c>d / branch-deleted on ANY path (normal stop, failed
+/// launch, anywhere). These tests lock that in behaviourally.
+///
+/// Reuses the <c>partial</c> harness in <see cref="AgentOrchestratorVendorTests"/>
+/// (<c>BuildOrchestrator</c>, <c>CreateGitRepo</c>, <c>CaptureServerConnection</c>,
+/// <c>SpyPtyProcessFactory</c>, <c>FixedPtyProcessFactory</c>, <c>OneChunkThenBlockPtyProcess</c>,
+/// <c>SpyHostedAgentLauncher</c>).
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    // ── A5: borrowed launch runs in the user's cwd and creates no daemon worktree ─────────
+
+    [Test]
+    public async Task Borrowed_launch_creates_no_worktree_and_runs_in_the_cwd() {
+        var (cwd, cleanup) = CreateGitRepo();
+
+        try {
+            var server     = new CaptureServerConnection();
+            // A blocking PTY keeps the agent registered so we can inspect Work/Worktree before cleanup.
+            var ptyFactory = new FixedPtyProcessFactory(new OneChunkThenBlockPtyProcess());
+            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude");
+            var launchers  = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
+
+            // Empty allowlist ⇒ BorrowAuthorizer authorizes any local git repo (allow-all-repos).
+            await using var orch = BuildOrchestrator(server, ptyFactory, launchers);
+
+            var before = SnapshotTree(cwd);
+
+            var cmd = new LaunchAgentCommand(
+                AgentId: "agent-borrow-1",
+                Prompt: "do work",
+                Model: "opus",
+                Effort: null,
+                RepoPath: cwd,
+                Tools: null,
+                AttachmentIds: ["would-be-attachment"], // set so we prove the attachment download-into-cwd is skipped
+                Vendor: "claude",
+                SyncFromRepoRoot: cwd,                   // set so we prove the launch-time mirror is skipped
+                Borrowed: true,
+                BorrowCwd: cwd
+            );
+
+            await orch.HandleLaunchAgentForTest(cmd);
+
+            var canonicalCwd = BorrowAuthorizer.Canonicalize(cwd);
+
+            // No daemon-owned worktree was created under the user's checkout...
+            await Assert.That(Directory.Exists(Path.Combine(cwd, ".capacitor", "worktrees"))).IsFalse();
+            // ...no attachments were downloaded into it...
+            await Assert.That(Directory.Exists(Path.Combine(cwd, ".attached"))).IsFalse();
+            await Assert.That(Directory.Exists(Path.Combine(canonicalCwd, ".attached"))).IsFalse();
+            // ...and the cwd tree is byte-identical (no worktree add, no launch-time mirror, no attachment).
+            await Assert.That(SnapshotTree(cwd)).IsEquivalentTo(before);
+
+            // The agent runs in the user's real (canonicalized) checkout, marked as a borrowed cwd.
+            var agent = orch.GetAgentForTest("agent-borrow-1");
+            await Assert.That(agent).IsNotNull();
+            await Assert.That(agent!.Work).IsEqualTo(WorkLocation.BorrowedCwd);
+            await Assert.That(agent.Worktree.Path).IsEqualTo(canonicalCwd);
+
+            // Clean stop (also exercises the normal-stop cleanup guard for a borrowed agent).
+            await orch.HandleStopAgentForTest("agent-borrow-1");
+            await Assert.That(Directory.Exists(cwd)).IsTrue();
+        } finally {
+            cleanup();
+        }
+    }
+
+    // ── A5: launch-time re-authorization fails loudly, leaving the cwd untouched ───────────
+
+    [Test]
+    public async Task Borrowed_launch_reauth_failure_fails_loudly() {
+        // RepoPath is an allowed git repo (passes the early repo-allowed/exists guards); the borrow
+        // cwd is a NON-git directory, which the authorizer rejects under an empty allowlist.
+        var (repoPath, cleanupRepo) = CreateGitRepo();
+        var borrowCwd = Path.Combine(Path.GetTempPath(), "kcap-borrow-nogit-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(borrowCwd);
+        File.WriteAllText(Path.Combine(borrowCwd, "user-file.txt"), "precious");
+
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new SpyPtyProcessFactory();
+            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude");
+            var launchers  = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, launchers);
+
+            var before = SnapshotTree(borrowCwd);
+
+            var cmd = new LaunchAgentCommand(
+                AgentId: "agent-borrow-auth",
+                Prompt: "do work",
+                Model: "opus",
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "claude",
+                Borrowed: true,
+                BorrowCwd: borrowCwd
+            );
+
+            await orch.HandleLaunchAgentForTest(cmd);
+
+            // Fails loudly with the machine-readable prefix Phase B (server) keys off.
+            await Assert.That(server.LaunchFailedCalls.Count).IsEqualTo(1);
+            await Assert.That(server.LaunchFailedCalls[0].AgentId).IsEqualTo("agent-borrow-auth");
+            await Assert.That(server.LaunchFailedCalls[0].Reason).Contains("borrow_auth_failed");
+
+            // No PTY ever spawned, and the user's directory is byte-identical (nothing created/removed).
+            await Assert.That(ptyFactory.SpawnCalls).IsEqualTo(0);
+            await Assert.That(Directory.Exists(borrowCwd)).IsTrue();
+            await Assert.That(SnapshotTree(borrowCwd)).IsEquivalentTo(before);
+            await Assert.That(File.ReadAllText(Path.Combine(borrowCwd, "user-file.txt"))).IsEqualTo("precious");
+        } finally {
+            cleanupRepo();
+            try { Directory.Delete(borrowCwd, true); } catch { /* best-effort */ }
+        }
+    }
+
+    // ── A6 (SAFETY): a failed borrowed launch must NOT remove the user's checkout ──────────
+
+    [Test]
+    public async Task Failed_borrowed_launch_does_not_remove_the_cwd() {
+        // The borrow cwd is a *linked* git worktree — the realistic danger: `git worktree remove`
+        // succeeds on a linked worktree and would silently delete the user's checkout. The launch
+        // fails AFTER the borrowed worktree is assigned (runtime StartAsync throws), reaching the
+        // failed-launch cleanup. Without the A6 guard that cleanup git-worktree-removes the cwd;
+        // this test fails there and passes once the removal is gated on OwnedWorktree.
+        var (_, linkedCwd, cleanup) = CreateLinkedWorktree();
+
+        try {
+            var server          = new CaptureServerConnection();
+            var ptyFactory      = new SpyPtyProcessFactory();
+            var throwingFactory = new ThrowingHostedAgentRuntimeFactory("boomvendor", "kaboom during start");
+
+            // No launcher for the vendor; the throwing runtime factory is injected directly.
+            await using var orch = BuildOrchestrator(
+                server,
+                ptyFactory,
+                new Dictionary<string, IHostedAgentLauncher>(),
+                extraRuntimeFactories: [throwingFactory]
+            );
+
+            // Capture BEFORE the launch: Canonicalize falls back to the lexical path once the dir is
+            // gone, so a post-failure recompute would mask a deletion instead of exposing it.
+            var canonicalCwd = BorrowAuthorizer.Canonicalize(linkedCwd);
+            var before       = SnapshotTree(linkedCwd);
+
+            var cmd = new LaunchAgentCommand(
+                AgentId: "agent-borrow-fail",
+                Prompt: "do work",
+                Model: "opus",
+                Effort: null,
+                RepoPath: linkedCwd,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "boomvendor",
+                Borrowed: true,
+                BorrowCwd: linkedCwd
+            );
+
+            await orch.HandleLaunchAgentForTest(cmd);
+
+            // SAFETY (asserted first, clearest): the user's REAL checkout SURVIVES, byte-identical.
+            // Pre-A6 guard the failed-launch cleanup `git worktree remove`d it and this is False —
+            // the whole reason A5 and A6 ship in one commit.
+            await Assert.That(Directory.Exists(linkedCwd)).IsTrue();
+            await Assert.That(SnapshotTree(linkedCwd)).IsEquivalentTo(before);
+            // The launch failed, and the runtime had received the borrowed (canonicalized) cwd.
+            await Assert.That(server.LaunchFailedCalls.Count).IsEqualTo(1);
+            await Assert.That(throwingFactory.LastWorktreePath).IsEqualTo(canonicalCwd);
+        } finally {
+            cleanup();
+        }
+    }
+
+    // ── Regression: the OWNED path still creates a worktree and removes it on failure ──────
+
+    [Test]
+    public async Task Owned_launch_still_creates_and_on_failure_removes_the_worktree() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server          = new CaptureServerConnection();
+            var ptyFactory      = new SpyPtyProcessFactory();
+            var throwingFactory = new ThrowingHostedAgentRuntimeFactory("boomvendor", "kaboom during start");
+
+            await using var orch = BuildOrchestrator(
+                server,
+                ptyFactory,
+                new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath,
+                extraRuntimeFactories: [throwingFactory]
+            );
+
+            var cmd = new LaunchAgentCommand(
+                AgentId: "agent-owned-fail",
+                Prompt: "do work",
+                Model: "opus",
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "boomvendor",
+                Borrowed: false
+            );
+
+            await orch.HandleLaunchAgentForTest(cmd);
+
+            // The launch failed after a daemon-OWNED worktree was created...
+            await Assert.That(server.LaunchFailedCalls.Count).IsEqualTo(1);
+            await Assert.That(throwingFactory.LastWorktreePath).IsNotNull();
+            // ...under the repo's .capacitor/worktrees...
+            await Assert.That(throwingFactory.LastWorktreePath!)
+                .StartsWith(Path.Combine(repoPath, ".capacitor", "worktrees"));
+            // ...and the failed-launch cleanup removed it (owned behaviour unchanged).
+            await Assert.That(Directory.Exists(throwingFactory.LastWorktreePath!)).IsFalse();
+        } finally {
+            cleanup();
+        }
+    }
+
+    // ── Helpers / test doubles ─────────────────────────────────────────────────────────────
+
+    /// <summary>Sorted list of every file-system entry (relative path) under <paramref name="root"/>,
+    /// so a before/after comparison catches ANY addition or removal in the user's tree.</summary>
+    static List<string> SnapshotTree(string root) =>
+        Directory.EnumerateFileSystemEntries(root, "*", SearchOption.AllDirectories)
+            .Select(p => Path.GetRelativePath(root, p))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
+
+    /// <summary>Creates a main git repo plus a linked worktree checked out from it, returning the
+    /// linked worktree path — a realistic "borrow the user's git worktree" cwd.</summary>
+    static (string mainRepo, string linkedCwd, Action cleanup) CreateLinkedWorktree() {
+        var (mainRepo, cleanupMain) = CreateGitRepo();
+        var linkedCwd = Path.Combine(Path.GetTempPath(), "kcap-borrow-link-" + Guid.NewGuid().ToString("N")[..8]);
+
+        Git(mainRepo, "worktree", "add", linkedCwd);
+
+        return (mainRepo, linkedCwd, () => {
+            try { if (Directory.Exists(linkedCwd)) Directory.Delete(linkedCwd, true); } catch { /* best-effort */ }
+            cleanupMain();
+        });
+    }
+
+    /// <summary>A runtime factory that records the worktree it was handed then throws a generic
+    /// (non-<see cref="CodexHooksNotInstalledException"/>) failure, driving the launch into the
+    /// main failed-launch cleanup path AFTER the worktree is assigned.</summary>
+    sealed class ThrowingHostedAgentRuntimeFactory(string vendor, string message) : IHostedAgentRuntimeFactory {
+        public string  Vendor            { get; }              = vendor;
+        public bool    SupportsUnattended                       => true;
+        public string? LastWorktreePath  { get; private set; }
+
+        public bool IsAvailable() => true;
+
+        public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+            LastWorktreePath = ctx.Worktree.Path;
+
+            throw new InvalidOperationException(message);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorProbeBorrowSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorProbeBorrowSourceTests.cs
@@ -1,0 +1,46 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-1207 Phase A (task A3): covers <see cref="AgentOrchestrator.HandleProbeBorrowSourceForTest"/>,
+/// the handler behind the server→daemon <c>ProbeBorrowSource</c> hub method. The handler is a thin
+/// mapping from <see cref="BorrowAuthorizer.AuthorizeBorrowAsync"/>'s <see cref="BorrowAuthResult"/>
+/// onto the wire-facing <see cref="BorrowProbeResult"/> — the policy itself (allowlist, git-root,
+/// symlink canonicalization) is already covered by <c>BorrowAuthorizerTests</c>.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task ProbeBorrowSource_allows_a_git_rooted_temp_dir() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server = new CaptureServerConnection();
+            await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+            var result = await orch.HandleProbeBorrowSourceForTest(repoPath);
+
+            await Assert.That(result.CanBorrow).IsTrue();
+            await Assert.That(result.CanonicalCwd).IsNotNull();
+            await Assert.That(result.CanonicalGitRoot).IsNotNull();
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test]
+    public async Task ProbeBorrowSource_rejects_a_missing_path_with_path_absent_reason() {
+        var missing = Path.Combine(Path.GetTempPath(), "kcap-probe-missing-" + Guid.NewGuid().ToString("N")[..8]);
+
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var result = await orch.HandleProbeBorrowSourceForTest(missing);
+
+        await Assert.That(result.CanBorrow).IsFalse();
+        await Assert.That(result.Reason).IsEqualTo("path_absent");
+        await Assert.That(result.CanonicalCwd).IsNull();
+        await Assert.That(result.CanonicalGitRoot).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/BorrowAuthorizerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BorrowAuthorizerTests.cs
@@ -109,6 +109,66 @@ public class BorrowAuthorizerTests {
         }
     }
 
+    [Test]
+    public async Task Ancestor_symlink_escaping_nonempty_allowlist_is_not_allowed() {
+        // Allowlisted tree: allowedRoot/*. Inside it, an ANCESTOR dir is a symlink pointing OUT of
+        // the tree; the leaf (cwd) is a real, non-symlink dir under that ancestor. A leaf-only
+        // canonicalization would leave the path textually under allowedRoot and wrongly allow it.
+        var allowedRoot  = Directory.CreateTempSubdirectory("kcap-borrow-anc-allowed-");
+        var outsideRoot  = Directory.CreateTempSubdirectory("kcap-borrow-anc-outside-");
+        var realLeaf     = Path.Combine(outsideRoot.FullName, "x");
+        var linkAncestor = Path.Combine(allowedRoot.FullName, "linkdir");
+        try {
+            Directory.CreateDirectory(realLeaf);
+            Directory.CreateSymbolicLink(linkAncestor, outsideRoot.FullName);
+
+            var cwd = Path.Combine(linkAncestor, "x"); // allowedRoot/linkdir/x → outsideRoot/x
+
+            var authorizer = new BorrowAuthorizer(
+                new DaemonConfig { AllowedRepoPaths = [BorrowAuthorizer.Canonicalize(allowedRoot.FullName) + "/*"] }
+            );
+
+            var result = await authorizer.AuthorizeBorrowAsync(cwd);
+
+            await Assert.That(result.Allowed).IsFalse();
+            await Assert.That(result.Reason).IsEqualTo("not_allowed");
+            await Assert.That(result.CanonicalCwd).IsEqualTo(BorrowAuthorizer.Canonicalize(realLeaf));
+        } finally {
+            Directory.Delete(linkAncestor); // remove symlink before recursing into the roots
+            allowedRoot.Delete(recursive: true);
+            outsideRoot.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Ancestor_symlink_resolving_into_allowed_root_is_allowed() {
+        // The reverse: an ancestor symlink that resolves INTO the allowlisted tree is allowed, and
+        // CanonicalCwd is the resolved real path (not the link path).
+        var allowedRoot  = Directory.CreateTempSubdirectory("kcap-borrow-anc-in-allowed-");
+        var linkParent   = Directory.CreateTempSubdirectory("kcap-borrow-anc-in-link-");
+        var realLeaf     = Path.Combine(allowedRoot.FullName, "proj", "x");
+        var linkAncestor = Path.Combine(linkParent.FullName, "to-allowed");
+        try {
+            Directory.CreateDirectory(realLeaf);
+            Directory.CreateSymbolicLink(linkAncestor, allowedRoot.FullName);
+
+            var cwd = Path.Combine(linkAncestor, "proj", "x"); // linkParent/to-allowed/proj/x → allowedRoot/proj/x
+
+            var authorizer = new BorrowAuthorizer(
+                new DaemonConfig { AllowedRepoPaths = [BorrowAuthorizer.Canonicalize(allowedRoot.FullName) + "/*"] }
+            );
+
+            var result = await authorizer.AuthorizeBorrowAsync(cwd);
+
+            await Assert.That(result.Allowed).IsTrue();
+            await Assert.That(result.CanonicalCwd).IsEqualTo(BorrowAuthorizer.Canonicalize(realLeaf));
+        } finally {
+            Directory.Delete(linkAncestor); // remove symlink before recursing into the roots
+            linkParent.Delete(recursive: true);
+            allowedRoot.Delete(recursive: true);
+        }
+    }
+
     static string MakeTempRepo() {
         var root = Path.Combine(Path.GetTempPath(), "kcap-borrow-repo-" + Guid.NewGuid().ToString("N")[..8]);
         Directory.CreateDirectory(root);

--- a/test/Capacitor.Cli.Tests.Unit/BorrowAuthorizerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BorrowAuthorizerTests.cs
@@ -102,8 +102,10 @@ public class BorrowAuthorizerTests {
             await Assert.That(result.Reason).IsEqualTo("not_allowed");
         } finally {
             // Remove the symlink itself first so recursive delete never has to reason about
-            // whether it would otherwise be followed into outsideRoot.
-            File.Delete(link);
+            // whether it would otherwise be followed into outsideRoot. Directory.Delete removes the
+            // reparse point cross-platform (File.Delete throws UnauthorizedAccessException on a
+            // Windows directory symlink).
+            Directory.Delete(link);
             allowedRoot.Delete(recursive: true);
             outsideRoot.Delete(recursive: true);
         }

--- a/test/Capacitor.Cli.Tests.Unit/BorrowAuthorizerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BorrowAuthorizerTests.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Behaviour tests for <see cref="BorrowAuthorizer"/> — the daemon-side gate deciding whether a
+/// cwd may be borrowed (a read-only reviewer run in it). Uses real temp dirs, real symlinks, and
+/// real <c>git init</c> repos so the canonicalization + git-root + allowlist policy is exercised
+/// against the actual filesystem rather than mocks.
+/// </summary>
+public class BorrowAuthorizerTests {
+    [Test]
+    public async Task Absent_path_is_not_allowed_with_path_absent_reason() {
+        var missing = Path.Combine(Path.GetTempPath(), "kcap-borrow-missing-" + Guid.NewGuid().ToString("N")[..8]);
+
+        var result = await new BorrowAuthorizer(new DaemonConfig()).AuthorizeBorrowAsync(missing);
+
+        await Assert.That(result.Allowed).IsFalse();
+        await Assert.That(result.Reason).IsEqualTo("path_absent");
+        await Assert.That(result.CanonicalCwd).IsNull();
+        await Assert.That(result.CanonicalGitRoot).IsNull();
+    }
+
+    [Test]
+    public async Task GitRooted_cwd_with_empty_allowlist_is_allowed() {
+        var repo = MakeTempRepo();
+        try {
+            var result = await new BorrowAuthorizer(new DaemonConfig()).AuthorizeBorrowAsync(repo);
+
+            await Assert.That(result.Allowed).IsTrue();
+            await Assert.That(result.CanonicalGitRoot).IsEqualTo(BorrowAuthorizer.Canonicalize(repo));
+        } finally {
+            Directory.Delete(repo, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task NonRepo_cwd_with_empty_allowlist_is_not_allowed() {
+        var tmp = Directory.CreateTempSubdirectory("kcap-borrow-norepo-");
+        try {
+            var result = await new BorrowAuthorizer(new DaemonConfig()).AuthorizeBorrowAsync(tmp.FullName);
+
+            await Assert.That(result.Allowed).IsFalse();
+            await Assert.That(result.Reason).IsEqualTo("not_allowed");
+            await Assert.That(result.CanonicalGitRoot).IsNull();
+        } finally {
+            tmp.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task NonRepo_cwd_matching_explicit_allowlist_is_allowed() {
+        var tmp = Directory.CreateTempSubdirectory("kcap-borrow-norepo-allow-");
+        try {
+            var canonical  = BorrowAuthorizer.Canonicalize(tmp.FullName);
+            var authorizer = new BorrowAuthorizer(new DaemonConfig { AllowedRepoPaths = [canonical] });
+
+            var result = await authorizer.AuthorizeBorrowAsync(tmp.FullName);
+
+            await Assert.That(result.Allowed).IsTrue();
+            await Assert.That(result.Reason).IsNull();
+        } finally {
+            tmp.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Symlinked_cwd_resolving_into_allowed_git_root_is_allowed() {
+        var repo       = MakeTempRepo();
+        var linkParent = Directory.CreateTempSubdirectory("kcap-borrow-link-");
+        var link       = Path.Combine(linkParent.FullName, "link-to-repo");
+        try {
+            Directory.CreateSymbolicLink(link, repo);
+
+            var result = await new BorrowAuthorizer(new DaemonConfig()).AuthorizeBorrowAsync(link);
+
+            await Assert.That(result.Allowed).IsTrue();
+            await Assert.That(result.CanonicalCwd).IsEqualTo(BorrowAuthorizer.Canonicalize(repo));
+        } finally {
+            linkParent.Delete(recursive: true);
+            Directory.Delete(repo, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Symlinked_cwd_escaping_nonempty_allowlist_is_not_allowed() {
+        var allowedRoot = Directory.CreateTempSubdirectory("kcap-borrow-allowed-");
+        var outsideRoot = Directory.CreateTempSubdirectory("kcap-borrow-outside-");
+        var link        = Path.Combine(allowedRoot.FullName, "escape-link");
+        try {
+            Directory.CreateSymbolicLink(link, outsideRoot.FullName);
+
+            var authorizer = new BorrowAuthorizer(
+                new DaemonConfig { AllowedRepoPaths = [BorrowAuthorizer.Canonicalize(allowedRoot.FullName)] }
+            );
+
+            var result = await authorizer.AuthorizeBorrowAsync(link);
+
+            await Assert.That(result.Allowed).IsFalse();
+            await Assert.That(result.Reason).IsEqualTo("not_allowed");
+        } finally {
+            // Remove the symlink itself first so recursive delete never has to reason about
+            // whether it would otherwise be followed into outsideRoot.
+            File.Delete(link);
+            allowedRoot.Delete(recursive: true);
+            outsideRoot.Delete(recursive: true);
+        }
+    }
+
+    static string MakeTempRepo() {
+        var root = Path.Combine(Path.GetTempPath(), "kcap-borrow-repo-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(root);
+        Run(root, "init", "-q");
+
+        return root;
+    }
+
+    static void Run(string cwd, params string[] args) {
+        var psi = new ProcessStartInfo("git", args) {
+            WorkingDirectory       = cwd,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true
+        };
+        using var proc = Process.Start(psi)!;
+        proc.WaitForExit();
+
+        if (proc.ExitCode != 0) {
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {proc.StandardError.ReadToEnd()}");
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherReviewFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherReviewFlowTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -200,5 +201,52 @@ public class ClaudeLauncherReviewFlowTests {
         var argsEmpty = launcher.BuildArgs(NewCtx(isReviewFlow: true) with { McpAllowlist = [] }).Args;
 
         await Assert.That(argsEmpty).IsEquivalentTo(argsNull, CollectionOrdering.Matching);
+    }
+
+    // === AI-1207 Phase A: read-only argv for a borrowed reviewer ===
+
+    [Test]
+    public async Task Review_flow_borrowed_cwd_denies_write_and_exec_tools_instead_of_bypass() {
+        // A borrowed reviewer runs in the user's REAL checkout — bypassPermissions would
+        // auto-approve writes there. Use an explicit deny-list instead of --permission-mode
+        // plan (which reshapes tool use, incl. the injected flow-result MCP tool).
+        var ctx  = NewCtx(isReviewFlow: true) with { Work = WorkLocation.BorrowedCwd };
+        var args = NewLauncher().BuildArgs(ctx).Args;
+
+        await Assert.That(args).DoesNotContain("--permission-mode");
+        await Assert.That(args).DoesNotContain("bypassPermissions");
+        await Assert.That(args).DoesNotContain("plan");
+
+        await Assert.That(args).Contains("--disallowedTools");
+        var i      = Array.IndexOf(args, "--disallowedTools");
+        var denied = args[i + 1];
+
+        foreach (var tool in new[] { "Agent", "Edit", "Write", "MultiEdit", "NotebookEdit", "Bash" }) {
+            await Assert.That(denied).Contains(tool);
+        }
+
+        await Assert.That(args).Contains("--strict-mcp-config");
+        await Assert.That(args).Contains("--mcp-config");
+    }
+
+    [Test]
+    public async Task Review_flow_owned_worktree_args_byte_identical_to_today() {
+        // Regression: the owned path's argv must stay exactly as it is today.
+        var ctx  = NewCtx(isReviewFlow: true) with { Work = WorkLocation.OwnedWorktree };
+        var args = NewLauncher(serverUrl: "https://t.example", capacitorPath: "/opt/kcap").BuildArgs(ctx).Args;
+
+        const string expectedMcpConfig =
+            """{"mcpServers":{"kcap-flow-result":{"command":"/opt/kcap","args":["mcp","flow-result"],"env":{"KCAP_URL":"https://t.example","KCAP_FLOW_AGENT_ID":"a-1"}}}}""";
+
+        string[] expected = [
+            "--permission-mode", "bypassPermissions",
+            "--strict-mcp-config",
+            "--mcp-config", expectedMcpConfig,
+            "--disallowedTools", "Agent",
+            "--model", "sonnet",
+            "--", "review this"
+        ];
+
+        await Assert.That(args).IsEquivalentTo(expected, CollectionOrdering.Matching);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -1,5 +1,6 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Commands;
+using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -549,5 +550,38 @@ public class CodexLauncherTests {
         var argsEmpty = launcher.BuildArgs(NewFlowCtx([])).Args;
 
         await Assert.That(argsEmpty).IsEquivalentTo(argsNull, CollectionOrdering.Matching);
+    }
+
+    // === AI-1207 Phase A: read-only sandbox for a borrowed reviewer ===
+
+    [Test]
+    public async Task BuildArgs_borrowed_cwd_uses_read_only_sandbox() {
+        // A borrowed reviewer runs in the user's REAL checkout — never workspace-write.
+        var ctx  = NewCtx(isReviewFlow: true) with { Work = WorkLocation.BorrowedCwd };
+        var args = NewLauncher().BuildArgs(ctx).Args;
+
+        await Assert.That(args).Contains("--sandbox");
+        var sIdx = Array.IndexOf(args, "--sandbox");
+        await Assert.That(args[sIdx + 1]).IsEqualTo("read-only");
+        await Assert.That(args).DoesNotContain("workspace-write");
+
+        await Assert.That(args).Contains("--ask-for-approval");
+        await Assert.That(args).Contains("never");
+
+        var cdIdx = Array.IndexOf(args, "--cd");
+        await Assert.That(cdIdx).IsGreaterThan(-1);
+        await Assert.That(args[cdIdx + 1]).IsEqualTo("/tmp/wt");
+    }
+
+    [Test]
+    public async Task BuildArgs_owned_worktree_keeps_workspace_write_sandbox() {
+        // Regression: the owned path's sandbox value must stay exactly as it is today.
+        var ctx  = NewCtx(isReviewFlow: true) with { Work = WorkLocation.OwnedWorktree };
+        var args = NewLauncher().BuildArgs(ctx).Args;
+
+        var sIdx = Array.IndexOf(args, "--sandbox");
+        await Assert.That(sIdx).IsGreaterThan(-1);
+        await Assert.That(args[sIdx + 1]).IsEqualTo("workspace-write");
+        await Assert.That(args).DoesNotContain("read-only");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/LaunchAgentCommandWireFormatTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LaunchAgentCommandWireFormatTests.cs
@@ -198,6 +198,50 @@ public class LaunchAgentCommandWireFormatTests {
     }
 
     [Test]
+    public async Task Borrowed_and_BorrowCwd_round_trip_snake_case() {
+        // AI-1207 Phase A: the server tells the daemon to launch against the user's own checkout
+        // (skip worktree creation) instead of a fresh daemon-owned worktree. Appended last after
+        // McpAllowlist, same wire-compat rule as the fields before it.
+        var cmd = new LaunchAgentCommand(
+            AgentId:       "borrow001",
+            Prompt:        null,
+            Model:         "opus",
+            Effort:        null,
+            RepoPath:      "/tmp/repo",
+            Tools:         null,
+            AttachmentIds: null,
+            Vendor:        "claude",
+            Borrowed:      true,
+            BorrowCwd:     "/some/path"
+        );
+
+        var wire   = JsonSerializer.Serialize(cmd, ServerWireOptions);
+        var parsed = JsonSerializer.Deserialize(wire, CapacitorJsonContext.Default.LaunchAgentCommand);
+
+        await Assert.That(wire).Contains("\"borrowed\":true");
+        await Assert.That(wire).Contains("\"borrow_cwd\":\"/some/path\"");
+        await Assert.That(parsed.Borrowed).IsTrue();
+        await Assert.That(parsed.BorrowCwd).IsEqualTo("/some/path");
+    }
+
+    [Test]
+    public async Task Legacy_payload_without_borrowed_fields_deserializes_defaults() {
+        // Version skew: an older server that predates AI-1207 never sends borrowed/borrow_cwd. The
+        // daemon must still bind the command (positional SignalR binding) and default Borrowed to
+        // false / BorrowCwd to null — i.e. behave exactly as an owned-worktree launch.
+        const string legacyWire =
+            """
+            {"agent_id":"legacy03","prompt":null,"model":"opus","effort":null,"repo_path":"/tmp/repo","tools":null,"attachment_ids":null,"vendor":"claude"}
+            """;
+
+        var parsed = JsonSerializer.Deserialize(legacyWire, CapacitorJsonContext.Default.LaunchAgentCommand);
+
+        await Assert.That(parsed.Borrowed).IsFalse();
+        await Assert.That(parsed.BorrowCwd).IsNull();
+        await Assert.That(parsed.RepoPath).IsEqualTo("/tmp/repo");
+    }
+
+    [Test]
     public async Task Vendor_field_round_trips_through_json_serializer() {
         var cmd = new LaunchAgentCommand(
             AgentId:       "agent-1",

--- a/test/Capacitor.Cli.Tests.Unit/MachineIdFileTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/MachineIdFileTests.cs
@@ -60,4 +60,23 @@ public class MachineIdFileTests {
         await Assert.That(again).IsEqualTo(seeded);
         await Assert.That(File.ReadAllText(MachinePath)).IsEqualTo(before);
     }
+
+    [Test]
+    public async Task Get_WhenMachineJsonIsCorrupt_HealsTheFileAndReturnsAStableId() {
+        // A corrupt machine.json (partial/garbled write) makes ReadPersisted() return null, so Get()
+        // falls to Create(). Without the heal, Create()'s exclusive FileMode.CreateNew can't overwrite
+        // the existing corrupt file, so every Get() churns a fresh, UNPERSISTED GUID (Qodo #290 #2).
+        File.WriteAllText(MachinePath, "{ this is not valid json");
+
+        var first = MachineId.Get();
+        await Assert.That(first).IsNotNull();
+        await Assert.That(first).IsNotEmpty();
+
+        // Stable across calls — the corrupt file was healed, not re-generated each time.
+        var second = MachineId.Get();
+        await Assert.That(second).IsEqualTo(first);
+
+        // The heal actually persisted: a fresh read off disk returns the same id.
+        await Assert.That(MachineId.ReadPersisted()).IsEqualTo(first);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/MachineIdFileTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/MachineIdFileTests.cs
@@ -1,0 +1,63 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="MachineId"/> — the AI-1207 stable per-machine id the daemon reports at
+/// registration (distinct from <see cref="MachineIdProvider"/>'s AI-1134 memory-tagging id; see
+/// MachineIdTests.cs for that one).
+///
+/// PathHelpers.ConfigDir is static readonly — captured once at class-load time from
+/// KCAP_CONFIG_DIR. RepoPathStoreGlobalSetup.[Before(Assembly)] sets that env var to a shared
+/// temp dir before PathHelpers is first touched, so all path-based tests in this process share
+/// that same base dir. [NotInParallel] plus per-test cleanup of machine.json keeps these tests
+/// from racing each other or RepoPathStoreTests/TokenStoreProfileTests over shared files.
+/// </summary>
+[NotInParallel(nameof(MachineIdFileTests))]
+public class MachineIdFileTests {
+    static string MachinePath => Path.Combine(RepoPathStoreGlobalSetup.SharedConfigDir, "machine.json");
+
+    [Before(Test)]
+    public void DeleteMachineJson() {
+        if (File.Exists(MachinePath)) File.Delete(MachinePath);
+    }
+
+    [Test]
+    public async Task Get_ReturnsNonEmptyId() {
+        var id = MachineId.Get();
+
+        await Assert.That(id).IsNotNull();
+        await Assert.That(id).IsNotEmpty();
+    }
+
+    [Test]
+    public async Task Get_IsStableAcrossCalls() {
+        var first  = MachineId.Get();
+        var second = MachineId.Get();
+
+        await Assert.That(second).IsEqualTo(first);
+    }
+
+    [Test]
+    public async Task Get_PersistsSoAFreshReadReturnsTheSameId() {
+        var id = MachineId.Get();
+
+        // Simulates a new process: reads machine.json straight off disk rather than relying on
+        // whatever Get() might keep in memory.
+        var persisted = MachineId.ReadPersisted();
+
+        await Assert.That(persisted).IsEqualTo(id);
+    }
+
+    [Test]
+    public async Task Get_WhenMachineJsonAlreadyExists_ReturnsThePersistedValueRatherThanRegenerating() {
+        // Simulate a peer process having already won the first-write race before we ever call Get().
+        var seeded = MachineId.Get();
+        var before = File.ReadAllText(MachinePath);
+
+        var again = MachineId.Get();
+
+        await Assert.That(again).IsEqualTo(seeded);
+        await Assert.That(File.ReadAllText(MachinePath)).IsEqualTo(before);
+    }
+}


### PR DESCRIPTION
Phase A (daemon-side) of **AI-1207** — a hosted review-flow reviewer runs read-only **directly in the requester's working directory** instead of a fragile mirrored worktree, so it always sees the real (uncommitted / untracked / gitignored) files. This PR is the kcap-cli half; the kcap-server half (Phase B) follows after this releases. Everything here is **additive and back-compatible** — an old server drives this daemon unchanged (owned-worktree launch is byte-identical; the new probe/borrow paths are only used by a new server).

### What's in it (8 TDD commits)
- **Stable machine id** (`MachineId`) reported at registration — lets the server later prove a daemon is on the requester's machine (not just that a path string matches).
- **`BorrowAuthorizer`** — daemon-side borrow authorization: a true `realpath` canonicalization (resolves ancestor symlinks, not just the leaf) + a pinned non-repo allowlist policy (empty allowlist borrows git-rooted repos only; a non-repo cwd needs an explicit allowlist match).
- **`ProbeBorrowSource`** RPC — server→daemon "can you borrow this path?" returning the daemon-computed canonical cwd + git root + authorization.
- **Additive wire** — `LaunchAgentCommand.Borrowed` / `BorrowCwd` (a `bool`, not the reversed `WorkLocation` enum, on the wire) threaded through `RuntimeStartContext` → `LauncherContext` → `AgentInstance`.
- **Borrowed launch branch** — skips worktree create / base fetch / mirror / attachment download; runs in the canonical cwd; re-authorizes at launch (defense-in-depth) and fails loudly with `borrow_auth_failed:` on a TOCTOU mismatch.
- **Read-only argv** — Codex `--sandbox read-only`; Claude an explicit `--disallowedTools` deny-list (`Edit Write MultiEdit NotebookEdit Bash` + `Agent`), **not** plan mode (verified `--disallowedTools` is comma/space-separated so the deny actually takes effect).

### Safety invariant (verified)
A borrowed cwd is the user's **real checkout** and must never be removed on any path. All 10 worktree-mutation/removal sites are gated on `Work == OwnedWorktree` or are inherently cwd-safe. The safety test went **red without the failed-launch cleanup guard** (a failed borrowed launch `git worktree remove`d the real checkout) and green with it — that's why the borrowed branch and the cleanup guard land in one commit.

### Testing
TDD throughout; full unit suite green. The review loop (per-task + a final whole-branch review) caught and fixed a machine-id write race, an **ancestor-symlink allowlist escape** (Critical), and the cwd-deletion-on-failed-launch case.

### Reviewer notes
- **Depends on the test-isolation fix #289 to run the full daemon suite safely.** Without it, the pre-existing daemon tests can resolve the real `~/.config/kcap/daemons/` and SIGKILL your live daemon (this happened during development). Land / merge #289 first, or run only the borrow-related test classes.
- Deferred non-blockers for follow-up: two machine-id mechanisms unreconciled (`MachineId` vs AI-1134 `MachineIdProvider`); `BorrowProbeResult` could be a `readonly record struct`; `Canonicalize` fails *open* to the lexical path on a mid-resolution I/O error (consider fail-closed); missing borrowed tests for the CodexHooks removal-guard and the `MachineId` race-retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
