### PR TITLE
[AI-699] Auto-register kcap MCP servers for Cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ Open the server URL in your browser. The dashboard shows repositories, sessions,
 
 ### Sessions and Flows MCP servers for agents
 
-The `kcap mcp sessions` stdio server lets coding agents search and recall past Capacitor sessions without leaving the chat. `kcap setup` **registers it (with `kcap-review`) for both Claude Code and Codex CLI** — no manual `claude mcp add` or TOML edit. For Claude Code it's carried by the plugin's `.mcp.json`; for Codex CLI, `kcap setup` / `kcap plugin install --codex` write it into `~/.codex/config.toml`. The server is repo-aware: `cd` into a project before spawning your agent and `search_sessions` defaults to that repo's sessions.
+The `kcap mcp sessions` stdio server lets coding agents search and recall past Capacitor sessions without leaving the chat. `kcap setup` **registers it (with `kcap-review`) for Claude Code, Codex CLI, and Cursor** — no manual `claude mcp add` or TOML/JSON edit. For Claude Code it's carried by the plugin's `.mcp.json`; for Codex CLI, `kcap setup` / `kcap plugin install --codex` write it into `~/.codex/config.toml`; for Cursor, `kcap setup` / `kcap plugin install --cursor` write it into `~/.cursor/mcp.json` (opt out with `--skip-cursor-mcp`). The server is repo-aware: `cd` into a project before spawning your agent and `search_sessions` defaults to that repo's sessions.
 
-The `kcap mcp flows` stdio server lets agents start and interact with AI-powered agent flows — any flow-definition catalog entry, not just reviews. The plugin **auto-registers it for Claude Code** (Codex stays manual). See the [Flows MCP server](#flows-mcp-server-for-agents) section for details.
+The `kcap mcp flows` stdio server lets agents start and interact with AI-powered agent flows — any flow-definition catalog entry, not just reviews. The plugin **auto-registers it for Claude Code**, and `kcap setup` / `kcap plugin install --cursor` also registers it for Cursor (Codex stays manual). See the [Flows MCP server](#flows-mcp-server-for-agents) section for details.
 
 The `kcap mcp flow-result` stdio server is the reviewer-side counterpart: the daemon injects it into hosted review-flow reviewer sessions so they can submit their result. It is not meant to be registered or run manually — see [Flow-result MCP server](#flow-result-mcp-server-hosted-reviewers).
 
-The `kcap mcp memory` stdio server lets agents search, save, and update durable team memories — preferences, feedback, project facts, and references scoped to you, your team, or the org. `kcap setup` **auto-registers it for both Claude Code** (via the plugin's `.mcp.json`) **and Codex CLI** (in `~/.codex/config.toml`, alongside `kcap-sessions` / `kcap-review`); Codex's native plugin loader also picks it up via `.codex-mcp.json`. See the [Memory MCP server](#memory-mcp-server-for-agents) section for details.
+The `kcap mcp memory` stdio server lets agents search, save, and update durable team memories — preferences, feedback, project facts, and references scoped to you, your team, or the org. `kcap setup` **auto-registers it for Claude Code** (via the plugin's `.mcp.json`), **Codex CLI** (in `~/.codex/config.toml`, alongside `kcap-sessions` / `kcap-review`), and **Cursor** (in `~/.cursor/mcp.json`, alongside the other three servers); Codex's native plugin loader also picks it up via `.codex-mcp.json`. See the [Memory MCP server](#memory-mcp-server-for-agents) section for details.
 
 ## What it records
 
@@ -291,7 +291,7 @@ The same MCP server (`kcap-review`) is also auto-registered by the Kurrent Capac
 kcap mcp sessions
 ```
 
-Stdio MCP server that exposes past Capacitor sessions to coding agents (Claude Code, Codex) so they can search and recall prior work without leaving the chat. **Claude Code:** auto-registered via the plugin's `.mcp.json`. **Codex CLI:** `kcap setup` / `kcap plugin install --codex` register it (alongside `kcap-review`) directly in `~/.codex/config.toml` under `[mcp_servers]`, so there's nothing extra to do — launch Codex from your repo directory so the server resolves the right repo. Enabling the kcap plugin through Codex's native plugin manager (`codex plugin add`) also provides them via the plugin's `.codex-mcp.json` descriptor.
+Stdio MCP server that exposes past Capacitor sessions to coding agents (Claude Code, Codex, Cursor) so they can search and recall prior work without leaving the chat. **Claude Code:** auto-registered via the plugin's `.mcp.json`. **Codex CLI:** `kcap setup` / `kcap plugin install --codex` register it (alongside `kcap-review`) directly in `~/.codex/config.toml` under `[mcp_servers]`, so there's nothing extra to do — launch Codex from your repo directory so the server resolves the right repo. Enabling the kcap plugin through Codex's native plugin manager (`codex plugin add`) also provides them via the plugin's `.codex-mcp.json` descriptor. **Cursor:** `kcap setup` / `kcap plugin install --cursor` register it (alongside the other three kcap servers) in `~/.cursor/mcp.json`; opt out with `--skip-cursor-mcp`.
 
 It provides four tools:
 
@@ -308,7 +308,7 @@ The server is repo-aware — it resolves the current working directory to a repo
 kcap mcp flows
 ```
 
-Stdio MCP server that lets coding agents start and interact with AI-powered agent flows — any entry in the server's flow-definition catalog, not just reviews — directly from within a session. The Kurrent Capacitor plugin **auto-registers it for Claude Code** (via `.mcp.json`), so there's nothing to do after `kcap setup` — the flows server derives the target repo from its launch working directory, and Claude Code always runs inside the repo, so one registration works for every repo. It's registered even with no daemon connected; the tools simply stay inert (and `start_flow` returns an error) until a daemon with the repo is available.
+Stdio MCP server that lets coding agents start and interact with AI-powered agent flows — any entry in the server's flow-definition catalog, not just reviews — directly from within a session. The Kurrent Capacitor plugin **auto-registers it for Claude Code** (via `.mcp.json`), so there's nothing to do after `kcap setup` — the flows server derives the target repo from its launch working directory, and Claude Code always runs inside the repo, so one registration works for every repo. It's registered even with no daemon connected; the tools simply stay inert (and `start_flow` returns an error) until a daemon with the repo is available. `kcap setup` / `kcap plugin install --cursor` registers it the same way for **Cursor**, in `~/.cursor/mcp.json` (opt out with `--skip-cursor-mcp`).
 
 For Codex, `kcap-flows` stays manual — unlike the `sessions` / `review` / `memory` servers (which `kcap setup` registers in `config.toml`), it launches a paid hosted participant, so it isn't auto-registered. Add it to `~/.codex/config.toml`:
 
@@ -345,7 +345,7 @@ Stdio MCP server the **daemon injects into hosted flow participant sessions** (b
 kcap mcp memory
 ```
 
-Stdio MCP server that lets coding agents search, save, and update durable "memories" — short, reusable notes (preferences, feedback, project facts, references) scoped to you, your team, or the whole org, so lessons learned in one session are available in the next. **Claude Code:** auto-registered via the plugin's `.mcp.json`. **Codex CLI:** `kcap setup` / `kcap plugin install --codex` register it in `~/.codex/config.toml` (alongside `kcap-sessions` / `kcap-review`), so there's nothing extra to do; enabling the plugin through Codex's native `codex plugin add` also provides it via the `.codex-mcp.json` descriptor.
+Stdio MCP server that lets coding agents search, save, and update durable "memories" — short, reusable notes (preferences, feedback, project facts, references) scoped to you, your team, or the whole org, so lessons learned in one session are available in the next. **Claude Code:** auto-registered via the plugin's `.mcp.json`. **Codex CLI:** `kcap setup` / `kcap plugin install --codex` register it in `~/.codex/config.toml` (alongside `kcap-sessions` / `kcap-review`), so there's nothing extra to do; enabling the plugin through Codex's native `codex plugin add` also provides it via the `.codex-mcp.json` descriptor. **Cursor:** `kcap setup` / `kcap plugin install --cursor` register it in `~/.cursor/mcp.json` (alongside the other three kcap servers); opt out with `--skip-cursor-mcp`.
 
 It provides six tools:
 
@@ -526,11 +526,12 @@ PR review is supported for hosted Codex agents as well as Claude — the same `k
 
 #### Cursor IDE hooks
 
-Cursor is detected by the presence of `~/.cursor/` — you don't need the `cursor` shell command on `PATH`. If `kcap setup` found Cursor and you said yes, hooks are already in place. To install or remove later:
+Cursor is detected by the presence of `~/.cursor/` — you don't need the `cursor` shell command on `PATH`. If `kcap setup` found Cursor and you said yes, hooks are already in place. Installing also registers the four kcap MCP servers in `~/.cursor/mcp.json` (non-destructive, idempotent); pass `--skip-cursor-mcp` to opt out. To install or remove later:
 
 ```bash
-kcap plugin install --cursor                # writes ~/.cursor/hooks.json
-kcap plugin remove --cursor                 # remove Cursor hooks
+kcap plugin install --cursor                # writes ~/.cursor/hooks.json + registers kcap MCP servers
+kcap plugin install --cursor --skip-cursor-mcp  # hooks only, skip ~/.cursor/mcp.json
+kcap plugin remove --cursor                 # remove Cursor hooks + kcap MCP servers
 ```
 
 #### GitHub Copilot CLI hooks

--- a/src/Capacitor.Cli.Core/Cursor/CursorPaths.cs
+++ b/src/Capacitor.Cli.Core/Cursor/CursorPaths.cs
@@ -55,6 +55,12 @@ public sealed record CursorPaths(string UserDir, string WorkspaceStorageDir) {
         return Path.Combine(home, ".cursor", "hooks.json");
     }
 
+    /// <summary>Path to <c>~/.cursor/mcp.json</c> — same on every OS.</summary>
+    public static string UserMcpJson(string? home = null) {
+        home ??= PathHelpers.HomeDirectory;
+        return Path.Combine(home, ".cursor", "mcp.json");
+    }
+
     /// <summary>Hook-event spool directory at <c>~/.cursor/kcap-pending/</c>.</summary>
     public static string SpoolDir(string? home = null) {
         home ??= PathHelpers.HomeDirectory;

--- a/src/Capacitor.Cli.Core/Mcp/JsonMcpConfigWriter.cs
+++ b/src/Capacitor.Cli.Core/Mcp/JsonMcpConfigWriter.cs
@@ -41,8 +41,8 @@ public static class JsonMcpConfigWriter {
             return changed;
         });
 
-    public static Change Unregister(string configPath, McpConfigShape shape, IMcpMarker marker) =>
-        Update(configPath, root => {
+    public static Change Unregister(string configPath, McpConfigShape shape, IMcpMarker marker) {
+        var change = Update(configPath, root => {
             if (root[shape.BlockKey] is not JsonObject block) return false;
             var changed = false;
 
@@ -51,9 +51,15 @@ public static class JsonMcpConfigWriter {
                     changed = true;
 
             if (block.Count == 0 && root.Remove(shape.BlockKey)) changed = true;
-            if (changed) marker.Clear(configPath);
             return changed;
         });
+
+        // Always clear kcap's ownership marker on unregister — even when there were no JSON entries
+        // to remove (e.g. the user hand-deleted them) — so no orphaned marker is left. Skip only on a
+        // hard failure (couldn't read/parse the config) so state stays recoverable.
+        if (change != Change.Failed) marker.Clear(configPath);
+        return change;
+    }
 
     static JsonObject RenderEntry(KcapMcpServer s, McpConfigShape shape, string? cwd) {
         var o = new JsonObject();

--- a/src/Capacitor.Cli.Core/Resources/help-plugin.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-plugin.txt
@@ -53,6 +53,11 @@ Options:
                       ~/.codex/config.toml) so kcap skills work. The
                       --if-installed refresh path never touches this, so the npm
                       postinstall hook leaves config.toml alone.
+  --skip-cursor-mcp   With --cursor: skip registering the kcap MCP servers in
+                      ~/.cursor/mcp.json. By default `install --cursor` also
+                      registers all 4 kcap MCP servers there (non-destructive,
+                      idempotent — preserves any user-authored servers) so
+                      Cursor picks them up with no manual JSON edit.
   --if-installed      Refresh-only mode: no-op unless the user has previously
                       installed the target (marker file or pre-marker entry
                       detected). Used by the npm postinstall hook to refresh
@@ -70,8 +75,10 @@ Notes:
   plugin manifest and is not affected by this command.
 
   --cursor writes all 8 supported hooks to ~/.cursor/hooks.json (merged with
-  any existing entries). Cursor uses a single user-scope hooks.json — there
-  is no project-scope variant, so --project has no effect with --cursor.
+  any existing entries) and then registers all 4 kcap MCP servers in
+  ~/.cursor/mcp.json (non-destructive, idempotent — see --skip-cursor-mcp to
+  opt out). Cursor uses a single user-scope hooks.json/mcp.json — there is no
+  project-scope variant, so --project has no effect with --cursor.
 
   install --codex and install --skills both clean up legacy ~/.codex/skills/kcap-*
   folders from prior installer versions.

--- a/src/Capacitor.Cli.Core/Resources/help-setup.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-setup.txt
@@ -27,6 +27,8 @@ Options:
                               leave ~/.codex/config.toml untouched.
   --skip-cursor-hooks         Don't install Cursor hooks even if the Cursor
                               user-dir is detected (~/.cursor/).
+  --skip-cursor-mcp           Skip registering the kcap MCP servers for Cursor
+                              (~/.cursor/mcp.json).
   --skip-copilot-hooks        Don't install Copilot CLI hooks even if Copilot
                               is detected (~/.copilot/ or copilot on PATH).
   --skip-gemini-hooks         Don't install Gemini CLI hooks even if Gemini

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Mcp;
 using Spectre.Console;
 
 namespace Capacitor.Cli.Commands;
@@ -13,7 +14,7 @@ internal static class CodingAgentsStep {
     // sites and the broad CodingAgentsStep test suite compile unchanged. Gemini
     // (AI-887), Kiro (AI-888), and Pi (AI-886) were all added after the original
     // four vendors.
-    internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool SkipCopilot, bool NoPrompt, bool SkipGemini = false, bool SkipKiro = false, bool SkipPi = false, bool SkipOpenCode = false, bool SkipCodexNetworkAccess = false, bool SkipAntigravity = false);
+    internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool SkipCopilot, bool NoPrompt, bool SkipGemini = false, bool SkipKiro = false, bool SkipPi = false, bool SkipOpenCode = false, bool SkipCodexNetworkAccess = false, bool SkipAntigravity = false, bool SkipCursorMcp = false);
 
     internal record DetectedAgents(bool Claude, bool Codex, bool Cursor, bool Copilot, bool Gemini = false, bool Kiro = false, bool Pi = false, bool OpenCode = false, bool Antigravity = false);
 
@@ -31,7 +32,8 @@ internal static class CodingAgentsStep {
             string  PiExtensionPath = "",
             string  OpenCodeExtensionPath = "",
             string  CodexConfigTomlPath = "",
-            string  AntigravityHooksPath = ""
+            string  AntigravityHooksPath = "",
+            string  CursorMcpPath = ""
         );
 
     internal record Installers(
@@ -48,7 +50,8 @@ internal static class CodingAgentsStep {
             Func<string /*pluginPath*/, bool>?                        InstallOpenCodeExtension = null,
             Func<CodexConfigToml.Change>?                            EnableCodexNetworkAccess = null,
             Func<CodexConfigToml.Change>?                            RegisterCodexMcp = null,
-            Func<string /*hooksPath*/, bool>?                        InstallAntigravityHooks = null
+            Func<string /*hooksPath*/, bool>?                        InstallAntigravityHooks = null,
+            Func<JsonMcpConfigWriter.Change>?                        RegisterCursorMcp = null
         );
 
     internal record Result(
@@ -63,7 +66,8 @@ internal static class CodingAgentsStep {
             bool OpenCodeExtensionInstalled = false,
             bool CodexNetworkAccessApplied = false,
             bool CodexMcpRegistered = false,
-            bool AntigravityHooksInstalled = false
+            bool AntigravityHooksInstalled = false,
+            bool CursorMcpRegistered = false
         ) {
         /// <summary>
         /// True when at least one agent's hooks were installed — i.e. there's a
@@ -95,6 +99,7 @@ internal static class CodingAgentsStep {
         var codexNetworkApplied   = HandleCodexNetworkAccess(options, paths, installers, prompt, writeLine, codexHooksInstalled);
         var codexMcpRegistered    = HandleCodexMcp(paths, installers, writeLine, codexHooksInstalled);
         var cursorHooksInstalled  = HandleCursorHooks(options, detected, paths, installers, prompt, writeLine);
+        var cursorMcpRegistered   = HandleCursorMcp(options, paths, installers, writeLine, cursorHooksInstalled);
         var copilotHooksInstalled = HandleCopilotHooks(options, detected, paths, installers, prompt, writeLine);
         var geminiHooksInstalled  = HandleGeminiHooks(options, detected, paths, installers, prompt, writeLine);
         var kiroHooksInstalled    = HandleKiroHooks(options, detected, paths, installers, prompt, writeLine);
@@ -119,7 +124,8 @@ internal static class CodingAgentsStep {
                 openCodeExtensionInstalled,
                 codexNetworkApplied,
                 codexMcpRegistered,
-                antigravityHooksInstalled
+                antigravityHooksInstalled,
+                CursorMcpRegistered: cursorMcpRegistered
             )
         );
     }
@@ -660,6 +666,41 @@ internal static class CodingAgentsStep {
         writeLine($"  [green]✓[/] Cursor hooks installed ({Markup.Escape(paths.CursorHooksPath)})");
 
         return true;
+    }
+
+    /// <summary>
+    /// Registers the kcap MCP servers in <c>~/.cursor/mcp.json</c> via
+    /// <see cref="Installers.RegisterCursorMcp"/> so Cursor picks them up with no manual
+    /// JSON edit. Gated on Cursor hooks installing — the same "full Cursor integration"
+    /// trigger used by <see cref="HandleCodexMcp"/> — and on <see cref="Options.SkipCursorMcp"/>.
+    /// No prompt: registration is non-destructive (only adds missing kcap servers) and
+    /// mirrors how the Claude plugin auto-registers its MCP servers.
+    /// </summary>
+    static bool HandleCursorMcp(
+            Options        options,
+            Paths          paths,
+            Installers     installers,
+            Action<string> writeLine,
+            bool           cursorHooksInstalled
+        ) {
+        if (installers.RegisterCursorMcp is null || !cursorHooksInstalled || options.SkipCursorMcp) return false;
+
+        var configPath = Markup.Escape(paths.CursorMcpPath);
+
+        switch (installers.RegisterCursorMcp()) {
+            case JsonMcpConfigWriter.Change.Updated:
+                writeLine($"  [green]✓[/] Cursor MCP servers registered ([dim]{configPath}[/])");
+
+                return true;
+            case JsonMcpConfigWriter.Change.Unchanged:
+                writeLine("  [dim]· Cursor MCP servers already registered — no change needed[/]");
+
+                return false;
+            default:
+                writeLine($"  [yellow]⚠[/] Could not register Cursor MCP servers in {configPath} — see README to add them manually.");
+
+                return false;
+        }
     }
 
     static bool HandleClaude(

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -8,6 +8,7 @@ using Capacitor.Cli.Core.Copilot;
 using Capacitor.Cli.Core.Cursor;
 using Capacitor.Cli.Core.Gemini;
 using Capacitor.Cli.Core.Kiro;
+using Capacitor.Cli.Core.Mcp;
 using Capacitor.Cli.Core.OpenCode;
 using Capacitor.Cli.Core.Pi;
 
@@ -694,33 +695,71 @@ public static class PluginCommand {
                 : $"Cursor hooks installed ({hooksPath})"
         );
 
+        // Register the kcap MCP servers in ~/.cursor/mcp.json so Cursor picks them up
+        // with no manual JSON edit. Non-destructive + idempotent. Never fails the
+        // install: a write error is a warning, not an error code (mirrors Codex).
+        if (!args.Contains("--skip-cursor-mcp"))
+            await RegisterCursorMcpServersAsync(env);
+
         return 0;
+    }
+
+    /// <summary>
+    /// Registers the kcap MCP servers in <c>~/.cursor/mcp.json</c> so Cursor loads them
+    /// without a manual JSON edit. Never fails the install: a write error is a warning,
+    /// not an error code.
+    /// </summary>
+    static async Task RegisterCursorMcpServersAsync(PluginEnvironment env) {
+        var change = JsonMcpConfigWriter.Register(
+            env.CursorMcpJson, KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new McpMarker("cursor"));
+
+        switch (change) {
+            case JsonMcpConfigWriter.Change.Updated:
+                await env.Stdout.WriteLineAsync($"Cursor MCP servers registered ({env.CursorMcpJson}).");
+                break;
+            case JsonMcpConfigWriter.Change.Failed:
+                await env.Stderr.WriteLineAsync(
+                    $"Warning: could not update {env.CursorMcpJson} to register Cursor MCP servers.");
+                break;
+            // Unchanged: silent — same as Codex's already-registered case.
+        }
     }
 
     static async Task<int> RemoveCursor(string[] args, PluginEnvironment env) {
         var hooksPath = GetArg(args, "--cursor-hooks-path") ?? env.CursorUserHooksJson;
 
+        var hooksFailed = false;
+
         if (!File.Exists(hooksPath)) {
             await env.Stdout.WriteLineAsync("Nothing to remove — Cursor hooks file not found.");
+        } else {
+            try {
+                var removed = RemoveCursorHooks(hooksPath);
 
-            return 0;
+                await env.Stdout.WriteLineAsync(
+                    removed
+                        ? $"Cursor hooks removed ({hooksPath})"
+                        : "Cursor hooks were not installed."
+                );
+            } catch (Exception ex) {
+                await env.Stderr.WriteLineAsync($"Could not update Cursor hooks at {hooksPath}: {ex.Message}");
+                hooksFailed = true;
+            }
         }
 
-        try {
-            var removed = RemoveCursorHooks(hooksPath);
+        // Cursor is user-scope only (no --project split like Codex), so the kcap MCP
+        // entries are always unregistered here, independent of whether hooks.json
+        // existed — the two files are unrelated on disk.
+        var mcpChange = JsonMcpConfigWriter.Unregister(env.CursorMcpJson, McpConfigShape.Standard, new McpMarker("cursor"));
+        var mcpFailed = mcpChange == JsonMcpConfigWriter.Change.Failed;
 
-            await env.Stdout.WriteLineAsync(
-                removed
-                    ? $"Cursor hooks removed ({hooksPath})"
-                    : "Cursor hooks were not installed."
-            );
-
-            return 0;
-        } catch (Exception ex) {
-            await env.Stderr.WriteLineAsync($"Could not update Cursor hooks at {hooksPath}: {ex.Message}");
-
-            return 1;
+        if (mcpChange == JsonMcpConfigWriter.Change.Updated) {
+            await env.Stdout.WriteLineAsync($"Cursor MCP servers removed ({env.CursorMcpJson})");
+        } else if (mcpFailed) {
+            await env.Stderr.WriteLineAsync($"Could not update {env.CursorMcpJson} to remove Cursor MCP servers.");
         }
+
+        return hooksFailed || mcpFailed ? 1 : 0;
     }
 
     /// <summary>

--- a/src/Capacitor.Cli/Commands/PluginEnvironment.cs
+++ b/src/Capacitor.Cli/Commands/PluginEnvironment.cs
@@ -32,6 +32,7 @@ public sealed record PluginEnvironment(
     public string CodexUserHooksJson  => Path.Combine(CodexHome, "hooks.json");
     public string CodexConfigTomlPath => Path.Combine(CodexHome, "config.toml");
     public string CursorUserHooksJson => CursorPaths.UserHooksJson(HomeDirectory);
+    public string CursorMcpJson       => CursorPaths.UserMcpJson(HomeDirectory);
     public string CopilotKcapHooksJson => CopilotPaths.KcapHooksJson(HomeDirectory);
     public string GeminiSettingsJson   => GeminiPaths.SettingsJson(HomeDirectory);
     public string KiroKcapAgentJson    => KiroPaths.KcapAgentJson(HomeDirectory);

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -8,6 +8,7 @@ using Capacitor.Cli.Core.Copilot;
 using Capacitor.Cli.Core.Cursor;
 using Capacitor.Cli.Core.Gemini;
 using Capacitor.Cli.Core.Kiro;
+using Capacitor.Cli.Core.Mcp;
 using Capacitor.Cli.Core.OpenCode;
 using Capacitor.Cli.Core.Pi;
 using Spectre.Console;
@@ -29,6 +30,7 @@ public static class SetupCommand {
         var skipCodexFlag    = args.Contains("--skip-codex-hooks");
         var skipCodexNetworkFlag = args.Contains("--skip-codex-network-access");
         var skipCursorFlag   = args.Contains("--skip-cursor-hooks");
+        var skipCursorMcpFlag = args.Contains("--skip-cursor-mcp");
         var skipCopilotFlag  = args.Contains("--skip-copilot-hooks");
         var skipGeminiFlag   = args.Contains("--skip-gemini-hooks");
         var skipKiroFlag     = args.Contains("--skip-kiro-hooks");
@@ -233,7 +235,8 @@ public static class SetupCommand {
             SkipOpenCode: skipOpenCodeFlag,
             SkipAntigravity: skipAntigravityFlag,
             NoPrompt:    noPrompt,
-            SkipCodexNetworkAccess: skipCodexNetworkFlag);
+            SkipCodexNetworkAccess: skipCodexNetworkFlag,
+            SkipCursorMcp: skipCursorMcpFlag);
 
         // AI-794 — allowlist the Capacitor server(s) Codex skills need to reach. A single
         // **.kcap.ai wildcard covers every SaaS tenant (current + future) and the auth
@@ -257,7 +260,8 @@ public static class SetupCommand {
             PiExtensionPath:      PiPaths.KcapExtension(),
             OpenCodeExtensionPath: OpenCodePaths.KcapPlugin(),
             AntigravityHooksPath: AntigravityPaths.GlobalHooksJson(),
-            CodexConfigTomlPath:  Path.Combine(CodexPaths.Home(), "config.toml"));
+            CodexConfigTomlPath:  Path.Combine(CodexPaths.Home(), "config.toml"),
+            CursorMcpPath:        CursorPaths.UserMcpJson());
 
         var stepInstallers = new CodingAgentsStep.Installers(
             InstallClaudePlugin:    InstallPlugin,
@@ -273,7 +277,9 @@ public static class SetupCommand {
             InstallOpenCodeExtension: OpenCodeExtensionInstaller.Install,
             InstallAntigravityHooks:  PluginCommand.InstallAntigravityHooks,
             EnableCodexNetworkAccess: () => CodexConfigToml.EnableNetworkAccess(codexAllowDomains),
-            RegisterCodexMcp:         () => CodexConfigToml.RegisterKcapMcpServers());
+            RegisterCodexMcp:         () => CodexConfigToml.RegisterKcapMcpServers(),
+            RegisterCursorMcp:        () => JsonMcpConfigWriter.Register(
+                CursorPaths.UserMcpJson(), KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new McpMarker("cursor")));
 
         bool PromptYesNo(string text) =>
             AnsiConsole.Prompt(new ConfirmationPrompt(text) { DefaultValue = true });

--- a/src/Capacitor.Cli/Commands/UninstallCommand.cs
+++ b/src/Capacitor.Cli/Commands/UninstallCommand.cs
@@ -2,7 +2,6 @@ using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Cursor;
 using Capacitor.Cli.Core.Gemini;
 using Capacitor.Cli.Core.Kiro;
-using Capacitor.Cli.Core.Mcp;
 using Capacitor.Cli.Core.OpenCode;
 using Capacitor.Cli.Services;
 
@@ -133,17 +132,23 @@ public static class UninstallCommand {
         // hooks file).
         if (await PluginCommand.HandleAsync(["plugin", "remove", "--skills"]) != 0) hadFailures = true;
 
-        // Belt-and-braces marker cleanup. Plugin remove deletes the marker
-        // only when JSON entries changed; if the user manually pruned the
+        // Belt-and-braces marker cleanup. These hooks installers delete their
+        // marker only when JSON entries changed; if the user manually pruned the
         // entries earlier (or installed via a pre-marker build that later
         // wrote a marker on first refresh), the marker survives and IsInstalled
         // still reports kcap as installed. uninstall promises a full
         // wipe, so always nuke the markers regardless of what the JSON state
         // looked like going in.
+        //
+        // The Cursor MCP marker is intentionally NOT swept here: `plugin remove
+        // --cursor` above owns it via JsonMcpConfigWriter.Unregister, which clears
+        // it on any non-Failed outcome (including hand-pruned entries) but
+        // deliberately RETAINS it when the unregister fails, so a retry can still
+        // identify the kcap-owned entries. An unconditional clear here would
+        // defeat that recovery path.
         ClaudePluginInstaller.DeleteMarker(ClaudePaths.UserSettings);
         CodexHooksInstaller.DeleteMarker(CodexPaths.UserHooksJson);
         CursorHooksInstaller.DeleteMarker(CursorPaths.UserHooksJson());
-        new McpMarker("cursor").Clear(CursorPaths.UserMcpJson());
         GeminiHooksInstaller.DeleteMarker(GeminiPaths.SettingsJson());
         KiroHooksInstaller.DeleteMarker(KiroPaths.KcapAgentJson());
 

--- a/src/Capacitor.Cli/Commands/UninstallCommand.cs
+++ b/src/Capacitor.Cli/Commands/UninstallCommand.cs
@@ -2,6 +2,7 @@ using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Cursor;
 using Capacitor.Cli.Core.Gemini;
 using Capacitor.Cli.Core.Kiro;
+using Capacitor.Cli.Core.Mcp;
 using Capacitor.Cli.Core.OpenCode;
 using Capacitor.Cli.Services;
 
@@ -142,6 +143,7 @@ public static class UninstallCommand {
         ClaudePluginInstaller.DeleteMarker(ClaudePaths.UserSettings);
         CodexHooksInstaller.DeleteMarker(CodexPaths.UserHooksJson);
         CursorHooksInstaller.DeleteMarker(CursorPaths.UserHooksJson());
+        new McpMarker("cursor").Clear(CursorPaths.UserMcpJson());
         GeminiHooksInstaller.DeleteMarker(GeminiPaths.SettingsJson());
         KiroHooksInstaller.DeleteMarker(KiroPaths.KcapAgentJson());
 

--- a/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Mcp;
 using static Capacitor.Cli.Commands.CodingAgentsStep;
 
 namespace Capacitor.Cli.Tests.Unit;
@@ -392,6 +393,70 @@ public class CodingAgentsStepTests {
         await Assert.That(calls.RegisterCodexMcpCalled).IsTrue();
         await Assert.That(result.CodexMcpRegistered).IsFalse();
         await Assert.That(sink.Lines).Contains(l => l.Contains("Could not register Codex MCP"));
+    }
+
+    [Test]
+    public async Task Cursor_mcp_registered_when_hooks_installed() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.CursorMcpRegistered).IsTrue();
+        await Assert.That(calls.RegisterCursorMcpCalled).IsTrue();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("MCP servers registered"));
+    }
+
+    [Test]
+    public async Task Cursor_mcp_not_registered_when_hooks_fail() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { CursorHooksReturns = false };
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.CursorHooksInstalled).IsFalse();
+        await Assert.That(calls.RegisterCursorMcpCalled).IsFalse();
+        await Assert.That(result.CursorMcpRegistered).IsFalse();
+    }
+
+    [Test]
+    public async Task Cursor_mcp_skipped_by_flag() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, SkipCopilot: true, NoPrompt: true, SkipCursorMcp: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.CursorHooksInstalled).IsTrue();
+        await Assert.That(result.CursorMcpRegistered).IsFalse();
+        await Assert.That(calls.RegisterCursorMcpCalled).IsFalse();
+    }
+
+    [Test]
+    public async Task Cursor_mcp_registration_failure_emits_warning() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { RegisterCursorMcpReturns = JsonMcpConfigWriter.Change.Failed };
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: false, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: true, Copilot: false);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(calls.RegisterCursorMcpCalled).IsTrue();
+        await Assert.That(result.CursorMcpRegistered).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("Could not register Cursor MCP"));
     }
 
     [Test]
@@ -1055,7 +1120,8 @@ public class CodingAgentsStepTests {
         KiroHooksPath:        "/fake/.kiro/agents/kcap.json",
         PiExtensionPath:      "/fake/.pi/agent/extensions/kcap.ts",
         OpenCodeExtensionPath: "/fake/.config/opencode/plugins/kcap.ts",
-        CodexConfigTomlPath:  "/fake/.codex/config.toml"
+        CodexConfigTomlPath:  "/fake/.codex/config.toml",
+        CursorMcpPath:        "/fake/.cursor/mcp.json"
     );
 
     sealed class Sink {
@@ -1112,6 +1178,9 @@ public class CodingAgentsStepTests {
 
         public bool                   RegisterCodexMcpCalled  { get; private set; }
         public CodexConfigToml.Change RegisterCodexMcpReturns { get; set; } = CodexConfigToml.Change.Updated;
+
+        public bool                     RegisterCursorMcpCalled  { get; private set; }
+        public JsonMcpConfigWriter.Change RegisterCursorMcpReturns { get; set; } = JsonMcpConfigWriter.Change.Updated;
 
         public Installers AsInstallers() => new(
             InstallClaudePlugin: (s, p) => {
@@ -1187,6 +1256,11 @@ public class CodingAgentsStepTests {
                 RegisterCodexMcpCalled = true;
 
                 return RegisterCodexMcpReturns;
+            },
+            RegisterCursorMcp: () => {
+                RegisterCursorMcpCalled = true;
+
+                return RegisterCursorMcpReturns;
             }
         );
     }

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorPathsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorPathsTests.cs
@@ -26,4 +26,9 @@ public class CursorPathsTests {
     public async Task ProjectsDir_is_under_dot_cursor_on_every_platform() {
         await Assert.That(CursorPaths.ProjectsDir(home: "/Users/me")).IsEqualTo(Path.Combine("/Users/me", ".cursor", "projects"));
     }
+
+    [Test]
+    public async Task UserMcpJson_is_dot_cursor_mcp_json_under_home() {
+        await Assert.That(CursorPaths.UserMcpJson("/h")).IsEqualTo(Path.Combine("/h", ".cursor", "mcp.json"));
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/FakeUserHome.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FakeUserHome.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// A disposable fake user home for one test, shared across the per-harness plugin
+/// test suites (Cursor, Copilot, Gemini, …) so each doesn't re-derive MCP-marker
+/// isolation.
+///
+/// Rooted UNDER the real user profile (<see cref="Environment.SpecialFolder.UserProfile"/>),
+/// because <c>McpMarker</c> classifies a config as user-scope — writing its
+/// ownership marker as a sidecar next to the config rather than centrally under
+/// <c>~/.kcap/mcp-markers</c> — only for configs under the profile. Rooting here
+/// keeps the common case a contained sidecar on every OS (GetFolderPath(UserProfile)
+/// ignores $HOME on Windows, and a redirected TEMP can sit outside the profile).
+///
+/// On <see cref="Dispose"/> it deletes the home AND sweeps <c>~/.kcap/mcp-markers</c>
+/// for any central marker whose recorded config points under this home — covering
+/// the edge where the real profile is itself a git repo (McpMarker.IsInsideRepo then
+/// treats the config as non-user-scope, so the marker lands centrally). So no
+/// ownership-marker state can persist past the test on any OS or repo layout, for
+/// either a test's direct McpMarker calls or the production <c>plugin --&lt;harness&gt;</c>
+/// paths it exercises.
+///
+/// Suites using this must be <c>[NotInParallel("HomeEnvVarMutation")]</c> so the
+/// profile McpMarker reads stays stable underneath the test.
+/// </summary>
+sealed class FakeUserHome : IDisposable {
+    public string Path { get; } = System.IO.Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        $"kcap-test-home-{Guid.NewGuid().ToString("N")[..8]}");
+
+    public FakeUserHome() => Directory.CreateDirectory(Path);
+
+    public void Dispose() {
+        SweepOwnedCentralMarkers();
+        try { Directory.Delete(Path, recursive: true); } catch { /* best effort */ }
+    }
+
+    // Central markers live at ~/.kcap/mcp-markers/<harness>-<hash>.json with a
+    // "config" field recording the absolute config path they own. Remove any whose
+    // config is under this home (the repo-profile edge); sidecar markers under Path
+    // are already removed with the directory.
+    void SweepOwnedCentralMarkers() {
+        var markersDir = System.IO.Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".kcap", "mcp-markers");
+        if (!Directory.Exists(markersDir)) return;
+
+        var homePrefix = System.IO.Path.GetFullPath(Path) + System.IO.Path.DirectorySeparatorChar;
+        foreach (var file in Directory.EnumerateFiles(markersDir, "*.json")) {
+            try {
+                if (JsonNode.Parse(File.ReadAllText(file)) is not JsonObject marker) continue;
+                var config = (string?)marker["config"];
+                if (config is null) continue;
+                if (System.IO.Path.GetFullPath(config).StartsWith(homePrefix, StringComparison.Ordinal))
+                    File.Delete(file);
+            } catch { /* ignore unreadable/foreign markers */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/JsonMcpConfigWriterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/JsonMcpConfigWriterTests.cs
@@ -130,6 +130,20 @@ public class JsonMcpConfigWriterTests {
     }
 
     [Test]
+    public async Task Unregister_clears_marker_even_when_no_kcap_entries_to_remove() {
+        var dir = Directory.CreateTempSubdirectory("kcap-unreg-").FullName;
+        var path = Path.Combine(dir, "mcp.json");
+        var marker = new McpMarker("test", _ => Path.Combine(dir, "marker.json"));
+        // Marker recorded, but the JSON has a user server and NO kcap entries (a hand-edit removed them).
+        File.WriteAllText(path, """{ "mcpServers": { "my-tool": { "command": "x" } } }""");
+        marker.Record(path, ["kcap-review"]);
+
+        var change = JsonMcpConfigWriter.Unregister(path, McpConfigShape.Standard, marker);
+        await Assert.That(change).IsEqualTo(JsonMcpConfigWriter.Change.Unchanged); // nothing kcap to remove; user server stays
+        await Assert.That(marker.Owned(path)).IsEmpty();                          // marker cleared regardless
+    }
+
+    [Test]
     public async Task Register_preserves_unrecorded_kcap_named_user_server() {
         var dir = Directory.CreateTempSubdirectory("kcap-collide-").FullName;
         var path = Path.Combine(dir, "mcp.json");

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
@@ -1,5 +1,7 @@
+using System.Text.Json.Nodes;
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Mcp;
 
 namespace Capacitor.Cli.Tests.Unit;
 
@@ -31,6 +33,120 @@ public class PluginCommandCursorTests {
         await Assert.That(exit).IsEqualTo(0);
         await Assert.That(File.ReadAllText(hooksPath)).IsEqualTo("{}");
     }
+
+    // AI-699: `plugin install/remove --cursor` also (un)registers the kcap MCP
+    // servers in ~/.cursor/mcp.json. These use an explicit PluginEnvironment
+    // (not PluginEnvironment.FromProcess()) so env.CursorMcpJson resolves under
+    // a temp home instead of the real machine's ~/.cursor — mirrors
+    // PluginCommandCodexInstallIntegrationTests.TestEnv. The `--if-installed`
+    // refresh branch is used (pre-marker hooks.json seeded) rather than a bare
+    // `install --cursor`, so the AgentDetector "kcap on PATH" precheck (which
+    // only runs on the non-refresh path) never comes into play.
+    [Test]
+    public async Task install_cursor_registers_mcp_servers_preserving_user_entries() {
+        using var fakeHome = new TempDir();
+        var cursorDir = System.IO.Path.Combine(fakeHome.Path, ".cursor");
+        Directory.CreateDirectory(cursorDir);
+
+        var hooksPath = System.IO.Path.Combine(cursorDir, "hooks.json");
+        await File.WriteAllTextAsync(hooksPath, """
+            {"version":1,"hooks":{"sessionStart":[{"command":"kcap hook --cursor"}]}}
+            """);
+
+        var mcpPath = System.IO.Path.Combine(cursorDir, "mcp.json");
+        await File.WriteAllTextAsync(mcpPath, """
+            {"mcpServers":{"my-tool":{"command":"my-tool","args":["serve"]}}}
+            """);
+
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "install", "--cursor", "--if-installed"],
+            TestEnv(fakeHome.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        var root    = JsonNode.Parse(await File.ReadAllTextAsync(mcpPath))!.AsObject();
+        var servers = root["mcpServers"]!.AsObject();
+        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo("kcap");
+        await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");
+        await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-flows");
+        await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-memory");
+        await Assert.That(servers["my-tool"]).IsNotNull(); // user server preserved
+    }
+
+    [Test]
+    public async Task install_cursor_if_installed_does_not_write_mcp_json_when_never_opted_in() {
+        using var fakeHome = new TempDir();
+
+        // Hooks were never installed, so the refresh-only postinstall path
+        // no-ops before ever touching hooks.json OR mcp.json.
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "install", "--cursor", "--if-installed"],
+            TestEnv(fakeHome.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        var mcpPath = System.IO.Path.Combine(fakeHome.Path, ".cursor", "mcp.json");
+        await Assert.That(File.Exists(mcpPath)).IsFalse();
+    }
+
+    [Test]
+    public async Task install_cursor_skip_cursor_mcp_flag_leaves_mcp_json_untouched() {
+        using var fakeHome = new TempDir();
+        var cursorDir = System.IO.Path.Combine(fakeHome.Path, ".cursor");
+        Directory.CreateDirectory(cursorDir);
+
+        var hooksPath = System.IO.Path.Combine(cursorDir, "hooks.json");
+        await File.WriteAllTextAsync(hooksPath, """
+            {"version":1,"hooks":{"sessionStart":[{"command":"kcap hook --cursor"}]}}
+            """);
+
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "install", "--cursor", "--if-installed", "--skip-cursor-mcp"],
+            TestEnv(fakeHome.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        var mcpPath = System.IO.Path.Combine(cursorDir, "mcp.json");
+        await Assert.That(File.Exists(mcpPath)).IsFalse();
+    }
+
+    [Test]
+    public async Task remove_cursor_unregisters_mcp_servers_preserving_user_entries() {
+        using var fakeHome = new TempDir();
+        var cursorDir = System.IO.Path.Combine(fakeHome.Path, ".cursor");
+        Directory.CreateDirectory(cursorDir);
+
+        var hooksPath = System.IO.Path.Combine(cursorDir, "hooks.json");
+        await File.WriteAllTextAsync(hooksPath, """
+            {"version":1,"hooks":{"sessionStart":[{"command":"kcap hook --cursor"}]}}
+            """);
+
+        // Seed mcp.json exactly as a prior real install would have (so the
+        // sidecar ownership marker exists), then splice in a user-authored
+        // server that must survive removal.
+        var mcpPath = System.IO.Path.Combine(cursorDir, "mcp.json");
+        JsonMcpConfigWriter.Register(mcpPath, KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new McpMarker("cursor"));
+        var seeded = JsonNode.Parse(await File.ReadAllTextAsync(mcpPath))!.AsObject();
+        seeded["mcpServers"]!["my-tool"] = JsonNode.Parse("""{"command":"my-tool","args":["serve"]}""");
+        await File.WriteAllTextAsync(mcpPath, seeded.ToJsonString());
+
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "remove", "--cursor"], TestEnv(fakeHome.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        var root    = JsonNode.Parse(await File.ReadAllTextAsync(mcpPath))!.AsObject();
+        var servers = root["mcpServers"]!.AsObject();
+        var keys    = servers.Select(kv => kv.Key).ToArray();
+        await Assert.That(keys).DoesNotContain("kcap-review");
+        await Assert.That(keys).DoesNotContain("kcap-sessions");
+        await Assert.That(keys).DoesNotContain("kcap-flows");
+        await Assert.That(keys).DoesNotContain("kcap-memory");
+        await Assert.That(servers["my-tool"]).IsNotNull(); // user server preserved
+    }
+
+    static PluginEnvironment TestEnv(string fakeHome) => new(
+        HomeDirectory:     fakeHome,
+        ResolvePluginPath: () => null,
+        Stdout:            TextWriter.Null,
+        Stderr:            TextWriter.Null
+    );
 
     sealed class TempDir : IDisposable {
         public string Path { get; } = System.IO.Path.Combine(

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
@@ -179,29 +179,22 @@ public class PluginCommandCursorTests {
         Stderr:            TextWriter.Null
     );
 
-    // Fake home for one test. Beyond redirecting PluginEnvironment.HomeDirectory
-    // (via TestEnv), it also points the *process* HOME here for its lifetime:
-    // McpMarker resolves its sidecar/central storage from
-    // Environment.GetFolderPath(UserProfile) (→ $HOME on Unix), NOT from
-    // PluginEnvironment.HomeDirectory. Without this, on Unix a temp-dir config is
-    // treated as non-user-scope and the ownership marker leaks into the real
-    // ~/.kcap/mcp-markers. Pinning HOME keeps all marker state under this dir (for
-    // both the test's direct McpMarker calls and the production plugin --cursor
-    // path) so it's cleaned on Dispose. Safe because the class is
-    // [NotInParallel("HomeEnvVarMutation")].
+    // Fake home for one test, rooted UNDER the real user profile (not
+    // Path.GetTempPath()). McpMarker treats a config as user-scope — and so writes
+    // its ownership marker as a sidecar next to the config — only when the config
+    // lives under Environment.GetFolderPath(UserProfile). That call ignores $HOME
+    // on Windows, and the process temp dir can sit outside the profile (e.g.
+    // TEMP=D:\Temp), which would otherwise send the marker to the real
+    // ~/.kcap/mcp-markers. Rooting here keeps the marker a sidecar under this dir
+    // on every OS — for both the test's direct McpMarker calls and the production
+    // `plugin --cursor` path — so it's removed with the dir on Dispose. The class
+    // is [NotInParallel("HomeEnvVarMutation")] so the profile/$HOME McpMarker reads
+    // can't shift underneath it.
     sealed class TempDir : IDisposable {
-        readonly string? _originalHome;
         public string Path { get; } = System.IO.Path.Combine(
-            System.IO.Path.GetTempPath(),
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             $"kcap-pluginc-cursor-test-{Guid.NewGuid().ToString("N")[..8]}");
-        public TempDir() {
-            Directory.CreateDirectory(Path);
-            _originalHome = Environment.GetEnvironmentVariable("HOME");
-            Environment.SetEnvironmentVariable("HOME", Path);
-        }
-        public void Dispose() {
-            Environment.SetEnvironmentVariable("HOME", _originalHome);
-            try { Directory.Delete(Path, true); } catch { }
-        }
+        public TempDir() => Directory.CreateDirectory(Path);
+        public void Dispose() { try { Directory.Delete(Path, true); } catch { } }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
@@ -141,6 +141,37 @@ public class PluginCommandCursorTests {
         await Assert.That(servers["my-tool"]).IsNotNull(); // user server preserved
     }
 
+    [Test]
+    public async Task remove_cursor_retains_marker_on_failed_unregister_then_retry_removes_entries() {
+        using var fakeHome = new TempDir();
+        var cursorDir = System.IO.Path.Combine(fakeHome.Path, ".cursor");
+        Directory.CreateDirectory(cursorDir);
+
+        // A prior real install: kcap entries + sidecar ownership marker.
+        var mcpPath = System.IO.Path.Combine(cursorDir, "mcp.json");
+        JsonMcpConfigWriter.Register(mcpPath, KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new McpMarker("cursor"));
+        var installed = await File.ReadAllTextAsync(mcpPath); // valid content to restore after the "fix"
+        await Assert.That(new McpMarker("cursor").Owned(mcpPath).ToArray()).IsNotEmpty();
+
+        // The config is temporarily malformed/unreadable → Unregister fails-closed.
+        await File.WriteAllTextAsync(mcpPath, "{ not valid json");
+
+        var failExit = await PluginCommand.HandleAsync(["plugin", "remove", "--cursor"], TestEnv(fakeHome.Path));
+        await Assert.That(failExit).IsEqualTo(1);                                          // failed MCP unregister propagates
+        await Assert.That(new McpMarker("cursor").Owned(mcpPath).ToArray()).IsNotEmpty();  // marker RETAINED for retry
+
+        // User fixes the file (kcap entries intact); the retry now succeeds and cleans up.
+        await File.WriteAllTextAsync(mcpPath, installed);
+        var retryExit = await PluginCommand.HandleAsync(["plugin", "remove", "--cursor"], TestEnv(fakeHome.Path));
+        await Assert.That(retryExit).IsEqualTo(0);
+
+        var root    = JsonNode.Parse(await File.ReadAllTextAsync(mcpPath))!.AsObject();
+        var servers = root["mcpServers"] as JsonObject;
+        var keys    = servers?.Select(kv => kv.Key).ToArray() ?? [];
+        await Assert.That(keys).DoesNotContain("kcap-review");
+        await Assert.That(new McpMarker("cursor").Owned(mcpPath).ToArray()).IsEmpty();     // marker cleared after clean removal
+    }
+
     static PluginEnvironment TestEnv(string fakeHome) => new(
         HomeDirectory:     fakeHome,
         ResolvePluginPath: () => null,

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
@@ -179,11 +179,29 @@ public class PluginCommandCursorTests {
         Stderr:            TextWriter.Null
     );
 
+    // Fake home for one test. Beyond redirecting PluginEnvironment.HomeDirectory
+    // (via TestEnv), it also points the *process* HOME here for its lifetime:
+    // McpMarker resolves its sidecar/central storage from
+    // Environment.GetFolderPath(UserProfile) (→ $HOME on Unix), NOT from
+    // PluginEnvironment.HomeDirectory. Without this, on Unix a temp-dir config is
+    // treated as non-user-scope and the ownership marker leaks into the real
+    // ~/.kcap/mcp-markers. Pinning HOME keeps all marker state under this dir (for
+    // both the test's direct McpMarker calls and the production plugin --cursor
+    // path) so it's cleaned on Dispose. Safe because the class is
+    // [NotInParallel("HomeEnvVarMutation")].
     sealed class TempDir : IDisposable {
+        readonly string? _originalHome;
         public string Path { get; } = System.IO.Path.Combine(
             System.IO.Path.GetTempPath(),
             $"kcap-pluginc-cursor-test-{Guid.NewGuid().ToString("N")[..8]}");
-        public TempDir() => Directory.CreateDirectory(Path);
-        public void Dispose() { try { Directory.Delete(Path, true); } catch { } }
+        public TempDir() {
+            Directory.CreateDirectory(Path);
+            _originalHome = Environment.GetEnvironmentVariable("HOME");
+            Environment.SetEnvironmentVariable("HOME", Path);
+        }
+        public void Dispose() {
+            Environment.SetEnvironmentVariable("HOME", _originalHome);
+            try { Directory.Delete(Path, true); } catch { }
+        }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
@@ -9,7 +9,7 @@ namespace Capacitor.Cli.Tests.Unit;
 public class PluginCommandCursorTests {
     [Test]
     public async Task install_cursor_if_installed_noops_when_marker_absent() {
-        using var tmp = new TempDir();
+        using var tmp = new FakeUserHome();
         var hooksPath = Path.Combine(tmp.Path, "hooks.json");
 
         var exit = await PluginCommand.HandleAsync(
@@ -20,7 +20,7 @@ public class PluginCommandCursorTests {
 
     [Test]
     public async Task install_cursor_if_installed_short_circuits_on_same_version_marker() {
-        using var tmp = new TempDir();
+        using var tmp = new FakeUserHome();
         var hooksPath = Path.Combine(tmp.Path, "hooks.json");
         CursorHooksInstaller.WriteMarker(hooksPath);
         File.WriteAllText(hooksPath, "{}");
@@ -44,7 +44,7 @@ public class PluginCommandCursorTests {
     // only runs on the non-refresh path) never comes into play.
     [Test]
     public async Task install_cursor_registers_mcp_servers_preserving_user_entries() {
-        using var fakeHome = new TempDir();
+        using var fakeHome = new FakeUserHome();
         var cursorDir = System.IO.Path.Combine(fakeHome.Path, ".cursor");
         Directory.CreateDirectory(cursorDir);
 
@@ -74,7 +74,7 @@ public class PluginCommandCursorTests {
 
     [Test]
     public async Task install_cursor_if_installed_does_not_write_mcp_json_when_never_opted_in() {
-        using var fakeHome = new TempDir();
+        using var fakeHome = new FakeUserHome();
 
         // Hooks were never installed, so the refresh-only postinstall path
         // no-ops before ever touching hooks.json OR mcp.json.
@@ -89,7 +89,7 @@ public class PluginCommandCursorTests {
 
     [Test]
     public async Task install_cursor_skip_cursor_mcp_flag_leaves_mcp_json_untouched() {
-        using var fakeHome = new TempDir();
+        using var fakeHome = new FakeUserHome();
         var cursorDir = System.IO.Path.Combine(fakeHome.Path, ".cursor");
         Directory.CreateDirectory(cursorDir);
 
@@ -109,7 +109,7 @@ public class PluginCommandCursorTests {
 
     [Test]
     public async Task remove_cursor_unregisters_mcp_servers_preserving_user_entries() {
-        using var fakeHome = new TempDir();
+        using var fakeHome = new FakeUserHome();
         var cursorDir = System.IO.Path.Combine(fakeHome.Path, ".cursor");
         Directory.CreateDirectory(cursorDir);
 
@@ -143,7 +143,7 @@ public class PluginCommandCursorTests {
 
     [Test]
     public async Task remove_cursor_retains_marker_on_failed_unregister_then_retry_removes_entries() {
-        using var fakeHome = new TempDir();
+        using var fakeHome = new FakeUserHome();
         var cursorDir = System.IO.Path.Combine(fakeHome.Path, ".cursor");
         Directory.CreateDirectory(cursorDir);
 
@@ -179,31 +179,4 @@ public class PluginCommandCursorTests {
         Stderr:            TextWriter.Null
     );
 
-    // Fake home for one test, rooted under the real user profile (not
-    // Path.GetTempPath()). McpMarker classifies a config as user-scope — writing
-    // its marker as a sidecar next to the config rather than centrally under
-    // ~/.kcap/mcp-markers — via Environment.GetFolderPath(UserProfile), which
-    // ignores $HOME on Windows and where the temp dir may sit outside the profile
-    // (e.g. TEMP=D:\Temp). Rooting under the profile makes the common case a
-    // contained sidecar on every OS.
-    //
-    // That classification still has one hole: if the real profile is itself a git
-    // repo (~/.git — e.g. tracked dotfiles), McpMarker.IsInsideRepo walks up to it
-    // and treats the config as NON-user-scope, so the production `plugin --cursor`
-    // path writes the marker centrally under the real ~/.kcap/mcp-markers. To
-    // guarantee no leak regardless of OS or repo layout, Dispose explicitly clears
-    // the marker for this test's cursor config: McpMarker.Clear resolves the exact
-    // same path the production code used to write it (sidecar or central), so the
-    // marker can never persist past the test. [NotInParallel("HomeEnvVarMutation")]
-    // keeps the profile/$HOME McpMarker reads stable underneath the test.
-    sealed class TempDir : IDisposable {
-        public string Path { get; } = System.IO.Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            $"kcap-pluginc-cursor-test-{Guid.NewGuid().ToString("N")[..8]}");
-        public TempDir() => Directory.CreateDirectory(Path);
-        public void Dispose() {
-            try { new McpMarker("cursor").Clear(System.IO.Path.Combine(Path, ".cursor", "mcp.json")); } catch { }
-            try { Directory.Delete(Path, true); } catch { }
-        }
-    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
@@ -34,7 +34,7 @@ public class PluginCommandCursorTests {
         await Assert.That(File.ReadAllText(hooksPath)).IsEqualTo("{}");
     }
 
-    // AI-699: `plugin install/remove --cursor` also (un)registers the kcap MCP
+    // `plugin install/remove --cursor` also (un)registers the kcap MCP
     // servers in ~/.cursor/mcp.json. These use an explicit PluginEnvironment
     // (not PluginEnvironment.FromProcess()) so env.CursorMcpJson resolves under
     // a temp home instead of the real machine's ~/.cursor — mirrors

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
@@ -179,22 +179,31 @@ public class PluginCommandCursorTests {
         Stderr:            TextWriter.Null
     );
 
-    // Fake home for one test, rooted UNDER the real user profile (not
-    // Path.GetTempPath()). McpMarker treats a config as user-scope — and so writes
-    // its ownership marker as a sidecar next to the config — only when the config
-    // lives under Environment.GetFolderPath(UserProfile). That call ignores $HOME
-    // on Windows, and the process temp dir can sit outside the profile (e.g.
-    // TEMP=D:\Temp), which would otherwise send the marker to the real
-    // ~/.kcap/mcp-markers. Rooting here keeps the marker a sidecar under this dir
-    // on every OS — for both the test's direct McpMarker calls and the production
-    // `plugin --cursor` path — so it's removed with the dir on Dispose. The class
-    // is [NotInParallel("HomeEnvVarMutation")] so the profile/$HOME McpMarker reads
-    // can't shift underneath it.
+    // Fake home for one test, rooted under the real user profile (not
+    // Path.GetTempPath()). McpMarker classifies a config as user-scope — writing
+    // its marker as a sidecar next to the config rather than centrally under
+    // ~/.kcap/mcp-markers — via Environment.GetFolderPath(UserProfile), which
+    // ignores $HOME on Windows and where the temp dir may sit outside the profile
+    // (e.g. TEMP=D:\Temp). Rooting under the profile makes the common case a
+    // contained sidecar on every OS.
+    //
+    // That classification still has one hole: if the real profile is itself a git
+    // repo (~/.git — e.g. tracked dotfiles), McpMarker.IsInsideRepo walks up to it
+    // and treats the config as NON-user-scope, so the production `plugin --cursor`
+    // path writes the marker centrally under the real ~/.kcap/mcp-markers. To
+    // guarantee no leak regardless of OS or repo layout, Dispose explicitly clears
+    // the marker for this test's cursor config: McpMarker.Clear resolves the exact
+    // same path the production code used to write it (sidecar or central), so the
+    // marker can never persist past the test. [NotInParallel("HomeEnvVarMutation")]
+    // keeps the profile/$HOME McpMarker reads stable underneath the test.
     sealed class TempDir : IDisposable {
         public string Path { get; } = System.IO.Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             $"kcap-pluginc-cursor-test-{Guid.NewGuid().ToString("N")[..8]}");
         public TempDir() => Directory.CreateDirectory(Path);
-        public void Dispose() { try { Directory.Delete(Path, true); } catch { } }
+        public void Dispose() {
+            try { new McpMarker("cursor").Clear(System.IO.Path.Combine(Path, ".cursor", "mcp.json")); } catch { }
+            try { Directory.Delete(Path, true); } catch { }
+        }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -442,11 +442,12 @@ public class UninstallCommandTests {
 
     [Test]
     public async Task User_level_uninstall_purges_cursor_mcp_marker_even_when_json_has_no_kcap_entries() {
-        // Same "marker survives manual JSON edit" story as the hooks/skills
-        // markers above: if a user hand-edited ~/.cursor/mcp.json to
-        // remove the kcap entries, JsonMcpConfigWriter.Unregister sees nothing
-        // to change and never clears the sidecar marker. uninstall's
-        // belt-and-braces sweep must nuke it regardless.
+        // If a user hand-edited ~/.cursor/mcp.json to remove the kcap entries,
+        // `plugin remove --cursor` still clears the sidecar ownership marker:
+        // JsonMcpConfigWriter.Unregister clears it on any non-Failed outcome,
+        // including when there were no entries left to remove. (The failure
+        // path — where the marker is deliberately retained for retry — is
+        // covered by User_level_uninstall_keeps_cursor_mcp_marker_when_unregister_fails.)
         await using var fixture = await Fixture.CreateAsync();
 
         var cursorDir = Path.Combine(fixture.Home, ".cursor");
@@ -463,6 +464,34 @@ public class UninstallCommandTests {
         await Assert.That(exit).IsEqualTo(0);
 
         await Assert.That(new McpMarker("cursor").Owned(mcpPath).ToArray()).IsEmpty();
+    }
+
+    [Test]
+    public async Task User_level_uninstall_keeps_cursor_mcp_marker_when_unregister_fails() {
+        // Regression (AI-699 self-review): when ~/.cursor/mcp.json can't be
+        // parsed/rewritten, JsonMcpConfigWriter.Unregister fails-closed and
+        // deliberately RETAINS the ownership marker so a later retry can still
+        // identify the kcap-* entries as kcap-owned. uninstall records the
+        // failure but must NOT then wipe the marker — doing so would orphan
+        // those entries (a retry would preserve them as user-authored). The
+        // Cursor MCP marker is owned by `plugin remove --cursor`, not the sweep.
+        await using var fixture = await Fixture.CreateAsync();
+
+        var cursorDir = Path.Combine(fixture.Home, ".cursor");
+        Directory.CreateDirectory(cursorDir);
+
+        var mcpPath = Path.Combine(cursorDir, "mcp.json");
+        await File.WriteAllTextAsync(mcpPath, "{ this is not valid json"); // → Unregister returns Failed
+
+        var marker = new McpMarker("cursor");
+        marker.Record(mcpPath, ["kcap-review"]);
+        await Assert.That(marker.Owned(mcpPath).ToArray()).IsNotEmpty();
+
+        var exit = await UninstallCommand.HandleAsync(["uninstall", "--yes", "--keep-config"]);
+        await Assert.That(exit).IsNotEqualTo(0); // the failed cursor MCP unregister propagates
+
+        // Marker retained → a retry after the user fixes the file can still find + remove the kcap entries.
+        await Assert.That(new McpMarker("cursor").Owned(mcpPath).ToArray()).IsNotEmpty();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -468,7 +468,7 @@ public class UninstallCommandTests {
 
     [Test]
     public async Task User_level_uninstall_keeps_cursor_mcp_marker_when_unregister_fails() {
-        // Regression (AI-699 self-review): when ~/.cursor/mcp.json can't be
+        // Regression (self-review): when ~/.cursor/mcp.json can't be
         // parsed/rewritten, JsonMcpConfigWriter.Unregister fails-closed and
         // deliberately RETAINS the ownership marker so a later retry can still
         // identify the kcap-* entries as kcap-owned. uninstall records the

--- a/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -3,6 +3,7 @@ using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Gemini;
 using Capacitor.Cli.Core.Kiro;
+using Capacitor.Cli.Core.Mcp;
 
 namespace Capacitor.Cli.Tests.Unit;
 
@@ -437,6 +438,31 @@ public class UninstallCommandTests {
         await Assert.That(File.Exists(Path.Combine(claudeDir, ClaudePluginInstaller.MarkerFileName))).IsFalse();
         await Assert.That(File.Exists(Path.Combine(codexDir,  CodexHooksInstaller.MarkerFileName))).IsFalse();
         await Assert.That(File.Exists(Path.Combine(cursorDir, CursorHooksInstaller.MarkerFileName))).IsFalse();
+    }
+
+    [Test]
+    public async Task User_level_uninstall_purges_cursor_mcp_marker_even_when_json_has_no_kcap_entries() {
+        // Same "marker survives manual JSON edit" story as the hooks/skills
+        // markers above (AI-699): if a user hand-edited ~/.cursor/mcp.json to
+        // remove the kcap entries, JsonMcpConfigWriter.Unregister sees nothing
+        // to change and never clears the sidecar marker. uninstall's
+        // belt-and-braces sweep must nuke it regardless.
+        await using var fixture = await Fixture.CreateAsync();
+
+        var cursorDir = Path.Combine(fixture.Home, ".cursor");
+        Directory.CreateDirectory(cursorDir);
+
+        var mcpPath = Path.Combine(cursorDir, "mcp.json");
+        await File.WriteAllTextAsync(mcpPath, """{"mcpServers":{}}""");
+
+        var marker = new McpMarker("cursor");
+        marker.Record(mcpPath, ["kcap-review"]); // simulates a marker surviving a manual JSON edit
+        await Assert.That(marker.Owned(mcpPath).ToArray()).IsNotEmpty();
+
+        var exit = await UninstallCommand.HandleAsync(["uninstall", "--yes", "--keep-config"]);
+        await Assert.That(exit).IsEqualTo(0);
+
+        await Assert.That(new McpMarker("cursor").Owned(mcpPath).ToArray()).IsEmpty();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -443,7 +443,7 @@ public class UninstallCommandTests {
     [Test]
     public async Task User_level_uninstall_purges_cursor_mcp_marker_even_when_json_has_no_kcap_entries() {
         // Same "marker survives manual JSON edit" story as the hooks/skills
-        // markers above (AI-699): if a user hand-edited ~/.cursor/mcp.json to
+        // markers above: if a user hand-edited ~/.cursor/mcp.json to
         // remove the kcap entries, JsonMcpConfigWriter.Unregister sees nothing
         // to change and never clears the sidecar marker. uninstall's
         // belt-and-braces sweep must nuke it regardless.


### PR DESCRIPTION
First per-harness rollout of the MCP auto-config epic (AI-1224) — wires the merged config-writer foundation (AI-1225) into the **Cursor** install path.

## What
- `kcap setup` and `kcap plugin install --cursor` now auto-register the 4 kcap MCP servers into `~/.cursor/mcp.json` (Standard shape: `mcpServers` map, `command: "kcap"` + `args`, no cwd — it's a user-global config). Uses `JsonMcpConfigWriter` + `KcapMcpServers.All` (Cursor is Claude-capable → includes `kcap-flows`) + `McpConfigShape.Standard` + `McpMarker("cursor")`.
- Non-destructive (preserves user-authored servers), idempotent, atomic; `kcap plugin remove --cursor` / `kcap uninstall` unregister the kcap entries + clear the sidecar marker.
- New `--skip-cursor-mcp` flag; wired through `CodingAgentsStep` (delegate + result flag + `HandleCursorMcp`), `SetupCommand`, `PluginCommand` (`InstallCursor`/`RemoveCursor`), `UninstallCommand`. Mirrors the existing Codex MCP-registration wiring.
- Docs: `--skip-cursor-mcp` added to help text; README's MCP auto-registration section now lists Cursor.

## Tests
- Unit: CodingAgentsStep (Cursor MCP registered / not-when-hooks-fail / skipped / failure-warning), PluginCommandCursor (install writes mcp.json + preserves a user server, `--if-installed` skips, remove unregisters), CursorPaths, UninstallCommand marker-clear. Full suite **2641/2641**, build clean (0 warnings, AOT-safe).
- **Live E2E (dev build vs real Cursor):** config write/idempotent/non-destructive/remove all verified against a real `~/.cursor`; stdio handshake confirmed AI-1233 behavior (version negotiation, `resources/list`/`prompts/list`/`ping` answered); and a real `search_sessions` call ("have we worked on ACP before") executed **through Cursor** and returned results.

Part of AI-1224. Depends on the merged foundations AI-1225 (#282) + AI-1233 (#284).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
