### PR TITLE
[AI-689] ACP hardening: design-of-record + hosted-Cursor operator docs (PR 1/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,38 @@ KCAP_CURSOR_PATH=/opt/cursor/bin/cursor-agent kcap daemon
 KCAP_CURSOR_MODEL=claude-opus-4-8 kcap daemon
 ```
 
+**Hosted Cursor agents run over ACP.** The `cursor` vendor is launched by the daemon as
+`cursor-agent acp` (Cursor's Agent Client Protocol server) in an isolated worktree, driven from the
+dashboard. This is **distinct from the Cursor recording hooks** (`~/.cursor/hooks.json`, which capture
+sessions you run yourself in Cursor) — a hosted ACP agent is one the daemon *starts and supervises*.
+It requires:
+
+- The Cursor CLI (`cursor-agent`) installed and on `PATH`, or pointed at via `KCAP_CURSOR_PATH`. If the
+  daemon can't find it, the `cursor` vendor is simply hidden from the launch dialog.
+- A **logged-in Cursor account on a Team-tier (paid) subscription** — run `cursor-agent login` first.
+  On the Free tier the agent refuses to run turns (it returns "Upgrade your plan to continue"); a
+  logged-out CLI fails the handshake.
+
+**Current limitations.** A hosted Cursor agent renders its transcript (messages, thinking, tool
+calls/results) but does **not** support interactive local-attach input, special keys, or terminal
+resize, and it emits no separate terminal-output stream — Cursor runs shell commands itself in the
+worktree and they surface as `execute` tool results in the transcript. Kapacitor advertises **no**
+client filesystem or terminal capabilities to the agent (it performs those operations itself).
+
+**Troubleshooting.**
+
+- *`cursor` missing from the launch dialog* — the daemon didn't find `cursor-agent`; install it or set
+  `KCAP_CURSOR_PATH`, then restart the daemon.
+- *Agent launches but errors immediately / produces nothing* — confirm `cursor-agent login` and that
+  the account has a Team-tier subscription; the daemon logs the handshake failure.
+- *Model not applied* — `KCAP_CURSOR_MODEL` (or the per-launch model) is matched against the models the
+  account actually offers; an unrecognized value falls back to Cursor's default.
+
+**Data handling.** A hosted Cursor agent runs as a local child process of the daemon with the daemon's
+own filesystem/process access — the same unsandboxed-in-a-worktree posture as every hosted agent — and
+its transcript (prompt text, tool arguments, tool results) is forwarded to the Capacitor server
+verbatim, exactly like every other agent, with no Cursor/ACP-specific redaction.
+
 **Codex session-end tuning.** Because Codex has no session-end hook, the watcher owns session-end via two triggers: parent `codex` process exit, and rollout-file idle timeout. The idle trigger is particularly important for the Codex desktop app, whose shared `codex app-server` process never exits per-conversation.
 
 | Environment variable | Default | Description |

--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ It requires:
 **Current limitations.** A hosted Cursor agent renders its transcript (messages, thinking, tool
 calls/results) but does **not** support interactive local-attach input, special keys, or terminal
 resize, and it emits no separate terminal-output stream — Cursor runs shell commands itself in the
-worktree and they surface as `execute` tool results in the transcript. Kapacitor advertises **no**
+worktree and they surface as `execute` tool results in the transcript. Capacitor advertises **no**
 client filesystem or terminal capabilities to the agent (it performs those operations itself).
 
 **Troubleshooting.**

--- a/README.md
+++ b/README.md
@@ -722,8 +722,11 @@ client filesystem or terminal capabilities to the agent (it performs those opera
 
 - *`cursor` missing from the launch dialog* — the daemon didn't find `cursor-agent`; install it or set
   `KCAP_CURSOR_PATH`, then restart the daemon.
-- *Agent launches but errors immediately / produces nothing* — confirm `cursor-agent login` and that
-  the account has a Team-tier subscription; the daemon logs the handshake failure.
+- *Agent connects but every turn fails with "Upgrade your plan to continue"* — the Cursor account is on
+  the Free tier; hosted turns require a **Team-tier** subscription. (The handshake succeeds; the refusal
+  is returned per-turn.)
+- *Agent fails at startup / never establishes a session* — the CLI is likely logged out (`cursor-agent
+  login`) or the binary is broken; the daemon logs the handshake failure.
 - *Model not applied* — `KCAP_CURSOR_MODEL` (or the per-launch model) is matched against the models the
   account actually offers; an unrecognized value falls back to Cursor's default.
 

--- a/docs/ai-689-design.md
+++ b/docs/ai-689-design.md
@@ -1,0 +1,170 @@
+# AI-689 — ACP production hardening & docs: design
+
+Parent epic **AI-682**. Follows merged AI-684 (foundation), AI-686 (permission/elicitation bridge),
+AI-687 (fs/terminal capability), AI-688 (Cursor prototype + transcript forwarding). Entirely in
+**kcap-cli** (the daemon). Branch `ai-689-acp-hardening-docs` off `origin/main` (`f724432`).
+
+**Scope = Full** (owner decision): the lean set (diagnostics + protocol/capability negotiation +
+observability logging + leak-vector fixes + docs + security posture) **plus** a metrics stack, an
+opt-in raw-frame debug stream, and **ACP process reconnect/resume**. See
+[gap analysis](ai-689-gap-analysis.md) for what AI-688 already delivered (most of Item-1 hardening) —
+this design does not redo that.
+
+## 1. Evidence (two probes)
+
+### 1.1 fs/terminal (AI-687, recap)
+Cursor runs file/shell ops itself as a local child process; requests no client `fs/*`/`terminal/*`.
+We advertise none and decline unhandled agent→client methods `-32601`.
+
+### 1.2 Reconnect + `initialize` response (AI-689, new — probe archived in scratchpad)
+The `initialize` response — **currently discarded** at `AcpHostedAgentRuntime.cs:271` — contains:
+```jsonc
+{ "protocolVersion": 1,
+  "agentCapabilities": {
+    "loadSession": true,                       // ← protocol-native session resume IS supported
+    "promptCapabilities": { "image": true, "audio": false, "embeddedContext": false },
+    "sessionCapabilities": { "list": {} },
+    "mcpCapabilities": { "http": true, "sse": true } },
+  "authMethods": [ { "id": "cursor_login", "name": "Cursor Login",
+                     "description": "…Run 'agent login' first if not logged in." } ] }
+```
+**`session/load` works across a process restart.** After hard-killing the first `cursor-agent`, a
+fresh process resumed the SAME `sessionId` via `session/load {sessionId, cwd, mcpServers}`:
+- it returned a normal result (modes/models/configOptions),
+- it **replayed prior history** as `session/update` notifications (`user_message_chunk`,
+  `agent_thought_chunk`, `agent_message_chunk`),
+- and a subsequent `session/prompt` on the loaded session completed (`stopReason: end_turn`).
+
+**Design consequences:** reconnect is protocol-native (relaunch → `initialize` → `session/load`, same
+sessionId; no `--resume` CLI flag). The replay means the forwarder must not re-emit already-sent
+envelopes (§4.3). The `initialize` response gives us protocolVersion, `loadSession`, and `authMethods`
+for negotiation + diagnostics (§2, §4).
+
+## 2. Workstream A — diagnostics + protocol/capability negotiation (PR 1)
+
+Stop discarding the `initialize` result; parse it into a typed `InitializeResult`
+(source-gen JSON, registered in `CapacitorJsonContext`) and:
+
+- **A1 protocol-version check.** If `result.protocolVersion != 1`, fail the handshake with a clear,
+  actionable `InvalidOperationException` ("cursor-agent negotiated ACP protocol vN; this build
+  supports v1 — update kcap or cursor-agent"). Do not silently proceed.
+- **A2 capability capture.** Record `agentCapabilities` (esp. `loadSession`) on the runtime; reconnect
+  (§4) only attempts `session/load` when `loadSession == true`. Log the negotiated capabilities once
+  at Info (§3).
+- **A3 missing-binary diagnostic.** When `CliResolver` can't find `cursor-agent`, the vendor is
+  omitted today with no explanation. Add a one-time operator-facing Warning on daemon start naming
+  the vendor and pointing at `KCAP_CURSOR_PATH` + `agent` install. (Keep the omission behavior — just
+  make it visible.)
+- **A4 auth/subscription diagnostic.** When `session/new` (or a prompt) fails in the way an
+  unauthenticated / non-Team account fails, surface an actionable message ("cursor-agent is not
+  logged in or lacks a Team subscription — run `cursor-agent login`"). Detection uses the failing
+  RPC's error text plus the presence of `authMethods`. **Caveat:** the exact unauthenticated failure
+  shape is unverified (the AI-684 probe never hit it); A4 is best-effort — it must never *mask* the
+  underlying error, only annotate it. A short live probe against a logged-out `cursor-agent` should
+  confirm the shape during implementation.
+
+## 3. Workstream B — observability (PR 2)
+
+- **B1 Info-level lifecycle logging** via source-gen `[LoggerMessage]` (the AOT-safe pattern already
+  used in `ServerConnection`/`AgentOrchestrator`; the `Acp/` files currently use raw `ILogger`).
+  Events, all payload-free (ids/metadata only): launch requested, handshake ok (protocolVersion +
+  loadSession + model), session started, session loaded/resumed, blocking request issued+resolved
+  (kind + decision, never content), reconnect attempt/success/give-up, session ended.
+- **B2 metrics stack.** Introduce a single `Meter` (`"Capacitor.Cli.Daemon.Acp"`) with counters:
+  `acp.launches`, `acp.sessions_started`, `acp.sessions_loaded`, `acp.blocking_requests` (tag: kind),
+  `acp.reconnects` (tag: outcome), `acp.failures` (tag: stage). `System.Diagnostics.Metrics` is
+  NativeAOT-safe (no reflection); **no exporter is wired** — counters are observable via
+  `dotnet-counters`/any future OTel exporter. Documented as such (acceptance is "metrics enough to
+  diagnose", not "shipped dashboards").
+- **B3 close the two Debug payload-leak vectors.** The Unknown-kind full-raw-update dump
+  (`AcpEventTranslator.cs:106-108`) and cursor-agent stderr (`AcpChildProcess.cs:54`) currently log
+  content unconditionally at Debug. Gate both behind the B4 opt-in flag; when the flag is off, log
+  only shape/metadata (kind, length), never content.
+- **B4 opt-in raw-frame debug stream.** Env var `KCAP_ACP_DEBUG_FRAMES=1` (default off, absent).
+  When set, log full inbound/outbound ACP frames + the B3 content at Debug under a dedicated
+  category, prefixed with a "may contain sensitive payloads" warning emitted once. Absent-by-default
+  satisfies the privacy acceptance criterion; the opt-in is bounded (frame length cap) and never
+  writes to the transcript/server.
+
+## 4. Workstream C — ACP process reconnect/resume (PR 3)
+
+The heart of Full scope. Today a mid-session `cursor-agent` death ends the read loop, faults pending
+requests, and finalizes the session. Replace that with a bounded resume attempt.
+
+- **C1 death detection.** In `AcpHostedAgentRuntime`, distinguish an *unexpected* child exit /
+  read-loop end (process died while the session was active and no intentional stop/dispose was
+  requested) from normal teardown. Only the unexpected case triggers reconnect.
+- **C2 resume.** If `loadSession` was advertised (A2): relaunch `cursor-agent acp` (same cwd/env via
+  the factory), `initialize` (re-run A1 protocol check + A2 capture), then
+  `session/load {sessionId, cwd, mcpServers}` with the SAME sessionId. On success the session is live
+  again and accepts prompts. Bounded attempts (default 3) with backoff; on give-up, finalize cleanly
+  (today's behavior) with a Warning + `acp.reconnects{outcome=failed}`.
+- **C3 replay dedup (subtle — from the probe).** `session/load` **replays prior history** as
+  `session/update` notifications. Those map to envelopes the forwarder has ALREADY sent. We must not
+  double-forward. Approach: the runtime tracks the highest transcript sequence already emitted before
+  the death; during a load-triggered replay it **suppresses re-emission up to that watermark** (drop
+  replayed updates whose reconstructed envelope index ≤ watermark), resuming live emission only for
+  post-watermark content. The forwarder's existing seq/ack machinery is the backstop (monotonic seq;
+  the server already ignores/acks by seq), but suppression at the source avoids relying on it for
+  correctness. Overlapping-turn single-flight (AI-688) still holds.
+- **C4 in-flight turn.** A turn interrupted by the death cannot be assumed complete. After resume,
+  the open aggregation run is flushed/closed at the death boundary (no fabricated completion); a
+  partial `AssistantText`/`Thinking` is emitted as-is. New prompts continue normally.
+- **C5 interaction vs SignalR re-bind.** C-reconnect (agent process) is orthogonal to the existing
+  `ReBindAcpSessionsAsync` (SignalR server binding). Both can fire; ordering: a process resume keeps
+  the same agentId/sessionId, so the existing binding stays valid — no re-bind needed for a pure
+  process resume. Document the interaction so the two mechanisms aren't conflated.
+
+## 5. Workstream D — docs + security posture (PR 4, mergeable first)
+
+- **D1 operator docs** (`README.md` + a focused `docs/` page): the hosted-Cursor/ACP path (explicitly
+  distinct from the Cursor *recording-hooks* path, a known confusion point); `cursor-agent acp` +
+  minimum version + **Team-tier subscription** + `cursor-agent login`; env vars (`KCAP_CURSOR_PATH`,
+  `KCAP_CURSOR_MODEL`, `KCAP_ACP_DEBUG_FRAMES`, `KCAP_URL`); **limitations** (no local-attach raw
+  input/special-keys/resize, no terminal-output surfacing, reconnect is best-effort resume);
+  **troubleshooting** (missing binary → `KCAP_CURSOR_PATH`; auth → `cursor-agent login`/Team;
+  model-resolution fallback; protocol-version mismatch).
+- **D2 security posture** (docs): the ACP transcript forwards prompt text, tool args, and tool
+  results **verbatim** — the same canonical-transcript posture as every other agent, with no
+  ACP-specific redaction; default logging is shape-only; the opt-in raw-frame stream may contain
+  sensitive payloads and is off by default; fs/terminal are declined (AI-687).
+
+## 6. PR sequencing
+
+1. **PR 4 (docs + security)** first — pure prose, zero code risk, unblocks dogfooding immediately.
+2. **PR 1 (diagnostics + negotiation)** — small, self-contained; also lands the typed `InitializeResult`
+   that PR 3 depends on.
+3. **PR 2 (observability)** — logging + metrics + leak fixes + raw-frame flag.
+4. **PR 3 (reconnect)** — largest; depends on PR 1's `InitializeResult`/capability capture. Includes a
+   short live probe to confirm the death→relaunch→`session/load` path end-to-end (gated
+   `KCAP_ACP_LIVE`), mirroring AI-688's live test.
+
+Each PR: unit tests (fake-agent harness already supports scripted server-requests, initialize
+capture, prompt scripts); NativeAOT publish gate warning-free; kcap-cli conventions (no Linear ids in
+comments; concise; `JsonElementExtensions`; README sync for new env vars).
+
+## 7. Test plan (highlights)
+
+- **A1:** initialize response with `protocolVersion:2` → handshake throws the clear mismatch error;
+  `:1` → proceeds. **A2:** `loadSession` captured + gates reconnect. **A3:** missing binary → the
+  operator Warning fires once. **A4:** simulated auth-style RPC error → annotated actionable message,
+  original error preserved.
+- **B1:** lifecycle events logged at Info with ids only (assert no payload). **B2:** counters
+  increment on launch/session/blocking/reconnect/failure. **B3/B4:** flag off → content-free logs;
+  flag on → full frames under the dedicated category.
+- **C:** fake agent that "dies" mid-session → runtime relaunches + `session/load`s the same
+  sessionId; **replayed updates ≤ watermark are suppressed** (assert no duplicate envelopes reach the
+  forwarder); post-watermark content forwards; give-up after N attempts finalizes cleanly. Live
+  `KCAP_ACP_LIVE` end-to-end resume.
+
+## 8. Risks / open questions
+
+- **R1 (A4):** unauthenticated `cursor-agent` failure shape unverified — confirm via a logged-out
+  live probe during PR 1; A4 annotates, never masks.
+- **R2 (C3):** replay-dedup watermark correctness is the riskiest piece — the forwarder seq/ack is the
+  backstop, but source suppression must be covered by a deterministic "died mid-transcript then
+  replays" test.
+- **R3 (B2):** metrics have no exporter yet — acceptable per acceptance ("enough to diagnose",
+  observable via `dotnet-counters`); a real exporter is out of scope.
+- **R4:** reconnect could mask a genuinely-crashing agent by relaunching repeatedly — the bounded
+  attempt cap + backoff + `acp.reconnects{failed}` metric + give-up-finalize prevent an infinite loop.

--- a/docs/ai-689-design.md
+++ b/docs/ai-689-design.md
@@ -134,12 +134,15 @@ answers each.
     streaming tradeoff). A pure content fingerprint is rejected (r2-review B1 — no occurrence identity).
   - **Boundary-turn completeness** (r3-review B4): the turn interrupted mid-prompt must reappear
     **complete** in the replay (not truncated), else C4's discard-and-replay is unsound.
-  - **A closed-world end-of-replay barrier** (r3-review B4, r5-review 3): C0 must establish a signal
-    after which **no further replay `session/update` can arrive** — a true drain/EOF barrier, not a mere
-    ordering hint. C8's PRESENT/ABSENT check and the C6 gate reopen run ONLY after this barrier, so if
-    `session/load`'s response is not closed-world, C0 must find the real drain signal (a terminal
-    notification, or draining until quiescence with a bound); if none exists, the interrupted-turn
-    decision has a mid-replay window and reconnect re-scopes.
+  - **A protocol-backed closed-world end-of-replay barrier** (r3-review B4, r5-review 3, r6-review 1):
+    C0 must establish a signal ACP itself **guarantees** is terminal for replay — the `session/load`
+    response contract, an explicit EOF, or a terminal notification — after which **no further replay
+    `session/update` can arrive**. A **bounded quiescence / quiet-period heuristic is NOT acceptable**
+    to drive C8's PRESENT/ABSENT (r6-review 1): a late replayed user turn arriving after the quiet
+    period would fire *after* the same occurrence id was already requeued, recreating the duplicate.
+    C8's check and the C6 gate reopen run ONLY after this protocol-backed barrier. **If ACP provides no
+    protocol-backed barrier, PRESENT/ABSENT is undecidable → C8 uses the at-most-once fallback and/or
+    reconnect re-scopes** — never a heuristic barrier.
   **If C0 fails any of these, reconnect is re-scoped to a follow-up issue and NOT shipped** — A/B/D
   stand alone. No reconnect code lands until C0 answers all three.
 
@@ -224,9 +227,16 @@ answers each.
      `AcpConnection` call it inline on the pre-fault path without risking a block.
   4. On give-up, the gate opens into the terminal path (worker completes, `_updates` completes,
      orchestrator finalizes) — same disposition as an intentional stop.
-  This gate is the coupling point between C1/C2/C4; tests must cover "prompt queued during reconnect runs
-  only after the replay barrier", "boundary partial discarded not flushed on the crash fault", and
-  "write-side send failure triggers reconnect".
+  5. **Reopen ordering on successful resume (r6-review 2) — strict sequence, gate stays CLOSED
+     throughout:** (a) drain replay to C0's protocol-backed barrier; (b) C9 stop/finalized re-check;
+     (c) C8 PRESENT/ABSENT decision; (d) if ABSENT, durably enqueue the requeue (same occurrence id) at
+     the **head** of the post-replay queue, **before any live update** can be delivered; (e) C9 re-check
+     again; (f) **only then reopen the gate** for live delivery. This guarantees a requeued user turn is
+     never trailed by its own assistant/tool updates and no live update overtakes the barrier.
+  This gate is the coupling point between C1/C2/C4/C8/C9; tests must cover "prompt queued during
+  reconnect runs only after the replay barrier", "boundary partial discarded not flushed on the crash
+  fault", "write-side send failure triggers reconnect", and "on ABSENT, the requeued user turn is
+  delivered before any post-resume live update".
 
 - **C7 — intentional stop serialized against an in-progress relaunch (addresses r3-review B3).** Stop
   today calls `RequestGracefulStopAsync`/`WaitForExitAsync`/`TerminateAsync` against the *current*

--- a/docs/ai-689-design.md
+++ b/docs/ai-689-design.md
@@ -108,14 +108,19 @@ answers each.
 > binding unregister (`:827,:887`) — the runtime is built for a single process lifetime and cannot
 > swap its process as originally described.
 
-- **C0 — replay-identity probe (FIRST step of PR3, before any code).** The reconnect design hinges on
+- **C0 — replay-identity probe (FIRST step of PR3, and a HARD GATE).** The reconnect design hinges on
   one unknown the AI-689 probe did not resolve: *what exactly does `session/load` replay, and can a
-  replayed turn be matched to an already-forwarded one?* Probe: establish a multi-turn session, kill
-  the process, `session/load`, and capture the replayed `session/update` stream — specifically
-  whether assistant/user messages carry a **stable message id** across the original vs the replay,
-  whether **turn order** is preserved, and whether chunk coalescing differs. The result picks the C3
-  dedup key (stable id preferred; content fingerprint fallback). No reconnect code lands until C0 is
-  answered.
+  replayed turn be matched to an already-forwarded one?* Probe: establish a multi-turn session
+  (including a deliberately **repeated** identical prompt/answer, to test occurrence identity), kill
+  the process, `session/load`, and capture the replayed `session/update` stream. C0 must establish
+  **one of two viable dedup keys** (r2-review B1): **(a)** a **stable per-message id** carried on each
+  message identically across the original and the replay (preferred); or **(b)** a stable **complete-
+  turn count + order** — i.e. the replay yields the same number of complete turns in the same order
+  (chunk re-coalescing within a turn is fine, since we re-aggregate) — which enables occurrence-safe
+  **ordinal** dedup. **A pure content fingerprint is explicitly rejected** (r2-review B1): it has no
+  occurrence identity and would drop legitimately-repeated content. **If C0 establishes neither (a)
+  nor (b), reconnect is re-scoped to a follow-up issue and NOT shipped** — the other three workstreams
+  (A/B/D) stand on their own. No reconnect code lands until C0 answers this.
 
 - **C1 — reconnect owner + crash-vs-stop.** Introduce an explicit reconnect owner inside the runtime
   (not the orchestrator). Add an `_intentionalStop` flag set by the dispose/stop paths; the read-loop
@@ -134,28 +139,51 @@ answers each.
   Bounded attempts (default 3) with backoff; on give-up, finalize cleanly (today's behavior) with a
   Warning + `acp.reconnects{outcome=failed}`.
 
-- **C3 — content-identity dedup (replaces the seq/index watermark).** Dedup lives in the **runtime's
-  emission layer**, keyed on **content identity**, never on our assigned seq (B1) or a positional
-  index (B2). The runtime maintains a set of identities of the COMPLETE turn envelopes it has already
-  emitted (stable ACP message id if C0 finds one; else a content fingerprint over role + text/tool
-  payload). During the `session/load` replay, updates are aggregated into complete turns exactly as in
-  live operation; each reconstructed complete turn is emitted **only if its identity is not already in
-  the set**. This is order- and boundary-independent: already-forwarded turns are dropped regardless of
-  how the replay re-chunks them; genuinely new content (incl. the completed boundary turn, see C4)
-  passes through. The forwarder seq/ack remains the transport backstop but is explicitly NOT relied on
-  for replay correctness. AI-688 single-flight still holds.
+- **C3 — occurrence-safe dedup (replaces the seq/index watermark AND the content-fingerprint idea).**
+  Dedup lives in the **runtime's emission layer**, never on our assigned seq (B1) or a positional
+  wire index (r1-B2). The key is whichever C0 validated: **(a)** the **stable per-message id**, or
+  **(b)** the **complete-turn ordinal** — the runtime remembers *how many complete turns it emitted*
+  before the death (N), and on replay re-aggregates into complete turns and emits only those at
+  ordinal > N. Both are **occurrence-safe**: two identical-content turns at different ordinals (or with
+  different ids) are distinct, so legitimately-repeated prompts/answers are NOT dropped (r2-review B1).
+  Re-aggregation makes it robust to within-turn chunk re-coalescing. Genuinely new content (incl. the
+  completed boundary turn, see C4) passes through; already-forwarded turns are dropped. The forwarder
+  seq/ack remains the transport backstop but is explicitly NOT relied on for replay correctness.
+  AI-688 single-flight still holds. (If C0 found neither key, this whole workstream re-scopes — see C0.)
 
-- **C4 — boundary turn: do NOT flush a partial.** Revised from r1: at the death boundary the in-flight
-  aggregation run is **discarded, not flushed** (no partial `AssistantText`/`Thinking` emitted, no
-  fabricated completion). Because the partial was never emitted, its identity is not in the C3 set, so
-  when `session/load` replays that turn *complete*, C3 emits it exactly once. This removes the
-  dup-prefix / drop-suffix hazard entirely. (If reconnect ultimately fails, the interrupted turn is
-  simply absent — acceptable, and better than a forwarded partial that never gets corrected.)
+- **C4 — boundary turn: do NOT flush a partial (must override the existing `finally` flush).** At the
+  death boundary the in-flight aggregation run is **discarded, not flushed** (no partial emitted, no
+  fabricated completion), so when `session/load` replays that turn *complete*, C3 emits it exactly
+  once. **Critical (r2-review B2):** this is NOT automatic — today when the read loop ends it faults
+  pending requests (`AcpConnection.cs:163`) and `ProcessTurnAsync`'s `finally { FlushOpenRun(); }`
+  (`AcpHostedAgentRuntime.cs:397`) would flush exactly the partial we intend to discard. The reconnect
+  gate (C6) must set the reconnecting state **before** that `finally` runs, and `FlushOpenRun` (or the
+  turn worker's fault path) must check it and **discard instead of flush** while reconnecting. Not
+  wiring this makes C4 a no-op. (If reconnect ultimately fails, the interrupted turn is simply absent —
+  acceptable, better than a forwarded partial that never gets corrected.)
 
 - **C5 — interaction vs SignalR re-bind.** C-reconnect (agent process) is orthogonal to the existing
   `ReBindAcpSessionsAsync` (SignalR server binding). A pure process resume keeps the same
   agentId/sessionId, so the existing SignalR binding stays valid — no re-bind needed. Documented so the
   two mechanisms aren't conflated.
+
+- **C6 — reconnect gate around the turn worker (addresses r2-review B2).** A single-process assumption
+  is baked into the turn worker: `ProcessTurnAsync` catches a prompt fault, runs its `finally`, and
+  keeps draining `_pendingTurns` (`AcpHostedAgentRuntime.cs:397,:421`), and `SendPromptAsync` uses the
+  swappable `_connection` directly (`:493`). Reconnect therefore needs an explicit **gate**, not just a
+  parked `ReadOutputAsync`:
+  1. A `Reconnecting` state (set by C1 on a crash-triggering read-loop end, cleared after
+     `session/load` succeeds or reconnect is abandoned).
+  2. The turn worker **awaits the gate before dequeuing/sending each turn**, and `SendUserInputAsync`
+     (and key/resize) awaits it too — so no queued prompt runs against a dead or half-swapped
+     connection. The connection/process swap happens only while the gate is closed.
+  3. The crash fault path enters `Reconnecting` **before** `ProcessTurnAsync`'s `finally` runs, so the
+     `finally`/`FlushOpenRun` discards the boundary partial (C4) instead of flushing it.
+  4. On give-up, the gate opens into the terminal path (worker completes, `_updates` completes,
+     orchestrator finalizes) — the same disposition as an intentional stop.
+  This gate is the concrete coupling point between C1 (crash-vs-stop), C2 (swap), and C4 (discard); the
+  test suite must cover "prompt queued during reconnect runs only after resume" and "boundary partial
+  discarded, not flushed, on the crash fault".
 
 **Scope note:** C1's runtime restructure (swappable process/connection, deferred finalize, crash-vs-stop
 gating) is the largest single change in AI-689 and touches AI-688's teardown ordering directly. It gets
@@ -165,13 +193,15 @@ follow-up issue rather than shipped unsound (flagged for owner decision at that 
 
 ## 5. Workstream D — docs + security posture (PR 4, mergeable first)
 
-- **D1 operator docs** (`README.md` + a focused `docs/` page): the hosted-Cursor/ACP path (explicitly
+- **D1 operator docs** (`README.md` + a focused `docs/` page) — **current reality only** (per §6 /
+  r2-review NB6; future knobs ship with their PR, NOT here): the hosted-Cursor/ACP path (explicitly
   distinct from the Cursor *recording-hooks* path, a known confusion point); `cursor-agent acp` +
-  minimum version + **Team-tier subscription** + `cursor-agent login`; env vars (`KCAP_CURSOR_PATH`,
-  `KCAP_CURSOR_MODEL`, `KCAP_ACP_DEBUG_FRAMES`, `KCAP_URL`); **limitations** (no local-attach raw
-  input/special-keys/resize, no terminal-output surfacing, reconnect is best-effort resume);
-  **troubleshooting** (missing binary → `KCAP_CURSOR_PATH`; auth → `cursor-agent login`/Team;
-  model-resolution fallback; protocol-version mismatch).
+  minimum version + **Team-tier subscription** + `cursor-agent login`; the env vars that exist today
+  (`KCAP_CURSOR_PATH`, `KCAP_CURSOR_MODEL`, `KCAP_URL`); current **limitations** (no local-attach raw
+  input/special-keys/resize, no terminal-output surfacing); **troubleshooting** (missing binary →
+  `KCAP_CURSOR_PATH`; auth → `cursor-agent login`/Team; model-resolution fallback). **Deferred to their
+  implementing PRs:** `KCAP_ACP_DEBUG_FRAMES` (with PR2) and reconnect/best-effort-resume limitations
+  (with PR3).
 - **D2 security posture** (docs): the ACP transcript forwards prompt text, tool args, and tool
   results **verbatim** — the same canonical-transcript posture as every other agent, with no
   ACP-specific redaction; default logging is shape-only; the opt-in raw-frame stream may contain
@@ -210,9 +240,12 @@ comments; concise; `JsonElementExtensions`; README sync for new env vars).
 - **B1:** lifecycle events logged at Info with ids only (assert no payload). **B2:** counters
   increment on launch/session/blocking/reconnect/failure. **B3/B4:** flag off → content-free logs;
   flag on → full frames under the dedicated category.
-- **C:** fake agent that "dies" mid-session → runtime relaunches + `session/load`s the same
-  sessionId; **replayed updates ≤ watermark are suppressed** (assert no duplicate envelopes reach the
-  forwarder); post-watermark content forwards; give-up after N attempts finalizes cleanly. Live
+- **C:** fake agent that "dies" mid-session → runtime relaunches + `session/load`s the same sessionId;
+  replayed complete turns at **ordinal ≤ N (or matching an already-emitted stable id)** are dropped
+  while ordinal > N forwards (assert no duplicate envelopes reach the forwarder, AND that a
+  legitimately-repeated identical turn is NOT dropped — the occurrence-safety case from r2-review B1);
+  the boundary partial is **discarded, not flushed** on the crash fault (C4/C6); a prompt queued during
+  reconnect runs **only after** resume (C6 gate); give-up after N attempts finalizes cleanly. Live
   `KCAP_ACP_LIVE` end-to-end resume.
 
 ## 8. Risks / open questions

--- a/docs/ai-689-design.md
+++ b/docs/ai-689-design.md
@@ -138,15 +138,15 @@ answers each.
     present)**. This mapping is exactly what C8 routes on (ABSENT→requeue, PRESENT-COMPLETE→no requeue,
     PRESENT-INCOMPLETE→surface-as-interrupted), so it must be observed, not assumed. Also confirm a
     *fully* completed turn reappears complete (not truncated), else C3/C4 dedup is unsound.
-  - **Acceptance-boundary invariant for ABSENT (r8-review 1):** C8's `ABSENT ⇒ safe to requeue` rests on
-    a claim that must be PROVEN, not inferred from absence: *once ACP has accepted/started a prompt, its
-    occurrence becomes replay-visible.* So C0 must also kill **after crossing the acceptance/execution
-    boundary** — after the first assistant/tool `session/update` evidence for that occurrence — and
-    verify the occurrence then appears in the replay as PRESENT-INCOMPLETE/COMPLETE, **never ABSENT**.
-    If a "started-but-not-yet-replay-visible" window exists (an accepted prompt can still be ABSENT),
-    then ABSENT is ambiguous and C8's auto-requeue would duplicate already-started, possibly
-    side-effecting work → in that case reconnect re-scopes, or ABSENT-after-possible-acceptance routes
-    to the interrupted/at-most-once path rather than auto-requeue.
+  - **Old-connection quiescence for the ABSENT decision (r8/r9-review 1):** C8 anchors auto-requeue on
+    a *local* "provably-not-sent" fact, not on proving "accepted ⇒ replay-visible" from the wire — so
+    C0's required job here is narrower: confirm reconnect can **quiesce/cancel the old process+connection
+    before the replay snapshot** (C1/C7), so the dead connection cannot still accept the interrupted
+    prompt after we decide. *(Optional/bonus: C0 may also kill just after the first assistant/tool
+    `session/update` for an occurrence and check it is then never ABSENT; if that "accepted ⇒
+    replay-visible" invariant holds it lets more ABSENT cases take the fast auto-requeue path, but the
+    design does NOT depend on it — any may-have-been-sent ABSENT is surfaced-as-interrupted regardless,
+    per C8.)*
   - **A protocol-backed closed-world end-of-replay barrier** (r3-review B4, r5-review 3, r6-review 1):
     C0 must establish a signal ACP itself **guarantees** is terminal for replay — the `session/load`
     response contract, an explicit EOF, or a terminal notification — after which **no further replay
@@ -283,13 +283,22 @@ answers each.
   `session/load` + the C0 **closed-world** end-of-replay barrier, decide **three ways** (r7-review 1 —
   "present" ≠ "complete", because ACP `session/load` does NOT auto-resume an interrupted turn; a new
   `session/prompt` starts a *new* turn):
-  - **ABSENT** (occurrence id not in the replay): the agent never got it → **requeue exactly once**,
-    carrying the *same* occurrence id (so a crash during the requeue is itself decidable). **This is
-    safe ONLY under the C0-proven invariant that an accepted/started prompt always becomes
-    replay-visible** (r8-review 1) — i.e. ABSENT genuinely means "never accepted." If C0 cannot prove
-    that (a started-but-not-replay-visible window exists), an ABSENT that could follow acceptance is
-    routed to the PRESENT-INCOMPLETE surface-as-interrupted path instead, never auto-requeued (blind
-    requeue would duplicate already-started, possibly side-effecting work).
+  - **ABSENT** (occurrence id not in the replay): split on a **local, observable client-side fact — did
+    the prompt's bytes provably never leave the client?** (r8/r9-review — replay-absence alone is NOT
+    proof of "never accepted", because bytes may have been written and accepted, or accepted by the
+    dying old connection, before any replay-visible evidence). ACP has no prompt-ack, so we do NOT try
+    to prove "never accepted" from the wire; we key on what we can observe locally:
+    - **Provably-not-sent** — the `session/prompt` write threw *before any byte was written* to the
+      connection (a purely local fact): the agent cannot have it → **auto-requeue exactly once** (same
+      occurrence id; a crash during the requeue is itself decidable).
+    - **May-have-been-sent** — any byte was (partially) written, or the send outcome is unknown, AND
+      the occurrence is ABSENT from replay: the prompt may have reached the agent with no replay
+      evidence yet → **surface-as-interrupted, NEVER auto-requeue** (the at-most-once floor; re-running
+      could duplicate side-effecting work already in flight).
+    This keys auto-requeue on "provably never left the client", not on "absent from replay", which
+    closes the accept-race window regardless of ACP's internal acceptance timing. It also requires C1/C7
+    reconnect to **quiesce/cancel the old connection before the replay snapshot** so it cannot still
+    accept the prompt after we decide.
   - **PRESENT-COMPLETE** (occurrence id present AND its turn reached a terminal assistant state /
     `StopReason` in the replay): fully handled → **do NOT requeue** (replay carries it; C3 forwards any
     new part).
@@ -393,10 +402,11 @@ comments; concise; `JsonElementExtensions`; README sync for new env vars).
   the boundary partial is **discarded, not flushed** on the crash fault (C4/C6); a prompt queued during
   reconnect runs **only after** the replay barrier (C6 gate); the interrupted prompt is **requeued iff
   its user turn is absent from the replay** (C8 — assert both branches: present→not requeued,
-  the C8 three-way keyed on the occurrence id at the three crash points: **absent** (before write) →
-  head-requeue once with the same id; **present-complete** (terminal assistant state in replay) → no
+  the C8 decision at the crash points: **absent + write provably-not-sent** (send threw before any
+  byte) → head-requeue once with the same id; **absent but bytes may-have-been-sent** → surfaced as
+  interrupted, NOT auto-requeued; **present-complete** (terminal assistant state in replay) → no
   requeue; **present-incomplete** (user turn but no terminal state) → surfaced as interrupted, NOT
-  auto-requeued and NOT dropped);
+  auto-requeued and NOT dropped; and the old connection is quiesced before the replay snapshot);
   **stop/finalize during an in-progress reconnect** (owner queued, or mid relaunch/initialize/load)
   finalizes exactly once, leaks no candidate child, and emits/requeues nothing post-stop (C7 lock-scope
   + C9 unwind); give-up after N attempts finalizes cleanly. Live `KCAP_ACP_LIVE` end-to-end resume.

--- a/docs/ai-689-design.md
+++ b/docs/ai-689-design.md
@@ -138,6 +138,15 @@ answers each.
     present)**. This mapping is exactly what C8 routes on (ABSENT→requeue, PRESENT-COMPLETE→no requeue,
     PRESENT-INCOMPLETE→surface-as-interrupted), so it must be observed, not assumed. Also confirm a
     *fully* completed turn reappears complete (not truncated), else C3/C4 dedup is unsound.
+  - **Acceptance-boundary invariant for ABSENT (r8-review 1):** C8's `ABSENT ⇒ safe to requeue` rests on
+    a claim that must be PROVEN, not inferred from absence: *once ACP has accepted/started a prompt, its
+    occurrence becomes replay-visible.* So C0 must also kill **after crossing the acceptance/execution
+    boundary** — after the first assistant/tool `session/update` evidence for that occurrence — and
+    verify the occurrence then appears in the replay as PRESENT-INCOMPLETE/COMPLETE, **never ABSENT**.
+    If a "started-but-not-yet-replay-visible" window exists (an accepted prompt can still be ABSENT),
+    then ABSENT is ambiguous and C8's auto-requeue would duplicate already-started, possibly
+    side-effecting work → in that case reconnect re-scopes, or ABSENT-after-possible-acceptance routes
+    to the interrupted/at-most-once path rather than auto-requeue.
   - **A protocol-backed closed-world end-of-replay barrier** (r3-review B4, r5-review 3, r6-review 1):
     C0 must establish a signal ACP itself **guarantees** is terminal for replay — the `session/load`
     response contract, an explicit EOF, or a terminal notification — after which **no further replay
@@ -275,7 +284,12 @@ answers each.
   "present" ≠ "complete", because ACP `session/load` does NOT auto-resume an interrupted turn; a new
   `session/prompt` starts a *new* turn):
   - **ABSENT** (occurrence id not in the replay): the agent never got it → **requeue exactly once**,
-    carrying the *same* occurrence id (so a crash during the requeue is itself decidable).
+    carrying the *same* occurrence id (so a crash during the requeue is itself decidable). **This is
+    safe ONLY under the C0-proven invariant that an accepted/started prompt always becomes
+    replay-visible** (r8-review 1) — i.e. ABSENT genuinely means "never accepted." If C0 cannot prove
+    that (a started-but-not-replay-visible window exists), an ABSENT that could follow acceptance is
+    routed to the PRESENT-INCOMPLETE surface-as-interrupted path instead, never auto-requeued (blind
+    requeue would duplicate already-started, possibly side-effecting work).
   - **PRESENT-COMPLETE** (occurrence id present AND its turn reached a terminal assistant state /
     `StopReason` in the replay): fully handled → **do NOT requeue** (replay carries it; C3 forwards any
     new part).

--- a/docs/ai-689-design.md
+++ b/docs/ai-689-design.md
@@ -118,20 +118,28 @@ answers each.
     its result, coalesced text runs — so a per-message set would drop valid later envelopes). The key
     must be a composite that is stable across replay and distinct per emitted envelope, e.g. `agent
     message id + envelope kind + (tool-call id | run index)`. C0 must confirm such a composite is
-    reconstructable identically on replay, AND — separately — that the **locally-synthesized
-    `UserMessage`** (which we create, not the agent) has its OWN occurrence-safe replayable key:
-    content-matching "by the prompt text" is duplicate-prompt-unsafe and is rejected, so C0 must find a
-    stable correlator on the replayed user turn (e.g. an id on the replayed `user_message_chunk` we can
-    also capture at synthesis time). **If C0 cannot establish the synthesized-user key, C3(a) is
-    DISALLOWED** → fall to C3(b) or re-scope. Or **(b)** stable **complete-turn count + order** enabling
+    reconstructable identically on replay, AND — separately — a **concrete occurrence-safe key for the
+    interrupted USER turn** (r5-review 1), named with its lifecycle, not hand-waved. The required
+    primary is a **client-generated prompt-occurrence-id**: the runtime mints a per-session monotonic
+    (or GUID) id, **persists it before the first byte of `session/prompt` is written**, and attaches it
+    to the outgoing prompt — and **C0 must confirm ACP `session/load` echoes that client id identically
+    on the replayed user turn**. (Content-matching by prompt text is rejected — duplicate-prompt-unsafe.
+    A stable ACP-provided user-turn id also qualifies ONLY if it is durably associated *before* any
+    crash window; an id first learned from the live echo is useless for a prompt whose echo never
+    arrived.) **If C0 confirms neither an echoed client id nor a pre-association ACP turn id, the
+    interrupted-turn PRESENT/ABSENT decision is undecidable by key → C8 falls back to documented
+    at-most-once semantics (see C8), and C3(a) is DISALLOWED** → C3(b) or re-scope. Or **(b)** stable
+    **complete-turn count + order** enabling
     occurrence-safe **turn-ordinal** dedup, which REQUIRES the whole-turn staging model in C3 (and its
     streaming tradeoff). A pure content fingerprint is rejected (r2-review B1 — no occurrence identity).
   - **Boundary-turn completeness** (r3-review B4): the turn interrupted mid-prompt must reappear
     **complete** in the replay (not truncated), else C4's discard-and-replay is unsound.
-  - **An end-of-replay barrier** (r3-review B4): whether the `session/load` *response* reliably means
-    all replay notifications have already arrived. C6 may only open the gate once replay is known
-    complete; if the response is not a barrier, C0 must find the actual signal (e.g. a terminal
-    notification) or the gate cannot safely reopen.
+  - **A closed-world end-of-replay barrier** (r3-review B4, r5-review 3): C0 must establish a signal
+    after which **no further replay `session/update` can arrive** — a true drain/EOF barrier, not a mere
+    ordering hint. C8's PRESENT/ABSENT check and the C6 gate reopen run ONLY after this barrier, so if
+    `session/load`'s response is not closed-world, C0 must find the real drain signal (a terminal
+    notification, or draining until quiescence with a bound); if none exists, the interrupted-turn
+    decision has a mid-replay window and reconnect re-scopes.
   **If C0 fails any of these, reconnect is re-scoped to a follow-up issue and NOT shipped** — A/B/D
   stand alone. No reconnect code lands until C0 answers all three.
 
@@ -243,17 +251,40 @@ answers each.
   blocking teardown runs outside the lock, the pre-fault hook and an in-progress stop cannot block each
   other.
 
-- **C8 — prompt commit: requeue-vs-replay for the interrupted turn (addresses r4-review 1).** ACP has
-  no per-prompt ack, so when a crash interrupts an active `session/prompt` we cannot know from the wire
-  alone whether the agent received/started it. Resolve it *after* resume using replay presence, not a
-  guess: once `session/load` + the C0 end-of-replay barrier complete, check whether the interrupted
-  prompt's **user turn is present in the replay** under the C3 occurrence-safe key. **Present → the
-  agent has it (do NOT requeue; the replay carries the turn, C3 forwards any new part). Absent → the
-  agent never got it (requeue the prompt once).** This single rule covers all three failure windows
-  r4-review 1 names — write failed before acceptance, partial write, or accepted-but-response-faulted —
-  without losing or duplicating the user turn, and it depends on exactly the C0 guarantees (occurrence-
-  safe key + reliable end-of-replay barrier) already required. The requeue is gated by C6 (runs only
-  after the gate reopens on the barrier).
+- **C8 — prompt commit: requeue-vs-replay for the interrupted turn (addresses r4-review 1, r5-review 1).**
+  ACP has no per-prompt ack, so a crash during an active `session/prompt` leaves the prompt's fate
+  unknown from the wire. **Primary rule (requires the C0 client-generated prompt-occurrence-id):** after
+  `session/load` + the C0 **closed-world** end-of-replay barrier, look for the interrupted prompt's
+  **occurrence id** (minted+persisted before the first write, C0) on the replayed user turn. **Found →
+  the agent has it: do NOT requeue** (replay carries the turn; C3 forwards any new part). **Not found →
+  the agent never got it: requeue exactly once**, carrying the *same* occurrence id (so a second crash
+  during the requeue is itself decidable — the retry-after-failed-requeue case). This is decidable only
+  because the check runs strictly after the closed-world barrier (no mid-replay window) and keys on the
+  pre-write occurrence id (not prompt text) — so it is correct even for **repeated identical prompts**.
+- **C8 fallback (when C0 yields no usable key — r5-review 1).** If C0 confirms neither an echoed client
+  id nor a pre-association ACP turn id, the interrupted turn is **undecidable**, so C8 adopts documented
+  **at-most-once** semantics: **do NOT requeue** an interrupted prompt of unknown fate (never silently
+  re-run it — a duplicate could re-execute tools with side effects), log it, and surface to the user
+  that the last prompt may not have been delivered. Under the C3(b) staging path the same rule applies,
+  keyed on whether the staged user turn appears in the replayed complete-turn sequence. This fallback is
+  a correctness floor, not the goal; if at-most-once is unacceptable for the product, reconnect
+  re-scopes until ACP gives a round-tripped prompt id.
+
+- **C9 — reconnect-owner unwind contract vs stop/finalize (addresses r5-review 2).** C6.3's "no-op
+  after stop" only guards *new* `BeginReconnect` calls; it does NOT cover an owner already scheduled and
+  mid-flight. The owner runs all its blocking work under the reconnect `CancellationToken` (C7) and
+  **re-checks stop/finalized state at every checkpoint**: before relaunch, after each await, before
+  `session/load`, before the connection/process swap, before reopening the gate, and before a C8
+  requeue. **Stop/finalize always wins:** on observing it (token cancelled or `_updates` completed), the
+  owner unwinds in a `finally` — dispose any candidate process/connection it created, resolve
+  `Reconnecting` and drive the gate to the terminal path (never leave it stuck closed), and perform **no
+  swap, no requeue, and no envelope emission** after intentional stop or `_updates` completion. This is
+  the explicit contract binding the reconnect owner to AI-688's `AcpCts`/`_updates`/orchestrator-finalize
+  teardown so a late owner cannot install a process after stop, emit into a completed `_updates`, requeue
+  after a user stop, or leak a child. Acceptance cases: stop while the owner is queued; stop during
+  relaunch / `initialize` / `session/load`; a graceful-exit/`TerminateAsync` overlapping a pre-fault
+  reconnect; and reconnect attempts exhausting *during* teardown — each must finalize once, leak nothing,
+  and emit/requeue nothing post-stop.
 
 **Scope note:** C1's runtime restructure (swappable process/connection, deferred finalize, crash-vs-stop
 gating) is the largest single change in AI-689 and touches AI-688's teardown ordering directly. It gets
@@ -317,9 +348,10 @@ comments; concise; `JsonElementExtensions`; README sync for new env vars).
   the boundary partial is **discarded, not flushed** on the crash fault (C4/C6); a prompt queued during
   reconnect runs **only after** the replay barrier (C6 gate); the interrupted prompt is **requeued iff
   its user turn is absent from the replay** (C8 — assert both branches: present→not requeued,
-  absent→requeued once); an **intentional stop during an in-progress reconnect** finalizes without
-  deadlock and without leaking a candidate child (C7 lock-scope); give-up after N attempts finalizes
-  cleanly. Live `KCAP_ACP_LIVE` end-to-end resume.
+  absent→requeued once, carrying the same occurrence id so a requeue-retry is itself decidable);
+  **stop/finalize during an in-progress reconnect** (owner queued, or mid relaunch/initialize/load)
+  finalizes exactly once, leaks no candidate child, and emits/requeues nothing post-stop (C7 lock-scope
+  + C9 unwind); give-up after N attempts finalizes cleanly. Live `KCAP_ACP_LIVE` end-to-end resume.
 
 ## 8. Risks / open questions
 

--- a/docs/ai-689-design.md
+++ b/docs/ai-689-design.md
@@ -56,12 +56,15 @@ Stop discarding the `initialize` result; parse it into a typed `InitializeResult
   the vendor and pointing at `KCAP_CURSOR_PATH` + `agent` install. (Keep the omission behavior — just
   make it visible.)
 - **A4 auth/subscription diagnostic.** When `session/new` (or a prompt) fails in the way an
-  unauthenticated / non-Team account fails, surface an actionable message ("cursor-agent is not
-  logged in or lacks a Team subscription — run `cursor-agent login`"). Detection uses the failing
-  RPC's error text plus the presence of `authMethods`. **Caveat:** the exact unauthenticated failure
-  shape is unverified (the AI-684 probe never hit it); A4 is best-effort — it must never *mask* the
-  underlying error, only annotate it. A short live probe against a logged-out `cursor-agent` should
-  confirm the shape during implementation.
+  unauthenticated / non-Team account fails, surface an actionable *annotation* ("possible
+  auth/subscription issue — try `cursor-agent login` / verify Team tier") that **preserves the
+  original RPC error code + data verbatim** and never replaces it. Per r1: `authMethods` presence is
+  **weak evidence** (it's advertised during normal init too), so it is a hint, not a trigger — do not
+  drive the diagnosis off `authMethods` alone or off broad substring matching until the shape is
+  confirmed. Also per r1: prompt failures are currently swallowed in the background turn worker
+  (`AcpHostedAgentRuntime.cs` turn worker), so A4 must hook the actual failure site (handshake /
+  `session/new` / the surfaced turn error), not assume the error reaches the launch path. A short
+  logged-out live probe confirms the real failure shape before any string matching is added.
 
 ## 3. Workstream B — observability (PR 2)
 
@@ -70,12 +73,14 @@ Stop discarding the `initialize` result; parse it into a typed `InitializeResult
   Events, all payload-free (ids/metadata only): launch requested, handshake ok (protocolVersion +
   loadSession + model), session started, session loaded/resumed, blocking request issued+resolved
   (kind + decision, never content), reconnect attempt/success/give-up, session ended.
-- **B2 metrics stack.** Introduce a single `Meter` (`"Capacitor.Cli.Daemon.Acp"`) with counters:
-  `acp.launches`, `acp.sessions_started`, `acp.sessions_loaded`, `acp.blocking_requests` (tag: kind),
-  `acp.reconnects` (tag: outcome), `acp.failures` (tag: stage). `System.Diagnostics.Metrics` is
-  NativeAOT-safe (no reflection); **no exporter is wired** — counters are observable via
-  `dotnet-counters`/any future OTel exporter. Documented as such (acceptance is "metrics enough to
-  diagnose", not "shipped dashboards").
+- **B2 metrics stack (OPTIONAL — per r1).** A single `Meter` (`"Capacitor.Cli.Daemon.Acp"`) with
+  counters: `acp.launches`, `acp.sessions_started`, `acp.sessions_loaded`, `acp.blocking_requests`
+  (tag: kind), `acp.reconnects` (tag: outcome), `acp.failures` (tag: stage). r1 confirmed
+  `System.Diagnostics.Metrics` is not an AOT hazard, but flagged that the acceptance criterion
+  ("logs/metrics *enough to diagnose*") is **already met by B1's Info logging** — there is no existing
+  `Meter`/exporter in the repo. So B2 is **optional/nice-to-have, not required**: implement it LAST
+  within PR2, and it is the first thing to drop if PR2 gets large. No exporter is wired (observable via
+  `dotnet-counters`).
 - **B3 close the two Debug payload-leak vectors.** The Unknown-kind full-raw-update dump
   (`AcpEventTranslator.cs:106-108`) and cursor-agent stderr (`AcpChildProcess.cs:54`) currently log
   content unconditionally at Debug. Gate both behind the B4 opt-in flag; when the flag is off, log
@@ -88,32 +93,75 @@ Stop discarding the `initialize` result; parse it into a typed `InitializeResult
 
 ## 4. Workstream C — ACP process reconnect/resume (PR 3)
 
-The heart of Full scope. Today a mid-session `cursor-agent` death ends the read loop, faults pending
-requests, and finalizes the session. Replace that with a bounded resume attempt.
+The heart of Full scope, and — per spec-review r1 (3 BLOCKING) — the part that needs a real design,
+not a bullet list. Today a mid-session `cursor-agent` death ends the read loop, faults pending
+requests, and drives finalization. The three findings below are load-bearing; the revised design
+answers each.
 
-- **C1 death detection.** In `AcpHostedAgentRuntime`, distinguish an *unexpected* child exit /
-  read-loop end (process died while the session was active and no intentional stop/dispose was
-  requested) from normal teardown. Only the unexpected case triggers reconnect.
-- **C2 resume.** If `loadSession` was advertised (A2): relaunch `cursor-agent acp` (same cwd/env via
+> **r1 findings addressed here:** (B1) seq is a *forwarder* concept (runtime envelopes carry
+> placeholder `Seq=0`; the forwarder assigns real seqs on dequeue, `IAcpTranscriptSource.cs:34`,
+> `AcpTranscriptForwarder.cs:232`) — so a seq/index watermark cannot be the dedup key. (B2) a
+> `session/load` replay is NOT proven to preserve envelope boundaries/order, and a partial death-
+> boundary flush can dup-prefix or drop-suffix the boundary turn. (B3) `_connection`/`_process` are
+> `readonly`, `_updates` completes on read-loop end, and `ReadOutputAsync` returning drives orchestrator
+> finalization (`AgentOrchestrator.cs:743`), disposal/final-drain (`:1336`), `AcpCts` cancel, and
+> binding unregister (`:827,:887`) — the runtime is built for a single process lifetime and cannot
+> swap its process as originally described.
+
+- **C0 — replay-identity probe (FIRST step of PR3, before any code).** The reconnect design hinges on
+  one unknown the AI-689 probe did not resolve: *what exactly does `session/load` replay, and can a
+  replayed turn be matched to an already-forwarded one?* Probe: establish a multi-turn session, kill
+  the process, `session/load`, and capture the replayed `session/update` stream — specifically
+  whether assistant/user messages carry a **stable message id** across the original vs the replay,
+  whether **turn order** is preserved, and whether chunk coalescing differs. The result picks the C3
+  dedup key (stable id preferred; content fingerprint fallback). No reconnect code lands until C0 is
+  answered.
+
+- **C1 — reconnect owner + crash-vs-stop.** Introduce an explicit reconnect owner inside the runtime
+  (not the orchestrator). Add an `_intentionalStop` flag set by the dispose/stop paths; the read-loop
+  ending or `ReadOutputAsync` returning while `!_intentionalStop` (and `loadSession` capable) means
+  *crash → reconnect*, NOT finalize. This requires restructuring the runtime so it does not signal
+  terminal to the orchestrator on an unexpected exit: `_updates` must **not** complete, `AcpCts` must
+  **not** cancel, and the orchestrator's finalize trigger (`ReadOutputAsync` return) must be gated on
+  the runtime's reconnect *outcome* — the runtime reports "done" only after reconnect attempts are
+  exhausted or an intentional stop. `_connection`/`_process` become swappable (guarded), no longer
+  `readonly`.
+
+- **C2 — resume.** If `loadSession` was advertised (A2): relaunch `cursor-agent acp` (same cwd/env via
   the factory), `initialize` (re-run A1 protocol check + A2 capture), then
-  `session/load {sessionId, cwd, mcpServers}` with the SAME sessionId. On success the session is live
-  again and accepts prompts. Bounded attempts (default 3) with backoff; on give-up, finalize cleanly
-  (today's behavior) with a Warning + `acp.reconnects{outcome=failed}`.
-- **C3 replay dedup (subtle — from the probe).** `session/load` **replays prior history** as
-  `session/update` notifications. Those map to envelopes the forwarder has ALREADY sent. We must not
-  double-forward. Approach: the runtime tracks the highest transcript sequence already emitted before
-  the death; during a load-triggered replay it **suppresses re-emission up to that watermark** (drop
-  replayed updates whose reconstructed envelope index ≤ watermark), resuming live emission only for
-  post-watermark content. The forwarder's existing seq/ack machinery is the backstop (monotonic seq;
-  the server already ignores/acks by seq), but suppression at the source avoids relying on it for
-  correctness. Overlapping-turn single-flight (AI-688) still holds.
-- **C4 in-flight turn.** A turn interrupted by the death cannot be assumed complete. After resume,
-  the open aggregation run is flushed/closed at the death boundary (no fabricated completion); a
-  partial `AssistantText`/`Thinking` is emitted as-is. New prompts continue normally.
-- **C5 interaction vs SignalR re-bind.** C-reconnect (agent process) is orthogonal to the existing
-  `ReBindAcpSessionsAsync` (SignalR server binding). Both can fire; ordering: a process resume keeps
-  the same agentId/sessionId, so the existing binding stays valid — no re-bind needed for a pure
-  process resume. Document the interaction so the two mechanisms aren't conflated.
+  `session/load {sessionId, cwd, mcpServers}` with the SAME sessionId; swap the new process/connection
+  into the runtime and re-arm the read loop, keeping the outer channels + forwarder binding alive.
+  Bounded attempts (default 3) with backoff; on give-up, finalize cleanly (today's behavior) with a
+  Warning + `acp.reconnects{outcome=failed}`.
+
+- **C3 — content-identity dedup (replaces the seq/index watermark).** Dedup lives in the **runtime's
+  emission layer**, keyed on **content identity**, never on our assigned seq (B1) or a positional
+  index (B2). The runtime maintains a set of identities of the COMPLETE turn envelopes it has already
+  emitted (stable ACP message id if C0 finds one; else a content fingerprint over role + text/tool
+  payload). During the `session/load` replay, updates are aggregated into complete turns exactly as in
+  live operation; each reconstructed complete turn is emitted **only if its identity is not already in
+  the set**. This is order- and boundary-independent: already-forwarded turns are dropped regardless of
+  how the replay re-chunks them; genuinely new content (incl. the completed boundary turn, see C4)
+  passes through. The forwarder seq/ack remains the transport backstop but is explicitly NOT relied on
+  for replay correctness. AI-688 single-flight still holds.
+
+- **C4 — boundary turn: do NOT flush a partial.** Revised from r1: at the death boundary the in-flight
+  aggregation run is **discarded, not flushed** (no partial `AssistantText`/`Thinking` emitted, no
+  fabricated completion). Because the partial was never emitted, its identity is not in the C3 set, so
+  when `session/load` replays that turn *complete*, C3 emits it exactly once. This removes the
+  dup-prefix / drop-suffix hazard entirely. (If reconnect ultimately fails, the interrupted turn is
+  simply absent — acceptable, and better than a forwarded partial that never gets corrected.)
+
+- **C5 — interaction vs SignalR re-bind.** C-reconnect (agent process) is orthogonal to the existing
+  `ReBindAcpSessionsAsync` (SignalR server binding). A pure process resume keeps the same
+  agentId/sessionId, so the existing SignalR binding stays valid — no re-bind needed. Documented so the
+  two mechanisms aren't conflated.
+
+**Scope note:** C1's runtime restructure (swappable process/connection, deferred finalize, crash-vs-stop
+gating) is the largest single change in AI-689 and touches AI-688's teardown ordering directly. It gets
+its own PR (PR3), its own C0 probe, and a deterministic "died mid-transcript → replay → dedup" test
+suite. If C0 reveals `session/load` replay is not reliably matchable, reconnect is re-scoped to a
+follow-up issue rather than shipped unsound (flagged for owner decision at that point).
 
 ## 5. Workstream D — docs + security posture (PR 4, mergeable first)
 
@@ -131,13 +179,23 @@ requests, and finalizes the session. Replace that with a bounded resume attempt.
 
 ## 6. PR sequencing
 
-1. **PR 4 (docs + security)** first — pure prose, zero code risk, unblocks dogfooding immediately.
-2. **PR 1 (diagnostics + negotiation)** — small, self-contained; also lands the typed `InitializeResult`
-   that PR 3 depends on.
-3. **PR 2 (observability)** — logging + metrics + leak fixes + raw-frame flag.
-4. **PR 3 (reconnect)** — largest; depends on PR 1's `InitializeResult`/capability capture. Includes a
-   short live probe to confirm the death→relaunch→`session/load` path end-to-end (gated
-   `KCAP_ACP_LIVE`), mirroring AI-688's live test.
+Per r1: docs describe only what's shipped — future knobs (`KCAP_ACP_DEBUG_FRAMES`, reconnect
+limitations) are documented **with their implementing PR**, not up front.
+
+1. **PR 4 (docs + security)** first — pure prose, zero code risk, unblocks dogfooding. Documents only
+   *current* reality: hosted-Cursor/ACP setup vs recording-hooks, `cursor-agent acp` + version + Team
+   tier + `login`, the env vars that exist today (`KCAP_CURSOR_PATH`, `KCAP_CURSOR_MODEL`, `KCAP_URL`),
+   current limitations (no local-attach input/keys/resize, no terminal-output), and the verbatim-
+   transcript security posture. **Does NOT** pre-document `KCAP_ACP_DEBUG_FRAMES` or reconnect.
+2. **PR 1 (diagnostics + negotiation)** — small, self-contained; lands the typed `InitializeResult`
+   that PR 3 depends on. Includes the A4 logged-out live probe.
+3. **PR 2 (observability)** — Info logging + leak-vector fixes + opt-in raw-frame flag; **B2 metrics
+   optional/last**. Ships the `KCAP_ACP_DEBUG_FRAMES` doc **with** this PR.
+4. **PR 3 (reconnect)** — largest; depends on PR 1's `InitializeResult`/capability capture. Starts with
+   the **C0 replay-identity probe**, then the C1 runtime restructure + C3 content-dedup, then a gated
+   `KCAP_ACP_LIVE` end-to-end resume test and a deterministic died-mid-transcript→replay→dedup unit
+   suite. Ships the reconnect-limitations doc **with** this PR. Re-scopes to a follow-up if C0 shows
+   replay is not reliably matchable.
 
 Each PR: unit tests (fake-agent harness already supports scripted server-requests, initialize
 capture, prompt scripts); NativeAOT publish gate warning-free; kcap-cli conventions (no Linear ids in
@@ -161,9 +219,15 @@ comments; concise; `JsonElementExtensions`; README sync for new env vars).
 
 - **R1 (A4):** unauthenticated `cursor-agent` failure shape unverified — confirm via a logged-out
   live probe during PR 1; A4 annotates, never masks.
-- **R2 (C3):** replay-dedup watermark correctness is the riskiest piece — the forwarder seq/ack is the
-  backstop, but source suppression must be covered by a deterministic "died mid-transcript then
-  replays" test.
+- **R2 (C3/C4 — reworked after r1):** replay-dedup no longer uses a seq/index watermark (unsafe — seq
+  is a forwarder concept, replay boundaries unproven). It now uses **content identity** at the runtime
+  emission layer + **not flushing the death-boundary partial**. Residual risk: the dedup key itself —
+  whether `session/load` replay carries a stable message id (preferred) or only content (fingerprint
+  fallback, with collision risk for identical turns). **C0 probe resolves this before code**; a
+  deterministic died-mid-transcript→replay→dedup test locks it.
+- **R2b (C1 restructure):** making the runtime swap its process + defer finalize touches AI-688's
+  teardown ordering (`ReadOutputAsync`→finalize, `AcpCts`, `_updates` completion, binding unregister).
+  Highest-blast-radius change; isolated to PR3 with focused tests, and re-scopable if C0 fails.
 - **R3 (B2):** metrics have no exporter yet — acceptable per acceptance ("enough to diagnose",
   observable via `dotnet-counters`); a real exporter is out of scope.
 - **R4:** reconnect could mask a genuinely-crashing agent by relaunching repeatedly — the bounded

--- a/docs/ai-689-design.md
+++ b/docs/ai-689-design.md
@@ -93,6 +93,16 @@ Stop discarding the `initialize` result; parse it into a typed `InitializeResult
 
 ## 4. Workstream C — ACP process reconnect/resume (PR 3)
 
+> **DESCOPED from AI-689 → follow-up issue AI-1325 (owner decision, at the C0 gate).** The C0 live
+> probe found cursor-agent's `session/load` replay carries **no per-message id**, so the
+> streaming-preserving dedup (C3(a)) is impossible; the only viable path is C3(b) whole-turn atomic
+> staging, which regresses within-turn live streaming for **all** hosted-Cursor sessions. Rather than
+> ship that regression, reconnect is deferred (revisit if ACP adds a per-message / round-tripped
+> prompt id, or if the tradeoff is explicitly accepted). This section is **retained as the
+> design-of-record for AI-1325** — the full C0–C9 contract below is Codex-reviewed-to-clean (10 rounds)
+> and remains correct; AI-1325 narrows C3 to the C3(b) path. AI-689 itself ships as PR4 (docs, this
+> branch) + PR1 diagnostics (#316) + PR2 observability (#317).
+
 The heart of Full scope, and — per spec-review r1 (3 BLOCKING) — the part that needs a real design,
 not a bullet list. Today a mid-session `cursor-agent` death ends the read loop, faults pending
 requests, and drives finalization. The three findings below are load-bearing; the revised design

--- a/docs/ai-689-design.md
+++ b/docs/ai-689-design.md
@@ -132,8 +132,12 @@ answers each.
     **complete-turn count + order** enabling
     occurrence-safe **turn-ordinal** dedup, which REQUIRES the whole-turn staging model in C3 (and its
     streaming tradeoff). A pure content fingerprint is rejected (r2-review B1 — no occurrence identity).
-  - **Boundary-turn completeness** (r3-review B4): the turn interrupted mid-prompt must reappear
-    **complete** in the replay (not truncated), else C4's discard-and-replay is unsound.
+  - **Boundary-turn shape (drives C8's three-way routing — r3-review B4, r7-review 1):** kill mid-prompt
+    and record which of three shapes the interrupted turn takes in the replay — **absent**, **user-only
+    / no terminal assistant state (incomplete)**, or **complete (terminal assistant state / `StopReason`
+    present)**. This mapping is exactly what C8 routes on (ABSENT→requeue, PRESENT-COMPLETE→no requeue,
+    PRESENT-INCOMPLETE→surface-as-interrupted), so it must be observed, not assumed. Also confirm a
+    *fully* completed turn reappears complete (not truncated), else C3/C4 dedup is unsound.
   - **A protocol-backed closed-world end-of-replay barrier** (r3-review B4, r5-review 3, r6-review 1):
     C0 must establish a signal ACP itself **guarantees** is terminal for replay — the `session/load`
     response contract, an explicit EOF, or a terminal notification — after which **no further replay
@@ -142,7 +146,10 @@ answers each.
     period would fire *after* the same occurrence id was already requeued, recreating the duplicate.
     C8's check and the C6 gate reopen run ONLY after this protocol-backed barrier. **If ACP provides no
     protocol-backed barrier, PRESENT/ABSENT is undecidable → C8 uses the at-most-once fallback and/or
-    reconnect re-scopes** — never a heuristic barrier.
+    reconnect re-scopes** — never a heuristic barrier. *(Encouraging: ACP v1 documents `session/load` as
+    responding only after all conversation entries have streamed — i.e. its response is a protocol-
+    backed closed-world barrier — so this is likely satisfiable; C0 confirms it against the real
+    `cursor-agent`.)*
   **If C0 fails any of these, reconnect is re-scoped to a follow-up issue and NOT shipped** — A/B/D
   stand alone. No reconnect code lands until C0 answers all three.
 
@@ -264,13 +271,27 @@ answers each.
 - **C8 — prompt commit: requeue-vs-replay for the interrupted turn (addresses r4-review 1, r5-review 1).**
   ACP has no per-prompt ack, so a crash during an active `session/prompt` leaves the prompt's fate
   unknown from the wire. **Primary rule (requires the C0 client-generated prompt-occurrence-id):** after
-  `session/load` + the C0 **closed-world** end-of-replay barrier, look for the interrupted prompt's
-  **occurrence id** (minted+persisted before the first write, C0) on the replayed user turn. **Found →
-  the agent has it: do NOT requeue** (replay carries the turn; C3 forwards any new part). **Not found →
-  the agent never got it: requeue exactly once**, carrying the *same* occurrence id (so a second crash
-  during the requeue is itself decidable — the retry-after-failed-requeue case). This is decidable only
-  because the check runs strictly after the closed-world barrier (no mid-replay window) and keys on the
-  pre-write occurrence id (not prompt text) — so it is correct even for **repeated identical prompts**.
+  `session/load` + the C0 **closed-world** end-of-replay barrier, decide **three ways** (r7-review 1 —
+  "present" ≠ "complete", because ACP `session/load` does NOT auto-resume an interrupted turn; a new
+  `session/prompt` starts a *new* turn):
+  - **ABSENT** (occurrence id not in the replay): the agent never got it → **requeue exactly once**,
+    carrying the *same* occurrence id (so a crash during the requeue is itself decidable).
+  - **PRESENT-COMPLETE** (occurrence id present AND its turn reached a terminal assistant state /
+    `StopReason` in the replay): fully handled → **do NOT requeue** (replay carries it; C3 forwards any
+    new part).
+  - **PRESENT-INCOMPLETE** (occurrence id present but the turn has **no terminal assistant state** in
+    the replay): the prompt is *stranded* — `session/load` will not finish it, and blind-requeuing the
+    same content would duplicate the user message in the agent's context. So: **do NOT auto-requeue and
+    do NOT silently drop** — surface it to the user as an interrupted turn to re-send (the at-most-once
+    floor for the incomplete case), logged with the occurrence id. (If the product needs automatic
+    continuation of an interrupted turn, that requires an ACP resume primitive ACP v1 does not provide →
+    re-scope; it must not be faked by re-prompting.)
+  Keys on the pre-write occurrence id (not prompt text), and runs strictly after the closed-world
+  barrier — so it is correct even for **repeated identical prompts** and has no mid-replay window.
+  "Terminal assistant state" detection uses the same replayed signal ACP represents turn completion with
+  (the `session/prompt` `StopReason` / a terminal assistant turn); **C0 must characterize which of the
+  three shapes a mid-prompt kill actually produces in the replay** so the routing is grounded, not
+  assumed.
 - **C8 fallback (when C0 yields no usable key — r5-review 1).** If C0 confirms neither an echoed client
   id nor a pre-association ACP turn id, the interrupted turn is **undecidable**, so C8 adopts documented
   **at-most-once** semantics: **do NOT requeue** an interrupted prompt of unknown fate (never silently
@@ -358,7 +379,10 @@ comments; concise; `JsonElementExtensions`; README sync for new env vars).
   the boundary partial is **discarded, not flushed** on the crash fault (C4/C6); a prompt queued during
   reconnect runs **only after** the replay barrier (C6 gate); the interrupted prompt is **requeued iff
   its user turn is absent from the replay** (C8 — assert both branches: present→not requeued,
-  absent→requeued once, carrying the same occurrence id so a requeue-retry is itself decidable);
+  the C8 three-way keyed on the occurrence id at the three crash points: **absent** (before write) →
+  head-requeue once with the same id; **present-complete** (terminal assistant state in replay) → no
+  requeue; **present-incomplete** (user turn but no terminal state) → surfaced as interrupted, NOT
+  auto-requeued and NOT dropped);
   **stop/finalize during an in-progress reconnect** (owner queued, or mid relaunch/initialize/load)
   finalizes exactly once, leaks no candidate child, and emits/requeues nothing post-stop (C7 lock-scope
   + C9 unwind); give-up after N attempts finalizes cleanly. Live `KCAP_ACP_LIVE` end-to-end resume.

--- a/docs/ai-689-design.md
+++ b/docs/ai-689-design.md
@@ -109,18 +109,25 @@ answers each.
 > swap its process as originally described.
 
 - **C0 — replay-identity probe (FIRST step of PR3, and a HARD GATE).** The reconnect design hinges on
-  one unknown the AI-689 probe did not resolve: *what exactly does `session/load` replay, and can a
-  replayed turn be matched to an already-forwarded one?* Probe: establish a multi-turn session
-  (including a deliberately **repeated** identical prompt/answer, to test occurrence identity), kill
-  the process, `session/load`, and capture the replayed `session/update` stream. C0 must establish
-  **one of two viable dedup keys** (r2-review B1): **(a)** a **stable per-message id** carried on each
-  message identically across the original and the replay (preferred); or **(b)** a stable **complete-
-  turn count + order** — i.e. the replay yields the same number of complete turns in the same order
-  (chunk re-coalescing within a turn is fine, since we re-aggregate) — which enables occurrence-safe
-  **ordinal** dedup. **A pure content fingerprint is explicitly rejected** (r2-review B1): it has no
-  occurrence identity and would drop legitimately-repeated content. **If C0 establishes neither (a)
-  nor (b), reconnect is re-scoped to a follow-up issue and NOT shipped** — the other three workstreams
-  (A/B/D) stand on their own. No reconnect code lands until C0 answers this.
+  unknowns the AI-689 probe did not resolve. Probe: establish a multi-turn session (with a deliberately
+  **repeated** identical prompt/answer, to test occurrence identity), then **kill the process DURING an
+  active prompt turn** (not between turns — r3-review B4), `session/load`, and capture the replayed
+  `session/update` stream. C0 must establish ALL of:
+  - **A dedup key**, one of: **(a)** a **stable per-message id** carried identically on each envelope
+    across original and replay (preferred — enables per-envelope dedup that preserves incremental
+    streaming; C0 must also confirm how the **locally-synthesized `UserMessage`** — which we create,
+    not the agent — appears in the replay so we can match it, e.g. by the prompt text we sent, r3-review
+    B1); or **(b)** stable **complete-turn count + order** enabling occurrence-safe **turn-ordinal**
+    dedup, which REQUIRES the whole-turn staging model in C3 (and its streaming tradeoff). A pure
+    content fingerprint is rejected (r2-review B1 — no occurrence identity).
+  - **Boundary-turn completeness** (r3-review B4): the turn interrupted mid-prompt must reappear
+    **complete** in the replay (not truncated), else C4's discard-and-replay is unsound.
+  - **An end-of-replay barrier** (r3-review B4): whether the `session/load` *response* reliably means
+    all replay notifications have already arrived. C6 may only open the gate once replay is known
+    complete; if the response is not a barrier, C0 must find the actual signal (e.g. a terminal
+    notification) or the gate cannot safely reopen.
+  **If C0 fails any of these, reconnect is re-scoped to a follow-up issue and NOT shipped** — A/B/D
+  stand alone. No reconnect code lands until C0 answers all three.
 
 - **C1 — reconnect owner + crash-vs-stop.** Introduce an explicit reconnect owner inside the runtime
   (not the orchestrator). Add an `_intentionalStop` flag set by the dispose/stop paths; the read-loop
@@ -139,51 +146,79 @@ answers each.
   Bounded attempts (default 3) with backoff; on give-up, finalize cleanly (today's behavior) with a
   Warning + `acp.reconnects{outcome=failed}`.
 
-- **C3 — occurrence-safe dedup (replaces the seq/index watermark AND the content-fingerprint idea).**
-  Dedup lives in the **runtime's emission layer**, never on our assigned seq (B1) or a positional
-  wire index (r1-B2). The key is whichever C0 validated: **(a)** the **stable per-message id**, or
-  **(b)** the **complete-turn ordinal** — the runtime remembers *how many complete turns it emitted*
-  before the death (N), and on replay re-aggregates into complete turns and emits only those at
-  ordinal > N. Both are **occurrence-safe**: two identical-content turns at different ordinals (or with
-  different ids) are distinct, so legitimately-repeated prompts/answers are NOT dropped (r2-review B1).
-  Re-aggregation makes it robust to within-turn chunk re-coalescing. Genuinely new content (incl. the
-  completed boundary turn, see C4) passes through; already-forwarded turns are dropped. The forwarder
-  seq/ack remains the transport backstop but is explicitly NOT relied on for replay correctness.
-  AI-688 single-flight still holds. (If C0 found neither key, this whole workstream re-scopes — see C0.)
+- **C3 — occurrence-safe dedup, at the right granularity (addresses r3-review B1).** A "turn" is NOT
+  one envelope: the runtime emits a synthesized `UserMessage`, then `ToolCall`/`ToolResult` and
+  completed thought/text runs *incrementally throughout the turn*, and the forwarder dequeues+sends
+  each as it is emitted (`AcpHostedAgentRuntime.cs:421-430,647-666`; `AcpEventTranslator.cs:137-146`).
+  So on a mid-turn death, part of the boundary turn is **already forwarded** — C4 discarding only the
+  open run cannot retract those, and a turn-ordinal `>N` scheme would re-forward them on replay. Two
+  admissible designs, chosen by C0:
+  - **(a) per-envelope stable-id dedup (preferred, streaming-preserving).** Every emitted envelope
+    carries C0's stable id; the runtime keeps the set of already-forwarded ids; each replayed envelope
+    is emitted only if its id is new. Incremental streaming is preserved. Requires the C0
+    synthesized-`UserMessage` matching story.
+  - **(b) whole-turn atomic staging (only if no stable id).** The runtime **buffers all envelopes of a
+    turn** and publishes them to the forwarder **atomically only when `session/prompt` completes**;
+    turn-ordinal `>N` dedup is then sound because turns are all-or-nothing at the forwarder boundary.
+    On a mid-turn crash the entire staged (incomplete) turn is discarded (C4). **Tradeoff:** this
+    removes within-turn incremental streaming to the server (the turn appears at completion), a
+    regression from AI-688's live tail — so (b) is a fallback, and if its tradeoff is unacceptable,
+    reconnect re-scopes rather than ship it.
+  Both are occurrence-safe (identical content at different ids/ordinals stays distinct — r2-review B1).
+  The forwarder seq/ack remains transport backstop, NOT relied on for replay correctness. AI-688
+  single-flight still holds. (If C0 found neither key, the workstream re-scopes — see C0.)
 
-- **C4 — boundary turn: do NOT flush a partial (must override the existing `finally` flush).** At the
-  death boundary the in-flight aggregation run is **discarded, not flushed** (no partial emitted, no
-  fabricated completion), so when `session/load` replays that turn *complete*, C3 emits it exactly
-  once. **Critical (r2-review B2):** this is NOT automatic — today when the read loop ends it faults
-  pending requests (`AcpConnection.cs:163`) and `ProcessTurnAsync`'s `finally { FlushOpenRun(); }`
-  (`AcpHostedAgentRuntime.cs:397`) would flush exactly the partial we intend to discard. The reconnect
-  gate (C6) must set the reconnecting state **before** that `finally` runs, and `FlushOpenRun` (or the
-  turn worker's fault path) must check it and **discard instead of flush** while reconnecting. Not
-  wiring this makes C4 a no-op. (If reconnect ultimately fails, the interrupted turn is simply absent —
-  acceptable, better than a forwarded partial that never gets corrected.)
+- **C4 — boundary turn: discard, don't flush (granularity per C3, must override the `finally` flush).**
+  On a mid-turn crash the boundary turn must be dropped from our side so the replay can re-emit it
+  exactly once: under C3(a) discard the open aggregation run (the already-forwarded boundary envelopes
+  are dropped on replay by id-dedup); under C3(b) discard the entire **staged** boundary turn (nothing
+  of it was forwarded). **Critical (r2-review B2):** this is NOT automatic — when the read loop ends it
+  faults pending requests (`AcpConnection.cs:163`) and `ProcessTurnAsync`'s `finally { FlushOpenRun(); }`
+  (`AcpHostedAgentRuntime.cs:397`) would flush/publish exactly what we intend to discard. The reconnect
+  state (C6) must be set **before** that `finally` runs, and the flush/publish path must check it and
+  **discard instead** while reconnecting. Not wiring this makes C4 a no-op. (If reconnect ultimately
+  fails, the interrupted turn is simply absent — acceptable, better than an uncorrectable partial.)
 
 - **C5 — interaction vs SignalR re-bind.** C-reconnect (agent process) is orthogonal to the existing
   `ReBindAcpSessionsAsync` (SignalR server binding). A pure process resume keeps the same
   agentId/sessionId, so the existing SignalR binding stays valid — no re-bind needed. Documented so the
   two mechanisms aren't conflated.
 
-- **C6 — reconnect gate around the turn worker (addresses r2-review B2).** A single-process assumption
-  is baked into the turn worker: `ProcessTurnAsync` catches a prompt fault, runs its `finally`, and
-  keeps draining `_pendingTurns` (`AcpHostedAgentRuntime.cs:397,:421`), and `SendPromptAsync` uses the
-  swappable `_connection` directly (`:493`). Reconnect therefore needs an explicit **gate**, not just a
-  parked `ReadOutputAsync`:
-  1. A `Reconnecting` state (set by C1 on a crash-triggering read-loop end, cleared after
-     `session/load` succeeds or reconnect is abandoned).
-  2. The turn worker **awaits the gate before dequeuing/sending each turn**, and `SendUserInputAsync`
-     (and key/resize) awaits it too — so no queued prompt runs against a dead or half-swapped
-     connection. The connection/process swap happens only while the gate is closed.
-  3. The crash fault path enters `Reconnecting` **before** `ProcessTurnAsync`'s `finally` runs, so the
-     `finally`/`FlushOpenRun` discards the boundary partial (C4) instead of flushing it.
+- **C6 — reconnect gate + a guaranteed happens-before (addresses r2-review B2, r3-review B2).** A
+  single-process assumption is baked into the turn worker: `ProcessTurnAsync` catches a prompt fault,
+  runs its `finally`, and keeps draining `_pendingTurns` (`AcpHostedAgentRuntime.cs:397,:421`);
+  `SendPromptAsync` uses the swappable `_connection` (`:493`). Reconnect needs an explicit gate:
+  1. A `Reconnecting` state; the turn worker **awaits the gate before dequeuing/sending each turn**, and
+     `SendUserInputAsync`/key/resize await it too — no queued prompt runs against a dead or half-swapped
+     connection; the process/connection swap happens only while the gate is closed; the gate reopens
+     **only after C0's end-of-replay barrier** (not merely on `session/load` returning).
+  2. **The happens-before is NOT free (r3-review B2).** `AcpConnection.RunAsync` faults pending requests
+     in its OWN `finally` (`AcpConnection.cs:147-165`) before the outer runtime observes `RunAsync`
+     ended, so the prompt continuation (→ `ProcessTurnAsync.finally` flush) and the runtime continuation
+     race — the flush can win. The fix is an explicit **pre-fault hook**: `AcpConnection` invokes a
+     `BeginReconnect` callback **before** it faults pending requests, and that callback atomically sets
+     `Reconnecting` AND starts the reconnect owner. Only then does it fault pending requests. This makes
+     "`Reconnecting` set before any `finally` runs" a guarantee, not a hope.
+  3. **Write-side faults too (r3-review B2):** a `SendPromptAsync`/write failure must funnel through the
+     same `BeginReconnect` — otherwise a send failure closes nothing and no read-loop exit ever starts
+     reconnect. `BeginReconnect` must be idempotent (read- and write-side may both fire).
   4. On give-up, the gate opens into the terminal path (worker completes, `_updates` completes,
-     orchestrator finalizes) — the same disposition as an intentional stop.
-  This gate is the concrete coupling point between C1 (crash-vs-stop), C2 (swap), and C4 (discard); the
-  test suite must cover "prompt queued during reconnect runs only after resume" and "boundary partial
-  discarded, not flushed, on the crash fault".
+     orchestrator finalizes) — same disposition as an intentional stop.
+  This gate is the coupling point between C1/C2/C4; tests must cover "prompt queued during reconnect runs
+  only after the replay barrier", "boundary partial discarded not flushed on the crash fault", and
+  "write-side send failure triggers reconnect".
+
+- **C7 — intentional stop serialized against an in-progress relaunch (addresses r3-review B3).** Stop
+  today calls `RequestGracefulStopAsync`/`WaitForExitAsync`/`TerminateAsync` against the *current*
+  connection/process (`AcpHostedAgentRuntime.cs:509-523`; `AgentOrchestrator.cs:937-963,1569-1576`). A
+  stop arriving mid-reconnect would target the dead child while the reconnect owner then installs
+  another — delaying finalization or leaking that child. Setting `_intentionalStop` (C1) is not enough;
+  stop must, under one lock governing reconnect: (i) **cancel** the reconnect owner's backoff/handshake
+  (a dedicated reconnect `CancellationTokenSource` stop cancels), (ii) **prevent any further launch or
+  swap** (checked after the cancellation point, before installing a candidate), (iii) **dispose any
+  in-flight candidate child** already spawned by the current attempt, and (iv) **release the parked
+  terminal signal** so finalization proceeds. Reconnect and stop must not both mutate
+  `_connection`/`_process` concurrently.
 
 **Scope note:** C1's runtime restructure (swappable process/connection, deferred finalize, crash-vs-stop
 gating) is the largest single change in AI-689 and touches AI-688's teardown ordering directly. It gets
@@ -252,12 +287,14 @@ comments; concise; `JsonElementExtensions`; README sync for new env vars).
 
 - **R1 (A4):** unauthenticated `cursor-agent` failure shape unverified — confirm via a logged-out
   live probe during PR 1; A4 annotates, never masks.
-- **R2 (C3/C4 — reworked after r1):** replay-dedup no longer uses a seq/index watermark (unsafe — seq
-  is a forwarder concept, replay boundaries unproven). It now uses **content identity** at the runtime
-  emission layer + **not flushing the death-boundary partial**. Residual risk: the dedup key itself —
-  whether `session/load` replay carries a stable message id (preferred) or only content (fingerprint
-  fallback, with collision risk for identical turns). **C0 probe resolves this before code**; a
-  deterministic died-mid-transcript→replay→dedup test locks it.
+- **R2 (C3/C4 — reworked across r1→r3):** replay-dedup uses neither a seq/index watermark (r1 — seq is
+  a forwarder concept) nor a content fingerprint (r2 — no occurrence identity). It is either
+  **per-envelope stable-id dedup** (C3a, preferred, streaming-preserving) or **whole-turn atomic
+  staging + ordinal** (C3b, fallback, with a within-turn-streaming regression), chosen by the C0 hard
+  gate. Residual risk is entirely front-loaded into C0: if it finds neither a stable id (incl. the
+  synthesized-`UserMessage` match) nor stable turn count+order, AND the C3b tradeoff is unacceptable,
+  reconnect re-scopes rather than shipping unsound. A deterministic died-**mid-prompt**→replay→dedup
+  test (occurrence-safety + gate-ordering + boundary-discard cases) locks the chosen path.
 - **R2b (C1 restructure):** making the runtime swap its process + defer finalize touches AI-688's
   teardown ordering (`ReadOutputAsync`→finalize, `AcpCts`, `_updates` completion, binding unregister).
   Highest-blast-radius change; isolated to PR3 with focused tests, and re-scopable if C0 fails.

--- a/docs/ai-689-design.md
+++ b/docs/ai-689-design.md
@@ -113,13 +113,19 @@ answers each.
   **repeated** identical prompt/answer, to test occurrence identity), then **kill the process DURING an
   active prompt turn** (not between turns — r3-review B4), `session/load`, and capture the replayed
   `session/update` stream. C0 must establish ALL of:
-  - **A dedup key**, one of: **(a)** a **stable per-message id** carried identically on each envelope
-    across original and replay (preferred — enables per-envelope dedup that preserves incremental
-    streaming; C0 must also confirm how the **locally-synthesized `UserMessage`** — which we create,
-    not the agent — appears in the replay so we can match it, e.g. by the prompt text we sent, r3-review
-    B1); or **(b)** stable **complete-turn count + order** enabling occurrence-safe **turn-ordinal**
-    dedup, which REQUIRES the whole-turn staging model in C3 (and its streaming tradeoff). A pure
-    content fingerprint is rejected (r2-review B1 — no occurrence identity).
+  - **A dedup key**, one of: **(a)** a **per-emitted-envelope, occurrence-safe key** (r4-review 2) —
+    NOT a per-*message* id (one ACP message can fan out to several emitted envelopes — a tool_call +
+    its result, coalesced text runs — so a per-message set would drop valid later envelopes). The key
+    must be a composite that is stable across replay and distinct per emitted envelope, e.g. `agent
+    message id + envelope kind + (tool-call id | run index)`. C0 must confirm such a composite is
+    reconstructable identically on replay, AND — separately — that the **locally-synthesized
+    `UserMessage`** (which we create, not the agent) has its OWN occurrence-safe replayable key:
+    content-matching "by the prompt text" is duplicate-prompt-unsafe and is rejected, so C0 must find a
+    stable correlator on the replayed user turn (e.g. an id on the replayed `user_message_chunk` we can
+    also capture at synthesis time). **If C0 cannot establish the synthesized-user key, C3(a) is
+    DISALLOWED** → fall to C3(b) or re-scope. Or **(b)** stable **complete-turn count + order** enabling
+    occurrence-safe **turn-ordinal** dedup, which REQUIRES the whole-turn staging model in C3 (and its
+    streaming tradeoff). A pure content fingerprint is rejected (r2-review B1 — no occurrence identity).
   - **Boundary-turn completeness** (r3-review B4): the turn interrupted mid-prompt must reappear
     **complete** in the replay (not truncated), else C4's discard-and-replay is unsound.
   - **An end-of-replay barrier** (r3-review B4): whether the `session/load` *response* reliably means
@@ -153,10 +159,12 @@ answers each.
   So on a mid-turn death, part of the boundary turn is **already forwarded** — C4 discarding only the
   open run cannot retract those, and a turn-ordinal `>N` scheme would re-forward them on replay. Two
   admissible designs, chosen by C0:
-  - **(a) per-envelope stable-id dedup (preferred, streaming-preserving).** Every emitted envelope
-    carries C0's stable id; the runtime keeps the set of already-forwarded ids; each replayed envelope
-    is emitted only if its id is new. Incremental streaming is preserved. Requires the C0
-    synthesized-`UserMessage` matching story.
+  - **(a) per-envelope composite-key dedup (preferred, streaming-preserving).** Every emitted envelope
+    carries C0's **per-envelope composite key** (`message id + kind + tool-call-id|run-index`, r4-review
+    2 — never a bare per-message id, which would drop the 2nd+ envelope of one message); the runtime
+    keeps the set of already-forwarded keys; each replayed envelope is emitted only if its key is new.
+    Incremental streaming is preserved. The synthesized `UserMessage` uses the C0-validated synthetic-
+    user key (if C0 couldn't establish one, C3(a) is disallowed — see C0).
   - **(b) whole-turn atomic staging (only if no stable id).** The runtime **buffers all envelopes of a
     turn** and publishes them to the forwarder **atomically only when `session/prompt` completes**;
     turn-ordinal `>N` dedup is then sound because turns are all-or-nothing at the forwarder boundary.
@@ -201,7 +209,11 @@ answers each.
      "`Reconnecting` set before any `finally` runs" a guarantee, not a hope.
   3. **Write-side faults too (r3-review B2):** a `SendPromptAsync`/write failure must funnel through the
      same `BeginReconnect` — otherwise a send failure closes nothing and no read-loop exit ever starts
-     reconnect. `BeginReconnect` must be idempotent (read- and write-side may both fire).
+     reconnect. **`BeginReconnect` must be synchronous, non-blocking, idempotent, and a no-op once
+     intentional stop is marked** (r4-review 3): it only flips `Reconnecting` + schedules the reconnect
+     owner and returns immediately; ALL blocking work (relaunch, handshake, `session/load`, disposal)
+     runs in the owner, never in the callback and never under the reconnect lock (C7). This is what lets
+     `AcpConnection` call it inline on the pre-fault path without risking a block.
   4. On give-up, the gate opens into the terminal path (worker completes, `_updates` completes,
      orchestrator finalizes) — same disposition as an intentional stop.
   This gate is the coupling point between C1/C2/C4; tests must cover "prompt queued during reconnect runs
@@ -219,6 +231,29 @@ answers each.
   in-flight candidate child** already spawned by the current attempt, and (iv) **release the parked
   terminal signal** so finalization proceeds. Reconnect and stop must not both mutate
   `_connection`/`_process` concurrently.
+
+  **Lock-scope acceptance criteria (r4-review 3 — deadlock avoidance).** The reconnect lock guards ONLY
+  fast, non-blocking state: the `Reconnecting`/`_intentionalStop` flags, cancelling the reconnect CTS,
+  the swap-prevention check, and transferring ownership of a candidate child. It is NEVER held across
+  connection I/O, a request await, a process wait (`WaitForExitAsync`), or a potentially-blocking
+  disposal (`TerminateAsync`) — those run OUTSIDE the lock. Otherwise the r4-review-3 deadlock occurs:
+  stop holds the lock awaiting graceful-stop/exit while `AcpConnection`'s pre-fault `BeginReconnect`
+  blocks on the same lock before it can fault pending requests, so the request stop is waiting on never
+  faults. Because `BeginReconnect` is synchronous/non-blocking and a no-op after stop (C6.3) and all
+  blocking teardown runs outside the lock, the pre-fault hook and an in-progress stop cannot block each
+  other.
+
+- **C8 — prompt commit: requeue-vs-replay for the interrupted turn (addresses r4-review 1).** ACP has
+  no per-prompt ack, so when a crash interrupts an active `session/prompt` we cannot know from the wire
+  alone whether the agent received/started it. Resolve it *after* resume using replay presence, not a
+  guess: once `session/load` + the C0 end-of-replay barrier complete, check whether the interrupted
+  prompt's **user turn is present in the replay** under the C3 occurrence-safe key. **Present → the
+  agent has it (do NOT requeue; the replay carries the turn, C3 forwards any new part). Absent → the
+  agent never got it (requeue the prompt once).** This single rule covers all three failure windows
+  r4-review 1 names — write failed before acceptance, partial write, or accepted-but-response-faulted —
+  without losing or duplicating the user turn, and it depends on exactly the C0 guarantees (occurrence-
+  safe key + reliable end-of-replay barrier) already required. The requeue is gated by C6 (runs only
+  after the gate reopens on the barrier).
 
 **Scope note:** C1's runtime restructure (swappable process/connection, deferred finalize, crash-vs-stop
 gating) is the largest single change in AI-689 and touches AI-688's teardown ordering directly. It gets
@@ -280,8 +315,11 @@ comments; concise; `JsonElementExtensions`; README sync for new env vars).
   while ordinal > N forwards (assert no duplicate envelopes reach the forwarder, AND that a
   legitimately-repeated identical turn is NOT dropped — the occurrence-safety case from r2-review B1);
   the boundary partial is **discarded, not flushed** on the crash fault (C4/C6); a prompt queued during
-  reconnect runs **only after** resume (C6 gate); give-up after N attempts finalizes cleanly. Live
-  `KCAP_ACP_LIVE` end-to-end resume.
+  reconnect runs **only after** the replay barrier (C6 gate); the interrupted prompt is **requeued iff
+  its user turn is absent from the replay** (C8 — assert both branches: present→not requeued,
+  absent→requeued once); an **intentional stop during an in-progress reconnect** finalizes without
+  deadlock and without leaking a candidate child (C7 lock-scope); give-up after N attempts finalizes
+  cleanly. Live `KCAP_ACP_LIVE` end-to-end resume.
 
 ## 8. Risks / open questions
 

--- a/docs/ai-689-gap-analysis.md
+++ b/docs/ai-689-gap-analysis.md
@@ -1,0 +1,77 @@
+# AI-689 — ACP hardening & docs: gap analysis + proposed decomposition
+
+Parent epic **AI-682**. Follows the now-merged AI-684 (foundation), AI-686 (permission/elicitation
+bridge), AI-687 (fs/terminal capability), AI-688 (Cursor prototype + transcript forwarding). This
+work is entirely in **kcap-cli** (the daemon). Branch `ai-689-acp-hardening-docs` off `origin/main`
+(`f724432`, includes both merges).
+
+The issue is broad (5pts, six scope items). A full inventory of the merged ACP code shows AI-688 did
+most of the *hardening* heavy-lifting, so the real remaining work is narrower and centers on
+**diagnostics, protocol-version negotiation, operator docs, observability, and a couple of privacy
+fixes** — not another pass over cancellation/reconnect/cleanup.
+
+## What's already done (do NOT redo)
+
+- **Item 1 hardening — mostly complete (AI-688).** Per-agent `CancellationTokenSource`; ordered
+  `DisposeAsync` teardown; bounded channels (`_updates`/`_transcript` 2000 DropOldest, `_pendingTurns`
+  50 DropWrite) with drop-count Warnings; fault isolation on all loops; bounded re-bind retry
+  (3×250ms) with unregister-on-give-up, gated before `IsReady`; forwarder seq/ack + gap-resend +
+  terminal-drop + hot-loop guard + bounded send-retry; child-process SIGTERM→kill + stderr-drain
+  deadlock avoidance; malformed-frame resilience (skip-and-continue, never kills the read loop);
+  inbound server-request answered exactly once (`-32601`/`-32603`/fallback). Handshake failures
+  rethrow a clear wrapped exception and the factory disposes a half-started child.
+- **Item 5 privacy — partially done.** Wire envelope is structured with **no** `Raw`/`rawInput`/
+  `rawOutput` field; `AcpConnection` logs frame *shape* only (never params/content); AI-687
+  fs/terminal decline; fail-closed permission mapping; session-id-from-params fail-safe.
+
+## Genuine remaining work (the real AI-689)
+
+| # | Gap | Evidence |
+|---|---|---|
+| 2a | **Protocol-version negotiation is entirely absent.** We send `protocolVersion:1` but discard the `initialize` response and never validate the agent's version. | `AcpHostedAgentRuntime.cs:271` discards result; `:264` sends v1 |
+| 2b | **Missing-binary is silent.** `cursor-agent` not found → vendor silently omitted, no operator message pointing at `KCAP_CURSOR_PATH`. | `AcpHostedAgentRuntimeFactory.cs:40`; `DaemonRunner.cs:286-290` |
+| 2c | **Auth / no-Team-subscription failures** surface only as cursor-agent stderr at Debug or a generic handshake error — no actionable messaging. (Real-world message quality unverified — the AI-684 probe never hit an unauthenticated agent.) | `AcpChildProcess.cs:54`; `AcpHostedAgentRuntime.cs:284` |
+| 3a | **No Info-level operational logging** for ACP launch / session-started / capability-negotiated / interaction outcome. Operator at default level sees nothing unless something fails. | ACP files: 0 Info, ~22 Debug, 6 Warning |
+| 3b | **Two Debug payload-leak vectors** (unredacted content): the Unknown-kind full-raw-update dump, and cursor-agent stderr. | `AcpEventTranslator.cs:106-108`; `AcpChildProcess.cs:54` |
+| 4 | **Essentially no operator docs** for the hosted-Cursor/ACP path: no `cursor-agent acp` / version / Team-tier requirement, no limitations (no local-attach input/keys/resize/terminal output), no troubleshooting. Only 2 env vars documented; the recording-hooks Cursor path is easily confused with the hosted path. | `README.md:493, 591-598, 687-696`; `docs/` are design-only |
+| 5b | **No documented ACP data-handling posture** (transcript forwards verbatim prompt/tool-args/results, same as every agent — needs to be stated, not silently true). | `AcpHostedAgentRuntime.cs:565,615-632` |
+
+## Scope-fork decisions (need your call)
+
+These three are genuine forks where the evidence points toward keeping AI-689 lean; I recommend
+deferring each and documenting why, but they're yours to set.
+
+- **D1 — Metrics infrastructure.** There is **no** metrics/telemetry stack anywhere in the repo
+  (no `System.Diagnostics.Metrics`, no `Meter`, no exporter — only ad-hoc `Interlocked` counters).
+  The acceptance criterion is "logs/metrics **enough to diagnose** launch/protocol failures," which
+  **Info-level structured logging satisfies**. Building a metrics stack (with AOT care) has no
+  existing consumer/exporter. **Recommend: Info-logging only now; defer a metrics stack** (separate
+  issue if/when there's a consumer).
+- **D2 — Raw-debug stream (Item 6).** None exists today. The acceptance criterion is "privacy-
+  sensitive raw capture is **absent by default** or opt-in with limits" — **absent already
+  satisfies it.** **Recommend: don't build raw capture; document the shape-only posture + close the
+  two Debug leak vectors (3b).** (An opt-in gated full-frame trace could be a later diagnostic
+  nicety, not needed for dogfooding.)
+- **D3 — ACP process reconnect (Item 1 residual).** Relaunching/resuming a dead `cursor-agent`
+  mid-session is a **feature**, not hardening — today a dead child cleanly finalizes the session
+  (acceptable for dogfooding). `AcpTranscriptForwarder.cs:51` already flags "deeper reconnect
+  resilience remains AI-689." **Recommend: out of scope for AI-689; spin a follow-up** if dogfooding
+  shows it's needed.
+
+## Proposed lean scope + slicing
+
+If D1/D2/D3 are all "defer" (my recommendation), AI-689 becomes a well-bounded, dogfooding-ready
+change, best delivered as **two PRs**:
+
+- **PR 1 — code (diagnostics + negotiation + observability):** validate `initialize.protocolVersion`
+  with a clear mismatch error (2a); actionable missing-binary + auth/subscription diagnostics (2b/2c);
+  Info-level lifecycle logging via source-gen `[LoggerMessage]`, AOT-safe (3a); close the two Debug
+  leak vectors (3b). Tests for each; NativeAOT gate clean.
+- **PR 2 — docs + security posture:** operator setup for the hosted-Cursor/ACP path, `cursor-agent
+  acp` + version + Team-tier requirement, env vars, limitations, troubleshooting (4); a short
+  documented ACP data-handling posture (5b). Pure docs — cheap, unblocks dogfooding, mergeable first.
+
+Acceptance-criteria coverage under this scope: documented setup/failure modes ✓ (PR 2 + 2a-c);
+logs enough to diagnose ✓ (3a/3b + 2a-c); raw capture absent-by-default ✓ (D2 + 3b); Cursor ready for
+routine dogfooding ✓. Deferred with rationale: metrics stack (D1), raw-debug stream (D2), process
+reconnect (D3).


### PR DESCRIPTION
## What & why

Part of the **AI-682 ACP epic**, closing child **AI-689** ("ACP production hardening & docs"). This is **PR 1 of 4** — the docs-only, zero-code-risk slice that unblocks dogfooding — carrying the AI-689 **design-of-record** plus **operator docs** for the hosted-Cursor/ACP path.

### Design-of-record
- `docs/ai-689-gap-analysis.md` — what AI-688 already delivered (most Item-1 hardening) vs the genuine remaining work.
- `docs/ai-689-design.md` — the full four-workstream design (diagnostics + negotiation, observability, reconnect/resume, docs), **Codex spec-reviewed to clean over 10 rounds** (every blocking finding was on the reconnect workstream; it converged to an at-most-once-by-default resume contract with a C0 hard-gate probe + re-scope escape hatch). PRs 2–4 implement it.

### Operator docs (README)
A focused **"Hosted Cursor agents run over ACP"** section under Daemon config settings, documenting **current reality only** (future knobs land with their implementing PR):
- The `cursor` vendor is `cursor-agent acp` launched by the daemon — **distinct from the Cursor recording hooks** (`~/.cursor/hooks.json`), a known point of confusion.
- Requirements: `cursor-agent` on `PATH` (or `KCAP_CURSOR_PATH`); a **logged-in Team-tier Cursor account** (`cursor-agent login`).
- Current limitations (no local-attach input/special-keys/resize, no separate terminal-output stream; Kapacitor advertises no client fs/terminal — AI-687).
- Troubleshooting (missing binary, auth/subscription, model-resolution fallback).
- Data-handling posture (local child process with the daemon's privileges — same as every hosted agent; transcript forwarded verbatim, no ACP-specific redaction).

## Risk
Docs only — no code changes. Nothing to build or test beyond the existing CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
