### PR TITLE
[AI-687] ACP: advertise no client fs/terminal; decline unhandled agent→client methods (-32601)

### DIFF
--- a/docs/ai-687-fs-terminal-capability-decision-design.md
+++ b/docs/ai-687-fs-terminal-capability-decision-design.md
@@ -1,0 +1,201 @@
+# AI-687 — ACP terminal & file capability integration: design
+
+Parent epic **AI-682** (ACP support). Builds on AI-684 (ACP foundation), AI-685 (server mapper),
+AI-686 (permission/elicitation bridge), all merged; independent of AI-688 (#301, canonical
+surfacing, unmerged). This work lives entirely in **kcap-cli** (the daemon).
+
+## 1. Purpose (from the issue)
+
+> Decide and implement only the ACP client capabilities Kapacitor can safely provide for terminal
+> and file operations. Start from the smallest advertised capability set: no `fs` and no `terminal`
+> unless Cursor requires them for useful operation.
+
+The issue is **decision-first**: the acceptance criteria are about *not advertising what we can't
+enforce* and *covering capability behavior with tests* — not about shipping an fs/terminal
+implementation. Whether we implement anything is contingent on the empirical answer to one question:
+
+> **Does Cursor-via-ACP require the client (us) to serve `fs/*` or `terminal/*` requests to do
+> useful file/shell work, or does it perform those operations itself?**
+
+## 2. Evidence — the capability probe
+
+A live probe drove the real `cursor-agent acp` agent (Team tier, authed) through a turn that forces
+both a file **write** and a file **read**, with the client capabilities advertised exactly as the
+daemon advertises them today (`fs.readTextFile=false`, `fs.writeTextFile=false`, `terminal=false`),
+and a fresh temp directory as the session `cwd`. The prompt: *"create a file named kcap687.txt whose
+exact contents are the single line HELLO687, then read that file back and report its exact
+contents."*
+
+Observed (probe script archived in the session scratchpad; reproducible against any Team-tier
+`cursor-agent`):
+
+- **Zero agent→client requests.** Cursor issued **no** `fs/*` and **no** `terminal/*` requests. The
+  recorded `client requests (agent→client)` list was empty.
+- **Tool calls ran locally, in our `cwd`.** Cursor emitted `tool_call`/`tool_call_update`
+  notifications of kinds `edit` (title "Edit File"), `read` (title "Read File"), and `execute`
+  (`ls -la`). The `edit` result arrived as a `content:[{type:"diff", path, oldText, newText}]` block
+  whose `path` was the file **inside our temp `cwd`**; the `execute` result arrived as
+  `rawOutput:{exitCode,stdout,stderr}` whose `ls -la` listing showed the file on local disk.
+- **The file really landed in our `cwd`.** After the turn, `kcap687.txt` existed in the temp
+  directory we passed and contained `HELLO687`.
+
+This corroborates the AI-688 E2E finding (execute-kind tools ran server-side via `rawOutput`,
+requesting no client capabilities) and extends it to `edit`/`read`: **`cursor-agent`, which runs as
+a local child process of the daemon, performs all file and shell operations itself, directly against
+the `cwd` we give it.** It never delegates them to the ACP client.
+
+### 2.1 Coverage and limits of the evidence
+
+The probe covers the `edit`, `read`, and `execute` tool kinds against a plain directory. It does not
+prove Cursor will *never*, in *any* future version or scenario (a permission-denied fallback, a
+sandboxed mode, a capability it gates on our advertisement), issue an `fs/*` or `terminal/*` request.
+That residual uncertainty is exactly why the design does not merely "advertise nothing and stop" — it
+also **makes the decline correct** (§4), so an unobserved future request is declined safely instead
+of silently mis-answered.
+
+## 3. Decision
+
+**Advertise no client `fs` and no client `terminal` capability.** This is already what
+`AcpHostedAgentRuntime.StartAsync` sends (`ClientCapabilities(Fs(false,false), Terminal:false)`), so
+the advertisement is **unchanged**. The evidence shows this empty set is *sufficient* — Cursor does
+useful file/shell work without any client capability — and it is the *smallest* set, satisfying the
+issue's "start from the smallest set unless required" directive.
+
+Mapping to the acceptance criteria:
+
+| Acceptance criterion | How this design meets it |
+|---|---|
+| Never advertise a capability we can't enforce safely | We advertise none. §4 additionally makes an unadvertised capability request *fail closed* (declined), so even a request we never advertised can't be mis-served. |
+| File and terminal operations bounded to the hosted worktree | Cursor runs them in the `cwd` we pass, which is the hosted worktree. We do not serve fs/terminal, so there is no client-side path we could fail to bound. The bounding that exists is Cursor's own (cwd + its permission model, bridged by AI-686) — see §6 for the honest limit. |
+| Terminal output visible through the existing remote terminal path | N/A — we serve no `terminal/*`. Cursor's shell output surfaces as `execute` tool `rawOutput` in the canonical transcript (AI-688), not via `terminal:{agentId}`. |
+| Capability behavior covered by tests, including path-escape rejection | §5. We reject the *whole method* (`-32601`), so there is no fs path to escape — the "path-escape rejection" case is satisfied at a coarser, stronger granularity (method refused before any path is parsed), and a test asserts that. |
+
+## 4. The one code change — make the default-decline correct
+
+### 4.1 The gap
+
+`AcpConnection` routes inbound agent→client requests to `OnServerRequest`, which the daemon wires to
+`AcpInteractionBridge.HandleAsync`. That handler is:
+
+```csharp
+request.Method switch {
+    "session/request_permission" => await HandlePermissionAsync(...),
+    "elicitation/create"         => await HandleElicitationAsync(...),
+    _                            => null          // any other method, incl. fs/*, terminal/*
+};
+```
+
+In `HandleServerRequestAsync`, a **wired** handler that returns `null` currently produces
+`result = null, error = null`, and `SerializeRawIdResponse` writes:
+
+```json
+{"jsonrpc":"2.0","id":N,"result":null}
+```
+
+That is a JSON-RPC **success** response with a null result — semantically *"I performed your
+`fs/write_text_file` and it returned nothing."* If a future or misbehaving Cursor ignores our
+`fs:false`/`terminal:false` advertisement and calls one of those methods, we would **falsely
+acknowledge** an operation we never performed. The correct answer for a method the client does not
+implement is `-32601 Method not found` — which is exactly what the connection already returns on the
+**no-handler** branch (`handler is null`). The bug exists *only because* a handler is wired.
+
+### 4.2 The fix
+
+Treat **handler-returned-`null`** identically to **no-handler**: a `null` return means *"this method
+is not handled"* → respond `-32601 Method not found`, never a null-result success.
+
+- In `AcpConnection.HandleServerRequestAsync`, when the handler ran and returned `null`, set the
+  `-32601` error (same `AcpError` shape as the `handler is null` branch) instead of writing a null
+  result. Emit one `logger.LogDebug` line noting the declined method (diagnostics: if Cursor ever
+  *does* start requesting `fs/*`/`terminal/*`, it will show up in daemon logs and we revisit this
+  decision).
+- Update the `OnServerRequest` XML-doc contract: *"A handler returning `null` signals the method is
+  unhandled; the connection answers `-32601 Method not found`. Handlers that intend a successful
+  empty result must return an explicit `JsonElement` (e.g. an empty object), never `null`."*
+
+### 4.3 Why this is safe (the invariant)
+
+`AcpInteractionBridge.HandleAsync` returns `null` **iff** the method hit the `_ => null` default.
+Both handled methods return non-null on every path:
+
+- `HandlePermissionAsync` returns either `CancelledResult()` or `MapPermissionDecision(...)`.
+- `HandleElicitationAsync` returns either `CancelledResult()` or `MapPermissionDecision(...)`.
+
+Neither ever returns literal `null`. Therefore the fix changes behavior **only** for methods the
+bridge does not handle (`fs/*`, `terminal/*`, and any other unadvertised agent→client method); it is
+a no-op for `session/request_permission` and `elicitation/create`.
+
+The PR #244 **"always answered"** guarantee (every inbound server request gets exactly one response
+frame — a value, a `-32603` on throw, or now a `-32601` on unhandled — never an orphaned/wedged
+request) is **preserved**; only the *shape* of the unhandled-method response changes from
+null-result to `-32601`.
+
+## 5. Test plan (kcap-cli daemon unit tests)
+
+All in `test/Capacitor.Cli.Tests.Unit/Acp/`.
+
+1. **Rewrite** `AcpConnectionTests.Inbound_server_request_handler_returning_null_writes_a_null_result_response`
+   → `…_writes_method_not_found_error`: a wired handler returning `null` for `fs/read_text_file`
+   yields a response with **no `result`** and `error.code == -32601`; assert the read loop is still
+   alive afterward (mirror the throw-test's liveness check) so the "always answered" guarantee is
+   re-locked at the new shape.
+2. **New** `AcpConnectionTests`: an unadvertised `terminal/create` request against the **real wired
+   bridge** (`OnServerRequest = bridge.HandleAsync`) yields `error.code == -32601` — proving the
+   production wiring (not just a fake null handler) declines cleanly.
+3. **Regression** (bridge unaffected): with the real bridge wired, `session/request_permission` and
+   `elicitation/create` still round-trip to their `result` outcome — no `-32601`. (Extend/confirm
+   existing `AcpInteractionBridgeTests` coverage rather than duplicate it.)
+4. **Capability-advertisement lock** (`AcpHostedAgentRuntimeTests` or the factory tests): assert the
+   `initialize` frame the runtime sends advertises `fs.readTextFile == false`,
+   `fs.writeTextFile == false`, `terminal == false`. This is the executable form of the acceptance
+   criterion "never advertises a capability it cannot enforce" and will fail loudly if a future
+   change flips one on without revisiting this design.
+
+No live/gated test is added — the probe (archived) is the empirical basis; the decision it drives is
+locked by the deterministic unit tests above. NativeAOT publish must stay warning-free (existing
+gate).
+
+## 6. Security note / limitations (feeds AI-689)
+
+Documenting the honest boundary, per the issue's "document which capabilities are advertised and
+why":
+
+- Because `cursor-agent` runs as a **local child process of the daemon**, its file and shell
+  operations execute with the **daemon's own filesystem and process privileges**. Kapacitor does
+  **not** sandbox them. "Bounded to the hosted worktree" holds in the normal case (Cursor uses `cwd`
+  as its working directory), but it is **not a hard boundary we enforce** — Cursor could, in
+  principle, touch paths outside `cwd`. The guardrails that exist are (a) the `cwd` we set and (b)
+  Cursor's own permission model, whose prompts we surface and gate through the AI-686 permission
+  bridge.
+- We advertise no `fs`/`terminal`, so we add **no** new client-served attack surface; the `-32601`
+  decline (§4) ensures we never perform an operation on Cursor's behalf.
+- Hardening beyond this — e.g. launching `cursor-agent` under an OS sandbox, or constraining its
+  filesystem view to the worktree — is explicitly **out of scope** and belongs to **AI-689**
+  (hardening). This design records the limitation rather than silently implying a boundary we don't
+  enforce.
+
+## 7. Out of scope / deferred
+
+- Implementing client `fs/*` or `terminal/*` handlers (worktree path resolution, symlink/escape
+  rejection, terminal streaming through `terminal:{agentId}`). Not built — the evidence shows Cursor
+  does not request them. If a future Cursor version *does* start requesting them (visible via the
+  §4.2 debug log), reopen this decision; the code change here guarantees the interim behavior is a
+  safe decline, not a silent false-success.
+- OS-level sandboxing of `cursor-agent` (AI-689).
+- Attaching terminal/file protocol IDs to canonical extensions "for UI/debug" — no client-served
+  fs/terminal means no such IDs exist on our side; the `execute`/`edit`/`read` tool calls already
+  carry their `toolCallId` in the AI-688 transcript.
+
+## 8. Risks & open questions
+
+- **R1 — Cursor's reaction to `-32601` is unobserved.** In the probe Cursor never sent `fs/*`, so we
+  have no direct evidence of how it degrades if we decline one. Accepted: a declined turn (worst
+  case, an errored turn) is strictly safer than a falsely-succeeded file operation. The debug log
+  makes any real occurrence visible.
+- **R2 — Behavior change to merged foundation code.** The fix alters an intentionally-tested contract
+  (the null-result test). Mitigated by §4.3 (invariant: no handled method returns null) + the
+  rewritten/added tests, which keep the "always answered" guarantee and add the production-wiring and
+  advertisement-lock coverage.
+- **R3 — The empty capability set is a *current-Cursor* fact, not a protocol guarantee.** Recorded as
+  such; the advertisement-lock test + the decline + the debug log together make a future change
+  observable and safe rather than silent.

--- a/docs/ai-687-fs-terminal-capability-decision-design.md
+++ b/docs/ai-687-fs-terminal-capability-decision-design.md
@@ -66,9 +66,43 @@ Mapping to the acceptance criteria:
 | Acceptance criterion | How this design meets it |
 |---|---|
 | Never advertise a capability we can't enforce safely | We advertise none. §4 additionally makes an unadvertised capability request *fail closed* (declined), so even a request we never advertised can't be mis-served. |
-| File and terminal operations bounded to the hosted worktree | Cursor runs them in the `cwd` we pass, which is the hosted worktree. We do not serve fs/terminal, so there is no client-side path we could fail to bound. The bounding that exists is Cursor's own (cwd + its permission model, bridged by AI-686) — see §6 for the honest limit. |
-| Terminal output visible through the existing remote terminal path | N/A — we serve no `terminal/*`. Cursor's shell output surfaces as `execute` tool `rawOutput` in the canonical transcript (AI-688), not via `terminal:{agentId}`. |
+| File and terminal operations bounded to the hosted worktree | **Explicitly re-scoped — see §3.1.** Met at the ACP-client layer (we serve no fs/terminal, so there is no client-served operation we could fail to bound). *Hard* OS-level enforcement of the locally-running `cursor-agent` process is **not** delivered by AI-687 and is deferred to AI-689; this matches how every hosted agent already runs. |
+| Terminal output visible through the existing remote terminal path | N/A — the criterion is conditional ("*if* implemented"); we serve no `terminal/*`, so nothing is implemented. Cursor's shell output surfaces as `execute` tool `rawOutput` in the canonical transcript (AI-688), not via `terminal:{agentId}`. |
 | Capability behavior covered by tests, including path-escape rejection | §5. We reject the *whole method* (`-32601`), so there is no fs path to escape — the "path-escape rejection" case is satisfied at a coarser, stronger granularity (method refused before any path is parsed), and a test asserts that. |
+
+### 3.1 Scope boundary — acceptance criteria #2 and #3 are re-scoped (issue-owner sign-off)
+
+Criteria #2 ("operations bounded to the hosted worktree") and #3 ("terminal output visible via the
+existing remote terminal path") are written as consequences of the Scope section's **conditional**
+bullets — *"**If** file-system support is required, constrain all paths…"* and *"**If** terminal
+support is required, run commands in the hosted worktree…"*. The probe (§2) shows neither is
+required: Cursor never issues client `fs/*`/`terminal/*`; it does file/shell work itself. So the
+conditional implementation work does not trigger, and with it the path-constraining / terminal-
+streaming obligations those criteria describe.
+
+That leaves one honestly-unmet reading of #2: the file/shell operations Cursor performs **itself**,
+as a local child process, are not *hard*-bounded to the worktree by anything AI-687 builds. AI-687
+does **not** provide OS-level enforcement, and this design does not claim to. Three reasons this is
+the right scope line, not a gap to paper over:
+
+1. **It is not achievable at the ACP-client layer.** The operations never cross the ACP boundary as
+   `fs/*`/`terminal/*` requests, so no client-side handler — bounded or not — can intercept them. The
+   only enforcement point is the OS/process layer (a sandbox, restricted user, or filesystem view),
+   which is a different mechanism from "the ACP client capabilities Kapacitor can safely provide"
+   that this issue is scoped to.
+2. **It is not a new or Cursor-specific exposure.** Every hosted agent the daemon runs today (Claude,
+   Codex, …) runs as a local child process in an *isolated git worktree* but is **not** OS-sandboxed —
+   it executes with the daemon's own filesystem/process privileges. Cursor-via-ACP has exactly this
+   posture. AI-687 introduces no new attack surface relative to the established hosted-agent model;
+   it explicitly adds **zero** client-served fs/terminal surface (§4 makes the decline correct).
+3. **Hardening is already a separate issue.** AI-689 (hardening) owns OS-level sandboxing of hosted
+   agents. Duplicating that scope into AI-687 would balloon a client-capability *decision* into a
+   cross-platform sandboxing project the evidence does not call for.
+
+**Decision (flagged for issue-owner confirmation at PR review):** AI-687 satisfies #2/#3 at the
+client-capability layer and **defers hard OS-level worktree enforcement to AI-689**. If the issue
+owner wants hard enforcement delivered under AI-687 instead, that is a materially larger,
+cross-platform effort and should be re-scoped explicitly before implementation.
 
 ## 4. The one code change — make the default-decline correct
 

--- a/src/Capacitor.Cli.Daemon/Acp/AcpConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpConnection.cs
@@ -76,6 +76,13 @@ internal sealed class AcpConnection : IAsyncDisposable {
     /// If unset, every inbound server request is answered with a method-not-found error — a safe
     /// default-decline posture. AI-684 leaves this unset; AI-686 wires it to the permission bridge.
     ///
+    /// A handler returning <see langword="null"/> signals the method is unhandled: the connection
+    /// answers <c>-32601 Method not found</c>, the SAME response a fully unset handler produces —
+    /// never a null-result success, which would falsely claim we performed an operation (e.g. an
+    /// <c>fs/*</c>/<c>terminal/*</c> request) we never actually served. A handler that intends a
+    /// successful EMPTY result must return an explicit <see cref="JsonElement"/> (e.g. an empty
+    /// object via <see cref="JsonSerializer.SerializeToElement"/>), never <see langword="null"/>.
+    ///
     /// Typed <see cref="JsonElement"/>? rather than <c>object?</c> (PR #244 review, Fix #3): the
     /// old <c>object?</c> contract let a handler return an un-serialized CLR object that
     /// <see cref="WriteServerResponseAsync"/> could only reject with a thrown
@@ -305,6 +312,15 @@ internal sealed class AcpConnection : IAsyncDisposable {
                 _logger.LogDebug(ex, "ACP: OnServerRequest handler threw for method={Method}", method);
                 error  = new AcpError(-32603, "Internal error", null);
                 result = null;
+            }
+
+            // A handler that ran without throwing but returned null means "I don't handle this
+            // method" (e.g. AcpInteractionBridge's `_ => null` default for fs/*, terminal/*) — treat
+            // it exactly like the no-handler branch above, never a null-result success that would
+            // falsely acknowledge an operation we never performed.
+            if (result is null && error is null) {
+                _logger.LogDebug("ACP: OnServerRequest handler declined method={Method}; responding -32601 Method not found", method);
+                error = new AcpError(-32601, $"Method not found: {method}", null);
             }
         }
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -114,11 +114,9 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime {
         _connectionRunTask = RunConnectionLoopAsync(_cts.Token);
 
         try {
-            // Advertise NO client fs/terminal. A live probe found cursor-agent performs file/shell
-            // operations itself (as a local child process, against `cwd`) and never asks the client
-            // to serve fs/*/terminal/*, so the smallest set is also sufficient — and we never
-            // advertise a capability we can't safely enforce. Any unadvertised request a future agent
-            // sends anyway is declined -32601 by AcpConnection (never falsely acknowledged).
+            // Advertise NO client fs/terminal: cursor-agent does file/shell ops itself and never asks
+            // the client to serve them (rationale: docs/ai-687-fs-terminal-capability-decision-design.md).
+            // Any unadvertised request is declined -32601 by AcpConnection, never falsely acknowledged.
             var initializeParams = JsonSerializer.SerializeToElement(
                 new InitializeParams(
                     ProtocolVersion: 1,

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -114,6 +114,11 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime {
         _connectionRunTask = RunConnectionLoopAsync(_cts.Token);
 
         try {
+            // Advertise NO client fs/terminal. A live probe found cursor-agent performs file/shell
+            // operations itself (as a local child process, against `cwd`) and never asks the client
+            // to serve fs/*/terminal/*, so the smallest set is also sufficient — and we never
+            // advertise a capability we can't safely enforce. Any unadvertised request a future agent
+            // sends anyway is declined -32601 by AcpConnection (never falsely acknowledged).
             var initializeParams = JsonSerializer.SerializeToElement(
                 new InitializeParams(
                     ProtocolVersion: 1,

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpConnectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpConnectionTests.cs
@@ -2,6 +2,7 @@
 using System.IO.Pipelines;
 using System.Text;
 using System.Text.Json;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
 using Capacitor.Cli.Daemon.Acp;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -209,9 +210,11 @@ public class AcpConnectionTests {
     // PR #244 review (Fix #3): OnServerRequest's contract is now Task<JsonElement?> — the handler
     // can no longer return an un-serializable CLR object that WriteServerResponseAsync could only
     // reject with a throw OUTSIDE any try/catch, silently orphaning the agent's request (no
-    // response ever written, wedging its wait on this id forever). These three tests assert the
-    // "always answered" guarantee holds across the three shapes a handler can produce: a value, a
-    // thrown exception, and a null result.
+    // response ever written, wedging its wait on this id forever). These tests assert the
+    // "always answered" guarantee holds across the three shapes a handler can produce: a value
+    // becomes the JSON-RPC `result`, a thrown exception becomes a `-32603 Internal error`, and a
+    // null return (the method ran but declined to handle it) becomes a `-32601 Method not found` —
+    // the same shape a fully unset handler produces, never a null-result success.
     [Test]
     public async Task Inbound_server_request_handler_throwing_still_writes_an_internal_error_response() {
         await using var harness = new Harness();
@@ -245,22 +248,73 @@ public class AcpConnectionTests {
     }
 
     [Test]
-    public async Task Inbound_server_request_handler_returning_null_writes_a_null_result_response() {
+    public async Task Inbound_server_request_handler_returning_null_writes_method_not_found_error() {
         await using var harness = new Harness();
         using var       cts     = new CancellationTokenSource();
         var              runTask = harness.Connection.RunAsync(cts.Token);
 
         harness.Connection.OnServerRequest = (_, _) => Task.FromResult<JsonElement?>(null);
 
+        // fs/read_text_file is unadvertised (the daemon sends fs.readTextFile=false in its
+        // initialize params) — a wired handler declining it must never look like a successful
+        // no-op file read.
         await harness.WriteFrameToConnectionAsync(
-            """{"jsonrpc":"2.0","id":8,"method":"session/request_permission","params":{}}"""
+            """{"jsonrpc":"2.0","id":8,"method":"fs/read_text_file","params":{"path":"/tmp/x"}}"""
         );
 
         var frame = await harness.ReadFrameFromConnectionAsync();
         using var doc = JsonDocument.Parse(frame);
         await Assert.That(doc.RootElement.GetProperty("id").GetInt64()).IsEqualTo(8L);
-        await Assert.That(doc.RootElement.TryGetProperty("error", out _)).IsFalse();
-        await Assert.That(doc.RootElement.GetProperty("result").ValueKind).IsEqualTo(JsonValueKind.Null);
+        await Assert.That(doc.RootElement.TryGetProperty("result", out _)).IsFalse();
+        var error = doc.RootElement.GetProperty("error");
+        await Assert.That(error.GetProperty("code").GetInt32()).IsEqualTo(-32601);
+
+        // Loop must still be alive afterward — mirrors the throw-test's liveness check, re-locking
+        // the "always answered" guarantee at this new response shape.
+        var tcs = new TaskCompletionSource<AcpNotification>(TaskCreationOptions.RunContinuationsAsynchronously);
+        harness.Connection.OnNotification += n => tcs.TrySetResult(n);
+        await harness.WriteFrameToConnectionAsync(
+            """{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"still-alive"}}"""
+        );
+        var notification = await tcs.Task.WaitAsync(HangGuard);
+        await Assert.That(notification.Params!.Value.GetProperty("sessionId").GetString()).IsEqualTo("still-alive");
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    // Proves the PRODUCTION wiring (a real AcpInteractionBridge, not a fake null-returning
+    // delegate) declines an unadvertised method cleanly. The bridge's `requestInteraction` delegate
+    // is never invoked here — terminal/create doesn't match either method the bridge recognizes, so
+    // it never reaches that delegate; asserting `called` stays false pins that.
+    [Test]
+    public async Task Inbound_unadvertised_terminal_request_through_real_bridge_writes_method_not_found_error() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var              runTask = harness.Connection.RunAsync(cts.Token);
+
+        var called = false;
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (_, _) => {
+                called = true;
+                return Task.FromResult(new AcpInteractionDecision("allow", null, null, null, null, null));
+            },
+            agentId: "agent-1",
+            logger: NullLogger.Instance);
+
+        harness.Connection.OnServerRequest = bridge.HandleAsync;
+
+        await harness.WriteFrameToConnectionAsync(
+            """{"jsonrpc":"2.0","id":42,"method":"terminal/create","params":{"command":"ls"}}"""
+        );
+
+        var frame = await harness.ReadFrameFromConnectionAsync();
+        using var doc = JsonDocument.Parse(frame);
+        await Assert.That(doc.RootElement.GetProperty("id").GetInt64()).IsEqualTo(42L);
+        await Assert.That(doc.RootElement.TryGetProperty("result", out _)).IsFalse();
+        var error = doc.RootElement.GetProperty("error");
+        await Assert.That(error.GetProperty("code").GetInt32()).IsEqualTo(-32601);
+        await Assert.That(called).IsFalse();
 
         cts.Cancel();
         await SwallowCancellation(runTask);

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
@@ -116,6 +116,31 @@ public class AcpHostedAgentRuntimeTests {
         await Assert.That(promptBlocks[0].GetProperty("text").GetString()).IsEqualTo("do the thing");
     }
 
+    // A live capability probe against the real cursor-agent found it performs file/shell operations
+    // itself and never requests client fs/terminal, so the daemon must keep advertising NONE of
+    // them — advertising a capability we can't safely enforce is exactly the failure mode this
+    // locks against. Fails loudly if a future change flips one on without revisiting that decision.
+    [Test]
+    public async Task StartAsync_advertises_no_fs_or_terminal_client_capabilities() {
+        await using var h = new Harness();
+        h.StartFakeAgentLoop();
+
+        await h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (h.Fake.ReceivedCalls.Count < 1 && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        var calls = h.Fake.ReceivedCalls;
+        await Assert.That(calls.Count).IsGreaterThanOrEqualTo(1);
+        await Assert.That(calls[0].Method).IsEqualTo("initialize");
+
+        var clientCapabilities = calls[0].Params!.Value.GetProperty("clientCapabilities");
+        await Assert.That(clientCapabilities.GetProperty("fs").GetProperty("readTextFile").GetBoolean()).IsFalse();
+        await Assert.That(clientCapabilities.GetProperty("fs").GetProperty("writeTextFile").GetBoolean()).IsFalse();
+        await Assert.That(clientCapabilities.GetProperty("terminal").GetBoolean()).IsFalse();
+    }
+
     [Test]
     public async Task Scripted_agent_message_chunk_update_is_surfaced_as_reduced_DTO() {
         await using var h = new Harness();


### PR DESCRIPTION
## What & why

Part of the **AI-682 ACP epic** (child issue **AI-687** — "terminal & file capability integration"). This is the **decision** for which ACP client capabilities Kapacitor advertises to Cursor, plus one defensive fix.

### The decision: advertise no `fs`/`terminal` (evidence-backed)

A live probe drove the real `cursor-agent acp` (Team tier) through a turn forcing a file **write** + **read**, with client capabilities advertised `fs.readTextFile=false`, `fs.writeTextFile=false`, `terminal=false`:
- **Zero** agent→client `fs/*`/`terminal/*` requests.
- Tool calls ran locally in our `cwd`: `edit` (result = a `diff` content block whose `path` was inside our `cwd`), `read`, `execute` (`ls -la` confirming the file on disk).
- The file really landed in our `cwd`.

`cursor-agent` runs as a **local child process** of the daemon and performs all file/shell work itself, against the `cwd` we pass; it never delegates to the ACP client. So the smallest advertised set (none) is also sufficient — and the daemon already advertises none, so **the advertisement is unchanged**.

### The one code change: make the default-decline correct

`AcpConnection` routes agent→client requests to `AcpInteractionBridge.HandleAsync`, whose `_ => null` default (any unhandled method) previously produced `{"result":null}` — a JSON-RPC **success** that falsely claims *"I performed your `fs/write` and it returned nothing."* If a future/misbehaving Cursor ignores the advertisement and calls `fs/*`/`terminal/*`, we'd falsely ACK an operation we never performed.

**Fix:** a handler returning `null` (unhandled method) now answers `-32601 Method not found` — the same shape the no-handler branch already produces — guarded so it never clobbers the `-32603` throw path or a real value. Safe because the bridge returns `null` **iff** the method hit `_ => null`; `session/request_permission` and `elicitation/create` always return non-null, so their behavior is unchanged. The PR #244 "always answered" guarantee is preserved — only the unhandled-method response *shape* changes (null-result → `-32601`).

## Scope note (⚠️ re-scope flagged for issue owner)

Acceptance criteria #2 ("operations bounded to the hosted worktree") and #3 ("terminal output via the remote terminal path") are consequences of the issue's **conditional** scope bullets ("*if* fs/terminal support is required…"), which the probe shows do **not** trigger. AI-687 satisfies them at the ACP-client layer (zero client-served surface + correct decline). **Hard OS-level worktree sandboxing of the locally-running `cursor-agent` is deferred to AI-689** — the same unsandboxed-in-a-worktree posture every hosted agent (Claude, Codex, …) already runs under, so no new exposure. See the design doc §3.1.

## Tests & gates

- Rewrote the null-result connection test → `fs/read_text_file` → `-32601` + read-loop liveness check.
- New production-wiring test: real `AcpInteractionBridge`, `terminal/create` → `-32601`, asserting the interaction delegate is never invoked (hit `_ => null`).
- Advertisement-lock test: the `initialize` frame advertises `fs`/`terminal` all false.
- AcpConnectionTests 16/16, AcpHostedAgentRuntimeTests 11/11, AcpInteractionBridgeTests 21/21 (unchanged); full unit suite 2688/2690 (2 pre-existing flakes, unrelated); NativeAOT `osx-arm64` Release gate warning-free.

Design doc: `docs/ai-687-fs-terminal-capability-decision-design.md`. Spec Codex-reviewed via kcap-flows (2 rounds → clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
