### PR TITLE
[AI-689] ACP diagnostics + protocol/capability negotiation (PR 2/4)

### DIFF
--- a/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
+++ b/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
@@ -30,6 +30,30 @@ public sealed record ClientCapabilities(
     [property: JsonPropertyName("terminal")] bool           Terminal
 );
 
+/// <summary>
+/// <c>initialize</c> result (AI-689 Workstream A) — <c>AcpHostedAgentRuntime.StartAsync</c>
+/// deserializes the agent's <c>initialize</c> response into this to validate
+/// <see cref="ProtocolVersion"/> (must be <c>1</c>; the daemon speaks no other version yet) and to
+/// capture <see cref="AgentCapabilities"/> for later features (e.g. a reconnect path gated on
+/// <see cref="Acp.AgentCapabilities.LoadSession"/>). Deliberately minimal — the real wire response
+/// also carries <c>promptCapabilities</c>/<c>authMethods</c> (see <c>FakeAcpAgent</c>'s
+/// probe-confirmed fixture), neither of which this workstream needs yet.
+/// </summary>
+public sealed record InitializeResult(
+    [property: JsonPropertyName("protocolVersion")]  int                 ProtocolVersion,
+    [property: JsonPropertyName("agentCapabilities")] AgentCapabilities?  AgentCapabilities
+);
+
+/// <summary>
+/// Agent-advertised capabilities from <c>initialize</c>'s result — only <see cref="LoadSession"/> is
+/// modeled for now (AI-689 Workstream A captures it for a future reconnect path; it does not act on
+/// it yet). <see cref="LoadSession"/> defaults to <see langword="false"/> when the wire omits it,
+/// matching the ACP spec's "absent means unsupported" convention.
+/// </summary>
+public sealed record AgentCapabilities(
+    [property: JsonPropertyName("loadSession")] bool LoadSession = false
+);
+
 public sealed record FsCapabilities(
     [property: JsonPropertyName("readTextFile")]  bool ReadTextFile,
     [property: JsonPropertyName("writeTextFile")] bool WriteTextFile

--- a/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
+++ b/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
@@ -31,13 +31,12 @@ public sealed record ClientCapabilities(
 );
 
 /// <summary>
-/// <c>initialize</c> result (AI-689 Workstream A) — <c>AcpHostedAgentRuntime.StartAsync</c>
-/// deserializes the agent's <c>initialize</c> response into this to validate
-/// <see cref="ProtocolVersion"/> (must be <c>1</c>; the daemon speaks no other version yet) and to
-/// capture <see cref="AgentCapabilities"/> for later features (e.g. a reconnect path gated on
-/// <see cref="Acp.AgentCapabilities.LoadSession"/>). Deliberately minimal — the real wire response
-/// also carries <c>promptCapabilities</c>/<c>authMethods</c> (see <c>FakeAcpAgent</c>'s
-/// probe-confirmed fixture), neither of which this workstream needs yet.
+/// <c>initialize</c> result — <c>AcpHostedAgentRuntime.StartAsync</c> deserializes the agent's
+/// <c>initialize</c> response into this to validate <see cref="ProtocolVersion"/> (must be <c>1</c>;
+/// the daemon speaks no other version yet) and to capture <see cref="AgentCapabilities"/> for later
+/// features (e.g. a reconnect path gated on <see cref="Acp.AgentCapabilities.LoadSession"/>).
+/// Deliberately minimal — the real wire response also carries <c>promptCapabilities</c>/
+/// <c>authMethods</c>, neither of which the daemon needs yet.
 /// </summary>
 public sealed record InitializeResult(
     [property: JsonPropertyName("protocolVersion")]  int                 ProtocolVersion,
@@ -46,8 +45,8 @@ public sealed record InitializeResult(
 
 /// <summary>
 /// Agent-advertised capabilities from <c>initialize</c>'s result — only <see cref="LoadSession"/> is
-/// modeled for now (AI-689 Workstream A captures it for a future reconnect path; it does not act on
-/// it yet). <see cref="LoadSession"/> defaults to <see langword="false"/> when the wire omits it,
+/// modeled for now (captured for a future reconnect path; nothing acts on it yet).
+/// <see cref="LoadSession"/> defaults to <see langword="false"/> when the wire omits it,
 /// matching the ACP spec's "absent means unsupported" convention.
 /// </summary>
 public sealed record AgentCapabilities(

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -898,6 +898,8 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(Acp.InitializeParams))]
 [JsonSerializable(typeof(Acp.ClientCapabilities))]
 [JsonSerializable(typeof(Acp.FsCapabilities))]
+[JsonSerializable(typeof(Acp.InitializeResult))]
+[JsonSerializable(typeof(Acp.AgentCapabilities))]
 [JsonSerializable(typeof(Acp.SessionNewParams))]
 [JsonSerializable(typeof(Acp.SessionPromptParams))]
 [JsonSerializable(typeof(Acp.PromptContentBlock))]

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -283,11 +283,20 @@ public static partial class DaemonRunner {
         // Cursor (which has no IHostedAgentLauncher) is advertised once cursor-agent is installed.
         // The launch dialog filters its vendor selector by this list. Ordered alphabetically so the
         // wire format is stable across restarts.
-        config.SupportedVendors = host.Services.GetServices<IHostedAgentRuntimeFactory>()
+        var runtimeFactories = host.Services.GetServices<IHostedAgentRuntimeFactory>().ToArray();
+
+        config.SupportedVendors = runtimeFactories
             .Where(f => f.IsAvailable())
             .Select(f => f.Vendor)
             .OrderBy(v => v, StringComparer.Ordinal)
             .ToArray();
+
+        // AI-689: IsAvailable()==false silently omits cursor from SupportedVendors above — correct
+        // behavior (the launch dialog just won't offer Cursor), but gave operators no clue WHY. One
+        // Warning at startup (not per-launch) so a missing/misconfigured cursor-agent install is
+        // visible in the daemon's own logs instead of only showing up as an absent vendor downstream.
+        if (ShouldWarnCursorUnavailable(runtimeFactories))
+            LogCursorUnavailable(logger, config.CursorPath);
 
         LogDaemonStarting(logger, config.Name, config.ServerUrl);
 
@@ -413,8 +422,21 @@ public static partial class DaemonRunner {
         _                              => null
     };
 
+    /// <summary>
+    /// AI-689: true when a "cursor" <see cref="IHostedAgentRuntimeFactory"/> is registered but
+    /// reports itself unavailable — the signal for <see cref="RunAsync"/>'s one-time startup
+    /// Warning. Pulled out as a pure predicate over the factory list (rather than inlined in
+    /// <see cref="RunAsync"/>) so it's testable without spinning up the whole DI host that method
+    /// builds.
+    /// </summary>
+    internal static bool ShouldWarnCursorUnavailable(IEnumerable<IHostedAgentRuntimeFactory> factories) =>
+        factories.FirstOrDefault(f => f.Vendor == "cursor") is { } cursorFactory && !cursorFactory.IsAvailable();
+
     [LoggerMessage(Level = LogLevel.Information, Message = "kcap daemon '{Name}' starting, connecting to {ServerUrl}")]
     static partial void LogDaemonStarting(ILogger logger, string name, string serverUrl);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Cursor ACP runtime unavailable: cursor-agent CLI not found (looked for '{CursorPath}'). Cursor will not be offered as a hosted-agent vendor until this is fixed. Set KCAP_CURSOR_PATH to the cursor-agent executable, or install the Cursor CLI, then restart the daemon.")]
+    static partial void LogCursorUnavailable(ILogger logger, string cursorPath);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Previous '{Name}' daemon (PID {Pid}) exited WITHOUT a graceful shutdown — its lock was left for the kernel to release. That is the signature of an uncatchable kill (macOS jetsam/OOM, `kill -9`), a power loss, or a hard native crash; an in-process signal handler cannot record it. If this recurs, run the daemon as a supervised service (`kcap daemon service install`) so it auto-restarts.")]
     static partial void LogPriorUncleanExit(ILogger logger, string name, string pid);

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -291,7 +291,7 @@ public static partial class DaemonRunner {
             .OrderBy(v => v, StringComparer.Ordinal)
             .ToArray();
 
-        // AI-689: IsAvailable()==false silently omits cursor from SupportedVendors above — correct
+        // IsAvailable()==false silently omits cursor from SupportedVendors above — correct
         // behavior (the launch dialog just won't offer Cursor), but gave operators no clue WHY. One
         // Warning at startup (not per-launch) so a missing/misconfigured cursor-agent install is
         // visible in the daemon's own logs instead of only showing up as an absent vendor downstream.
@@ -423,7 +423,7 @@ public static partial class DaemonRunner {
     };
 
     /// <summary>
-    /// AI-689: true when a "cursor" <see cref="IHostedAgentRuntimeFactory"/> is registered but
+    /// True when a "cursor" <see cref="IHostedAgentRuntimeFactory"/> is registered but
     /// reports itself unavailable — the signal for <see cref="RunAsync"/>'s one-time startup
     /// Warning. Pulled out as a pure predicate over the factory list (rather than inlined in
     /// <see cref="RunAsync"/>) so it's testable without spinning up the whole DI host that method

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -149,6 +149,18 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
     sealed class AcpProtocolVersionException(string message) : InvalidOperationException(message);
 
     /// <summary>
+    /// Makes an error message safe to fold into a forwarded launch-failure string: collapses line
+    /// breaks to spaces and caps the length. The source can be an agent-controlled JSON-RPC
+    /// <c>error.message</c> (via <see cref="AcpRpcException"/>), which could otherwise be arbitrarily
+    /// long or multi-line and degrade logs/UI downstream. The full original exception is retained as
+    /// the thrown exception's <c>InnerException</c>, so nothing is lost for daemon-side diagnostics.
+    /// </summary>
+    static string SanitizeForForward(string message, int maxLength = 500) {
+        var oneLine = message.ReplaceLineEndings(" ").Trim();
+        return oneLine.Length <= maxLength ? oneLine : oneLine[..maxLength] + "…";
+    }
+
+    /// <summary>
     /// <paramref name="requestInteraction"/> is optional (AI-686) — when null, matches AI-684's
     /// original behavior exactly: <see cref="AcpConnection.OnServerRequest"/> stays unset, and any
     /// <c>session/request_permission</c>/<c>elicitation/create</c> the agent sends gets the
@@ -291,10 +303,9 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
 
             var initializeResultElement = await _connection.RequestAsync("initialize", initializeParams, ct).ConfigureAwait(false);
 
-            // Defensive: a malformed initialize response (wrong-typed protocolVersion, etc.) must
-            // not surface as a raw JsonException — it falls back to negotiatedVersion 0 below,
-            // which the version check rejects with the same clear, actionable message a real
-            // mismatch would get.
+            // Defensive: a malformed initialize response (wrong-typed protocolVersion, etc.) must not
+            // surface as a raw JsonException. We distinguish a parse failure from a real version
+            // mismatch so the error doesn't misreport a malformed response as "negotiated version 0".
             InitializeResult? initializeResult;
             try {
                 initializeResult = JsonSerializer.Deserialize(initializeResultElement.GetRawText(), CapacitorJsonContext.Default.InitializeResult);
@@ -302,22 +313,22 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
                 initializeResult = null;
             }
 
-            var negotiatedVersion = initializeResult?.ProtocolVersion ?? 0;
-
-            // This build only ever speaks version 1 — fail loud and clearly BEFORE session/new
-            // rather than proceeding against an agent that negotiated something else.
-            if (negotiatedVersion != 1)
+            // This build only ever speaks version 1 — fail loud and clearly BEFORE session/new.
+            if (initializeResult is null)
                 throw new AcpProtocolVersionException(
-                    $"cursor-agent negotiated ACP protocol version {negotiatedVersion}; this build supports version 1 — update kcap or cursor-agent.");
+                    "cursor-agent's initialize response was malformed or omitted protocolVersion; this build supports ACP protocol version 1 — update kcap or cursor-agent.");
+            if (initializeResult.ProtocolVersion != 1)
+                throw new AcpProtocolVersionException(
+                    $"cursor-agent negotiated ACP protocol version {initializeResult.ProtocolVersion}; this build supports version 1 — update kcap or cursor-agent.");
 
             // Missing agentCapabilities defensively means "advertises nothing" (loadSession=false),
             // not a throw — captured for a later reconnect path (only exposed here; nothing acts on
             // it yet).
-            _negotiatedCapabilities = initializeResult?.AgentCapabilities ?? new AgentCapabilities(LoadSession: false);
+            _negotiatedCapabilities = initializeResult.AgentCapabilities ?? new AgentCapabilities(LoadSession: false);
 
             _logger.LogDebug(
                 "ACP: negotiated protocol version {ProtocolVersion}, loadSession={LoadSession}.",
-                negotiatedVersion, _negotiatedCapabilities.LoadSession);
+                initializeResult.ProtocolVersion, _negotiatedCapabilities.LoadSession);
 
             var sessionNewParams = JsonSerializer.SerializeToElement(
                 new SessionNewParams(Cwd: cwd, McpServers: NoMcpServers),
@@ -333,14 +344,15 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
             // Already actionable and NOT an auth issue — rethrow verbatim, without the auth hint.
             throw;
         } catch (Exception ex) when (ex is not OperationCanceledException) {
-            // Preserve the original RPC/parse error verbatim — folded into this message via
-            // ex.Message, with ex kept as InnerException — and append a generic, actionable hint.
-            // Deliberately conservative: the exact wire shape of a logged-out or unsubscribed
-            // cursor-agent failure is unverified, so this does NOT pattern-match specific error text;
-            // a live logged-out probe to pin down the precise shape is a follow-up. Never masks the
-            // original error, only annotates it.
+            // Fold the original error's message into this one (single-lined + length-capped, since an
+            // AcpRpcException carries the agent's arbitrary JSON-RPC error.message and this text is
+            // forwarded to the server/UI via LaunchFailedAsync) and append a generic, actionable hint.
+            // The full original exception is kept as InnerException, so daemon logs retain everything.
+            // Deliberately conservative: the exact wire shape of a logged-out/unsubscribed cursor-agent
+            // failure is unverified, so this does NOT pattern-match specific error text (a live
+            // logged-out probe is a follow-up). Never masks the original error, only annotates it.
             throw new InvalidOperationException(
-                $"ACP handshake (initialize/session-new) failed: {ex.Message} — if this is an auth/subscription issue, run `cursor-agent login` and verify a Team-tier subscription.",
+                $"ACP handshake (initialize/session-new) failed: {SanitizeForForward(ex.Message)} — if this is an auth/subscription issue, run `cursor-agent login` and verify a Team-tier subscription.",
                 ex);
         }
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -141,6 +141,14 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
     AgentCapabilities? _negotiatedCapabilities;
 
     /// <summary>
+    /// A deliberate, already-actionable handshake error (unsupported ACP protocol version) — NOT an
+    /// auth/connection failure. The handshake catch rethrows it unwrapped so the auth/subscription
+    /// hint isn't misapplied to it. Derives from <see cref="InvalidOperationException"/> so callers
+    /// that catch that still see it as one.
+    /// </summary>
+    sealed class AcpProtocolVersionException(string message) : InvalidOperationException(message);
+
+    /// <summary>
     /// <paramref name="requestInteraction"/> is optional (AI-686) — when null, matches AI-684's
     /// original behavior exactly: <see cref="AcpConnection.OnServerRequest"/> stays unset, and any
     /// <c>session/request_permission</c>/<c>elicitation/create</c> the agent sends gets the
@@ -299,7 +307,7 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
             // This build only ever speaks version 1 — fail loud and clearly BEFORE session/new
             // rather than proceeding against an agent that negotiated something else.
             if (negotiatedVersion != 1)
-                throw new InvalidOperationException(
+                throw new AcpProtocolVersionException(
                     $"cursor-agent negotiated ACP protocol version {negotiatedVersion}; this build supports version 1 — update kcap or cursor-agent.");
 
             // Missing agentCapabilities defensively means "advertises nothing" (loadSession=false),
@@ -321,14 +329,16 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
                 throw new InvalidOperationException("ACP session/new response did not contain a sessionId.");
 
             _sessionId = sessionId;
+        } catch (AcpProtocolVersionException) {
+            // Already actionable and NOT an auth issue — rethrow verbatim, without the auth hint.
+            throw;
         } catch (Exception ex) when (ex is not OperationCanceledException) {
-            // Preserve the original RPC/parse/version error verbatim — folded into this message via
-            // ex.Message, with ex itself kept as InnerException — and append a generic, actionable
-            // hint. Deliberately conservative (AI-689 A4): the exact wire shape of a logged-out or
-            // unsubscribed cursor-agent failure is unverified, so this does NOT pattern-match
-            // specific error text; a live logged-out probe to pin down the precise shape is a
-            // follow-up. The hint is appended to EVERY handshake failure (including e.g. a protocol
-            // version mismatch), never masking the original error, only annotating it.
+            // Preserve the original RPC/parse error verbatim — folded into this message via
+            // ex.Message, with ex kept as InnerException — and append a generic, actionable hint.
+            // Deliberately conservative: the exact wire shape of a logged-out or unsubscribed
+            // cursor-agent failure is unverified, so this does NOT pattern-match specific error text;
+            // a live logged-out probe to pin down the precise shape is a follow-up. Never masks the
+            // original error, only annotates it.
             throw new InvalidOperationException(
                 $"ACP handshake (initialize/session-new) failed: {ex.Message} — if this is an auth/subscription issue, run `cursor-agent login` and verify a Team-tier subscription.",
                 ex);

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -137,6 +137,9 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
     string? _resolvedModel;
     int     _disposed;
 
+    /// <summary>Agent capabilities negotiated by <see cref="StartAsync"/>'s <c>initialize</c> call; null before that.</summary>
+    AgentCapabilities? _negotiatedCapabilities;
+
     /// <summary>
     /// <paramref name="requestInteraction"/> is optional (AI-686) — when null, matches AI-684's
     /// original behavior exactly: <see cref="AcpConnection.OnServerRequest"/> stays unset, and any
@@ -227,6 +230,16 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
     /// <inheritdoc cref="IAcpTranscriptSource.ResolvedModel"/>
     public string? ResolvedModel => _resolvedModel;
 
+    /// <summary>
+    /// Agent capabilities negotiated by <see cref="StartAsync"/>'s <c>initialize</c> call; null
+    /// before <see cref="StartAsync"/> resolves. Captured for a later reconnect path (gated on
+    /// <see cref="AgentCapabilities.LoadSession"/>) — this workstream only captures and exposes it.
+    /// </summary>
+    public AgentCapabilities? NegotiatedCapabilities => _negotiatedCapabilities;
+
+    /// <summary>Convenience projection of <see cref="NegotiatedCapabilities"/>'s <c>loadSession</c> flag — false before <see cref="StartAsync"/> resolves, or if the agent didn't advertise it.</summary>
+    public bool SupportsLoadSession => _negotiatedCapabilities?.LoadSession ?? false;
+
     /// <inheritdoc cref="IAcpTranscriptSource.Envelopes"/>
     public ChannelReader<AcpEventEnvelope> Envelopes => _transcript.Reader;
 
@@ -268,7 +281,35 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
                         Terminal: false)),
                 CapacitorJsonContext.Default.InitializeParams);
 
-            await _connection.RequestAsync("initialize", initializeParams, ct).ConfigureAwait(false);
+            var initializeResultElement = await _connection.RequestAsync("initialize", initializeParams, ct).ConfigureAwait(false);
+
+            // Defensive: a malformed initialize response (wrong-typed protocolVersion, etc.) must
+            // not surface as a raw JsonException — it falls back to negotiatedVersion 0 below,
+            // which the version check rejects with the same clear, actionable message a real
+            // mismatch would get.
+            InitializeResult? initializeResult;
+            try {
+                initializeResult = JsonSerializer.Deserialize(initializeResultElement.GetRawText(), CapacitorJsonContext.Default.InitializeResult);
+            } catch (JsonException) {
+                initializeResult = null;
+            }
+
+            var negotiatedVersion = initializeResult?.ProtocolVersion ?? 0;
+
+            // This build only ever speaks version 1 — fail loud and clearly BEFORE session/new
+            // rather than proceeding against an agent that negotiated something else.
+            if (negotiatedVersion != 1)
+                throw new InvalidOperationException(
+                    $"cursor-agent negotiated ACP protocol version {negotiatedVersion}; this build supports version 1 — update kcap or cursor-agent.");
+
+            // Missing agentCapabilities defensively means "advertises nothing" (loadSession=false),
+            // not a throw — captured for a later reconnect path (AI-689 Workstream A only exposes
+            // it; nothing here acts on it yet).
+            _negotiatedCapabilities = initializeResult?.AgentCapabilities ?? new AgentCapabilities(LoadSession: false);
+
+            _logger.LogDebug(
+                "ACP: negotiated protocol version {ProtocolVersion}, loadSession={LoadSession}.",
+                negotiatedVersion, _negotiatedCapabilities.LoadSession);
 
             var sessionNewParams = JsonSerializer.SerializeToElement(
                 new SessionNewParams(Cwd: cwd, McpServers: NoMcpServers),
@@ -281,7 +322,16 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
 
             _sessionId = sessionId;
         } catch (Exception ex) when (ex is not OperationCanceledException) {
-            throw new InvalidOperationException("ACP handshake (initialize/session-new) failed.", ex);
+            // Preserve the original RPC/parse/version error verbatim — folded into this message via
+            // ex.Message, with ex itself kept as InnerException — and append a generic, actionable
+            // hint. Deliberately conservative (AI-689 A4): the exact wire shape of a logged-out or
+            // unsubscribed cursor-agent failure is unverified, so this does NOT pattern-match
+            // specific error text; a live logged-out probe to pin down the precise shape is a
+            // follow-up. The hint is appended to EVERY handshake failure (including e.g. a protocol
+            // version mismatch), never masking the original error, only annotating it.
+            throw new InvalidOperationException(
+                $"ACP handshake (initialize/session-new) failed: {ex.Message} — if this is an auth/subscription issue, run `cursor-agent login` and verify a Team-tier subscription.",
+                ex);
         }
 
         // Select the requested model (if any) BEFORE the first prompt fires. Awaited, but never

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -311,8 +311,8 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
                     $"cursor-agent negotiated ACP protocol version {negotiatedVersion}; this build supports version 1 — update kcap or cursor-agent.");
 
             // Missing agentCapabilities defensively means "advertises nothing" (loadSession=false),
-            // not a throw — captured for a later reconnect path (AI-689 Workstream A only exposes
-            // it; nothing here acts on it yet).
+            // not a throw — captured for a later reconnect path (only exposed here; nothing acts on
+            // it yet).
             _negotiatedCapabilities = initializeResult?.AgentCapabilities ?? new AgentCapabilities(LoadSession: false);
 
             _logger.LogDebug(

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
@@ -1,4 +1,5 @@
 // test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
+using System.Text.Json;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -125,5 +126,22 @@ public class AcpHostedAgentRuntimeProtocolNegotiationTests {
 
         await Assert.That(ex!.Message).Contains("Unauthorized: no active session");
         await Assert.That(ex.Message).Contains("cursor-agent login");
+    }
+
+    [Test]
+    public async Task StartAsync_MalformedInitializeResult_ThrowsClearVersionError_WithoutAuthHint() {
+        await using var h = new Harness();
+        // A wrong-typed protocolVersion makes the defensive parse throw JsonException internally; it
+        // must fall back to negotiated version 0 (rejected with the clear version error) rather than
+        // surfacing a raw JsonException — and, being a version problem, carry no auth hint.
+        using var doc = JsonDocument.Parse("""{"protocolVersion":"not-a-number","agentCapabilities":{"loadSession":true}}""");
+        h.Fake.SetInitializeResult(doc.RootElement.Clone());
+        h.StartFakeAgentLoop();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard));
+
+        await Assert.That(ex!.Message).Contains("version 1");
+        await Assert.That(ex.Message).DoesNotContain("cursor-agent login");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
@@ -141,7 +141,9 @@ public class AcpHostedAgentRuntimeProtocolNegotiationTests {
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
             () => h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard));
 
-        await Assert.That(ex!.Message).Contains("version 1");
+        await Assert.That(ex!.Message).Contains("malformed");   // reported as a parse failure, not "negotiated version 0"
+        await Assert.That(ex.Message).Contains("version 1");
+        await Assert.That(ex.Message).DoesNotContain("version 0");
         await Assert.That(ex.Message).DoesNotContain("cursor-agent login");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
@@ -75,6 +75,8 @@ public class AcpHostedAgentRuntimeProtocolNegotiationTests {
 
         await Assert.That(ex!.Message).Contains("version 2");
         await Assert.That(ex.Message).Contains("version 1");
+        // A protocol-version mismatch is NOT an auth issue — it must not carry the auth/subscription hint.
+        await Assert.That(ex.Message).DoesNotContain("cursor-agent login");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
@@ -1,0 +1,127 @@
+// test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// AI-689 Workstream A: exercises <see cref="AcpHostedAgentRuntime.StartAsync"/>'s handling of the
+/// <c>initialize</c> response — protocol-version validation (A1), captured
+/// <c>agentCapabilities</c> (A2), and the auth/subscription hint appended to a handshake failure
+/// without masking the original error (A4). Mirrors the <c>AcpHostedAgentRuntimeTests</c> harness
+/// pattern; no real <c>cursor-agent acp</c> process.
+/// </summary>
+public class AcpHostedAgentRuntimeProtocolNegotiationTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    /// <summary>Minimal <see cref="IAcpProcess"/> stand-in — these tests never exercise process exit/terminate.</summary>
+    sealed class FakeAcpProcess : IAcpProcess {
+        public int  Pid       { get; init; } = 4242;
+        public bool HasExited { get; private set; }
+        public int? ExitCode  { get; private set; }
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) =>
+            timeout is { } t ? Task.Delay(t) : Task.Delay(Timeout.InfiniteTimeSpan);
+
+        public Task TerminateAsync(TimeSpan? timeout = null) {
+            HasExited = true;
+            ExitCode  = 0;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    sealed class Harness : IAsyncDisposable {
+        public FakeAcpAgent          Fake    { get; }
+        public AcpConnection         Conn    { get; }
+        public FakeAcpProcess        Process { get; }
+        public AcpHostedAgentRuntime Runtime { get; }
+        public CancellationTokenSource Cts   { get; } = new();
+
+        Task _fakeRunTask = Task.CompletedTask;
+
+        public Harness() {
+            Fake    = new FakeAcpAgent();
+            Conn    = new AcpConnection(Fake.ClientWriteStream, Fake.ClientReadStream, NullLogger.Instance);
+            Process = new FakeAcpProcess();
+            Runtime = new AcpHostedAgentRuntime(Conn, Process, NullLogger.Instance);
+        }
+
+        public void StartFakeAgentLoop() => _fakeRunTask = Fake.RunAsync(Cts.Token);
+
+        public async ValueTask DisposeAsync() {
+            Cts.Cancel();
+            try {
+                await _fakeRunTask.WaitAsync(HangGuard);
+            } catch (OperationCanceledException) {
+                // expected shutdown path
+            }
+            await Runtime.DisposeAsync();
+            await Fake.DisposeAsync();
+            Cts.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task StartAsync_ProtocolVersionMismatch_ThrowsClearVersionError() {
+        await using var h = new Harness();
+        h.Fake.SetInitializeResult(FakeAcpAgent.BuildInitializeResult(protocolVersion: 2, loadSession: true));
+        h.StartFakeAgentLoop();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard));
+
+        await Assert.That(ex!.Message).Contains("version 2");
+        await Assert.That(ex.Message).Contains("version 1");
+    }
+
+    [Test]
+    public async Task StartAsync_LoadSessionTrue_ExposesSupportsLoadSession() {
+        await using var h = new Harness();
+        h.Fake.SetInitializeResult(FakeAcpAgent.BuildInitializeResult(protocolVersion: 1, loadSession: true));
+        h.StartFakeAgentLoop();
+
+        await h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard);
+
+        await Assert.That(h.Runtime.SupportsLoadSession).IsTrue();
+        await Assert.That(h.Runtime.NegotiatedCapabilities).IsNotNull();
+        await Assert.That(h.Runtime.NegotiatedCapabilities!.LoadSession).IsTrue();
+    }
+
+    [Test]
+    public async Task StartAsync_LoadSessionFalse_ExposesSupportsLoadSessionFalse() {
+        await using var h = new Harness();
+        h.Fake.SetInitializeResult(FakeAcpAgent.BuildInitializeResult(protocolVersion: 1, loadSession: false));
+        h.StartFakeAgentLoop();
+
+        await h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard);
+
+        await Assert.That(h.Runtime.SupportsLoadSession).IsFalse();
+    }
+
+    [Test]
+    public async Task StartAsync_AgentCapabilitiesAbsent_ExposesSupportsLoadSessionFalse_AndDoesNotThrow() {
+        await using var h = new Harness();
+        h.Fake.SetInitializeResult(FakeAcpAgent.BuildInitializeResult(protocolVersion: 1, loadSession: null));
+        h.StartFakeAgentLoop();
+
+        await h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard);
+
+        await Assert.That(h.Runtime.SupportsLoadSession).IsFalse();
+    }
+
+    [Test]
+    public async Task StartAsync_InitializeRpcError_SurfacesOriginalErrorAndAuthHint() {
+        await using var h = new Harness();
+        h.Fake.FailNextInitialize(-32000, "Unauthorized: no active session");
+        h.StartFakeAgentLoop();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard));
+
+        await Assert.That(ex!.Message).Contains("Unauthorized: no active session");
+        await Assert.That(ex.Message).Contains("cursor-agent login");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
@@ -54,6 +54,9 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     JsonElement _sessionNewResult = ProbeConfirmedSessionNewResult;
     bool        _failNextSetConfigOption;
 
+    JsonElement                  _initializeResult = ProbeConfirmedInitializeResult;
+    (int Code, string Message)? _failNextInitialize;
+
     readonly List<(string Method, JsonElement? Params)>          _sentServerRequests = new();
     readonly object                                              _sentServerRequestsLock = new();
     JsonElement?                                                 _lastServerRequestResponse;
@@ -172,6 +175,46 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     /// continue with Cursor's default model" handling.
     /// </summary>
     public void FailNextSetConfigOption() => _failNextSetConfigOption = true;
+
+    /// <summary>
+    /// Overrides the <c>initialize</c> response this fake returns for every subsequent
+    /// <c>initialize</c> request (default: <see cref="ProbeConfirmedInitializeResult"/>, protocol
+    /// version 1 with <c>loadSession: true</c>) — AI-689 protocol-negotiation tests use this to
+    /// script a mismatched <c>protocolVersion</c> or a missing/false <c>agentCapabilities</c>.
+    /// <see cref="BuildInitializeResult"/> is the easiest way to build a well-formed override.
+    /// </summary>
+    public void SetInitializeResult(JsonElement result) => _initializeResult = result;
+
+    /// <summary>
+    /// Arranges the NEXT <c>initialize</c> request to be answered with a JSON-RPC error instead of
+    /// a success result (AI-689) — models a logged-out/unsubscribed <c>cursor-agent</c> rejecting
+    /// the handshake, exercising <c>AcpHostedAgentRuntime.StartAsync</c>'s auth/subscription hint.
+    /// </summary>
+    public void FailNextInitialize(int code, string message) => _failNextInitialize = (code, message);
+
+    /// <summary>
+    /// Convenience builder for a caller-controlled <c>initialize</c> result (AI-689) — narrower than
+    /// the full <see cref="ProbeConfirmedInitializeResult"/> fixture, carrying only the two fields
+    /// <c>AcpHostedAgentRuntime.StartAsync</c> actually reads: <paramref name="protocolVersion"/>
+    /// and, when non-null, an <c>agentCapabilities.loadSession</c> flag. Passing
+    /// <paramref name="loadSession"/> as <see langword="null"/> omits <c>agentCapabilities</c>
+    /// entirely, exercising the "missing agentCapabilities" defensive-default path.
+    /// </summary>
+    public static JsonElement BuildInitializeResult(int protocolVersion, bool? loadSession = null) {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream)) {
+            writer.WriteStartObject();
+            writer.WriteNumber("protocolVersion", protocolVersion);
+            if (loadSession is { } ls) {
+                writer.WriteStartObject("agentCapabilities");
+                writer.WriteBoolean("loadSession", ls);
+                writer.WriteEndObject();
+            }
+            writer.WriteEndObject();
+        }
+
+        return JsonDocument.Parse(stream.ToArray()).RootElement.Clone();
+    }
 
     /// <summary>
     /// Convenience builder for a probe-shaped <c>session/new</c> result (AI-688 gap 1) with a
@@ -311,7 +354,12 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
 
         switch (method) {
             case "initialize":
-                await WriteResponseAsync(id, ProbeConfirmedInitializeResult, ct).ConfigureAwait(false);
+                if (_failNextInitialize is { } failInit) {
+                    _failNextInitialize = null;
+                    await WriteErrorResponseAsync(id, failInit.Code, failInit.Message, ct).ConfigureAwait(false);
+                } else {
+                    await WriteResponseAsync(id, _initializeResult, ct).ConfigureAwait(false);
+                }
                 break;
 
             case "session/new":

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerCursorAvailabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerCursorAvailabilityTests.cs
@@ -1,0 +1,57 @@
+// test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerCursorAvailabilityTests.cs
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// AI-689 A3: <c>DaemonRunner.RunAsync</c> silently omits an unavailable vendor from
+/// <c>DaemonConfig.SupportedVendors</c> (correct — the launch dialog just won't offer it), but gave
+/// operators no clue WHY when that vendor is Cursor. <see cref="DaemonRunner.ShouldWarnCursorUnavailable"/>
+/// is the pure predicate extracted from that startup seam so it's testable without spinning up the
+/// full DI host <c>RunAsync</c> builds — this only proves the predicate; the actual
+/// <c>LogCursorUnavailable</c> Warning call at the <c>RunAsync</c> call site is not independently
+/// unit-tested (would require a full host boot).
+/// </summary>
+public class DaemonRunnerCursorAvailabilityTests {
+    /// <summary>Minimal <see cref="IHostedAgentRuntimeFactory"/> stand-in — only <see cref="Vendor"/>/<see cref="IsAvailable"/> matter here.</summary>
+    sealed class FakeRuntimeFactory(string vendor, bool isAvailable) : IHostedAgentRuntimeFactory {
+        public string Vendor             { get; } = vendor;
+        public bool   SupportsUnattended => false;
+
+        public bool IsAvailable() => isAvailable;
+
+        public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) =>
+            throw new NotSupportedException("not exercised by this test");
+    }
+
+    [Test]
+    public async Task ShouldWarnCursorUnavailable_CursorFactoryUnavailable_ReturnsTrue() {
+        IHostedAgentRuntimeFactory[] factories = [
+            new FakeRuntimeFactory("claude", isAvailable: true),
+            new FakeRuntimeFactory("cursor", isAvailable: false),
+        ];
+
+        await Assert.That(DaemonRunner.ShouldWarnCursorUnavailable(factories)).IsTrue();
+    }
+
+    [Test]
+    public async Task ShouldWarnCursorUnavailable_CursorFactoryAvailable_ReturnsFalse() {
+        IHostedAgentRuntimeFactory[] factories = [
+            new FakeRuntimeFactory("claude", isAvailable: true),
+            new FakeRuntimeFactory("cursor", isAvailable: true),
+        ];
+
+        await Assert.That(DaemonRunner.ShouldWarnCursorUnavailable(factories)).IsFalse();
+    }
+
+    [Test]
+    public async Task ShouldWarnCursorUnavailable_NoCursorFactoryRegistered_ReturnsFalse() {
+        IHostedAgentRuntimeFactory[] factories = [
+            new FakeRuntimeFactory("claude", isAvailable: true),
+            new FakeRuntimeFactory("codex", isAvailable: false),
+        ];
+
+        await Assert.That(DaemonRunner.ShouldWarnCursorUnavailable(factories)).IsFalse();
+    }
+}


### PR DESCRIPTION
## What & why

**AI-689** Workstream A — **PR 2 of 4** (diagnostics + protocol/capability negotiation). Design-of-record in [#315](https://github.com/kurrent-io/kcap-cli/pull/315) (`docs/ai-689-design.md`).

Today the daemon **discards** the ACP `initialize` response and gives no operator-facing signal for the common failure modes. This PR makes the handshake informative:

- **A1 — protocol negotiation.** Parse a typed `InitializeResult` (source-gen JSON) instead of discarding the `initialize` response; if the agent negotiates a protocol version ≠ 1, **fail the handshake with a clear, actionable error before `session/new`** (distinct `AcpProtocolVersionException`, rethrown unwrapped). Malformed responses fall back defensively to the same clear error, never a raw `JsonException`.
- **A2 — capability capture.** Capture `agentCapabilities` (esp. `loadSession`) and expose `NegotiatedCapabilities` / `SupportsLoadSession` for the later reconnect PR to gate on. No behavior change yet — just capture (Debug log only; Info-level lifecycle logging is PR 3).
- **A3 — missing-binary diagnostic.** When `cursor-agent` isn't found (so the `cursor` vendor is omitted from `SupportedVendors`), emit a **one-time startup Warning** naming the vendor and pointing at `KCAP_CURSOR_PATH`. Omission behavior unchanged — just made visible.
- **A4 — auth/subscription hint.** A handshake RPC failure now **preserves the original error verbatim** and appends a generic, actionable hint ("run `cursor-agent login` and verify a Team-tier subscription"). Deliberately conservative — no substring pattern-matching (the exact logged-out failure shape is unverified; a live probe is a follow-up), and it never masks the original error. The hint is scoped to real handshake failures — **not** the protocol-version mismatch (that's not an auth issue).

## Tests & gates
New: `AcpHostedAgentRuntimeProtocolNegotiationTests` (version mismatch → clear error with no auth hint; `loadSession` true/false/absent capture; handshake RPC error → original error + auth hint) and `DaemonRunnerCursorAvailabilityTests` (the warn-when-unavailable predicate). `FakeAcpAgent` extended to script a configurable `initialize` result. Full unit suite **2862/2864** (2 pre-existing `KCAP_ACP_LIVE`-gated skips); NativeAOT `osx-arm64` gate warning-free.

## Follow-ups (later AI-689 PRs)
Info-level lifecycle logging + metrics + raw-frame flag (PR 3, observability); reconnect/resume gated on the `loadSession` captured here (PR 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
