### PR TITLE
[AI-1271] MCP tool discoverability — route why/history/prior-work intents to the kcap tools

### DIFF
--- a/kcap/.mcp.json
+++ b/kcap/.mcp.json
@@ -8,7 +8,8 @@
     "kcap-sessions": {
       "command": "kcap",
       "args": ["mcp", "sessions"],
-      "cwd": "${CLAUDE_PROJECT_DIR}"
+      "cwd": "${CLAUDE_PROJECT_DIR}",
+      "description": "Search and recall past Kurrent Capacitor sessions — the reasoning behind prior work (why / what-was-tried / who-decided / when). For 'have we done X before' or 'why did we' questions, reach for search_sessions before git log or grep. Repo-aware: cd into a project and search_sessions defaults to that repo's sessions."
     },
     "kcap-flows": {
       "command": "kcap",

--- a/src/Capacitor.Cli.Core/Mcp/KcapMcpServers.cs
+++ b/src/Capacitor.Cli.Core/Mcp/KcapMcpServers.cs
@@ -16,7 +16,8 @@ public static class KcapMcpServers {
     public static readonly IReadOnlyList<KcapMcpServer> All = [
         new("kcap-review",   ["mcp", "review"],   NeedsProjectCwd: false,
             "PR review context tools — query implementation session transcripts.", ReadOnly: true),
-        new("kcap-sessions", ["mcp", "sessions"], NeedsProjectCwd: true,  null, ReadOnly: true),
+        new("kcap-sessions", ["mcp", "sessions"], NeedsProjectCwd: true,
+            "Search and recall past Kurrent Capacitor sessions — the reasoning behind prior work (why / what-was-tried / who-decided). Repo-aware; reach for it before git log or grep for history questions.", ReadOnly: true),
         new("kcap-flows",    ["mcp", "flows"],    NeedsProjectCwd: true,
             "Structured AI agent flows — launches a SEPARATE hosted participant agent; requires login + a running daemon."),
         new("kcap-memory",   ["mcp", "memory"],   NeedsProjectCwd: true,

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -114,10 +114,17 @@ static class McpMemoryServer {
         try { return await MachineIdProvider.GetOrCreateAsync(); } catch { return null; }
     }
 
+    // Server-level usage preamble (MCP `instructions`) — steers clients to check for prior art here
+    // before assuming none, and to save durable learnings.
+    const string ServerInstructions =
+        "Use these tools for durable team knowledge — preferences, feedback, project facts, references. " +
+        "Search memories before assuming there's no prior art on a task, and before saving a new one — they " +
+        "hold learnings that aren't in the code.";
+
     static string BuildInitializeResponse(JsonNode id, JsonObject request) =>
         ToResponse<McpInitResult>(
             id,
-            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-memory", "1.0.0")),
+            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-memory", "1.0.0"), ServerInstructions),
             McpJsonContext.Default.McpInitResult
         );
 
@@ -341,7 +348,7 @@ static class McpMemoryServer {
 
     internal static McpTool[] BuildToolsList() => [
         new("search_memories",
-            "Search the team's shared memories (hybrid semantic + keyword). Call this BEFORE saving a new memory and when starting work that might have prior learnings.",
+            "Search the team's shared memories (hybrid semantic + keyword). Call this before saving a new memory, and before assuming there's no prior art on a task — it surfaces durable team learnings (preferences, feedback, project facts) that aren't in the code.",
             new("object", new() {
                 ["query"] = new("string", "What to search for."),
                 ["limit"] = new("number", "Max results (default 10, max 50).")

--- a/src/Capacitor.Cli/Commands/McpReviewServer.cs
+++ b/src/Capacitor.Cli/Commands/McpReviewServer.cs
@@ -127,10 +127,19 @@ static class McpReviewServer {
         }
     }
 
+    // Server-level usage preamble (MCP `instructions`) — a model-facing hint some clients add to the
+    // system prompt. Same "reach for kcap before native git/GitHub/grep for why/history" framing as the
+    // per-tool descriptions, at the server level (belt-and-suspenders behind the descriptions).
+    const string ServerInstructions =
+        "Use these tools when reviewing a PR or asking why code was written this way. Reach for them before " +
+        "native git/GitHub/grep for why / history / prior-work questions — they surface the implementer's " +
+        "reasoning from the recorded session transcript, which commits and diffs don't capture — while you " +
+        "still read the diff itself for correctness.";
+
     static string BuildInitializeResponse(JsonNode id, JsonObject request) =>
         ToResponse<McpInitResult>(
             id,
-            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-review", "1.0.0")),
+            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-review", "1.0.0"), ServerInstructions),
             McpJsonContext.Default.McpInitResult
         );
 
@@ -264,7 +273,7 @@ static class McpReviewServer {
         return [
             new(
                 "get_pr_summary",
-                "Get an overview of the PR: which Claude Code sessions contributed, which files were changed (with event counts), and what test commands were run with their pass/fail outcomes. Call this first to orient yourself.",
+                "Get an overview of the PR: which Claude Code sessions contributed, which files were changed (with event counts), and what test commands were run with their pass/fail outcomes. Call this first to orient yourself. When reviewing a PR or asking why code was written this way, reach for this before git blame or git log — and alongside the diff — because it surfaces the implementer's actual reasoning from the session transcript, which commits and diffs don't capture.",
                 new("object", new() { ["pr"] = new("string", PrArgDescription) }, [])
             ),
             new(
@@ -274,7 +283,7 @@ static class McpReviewServer {
             ),
             new(
                 "get_file_context",
-                "Get deep context for a specific file: which sessions modified it, when, and relevant transcript excerpts where the file was discussed or changed. Use this when a reviewer asks 'why was this file changed?'",
+                "Get deep context for a specific file: which sessions modified it, when, and relevant transcript excerpts where the file was discussed or changed. When a reviewer asks 'why was this file changed?', reach for this before git blame or git log — it surfaces the reasoning behind the change from the session transcript, complementing (not replacing) the diff.",
                 new(
                     "object",
                     new() {
@@ -286,7 +295,7 @@ static class McpReviewServer {
             ),
             new(
                 "search_context",
-                "Full-text search across all session transcripts linked to this PR. Returns ranked excerpts with speaker (user/assistant/tool), content, and highlighted snippets. Use for 'why' questions: 'why retry logic', 'what alternatives', 'error handling rationale'.",
+                "Full-text search across all session transcripts linked to this PR. Returns ranked excerpts with speaker (user/assistant/tool), content, and highlighted snippets. For 'why' questions ('why retry logic', 'what alternatives', 'error handling rationale'), search here before git blame or git log — it finds the implementer's reasoning across the session, which commits and diffs don't capture; still read the diff for correctness.",
                 new(
                     "object",
                     new() {
@@ -369,8 +378,10 @@ static class PrResolution {
     }
 }
 
-// MCP protocol types — serialized with source-generated McpJsonContext for AOT compatibility
-record McpInitResult(string ProtocolVersion, McpCapabilities Capabilities, McpServerInfo ServerInfo);
+// MCP protocol types — serialized with source-generated McpJsonContext for AOT compatibility.
+// `Instructions` is the optional MCP-standard server-level usage preamble (camelCase + omitted when
+// null via McpJsonContext's global options); servers that pass none simply omit it.
+record McpInitResult(string ProtocolVersion, McpCapabilities Capabilities, McpServerInfo ServerInfo, string? Instructions = null);
 
 record McpCapabilities(McpToolsCapability Tools);
 

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -109,10 +109,17 @@ static class McpSessionsServer {
         }
     }
 
+    // Server-level usage preamble (MCP `instructions`) — steers clients toward these tools for
+    // prior-work / why / who-decided questions over native grep / git log.
+    const string ServerInstructions =
+        "Use these tools to recall prior work — 'have we done X before', 'why did we', 'who decided Y', " +
+        "'when did we work on Z'. Search here before grepping the code or git log — they search the reasoning " +
+        "across past sessions, not just the code.";
+
     static string BuildInitializeResponse(JsonNode id, JsonObject request) =>
         ToResponse<McpInitResult>(
             id,
-            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-sessions", "1.0.0")),
+            new(McpProtocol.NegotiateVersion(request), new(new()), new("kcap-sessions", "1.0.0"), ServerInstructions),
             McpJsonContext.Default.McpInitResult
         );
 
@@ -490,7 +497,7 @@ static class McpSessionsServer {
     static McpTool[] BuildToolsList() => [
         new(
             "search_sessions",
-            "Search past Kurrent Capacitor sessions in the current repo (or across all visible repos with repo: \"all\") by free-text question and/or author name. Returns ranked hits with session_id, title, owner, snippet, and (for transcript hits) hit_event_index + agent_id for drilling into the exact moment with get_session_transcript. Use this for 'why did X happen?', 'who decided Y?', 'when did we work on Z?' questions.",
+            "Search past Kurrent Capacitor sessions in the current repo (or across all visible repos with repo: \"all\") by free-text question and/or author name. Returns ranked hits with session_id, title, owner, snippet, and (for transcript hits) hit_event_index + agent_id for drilling into the exact moment with get_session_transcript. For 'have we done this before / why did we / who decided X / when did we work on Y' questions, search here before grepping the code or git log — it searches the reasoning across past sessions, not just the code.",
             new(
                 "object",
                 new() {

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -214,6 +214,9 @@ public class McpFlowsServerTests : IDisposable {
             await Assert.That(result).IsNotNull();
             await Assert.That(result!["serverInfo"]?["name"]?.GetValue<string>()).IsEqualTo("kcap-flows");
             await Assert.That(result["protocolVersion"]?.GetValue<string>()).IsEqualTo("2024-11-05");
+            // AI-1271: flows deliberately gets NO server-level instructions (we don't want more
+            // routing to a paid hosted reviewer) — the field must be omitted.
+            await Assert.That(result["instructions"]).IsNull();
         } finally {
             await ShutdownAsync(proc);
         }

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -214,7 +214,7 @@ public class McpFlowsServerTests : IDisposable {
             await Assert.That(result).IsNotNull();
             await Assert.That(result!["serverInfo"]?["name"]?.GetValue<string>()).IsEqualTo("kcap-flows");
             await Assert.That(result["protocolVersion"]?.GetValue<string>()).IsEqualTo("2024-11-05");
-            // AI-1271: flows deliberately gets NO server-level instructions (we don't want more
+            // flows deliberately gets NO server-level instructions (we don't want more
             // routing to a paid hosted reviewer) — the field must be omitted.
             await Assert.That(result["instructions"]).IsNull();
         } finally {

--- a/test/Capacitor.Cli.Tests.Integration/McpMemoryServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpMemoryServerTests.cs
@@ -1,0 +1,161 @@
+using System.Diagnostics;
+using System.Text.Json.Nodes;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// End-to-end stdio JSON-RPC handshake tests for <c>kcap mcp memory</c>. Memory previously had
+/// only unit coverage of its URL/body builders (<c>McpMemoryServerTests</c> in the unit project);
+/// this adds a spawned-process handshake so the AI-1271 server-level <c>instructions</c> preamble
+/// and the <c>search_memories</c> routing cue can't be silently dropped. Mirrors the sessions
+/// integration harness.
+/// </summary>
+public class McpMemoryServerTests : IDisposable {
+    readonly WireMockServer _server           = WireMockServer.Start();
+    readonly string         _cfgDir           = Path.Combine(Path.GetTempPath(), $"kcap-mcp-mem-cfg-{Guid.NewGuid():N}");
+    readonly string         _cwdDir           = Path.Combine(Path.GetTempPath(), $"kcap-mcp-mem-cwd-{Guid.NewGuid():N}");
+    readonly List<Process>  _spawnedProcesses = [];
+
+    public McpMemoryServerTests() {
+        Directory.CreateDirectory(_cfgDir);
+        Directory.CreateDirectory(_cwdDir);
+    }
+
+    public void Dispose() {
+        foreach (var p in _spawnedProcesses) {
+            try {
+                if (!p.HasExited) p.Kill(entireProcessTree: true);
+                p.Dispose();
+            } catch {
+                // best-effort cleanup
+            }
+        }
+
+        _server.Stop();
+        try { Directory.Delete(_cfgDir, recursive: true); } catch { /* best effort */ }
+        try { Directory.Delete(_cwdDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    static string GetCliBinaryPath() {
+        var asmDir      = Path.GetDirectoryName(typeof(McpMemoryServerTests).Assembly.Location)!;
+        var binDir      = Path.GetDirectoryName(asmDir)!;
+        var config      = Path.GetFileName(binDir);
+        var testBin     = Path.GetDirectoryName(binDir)!;
+        var testProjDir = Path.GetDirectoryName(testBin)!;
+        var testRoot    = Path.GetDirectoryName(testProjDir)!;
+        var repoRoot    = Path.GetDirectoryName(testRoot)!;
+        var binaryName  = OperatingSystem.IsWindows() ? "kcap.exe" : "kcap";
+
+        return Path.Combine(repoRoot, "src", "Capacitor.Cli", "bin", config, "net10.0", binaryName);
+    }
+
+    Process SpawnMcpServer(string provider = "None") {
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($$"""{"provider":"{{provider}}"}"""));
+
+        var binary = GetCliBinaryPath();
+        if (!File.Exists(binary)) {
+            throw new FileNotFoundException(
+                $"kcap binary not found at {binary}. Build it first: " +
+                "dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj",
+                binary
+            );
+        }
+
+        var psi = new ProcessStartInfo(binary, "mcp memory") {
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+            CreateNoWindow         = true,
+            WorkingDirectory       = _cwdDir,
+            Environment = {
+                ["KCAP_URL"]        = _server.Url!,
+                ["KCAP_CONFIG_DIR"] = _cfgDir
+            }
+        };
+
+        var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start kcap process");
+        _spawnedProcesses.Add(process);
+
+        return process;
+    }
+
+    [Test]
+    public async Task Initialize_returns_kcap_memory_server_info_with_instructions() {
+        using var proc = SpawnMcpServer();
+        try {
+            var response = await SendRequest(proc, InitializeRequest(1));
+
+            await Assert.That(response["id"]?.GetValue<int>()).IsEqualTo(1);
+            var result = response["result"]?.AsObject();
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!["serverInfo"]?["name"]?.GetValue<string>()).IsEqualTo("kcap-memory");
+            // AI-1271: server-level instructions preamble.
+            await Assert.That(result["instructions"]?.GetValue<string>()).IsNotNull();
+            await Assert.That(result["instructions"]!.GetValue<string>()).IsNotEmpty();
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    [Test]
+    public async Task Tools_list_search_memories_carries_the_routing_cue() {
+        using var proc = SpawnMcpServer();
+        try {
+            var response = await SendRequest(proc, ToolsListRequest(2));
+
+            var tools = response["result"]?["tools"]?.AsArray();
+            await Assert.That(tools).IsNotNull();
+
+            var searchDesc = tools!.First(t => t?["name"]?.GetValue<string>() == "search_memories")!["description"]!.GetValue<string>();
+            // AI-1271 hard gate: the comparative routing cue must be present.
+            await Assert.That(searchDesc).Contains("before assuming there's no prior art");
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
+    static async Task<JsonObject> SendRequest(Process proc, JsonObject request, TimeSpan? timeout = null) {
+        await proc.StandardInput.WriteLineAsync(request.ToJsonString());
+        await proc.StandardInput.FlushAsync();
+
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(15));
+        var line      = await proc.StandardOutput.ReadLineAsync(cts.Token);
+
+        if (line is null) {
+            var stderr = await proc.StandardError.ReadToEndAsync();
+            throw new InvalidOperationException($"MCP server closed stdout without responding. Stderr: {stderr}");
+        }
+
+        return JsonNode.Parse(line)?.AsObject()
+            ?? throw new InvalidOperationException($"Could not parse response as JSON object: {line}");
+    }
+
+    static async Task ShutdownAsync(Process proc) {
+        try { proc.StandardInput.Close(); } catch { /* already closed */ }
+        try {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await proc.WaitForExitAsync(cts.Token);
+        } catch {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
+        }
+    }
+
+    static JsonObject InitializeRequest(int id) => new() {
+        ["jsonrpc"] = "2.0",
+        ["id"]      = id,
+        ["method"]  = "initialize",
+        ["params"]  = new JsonObject()
+    };
+
+    static JsonObject ToolsListRequest(int id) => new() {
+        ["jsonrpc"] = "2.0",
+        ["id"]      = id,
+        ["method"]  = "tools/list",
+        ["params"]  = new JsonObject()
+    };
+}

--- a/test/Capacitor.Cli.Tests.Integration/McpMemoryServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpMemoryServerTests.cs
@@ -9,7 +9,7 @@ namespace Capacitor.Cli.Tests.Integration;
 /// <summary>
 /// End-to-end stdio JSON-RPC handshake tests for <c>kcap mcp memory</c>. Memory previously had
 /// only unit coverage of its URL/body builders (<c>McpMemoryServerTests</c> in the unit project);
-/// this adds a spawned-process handshake so the AI-1271 server-level <c>instructions</c> preamble
+/// this adds a spawned-process handshake so the server-level <c>instructions</c> preamble
 /// and the <c>search_memories</c> routing cue can't be silently dropped. Mirrors the sessions
 /// integration harness.
 /// </summary>
@@ -94,7 +94,7 @@ public class McpMemoryServerTests : IDisposable {
             var result = response["result"]?.AsObject();
             await Assert.That(result).IsNotNull();
             await Assert.That(result!["serverInfo"]?["name"]?.GetValue<string>()).IsEqualTo("kcap-memory");
-            // AI-1271: server-level instructions preamble.
+            // server-level instructions preamble.
             await Assert.That(result["instructions"]?.GetValue<string>()).IsNotNull();
             await Assert.That(result["instructions"]!.GetValue<string>()).IsNotEmpty();
         } finally {
@@ -112,7 +112,7 @@ public class McpMemoryServerTests : IDisposable {
             await Assert.That(tools).IsNotNull();
 
             var searchDesc = tools!.First(t => t?["name"]?.GetValue<string>() == "search_memories")!["description"]!.GetValue<string>();
-            // AI-1271 hard gate: the comparative routing cue must be present.
+            // Hard gate: the comparative routing cue must be present.
             await Assert.That(searchDesc).Contains("before assuming there's no prior art");
         } finally {
             await ShutdownAsync(proc);

--- a/test/Capacitor.Cli.Tests.Integration/McpReviewServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpReviewServerTests.cs
@@ -153,7 +153,7 @@ public class McpReviewServerTests : IDisposable {
             var result = response["result"]?.AsObject();
             await Assert.That(result).IsNotNull();
             await Assert.That(result!["serverInfo"]?["name"]?.GetValue<string>()).IsEqualTo("kcap-review");
-            // AI-1271: server-level instructions preamble steers clients toward kcap for why/history.
+            // server-level instructions preamble steers clients toward kcap for why/history.
             await Assert.That(result["instructions"]?.GetValue<string>()).IsNotNull();
             await Assert.That(result["instructions"]!.GetValue<string>()).IsNotEmpty();
         } finally {
@@ -174,7 +174,7 @@ public class McpReviewServerTests : IDisposable {
             await Assert.That(names.Contains("get_pr_summary")).IsTrue();
             await Assert.That(names.Contains("get_transcript")).IsTrue();
 
-            // AI-1271 hard gate: the entrypoint tools carry the comparative routing cue so a future
+            // Hard gate: the entrypoint tools carry the comparative routing cue so a future
             // edit can't silently drop it.
             string Desc(string tool) => tools!.First(t => t?["name"]?.GetValue<string>() == tool)!["description"]!.GetValue<string>();
             await Assert.That(Desc("get_pr_summary")).Contains("before git blame or git log");

--- a/test/Capacitor.Cli.Tests.Integration/McpReviewServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpReviewServerTests.cs
@@ -153,6 +153,9 @@ public class McpReviewServerTests : IDisposable {
             var result = response["result"]?.AsObject();
             await Assert.That(result).IsNotNull();
             await Assert.That(result!["serverInfo"]?["name"]?.GetValue<string>()).IsEqualTo("kcap-review");
+            // AI-1271: server-level instructions preamble steers clients toward kcap for why/history.
+            await Assert.That(result["instructions"]?.GetValue<string>()).IsNotNull();
+            await Assert.That(result["instructions"]!.GetValue<string>()).IsNotEmpty();
         } finally {
             await ShutdownAsync(proc);
         }
@@ -170,6 +173,13 @@ public class McpReviewServerTests : IDisposable {
             var names = tools!.Select(t => t?["name"]?.GetValue<string>()).ToHashSet();
             await Assert.That(names.Contains("get_pr_summary")).IsTrue();
             await Assert.That(names.Contains("get_transcript")).IsTrue();
+
+            // AI-1271 hard gate: the entrypoint tools carry the comparative routing cue so a future
+            // edit can't silently drop it.
+            string Desc(string tool) => tools!.First(t => t?["name"]?.GetValue<string>() == tool)!["description"]!.GetValue<string>();
+            await Assert.That(Desc("get_pr_summary")).Contains("before git blame or git log");
+            await Assert.That(Desc("get_file_context")).Contains("before git blame or git log");
+            await Assert.That(Desc("search_context")).Contains("before git blame or git log");
         } finally {
             await ShutdownAsync(proc);
         }

--- a/test/Capacitor.Cli.Tests.Integration/McpSessionsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpSessionsServerTests.cs
@@ -189,6 +189,9 @@ public class McpSessionsServerTests : IDisposable {
             await Assert.That(result).IsNotNull();
             await Assert.That(result!["serverInfo"]?["name"]?.GetValue<string>()).IsEqualTo("kcap-sessions");
             await Assert.That(result["protocolVersion"]?.GetValue<string>()).IsEqualTo("2024-11-05");
+            // AI-1271: server-level instructions preamble.
+            await Assert.That(result["instructions"]?.GetValue<string>()).IsNotNull();
+            await Assert.That(result["instructions"]!.GetValue<string>()).IsNotEmpty();
         } finally {
             await ShutdownAsync(proc);
         }
@@ -210,6 +213,10 @@ public class McpSessionsServerTests : IDisposable {
             await Assert.That(names.Contains("get_session_transcript")).IsTrue();
             await Assert.That(names.Contains("get_turn")).IsTrue();
             await Assert.That(names.Contains("list_turns")).IsTrue();
+
+            // AI-1271 hard gate: search_sessions carries the comparative routing cue.
+            var searchDesc = tools.First(t => t?["name"]?.GetValue<string>() == "search_sessions")!["description"]!.GetValue<string>();
+            await Assert.That(searchDesc).Contains("before grepping the code or git log");
         } finally {
             await ShutdownAsync(proc);
         }

--- a/test/Capacitor.Cli.Tests.Integration/McpSessionsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpSessionsServerTests.cs
@@ -189,7 +189,7 @@ public class McpSessionsServerTests : IDisposable {
             await Assert.That(result).IsNotNull();
             await Assert.That(result!["serverInfo"]?["name"]?.GetValue<string>()).IsEqualTo("kcap-sessions");
             await Assert.That(result["protocolVersion"]?.GetValue<string>()).IsEqualTo("2024-11-05");
-            // AI-1271: server-level instructions preamble.
+            // server-level instructions preamble.
             await Assert.That(result["instructions"]?.GetValue<string>()).IsNotNull();
             await Assert.That(result["instructions"]!.GetValue<string>()).IsNotEmpty();
         } finally {
@@ -214,7 +214,7 @@ public class McpSessionsServerTests : IDisposable {
             await Assert.That(names.Contains("get_turn")).IsTrue();
             await Assert.That(names.Contains("list_turns")).IsTrue();
 
-            // AI-1271 hard gate: search_sessions carries the comparative routing cue.
+            // Hard gate: search_sessions carries the comparative routing cue.
             var searchDesc = tools.First(t => t?["name"]?.GetValue<string>() == "search_sessions")!["description"]!.GetValue<string>();
             await Assert.That(searchDesc).Contains("before grepping the code or git log");
         } finally {

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpCanonicalContractTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpCanonicalContractTests.cs
@@ -26,7 +26,7 @@ public class McpCanonicalContractTests {
 
     [Test]
     public async Task Every_canonical_server_has_a_description() {
-        // AI-1271: kcap-sessions previously had a null Description. Pin that every canonical server
+        // kcap-sessions previously had a null Description. Pin that every canonical server
         // carries one so the routing/discoverability gap can't silently reopen.
         foreach (var s in KcapMcpServers.All)
             await Assert.That(string.IsNullOrWhiteSpace(s.Description))

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpCanonicalContractTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpCanonicalContractTests.cs
@@ -25,6 +25,23 @@ public class McpCanonicalContractTests {
     }
 
     [Test]
+    public async Task Every_canonical_server_has_a_description() {
+        // AI-1271: kcap-sessions previously had a null Description. Pin that every canonical server
+        // carries one so the routing/discoverability gap can't silently reopen.
+        foreach (var s in KcapMcpServers.All)
+            await Assert.That(string.IsNullOrWhiteSpace(s.Description))
+                .IsFalse().Because($"{s.Name} must have a non-empty Description");
+    }
+
+    [Test]
+    public async Task Every_bundled_claude_mcp_server_has_a_description() {
+        var servers = (JsonObject)JsonNode.Parse(File.ReadAllText(Path.Combine(KcapDir(), ".mcp.json")))!["mcpServers"]!;
+        foreach (var (name, node) in servers)
+            await Assert.That(string.IsNullOrWhiteSpace(node?["description"]?.GetValue<string>()))
+                .IsFalse().Because($"{name} in .mcp.json must have a non-empty description");
+    }
+
+    [Test]
     public async Task Bundled_codex_mcp_json_matches_the_codex_subset() {
         await Assert.That(Keys(".codex-mcp.json"))
             .IsEquivalentTo(KcapMcpServers.ForCodex.Select(s => s.Name).ToArray());


### PR DESCRIPTION
## Summary

Registration ≠ routing. The kcap MCP servers are wired across harnesses, but agents still reach for native tools — "review this PR" → GitHub/`git blame`, "have we done X" → grep. This sharpens the **one lever that reaches every MCP client identically** (per-tool `description` from `tools/list`) plus the server-level `instructions` preamble. Implements [AI-1271](https://linear.app/kurrent/issue/AI-1271).

## Changes

- **Entrypoint tool descriptions** get one comparative routing cue each — naming the native alternative to beat *and* the unique value kcap adds (always complementary to the diff, never a replacement):
  - `kcap-review` `get_pr_summary` / `get_file_context` / `search_context` → *"before git blame or git log … which commits and diffs don't capture; still read the diff for correctness"*
  - `kcap-sessions` `search_sessions` → *"before grepping the code or git log — searches the reasoning across past sessions"*
  - `kcap-memory` `search_memories` → *"before assuming there's no prior art"*
  - Drill-down tools (`list_pr_files`, `list_turns`, `get_turn`, `get_transcript`, …) unchanged — they're reached only after an entrypoint already selected kcap.
- **Server-level `instructions`** — added optional `string? Instructions` to `McpInitResult` (camelCase, omitted-when-null via the existing source-gen options). `kcap-review` / `kcap-sessions` / `kcap-memory` return a one-paragraph usage preamble on `initialize`. **`kcap-flows` returns none** — its defensive posture is intentional (no extra routing to a *paid* hosted reviewer).
- **Missing `kcap-sessions` description** filled in both the canonical `KcapMcpServers` list and the bundled `kcap/.mcp.json`. Kept Claude-`.mcp.json`-only (routing rides on `tools/list`, so `JsonMcpConfigWriter` is not threaded — a conscious §3 decision).

## Why this reaches Claude (and every harness)

These live in the MCP servers and are answered over JSON-RPC, so the exact same text lands on **every** client that launches the server — Claude, Cursor, Codex, Gemini, Kiro, OpenCode, Pi — with no per-harness code. (The `*-instructions.md` steering files we added earlier only reach the JSON harnesses; Claude doesn't read them.)

## Testing

- **Integration handshake** (`kcap mcp review|sessions|memory|flows`): asserts non-empty `instructions` for review/sessions/memory, **absent** for flows, and the entrypoint routing-cue marker substrings on `tools/list` (new `McpMemoryServerTests`). Hard-gate so a future edit can't silently drop a cue.
- **Contract test**: every canonical `KcapMcpServer` and every bundled `.mcp.json` entry must carry a description — so the `kcap-sessions` gap can't reopen.
- Full unit + integration suites green (MCP integration 103/103; one unrelated pre-existing turn-buffer flake, passes in isolation).

Spec: `docs/superpowers/specs/2026-07-08-mcp-tool-discoverability-design.md` (kcap-server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
