### PR TITLE
Fix release by pinning npm 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,10 +238,10 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
-      # npm trusted publishing (OIDC) requires npm >= 11.5.1. Node 24 ships
-      # with npm 11.x but the exact patch can lag, so pin to latest explicitly.
+      # npm trusted publishing (OIDC) requires npm >= 11.5.1. Pin a known-good
+      # npm 11 release; npm 12.0.0 has a broken bundled sigstore dependency.
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Extract version from tag
         id: version


### PR DESCRIPTION
## Summary
- pin the release workflow to npm 11.18.0
- avoid the npm 12.0.0 bundled `sigstore` dependency failure

## Details
The v0.10.6 release build succeeded, but npm publishing failed with `Cannot find module 'sigstore'` after installing `npm@latest`.\n\nFailed run: https://github.com/kurrent-io/kcap-cli/actions/runs/29081690072/job/86326832773