### PR TITLE
[AI-1293] Auto-approve read-only kcap MCP servers on registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ The `kcap mcp memory` stdio server lets agents search, save, and update durable 
 
 Beyond registering the servers, `kcap setup` / `kcap plugin install` also installs a small kcap-owned **agent-instructions block** for harnesses that read a user-level instructions file (GitHub Copilot CLI's `~/.copilot/copilot-instructions.md` and Gemini CLI's global `~/.gemini/GEMINI.md` today; more rolling out per harness). It's a marker-delimited, non-destructive note (preserves any instructions you've written) that steers the agent to prefer the kcap tools for "why / history / prior-work" questions over native `git`/GitHub/grep — registration alone doesn't make agents route to the tools. Opt out with `--skip-<harness>-instructions`.
 
+Where a harness exposes a per-server trust knob, registration also marks the **read-only** kcap servers (`kcap-review`, `kcap-sessions`) auto-approved so the agent doesn't stop to ask before every read: **Gemini** via `"trust": true` on those entries in `~/.gemini/settings.json`, and **Codex** via `default_tools_approval_mode = "approve"` in `~/.codex/config.toml`. The write-capable `kcap-memory` (saves memories) and the work-launching `kcap-flows` (starts a *paid* hosted reviewer) are deliberately left prompting. **Cursor** and **Copilot** have no per-server auto-approve field in the config we write — auto-approve kcap's read tools there through the harness's own controls instead (Cursor's Auto-run mode or `cursor-agent --approve-mcps`; Copilot's `--allow-tool` / `--allow-all-tools`).
+
 ## What it records
 
 Once set up, Capacitor runs silently in the background. Every Claude Code (and Codex CLI, if you installed those hooks) session is captured automatically:

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -245,15 +245,30 @@ public static class CodexConfigToml {
         var changed = false;
 
         foreach (var server in KcapMcpServers.ForCodex) {
-            // Never clobber an existing entry: a prior kcap registration is already
-            // correct, and a user may have customized it (e.g. an absolute-path command
-            // for a GUI host). Only create the server when it's missing entirely.
-            if (servers.ContainsKey(server.Name)) continue;
+            // Never clobber an existing entry's command/args: a prior kcap registration is already
+            // correct, and a user may have customized it (e.g. an absolute-path command for a GUI
+            // host). For an existing entry we only ADDITIVELY set the read-only auto-approve key,
+            // and only when absent — so we never override a user who deliberately chose to be
+            // prompted. This lets pre-existing installs pick up the trust on the next register.
+            if (servers.TryGetValue(server.Name, out var existingVal)) {
+                if (server.ReadOnly
+                 && existingVal is TomlTable existingTable
+                 && !existingTable.ContainsKey("default_tools_approval_mode")) {
+                    existingTable["default_tools_approval_mode"] = "approve";
+                    changed = true;
+                }
+                continue;
+            }
 
-            servers[server.Name] = new TomlTable {
+            var table = new TomlTable {
                 ["command"] = KcapMcpServers.Command,
                 ["args"]    = ToTomlArray(server.Args)
             };
+            // Auto-approve read-only servers (pure reads: kcap-review, kcap-sessions) so Codex runs
+            // them without a prompt. kcap-memory (writes via save) is omitted → keeps prompting.
+            // (kcap-flows isn't in ForCodex at all.) Valid Codex values: auto | prompt | approve.
+            if (server.ReadOnly) table["default_tools_approval_mode"] = "approve";
+            servers[server.Name] = table;
             changed = true;
         }
 

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -247,12 +247,21 @@ public static class CodexConfigToml {
         foreach (var server in KcapMcpServers.ForCodex) {
             // Never clobber an existing entry's command/args: a prior kcap registration is already
             // correct, and a user may have customized it (e.g. an absolute-path command for a GUI
-            // host). For an existing entry we only ADDITIVELY set the read-only auto-approve key,
-            // and only when absent — so we never override a user who deliberately chose to be
-            // prompted. This lets pre-existing installs pick up the trust on the next register.
+            // host). For an existing entry we only ADDITIVELY set the read-only auto-approve key, and
+            // only when it is DEMONSTRABLY the read-only server: command == "kcap" AND args match the
+            // expected read-only args. The args check matters because the heal never rewrites args — a
+            // hand-written `[mcp_servers.kcap-review]` that actually points at a write-capable server
+            // (e.g. args = ["mcp","memory"]) would otherwise pass a command-only gate and be
+            // auto-approved under the read-only name. Also require the user hasn't set their own
+            // approval mode. This lets genuine pre-existing installs pick up trust; anything ambiguous
+            // keeps prompting.
             if (servers.TryGetValue(server.Name, out var existingVal)) {
                 if (server.ReadOnly
                  && existingVal is TomlTable existingTable
+                 && existingTable.TryGetValue("command", out var existingCmd)
+                 && existingCmd is string existingCmdStr && existingCmdStr == KcapMcpServers.Command
+                 && existingTable.TryGetValue("args", out var existingArgsObj)
+                 && existingArgsObj is TomlArray existingArgs && ArgsMatch(existingArgs, server.Args)
                  && !existingTable.ContainsKey("default_tools_approval_mode")) {
                     existingTable["default_tools_approval_mode"] = "approve";
                     changed = true;
@@ -294,6 +303,17 @@ public static class CodexConfigToml {
         foreach (var v in values) arr.Add(v);
 
         return arr;
+    }
+
+    /// <summary>True when a TOML <c>args</c> array equals the expected string args exactly (order +
+    /// values). Used to confirm an existing kcap-named server really is the expected read-only one
+    /// before the heal auto-approves it.</summary>
+    static bool ArgsMatch(TomlArray actual, string[] expected) {
+        if (actual.Count != expected.Length) return false;
+        for (var i = 0; i < expected.Length; i++)
+            if (actual[i] is not string s || s != expected[i]) return false;
+
+        return true;
     }
 
     static bool MutateNetworkAccess(TomlTable root, IReadOnlyCollection<string> allowDomains) {

--- a/src/Capacitor.Cli.Core/Mcp/JsonMcpConfigWriter.cs
+++ b/src/Capacitor.Cli.Core/Mcp/JsonMcpConfigWriter.cs
@@ -82,6 +82,11 @@ public static class JsonMcpConfigWriter {
 
         if (cwd is not null && s.NeedsProjectCwd) o["cwd"] = cwd;
         if (shape.Enable == EnableStyle.EnabledTrue) o["enabled"] = true;
+
+        // Auto-approve only read-only servers, and only where the harness has a per-server trust knob.
+        // Write-capable / work-launching servers (kcap-memory, kcap-flows) keep prompting.
+        if (s.ReadOnly && shape.Trust == TrustStyle.TrustBool) o["trust"] = true;   // Gemini
+
         return o;
     }
 

--- a/src/Capacitor.Cli.Core/Mcp/KcapMcpServers.cs
+++ b/src/Capacitor.Cli.Core/Mcp/KcapMcpServers.cs
@@ -1,7 +1,12 @@
 namespace Capacitor.Cli.Core.Mcp;
 
-/// <summary>One kcap MCP server, described semantically (no harness field names).</summary>
-public sealed record KcapMcpServer(string Name, string[] Args, bool NeedsProjectCwd, string? Description);
+/// <summary>One kcap MCP server, described semantically (no harness field names).
+/// <paramref name="ReadOnly"/> marks a server whose tools are all side-effect-free (pure reads),
+/// so it is safe to auto-approve on registration where the harness supports per-server trust —
+/// see <see cref="McpConfigShape.Trust"/>. Servers that write (kcap-memory's save) or launch work
+/// (kcap-flows' start_review_flow spawns a paid hosted reviewer) are NOT read-only and keep
+/// prompting.</summary>
+public sealed record KcapMcpServer(string Name, string[] Args, bool NeedsProjectCwd, string? Description, bool ReadOnly = false);
 
 /// <summary>The single source of truth for the kcap MCP servers. Every writer
 /// (Codex TOML, the JSON harnesses, the bundled `.mcp.json`) derives from this.</summary>
@@ -10,8 +15,8 @@ public static class KcapMcpServers {
 
     public static readonly IReadOnlyList<KcapMcpServer> All = [
         new("kcap-review",   ["mcp", "review"],   NeedsProjectCwd: false,
-            "PR review context tools — query implementation session transcripts."),
-        new("kcap-sessions", ["mcp", "sessions"], NeedsProjectCwd: true,  null),
+            "PR review context tools — query implementation session transcripts.", ReadOnly: true),
+        new("kcap-sessions", ["mcp", "sessions"], NeedsProjectCwd: true,  null, ReadOnly: true),
         new("kcap-flows",    ["mcp", "flows"],    NeedsProjectCwd: true,
             "Structured AI agent flows — launches a SEPARATE hosted participant agent; requires login + a running daemon."),
         new("kcap-memory",   ["mcp", "memory"],   NeedsProjectCwd: true,

--- a/src/Capacitor.Cli.Core/Mcp/McpConfigShape.cs
+++ b/src/Capacitor.Cli.Core/Mcp/McpConfigShape.cs
@@ -2,6 +2,21 @@ namespace Capacitor.Cli.Core.Mcp;
 
 public enum EnableStyle { None, EnabledTrue }
 
+/// <summary>How a harness expresses "auto-approve this server's tools" (skip the per-tool prompt) in
+/// the config file we write, applied only to <see cref="KcapMcpServer.ReadOnly"/> servers. <c>None</c>
+/// = the harness has no per-server trust knob we can write:
+///  • Cursor — <c>mcp.json</c> has no trust field; auto-approve is a separate <c>permissions.json</c>
+///    classifier or the <c>--approve-mcps</c> CLI flag.
+///  • Copilot — <c>mcp-config.json</c>'s <c>tools</c> field is an AVAILABILITY allowlist (default
+///    <c>*</c>), not an approval knob; approval is governed by runtime <c>--allow-tool</c> /
+///    <c>--allow-all-tools</c> flags.
+/// Codex is not represented here — its per-server approval lives in TOML (<c>CodexConfigToml</c>),
+/// not this JSON writer.</summary>
+public enum TrustStyle {
+    None,      // no per-server trust field we can write (Cursor / Copilot / OpenCode)
+    TrustBool  // Gemini: "trust": true → bypasses tool-call confirmations for the server
+}
+
 /// <summary>How one harness renders an MCP server entry. The canonical
 /// <see cref="KcapMcpServer"/> is field-name-agnostic; this maps it to a host's on-disk shape.</summary>
 public sealed record McpConfigShape(
@@ -9,10 +24,15 @@ public sealed record McpConfigShape(
     bool        CommandAsArgvArray, // OpenCode: command = ["kcap","mcp","review"]; else command="kcap" + args=[...]
     string?     TypeValue,          // "stdio" (Copilot), "local" (OpenCode), or null
     string      EnvKey,             // "env" (most) or "environment" (OpenCode) — reserved for future env support
-    EnableStyle Enable              // OpenCode wants "enabled": true
+    EnableStyle Enable,             // OpenCode wants "enabled": true
+    TrustStyle  Trust = TrustStyle.None // per-server auto-approve for ReadOnly servers, if the harness supports it
 ) {
-    // Cursor / Gemini / Kiro / Antigravity all share the plain shape.
+    // Cursor / Kiro / Antigravity share the plain, trust-less shape (Cursor has no per-server trust
+    // field — auto-approve there is a separate permissions.json classifier / the --approve-mcps flag).
     public static readonly McpConfigShape Standard = new("mcpServers", CommandAsArgvArray: false, TypeValue: null,    EnvKey: "env",         Enable: EnableStyle.None);
+    // Gemini is the plain shape PLUS a per-server "trust" boolean for read-only servers.
+    public static readonly McpConfigShape Gemini   = new("mcpServers", CommandAsArgvArray: false, TypeValue: null,    EnvKey: "env",         Enable: EnableStyle.None, Trust: TrustStyle.TrustBool);
+    // Copilot's `tools` field is availability, not approval — no per-server trust knob to write here.
     public static readonly McpConfigShape Copilot  = new("mcpServers", CommandAsArgvArray: false, TypeValue: "stdio", EnvKey: "env",         Enable: EnableStyle.None);
     public static readonly McpConfigShape OpenCode = new("mcp",        CommandAsArgvArray: true,  TypeValue: "local", EnvKey: "environment", Enable: EnableStyle.EnabledTrue);
 }

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -1569,7 +1569,7 @@ public static class PluginCommand {
     /// </summary>
     static async Task RegisterGeminiMcpServersAsync(PluginEnvironment env, string settingsPath) {
         var change = JsonMcpConfigWriter.Register(
-            settingsPath, KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new McpMarker("gemini"));
+            settingsPath, KcapMcpServers.All, McpConfigShape.Gemini, cwd: null, new McpMarker("gemini"));
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:
@@ -1633,7 +1633,7 @@ public static class PluginCommand {
         // leave a STALE marker that could later misclassify a user-authored mcpServers.kcap-* entry as
         // kcap-owned. On an absent file it's a no-op (Unchanged) that still clears the marker and
         // never creates a config file.
-        var mcpChange = JsonMcpConfigWriter.Unregister(settingsPath, McpConfigShape.Standard, new McpMarker("gemini"));
+        var mcpChange = JsonMcpConfigWriter.Unregister(settingsPath, McpConfigShape.Gemini, new McpMarker("gemini"));
         mcpFailed = mcpChange == JsonMcpConfigWriter.Change.Failed;
 
         if (mcpChange == JsonMcpConfigWriter.Change.Updated) {

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -301,7 +301,7 @@ public static class SetupCommand {
             // fast path). A missing/stale marker reads as "not current" → prompt + install.
             AgentSkillsCurrent:       dir => AgentsSkillsInstaller.ReadMarker(dir) == AgentsSkillsInstaller.CurrentVersion(),
             RegisterGeminiMcp:        () => JsonMcpConfigWriter.Register(
-                GeminiPaths.SettingsJson(), KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new McpMarker("gemini")),
+                GeminiPaths.SettingsJson(), KcapMcpServers.All, McpConfigShape.Gemini, cwd: null, new McpMarker("gemini")),
             InstallGeminiInstructions: () => AgentInstructionsWriter.Write(
                 GeminiPaths.GeminiMd(), KcapAgentInstructions.Body));
 

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
@@ -230,6 +230,47 @@ public class CodexConfigTomlTests {
     }
 
     [Test]
+    public async Task RegisterKcapMcpServers_auto_approves_only_read_only_servers() {
+        var path = TempConfig();
+
+        CodexConfigToml.RegisterKcapMcpServers(path);
+
+        var servers  = (TomlTable)ReadToml(path)["mcp_servers"];
+        var review   = (TomlTable)servers["kcap-review"];
+        var sessions = (TomlTable)servers["kcap-sessions"];
+        var memory   = (TomlTable)servers["kcap-memory"];
+
+        // Read-only servers auto-approve (never prompt); kcap-memory (writes via save) keeps the default.
+        await Assert.That((string)review["default_tools_approval_mode"]).IsEqualTo("approve");
+        await Assert.That((string)sessions["default_tools_approval_mode"]).IsEqualTo("approve");
+        await Assert.That(memory.ContainsKey("default_tools_approval_mode")).IsFalse();
+    }
+
+    [Test]
+    public async Task RegisterKcapMcpServers_heals_existing_entry_without_overriding_user_mode() {
+        var path = TempConfig();
+        // Pre-existing kcap entries: kcap-review with no approval mode (older install); kcap-sessions
+        // where the user deliberately chose "prompt".
+        File.WriteAllText(path, """
+            [mcp_servers.kcap-review]
+            command = "kcap"
+            args = ["mcp", "review"]
+
+            [mcp_servers.kcap-sessions]
+            command = "kcap"
+            args = ["mcp", "sessions"]
+            default_tools_approval_mode = "prompt"
+            """);
+
+        var change = CodexConfigToml.RegisterKcapMcpServers(path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
+        var servers = (TomlTable)ReadToml(path)["mcp_servers"];
+        await Assert.That((string)((TomlTable)servers["kcap-review"])["default_tools_approval_mode"]).IsEqualTo("approve");    // healed (was absent)
+        await Assert.That((string)((TomlTable)servers["kcap-sessions"])["default_tools_approval_mode"]).IsEqualTo("prompt");  // user choice preserved
+    }
+
+    [Test]
     public async Task RegisterKcapMcpServers_emits_snake_case_mcp_servers_table() {
         // Codex config.toml uses the snake_case `mcp_servers` table — NOT the
         // camelCase `mcpServers` key the plugin *descriptor* JSON requires.

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
@@ -271,6 +271,43 @@ public class CodexConfigTomlTests {
     }
 
     [Test]
+    public async Task RegisterKcapMcpServers_does_not_auto_approve_a_foreign_same_named_entry() {
+        var path = TempConfig();
+        // A user-authored server that shares the name "kcap-review" but is NOT kcap (different command).
+        // The heal must NOT auto-approve it — ownership is keyed off command == "kcap".
+        File.WriteAllText(path, """
+            [mcp_servers.kcap-review]
+            command = "my-wrapper"
+            args = ["review"]
+            """);
+
+        CodexConfigToml.RegisterKcapMcpServers(path);
+
+        var review = (TomlTable)((TomlTable)ReadToml(path)["mcp_servers"])["kcap-review"];
+        await Assert.That((string)review["command"]).IsEqualTo("my-wrapper");                 // untouched
+        await Assert.That(review.ContainsKey("default_tools_approval_mode")).IsFalse();        // NOT auto-approved
+    }
+
+    [Test]
+    public async Task RegisterKcapMcpServers_does_not_auto_approve_kcap_named_entry_with_wrong_args() {
+        var path = TempConfig();
+        // command == "kcap" but args point at the WRITE-capable memory server under the read-only
+        // "kcap-review" name. The heal must NOT auto-approve it — args don't match the expected
+        // read-only server's args, and the heal never rewrites args.
+        File.WriteAllText(path, """
+            [mcp_servers.kcap-review]
+            command = "kcap"
+            args = ["mcp", "memory"]
+            """);
+
+        CodexConfigToml.RegisterKcapMcpServers(path);
+
+        var review = (TomlTable)((TomlTable)ReadToml(path)["mcp_servers"])["kcap-review"];
+        await Assert.That(review.ContainsKey("default_tools_approval_mode")).IsFalse();  // NOT auto-approved
+        await Assert.That(ArgsOf(review)).IsEquivalentTo(new[] { "mcp", "memory" });      // args untouched
+    }
+
+    [Test]
     public async Task RegisterKcapMcpServers_emits_snake_case_mcp_servers_table() {
         // Codex config.toml uses the snake_case `mcp_servers` table — NOT the
         // camelCase `mcpServers` key the plugin *descriptor* JSON requires.

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/JsonMcpConfigWriterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/JsonMcpConfigWriterTests.cs
@@ -32,6 +32,41 @@ public class JsonMcpConfigWriterTests {
     }
 
     [Test]
+    public async Task Register_gemini_shape_marks_only_read_only_servers_trusted() {
+        var path = TempConfig();
+        JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Gemini, cwd: null, new FakeMarker());
+
+        var servers = (JsonObject)Read(path)["mcpServers"]!;
+        // Read-only servers (pure reads) get trust:true; write/flow-launching servers keep prompting.
+        await Assert.That((bool)servers["kcap-review"]!["trust"]!).IsTrue();
+        await Assert.That((bool)servers["kcap-sessions"]!["trust"]!).IsTrue();
+        await Assert.That(servers["kcap-memory"]!["trust"]).IsNull();   // writes (save) → still prompts
+        await Assert.That(servers["kcap-flows"]!["trust"]).IsNull();    // spawns reviewer → still prompts
+    }
+
+    [Test]
+    public async Task Register_standard_shape_emits_no_trust_field() {
+        var path = TempConfig();
+        JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new FakeMarker());
+
+        // Cursor uses the plain Standard shape — no per-server trust knob, so we emit none anywhere.
+        var servers = (JsonObject)Read(path)["mcpServers"]!;
+        foreach (var kv in servers) await Assert.That(kv.Value!["trust"]).IsNull();
+    }
+
+    [Test]
+    public async Task Register_gemini_heals_existing_untrusted_read_only_entry() {
+        var path = TempConfig();
+        // A pre-trust kcap-review entry (no trust field) as an older install would have written.
+        File.WriteAllText(path, """{ "mcpServers": { "kcap-review": { "command": "kcap", "args": ["mcp","review"] } } }""");
+
+        var change = JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Gemini, cwd: null, new FakeMarker());
+
+        await Assert.That(change).IsEqualTo(JsonMcpConfigWriter.Change.Updated);
+        await Assert.That((bool)((JsonObject)Read(path)["mcpServers"]!)["kcap-review"]!["trust"]!).IsTrue();
+    }
+
+    [Test]
     public async Task Register_preserves_user_servers() {
         var path = TempConfig();
         File.WriteAllText(path, """{ "mcpServers": { "playwright": { "command": "npx", "args": ["-y","playwright"] } } }""");

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandGeminiTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandGeminiTests.cs
@@ -37,10 +37,15 @@ public class PluginCommandGeminiTests {
         var root    = JsonNode.Parse(await File.ReadAllTextAsync(env.GeminiSettingsJson))!.AsObject();
         var servers = root["mcpServers"]!.AsObject();
         await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo("kcap");
-        await Assert.That(servers["kcap-review"]!["type"]).IsNull();  // Standard shape: no `type`
+        await Assert.That(servers["kcap-review"]!["type"]).IsNull();  // Gemini shape: no `type`
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-flows");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-memory");
+        // Read-only servers auto-approved via Gemini's per-server trust; write/flow servers still prompt.
+        await Assert.That(servers["kcap-review"]!["trust"]!.GetValue<bool>()).IsTrue();
+        await Assert.That(servers["kcap-sessions"]!["trust"]!.GetValue<bool>()).IsTrue();
+        await Assert.That(servers["kcap-flows"]!["trust"]).IsNull();
+        await Assert.That(servers["kcap-memory"]!["trust"]).IsNull();
         await Assert.That(servers["my-tool"]).IsNotNull();  // user server preserved
         await Assert.That(root["hooks"]).IsNotNull();       // hooks block preserved
         await Assert.That(root["theme"]!.GetValue<string>()).IsEqualTo("dark");  // unrelated setting preserved


### PR DESCRIPTION
> **Stacked on the AI-1227 Gemini branch** (`tonyyoung/ai-1227-gemini-mcp`) — base is that branch, **not** `main`, until AI-1227 lands; then retarget to `main`. Both branches are rebased onto current `main` (post #296/#297 merge). The diff below is the trust commit only.

## What

On registration, mark the **read-only** kcap servers (`kcap-review`, `kcap-sessions`) auto-approved wherever the harness has a per-server trust knob, so agents don't stop to ask before every read:

- **Gemini** → `"trust": true` on those entries in `~/.gemini/settings.json`
- **Codex** → `default_tools_approval_mode = "approve"` in `~/.codex/config.toml` (additively heals existing installs; never overrides a user's explicit mode or touches command/args)

## Security: read-only only

`kcap-memory` (silent `save_memory`) and `kcap-flows` (`start_review_flow` spawns a **paid** hosted reviewer) are deliberately **left prompting** — auto-approving those would let an agent write or bill work with no confirmation.

## Cursor + Copilot: no config knob (documented, not emitted)

Neither exposes a per-server auto-approve field in the config we write — Cursor's `mcp.json` has no trust field (auto-approve is a `permissions.json` classifier / `cursor-agent --approve-mcps`), and Copilot's `tools` is an *availability* allowlist, not approval (approval is runtime `--allow-tool`/`--allow-all-tools`). The README documents their runtime-flag path rather than writing a no-op field.

## Generic

`KcapMcpServer.ReadOnly` + `McpConfigShape.TrustStyle` keep the policy (which servers) and representation (how) separate — the remaining harnesses (Kiro/OpenCode/Antigravity/Pi) get trust for free when their MCP registration lands. Ownership/idempotency unaffected (marker keys off `command`); existing untrusted entries self-heal on re-register.

## Tests

`JsonMcpConfigWriter` (trust on read-only only / none on `Standard` / self-heal), `CodexConfigToml` (approve on read-only / heal without override), Gemini plugin e2e trust assertions. **Full unit suite 2701/2701.**

Linear: AI-1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)