### PR TITLE
Trim the Claude SessionStart hook critical path so facts inject reliably

### DIFF
--- a/docs/superpowers/specs/2026-07-07-hook-critical-path-latency-design.md
+++ b/docs/superpowers/specs/2026-07-07-hook-critical-path-latency-design.md
@@ -1,0 +1,110 @@
+# SessionStart facts injection — trim the hook critical path
+
+## Problem
+
+The Claude `SessionStart` hook is supposed to inject "facts from Capacitor"
+(server-side guideline clusters + the team-memory index) as
+`hookSpecificOutput.additionalContext`. In practice users rarely see it.
+
+Evidence (from live transcripts under `~/.claude/projects/.../*.jsonl`, the
+`hook_success` attachments):
+
+- Across 6 recent sessions, `kcap hook --claude` ran at `SessionStart` in only
+  **1**. In the other 5 there is no attachment at all — the hook exceeded
+  Claude Code's **5 s** `SessionStart` timeout and was killed (killed hooks
+  leave no attachment; 0 hook errors were recorded).
+- In the one session it did run: `durationMs: 3629`, exit 0, **empty stdout** —
+  the internal `HookBudget` (5 s ceiling − 1.5 s safety) was exhausted before
+  the POST could emit, so nothing was injected.
+
+The CLI logic is correct: invoked with a valid payload it emits the full
+envelope (guidelines + team memory). The failure is **latency**, not logic.
+
+## Root cause
+
+The server is fast. Measured against `kurrent.kcap.ai`:
+
+- `POST /hooks/session-start` — 130–250 ms
+- `GET /api/memories/index` — 120–190 ms
+
+The 3.6 s is spent **client-side**, as a chain of network round-trips the hook
+makes before it can emit facts:
+
+| Step | Cost | Needed to emit facts? |
+|---|---|---|
+| `GET /auth/config` provider discovery | ~150–250 ms | No — and it is re-fetched on **every** hook (cached only in a per-process static) |
+| token refresh (near expiry) | variable | No |
+| **`gh pr view` live PR detection** | **~600 ms** | **No** — facts scope by owner/repo (git, ~10 ms); the watcher backfills PR info independently |
+| `POST /hooks/session-start` | ~150 ms | Yes |
+| `GET /api/memories/index` (parallel) | ~150 ms | Yes |
+
+The two avoidable costs — `gh pr view` and the repeated `/auth/config` fetch —
+are what push a fresh hook process past 5 s. Neither touches the daemon, so the
+fix works even for users who never run the daemon.
+
+`RepositoryDetection`'s own comment already flags the PR round-trip as "pure
+wasted latency" when PR fields aren't needed (import passes
+`detectPullRequest: false`, AI-1122). And `WatchCommand` runs its own
+`DetectRepositoryAsync` (with PR detection) — so the hook's pre-POST PR probe is
+redundant for the session record; the watcher provides PR info anyway.
+
+## Approach
+
+Trim the critical path rather than cache the symptom. Two focused changes; both
+speed up **every** hook event (and the watcher start), not just facts injection.
+
+### Change A — the hook never does live PR detection
+
+The watcher owns PR detection. The hook only needs owner/repo (git).
+
+- `RepositoryDetection.EnrichWithRepositoryInfo` gains a
+  `bool detectPullRequest = true` parameter, threaded to
+  `DetectRepositoryAsync` (default preserves existing behavior for other
+  callers).
+- All `ClaudeHookCommand` enrichment calls pass `detectPullRequest: false`
+  (session-start, session-end, subagent-stop, and the inline "other commands"
+  path).
+- `RepoExclusion.IsExcludedAsync` and `ClaudeHookCommand.TryResolveRepoHashAsync`
+  pass `detectPullRequest: false` — both need only owner/repo.
+
+Behavioral effect: the session-start event reaches the server without
+`pr_number/pr_title/pr_url`; the watcher's own detection backfills them within
+seconds. Base repo info (owner/repo/branch/host/user) is unchanged.
+
+### Change B — persist `/auth/config` discovery to disk
+
+`DiscoverProviderAsync` currently caches only in a per-process static, so every
+fresh hook process re-fetches `/auth/config`.
+
+- New `AuthProviderCache` (Capacitor.Cli.Core): a small JSON store at
+  `cache/auth-providers.json` mapping `baseUrl → { provider, fetched_at }`, with
+  a 24 h TTL. Pure `Read`/`Upsert` helpers (unit-tested without disk) plus thin
+  fail-open disk wrappers (`TryGet`/`Set`). JSON via `JsonNode` (AOT-safe, no
+  reflection).
+- `DiscoverProviderAsync`: on a static miss, consult the disk cache before the
+  network; on a successful network discovery, write both the static and the disk
+  cache. The unreachable→token fallback stays uncached (as today).
+
+## Non-goals (YAGNI)
+
+- No local facts cache / staleness layer — with a lean path the live round-trip
+  fits comfortably in 5 s.
+- No daemon involvement.
+- Other vendor hooks (Codex/Cursor/…) keep current behavior; this change is
+  scoped to the Claude hook path where the problem was measured.
+
+## Testing
+
+- `DetectRepositoryAsync(..., detectPullRequest: false, run)` never issues a
+  `gh`/`glab` command (injected `CommandRunner` records commands); the
+  contrasting `true` case does. Base fields still resolve.
+- `AuthProviderCache.Read`/`Upsert` pure-function tests: hit within TTL, miss
+  when expired, upsert replaces per-baseUrl, malformed store → null.
+- Existing `ClaudeHookStdoutTests` / `SessionStartVisibilityTests` continue to
+  pass (envelope + visibility unaffected).
+
+## Verification
+
+- `dotnet publish -c Release` with no new IL3050/IL2026 warnings.
+- Re-measure a real `kcap hook --claude` end-to-end: expect ≈400–600 ms
+  (down from 1.9–3.6 s).

--- a/src/Capacitor.Cli.Core/AuthProviderCache.cs
+++ b/src/Capacitor.Cli.Core/AuthProviderCache.cs
@@ -1,0 +1,104 @@
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Core;
+
+/// <summary>
+/// Cross-process cache of the server's auth provider (the result of
+/// <c>GET /auth/config</c>), keyed by base URL. A fresh hook process would
+/// otherwise re-fetch <c>/auth/config</c> on every single event — a ~150–250 ms
+/// round-trip on the SessionStart critical path (the in-process static in
+/// <see cref="HttpClientExtensions"/> only helps within one process, and each
+/// hook invocation is its own process).
+///
+/// <para>The provider for a given server is effectively static, so entries carry
+/// a generous 24 h TTL and are refreshed opportunistically. Everything is
+/// best-effort/fail-open: any read/write/parse error yields "no cache" and the
+/// caller falls back to the live fetch — the cache never changes the auth
+/// outcome, only whether the network call is skipped.</para>
+/// </summary>
+static class AuthProviderCache {
+    static readonly TimeSpan Ttl = TimeSpan.FromHours(24);
+
+    /// <summary>Test seam: when set, the store lives here instead of the real config dir.</summary>
+    internal static string? OverridePathForTesting;
+
+    static string StorePath => OverridePathForTesting ?? PathHelpers.ConfigPath(Path.Combine("cache", "auth-providers.json"));
+
+    /// <summary>
+    /// Pure: returns the still-fresh provider recorded for <paramref name="baseUrl"/> in
+    /// <paramref name="storeJson"/>, or <c>null</c> when absent, expired, or malformed.
+    /// </summary>
+    internal static string? Read(string? storeJson, string baseUrl, long nowUnix, TimeSpan? ttl = null) {
+        if (string.IsNullOrWhiteSpace(storeJson)) return null;
+
+        try {
+            if (JsonNode.Parse(storeJson) is not JsonObject obj) return null;
+            if (obj[baseUrl] is not JsonObject entry) return null;
+
+            var provider = entry["provider"]?.GetValue<string>();
+            var fetched  = entry["fetched_at"]?.GetValue<long>();
+
+            if (string.IsNullOrEmpty(provider) || fetched is null) return null;
+
+            var age = nowUnix - fetched.Value;
+
+            // Negative age (clock skew / tampered file) is treated as stale, not fresh.
+            if (age < 0 || age > (long)(ttl ?? Ttl).TotalSeconds) return null;
+
+            return provider;
+        } catch {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Pure: returns <paramref name="storeJson"/> with <paramref name="baseUrl"/> upserted to
+    /// <paramref name="provider"/> stamped at <paramref name="nowUnix"/>. A malformed store is
+    /// replaced rather than propagated.
+    /// </summary>
+    internal static string Upsert(string? storeJson, string baseUrl, string provider, long nowUnix) {
+        JsonObject obj;
+
+        try {
+            obj = (string.IsNullOrWhiteSpace(storeJson) ? null : JsonNode.Parse(storeJson)) as JsonObject ?? new JsonObject();
+        } catch {
+            obj = new JsonObject();
+        }
+
+        obj[baseUrl] = new JsonObject {
+            ["provider"]   = provider,
+            ["fetched_at"] = nowUnix
+        };
+
+        return obj.ToJsonString();
+    }
+
+    /// <summary>Best-effort disk read. Returns the cached provider or <c>null</c>.</summary>
+    public static string? TryGet(string baseUrl) {
+        try {
+            var path = StorePath;
+
+            return File.Exists(path)
+                ? Read(File.ReadAllText(path), baseUrl, DateTimeOffset.UtcNow.ToUnixTimeSeconds())
+                : null;
+        } catch {
+            return null;
+        }
+    }
+
+    /// <summary>Best-effort disk write. Silently no-ops on any failure.</summary>
+    public static void Set(string baseUrl, string provider) {
+        try {
+            var path = StorePath;
+            var dir  = Path.GetDirectoryName(path);
+
+            if (dir is not null) Directory.CreateDirectory(dir);
+
+            var existing = File.Exists(path) ? File.ReadAllText(path) : null;
+
+            File.WriteAllText(path, Upsert(existing, baseUrl, provider, DateTimeOffset.UtcNow.ToUnixTimeSeconds()));
+        } catch {
+            // Best effort — the cache never breaks auth.
+        }
+    }
+}

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -92,6 +92,16 @@ public static class HttpClientExtensions {
         // the same actionable message the retry guards print.
         EnsureAbsolute(baseUrl);
 
+        // Cross-process cache: each hook invocation is a fresh process, so the in-process static
+        // above never helps a hook. Skip the /auth/config round-trip when a recent result is on disk.
+        var cached = AuthProviderCache.TryGet(baseUrl);
+
+        if (cached is not null) {
+            cachedProvider = cached;
+
+            return cached;
+        }
+
         using var http = new HttpClient();
 
         try {
@@ -100,7 +110,8 @@ public static class HttpClientExtensions {
             if (response.IsSuccessStatusCode) {
                 var config   = await response.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.AuthDiscoveryResponse, ct);
                 var provider = config?.Provider ?? "None";
-                cachedProvider = provider; // Only cache successful discovery
+                cachedProvider = provider;          // in-process
+                AuthProviderCache.Set(baseUrl, provider); // cross-process; only cache successful discovery
 
                 return provider;
             }

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -256,17 +256,20 @@ public static class ClaudeHookCommand {
         // after EnsureWatcherRunning. Other commands enrich inline.
         Task<string>? deferredRepoTask = null;
 
+        // detectPullRequest:false everywhere: a live `gh pr view` / `glab` round-trip (~600ms to
+        // GitHub) is the single biggest client cost on the hook path and would push the facts
+        // envelope past Claude's 5s SessionStart timeout. PR info is not needed here — the watcher
+        // runs its own DetectRepositoryAsync (with PR detection) and backfills it independently.
         if (command == "session-start") {
-            // Budgeted so a slow git/gh probe self-skips under deadline pressure (repo info
-            // still arrives via the watcher's own detection). Awaited INSIDE the session-start
-            // block after EnsureWatcherRunning so it never delays transcript-capture start.
-            deferredRepoTask = RepositoryDetection.EnrichWithRepositoryInfo(body, HookBudget.Remaining(processStart, command));
+            // Awaited INSIDE the session-start block after EnsureWatcherRunning so it never delays
+            // transcript-capture start.
+            deferredRepoTask = RepositoryDetection.EnrichWithRepositoryInfo(body, HookBudget.Remaining(processStart, command), detectPullRequest: false);
         } else if (command is "session-end" or "subagent-stop") {
-            // Budgeted like session-start so a slow git/gh probe can't push the bounded POST/spool
-            // path past the hook deadline. The await below is also budget-bounded as a hard backstop.
-            deferredRepoTask = RepositoryDetection.EnrichWithRepositoryInfo(body, HookBudget.Remaining(processStart, command));
+            // Budgeted so a slow git probe can't push the bounded POST/spool path past the hook
+            // deadline. The await below is also budget-bounded as a hard backstop.
+            deferredRepoTask = RepositoryDetection.EnrichWithRepositoryInfo(body, HookBudget.Remaining(processStart, command), detectPullRequest: false);
         } else {
-            body = await RepositoryDetection.EnrichWithRepositoryInfo(body);
+            body = await RepositoryDetection.EnrichWithRepositoryInfo(body, detectPullRequest: false);
         }
 
         // Resolve the V2 profile once for repo/path exclusion and
@@ -810,7 +813,8 @@ public static class ClaudeHookCommand {
     static async Task<string?> TryResolveRepoHashAsync(string? sessionCwd) {
         try {
             var cwd      = string.IsNullOrWhiteSpace(sessionCwd) ? Directory.GetCurrentDirectory() : sessionCwd;
-            var repoInfo = await RepositoryDetection.DetectRepositoryAsync(cwd);
+            // Memory-index scoping needs only owner/repo → skip the PR round-trip.
+            var repoInfo = await RepositoryDetection.DetectRepositoryAsync(cwd, detectPullRequest: false);
             if (repoInfo?.Owner is null || repoInfo.RepoName is null) return null;
 
             return RepoHashHelper.ComputeRepoHash(repoInfo.Owner, repoInfo.RepoName);

--- a/src/Capacitor.Cli/RepoExclusion.cs
+++ b/src/Capacitor.Cli/RepoExclusion.cs
@@ -28,7 +28,8 @@ static class RepoExclusion {
 
             if (cwd is null) return false;
 
-            var repo = await RepositoryDetection.DetectRepositoryAsync(cwd, budget);
+            // Exclusion matches on owner/repo only → skip the PR round-trip (~600ms to GitHub).
+            var repo = await RepositoryDetection.DetectRepositoryAsync(cwd, budget, detectPullRequest: false);
 
             if (repo?.Owner is not null && repo.RepoName is not null) {
                 return excludedRepos.Contains($"{repo.Owner}/{repo.RepoName}", StringComparer.OrdinalIgnoreCase);

--- a/src/Capacitor.Cli/RepositoryDetection.cs
+++ b/src/Capacitor.Cli/RepositoryDetection.cs
@@ -18,7 +18,8 @@ static class RepositoryDetection {
 
     internal static CommandRunner DefaultRunner => RunCommandAsync;
 
-    public static async Task<string> EnrichWithRepositoryInfo(string json, TimeSpan? budget = null) {
+    public static async Task<string> EnrichWithRepositoryInfo(
+            string json, TimeSpan? budget = null, bool detectPullRequest = true, CommandRunner? run = null) {
         try {
             var node = JsonNode.Parse(json);
 
@@ -32,7 +33,7 @@ static class RepositoryDetection {
                 return json;
             }
 
-            var repo = await DetectRepositoryAsync(cwd, budget);
+            var repo = await DetectRepositoryAsync(cwd, budget, detectPullRequest, run);
 
             if (repo is null) {
                 return json;

--- a/test/Capacitor.Cli.Tests.Unit/AuthProviderCacheGlobalSetup.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthProviderCacheGlobalSetup.cs
@@ -1,0 +1,27 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Assembly-level isolation for <see cref="AuthProviderCache"/>. Unit tests run against the
+/// developer's real <c>~/.config/kcap</c> (only the daemons dir is pinned elsewhere), so without
+/// this any test whose SUT calls <c>DiscoverProviderAsync</c> could read a provider cached by a
+/// prior run (an OS-reused WireMock port would collide) and skip its own <c>/auth/config</c> stub,
+/// or pollute the real cache file. Pinning the store to a throwaway temp file per run keeps the
+/// cache a clean no-op for every test that doesn't explicitly exercise it.
+/// </summary>
+public class AuthProviderCacheGlobalSetup {
+    static readonly string StoreFile = Path.Combine(
+        Path.GetTempPath(),
+        "kcap-authprovider-tests-" + Guid.NewGuid().ToString("N")[..8] + ".json"
+    );
+
+    [Before(Assembly)]
+    public static void PinStore() => AuthProviderCache.OverridePathForTesting = StoreFile;
+
+    [After(Assembly)]
+    public static void CleanupStore() {
+        AuthProviderCache.OverridePathForTesting = null;
+        try { File.Delete(StoreFile); } catch { /* best effort */ }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/AuthProviderCacheTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthProviderCacheTests.cs
@@ -1,0 +1,83 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// <see cref="AuthProviderCache"/> lets a fresh hook process skip the ~150–250 ms
+/// <c>/auth/config</c> round-trip by reading a recent result from disk. The pure
+/// <c>Read</c>/<c>Upsert</c> helpers carry the TTL + scoping logic and are tested
+/// here without touching disk; a single round-trip test covers the disk wrappers.
+/// </summary>
+public class AuthProviderCacheTests {
+    const long Now = 1_000_000;
+
+    [Test]
+    public async Task Read_returns_provider_within_ttl() {
+        var store = AuthProviderCache.Upsert(null, "https://a.example", "WorkOS", Now);
+
+        await Assert.That(AuthProviderCache.Read(store, "https://a.example", Now + 60)).IsEqualTo("WorkOS");
+    }
+
+    [Test]
+    public async Task Read_returns_null_when_expired() {
+        var store   = AuthProviderCache.Upsert(null, "https://a.example", "WorkOS", Now);
+        var wayLater = Now + (long)TimeSpan.FromHours(48).TotalSeconds;
+
+        await Assert.That(AuthProviderCache.Read(store, "https://a.example", wayLater)).IsNull();
+    }
+
+    [Test]
+    public async Task Read_treats_negative_age_as_stale() {
+        // fetched_at in the future (clock skew / tampered file) must not count as fresh.
+        var store = AuthProviderCache.Upsert(null, "https://a.example", "WorkOS", Now);
+
+        await Assert.That(AuthProviderCache.Read(store, "https://a.example", Now - 60)).IsNull();
+    }
+
+    [Test]
+    public async Task Read_is_scoped_per_base_url() {
+        var store = AuthProviderCache.Upsert(null, "https://a.example", "WorkOS", Now);
+
+        await Assert.That(AuthProviderCache.Read(store, "https://b.example", Now)).IsNull();
+    }
+
+    [Test]
+    public async Task Upsert_replaces_existing_entry_and_preserves_others() {
+        var store = AuthProviderCache.Upsert(null, "https://a.example", "WorkOS", Now);
+        store     = AuthProviderCache.Upsert(store, "https://b.example", "GitHubApp", Now);
+        store     = AuthProviderCache.Upsert(store, "https://a.example", "None", Now + 5);
+
+        await Assert.That(AuthProviderCache.Read(store, "https://a.example", Now + 5)).IsEqualTo("None");
+        await Assert.That(AuthProviderCache.Read(store, "https://b.example", Now + 5)).IsEqualTo("GitHubApp");
+    }
+
+    [Test]
+    public async Task Read_returns_null_on_malformed_store() {
+        await Assert.That(AuthProviderCache.Read("not json", "https://a.example", Now)).IsNull();
+        await Assert.That(AuthProviderCache.Read("[]", "https://a.example", Now)).IsNull();
+        await Assert.That(AuthProviderCache.Read(null, "https://a.example", Now)).IsNull();
+    }
+
+    [Test]
+    public async Task Upsert_replaces_malformed_store_rather_than_throwing() {
+        var store = AuthProviderCache.Upsert("{ broken", "https://a.example", "WorkOS", Now);
+
+        await Assert.That(AuthProviderCache.Read(store, "https://a.example", Now)).IsEqualTo("WorkOS");
+    }
+
+    [Test, NotInParallel]
+    public async Task Set_then_TryGet_round_trips_on_disk() {
+        var previous = AuthProviderCache.OverridePathForTesting;
+        var tempFile = Path.Combine(Path.GetTempPath(), "kcap-authprovider-rt-" + Guid.NewGuid().ToString("N") + ".json");
+        AuthProviderCache.OverridePathForTesting = tempFile;
+
+        try {
+            await Assert.That(AuthProviderCache.TryGet("https://rt.example")).IsNull(); // cold
+            AuthProviderCache.Set("https://rt.example", "GitHubApp");
+            await Assert.That(AuthProviderCache.TryGet("https://rt.example")).IsEqualTo("GitHubApp");
+        } finally {
+            AuthProviderCache.OverridePathForTesting = previous;
+            try { File.Delete(tempFile); } catch { /* best effort */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/RepositoryDetectionPrSkipTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RepositoryDetectionPrSkipTests.cs
@@ -1,0 +1,72 @@
+using Capacitor.Cli;
+using Capacitor.Cli.PrDetection;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The Claude hook path passes <c>detectPullRequest: false</c> so a live
+/// <c>gh pr view</c> / <c>glab</c> round-trip (~600 ms to GitHub) never blocks
+/// the 5 s SessionStart deadline. The watcher owns PR detection and backfills
+/// it independently, so the hook only needs base repo info (owner/repo/branch).
+/// </summary>
+public class RepositoryDetectionPrSkipTests {
+    [Before(Test)]
+    public void Reset() => GitProviderRouter.ResetMemoForTests();
+
+    static CommandRunner RecordingRunner(List<string> commands) =>
+        (cmd, args, _, _) => {
+            commands.Add(cmd);
+            string? reply = (cmd, args) switch {
+                ("git", "branch --show-current") => "main",
+                ("git", "config user.name")      => "Tester",
+                ("git", "config user.email")     => "t@example.com",
+                ("git", "remote get-url origin") => "git@github.com:acme/widget.git",
+                _                                => null
+            };
+            return Task.FromResult(reply);
+        };
+
+    static string FreshCwd() => Path.Combine(Path.GetTempPath(), "kcap-prskip-" + Guid.NewGuid().ToString("N"));
+
+    [Test]
+    public async Task DetectPullRequest_false_never_spawns_gh_or_glab() {
+        var commands = new List<string>();
+
+        var repo = await RepositoryDetection.DetectRepositoryAsync(
+            FreshCwd(), budget: TimeSpan.FromSeconds(5), detectPullRequest: false, run: RecordingRunner(commands));
+
+        await Assert.That(repo).IsNotNull();
+        await Assert.That(repo!.Owner).IsEqualTo("acme");
+        await Assert.That(repo.RepoName).IsEqualTo("widget");
+        await Assert.That(repo.Branch).IsEqualTo("main");
+        await Assert.That(repo.PrNumber).IsNull();
+
+        // The gate is the whole point: no provider probe (gh auth status) and no
+        // detector (gh/glab) was ever spawned — only git commands ran.
+        await Assert.That(commands.All(c => c == "git")).IsTrue();
+    }
+
+    [Test]
+    public async Task DetectPullRequest_true_does_probe_the_provider() {
+        var commands = new List<string>();
+
+        await RepositoryDetection.DetectRepositoryAsync(
+            FreshCwd(), budget: TimeSpan.FromSeconds(5), detectPullRequest: true, run: RecordingRunner(commands));
+
+        // Proves the flag actually gates the round-trip: with detection ON, the
+        // GitHub provider probe (gh) is attempted.
+        await Assert.That(commands.Any(c => c == "gh")).IsTrue();
+    }
+
+    [Test]
+    public async Task EnrichWithRepositoryInfo_false_never_spawns_gh_or_glab() {
+        var commands = new List<string>();
+        var payload  = $$"""{"cwd":"{{FreshCwd().Replace("\\", "/")}}","hook_event_name":"session-start"}""";
+
+        var enriched = await RepositoryDetection.EnrichWithRepositoryInfo(
+            payload, budget: TimeSpan.FromSeconds(5), detectPullRequest: false, run: RecordingRunner(commands));
+
+        await Assert.That(enriched).Contains("acme");
+        await Assert.That(commands.All(c => c == "git")).IsTrue();
+    }
+}


### PR DESCRIPTION
Closes #293 — AI-1256. Follow-up to AI-1219 (async→sync): making the hook sync was necessary but insufficient — it still lost the 5 s race.

## Problem

The Claude `SessionStart` hook injects Capacitor facts (guideline clusters + team-memory index) as `additionalContext`, but users rarely saw them. Live transcripts (`hook_success` attachments) show `kcap hook --claude` ran at SessionStart in only 1 of 6 recent sessions — the rest exceeded Claude Code's **5 s** timeout and were killed; the one that ran took 3629 ms and emitted empty stdout (internal `HookBudget` exhausted).

The CLI logic is correct; the failure is **latency**. The server is fast (`POST /hooks/session-start` ~150 ms, `/api/memories/index` ~150 ms). The time went to a chain of client-side round-trips before the hook could emit:

| Step | Cost | Needed for facts? |
|---|---|---|
| `GET /auth/config` provider discovery | ~150–250 ms | No — re-fetched every hook (per-process static only) |
| `gh pr view` live PR detection | ~600 ms | No — facts scope by owner/repo (git); the watcher backfills PR |
| `POST /hooks/session-start` | ~150 ms | Yes |
| `GET /api/memories/index` (parallel) | ~150 ms | Yes |

## Changes

**A — the hook never does live PR detection.** `RepositoryDetection.EnrichWithRepositoryInfo` gains `detectPullRequest` (default `true`, other callers unchanged); all Claude hook enrichment + `RepoExclusion` + the memory-index repo-hash resolver pass `false`. The watcher already runs its own `DetectRepositoryAsync` (with PR detection) and backfills PR info.

**B — persist `/auth/config` discovery to disk.** New `AuthProviderCache` (Core): pure `Read`/`Upsert` helpers + fail-open disk wrappers, 24 h TTL, keyed by base URL, `JsonNode`-based (AOT-safe). A fresh hook process now skips the round-trip.

Both help every hook event (and watcher start), not just facts; neither touches the daemon.

## Verification

- Full unit suite **2639 passed, 0 failed** (new: `RepositoryDetectionPrSkipTests`, `AuthProviderCacheTests`); integration `ClaudeHookStdoutTests` / `SessionStartVisibilityTests` / `HookRoundTripTests` green.
- `dotnet publish -c Release`: **0 errors, 0 IL2026/IL3050 warnings**.
- Real end-to-end hook latency: **1144 ms cold / 326 ms warm** (was 1.9–3.6 s); facts envelope emitted in both.

Design doc: `docs/superpowers/specs/2026-07-07-hook-critical-path-latency-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)