### PR TITLE
[AI-1239] Auto-register kcap MCP servers for Pi (MCP-bridge extension)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ kcap import --opencode          # only OpenCode
 kcap import --antigravity       # only Antigravity
 ```
 
-> **Pi** has no shell hooks, so live capture uses a shipped Pi extension rather than a hooks file: run `kcap plugin install --pi` (or accept the `kcap setup` prompt) to write `~/.pi/agent/extensions/kcap.ts`, which `pi` auto-loads and streams each session live. Historical `kcap import --pi` works with or without it.
+> **Pi** has no shell hooks, so live capture uses a shipped Pi extension rather than a hooks file: run `kcap plugin install --pi` (or accept the `kcap setup` prompt) to write `~/.pi/agent/extensions/kcap.ts`, which `pi` auto-loads and streams each session live. Because Pi also ships no built-in MCP, the same command installs an MCP-bridge extension (`~/.pi/agent/extensions/kcap-mcp.ts`, opt out `--skip-pi-mcp`) that exposes the kcap MCP servers as native Pi tools, plus a steering block in `~/.pi/agent/AGENTS.md` (opt out `--skip-pi-instructions`). Historical `kcap import --pi` works with or without any of it.
 
 > **OpenCode** likewise has no shell hooks: live capture uses a shipped OpenCode plugin. Run `kcap plugin install --opencode` (or accept the `kcap setup` prompt) to write `~/.config/opencode/plugins/kcap.ts`, which `opencode` auto-loads and streams each session live (`vendor=opencode`). Subagents (the `task` tool / `@agent`) are captured too — the plugin fetches each child session via the SDK and streams it, so it nests under the parent in the trace. Historical `kcap import --opencode` reads OpenCode's SQLite database (`~/.local/share/opencode/opencode.db`) and imports child sessions as subagents, so it backfills sessions from before the plugin was installed.
 
@@ -637,6 +637,24 @@ kcap plugin remove --kiro                   # restore previous default, delete k
 
 Kiro writes an append-only JSONL log per session at `~/.kiro/sessions/cli/{id}.jsonl` (plus a sibling `{id}.json` for cwd / model / title; honours `KIRO_HOME`), so the kcap watcher tails it like every other vendor. Lifecycle comes from Kiro's `agentSpawn` hook (fires every prompt → deduped server-side); since Kiro has **no session-end trigger**, the watcher synthesizes session-end on `kiro-cli` exit. Historical sessions import via `kcap import --kiro`. Kiro persists no token counts, so Kiro sessions show no token usage by design.
 
+#### Pi extension
+
+Pi (`badlogic/pi-mono`) is detected via `~/.pi/agent/` or the `pi` binary on `PATH`. Pi has **no shell hooks** and **no built-in MCP** — it exposes an in-process extension API — so `install --pi` writes dependency-free TypeScript extensions that `pi` auto-loads at startup:
+
+- **`~/.pi/agent/extensions/kcap.ts`** — the live-ingest extension (shells out to `kcap hook --pi` on session start/end).
+- **`~/.pi/agent/extensions/kcap-mcp.ts`** — the MCP bridge (opt out `--skip-pi-mcp`). At load it spawns each `kcap mcp <name>` server as a stdio subprocess, performs the MCP handshake, and registers every advertised tool as a native Pi tool `kcap_<server>_<tool>`, torn down on session exit.
+- **`~/.pi/agent/AGENTS.md`** — a kcap-owned, marker-delimited steering block (opt out `--skip-pi-instructions`, non-destructive — your own instructions are preserved) nudging Pi to prefer the kcap tools.
+
+`kcap` must be on `PATH` (both extensions shell out to it). Restart any running `pi` session after installing.
+
+```bash
+kcap plugin install --pi                    # write kcap.ts + kcap-mcp.ts + AGENTS.md block
+kcap plugin install --pi --skip-pi-mcp      # ingest + steering only, no MCP bridge
+kcap plugin remove --pi                     # delete both extensions + strip the AGENTS.md block
+```
+
+Live sessions stream from `~/.pi/agent/sessions/` (honours `PI_CODING_AGENT_DIR`); historical sessions import via `kcap import --pi`.
+
 #### SST OpenCode plugin
 
 SST OpenCode is detected via `~/.config/opencode/` (or `~/.local/share/opencode/`) or the `opencode` binary on `PATH`. OpenCode has **no shell hooks** — it exposes an in-process plugin API — so `install --opencode` writes a dependency-free plugin to `~/.config/opencode/plugins/kcap.ts`, which `opencode` auto-loads at startup. Restart any running `opencode` session after installing.
@@ -924,7 +942,7 @@ kcap uninstall --project --yes  # also strip project-scope hooks in cwd's repo
 kcap uninstall --keep-config    # remove integrations, keep ~/.config/kcap
 ```
 
-`uninstall` covers every supported agent: it stops running daemons and watcher processes, strips kcap entries from user-level Claude Code, Codex CLI, Cursor, and Copilot CLI hook files (preserving any non-kcap entries), deletes the Pi live-ingest extension (`~/.pi/agent/extensions/kcap.ts`) and the OpenCode plugin (`~/.config/opencode/plugins/kcap.ts`), removes the kcap capture plugin from Antigravity's `~/.gemini/config/plugins/kcap/`, removes agent skills under `~/.agents/skills/` (plus the legacy `~/.codex/skills/kcap-*` folders), and deletes `~/.config/kcap/`.
+`uninstall` covers every supported agent: it stops running daemons and watcher processes, strips kcap entries from user-level Claude Code, Codex CLI, Cursor, and Copilot CLI hook files (preserving any non-kcap entries), deletes the Pi extensions (`~/.pi/agent/extensions/kcap.ts` + the `kcap-mcp.ts` bridge) and strips kcap's block from `~/.pi/agent/AGENTS.md`, deletes the OpenCode plugin (`~/.config/opencode/plugins/kcap.ts`), removes the kcap capture plugin from Antigravity's `~/.gemini/config/plugins/kcap/`, removes agent skills under `~/.agents/skills/` (plus the legacy `~/.codex/skills/kcap-*` folders), and deletes `~/.config/kcap/`.
 
 `--project` additionally cleans up `<repo>/.claude/settings.local.json` and `<repo>/.codex/hooks.json` in the current git working tree (errors if you're not inside one). Cursor only has a user-scope `hooks.json`, so `--project` does not affect it. Project-scope hooks in other repos are not touched — re-run from each repo that has them.
 

--- a/src/Capacitor.Cli.Core/Pi/PiMcpExtensionInstaller.cs
+++ b/src/Capacitor.Cli.Core/Pi/PiMcpExtensionInstaller.cs
@@ -1,0 +1,356 @@
+namespace Capacitor.Cli.Core.Pi;
+
+/// <summary>
+/// Installs / removes kcap's <b>MCP-bridge</b> extension for Pi. Pi ships no
+/// built-in MCP (<c>badlogic/pi-mono</c> deliberately omits it), so there is no
+/// JSON <c>mcpServers</c> config to write the way the other harnesses have.
+/// Instead kcap ships a second TypeScript extension
+/// (<c>~/.pi/agent/extensions/kcap-mcp.ts</c>) that Pi auto-discovers: at load it
+/// spawns each <c>kcap mcp &lt;name&gt;</c> stdio server as a persistent
+/// subprocess, performs the MCP handshake, and re-registers every advertised tool
+/// as a native Pi tool (<c>kcap_&lt;server&gt;_&lt;tool&gt;</c>) whose
+/// <c>execute()</c> proxies <c>tools/call</c> back to that subprocess.
+///
+/// <para>This is a sibling of <see cref="PiExtensionInstaller"/> (the live-ingest
+/// extension) — same embedded-const + version-marker shape, but a distinct file
+/// and marker so the two install/refresh/remove independently. <see cref="ExtensionContent"/>
+/// is the single source of truth (embedding it as a const keeps NativeAOT happy —
+/// no manifest resource reflection).</para>
+/// </summary>
+public static class PiMcpExtensionInstaller {
+    public const string MarkerFileName = ".kcap-mcp-extension-version";
+
+    /// <summary>
+    /// The kcap Pi MCP-bridge extension. Untyped (<c>pi: any</c>) so it carries no
+    /// runtime dependency on the <c>@earendil-works/pi-coding-agent</c> types, and
+    /// fail-safe so a kcap/server hiccup never disrupts the pi session: each server
+    /// is spawned/handshaken independently and failures are logged and skipped.
+    /// </summary>
+    public const string ExtensionContent =
+        """
+        // kcap-mcp.ts — Kurrent Capacitor MCP-bridge extension for Pi (badlogic/pi-mono).
+        //
+        // Installed by `kcap plugin install --pi` into ~/.pi/agent/extensions/kcap-mcp.ts.
+        // Pi has no built-in MCP, so this extension bridges the kcap stdio MCP servers
+        // (`kcap mcp <name>`) into Pi as native tools: at load it spawns each server as a
+        // persistent subprocess, performs the MCP handshake, and re-registers every tool
+        // the server advertises as a Pi tool named `kcap_<server>_<tool>` whose execute()
+        // proxies `tools/call` back to that subprocess.
+        //
+        // Dependency-free (only the node:child_process builtin; no pi SDK import) and
+        // fail-safe: each server is spawned/handshaken/registered independently so one
+        // bad server never blocks the others or the pi session.
+
+        import { spawn } from "node:child_process";
+
+        // The kcap MCP servers to bridge, in `kcap mcp <name>` form. `flows` starts a
+        // *paid* hosted reviewer only on explicit invocation; its tool descriptions
+        // (surfaced verbatim from the server) name that cost so the model/user see it.
+        const KCAP_MCP_SERVERS = ["review", "sessions", "flows", "memory"];
+
+        // Bound the initialize + tools/list handshake per server so a hung server can
+        // never stall pi's startup indefinitely.
+        const HANDSHAKE_TIMEOUT_MS = 10000;
+
+        // A minimal line-delimited JSON-RPC 2.0 client over one `kcap mcp <name>`
+        // subprocess. No external MCP SDK.
+        class McpStdioClient {
+          server: string;
+          child: any = null;
+          nextId = 1;
+          pending = new Map<number, { resolve: (v: any) => void; reject: (e: any) => void }>();
+          buffer = "";
+          closed = false;
+
+          constructor(server: string) {
+            this.server = server;
+          }
+
+          // spawn + MCP handshake (initialize -> notifications/initialized).
+          async start(): Promise<void> {
+            const child = spawn("kcap", ["mcp", this.server], { stdio: ["pipe", "pipe", "ignore"] });
+            this.child = child;
+            child.on("exit", () => this.fail(new Error("kcap mcp " + this.server + " exited")));
+            child.on("error", (e: any) => this.fail(e instanceof Error ? e : new Error(String(e))));
+            child.stdout.setEncoding("utf8");
+            child.stdout.on("data", (chunk: string) => this.onData(chunk));
+
+            await this.request("initialize", {
+              protocolVersion: "2024-11-05",
+              capabilities: {},
+              clientInfo: { name: "kcap-pi-bridge", version: "1" },
+            });
+            // Per the MCP spec the client must send `notifications/initialized`
+            // after the initialize response and before any further requests.
+            this.notify("notifications/initialized", {});
+          }
+
+          onData(chunk: string) {
+            this.buffer += chunk;
+            let nl: number;
+            while ((nl = this.buffer.indexOf("\n")) >= 0) {
+              const line = this.buffer.slice(0, nl).trim();
+              this.buffer = this.buffer.slice(nl + 1);
+              if (!line) continue;
+              let msg: any;
+              try {
+                msg = JSON.parse(line);
+              } catch {
+                continue; // ignore non-JSON lines (defensive)
+              }
+              const id = msg && msg.id;
+              if (typeof id === "number" && this.pending.has(id)) {
+                const p = this.pending.get(id)!;
+                this.pending.delete(id);
+                if (msg.error) p.reject(new Error((msg.error && msg.error.message) || "MCP error"));
+                else p.resolve(msg.result);
+              }
+            }
+          }
+
+          // Reject every in-flight call when the subprocess dies so execute() never
+          // hangs; mark closed so later calls fail fast too.
+          fail(err: Error) {
+            if (this.closed) return;
+            this.closed = true;
+            for (const p of this.pending.values()) p.reject(err);
+            this.pending.clear();
+          }
+
+          send(obj: any) {
+            if (this.closed || !this.child || !this.child.stdin || !this.child.stdin.writable) {
+              throw new Error("kcap mcp " + this.server + " not available");
+            }
+            this.child.stdin.write(JSON.stringify(obj) + "\n");
+          }
+
+          notify(method: string, params: any) {
+            try {
+              this.send({ jsonrpc: "2.0", method, params });
+            } catch {
+              // notifications are best-effort
+            }
+          }
+
+          request(method: string, params: any, timeoutMs?: number): Promise<any> {
+            if (this.closed) return Promise.reject(new Error("kcap mcp " + this.server + " not available"));
+            const id = this.nextId++;
+            return new Promise((resolve, reject) => {
+              let timer: any = null;
+              const clear = () => {
+                if (timer) clearTimeout(timer);
+              };
+              this.pending.set(id, {
+                resolve: (v) => { clear(); resolve(v); },
+                reject: (e) => { clear(); reject(e); },
+              });
+              if (timeoutMs && timeoutMs > 0) {
+                timer = setTimeout(() => {
+                  if (this.pending.delete(id)) reject(new Error("kcap mcp " + this.server + " " + method + " timed out"));
+                }, timeoutMs);
+              }
+              try {
+                this.send({ jsonrpc: "2.0", id, method, params });
+              } catch (e) {
+                this.pending.delete(id);
+                clear();
+                reject(e);
+              }
+            });
+          }
+
+          async listTools(): Promise<any[]> {
+            const res = await this.request("tools/list", {}, HANDSHAKE_TIMEOUT_MS);
+            return res && Array.isArray(res.tools) ? res.tools : [];
+          }
+
+          callTool(name: string, args: any): Promise<any> {
+            return this.request("tools/call", { name, arguments: args || {} });
+          }
+
+          stop() {
+            this.fail(new Error("kcap mcp " + this.server + " stopped"));
+            const child = this.child;
+            this.child = null;
+            if (!child) return;
+            // Close stdin (EOF) to let a well-behaved server exit, then kill it.
+            try {
+              if (child.stdin) child.stdin.end();
+            } catch {
+              // ignore
+            }
+            try {
+              child.kill();
+            } catch {
+              // ignore
+            }
+          }
+        }
+
+        function sanitizeToolName(name: string): string {
+          return String(name)
+            .toLowerCase()
+            .replace(/[^a-z0-9_]+/g, "_")
+            .replace(/^_+|_+$/g, "");
+        }
+
+        function withTimeout<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
+          return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => reject(new Error(what + " timed out")), ms);
+            p.then(
+              (v) => { clearTimeout(timer); resolve(v); },
+              (e) => { clearTimeout(timer); reject(e); },
+            );
+          });
+        }
+
+        // Async factory: pi awaits it before session_start, so the bridged tools are
+        // registered before the first turn. Pi reloads/rebinds extensions per session,
+        // so each session gets its own subprocesses, torn down on session_shutdown.
+        export default async function (pi: any) {
+          const clients: McpStdioClient[] = [];
+
+          await Promise.all(
+            KCAP_MCP_SERVERS.map(async (server) => {
+              const client = new McpStdioClient(server);
+              let tools: any[];
+              try {
+                // One 10s budget for the whole handshake (spawn + initialize + tools/list).
+                tools = await withTimeout(
+                  (async () => {
+                    await client.start();
+                    return client.listTools();
+                  })(),
+                  HANDSHAKE_TIMEOUT_MS,
+                  "kcap mcp " + server + " handshake",
+                );
+              } catch {
+                client.stop(); // skip this server; leave the others registered
+                return;
+              }
+
+              clients.push(client);
+
+              for (const tool of tools) {
+                const mcpName = tool && tool.name;
+                if (!mcpName) continue;
+                const toolName = sanitizeToolName("kcap_" + server + "_" + mcpName);
+                if (!toolName) continue;
+                const description = String((tool && tool.description) || ("kcap " + server + " " + mcpName));
+                pi.registerTool({
+                  name: toolName,
+                  label: "kcap " + server + ": " + mcpName,
+                  description,
+                  // Surface it in the system prompt's Available tools section too.
+                  promptSnippet: "kcap " + server + " — " + description.split("\n")[0],
+                  // MCP inputSchema is already JSON Schema; pi forwards `parameters`
+                  // to the provider as-is.
+                  parameters: (tool && tool.inputSchema) || { type: "object", properties: {} },
+                  async execute(_toolCallId: string, params: any) {
+                    try {
+                      const result = await client.callTool(mcpName, params);
+                      const content =
+                        result && Array.isArray(result.content) && result.content.length
+                          ? result.content
+                          : [{ type: "text", text: typeof result === "string" ? result : JSON.stringify(result || {}) }];
+                      // AgentToolResult has no isError field — an MCP error surfaces as
+                      // content text so the model can see it.
+                      return { content, details: { server, tool: mcpName, isError: !!(result && result.isError) } };
+                    } catch (e: any) {
+                      return {
+                        content: [{ type: "text", text: "kcap " + server + " " + mcpName + " failed: " + ((e && e.message) || String(e)) }],
+                        details: { server, tool: mcpName, isError: true },
+                      };
+                    }
+                  },
+                });
+              }
+            }),
+          );
+
+          let done = false;
+          const onExit = () => {
+            for (const c of clients) c.stop();
+          };
+          const shutdown = () => {
+            if (done) return;
+            done = true;
+            onExit();
+            // Pi reloads/rebinds this extension per session switch and re-runs the
+            // factory, so drop our process-exit listener to avoid accumulating one
+            // per session (Node's MaxListeners warning).
+            try {
+              process.removeListener("exit", onExit);
+            } catch {
+              // ignore
+            }
+          };
+          // session_shutdown fires on session switch AND on process exit
+          // (Ctrl+C/Ctrl+D/SIGHUP/SIGTERM) — the primary teardown hook.
+          pi.on("session_shutdown", async () => shutdown());
+          // Sync backstop for an abrupt exit where the async handler may not finish.
+          try {
+            process.once("exit", onExit);
+          } catch {
+            // ignore
+          }
+        }
+        """;
+
+    /// <summary>
+    /// True when kcap-mcp.ts (or its marker) is present. Marker covers the case
+    /// where a user deleted kcap-mcp.ts but kept the dir.
+    /// </summary>
+    public static bool IsInstalled(string extensionPath) {
+        if (File.Exists(extensionPath)) return true;
+        var dir = Path.GetDirectoryName(extensionPath);
+        return dir is not null && File.Exists(Path.Combine(dir, MarkerFileName));
+    }
+
+    public static string? ReadMarker(string extensionPath) {
+        var dir = Path.GetDirectoryName(extensionPath);
+        if (string.IsNullOrEmpty(dir)) return null;
+        var marker = Path.Combine(dir, MarkerFileName);
+        try { return File.Exists(marker) ? File.ReadAllText(marker).Trim() : null; }
+        catch { return null; }
+    }
+
+    public static void WriteMarker(string extensionPath) {
+        var dir = Path.GetDirectoryName(extensionPath);
+        if (string.IsNullOrEmpty(dir)) return;
+        try {
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, MarkerFileName), CapacitorVersion.Current());
+        } catch { /* best effort */ }
+    }
+
+    public static void DeleteMarker(string extensionPath) {
+        var dir = Path.GetDirectoryName(extensionPath);
+        if (string.IsNullOrEmpty(dir)) return;
+        var marker = Path.Combine(dir, MarkerFileName);
+        try { if (File.Exists(marker)) File.Delete(marker); } catch { }
+    }
+
+    public static bool Install(string extensionPath) {
+        try {
+            Directory.CreateDirectory(Path.GetDirectoryName(extensionPath)!);
+            File.WriteAllText(extensionPath, ExtensionContent);
+            WriteMarker(extensionPath);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /// <summary>Removes kcap-mcp.ts + marker. Returns true if kcap-mcp.ts existed.</summary>
+    public static bool Remove(string extensionPath) {
+        var existed = File.Exists(extensionPath);
+        try {
+            if (existed) File.Delete(extensionPath);
+            DeleteMarker(extensionPath);
+        } catch {
+            return false;
+        }
+        return existed;
+    }
+}

--- a/src/Capacitor.Cli.Core/Pi/PiMcpExtensionInstaller.cs
+++ b/src/Capacitor.Cli.Core/Pi/PiMcpExtensionInstaller.cs
@@ -1,21 +1,12 @@
 namespace Capacitor.Cli.Core.Pi;
 
 /// <summary>
-/// Installs / removes kcap's <b>MCP-bridge</b> extension for Pi. Pi ships no
-/// built-in MCP (<c>badlogic/pi-mono</c> deliberately omits it), so there is no
-/// JSON <c>mcpServers</c> config to write the way the other harnesses have.
-/// Instead kcap ships a second TypeScript extension
-/// (<c>~/.pi/agent/extensions/kcap-mcp.ts</c>) that Pi auto-discovers: at load it
-/// spawns each <c>kcap mcp &lt;name&gt;</c> stdio server as a persistent
-/// subprocess, performs the MCP handshake, and re-registers every advertised tool
-/// as a native Pi tool (<c>kcap_&lt;server&gt;_&lt;tool&gt;</c>) whose
-/// <c>execute()</c> proxies <c>tools/call</c> back to that subprocess.
-///
-/// <para>This is a sibling of <see cref="PiExtensionInstaller"/> (the live-ingest
-/// extension) — same embedded-const + version-marker shape, but a distinct file
-/// and marker so the two install/refresh/remove independently. <see cref="ExtensionContent"/>
-/// is the single source of truth (embedding it as a const keeps NativeAOT happy —
-/// no manifest resource reflection).</para>
+/// Installs / removes kcap's MCP-bridge extension for Pi. Pi has no built-in MCP, so
+/// instead of a JSON <c>mcpServers</c> config kcap ships a TypeScript extension
+/// (<c>~/.pi/agent/extensions/kcap-mcp.ts</c>) that spawns the <c>kcap mcp &lt;name&gt;</c>
+/// servers and registers their tools as native Pi tools. Sibling of
+/// <see cref="PiExtensionInstaller"/> with a distinct file + marker; <see cref="ExtensionContent"/>
+/// is the embedded source of truth (const, not a resource — NativeAOT-safe).
 /// </summary>
 public static class PiMcpExtensionInstaller {
     public const string MarkerFileName = ".kcap-mcp-extension-version";
@@ -28,18 +19,10 @@ public static class PiMcpExtensionInstaller {
     /// </summary>
     public const string ExtensionContent =
         """
-        // kcap-mcp.ts — Kurrent Capacitor MCP-bridge extension for Pi (badlogic/pi-mono).
-        //
-        // Installed by `kcap plugin install --pi` into ~/.pi/agent/extensions/kcap-mcp.ts.
-        // Pi has no built-in MCP, so this extension bridges the kcap stdio MCP servers
-        // (`kcap mcp <name>`) into Pi as native tools: at load it spawns each server as a
-        // persistent subprocess, performs the MCP handshake, and re-registers every tool
-        // the server advertises as a Pi tool named `kcap_<server>_<tool>` whose execute()
-        // proxies `tools/call` back to that subprocess.
-        //
-        // Dependency-free (only the node:child_process builtin; no pi SDK import) and
-        // fail-safe: each server is spawned/handshaken/registered independently so one
-        // bad server never blocks the others or the pi session.
+        // kcap-mcp.ts — Kurrent Capacitor MCP-bridge extension for Pi.
+        // Pi has no built-in MCP, so this bridges the kcap stdio servers (`kcap mcp <name>`)
+        // into Pi as native tools: spawn each, handshake, register its tools. Dependency-free
+        // (node:child_process only) and fail-safe — one bad server never blocks the rest.
 
         import { spawn } from "node:child_process";
 
@@ -51,6 +34,11 @@ public static class PiMcpExtensionInstaller {
         // Bound the initialize + tools/list handshake per server so a hung server can
         // never stall pi's startup indefinitely.
         const HANDSHAKE_TIMEOUT_MS = 10000;
+
+        // Bound each tools/call so a stalled (but not exited) server can't hang a pi tool
+        // forever. Generous — well above the flows server's own long-poll/round timeouts,
+        // since it's only a backstop; on timeout the error surfaces as tool-result content.
+        const TOOL_CALL_TIMEOUT_MS = 1200000; // 20 min
 
         // A minimal line-delimited JSON-RPC 2.0 client over one `kcap mcp <name>`
         // subprocess. No external MCP SDK.
@@ -68,12 +56,22 @@ public static class PiMcpExtensionInstaller {
 
           // spawn + MCP handshake (initialize -> notifications/initialized).
           async start(): Promise<void> {
-            const child = spawn("kcap", ["mcp", this.server], { stdio: ["pipe", "pipe", "ignore"] });
+            const child = spawn("kcap", ["mcp", this.server], { stdio: ["pipe", "pipe", "pipe"] });
             this.child = child;
             child.on("exit", () => this.fail(new Error("kcap mcp " + this.server + " exited")));
             child.on("error", (e: any) => this.fail(e instanceof Error ? e : new Error(String(e))));
             child.stdout.setEncoding("utf8");
             child.stdout.on("data", (chunk: string) => this.onData(chunk));
+            // Forward the server's stderr (its primary diagnostics channel) with a prefix so
+            // failures are debuggable; kept off stdout so it never corrupts the JSON-RPC stream.
+            if (child.stderr) {
+              child.stderr.setEncoding("utf8");
+              child.stderr.on("data", (chunk: string) => {
+                for (const line of String(chunk).split("\n")) {
+                  if (line.trim()) console.error("[kcap-mcp " + this.server + "] " + line);
+                }
+              });
+            }
 
             await this.request("initialize", {
               protocolVersion: "2024-11-05",
@@ -165,7 +163,7 @@ public static class PiMcpExtensionInstaller {
           }
 
           callTool(name: string, args: any): Promise<any> {
-            return this.request("tools/call", { name, arguments: args || {} });
+            return this.request("tools/call", { name, arguments: args || {} }, TOOL_CALL_TIMEOUT_MS);
           }
 
           stop() {
@@ -224,7 +222,9 @@ public static class PiMcpExtensionInstaller {
                   HANDSHAKE_TIMEOUT_MS,
                   "kcap mcp " + server + " handshake",
                 );
-              } catch {
+              } catch (e: any) {
+                // Log why this server was skipped so its tools' absence is explainable.
+                console.error("[kcap-mcp] " + server + " unavailable, skipping: " + ((e && e.message) || String(e)));
                 client.stop(); // skip this server; leave the others registered
                 return;
               }

--- a/src/Capacitor.Cli.Core/Pi/PiMcpExtensionInstaller.cs
+++ b/src/Capacitor.Cli.Core/Pi/PiMcpExtensionInstaller.cs
@@ -26,22 +26,58 @@ public static class PiMcpExtensionInstaller {
 
         import { spawn } from "node:child_process";
 
-        // The kcap MCP servers to bridge, in `kcap mcp <name>` form. `flows` starts a
-        // *paid* hosted reviewer only on explicit invocation; its tool descriptions
-        // (surfaced verbatim from the server) name that cost so the model/user see it.
         const KCAP_MCP_SERVERS = ["review", "sessions", "flows", "memory"];
-
-        // Bound the initialize + tools/list handshake per server so a hung server can
-        // never stall pi's startup indefinitely.
         const HANDSHAKE_TIMEOUT_MS = 10000;
-
-        // Bound each tools/call so a stalled (but not exited) server can't hang a pi tool
-        // forever. Generous — well above the flows server's own long-poll/round timeouts,
-        // since it's only a backstop; on timeout the error surfaces as tool-result content.
+        // Generous — above the flows server's own round timeouts; only a backstop against a
+        // stalled-but-not-exited server. A timeout surfaces as a tool failure (execute throws).
         const TOOL_CALL_TIMEOUT_MS = 1200000; // 20 min
+        const KILL_GRACE_MS = 2000;
 
-        // A minimal line-delimited JSON-RPC 2.0 client over one `kcap mcp <name>`
-        // subprocess. No external MCP SDK.
+        // Process-wide child registry + a single exit hook, guarded on globalThis so repeated
+        // per-session extension loads never accumulate process listeners (Node's MaxListeners).
+        const KCAP_BRIDGE = ((globalThis as any).__kcapPiMcpBridge ||= { children: new Set(), exitHooked: false });
+
+        function trackChild(child: any) {
+          KCAP_BRIDGE.children.add(child);
+          child.once("exit", () => KCAP_BRIDGE.children.delete(child));
+        }
+
+        function ensureExitHook() {
+          if (KCAP_BRIDGE.exitHooked) return;
+          KCAP_BRIDGE.exitHooked = true;
+          // Synchronous-only backstop: an `exit` handler can't await the graceful ladder, so it
+          // hard-SIGKILLs any child still tracked at process teardown (no orphans).
+          try {
+            process.on("exit", () => {
+              for (const c of KCAP_BRIDGE.children) { try { c.kill("SIGKILL"); } catch { /* ignore */ } }
+            });
+          } catch {
+            // ignore
+          }
+        }
+
+        function waitExit(child: any, ms: number): Promise<boolean> {
+          return new Promise((resolve) => {
+            if (child.exitCode !== null || child.signalCode !== null) { resolve(true); return; }
+            let settled = false;
+            const onExit = () => { if (!settled) { settled = true; resolve(true); } };
+            child.once("exit", onExit);
+            setTimeout(() => {
+              if (!settled) { settled = true; try { child.removeListener("exit", onExit); } catch { /* ignore */ } resolve(false); }
+            }, ms);
+          });
+        }
+
+        // EOF -> SIGTERM -> SIGKILL ladder: a child may ignore EOF and SIGTERM, so escalate.
+        async function killLadder(child: any) {
+          try { if (child.stdin) child.stdin.end(); } catch { /* ignore */ }
+          if (await waitExit(child, KILL_GRACE_MS)) return;
+          try { child.kill("SIGTERM"); } catch { /* ignore */ }
+          if (await waitExit(child, KILL_GRACE_MS)) return;
+          try { child.kill("SIGKILL"); } catch { /* ignore */ }
+        }
+
+        // A minimal line-delimited JSON-RPC 2.0 client over one `kcap mcp <name>` subprocess.
         class McpStdioClient {
           server: string;
           child: any = null;
@@ -49,15 +85,18 @@ public static class PiMcpExtensionInstaller {
           pending = new Map<number, { resolve: (v: any) => void; reject: (e: any) => void }>();
           buffer = "";
           closed = false;
+          protocolVersion: string | null = null;
 
           constructor(server: string) {
             this.server = server;
           }
 
-          // spawn + MCP handshake (initialize -> notifications/initialized).
+          // spawn + MCP handshake (initialize -> validate -> notifications/initialized).
           async start(): Promise<void> {
             const child = spawn("kcap", ["mcp", this.server], { stdio: ["pipe", "pipe", "pipe"] });
             this.child = child;
+            trackChild(child);
+            ensureExitHook();
             child.on("exit", () => this.fail(new Error("kcap mcp " + this.server + " exited")));
             child.on("error", (e: any) => this.fail(e instanceof Error ? e : new Error(String(e))));
             child.stdout.setEncoding("utf8");
@@ -73,13 +112,15 @@ public static class PiMcpExtensionInstaller {
               });
             }
 
-            await this.request("initialize", {
+            // Full MCP initialize; validate + capture the negotiated protocol version, THEN send
+            // notifications/initialized before any tools/list or tools/call (a spec-strict server
+            // rejects requests that arrive before it).
+            const result = await this.request("initialize", {
               protocolVersion: "2024-11-05",
               capabilities: {},
               clientInfo: { name: "kcap-pi-bridge", version: "1" },
-            });
-            // Per the MCP spec the client must send `notifications/initialized`
-            // after the initialize response and before any further requests.
+            }, HANDSHAKE_TIMEOUT_MS);
+            this.protocolVersion = (result && result.protocolVersion) || "2024-11-05";
             this.notify("notifications/initialized", {});
           }
 
@@ -106,8 +147,8 @@ public static class PiMcpExtensionInstaller {
             }
           }
 
-          // Reject every in-flight call when the subprocess dies so execute() never
-          // hangs; mark closed so later calls fail fast too.
+          // Reject every in-flight call when the subprocess dies so execute() never hangs;
+          // mark closed so later calls fail fast too.
           fail(err: Error) {
             if (this.closed) return;
             this.closed = true;
@@ -166,22 +207,13 @@ public static class PiMcpExtensionInstaller {
             return this.request("tools/call", { name, arguments: args || {} }, TOOL_CALL_TIMEOUT_MS);
           }
 
-          stop() {
+          // Graceful teardown via the EOF -> SIGTERM -> SIGKILL ladder.
+          async stop(): Promise<void> {
             this.fail(new Error("kcap mcp " + this.server + " stopped"));
             const child = this.child;
             this.child = null;
             if (!child) return;
-            // Close stdin (EOF) to let a well-behaved server exit, then kill it.
-            try {
-              if (child.stdin) child.stdin.end();
-            } catch {
-              // ignore
-            }
-            try {
-              child.kill();
-            } catch {
-              // ignore
-            }
+            await killLadder(child);
           }
         }
 
@@ -202,98 +234,108 @@ public static class PiMcpExtensionInstaller {
           });
         }
 
-        // Async factory: pi awaits it before session_start, so the bridged tools are
-        // registered before the first turn. Pi reloads/rebinds extensions per session,
-        // so each session gets its own subprocesses, torn down on session_shutdown.
+        function mcpText(result: any): string {
+          if (!result || !Array.isArray(result.content)) return "";
+          return result.content
+            .filter((b: any) => b && b.type === "text" && typeof b.text === "string")
+            .map((b: any) => b.text)
+            .join("\n");
+        }
+
+        // Session-scoped bridge. Registered tools route through a per-server holder that
+        // startBridge() refreshes on every session_start, so a session switch never leaves a tool
+        // bound to a dead subprocess. Registration is guarded per tool name (Pi has no unregister),
+        // so a reused instance never double-registers.
         export default async function (pi: any) {
-          const clients: McpStdioClient[] = [];
+          const holders = new Map<string, { client: McpStdioClient | null }>();
+          const registered = new Set<string>();
+          let startInFlight: Promise<void> | null = null;
 
-          await Promise.all(
-            KCAP_MCP_SERVERS.map(async (server) => {
-              const client = new McpStdioClient(server);
-              let tools: any[];
-              try {
-                // One 10s budget for the whole handshake (spawn + initialize + tools/list).
-                tools = await withTimeout(
-                  (async () => {
-                    await client.start();
-                    return client.listTools();
-                  })(),
-                  HANDSHAKE_TIMEOUT_MS,
-                  "kcap mcp " + server + " handshake",
-                );
-              } catch (e: any) {
-                // Log why this server was skipped so its tools' absence is explainable.
-                console.error("[kcap-mcp] " + server + " unavailable, skipping: " + ((e && e.message) || String(e)));
-                client.stop(); // skip this server; leave the others registered
-                return;
-              }
-
-              clients.push(client);
-
-              for (const tool of tools) {
-                const mcpName = tool && tool.name;
-                if (!mcpName) continue;
-                const toolName = sanitizeToolName("kcap_" + server + "_" + mcpName);
-                if (!toolName) continue;
-                const description = String((tool && tool.description) || ("kcap " + server + " " + mcpName));
-                pi.registerTool({
-                  name: toolName,
-                  label: "kcap " + server + ": " + mcpName,
-                  description,
-                  // Surface it in the system prompt's Available tools section too.
-                  promptSnippet: "kcap " + server + " — " + description.split("\n")[0],
-                  // MCP inputSchema is already JSON Schema; pi forwards `parameters`
-                  // to the provider as-is.
-                  parameters: (tool && tool.inputSchema) || { type: "object", properties: {} },
-                  async execute(_toolCallId: string, params: any) {
-                    try {
-                      const result = await client.callTool(mcpName, params);
-                      const content =
-                        result && Array.isArray(result.content) && result.content.length
-                          ? result.content
-                          : [{ type: "text", text: typeof result === "string" ? result : JSON.stringify(result || {}) }];
-                      // AgentToolResult has no isError field — an MCP error surfaces as
-                      // content text so the model can see it.
-                      return { content, details: { server, tool: mcpName, isError: !!(result && result.isError) } };
-                    } catch (e: any) {
-                      return {
-                        content: [{ type: "text", text: "kcap " + server + " " + mcpName + " failed: " + ((e && e.message) || String(e)) }],
-                        details: { server, tool: mcpName, isError: true },
-                      };
-                    }
-                  },
-                });
-              }
-            }),
-          );
-
-          let done = false;
-          const onExit = () => {
-            for (const c of clients) c.stop();
-          };
-          const shutdown = () => {
-            if (done) return;
-            done = true;
-            onExit();
-            // Pi reloads/rebinds this extension per session switch and re-runs the
-            // factory, so drop our process-exit listener to avoid accumulating one
-            // per session (Node's MaxListeners warning).
-            try {
-              process.removeListener("exit", onExit);
-            } catch {
-              // ignore
-            }
-          };
-          // session_shutdown fires on session switch AND on process exit
-          // (Ctrl+C/Ctrl+D/SIGHUP/SIGTERM) — the primary teardown hook.
-          pi.on("session_shutdown", async () => shutdown());
-          // Sync backstop for an abrupt exit where the async handler may not finish.
-          try {
-            process.once("exit", onExit);
-          } catch {
-            // ignore
+          function registerTool(server: string, tool: any) {
+            const mcpName = tool && tool.name;
+            if (!mcpName) return;
+            const toolName = sanitizeToolName("kcap_" + server + "_" + mcpName);
+            if (!toolName || registered.has(toolName)) return;
+            registered.add(toolName);
+            const description = String((tool && tool.description) || ("kcap " + server + " " + mcpName));
+            pi.registerTool({
+              name: toolName,
+              label: "kcap " + server + ": " + mcpName,
+              description,
+              // Surface it in the system prompt's Available tools section too.
+              promptSnippet: "kcap " + server + " — " + description.split("\n")[0],
+              // MCP inputSchema is already JSON Schema; pi forwards `parameters` to the provider as-is.
+              parameters: (tool && tool.inputSchema) || { type: "object", properties: {} },
+              async execute(_toolCallId: string, params: any) {
+                const holder = holders.get(server);
+                const client = holder && holder.client;
+                if (!client || client.closed) {
+                  throw new Error("kcap " + server + " " + mcpName + " unavailable — no live server");
+                }
+                // callTool rejects on timeout or subprocess death — let it propagate as a failure.
+                const result = await client.callTool(mcpName, params);
+                // AgentToolResult has no isError field, so signal an MCP error by THROWING (pi-agent-core
+                // records a thrown execute as an isError tool result the model sees).
+                if (result && result.isError) {
+                  throw new Error(mcpText(result) || ("kcap " + server + " " + mcpName + " returned an error"));
+                }
+                const content =
+                  result && Array.isArray(result.content) && result.content.length
+                    ? result.content
+                    : [{ type: "text", text: typeof result === "string" ? result : JSON.stringify(result || {}) }];
+                return { content, details: { server, tool: mcpName } };
+              },
+            });
           }
+
+          // Start (or re-establish) every server CONCURRENTLY — one 10s handshake budget each, so
+          // four hung servers add ~10s wall-clock, not 4x. Healthy servers register + route; a bad
+          // one is logged and skipped. Idempotent: a server already live is left as-is.
+          async function startBridge(): Promise<void> {
+            if (startInFlight) return startInFlight;
+            startInFlight = (async () => {
+              await Promise.all(
+                KCAP_MCP_SERVERS.map(async (server) => {
+                  const existing = holders.get(server);
+                  if (existing && existing.client && !existing.client.closed) return; // already live
+                  const client = new McpStdioClient(server);
+                  let tools: any[];
+                  try {
+                    tools = await withTimeout(
+                      (async () => { await client.start(); return client.listTools(); })(),
+                      HANDSHAKE_TIMEOUT_MS,
+                      "kcap mcp " + server + " handshake",
+                    );
+                  } catch (e: any) {
+                    console.error("[kcap-mcp] " + server + " unavailable, skipping: " + ((e && e.message) || String(e)));
+                    await client.stop();
+                    return;
+                  }
+                  holders.set(server, { client });
+                  for (const tool of tools) registerTool(server, tool);
+                }),
+              );
+            })();
+            try {
+              await startInFlight;
+            } finally {
+              startInFlight = null;
+            }
+          }
+
+          async function stopBridge(): Promise<void> {
+            const live = [...holders.values()].map((h) => h.client).filter(Boolean) as McpStdioClient[];
+            holders.clear();
+            await Promise.all(live.map((c) => c.stop()));
+          }
+
+          // Turn-1 readiness: pi awaits the async factory before session_start.
+          await startBridge();
+
+          // Respawn on a session switch/restart within the same process (idempotent).
+          pi.on("session_start", async () => { await startBridge(); });
+          // Primary teardown — fires on switch AND on process exit (Ctrl+C/Ctrl+D/SIGHUP/SIGTERM).
+          pi.on("session_shutdown", async () => { await stopBridge(); });
         }
         """;
 

--- a/src/Capacitor.Cli.Core/Pi/PiMcpExtensionInstaller.cs
+++ b/src/Capacitor.Cli.Core/Pi/PiMcpExtensionInstaller.cs
@@ -111,6 +111,9 @@ public static class PiMcpExtensionInstaller {
                 }
               });
             }
+            // A just-closed/dead stdin can surface EPIPE (or another stream error) asynchronously;
+            // route it through fail() — rejecting pending calls — instead of letting it crash pi.
+            if (child.stdin) child.stdin.on("error", (e: any) => this.fail(e instanceof Error ? e : new Error(String(e))));
 
             // Full MCP initialize; validate + capture the negotiated protocol version, THEN send
             // notifications/initialized before any tools/list or tools/call (a spec-strict server
@@ -247,6 +250,11 @@ public static class PiMcpExtensionInstaller {
         // bound to a dead subprocess. Registration is guarded per tool name (Pi has no unregister),
         // so a reused instance never double-registers.
         export default async function (pi: any) {
+          // holders + registered are INSTANCE-LOCAL by design. Pi builds a fresh ExtensionRunner
+          // (fresh tool registry) per session and re-invokes this factory with a `pi` bound to it,
+          // so each instance must register into its OWN runner — a process-global `registered` set
+          // would starve a freshly-rebuilt runner of tools. The child-process registry + the single
+          // process-exit hook are the only things that ARE process-global (see KCAP_BRIDGE above).
           const holders = new Map<string, { client: McpStdioClient | null }>();
           const registered = new Set<string>();
           let startInFlight: Promise<void> | null = null;
@@ -256,36 +264,42 @@ public static class PiMcpExtensionInstaller {
             if (!mcpName) return;
             const toolName = sanitizeToolName("kcap_" + server + "_" + mcpName);
             if (!toolName || registered.has(toolName)) return;
-            registered.add(toolName);
             const description = String((tool && tool.description) || ("kcap " + server + " " + mcpName));
-            pi.registerTool({
-              name: toolName,
-              label: "kcap " + server + ": " + mcpName,
-              description,
-              // Surface it in the system prompt's Available tools section too.
-              promptSnippet: "kcap " + server + " — " + description.split("\n")[0],
-              // MCP inputSchema is already JSON Schema; pi forwards `parameters` to the provider as-is.
-              parameters: (tool && tool.inputSchema) || { type: "object", properties: {} },
-              async execute(_toolCallId: string, params: any) {
-                const holder = holders.get(server);
-                const client = holder && holder.client;
-                if (!client || client.closed) {
-                  throw new Error("kcap " + server + " " + mcpName + " unavailable — no live server");
-                }
-                // callTool rejects on timeout or subprocess death — let it propagate as a failure.
-                const result = await client.callTool(mcpName, params);
-                // AgentToolResult has no isError field, so signal an MCP error by THROWING (pi-agent-core
-                // records a thrown execute as an isError tool result the model sees).
-                if (result && result.isError) {
-                  throw new Error(mcpText(result) || ("kcap " + server + " " + mcpName + " returned an error"));
-                }
-                const content =
-                  result && Array.isArray(result.content) && result.content.length
-                    ? result.content
-                    : [{ type: "text", text: typeof result === "string" ? result : JSON.stringify(result || {}) }];
-                return { content, details: { server, tool: mcpName } };
-              },
-            });
+            try {
+              pi.registerTool({
+                name: toolName,
+                label: "kcap " + server + ": " + mcpName,
+                description,
+                // Surface it in the system prompt's Available tools section too.
+                promptSnippet: "kcap " + server + " — " + description.split("\n")[0],
+                // MCP inputSchema is already JSON Schema; pi forwards `parameters` to the provider as-is.
+                parameters: (tool && tool.inputSchema) || { type: "object", properties: {} },
+                async execute(_toolCallId: string, params: any) {
+                  const holder = holders.get(server);
+                  const client = holder && holder.client;
+                  if (!client || client.closed) {
+                    throw new Error("kcap " + server + " " + mcpName + " unavailable — no live server");
+                  }
+                  // callTool rejects on timeout or subprocess death — let it propagate as a failure.
+                  const result = await client.callTool(mcpName, params);
+                  // AgentToolResult has no isError field, so signal an MCP error by THROWING (pi-agent-core
+                  // records a thrown execute as an isError tool result the model sees).
+                  if (result && result.isError) {
+                    throw new Error(mcpText(result) || ("kcap " + server + " " + mcpName + " returned an error"));
+                  }
+                  const content =
+                    result && Array.isArray(result.content) && result.content.length
+                      ? result.content
+                      : [{ type: "text", text: typeof result === "string" ? result : JSON.stringify(result || {}) }];
+                  return { content, details: { server, tool: mcpName } };
+                },
+              });
+              // Mark registered only after a successful call, so a failure (dup name / bad schema /
+              // Pi API error) can retry later and never aborts the factory or the other servers.
+              registered.add(toolName);
+            } catch (e: any) {
+              console.error("[kcap-mcp] could not register " + toolName + ": " + ((e && e.message) || String(e)));
+            }
           }
 
           // Start (or re-establish) every server CONCURRENTLY — one 10s handshake budget each, so
@@ -299,6 +313,10 @@ public static class PiMcpExtensionInstaller {
                   const existing = holders.get(server);
                   if (existing && existing.client && !existing.client.closed) return; // already live
                   const client = new McpStdioClient(server);
+                  // Register the holder BEFORE the handshake (synchronously, before any await) so an
+                  // overlapping stopBridge() sees and stops this in-flight subprocess — otherwise it
+                  // could finish after shutdown and leave an orphaned, unmanaged child.
+                  holders.set(server, { client });
                   let tools: any[];
                   try {
                     tools = await withTimeout(
@@ -308,10 +326,16 @@ public static class PiMcpExtensionInstaller {
                     );
                   } catch (e: any) {
                     console.error("[kcap-mcp] " + server + " unavailable, skipping: " + ((e && e.message) || String(e)));
+                    if (holders.get(server)?.client === client) holders.delete(server);
                     await client.stop();
                     return;
                   }
-                  holders.set(server, { client });
+                  // An overlapping stopBridge() may have stopped this client mid-handshake — if so,
+                  // don't register tools bound to a dead subprocess.
+                  if (client.closed) {
+                    if (holders.get(server)?.client === client) holders.delete(server);
+                    return;
+                  }
                   for (const tool of tools) registerTool(server, tool);
                 }),
               );
@@ -384,15 +408,15 @@ public static class PiMcpExtensionInstaller {
         }
     }
 
-    /// <summary>Removes kcap-mcp.ts + marker. Returns true if kcap-mcp.ts existed.</summary>
+    /// <summary>
+    /// Removes kcap-mcp.ts + marker. Returns true if kcap-mcp.ts existed. IO/permission failures on
+    /// the file delete PROPAGATE (so callers can distinguish a failure from "nothing to remove" and
+    /// warn); marker deletion stays best-effort.
+    /// </summary>
     public static bool Remove(string extensionPath) {
         var existed = File.Exists(extensionPath);
-        try {
-            if (existed) File.Delete(extensionPath);
-            DeleteMarker(extensionPath);
-        } catch {
-            return false;
-        }
+        if (existed) File.Delete(extensionPath);
+        DeleteMarker(extensionPath);
         return existed;
     }
 }

--- a/src/Capacitor.Cli.Core/Pi/PiPaths.cs
+++ b/src/Capacitor.Cli.Core/Pi/PiPaths.cs
@@ -55,6 +55,23 @@ public static class PiPaths {
     public static string KcapExtensionMarker(string? home = null) => Path.Combine(ExtensionsDir(home), ".kcap-extension-version");
 
     /// <summary>
+    /// The kcap MCP-bridge extension (Pi has no built-in MCP, so kcap ships a second
+    /// extension that spawns the <c>kcap mcp &lt;name&gt;</c> servers and registers
+    /// their tools). Installed by <see cref="PiMcpExtensionInstaller"/>.
+    /// </summary>
+    public static string KcapMcpExtension(string? home = null) => Path.Combine(ExtensionsDir(home), "kcap-mcp.ts");
+
+    /// <summary>Marker recording the installed MCP-bridge extension version (sibling of kcap-mcp.ts).</summary>
+    public static string KcapMcpExtensionMarker(string? home = null) => Path.Combine(ExtensionsDir(home), ".kcap-mcp-extension-version");
+
+    /// <summary>
+    /// Pi's native user-global agent-instructions file (<c>~/.pi/agent/AGENTS.md</c>),
+    /// a sibling of <c>extensions/</c>. kcap writes its marker-delimited steering block
+    /// here (see <c>AgentInstructionsWriter</c>).
+    /// </summary>
+    public static string AgentsMd(string? home = null) => Path.Combine(AgentDir(home), "AGENTS.md");
+
+    /// <summary>
     /// Detection by <c>~/.pi/agent</c> presence — Pi creates it on first run.
     /// The binary name <c>pi</c> is too generic for a PATH probe to be the only
     /// signal, so callers that also want the PATH probe OR this with

--- a/src/Capacitor.Cli.Core/Resources/help-plugin.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-plugin.txt
@@ -39,8 +39,12 @@ Options:
   --pi                Target Pi (badlogic/pi-mono): install the live-ingest
                       extension to ~/.pi/agent/extensions/kcap.ts. Pi has no
                       shell hooks; the extension auto-loads on `pi` startup and
-                      streams each session. User-wide only — --project has no
-                      effect with --pi.
+                      streams each session. Also installs the kcap MCP-bridge
+                      extension (~/.pi/agent/extensions/kcap-mcp.ts — Pi has no
+                      native MCP, so this spawns the kcap mcp servers and
+                      registers their tools; see --skip-pi-mcp) and a steering
+                      block in ~/.pi/agent/AGENTS.md (see --skip-pi-instructions).
+                      User-wide only — --project has no effect with --pi.
   --opencode          Target SST OpenCode: install the live-ingest plugin to
                       ~/.config/opencode/plugins/kcap.ts. OpenCode has no shell
                       hooks; the plugin auto-loads on `opencode` startup and
@@ -104,6 +108,17 @@ Options:
   --skip-antigravity-skills
                       With --antigravity: skip copying the kcap skills into
                       ~/.gemini/skills (where Antigravity reads them, not ~/.agents/skills).
+  --skip-pi-mcp       With --pi: skip installing the kcap MCP-bridge extension
+                      (~/.pi/agent/extensions/kcap-mcp.ts). By default `install
+                      --pi` writes it so Pi exposes the 4 kcap MCP servers as
+                      native tools (Pi has no JSON mcpServers config, so the
+                      bridge extension is the only way to surface them).
+  --skip-pi-instructions
+                      With --pi: skip installing kcap's steering-instructions
+                      block into Pi's global ~/.pi/agent/AGENTS.md. By default
+                      `install --pi` writes a small kcap-owned, marker-delimited
+                      block (non-destructive — preserves your own instructions)
+                      that nudges Pi to use the kcap tools for why/history questions.
   --if-installed      Refresh-only mode: no-op unless the user has previously
                       installed the target (marker file or pre-marker entry
                       detected). Used by the npm postinstall hook to refresh
@@ -161,12 +176,17 @@ Notes:
   default, deletes kcap.json, and unregisters the MCP servers. Kiro has no
   project-scope hooks, so --project has no effect with --kiro.
 
-  --pi writes a single extension file (~/.pi/agent/extensions/kcap.ts) instead
-  of a hooks file — Pi exposes no shell hooks, only an in-process extension API.
-  The extension shells out to `kcap hook --pi` on session start/end, so kcap
-  must be on PATH. Pi loads extensions at startup, so restart any running `pi`
-  session after install. Pi has no project-scope extensions dir, so --project
-  has no effect with --pi.
+  --pi writes extension files instead of a hooks file — Pi exposes no shell
+  hooks, only an in-process extension API. The live-ingest extension
+  (~/.pi/agent/extensions/kcap.ts) shells out to `kcap hook --pi` on session
+  start/end. Because Pi also ships no built-in MCP, a second MCP-bridge extension
+  (~/.pi/agent/extensions/kcap-mcp.ts, see --skip-pi-mcp) spawns the `kcap mcp
+  <name>` servers as subprocesses and registers their tools as native Pi tools
+  (kcap_<server>_<tool>), and a kcap-owned steering block is written to
+  ~/.pi/agent/AGENTS.md (see --skip-pi-instructions). All are non-destructive and
+  idempotent; kcap must be on PATH. Pi loads extensions at startup, so restart
+  any running `pi` session after install. Pi has no project-scope extensions dir,
+  so --project has no effect with --pi.
 
   --antigravity installs the kcap plugin to ~/.gemini/config/plugins/kcap/ — a
   plugin.json manifest (which the GUI requires to load the dir) plus a hooks.json

--- a/src/Capacitor.Cli.Core/Resources/help-setup.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-setup.txt
@@ -49,6 +49,10 @@ Options:
                               (~/.kiro/skills).
   --skip-pi-hooks             Don't install the Pi live-ingest extension even if
                               Pi is detected (~/.pi/ or pi on PATH).
+  --skip-pi-mcp               Skip installing the kcap MCP-bridge extension for
+                              Pi (~/.pi/agent/extensions/kcap-mcp.ts).
+  --skip-pi-instructions      Skip installing kcap's steering instructions for
+                              Pi (~/.pi/agent/AGENTS.md).
   --skip-opencode-hooks       Don't install the OpenCode plugin even if OpenCode
                               is detected (~/.config/opencode/ or opencode on PATH).
   --skip-opencode-mcp         Skip registering the kcap MCP servers for OpenCode

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -15,7 +15,7 @@ internal static class CodingAgentsStep {
     // sites and the broad CodingAgentsStep test suite compile unchanged. Gemini
     // (AI-887), Kiro (AI-888), and Pi (AI-886) were all added after the original
     // four vendors.
-    internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool SkipCopilot, bool NoPrompt, bool SkipGemini = false, bool SkipKiro = false, bool SkipPi = false, bool SkipOpenCode = false, bool SkipCodexNetworkAccess = false, bool SkipAntigravity = false, bool SkipCursorMcp = false, bool SkipCopilotMcp = false, bool SkipCopilotInstructions = false, bool SkipGeminiMcp = false, bool SkipGeminiInstructions = false, bool SkipAntigravityMcp = false, bool SkipAntigravityInstructions = false, bool SkipAntigravitySkills = false, bool SkipOpenCodeMcp = false, bool SkipOpenCodeInstructions = false, bool SkipKiroMcp = false, bool SkipKiroSkills = false);
+    internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool SkipCopilot, bool NoPrompt, bool SkipGemini = false, bool SkipKiro = false, bool SkipPi = false, bool SkipOpenCode = false, bool SkipCodexNetworkAccess = false, bool SkipAntigravity = false, bool SkipCursorMcp = false, bool SkipCopilotMcp = false, bool SkipCopilotInstructions = false, bool SkipGeminiMcp = false, bool SkipGeminiInstructions = false, bool SkipAntigravityMcp = false, bool SkipAntigravityInstructions = false, bool SkipAntigravitySkills = false, bool SkipOpenCodeMcp = false, bool SkipOpenCodeInstructions = false, bool SkipKiroMcp = false, bool SkipKiroSkills = false, bool SkipPiMcp = false, bool SkipPiInstructions = false);
 
     internal record DetectedAgents(bool Claude, bool Codex, bool Cursor, bool Copilot, bool Gemini = false, bool Kiro = false, bool Pi = false, bool OpenCode = false, bool Antigravity = false);
 
@@ -44,7 +44,9 @@ internal static class CodingAgentsStep {
             string  OpenCodeMcpPath = "",
             string  OpenCodeInstructionsPath = "",
             string  KiroMcpPath = "",
-            string  KiroSkillsDir = ""
+            string  KiroSkillsDir = "",
+            string  PiMcpExtensionPath = "",
+            string  PiAgentsMdPath = ""
         );
 
     internal record Installers(
@@ -72,7 +74,9 @@ internal static class CodingAgentsStep {
             Func<AgentInstructionsWriter.Change>?                    InstallAntigravityInstructions = null,
             Func<JsonMcpConfigWriter.Change>?                        RegisterOpenCodeMcp = null,
             Func<AgentInstructionsWriter.Change>?                    InstallOpenCodeInstructions = null,
-            Func<JsonMcpConfigWriter.Change>?                        RegisterKiroMcp = null
+            Func<JsonMcpConfigWriter.Change>?                        RegisterKiroMcp = null,
+            Func<string /*mcpExtensionPath*/, bool>?                 InstallPiMcp = null,
+            Func<AgentInstructionsWriter.Change>?                    InstallPiInstructions = null
         );
 
     internal record Result(
@@ -99,7 +103,9 @@ internal static class CodingAgentsStep {
             bool OpenCodeMcpRegistered = false,
             bool OpenCodeInstructionsInstalled = false,
             bool KiroMcpRegistered = false,
-            bool KiroSkillsInstalled = false
+            bool KiroSkillsInstalled = false,
+            bool PiMcpInstalled = false,
+            bool PiInstructionsInstalled = false
         ) {
         /// <summary>
         /// True when at least one agent's hooks were installed — i.e. there's a
@@ -145,7 +151,12 @@ internal static class CodingAgentsStep {
         // Kiro's skills live in ~/.kiro/skills (Kiro doesn't read ~/.agents/skills) and steer it toward
         // the kcap MCP tools — gate on the user having SELECTED Kiro, like the MCP registration.
         var kiroSkillsInstalled   = HandleKiroSkills(options, paths, installers, writeLine, kiroSelected);
-        var piExtensionInstalled  = HandlePiExtension(options, detected, paths, installers, prompt, writeLine);
+        var piExtensionInstalled  = HandlePiExtension(options, detected, paths, installers, prompt, writeLine, out var piSelected);
+        // Pi has no JSON MCP config: the "MCP" is a second extension file (kcap-mcp.ts) and the
+        // instructions live in the independent ~/.pi/agent/AGENTS.md — gate both on the user having
+        // SELECTED Pi (not on the ingest-write result) so a failed ingest write doesn't block them.
+        var piMcpInstalled        = HandlePiMcp(options, paths, installers, writeLine, piSelected);
+        var piInstructionsInstalled = HandlePiInstructions(options, paths, installers, writeLine, piSelected);
         var openCodeExtensionInstalled = HandleOpenCodeExtension(options, detected, paths, installers, prompt, writeLine);
         var openCodeMcpRegistered      = HandleOpenCodeMcp(options, paths, installers, writeLine, openCodeExtensionInstalled);
         var openCodeInstructionsInstalled = HandleOpenCodeInstructions(options, paths, installers, writeLine, openCodeExtensionInstalled);
@@ -191,7 +202,9 @@ internal static class CodingAgentsStep {
                 OpenCodeMcpRegistered: openCodeMcpRegistered,
                 OpenCodeInstructionsInstalled: openCodeInstructionsInstalled,
                 KiroMcpRegistered: kiroMcpRegistered,
-                KiroSkillsInstalled: kiroSkillsInstalled
+                KiroSkillsInstalled: kiroSkillsInstalled,
+                PiMcpInstalled: piMcpInstalled,
+                PiInstructionsInstalled: piInstructionsInstalled
             )
         );
     }
@@ -462,8 +475,15 @@ internal static class CodingAgentsStep {
             Paths              paths,
             Installers         installers,
             Func<string, bool> prompt,
-            Action<string>     writeLine
+            Action<string>     writeLine,
+            out bool           selected
         ) {
+        // `selected` = the user opted into Pi (detected + not skipped + prompt-yes/NoPrompt) AND
+        // kcap is on PATH — i.e. a full Pi integration was requested. It stays true even when the
+        // ingest-extension WRITE fails, so the independent MCP-bridge extension + ~/.pi/agent/AGENTS.md
+        // can still be installed; the bool return still reflects only actual ingest-write success.
+        selected = false;
+
         if (!detected.Pi) {
             writeLine("  [dim]· Pi not detected — skipping[/]");
 
@@ -488,15 +508,17 @@ internal static class CodingAgentsStep {
             return false;
         }
 
-        // Pi has no shell hooks — the extension (kcap.ts) shells out to the bare
-        // "kcap hook --pi" command, so pi must find kcap on PATH (same precheck
-        // as the Cursor/Copilot branches).
+        // Pi has no shell hooks — the extensions (kcap.ts / kcap-mcp.ts) shell out to
+        // the bare "kcap" command, so pi must find kcap on PATH (same precheck as the
+        // Cursor/Copilot branches).
         if (!installers.CapacitorOnPath()) {
             writeLine("  [yellow]⚠[/] Pi extension not installed — 'kcap' is not on PATH.");
             writeLine("    [dim]Re-install via npm: [/][cyan]npm install -g @kurrent/kcap[/]");
 
             return false;
         }
+
+        selected = true;  // opted in + kcap on PATH → MCP bridge + AGENTS.md may install even if the ingest write fails
 
         var ok = installers.InstallPiExtension(paths.PiExtensionPath);
 
@@ -510,6 +532,68 @@ internal static class CodingAgentsStep {
         writeLine("  [dim]  Note: Pi loads extensions at startup — restart any running pi session to pick it up.[/]");
 
         return true;
+    }
+
+    /// <summary>
+    /// Installs the kcap MCP-bridge extension (<c>~/.pi/agent/extensions/kcap-mcp.ts</c>). Pi has no
+    /// JSON <c>mcpServers</c> config, so the "MCP" for Pi is this extension file — spawning the
+    /// <c>kcap mcp &lt;name&gt;</c> servers and registering their tools. Gated on the user having
+    /// SELECTED Pi (<paramref name="piSelected"/>, not on the ingest-write result — it's a separate
+    /// file) and on <see cref="Options.SkipPiMcp"/>.
+    /// </summary>
+    static bool HandlePiMcp(
+            Options        options,
+            Paths          paths,
+            Installers     installers,
+            Action<string> writeLine,
+            bool           piSelected
+        ) {
+        if (installers.InstallPiMcp is null || !piSelected || options.SkipPiMcp) return false;
+
+        var path = Markup.Escape(paths.PiMcpExtensionPath);
+
+        if (installers.InstallPiMcp(paths.PiMcpExtensionPath)) {
+            writeLine($"  [green]✓[/] Pi MCP extension installed ([dim]{path}[/])");
+
+            return true;
+        }
+
+        writeLine($"  [yellow]⚠[/] Could not write the Pi MCP extension ({path}).");
+
+        return false;
+    }
+
+    /// <summary>
+    /// Installs kcap's agent-instructions block into Pi's global <c>~/.pi/agent/AGENTS.md</c> so Pi's
+    /// model is steered toward the kcap MCP tools. Gated on the user having SELECTED Pi (same trigger
+    /// as <see cref="HandlePiMcp"/>) and on <see cref="Options.SkipPiInstructions"/>. Non-destructive:
+    /// only kcap's marker-delimited block is written.
+    /// </summary>
+    static bool HandlePiInstructions(
+            Options        options,
+            Paths          paths,
+            Installers     installers,
+            Action<string> writeLine,
+            bool           piSelected
+        ) {
+        if (installers.InstallPiInstructions is null || !piSelected || options.SkipPiInstructions) return false;
+
+        var path = Markup.Escape(paths.PiAgentsMdPath);
+
+        switch (installers.InstallPiInstructions()) {
+            case AgentInstructionsWriter.Change.Updated:
+                writeLine($"  [green]✓[/] Pi instructions installed ([dim]{path}[/])");
+
+                return true;
+            case AgentInstructionsWriter.Change.Unchanged:
+                writeLine("  [dim]· Pi instructions already up to date — no change needed[/]");
+
+                return false;
+            default:
+                writeLine($"  [yellow]⚠[/] Could not write Pi instructions to {path}.");
+
+                return false;
+        }
     }
 
     static bool HandleOpenCodeExtension(

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -829,10 +829,11 @@ static class McpFlowsServer {
         return envelope.ToJsonString();
     }
 
-    static McpTool[] BuildToolsList() => [
+    internal static McpTool[] BuildToolsList() => [
         new(
             "start_review_flow",
             "Start a new review flow. This hands the work to a SEPARATE hosted reviewer agent and iterates to sign-off — it is NOT how you review something yourself. " +
+            "COST: this spawns a PAID hosted reviewer (a real model running to completion), so only start one when a review flow is genuinely wanted. " +
             "Only call this when the user explicitly asked for a review *flow* / to submit for review; for an ordinary 'review my PR' or 'code review' request, review directly and do NOT call this tool. " +
             "Returns findings (same UX); the server runs the reviewer asynchronously and the CLI polls internally. " +
             "Returns a flow_run_id that identifies this review session — save it to call submit_review_round or get_review_flow_status later. " +

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -823,46 +823,120 @@ public static class PluginCommand {
     // ── Pi (badlogic/pi-mono): a TypeScript extension, not a hooks.json ──────
 
     static async Task<int> InstallPi(string[] args, PluginEnvironment env) {
-        var extensionPath = GetArg(args, "--pi-extension-path") ?? env.PiKcapExtension;
+        var extensionPath    = GetArg(args, "--pi-extension-path") ?? env.PiKcapExtension;
+        var mcpExtensionPath = env.PiKcapMcpExtension;
 
-        var refreshOnly = args.Contains("--if-installed");
+        var refreshOnly      = args.Contains("--if-installed");
+        var skipMcp          = args.Contains("--skip-pi-mcp");
+        var skipInstructions = args.Contains("--skip-pi-instructions");
 
-        switch (refreshOnly) {
-            case true when !PiExtensionInstaller.IsInstalled(extensionPath):
-            case true when PiExtensionInstaller.ReadMarker(extensionPath) == CapacitorVersion.Current():
-                return 0;
-            // The extension shells out to the bare `kcap hook --pi` command, so
-            // pi (and therefore kcap) must find kcap on PATH. Skipped on the
-            // postinstall (--if-installed) refresh path, like the other vendors.
-            case false when !AgentDetector.IsInstalled("kcap"):
-                await env.Stderr.WriteLineAsync(
-                    "Cannot install the Pi extension: 'kcap' is not on PATH. "
-                  + "Re-install kcap via npm: npm install -g @kurrent/kcap"
-                );
+        // Refresh-only mode never touches a machine that never opted into Pi. The
+        // live-ingest extension is the opt-in signal; if it's present, a refresh also
+        // heals the (newer) MCP bridge + AGENTS.md steering below — mirroring how the
+        // Gemini refresh heals MCP + instructions even when a prior version had hooks only.
+        if (refreshOnly && !PiExtensionInstaller.IsInstalled(extensionPath)) return 0;
 
-                return 1;
-        }
-
-        if (!PiExtensionInstaller.Install(extensionPath)) {
-            if (refreshOnly) return 0;
-
-            await env.Stderr.WriteLineAsync("Could not write the Pi extension file.");
+        // Fresh install needs kcap on PATH: both extensions shell out to the bare
+        // `kcap` command (ingest → `kcap hook --pi`; bridge → `kcap mcp <name>`), so
+        // pi must find kcap on PATH. Skipped on the postinstall (--if-installed) path.
+        if (!refreshOnly && !AgentDetector.IsInstalled("kcap")) {
+            await env.Stderr.WriteLineAsync(
+                "Cannot install the Pi extension: 'kcap' is not on PATH. "
+              + "Re-install kcap via npm: npm install -g @kurrent/kcap"
+            );
 
             return 1;
         }
 
-        await env.Stdout.WriteLineAsync(
-            refreshOnly
-                ? $"Pi extension refreshed ({extensionPath})"
-                : $"Pi extension installed ({extensionPath})"
-        );
+        var extensionFailed = false;
 
-        return 0;
+        // 1. Live-ingest extension (kcap.ts). On refresh, skip only when already current.
+        var ingestCurrent = refreshOnly
+                         && PiExtensionInstaller.IsInstalled(extensionPath)
+                         && PiExtensionInstaller.ReadMarker(extensionPath) == CapacitorVersion.Current();
+        if (!ingestCurrent) {
+            if (PiExtensionInstaller.Install(extensionPath)) {
+                await env.Stdout.WriteLineAsync(
+                    refreshOnly
+                        ? $"Pi extension refreshed ({extensionPath})"
+                        : $"Pi extension installed ({extensionPath})"
+                );
+            } else if (!refreshOnly) {
+                // Fresh install: the ingest write failed. Report + return non-zero, but
+                // DON'T bail — the independent MCP bridge + AGENTS.md still install below.
+                await env.Stderr.WriteLineAsync("Could not write the Pi extension file.");
+                extensionFailed = true;
+            } else {
+                await env.Stderr.WriteLineAsync(
+                    $"Warning: could not refresh the Pi extension ({extensionPath}); continuing with MCP + instructions.");
+            }
+        }
+
+        // 2. MCP-bridge extension (kcap-mcp.ts) — a separate file + marker, healed
+        //    independently. Non-fatal: a write error is a warning, not an error code.
+        if (!skipMcp)
+            await InstallPiMcpExtensionAsync(env, mcpExtensionPath, refreshOnly);
+
+        // 3. Agent-instructions block in ~/.pi/agent/AGENTS.md so Pi's model is steered
+        //    toward the kcap tools. Non-destructive (only our block) + idempotent. Never fails.
+        if (!skipInstructions)
+            await InstallPiInstructionsAsync(env);
+
+        // Non-zero only when a FRESH ingest install failed (the integration is incomplete) —
+        // the independent MCP bridge + AGENTS.md steering above were still installed.
+        return extensionFailed ? 1 : 0;
+    }
+
+    /// <summary>
+    /// Installs the kcap MCP-bridge extension (<c>~/.pi/agent/extensions/kcap-mcp.ts</c>).
+    /// Its own file + version marker, so on refresh it is skipped only when already at the
+    /// current version. Never fails the install: a write error is a warning.
+    /// </summary>
+    static async Task InstallPiMcpExtensionAsync(PluginEnvironment env, string mcpExtensionPath, bool refreshOnly) {
+        if (refreshOnly
+            && PiMcpExtensionInstaller.IsInstalled(mcpExtensionPath)
+            && PiMcpExtensionInstaller.ReadMarker(mcpExtensionPath) == CapacitorVersion.Current())
+            return;
+
+        if (PiMcpExtensionInstaller.Install(mcpExtensionPath)) {
+            await env.Stdout.WriteLineAsync(
+                refreshOnly
+                    ? $"Pi MCP extension refreshed ({mcpExtensionPath})"
+                    : $"Pi MCP extension installed ({mcpExtensionPath})"
+            );
+        } else {
+            await env.Stderr.WriteLineAsync(
+                $"Warning: could not write the Pi MCP extension ({mcpExtensionPath}).");
+        }
+    }
+
+    /// <summary>
+    /// Installs kcap's marker-delimited instructions block into <c>~/.pi/agent/AGENTS.md</c>
+    /// (Pi's native user-global instructions file) so Pi's model is steered toward the kcap
+    /// tools. Non-destructive (only our block). Never fails the install: a write error is a warning.
+    /// </summary>
+    static async Task InstallPiInstructionsAsync(PluginEnvironment env) {
+        var change = AgentInstructionsWriter.Write(env.PiAgentsMd, KcapAgentInstructions.Body);
+
+        switch (change) {
+            case AgentInstructionsWriter.Change.Updated:
+                await env.Stdout.WriteLineAsync($"Pi instructions installed ({env.PiAgentsMd}).");
+                break;
+            case AgentInstructionsWriter.Change.Failed:
+                await env.Stderr.WriteLineAsync(
+                    $"Warning: could not update {env.PiAgentsMd} to install Pi instructions.");
+                break;
+            // Unchanged: silent.
+        }
     }
 
     static async Task<int> RemovePi(string[] args, PluginEnvironment env) {
-        var extensionPath = GetArg(args, "--pi-extension-path") ?? env.PiKcapExtension;
+        var extensionPath    = GetArg(args, "--pi-extension-path") ?? env.PiKcapExtension;
+        var mcpExtensionPath = env.PiKcapMcpExtension;
 
+        var failed = false;
+
+        // 1. Live-ingest extension.
         try {
             var removed = PiExtensionInstaller.Remove(extensionPath);
 
@@ -871,13 +945,30 @@ public static class PluginCommand {
                     ? $"Pi extension removed ({extensionPath})"
                     : "Nothing to remove — Pi extension file not found."
             );
-
-            return 0;
         } catch (Exception ex) {
             await env.Stderr.WriteLineAsync($"Could not remove the Pi extension at {extensionPath}: {ex.Message}");
-
-            return 1;
+            failed = true;
         }
+
+        // 2. MCP-bridge extension.
+        try {
+            if (PiMcpExtensionInstaller.Remove(mcpExtensionPath))
+                await env.Stdout.WriteLineAsync($"Pi MCP extension removed ({mcpExtensionPath})");
+        } catch (Exception ex) {
+            await env.Stderr.WriteLineAsync($"Could not remove the Pi MCP extension at {mcpExtensionPath}: {ex.Message}");
+            failed = true;
+        }
+
+        // 3. Instructions block in ~/.pi/agent/AGENTS.md — strip our block, preserving user content.
+        var instrChange = AgentInstructionsWriter.Remove(env.PiAgentsMd);
+        if (instrChange == AgentInstructionsWriter.Change.Updated) {
+            await env.Stdout.WriteLineAsync($"Pi instructions removed ({env.PiAgentsMd}).");
+        } else if (instrChange == AgentInstructionsWriter.Change.Failed) {
+            await env.Stderr.WriteLineAsync($"Could not update {env.PiAgentsMd} to remove Pi instructions.");
+            failed = true;
+        }
+
+        return failed ? 1 : 0;
     }
 
     // ── OpenCode (SST): a TypeScript plugin, not a hooks.json (AI-919) ───────

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -893,8 +893,11 @@ public static class PluginCommand {
     /// current version. Never fails the install: a write error is a warning.
     /// </summary>
     static async Task InstallPiMcpExtensionAsync(PluginEnvironment env, string mcpExtensionPath, bool refreshOnly) {
+        // Require the extension FILE itself (not just a current marker) for the "already current"
+        // fast path — otherwise a deleted kcap-mcp.ts with a stale-but-current marker would skip the
+        // heal and never recreate the file. (Marker-only state is only the opt-in signal in InstallPi.)
         if (refreshOnly
-            && PiMcpExtensionInstaller.IsInstalled(mcpExtensionPath)
+            && File.Exists(mcpExtensionPath)
             && PiMcpExtensionInstaller.ReadMarker(mcpExtensionPath) == CapacitorVersion.Current())
             return;
 

--- a/src/Capacitor.Cli/Commands/PluginEnvironment.cs
+++ b/src/Capacitor.Cli/Commands/PluginEnvironment.cs
@@ -43,6 +43,8 @@ public sealed record PluginEnvironment(
     public string KiroMcpJson          => KiroPaths.SettingsMcpJson(HomeDirectory);
     public string KiroSkillsDir        => KiroPaths.SkillsDir(HomeDirectory);
     public string PiKcapExtension      => PiPaths.KcapExtension(HomeDirectory);
+    public string PiKcapMcpExtension   => PiPaths.KcapMcpExtension(HomeDirectory);
+    public string PiAgentsMd           => PiPaths.AgentsMd(HomeDirectory);
     public string OpenCodeKcapPlugin    => OpenCodePaths.KcapPlugin(HomeDirectory);
     public string OpenCodeMcpConfigJson => OpenCodePaths.McpConfigJson(HomeDirectory);
     public string OpenCodeAgentsMd      => OpenCodePaths.AgentsMd(HomeDirectory);

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -42,6 +42,8 @@ public static class SetupCommand {
         var skipKiroMcpFlag  = args.Contains("--skip-kiro-mcp");
         var skipKiroSkillsFlag = args.Contains("--skip-kiro-skills");
         var skipPiFlag       = args.Contains("--skip-pi-hooks");
+        var skipPiMcpFlag    = args.Contains("--skip-pi-mcp");
+        var skipPiInstructionsFlag = args.Contains("--skip-pi-instructions");
         var skipOpenCodeFlag = args.Contains("--skip-opencode-hooks");
         var skipOpenCodeMcpFlag = args.Contains("--skip-opencode-mcp");
         var skipOpenCodeInstructionsFlag = args.Contains("--skip-opencode-instructions");
@@ -259,7 +261,9 @@ public static class SetupCommand {
             SkipOpenCodeMcp: skipOpenCodeMcpFlag,
             SkipOpenCodeInstructions: skipOpenCodeInstructionsFlag,
             SkipKiroMcp: skipKiroMcpFlag,
-            SkipKiroSkills: skipKiroSkillsFlag);
+            SkipKiroSkills: skipKiroSkillsFlag,
+            SkipPiMcp: skipPiMcpFlag,
+            SkipPiInstructions: skipPiInstructionsFlag);
 
         // AI-794 — allowlist the Capacitor server(s) Codex skills need to reach. A single
         // **.kcap.ai wildcard covers every SaaS tenant (current + future) and the auth
@@ -294,7 +298,9 @@ public static class SetupCommand {
             OpenCodeMcpPath:      OpenCodePaths.McpConfigJson(),
             OpenCodeInstructionsPath: OpenCodePaths.AgentsMd(),
             KiroMcpPath:          KiroPaths.SettingsMcpJson(),
-            KiroSkillsDir:        KiroPaths.SkillsDir());
+            KiroSkillsDir:        KiroPaths.SkillsDir(),
+            PiMcpExtensionPath:   PiPaths.KcapMcpExtension(),
+            PiAgentsMdPath:       PiPaths.AgentsMd());
 
         var stepInstallers = new CodingAgentsStep.Installers(
             InstallClaudePlugin:    InstallPlugin,
@@ -335,7 +341,11 @@ public static class SetupCommand {
             RegisterAntigravityMcp:   () => JsonMcpConfigWriter.Register(
                 AntigravityPaths.McpConfigJson(), KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new McpMarker("antigravity")),
             InstallAntigravityInstructions: () => AgentInstructionsWriter.Write(
-                AntigravityPaths.InstructionsMd(), KcapAgentInstructions.Body));
+                AntigravityPaths.InstructionsMd(), KcapAgentInstructions.Body),
+            // Pi has no JSON MCP config — the "MCP" is a second extension file (kcap-mcp.ts).
+            InstallPiMcp:             PiMcpExtensionInstaller.Install,
+            InstallPiInstructions:    () => AgentInstructionsWriter.Write(
+                PiPaths.AgentsMd(), KcapAgentInstructions.Body));
 
         bool PromptYesNo(string text) =>
             AnsiConsole.Prompt(new ConfirmationPrompt(text) { DefaultValue = true });

--- a/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
@@ -1062,7 +1062,7 @@ public class CodingAgentsStepTests {
         await Assert.That(sink.Lines).Contains(l => l.Contains("Could not write Gemini instructions"));
     }
 
-    // ── Pi MCP-bridge extension + AGENTS.md steering (AI-1239) ──────────────
+    // ── Pi MCP-bridge extension + AGENTS.md steering ──────────────
     // Pi has no JSON mcpServers config: the "MCP" is a second extension file
     // (kcap-mcp.ts) and the instructions live in ~/.pi/agent/AGENTS.md — both
     // gated on the user having SELECTED Pi, independent of the ingest write.

--- a/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
@@ -1062,6 +1062,173 @@ public class CodingAgentsStepTests {
         await Assert.That(sink.Lines).Contains(l => l.Contains("Could not write Gemini instructions"));
     }
 
+    // ── Pi MCP-bridge extension + AGENTS.md steering (AI-1239) ──────────────
+    // Pi has no JSON mcpServers config: the "MCP" is a second extension file
+    // (kcap-mcp.ts) and the instructions live in ~/.pi/agent/AGENTS.md — both
+    // gated on the user having SELECTED Pi, independent of the ingest write.
+
+    [Test]
+    public async Task Pi_mcp_installed_when_selected() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false, Pi: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.PiMcpInstalled).IsTrue();
+        await Assert.That(calls.InstallPiMcpCalled).IsTrue();
+        await Assert.That(calls.InstallPiMcpArg).IsEqualTo("/fake/.pi/agent/extensions/kcap-mcp.ts");
+        await Assert.That(sink.Lines).Contains(l => l.Contains("Pi MCP extension installed"));
+    }
+
+    [Test]
+    public async Task Pi_mcp_installed_even_when_ingest_write_fails() {
+        // The user SELECTED Pi (detected + opted-in + kcap on PATH) but the ingest
+        // extension write failed. kcap-mcp.ts is a separate file, so it still installs.
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { PiExtensionReturns = false };
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false, Pi: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.PiExtensionInstalled).IsFalse();  // ingest write failed
+        await Assert.That(calls.InstallPiMcpCalled).IsTrue();      // but kcap-mcp.ts still installs
+        await Assert.That(result.PiMcpInstalled).IsTrue();
+    }
+
+    [Test]
+    public async Task Pi_mcp_not_installed_when_not_selected() {
+        // kcap not on PATH → Pi integration NOT selected → kcap-mcp.ts must NOT install.
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { CapacitorOnPathReturns = false };
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false, Pi: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(calls.InstallPiMcpCalled).IsFalse();
+        await Assert.That(result.PiMcpInstalled).IsFalse();
+    }
+
+    [Test]
+    public async Task Pi_mcp_skipped_by_flag() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: true, SkipPiMcp: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false, Pi: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.PiExtensionInstalled).IsTrue();   // ingest still installs
+        await Assert.That(result.PiMcpInstalled).IsFalse();
+        await Assert.That(calls.InstallPiMcpCalled).IsFalse();
+    }
+
+    [Test]
+    public async Task Pi_mcp_failure_emits_warning() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { InstallPiMcpReturns = false };
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false, Pi: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(calls.InstallPiMcpCalled).IsTrue();
+        await Assert.That(result.PiMcpInstalled).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("Could not write the Pi MCP extension"));
+    }
+
+    [Test]
+    public async Task Pi_instructions_installed_when_selected() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false, Pi: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.PiInstructionsInstalled).IsTrue();
+        await Assert.That(calls.InstallPiInstructionsCalled).IsTrue();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("Pi instructions installed"));
+    }
+
+    [Test]
+    public async Task Pi_instructions_installed_even_when_ingest_write_fails() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { PiExtensionReturns = false };
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false, Pi: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.PiExtensionInstalled).IsFalse();          // ingest write failed
+        await Assert.That(calls.InstallPiInstructionsCalled).IsTrue();     // but AGENTS.md still installs
+        await Assert.That(result.PiInstructionsInstalled).IsTrue();
+    }
+
+    [Test]
+    public async Task Pi_instructions_not_installed_when_not_selected() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { CapacitorOnPathReturns = false };
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false, Pi: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(calls.InstallPiInstructionsCalled).IsFalse();
+        await Assert.That(result.PiInstructionsInstalled).IsFalse();
+    }
+
+    [Test]
+    public async Task Pi_instructions_skipped_by_flag() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls();
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: true, SkipPiInstructions: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false, Pi: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(result.PiExtensionInstalled).IsTrue();
+        await Assert.That(result.PiInstructionsInstalled).IsFalse();
+        await Assert.That(calls.InstallPiInstructionsCalled).IsFalse();
+    }
+
+    [Test]
+    public async Task Pi_instructions_failure_emits_warning() {
+        var sink     = new Sink();
+        var calls    = new InstallerCalls { InstallPiInstructionsReturns = AgentInstructionsWriter.Change.Failed };
+        var options  = new Options(SkipClaude: true, SkipCodex: true, SkipCursor: true, SkipCopilot: true, NoPrompt: true);
+        var detected = new DetectedAgents(Claude: false, Codex: false, Cursor: false, Copilot: false, Pi: true);
+
+        var result = await RunAsync(
+            options, detected, TestPaths(), calls.AsInstallers(),
+            prompt: _ => true, writeLine: sink.Write);
+
+        await Assert.That(calls.InstallPiInstructionsCalled).IsTrue();
+        await Assert.That(result.PiInstructionsInstalled).IsFalse();
+        await Assert.That(sink.Lines).Contains(l => l.Contains("Could not write Pi instructions"));
+    }
+
     [Test]
     public async Task Codex_network_access_not_attempted_when_hooks_fail() {
         var sink     = new Sink();
@@ -2008,7 +2175,9 @@ public class CodingAgentsStepTests {
         OpenCodeMcpPath:      "/fake/.config/opencode/opencode.json",
         OpenCodeInstructionsPath: "/fake/.config/opencode/AGENTS.md",
         KiroMcpPath:          "/fake/.kiro/settings/mcp.json",
-        KiroSkillsDir:        "/fake/.kiro/skills"
+        KiroSkillsDir:        "/fake/.kiro/skills",
+        PiMcpExtensionPath:   "/fake/.pi/agent/extensions/kcap-mcp.ts",
+        PiAgentsMdPath:       "/fake/.pi/agent/AGENTS.md"
     );
 
     sealed class Sink {
@@ -2107,6 +2276,13 @@ public class CodingAgentsStepTests {
 
         public bool                     RegisterKiroMcpCalled  { get; private set; }
         public JsonMcpConfigWriter.Change RegisterKiroMcpReturns { get; set; } = JsonMcpConfigWriter.Change.Updated;
+
+        public bool    InstallPiMcpCalled  { get; private set; }
+        public string? InstallPiMcpArg     { get; private set; }
+        public bool    InstallPiMcpReturns { get; set; } = true;
+
+        public bool                          InstallPiInstructionsCalled  { get; private set; }
+        public AgentInstructionsWriter.Change InstallPiInstructionsReturns { get; set; } = AgentInstructionsWriter.Change.Updated;
 
         public Installers AsInstallers() => new(
             InstallClaudePlugin: (s, p) => {
@@ -2245,6 +2421,17 @@ public class CodingAgentsStepTests {
                 InstallAntigravityInstructionsCalled = true;
 
                 return InstallAntigravityInstructionsReturns;
+            },
+            InstallPiMcp: p => {
+                InstallPiMcpCalled = true;
+                InstallPiMcpArg    = p;
+
+                return InstallPiMcpReturns;
+            },
+            InstallPiInstructions: () => {
+                InstallPiInstructionsCalled = true;
+
+                return InstallPiInstructionsReturns;
             }
         );
     }

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsServerTests.cs
@@ -10,6 +10,16 @@ public class McpFlowsServerTests {
     static Func<TimeSpan, Task> NoDelay(List<TimeSpan> recorded) => ts => { recorded.Add(ts); return Task.CompletedTask; };
 
     [Test]
+    public async Task start_review_flow_description_discloses_the_paid_hosted_reviewer() {
+        // Contract: the paid-cost disclosure the Pi bridge (and every harness that shows the flows
+        // tool descriptions) relies on must actually be present in the tools/list output.
+        var startReviewFlow = McpFlowsServer.BuildToolsList().Single(t => t.Name == "start_review_flow");
+
+        await Assert.That(startReviewFlow.Description).Contains("PAID");
+        await Assert.That(startReviewFlow.Description.ToLowerInvariant()).Contains("hosted reviewer");
+    }
+
+    [Test]
     public async Task Roundless_start_renders_started_envelope() {
         var body = """{"flow_run_id":"f1","round_id":null,"round_number":null,"status":"running","result_kind":null,"result_text":null,"reviewer_agent_id":null,"reviewer_session_id":null}""";
 

--- a/test/Capacitor.Cli.Tests.Unit/PiMcpExtensionInstallerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PiMcpExtensionInstallerTests.cs
@@ -1,0 +1,105 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Pi;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Covers the Pi MCP-bridge extension installer (AI-1239): kcap-mcp.ts write/remove
+/// + the version-marker helpers, and content assertions on the embedded bridge. Pi
+/// has no built-in MCP, so kcap ships a second TypeScript extension that spawns the
+/// <c>kcap mcp &lt;name&gt;</c> servers and registers their tools. It's a sibling of
+/// the live-ingest extension with a DISTINCT marker so the two install independently.
+/// </summary>
+public class PiMcpExtensionInstallerTests {
+    [Test]
+    public async Task install_writes_extension_and_marker() {
+        using var tmp = new TempDir();
+        var path = Path.Combine(tmp.Path, "extensions", "kcap-mcp.ts");
+
+        var ok = PiMcpExtensionInstaller.Install(path);
+        await Assert.That(ok).IsTrue();
+        await Assert.That(File.Exists(path)).IsTrue();
+
+        await Assert.That(PiMcpExtensionInstaller.IsInstalled(path)).IsTrue();
+        await Assert.That(PiMcpExtensionInstaller.ReadMarker(path)).IsEqualTo(CapacitorVersion.Current());
+    }
+
+    [Test]
+    public async Task embedded_bridge_has_the_required_shape() {
+        using var tmp = new TempDir();
+        var path = Path.Combine(tmp.Path, "extensions", "kcap-mcp.ts");
+        PiMcpExtensionInstaller.Install(path);
+
+        var content = await File.ReadAllTextAsync(path);
+
+        // Async factory (pi awaits it before session_start → tools ready turn 1).
+        await Assert.That(content).Contains("export default async function");
+        // Bridges all four kcap servers.
+        await Assert.That(content).Contains("[\"review\", \"sessions\", \"flows\", \"memory\"]");
+        // MCP handshake incl. the mandatory notifications/initialized.
+        await Assert.That(content).Contains("initialize");
+        await Assert.That(content).Contains("notifications/initialized");
+        await Assert.That(content).Contains("tools/list");
+        await Assert.That(content).Contains("tools/call");
+        // Registers each tool as a Pi tool with the all-underscore name.
+        await Assert.That(content).Contains("pi.registerTool");
+        await Assert.That(content).Contains("\"kcap_\" + server + \"_\"");
+        // Teardown: session_shutdown (switch + exit) plus a sync process-exit backstop.
+        await Assert.That(content).Contains("session_shutdown");
+        await Assert.That(content).Contains("process.once(\"exit\"");
+        // Dependency-free spawn of the stdio servers.
+        await Assert.That(content).Contains("node:child_process");
+        await Assert.That(content).Contains("\"mcp\", this.server");
+    }
+
+    [Test]
+    public async Task marker_is_distinct_from_the_ingest_extension_marker() {
+        // The bridge and the ingest extension live in the same dir; a shared marker
+        // would make one clobber the other's version tracking.
+        await Assert.That(PiMcpExtensionInstaller.MarkerFileName)
+            .IsNotEqualTo(PiExtensionInstaller.MarkerFileName);
+    }
+
+    [Test]
+    public async Task is_installed_true_when_only_marker_present() {
+        using var tmp = new TempDir();
+        var path = Path.Combine(tmp.Path, "extensions", "kcap-mcp.ts");
+        var dir  = Path.GetDirectoryName(path)!;
+        Directory.CreateDirectory(dir);
+        await File.WriteAllTextAsync(Path.Combine(dir, PiMcpExtensionInstaller.MarkerFileName), "9.9.9");
+
+        await Assert.That(PiMcpExtensionInstaller.IsInstalled(path)).IsTrue();
+        await Assert.That(File.Exists(path)).IsFalse();
+    }
+
+    [Test]
+    public async Task remove_deletes_extension_and_marker() {
+        using var tmp = new TempDir();
+        var path = Path.Combine(tmp.Path, "extensions", "kcap-mcp.ts");
+        PiMcpExtensionInstaller.Install(path);
+
+        var removed = PiMcpExtensionInstaller.Remove(path);
+        await Assert.That(removed).IsTrue();
+        await Assert.That(File.Exists(path)).IsFalse();
+        await Assert.That(PiMcpExtensionInstaller.IsInstalled(path)).IsFalse();
+    }
+
+    [Test]
+    public async Task remove_returns_false_when_absent() {
+        using var tmp = new TempDir();
+        var path = Path.Combine(tmp.Path, "extensions", "kcap-mcp.ts");
+
+        await Assert.That(PiMcpExtensionInstaller.Remove(path)).IsFalse();
+    }
+
+    sealed class TempDir : IDisposable {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            $"kcap-pi-mcp-ext-test-{Guid.NewGuid().ToString("N")[..8]}"
+        );
+        public TempDir() => Directory.CreateDirectory(Path);
+        public void Dispose() {
+            try { Directory.Delete(Path, true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/PiMcpExtensionInstallerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PiMcpExtensionInstallerTests.cs
@@ -44,9 +44,21 @@ public class PiMcpExtensionInstallerTests {
         // Registers each tool as a Pi tool with the all-underscore name.
         await Assert.That(content).Contains("pi.registerTool");
         await Assert.That(content).Contains("\"kcap_\" + server + \"_\"");
-        // Teardown: session_shutdown (switch + exit) plus a sync process-exit backstop.
+        // Session-scoped lifecycle: register-once guard + holder + respawn on session_start.
+        await Assert.That(content).Contains("function startBridge");
+        await Assert.That(content).Contains("function stopBridge");
+        await Assert.That(content).Contains("session_start");
         await Assert.That(content).Contains("session_shutdown");
-        await Assert.That(content).Contains("process.once(\"exit\"");
+        // Parallel, bounded startup (four hung servers ⇒ ~one timeout, not 4×).
+        await Assert.That(content).Contains("Promise.all");
+        // Teardown ladder EOF → SIGTERM → SIGKILL, plus a globalThis-guarded sync exit backstop.
+        await Assert.That(content).Contains("SIGTERM");
+        await Assert.That(content).Contains("SIGKILL");
+        await Assert.That(content).Contains("process.on(\"exit\"");
+        await Assert.That(content).Contains("__kcapPiMcpBridge");
+        // MCP isError → Pi tool failure (execute throws).
+        await Assert.That(content).Contains("result.isError");
+        await Assert.That(content).Contains("throw new Error");
         // Dependency-free spawn of the stdio servers.
         await Assert.That(content).Contains("node:child_process");
         await Assert.That(content).Contains("\"mcp\", this.server");

--- a/test/Capacitor.Cli.Tests.Unit/PiMcpExtensionInstallerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PiMcpExtensionInstallerTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core.Pi;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Covers the Pi MCP-bridge extension installer (AI-1239): kcap-mcp.ts write/remove
+/// Covers the Pi MCP-bridge extension installer: kcap-mcp.ts write/remove
 /// + the version-marker helpers, and content assertions on the embedded bridge. Pi
 /// has no built-in MCP, so kcap ships a second TypeScript extension that spawns the
 /// <c>kcap mcp &lt;name&gt;</c> servers and registers their tools. It's a sibling of

--- a/test/Capacitor.Cli.Tests.Unit/PiPathsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PiPathsTests.cs
@@ -26,6 +26,19 @@ public class PiPathsTests {
             .IsEqualTo(Path.Combine("/fake/home", ".pi", "agent"));
     }
 
+    // Parallel-safe: home is non-null, so no env var is read.
+    [Test]
+    public async Task McpExtension_and_AgentsMd_sit_under_the_agent_dir() {
+        var agentDir = Path.Combine("/fake/home", ".pi", "agent");
+        // kcap-mcp.ts lives in extensions/ (beside kcap.ts); AGENTS.md is directly under agent/.
+        await Assert.That(PiPaths.KcapMcpExtension(home: "/fake/home"))
+            .IsEqualTo(Path.Combine(agentDir, "extensions", "kcap-mcp.ts"));
+        await Assert.That(PiPaths.KcapMcpExtensionMarker(home: "/fake/home"))
+            .IsEqualTo(Path.Combine(agentDir, "extensions", ".kcap-mcp-extension-version"));
+        await Assert.That(PiPaths.AgentsMd(home: "/fake/home"))
+            .IsEqualTo(Path.Combine(agentDir, "AGENTS.md"));
+    }
+
     [Test]
     [NotInParallel("HomeEnvVarMutation")]
     public async Task AgentDir_reads_PI_CODING_AGENT_DIR_and_derived_members_follow() {
@@ -41,6 +54,10 @@ public class PiPathsTests {
             await Assert.That(PiPaths.AgentDir()).IsEqualTo(relocated);
             await Assert.That(PiPaths.KcapExtension())
                 .IsEqualTo(Path.Combine(relocated, "extensions", "kcap.ts"));
+            await Assert.That(PiPaths.KcapMcpExtension())
+                .IsEqualTo(Path.Combine(relocated, "extensions", "kcap-mcp.ts"));
+            await Assert.That(PiPaths.AgentsMd())
+                .IsEqualTo(Path.Combine(relocated, "AGENTS.md"));
             await Assert.That(PiPaths.SessionsDir())
                 .IsEqualTo(Path.Combine(relocated, "sessions"));
         } finally {

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandPiTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandPiTests.cs
@@ -1,5 +1,6 @@
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core.Instructions;
+using Capacitor.Cli.Core.Pi;
 
 namespace Capacitor.Cli.Tests.Unit;
 
@@ -70,7 +71,7 @@ public class PluginCommandPiTests {
         await Assert.That(File.Exists(marker)).IsFalse();
     }
 
-    // ── MCP-bridge extension + AGENTS.md steering (AI-1239) ─────────────────
+    // ── MCP-bridge extension + AGENTS.md steering ─────────────────
     // Exercised via the --if-installed refresh path (PATH-independent) with a
     // seeded ingest extension as the opt-in signal, mirroring the Gemini tests.
 
@@ -89,6 +90,26 @@ public class PluginCommandPiTests {
         var agents = Path.Combine(fakeHome.Path, ".pi", "agent", "AGENTS.md");
         await Assert.That(File.Exists(agents)).IsTrue();
         await Assert.That(await File.ReadAllTextAsync(agents)).Contains(AgentInstructionsWriter.BeginMarker);
+    }
+
+    [Test]
+    public async Task Install_pi_if_installed_heals_deleted_mcp_bridge_with_current_marker() {
+        using var fakeHome = new TempDir();
+        var extDir = Path.Combine(fakeHome.Path, ".pi", "agent", "extensions");
+        Directory.CreateDirectory(extDir);
+        // Opt-in signal: the ingest extension is present.
+        await File.WriteAllTextAsync(Path.Combine(extDir, "kcap.ts"), "// stale ingest");
+        // A CURRENT MCP marker but NO kcap-mcp.ts (user deleted the file). A marker-only "current"
+        // state must NOT let the refresh skip recreating the bridge file.
+        var mcpPath = Path.Combine(extDir, "kcap-mcp.ts");
+        PiMcpExtensionInstaller.WriteMarker(mcpPath);
+        await Assert.That(File.Exists(mcpPath)).IsFalse();
+
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "install", "--pi", "--if-installed"], TestEnv(fakeHome.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        await Assert.That(File.Exists(mcpPath)).IsTrue();  // healed despite the current marker
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandPiTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandPiTests.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core.Instructions;
 
 namespace Capacitor.Cli.Tests.Unit;
 
@@ -67,6 +68,98 @@ public class PluginCommandPiTests {
 
         await Assert.That(File.Exists(extPath)).IsFalse();
         await Assert.That(File.Exists(marker)).IsFalse();
+    }
+
+    // ── MCP-bridge extension + AGENTS.md steering (AI-1239) ─────────────────
+    // Exercised via the --if-installed refresh path (PATH-independent) with a
+    // seeded ingest extension as the opt-in signal, mirroring the Gemini tests.
+
+    [Test]
+    public async Task Install_pi_if_installed_installs_mcp_bridge_and_agents_md() {
+        using var fakeHome = new TempDir();
+        var extDir = Path.Combine(fakeHome.Path, ".pi", "agent", "extensions");
+        Directory.CreateDirectory(extDir);
+        await File.WriteAllTextAsync(Path.Combine(extDir, "kcap.ts"), "// stale ingest");
+
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "install", "--pi", "--if-installed"], TestEnv(fakeHome.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        await Assert.That(File.Exists(Path.Combine(extDir, "kcap-mcp.ts"))).IsTrue();
+        var agents = Path.Combine(fakeHome.Path, ".pi", "agent", "AGENTS.md");
+        await Assert.That(File.Exists(agents)).IsTrue();
+        await Assert.That(await File.ReadAllTextAsync(agents)).Contains(AgentInstructionsWriter.BeginMarker);
+    }
+
+    [Test]
+    public async Task Install_pi_skip_mcp_omits_bridge_but_keeps_instructions() {
+        using var fakeHome = new TempDir();
+        var extDir = Path.Combine(fakeHome.Path, ".pi", "agent", "extensions");
+        Directory.CreateDirectory(extDir);
+        await File.WriteAllTextAsync(Path.Combine(extDir, "kcap.ts"), "// stale ingest");
+
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "install", "--pi", "--if-installed", "--skip-pi-mcp"], TestEnv(fakeHome.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        await Assert.That(File.Exists(Path.Combine(extDir, "kcap-mcp.ts"))).IsFalse();
+        await Assert.That(File.Exists(Path.Combine(fakeHome.Path, ".pi", "agent", "AGENTS.md"))).IsTrue();
+    }
+
+    [Test]
+    public async Task Install_pi_skip_instructions_omits_agents_md_but_keeps_bridge() {
+        using var fakeHome = new TempDir();
+        var extDir = Path.Combine(fakeHome.Path, ".pi", "agent", "extensions");
+        Directory.CreateDirectory(extDir);
+        await File.WriteAllTextAsync(Path.Combine(extDir, "kcap.ts"), "// stale ingest");
+
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "install", "--pi", "--if-installed", "--skip-pi-instructions"], TestEnv(fakeHome.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        await Assert.That(File.Exists(Path.Combine(extDir, "kcap-mcp.ts"))).IsTrue();
+        await Assert.That(File.Exists(Path.Combine(fakeHome.Path, ".pi", "agent", "AGENTS.md"))).IsFalse();
+    }
+
+    [Test]
+    public async Task Install_pi_preserves_user_agents_md_content() {
+        using var fakeHome = new TempDir();
+        var agentDir = Path.Combine(fakeHome.Path, ".pi", "agent");
+        var extDir   = Path.Combine(agentDir, "extensions");
+        Directory.CreateDirectory(extDir);
+        await File.WriteAllTextAsync(Path.Combine(extDir, "kcap.ts"), "// stale ingest");
+        var agents = Path.Combine(agentDir, "AGENTS.md");
+        await File.WriteAllTextAsync(agents, "# My Pi instructions\nKeep this line.\n");
+
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "install", "--pi", "--if-installed"], TestEnv(fakeHome.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        var body = await File.ReadAllTextAsync(agents);
+        await Assert.That(body).Contains("Keep this line.");                    // user content preserved
+        await Assert.That(body).Contains(AgentInstructionsWriter.BeginMarker);  // kcap block added
+    }
+
+    [Test]
+    public async Task Remove_pi_removes_mcp_bridge_and_instructions_block() {
+        using var fakeHome = new TempDir();
+        var agentDir = Path.Combine(fakeHome.Path, ".pi", "agent");
+        var extDir   = Path.Combine(agentDir, "extensions");
+        Directory.CreateDirectory(extDir);
+        await File.WriteAllTextAsync(Path.Combine(extDir, "kcap.ts"), "export default function(pi){}");
+        await File.WriteAllTextAsync(Path.Combine(extDir, "kcap-mcp.ts"), "export default async function(pi){}");
+        var agents = Path.Combine(agentDir, "AGENTS.md");
+        await File.WriteAllTextAsync(agents, "# Mine\n");
+        AgentInstructionsWriter.Write(agents, "kcap steering body");
+
+        var exit = await PluginCommand.HandleAsync(
+            ["plugin", "remove", "--pi"], TestEnv(fakeHome.Path));
+        await Assert.That(exit).IsEqualTo(0);
+
+        await Assert.That(File.Exists(Path.Combine(extDir, "kcap-mcp.ts"))).IsFalse();
+        var body = await File.ReadAllTextAsync(agents);
+        await Assert.That(body).DoesNotContain(AgentInstructionsWriter.BeginMarker);  // kcap block stripped
+        await Assert.That(body).Contains("# Mine");                                    // user content kept
     }
 
     static PluginEnvironment TestEnv(string fakeHome) => new(


### PR DESCRIPTION
## Summary

Pi (`badlogic/pi-mono`) intentionally ships **no built-in MCP**, so there is no JSON `mcpServers` config to write the way the other harnesses have. This adds a kcap-owned **MCP-bridge extension** so Pi still gets the kcap MCP tools.

`kcap plugin install --pi` now installs, alongside the existing live-ingest extension:

- **`~/.pi/agent/extensions/kcap-mcp.ts`** — at load it spawns each `kcap mcp <name>` server (review, sessions, flows, memory) as a persistent stdio subprocess, performs the MCP handshake (`initialize` → `notifications/initialized` → `tools/list`), and re-registers every advertised tool as a native Pi tool named `kcap_<server>_<tool>` (all underscores — dodges the mixed `-`/`_` naming that trips weaker models, AI-1301) whose `execute()` proxies `tools/call` back to the subprocess.
- **`~/.pi/agent/AGENTS.md`** — kcap's marker-delimited steering block (reused across harnesses) nudging Pi toward the kcap tools.

## The bridge extension

Dependency-free (only `node:child_process`) and fail-safe:

- **Per-server isolation** — each server is spawned/handshaken/registered independently; one bad server never blocks the others or the pi session.
- **Bounded handshake** — 10s per server; a hung server is killed and skipped.
- **Pending-call rejection** — in-flight `tools/call`s are rejected (not hung) when a subprocess dies.
- **Teardown** — `session_shutdown` (fires on session switch *and* process exit) kills all subprocesses; a sync `process.once("exit")` backstop covers abrupt exits, and each instance drops its own exit listener on shutdown so per-session-switch reloads don't accumulate listeners. **No orphaned `kcap mcp *` processes survive a normal pi exit.**
- **Async factory** — pi awaits it before `session_start`, so the tools are registered before turn 1. Schema passthrough: the MCP `inputSchema` is passed verbatim as `parameters` (pi forwards it to the provider as JSON Schema; confirmed no runtime typebox validation on tool params).

## Wiring (mirrors the other harnesses)

- **Core:** `PiPaths.KcapMcpExtension` / `KcapMcpExtensionMarker` / `AgentsMd`; `PiMcpExtensionInstaller` (embedded const + distinct `.kcap-mcp-extension-version` marker).
- **PluginEnvironment:** `PiKcapMcpExtension`, `PiAgentsMd`.
- **PluginCommand:** `InstallPi` also writes `kcap-mcp.ts` (`--skip-pi-mcp`) + the AGENTS.md block (`--skip-pi-instructions`); `--if-installed` heals both when the ingest extension is present; `RemovePi` removes all three.
- **Setup flow:** `HandlePiExtension` gains an `out selected` signal; `HandlePiMcp` + `HandlePiInstructions` gate on it (so they install even if the ingest write fails); `SetupCommand` parses the two new flags.
- **Docs:** `help-plugin.txt`, `help-setup.txt`.

## Testing

Full unit suite green (the one intermittent failure is a pre-existing `LocalPermissionBridge` port-bind flake in an unrelated daemon test — passes in isolation). New/extended coverage:

- `PiMcpExtensionInstallerTests` — write/remove, marker, distinct-from-ingest marker, and bridge-content assertions (async factory, all 4 servers, `notifications/initialized`, `kcap_<server>_<tool>` naming, `session_shutdown` + `process.once("exit")` teardown).
- `PiPathsTests` — new path members + env-var derivation.
- `PluginCommandPiTests` — MCP + AGENTS.md install, `--skip-pi-mcp` / `--skip-pi-instructions`, AGENTS.md content preservation, remove strips all three.
- `CodingAgentsStepTests` — `HandlePiMcp` / `HandlePiInstructions` wiring, `selected`-independence (install even when the ingest write fails), skip flags, failure warnings.

Design: `docs/superpowers/specs/2026-07-10-pi-mcp-bridge-extension-design.md` (in the kcap-server repo).

Part of the AI-1224 MCP auto-config epic — Pi is the last harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
