### PR TITLE
[AI-1264] kcap mcp workitems — declare_work_item + get_session_work_items

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ The `kcap mcp flow-result` stdio server is the reviewer-side counterpart: the da
 
 The `kcap mcp memory` stdio server lets agents search, save, and update durable team memories — preferences, feedback, project facts, and references scoped to you, your team, or the org. `kcap setup` **auto-registers it for Claude Code** (via the plugin's `.mcp.json`), **Codex CLI** (in `~/.codex/config.toml`, alongside `kcap-sessions` / `kcap-review`), and **Cursor** (in `~/.cursor/mcp.json`, alongside the other three servers); Codex's native plugin loader also picks it up via `.codex-mcp.json`. See the [Memory MCP server](#memory-mcp-server-for-agents) section for details.
 
+The `kcap mcp workitems` stdio server lets agents attach the current session (and its continuation chain) to a work item — by issue key, PR number, work item id, or a brand-new title — or list what a session is already attached to. The plugin **auto-registers it for Claude Code only**; it isn't offered for Cursor or Codex. See the [Work items MCP server](#work-items-mcp-server-for-agents) section for details.
+
 ## What it records
 
 Once set up, Capacitor runs silently in the background. Every Claude Code (and Codex CLI, if you installed those hooks) session is captured automatically:
@@ -359,6 +361,21 @@ It provides six tools:
 The server is repo- and machine-aware: it resolves the current working directory to a repo hash and the local persisted machine id at startup, and uses both to scope `save_memory` and to bias `search_memories` / `get_memory` results.
 
 At SessionStart (Claude Code), `kcap` also injects a compact **index** of the memories visible for the current repo/machine into the session context, so the agent starts each session aware of what's saved without a search — see [SessionStart team-memory index](#what-it-records) above. Opt out with `kcap config set disable_memory_index true`.
+
+### Work items MCP server (for agents)
+
+```bash
+kcap mcp workitems
+```
+
+Stdio MCP server that lets coding agents correlate the current session to the SDLC work item (issue/PR) it belongs to, or list what it's already correlated to. **Claude Code:** auto-registered via the plugin's `.mcp.json`; it isn't offered for Cursor or Codex.
+
+It provides two tools:
+
+- **`declare_work_item`** — attach the current session (and its continuation chain) to a work item. Pass exactly one of `issue_key` (e.g. `"AI-1234"`), `pr_number`, `work_item_id`, or `new_title` (creates a brand-new work item).
+- **`get_session_work_items`** — list the work items the current session is attached to.
+
+Both tools default `session_id` to the current kcap-hooked session (`KCAP_SESSION_ID`) when omitted. This is the manual-declare path alongside the server's own mechanical and LLM-assisted correlation — use it when an agent already knows which issue or PR a session belongs to.
 
 ### Curate guidelines
 

--- a/kcap/.mcp.json
+++ b/kcap/.mcp.json
@@ -21,6 +21,12 @@
       "args": ["mcp", "memory"],
       "cwd": "${CLAUDE_PROJECT_DIR}",
       "description": "Team memory — search, read, and save durable learnings scoped to you, your team, or the org."
+    },
+    "kcap-workitems": {
+      "command": "kcap",
+      "args": ["mcp", "workitems"],
+      "cwd": "${CLAUDE_PROJECT_DIR}",
+      "description": "Attach the current session to a work item (issue, PR, or a brand-new item) on the Capacitor server, and list the work items a session is attached to."
     }
   }
 }

--- a/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
+++ b/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
@@ -9,10 +9,11 @@ public sealed record KcapMcpServerDescriptor(string Id, string[] Args, bool Star
 
 public static class KcapMcpRegistry {
     static readonly Dictionary<string, KcapMcpServerDescriptor> Entries = new(StringComparer.OrdinalIgnoreCase) {
-        ["kcap-review"]   = new("kcap-review",   ["mcp", "review"],   false),
-        ["kcap-sessions"] = new("kcap-sessions", ["mcp", "sessions"], false),
-        ["kcap-memory"]   = new("kcap-memory",   ["mcp", "memory"],   false),
-        ["kcap-flows"]    = new("kcap-flows",    ["mcp", "flows"],    true),
+        ["kcap-review"]    = new("kcap-review",    ["mcp", "review"],    false),
+        ["kcap-sessions"]  = new("kcap-sessions",  ["mcp", "sessions"],  false),
+        ["kcap-memory"]    = new("kcap-memory",    ["mcp", "memory"],    false),
+        ["kcap-flows"]     = new("kcap-flows",     ["mcp", "flows"],     true),
+        ["kcap-workitems"] = new("kcap-workitems", ["mcp", "workitems"], false),
     };
 
     /// <summary>Resolves an allowlist entry to its descriptor. Case-insensitive, trims

--- a/src/Capacitor.Cli.Core/Mcp/KcapMcpServers.cs
+++ b/src/Capacitor.Cli.Core/Mcp/KcapMcpServers.cs
@@ -16,9 +16,17 @@ public static class KcapMcpServers {
             "Structured AI agent flows — launches a SEPARATE hosted participant agent; requires login + a running daemon."),
         new("kcap-memory",   ["mcp", "memory"],   NeedsProjectCwd: true,
             "Team memory — search, read, and save durable learnings."),
+        new("kcap-workitems", ["mcp", "workitems"], NeedsProjectCwd: true,
+            "Attach the current session to a work item (issue, PR, or a brand-new item), and list what a session is attached to."),
     ];
 
-    /// <summary>Codex omits `kcap-flows` (AI-1056: paid hosted reviewer, Claude-only).</summary>
+    /// <summary>Codex omits `kcap-flows` (AI-1056: paid hosted reviewer, Claude-only) and
+    /// `kcap-workitems` (AI-1264: Claude Code plugin only, not yet exposed to Codex).</summary>
     public static IReadOnlyList<KcapMcpServer> ForCodex =>
-        All.Where(s => s.Name != "kcap-flows").ToArray();
+        All.Where(s => s.Name is not ("kcap-flows" or "kcap-workitems")).ToArray();
+
+    /// <summary>Cursor omits `kcap-workitems` (AI-1264: Claude Code plugin only, not yet
+    /// exposed to Cursor). Unlike Codex, Cursor still gets `kcap-flows`.</summary>
+    public static IReadOnlyList<KcapMcpServer> ForCursor =>
+        All.Where(s => s.Name != "kcap-workitems").ToArray();
 }

--- a/src/Capacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-mcp.txt
@@ -13,6 +13,9 @@ Subcommands:
                           review flows from within an agent session.
   memory                  Start the MCP memory server (stdio) — team memory
                           tools (search, get, save, update, rescope, archive).
+  workitems               Start the MCP workitems server (stdio) — declare and
+                          list a session's work-item attachments. Claude Code
+                          only.
 
 Options for review:
   --owner <owner>         Repository owner (session default)
@@ -80,6 +83,21 @@ mcp memory:
       args    = ["mcp", "memory"]
       # desktop app launches with no shell PATH, so command
       # needs an absolute path (e.g. /opt/homebrew/bin/kcap)
+
+mcp workitems:
+  Exposes two tools — declare_work_item, get_session_work_items — for agents
+  to attach the current session (and its continuation chain) to a work item,
+  or list what it's already attached to. Requires `kcap login`.
+
+    Tools:
+      declare_work_item        Attach the current session to a work item by
+                                issue key, PR number, work item id, or a new
+                                title (exactly one of the four).
+      get_session_work_items   List the work items the current session is
+                                attached to.
+
+  Claude Code auto-registers `kcap-workitems` via the plugin's `.mcp.json`
+  (installed by `kcap setup`); it is not offered for Cursor or Codex.
 
 INSTALL
 

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -61,6 +61,7 @@ MCP servers (stdio):
   mcp sessions                       Search/inspect past sessions from agents
   mcp flows                          Start and manage review flows from agents
   mcp memory                         Team memory tools (search, get, save, update, rescope, archive)
+  mcp workitems                      Declare/list a session's work-item attachments (Claude Code only)
 
 Plugin:
   plugin install [--project] [--codex|--cursor|--copilot|--gemini|--kiro|--pi|--opencode|--skills]   Register hooks/skills (Claude default; flag picks the vendor)

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -285,7 +285,7 @@ static class McpWorkItemsServer {
         new("declare_work_item",
             "Attach the CURRENT session (and its continuation chain) to a work item on the Capacitor server. Provide exactly one of issue_key, pr_number, work_item_id, or new_title.",
             new("object", new() {
-                ["issue_key"]    = new("string", "Attach to the existing work item linked to this issue key (e.g. 'AI-1234')."),
+                ["issue_key"]    = new("string", "Attach to the work item for this issue key (e.g. 'AI-1234'), creating it if none exists yet."),
                 ["pr_number"]    = new("number", "Attach to the existing work item linked to this PR number."),
                 ["work_item_id"] = new("string", "Attach directly to this work item id."),
                 ["new_title"]    = new("string", "Create a brand-new work item with this title and attach to it."),

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -286,7 +286,7 @@ static class McpWorkItemsServer {
             "Attach the CURRENT session (and its continuation chain) to a work item on the Capacitor server. Provide exactly one of issue_key, pr_number, work_item_id, or new_title.",
             new("object", new() {
                 ["issue_key"]    = new("string", "Attach to the work item for this issue key (e.g. 'AI-1234'), creating it if none exists yet."),
-                ["pr_number"]    = new("number", "Attach to the existing work item linked to this PR number."),
+                ["pr_number"]    = new("number", "Attach to the work item for this PR number, creating it if none exists yet."),
                 ["work_item_id"] = new("string", "Attach directly to this work item id."),
                 ["new_title"]    = new("string", "Create a brand-new work item with this title and attach to it."),
                 ["session_id"]   = new("string", "Session id to attach. Defaults to the current kcap-hooked session (KCAP_SESSION_ID) when omitted.")

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -18,7 +18,7 @@ static class McpWorkItemsServer {
     internal const string NotLoggedInMessage = "Not logged in. Run 'kcap login' on the host shell.";
 
     internal const string NoSessionIdMessage =
-        "No session id: pass session_id explicitly or run inside a kcap-hooked session (KCAP_SESSION_ID).";
+        "No session id: pass session_id explicitly or run inside a kcap-hooked session (KCAP_SESSION_ID or CODEX_THREAD_ID).";
 
     public static async Task<int> RunAsync(string baseUrl) {
         var tools = BuildToolsList();
@@ -181,10 +181,13 @@ static class McpWorkItemsServer {
     /// else the ambient <c>KCAP_SESSION_ID</c> (or <c>CODEX_THREAD_ID</c>) env var via
     /// <see cref="ArgParsing.ResolveSessionIdFromEnv"/>. Throws when neither is available, so
     /// the caller (via <see cref="HandleToolCallAsync"/>) surfaces a clean tool error instead
-    /// of sending a request with a missing/blank session id.
+    /// of sending a request with a missing/blank session id. Dashes are stripped from the
+    /// explicit argument too — matching <see cref="ArgParsing.ResolveSessionIdFromEnv"/> — so a
+    /// caller passing a dashed GUID (e.g. copy-pasted from a UI) still resolves to the same
+    /// dashless key the server expects, instead of silently missing the intended session.
     /// </summary>
     internal static string ResolveSessionId(JsonObject? args) {
-        if (args?["session_id"]?.GetValue<string>() is { Length: > 0 } explicitId) return explicitId;
+        if (args?["session_id"]?.GetValue<string>() is { Length: > 0 } explicitId) return explicitId.Replace("-", "");
         if (ArgParsing.ResolveSessionIdFromEnv() is { Length: > 0 } fromEnv) return fromEnv;
 
         throw new ArgumentException(NoSessionIdMessage);

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -1,0 +1,300 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>AI-1264 P2 task 17: MCP tools for the work-items correlation surface — attach the
+/// current session (and its continuation chain) to a work item, and list what a session is
+/// already attached to. Cloned from <see cref="McpMemoryServer"/>'s stdio JSON-RPC loop; unlike
+/// memory this server has no repo/machine context to resolve — the only per-call input is the
+/// session id and the declare selector, both carried in the tool arguments.</summary>
+static class McpWorkItemsServer {
+    internal const string NotLoggedInMessage = "Not logged in. Run 'kcap login' on the host shell.";
+
+    internal const string NoSessionIdMessage =
+        "No session id: pass session_id explicitly or run inside a kcap-hooked session (KCAP_SESSION_ID).";
+
+    public static async Task<int> RunAsync(string baseUrl) {
+        var tools = BuildToolsList();
+
+        // Validate the server_url shape once, locally (pure string check — no network, token,
+        // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
+        var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
+
+        // Created on demand (not at startup) so a session that never calls a tool pays no
+        // network/token/stderr cost. Nullable field rather than Lazy<Task> so a transient
+        // creation failure leaves it null and the next call retries. Safe without locking:
+        // the stdio loop handles one request at a time.
+        HttpClient? client = null;
+
+        // Guarded tool dispatch: never let the stdio JSON-RPC loop die on one bad request. An
+        // unusable server_url would otherwise reach EnsureAbsolute inside the auth-client factory,
+        // which hard-exits the process (Environment.Exit(2)) mid-request; and an unexpected
+        // failure would bubble out of the loop. Return a JSON-RPC tool error in both cases so the
+        // server keeps serving.
+        async Task<string> DispatchToolCallAsync(JsonNode callId, JsonObject callRequest) {
+            if (!urlOk)
+                return BuildToolResult(callId, HttpClientExtensions.SchemeMissingHint, isError: true);
+
+            try {
+                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+                return await HandleToolCallAsync(callId, callRequest, client, baseUrl);
+            } catch (Exception ex) {
+                // Unexpected: log the detail to stderr (not to the client, which could leak local
+                // paths from IO errors) and return a generic tool error, keeping the loop alive.
+                await Console.Error.WriteLineAsync($"kcap mcp workitems: unexpected error handling tools/call: {ex}");
+                return BuildToolResult(callId, "Error: internal error handling the request.", isError: true);
+            }
+        }
+
+        await using var stdin  = Console.OpenStandardInput();
+        await using var stdout = Console.OpenStandardOutput();
+        using var       reader = new StreamReader(stdin, Encoding.UTF8);
+        await using var writer = new StreamWriter(stdout, new UTF8Encoding(false));
+        writer.AutoFlush = true;
+
+        try {
+            while (await reader.ReadLineAsync() is { } line) {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+
+                JsonObject? request;
+
+                try {
+                    request = JsonNode.Parse(line)?.AsObject();
+                } catch {
+                    continue; // skip malformed JSON
+                }
+
+                if (request is null) continue;
+
+                var id     = request["id"];
+                var method = request["method"]?.GetValue<string>();
+
+                // Notifications have no id — don't send a response
+                if (id is null) continue;
+
+                var response = method switch {
+                    "initialize" => BuildInitializeResponse(id, request),
+                    "tools/list" => BuildToolsListResponse(id, tools),
+                    "tools/call" => await DispatchToolCallAsync(id, request),
+                    _            => McpProtocol.TryHandleStandardMethod(method, id)
+                                    ?? BuildErrorResponse(id, -32601, $"Method not found: {method}")
+                };
+
+                await writer.WriteLineAsync(response);
+            }
+        } finally {
+            if (client is not null) {
+                try { client.Dispose(); } catch {
+                    /* swallow — best-effort cleanup */
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    static string BuildInitializeResponse(JsonNode id, JsonObject request) =>
+        ToResponse<McpInitResult>(
+            id,
+            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-workitems", "1.0.0")),
+            McpJsonContext.Default.McpInitResult
+        );
+
+    static string BuildToolsListResponse(JsonNode id, McpTool[] tools) =>
+        ToResponse(id, new McpToolsResult(tools), McpJsonContext.Default.McpToolsResult);
+
+    internal static async Task<string> HandleToolCallAsync(
+            JsonNode   id,
+            JsonObject request,
+            HttpClient client,
+            string     baseUrl
+        ) {
+        var paramsNode = request["params"]?.AsObject();
+        var toolName   = paramsNode?["name"]?.GetValue<string>();
+        var arguments  = paramsNode?["arguments"]?.AsObject();
+
+        if (toolName is null) {
+            return BuildErrorResponse(id, -32602, "Missing params.name");
+        }
+
+        try {
+            using var httpResponse = toolName switch {
+                "declare_work_item"      => await SendWithRefreshRetryAsync(client, c => c.PostAsync($"{baseUrl}/api/work-items/declare", ToJsonContent(BuildDeclareBody(arguments)))),
+                "get_session_work_items" => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildSessionUrl(baseUrl, arguments))),
+                _                        => throw new ArgumentException($"Unknown tool: {toolName}")
+            };
+
+            var body = await httpResponse.Content.ReadAsStringAsync();
+
+            if (httpResponse.StatusCode == HttpStatusCode.Unauthorized) {
+                return BuildToolResult(id, NotLoggedInMessage, isError: true);
+            }
+
+            if (!httpResponse.IsSuccessStatusCode) {
+                return BuildToolResult(id, $"Error: HTTP {(int)httpResponse.StatusCode} — {body}", isError: true);
+            }
+
+            return BuildToolResult(id, body);
+        } catch (ArgumentException ex) {
+            return BuildToolResult(id, $"Error: {ex.Message}", isError: true);
+        } catch (HttpRequestException ex) {
+            return BuildToolResult(id, $"Error: {ex.Message}", isError: true);
+        }
+    }
+
+    /// <summary>
+    /// Sends an HTTP request with one-shot retry on 401. The MCP server reuses a single
+    /// <see cref="HttpClient"/> for the lifetime of the agent session, so a cached token
+    /// that was valid at startup may have expired by the time a tool call is made. On 401
+    /// we ask <see cref="TokenStore.GetValidTokensAsync"/> for a fresh token (which triggers
+    /// the refresh flow for WorkOS / GitHubApp), update the client's <c>Authorization</c>
+    /// header, and retry the same request once. If refresh fails (genuinely not logged in
+    /// or refresh-token expired), the original 401 is returned and the caller surfaces the
+    /// friendly "Not logged in" message.
+    /// </summary>
+    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, Func<HttpClient, Task<HttpResponseMessage>> send) {
+        var response = await send(client);
+
+        if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
+
+        var refreshed = await TokenStore.GetValidTokensAsync();
+
+        if (refreshed is null) return response; // genuinely not logged in; keep the original 401
+
+        response.Dispose();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", refreshed.AccessToken);
+
+        return await send(client);
+    }
+
+    static StringContent ToJsonContent(JsonObject body) => new(body.ToJsonString(), Encoding.UTF8, "application/json");
+
+    /// <summary>
+    /// Resolves the session id to act on: an explicit <c>session_id</c> tool argument wins,
+    /// else the ambient <c>KCAP_SESSION_ID</c> (or <c>CODEX_THREAD_ID</c>) env var via
+    /// <see cref="ArgParsing.ResolveSessionIdFromEnv"/>. Throws when neither is available, so
+    /// the caller (via <see cref="HandleToolCallAsync"/>) surfaces a clean tool error instead
+    /// of sending a request with a missing/blank session id.
+    /// </summary>
+    internal static string ResolveSessionId(JsonObject? args) {
+        if (args?["session_id"]?.GetValue<string>() is { Length: > 0 } explicitId) return explicitId;
+        if (ArgParsing.ResolveSessionIdFromEnv() is { Length: > 0 } fromEnv) return fromEnv;
+
+        throw new ArgumentException(NoSessionIdMessage);
+    }
+
+    // NOTE: request bodies use snake_case keys — the server's global JSON policy is
+    // JsonNamingPolicy.SnakeCaseLower (see AI-1134 task 9). Responses are passed through as raw
+    // text, so only this request-body builder is affected. The server enforces "exactly one of
+    // issue_key/pr_number/work_item_id/new_title" (400 on violation) — this builder passes
+    // through whichever selector(s) were supplied and lets that validation surface as a tool
+    // error via the 4xx-body mapping in HandleToolCallAsync, rather than duplicating the rule
+    // client-side.
+    internal static JsonObject BuildDeclareBody(JsonObject? args) {
+        var body = new JsonObject { ["session_id"] = ResolveSessionId(args) };
+
+        if (args?["issue_key"]?.GetValue<string>() is { Length: > 0 } issueKey) body["issue_key"] = issueKey;
+        if (args?["work_item_id"]?.GetValue<string>() is { Length: > 0 } workItemId) body["work_item_id"] = workItemId;
+        if (args?["new_title"]?.GetValue<string>() is { Length: > 0 } newTitle) body["new_title"] = newTitle;
+        if (TryReadInt(args, "pr_number", out var prNumber)) body["pr_number"] = prNumber;
+
+        return body;
+    }
+
+    internal static string BuildSessionUrl(string baseUrl, JsonObject? args) =>
+        $"{baseUrl}/api/work-items/session/{Uri.EscapeDataString(ResolveSessionId(args))}";
+
+    /// <summary>
+    /// Reads a numeric field as int, tolerant of JsonValue holding any underlying numeric type
+    /// (int/long/double) — TryGetValue&lt;int&gt; on a JsonValue constructed from a long returns false.
+    /// Returns false when the key is missing or the value is the wrong shape (e.g., a string).
+    /// Throws <see cref="ArgumentException"/> when the value is numeric but out of range for int,
+    /// so the caller (via <see cref="HandleToolCallAsync"/>) surfaces it as a JSON-RPC validation error
+    /// rather than silently falling back to the default.
+    /// </summary>
+    internal static bool TryReadInt(JsonObject? args, string key, out int value) {
+        value = 0;
+        var node = args?[key];
+
+        if (node is null) return false;
+
+        JsonValue v;
+
+        try {
+            v = node.AsValue();
+        } catch {
+            return false; // wrong shape (object/array)
+        }
+
+        if (v.TryGetValue(out value)) return true;
+
+        if (v.TryGetValue<long>(out var lv)) {
+            if (lv is < int.MinValue or > int.MaxValue)
+                throw new ArgumentException($"'{key}' value {lv} is out of range for int.");
+
+            value = (int)lv;
+
+            return true;
+        }
+
+        if (v.TryGetValue<double>(out var dv)) {
+            var rounded = (long)dv;
+
+            if (rounded < int.MinValue || rounded > int.MaxValue || rounded != dv)
+                throw new ArgumentException($"'{key}' value {dv} is out of range or non-integer for int.");
+
+            value = (int)rounded;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    static string BuildToolResult(JsonNode id, string text, bool isError = false) =>
+        ToResponse<McpToolCallResult>(id, new([new("text", text)], isError ? true : null), McpJsonContext.Default.McpToolCallResult);
+
+    static string BuildErrorResponse(JsonNode id, int code, string message) {
+        var envelope = new JsonObject {
+            ["jsonrpc"] = "2.0",
+            ["id"]      = id.DeepClone(),
+            ["error"]   = JsonSerializer.SerializeToNode(new McpError(code, message), McpJsonContext.Default.McpError)
+        };
+
+        return envelope.ToJsonString();
+    }
+
+    static string ToResponse<T>(JsonNode id, T result, JsonTypeInfo<T> typeInfo) {
+        var envelope = new JsonObject {
+            ["jsonrpc"] = "2.0",
+            ["id"]      = id.DeepClone(),
+            ["result"]  = JsonSerializer.SerializeToNode(result, typeInfo)
+        };
+
+        return envelope.ToJsonString();
+    }
+
+    internal static McpTool[] BuildToolsList() => [
+        new("declare_work_item",
+            "Attach the CURRENT session (and its continuation chain) to a work item on the Capacitor server. Provide exactly one of issue_key, pr_number, work_item_id, or new_title.",
+            new("object", new() {
+                ["issue_key"]    = new("string", "Attach to the existing work item linked to this issue key (e.g. 'AI-1234')."),
+                ["pr_number"]    = new("number", "Attach to the existing work item linked to this PR number."),
+                ["work_item_id"] = new("string", "Attach directly to this work item id."),
+                ["new_title"]    = new("string", "Create a brand-new work item with this title and attach to it."),
+                ["session_id"]   = new("string", "Session id to attach. Defaults to the current kcap-hooked session (KCAP_SESSION_ID) when omitted.")
+            }, [])),
+        new("get_session_work_items",
+            "List the work items the current session is attached to.",
+            new("object", new() {
+                ["session_id"] = new("string", "Session id to look up. Defaults to the current kcap-hooked session (KCAP_SESSION_ID) when omitted.")
+            }, []))
+    ];
+}

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -74,12 +74,13 @@ static class McpWorkItemsServer {
                 if (request is null) continue;
 
                 var id     = request["id"];
-                var method = request["method"]?.GetValue<string>();
+                var method = DecodeMethod(request);
 
                 // Notifications have no id — don't send a response
                 if (id is null) continue;
 
                 var response = method switch {
+                    null         => BuildErrorResponse(id, -32600, "Invalid request: method must be a string"),
                     "initialize" => BuildInitializeResponse(id, request),
                     "tools/list" => BuildToolsListResponse(id, tools),
                     "tools/call" => await DispatchToolCallAsync(id, request),
@@ -214,13 +215,26 @@ static class McpWorkItemsServer {
     internal static string BuildSessionUrl(string baseUrl, JsonObject? args) =>
         $"{baseUrl}/api/work-items/session/{Uri.EscapeDataString(ResolveSessionId(args))}";
 
+    /// <summary>Decodes the JSON-RPC <c>method</c> field, returning null for a present but
+    /// wrong-shaped value (e.g. an object) instead of throwing — a malformed request must yield
+    /// an invalid-request response, never terminate the stdio loop.</summary>
+    internal static string? DecodeMethod(JsonObject request) {
+        try {
+            return request["method"]?.GetValue<string>();
+        } catch {
+            return null;
+        }
+    }
+
     /// <summary>
-    /// Reads a numeric field as int, tolerant of JsonValue holding any underlying numeric type
-    /// (int/long/double) — TryGetValue&lt;int&gt; on a JsonValue constructed from a long returns false.
-    /// Returns false when the key is missing or the value is the wrong shape (e.g., a string).
-    /// Throws <see cref="ArgumentException"/> when the value is numeric but out of range for int,
-    /// so the caller (via <see cref="HandleToolCallAsync"/>) surfaces it as a JSON-RPC validation error
-    /// rather than silently falling back to the default.
+    /// Reads a numeric field as int. Returns false ONLY when the key is absent (or JSON null) —
+    /// any PRESENT non-integer shape (string, object, array, fractional or out-of-range number)
+    /// throws <see cref="ArgumentException"/> so the caller surfaces a validation error instead
+    /// of silently dropping the selector: a malformed two-selector declare (e.g. issue_key plus
+    /// a string pr_number) must fail, not degrade into a "valid" single-selector attach. Wire
+    /// JSON (JsonElement-backed) is validated against the RAW token via TryGetInt32 — exact, no
+    /// lossy double round-trip, so a fractional part below double precision still rejects;
+    /// int/long branches cover programmatically constructed nodes.
     /// </summary>
     internal static bool TryReadInt(JsonObject? args, string key, out int value) {
         value = 0;
@@ -228,37 +242,26 @@ static class McpWorkItemsServer {
 
         if (node is null) return false;
 
-        JsonValue v;
+        if (node is JsonValue v) {
+            if (v.TryGetValue<JsonElement>(out var el)) {
+                if (el.ValueKind == JsonValueKind.Number && el.TryGetInt32(out value)) return true;
 
-        try {
-            v = node.AsValue();
-        } catch {
-            return false; // wrong shape (object/array)
+                throw new ArgumentException($"'{key}' must be an integer within int range.");
+            }
+
+            if (v.TryGetValue(out value)) return true;
+
+            if (v.TryGetValue<long>(out var lv)) {
+                if (lv is < int.MinValue or > int.MaxValue)
+                    throw new ArgumentException($"'{key}' value {lv} is out of range for int.");
+
+                value = (int)lv;
+
+                return true;
+            }
         }
 
-        if (v.TryGetValue(out value)) return true;
-
-        if (v.TryGetValue<long>(out var lv)) {
-            if (lv is < int.MinValue or > int.MaxValue)
-                throw new ArgumentException($"'{key}' value {lv} is out of range for int.");
-
-            value = (int)lv;
-
-            return true;
-        }
-
-        if (v.TryGetValue<double>(out var dv)) {
-            var rounded = (long)dv;
-
-            if (rounded < int.MinValue || rounded > int.MaxValue || rounded != dv)
-                throw new ArgumentException($"'{key}' value {dv} is out of range or non-integer for int.");
-
-            value = (int)rounded;
-
-            return true;
-        }
-
-        return false;
+        throw new ArgumentException($"'{key}' must be an integer.");
     }
 
     static string BuildToolResult(JsonNode id, string text, bool isError = false) =>
@@ -289,7 +292,7 @@ static class McpWorkItemsServer {
             "Attach the CURRENT session (and its continuation chain) to a work item on the Capacitor server. Provide exactly one of issue_key, pr_number, work_item_id, or new_title.",
             new("object", new() {
                 ["issue_key"]    = new("string", "Attach to the work item for this issue key (e.g. 'AI-1234'), creating it if none exists yet."),
-                ["pr_number"]    = new("number", "Attach to the work item for this PR number, creating it if none exists yet."),
+                ["pr_number"]    = new("integer", "Attach to the work item for this PR number, creating it if none exists yet."),
                 ["work_item_id"] = new("string", "Attach directly to this work item id."),
                 ["new_title"]    = new("string", "Create a brand-new work item with this title and attach to it."),
                 ["session_id"]   = new("string", "Session id to attach. Defaults to the current kcap-hooked session (KCAP_SESSION_ID) when omitted.")

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -711,7 +711,7 @@ public static class PluginCommand {
     /// </summary>
     static async Task RegisterCursorMcpServersAsync(PluginEnvironment env) {
         var change = JsonMcpConfigWriter.Register(
-            env.CursorMcpJson, KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new McpMarker("cursor"));
+            env.CursorMcpJson, KcapMcpServers.ForCursor, McpConfigShape.Standard, cwd: null, new McpMarker("cursor"));
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -279,7 +279,7 @@ public static class SetupCommand {
             EnableCodexNetworkAccess: () => CodexConfigToml.EnableNetworkAccess(codexAllowDomains),
             RegisterCodexMcp:         () => CodexConfigToml.RegisterKcapMcpServers(),
             RegisterCursorMcp:        () => JsonMcpConfigWriter.Register(
-                CursorPaths.UserMcpJson(), KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new McpMarker("cursor")));
+                CursorPaths.UserMcpJson(), KcapMcpServers.ForCursor, McpConfigShape.Standard, cwd: null, new McpMarker("cursor")));
 
         bool PromptYesNo(string text) =>
             AnsiConsole.Prompt(new ConfirmationPrompt(text) { DefaultValue = true });

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -324,13 +324,14 @@ switch (command) {
     }
     case "mcp": {
         if (args.Length < 2) {
-            Console.Error.WriteLine("Usage: kcap mcp review|judge|sessions|flows|flow-result|memory …");
+            Console.Error.WriteLine("Usage: kcap mcp review|judge|sessions|flows|flow-result|memory|workitems …");
             Console.Error.WriteLine("  kcap mcp review [--owner <owner> --repo <repo> --pr <number>]");
             Console.Error.WriteLine("  kcap mcp judge --session <sessionId>");
             Console.Error.WriteLine("  kcap mcp sessions");
             Console.Error.WriteLine("  kcap mcp flows");
             Console.Error.WriteLine("  kcap mcp flow-result   (launched by the daemon for hosted reviewers)");
             Console.Error.WriteLine("  kcap mcp memory");
+            Console.Error.WriteLine("  kcap mcp workitems");
 
             return 1;
         }
@@ -368,6 +369,8 @@ switch (command) {
                 return await McpFlowResultServer.RunAsync(baseUrl!);
             case "memory":
                 return await McpMemoryServer.RunAsync(baseUrl!);
+            case "workitems":
+                return await McpWorkItemsServer.RunAsync(baseUrl!);
             default:
                 Console.Error.WriteLine($"Unknown mcp subcommand: {args[1]}");
 

--- a/test/Capacitor.Cli.Tests.Unit/KcapMcpRegistryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/KcapMcpRegistryTests.cs
@@ -74,6 +74,27 @@ public class KcapMcpRegistryTests {
     }
 
     [Test]
+    public async Task Resolve_KcapWorkItems_ReturnsDescriptor() {
+        var result = KcapMcpRegistry.Resolve("kcap-workitems");
+
+        await Assert.That(result).IsNotNull();
+    }
+
+    [Test]
+    public async Task Resolve_KcapWorkItems_CorrectArgs() {
+        var result = KcapMcpRegistry.Resolve("kcap-workitems");
+
+        await Assert.That(result!.Args).IsEquivalentTo(new[] { "mcp", "workitems" });
+    }
+
+    [Test]
+    public async Task Resolve_KcapWorkItems_StartsFlowsFalse() {
+        var result = KcapMcpRegistry.Resolve("kcap-workitems");
+
+        await Assert.That(result!.StartsFlows).IsFalse();
+    }
+
+    [Test]
     public async Task Resolve_KcapFlows_ReturnsDescriptor() {
         var result = KcapMcpRegistry.Resolve("kcap-flows");
 

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/JsonMcpConfigWriterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/JsonMcpConfigWriterTests.cs
@@ -26,7 +26,7 @@ public class JsonMcpConfigWriterTests {
 
         await Assert.That(change).IsEqualTo(JsonMcpConfigWriter.Change.Updated);
         var servers = (JsonObject)Read(path)["mcpServers"]!;
-        await Assert.That(servers.Count).IsEqualTo(4);
+        await Assert.That(servers.Count).IsEqualTo(5);
         await Assert.That((string)servers["kcap-review"]!["command"]!).IsEqualTo("kcap");
         await Assert.That(servers["kcap-review"]!["args"]!.AsArray().Count).IsEqualTo(2);
     }

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/KcapMcpServersTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/KcapMcpServersTests.cs
@@ -4,20 +4,26 @@ namespace Capacitor.Cli.Tests.Unit.Mcp;
 
 public class KcapMcpServersTests {
     [Test]
-    public async Task All_contains_the_four_canonical_servers() {
+    public async Task All_contains_the_five_canonical_servers() {
         var names = KcapMcpServers.All.Select(s => s.Name).ToArray();
-        await Assert.That(names).IsEquivalentTo(new[] { "kcap-review", "kcap-sessions", "kcap-flows", "kcap-memory" });
+        await Assert.That(names).IsEquivalentTo(new[] { "kcap-review", "kcap-sessions", "kcap-flows", "kcap-memory", "kcap-workitems" });
     }
 
     [Test]
-    public async Task ForCodex_excludes_flows_only() {
+    public async Task ForCodex_excludes_flows_and_workitems() {
         var names = KcapMcpServers.ForCodex.Select(s => s.Name).ToArray();
         await Assert.That(names).IsEquivalentTo(new[] { "kcap-review", "kcap-sessions", "kcap-memory" });
     }
 
     [Test]
+    public async Task ForCursor_excludes_workitems_only() {
+        var names = KcapMcpServers.ForCursor.Select(s => s.Name).ToArray();
+        await Assert.That(names).IsEquivalentTo(new[] { "kcap-review", "kcap-sessions", "kcap-flows", "kcap-memory" });
+    }
+
+    [Test]
     public async Task Review_is_the_only_non_repo_scoped_server() {
         var repoScoped = KcapMcpServers.All.Where(s => s.NeedsProjectCwd).Select(s => s.Name).ToArray();
-        await Assert.That(repoScoped).IsEquivalentTo(new[] { "kcap-sessions", "kcap-flows", "kcap-memory" });
+        await Assert.That(repoScoped).IsEquivalentTo(new[] { "kcap-sessions", "kcap-flows", "kcap-memory", "kcap-workitems" });
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpCanonicalContractTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpCanonicalContractTests.cs
@@ -36,4 +36,18 @@ public class McpCanonicalContractTests {
         await Assert.That(names).DoesNotContain("kcap-flows");
         await Assert.That(names).Contains("kcap-memory");
     }
+
+    [Test]
+    public async Task Codex_subset_excludes_workitems() {
+        var names = KcapMcpServers.ForCodex.Select(s => s.Name).ToArray();
+        await Assert.That(names).DoesNotContain("kcap-workitems");
+    }
+
+    [Test]
+    public async Task Cursor_subset_excludes_workitems_but_keeps_flows_and_memory() {
+        var names = KcapMcpServers.ForCursor.Select(s => s.Name).ToArray();
+        await Assert.That(names).DoesNotContain("kcap-workitems");
+        await Assert.That(names).Contains("kcap-flows");
+        await Assert.That(names).Contains("kcap-memory");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/McpWorkItemsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpWorkItemsServerTests.cs
@@ -15,9 +15,18 @@ public class McpWorkItemsServerTests {
 
     [Test]
     public async Task Resolve_session_id_prefers_explicit_argument() {
-        var id = McpWorkItemsServer.ResolveSessionId(Args("""{"session_id":"explicit-1"}"""));
+        var id = McpWorkItemsServer.ResolveSessionId(Args("""{"session_id":"explicit1"}"""));
 
-        await Assert.That(id).IsEqualTo("explicit-1");
+        await Assert.That(id).IsEqualTo("explicit1");
+    }
+
+    [Test]
+    public async Task Resolve_session_id_strips_dashes_from_explicit_argument() {
+        // Matches ArgParsing.ResolveSessionIdFromEnv's normalization so an explicit dashed GUID
+        // (e.g. copy-pasted from a UI) resolves to the same dashless key as the ambient env var.
+        var id = McpWorkItemsServer.ResolveSessionId(Args("""{"session_id":"1234abcd-56ef-78ab-90cd-1234567890ab"}"""));
+
+        await Assert.That(id).IsEqualTo("1234abcd56ef78ab90cd1234567890ab");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/McpWorkItemsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpWorkItemsServerTests.cs
@@ -104,6 +104,53 @@ public class McpWorkItemsServerTests {
         await Assert.That(url).IsEqualTo("http://x/api/work-items/session/sess%20a%2Fb");
     }
 
+    // ── flow-review round 2 findings ─────────────────────────────────────────
+
+    [Test]
+    public async Task Decode_method_returns_null_for_wrong_shaped_method_instead_of_throwing() {
+        // {"id":1,"method":{}} must yield an invalid-request response, never kill the stdio loop.
+        var method = McpWorkItemsServer.DecodeMethod(Args("""{"id":1,"method":{}}"""));
+
+        await Assert.That(method).IsNull();
+    }
+
+    [Test]
+    public async Task Declare_body_rejects_string_pr_number_instead_of_dropping_it() {
+        // A malformed two-selector declare (issue_key + string pr_number) must FAIL — silently
+        // dropping the wrong-shaped selector would let the server's exactly-one rule pass and
+        // perform an attach the caller never validly requested.
+        var ex = Assert.Throws<ArgumentException>(
+            () => McpWorkItemsServer.BuildDeclareBody(Args("""{"session_id":"s1","issue_key":"AI-1","pr_number":"123"}""")));
+
+        await Assert.That(ex!.Message).Contains("pr_number");
+    }
+
+    [Test]
+    public async Task Declare_body_rejects_object_shaped_pr_number() {
+        var ex = Assert.Throws<ArgumentException>(
+            () => McpWorkItemsServer.BuildDeclareBody(Args("""{"session_id":"s1","pr_number":{}}""")));
+
+        await Assert.That(ex!.Message).Contains("pr_number");
+    }
+
+    [Test]
+    public async Task Declare_body_rejects_fractional_pr_number_via_raw_token() {
+        // Raw-token validation (JsonElement.TryGetInt32) — a fractional part below double
+        // precision must still reject; the lossy double round-trip would have accepted it.
+        var ex = Assert.Throws<ArgumentException>(
+            () => McpWorkItemsServer.BuildDeclareBody(Args("""{"session_id":"s1","pr_number":2147483646.0000000001}""")));
+
+        await Assert.That(ex!.Message).Contains("pr_number");
+    }
+
+    [Test]
+    public async Task Declare_body_rejects_out_of_range_pr_number() {
+        var ex = Assert.Throws<ArgumentException>(
+            () => McpWorkItemsServer.BuildDeclareBody(Args("""{"session_id":"s1","pr_number":2147483648}""")));
+
+        await Assert.That(ex!.Message).Contains("pr_number");
+    }
+
     [Test]
     public async Task Tools_list_has_two_tools() {
         var tools = McpWorkItemsServer.BuildToolsList();

--- a/test/Capacitor.Cli.Tests.Unit/McpWorkItemsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpWorkItemsServerTests.cs
@@ -1,0 +1,105 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class McpWorkItemsServerTests {
+    const string CapacitorSessionIdEnvVar = "KCAP_SESSION_ID";
+    const string CodexThreadIdEnvVar      = "CODEX_THREAD_ID";
+
+    // Shares ArgParsingTests' NotInParallel key: both suites mutate the same process-global
+    // KCAP_SESSION_ID / CODEX_THREAD_ID env vars, so tests in either must not interleave.
+    const string SessionEnvVarMutation = "SessionEnvVarMutation";
+
+    static JsonObject Args(string json) => JsonNode.Parse(json)!.AsObject();
+
+    [Test]
+    public async Task Resolve_session_id_prefers_explicit_argument() {
+        var id = McpWorkItemsServer.ResolveSessionId(Args("""{"session_id":"explicit-1"}"""));
+
+        await Assert.That(id).IsEqualTo("explicit-1");
+    }
+
+    [Test]
+    [NotInParallel(SessionEnvVarMutation)]
+    public async Task Resolve_session_id_falls_back_to_env_when_argument_missing() {
+        var savedKap = Environment.GetEnvironmentVariable(CapacitorSessionIdEnvVar);
+        var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
+        Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, "envsess1");
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, null);
+
+        try {
+            var id = McpWorkItemsServer.ResolveSessionId(new JsonObject());
+
+            await Assert.That(id).IsEqualTo("envsess1");
+        } finally {
+            Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, savedKap);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, savedCdx);
+        }
+    }
+
+    [Test]
+    [NotInParallel(SessionEnvVarMutation)]
+    public async Task Resolve_session_id_throws_when_neither_argument_nor_env_present() {
+        var savedKap = Environment.GetEnvironmentVariable(CapacitorSessionIdEnvVar);
+        var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
+        Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, null);
+        Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, null);
+
+        try {
+            var ex = Assert.Throws<ArgumentException>(() => McpWorkItemsServer.ResolveSessionId(new JsonObject()));
+
+            await Assert.That(ex!.Message).IsEqualTo(McpWorkItemsServer.NoSessionIdMessage);
+        } finally {
+            Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, savedKap);
+            Environment.SetEnvironmentVariable(CodexThreadIdEnvVar, savedCdx);
+        }
+    }
+
+    [Test]
+    public async Task Declare_body_carries_session_id_and_issue_key() {
+        var body = McpWorkItemsServer.BuildDeclareBody(Args("""{"session_id":"s1","issue_key":"AI-1234"}"""));
+
+        await Assert.That(body["session_id"]!.GetValue<string>()).IsEqualTo("s1");
+        await Assert.That(body["issue_key"]!.GetValue<string>()).IsEqualTo("AI-1234");
+        await Assert.That(body["pr_number"]).IsNull();
+        await Assert.That(body["work_item_id"]).IsNull();
+        await Assert.That(body["new_title"]).IsNull();
+    }
+
+    [Test]
+    public async Task Declare_body_carries_pr_number() {
+        var body = McpWorkItemsServer.BuildDeclareBody(Args("""{"session_id":"s1","pr_number":123}"""));
+
+        await Assert.That(body["pr_number"]!.GetValue<int>()).IsEqualTo(123);
+    }
+
+    [Test]
+    public async Task Declare_body_carries_work_item_id() {
+        var body = McpWorkItemsServer.BuildDeclareBody(Args("""{"session_id":"s1","work_item_id":"wi-9"}"""));
+
+        await Assert.That(body["work_item_id"]!.GetValue<string>()).IsEqualTo("wi-9");
+    }
+
+    [Test]
+    public async Task Declare_body_carries_new_title() {
+        var body = McpWorkItemsServer.BuildDeclareBody(Args("""{"session_id":"s1","new_title":"Investigate flaky test"}"""));
+
+        await Assert.That(body["new_title"]!.GetValue<string>()).IsEqualTo("Investigate flaky test");
+    }
+
+    [Test]
+    public async Task Session_url_escapes_and_resolves_explicit_session_id() {
+        var url = McpWorkItemsServer.BuildSessionUrl("http://x", Args("""{"session_id":"sess a/b"}"""));
+
+        await Assert.That(url).IsEqualTo("http://x/api/work-items/session/sess%20a%2Fb");
+    }
+
+    [Test]
+    public async Task Tools_list_has_two_tools() {
+        var tools = McpWorkItemsServer.BuildToolsList();
+
+        await Assert.That(tools.Length).IsEqualTo(2);
+        await Assert.That(tools.Select(t => t.Name).ToArray()).IsEquivalentTo(new[] { "declare_work_item", "get_session_work_items" });
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
@@ -69,6 +69,8 @@ public class PluginCommandCursorTests {
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-flows");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-memory");
+        // AI-1264: kcap-workitems is Claude Code plugin only — not auto-registered for Cursor.
+        await Assert.That(servers.Select(kv => kv.Key)).DoesNotContain("kcap-workitems");
         await Assert.That(servers["my-tool"]).IsNotNull(); // user server preserved
     }
 


### PR DESCRIPTION
CLI half of SDLC work items Phase 2 (server PR: kurrent-io/kcap-server#1005). Adds the `kcap mcp workitems` stdio MCP server with two tools backed by the server's new `/api/work-items` endpoints:

- `declare_work_item(issue_key | pr_number | work_item_id | new_title, session_id?)` — attaches the current session (and its continuation chain) to a work item at `mcp` precedence; issue/PR keys create the work item if none exists yet; session id resolves from `KCAP_SESSION_ID`/`CODEX_THREAD_ID` (the flows-server precedent) with an explicit-argument override.
- `get_session_work_items(session_id?)` — lists the session's current work-item assignments.

Cloned from the `McpMemoryServer` stdio shape (authenticated client, refresh retry, 4xx bodies surfaced as tool errors). Registered in `KcapMcpRegistry` and the Claude Code plugin's `.mcp.json` only — to keep it off Codex/Cursor after AI-699's canonical registry, this adds a `KcapMcpServers.ForCursor` split mirroring `ForCodex` (byte-identical behavior for the existing four servers). Help text + README updated.

Tests: unit suite 2659/2659; Release AOT publish clean (no IL3050/IL2026).

Merge after the server PR; the kcap-server submodule bump follows as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)