### PR TITLE
[AI-701] validate-plan artifact endpoint + workspace_root emission

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ Verify that all items in a session's plan were completed.
 kcap validate-plan <sessionId>
 ```
 
+Fetches the session's discovered plan artifacts (`GET /api/sessions/{id}/plan-artifacts?chain=true`) — the primary artifact plus any other candidates the server found, in an ordered set — and pairs them with the existing `recap` call for the current session's file writes/edits and AI-generated "what's done" summaries. On an older server without the artifacts route (or a non-visible session), `validate-plan` falls back automatically to the previous recap-only behavior. A degraded, truncated, or unavailable plan renders an explicit marker line instead of failing silently; if the primary artifact's content can't be retrieved, the command reports that validation isn't possible and exits with status 2 (0 for a normal render or when no plan is found at all — absence is a valid answer).
+
 With the plugin installed, use the `/kcap:validate-plan` skill or ask naturally:
 
 ```

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -790,6 +790,52 @@ public sealed record CliProjectError {
     public required string Message { get; init; }
 }
 
+/// <summary>
+/// One discovered plan/spec/design/checklist artifact returned by
+/// <c>GET /api/sessions/{id}/plan-artifacts</c> (AI-701). Mirrors the server's
+/// <c>Capacitor.Plans.PlanArtifact</c> record field-for-field; string fields
+/// (<see cref="Kind"/>, <see cref="Source"/>, <see cref="ContentState"/>,
+/// <see cref="Confidence"/>) carry the server's snake_case enum values verbatim
+/// (e.g. "plan", "repo_file", "truncated") — no local enum type, since the CLI
+/// only needs to compare/display them, never branch on the full server vocabulary.
+/// </summary>
+public sealed record PlanArtifactDto {
+    [JsonPropertyName("artifact_id")]     public required string ArtifactId { get; init; }
+    [JsonPropertyName("kind")]            public required string Kind { get; init; }
+    [JsonPropertyName("title")]           public required string Title { get; init; }
+    [JsonPropertyName("source")]          public required string Source { get; init; }
+    [JsonPropertyName("session_id")]      public required string SessionId { get; init; }
+    [JsonPropertyName("agent_id")]        public string? AgentId { get; init; }
+    [JsonPropertyName("agent_type")]      public string? AgentType { get; init; }
+    [JsonPropertyName("head_session_id")] public string? HeadSessionId { get; init; }
+    [JsonPropertyName("head_agent_id")]   public string? HeadAgentId { get; init; }
+    [JsonPropertyName("head_agent_type")] public string? HeadAgentType { get; init; }
+    [JsonPropertyName("head_discovered_at")]      public DateTimeOffset? HeadDiscoveredAt { get; init; }
+    [JsonPropertyName("last_observed_session_id")] public string? LastObservedSessionId { get; init; }
+    [JsonPropertyName("last_observed_at")] public DateTimeOffset? LastObservedAt { get; init; }
+    [JsonPropertyName("path")]            public string? Path { get; init; }
+    [JsonPropertyName("content")]         public string? Content { get; init; }
+    [JsonPropertyName("content_state")]   public required string ContentState { get; init; } // "ok" | "truncated" | "unavailable"
+    [JsonPropertyName("is_complete")]     public required bool IsComplete { get; init; }
+    [JsonPropertyName("is_confirmed")]    public required bool IsConfirmed { get; init; }
+    [JsonPropertyName("is_truncated")]    public bool IsTruncated { get; init; }
+    [JsonPropertyName("original_bytes")]  public long? OriginalBytes { get; init; }
+    [JsonPropertyName("content_hash")]    public required string ContentHash { get; init; }
+    [JsonPropertyName("head_change_hash")] public string? HeadChangeHash { get; init; }
+    [JsonPropertyName("version")]         public required int Version { get; init; }
+    [JsonPropertyName("discovered_at")]   public required DateTimeOffset DiscoveredAt { get; init; }
+    [JsonPropertyName("confidence")]      public required string Confidence { get; init; } // "high" | "medium" | "low"
+    [JsonPropertyName("reason")]          public required string Reason { get; init; }
+    [JsonPropertyName("is_primary")]      public bool IsPrimary { get; init; }
+}
+
+/// <summary>Body of <c>GET /api/sessions/{id}/plan-artifacts</c> (AI-701).</summary>
+public sealed record PlanArtifactsResponseDto {
+    [JsonPropertyName("primary")]     public PlanArtifactDto? Primary { get; init; }
+    [JsonPropertyName("artifacts")]   public List<PlanArtifactDto> Artifacts { get; init; } = [];
+    [JsonPropertyName("diagnostics")] public List<string> Diagnostics { get; init; } = [];
+}
+
 public sealed record CurationApplyItem {
     [JsonPropertyName("category")]      public string?               Category     { get; init; }
     [JsonPropertyName("cluster_id")]    public string?               ClusterId    { get; init; }
@@ -805,6 +851,8 @@ public sealed record CurationApplyResponse {
 
 [JsonSerializable(typeof(List<RecapEntry>))]
 [JsonSerializable(typeof(List<RepoRecapEntry>))]
+[JsonSerializable(typeof(PlanArtifactDto))]
+[JsonSerializable(typeof(PlanArtifactsResponseDto))]
 [JsonSerializable(typeof(EvalContextResult))]
 [JsonSerializable(typeof(EvalQuestionDto))]
 [JsonSerializable(typeof(EvalQuestionDto[]))]

--- a/src/Capacitor.Cli/Commands/AntigravityHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/AntigravityHookCommand.cs
@@ -100,7 +100,12 @@ static class AntigravityHookCommand {
             ["started_at"]      = DateTimeOffset.UtcNow.ToString("O")
         };
 
-        if (cwd is not null) forwarded["cwd"] = cwd;
+        if (cwd is not null) {
+            forwarded["cwd"] = cwd;
+
+            // AI-701: best-effort git-root discovery, fail-open (omitted when no repo is found).
+            if (GitRepository.FindRoot(cwd) is { } workspaceRoot) forwarded["workspace_root"] = workspaceRoot;
+        }
         if (Str(payload, "antigravityVersion") is { } version)
             forwarded["antigravity_version"] = version;
 

--- a/src/Capacitor.Cli/Commands/AntigravityImportSource.cs
+++ b/src/Capacitor.Cli/Commands/AntigravityImportSource.cs
@@ -345,6 +345,9 @@ internal sealed class AntigravityImportSource : IImportSource {
     static JsonObject BuildSessionStartPayload(string sid, string? cwd, DateTimeOffset? startedAt, bool forcePrivate) {
         var p = new JsonObject { ["hook_event_name"] = "sessionStart", ["session_id"] = sid };
         if (cwd is not null) p["cwd"] = cwd;
+        // AI-701 (finding 4): fail-open git-root discovery, mirroring ImportChainsAsync
+        // so routed imports carry the same workspace_root the file-based path does.
+        if (cwd is not null && GitRepository.FindRoot(cwd) is { } workspaceRoot) p["workspace_root"] = workspaceRoot;
         if (startedAt is { } ts) p["started_at"] = ts.ToString("O");
         if (forcePrivate) p["default_visibility"] = "private";
         return p;

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -426,6 +426,24 @@ public static class ClaudeHookCommand {
             // plan_content onto the enriched body before the POST.
             body = await deferredRepoTask!;
 
+            // AI-701: best-effort git-root discovery for the session's cwd, fed to the server's
+            // plan-artifact discovery so a repo-file plan/spec found at the workspace root can be
+            // attributed even when cwd is a subdirectory. Fail-open: GitRepository.FindRoot swallows
+            // I/O errors and returns null when no repo is found, in which case the field is simply
+            // omitted (older servers ignore unknown fields regardless).
+            if (sessionCwd is not null && GitRepository.FindRoot(sessionCwd) is { } workspaceRoot) {
+                try {
+                    var node = JsonNode.Parse(body);
+
+                    if (node is not null) {
+                        node["workspace_root"] = workspaceRoot;
+                        body                    = node.ToJsonString();
+                    }
+                } catch {
+                    // Best effort
+                }
+            }
+
             // Inject default_visibility from the active V2 profile. The legacy top-level
             // LegacyV1Config.DefaultVisibility shape is not populated by v2 configs (the field
             // lives under the profile), so reading it there silently fell back to "org_public"

--- a/src/Capacitor.Cli/Commands/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CodexHookCommand.cs
@@ -179,6 +179,12 @@ static class CodexHookCommand {
             node["default_visibility"] = visibility;
         }
 
+        // AI-701: best-effort git-root discovery, fail-open (omitted when cwd is absent or no
+        // repo is found) — see the mirrored ClaudeHookCommand comment for rationale.
+        if (TryGetString(node, "cwd") is { } startCwd && GitRepository.FindRoot(startCwd) is { } workspaceRoot) {
+            node["workspace_root"] = workspaceRoot;
+        }
+
         var enriched = await RepositoryDetection.EnrichWithRepositoryInfo(node.ToJsonString());
 
         // Repo exclusion runs here (not above the event switch) so that the

--- a/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
@@ -135,7 +135,12 @@ static class CopilotHookCommand {
             ["home_dir"]        = PathHelpers.HomeDirectory
         };
 
-        if (cwd is not null) forwarded["cwd"] = cwd;
+        if (cwd is not null) {
+            forwarded["cwd"] = cwd;
+
+            // AI-701: best-effort git-root discovery, fail-open (omitted when no repo is found).
+            if (GitRepository.FindRoot(cwd) is { } workspaceRoot) forwarded["workspace_root"] = workspaceRoot;
+        }
 
         if (TryGetString(node, "initialPrompt") is { } prompt) {
             forwarded["initial_prompt"] = prompt;

--- a/src/Capacitor.Cli/Commands/CopilotImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CopilotImportSource.cs
@@ -314,6 +314,9 @@ internal sealed class CopilotImportSource : IImportSource {
             ["source"]          = "startup",
         };
         if (cwd is not null) payload["cwd"] = cwd;
+        // AI-701 (finding 4): fail-open git-root discovery, mirroring ImportChainsAsync
+        // so routed imports carry the same workspace_root the file-based path does.
+        if (cwd is not null && GitRepository.FindRoot(cwd) is { } workspaceRoot) payload["workspace_root"] = workspaceRoot;
         if (startedAt is { } ts) payload["started_at"] = ts.ToString("O");
         return payload;
     }

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -100,7 +100,12 @@ static class GeminiHookCommand {
             ["home_dir"]        = PathHelpers.HomeDirectory
         };
 
-        if (cwd is not null) forwarded["cwd"] = cwd;
+        if (cwd is not null) {
+            forwarded["cwd"] = cwd;
+
+            // AI-701: best-effort git-root discovery, fail-open (omitted when no repo is found).
+            if (GitRepository.FindRoot(cwd) is { } workspaceRoot) forwarded["workspace_root"] = workspaceRoot;
+        }
 
         // Gemini stamps hook payloads with an ISO-8601 `timestamp`; forward it
         // as started_at so canonical SessionStarted carries the real start time

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -2353,6 +2353,15 @@ static class ImportCommand {
         if (session.PreviousSessionId is not null) startHook["previous_session_id"] = session.PreviousSessionId;
         if (meta.Slug is not null) startHook["slug"]                                = meta.Slug;
 
+        // AI-701: best-effort git-root discovery from the (already remap-resolved) cwd, so
+        // historical imports carry the same workspace_root the live hooks do. Fail-open:
+        // GitRepository.FindRoot swallows I/O errors and returns null when no repo is found
+        // on this machine (e.g. the recorded path no longer exists), in which case the field
+        // is simply omitted.
+        if (!string.IsNullOrEmpty(cwd) && GitRepository.FindRoot(cwd) is { } workspaceRoot) {
+            startHook["workspace_root"] = workspaceRoot;
+        }
+
         // Codex sessions carry a `git` block on session_meta — prefer it over a fresh
         // RepositoryDetection probe (which reads the live git config and might disagree
         // with what was true when the rollout was recorded). Detection still runs as a

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -1119,7 +1119,7 @@ static class ImportCommand {
                                 },
                             };
 
-                            r = await ImportChainsAsync(httpClient, baseUrl, chains, wrappedEvents, CancellationToken.None);
+                            r = await ImportChainsAsync(httpClient, baseUrl, chains, wrappedEvents, CancellationToken.None, sessionCwds);
 
                             // After the await, all workers have drained; mark every slot idle.
                             for (var i = 0; i < ImportWorkerCount; i++) IdleSlot(i);
@@ -1142,7 +1142,7 @@ static class ImportCommand {
                     );
                 importResult = r!;
             } else {
-                importResult = await ImportChainsAsync(httpClient, baseUrl, chains, events, CancellationToken.None);
+                importResult = await ImportChainsAsync(httpClient, baseUrl, chains, events, CancellationToken.None, sessionCwds);
             }
         } else {
             importResult = new(0, 0, 0);
@@ -2213,7 +2213,8 @@ static class ImportCommand {
             string                            baseUrl,
             List<List<SessionClassification>> chains,
             ChainWorkerEvents                 events,
-            CancellationToken                 ct
+            CancellationToken                 ct,
+            IReadOnlyDictionary<string, string>? sessionCwds = null
         ) {
         var loaded  = 0;
         var resumed = 0;
@@ -2247,7 +2248,7 @@ static class ImportCommand {
                                 var linesSent = 0;
 
                                 try {
-                                    (r, linesSent) = await ImportSingleSessionAsync(httpClient, baseUrl, session, slot, events, ct);
+                                    (r, linesSent) = await ImportSingleSessionAsync(httpClient, baseUrl, session, slot, events, ct, sessionCwds);
                                 } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
                                     throw;
                                 } catch (Exception ex) {
@@ -2285,7 +2286,8 @@ static class ImportCommand {
             SessionClassification session,
             int                   slot,
             ChainWorkerEvents     events,
-            CancellationToken     ct
+            CancellationToken     ct,
+            IReadOnlyDictionary<string, string>? sessionCwds = null
         ) {
         // Denominator for the per-slot progress bar: the number of parent-transcript
         // lines this import will POST. For a resume, only the lines past the server's
@@ -2339,7 +2341,14 @@ static class ImportCommand {
 
         // status == New: session-start → import → session-end → enqueue background tasks
         var meta = session.Meta;
-        var cwd  = meta.Cwd ?? SessionImporter.DecodeCwdFromDirName(session.EncodedCwd);
+        // Prefer the already remap-/worktree-resolved cwd computed up front into sessionCwds
+        // (see ResolveTranscriptReposAsync / the Cursor branch above it) so workspace_root
+        // discovery below and repo detection agree with what the missing-cwd report showed
+        // the user — falling back to the raw transcript cwd when this session has no entry
+        // (e.g. a Cursor-less non-file source, or resolution failed to produce one).
+        var cwd = sessionCwds is not null && sessionCwds.TryGetValue(session.SessionId, out var resolvedCwd)
+            ? resolvedCwd
+            : meta.Cwd ?? SessionImporter.DecodeCwdFromDirName(session.EncodedCwd);
 
         var startHook = new JsonObject {
             ["session_id"]      = session.SessionId,

--- a/src/Capacitor.Cli/Commands/KiroHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/KiroHookCommand.cs
@@ -98,7 +98,12 @@ static class KiroHookCommand {
             ["home_dir"]        = PathHelpers.HomeDirectory
         };
 
-        if (cwd is not null) forwarded["cwd"] = cwd;
+        if (cwd is not null) {
+            forwarded["cwd"] = cwd;
+
+            // AI-701: best-effort git-root discovery, fail-open (omitted when no repo is found).
+            if (GitRepository.FindRoot(cwd) is { } workspaceRoot) forwarded["workspace_root"] = workspaceRoot;
+        }
 
         if (Environment.GetEnvironmentVariable("KCAP_AGENT_ID") is { } agentHostId) {
             forwarded["agent_host_id"] = agentHostId;

--- a/src/Capacitor.Cli/Commands/KiroImportSource.cs
+++ b/src/Capacitor.Cli/Commands/KiroImportSource.cs
@@ -309,6 +309,9 @@ internal sealed class KiroImportSource : IImportSource {
             ["session_id"]      = sessionId,
         };
         if (cwd is not null) payload["cwd"] = cwd;
+        // AI-701 (finding 4): fail-open git-root discovery, mirroring ImportChainsAsync
+        // so routed imports carry the same workspace_root the file-based path does.
+        if (cwd is not null && GitRepository.FindRoot(cwd) is { } workspaceRoot) payload["workspace_root"] = workspaceRoot;
         if (model is not null) payload["model"] = model;
         if (startedAt is { } ts) payload["started_at"] = ts.ToString("O");
         return payload;

--- a/src/Capacitor.Cli/Commands/OpenCodeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/OpenCodeHookCommand.cs
@@ -76,7 +76,12 @@ static class OpenCodeHookCommand {
             ["started_at"]      = DateTimeOffset.UtcNow.ToString("O")
         };
 
-        if (cwd is not null) forwarded["cwd"] = cwd;
+        if (cwd is not null) {
+            forwarded["cwd"] = cwd;
+
+            // AI-701: best-effort git-root discovery, fail-open (omitted when no repo is found).
+            if (GitRepository.FindRoot(cwd) is { } workspaceRoot) forwarded["workspace_root"] = workspaceRoot;
+        }
         if (GetArg(args, "--model")    is { } model)    forwarded["model"]            = model;
         if (GetArg(args, "--provider") is { } provider) forwarded["provider_id"]      = provider;
         if (GetArg(args, "--version")  is { } version)  forwarded["opencode_version"] = version;

--- a/src/Capacitor.Cli/Commands/OpenCodeImportSource.cs
+++ b/src/Capacitor.Cli/Commands/OpenCodeImportSource.cs
@@ -356,6 +356,9 @@ internal sealed class OpenCodeImportSource : IImportSource {
             ["source"]          = "startup",
         };
         if (cwd is not null) p["cwd"] = cwd;
+        // AI-701 (finding 4): fail-open git-root discovery, mirroring ImportChainsAsync
+        // so routed imports carry the same workspace_root the file-based path does.
+        if (cwd is not null && GitRepository.FindRoot(cwd) is { } workspaceRoot) p["workspace_root"] = workspaceRoot;
         if (startedAt is { } ts) p["started_at"] = ts.ToString("O");
         if (forcePrivate) p["default_visibility"] = "private";
         return p;

--- a/src/Capacitor.Cli/Commands/PiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/PiHookCommand.cs
@@ -95,7 +95,12 @@ static class PiHookCommand {
             ["home_dir"]        = PathHelpers.HomeDirectory
         };
 
-        if (cwd is not null) forwarded["cwd"] = cwd;
+        if (cwd is not null) {
+            forwarded["cwd"] = cwd;
+
+            // AI-701: best-effort git-root discovery, fail-open (omitted when no repo is found).
+            if (GitRepository.FindRoot(cwd) is { } workspaceRoot) forwarded["workspace_root"] = workspaceRoot;
+        }
         if (startedAt is { } ts) forwarded["started_at"] = ts.ToString("O");
         if (Environment.GetEnvironmentVariable("KCAP_AGENT_ID") is { } agentHostId) forwarded["agent_host_id"] = agentHostId;
 

--- a/src/Capacitor.Cli/Commands/PiImportSource.cs
+++ b/src/Capacitor.Cli/Commands/PiImportSource.cs
@@ -279,6 +279,9 @@ internal sealed class PiImportSource : IImportSource {
             ["source"]          = "startup",
         };
         if (cwd is not null) payload["cwd"] = cwd;
+        // AI-701 (finding 4): fail-open git-root discovery, mirroring ImportChainsAsync
+        // so routed imports carry the same workspace_root the file-based path does.
+        if (cwd is not null && GitRepository.FindRoot(cwd) is { } workspaceRoot) payload["workspace_root"] = workspaceRoot;
         if (startedAt is { } ts) payload["started_at"] = ts.ToString("O");
         if (forcePrivate) payload["default_visibility"] = "private";
         return payload;

--- a/src/Capacitor.Cli/Commands/ValidatePlanCommand.cs
+++ b/src/Capacitor.Cli/Commands/ValidatePlanCommand.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Text;
 using System.Text.Json;
 using Capacitor.Cli.Core;
 
@@ -7,7 +9,200 @@ static class ValidatePlanCommand {
     public static async Task<int> Handle(string baseUrl, string sessionId) {
         using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
 
-        // Fetch chain recap to find plans from previous sessions (e.g. ExitPlanMode in parent)
+        return await HandleCore(httpClient, baseUrl, sessionId);
+    }
+
+    /// <summary>
+    /// Test-friendly core: caller owns the <see cref="HttpClient"/> (mirrors
+    /// <see cref="ClaudeHookCommand.HandleCore"/>'s seam). Two-call flow (AI-701):
+    /// <c>GET /api/sessions/{id}/plan-artifacts?chain=true</c> for the discovered plan
+    /// artifact set, then the existing <c>GET /api/sessions/{id}/recap?chain=true</c> for
+    /// current-session work rows and AI-generated "what's done" summaries. A 404 on the
+    /// artifacts route (old server without the route, or a non-visible session) falls back
+    /// to <see cref="RenderLegacyAsync"/> — the original recap-only behavior, unchanged.
+    /// </summary>
+    internal static async Task<int> HandleCore(HttpClient httpClient, string baseUrl, string sessionId) {
+        HttpResponseMessage artifactsResp;
+
+        try {
+            artifactsResp = await httpClient.GetWithRetryAsync($"{baseUrl}/api/sessions/{sessionId}/plan-artifacts?chain=true");
+        } catch (HttpRequestException ex) {
+            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
+
+            return 1;
+        }
+
+        if (await HttpClientExtensions.HandleUnauthorizedAsync(artifactsResp)) {
+            return 1;
+        }
+
+        if (artifactsResp.StatusCode == HttpStatusCode.NotFound) {
+            // Older server without the route, or the session/candidate isn't visible —
+            // preserve the original recap-only behavior byte-for-byte.
+            return await RenderLegacyAsync(httpClient, baseUrl, sessionId);
+        }
+
+        if (!artifactsResp.IsSuccessStatusCode) {
+            await Console.Error.WriteLineAsync($"HTTP {(int)artifactsResp.StatusCode}");
+
+            return 1;
+        }
+
+        var artifactsJson     = await artifactsResp.Content.ReadAsStringAsync();
+        var artifactsResponse = JsonSerializer.Deserialize(artifactsJson, CapacitorJsonContext.Default.PlanArtifactsResponseDto);
+
+        var primary   = artifactsResponse?.Primary;
+        var artifacts = artifactsResponse?.Artifacts ?? [];
+
+        if (primary is null && artifacts.Count == 0) {
+            await Console.Out.WriteLineAsync("No plan found for this session.");
+
+            return 0;
+        }
+
+        // Work done + AI summaries still come from the existing recap endpoint — the
+        // plan-artifacts route only carries the discovered plan/spec/design/checklist set.
+        HttpResponseMessage recapResp;
+
+        try {
+            recapResp = await httpClient.GetWithRetryAsync($"{baseUrl}/api/sessions/{sessionId}/recap?chain=true");
+        } catch (HttpRequestException ex) {
+            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
+
+            return 1;
+        }
+
+        if (await HttpClientExtensions.HandleUnauthorizedAsync(recapResp)) {
+            return 1;
+        }
+
+        if (recapResp.StatusCode == HttpStatusCode.NotFound) {
+            await Console.Error.WriteLineAsync($"Session not found: {sessionId}");
+
+            return 1;
+        }
+
+        if (!recapResp.IsSuccessStatusCode) {
+            await Console.Error.WriteLineAsync($"HTTP {(int)recapResp.StatusCode}");
+
+            return 1;
+        }
+
+        var recapJson = await recapResp.Content.ReadAsStringAsync();
+        var entries   = JsonSerializer.Deserialize(recapJson, CapacitorJsonContext.Default.ListRecapEntry) ?? [];
+
+        // Work done: only from the current session being validated (matches the legacy filter).
+        var work      = entries.Where(e => e.Type is "write" or "edit" && e.SessionId == sessionId).ToList();
+        var summaries = entries.Where(e => e.Type == "whats_done").ToList();
+
+        await RenderPlanArtifacts(primary, artifacts);
+        await RenderWhatsDoneAndInstructions(summaries, work);
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Renders the "## Plan" section from the discovery response: the primary artifact
+    /// first (the server's designated best candidate for validation — see
+    /// <c>PlanArtifactComposer</c>), followed by any other discovered artifacts in the
+    /// order returned (newest-first). A truncated artifact is prefixed with a byte-count
+    /// marker; an unavailable one renders a placeholder — and, when the PRIMARY itself is
+    /// unavailable, an explicit note that full validation isn't possible without its content.
+    /// </summary>
+    static async Task RenderPlanArtifacts(PlanArtifactDto? primary, IReadOnlyList<PlanArtifactDto> artifacts) {
+        var ordered = primary is null
+            ? artifacts
+            : new List<PlanArtifactDto> { primary }
+                .Concat(artifacts.Where(a => a.ArtifactId != primary.ArtifactId))
+                .ToList();
+
+        await Console.Out.WriteLineAsync("## Plan");
+        await Console.Out.WriteLineAsync();
+
+        foreach (var artifact in ordered) {
+            var isPrimary = primary is not null && artifact.ArtifactId == primary.ArtifactId;
+
+            switch (artifact.ContentState) {
+                case "truncated": {
+                    var n = artifact.Content is null ? 0 : Encoding.UTF8.GetByteCount(artifact.Content);
+                    await Console.Out.WriteLineAsync($"[plan truncated: first {n} of {artifact.OriginalBytes} bytes]");
+
+                    if (artifact.Content is not null) {
+                        await Console.Out.WriteLineAsync(artifact.Content);
+                    }
+
+                    break;
+                }
+                case "unavailable": {
+                    await Console.Out.WriteLineAsync("[plan content unavailable due to size bounds]");
+
+                    if (isPrimary) {
+                        await Console.Out.WriteLineAsync(
+                            "Validation is not possible: the plan content could not be retrieved (exceeds size bounds).");
+                    }
+
+                    break;
+                }
+                default: {
+                    if (artifact.Content is not null) {
+                        await Console.Out.WriteLineAsync(artifact.Content);
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        await Console.Out.WriteLineAsync();
+    }
+
+    /// <summary>Shared "## What's Done" + "## Instructions" rendering, used by both the
+    /// plan-artifacts path and the legacy recap-only path so the two stay in sync.</summary>
+    static async Task RenderWhatsDoneAndInstructions(List<RecapEntry> summaries, List<RecapEntry> work) {
+        await Console.Out.WriteLineAsync("## What's Done");
+        await Console.Out.WriteLineAsync();
+
+        if (summaries.Count > 0) {
+            await Console.Out.WriteLineAsync("### Summary");
+            await Console.Out.WriteLineAsync();
+
+            foreach (var summary in summaries) {
+                await Console.Out.WriteLineAsync(summary.Content);
+            }
+
+            await Console.Out.WriteLineAsync();
+        }
+
+        await Console.Out.WriteLineAsync("### Details");
+        await Console.Out.WriteLineAsync();
+
+        if (work.Count == 0) {
+            await Console.Out.WriteLineAsync("No file writes or edits recorded.");
+        } else {
+            foreach (var entry in work) {
+                var label = entry.Type == "write" ? "Write" : "Edit";
+                var path  = entry.FilePath ?? "unknown";
+                await Console.Out.WriteLineAsync($"- {label}: {path}");
+            }
+        }
+
+        await Console.Out.WriteLineAsync();
+
+        await Console.Out.WriteLineAsync("## Instructions");
+        await Console.Out.WriteLineAsync();
+
+        await Console.Out.WriteLineAsync(
+            "Compare the plan above against the summary and file list under \"What's Done\". Identify any planned items that were NOT completed. If everything is done, confirm that. If there are gaps, list them and complete the remaining work now."
+        );
+    }
+
+    /// <summary>
+    /// Original (pre-AI-701) recap-only behavior, preserved byte-for-byte for old servers that
+    /// don't yet expose <c>GET /api/sessions/{id}/plan-artifacts</c> (or a session/candidate the
+    /// route can't resolve). Plans come from <c>recap</c> entries of type "plan" across the
+    /// session chain; work/summaries are filtered exactly as before.
+    /// </summary>
+    static async Task<int> RenderLegacyAsync(HttpClient httpClient, string baseUrl, string sessionId) {
         HttpResponseMessage resp;
 
         try {
@@ -22,7 +217,7 @@ static class ValidatePlanCommand {
             return 1;
         }
 
-        if (resp.StatusCode == System.Net.HttpStatusCode.NotFound) {
+        if (resp.StatusCode == HttpStatusCode.NotFound) {
             await Console.Error.WriteLineAsync($"Session not found: {sessionId}");
 
             return 1;
@@ -66,43 +261,7 @@ static class ValidatePlanCommand {
 
         await Console.Out.WriteLineAsync();
 
-        // Output what's done
-        await Console.Out.WriteLineAsync("## What's Done");
-        await Console.Out.WriteLineAsync();
-
-        if (summaries.Count > 0) {
-            await Console.Out.WriteLineAsync("### Summary");
-            await Console.Out.WriteLineAsync();
-
-            foreach (var summary in summaries) {
-                await Console.Out.WriteLineAsync(summary.Content);
-            }
-
-            await Console.Out.WriteLineAsync();
-        }
-
-        await Console.Out.WriteLineAsync("### Details");
-        await Console.Out.WriteLineAsync();
-
-        if (work.Count == 0) {
-            await Console.Out.WriteLineAsync("No file writes or edits recorded.");
-        } else {
-            foreach (var entry in work) {
-                var label = entry.Type == "write" ? "Write" : "Edit";
-                var path  = entry.FilePath ?? "unknown";
-                await Console.Out.WriteLineAsync($"- {label}: {path}");
-            }
-        }
-
-        await Console.Out.WriteLineAsync();
-
-        // Verification instruction
-        await Console.Out.WriteLineAsync("## Instructions");
-        await Console.Out.WriteLineAsync();
-
-        await Console.Out.WriteLineAsync(
-            "Compare the plan above against the summary and file list under \"What's Done\". Identify any planned items that were NOT completed. If everything is done, confirm that. If there are gaps, list them and complete the remaining work now."
-        );
+        await RenderWhatsDoneAndInstructions(summaries, work);
 
         return 0;
     }

--- a/src/Capacitor.Cli/Commands/ValidatePlanCommand.cs
+++ b/src/Capacitor.Cli/Commands/ValidatePlanCommand.cs
@@ -102,12 +102,24 @@ static class ValidatePlanCommand {
     }
 
     /// <summary>
+    /// Bracketed marker for a degraded artifact (<c>IsComplete == false</c>) — a newer revision
+    /// exists but hasn't resolved yet, so this is the last known complete text. Single-sourced
+    /// here (rather than referenced from the server) because the CLI has no dependency on
+    /// <c>Capacitor.Server</c>; text and spacing must stay byte-for-byte identical to the
+    /// server's <c>PlanRowRendering.DegradedText</c> (AI-701 review finding).
+    /// </summary>
+    const string DegradedMarker = "[plan state: unresolved newer revision — last known complete text]";
+
+    /// <summary>
     /// Renders the "## Plan" section from the discovery response: the primary artifact
     /// first (the server's designated best candidate for validation — see
     /// <c>PlanArtifactComposer</c>), followed by any other discovered artifacts in the
-    /// order returned (newest-first). A truncated artifact is prefixed with a byte-count
-    /// marker; an unavailable one renders a placeholder — and, when the PRIMARY itself is
-    /// unavailable, an explicit note that full validation isn't possible without its content.
+    /// order returned (newest-first). A degraded artifact (<c>is_complete == false</c>) is
+    /// prefixed with <see cref="DegradedMarker"/>; a truncated one additionally gets a
+    /// byte-count marker (degraded composes WITH truncated: degraded line first, then the
+    /// truncation line, mirroring the server's <c>PlanRowRendering</c> ordering); an
+    /// unavailable one renders a placeholder — and, when the PRIMARY itself is unavailable,
+    /// an explicit note that full validation isn't possible without its content.
     /// </summary>
     static async Task RenderPlanArtifacts(PlanArtifactDto? primary, IReadOnlyList<PlanArtifactDto> artifacts) {
         var ordered = primary is null
@@ -121,6 +133,10 @@ static class ValidatePlanCommand {
 
         foreach (var artifact in ordered) {
             var isPrimary = primary is not null && artifact.ArtifactId == primary.ArtifactId;
+
+            if (!artifact.IsComplete) {
+                await Console.Out.WriteLineAsync(DegradedMarker);
+            }
 
             switch (artifact.ContentState) {
                 case "truncated": {

--- a/src/Capacitor.Cli/Commands/ValidatePlanCommand.cs
+++ b/src/Capacitor.Cli/Commands/ValidatePlanCommand.cs
@@ -20,6 +20,9 @@ static class ValidatePlanCommand {
     /// current-session work rows and AI-generated "what's done" summaries. A 404 on the
     /// artifacts route (old server without the route, or a non-visible session) falls back
     /// to <see cref="RenderLegacyAsync"/> — the original recap-only behavior, unchanged.
+    /// Exit codes: 0 for a normal render or "no plan found" (absence is a valid answer); 2
+    /// when the PRIMARY artifact's content is unavailable (validation genuinely isn't
+    /// possible); 1 for transport/HTTP errors (AI-701 review finding 3).
     /// </summary>
     internal static async Task<int> HandleCore(HttpClient httpClient, string baseUrl, string sessionId) {
         HttpResponseMessage artifactsResp;
@@ -95,10 +98,13 @@ static class ValidatePlanCommand {
         var work      = entries.Where(e => e.Type is "write" or "edit" && e.SessionId == sessionId).ToList();
         var summaries = entries.Where(e => e.Type == "whats_done").ToList();
 
-        await RenderPlanArtifacts(primary, artifacts);
+        var primaryUnavailable = await RenderPlanArtifacts(primary, artifacts);
         await RenderWhatsDoneAndInstructions(summaries, work);
 
-        return 0;
+        // AI-701 review finding 3: an unavailable PRIMARY means validation genuinely couldn't
+        // happen — distinct from both success (0, including the "no plan found" case above,
+        // where absence of a plan is itself a valid answer) and a generic error (1).
+        return primaryUnavailable ? 2 : 0;
     }
 
     /// <summary>
@@ -121,12 +127,19 @@ static class ValidatePlanCommand {
     /// unavailable one renders a placeholder — and, when the PRIMARY itself is unavailable,
     /// an explicit note that full validation isn't possible without its content.
     /// </summary>
-    static async Task RenderPlanArtifacts(PlanArtifactDto? primary, IReadOnlyList<PlanArtifactDto> artifacts) {
+    /// <returns>
+    /// <c>true</c> when the PRIMARY artifact's content could not be retrieved
+    /// (<c>content_state == "unavailable"</c>) — the caller uses this to exit 2 instead of 0
+    /// (AI-701 review finding 3): distinguishable from success (0) and from a generic error (1).
+    /// </returns>
+    static async Task<bool> RenderPlanArtifacts(PlanArtifactDto? primary, IReadOnlyList<PlanArtifactDto> artifacts) {
         var ordered = primary is null
             ? artifacts
             : new List<PlanArtifactDto> { primary }
                 .Concat(artifacts.Where(a => a.ArtifactId != primary.ArtifactId))
                 .ToList();
+
+        var primaryUnavailable = false;
 
         await Console.Out.WriteLineAsync("## Plan");
         await Console.Out.WriteLineAsync();
@@ -138,14 +151,23 @@ static class ValidatePlanCommand {
                 await Console.Out.WriteLineAsync(DegradedMarker);
             }
 
-            switch (artifact.ContentState) {
-                case "truncated": {
-                    var n = artifact.Content is null ? 0 : Encoding.UTF8.GetByteCount(artifact.Content);
-                    await Console.Out.WriteLineAsync($"[plan truncated: first {n} of {artifact.OriginalBytes} bytes]");
+            // "truncated" with null Content is treated like "unavailable" (AI-701 review
+            // finding 2): the server contract pairs content_state=="truncated" with non-null
+            // Content, but a malformed/edge response with Content == null must not render the
+            // nonsensical "first 0 of ... bytes" — fall through to the unavailable placeholder.
+            var effectiveState = artifact.ContentState == "truncated" && artifact.Content is null
+                ? "unavailable"
+                : artifact.ContentState;
 
-                    if (artifact.Content is not null) {
-                        await Console.Out.WriteLineAsync(artifact.Content);
-                    }
+            switch (effectiveState) {
+                case "truncated": {
+                    var n = Encoding.UTF8.GetByteCount(artifact.Content!);
+                    // OriginalBytes is nullable — a well-formed truncated artifact always
+                    // carries it, but fall back to "?" rather than emit "of  bytes" if it's
+                    // ever missing (AI-701 review finding 2).
+                    var total = artifact.OriginalBytes?.ToString() ?? "?";
+                    await Console.Out.WriteLineAsync($"[plan truncated: first {n} of {total} bytes]");
+                    await Console.Out.WriteLineAsync(artifact.Content!);
 
                     break;
                 }
@@ -153,6 +175,7 @@ static class ValidatePlanCommand {
                     await Console.Out.WriteLineAsync("[plan content unavailable due to size bounds]");
 
                     if (isPrimary) {
+                        primaryUnavailable = true;
                         await Console.Out.WriteLineAsync(
                             "Validation is not possible: the plan content could not be retrieved (exceeds size bounds).");
                     }
@@ -170,6 +193,8 @@ static class ValidatePlanCommand {
         }
 
         await Console.Out.WriteLineAsync();
+
+        return primaryUnavailable;
     }
 
     /// <summary>Shared "## What's Done" + "## Instructions" rendering, used by both the

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
@@ -16,6 +16,38 @@ public class ClaudeHookCommandTests {
         await Assert.That(fx.RouteOrder).Contains("session-start");
     }
 
+    // AI-701: the session-start payload gains a best-effort workspace_root (the git repo root
+    // for cwd), used server-side by plan-artifact discovery. Fail-open: a cwd with no
+    // discoverable .git entry (e.g. "/tmp") must omit the field entirely rather than send null.
+    [Test]
+    public async Task session_start_includes_workspace_root_when_cwd_is_inside_a_git_repo() {
+        var tmp = Directory.CreateTempSubdirectory("kcap-claude-hook-git-");
+        try {
+            Directory.CreateDirectory(Path.Combine(tmp.FullName, ".git"));
+            var nested = Path.Combine(tmp.FullName, "nested", "dir");
+            Directory.CreateDirectory(nested);
+
+            using var fx = new Fixture();
+            await fx.HandleAsync($$"""{"hook_event_name":"SessionStart","session_id":"{{Sid}}","cwd":"{{nested.Replace("\\", "\\\\")}}"}""");
+
+            var posted = fx.Sent.Single(s => s.StartsWith("/hooks/session-start|"));
+            var body   = JsonNode.Parse(posted[(posted.IndexOf('|') + 1)..]);
+            await Assert.That(body!["workspace_root"]?.GetValue<string>()).IsEqualTo(tmp.FullName);
+        } finally {
+            tmp.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task session_start_omits_workspace_root_when_cwd_has_no_git_repo() {
+        using var fx = new Fixture();
+        await fx.HandleAsync($$"""{"hook_event_name":"SessionStart","session_id":"{{Sid}}","cwd":"/tmp"}""");
+
+        var posted = fx.Sent.Single(s => s.StartsWith("/hooks/session-start|"));
+        var body   = JsonNode.Parse(posted[(posted.IndexOf('|') + 1)..]);
+        await Assert.That(body!["workspace_root"]).IsNull();
+    }
+
     // Covers the auth-hang case from the spec: the hard cap must beat an
     // uncancellable hang (e.g. TokenStore.RefreshAsync's untimed HttpClient.PostAsync).
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
@@ -34,7 +34,22 @@ public class ClaudeHookCommandTests {
             var body   = JsonNode.Parse(posted[(posted.IndexOf('|') + 1)..]);
             await Assert.That(body!["workspace_root"]?.GetValue<string>()).IsEqualTo(tmp.FullName);
         } finally {
-            tmp.Delete(recursive: true);
+            // Best-effort: on windows-latest runners the AV/indexer can transiently hold a
+            // handle on a just-created directory and fail the recursive delete with
+            // IOException ("being used by another process"). The temp dir is on an
+            // ephemeral runner — retry briefly, then let it go rather than fail the test.
+            for (var attempt = 1; ; attempt++) {
+                try {
+                    tmp.Delete(recursive: true);
+                    break;
+                } catch (IOException) when (attempt < 4) {
+                    await Task.Delay(100 * attempt);
+                } catch (IOException) {
+                    break;
+                } catch (UnauthorizedAccessException) {
+                    break;
+                }
+            }
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportChainsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportChainsTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text.Json.Nodes;
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core;
 using WireMock.RequestBuilders;
@@ -294,5 +295,65 @@ public class ImportChainsTests : IDisposable {
         // If serial, spread ≥ 3 × 200ms = 600ms (each chain waits for the previous).
         // If parallel, spread < 100ms (all chains start simultaneously).
         await Assert.That(spreadMs).IsLessThan(160);
+    }
+
+    [Test]
+    public async Task ImportChainsAsync_derives_workspace_root_from_the_remapped_cwd_not_the_raw_meta_cwd() {
+        // Regression (AI-701 review): workspace_root discovery used to run
+        // GitRepository.FindRoot against the RAW transcript cwd (session.Meta.Cwd)
+        // instead of the already remap-/worktree-resolved path the import flow
+        // computes up front into sessionCwds. A historical transcript whose recorded
+        // cwd no longer exists (moved/renamed repo) would silently omit
+        // workspace_root even though the user had configured a cwd_remap that
+        // resolves to a real git working tree.
+        StubAllHookEndpoints();
+
+        var resolvedRepoDir = Path.Combine(_tempDir, "resolved-repo");
+        Directory.CreateDirectory(Path.Combine(resolvedRepoDir, ".git"));
+
+        const string sid = "workspace-root-remap";
+        var path = Path.Combine(_tempDir, $"{sid}.jsonl");
+        File.WriteAllLines(path, new[] {
+            """{"type":"user","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/proj","message":{"content":"line-0"}}""",
+        });
+
+        var session = new ImportCommand.SessionClassification {
+            SessionId  = sid,
+            FilePath   = path,
+            EncodedCwd = "-tmp-proj",
+            // The raw recorded cwd no longer exists on disk / has no git repo — if this
+            // were used directly, FindRoot would return null and workspace_root would
+            // be omitted entirely.
+            Meta       = new() { Cwd = "/definitely/does-not-exist/raw-cwd" },
+            Status     = ImportCommand.ClassificationStatus.New,
+            TotalLines = 1,
+        };
+        var chains = new List<List<ImportCommand.SessionClassification>> { new() { session } };
+
+        // Mirrors what ResolveTranscriptReposAsync populates: the remapped/worktree-resolved
+        // cwd for this session, fed back to ImportSingleSessionAsync's workspace_root lookup.
+        var sessionCwds = new Dictionary<string, string> { [sid] = resolvedRepoDir };
+
+        var events = new ImportCommand.ChainWorkerEvents {
+            OnSessionStarted      = (_, _) => { },
+            OnSubagentStarted     = (_, _, _) => { },
+            OnSubagentFinished    = (_, _, _, _) => { },
+            OnSessionProgress     = (_, _, _) => { },
+            OnSessionErrored      = (_, _, _) => { },
+            OnSessionEnded        = (_, _, _, _) => { },
+            OnTitleTaskReady      = _ => { },
+            OnBackgroundWorkReady = _ => { },
+        };
+
+        using var client = new HttpClient();
+        var result = await ImportCommand.ImportChainsAsync(client, _server.Url!, chains, events, CancellationToken.None, sessionCwds);
+
+        await Assert.That(result.Loaded).IsEqualTo(1);
+
+        var startEntry = _server.LogEntries.Single(e => e.RequestMessage.Path == "/hooks/session-start/claude");
+        var body       = JsonNode.Parse(startEntry.RequestMessage.Body!)!.AsObject();
+
+        await Assert.That(body["workspace_root"]?.GetValue<string>()).IsEqualTo(resolvedRepoDir);
+        await Assert.That(body["cwd"]?.GetValue<string>()).IsEqualTo(resolvedRepoDir);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/OpenCodeImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OpenCodeImportSourceTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using Capacitor.Cli.Commands;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -186,5 +187,70 @@ public class OpenCodeImportSourceTests {
             CancellationToken.None);
 
         await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.TooShort);
+    }
+
+    [Test]
+    public async Task import_session_derives_workspace_root_from_cwd_when_a_git_repo_is_present() {
+        // AI-701 review finding 4: routed imports (OpenCode/Pi/Copilot/Kiro/Antigravity) went
+        // straight to ImportSessionAsync and never derived workspace_root — only the file-based
+        // chain path (ImportChainsAsync) did. Mirrors ImportChainsTests'
+        // ImportChainsAsync_derives_workspace_root_from_the_remapped_cwd_not_the_raw_meta_cwd.
+        using var fix = new OpenCodeDbFixture();
+        var repoDir = Path.Combine(fix.Dir, "repo");
+        Directory.CreateDirectory(Path.Combine(repoDir, ".git"));
+
+        fix.AddSession("ses_wr", null, repoDir, "T", 100);
+        fix.AddMessageWithText("ses_wr", "m1", "hello", 100);
+
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+              .RespondWith(Response.Create().WithStatusCode(404));
+        foreach (var p in new[] { "/hooks/session-start/opencode", "/hooks/transcript",
+                                  "/hooks/set-title", "/hooks/session-end/opencode" })
+            server.Given(Request.Create().WithPath(p).UsingPost()).RespondWith(Response.Create().WithStatusCode(200));
+        using var client = new HttpClient();
+        var ctx = new ClassifyContext(client, server.Url!, MinLines: 1, ExcludedRepos: null, ExcludedPaths: null);
+
+        var source     = new OpenCodeImportSource(fix.DbPath, fix.LedgerPath);
+        var discovered = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+        var classified = await source.ClassifyAsync(discovered, ctx, CancellationToken.None);
+
+        await source.ImportSessionAsync(classified[0], new ImportContext(client, server.Url!, false), CancellationToken.None);
+
+        var startEntry = server.LogEntries.Single(e => e.RequestMessage.Path == "/hooks/session-start/opencode");
+        var body        = JsonNode.Parse(startEntry.RequestMessage.Body!)!.AsObject();
+
+        await Assert.That(body["cwd"]?.GetValue<string>()).IsEqualTo(repoDir);
+        await Assert.That(body["workspace_root"]?.GetValue<string>()).IsEqualTo(repoDir);
+    }
+
+    [Test]
+    public async Task import_session_omits_workspace_root_when_cwd_has_no_git_repo() {
+        using var fix = new OpenCodeDbFixture();
+        var noGitDir = Path.Combine(fix.Dir, "no-git");
+        Directory.CreateDirectory(noGitDir);
+
+        fix.AddSession("ses_nowr", null, noGitDir, "T", 100);
+        fix.AddMessageWithText("ses_nowr", "m1", "hello", 100);
+
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+              .RespondWith(Response.Create().WithStatusCode(404));
+        foreach (var p in new[] { "/hooks/session-start/opencode", "/hooks/transcript",
+                                  "/hooks/set-title", "/hooks/session-end/opencode" })
+            server.Given(Request.Create().WithPath(p).UsingPost()).RespondWith(Response.Create().WithStatusCode(200));
+        using var client = new HttpClient();
+        var ctx = new ClassifyContext(client, server.Url!, MinLines: 1, ExcludedRepos: null, ExcludedPaths: null);
+
+        var source     = new OpenCodeImportSource(fix.DbPath, fix.LedgerPath);
+        var discovered = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+        var classified = await source.ClassifyAsync(discovered, ctx, CancellationToken.None);
+
+        await source.ImportSessionAsync(classified[0], new ImportContext(client, server.Url!, false), CancellationToken.None);
+
+        var startEntry = server.LogEntries.Single(e => e.RequestMessage.Path == "/hooks/session-start/opencode");
+        var body        = JsonNode.Parse(startEntry.RequestMessage.Body!)!.AsObject();
+
+        await Assert.That(body["workspace_root"]).IsNull();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ValidatePlanCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ValidatePlanCommandTests.cs
@@ -223,4 +223,207 @@ public class ValidatePlanCommandTests : IDisposable {
         await Assert.That(stdout).Contains("[plan content unavailable due to size bounds]");
         await Assert.That(stdout).Contains("Validation is not possible");
     }
+
+    [Test, NotInParallel]
+    public async Task Degraded_primary_prefixes_the_plan_section_with_the_degraded_marker() {
+        // CRITICAL (AI-701 review): is_complete == false on the primary — a newer
+        // revision exists but hasn't resolved yet — must render the
+        // "unresolved newer revision" marker before the content. This mirrors the
+        // server's PlanRowRendering.DegradedText byte-for-byte (em-dash, spacing).
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/plan-artifacts").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody($$"""
+                {
+                  "primary": {
+                    "artifact_id": "art-degraded",
+                    "kind": "plan",
+                    "title": "Plan D",
+                    "source": "native_plan",
+                    "session_id": "{{SessionId}}",
+                    "content": "Step 1\nStep 2",
+                    "content_state": "ok",
+                    "is_complete": false,
+                    "is_confirmed": true,
+                    "is_truncated": false,
+                    "content_hash": "deg111",
+                    "version": 1,
+                    "discovered_at": "2026-07-01T00:00:00Z",
+                    "confidence": "high",
+                    "reason": "native plan tool",
+                    "is_primary": true
+                  },
+                  "artifacts": [],
+                  "diagnostics": []
+                }
+                """));
+
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(RecapJson()));
+
+        using var client = new HttpClient();
+        var stdout = await CaptureStdoutAsync(() => ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+
+        await Assert.That(stdout).Contains("[plan state: unresolved newer revision — last known complete text]");
+        await Assert.That(stdout).Contains("Step 1\nStep 2");
+
+        // Marker precedes the content.
+        var markerIndex  = stdout.IndexOf("[plan state: unresolved newer revision", StringComparison.Ordinal);
+        var contentIndex = stdout.IndexOf("Step 1\nStep 2", StringComparison.Ordinal);
+        await Assert.That(markerIndex).IsLessThan(contentIndex);
+    }
+
+    [Test, NotInParallel]
+    public async Task Degraded_and_truncated_primary_renders_both_markers_degraded_first() {
+        // Degraded composes WITH truncated: degraded line first, then the truncation
+        // line, mirroring the server's PlanRowRendering ordering.
+        const string content = "Truncated prefix of a degraded plan...";
+        var byteCount        = Encoding.UTF8.GetByteCount(content);
+
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/plan-artifacts").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody($$"""
+                {
+                  "primary": {
+                    "artifact_id": "art-degraded-truncated",
+                    "kind": "plan",
+                    "title": "Plan E",
+                    "source": "repo_file",
+                    "session_id": "{{SessionId}}",
+                    "content": "{{content}}",
+                    "content_state": "truncated",
+                    "is_complete": false,
+                    "is_confirmed": true,
+                    "is_truncated": true,
+                    "original_bytes": 5000,
+                    "content_hash": "deg222",
+                    "version": 1,
+                    "discovered_at": "2026-07-01T00:00:00Z",
+                    "confidence": "medium",
+                    "reason": "repo file over size bound",
+                    "is_primary": true
+                  },
+                  "artifacts": [],
+                  "diagnostics": []
+                }
+                """));
+
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(RecapJson()));
+
+        using var client = new HttpClient();
+        var stdout = await CaptureStdoutAsync(() => ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+
+        var degradedIndex  = stdout.IndexOf("[plan state: unresolved newer revision", StringComparison.Ordinal);
+        var truncatedIndex = stdout.IndexOf($"[plan truncated: first {byteCount} of 5000 bytes]", StringComparison.Ordinal);
+        var contentIndex   = stdout.IndexOf(content, StringComparison.Ordinal);
+
+        await Assert.That(degradedIndex).IsGreaterThanOrEqualTo(0);
+        await Assert.That(truncatedIndex).IsGreaterThan(degradedIndex);
+        await Assert.That(contentIndex).IsGreaterThan(truncatedIndex);
+    }
+
+    [Test, NotInParallel]
+    public async Task Primary_not_first_in_artifacts_array_still_renders_first_then_others_in_server_order() {
+        // MINOR (AI-701 review): the primary artifact can appear anywhere in the
+        // "artifacts" array (the server's discovery order is newest-first, not
+        // primary-first). Rendering must still put the primary's section first,
+        // followed by the OTHER artifacts in the order the server returned them.
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/plan-artifacts").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody($$"""
+                {
+                  "primary": {
+                    "artifact_id": "art-primary",
+                    "kind": "plan",
+                    "title": "Primary Plan",
+                    "source": "native_plan",
+                    "session_id": "{{SessionId}}",
+                    "content": "PRIMARY-CONTENT",
+                    "content_state": "ok",
+                    "is_complete": true,
+                    "is_confirmed": true,
+                    "is_truncated": false,
+                    "content_hash": "p1",
+                    "version": 1,
+                    "discovered_at": "2026-07-01T00:00:00Z",
+                    "confidence": "high",
+                    "reason": "native plan tool",
+                    "is_primary": true
+                  },
+                  "artifacts": [
+                    {
+                      "artifact_id": "art-other-1",
+                      "kind": "plan",
+                      "title": "Other Plan 1",
+                      "source": "repo_file",
+                      "session_id": "{{SessionId}}",
+                      "content": "OTHER-ONE-CONTENT",
+                      "content_state": "ok",
+                      "is_complete": true,
+                      "is_confirmed": true,
+                      "is_truncated": false,
+                      "content_hash": "o1",
+                      "version": 1,
+                      "discovered_at": "2026-07-01T00:00:00Z",
+                      "confidence": "low",
+                      "reason": "candidate",
+                      "is_primary": false
+                    },
+                    {
+                      "artifact_id": "art-primary",
+                      "kind": "plan",
+                      "title": "Primary Plan",
+                      "source": "native_plan",
+                      "session_id": "{{SessionId}}",
+                      "content": "PRIMARY-CONTENT",
+                      "content_state": "ok",
+                      "is_complete": true,
+                      "is_confirmed": true,
+                      "is_truncated": false,
+                      "content_hash": "p1",
+                      "version": 1,
+                      "discovered_at": "2026-07-01T00:00:00Z",
+                      "confidence": "high",
+                      "reason": "native plan tool",
+                      "is_primary": true
+                    },
+                    {
+                      "artifact_id": "art-other-2",
+                      "kind": "plan",
+                      "title": "Other Plan 2",
+                      "source": "repo_file",
+                      "session_id": "{{SessionId}}",
+                      "content": "OTHER-TWO-CONTENT",
+                      "content_state": "ok",
+                      "is_complete": true,
+                      "is_confirmed": true,
+                      "is_truncated": false,
+                      "content_hash": "o2",
+                      "version": 1,
+                      "discovered_at": "2026-07-01T00:00:00Z",
+                      "confidence": "low",
+                      "reason": "candidate",
+                      "is_primary": false
+                    }
+                  ],
+                  "diagnostics": []
+                }
+                """));
+
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(RecapJson()));
+
+        using var client = new HttpClient();
+        var stdout = await CaptureStdoutAsync(() => ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+
+        var primaryIndex = stdout.IndexOf("PRIMARY-CONTENT", StringComparison.Ordinal);
+        var other1Index  = stdout.IndexOf("OTHER-ONE-CONTENT", StringComparison.Ordinal);
+        var other2Index  = stdout.IndexOf("OTHER-TWO-CONTENT", StringComparison.Ordinal);
+
+        await Assert.That(primaryIndex).IsGreaterThanOrEqualTo(0);
+        await Assert.That(primaryIndex).IsLessThan(other1Index);
+        await Assert.That(other1Index).IsLessThan(other2Index);
+
+        // The primary's content is rendered exactly once (not duplicated because it
+        // also appears in the "artifacts" array).
+        var occurrences = System.Text.RegularExpressions.Regex.Matches(stdout, "PRIMARY-CONTENT").Count;
+        await Assert.That(occurrences).IsEqualTo(1);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ValidatePlanCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ValidatePlanCommandTests.cs
@@ -74,13 +74,15 @@ public class ValidatePlanCommandTests : IDisposable {
             .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(RecapJson()));
 
         using var client = new HttpClient();
-        var stdout = await CaptureStdoutAsync(() => ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+        var exitCode = -1;
+        var stdout = await CaptureStdoutAsync(async () => exitCode = await ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
 
         await Assert.That(stdout).Contains("## Plan");
         await Assert.That(stdout).Contains("Step 1\nStep 2");
         await Assert.That(stdout).Contains("## What's Done");
         await Assert.That(stdout).Contains("Implemented Foo.");
         await Assert.That(stdout).Contains("- Write: src/Foo.cs");
+        await Assert.That(exitCode).IsEqualTo(0);
 
         var hits = _server.FindLogEntries(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet());
         await Assert.That(hits.Count).IsEqualTo(1); // recap is still consulted for work/whats_done
@@ -94,9 +96,11 @@ public class ValidatePlanCommandTests : IDisposable {
                 """));
 
         using var client = new HttpClient();
-        var stdout = await CaptureStdoutAsync(() => ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+        var exitCode = -1;
+        var stdout = await CaptureStdoutAsync(async () => exitCode = await ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
 
         await Assert.That(stdout.Trim()).IsEqualTo("No plan found for this session.");
+        await Assert.That(exitCode).IsEqualTo(0); // absence of a plan is a valid answer
 
         var recapHits = _server.FindLogEntries(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet());
         await Assert.That(recapHits.Count).IsEqualTo(0);
@@ -218,10 +222,107 @@ public class ValidatePlanCommandTests : IDisposable {
             .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(RecapJson()));
 
         using var client = new HttpClient();
-        var stdout = await CaptureStdoutAsync(() => ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+        var exitCode = -1;
+        var stdout = await CaptureStdoutAsync(async () => exitCode = await ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
 
         await Assert.That(stdout).Contains("[plan content unavailable due to size bounds]");
         await Assert.That(stdout).Contains("Validation is not possible");
+        // AI-701 review finding 3: distinguishable from success (0) and from a generic error (1).
+        await Assert.That(exitCode).IsEqualTo(2);
+    }
+
+    [Test, NotInParallel]
+    public async Task Truncated_primary_with_null_original_bytes_falls_back_to_unknown_total_marker() {
+        // AI-701 review finding 2: OriginalBytes is nullable — a malformed/edge response could
+        // omit it even on a "truncated" artifact. The marker must stay well-formed ("of ? bytes"),
+        // never "of  bytes".
+        const string content = "Truncated prefix with no known original size...";
+
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/plan-artifacts").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody($$"""
+                {
+                  "primary": {
+                    "artifact_id": "art-no-total",
+                    "kind": "plan",
+                    "title": "Plan F",
+                    "source": "repo_file",
+                    "session_id": "{{SessionId}}",
+                    "content": "{{content}}",
+                    "content_state": "truncated",
+                    "is_complete": true,
+                    "is_confirmed": true,
+                    "is_truncated": true,
+                    "original_bytes": null,
+                    "content_hash": "notot1",
+                    "version": 1,
+                    "discovered_at": "2026-07-01T00:00:00Z",
+                    "confidence": "medium",
+                    "reason": "repo file over size bound",
+                    "is_primary": true
+                  },
+                  "artifacts": [],
+                  "diagnostics": []
+                }
+                """));
+
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(RecapJson()));
+
+        using var client = new HttpClient();
+        var exitCode = -1;
+        var stdout = await CaptureStdoutAsync(async () => exitCode = await ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+
+        var byteCount = Encoding.UTF8.GetByteCount(content);
+        await Assert.That(stdout).Contains($"[plan truncated: first {byteCount} of ? bytes]");
+        await Assert.That(stdout).DoesNotContain("of  bytes"); // malformed: double space, no total
+        await Assert.That(stdout).Contains(content);
+        await Assert.That(exitCode).IsEqualTo(0); // content did render — this isn't the unavailable case
+    }
+
+    [Test, NotInParallel]
+    public async Task Truncated_primary_with_null_content_renders_like_unavailable() {
+        // AI-701 review finding 2: content_state=="truncated" with Content == null is an edge
+        // shape the server contract doesn't normally produce, but the CLI must not print
+        // "first 0 of {n} bytes" — treat it like "unavailable" (placeholder + exit 2 since this
+        // is the primary).
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/plan-artifacts").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody($$"""
+                {
+                  "primary": {
+                    "artifact_id": "art-null-content",
+                    "kind": "plan",
+                    "title": "Plan G",
+                    "source": "repo_file",
+                    "session_id": "{{SessionId}}",
+                    "content": null,
+                    "content_state": "truncated",
+                    "is_complete": true,
+                    "is_confirmed": true,
+                    "is_truncated": true,
+                    "original_bytes": 5000,
+                    "content_hash": "nullc1",
+                    "version": 1,
+                    "discovered_at": "2026-07-01T00:00:00Z",
+                    "confidence": "medium",
+                    "reason": "repo file over size bound",
+                    "is_primary": true
+                  },
+                  "artifacts": [],
+                  "diagnostics": []
+                }
+                """));
+
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(RecapJson()));
+
+        using var client = new HttpClient();
+        var exitCode = -1;
+        var stdout = await CaptureStdoutAsync(async () => exitCode = await ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+
+        await Assert.That(stdout).DoesNotContain("first 0");
+        await Assert.That(stdout).Contains("[plan content unavailable due to size bounds]");
+        await Assert.That(stdout).Contains("Validation is not possible");
+        await Assert.That(exitCode).IsEqualTo(2);
     }
 
     [Test, NotInParallel]

--- a/test/Capacitor.Cli.Tests.Unit/ValidatePlanCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ValidatePlanCommandTests.cs
@@ -1,0 +1,226 @@
+using System.Text;
+using Capacitor.Cli.Commands;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-701: <see cref="ValidatePlanCommand"/>'s two-call flow — <c>GET .../plan-artifacts?chain=true</c>
+/// for the discovered plan set, then the existing <c>GET .../recap?chain=true</c> for current-session
+/// work rows and "what's done" summaries. A 404 on the artifacts route (old server / non-visible
+/// session) falls back to the original recap-only rendering unchanged.
+///
+/// Every test is <c>[NotInParallel]</c> with NO group key (globally sequential), mirroring
+/// <c>ClaudeHookStdoutTests</c>: the SUT writes to the process-global <see cref="Console.Out"/>,
+/// and a group key alone would not stop a different file's test from leaking into the capture.
+/// </summary>
+public class ValidatePlanCommandTests : IDisposable {
+    const string SessionId = "9dc2775376454e4691ecc2d69973c152";
+
+    readonly WireMockServer _server = WireMockServer.Start();
+
+    public void Dispose() => _server.Stop();
+
+    static async Task<string> CaptureStdoutAsync(Func<Task> action) {
+        var original = Console.Out;
+        var sw       = new StringWriter();
+        Console.SetOut(sw);
+        try {
+            await action();
+        } finally {
+            Console.SetOut(original);
+        }
+        return sw.ToString();
+    }
+
+    static string RecapJson(string extraEntries = "") => $$"""
+        [
+          {"type":"write","session_id":"{{SessionId}}","agent_id":null,"agent_type":null,"content":"","file_path":"src/Foo.cs","timestamp":"2026-07-01T00:00:00Z"},
+          {"type":"whats_done","session_id":null,"agent_id":null,"agent_type":null,"content":"Implemented Foo.","file_path":null,"timestamp":"2026-07-01T00:05:00Z"}{{extraEntries}}
+        ]
+        """;
+
+    [Test, NotInParallel]
+    public async Task Primary_artifact_renders_under_plan_and_recap_supplies_work_and_whats_done() {
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/plan-artifacts").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody($$"""
+                {
+                  "primary": {
+                    "artifact_id": "art-1",
+                    "kind": "plan",
+                    "title": "Plan A",
+                    "source": "native_plan",
+                    "session_id": "{{SessionId}}",
+                    "content": "Step 1\nStep 2",
+                    "content_state": "ok",
+                    "is_complete": true,
+                    "is_confirmed": true,
+                    "is_truncated": false,
+                    "content_hash": "abc123",
+                    "version": 1,
+                    "discovered_at": "2026-07-01T00:00:00Z",
+                    "confidence": "high",
+                    "reason": "native plan tool",
+                    "is_primary": true
+                  },
+                  "artifacts": [],
+                  "diagnostics": []
+                }
+                """));
+
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(RecapJson()));
+
+        using var client = new HttpClient();
+        var stdout = await CaptureStdoutAsync(() => ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+
+        await Assert.That(stdout).Contains("## Plan");
+        await Assert.That(stdout).Contains("Step 1\nStep 2");
+        await Assert.That(stdout).Contains("## What's Done");
+        await Assert.That(stdout).Contains("Implemented Foo.");
+        await Assert.That(stdout).Contains("- Write: src/Foo.cs");
+
+        var hits = _server.FindLogEntries(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet());
+        await Assert.That(hits.Count).IsEqualTo(1); // recap is still consulted for work/whats_done
+    }
+
+    [Test, NotInParallel]
+    public async Task Empty_response_prints_no_plan_found_and_skips_recap() {
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/plan-artifacts").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody("""
+                { "primary": null, "artifacts": [], "diagnostics": [] }
+                """));
+
+        using var client = new HttpClient();
+        var stdout = await CaptureStdoutAsync(() => ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+
+        await Assert.That(stdout.Trim()).IsEqualTo("No plan found for this session.");
+
+        var recapHits = _server.FindLogEntries(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet());
+        await Assert.That(recapHits.Count).IsEqualTo(0);
+    }
+
+    [Test, NotInParallel]
+    public async Task NotFound_falls_back_to_legacy_recap_only_rendering() {
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/plan-artifacts").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404));
+
+        // Legacy path: a single recap call carrying a "plan" entry plus the usual work/whats_done.
+        var extra = $$""", {"type":"plan","session_id":"{{SessionId}}","agent_id":null,"agent_type":null,"content":"Legacy plan text","file_path":null,"timestamp":"2026-06-30T00:00:00Z"}""";
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(RecapJson(extra)));
+
+        using var client = new HttpClient();
+        var stdout = await CaptureStdoutAsync(() => ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+
+        await Assert.That(stdout).Contains("## Plan");
+        await Assert.That(stdout).Contains("Legacy plan text");
+        await Assert.That(stdout).Contains("## What's Done");
+        await Assert.That(stdout).Contains("Implemented Foo.");
+        await Assert.That(stdout).DoesNotContain("plan truncated");
+        await Assert.That(stdout).DoesNotContain("plan content unavailable");
+
+        // Both routes were attempted: plan-artifacts first (404), then the recap fallback.
+        var artifactHits = _server.FindLogEntries(Request.Create().WithPath($"/api/sessions/{SessionId}/plan-artifacts").UsingGet());
+        await Assert.That(artifactHits.Count).IsEqualTo(1);
+        var recapHits = _server.FindLogEntries(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet());
+        await Assert.That(recapHits.Count).IsEqualTo(1);
+    }
+
+    [Test, NotInParallel]
+    public async Task NotFound_with_no_plan_entries_prints_no_plan_found() {
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/plan-artifacts").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404));
+
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(RecapJson()));
+
+        using var client = new HttpClient();
+        var stdout = await CaptureStdoutAsync(() => ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+
+        await Assert.That(stdout.Trim()).IsEqualTo("No plan found for this session.");
+    }
+
+    [Test, NotInParallel]
+    public async Task Truncated_primary_prefixes_the_plan_section_with_a_byte_count_marker() {
+        const string content = "Truncated prefix of the plan...";
+        var byteCount        = Encoding.UTF8.GetByteCount(content);
+
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/plan-artifacts").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody($$"""
+                {
+                  "primary": {
+                    "artifact_id": "art-2",
+                    "kind": "plan",
+                    "title": "Plan B",
+                    "source": "repo_file",
+                    "session_id": "{{SessionId}}",
+                    "content": "{{content}}",
+                    "content_state": "truncated",
+                    "is_complete": true,
+                    "is_confirmed": true,
+                    "is_truncated": true,
+                    "original_bytes": 5000,
+                    "content_hash": "def456",
+                    "version": 1,
+                    "discovered_at": "2026-07-01T00:00:00Z",
+                    "confidence": "medium",
+                    "reason": "repo file over size bound",
+                    "is_primary": true
+                  },
+                  "artifacts": [],
+                  "diagnostics": []
+                }
+                """));
+
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(RecapJson()));
+
+        using var client = new HttpClient();
+        var stdout = await CaptureStdoutAsync(() => ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+
+        await Assert.That(stdout).Contains($"[plan truncated: first {byteCount} of 5000 bytes]");
+        await Assert.That(stdout).Contains(content);
+    }
+
+    [Test, NotInParallel]
+    public async Task Unavailable_primary_renders_placeholder_and_states_validation_is_not_possible() {
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/plan-artifacts").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody($$"""
+                {
+                  "primary": {
+                    "artifact_id": "art-3",
+                    "kind": "plan",
+                    "title": "Plan C",
+                    "source": "repo_file",
+                    "session_id": "{{SessionId}}",
+                    "content": null,
+                    "content_state": "unavailable",
+                    "is_complete": true,
+                    "is_confirmed": true,
+                    "is_truncated": false,
+                    "original_bytes": 999999,
+                    "content_hash": "ghi789",
+                    "version": 1,
+                    "discovered_at": "2026-07-01T00:00:00Z",
+                    "confidence": "low",
+                    "reason": "content exceeds hard size bound",
+                    "is_primary": true
+                  },
+                  "artifacts": [],
+                  "diagnostics": []
+                }
+                """));
+
+        _server.Given(Request.Create().WithPath($"/api/sessions/{SessionId}/recap").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(RecapJson()));
+
+        using var client = new HttpClient();
+        var stdout = await CaptureStdoutAsync(() => ValidatePlanCommand.HandleCore(client, _server.Url!, SessionId));
+
+        await Assert.That(stdout).Contains("[plan content unavailable due to size bounds]");
+        await Assert.That(stdout).Contains("Validation is not possible");
+    }
+}


### PR DESCRIPTION
CLI half of [AI-701](https://linear.app/kurrent/issue/AI-701) — pairs with kurrent-io/kcap-server#1039 (either side works without the other).

- `kcap validate-plan` now makes two calls on new servers: `GET /api/sessions/{id}/plan-artifacts?chain=true` for plans (primary selected by `is_primary`, degraded/truncated/unavailable markers byte-identical to the server's `PlanRowRendering`) plus the existing recap call for current-session work rows and `whats_done`. A 404 from plan-artifacts falls back to the legacy recap-only filtering unchanged; 200-empty renders "No plan found"; an unavailable primary is reported as not validatable.
- Session-start hooks for all supported harnesses (and the history importer, remap-aware) emit an optional `workspace_root` from the existing fail-open git-root discovery — feeds workspace-scoped artifact identity server-side.
- `PlanArtifactDto`/`PlanArtifactsResponseDto` registered in the AOT `CapacitorJsonContext`; osx-arm64 publish clean with zero AOT warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)