### PR TITLE
[AI-1292] Unattended review-flow reviewer auto-approves its kcap MCP tools

### DIFF
--- a/docs/superpowers/plans/2026-07-09-reviewer-auto-approve-plan.md
+++ b/docs/superpowers/plans/2026-07-09-reviewer-auto-approve-plan.md
@@ -1,0 +1,231 @@
+# Unattended reviewer auto-approve — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Let a daemon-hosted, unattended review-flow reviewer auto-approve its kcap-owned MCP tool calls (no interactive prompt, no hang), without weakening permissions for interactive agents.
+
+**Architecture:** The orchestrator mints a per-launch **CSPRNG reviewer token** (bound to the launch's read-only kcap allowlist) and gives the reviewer that token's URL as `KCAP_DAEMON_URL`. `LocalPermissionBridge` holds a live-token registry; requests on a reviewer token auto-approve tools from the bound allowlist (and deny out-of-allowlist server-qualified calls), while the shared token behaves exactly as today. Authorization is the secret token; the reviewer's Codex MCP-config lock bounds which servers it can even call.
+
+**Tech Stack:** .NET 10, C#, TUnit, `System.Security.Cryptography.RandomNumberGenerator`, `System.Text.Json.Nodes`. Repo: kcap-cli (daemon). Full design: [../specs/2026-07-09-reviewer-auto-approve-design.md](../specs/2026-07-09-reviewer-auto-approve-design.md).
+
+## Global Constraints
+
+- **Daemon-originated trust:** the "unattended" signal is a CSPRNG secret only the reviewer process holds. Never a body flag / fixed path segment (all agents share the base token).
+- **Scope:** `LaunchKind.ReviewFlow` only. `Default`/`Review` unchanged.
+- **Server-granularity contract:** auto-approve is bounded to a **read-only** kcap server set (`ReviewFlowAutoApprovableServers` = `kcap-review`, `kcap-sessions`). `kcap-memory` (writes) / `kcap-flows` (flow-starting) are NOT auto-approvable. `submit_review_result` keeps its own unconditional carve-out (#255).
+- **Fail-fast, not hang:** an invalid reviewer allowlist fails the launch (`LaunchFailedAsync`); an out-of-allowlist server-qualified call on a reviewer token is DENIED — neither falls through to an interactive prompt.
+- **Fail-safe:** unknown/revoked token or malformed body → 404/400/deny. Never auto-allow on doubt.
+- **Secrecy:** the reviewer token must never be logged/persisted/surfaced (transcript, run metadata, launch/debug logs). `KCAP_DAEMON_URL` is already in `PtyEnvScrub`.
+- **No wire/protocol/server change.** With no reviewer tokens registered, behaviour is byte-identical to today.
+
+## File Structure
+
+- `src/Capacitor.Cli.Core/KcapMcpRegistry.cs` — **modify**: add `ReviewFlowAutoApprovableServers`, `ReviewFlowUnattendedSafeTools`, and `TryResolveReviewFlowAllowlist`.
+- `src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs` — **modify**: live reviewer-token registry (`RegisterReviewerToken`/`RevokeReviewerToken`), request classification (token→context, body-first, reviewer-token approve/deny), CSPRNG helper, keep `IsFlowResultSubmission`.
+- `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` — **modify**: mint/validate/register the reviewer token for `ReviewFlow`, thread its URL into `RuntimeStartContext.DaemonBridgeUrl`, revoke on every teardown path.
+- `src/Capacitor.Cli.Daemon/Services/AgentInstance.cs` (or its definition site) — **modify**: add `string? ReviewerBridgeToken`.
+- Tests: `test/Capacitor.Cli.Tests.Unit/Services/LocalPermissionBridgeTests.cs` (extend), a new `KcapMcpRegistryReviewFlowTests.cs`, and the existing daemon orchestrator test file (extend). A guard test for the tool classification.
+
+---
+
+### Task 1: Registry — auto-approvable set, tool classification, allowlist resolver
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/KcapMcpRegistry.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/KcapMcpRegistryReviewFlowTests.cs` (create)
+
+**Interfaces (produced):**
+```csharp
+// The read-only kcap servers whose tools are safe to auto-approve for an unattended reviewer.
+public static readonly IReadOnlySet<string> ReviewFlowAutoApprovableServers; // {"kcap-review","kcap-sessions"} (case-insensitive)
+
+// Explicit, reviewed classification: server id -> its unattended-safe (read/result-submit) tool names.
+// The guard test cross-checks each auto-approvable server's ACTUAL tools/list against this.
+public static readonly IReadOnlyDictionary<string, IReadOnlySet<string>> ReviewFlowUnattendedSafeTools;
+
+// Resolve a flow reviewer allowlist to canonical, auto-approvable server ids.
+// true  + servers (canonical, deduped) when EVERY entry resolves to a ReviewFlowAutoApprovableServers member;
+// false + rejected (the offending name) when any entry is unknown, flow-starting, or not auto-approvable.
+// null/empty input -> true + empty array (a reviewer with only the flow-result channel is valid).
+public static bool TryResolveReviewFlowAllowlist(IReadOnlyList<string>? names, out string[] servers, out string? rejected);
+```
+
+- [ ] **Step 1: Write failing tests** in `KcapMcpRegistryReviewFlowTests.cs`:
+```csharp
+using Capacitor.Cli.Core;
+namespace Capacitor.Cli.Tests.Unit;
+
+public class KcapMcpRegistryReviewFlowTests {
+    [Test] public async Task Resolve_accepts_read_only_servers_case_insensitively() {
+        var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(["Kcap-Review"], out var s, out var rej);
+        await Assert.That(ok).IsTrue();
+        await Assert.That(s).IsEquivalentTo(["kcap-review"]);
+        await Assert.That(rej).IsNull();
+    }
+    [Test] public async Task Resolve_rejects_flow_starting_server() {
+        var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(["kcap-review","kcap-flows"], out _, out var rej);
+        await Assert.That(ok).IsFalse();
+        await Assert.That(rej).IsEqualTo("kcap-flows");
+    }
+    [Test] public async Task Resolve_rejects_write_server_kcap_memory() {
+        var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(["kcap-memory"], out _, out var rej);
+        await Assert.That(ok).IsFalse();
+        await Assert.That(rej).IsEqualTo("kcap-memory");
+    }
+    [Test] public async Task Resolve_rejects_unknown_server() {
+        var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(["not-a-server"], out _, out var rej);
+        await Assert.That(ok).IsFalse();
+        await Assert.That(rej).IsEqualTo("not-a-server");
+    }
+    [Test] public async Task Resolve_empty_is_ok_empty() {
+        var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(null, out var s, out var rej);
+        await Assert.That(ok).IsTrue();
+        await Assert.That(s).IsEmpty();
+        await Assert.That(rej).IsNull();
+    }
+    // Contract guard: every auto-approvable server has a classification entry, and it only names read/submit tools.
+    [Test] public async Task Every_auto_approvable_server_is_classified() {
+        foreach (var srv in KcapMcpRegistry.ReviewFlowAutoApprovableServers)
+            await Assert.That(KcapMcpRegistry.ReviewFlowUnattendedSafeTools.ContainsKey(srv)).IsTrue();
+    }
+}
+```
+- [ ] **Step 2: Run — verify FAIL** (`TryResolveReviewFlowAllowlist` not defined).
+  Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit -- --treenode-filter "/*/*/KcapMcpRegistryReviewFlowTests/*"`
+- [ ] **Step 3: Implement** in `KcapMcpRegistry.cs`: add the set, the classification (tool names verified from `kcap mcp review`/`kcap mcp sessions` `tools/list`), and the resolver (using the existing `Resolve` + `StartsFlows` + membership in `ReviewFlowAutoApprovableServers`; first offending name → `rejected`).
+- [ ] **Step 4: Run — verify PASS** (same filter).
+- [ ] **Step 5: Commit** `feat(AI-1292): registry review-flow auto-approvable set + tool classification + resolver`.
+
+---
+
+### Task 2: LocalPermissionBridge — reviewer-token registry + classification
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/Services/LocalPermissionBridgeTests.cs` (extend)
+
+**Interfaces (produced):**
+```csharp
+// Mint a live reviewer token bound to `allowlistServers` (canonical read-only ids); returns the
+// full base URL (http://127.0.0.1:{port}/{reviewerToken}) the reviewer should use as KCAP_DAEMON_URL.
+// Throws if the bridge isn't started. Token is CSPRNG (32 hex ≡ the shared token's shape).
+public string RegisterReviewerToken(IReadOnlyList<string> allowlistServers);
+public void   RevokeReviewerToken(string reviewerBridgeUrlOrToken);
+```
+
+**Design notes (implementation):**
+- Replace the single `_token` field with a token registry: keep the shared token (interactive) + a
+  `ConcurrentDictionary<string, string[]>` of reviewer token → bound allowlist servers. `HandleAsync`
+  extracts the path token, then: (step 1) token must be the shared token OR a live reviewer token → else 404;
+  (step 2) parse body, require non-empty `session_id` **and** `tool_name` → else 400; (step 3)
+  `IsFlowResultSubmission(tool)` → allow (any live token, unchanged); (step 4) if the request is on a
+  **reviewer** token: server-qualified `mcp__<server>__<tool>` whose `<server>` ∉ bound allowlist →
+  **deny** (`new PermissionDecision("deny", null, null)`, log a diagnostic WITHOUT the token); otherwise
+  (in-allowlist qualified, or bare Codex name) → allow; (step 5) shared token, other tool → server round-trip.
+- `RegisterReviewerToken` mints a CSPRNG token via a new `NewToken()` helper (`RandomNumberGenerator.GetHexString(32)` or `Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant()`); the shared token in `StartAsync` uses the same helper (replacing `Guid.NewGuid().ToString("N")`). Reject a mint that collides with a live token.
+- Never log the token in any `LoggerMessage`.
+
+- [ ] **Step 1: Write failing tests** (extend `LocalPermissionBridgeTests`, all `[Test, NotInParallel(nameof(LocalPermissionBridgeTests))]`). Helper to register + build a reviewer POST URL:
+```csharp
+static string ReviewerUrl(LocalPermissionBridge bridge, params string[] servers)
+    => bridge.RegisterReviewerToken(servers); // returns http://127.0.0.1:{port}/{token}
+
+[Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+public async Task Reviewer_token_auto_approves_bound_read_tool_without_server_round_trip() {
+    var (bridge, server) = CreateBridge((_,_,_,_,_) => Task.FromResult(new PermissionDecision("deny", null, null)));
+    try {
+        await bridge.StartAsync(CancellationToken.None);
+        var url = ReviewerUrl(bridge, "kcap-review");
+        using var client = CreateClient();
+        var payload = new { session_id = "abc", tool_name = "get_pr_summary" };
+        using var r = await client.PostAsync($"{url}/codex/permission-request", JsonContent.Create(payload));
+        await Assert.That((int)r.StatusCode).IsEqualTo(200);
+        await Assert.That(server.Calls.Count).IsEqualTo(0);           // no prompt
+        using var doc = JsonDocument.Parse(await r.Content.ReadAsStringAsync());
+        await Assert.That(doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("decision").GetProperty("behavior").GetString()).IsEqualTo("allow");
+    } finally { await bridge.DisposeAsync(); }
+}
+```
+Add the rest (each asserting `server.Calls.Count` and/or `behavior`):
+  - reviewer token + `submit_review_result` (bare) → allow, 0 server calls;
+  - reviewer token + `mcp__kcap_review__get_pr_summary` (qualified, in allowlist) → allow, 0 calls;
+  - reviewer token + `mcp__kcap_memory__save_memory` (qualified, server NOT in bound allowlist) → **deny**, 0 calls;
+  - reviewer token + malformed JSON → 400; + missing/empty `tool_name` → 400; + missing/empty `session_id` → 400 (no server call);
+  - **shared** token + `get_pr_summary` → prompts (1 server call) — no escalation;
+  - **shared** token + `submit_review_result` → allow, 0 calls (#255 regression, existing tests still pass);
+  - **revoked** reviewer token (register→revoke) + `get_pr_summary` → 404; + `submit_review_result` → 404;
+  - concurrency: register token A + token B; revoke A; B + `get_pr_summary` → still allow;
+  - secrecy: after `RegisterReviewerToken`, the token substring does not appear in captured `NullLogger`… (use a capturing `ILogger` — see Step 3) bridge log output.
+- [ ] **Step 2: Run — verify FAIL** (`RegisterReviewerToken` not defined).
+- [ ] **Step 3: Implement** the registry + classification + CSPRNG in `LocalPermissionBridge.cs` per the design notes; for the secrecy test use a small capturing logger (list of formatted messages) and assert none contains the token.
+- [ ] **Step 4: Run — verify PASS** (`/*/*/LocalPermissionBridgeTests/*`), incl. all pre-existing tests.
+- [ ] **Step 5: Commit** `feat(AI-1292): reviewer-token registry + auto-approve classification in LocalPermissionBridge`.
+
+---
+
+### Task 3: AgentOrchestrator — mint/validate/register + revoke
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (launch build 386–405; early-return cleanup 411–424; catch cleanup 469–507; normal teardown in `CleanupAgentAsync`)
+- Modify: `AgentInstance` definition — add `public string? ReviewerBridgeToken { get; init; }`
+- Test: the existing daemon orchestrator test file (e.g. `AgentOrchestratorRoundResyncTests.cs` sibling) — add reviewer-token cases
+
+**Interfaces (consumed):** `KcapMcpRegistry.TryResolveReviewFlowAllowlist` (Task 1); `LocalPermissionBridge.RegisterReviewerToken` / `RevokeReviewerToken` (Task 2).
+
+**Implementation (before building `runtimeCtx` at line 386):**
+```csharp
+var daemonBridgeUrl = _permissionBridge.BaseUrl;   // shared token by default
+string? reviewerBridgeToken = null;
+var effectiveAllowlist = cmd.McpAllowlist;
+
+if (isReviewFlow) {
+    if (!KcapMcpRegistry.TryResolveReviewFlowAllowlist(cmd.McpAllowlist, out var servers, out var rejected)) {
+        await _server.LaunchFailedAsync(agentId,
+            $"Review-flow reviewer allowlist contains a server that is not auto-approvable: '{rejected}'.");
+        return;   // FAIL FAST — never a shared-token launch that would hang
+    }
+    var reviewerUrl = _permissionBridge.RegisterReviewerToken(servers);   // http://127.0.0.1:{port}/{token}
+    daemonBridgeUrl     = reviewerUrl;
+    reviewerBridgeToken = reviewerUrl;   // store the URL/token for revocation
+    effectiveAllowlist  = servers;       // single source: same set the launcher uses for the MCP config
+}
+```
+Then set `DaemonBridgeUrl: daemonBridgeUrl` (was `_permissionBridge.BaseUrl`) and `McpAllowlist: effectiveAllowlist` in `runtimeCtx`, and add `ReviewerBridgeToken = reviewerBridgeToken` to the `AgentInstance` initializer (line 433). Revoke in **all** teardown paths, after the process is gone:
+  - the `CodexHooksNotInstalledException` early-return (411–424): `if (reviewerBridgeToken != null) _permissionBridge.RevokeReviewerToken(reviewerBridgeToken);`
+  - the `catch` (469–507): same;
+  - normal teardown in `CleanupAgentAsync`: `if (agent.ReviewerBridgeToken != null) _permissionBridge.RevokeReviewerToken(agent.ReviewerBridgeToken);` after the runtime has exited.
+
+- [ ] **Step 1: Write failing tests** (extend the daemon orchestrator test suite; reuse its existing harness/fakes). Because `LocalPermissionBridge.BaseUrl` needs the bridge started, start the orchestrator's bridge in the fixture (or assert via a fake bridge seam if the suite has one — check the existing tests first). Assertions:
+  - a `ReviewFlow` launch with allowlist `["kcap-review"]` → the reviewer runtime's `KCAP_DAEMON_URL` (captured via the fake runtime factory's `RuntimeStartContext.DaemonBridgeUrl`) is a reviewer-token URL **different** from `_permissionBridge.BaseUrl`, and a token is registered;
+  - a `Default` launch → `DaemonBridgeUrl == _permissionBridge.BaseUrl` (shared), no token registered;
+  - a `ReviewFlow` launch with allowlist `["kcap-memory"]` → `LaunchFailedAsync` called, **no** runtime spawned, **no** reviewer token registered;
+  - after teardown, the reviewer token is revoked (a subsequent POST to its URL → 404 via the real bridge, or the fake records a revoke).
+- [ ] **Step 2: Run — verify FAIL.**
+- [ ] **Step 3: Implement** per the block above (+ `AgentInstance.ReviewerBridgeToken`).
+- [ ] **Step 4: Run — verify PASS** (orchestrator filter).
+- [ ] **Step 5: Commit** `feat(AI-1292): mint+register a reviewer bridge token for unattended review-flow launches`.
+
+---
+
+### Task 4: Secrecy + contract guard hardening
+
+**Files:**
+- Test: extend `LocalPermissionBridgeTests` / orchestrator tests / `KcapMcpRegistryReviewFlowTests`.
+
+- [ ] **Step 1: Contract guard (tools/list cross-check).** Add a test (in `KcapMcpRegistryReviewFlowTests` or a daemon integration test) that, for each `ReviewFlowAutoApprovableServers` member, spawns `kcap mcp <review|sessions>` and does the `initialize`+`tools/list` handshake (pattern proven in the AI-1224 E2E), asserting every returned tool name ∈ `ReviewFlowUnattendedSafeTools[server]`. If the test project can't spawn the built binary, fall back to a static assertion + open a follow-up; note the decision in the test. Run + PASS.
+- [ ] **Step 2: Secrecy surfaces.** Verify + assert the reviewer token/URL is absent from: orchestrator launch logs (capturing logger), `PtyEnvScrub` coverage (assert `KCAP_DAEMON_URL` scrubbed from the recorded env), and agent run/status metadata (the `AgentStatusChangedAsync` payload carries `SessionId`, not the bridge URL — assert). Run + PASS.
+- [ ] **Step 3: Commit** `test(AI-1292): contract guard (tools/list) + reviewer-token secrecy assertions`.
+
+---
+
+### Task 5: Full suite + build
+
+- [ ] **Step 1:** `git submodule update --init` if needed (worktree). Build: `dotnet build test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj` → 0 errors.
+- [ ] **Step 2:** Run the full daemon/unit suite (`dotnet run --project test/Capacitor.Cli.Tests.Unit`) → all green, no regressions in the pre-existing `LocalPermissionBridgeTests` (esp. the #255 flow-result + shared-token cases).
+- [ ] **Step 3: Commit** any test-fixup; the branch is ready for PR + Codex code-review.
+
+## Self-Review
+
+- **Spec coverage:** per-reviewer CSPRNG token (T2), token+body classification order (T2), reviewer-token deny-not-defer (T2), submit_review_result carve-out preserved (T2), fail-fast invalid allowlist (T3), revoke on all teardown paths (T3), server-level contract + machine-checkable guard (T1+T4), secrecy surfaces (T4), lifecycle/concurrency (T2 concurrency + T3 revoke). ✓
+- **Deviation noted:** the spec's "kcap-owned + non-flow-starting" launch validation is realized concretely as `ReviewFlowAutoApprovableServers` (read-only: `kcap-review`, `kcap-sessions`), excluding the write server `kcap-memory` — a tightening of constraint 3 ("unattended-safe servers only"), so a flow allowlisting a write/flow-starting server fails fast rather than auto-approving or hanging.
+- **Types:** `TryResolveReviewFlowAllowlist(out string[] servers, out string? rejected)`, `RegisterReviewerToken(IReadOnlyList<string>) → string url`, `RevokeReviewerToken(string)`, `AgentInstance.ReviewerBridgeToken` — used consistently across T1–T3.

--- a/docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md
+++ b/docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md
@@ -39,13 +39,19 @@ so the fix should be vendor-agnostic at the bridge).
    signal must be a **secret only the reviewer process holds**.
 2. **Scope:** unattended launches only — `LaunchKind.ReviewFlow`. Never `Default`
    (interactive) or `Review` (PR-review, on-request by design).
-3. **Bounded by the launch's MCP allowlist.** The reviewer's *callable* MCP tools are
-   physically confined by its Codex MCP config, which `CodexLauncher` clears
-   (`mcp_servers={}`) then whitelists to exactly the launch's kcap-owned allowlist
-   (`kcap-flow-result` + the flow's allowlist via `KcapMcpRegistry`, flow-starting servers
-   stripped). Auto-approval is *authorized by the reviewer token* and *bounded by that config
-   lock* — it can never exceed what the launch granted. Adding a mutating server to a flow's
-   allowlist is therefore an intentional grant of unattended use.
+3. **Bounded by the launch's MCP allowlist — at SERVER granularity (deliberate contract).**
+   The reviewer's *callable* MCP tools are physically confined by its Codex MCP config, which
+   `CodexLauncher` clears (`mcp_servers={}`) then whitelists to exactly the launch's kcap-owned
+   allowlist (`kcap-flow-result` + the flow's allowlist via `KcapMcpRegistry`, flow-starting
+   servers stripped). Auto-approval is *authorized by the reviewer token* and *bounded by that
+   config lock* — it can never exceed the servers the launch granted. The permission unit is
+   the **server**, not the individual tool: a bare Codex `tool_name` carries no server, and an
+   exact tool-name set would silently **hang** the unattended reviewer the day it calls a tool
+   we forgot to curate — the exact failure this change fixes. This is therefore a **deliberate
+   security contract**: *any server whitelistable for review flows MUST expose only
+   unattended-safe (read / result-submit) tools.* Adding a mutating tool to such a server, or a
+   new server to a flow allowlist, is a security-relevant change — guarded by a test (see Test
+   plan) and code review. (kcap-owned servers are first-party, so this is enforceable by us.)
 4. **Fail-safe.** Any uncertainty — unknown/revoked token, malformed body — falls through to
    the existing 404 / prompt / deny path. Never auto-allow on doubt.
 5. Native (shell/exec/patch) tools are already covered by `--ask-for-approval never` + the
@@ -85,10 +91,11 @@ Instead, at launch of an unattended reviewer:
   config — computed once, used for both, so the config lock and the bridge's bound allowlist
   cannot drift. Before minting, the orchestrator asserts that allowlist ⊆ kcap-owned,
   non-flow-starting servers (reusing `KcapMcpRegistry` + the same `FlowMcpServers.Sanitize`
-  check the config uses). If it contains anything else, the orchestrator does **not** mint an
-  unattended token (logs + falls back to the shared token) — so a future config regression
-  that leaks a non-kcap or flow-starting server can never be silently auto-approved; those
-  tools simply prompt.
+  check the config uses). If it contains anything else, the launch is treated as a **hard
+  failure**: for `LaunchKind.ReviewFlow` the orchestrator calls `LaunchFailedAsync` with a
+  clear error and does **not** spawn the reviewer. It must NOT fall back to the shared token —
+  that would drop the reviewer into the interactive-prompt path with no human present, i.e.
+  reintroduce the very unattended hang this change fixes. **Fail fast, not hang.**
 - The bridge keeps a map of **live** tokens: the **shared** token → interactive (prompt as
   today); each **per-reviewer** token → unattended (auto-approve, bound to its allowlist).
 - On agent exit/cleanup the orchestrator **revokes** the token (see Lifecycle).
@@ -176,6 +183,11 @@ bridge benefits for free.
   segment** — rejected: violates constraint 1 (any hosted agent knows the shared token).
 - **Tool-name "kcap-owned" filter at the bridge** — rejected: Codex sends bare names
   (unverifiable + spoofable); token + config-lock is safer and simpler (see above).
+- **Exact per-tool allowlist bound to the token** — rejected: it makes the permission unit the
+  tool, so the day the reviewer calls a tool we forgot to curate it would **hang** (no human to
+  approve) — the exact failure this change fixes. Server-level grant + the read-only-tools
+  contract guard (constraint 3) is chosen instead: it can't hang and still bounds auto-approval
+  to first-party, unattended-safe servers.
 - **Auto-approve kcap-owned tools for all sessions** — rejected: would suppress prompts in
   interactive hosted agents and the user's own sessions.
 
@@ -187,6 +199,8 @@ bridge benefits for free.
 - live reviewer token + `submit_review_result` → auto-approved (regression);
 - live reviewer token + **malformed JSON** → 400, no approval;
 - live reviewer token + **missing/empty `tool_name`** → 400, no approval (never blanket-approve);
+- live reviewer token **and** shared token + **missing/empty `session_id`** → 400, no approval
+  and **not** forwarded to `server.RequestPermissionAsync`;
 - live reviewer token + server-qualified name whose `<server>` is **not** in the bound
   allowlist → prompts (bound-allowlist enforcement);
 - **shared** token + `get_pr_summary` → prompts (interactive unchanged — proves an agent
@@ -202,9 +216,16 @@ bridge benefits for free.
   `KCAP_DAEMON_URL`; a `Default` launch uses the shared token;
 - the token's registered allowlist **equals** the allowlist used to build the reviewer MCP
   config (single source, no drift);
-- a launch whose computed allowlist contains a non-kcap or flow-starting server mints **no**
-  reviewer token — it falls back to the shared token so those tools prompt;
+- a `ReviewFlow` launch whose computed allowlist contains a non-kcap or flow-starting server
+  **fails fast** (`LaunchFailedAsync`, no reviewer spawned) and produces **no** interactive
+  permission request — it does NOT fall back to the shared token;
 - the reviewer token is revoked on normal teardown (after exit) **and** on failed-launch cleanup.
+
+Contract guard test:
+- every tool exposed by the kcap servers eligible for review-flow allowlists (`kcap-review`,
+  `kcap-flow-result`, and any others the flow catalog can whitelist) is **unattended-safe**
+  (read / result-submit only) — enumerate them and assert none is mutating or flow-starting, so
+  adding such a tool to a review-flow-eligible server trips this test (constraint 3's contract).
 
 **Secrecy assertions** (a minted reviewer token must not appear in): the bridge's emitted logs;
 the daemon/launch logs; the recorded session env (`PtyEnvScrub` coverage); the session

--- a/docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md
+++ b/docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md
@@ -52,11 +52,15 @@ so the fix should be vendor-agnostic at the bridge).
    sandbox and never reach the bridge — out of scope.
 6. **Token secrecy.** The per-reviewer token is a bearer credential carrying extra
    permission. It MUST be **CSPRNG-generated** (`RandomNumberGenerator`, ≥128 bits),
-   unguessable, and unique per launch. `KCAP_DAEMON_URL` (which carries it) is already in
-   `PtyEnvScrub`'s scrub list (`PtyEnvScrub.cs:24`) so it is not propagated to child/native
-   processes; it MUST NOT be logged, persisted, or surfaced via session/transcript/
-   agent-visible diagnostics. (Residual, accepted — same as today's shared token: a same-user
-   process reading another process's env is out of scope.)
+   unguessable, and unique per launch. It MUST NOT leak onto any surface another hosted agent
+   could later read — otherwise the correlation property (constraint 1) fails. Concretely it
+   must not appear in: (a) the recorded session env — `KCAP_DAEMON_URL` is already in
+   `PtyEnvScrub`'s scrub list (`PtyEnvScrub.cs:24`); verify it also covers any per-reviewer
+   variant; (b) the session **transcript** / recorded events (readable via the kcap-owned read
+   tools like `kcap-sessions`/`kcap-review`); (c) agent run/status metadata broadcast to the
+   server; (d) daemon/launch/debug logs. Add absence assertions for each surface. (Residual,
+   accepted — same as today's shared token: a same-user process reading another process's live
+   env is out of scope.)
 
 ## Design
 
@@ -76,6 +80,15 @@ Instead, at launch of an unattended reviewer:
   (→ `KCAP_DAEMON_URL`, `AgentOrchestrator.cs:401`) to the minted token's URL instead of the
   shared one. The URL stays `http://127.0.0.1:{port}/{reviewerToken}`, so it still passes the
   reviewer hook's loopback validation (`DaemonBridgeUrl.cs`).
+- **Register-time validation (defense in depth).** The token is bound to the **exact same
+  post-strip allowlist** the orchestrator hands `CodexLauncher` to build the reviewer's MCP
+  config — computed once, used for both, so the config lock and the bridge's bound allowlist
+  cannot drift. Before minting, the orchestrator asserts that allowlist ⊆ kcap-owned,
+  non-flow-starting servers (reusing `KcapMcpRegistry` + the same `FlowMcpServers.Sanitize`
+  check the config uses). If it contains anything else, the orchestrator does **not** mint an
+  unattended token (logs + falls back to the shared token) — so a future config regression
+  that leaks a non-kcap or flow-starting server can never be silently auto-approved; those
+  tools simply prompt.
 - The bridge keeps a map of **live** tokens: the **shared** token → interactive (prompt as
   today); each **per-reviewer** token → unattended (auto-approve, bound to its allowlist).
 - On agent exit/cleanup the orchestrator **revokes** the token (see Lifecycle).
@@ -87,19 +100,27 @@ confined to that one token, torn down when the reviewer ends).
 
 ### Request classification (explicit order)
 
-On each POST the bridge decides in this order — token authenticity is checked **before** any
-tool-specific auto-approval (constraint 4):
+On each POST the bridge decides in this order — token **and body** authenticity are checked
+**before** any tool-specific auto-approval (constraint 4). No step may approve on a request it
+hasn't fully validated:
 
 1. **Token check.** The path token must be one of the **live** registered tokens (shared +
-   reviewer). Unknown/revoked/malformed → **404** (as today).
-2. **`submit_review_result` → auto-approve**, on any live token (unchanged; preserves #255 —
+   reviewer). Unknown/revoked/malformed token → **404** (as today).
+2. **Body check.** Parse the JSON body and require a well-formed permission request — a
+   non-empty `session_id` and a non-empty `tool_name`. Malformed JSON, missing/empty required
+   fields, or an unrecognised request shape → **400** (as today), **never** an approval. Only a
+   well-formed tool-call permission request can reach steps 3–4. (Native tool requests never
+   reach the bridge — constraint 5 — so a reviewer-token request is always an MCP tool call.)
+3. **`submit_review_result` → auto-approve**, on any live token (unchanged; preserves #255 —
    the tool is unique to `kcap-flow-result`, only injected for reviewers).
-3. **Live reviewer token → auto-approve.** The token is the daemon-minted authorization, and
-   the reviewer's Codex MCP config confines its callable tools to the launch's kcap-owned
-   allowlist (constraint 3) — so every MCP tool call arriving on the reviewer token is, by
-   construction, a launch-granted kcap tool.
-4. **Else** (shared token, any other tool) → `server.RequestPermissionAsync` (interactive
-   prompt, unchanged).
+4. **Live reviewer token → auto-approve**, bounded by the token's **registered allowlist**:
+   - if `tool_name` is **server-qualified** (Claude `mcp__<server>__<tool>`), require
+     `<server>` ∈ the token's bound allowlist, else fall through to step 5;
+   - if `tool_name` is **bare** (Codex), auto-approve — bounded by the Codex MCP-config lock
+     (constraint 3) + the orchestrator's register-time allowlist validation (below), which
+     together guarantee the reviewer can only call servers in the bound allowlist.
+5. **Else** (shared token / server not in the bound allowlist / any other tool) →
+   `server.RequestPermissionAsync` (interactive prompt, unchanged).
 
 ### Why token-based, not tool-name parsing
 
@@ -136,13 +157,16 @@ bridge benefits for free.
 ## Components touched
 
 - **`LocalPermissionBridge`** — a live-token registry (shared token + reviewer tokens;
-  `RegisterReviewerToken(...)` returning the token/URL, `RevokeReviewerToken(...)`); classify
-  requests per §Request classification; `IsFlowResultSubmission` unchanged; CSPRNG token gen;
-  never log the token.
-- **`AgentOrchestrator`** — for an unattended `ReviewFlow` launch: mint+register a reviewer
-  token (bound to the launch's kcap-owned allowlist), use its URL as this launch's
-  `DaemonBridgeUrl`; revoke on cleanup/exit (both the success teardown and the failed-launch
-  cleanup path), **after** process exit.
+  `RegisterReviewerToken(allowlist)` returning the token/URL, `RevokeReviewerToken(...)`, each
+  token carrying its bound allowlist); parse+validate the body then classify per §Request
+  classification (enforcing server-qualified names against the bound allowlist);
+  `IsFlowResultSubmission` unchanged; CSPRNG token gen; never log the token.
+- **`AgentOrchestrator`** — for an unattended `ReviewFlow` launch: compute the post-strip
+  kcap-owned allowlist **once**, use it both to build the reviewer MCP config (via
+  `CodexLauncher`) and to register the reviewer token; assert it is kcap-owned +
+  non-flow-starting before minting (else fall back to the shared token); use the minted URL as
+  this launch's `DaemonBridgeUrl`; revoke on cleanup/exit (success teardown **and**
+  failed-launch cleanup), **after** process exit.
 
 ## Alternatives considered
 
@@ -158,21 +182,33 @@ bridge benefits for free.
 ## Test plan
 
 `LocalPermissionBridge` unit tests (extend `LocalPermissionBridgeTests`):
-- live reviewer token + `get_pr_summary` → auto-approved, **no** `server.RequestPermissionAsync` call;
+- live reviewer token + `get_pr_summary` (bare + server-qualified in-allowlist forms) →
+  auto-approved, **no** `server.RequestPermissionAsync` call;
 - live reviewer token + `submit_review_result` → auto-approved (regression);
+- live reviewer token + **malformed JSON** → 400, no approval;
+- live reviewer token + **missing/empty `tool_name`** → 400, no approval (never blanket-approve);
+- live reviewer token + server-qualified name whose `<server>` is **not** in the bound
+  allowlist → prompts (bound-allowlist enforcement);
 - **shared** token + `get_pr_summary` → prompts (interactive unchanged — proves an agent
   holding only the shared token can't get kcap tools auto-approved, i.e. no escalation);
 - **shared** token + `submit_review_result` → auto-approved (#255 regression);
 - **revoked** reviewer token + `get_pr_summary` **and** + `submit_review_result` → 404/deny
   (fail-safe; a revoked reviewer token auto-approves nothing);
-- unknown/malformed token → 404 (unchanged);
-- **secrecy:** the minted token does not appear in the bridge's emitted log output;
+- unknown/malformed **token** → 404 (unchanged);
 - **concurrency:** two live reviewer tokens; revoking token A still auto-approves on token B.
 
 `AgentOrchestrator` tests:
 - an unattended `ReviewFlow` launch mints+registers a reviewer token and injects its URL as
   `KCAP_DAEMON_URL`; a `Default` launch uses the shared token;
+- the token's registered allowlist **equals** the allowlist used to build the reviewer MCP
+  config (single source, no drift);
+- a launch whose computed allowlist contains a non-kcap or flow-starting server mints **no**
+  reviewer token — it falls back to the shared token so those tools prompt;
 - the reviewer token is revoked on normal teardown (after exit) **and** on failed-launch cleanup.
+
+**Secrecy assertions** (a minted reviewer token must not appear in): the bridge's emitted logs;
+the daemon/launch logs; the recorded session env (`PtyEnvScrub` coverage); the session
+transcript / recorded events; agent run/status metadata sent to the server.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md
+++ b/docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md
@@ -129,9 +129,10 @@ hasn't fully validated:
      diagnostic log), **never** fall through to `server.RequestPermissionAsync`. An unattended
      reviewer has no human, so an out-of-allowlist call is an authorization failure to reject,
      not a decision to defer — and deferring would hang.
-   - `tool_name` **bare** (Codex): auto-approve — bounded by the Codex MCP-config lock
-     (constraint 3) + the orchestrator's register-time allowlist validation, which together
-     guarantee the reviewer can only call servers in the bound allowlist.
+   - `tool_name` **bare** (no server qualifier): auto-approve **only when the request's vendor is
+     `codex`** — its MCP-config lock is what makes a bare name provably a bound kcap tool (constraint
+     3 + register-time validation). Any other vendor's bare name (e.g. Claude's built-in `Bash`) is
+     **denied** — not proven to be a kcap tool.
 5. **Else** (shared token, any non-`submit_review_result` tool) → `server.RequestPermissionAsync`
    (interactive prompt, unchanged). A reviewer token never reaches this step.
 
@@ -146,11 +147,13 @@ enforcement of *which* tools. No tool-name heuristic, no spoof surface. (Forward
 future vendor sends server-qualified names, the bridge MAY additionally verify the `<server>`
 ∈ the token's bound allowlist; not needed for Codex today.)
 
-### Vendor-agnostic
+### Vendor gating
 
-Keyed by the reviewer token, not the vendor. Codex is the only current beneficiary (Claude
-uses `bypassPermissions`); a future unattended vendor that routes MCP prompts through the
-bridge benefits for free.
+Only **Codex** reviewers are minted a token (the orchestrator gates the mint on `cmd.Vendor ==
+codex`): Codex's MCP-config lock is what bounds a bare tool name to the allowlist. Claude reviewers
+run via `bypassPermissions` and only get the flow-result submit channel, so they need none. As
+defense in depth the bridge also denies a non-`codex` bare name on a reviewer token (step 4), so
+even a mis-minted token can't auto-approve an unconstrained built-in.
 
 ## Lifecycle & concurrency
 

--- a/docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md
+++ b/docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md
@@ -1,0 +1,162 @@
+# Unattended review-flow reviewer: auto-approve its kcap-owned MCP tools
+
+**Issue:** AI-1292
+**Repo:** kcap-cli (daemon)
+**Status:** design
+
+## Problem
+
+A daemon-hosted **review-flow reviewer** (Codex) is launched unattended
+(`CodexLauncher`: `--ask-for-approval never`), but Codex still fires a `PermissionRequest`
+hook for **MCP tool calls** even under that flag. `LocalPermissionBridge` auto-approves
+exactly one tool — `submit_review_result` (`IsFlowResultSubmission`) — and routes every
+other MCP tool call to `server.RequestPermissionAsync`, i.e. an **interactive UI prompt
+with no human present**. The code-review flow whitelists `kcap-review` for the reviewer, so
+its first `get_pr_summary` call blocks the flow until someone manually clicks *Allow*,
+defeating the "unattended reviewer" promise.
+
+This is **requester-independent**: the code-review reviewer is always Codex
+(`code-review.yaml` → `vendor: codex`), and neither the server nor the daemon branches on
+the requesting agent's vendor. Claude reviewers avoid the symptom only because
+`bypassPermissions` suppresses MCP-tool prompts entirely (and they also run through the
+same bridge, which is why the fix should be vendor-agnostic at the bridge).
+
+## Goal / success criteria
+
+1. An unattended review-flow reviewer completes **without any interactive permission
+   prompt** for its kcap-owned MCP tools (`get_pr_summary`, `search_context`,
+   `list_pr_files`, `get_transcript`, `submit_review_result`, …), for **every** requester.
+2. **No behavioural change** for interactive hosted agents or the user's own sessions —
+   they prompt exactly as today.
+3. The server permission boundary is **not** weakened for anything except an unattended
+   reviewer's own kcap-owned tools.
+
+## Constraints & safety (non-negotiable)
+
+1. **Daemon-originated trust.** The "this is an unattended reviewer" signal MUST originate
+   from the daemon's launch knowledge, never from the agent's self-declaration. Every
+   spawned agent today receives the *same* bridge URL/token via `KCAP_DAEMON_URL`
+   (`PtyHostedAgentRuntimeFactory.cs:91`), so a body flag or a fixed path segment would let
+   an interactive hosted agent (which knows that shared token) claim unattended status and
+   bypass the user's prompt. The signal must be a **secret only the reviewer process holds**.
+2. **Scope:** unattended launches only — `LaunchKind.ReviewFlow`. Never `Default`
+   (interactive) or `Review` (PR-review, on-request by design).
+3. **kcap-owned tools only.** The reviewer's MCP set is already locked to kcap-owned
+   servers (`CodexLauncher` clears `mcp_servers={}`, then whitelists `kcap-flow-result` +
+   the flow's kcap-owned allowlist via `KcapMcpRegistry`, with flow-starting servers
+   stripped). Auto-approve only tools that name a kcap-owned MCP server; anything else on
+   the reviewer still prompts.
+4. **Fail-safe.** Any uncertainty — unknown/revoked token, lookup miss, malformed body —
+   falls through to the existing prompt/deny path. Never auto-allow on doubt.
+5. Native (shell/exec/patch) tools are already covered by `--ask-for-approval never` + the
+   sandbox and never reach the bridge — out of scope.
+
+## Design
+
+### Correlation: a per-reviewer bridge token (recommended)
+
+Today the bridge binds a single secret path token
+(`http://127.0.0.1:{port}/{token}`, `LocalPermissionBridge.StartAsync`), published to every
+agent via `KCAP_DAEMON_URL`, and distinguishes callers only by `session_id` in the POST
+body. Two facts rule out a `session_id`-keyed lookup: the daemon *"doesn't track sessionId
+on its own (only agentId)"* (`AgentOrchestrator.cs:741`) and learns it late, so the first
+tool call can precede it (race); and `session_id` is not a secret, so it can't satisfy
+constraint 1.
+
+Instead, at launch of an unattended reviewer:
+
+- The orchestrator asks the bridge to **mint a distinct per-reviewer token** bound to an
+  "unattended reviewer" context, and sets that reviewer's `DaemonBridgeUrl`
+  (→ `KCAP_DAEMON_URL`, `AgentOrchestrator.cs:401`) to the minted token's URL instead of the
+  shared one. The URL stays `http://127.0.0.1:{port}/{reviewerToken}`, so it still passes the
+  reviewer hook's loopback validation (`DaemonBridgeUrl.cs`).
+- The bridge keeps a small map of live tokens: the **shared** token → interactive (prompt as
+  today); each **per-reviewer** token → unattended (auto-approve kcap-owned tools).
+- On agent exit/cleanup the orchestrator **revokes** the token.
+
+Why this is right:
+- **Secure** — only the reviewer process receives its token (in its own env). Interactive
+  agents keep the shared token and cannot address the unattended path.
+- **Race-free** — the token exists at launch; no dependence on `session_id` timing.
+- **Small blast radius** — auto-approve is confined to requests bearing that one token, and
+  is torn down when the reviewer ends.
+
+### Auto-approve rule
+
+Two independent carve-outs, evaluated before the fall-through to `server.RequestPermissionAsync`:
+
+1. **`submit_review_result` — unconditional (unchanged, preserves #255).** Keep the existing
+   `IsFlowResultSubmission` auto-approve exactly as-is, on **any** token. The tool is unique to
+   the `kcap-flow-result` server, which is only injected for review-flow reviewers, so matching
+   it is always safe and must not regress if a reviewer ever runs without a reviewer token
+   (feature-off fallback).
+2. **kcap-owned tools — only on an unattended-reviewer token (new).** When the request arrives
+   on a per-reviewer token, also auto-approve any tool that **names a kcap-owned MCP server**.
+   Add an `IsKcapOwnedTool` matcher alongside `IsFlowResultSubmission`, accepting both naming
+   conventions the bridge already handles: Claude's sanitised `mcp__kcap_<server>__<tool>` and
+   Codex's bare/`kcap-<server>` forms (kcap servers: `kcap-review`, `kcap-sessions`,
+   `kcap-memory`, `kcap-flows`, `kcap-flow-result`).
+
+Anything else on the reviewer token, and every non-`submit_review_result` tool on the shared
+token, still prompts — no change to interactive behaviour.
+
+*Alternative (rejected): blanket auto-approve any tool on the reviewer token.* The reviewer's
+MCP set is already kcap-owned, so this is functionally equivalent, but the explicit
+kcap-owned filter is defense-in-depth + auditable, so it wins.
+
+### Vendor-agnostic
+
+Keyed by the reviewer token, not the vendor. Codex is the only current beneficiary (Claude
+uses `bypassPermissions` and needs no bridge auto-approve), but a future unattended vendor
+that routes MCP prompts through the bridge benefits with no extra work.
+
+## Components touched
+
+- **`LocalPermissionBridge`** — a token→context registry (register/revoke an
+  unattended-reviewer token; accept & classify requests by which live token they arrive on);
+  add `IsKcapOwnedTool` **alongside** the unchanged `IsFlowResultSubmission`; auto-approve
+  kcap-owned tools on a reviewer token, else fall through unchanged.
+- **`AgentOrchestrator`** — for an unattended `ReviewFlow` launch: mint+register a reviewer
+  token, use its URL as this launch's `DaemonBridgeUrl`; revoke on cleanup/exit (both the
+  success teardown and the failed-launch cleanup path).
+
+## Alternatives considered
+
+- **`session_id` registry** (orchestrator records reviewer `session_id` → auto-approve):
+  rejected — learned late (race with the first tool call), needs a reverse map, and
+  `session_id` is spoofable by any agent holding the shared token.
+- **Agent self-declared "unattended" flag in the POST body / fixed `/unattended` path
+  segment**: rejected — violates constraint 1 (any hosted agent knows the shared token and
+  could claim it).
+- **Auto-approve kcap-owned tools for all sessions**: rejected — would suppress prompts in
+  interactive hosted agents and the user's own sessions.
+
+## Test plan
+
+`LocalPermissionBridge` unit tests (extend `LocalPermissionBridgeTests`):
+- reviewer token + `get_pr_summary` in **both** name forms (`mcp__kcap_review__get_pr_summary`
+  and the Codex bare form) → auto-approved, **no** `server.RequestPermissionAsync` call;
+- reviewer token + `submit_review_result` → auto-approved (regression);
+- reviewer token + a **non-kcap** tool (e.g. `Bash`/`shell`) → prompts (server call);
+- **shared** token + `get_pr_summary` → prompts (interactive unchanged);
+- **shared** token + `submit_review_result` → auto-approved (unconditional carve-out, #255 regression);
+- unknown/revoked token → 404/deny (fail-safe).
+
+`AgentOrchestrator` test:
+- launching an unattended `ReviewFlow` reviewer registers a reviewer token and injects its
+  URL as `KCAP_DAEMON_URL`; a `Default` launch uses the shared token; the token is revoked on
+  teardown.
+
+## Out of scope
+
+- Client-side per-harness MCP tool-trust (Gemini `trust:true` / Copilot `tools` allowlist) —
+  tracked separately (the "B" workstream).
+- The Claude reviewer path (already clean via `bypassPermissions`).
+- `LaunchKind.Review` (PR-review) — interactive by design.
+
+## Rollout / risk
+
+- Pure daemon change; no server or wire-protocol change. With no reviewer tokens registered
+  the behaviour is byte-identical to today (feature effectively off).
+- Touches the daemon flow/permission internals (Alexey's area) — request his review after the
+  Codex code-review cycle.

--- a/docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md
+++ b/docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md
@@ -49,9 +49,12 @@ so the fix should be vendor-agnostic at the bridge).
    exact tool-name set would silently **hang** the unattended reviewer the day it calls a tool
    we forgot to curate — the exact failure this change fixes. This is therefore a **deliberate
    security contract**: *any server whitelistable for review flows MUST expose only
-   unattended-safe (read / result-submit) tools.* Adding a mutating tool to such a server, or a
-   new server to a flow allowlist, is a security-relevant change — guarded by a test (see Test
-   plan) and code review. (kcap-owned servers are first-party, so this is enforceable by us.)
+   unattended-safe (read / result-submit) tools.* This contract is backed by an **explicit,
+   machine-checkable unattended-safe tool classification** (first-party metadata / a reviewed
+   allowlist — not naming heuristics or human interpretation), enforced by a guard test (see
+   Test plan). Adding a mutating tool to such a server, or a new server to a flow allowlist, is
+   a security-relevant change that fails the guard until the tool is explicitly classified in a
+   reviewed change. (kcap-owned servers are first-party, so this is enforceable by us.)
 4. **Fail-safe.** Any uncertainty — unknown/revoked token, malformed body — falls through to
    the existing 404 / prompt / deny path. Never auto-allow on doubt.
 5. Native (shell/exec/patch) tools are already covered by `--ask-for-approval never` + the
@@ -120,14 +123,17 @@ hasn't fully validated:
    reach the bridge — constraint 5 — so a reviewer-token request is always an MCP tool call.)
 3. **`submit_review_result` → auto-approve**, on any live token (unchanged; preserves #255 —
    the tool is unique to `kcap-flow-result`, only injected for reviewers).
-4. **Live reviewer token → auto-approve**, bounded by the token's **registered allowlist**:
-   - if `tool_name` is **server-qualified** (Claude `mcp__<server>__<tool>`), require
-     `<server>` ∈ the token's bound allowlist, else fall through to step 5;
-   - if `tool_name` is **bare** (Codex), auto-approve — bounded by the Codex MCP-config lock
-     (constraint 3) + the orchestrator's register-time allowlist validation (below), which
-     together guarantee the reviewer can only call servers in the bound allowlist.
-5. **Else** (shared token / server not in the bound allowlist / any other tool) →
-   `server.RequestPermissionAsync` (interactive prompt, unchanged).
+4. **Live reviewer token** — bounded by the token's **registered allowlist**:
+   - `tool_name` **server-qualified** (Claude `mcp__<server>__<tool>`): if `<server>` ∈ the
+     bound allowlist → **auto-approve**; if **not** → **deny directly** (a deny decision + a
+     diagnostic log), **never** fall through to `server.RequestPermissionAsync`. An unattended
+     reviewer has no human, so an out-of-allowlist call is an authorization failure to reject,
+     not a decision to defer — and deferring would hang.
+   - `tool_name` **bare** (Codex): auto-approve — bounded by the Codex MCP-config lock
+     (constraint 3) + the orchestrator's register-time allowlist validation, which together
+     guarantee the reviewer can only call servers in the bound allowlist.
+5. **Else** (shared token, any non-`submit_review_result` tool) → `server.RequestPermissionAsync`
+   (interactive prompt, unchanged). A reviewer token never reaches this step.
 
 ### Why token-based, not tool-name parsing
 
@@ -202,7 +208,8 @@ bridge benefits for free.
 - live reviewer token **and** shared token + **missing/empty `session_id`** → 400, no approval
   and **not** forwarded to `server.RequestPermissionAsync`;
 - live reviewer token + server-qualified name whose `<server>` is **not** in the bound
-  allowlist → prompts (bound-allowlist enforcement);
+  allowlist → **deny** (deny decision), with **no** `server.RequestPermissionAsync` call (no
+  hang, no interactive deferral);
 - **shared** token + `get_pr_summary` → prompts (interactive unchanged — proves an agent
   holding only the shared token can't get kcap tools auto-approved, i.e. no escalation);
 - **shared** token + `submit_review_result` → auto-approved (#255 regression);
@@ -221,11 +228,15 @@ bridge benefits for free.
   permission request — it does NOT fall back to the shared token;
 - the reviewer token is revoked on normal teardown (after exit) **and** on failed-launch cleanup.
 
-Contract guard test:
-- every tool exposed by the kcap servers eligible for review-flow allowlists (`kcap-review`,
-  `kcap-flow-result`, and any others the flow catalog can whitelist) is **unattended-safe**
-  (read / result-submit only) — enumerate them and assert none is mutating or flow-starting, so
-  adding such a tool to a review-flow-eligible server trips this test (constraint 3's contract).
+Contract guard test (machine-checkable, not naming-based):
+- derive the review-flow-eligible server set from the **same source used at launch** — the flow
+  catalog's allowlists ∩ `KcapMcpRegistry` — never a hand-maintained list;
+- enumerate each such server's **actually-exposed** tools (via its `tools/list`) and assert
+  every one appears in an **explicit unattended-safe classification** (a first-party, reviewed
+  `ReviewFlowUnattendedSafeTools` allowlist / per-tool metadata on `KcapMcpRegistry`);
+- an unclassified or unsafe tool **fails** the guard — tripping CI and, by contract, making the
+  server ineligible for review-flow whitelisting until the tool is explicitly classified in a
+  reviewed change.
 
 **Secrecy assertions** (a minted reviewer token must not appear in): the bridge's emitted logs;
 the daemon/launch logs; the recorded session env (`PtyEnvScrub` coverage); the session

--- a/docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md
+++ b/docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md
@@ -1,8 +1,6 @@
 # Unattended review-flow reviewer: auto-approve its kcap-owned MCP tools
 
-**Issue:** AI-1292
-**Repo:** kcap-cli (daemon)
-**Status:** design
+**Issue:** AI-1292 · **Repo:** kcap-cli (daemon) · **Status:** design (rev 2 — addresses Codex spec-review round 1)
 
 ## Problem
 
@@ -18,18 +16,18 @@ defeating the "unattended reviewer" promise.
 This is **requester-independent**: the code-review reviewer is always Codex
 (`code-review.yaml` → `vendor: codex`), and neither the server nor the daemon branches on
 the requesting agent's vendor. Claude reviewers avoid the symptom only because
-`bypassPermissions` suppresses MCP-tool prompts entirely (and they also run through the
-same bridge, which is why the fix should be vendor-agnostic at the bridge).
+`bypassPermissions` suppresses MCP-tool prompts entirely (they run through the same bridge,
+so the fix should be vendor-agnostic at the bridge).
 
 ## Goal / success criteria
 
 1. An unattended review-flow reviewer completes **without any interactive permission
-   prompt** for its kcap-owned MCP tools (`get_pr_summary`, `search_context`,
+   prompt** for the MCP tools its launch grants it (`get_pr_summary`, `search_context`,
    `list_pr_files`, `get_transcript`, `submit_review_result`, …), for **every** requester.
 2. **No behavioural change** for interactive hosted agents or the user's own sessions —
    they prompt exactly as today.
 3. The server permission boundary is **not** weakened for anything except an unattended
-   reviewer's own kcap-owned tools.
+   reviewer's own launch-granted MCP tools.
 
 ## Constraints & safety (non-negotiable)
 
@@ -37,19 +35,28 @@ same bridge, which is why the fix should be vendor-agnostic at the bridge).
    from the daemon's launch knowledge, never from the agent's self-declaration. Every
    spawned agent today receives the *same* bridge URL/token via `KCAP_DAEMON_URL`
    (`PtyHostedAgentRuntimeFactory.cs:91`), so a body flag or a fixed path segment would let
-   an interactive hosted agent (which knows that shared token) claim unattended status and
-   bypass the user's prompt. The signal must be a **secret only the reviewer process holds**.
+   an interactive hosted agent (which knows that shared token) claim unattended status. The
+   signal must be a **secret only the reviewer process holds**.
 2. **Scope:** unattended launches only — `LaunchKind.ReviewFlow`. Never `Default`
    (interactive) or `Review` (PR-review, on-request by design).
-3. **kcap-owned tools only.** The reviewer's MCP set is already locked to kcap-owned
-   servers (`CodexLauncher` clears `mcp_servers={}`, then whitelists `kcap-flow-result` +
-   the flow's kcap-owned allowlist via `KcapMcpRegistry`, with flow-starting servers
-   stripped). Auto-approve only tools that name a kcap-owned MCP server; anything else on
-   the reviewer still prompts.
-4. **Fail-safe.** Any uncertainty — unknown/revoked token, lookup miss, malformed body —
-   falls through to the existing prompt/deny path. Never auto-allow on doubt.
+3. **Bounded by the launch's MCP allowlist.** The reviewer's *callable* MCP tools are
+   physically confined by its Codex MCP config, which `CodexLauncher` clears
+   (`mcp_servers={}`) then whitelists to exactly the launch's kcap-owned allowlist
+   (`kcap-flow-result` + the flow's allowlist via `KcapMcpRegistry`, flow-starting servers
+   stripped). Auto-approval is *authorized by the reviewer token* and *bounded by that config
+   lock* — it can never exceed what the launch granted. Adding a mutating server to a flow's
+   allowlist is therefore an intentional grant of unattended use.
+4. **Fail-safe.** Any uncertainty — unknown/revoked token, malformed body — falls through to
+   the existing 404 / prompt / deny path. Never auto-allow on doubt.
 5. Native (shell/exec/patch) tools are already covered by `--ask-for-approval never` + the
    sandbox and never reach the bridge — out of scope.
+6. **Token secrecy.** The per-reviewer token is a bearer credential carrying extra
+   permission. It MUST be **CSPRNG-generated** (`RandomNumberGenerator`, ≥128 bits),
+   unguessable, and unique per launch. `KCAP_DAEMON_URL` (which carries it) is already in
+   `PtyEnvScrub`'s scrub list (`PtyEnvScrub.cs:24`) so it is not propagated to child/native
+   processes; it MUST NOT be logged, persisted, or surfaced via session/transcript/
+   agent-visible diagnostics. (Residual, accepted — same as today's shared token: a same-user
+   process reading another process's env is out of scope.)
 
 ## Design
 
@@ -58,94 +65,114 @@ same bridge, which is why the fix should be vendor-agnostic at the bridge).
 Today the bridge binds a single secret path token
 (`http://127.0.0.1:{port}/{token}`, `LocalPermissionBridge.StartAsync`), published to every
 agent via `KCAP_DAEMON_URL`, and distinguishes callers only by `session_id` in the POST
-body. Two facts rule out a `session_id`-keyed lookup: the daemon *"doesn't track sessionId
-on its own (only agentId)"* (`AgentOrchestrator.cs:741`) and learns it late, so the first
-tool call can precede it (race); and `session_id` is not a secret, so it can't satisfy
-constraint 1.
+body. Two facts rule out a `session_id`-keyed lookup: the daemon *"doesn't track sessionId on
+its own (only agentId)"* (`AgentOrchestrator.cs:741`) and learns it late, so the first tool
+call can precede it (race); and `session_id` is not a secret, so it can't satisfy constraint 1.
 
 Instead, at launch of an unattended reviewer:
 
-- The orchestrator asks the bridge to **mint a distinct per-reviewer token** bound to an
-  "unattended reviewer" context, and sets that reviewer's `DaemonBridgeUrl`
+- The orchestrator asks the bridge to **mint a distinct per-reviewer token** (CSPRNG) bound
+  to that launch's kcap-owned MCP allowlist, and sets the reviewer's `DaemonBridgeUrl`
   (→ `KCAP_DAEMON_URL`, `AgentOrchestrator.cs:401`) to the minted token's URL instead of the
   shared one. The URL stays `http://127.0.0.1:{port}/{reviewerToken}`, so it still passes the
   reviewer hook's loopback validation (`DaemonBridgeUrl.cs`).
-- The bridge keeps a small map of live tokens: the **shared** token → interactive (prompt as
-  today); each **per-reviewer** token → unattended (auto-approve kcap-owned tools).
-- On agent exit/cleanup the orchestrator **revokes** the token.
+- The bridge keeps a map of **live** tokens: the **shared** token → interactive (prompt as
+  today); each **per-reviewer** token → unattended (auto-approve, bound to its allowlist).
+- On agent exit/cleanup the orchestrator **revokes** the token (see Lifecycle).
 
-Why this is right:
-- **Secure** — only the reviewer process receives its token (in its own env). Interactive
-  agents keep the shared token and cannot address the unattended path.
-- **Race-free** — the token exists at launch; no dependence on `session_id` timing.
-- **Small blast radius** — auto-approve is confined to requests bearing that one token, and
-  is torn down when the reviewer ends.
+Why this is right: **secure** (only the reviewer process gets its token; interactive agents
+keep the shared token and cannot address the unattended path); **race-free** (the token
+exists at launch, no `session_id` timing dependence); **small blast radius** (auto-approve
+confined to that one token, torn down when the reviewer ends).
 
-### Auto-approve rule
+### Request classification (explicit order)
 
-Two independent carve-outs, evaluated before the fall-through to `server.RequestPermissionAsync`:
+On each POST the bridge decides in this order — token authenticity is checked **before** any
+tool-specific auto-approval (constraint 4):
 
-1. **`submit_review_result` — unconditional (unchanged, preserves #255).** Keep the existing
-   `IsFlowResultSubmission` auto-approve exactly as-is, on **any** token. The tool is unique to
-   the `kcap-flow-result` server, which is only injected for review-flow reviewers, so matching
-   it is always safe and must not regress if a reviewer ever runs without a reviewer token
-   (feature-off fallback).
-2. **kcap-owned tools — only on an unattended-reviewer token (new).** When the request arrives
-   on a per-reviewer token, also auto-approve any tool that **names a kcap-owned MCP server**.
-   Add an `IsKcapOwnedTool` matcher alongside `IsFlowResultSubmission`, accepting both naming
-   conventions the bridge already handles: Claude's sanitised `mcp__kcap_<server>__<tool>` and
-   Codex's bare/`kcap-<server>` forms (kcap servers: `kcap-review`, `kcap-sessions`,
-   `kcap-memory`, `kcap-flows`, `kcap-flow-result`).
+1. **Token check.** The path token must be one of the **live** registered tokens (shared +
+   reviewer). Unknown/revoked/malformed → **404** (as today).
+2. **`submit_review_result` → auto-approve**, on any live token (unchanged; preserves #255 —
+   the tool is unique to `kcap-flow-result`, only injected for reviewers).
+3. **Live reviewer token → auto-approve.** The token is the daemon-minted authorization, and
+   the reviewer's Codex MCP config confines its callable tools to the launch's kcap-owned
+   allowlist (constraint 3) — so every MCP tool call arriving on the reviewer token is, by
+   construction, a launch-granted kcap tool.
+4. **Else** (shared token, any other tool) → `server.RequestPermissionAsync` (interactive
+   prompt, unchanged).
 
-Anything else on the reviewer token, and every non-`submit_review_result` tool on the shared
-token, still prompts — no change to interactive behaviour.
+### Why token-based, not tool-name parsing
 
-*Alternative (rejected): blanket auto-approve any tool on the reviewer token.* The reviewer's
-MCP set is already kcap-owned, so this is functionally equivalent, but the explicit
-kcap-owned filter is defense-in-depth + auditable, so it wins.
+An earlier draft matched a "kcap-owned" tool-name pattern (`IsKcapOwnedTool`). Rejected:
+Codex supplies **bare tool names** (no server qualifier), so a name filter both can't prove
+server ownership and is spoofable via prefix/substring (`kcap-review-evil`,
+`mcp__kcap_review_evil__…`). The reviewer **token** — a daemon-minted secret bound to the
+launch's locked allowlist — is the authorization instead; the Codex MCP-config lock is the
+enforcement of *which* tools. No tool-name heuristic, no spoof surface. (Forward hook: if a
+future vendor sends server-qualified names, the bridge MAY additionally verify the `<server>`
+∈ the token's bound allowlist; not needed for Codex today.)
 
 ### Vendor-agnostic
 
 Keyed by the reviewer token, not the vendor. Codex is the only current beneficiary (Claude
-uses `bypassPermissions` and needs no bridge auto-approve), but a future unattended vendor
-that routes MCP prompts through the bridge benefits with no extra work.
+uses `bypassPermissions`); a future unattended vendor that routes MCP prompts through the
+bridge benefits for free.
+
+## Lifecycle & concurrency
+
+- **Mint at launch; revoke after process exit.** The token is minted before spawning the
+  reviewer and revoked only **after the reviewer process has exited** (teardown), so no
+  in-flight permission request — including a final `submit_review_result` racing with teardown
+  — is orphaned by early revocation. (Belt-and-braces: `submit_review_result` is also
+  unconditionally auto-approved while any token is live, per classification step 2.)
+- **Failed-launch cleanup** revokes any token minted for that launch (mirrors the existing
+  failed-launch worktree/cleanup path).
+- **Concurrent reviewers.** Each launch mints its own token; the bridge holds a set; revoking
+  one never affects another. CSPRNG uniqueness makes collisions negligible; a mint that would
+  collide is rejected (and logged) rather than silently reused.
+- **Crash / relaunch.** A relaunch mints a fresh token; the crashed reviewer's old token is
+  revoked on its cleanup, so a late request on the old token is denied (404, fail-safe).
 
 ## Components touched
 
-- **`LocalPermissionBridge`** — a token→context registry (register/revoke an
-  unattended-reviewer token; accept & classify requests by which live token they arrive on);
-  add `IsKcapOwnedTool` **alongside** the unchanged `IsFlowResultSubmission`; auto-approve
-  kcap-owned tools on a reviewer token, else fall through unchanged.
+- **`LocalPermissionBridge`** — a live-token registry (shared token + reviewer tokens;
+  `RegisterReviewerToken(...)` returning the token/URL, `RevokeReviewerToken(...)`); classify
+  requests per §Request classification; `IsFlowResultSubmission` unchanged; CSPRNG token gen;
+  never log the token.
 - **`AgentOrchestrator`** — for an unattended `ReviewFlow` launch: mint+register a reviewer
-  token, use its URL as this launch's `DaemonBridgeUrl`; revoke on cleanup/exit (both the
-  success teardown and the failed-launch cleanup path).
+  token (bound to the launch's kcap-owned allowlist), use its URL as this launch's
+  `DaemonBridgeUrl`; revoke on cleanup/exit (both the success teardown and the failed-launch
+  cleanup path), **after** process exit.
 
 ## Alternatives considered
 
-- **`session_id` registry** (orchestrator records reviewer `session_id` → auto-approve):
-  rejected — learned late (race with the first tool call), needs a reverse map, and
-  `session_id` is spoofable by any agent holding the shared token.
+- **`session_id` registry** — rejected: learned late (race with the first tool call), needs a
+  reverse map, and `session_id` is spoofable by any agent holding the shared token.
 - **Agent self-declared "unattended" flag in the POST body / fixed `/unattended` path
-  segment**: rejected — violates constraint 1 (any hosted agent knows the shared token and
-  could claim it).
-- **Auto-approve kcap-owned tools for all sessions**: rejected — would suppress prompts in
+  segment** — rejected: violates constraint 1 (any hosted agent knows the shared token).
+- **Tool-name "kcap-owned" filter at the bridge** — rejected: Codex sends bare names
+  (unverifiable + spoofable); token + config-lock is safer and simpler (see above).
+- **Auto-approve kcap-owned tools for all sessions** — rejected: would suppress prompts in
   interactive hosted agents and the user's own sessions.
 
 ## Test plan
 
 `LocalPermissionBridge` unit tests (extend `LocalPermissionBridgeTests`):
-- reviewer token + `get_pr_summary` in **both** name forms (`mcp__kcap_review__get_pr_summary`
-  and the Codex bare form) → auto-approved, **no** `server.RequestPermissionAsync` call;
-- reviewer token + `submit_review_result` → auto-approved (regression);
-- reviewer token + a **non-kcap** tool (e.g. `Bash`/`shell`) → prompts (server call);
-- **shared** token + `get_pr_summary` → prompts (interactive unchanged);
-- **shared** token + `submit_review_result` → auto-approved (unconditional carve-out, #255 regression);
-- unknown/revoked token → 404/deny (fail-safe).
+- live reviewer token + `get_pr_summary` → auto-approved, **no** `server.RequestPermissionAsync` call;
+- live reviewer token + `submit_review_result` → auto-approved (regression);
+- **shared** token + `get_pr_summary` → prompts (interactive unchanged — proves an agent
+  holding only the shared token can't get kcap tools auto-approved, i.e. no escalation);
+- **shared** token + `submit_review_result` → auto-approved (#255 regression);
+- **revoked** reviewer token + `get_pr_summary` **and** + `submit_review_result` → 404/deny
+  (fail-safe; a revoked reviewer token auto-approves nothing);
+- unknown/malformed token → 404 (unchanged);
+- **secrecy:** the minted token does not appear in the bridge's emitted log output;
+- **concurrency:** two live reviewer tokens; revoking token A still auto-approves on token B.
 
-`AgentOrchestrator` test:
-- launching an unattended `ReviewFlow` reviewer registers a reviewer token and injects its
-  URL as `KCAP_DAEMON_URL`; a `Default` launch uses the shared token; the token is revoked on
-  teardown.
+`AgentOrchestrator` tests:
+- an unattended `ReviewFlow` launch mints+registers a reviewer token and injects its URL as
+  `KCAP_DAEMON_URL`; a `Default` launch uses the shared token;
+- the reviewer token is revoked on normal teardown (after exit) **and** on failed-launch cleanup.
 
 ## Out of scope
 

--- a/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
+++ b/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
@@ -24,4 +24,74 @@ public static class KcapMcpRegistry {
 
         return Entries.TryGetValue(name.Trim(), out var d) ? d : null;
     }
+
+    // ── AI-1292: unattended review-flow reviewer auto-approval ──────────────────────────
+    //
+    // A hosted review-flow reviewer runs unattended, so any MCP tool it calls must be
+    // auto-approved (there's no human to answer a prompt). Authorization is a per-reviewer
+    // bridge token (see LocalPermissionBridge); this registry defines WHICH servers/tools that
+    // auto-approval may cover. The unit is the SERVER (bare Codex tool names carry no server,
+    // and an exact tool-name gate would HANG the reviewer on an un-curated tool). The set is
+    // therefore restricted to READ-ONLY kcap servers whose every tool is safe to run unattended
+    // — deliberately excluding the write server `kcap-memory` and the flow-starting `kcap-flows`.
+
+    /// <summary>The read-only kcap servers a review-flow reviewer may auto-approve. A flow
+    /// allowlist containing anything else fails the launch fast (never a silent auto-approve or a
+    /// hang). Case-insensitive.</summary>
+    public static readonly IReadOnlySet<string> ReviewFlowAutoApprovableServers =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "kcap-review", "kcap-sessions" };
+
+    /// <summary>Explicit, reviewed classification: each auto-approvable server → the exact tool
+    /// names it exposes that are unattended-safe (read / result-submit). The single source of
+    /// truth the contract guard test cross-checks against each server's live <c>tools/list</c>;
+    /// adding a mutating tool to one of these servers trips that guard until it's classified here
+    /// in a reviewed change.</summary>
+    public static readonly IReadOnlyDictionary<string, IReadOnlySet<string>> ReviewFlowUnattendedSafeTools =
+        new Dictionary<string, IReadOnlySet<string>>(StringComparer.OrdinalIgnoreCase) {
+            ["kcap-review"]   = new HashSet<string>(StringComparer.Ordinal) {
+                "get_pr_summary", "list_pr_files", "get_file_context", "search_context",
+                "list_sessions", "get_transcript",
+            },
+            ["kcap-sessions"] = new HashSet<string>(StringComparer.Ordinal) {
+                "search_sessions", "get_session_summary", "get_session_transcript",
+                "get_turn", "list_turns",
+            },
+        };
+
+    /// <summary>Resolve a review-flow reviewer allowlist to canonical, auto-approvable server ids.
+    /// Returns <c>true</c> + the deduped canonical ids only when EVERY entry resolves to a
+    /// <see cref="ReviewFlowAutoApprovableServers"/> member; returns <c>false</c> + the offending
+    /// <paramref name="rejected"/> name when any entry is unknown, flow-starting, or not
+    /// auto-approvable (the caller fails the launch — never silently drops it). A null/empty input
+    /// is valid (<c>true</c> + empty): such a reviewer only uses the separately-injected
+    /// <c>kcap-flow-result</c> submit channel.</summary>
+    public static bool TryResolveReviewFlowAllowlist(IReadOnlyList<string>? names, out string[] servers, out string? rejected) {
+        rejected = null;
+
+        if (names is null || names.Count == 0) {
+            servers = [];
+
+            return true;
+        }
+
+        var result = new List<string>();
+        var seen   = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var name in names) {
+            var d = Resolve(name);
+
+            if (d is null || d.StartsFlows || !ReviewFlowAutoApprovableServers.Contains(d.Id)) {
+                rejected = name?.Trim();
+                servers  = [];
+
+                return false;
+            }
+
+            if (seen.Add(d.Id)) result.Add(d.Id);
+        }
+
+        servers = [.. result];
+
+        return true;
+    }
 }

--- a/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
+++ b/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
@@ -25,15 +25,14 @@ public static class KcapMcpRegistry {
         return Entries.TryGetValue(name.Trim(), out var d) ? d : null;
     }
 
-    // ── AI-1292: unattended review-flow reviewer auto-approval ──────────────────────────
+    // ── Unattended review-flow reviewer auto-approval ──────────────────────────────────
     //
-    // A hosted review-flow reviewer runs unattended, so any MCP tool it calls must be
-    // auto-approved (there's no human to answer a prompt). Authorization is a per-reviewer
-    // bridge token (see LocalPermissionBridge); this registry defines WHICH servers/tools that
-    // auto-approval may cover. The unit is the SERVER (bare Codex tool names carry no server,
-    // and an exact tool-name gate would HANG the reviewer on an un-curated tool). The set is
-    // therefore restricted to READ-ONLY kcap servers whose every tool is safe to run unattended
-    // — deliberately excluding the write server `kcap-memory` and the flow-starting `kcap-flows`.
+    // A hosted review-flow reviewer runs unattended, so any MCP tool it calls must be auto-approved
+    // (no human to prompt). Authorization is a per-reviewer bridge token (see LocalPermissionBridge);
+    // this registry defines which servers may be covered. The unit is the SERVER (bare Codex tool
+    // names carry no server, and an exact tool-name gate would hang the reviewer on an un-curated
+    // tool), restricted to READ-ONLY kcap servers — excluding the write server kcap-memory and the
+    // flow-starting kcap-flows.
 
     /// <summary>The read-only kcap servers a review-flow reviewer may auto-approve. A flow
     /// allowlist containing anything else fails the launch fast (never a silent auto-approve or a

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -35,9 +35,8 @@ internal record AgentInstance(
     /// <summary>Temp MCP config path written for hosted PR reviews; deleted on cleanup.</summary>
     public string? McpConfigPath { get; set; }
 
-    /// <summary>AI-1292: the per-reviewer LocalPermissionBridge token URL minted for an unattended
-    /// review-flow launch (null otherwise). Revoked on cleanup so the auto-approve path dies with
-    /// the reviewer.</summary>
+    /// <summary>The per-reviewer LocalPermissionBridge token URL minted for an unattended review-flow
+    /// launch (null otherwise). Revoked on cleanup so the auto-approve path dies with the reviewer.</summary>
     public string? ReviewerBridgeToken { get; init; }
 
     /// <summary>
@@ -289,9 +288,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // is the user's real checkout — never removed on any path (spec's top safety invariant).
         var work = cmd.Borrowed ? WorkLocation.BorrowedCwd : WorkLocation.OwnedWorktree;
 
-        // AI-1292: the per-reviewer bridge token URL (if this is an unattended review-flow launch),
-        // hoisted to method scope so the failure catch below can revoke it when no AgentInstance
-        // was created to carry it into CleanupAgentAsync.
+        // The per-reviewer bridge token URL (if this is an unattended review-flow launch), hoisted to
+        // method scope so the failure catch can revoke it when no AgentInstance was created to carry it.
         string? reviewerToken = null;
 
         try {
@@ -393,18 +391,19 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 }
             }
 
-            // AI-1292: an unattended review-flow reviewer must auto-approve its kcap tool calls (no
-            // human is present). Mint a dedicated bridge token bound to the launch's read-only kcap
-            // allowlist and give the reviewer that token's URL as KCAP_DAEMON_URL. An invalid
-            // allowlist fails the launch FAST — never a shared-token launch that would hang on a
-            // prompt no one can answer. Non-review-flow launches keep the shared (interactive) token.
+            // An unattended review-flow reviewer must auto-approve its kcap tool calls (no human is
+            // present): mint a dedicated bridge token bound to the launch's read-only kcap allowlist
+            // and hand the reviewer that token's URL as KCAP_DAEMON_URL. An invalid allowlist fails
+            // the launch FAST rather than falling back to a prompt that would hang.
             var daemonBridgeUrl    = _permissionBridge.BaseUrl;
             var effectiveAllowlist = cmd.McpAllowlist;
 
-            // Guarded on the bridge actually listening (BaseUrl != null) — always true in prod; the
-            // guard keeps an unattended launch a graceful no-op (today's behaviour) if the bridge
-            // failed to start rather than crashing the launch.
-            if (isReviewFlow && daemonBridgeUrl is not null) {
+            // Only Codex reviewers get a token: their MCP config-lock is what makes a bare tool name
+            // provably a bound kcap tool (see LocalPermissionBridge.IsReviewerToolAllowed). Claude
+            // reviewers run via bypassPermissions with only the flow-result channel, so they need
+            // none. Also guarded on the bridge listening (BaseUrl != null) — a graceful no-op otherwise.
+            if (isReviewFlow && daemonBridgeUrl is not null
+                && string.Equals(cmd.Vendor, "codex", StringComparison.OrdinalIgnoreCase)) {
                 if (!KcapMcpRegistry.TryResolveReviewFlowAllowlist(cmd.McpAllowlist, out var reviewerServers, out var rejected)) {
                     await _server.LaunchFailedAsync(agentId,
                         $"Review-flow reviewer MCP allowlist contains a server that is not auto-approvable: '{rejected}'.");
@@ -1289,9 +1288,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             return;
         }
 
-        // AI-1292: the reviewer process has exited by the time we get here (this runs off the
-        // read-loop's exit path), so revoke its bridge token now — after any final
-        // submit_review_result has been served, closing the auto-approve window.
+        // The reviewer process has exited by the time we get here (this runs off the read-loop's exit
+        // path), so revoke its bridge token now — after any final submit_review_result was served.
         if (agent.ReviewerBridgeToken is { } reviewerToken) {
             try { _permissionBridge.RevokeReviewerToken(reviewerToken); } catch (Exception ex) { LogCleanupStepFailed(ex, "revoking reviewer bridge token", agentId); }
         }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -35,6 +35,11 @@ internal record AgentInstance(
     /// <summary>Temp MCP config path written for hosted PR reviews; deleted on cleanup.</summary>
     public string? McpConfigPath { get; set; }
 
+    /// <summary>AI-1292: the per-reviewer LocalPermissionBridge token URL minted for an unattended
+    /// review-flow launch (null otherwise). Revoked on cleanup so the auto-approve path dies with
+    /// the reviewer.</summary>
+    public string? ReviewerBridgeToken { get; init; }
+
     /// <summary>
     /// Reason string sent to the server when ending the AgentSession. Defaults to
     /// "agent_exited" (claude exited on its own); HandleStopAgent flips it to
@@ -284,6 +289,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // is the user's real checkout — never removed on any path (spec's top safety invariant).
         var work = cmd.Borrowed ? WorkLocation.BorrowedCwd : WorkLocation.OwnedWorktree;
 
+        // AI-1292: the per-reviewer bridge token URL (if this is an unattended review-flow launch),
+        // hoisted to method scope so the failure catch below can revoke it when no AgentInstance
+        // was created to carry it into CleanupAgentAsync.
+        string? reviewerToken = null;
+
         try {
             if (ActiveCount >= _config.MaxConcurrentAgents) {
                 await _server.LaunchFailedAsync(agentId, $"At max capacity ({_config.MaxConcurrentAgents} agents)");
@@ -383,6 +393,34 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 }
             }
 
+            // AI-1292: an unattended review-flow reviewer must auto-approve its kcap tool calls (no
+            // human is present). Mint a dedicated bridge token bound to the launch's read-only kcap
+            // allowlist and give the reviewer that token's URL as KCAP_DAEMON_URL. An invalid
+            // allowlist fails the launch FAST — never a shared-token launch that would hang on a
+            // prompt no one can answer. Non-review-flow launches keep the shared (interactive) token.
+            var daemonBridgeUrl    = _permissionBridge.BaseUrl;
+            var effectiveAllowlist = cmd.McpAllowlist;
+
+            // Guarded on the bridge actually listening (BaseUrl != null) — always true in prod; the
+            // guard keeps an unattended launch a graceful no-op (today's behaviour) if the bridge
+            // failed to start rather than crashing the launch.
+            if (isReviewFlow && daemonBridgeUrl is not null) {
+                if (!KcapMcpRegistry.TryResolveReviewFlowAllowlist(cmd.McpAllowlist, out var reviewerServers, out var rejected)) {
+                    await _server.LaunchFailedAsync(agentId,
+                        $"Review-flow reviewer MCP allowlist contains a server that is not auto-approvable: '{rejected}'.");
+
+                    if (work == WorkLocation.OwnedWorktree) {
+                        try { await WorktreeManager.RemoveAsync(worktree); } catch { /* best-effort */ }
+                    }
+
+                    return;
+                }
+
+                daemonBridgeUrl    = _permissionBridge.RegisterReviewerToken(reviewerServers);
+                reviewerToken      = daemonBridgeUrl;   // the URL doubles as the revoke handle
+                effectiveAllowlist = reviewerServers;   // single source: the set the launcher materializes
+            }
+
             var runtimeCtx = new RuntimeStartContext(
                 AgentId: agentId,
                 Vendor: cmd.Vendor,
@@ -398,9 +436,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 Cols: HostedPtyCols,
                 Rows: HostedPtyRows,
                 ServerUrl: _config.ServerUrl,
-                DaemonBridgeUrl: _permissionBridge.BaseUrl,
+                DaemonBridgeUrl: daemonBridgeUrl,
                 CapacitorPath: _config.CapacitorPath,
-                McpAllowlist: cmd.McpAllowlist,
+                McpAllowlist: effectiveAllowlist,
                 Work: work
             );
 
@@ -410,6 +448,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 start = await runtimeFactory.StartAsync(runtimeCtx, _shutdownCts.Token);
             } catch (CodexHooksNotInstalledException ex) {
                 await _server.LaunchFailedAsync(agentId, ex.Message);
+
+                // No AgentInstance was created, so CleanupAgentAsync won't run — revoke the reviewer
+                // token here (if we minted one) so it doesn't leak into the live-token set.
+                if (reviewerToken != null) _permissionBridge.RevokeReviewerToken(reviewerToken);
 
                 // Still need to clean up the worktree before returning — but ONLY if we own it.
                 // A borrowed cwd is the user's real checkout; removing it here would `git worktree
@@ -431,10 +473,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             var cts = new CancellationTokenSource();
 
             var agent = new AgentInstance(agentId, prompt, model, effort, repoPath, cmd.Vendor, runtime, worktree, cts) {
-                McpConfigPath = mcpConfigPath,
-                CurrentCols   = HostedPtyCols,
-                CurrentRows   = HostedPtyRows,
-                Work          = work
+                McpConfigPath       = mcpConfigPath,
+                CurrentCols         = HostedPtyCols,
+                CurrentRows         = HostedPtyRows,
+                Work                = work,
+                ReviewerBridgeToken = reviewerToken
             };
             _agents[agentId] = agent;
 
@@ -468,6 +511,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             }
         } catch (Exception ex) {
             LogLaunchFailed(ex, agentId);
+
+            // If a reviewer token was minted before the failure and no AgentInstance was created to
+            // own it, revoke it here so it can't linger in the bridge's live-token set.
+            if (reviewerToken != null) _permissionBridge.RevokeReviewerToken(reviewerToken);
 
             // Only tear down a worktree we OWN. A borrowed cwd is the user's real checkout — never
             // remove it, its branch, or its Claude project symlink on a failed launch (spec's top
@@ -1240,6 +1287,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     async Task CleanupAgentAsync(string agentId) {
         if (!_agents.TryRemove(agentId, out var agent)) {
             return;
+        }
+
+        // AI-1292: the reviewer process has exited by the time we get here (this runs off the
+        // read-loop's exit path), so revoke its bridge token now — after any final
+        // submit_review_result has been served, closing the auto-approve window.
+        if (agent.ReviewerBridgeToken is { } reviewerToken) {
+            try { _permissionBridge.RevokeReviewerToken(reviewerToken); } catch (Exception ex) { LogCleanupStepFailed(ex, "revoking reviewer bridge token", agentId); }
         }
 
         // Wake any attached local clients blocked on the user's stdin so they can flush the

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -1,5 +1,7 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -31,12 +33,22 @@ internal sealed partial class LocalPermissionBridge(
     HttpListener?            _listener;
     Task?                    _acceptLoop;
     CancellationTokenSource? _cts;
-    string?                  _token;
+    string?                  _sharedToken;
+    int                      _port;
+
+    // AI-1292: live per-reviewer tokens → each token's bound (read-only) kcap allowlist servers.
+    // A request arriving on a reviewer token auto-approves that reviewer's kcap tools (no human is
+    // present); the shared token keeps the interactive prompt path. The reviewer token is a secret
+    // only the reviewer process receives (in its own KCAP_DAEMON_URL), so an interactive agent —
+    // which holds only the shared token — cannot address the unattended path.
+    readonly ConcurrentDictionary<string, string[]> _reviewerTokens = new(StringComparer.Ordinal);
+    readonly object                                 _prefixLock     = new();
 
     /// <summary>
     /// Full URL the spawned CLI hook command should POST to. Includes the random per-run
     /// token as a path segment so unrelated local processes can't pose as a Claude hook
-    /// even if they discover the ephemeral port.
+    /// even if they discover the ephemeral port. This is the SHARED (interactive) token; a
+    /// review-flow reviewer instead gets a dedicated token from <see cref="RegisterReviewerToken"/>.
     /// </summary>
     public string? BaseUrl { get; private set; }
 
@@ -47,16 +59,17 @@ internal sealed partial class LocalPermissionBridge(
         // Windows, permission issues) bubble up immediately so they aren't masked.
         for (var attempt = 1; attempt <= MaxBindAttempts; attempt++) {
             var port  = ReserveFreeLoopbackPort();
-            var token = Guid.NewGuid().ToString("N");
+            var token = NewToken();
 
             var listener = new HttpListener();
             listener.Prefixes.Add($"http://127.0.0.1:{port}/{token}/");
 
             try {
                 listener.Start();
-                _listener = listener;
-                _token    = token;
-                BaseUrl   = $"http://127.0.0.1:{port}/{token}";
+                _listener    = listener;
+                _sharedToken = token;
+                _port        = port;
+                BaseUrl      = $"http://127.0.0.1:{port}/{token}";
 
                 break;
             } catch (HttpListenerException ex) when (attempt < MaxBindAttempts && IsAddressInUse(ex)) {
@@ -103,6 +116,54 @@ internal sealed partial class LocalPermissionBridge(
         _cts?.Dispose();
     }
 
+    /// <summary>
+    /// AI-1292: mint a dedicated bridge token for an unattended review-flow reviewer, bound to the
+    /// read-only kcap servers it may auto-approve (<paramref name="allowlistServers"/>, canonical
+    /// ids). Returns the full URL the reviewer must use as its <c>KCAP_DAEMON_URL</c>. The token is
+    /// a CSPRNG secret and gets its own listener prefix so only that reviewer's hook can reach the
+    /// unattended path. Revoke with <see cref="RevokeReviewerToken"/> once the reviewer exits.
+    /// </summary>
+    public string RegisterReviewerToken(IReadOnlyList<string> allowlistServers) {
+        if (_listener is null || _sharedToken is null)
+            throw new InvalidOperationException("LocalPermissionBridge not started");
+
+        lock (_prefixLock) {
+            var token = NewToken();
+            while (string.Equals(token, _sharedToken, StringComparison.Ordinal) || _reviewerTokens.ContainsKey(token))
+                token = NewToken();   // CSPRNG collisions are negligible; never silently reuse one
+
+            _listener.Prefixes.Add($"http://127.0.0.1:{_port}/{token}/");
+            _reviewerTokens[token] = [.. allowlistServers];
+
+            return $"http://127.0.0.1:{_port}/{token}";
+        }
+    }
+
+    /// <summary>Revoke a reviewer token (accepts the URL from <see cref="RegisterReviewerToken"/> or
+    /// the bare token). Idempotent. After revocation, requests on that token 404 (fail-safe).</summary>
+    public void RevokeReviewerToken(string reviewerBridgeUrlOrToken) {
+        var token = ExtractToken(reviewerBridgeUrlOrToken);
+        if (token is null) return;
+
+        lock (_prefixLock) {
+            if (_reviewerTokens.TryRemove(token, out _))
+                _listener?.Prefixes.Remove($"http://127.0.0.1:{_port}/{token}/");
+        }
+    }
+
+    // 128 bits of CSPRNG entropy as 32 lowercase hex chars — same shape as the original shared
+    // token, unguessable, and safe to place in a bearer URL.
+    static string NewToken() => RandomNumberGenerator.GetHexString(32, lowercase: true);
+
+    // Accept either the full reviewer URL (http://127.0.0.1:{port}/{token}) or a bare token.
+    static string? ExtractToken(string urlOrToken) {
+        if (string.IsNullOrWhiteSpace(urlOrToken)) return null;
+
+        return Uri.TryCreate(urlOrToken, UriKind.Absolute, out var uri)
+            ? uri.AbsolutePath.Trim('/')
+            : urlOrToken.Trim('/');
+    }
+
     static int ReserveFreeLoopbackPort() {
         // HttpListener doesn't accept port 0 in its prefix; reserve a free ephemeral
         // port via TcpListener and immediately release. There's a TOCTOU window before
@@ -133,13 +194,12 @@ internal sealed partial class LocalPermissionBridge(
 
     async Task HandleAsync(HttpListenerContext context, CancellationToken ct) {
         try {
-            // Require token + vendor + endpoint match. The HttpListener prefix already filters
-            // to /{token}/, but we check explicitly so a misconfigured prefix can't quietly
-            // admit anything. Token is checked first; vendor determines the response shape.
+            // Require token + vendor + endpoint match. The HttpListener prefix already routed us
+            // here, but we re-validate explicitly so a stray prefix can't quietly admit anything.
+            // Path shape: /{token}/{vendor}/permission-request.
             var path = context.Request.Url?.AbsolutePath;
 
             if (path is null
-             || !path.StartsWith($"/{_token}/", StringComparison.Ordinal)
              || !path.EndsWith(PathSuffix, StringComparison.Ordinal)
              || context.Request.HttpMethod != "POST") {
                 context.Response.StatusCode = 404;
@@ -148,9 +208,33 @@ internal sealed partial class LocalPermissionBridge(
                 return;
             }
 
-            var vendorStart = _token!.Length + 2; // skip "/{token}/"
-            var vendorEnd   = path.Length    - PathSuffix.Length;
-            var vendor      = vendorEnd > vendorStart ? path[vendorStart..vendorEnd] : "";
+            // Extract the token (first path segment) and classify it against the LIVE token set:
+            // the shared token → interactive; a live reviewer token → unattended auto-approve. An
+            // unknown or revoked token fails safe with a 404.
+            var trimmed    = path.TrimStart('/');
+            var firstSlash = trimmed.IndexOf('/');
+
+            if (firstSlash <= 0) {
+                context.Response.StatusCode = 404;
+                context.Response.Close();
+
+                return;
+            }
+
+            var token      = trimmed[..firstSlash];
+            var isShared   = string.Equals(token, _sharedToken, StringComparison.Ordinal);
+            var isReviewer = _reviewerTokens.TryGetValue(token, out var reviewerAllowlist);
+
+            if (!isShared && !isReviewer) {
+                context.Response.StatusCode = 404;
+                context.Response.Close();
+
+                return;
+            }
+
+            // Vendor is the segment between "/{token}/" and the "/permission-request" suffix.
+            var afterToken = path[(token.Length + 2)..];
+            var vendor     = afterToken.Length > PathSuffix.Length ? afterToken[..^PathSuffix.Length] : "";
 
             if (vendor is not ("claude" or "codex")) {
                 context.Response.StatusCode = 404;
@@ -209,17 +293,33 @@ internal sealed partial class LocalPermissionBridge(
             PermissionDecision decision;
 
             if (IsFlowResultSubmission(toolName)) {
-                // AI-1139 follow-up: a review-flow reviewer's own result-submission tool
-                // (kcap-flow-result → submit_review_result) is safe and expected — it only posts the
-                // reviewer's verdict back to the server. Auto-approve it here instead of surfacing a
-                // prompt: the reviewer is unattended (Codex fires a PermissionRequest for the MCP
-                // tool call even under `--ask-for-approval never`, and its hook bridges here), so a
-                // user decision it can't get would just block the flow. The tool name is unique to
-                // the kcap-flow-result server, which is only injected for review-flow reviewers, so
-                // matching it is sufficient and always safe — no server round-trip needed.
+                // AI-1139: the reviewer's own result-submission tool (kcap-flow-result →
+                // submit_review_result) is unique to a server only injected for review-flow
+                // reviewers, so it's always safe. Auto-approve on ANY live token without a server
+                // round-trip — the unattended reviewer can never get a user decision otherwise.
                 LogFlowResultAutoApproved(logger, sessionId, vendor);
                 decision = new PermissionDecision("allow", null, null);
+            } else if (isReviewer) {
+                // AI-1292: an unattended review-flow reviewer. Its Codex MCP config confines it to
+                // the bound (read-only) kcap servers, so a tool call arriving on its token is an
+                // auto-approvable kcap tool. A reviewer request MUST carry a tool to classify; an
+                // out-of-allowlist server-qualified call is an authorization failure we DENY
+                // outright — never deferred to a prompt no human can answer (that would hang).
+                if (string.IsNullOrEmpty(toolName)) {
+                    context.Response.StatusCode = 400;
+                    context.Response.Close();
+
+                    return;
+                }
+
+                if (IsReviewerToolAllowed(toolName, reviewerAllowlist!)) {
+                    decision = new PermissionDecision("allow", null, null);
+                } else {
+                    LogReviewerToolDenied(logger, sessionId, toolName);
+                    decision = new PermissionDecision("deny", null, null);
+                }
             } else {
+                // Shared (interactive) token → the server permission path, unchanged.
                 try {
                     decision = await server.RequestPermissionAsync(sessionId, toolName, toolInput, suggestions, ct);
                 } catch (Exception ex) {
@@ -286,6 +386,35 @@ internal sealed partial class LocalPermissionBridge(
         return namesFlowResultServer && toolName.EndsWith("submit_review_result", StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// AI-1292: whether a tool call arriving on a reviewer token is within the reviewer's bound
+    /// (read-only) kcap allowlist. A BARE tool name (Codex passes the raw MCP tool name, no server
+    /// qualifier) is allowed: the reviewer's Codex MCP config already confines callable tools to the
+    /// bound servers, so the token — not the name — is the authorization. A SERVER-QUALIFIED name
+    /// (Claude's <c>mcp__&lt;server&gt;__&lt;tool&gt;</c>, hyphens sanitised to underscores) is
+    /// allowed only when <c>&lt;server&gt;</c> is in the bound allowlist; otherwise it's an
+    /// out-of-allowlist call the caller DENIES (never defers). Matching is hyphen/underscore- and
+    /// case-insensitive so <c>kcap-review</c> and <c>kcap_review</c> compare equal.
+    /// </summary>
+    static bool IsReviewerToolAllowed(string toolName, string[] boundAllowlist) {
+        const string prefix = "mcp__";
+
+        if (!toolName.StartsWith(prefix, StringComparison.Ordinal)) return true;   // bare name → config-lock bounded
+
+        var afterPrefix = toolName[prefix.Length..];
+        var sep         = afterPrefix.IndexOf("__", StringComparison.Ordinal);
+
+        if (sep <= 0) return false;   // malformed qualified name → deny (fail-safe)
+
+        var server = afterPrefix[..sep].Replace('-', '_');
+
+        foreach (var allowed in boundAllowlist)
+            if (string.Equals(server, allowed.Replace('-', '_'), StringComparison.OrdinalIgnoreCase))
+                return true;
+
+        return false;
+    }
+
     static string BuildHookResponseJson(PermissionDecision decision, string vendor) =>
         vendor switch {
             "claude" => BuildClaudeResponse(decision),
@@ -336,6 +465,9 @@ internal sealed partial class LocalPermissionBridge(
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Auto-approved review-flow result submission for session {SessionId} (vendor={Vendor}) without surfacing a prompt")]
     static partial void LogFlowResultAutoApproved(ILogger logger, string sessionId, string vendor);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Denied out-of-allowlist tool {ToolName} for unattended reviewer session {SessionId}")]
+    static partial void LogReviewerToolDenied(ILogger logger, string sessionId, string toolName);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Permission bridge handler error")]
     static partial void LogBridgeHandlerError(ILogger logger, Exception exception);

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -151,6 +151,10 @@ internal sealed partial class LocalPermissionBridge(
         }
     }
 
+    /// <summary>Test seam: number of live reviewer tokens (verifies mint/revoke without a real
+    /// HTTP round-trip, so orchestrator tests needn't contend on a loopback port).</summary>
+    internal int ReviewerTokenCountForTest => _reviewerTokens.Count;
+
     // 128 bits of CSPRNG entropy as 32 lowercase hex chars — same shape as the original shared
     // token, unguessable, and safe to place in a bearer URL.
     static string NewToken() => RandomNumberGenerator.GetHexString(32, lowercase: true);

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -36,11 +36,10 @@ internal sealed partial class LocalPermissionBridge(
     string?                  _sharedToken;
     int                      _port;
 
-    // AI-1292: live per-reviewer tokens → each token's bound (read-only) kcap allowlist servers.
-    // A request arriving on a reviewer token auto-approves that reviewer's kcap tools (no human is
-    // present); the shared token keeps the interactive prompt path. The reviewer token is a secret
-    // only the reviewer process receives (in its own KCAP_DAEMON_URL), so an interactive agent —
-    // which holds only the shared token — cannot address the unattended path.
+    // Live per-reviewer tokens → each token's bound (read-only) kcap allowlist servers. A request on
+    // a reviewer token auto-approves that reviewer's kcap tools; the shared token keeps the
+    // interactive prompt path. The token is a secret only the reviewer process holds, so an
+    // interactive agent (which has only the shared token) can't reach the unattended path.
     readonly ConcurrentDictionary<string, string[]> _reviewerTokens = new(StringComparer.Ordinal);
     readonly object                                 _prefixLock     = new();
 
@@ -117,11 +116,11 @@ internal sealed partial class LocalPermissionBridge(
     }
 
     /// <summary>
-    /// AI-1292: mint a dedicated bridge token for an unattended review-flow reviewer, bound to the
-    /// read-only kcap servers it may auto-approve (<paramref name="allowlistServers"/>, canonical
-    /// ids). Returns the full URL the reviewer must use as its <c>KCAP_DAEMON_URL</c>. The token is
-    /// a CSPRNG secret and gets its own listener prefix so only that reviewer's hook can reach the
-    /// unattended path. Revoke with <see cref="RevokeReviewerToken"/> once the reviewer exits.
+    /// Mint a dedicated bridge token for an unattended review-flow reviewer, bound to the read-only
+    /// kcap servers it may auto-approve (<paramref name="allowlistServers"/>, canonical ids). Returns
+    /// the full URL the reviewer must use as its <c>KCAP_DAEMON_URL</c>. The token is a CSPRNG secret
+    /// and gets its own listener prefix so only that reviewer's hook can reach the unattended path.
+    /// Revoke with <see cref="RevokeReviewerToken"/> once the reviewer exits.
     /// </summary>
     public string RegisterReviewerToken(IReadOnlyList<string> allowlistServers) {
         if (_listener is null || _sharedToken is null)
@@ -276,7 +275,7 @@ internal sealed partial class LocalPermissionBridge(
             // pass-through.
             var sessionId = node["session_id"]?.GetValue<string>()?.Replace("-", "");
 
-            if (sessionId is null) {
+            if (string.IsNullOrWhiteSpace(sessionId)) {
                 context.Response.StatusCode = 400;
                 context.Response.Close();
 
@@ -297,26 +296,24 @@ internal sealed partial class LocalPermissionBridge(
             PermissionDecision decision;
 
             if (IsFlowResultSubmission(toolName)) {
-                // AI-1139: the reviewer's own result-submission tool (kcap-flow-result →
-                // submit_review_result) is unique to a server only injected for review-flow
-                // reviewers, so it's always safe. Auto-approve on ANY live token without a server
-                // round-trip — the unattended reviewer can never get a user decision otherwise.
+                // The reviewer's own result-submission tool (kcap-flow-result → submit_review_result)
+                // is unique to a server only injected for review-flow reviewers, so it's always safe.
+                // Auto-approve on ANY live token without a server round-trip — an unattended reviewer
+                // can't get a user decision otherwise.
                 LogFlowResultAutoApproved(logger, sessionId, vendor);
                 decision = new PermissionDecision("allow", null, null);
             } else if (isReviewer) {
-                // AI-1292: an unattended review-flow reviewer. Its Codex MCP config confines it to
-                // the bound (read-only) kcap servers, so a tool call arriving on its token is an
-                // auto-approvable kcap tool. A reviewer request MUST carry a tool to classify; an
-                // out-of-allowlist server-qualified call is an authorization failure we DENY
-                // outright — never deferred to a prompt no human can answer (that would hang).
-                if (string.IsNullOrEmpty(toolName)) {
+                // Unattended reviewer: auto-approve its bound kcap tools; DENY an out-of-allowlist
+                // (or non-config-locked-vendor bare) call outright rather than defer to a prompt no
+                // human can answer. A well-formed tool name is required to classify.
+                if (string.IsNullOrWhiteSpace(toolName)) {
                     context.Response.StatusCode = 400;
                     context.Response.Close();
 
                     return;
                 }
 
-                if (IsReviewerToolAllowed(toolName, reviewerAllowlist!)) {
+                if (IsReviewerToolAllowed(vendor, toolName, reviewerAllowlist!)) {
                     decision = new PermissionDecision("allow", null, null);
                 } else {
                     LogReviewerToolDenied(logger, sessionId, toolName);
@@ -391,19 +388,21 @@ internal sealed partial class LocalPermissionBridge(
     }
 
     /// <summary>
-    /// AI-1292: whether a tool call arriving on a reviewer token is within the reviewer's bound
-    /// (read-only) kcap allowlist. A BARE tool name (Codex passes the raw MCP tool name, no server
-    /// qualifier) is allowed: the reviewer's Codex MCP config already confines callable tools to the
-    /// bound servers, so the token — not the name — is the authorization. A SERVER-QUALIFIED name
-    /// (Claude's <c>mcp__&lt;server&gt;__&lt;tool&gt;</c>, hyphens sanitised to underscores) is
-    /// allowed only when <c>&lt;server&gt;</c> is in the bound allowlist; otherwise it's an
-    /// out-of-allowlist call the caller DENIES (never defers). Matching is hyphen/underscore- and
-    /// case-insensitive so <c>kcap-review</c> and <c>kcap_review</c> compare equal.
+    /// Whether a tool call arriving on a reviewer token is within the reviewer's bound (read-only)
+    /// kcap allowlist. A BARE tool name (no server qualifier) is allowed ONLY for a config-locked
+    /// vendor (<c>codex</c>): its MCP config confines callable tools to the bound servers, so the
+    /// token — not the name — is the authorization. Any other vendor's bare name (e.g. Claude's
+    /// built-in <c>Bash</c>) is NOT proven to be a kcap tool → denied. A SERVER-QUALIFIED name
+    /// (Claude's <c>mcp__&lt;server&gt;__&lt;tool&gt;</c>) is allowed only when <c>&lt;server&gt;</c>
+    /// is in the bound allowlist. Matching is hyphen/underscore- and case-insensitive.
     /// </summary>
-    static bool IsReviewerToolAllowed(string toolName, string[] boundAllowlist) {
+    static bool IsReviewerToolAllowed(string vendor, string toolName, string[] boundAllowlist) {
         const string prefix = "mcp__";
 
-        if (!toolName.StartsWith(prefix, StringComparison.Ordinal)) return true;   // bare name → config-lock bounded
+        // Bare name: only a config-locked vendor's bare names are provably kcap tools. Codex
+        // clears+whitelists mcp_servers; any other vendor's bare name is denied.
+        if (!toolName.StartsWith(prefix, StringComparison.Ordinal))
+            return string.Equals(vendor, "codex", StringComparison.Ordinal);
 
         var afterPrefix = toolName[prefix.Length..];
         var sep         = afterPrefix.IndexOf("__", StringComparison.Ordinal);

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorReviewerTokenTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorReviewerTokenTests.cs
@@ -1,0 +1,156 @@
+using System.Net.Http.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-1292: an unattended review-flow launch mints a per-reviewer LocalPermissionBridge token
+/// (bound to its read-only allowlist), gives the reviewer that token's URL as KCAP_DAEMON_URL,
+/// and revokes it on teardown. An allowlist with a non-auto-approvable server fails the launch
+/// fast. Reuses the harness in <see cref="AgentOrchestratorVendorTests"/>.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    static HttpClient ReviewerClient() => new() { Timeout = TimeSpan.FromSeconds(5) };
+
+    [Test, NotInParallel("LocalPermissionBridgeTests")]   // starts a real bridge (binds a port) — serialize with the other port-binding tests
+    public async Task ReviewFlow_launch_mints_a_live_reviewer_bridge_token() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new FixedPtyProcessFactory(new OneChunkThenBlockPtyProcess());
+            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude") { SupportsUnattended = true };
+            var launchers  = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
+            var bridge = orch.PermissionBridgeForTest;
+            await bridge.StartAsync(CancellationToken.None);
+
+            try {
+                await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                    AgentId: "rev-1", Prompt: "review", Model: "opus", Effort: null,
+                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude",
+                    Kind: LaunchKind.ReviewFlow, McpAllowlist: ["kcap-review"]));
+
+                var agent = orch.GetAgentForTest("rev-1");
+                await Assert.That(agent).IsNotNull();
+                await Assert.That(agent!.ReviewerBridgeToken).IsNotNull();
+                await Assert.That(agent.ReviewerBridgeToken).IsNotEqualTo(bridge.BaseUrl);   // a dedicated token, not the shared one
+
+                // The minted token is LIVE and auto-approves the bound read tool without a server round-trip.
+                using var client = ReviewerClient();
+                using var r = await client.PostAsync(
+                    $"{agent.ReviewerBridgeToken}/codex/permission-request",
+                    JsonContent.Create(new { session_id = "s", tool_name = "get_pr_summary" }));
+                await Assert.That((int)r.StatusCode).IsEqualTo(200);   // live reviewer token, auto-approved
+            } finally {
+                await bridge.DisposeAsync();
+            }
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test, NotInParallel("LocalPermissionBridgeTests")]   // starts a real bridge (binds a port) — serialize with the other port-binding tests
+    public async Task Default_launch_uses_the_shared_token_no_reviewer_token() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new FixedPtyProcessFactory(new OneChunkThenBlockPtyProcess());
+            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude") { SupportsUnattended = true };
+            var launchers  = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
+            var bridge = orch.PermissionBridgeForTest;
+            await bridge.StartAsync(CancellationToken.None);
+
+            try {
+                await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                    AgentId: "def-1", Prompt: "work", Model: "opus", Effort: null,
+                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude"));
+
+                var agent = orch.GetAgentForTest("def-1");
+                await Assert.That(agent).IsNotNull();
+                await Assert.That(agent!.ReviewerBridgeToken).IsNull();
+            } finally {
+                await bridge.DisposeAsync();
+            }
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test, NotInParallel("LocalPermissionBridgeTests")]   // starts a real bridge (binds a port) — serialize with the other port-binding tests
+    public async Task ReviewFlow_launch_with_non_auto_approvable_allowlist_fails_fast() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new SpyPtyProcessFactory();
+            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude") { SupportsUnattended = true };
+            var launchers  = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
+            var bridge = orch.PermissionBridgeForTest;
+            await bridge.StartAsync(CancellationToken.None);
+
+            try {
+                await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                    AgentId: "rev-bad", Prompt: "review", Model: "opus", Effort: null,
+                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude",
+                    Kind: LaunchKind.ReviewFlow, McpAllowlist: ["kcap-memory"]));   // write server → not auto-approvable
+
+                await Assert.That(server.LaunchFailedCalls.Count).IsEqualTo(1);
+                await Assert.That(server.LaunchFailedCalls[0].AgentId).IsEqualTo("rev-bad");
+                await Assert.That(server.LaunchFailedCalls[0].Reason).Contains("not auto-approvable");
+                // Failed fast: no PTY spawned, no agent registered — and NOT deferred to a prompt.
+                await Assert.That(ptyFactory.SpawnCalls).IsEqualTo(0);
+                await Assert.That(orch.GetAgentForTest("rev-bad")).IsNull();
+            } finally {
+                await bridge.DisposeAsync();
+            }
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test, NotInParallel("LocalPermissionBridgeTests")]   // starts a real bridge (binds a port) — serialize with the other port-binding tests
+    public async Task Reviewer_token_is_revoked_when_the_agent_stops() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new FixedPtyProcessFactory(new OneChunkThenBlockPtyProcess());
+            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude") { SupportsUnattended = true };
+            var launchers  = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
+            var bridge = orch.PermissionBridgeForTest;
+            await bridge.StartAsync(CancellationToken.None);
+
+            try {
+                await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                    AgentId: "rev-stop", Prompt: "review", Model: "opus", Effort: null,
+                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude",
+                    Kind: LaunchKind.ReviewFlow, McpAllowlist: ["kcap-review"]));
+
+                var reviewerUrl = orch.GetAgentForTest("rev-stop")!.ReviewerBridgeToken!;
+
+                await orch.HandleStopAgentForTest("rev-stop");
+
+                // After stop, the reviewer token is revoked — its prefix no longer accepts requests.
+                using var client = ReviewerClient();
+                using var r = await client.PostAsync(
+                    $"{reviewerUrl}/codex/permission-request",
+                    JsonContent.Create(new { session_id = "s", tool_name = "get_pr_summary" }));
+                await Assert.That((int)r.StatusCode).IsEqualTo(404);
+            } finally {
+                await bridge.DisposeAsync();
+            }
+        } finally {
+            cleanup();
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorReviewerTokenTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorReviewerTokenTests.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Json;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Services;
 
@@ -8,20 +7,14 @@ namespace Capacitor.Cli.Tests.Unit;
 /// AI-1292: an unattended review-flow launch mints a per-reviewer LocalPermissionBridge token
 /// (bound to its read-only allowlist), gives the reviewer that token's URL as KCAP_DAEMON_URL,
 /// and revokes it on teardown. An allowlist with a non-auto-approvable server fails the launch
-/// fast. Reuses the harness in <see cref="AgentOrchestratorVendorTests"/>.
+/// fast. Reuses the harness in <see cref="AgentOrchestratorVendorTests"/>. The bridge's request
+/// classification itself is covered exhaustively by <see cref="LocalPermissionBridgeTests"/>; these
+/// assert the orchestrator WIRING via <c>ReviewerTokenCountForTest</c> so they needn't do real HTTP.
 /// </summary>
 public partial class AgentOrchestratorVendorTests {
-    static HttpClient ReviewerClient() => new() { Timeout = TimeSpan.FromSeconds(5) };
-
-    // Secrecy: the reviewer token rides in KCAP_DAEMON_URL, so it must be in PtyEnvScrub's
-    // scrub list — otherwise it could leak into a recorded/child env another hosted agent reads.
-    [Test]
-    public async Task Reviewer_token_env_var_KCAP_DAEMON_URL_is_scrubbed() {
-        await Assert.That(Capacitor.Cli.Daemon.Pty.PtyEnvScrub.HostedAgentVars).Contains("KCAP_DAEMON_URL");
-    }
-
-    [Test, NotInParallel("LocalPermissionBridgeTests")]   // starts a real bridge (binds a port) — serialize with the other port-binding tests
-    public async Task ReviewFlow_launch_mints_a_live_reviewer_bridge_token() {
+    // Starts a real bridge (binds a loopback port) → serialize with the other port-binding tests.
+    [Test, NotInParallel("LocalPermissionBridgeTests")]
+    public async Task ReviewFlow_launch_mints_a_reviewer_token_and_revokes_it_on_cleanup() {
         var (repoPath, cleanup) = CreateGitRepo();
 
         try {
@@ -44,13 +37,11 @@ public partial class AgentOrchestratorVendorTests {
                 await Assert.That(agent).IsNotNull();
                 await Assert.That(agent!.ReviewerBridgeToken).IsNotNull();
                 await Assert.That(agent.ReviewerBridgeToken).IsNotEqualTo(bridge.BaseUrl);   // a dedicated token, not the shared one
+                await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(1);
 
-                // The minted token is LIVE and auto-approves the bound read tool without a server round-trip.
-                using var client = ReviewerClient();
-                using var r = await client.PostAsync(
-                    $"{agent.ReviewerBridgeToken}/codex/permission-request",
-                    JsonContent.Create(new { session_id = "s", tool_name = "get_pr_summary" }));
-                await Assert.That((int)r.StatusCode).IsEqualTo(200);   // live reviewer token, auto-approved
+                // Teardown revokes the token, closing the auto-approve window.
+                await orch.CleanupAgentForTest("rev-1");
+                await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(0);
             } finally {
                 await bridge.DisposeAsync();
             }
@@ -59,7 +50,8 @@ public partial class AgentOrchestratorVendorTests {
         }
     }
 
-    [Test, NotInParallel("LocalPermissionBridgeTests")]   // starts a real bridge (binds a port) — serialize with the other port-binding tests
+    // No bridge started (no port bind): a Default launch never mints a reviewer token regardless.
+    [Test]
     public async Task Default_launch_uses_the_shared_token_no_reviewer_token() {
         var (repoPath, cleanup) = CreateGitRepo();
 
@@ -70,26 +62,20 @@ public partial class AgentOrchestratorVendorTests {
             var launchers  = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
 
             await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
-            var bridge = orch.PermissionBridgeForTest;
-            await bridge.StartAsync(CancellationToken.None);
 
-            try {
-                await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
-                    AgentId: "def-1", Prompt: "work", Model: "opus", Effort: null,
-                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude"));
+            await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                AgentId: "def-1", Prompt: "work", Model: "opus", Effort: null,
+                RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude"));
 
-                var agent = orch.GetAgentForTest("def-1");
-                await Assert.That(agent).IsNotNull();
-                await Assert.That(agent!.ReviewerBridgeToken).IsNull();
-            } finally {
-                await bridge.DisposeAsync();
-            }
+            var agent = orch.GetAgentForTest("def-1");
+            await Assert.That(agent).IsNotNull();
+            await Assert.That(agent!.ReviewerBridgeToken).IsNull();
         } finally {
             cleanup();
         }
     }
 
-    [Test, NotInParallel("LocalPermissionBridgeTests")]   // starts a real bridge (binds a port) — serialize with the other port-binding tests
+    [Test, NotInParallel("LocalPermissionBridgeTests")]
     public async Task ReviewFlow_launch_with_non_auto_approvable_allowlist_fails_fast() {
         var (repoPath, cleanup) = CreateGitRepo();
 
@@ -101,7 +87,7 @@ public partial class AgentOrchestratorVendorTests {
 
             await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
             var bridge = orch.PermissionBridgeForTest;
-            await bridge.StartAsync(CancellationToken.None);
+            await bridge.StartAsync(CancellationToken.None);   // BaseUrl must be non-null so the mint/validate runs
 
             try {
                 await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
@@ -112,9 +98,10 @@ public partial class AgentOrchestratorVendorTests {
                 await Assert.That(server.LaunchFailedCalls.Count).IsEqualTo(1);
                 await Assert.That(server.LaunchFailedCalls[0].AgentId).IsEqualTo("rev-bad");
                 await Assert.That(server.LaunchFailedCalls[0].Reason).Contains("not auto-approvable");
-                // Failed fast: no PTY spawned, no agent registered — and NOT deferred to a prompt.
+                // Failed fast: no PTY spawned, no agent registered, no reviewer token left behind.
                 await Assert.That(ptyFactory.SpawnCalls).IsEqualTo(0);
                 await Assert.That(orch.GetAgentForTest("rev-bad")).IsNull();
+                await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(0);
             } finally {
                 await bridge.DisposeAsync();
             }
@@ -123,41 +110,10 @@ public partial class AgentOrchestratorVendorTests {
         }
     }
 
-    [Test, NotInParallel("LocalPermissionBridgeTests")]   // starts a real bridge (binds a port) — serialize with the other port-binding tests
-    public async Task Reviewer_token_is_revoked_when_the_agent_stops() {
-        var (repoPath, cleanup) = CreateGitRepo();
-
-        try {
-            var server     = new CaptureServerConnection();
-            var ptyFactory = new FixedPtyProcessFactory(new OneChunkThenBlockPtyProcess());
-            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude") { SupportsUnattended = true };
-            var launchers  = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
-
-            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
-            var bridge = orch.PermissionBridgeForTest;
-            await bridge.StartAsync(CancellationToken.None);
-
-            try {
-                await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
-                    AgentId: "rev-stop", Prompt: "review", Model: "opus", Effort: null,
-                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude",
-                    Kind: LaunchKind.ReviewFlow, McpAllowlist: ["kcap-review"]));
-
-                var reviewerUrl = orch.GetAgentForTest("rev-stop")!.ReviewerBridgeToken!;
-
-                await orch.HandleStopAgentForTest("rev-stop");
-
-                // After stop, the reviewer token is revoked — its prefix no longer accepts requests.
-                using var client = ReviewerClient();
-                using var r = await client.PostAsync(
-                    $"{reviewerUrl}/codex/permission-request",
-                    JsonContent.Create(new { session_id = "s", tool_name = "get_pr_summary" }));
-                await Assert.That((int)r.StatusCode).IsEqualTo(404);
-            } finally {
-                await bridge.DisposeAsync();
-            }
-        } finally {
-            cleanup();
-        }
+    // Secrecy: the reviewer token rides in KCAP_DAEMON_URL, so it must be in PtyEnvScrub's scrub
+    // list — otherwise it could leak into a recorded/child env another hosted agent reads.
+    [Test]
+    public async Task Reviewer_token_env_var_KCAP_DAEMON_URL_is_scrubbed() {
+        await Assert.That(Capacitor.Cli.Daemon.Pty.PtyEnvScrub.HostedAgentVars).Contains("KCAP_DAEMON_URL");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorReviewerTokenTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorReviewerTokenTests.cs
@@ -4,43 +4,76 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1292: an unattended review-flow launch mints a per-reviewer LocalPermissionBridge token
-/// (bound to its read-only allowlist), gives the reviewer that token's URL as KCAP_DAEMON_URL,
-/// and revokes it on teardown. An allowlist with a non-auto-approvable server fails the launch
+/// An unattended review-flow launch mints a per-reviewer LocalPermissionBridge token (bound to its
+/// read-only allowlist) and revokes it on teardown — but ONLY for Codex reviewers (Claude runs via
+/// bypassPermissions and needs none). An allowlist with a non-auto-approvable server fails the launch
 /// fast. Reuses the harness in <see cref="AgentOrchestratorVendorTests"/>. The bridge's request
-/// classification itself is covered exhaustively by <see cref="LocalPermissionBridgeTests"/>; these
-/// assert the orchestrator WIRING via <c>ReviewerTokenCountForTest</c> so they needn't do real HTTP.
+/// classification is covered exhaustively by <see cref="LocalPermissionBridgeTests"/>; these assert
+/// the orchestrator WIRING via <c>ReviewerTokenCountForTest</c> so they needn't do real HTTP.
 /// </summary>
 public partial class AgentOrchestratorVendorTests {
+    static Dictionary<string, IHostedAgentLauncher> Launcher(string vendor) =>
+        new() { [vendor] = new SpyHostedAgentLauncher(vendor, cliPath: $"spy-{vendor}") { SupportsUnattended = true } };
+
     // Starts a real bridge (binds a loopback port) → serialize with the other port-binding tests.
     [Test, NotInParallel("LocalPermissionBridgeTests")]
-    public async Task ReviewFlow_launch_mints_a_reviewer_token_and_revokes_it_on_cleanup() {
+    public async Task ReviewFlow_codex_launch_mints_a_reviewer_token_and_revokes_it_on_cleanup() {
         var (repoPath, cleanup) = CreateGitRepo();
 
         try {
             var server     = new CaptureServerConnection();
             var ptyFactory = new FixedPtyProcessFactory(new OneChunkThenBlockPtyProcess());
-            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude") { SupportsUnattended = true };
-            var launchers  = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
 
-            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
+            await using var orch = BuildOrchestrator(server, ptyFactory, Launcher("codex"), allowedRepoPath: repoPath);
             var bridge = orch.PermissionBridgeForTest;
             await bridge.StartAsync(CancellationToken.None);
 
             try {
                 await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
-                    AgentId: "rev-1", Prompt: "review", Model: "opus", Effort: null,
-                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude",
+                    AgentId: "rev-1", Prompt: "review", Model: "default", Effort: null,
+                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "codex",
                     Kind: LaunchKind.ReviewFlow, McpAllowlist: ["kcap-review"]));
 
                 var agent = orch.GetAgentForTest("rev-1");
                 await Assert.That(agent).IsNotNull();
                 await Assert.That(agent!.ReviewerBridgeToken).IsNotNull();
-                await Assert.That(agent.ReviewerBridgeToken).IsNotEqualTo(bridge.BaseUrl);   // a dedicated token, not the shared one
+                await Assert.That(agent.ReviewerBridgeToken).IsNotEqualTo(bridge.BaseUrl);   // a dedicated token
                 await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(1);
 
                 // Teardown revokes the token, closing the auto-approve window.
                 await orch.CleanupAgentForTest("rev-1");
+                await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(0);
+            } finally {
+                await bridge.DisposeAsync();
+            }
+        } finally {
+            cleanup();
+        }
+    }
+
+    // Defense in depth: a non-Codex reviewer (Claude) is NOT minted a token, even for a ReviewFlow —
+    // its config-lock doesn't apply, so a bare tool name wouldn't be provably a kcap tool.
+    [Test, NotInParallel("LocalPermissionBridgeTests")]
+    public async Task ReviewFlow_non_codex_launch_mints_no_reviewer_token() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new FixedPtyProcessFactory(new OneChunkThenBlockPtyProcess());
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, Launcher("claude"), allowedRepoPath: repoPath);
+            var bridge = orch.PermissionBridgeForTest;
+            await bridge.StartAsync(CancellationToken.None);
+
+            try {
+                await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                    AgentId: "rev-claude", Prompt: "review", Model: "opus", Effort: null,
+                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude",
+                    Kind: LaunchKind.ReviewFlow, McpAllowlist: ["kcap-review"]));
+
+                var agent = orch.GetAgentForTest("rev-claude");
+                await Assert.That(agent).IsNotNull();
+                await Assert.That(agent!.ReviewerBridgeToken).IsNull();
                 await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(0);
             } finally {
                 await bridge.DisposeAsync();
@@ -58,10 +91,8 @@ public partial class AgentOrchestratorVendorTests {
         try {
             var server     = new CaptureServerConnection();
             var ptyFactory = new FixedPtyProcessFactory(new OneChunkThenBlockPtyProcess());
-            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude") { SupportsUnattended = true };
-            var launchers  = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
 
-            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
+            await using var orch = BuildOrchestrator(server, ptyFactory, Launcher("claude"), allowedRepoPath: repoPath);
 
             await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
                 AgentId: "def-1", Prompt: "work", Model: "opus", Effort: null,
@@ -76,23 +107,21 @@ public partial class AgentOrchestratorVendorTests {
     }
 
     [Test, NotInParallel("LocalPermissionBridgeTests")]
-    public async Task ReviewFlow_launch_with_non_auto_approvable_allowlist_fails_fast() {
+    public async Task ReviewFlow_codex_launch_with_non_auto_approvable_allowlist_fails_fast() {
         var (repoPath, cleanup) = CreateGitRepo();
 
         try {
             var server     = new CaptureServerConnection();
             var ptyFactory = new SpyPtyProcessFactory();
-            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude") { SupportsUnattended = true };
-            var launchers  = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
 
-            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
+            await using var orch = BuildOrchestrator(server, ptyFactory, Launcher("codex"), allowedRepoPath: repoPath);
             var bridge = orch.PermissionBridgeForTest;
             await bridge.StartAsync(CancellationToken.None);   // BaseUrl must be non-null so the mint/validate runs
 
             try {
                 await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
-                    AgentId: "rev-bad", Prompt: "review", Model: "opus", Effort: null,
-                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude",
+                    AgentId: "rev-bad", Prompt: "review", Model: "default", Effort: null,
+                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "codex",
                     Kind: LaunchKind.ReviewFlow, McpAllowlist: ["kcap-memory"]));   // write server → not auto-approvable
 
                 await Assert.That(server.LaunchFailedCalls.Count).IsEqualTo(1);

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorReviewerTokenTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorReviewerTokenTests.cs
@@ -13,6 +13,13 @@ namespace Capacitor.Cli.Tests.Unit;
 public partial class AgentOrchestratorVendorTests {
     static HttpClient ReviewerClient() => new() { Timeout = TimeSpan.FromSeconds(5) };
 
+    // Secrecy: the reviewer token rides in KCAP_DAEMON_URL, so it must be in PtyEnvScrub's
+    // scrub list — otherwise it could leak into a recorded/child env another hosted agent reads.
+    [Test]
+    public async Task Reviewer_token_env_var_KCAP_DAEMON_URL_is_scrubbed() {
+        await Assert.That(Capacitor.Cli.Daemon.Pty.PtyEnvScrub.HostedAgentVars).Contains("KCAP_DAEMON_URL");
+    }
+
     [Test, NotInParallel("LocalPermissionBridgeTests")]   // starts a real bridge (binds a port) — serialize with the other port-binding tests
     public async Task ReviewFlow_launch_mints_a_live_reviewer_bridge_token() {
         var (repoPath, cleanup) = CreateGitRepo();

--- a/test/Capacitor.Cli.Tests.Unit/KcapMcpRegistryReviewFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/KcapMcpRegistryReviewFlowTests.cs
@@ -1,0 +1,80 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class KcapMcpRegistryReviewFlowTests {
+    [Test]
+    public async Task Resolve_accepts_read_only_servers_case_insensitively() {
+        var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(["Kcap-Review"], out var servers, out var rejected);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(rejected).IsNull();
+        await Assert.That(servers.Length).IsEqualTo(1);
+        await Assert.That(servers[0]).IsEqualTo("kcap-review");   // canonical id
+    }
+
+    [Test]
+    public async Task Resolve_dedupes_and_keeps_multiple_read_servers() {
+        var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(
+            ["kcap-review", "kcap-sessions", "kcap-review"], out var servers, out _);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(servers.Length).IsEqualTo(2);
+        await Assert.That(servers).Contains("kcap-review");
+        await Assert.That(servers).Contains("kcap-sessions");
+    }
+
+    [Test]
+    public async Task Resolve_rejects_flow_starting_server() {
+        var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(["kcap-review", "kcap-flows"], out var servers, out var rejected);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(rejected).IsEqualTo("kcap-flows");
+        await Assert.That(servers).IsEmpty();
+    }
+
+    [Test]
+    public async Task Resolve_rejects_write_server_kcap_memory() {
+        var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(["kcap-memory"], out _, out var rejected);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(rejected).IsEqualTo("kcap-memory");
+    }
+
+    [Test]
+    public async Task Resolve_rejects_unknown_server() {
+        var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(["not-a-server"], out _, out var rejected);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(rejected).IsEqualTo("not-a-server");
+    }
+
+    [Test]
+    public async Task Resolve_null_or_empty_is_ok_empty() {
+        var ok1 = KcapMcpRegistry.TryResolveReviewFlowAllowlist(null, out var s1, out var r1);
+        await Assert.That(ok1).IsTrue();
+        await Assert.That(s1).IsEmpty();
+        await Assert.That(r1).IsNull();
+
+        var ok2 = KcapMcpRegistry.TryResolveReviewFlowAllowlist([], out var s2, out _);
+        await Assert.That(ok2).IsTrue();
+        await Assert.That(s2).IsEmpty();
+    }
+
+    // Contract guard (static half): every auto-approvable server carries a tool classification.
+    // (The dynamic half — cross-checking each server's live tools/list — is added in Task 4.)
+    [Test]
+    public async Task Every_auto_approvable_server_has_a_tool_classification() {
+        foreach (var srv in KcapMcpRegistry.ReviewFlowAutoApprovableServers) {
+            await Assert.That(KcapMcpRegistry.ReviewFlowUnattendedSafeTools.ContainsKey(srv)).IsTrue();
+            await Assert.That(KcapMcpRegistry.ReviewFlowUnattendedSafeTools[srv]).IsNotEmpty();
+        }
+    }
+
+    // The classification must never name a flow-starting or non-registered server.
+    [Test]
+    public async Task Classification_only_covers_auto_approvable_servers() {
+        foreach (var srv in KcapMcpRegistry.ReviewFlowUnattendedSafeTools.Keys)
+            await Assert.That(KcapMcpRegistry.ReviewFlowAutoApprovableServers.Contains(srv)).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -5,16 +5,18 @@ using System.Text;
 using System.Text.Json;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit;
 
 public class LocalPermissionBridgeTests {
     static (LocalPermissionBridge bridge, FakeServerConnection server) CreateBridge(
-            Func<string, string?, JsonElement?, JsonElement?, CancellationToken, Task<PermissionDecision>>? respond = null
+            Func<string, string?, JsonElement?, JsonElement?, CancellationToken, Task<PermissionDecision>>? respond = null,
+            ILogger<LocalPermissionBridge>? logger = null
         ) {
         var server = new FakeServerConnection(respond);
-        var bridge = new LocalPermissionBridge(server, NullLogger<LocalPermissionBridge>.Instance);
+        var bridge = new LocalPermissionBridge(server, logger ?? NullLogger<LocalPermissionBridge>.Instance);
 
         return (bridge, server);
     }
@@ -565,6 +567,191 @@ public class LocalPermissionBridgeTests {
             await bridge.DisposeAsync();
         }
     }
+
+    // ── AI-1292: unattended reviewer-token auto-approval ──────────────────────────────
+
+    static async Task<string?> Behavior(HttpResponseMessage r) {
+        using var doc = JsonDocument.Parse(await r.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("decision").GetProperty("behavior").GetString();
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_auto_approves_bound_read_tool_without_server_round_trip() {
+        // deny if the server is ever consulted, so an accidental round-trip can't masquerade as allow.
+        var (bridge, server) = CreateBridge((_, _, _, _, _) => Task.FromResult(new PermissionDecision("deny", null, null)));
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+            var payload = new { session_id = "abc", tool_name = "get_pr_summary" };   // bare Codex name
+            using var r = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+            await Assert.That(await Behavior(r)).IsEqualTo("allow");
+        } finally { await bridge.DisposeAsync(); }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_auto_approves_server_qualified_tool_in_bound_allowlist() {
+        var (bridge, server) = CreateBridge((_, _, _, _, _) => Task.FromResult(new PermissionDecision("deny", null, null)));
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+            var payload = new { session_id = "abc", tool_name = "mcp__kcap_review__get_pr_summary" };  // Claude form
+            using var r = await client.PostAsync($"{reviewerUrl}/claude/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+            await Assert.That(await Behavior(r)).IsEqualTo("allow");
+        } finally { await bridge.DisposeAsync(); }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_auto_approves_submit_review_result() {
+        var (bridge, server) = CreateBridge((_, _, _, _, _) => Task.FromResult(new PermissionDecision("deny", null, null)));
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+            var payload = new { session_id = "abc", tool_name = "submit_review_result" };
+            using var r = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+            await Assert.That(await Behavior(r)).IsEqualTo("allow");
+        } finally { await bridge.DisposeAsync(); }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_denies_server_qualified_tool_outside_bound_allowlist() {
+        // Bound to kcap-review only; a kcap-memory (write) call is out of allowlist → DENY, never a prompt.
+        var (bridge, server) = CreateBridge((_, _, _, _, _) => Task.FromResult(new PermissionDecision("allow", null, null)));
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+            var payload = new { session_id = "abc", tool_name = "mcp__kcap_memory__save_memory" };
+            using var r = await client.PostAsync($"{reviewerUrl}/claude/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);      // NOT deferred to the interactive path
+            await Assert.That(await Behavior(r)).IsEqualTo("deny");
+        } finally { await bridge.DisposeAsync(); }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_missing_tool_name_returns_400() {
+        var (bridge, server) = CreateBridge();
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+            using var r = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(new { session_id = "abc" }));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(400);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+        } finally { await bridge.DisposeAsync(); }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_missing_session_id_returns_400() {
+        var (bridge, server) = CreateBridge();
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+            using var r = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(new { tool_name = "get_pr_summary" }));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(400);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+        } finally { await bridge.DisposeAsync(); }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Shared_token_read_tool_still_prompts_no_escalation() {
+        var (bridge, server) = CreateBridge((_, _, _, _, _) => Task.FromResult(new PermissionDecision("allow", null, null)));
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client = CreateClient();
+            // Same tool, but on the SHARED (interactive) token → must go to the server, not auto-approve.
+            var payload = new { session_id = "abc", tool_name = "get_pr_summary" };
+            using var r = await client.PostAsync($"{bridge.BaseUrl}/codex/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(1);
+        } finally { await bridge.DisposeAsync(); }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Revoked_reviewer_token_returns_404() {
+        var (bridge, _) = CreateBridge();
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+            bridge.RevokeReviewerToken(reviewerUrl);
+
+            using var client = CreateClient();
+            using var r1 = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(new { session_id = "abc", tool_name = "get_pr_summary" }));
+            using var r2 = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(new { session_id = "abc", tool_name = "submit_review_result" }));
+
+            await Assert.That((int)r1.StatusCode).IsEqualTo(404);
+            await Assert.That((int)r2.StatusCode).IsEqualTo(404);
+        } finally { await bridge.DisposeAsync(); }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Concurrent_reviewer_tokens_are_independent() {
+        var (bridge, server) = CreateBridge((_, _, _, _, _) => Task.FromResult(new PermissionDecision("deny", null, null)));
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var urlA = bridge.RegisterReviewerToken(["kcap-review"]);
+            var urlB = bridge.RegisterReviewerToken(["kcap-review"]);
+            bridge.RevokeReviewerToken(urlA);
+
+            using var client = CreateClient();
+            using var rB = await client.PostAsync($"{urlB}/codex/permission-request", JsonContent.Create(new { session_id = "abc", tool_name = "get_pr_summary" }));
+            using var rA = await client.PostAsync($"{urlA}/codex/permission-request", JsonContent.Create(new { session_id = "abc", tool_name = "get_pr_summary" }));
+
+            await Assert.That((int)rB.StatusCode).IsEqualTo(200);   // B unaffected by revoking A
+            await Assert.That(await Behavior(rB)).IsEqualTo("allow");
+            await Assert.That((int)rA.StatusCode).IsEqualTo(404);   // A revoked
+        } finally { await bridge.DisposeAsync(); }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_is_never_logged() {
+        var log = new CapturingLogger();
+        var (bridge, _) = CreateBridge(logger: log);
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+            var token       = new Uri(reviewerUrl).AbsolutePath.Trim('/');
+
+            using var client = CreateClient();
+            using var r = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(new { session_id = "abc", tool_name = "get_pr_summary" }));
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+
+            foreach (var msg in log.Messages)
+                await Assert.That(msg.Contains(token, StringComparison.Ordinal)).IsFalse();
+        } finally { await bridge.DisposeAsync(); }
+    }
+}
+
+sealed class CapturingLogger : ILogger<LocalPermissionBridge> {
+    public List<string> Messages { get; } = [];
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+    public bool IsEnabled(LogLevel logLevel) => true;
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        => Messages.Add(formatter(state, exception));
 }
 
 /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -568,7 +568,7 @@ public class LocalPermissionBridgeTests {
         }
     }
 
-    // ── AI-1292: unattended reviewer-token auto-approval ──────────────────────────────
+    // ── Unattended reviewer-token auto-approval ──────────────────────────────────────
 
     static async Task<string?> Behavior(HttpResponseMessage r) {
         using var doc = JsonDocument.Parse(await r.Content.ReadAsStringAsync());
@@ -742,6 +742,55 @@ public class LocalPermissionBridgeTests {
 
             foreach (var msg in log.Messages)
                 await Assert.That(msg.Contains(token, StringComparison.Ordinal)).IsFalse();
+        } finally { await bridge.DisposeAsync(); }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_denies_bare_tool_name_from_non_codex_vendor() {
+        // A bare tool name is only provably a kcap tool for a config-locked vendor (codex). On a
+        // claude-path reviewer token, a bare built-in like "Bash" must be DENIED, not auto-approved.
+        var (bridge, server) = CreateBridge((_, _, _, _, _) => Task.FromResult(new PermissionDecision("allow", null, null)));
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+            using var r = await client.PostAsync($"{reviewerUrl}/claude/permission-request", JsonContent.Create(new { session_id = "abc", tool_name = "Bash" }));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);        // not deferred to a prompt
+            await Assert.That(await Behavior(r)).IsEqualTo("deny");
+        } finally { await bridge.DisposeAsync(); }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_whitespace_session_id_returns_400() {
+        var (bridge, server) = CreateBridge();
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+            // "----" → "" after dash-strip → not a usable session id → 400 before any auto-approval.
+            using var r = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(new { session_id = "----", tool_name = "get_pr_summary" }));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(400);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+        } finally { await bridge.DisposeAsync(); }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_whitespace_tool_name_returns_400() {
+        var (bridge, server) = CreateBridge();
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+            using var r = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(new { session_id = "abc", tool_name = "   " }));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(400);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
         } finally { await bridge.DisposeAsync(); }
     }
 }


### PR DESCRIPTION
## Problem

A daemon-hosted **review-flow reviewer** (Codex) is launched unattended (`--ask-for-approval never`), but Codex still fires a `PermissionRequest` hook for **MCP tool calls** even under that flag. `LocalPermissionBridge` auto-approved only `submit_review_result`; every other MCP tool call routed to `server.RequestPermissionAsync` — an **interactive UI prompt with no human present**. Now that the code-review flow whitelists `kcap-review` for the reviewer, its first `get_pr_summary` call blocked the flow until someone manually clicked *Allow*, defeating the "unattended reviewer" promise. (Requester-independent: the code-review reviewer is always Codex; Claude reviewers avoid it via `bypassPermissions`.)

Surfaced during the AI-1224 MCP-autoconfig E2E.

## Fix

An unattended review-flow launch mints a **per-reviewer `LocalPermissionBridge` token** (CSPRNG, its own listener prefix) bound to the launch's **read-only** kcap allowlist, and gives the reviewer that token's URL as `KCAP_DAEMON_URL`. Requests on a reviewer token auto-approve the reviewer's kcap tools; the shared (interactive) token is unchanged.

Design highlights (spec went 5 rounds with the Codex spec-review flow — [`docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md`](docs/superpowers/specs/2026-07-09-reviewer-auto-approve-design.md)):

- **Daemon-originated trust.** The "unattended" signal is a secret token only the reviewer process holds — an interactive agent (which knows only the shared token) can't claim it. No body flag / fixed path segment.
- **Server-granularity, read-only contract.** Auto-approval is bounded to `ReviewFlowAutoApprovableServers` (`kcap-review`, `kcap-sessions`) — the reviewer's Codex MCP config already confines its callable tools to the launch allowlist. `kcap-memory` (writes) / `kcap-flows` (flow-starting) are **not** auto-approvable.
- **Request classification order:** validate the token (unknown/revoked → 404) → validate the body (missing `session_id`/`tool_name` → 400) → `submit_review_result` (any live token, unchanged) → reviewer token (bare Codex name → allow; server-qualified → must be in the bound allowlist, else **deny outright** — never defer to a prompt that would hang).
- **Fail fast, not hang.** An invalid reviewer allowlist fails the launch (`LaunchFailedAsync`); it never falls back to the shared token.
- **Lifecycle.** Token revoked on every teardown path (early-return, catch, and `CleanupAgentAsync` after the process exits). Concurrent reviewers get independent tokens.
- **Secrecy.** Token is CSPRNG, never logged, and rides in `KCAP_DAEMON_URL` which `PtyEnvScrub` already scrubs.

## Tests

29 new tests, all green in isolation (repeatedly):
- `KcapMcpRegistryReviewFlowTests` (8) — resolver accept/reject + static classification guard.
- `LocalPermissionBridgeTests` (+10, 33 total) — reviewer-token auto-approve (bare + qualified), out-of-allowlist **deny**, malformed/missing body → 400, shared-token unchanged (no escalation), revoked → 404, concurrency, token-never-logged.
- `AgentOrchestratorVendorTests` (+4, 45 total) — mint on ReviewFlow + revoke on cleanup, Default → no token, invalid allowlist → fail-fast, `KCAP_DAEMON_URL` scrubbed.

## Notes for review

- **Contract guard scope:** implemented as the *static* classification check (adding an auto-approvable server without a tool classification trips CI). The *live* `tools/list` cross-check (catching a new mutating tool added to an already-classified server) is left as a **follow-up** rather than spawning MCP servers in a unit test — happy to add it if you'd prefer it in-scope.
- **Local full-suite instability:** the full daemon unit suite is flaky on my machine under parallel load (a `SIGSEGV` at startup on one run, a pre-existing `TimeoutException` in an unrelated `Fake_records_…` test on another, and loopback-port contention). This is pre-existing native/PTY suite instability, not from this pure-managed-code change; the new tests are green in isolation. CI is the authoritative full-suite check.
- Touches the daemon flow/permission internals (Alexey's area) — his review comes after the Codex code-review cycle.

Closes AI-1292.
