### PR TITLE
[AI-689] ACP observability: lifecycle logging + opt-in debug-frame gate + metrics (PR 3/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,12 @@ KCAP_DAEMON_LOG_LEVEL=debug kcap daemon    # env var; read directly, works in an
 
 Accepted values: `trace`, `debug`, `information` (default), `warning`, `error`, `critical`, `none`. The `--log-level` flag wins over the env var when both are set. `Debug` is verbose — it also enables the SignalR client's framework logs — so use it for a diagnostic window rather than steady state.
 
+**Full ACP frame logging (`KCAP_ACP_DEBUG_FRAMES`).** Off by default. When set to `1`/`true`, a hosted Cursor (ACP) session logs full inbound/outbound JSON-RPC frames, raw unrecognized `session/update` payloads, and `cursor-agent` stderr at `Debug` (length-capped); with it off, only their shape (kind + length) is logged. **These frames can contain prompts, tool arguments, and file contents** — enable it only for a diagnostic window, never in a shared or persistently-logged environment. It needs `Debug` logging on to be visible:
+
+```bash
+KCAP_ACP_DEBUG_FRAMES=1 KCAP_DAEMON_LOG_LEVEL=debug kcap daemon
+```
+
 #### Diagnosing a hard death
 
 A daemon killed by an uncatchable `SIGKILL` (macOS **jetsam** / Linux **OOM**, `kill -9`, power loss) or a hard native crash can't log its own exit — the process is gone before any handler runs. Two things help tell those apart from a normal stop:

--- a/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
@@ -14,20 +14,29 @@ namespace Capacitor.Cli.Daemon.Acp;
 /// with <c>RedirectStandardError = true</c> (see <see cref="Services.AcpHostedAgentRuntimeFactory"/>),
 /// and nothing else ever reads that stream — if we didn't drain it here, the OS pipe buffer (~64KB)
 /// would eventually fill and cursor-agent would block on its next stderr write, deadlocking a long
-/// session. The drain loop reads lines until EOF (process exit) or cancellation and logs them at
-/// Debug so cursor-agent diagnostics are still captured, just not on the critical path.
+/// session. The drain loop reads lines until EOF (process exit) or cancellation and logs each line's
+/// LENGTH at Debug by default (stderr can carry paths/prompt fragments/error detail); the full line
+/// text is only logged when the operator opts in via <c>KCAP_ACP_DEBUG_FRAMES</c> (see
+/// <see cref="DaemonConfig.DebugFrames"/>).
 /// </summary>
-internal sealed class AcpChildProcess : IAcpProcess {
+internal sealed partial class AcpChildProcess : IAcpProcess {
     readonly Process                 _process;
     readonly ILogger                 _logger;
+    readonly bool                    _debugFrames;
     readonly CancellationTokenSource _stderrDrainCts = new();
     readonly Task                    _stderrDrainTask;
 
     int _disposed;
 
-    public AcpChildProcess(Process process, ILogger logger) {
-        _process = process;
-        _logger  = logger;
+    /// <param name="debugFrames">
+    /// <c>KCAP_ACP_DEBUG_FRAMES</c> (<see cref="DaemonConfig.DebugFrames"/>) — off by default. When
+    /// on, <see cref="DrainStderrAsync"/> logs full (length-capped) stderr line text at Debug instead
+    /// of just its length; cursor-agent stderr can carry paths/prompt fragments/error detail.
+    /// </param>
+    public AcpChildProcess(Process process, ILogger logger, bool debugFrames = false) {
+        _process     = process;
+        _logger      = logger;
+        _debugFrames = debugFrames;
 
         // Fire-and-forget from the ctor's perspective — DisposeAsync cancels and (best-effort)
         // awaits it. Never let this task fault unobserved; DrainStderrAsync swallows everything
@@ -50,8 +59,15 @@ internal sealed class AcpChildProcess : IAcpProcess {
 
                 if (line is null) break; // EOF — process exited and closed the stream.
 
-                if (line.Length > 0)
-                    _logger.LogDebug("cursor-agent stderr: {Line}", line);
+                if (line.Length == 0) continue;
+
+                // KCAP_ACP_DEBUG_FRAMES gate (Off by default) — stderr can carry paths, prompt
+                // fragments, or error detail, so it is only logged verbatim when explicitly opted in;
+                // otherwise only its length is logged.
+                if (_debugFrames)
+                    LogStderrLineFull(AcpDebugFrameLog.Cap(line));
+                else
+                    LogStderrLineShape(line.Length);
             }
         } catch (OperationCanceledException) {
             // Disposal requested the drain stop — expected, not an error.
@@ -159,4 +175,10 @@ internal sealed class AcpChildProcess : IAcpProcess {
             // Best-effort.
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "cursor-agent stderr: {Line}")]
+    partial void LogStderrLineFull(string line);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "cursor-agent stderr: {Length} chars")]
+    partial void LogStderrLineShape(int length);
 }

--- a/src/Capacitor.Cli.Daemon/Acp/AcpConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpConnection.cs
@@ -50,20 +50,28 @@ internal sealed class AcpRpcException : Exception {
 /// call on the client side (removes the correlation entry and faults the awaiter); it does not by
 /// itself tell the agent to stop working.
 /// </summary>
-internal sealed class AcpConnection : IAsyncDisposable {
+internal sealed partial class AcpConnection : IAsyncDisposable {
     readonly Stream                                                  _writeStream;
     readonly Stream                                                  _readStream;
     readonly ILogger                                                 _logger;
+    readonly bool                                                    _debugFrames;
     readonly ConcurrentDictionary<long, TaskCompletionSource<JsonElement>> _pending = new();
     readonly SemaphoreSlim                                           _writeGate = new(1, 1);
 
     long     _nextId;
     int      _disposed;
 
-    public AcpConnection(Stream writeStream, Stream readStream, ILogger logger) {
+    /// <param name="debugFrames">
+    /// <c>KCAP_ACP_DEBUG_FRAMES</c> (<see cref="DaemonConfig.DebugFrames"/>) — off by default. When
+    /// on, every inbound/outbound JSON-RPC frame is ALSO logged in full (length-capped) at Debug
+    /// (<see cref="LogInboundFrame"/>/<see cref="LogOutboundFrame"/>); the existing shape-only Debug
+    /// logging in <see cref="DispatchLineAsync"/> is unchanged either way.
+    /// </param>
+    public AcpConnection(Stream writeStream, Stream readStream, ILogger logger, bool debugFrames = false) {
         _writeStream = writeStream;
         _readStream  = readStream;
         _logger      = logger;
+        _debugFrames = debugFrames;
     }
 
     /// <summary>Raised for inbound agent→client notifications (e.g. <c>session/update</c>).</summary>
@@ -166,6 +174,13 @@ internal sealed class AcpConnection : IAsyncDisposable {
     }
 
     async Task DispatchLineAsync(string line, CancellationToken ct) {
+        // KCAP_ACP_DEBUG_FRAMES gate (Off by default) — an ACP frame can carry prompt/tool/file
+        // content, so the FULL frame is only ever logged when the operator has explicitly opted in.
+        // This is additive: the shape-only Debug logging further down (unparseable/unrecognized/
+        // wrong-typed frames) is unchanged regardless of this flag.
+        if (_debugFrames)
+            LogInboundFrame(AcpDebugFrameLog.Cap(line));
+
         JsonDocument doc;
 
         try {
@@ -410,6 +425,9 @@ internal sealed class AcpConnection : IAsyncDisposable {
     }
 
     async Task WriteLineAsync(string json, CancellationToken ct) {
+        if (_debugFrames)
+            LogOutboundFrame(AcpDebugFrameLog.Cap(json));
+
         var bytes = Encoding.UTF8.GetBytes(json + "\n");
 
         await _writeGate.WaitAsync(ct).ConfigureAwait(false);
@@ -439,4 +457,10 @@ internal sealed class AcpConnection : IAsyncDisposable {
         await _writeStream.DisposeAsync().ConfigureAwait(false);
         await _readStream.DisposeAsync().ConfigureAwait(false);
     }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "ACP <<< {Frame}")]
+    partial void LogInboundFrame(string frame);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "ACP >>> {Frame}")]
+    partial void LogOutboundFrame(string frame);
 }

--- a/src/Capacitor.Cli.Daemon/Acp/AcpConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpConnection.cs
@@ -425,15 +425,18 @@ internal sealed partial class AcpConnection : IAsyncDisposable {
     }
 
     async Task WriteLineAsync(string json, CancellationToken ct) {
-        if (_debugFrames)
-            LogOutboundFrame(AcpDebugFrameLog.Cap(json));
-
         var bytes = Encoding.UTF8.GetBytes(json + "\n");
 
         await _writeGate.WaitAsync(ct).ConfigureAwait(false);
         try {
             await _writeStream.WriteAsync(bytes, ct).ConfigureAwait(false);
             await _writeStream.FlushAsync(ct).ConfigureAwait(false);
+
+            // Log the outbound frame only after it is actually on the wire — and still under the gate,
+            // so the debug log order matches wire order. A cancelled/failed write skips this, never
+            // leaving a line that implies a frame was sent when it wasn't.
+            if (_debugFrames)
+                LogOutboundFrame(AcpDebugFrameLog.Cap(json));
         } finally {
             _writeGate.Release();
         }

--- a/src/Capacitor.Cli.Daemon/Acp/AcpDebugFrameLog.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpDebugFrameLog.cs
@@ -1,0 +1,24 @@
+namespace Capacitor.Cli.Daemon.Acp;
+
+/// <summary>
+/// Shared length cap for the three <c>KCAP_ACP_DEBUG_FRAMES</c> call sites —
+/// <c>AcpEventTranslator</c>'s unknown-update-kind dump, <c>AcpChildProcess</c>'s stderr drain, and
+/// <c>AcpConnection</c>'s full inbound/outbound frame logging. Even with debug-frame logging
+/// deliberately turned on, a single pathological blob (a huge tool result, a runaway diagnostic
+/// line) must not itself become a log-volume/memory problem — capped independently of the
+/// enclosing log line's own formatting.
+///
+/// The "this may contain sensitive payloads" warning for this flag is emitted once, at daemon
+/// startup, by <c>DaemonRunner</c> — not lazily from these call sites — since
+/// <c>DaemonConfig.DebugFrames</c> is a static, daemon-wide setting resolved once at startup, never
+/// toggled mid-session.
+/// </summary>
+internal static class AcpDebugFrameLog {
+    /// <summary>A few KB — generous for one diagnostic line while still bounding a single dump.</summary>
+    const int MaxChars = 4096;
+
+    public static string Cap(string content) =>
+        content.Length <= MaxChars
+            ? content
+            : content[..MaxChars] + $"...[+{content.Length - MaxChars} chars truncated]";
+}

--- a/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
@@ -107,10 +107,12 @@ internal static partial class AcpEventTranslator {
 
             case AcpUpdateKind.Unknown:
             default:
-                if (logger is not null) {
+                // Gate on IsEnabled(Debug) first so the default path never materializes the raw JSON
+                // (GetRawText allocates the full payload) when Debug logging is disabled.
+                if (logger is not null && logger.IsEnabled(LogLevel.Debug)) {
                     // KCAP_ACP_DEBUG_FRAMES gate (Off by default): the raw update JSON can carry
                     // prompt/tool/file content, so it is only ever logged verbatim when the operator
-                    // has explicitly opted in — otherwise this logs shape (kind + length) only.
+                    // has explicitly opted in — otherwise this logs shape (length) only.
                     if (debugFrames)
                         LogUnknownUpdateFull(logger, AcpDebugFrameLog.Cap(update.Raw?.GetRawText() ?? ""));
                     else

--- a/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
@@ -16,7 +16,7 @@ namespace Capacitor.Cli.Daemon.Acp;
 /// inputs, not derived here). <see cref="Translate"/> never throws: an unmappable/dropped kind
 /// returns <see langword="null"/> rather than fabricating an empty envelope.
 /// </summary>
-internal static class AcpEventTranslator {
+internal static partial class AcpEventTranslator {
     /// <summary>
     /// ACP <c>ToolCallStatus</c> values that represent a FINISHED tool call —
     /// <c>pending</c>/<c>in_progress</c>/a missing status are non-terminal, status-only updates that
@@ -48,8 +48,11 @@ internal static class AcpEventTranslator {
     /// <item><description><see cref="AcpUpdateKind.Plan"/>/<see cref="AcpUpdateKind.AvailableCommands"/>
     /// → always <see langword="null"/> (not transcript content; deferred to AI-689).</description></item>
     /// <item><description><see cref="AcpUpdateKind.Unknown"/> → <see langword="null"/>, but
-    /// <see cref="AcpSessionUpdate.Raw"/> is logged via <paramref name="logger"/> (when supplied) at
-    /// debug level — never silently swallowed.</description></item>
+    /// logged via <paramref name="logger"/> (when supplied) at debug level — never silently
+    /// swallowed. <see cref="AcpSessionUpdate.Raw"/> itself is only logged verbatim when
+    /// <paramref name="debugFrames"/> is <see langword="true"/> (the operator-opt-in
+    /// <c>KCAP_ACP_DEBUG_FRAMES</c>); otherwise only its length is logged, since an unknown update's
+    /// raw JSON can carry prompt/tool/file content.</description></item>
     /// </list>
     /// Every emitted envelope carries <paramref name="seq"/>/<paramref name="timestampIso"/> and the
     /// default <c>ContractVersion = 1</c> (the <see cref="AcpEventEnvelope"/> record's own default —
@@ -60,7 +63,8 @@ internal static class AcpEventTranslator {
             long             seq,
             string           timestampIso,
             string?          aggregatedText = null,
-            ILogger?         logger         = null) {
+            ILogger?         logger         = null,
+            bool             debugFrames    = false) {
         switch (update.Kind) {
             case AcpUpdateKind.AgentMessageChunk:
                 return new AcpEventEnvelope(
@@ -103,12 +107,25 @@ internal static class AcpEventTranslator {
 
             case AcpUpdateKind.Unknown:
             default:
-                logger?.LogDebug(
-                    "ACP: dropping unrecognized session/update kind (Unknown); Raw={Raw}",
-                    update.Raw?.GetRawText());
+                if (logger is not null) {
+                    // KCAP_ACP_DEBUG_FRAMES gate (Off by default): the raw update JSON can carry
+                    // prompt/tool/file content, so it is only ever logged verbatim when the operator
+                    // has explicitly opted in — otherwise this logs shape (kind + length) only.
+                    if (debugFrames)
+                        LogUnknownUpdateFull(logger, AcpDebugFrameLog.Cap(update.Raw?.GetRawText() ?? ""));
+                    else
+                        LogUnknownUpdateShape(logger, update.Raw?.GetRawText()?.Length ?? 0);
+                }
+
                 return null;
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "ACP: dropping unrecognized session/update kind (Unknown); Raw={Raw}")]
+    static partial void LogUnknownUpdateFull(ILogger logger, string raw);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "ACP: dropping unrecognized session/update kind (Unknown); RawLength={RawLength} chars")]
+    static partial void LogUnknownUpdateShape(ILogger logger, int rawLength);
 
     /// <summary>
     /// Builds the daemon-synthesized <c>SessionStarted</c> envelope — NOT derived

--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -26,7 +26,7 @@ namespace Capacitor.Cli.Daemon.Acp;
 /// response is always a well-formed ACP outcome, never a generic JSON-RPC "Internal error" that
 /// would tell the agent nothing about WHY the permission was denied.
 /// </summary>
-internal sealed class AcpInteractionBridge(
+internal sealed partial class AcpInteractionBridge(
         Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> requestInteraction,
         string                                                                       agentId,
         ILogger                                                                      logger
@@ -116,6 +116,11 @@ internal sealed class AcpInteractionBridge(
 
         AcpInteractionDecision decision;
 
+        // Payload-free lifecycle logging — kind + eventual decision ONLY, never the tool
+        // name/args/options content already captured above in interactionRequest.
+        LogInteractionIssued(agentId, "permission");
+        AcpMetrics.RecordBlockingRequest("permission");
+
         try {
             decision = await requestInteraction(interactionRequest, ct).ConfigureAwait(false);
         } catch (OperationCanceledException) {
@@ -132,15 +137,20 @@ internal sealed class AcpInteractionBridge(
             // down (AcpConnection's own catch around the write handles that silently) — this
             // bridge's only job is to make the ATTEMPTED response well-formed.
             logger.LogDebug("ACP: session/request_permission cancelled (connection closing) for agent {AgentId}; defaulting to cancelled", agentId);
+            LogInteractionResolved(agentId, "permission", "cancelled");
 
             return CancelledResult();
         } catch (Exception ex) {
             logger.LogDebug(ex, "ACP: RequestAcpInteractionAsync threw for agent {AgentId}; defaulting to cancelled", agentId);
+            LogInteractionResolved(agentId, "permission", "cancelled");
 
             return CancelledResult();
         }
 
-        return MapPermissionDecision(decision, options);
+        var mapped = MapPermissionDecision(decision, options);
+        LogInteractionResolved(agentId, "permission", OutcomeLabel(mapped));
+
+        return mapped;
     }
 
     async Task<JsonElement?> HandleElicitationAsync(AcpRequest request, CancellationToken ct) {
@@ -197,20 +207,28 @@ internal sealed class AcpInteractionBridge(
 
         AcpInteractionDecision decision;
 
+        LogInteractionIssued(agentId, "elicitation");
+        AcpMetrics.RecordBlockingRequest("elicitation");
+
         try {
             decision = await requestInteraction(interactionRequest, ct).ConfigureAwait(false);
         } catch (OperationCanceledException) {
             // Spec-review Finding 3(b) — same disconnect handling as HandlePermissionAsync above.
             logger.LogDebug("ACP: elicitation/create cancelled (connection closing) for agent {AgentId}; defaulting to cancelled", agentId);
+            LogInteractionResolved(agentId, "elicitation", "cancelled");
 
             return CancelledResult();
         } catch (Exception ex) {
             logger.LogDebug(ex, "ACP: RequestAcpInteractionAsync threw for elicitation on agent {AgentId}; defaulting to cancelled", agentId);
+            LogInteractionResolved(agentId, "elicitation", "cancelled");
 
             return CancelledResult();
         }
 
-        return MapPermissionDecision(decision, options);
+        var mapped = MapPermissionDecision(decision, options);
+        LogInteractionResolved(agentId, "elicitation", OutcomeLabel(mapped));
+
+        return mapped;
     }
 
     /// <summary>
@@ -301,6 +319,14 @@ internal sealed class AcpInteractionBridge(
             new PermissionOutcomeResult(new PermissionOutcomeDto("cancelled")),
             CapacitorJsonContext.Default.PermissionOutcomeResult);
 
+    /// <summary>
+    /// Pulls just the <c>"selected"</c>/<c>"cancelled"</c> discriminator back out of a mapped result
+    /// for the "resolved" lifecycle log — never the chosen <c>optionId</c> or anything else
+    /// payload-shaped.
+    /// </summary>
+    static string OutcomeLabel(JsonElement mapped) =>
+        mapped.GetProperty("outcome").GetProperty("outcome").GetString() ?? "cancelled";
+
     static string? TryGetToolTitle(JsonElement toolCall) =>
         toolCall.ValueKind == JsonValueKind.Object && toolCall.TryGetProperty("title", out var t) && t.ValueKind == JsonValueKind.String
             ? t.GetString()
@@ -310,4 +336,14 @@ internal sealed class AcpInteractionBridge(
         toolCall.ValueKind == JsonValueKind.Object && toolCall.TryGetProperty("toolCallId", out var id) && id.ValueKind == JsonValueKind.String
             ? id.GetString()
             : null;
+
+    // ── LoggerMessage source-generated methods ──────────────────────────────────────────────────
+    // Payload-free by construction: kind ("permission"/"elicitation") and decision
+    // ("selected"/"cancelled") ONLY — never tool name/args, prompt text, or option content.
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ACP blocking request issued: agentId={AgentId} kind={Kind}")]
+    partial void LogInteractionIssued(string agentId, string kind);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ACP blocking request resolved: agentId={AgentId} kind={Kind} decision={Decision}")]
+    partial void LogInteractionResolved(string agentId, string kind, string decision);
 }

--- a/src/Capacitor.Cli.Daemon/Acp/AcpMetrics.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpMetrics.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics.Metrics;
+
+namespace Capacitor.Cli.Daemon.Acp;
+
+/// <summary>
+/// Minimal ACP hosted-agent counters, incremented alongside the Info-level lifecycle logs. No
+/// exporter is wired — these are observable via <c>dotnet-counters monitor -p &lt;pid&gt;
+/// Capacitor.Cli.Daemon.Acp</c> for local troubleshooting. Deliberately does NOT cover reconnect
+/// (no reconnect path exists yet) and stays process-wide/static rather than DI-injected: there is
+/// exactly one of these per daemon process and no test needs to substitute a fake meter.
+/// </summary>
+internal static class AcpMetrics {
+    static readonly Meter Meter = new("Capacitor.Cli.Daemon.Acp");
+
+    public static readonly Counter<long> Launches        = Meter.CreateCounter<long>("acp.launches");
+    public static readonly Counter<long> SessionsStarted = Meter.CreateCounter<long>("acp.sessions_started");
+    public static readonly Counter<long> BlockingRequests = Meter.CreateCounter<long>("acp.blocking_requests");
+    public static readonly Counter<long> Failures         = Meter.CreateCounter<long>("acp.failures");
+
+    /// <summary><paramref name="kind"/> is <c>"permission"</c> or <c>"elicitation"</c> — mirrors <see cref="Daemon.Acp.AcpInteractionBridge"/>'s own kind vocabulary.</summary>
+    public static void RecordBlockingRequest(string kind) =>
+        BlockingRequests.Add(1, new KeyValuePair<string, object?>("kind", kind));
+
+    /// <summary><paramref name="stage"/> is a short token, e.g. <c>"handshake"</c>.</summary>
+    public static void RecordFailure(string stage) =>
+        Failures.Add(1, new KeyValuePair<string, object?>("stage", stage));
+}

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -63,6 +63,19 @@ public class DaemonConfig {
     public string CursorModel { get; set; } = "claude-sonnet-4-5";
 
     /// <summary>
+    /// Opt-in, off-by-default ACP wire/content debug logging (<c>KCAP_ACP_DEBUG_FRAMES</c>). When
+    /// <see langword="false"/> (the default), the ACP layers (<c>AcpEventTranslator</c>,
+    /// <c>AcpChildProcess</c>, <c>AcpConnection</c>) log shape/length only for the traffic that would
+    /// otherwise carry prompt/tool/file content — an unrecognized <c>session/update</c> kind, raw
+    /// <c>cursor-agent</c> stderr lines, and full inbound/outbound JSON-RPC frames. When
+    /// <see langword="true"/>, those same call sites log full (length-capped) content at Debug for
+    /// local troubleshooting — never sent to the server, never written to the transcript. Read from
+    /// the env var in <c>DaemonRunner.RunAsync</c>, which also emits a one-time startup Warning when
+    /// this is on, since the logged content may include sensitive payloads.
+    /// </summary>
+    public bool DebugFrames { get; set; }
+
+    /// <summary>
     /// Path to the kcap CLI binary. Used by the daemon to spawn auxiliary
     /// processes (e.g. <c>generate-whats-done</c>) when claude didn't fire its
     /// own session-end hook. Defaults to "kcap" — resolved via PATH, which

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -436,7 +436,7 @@ public static partial class DaemonRunner {
     /// pure predicate (mirroring <see cref="ParseLogLevel"/>) so it's testable without an env var.
     /// </summary>
     internal static bool ParseDebugFramesFlag(string? value) =>
-        value == "1" || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+        value?.Trim() is { } v && (v == "1" || string.Equals(v, "true", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// True when a "cursor" <see cref="IHostedAgentRuntimeFactory"/> is registered but

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -128,6 +128,8 @@ public static partial class DaemonRunner {
         if (Environment.GetEnvironmentVariable("KCAP_CURSOR_MODEL") is { Length: > 0 } envCursorModel)
             config.CursorModel = envCursorModel;
 
+        config.DebugFrames = ParseDebugFramesFlag(Environment.GetEnvironmentVariable("KCAP_ACP_DEBUG_FRAMES"));
+
         // Shared name resolution with the CLI supervisor — the CLI's
         // DaemonCommands and the daemon binary must agree on the name so
         // the per-name PID file the CLI inspects is the one the daemon
@@ -298,6 +300,12 @@ public static partial class DaemonRunner {
         if (ShouldWarnCursorUnavailable(runtimeFactories))
             LogCursorUnavailable(logger, config.CursorPath);
 
+        // KCAP_ACP_DEBUG_FRAMES is a static, daemon-wide setting read once above — warn once here,
+        // at the point it takes effect, rather than lazily the first time some ACP call site actually
+        // logs full content (which could fire dozens of times across one busy session).
+        if (config.DebugFrames)
+            LogAcpDebugFramesEnabled(logger);
+
         LogDaemonStarting(logger, config.Name, config.ServerUrl);
 
         // AI-1155: if the previous daemon under this name vanished without
@@ -423,6 +431,14 @@ public static partial class DaemonRunner {
     };
 
     /// <summary>
+    /// Parses <c>KCAP_ACP_DEBUG_FRAMES</c> ("1"/"true", case-insensitive, are On; anything else —
+    /// including unset/blank — is Off) into <see cref="DaemonConfig.DebugFrames"/>. Pulled out as a
+    /// pure predicate (mirroring <see cref="ParseLogLevel"/>) so it's testable without an env var.
+    /// </summary>
+    internal static bool ParseDebugFramesFlag(string? value) =>
+        value == "1" || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// True when a "cursor" <see cref="IHostedAgentRuntimeFactory"/> is registered but
     /// reports itself unavailable — the signal for <see cref="RunAsync"/>'s one-time startup
     /// Warning. Pulled out as a pure predicate over the factory list (rather than inlined in
@@ -437,6 +453,9 @@ public static partial class DaemonRunner {
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Cursor ACP runtime unavailable: cursor-agent CLI not found (looked for '{CursorPath}'). Cursor will not be offered as a hosted-agent vendor until this is fixed. Set KCAP_CURSOR_PATH to the cursor-agent executable, or install the Cursor CLI, then restart the daemon.")]
     static partial void LogCursorUnavailable(ILogger logger, string cursorPath);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "KCAP_ACP_DEBUG_FRAMES is enabled — ACP Debug logs may now contain full prompts, tool arguments, and file contents from every hosted Cursor session. Disable in any shared or persistently-logged environment.")]
+    static partial void LogAcpDebugFramesEnabled(ILogger logger);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Previous '{Name}' daemon (PID {Pid}) exited WITHOUT a graceful shutdown — its lock was left for the kernel to release. That is the signature of an uncatchable kill (macOS jetsam/OOM, `kill -9`), a power loss, or a hard native crash; an in-process signal handler cannot record it. If this recurs, run the daemon as a supervised service (`kcap daemon service install`) so it auto-restarts.")]
     static partial void LogPriorUncleanExit(ILogger logger, string name, string pid);

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -33,13 +33,15 @@ namespace Capacitor.Cli.Daemon.Services;
 /// mechanism between the worker's turn-end flush and the connection read-loop's kind-transition
 /// flush.
 /// </summary>
-internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscriptSource {
+internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscriptSource {
     static readonly object[] NoMcpServers = [];
 
     readonly AcpConnection _connection;
     readonly IAcpProcess   _process;
     readonly ILogger       _logger;
     readonly TimeProvider  _timeProvider;
+    readonly string        _agentId;
+    readonly bool          _debugFrames;
     readonly AcpInteractionBridge? _interactionBridge;
     readonly CancellationTokenSource _cts = new();
     // Raw reduced-update surface, used only for test/live-inspection — the production transcript
@@ -140,6 +142,9 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
     /// <summary>Agent capabilities negotiated by <see cref="StartAsync"/>'s <c>initialize</c> call; null before that.</summary>
     AgentCapabilities? _negotiatedCapabilities;
 
+    /// <summary>The <c>protocolVersion</c> negotiated by <see cref="StartAsync"/>'s <c>initialize</c> call — captured purely for the <see cref="LogHandshakeOk"/> lifecycle log; 0 before that.</summary>
+    int _negotiatedProtocolVersion;
+
     /// <summary>
     /// A deliberate, already-actionable handshake error (unsupported ACP protocol version) — NOT an
     /// auth/connection failure. The handshake catch rethrows it unwrapped so the auth/subscription
@@ -188,12 +193,15 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
             Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>>?   requestInteraction = null,
             TimeProvider?                                                                  timeProvider = null,
             int?                                                                           transcriptCapacity = null,
-            int?                                                                           pendingTurnsCapacity = null
+            int?                                                                           pendingTurnsCapacity = null,
+            bool                                                                           debugFrames = false
         ) {
         _connection   = connection;
         _process      = process;
         _logger       = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _agentId      = agentId;
+        _debugFrames  = debugFrames;
 
         // Bounded, not unbounded — see the fields' own remarks for the FullMode rationale.
         // transcriptCapacity/pendingTurnsCapacity are production-null (defaults apply); tests
@@ -313,22 +321,25 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
                 initializeResult = null;
             }
 
-            // This build only ever speaks version 1 — fail loud and clearly BEFORE session/new.
-            if (initializeResult is null)
+            // This build only ever speaks version 1 — fail loud and clearly BEFORE session/new,
+            // distinguishing a malformed/parse-failed response from a real version mismatch.
+            if (initializeResult is null) {
+                AcpMetrics.RecordFailure("handshake");
                 throw new AcpProtocolVersionException(
                     "cursor-agent's initialize response was malformed or omitted protocolVersion; this build supports ACP protocol version 1 — update kcap or cursor-agent.");
-            if (initializeResult.ProtocolVersion != 1)
+            }
+            if (initializeResult.ProtocolVersion != 1) {
+                AcpMetrics.RecordFailure("handshake");
                 throw new AcpProtocolVersionException(
                     $"cursor-agent negotiated ACP protocol version {initializeResult.ProtocolVersion}; this build supports version 1 — update kcap or cursor-agent.");
+            }
+
+            _negotiatedProtocolVersion = initializeResult.ProtocolVersion;
 
             // Missing agentCapabilities defensively means "advertises nothing" (loadSession=false),
             // not a throw — captured for a later reconnect path (only exposed here; nothing acts on
             // it yet).
             _negotiatedCapabilities = initializeResult.AgentCapabilities ?? new AgentCapabilities(LoadSession: false);
-
-            _logger.LogDebug(
-                "ACP: negotiated protocol version {ProtocolVersion}, loadSession={LoadSession}.",
-                initializeResult.ProtocolVersion, _negotiatedCapabilities.LoadSession);
 
             var sessionNewParams = JsonSerializer.SerializeToElement(
                 new SessionNewParams(Cwd: cwd, McpServers: NoMcpServers),
@@ -340,10 +351,16 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
                 throw new InvalidOperationException("ACP session/new response did not contain a sessionId.");
 
             _sessionId = sessionId;
+
+            LogSessionStarted(_agentId, sessionId);
+            AcpMetrics.SessionsStarted.Add(1);
         } catch (AcpProtocolVersionException) {
             // Already actionable and NOT an auth issue — rethrow verbatim, without the auth hint.
+            // Failure already recorded above, at the point the version mismatch was detected.
             throw;
         } catch (Exception ex) when (ex is not OperationCanceledException) {
+            AcpMetrics.RecordFailure("handshake");
+
             // Fold the original error's message into this one (single-lined + length-capped, since an
             // AcpRpcException carries the agent's arbitrary JSON-RPC error.message and this text is
             // forwarded to the server/UI via LaunchFailedAsync) and append a generic, actionable hint.
@@ -359,6 +376,11 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
         // Select the requested model (if any) BEFORE the first prompt fires. Awaited, but never
         // fatal — see TrySelectModelAsync's remarks.
         await TrySelectModelAsync(sessionNewResult, requestedModel, ct).ConfigureAwait(false);
+
+        // Handshake is now fully complete (initialize + session/new + best-effort model selection) —
+        // one consolidated Info log carrying the negotiated protocol version, loadSession, and the
+        // resolved model (null if none was requested/matched).
+        LogHandshakeOk(_agentId, _negotiatedProtocolVersion, _negotiatedCapabilities.LoadSession, _resolvedModel);
 
         // The session is established (initialize + session/new both completed) — the caller
         // (orchestrator) can now treat this agent as live. Enqueue the initial turn without
@@ -732,7 +754,7 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
 
                 default:
                     FlushOpenRunLocked(); // kind-transition — the open run (if any) ends here
-                    var envelope = AcpEventTranslator.Translate(update, seq: 0, NowIso(), logger: _logger);
+                    var envelope = AcpEventTranslator.Translate(update, seq: 0, NowIso(), logger: _logger, debugFrames: _debugFrames);
                     if (envelope is { } e)
                         EmitEnvelope(e);
                     break;
@@ -768,7 +790,7 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
         _openRunText = null;
 
         var representative = new AcpSessionUpdate(kind);
-        var envelope        = AcpEventTranslator.Translate(representative, seq: 0, NowIso(), aggregatedText: text, logger: _logger);
+        var envelope        = AcpEventTranslator.Translate(representative, seq: 0, NowIso(), aggregatedText: text, logger: _logger, debugFrames: _debugFrames);
         if (envelope is { } e)
             EmitEnvelope(e);
     }
@@ -817,6 +839,8 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
+        LogSessionEnded(_agentId, _sessionId ?? "");
+
         _connection.OnNotification -= HandleNotification;
 
         await _cts.CancelAsync().ConfigureAwait(false);
@@ -852,4 +876,17 @@ internal sealed class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscrip
         await _connection.DisposeAsync().ConfigureAwait(false);
         await _process.DisposeAsync().ConfigureAwait(false);
     }
+
+    // ── LoggerMessage source-generated methods ──────────────────────────────────────────────────
+    // Payload-free by construction: ids, protocol/capability metadata, and the resolved model NAME
+    // only — never prompt/assistant/tool content.
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ACP session started: agentId={AgentId} acpSessionId={AcpSessionId}")]
+    partial void LogSessionStarted(string agentId, string acpSessionId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ACP handshake OK: agentId={AgentId} protocolVersion={ProtocolVersion} loadSession={LoadSession} resolvedModel={ResolvedModel}")]
+    partial void LogHandshakeOk(string agentId, int protocolVersion, bool loadSession, string? resolvedModel);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ACP hosted agent session ended: agentId={AgentId} acpSessionId={AcpSessionId}")]
+    partial void LogSessionEnded(string agentId, string acpSessionId);
 }

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -839,7 +839,12 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
-        LogSessionEnded(_agentId, _sessionId ?? "");
+        // Only emit the session-ended lifecycle event when a session actually started — a startup
+        // failure (bad protocol version / handshake / session/new) disposes the runtime before
+        // _sessionId is assigned, and pairing "ended" with a session that never started would make
+        // the lifecycle telemetry incoherent.
+        if (_sessionId is { Length: > 0 } endedSessionId)
+            LogSessionEnded(_agentId, endedSessionId);
 
         _connection.OnNotification -= HandleNotification;
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -25,7 +25,7 @@ namespace Capacitor.Cli.Daemon.Services;
 /// <c>cursor-agent acp</c> child process (unavailable and non-portable in CI) — the seam changes
 /// nothing about production behavior, since the default IS the real `Process.Start`-backed path.
 /// </summary>
-internal sealed class AcpHostedAgentRuntimeFactory(
+internal sealed partial class AcpHostedAgentRuntimeFactory(
         DaemonConfig                                                                   config,
         ILoggerFactory                                                                 loggerFactory,
         ServerConnection                                                               connection,
@@ -34,17 +34,22 @@ internal sealed class AcpHostedAgentRuntimeFactory(
     readonly Func<RuntimeStartContext, (Stream Input, Stream Output, IAcpProcess Process)> _connectionSource =
         connectionSource ?? (ctx => StartRealProcess(config, ctx, loggerFactory));
 
+    readonly ILogger _logger = loggerFactory.CreateLogger<AcpHostedAgentRuntimeFactory>();
+
     public string Vendor             => "cursor";
     public bool   SupportsUnattended => false;
 
     public bool IsAvailable() => CliResolver.Exists(config.CursorPath);
 
     public async Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+        LogLaunching(ctx.AgentId, Vendor, ctx.Worktree.Path);
+        AcpMetrics.Launches.Add(1);
+
         var runtimeLogger = loggerFactory.CreateLogger<AcpHostedAgentRuntime>();
         var connLogger    = loggerFactory.CreateLogger<AcpConnection>();
 
         var (input, output, acpProcess) = _connectionSource(ctx);
-        var acpConnection = new AcpConnection(input, output, connLogger);
+        var acpConnection = new AcpConnection(input, output, connLogger, config.DebugFrames);
 
         // Spec-review Finding 4: real production wiring — every Cursor launch now gets the
         // permission/elicitation bridge, not AI-684's default MethodNotFound/decline.
@@ -53,7 +58,8 @@ internal sealed class AcpHostedAgentRuntimeFactory(
             acpProcess,
             runtimeLogger,
             agentId: ctx.AgentId,
-            requestInteraction: connection.RequestAcpInteractionAsync
+            requestInteraction: connection.RequestAcpInteractionAsync,
+            debugFrames: config.DebugFrames
         );
 
         try {
@@ -112,8 +118,11 @@ internal sealed class AcpHostedAgentRuntimeFactory(
          ?? throw new InvalidOperationException($"Failed to start '{config.CursorPath} acp' (Process.Start returned null).");
 
         var processLogger = loggerFactory.CreateLogger<AcpChildProcess>();
-        var acpProcess    = new AcpChildProcess(process, processLogger);
+        var acpProcess    = new AcpChildProcess(process, processLogger, config.DebugFrames);
 
         return (process.StandardInput.BaseStream, process.StandardOutput.BaseStream, acpProcess);
     }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ACP hosted agent launch: agentId={AgentId} vendor={Vendor} cwd={Cwd}")]
+    partial void LogLaunching(string agentId, string vendor, string cwd);
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpConnectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpConnectionTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
 using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit.Acp;
@@ -31,7 +32,7 @@ public class AcpConnectionTests {
 
         public AcpConnection Connection { get; }
 
-        public Harness() {
+        public Harness(ILogger? logger = null, bool debugFrames = false) {
             // Connection writes requests/notifications/responses into _toAgent; the "agent side"
             // (this harness) reads them from the same pipe.
             _agentReadsFromClient = _toAgent.Reader.AsStream();
@@ -43,7 +44,8 @@ public class AcpConnectionTests {
             Connection = new AcpConnection(
                 writeStream: _toAgent.Writer.AsStream(),
                 readStream: _toClient.Reader.AsStream(),
-                logger: NullLogger<AcpConnection>.Instance
+                logger: logger ?? NullLogger<AcpConnection>.Instance,
+                debugFrames: debugFrames
             );
         }
 
@@ -529,5 +531,114 @@ public class AcpConnectionTests {
         } catch (OperationCanceledException) {
             // expected shutdown path for this test's owned CTS
         }
+    }
+
+    // ── KCAP_ACP_DEBUG_FRAMES gate: full inbound/outbound frame logging ────────────────────────
+
+    /// <summary>Records every log call — mirrors <c>AcpTranscriptAggregationTests.CaptureLogger</c>'s
+    /// established pattern.</summary>
+    sealed class CaptureLogger : ILogger {
+        public readonly List<(LogLevel Level, string Message)> Entries = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool         IsEnabled(LogLevel logLevel)                            => true;
+
+        public void Log<TState>(LogLevel level, EventId id, TState state, Exception? ex, Func<TState, Exception?, string> formatter)
+            => Entries.Add((level, formatter(state, ex)));
+    }
+
+    [Test]
+    public async Task DebugFrames_off_by_default_never_logs_the_full_outbound_or_inbound_frame() {
+        var logger = new CaptureLogger();
+        // debugFrames omitted — proves the default is Off, matching every pre-existing call site.
+        await using var harness = new Harness(logger);
+        using var        cts     = new CancellationTokenSource();
+        var               runTask = harness.Connection.RunAsync(cts.Token);
+
+        var requestTask = harness.Connection.RequestAsync("session/prompt", null, CancellationToken.None);
+        var frame        = await harness.ReadFrameFromConnectionAsync();
+        var id           = JsonDocument.Parse(frame).RootElement.GetProperty("id").GetInt64();
+
+        await harness.WriteFrameToConnectionAsync(
+            $$$"""{"jsonrpc":"2.0","id":{{{id}}},"result":{"stopReason":"end_turn"}}"""
+        );
+        await requestTask.WaitAsync(HangGuard);
+
+        await Assert.That(logger.Entries).DoesNotContain(e => e.Message.Contains("ACP >>>"));
+        await Assert.That(logger.Entries).DoesNotContain(e => e.Message.Contains("ACP <<<"));
+        await Assert.That(logger.Entries).DoesNotContain(e => e.Message.Contains("session/prompt"));
+        await Assert.That(logger.Entries).DoesNotContain(e => e.Message.Contains("stopReason"));
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task DebugFrames_on_logs_the_full_outbound_request_frame() {
+        var logger = new CaptureLogger();
+        await using var harness = new Harness(logger, debugFrames: true);
+        using var        cts     = new CancellationTokenSource();
+        var               runTask = harness.Connection.RunAsync(cts.Token);
+
+        _ = harness.Connection.RequestAsync("session/prompt", null, CancellationToken.None);
+        var frame = await harness.ReadFrameFromConnectionAsync();
+        var id    = JsonDocument.Parse(frame).RootElement.GetProperty("id").GetInt64();
+
+        await Assert.That(logger.Entries).Contains(e =>
+            e.Level == LogLevel.Debug && e.Message.Contains("ACP >>>") && e.Message.Contains("session/prompt"));
+
+        // Clean shutdown: still owe the pending request a response before disposing.
+        await harness.WriteFrameToConnectionAsync($$$"""{"jsonrpc":"2.0","id":{{{id}}},"result":{}}""");
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task DebugFrames_on_logs_the_full_inbound_notification_frame() {
+        var logger = new CaptureLogger();
+        await using var harness = new Harness(logger, debugFrames: true);
+        using var        cts     = new CancellationTokenSource();
+        var               runTask = harness.Connection.RunAsync(cts.Token);
+
+        var tcs = new TaskCompletionSource<AcpNotification>(TaskCreationOptions.RunContinuationsAsynchronously);
+        harness.Connection.OnNotification += n => tcs.TrySetResult(n);
+
+        await harness.WriteFrameToConnectionAsync(
+            """{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"abc-secret-marker"}}"""
+        );
+        await tcs.Task.WaitAsync(HangGuard);
+
+        await Assert.That(logger.Entries).Contains(e =>
+            e.Level == LogLevel.Debug && e.Message.Contains("ACP <<<") && e.Message.Contains("abc-secret-marker"));
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task DebugFrames_on_does_not_regress_the_existing_shape_only_malformed_line_logging() {
+        // AcpConnection already logs frame SHAPE only for malformed/unrecognized lines — that must
+        // not regress when the opt-in full-frame logging is added. This proves the pre-existing
+        // malformed-line handling is unchanged with the flag on: still skipped, still keeps the loop
+        // alive, no throw.
+        var logger = new CaptureLogger();
+        await using var harness = new Harness(logger, debugFrames: true);
+        using var        cts     = new CancellationTokenSource();
+        var               runTask = harness.Connection.RunAsync(cts.Token);
+
+        var tcs = new TaskCompletionSource<AcpNotification>(TaskCreationOptions.RunContinuationsAsynchronously);
+        harness.Connection.OnNotification += n => tcs.TrySetResult(n);
+
+        await harness.WriteFrameToConnectionAsync("{not valid json at all");
+        await harness.WriteFrameToConnectionAsync(
+            """{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"still-alive"}}"""
+        );
+
+        var notification = await tcs.Task.WaitAsync(HangGuard);
+        await Assert.That(notification.Params!.Value.GetProperty("sessionId").GetString()).IsEqualTo("still-alive");
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpDebugFrameLogTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpDebugFrameLogTests.cs
@@ -1,0 +1,46 @@
+// test/Capacitor.Cli.Tests.Unit/Acp/AcpDebugFrameLogTests.cs
+using Capacitor.Cli.Daemon.Acp;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// Pure unit tests for <see cref="AcpDebugFrameLog.Cap"/>, the shared
+/// length cap used by every <c>KCAP_ACP_DEBUG_FRAMES</c> call site (the translator's unknown-kind
+/// dump, <c>AcpChildProcess</c>'s stderr drain, <c>AcpConnection</c>'s full-frame logging). Those
+/// call sites are covered by their own test files; this isolates the cap logic itself.
+/// </summary>
+public class AcpDebugFrameLogTests {
+    [Test]
+    public async Task Cap_ShortContent_ReturnsItUnchanged() {
+        var result = AcpDebugFrameLog.Cap("short content");
+
+        await Assert.That(result).IsEqualTo("short content");
+    }
+
+    [Test]
+    public async Task Cap_EmptyContent_ReturnsEmpty() {
+        var result = AcpDebugFrameLog.Cap("");
+
+        await Assert.That(result).IsEqualTo("");
+    }
+
+    [Test]
+    public async Task Cap_ContentOverTheLimit_TruncatesAndAnnotatesHowMuchWasCut() {
+        var huge = new string('x', 10_000);
+
+        var result = AcpDebugFrameLog.Cap(huge);
+
+        await Assert.That(result.Length).IsLessThan(huge.Length);
+        await Assert.That(result).Contains("truncated");
+        await Assert.That(result).Contains("5904"); // 10_000 - 4096
+    }
+
+    [Test]
+    public async Task Cap_ContentExactlyAtTheLimit_ReturnsItUnchanged() {
+        var exact = new string('y', 4096);
+
+        var result = AcpDebugFrameLog.Cap(exact);
+
+        await Assert.That(result).IsEqualTo(exact);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpEventTranslatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpEventTranslatorTests.cs
@@ -1,6 +1,7 @@
 // test/Capacitor.Cli.Tests.Unit/Acp/AcpEventTranslatorTests.cs
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
@@ -13,6 +14,18 @@ namespace Capacitor.Cli.Tests.Unit.Acp;
 /// </summary>
 public class AcpEventTranslatorTests {
     const string TimestampIso = "2026-07-08T12:00:00Z";
+
+    /// <summary>Records every log call — mirrors the pattern established in
+    /// <c>AcpTranscriptAggregationTests.CaptureLogger</c>.</summary>
+    sealed class CaptureLogger : ILogger {
+        public readonly List<(LogLevel Level, string Message)> Entries = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool         IsEnabled(LogLevel logLevel)                            => true;
+
+        public void Log<TState>(LogLevel level, EventId id, TState state, Exception? ex, Func<TState, Exception?, string> formatter)
+            => Entries.Add((level, formatter(state, ex)));
+    }
 
     [Test]
     public async Task AgentMessageChunk_translates_to_AssistantText_using_the_updates_own_text() {
@@ -127,6 +140,62 @@ public class AcpEventTranslatorTests {
         await Assert.That(AcpEventTranslator.Translate(new AcpSessionUpdate(AcpUpdateKind.Plan), 1, TimestampIso)).IsNull();
         await Assert.That(AcpEventTranslator.Translate(new AcpSessionUpdate(AcpUpdateKind.AvailableCommands), 1, TimestampIso)).IsNull();
         await Assert.That(AcpEventTranslator.Translate(new AcpSessionUpdate(AcpUpdateKind.Unknown), 1, TimestampIso)).IsNull();
+    }
+
+    // ── KCAP_ACP_DEBUG_FRAMES gate: Unknown-kind raw-JSON dump ──────────────────────────────────
+
+    static AcpSessionUpdate UnknownUpdateWithSecretMarker() {
+        const string secretMarker = "sk-super-secret-prompt-content-marker";
+        using var doc = System.Text.Json.JsonDocument.Parse($$"""{"sessionUpdate":"something_new","detail":"{{secretMarker}}"}""");
+
+        return new AcpSessionUpdate(AcpUpdateKind.Unknown, Raw: doc.RootElement.Clone());
+    }
+
+    [Test]
+    public async Task Unknown_kind_with_DebugFrames_off_by_default_logs_shape_only_never_the_raw_content() {
+        var logger = new CaptureLogger();
+        var update = UnknownUpdateWithSecretMarker();
+
+        // debugFrames omitted entirely — proves the parameter defaults to Off, matching every
+        // pre-existing call site that doesn't pass it.
+        var env = AcpEventTranslator.Translate(update, seq: 1, timestampIso: TimestampIso, logger: logger);
+
+        await Assert.That(env).IsNull();
+        await Assert.That(logger.Entries).HasCount(1);
+        await Assert.That(logger.Entries[0].Level).IsEqualTo(LogLevel.Debug);
+        await Assert.That(logger.Entries[0].Message).DoesNotContain("sk-super-secret-prompt-content-marker");
+        await Assert.That(logger.Entries[0].Message).Contains("RawLength");
+    }
+
+    [Test]
+    public async Task Unknown_kind_with_DebugFrames_explicitly_off_logs_shape_only_never_the_raw_content() {
+        var logger = new CaptureLogger();
+        var update = UnknownUpdateWithSecretMarker();
+
+        AcpEventTranslator.Translate(update, seq: 1, timestampIso: TimestampIso, logger: logger, debugFrames: false);
+
+        await Assert.That(logger.Entries).HasCount(1);
+        await Assert.That(logger.Entries[0].Message).DoesNotContain("sk-super-secret-prompt-content-marker");
+    }
+
+    [Test]
+    public async Task Unknown_kind_with_DebugFrames_on_logs_the_full_raw_content() {
+        var logger = new CaptureLogger();
+        var update = UnknownUpdateWithSecretMarker();
+
+        AcpEventTranslator.Translate(update, seq: 1, timestampIso: TimestampIso, logger: logger, debugFrames: true);
+
+        await Assert.That(logger.Entries).HasCount(1);
+        await Assert.That(logger.Entries[0].Level).IsEqualTo(LogLevel.Debug);
+        await Assert.That(logger.Entries[0].Message).Contains("sk-super-secret-prompt-content-marker");
+    }
+
+    [Test]
+    public async Task Unknown_kind_with_no_logger_supplied_never_throws_regardless_of_DebugFrames() {
+        var update = UnknownUpdateWithSecretMarker();
+
+        await Assert.That(AcpEventTranslator.Translate(update, seq: 1, timestampIso: TimestampIso, debugFrames: true)).IsNull();
+        await Assert.That(AcpEventTranslator.Translate(update, seq: 1, timestampIso: TimestampIso, debugFrames: false)).IsNull();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
@@ -2,6 +2,7 @@
 using System.Text.Json;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit.Acp;
@@ -43,11 +44,11 @@ public class AcpHostedAgentRuntimeProtocolNegotiationTests {
 
         Task _fakeRunTask = Task.CompletedTask;
 
-        public Harness() {
+        public Harness(ILogger? logger = null, string agentId = "") {
             Fake    = new FakeAcpAgent();
-            Conn    = new AcpConnection(Fake.ClientWriteStream, Fake.ClientReadStream, NullLogger.Instance);
+            Conn    = new AcpConnection(Fake.ClientWriteStream, Fake.ClientReadStream, logger ?? NullLogger.Instance);
             Process = new FakeAcpProcess();
-            Runtime = new AcpHostedAgentRuntime(Conn, Process, NullLogger.Instance);
+            Runtime = new AcpHostedAgentRuntime(Conn, Process, logger ?? NullLogger.Instance, agentId: agentId);
         }
 
         public void StartFakeAgentLoop() => _fakeRunTask = Fake.RunAsync(Cts.Token);
@@ -145,5 +146,74 @@ public class AcpHostedAgentRuntimeProtocolNegotiationTests {
         await Assert.That(ex.Message).Contains("version 1");
         await Assert.That(ex.Message).DoesNotContain("version 0");
         await Assert.That(ex.Message).DoesNotContain("cursor-agent login");
+    }
+
+    // ── Payload-free handshake/session-lifecycle Info logging ──────────────────────────────────
+
+    /// <summary>Records every log call — mirrors <c>AcpTranscriptAggregationTests.CaptureLogger</c>'s
+    /// established pattern.</summary>
+    sealed class CaptureLogger : ILogger {
+        public readonly List<(LogLevel Level, string Message)> Entries = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool         IsEnabled(LogLevel logLevel)                            => true;
+
+        public void Log<TState>(LogLevel level, EventId id, TState state, Exception? ex, Func<TState, Exception?, string> formatter)
+            => Entries.Add((level, formatter(state, ex)));
+    }
+
+    [Test]
+    public async Task StartAsync_Success_LogsSessionStartedAndHandshakeOk_NeverThePromptText() {
+        var logger = new CaptureLogger();
+        await using var h = new Harness(logger, agentId: "agent-42");
+        h.Fake.SetInitializeResult(FakeAcpAgent.BuildInitializeResult(protocolVersion: 1, loadSession: true));
+        h.StartFakeAgentLoop();
+
+        const string secretPrompt = "do the super-secret prompt thing";
+        await h.Runtime.StartAsync("/abs/worktree", secretPrompt, h.Cts.Token).WaitAsync(HangGuard);
+
+        var infoEntries = logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+
+        await Assert.That(infoEntries).Contains(e =>
+            e.Message.Contains("session started") && e.Message.Contains("agent-42"));
+
+        await Assert.That(infoEntries).Contains(e =>
+            e.Message.Contains("handshake OK")
+            && e.Message.Contains("protocolVersion")
+            && e.Message.Contains("loadSession=True")
+            && e.Message.Contains("agent-42"));
+
+        // Payload-free: the prompt text must never appear in any Info-level log line.
+        await Assert.That(infoEntries).DoesNotContain(e => e.Message.Contains(secretPrompt));
+    }
+
+    [Test]
+    public async Task StartAsync_ProtocolVersionMismatch_NeverLogsSessionStartedOrHandshakeOk() {
+        var logger = new CaptureLogger();
+        await using var h = new Harness(logger);
+        h.Fake.SetInitializeResult(FakeAcpAgent.BuildInitializeResult(protocolVersion: 2, loadSession: true));
+        h.StartFakeAgentLoop();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard));
+
+        var infoEntries = logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        await Assert.That(infoEntries).DoesNotContain(e => e.Message.Contains("session started"));
+        await Assert.That(infoEntries).DoesNotContain(e => e.Message.Contains("handshake OK"));
+    }
+
+    [Test]
+    public async Task DisposeAsync_AfterSuccessfulStart_LogsSessionEnded() {
+        var logger = new CaptureLogger();
+        var h = new Harness(logger, agentId: "agent-7");
+        h.Fake.SetInitializeResult(FakeAcpAgent.BuildInitializeResult(protocolVersion: 1, loadSession: false));
+        h.StartFakeAgentLoop();
+
+        await h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard);
+        await h.DisposeAsync();
+
+        var infoEntries = logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        await Assert.That(infoEntries).Contains(e =>
+            e.Message.Contains("session ended") && e.Message.Contains("agent-7"));
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
@@ -216,4 +216,21 @@ public class AcpHostedAgentRuntimeProtocolNegotiationTests {
         await Assert.That(infoEntries).Contains(e =>
             e.Message.Contains("session ended") && e.Message.Contains("agent-7"));
     }
+
+    [Test]
+    public async Task DisposeAsync_AfterFailedStart_DoesNotLogSessionEnded() {
+        var logger = new CaptureLogger();
+        var h = new Harness(logger, agentId: "agent-8");
+        // Fail the handshake before a session is ever established.
+        h.Fake.SetInitializeResult(FakeAcpAgent.BuildInitializeResult(protocolVersion: 2, loadSession: true));
+        h.StartFakeAgentLoop();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard));
+        await h.DisposeAsync();
+
+        // No session started → no "session ended" event (lifecycle telemetry stays coherent).
+        var infoEntries = logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        await Assert.That(infoEntries).DoesNotContain(e => e.Message.Contains("session ended"));
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
 using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit.Acp;
@@ -533,5 +534,89 @@ public class AcpInteractionBridgeTests {
         await Assert.That(result).IsNotNull();
         var outcome = result!.Value.GetProperty("outcome");
         await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    // ── Payload-free "blocking request issued/resolved" lifecycle logging ──────────────────────
+
+    /// <summary>Records every log call — mirrors <c>AcpTranscriptAggregationTests.CaptureLogger</c>'s
+    /// established pattern.</summary>
+    sealed class CaptureLogger : ILogger {
+        public readonly List<(LogLevel Level, string Message)> Entries = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool         IsEnabled(LogLevel logLevel)                            => true;
+
+        public void Log<TState>(LogLevel level, EventId id, TState state, Exception? ex, Func<TState, Exception?, string> formatter)
+            => Entries.Add((level, formatter(state, ex)));
+    }
+
+    [Test]
+    public async Task RequestPermission_Selected_LogsIssuedAndResolvedWithKindAndDecision_NeverToolContent() {
+        var logger = new CaptureLogger();
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", "allow-once", "Allow", null, null, null)),
+            agentId: AgentId,
+            logger: logger);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+        await bridge.HandleAsync(request, CancellationToken.None);
+
+        var infoEntries = logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        await Assert.That(infoEntries).Contains(e => e.Message.Contains("issued") && e.Message.Contains("permission"));
+        await Assert.That(infoEntries).Contains(e => e.Message.Contains("resolved") && e.Message.Contains("permission") && e.Message.Contains("selected"));
+
+        // Payload-free: the tool title ("Run ls") and the chosen optionId ("allow-once") must never
+        // leak into these Info logs, even though "allow-once" happens to also be a log-safe kind
+        // token elsewhere — check the actual tool content, not option ids.
+        await Assert.That(infoEntries).DoesNotContain(e => e.Message.Contains("Run ls"));
+    }
+
+    [Test]
+    public async Task RequestPermission_Cancelled_LogsResolvedWithCancelledDecision() {
+        var logger = new CaptureLogger();
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("deny", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: logger);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+        await bridge.HandleAsync(request, CancellationToken.None);
+
+        var infoEntries = logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        await Assert.That(infoEntries).Contains(e => e.Message.Contains("resolved") && e.Message.Contains("cancelled"));
+    }
+
+    [Test]
+    public async Task RequestPermission_MissingParams_NeverLogsIssuedOrResolved_NoInteractionWasActuallyDispatched() {
+        // A malformed/unparsable request never reaches requestInteraction at all — there is no
+        // "blocking request" to report as issued or resolved.
+        var logger = new CaptureLogger();
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: logger);
+
+        var request = new AcpRequest(1, "session/request_permission", Params: null);
+        await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(logger.Entries.Where(e => e.Level == LogLevel.Information)).IsEmpty();
+    }
+
+    [Test]
+    public async Task ElicitationCreate_Selected_LogsIssuedAndResolvedWithElicitationKind() {
+        var logger = new CaptureLogger();
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("answered", "yes", "Yes", 0, null, null)),
+            agentId: AgentId,
+            logger: logger);
+
+        var json = $$"""{"sessionId":"{{AcpSessionId}}","message":"Proceed?","options":[{"optionId":"yes","name":"Yes","kind":"allow_once"},{"optionId":"no","name":"No","kind":"reject_once"}]}""";
+        var request = new AcpRequest(1, "elicitation/create", JsonDocument.Parse(json).RootElement.Clone());
+        await bridge.HandleAsync(request, CancellationToken.None);
+
+        var infoEntries = logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        await Assert.That(infoEntries).Contains(e => e.Message.Contains("issued") && e.Message.Contains("elicitation"));
+        await Assert.That(infoEntries).Contains(e => e.Message.Contains("resolved") && e.Message.Contains("elicitation") && e.Message.Contains("selected"));
+        await Assert.That(infoEntries).DoesNotContain(e => e.Message.Contains("Proceed?")); // never the prompt text
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpMetricsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpMetricsTests.cs
@@ -1,0 +1,79 @@
+// test/Capacitor.Cli.Tests.Unit/Acp/AcpMetricsTests.cs
+using System.Diagnostics.Metrics;
+using Capacitor.Cli.Daemon.Acp;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// A light smoke test that <see cref="AcpMetrics"/>'s
+/// <see cref="Meter"/>/<see cref="Counter{T}"/> construction and every increment call site are
+/// AOT-safe (no throw) and actually publish a measurement observable via
+/// <see cref="MeterListener"/> — the same mechanism <c>dotnet-counters</c> uses. No reconnect
+/// counters are covered here — none exist yet (a later phase).
+/// </summary>
+public class AcpMetricsTests {
+    [Test]
+    public async Task AllCounters_CanBeIncremented_WithoutThrowing() {
+        AcpMetrics.Launches.Add(1);
+        AcpMetrics.SessionsStarted.Add(1);
+        AcpMetrics.RecordBlockingRequest("permission");
+        AcpMetrics.RecordBlockingRequest("elicitation");
+        AcpMetrics.RecordFailure("handshake");
+
+        // Reaching here without an exception IS the assertion — AcpMetrics has no other
+        // externally-observable state to assert on for the "doesn't throw" half of this test.
+        await Assert.That(true).IsTrue();
+    }
+
+    [Test]
+    public async Task RecordBlockingRequest_PublishesAMeasurement_TaggedWithKind() {
+        long?   observedValue = null;
+        string? observedKind  = null;
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) => {
+            if (instrument.Meter.Name == "Capacitor.Cli.Daemon.Acp" && instrument.Name == "acp.blocking_requests")
+                l.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) => {
+            observedValue = measurement;
+
+            foreach (var tag in tags) {
+                if (tag.Key == "kind")
+                    observedKind = tag.Value?.ToString();
+            }
+        });
+        listener.Start();
+
+        AcpMetrics.RecordBlockingRequest("elicitation");
+
+        await Assert.That(observedValue).IsEqualTo(1L);
+        await Assert.That(observedKind).IsEqualTo("elicitation");
+    }
+
+    [Test]
+    public async Task RecordFailure_PublishesAMeasurement_TaggedWithStage() {
+        long?   observedValue = null;
+        string? observedStage = null;
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) => {
+            if (instrument.Meter.Name == "Capacitor.Cli.Daemon.Acp" && instrument.Name == "acp.failures")
+                l.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) => {
+            observedValue = measurement;
+
+            foreach (var tag in tags) {
+                if (tag.Key == "stage")
+                    observedStage = tag.Value?.ToString();
+            }
+        });
+        listener.Start();
+
+        AcpMetrics.RecordFailure("handshake");
+
+        await Assert.That(observedValue).IsEqualTo(1L);
+        await Assert.That(observedStage).IsEqualTo("handshake");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonDebugFramesFlagTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonDebugFramesFlagTests.cs
@@ -16,6 +16,8 @@ public class DaemonDebugFramesFlagTests {
     [Arguments("true")]
     [Arguments("TRUE")]
     [Arguments("True")]
+    [Arguments(" 1 ")]
+    [Arguments("  true  ")]
     public async Task ParseDebugFramesFlag_OnValues_ReturnsTrue(string input) {
         await Assert.That(DaemonRunner.ParseDebugFramesFlag(input)).IsTrue();
     }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonDebugFramesFlagTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonDebugFramesFlagTests.cs
@@ -1,0 +1,33 @@
+using Capacitor.Cli.Daemon;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// Covers <c>KCAP_ACP_DEBUG_FRAMES</c>'s
+/// <see cref="DaemonRunner.ParseDebugFramesFlag"/> string parse — mirrors
+/// <c>DaemonLogLevelTests.ParseLogLevel_*</c>'s pattern for the same kind of env-var-to-config
+/// toggle. The actual <c>DaemonConfig.DebugFrames</c> wiring and the one-time startup Warning at the
+/// <c>RunAsync</c> call site are not independently unit-tested (would require a full host boot),
+/// matching <c>DaemonRunnerCursorAvailabilityTests</c>' own note about its sibling one-time warning.
+/// </summary>
+public class DaemonDebugFramesFlagTests {
+    [Test]
+    [Arguments("1")]
+    [Arguments("true")]
+    [Arguments("TRUE")]
+    [Arguments("True")]
+    public async Task ParseDebugFramesFlag_OnValues_ReturnsTrue(string input) {
+        await Assert.That(DaemonRunner.ParseDebugFramesFlag(input)).IsTrue();
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("0")]
+    [Arguments("false")]
+    [Arguments("yes")]
+    [Arguments("nonsense")]
+    public async Task ParseDebugFramesFlag_EverythingElse_ReturnsFalse(string? input) {
+        await Assert.That(DaemonRunner.ParseDebugFramesFlag(input)).IsFalse();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -3,6 +3,7 @@ using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Capacitor.Cli.Tests.Unit.Acp;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit.Services;
@@ -200,6 +201,62 @@ public class AcpHostedAgentRuntimeFactoryTests {
         cts.Cancel();
         try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
         await runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    // ── Payload-free "ACP hosted agent launch" Info logging ────────────────────────────────────
+
+    /// <summary>Records every log call across every category (one instance shared by every
+    /// <c>CreateLogger&lt;T&gt;()</c> call) — mirrors <c>AcpTranscriptAggregationTests.CaptureLogger</c>'s
+    /// established pattern, wrapped in a minimal <see cref="ILoggerFactory"/> so it can be handed to
+    /// the factory's real constructor.</summary>
+    sealed class CaptureLogger : ILogger {
+        public readonly List<(LogLevel Level, string Message)> Entries = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool         IsEnabled(LogLevel logLevel)                            => true;
+
+        public void Log<TState>(LogLevel level, EventId id, TState state, Exception? ex, Func<TState, Exception?, string> formatter)
+            => Entries.Add((level, formatter(state, ex)));
+    }
+
+    sealed class CaptureLoggerFactory : ILoggerFactory {
+        public readonly CaptureLogger Logger = new();
+
+        public ILogger CreateLogger(string categoryName) => Logger;
+        public void    AddProvider(ILoggerProvider provider) { }
+        public void    Dispose() { }
+    }
+
+    [Test]
+    public async Task StartAsync_LogsAcpHostedAgentLaunch_WithAgentIdVendorAndCwd() {
+        var fake           = new FakeAcpAgent();
+        var connection     = new CaptureServerConnection();
+        var loggerFactory  = new CaptureLoggerFactory();
+
+        var factory = new AcpHostedAgentRuntimeFactory(
+            config: new DaemonConfig { CursorPath = "cursor-agent" },
+            loggerFactory: loggerFactory,
+            connection: connection,
+            connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, new FakeAcpProcess())
+        );
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var ctx     = MakeContext("agent-launch-log") with { Worktree = new WorktreeInfo(Path: "/abs/some-worktree", Branch: "b", SourceRepo: "/repo") };
+        var started = await factory.StartAsync(ctx, cts.Token).WaitAsync(HangGuard);
+
+        var infoEntries = loggerFactory.Logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        await Assert.That(infoEntries).Contains(e =>
+            e.Message.Contains("ACP hosted agent launch")
+            && e.Message.Contains("agent-launch-log")
+            && e.Message.Contains("cursor")
+            && e.Message.Contains("/abs/some-worktree"));
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await started.Runtime.DisposeAsync();
         await fake.DisposeAsync();
     }
 }


### PR DESCRIPTION
## What & why

**AI-689** Workstream B — **PR 3 of 4** (observability). Design-of-record in [#315](https://github.com/kurrent-io/kcap-cli/pull/315). **Stacked on [#316](https://github.com/kurrent-io/kcap-cli/pull/316)** (diagnostics) — base is `ai-689-diagnostics`; retarget to `main` once #316 merges.

An operator watching at the default level currently sees nothing ACP-specific unless something fails, and two Debug logs leak unredacted content. This PR fixes both, plus adds minimal metrics.

- **B1 — Info-level lifecycle logging** (source-gen `[LoggerMessage]`, **payload-free** — ids/kinds/metadata only, never prompt/tool/assistant content): hosted-agent launch, handshake OK (protocolVersion + loadSession + resolved model), session started, blocking-request issued+resolved (kind + decision only), session ended.
- **B3/B4 — close two Debug payload-leak vectors behind an opt-in flag.** New `KCAP_ACP_DEBUG_FRAMES` (default **off**): when off, the Unknown-kind update dump and cursor-agent stderr log **shape only** (kind + length), and `AcpConnection` keeps its existing shape-only frame logging. When on, full raw updates / stderr lines / inbound+outbound frames are logged at Debug under a dedicated path, **length-capped**, with a one-time loud "may contain full prompts, tool arguments, and file contents" Warning. Nothing is ever written to the transcript or forwarded to the server.
- **B2 — minimal metrics** (`Meter "Capacitor.Cli.Daemon.Acp"`: `acp.launches`, `acp.sessions_started`, `acp.blocking_requests{kind}`, `acp.failures{stage}`). No exporter — observable via `dotnet-counters`. Confirmed NativeAOT-clean.

## Tests & gates
New: `AcpEventTranslatorTests`, `AcpDebugFrameLogTests`, `AcpMetricsTests`, `DaemonDebugFramesFlagTests`, `AcpHostedAgentRuntimeFactoryTests`, plus extended `AcpConnectionTests` / `AcpInteractionBridgeTests` — assert default-off gating logs shape-not-content, the enable-warning fires once, and blocking-request logs carry kind+decision but no content. Full unit suite **2896/2898** (2 pre-existing `KCAP_ACP_LIVE`-gated skips); NativeAOT `osx-arm64` gate warning-free (incl. metrics).

## Follow-up
Reconnect/resume + its lifecycle events/metrics land in PR 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
