### PR TITLE
Watcher: don't consume half-written transcript lines

### DIFF
--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -360,7 +360,7 @@ static partial class WatchCommand {
             Log($"Session below threshold ({state.BufferedLines.Count}/{WatchState.TranscriptThreshold} lines), skipping final drain");
         } else {
             Log("Draining remaining lines...");
-            await DrainNewLines(hubConnection, sessionId, transcriptPath, agentId, state, vendor, CancellationToken.None);
+            await DrainNewLines(hubConnection, sessionId, transcriptPath, agentId, state, vendor, CancellationToken.None, isFinalDrain: true);
         }
 
         // Signal drain complete to server.
@@ -765,42 +765,25 @@ static partial class WatchCommand {
             string?           agentId,
             WatchState        state,
             string            vendor,
-            CancellationToken ct
+            CancellationToken ct,
+            bool              isFinalDrain = false
         ) {
         try {
             if (!File.Exists(transcriptPath)) {
                 return;
             }
 
-            var newLines       = new List<string>();
-            var newLineNumbers = new List<int>();
+            // Read only newline-TERMINATED lines. A final line still being written by the agent
+            // (no trailing '\n' yet) is held back — sending its truncated prefix and advancing the
+            // position past it permanently drops the completed line (AI-1243: dropped Read results;
+            // large tool_result lines are slow to flush and get caught mid-write). The next drain
+            // re-reads it once complete.
+            var fileText  = await File.ReadAllTextAsync(transcriptPath, ct);
+            var drainRead = SplitNewCompleteLines(fileText, state.LinesProcessed, holdIncompleteFinalLine: !isFinalDrain);
 
-            await using var stream = new FileStream(
-                transcriptPath,
-                FileMode.Open,
-                FileAccess.Read,
-                FileShare.ReadWrite
-            );
-            using var reader = new StreamReader(stream);
-
-            var lineIndex = 0;
-
-            while (await reader.ReadLineAsync(ct) is { } line) {
-                if (lineIndex < state.LinesProcessed) {
-                    lineIndex++;
-
-                    continue;
-                }
-
-                if (!string.IsNullOrWhiteSpace(line)) {
-                    newLines.Add(SecretRedactor.RedactLine(line));
-                    newLineNumbers.Add(lineIndex);
-                }
-
-                lineIndex++;
-            }
-
-            var linesRead = lineIndex;
+            var newLineNumbers = drainRead.LineNumbers;
+            var newLines       = drainRead.Lines.Select(SecretRedactor.RedactLine).ToList();
+            var linesRead      = drainRead.NextPosition;
 
             // Track Antigravity in-flight tool calls + the latest step timestamp from this
             // drain's transcript lines (BEFORE appending USAGE lines, which aren't transcript
@@ -1667,6 +1650,65 @@ static partial class WatchCommand {
     }
 
     static void Log(string message) => Console.Error.WriteLine($"[{DateTimeOffset.Now:HH:mm:ss.fff}] [watch] {message}");
+
+    /// <summary>
+    /// Result of a transcript drain read: the new non-blank <see cref="Lines"/> (beyond the
+    /// caller's processed position), their 0-based <see cref="LineNumbers"/>, and the
+    /// <see cref="NextPosition"/> the caller should advance its watermark to.
+    /// </summary>
+    public readonly record struct NewTranscriptLines(List<string> Lines, List<int> LineNumbers, int NextPosition);
+
+    /// <summary>
+    /// Split <paramref name="fileText"/> into the new complete (newline-terminated) transcript
+    /// lines beyond <paramref name="linesProcessed"/>. A final line that is NOT newline-terminated
+    /// means the agent is mid-write of it: it is held back — excluded from the batch AND from
+    /// <see cref="NewTranscriptLines.NextPosition"/> — so a later drain re-reads it once complete.
+    /// Consuming it would send a truncated line that fails to normalize server-side and permanently
+    /// drop the completed line (AI-1243, the "endless reads" bug; large Read tool_result lines were
+    /// the common victim). Blank lines are skipped from the output but still advance the position,
+    /// matching the long-standing drain behaviour.
+    /// </summary>
+    public static NewTranscriptLines SplitNewCompleteLines(
+            string fileText,
+            int    linesProcessed,
+            bool   holdIncompleteFinalLine = true
+        ) {
+        var newLines       = new List<string>();
+        var newLineNumbers = new List<int>();
+
+        var endsWithNewline = fileText.Length == 0 || fileText[^1] == '\n';
+
+        using var reader    = new StringReader(fileText);
+        var       lineIndex = 0;
+
+        while (reader.ReadLine() is { } line) {
+            if (lineIndex >= linesProcessed && !string.IsNullOrWhiteSpace(line)) {
+                newLines.Add(line);
+                newLineNumbers.Add(lineIndex);
+            }
+
+            lineIndex++;
+        }
+
+        var nextPosition = lineIndex;
+
+        // Hold back a still-being-written final line (no trailing newline yet): keep the position
+        // before it and drop it from this batch if it was collected. The final drain at session end
+        // opts out (holdIncompleteFinalLine: false) — the file is static then, so an unterminated
+        // last line is genuinely the end and must be delivered, not lost.
+        if (holdIncompleteFinalLine && !endsWithNewline && nextPosition > linesProcessed) {
+            var partialIndex = nextPosition - 1;
+
+            if (newLineNumbers.Count > 0 && newLineNumbers[^1] == partialIndex) {
+                newLines.RemoveAt(newLines.Count - 1);
+                newLineNumbers.RemoveAt(newLineNumbers.Count - 1);
+            }
+
+            nextPosition = partialIndex;
+        }
+
+        return new NewTranscriptLines(newLines, newLineNumbers, nextPosition);
+    }
 
     public static int CountFileLines(string path) {
         try {

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -778,8 +778,12 @@ static partial class WatchCommand {
             // position past it permanently drops the completed line (AI-1243: dropped Read results;
             // large tool_result lines are slow to flush and get caught mid-write). The next drain
             // re-reads it once complete.
-            var fileText  = await File.ReadAllTextAsync(transcriptPath, ct);
-            var drainRead = SplitNewCompleteLines(fileText, state.LinesProcessed, holdIncompleteFinalLine: !isFinalDrain);
+            NewTranscriptLines drainRead;
+            await using (var stream = new FileStream(
+                    transcriptPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) {
+                drainRead = await ReadNewCompleteLinesAsync(
+                    stream, state.LinesProcessed, holdIncompleteFinalLine: !isFinalDrain, ct);
+            }
 
             var newLineNumbers = drainRead.LineNumbers;
             var newLines       = drainRead.Lines.Select(SecretRedactor.RedactLine).ToList();
@@ -1690,12 +1694,64 @@ static partial class WatchCommand {
             lineIndex++;
         }
 
-        var nextPosition = lineIndex;
+        return ApplyPartialLineHoldback(
+            newLines, newLineNumbers, nextPosition: lineIndex, linesProcessed, endsWithNewline, holdIncompleteFinalLine);
+    }
 
-        // Hold back a still-being-written final line (no trailing newline yet): keep the position
-        // before it and drop it from this batch if it was collected. The final drain at session end
-        // opts out (holdIncompleteFinalLine: false) — the file is static then, so an unterminated
-        // last line is genuinely the end and must be delivered, not lost.
+    /// <summary>
+    /// Streams the new complete transcript lines from <paramref name="stream"/> WITHOUT materializing
+    /// the whole file (Qodo #291 #2): only lines beyond <paramref name="linesProcessed"/> are retained.
+    /// The file length is sampled once and the end-of-file newline is read from the last byte, then the
+    /// read is CAPPED at that length — so a concurrent append after the sample can't make an as-yet
+    /// unterminated final line look complete and get consumed (which would re-drop it — AI-1243).
+    /// Opened by the caller with FileShare.ReadWrite (Qodo #291 #1) so the writing agent is never blocked.
+    /// </summary>
+    internal static async Task<NewTranscriptLines> ReadNewCompleteLinesAsync(
+            FileStream        stream,
+            int               linesProcessed,
+            bool              holdIncompleteFinalLine,
+            CancellationToken ct) {
+        var length = stream.Length;
+
+        bool endsWithNewline;
+        if (length == 0) {
+            endsWithNewline = true;
+        } else {
+            stream.Seek(length - 1, SeekOrigin.Begin);
+            endsWithNewline = stream.ReadByte() == '\n';
+            stream.Seek(0, SeekOrigin.Begin);
+        }
+
+        var newLines       = new List<string>();
+        var newLineNumbers = new List<int>();
+        var lineIndex      = 0;
+
+        using var reader = new StreamReader(new LengthLimitedReadStream(stream, length), leaveOpen: true);
+        while (await reader.ReadLineAsync(ct) is { } line) {
+            if (lineIndex >= linesProcessed && !string.IsNullOrWhiteSpace(line)) {
+                newLines.Add(line);
+                newLineNumbers.Add(lineIndex);
+            }
+
+            lineIndex++;
+        }
+
+        return ApplyPartialLineHoldback(
+            newLines, newLineNumbers, nextPosition: lineIndex, linesProcessed, endsWithNewline, holdIncompleteFinalLine);
+    }
+
+    // Hold back a still-being-written final line (no trailing newline yet): keep the position
+    // before it and drop it from this batch if it was collected. The final drain at session end
+    // opts out (holdIncompleteFinalLine: false) — the file is static then, so an unterminated
+    // last line is genuinely the end and must be delivered, not lost. Shared by the string helper
+    // (SplitNewCompleteLines) and the streaming reader (ReadNewCompleteLinesAsync).
+    static NewTranscriptLines ApplyPartialLineHoldback(
+            List<string> newLines,
+            List<int>    newLineNumbers,
+            int          nextPosition,
+            int          linesProcessed,
+            bool         endsWithNewline,
+            bool         holdIncompleteFinalLine) {
         if (holdIncompleteFinalLine && !endsWithNewline && nextPosition > linesProcessed) {
             var partialIndex = nextPosition - 1;
 
@@ -1708,6 +1764,43 @@ static partial class WatchCommand {
         }
 
         return new NewTranscriptLines(newLines, newLineNumbers, nextPosition);
+    }
+
+    /// <summary>Read-only view of <c>inner</c> that reports EOF after <c>limit</c> bytes, so a
+    /// StreamReader over it can't read past a length sampled before a concurrent append.</summary>
+    internal sealed class LengthLimitedReadStream(Stream inner, long limit) : Stream {
+        long _consumed;
+
+        public override int Read(byte[] buffer, int offset, int count) {
+            var allowed = (int)Math.Min(count, limit - _consumed);
+            if (allowed <= 0) return 0;
+            var n = inner.Read(buffer, offset, allowed);
+            _consumed += n;
+            return n;
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default) {
+            var allowed = (int)Math.Min(buffer.Length, limit - _consumed);
+            if (allowed <= 0) return 0;
+            var n = await inner.ReadAsync(buffer[..allowed], ct);
+            _consumed += n;
+            return n;
+        }
+
+        public override bool CanRead  => true;
+        public override bool CanSeek  => false;
+        public override bool CanWrite => false;
+        public override long Length   => limit;
+
+        public override long Position {
+            get => _consumed;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
     public static int CountFileLines(string path) {

--- a/test/Capacitor.Cli.Tests.Unit/ReadNewCompleteLinesAsyncTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ReadNewCompleteLinesAsyncTests.cs
@@ -1,0 +1,183 @@
+using System.Text;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+// AI-1243 / Qodo #291: the streaming drain reader (ReadNewCompleteLinesAsync) replaces
+// File.ReadAllTextAsync in DrainNewLines. It must (1) open with FileShare.ReadWrite so a
+// concurrently-writing agent is never blocked (#291 #1), (2) NOT materialize the whole file
+// (#291 #2), and (3) stay byte-for-byte behaviour-equivalent to the string helper
+// (SplitNewCompleteLines) — same partial-final-line hold-back, so a mid-write final line is
+// never consumed and dropped. The length-cap makes that hold-back robust against a concurrent
+// append happening after the length was sampled.
+public class ReadNewCompleteLinesAsyncTests {
+    static string WriteTemp(string content) {
+        var path = Path.Combine(Path.GetTempPath(), $"kcap-drain-{Guid.NewGuid():N}.jsonl");
+        File.WriteAllText(path, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        return path;
+    }
+
+    static async Task<WatchCommand.NewTranscriptLines> ReadViaStream(
+            string path, int linesProcessed, bool holdIncompleteFinalLine) {
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        return await WatchCommand.ReadNewCompleteLinesAsync(stream, linesProcessed, holdIncompleteFinalLine, default);
+    }
+
+    static async Task AssertParity(string content, int linesProcessed, bool holdIncompleteFinalLine) {
+        var expected = WatchCommand.SplitNewCompleteLines(content, linesProcessed, holdIncompleteFinalLine);
+
+        var path = WriteTemp(content);
+        try {
+            var actual = await ReadViaStream(path, linesProcessed, holdIncompleteFinalLine);
+
+            await Assert.That(actual.Lines).IsEquivalentTo(expected.Lines);
+            await Assert.That(actual.LineNumbers).IsEquivalentTo(expected.LineNumbers);
+            await Assert.That(actual.NextPosition).IsEqualTo(expected.NextPosition);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    // ---- 1. Parity with the string helper across the interesting shapes ----
+
+    [Test]
+    public async Task Parity_all_lines_when_file_ends_with_newline() =>
+        await AssertParity("a\nb\nc\n", 0, holdIncompleteFinalLine: true);
+
+    [Test]
+    public async Task Parity_partial_final_line_held_back_when_no_trailing_newline() =>
+        await AssertParity("a\nb\nc", 0, holdIncompleteFinalLine: true);
+
+    [Test]
+    public async Task Parity_blank_lines_skipped_but_counted() =>
+        await AssertParity("a\n\nb\n", 0, holdIncompleteFinalLine: true);
+
+    [Test]
+    public async Task Parity_blank_partial_final_line() =>
+        await AssertParity("real\n   ", 0, holdIncompleteFinalLine: true);
+
+    [Test]
+    public async Task Parity_respects_lines_already_processed() =>
+        await AssertParity("a\nb\nc\n", 2, holdIncompleteFinalLine: true);
+
+    [Test]
+    public async Task Parity_crlf_terminated_lines() =>
+        await AssertParity("a\r\nb\r\n", 0, holdIncompleteFinalLine: true);
+
+    [Test]
+    public async Task Parity_lone_partial_line_holds_at_start() =>
+        await AssertParity("partial-json-being-written", 0, holdIncompleteFinalLine: true);
+
+    [Test]
+    public async Task Parity_empty_file() =>
+        await AssertParity("", 0, holdIncompleteFinalLine: true);
+
+    // ---- 2. Final drain delivers the unterminated final line ----
+
+    [Test]
+    public async Task Final_drain_delivers_unterminated_final_line() {
+        var path = WriteTemp("a\nb\nc");
+        try {
+            var r = await ReadViaStream(path, 0, holdIncompleteFinalLine: false);
+
+            await Assert.That(r.Lines).IsEquivalentTo(new[] { "a", "b", "c" });
+            await Assert.That(r.LineNumbers).IsEquivalentTo(new[] { 0, 1, 2 });
+            await Assert.That(r.NextPosition).IsEqualTo(3);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    // ---- 3. FileShare.ReadWrite doesn't block a concurrent writer (#291 #1) ----
+
+    [Test]
+    public async Task Read_does_not_block_a_concurrent_append_writer() {
+        var path = WriteTemp("a\nb\n");
+        try {
+            // Hold the file open for reading exactly the way DrainNewLines does.
+            await using var readStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+            // A concurrent agent appending to the same file must succeed (no sharing violation).
+            // With default FileShare.Read this would throw IOException — the #291 #1 regression.
+            await using (var writeStream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+            await using (var writer = new StreamWriter(writeStream)) {
+                await writer.WriteLineAsync("c");
+            }
+
+            // The read still works while the handle is shared; the append landed before the read,
+            // so all three complete lines are surfaced.
+            var r = await WatchCommand.ReadNewCompleteLinesAsync(readStream, 0, holdIncompleteFinalLine: true, default);
+            await Assert.That(r.Lines).IsEquivalentTo(new[] { "a", "b", "c" });
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    // ---- 4. Cap correctness: reads stop at the sampled length ----
+
+    [Test]
+    public async Task Cap_stops_reading_at_the_sampled_length() {
+        // The wrapper mirrors a length sampled BEFORE a concurrent append: bytes past `limit`
+        // exist in `inner` but must never be surfaced, so an as-yet unterminated final line can't
+        // be made to look complete and get consumed (the AI-1243 bug this PR fixes).
+        var full  = Encoding.UTF8.GetBytes("a\nb\nc\n");   // 6 bytes
+        var limit = 4L;                                     // "a\nb\n" only
+        using var inner = new MemoryStream(full);
+
+        var capped = new WatchCommand.LengthLimitedReadStream(inner, limit);
+
+        var buffer = new byte[full.Length];
+        var total  = 0;
+        int n;
+        while ((n = await capped.ReadAsync(buffer.AsMemory(total))) > 0) {
+            total += n;
+        }
+
+        await Assert.That(total).IsEqualTo((int)limit);
+        await Assert.That(Encoding.UTF8.GetString(buffer, 0, total)).IsEqualTo("a\nb\n");
+    }
+
+    [Test]
+    public async Task Cap_appended_bytes_are_not_read_this_pass() {
+        // End-to-end feel: sample the length while the file is "a\nb\n", append "c\n" AFTER
+        // sampling, then read. The appended line must not appear this pass (it's re-read next pass).
+        var path = WriteTemp("a\nb\n");
+        try {
+            await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            var sampledLength = stream.Length;
+
+            await using (var writeStream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+            await using (var writer = new StreamWriter(writeStream)) {
+                await writer.WriteLineAsync("c");
+            }
+
+            // Read only up to the sampled length, exactly as ReadNewCompleteLinesAsync does internally.
+            using var reader = new StreamReader(new WatchCommand.LengthLimitedReadStream(stream, sampledLength), leaveOpen: true);
+            var text = await reader.ReadToEndAsync();
+
+            await Assert.That(text).IsEqualTo("a\nb\n");
+            await Assert.That(text).DoesNotContain("c");
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task Cap_sync_read_stops_at_the_sampled_length() {
+        var full  = Encoding.UTF8.GetBytes("hello-world");
+        var limit = 5L;
+        using var inner = new MemoryStream(full);
+
+        var capped = new WatchCommand.LengthLimitedReadStream(inner, limit);
+
+        var buffer = new byte[full.Length];
+        var total  = 0;
+        int n;
+        while ((n = capped.Read(buffer, total, buffer.Length - total)) > 0) {
+            total += n;
+        }
+
+        await Assert.That(total).IsEqualTo((int)limit);
+        await Assert.That(Encoding.UTF8.GetString(buffer, 0, total)).IsEqualTo("hello");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/SplitNewCompleteLinesTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SplitNewCompleteLinesTests.cs
@@ -1,0 +1,115 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+// AI-1243 ("endless reads in chat"): the live watcher drain must NOT consume a transcript
+// line that is not yet newline-terminated — the agent is mid-write of it. Sending the
+// truncated prefix and advancing the position past it permanently drops the completed line
+// (its truncated JSON fails to normalize server-side, and the next drain starts after it).
+// This disproportionately hit large `Read` tool_result lines (long JSON, slower to flush),
+// which then rendered as orphaned tool calls. The guard holds the partial line back until a
+// later drain sees it newline-terminated.
+public class SplitNewCompleteLinesTests {
+    [Test]
+    public async Task All_lines_returned_when_file_ends_with_newline() {
+        var r = WatchCommand.SplitNewCompleteLines("a\nb\nc\n", 0);
+
+        await Assert.That(r.Lines).IsEquivalentTo(new[] { "a", "b", "c" });
+        await Assert.That(r.LineNumbers).IsEquivalentTo(new[] { 0, 1, 2 });
+        await Assert.That(r.NextPosition).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Partial_final_line_is_held_back() {
+        // "c" has no trailing newline — still being written.
+        var r = WatchCommand.SplitNewCompleteLines("a\nb\nc", 0);
+
+        await Assert.That(r.Lines).IsEquivalentTo(new[] { "a", "b" });
+        await Assert.That(r.LineNumbers).IsEquivalentTo(new[] { 0, 1 });
+        // Position stays BEFORE the partial line so the next drain re-reads it complete.
+        await Assert.That(r.NextPosition).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Dropped_read_result_is_delivered_once_complete() {
+        // Reproduces AI-1243: a tool_use line (complete) followed by its tool_result line
+        // caught mid-write (no trailing newline yet).
+        var first = WatchCommand.SplitNewCompleteLines("tool_use_A\ntool_result_A", 0);
+
+        // Only the complete tool_use is sent; the partial result is held back — NOT dropped.
+        await Assert.That(first.Lines).IsEquivalentTo(new[] { "tool_use_A" });
+        await Assert.That(first.NextPosition).IsEqualTo(1);
+
+        // Next drain, after the writer finished the result line and appended the next tool_use.
+        var second = WatchCommand.SplitNewCompleteLines("tool_use_A\ntool_result_A\ntool_use_B\n", first.NextPosition);
+
+        await Assert.That(second.Lines).IsEquivalentTo(new[] { "tool_result_A", "tool_use_B" });
+        await Assert.That(second.LineNumbers).IsEquivalentTo(new[] { 1, 2 });
+        await Assert.That(second.NextPosition).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Respects_lines_already_processed() {
+        var r = WatchCommand.SplitNewCompleteLines("a\nb\nc\n", 2);
+
+        await Assert.That(r.Lines).IsEquivalentTo(new[] { "c" });
+        await Assert.That(r.LineNumbers).IsEquivalentTo(new[] { 2 });
+        await Assert.That(r.NextPosition).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Blank_lines_skipped_from_output_but_counted_in_position() {
+        var r = WatchCommand.SplitNewCompleteLines("a\n\nb\n", 0);
+
+        await Assert.That(r.Lines).IsEquivalentTo(new[] { "a", "b" });
+        await Assert.That(r.LineNumbers).IsEquivalentTo(new[] { 0, 2 });
+        await Assert.That(r.NextPosition).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Crlf_terminated_lines_are_complete() {
+        var r = WatchCommand.SplitNewCompleteLines("a\r\nb\r\n", 0);
+
+        await Assert.That(r.Lines).IsEquivalentTo(new[] { "a", "b" });
+        await Assert.That(r.NextPosition).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Empty_file_yields_nothing() {
+        var r = WatchCommand.SplitNewCompleteLines("", 0);
+
+        await Assert.That(r.Lines).IsEmpty();
+        await Assert.That(r.NextPosition).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Final_drain_flushes_the_incomplete_final_line() {
+        // At session end the file is static — an unterminated final line is genuinely the end, so
+        // the final drain must deliver it (a vendor that never newline-terminates its last line
+        // must not lose it). Only the LIVE polling drain holds partial lines back.
+        var r = WatchCommand.SplitNewCompleteLines("a\nb\nc", 0, holdIncompleteFinalLine: false);
+
+        await Assert.That(r.Lines).IsEquivalentTo(new[] { "a", "b", "c" });
+        await Assert.That(r.LineNumbers).IsEquivalentTo(new[] { 0, 1, 2 });
+        await Assert.That(r.NextPosition).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task A_lone_partial_line_holds_position_at_start() {
+        var r = WatchCommand.SplitNewCompleteLines("partial-json-being-written", 0);
+
+        await Assert.That(r.Lines).IsEmpty();
+        await Assert.That(r.NextPosition).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Blank_partial_final_line_held_back_without_dropping_prior_content() {
+        // A whitespace-only final line lacking a newline must not advance the position past
+        // itself (it may still be completing), but the real line before it is still delivered.
+        var r = WatchCommand.SplitNewCompleteLines("real\n   ", 0);
+
+        await Assert.That(r.Lines).IsEquivalentTo(new[] { "real" });
+        await Assert.That(r.LineNumbers).IsEquivalentTo(new[] { 0 });
+        await Assert.That(r.NextPosition).IsEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Problem

The live watcher's 1-second drain (`WatchCommand.DrainNewLines`) reads the transcript to EOF with `StreamReader.ReadLineAsync`, which returns the final line **even when it is not yet newline-terminated** — i.e. the agent is mid-write of it. The watcher sends that truncated prefix and advances `state.LinesProcessed` past it, so when the writer completes the line and appends more, the completed line is never re-read. Its truncated JSON fails to normalize server-side, so the event is permanently lost (and the gap sits below the high-water mark, where a resend can't back-fill it).

Large `Read` tool_result lines (long JSON, slow to flush) are the common victim — they land as orphaned tool calls that render as an eternal spinner in the Capacitor chat view.

Diagnosed from a real hosted-subagent session: two `Read` results present in the source `.jsonl` were absent from the ingested stream, with matching `$lineNumber` gaps at exactly those tool_result lines.

## Fix

`SplitNewCompleteLines(fileText, linesProcessed, holdIncompleteFinalLine = true)`:
- Emits only newline-terminated lines.
- Holds a partial final line back — excluded from the batch **and** the watermark — so the next drain re-reads it once complete.
- The final drain at session end passes `holdIncompleteFinalLine: false` (the file is static then), so a vendor that leaves its last line unterminated is still delivered.

Blank-line skipping and line-number semantics are unchanged.

## Tests

`SplitNewCompleteLinesTests` — 10 cases incl. the exact bug shape (tool_use complete + tool_result mid-write → held back, then delivered once the line completes). Full CLI unit suite green (2481); AOT publish clean (no IL2026/IL3050).

Linear: AI-1243. Paired with the server-side chat-rendering guard (kurrent-io/kcap-server) that stops already-orphaned calls from spinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
