### PR TITLE
[AI-1313] Flow-reviewer capacity reaping — daemon self-defense (Phase B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,18 @@ verbatim, exactly like every other agent, with no Cursor/ACP-specific redaction.
 | `KCAP_CODEX_IDLE_MINUTES` | `60` | How long a Codex rollout file may be idle (no new rollout lines and no Codex tool call in flight) before the `kcap watch` background watcher ends the session (`reason: idle_timeout`). Increase for very long thinking/compute turns; decrease for faster cleanup of abandoned sessions. Invalid or non-positive values fall back to the 60-minute default. |
 | `KCAP_PARENT_DEAD_CEILING_MINUTES` | `360` | Staged recovery ceiling for a watcher whose parent coding-agent PID was already dead at startup (a resolution glitch) and can't be re-resolved. The watcher first periodically re-resolves and re-arms the parent-exit watchdog; only if that keeps failing AND the transcript makes no progress for this long does it post `session-end` (`reason: parent_dead_ceiling`). Deliberately far above the idle timeout so a user parked at a Kiro/OpenCode prompt is never ended prematurely. Invalid or non-positive values fall back to 360 minutes (6h). |
 
+#### Review-flow reviewer backstops & crash-survivor reaping
+
+Hosted review-flow reviewers are *unattended* and count against the daemon's `--max-agents` budget. To keep a stuck or abandoned reviewer from holding a slot forever, the daemon defends its own capacity:
+
+- **Lifetime / idle backstop.** The heartbeat reaps a review-flow reviewer that has run past a maximum lifetime or gone idle too long (the driver vanished, or its run went terminal on the server without the daemon hearing about it). Interactive agents are never touched by these bounds.
+- **Crash-survivor reaping.** Each hosted child's pid + an exact OS-native start-identity is written to a durable per-daemon record under `{state-dir}/{name}/agents/` at spawn, and every child is stamped with `KCAP_AGENT_ID` / `KCAP_DAEMON_ID` / `KCAP_DAEMON_EPOCH` env markers. On the next boot (and on the heartbeat) the daemon reaps any child that outlived a **prior** incarnation of itself — matched by exact `(pid, start-identity)` from the record, or, for a recordless survivor, by the env markers (same daemon id, older epoch). A process is killed only when its identity is *proven*; anything ambiguous is spared (never a wrong kill). On Linux the env checks read `/proc/{pid}/environ`; on macOS 26 process env is redacted from other processes, so the record-based path is the effective mechanism there (production runs on Linux).
+
+| Environment variable | Default | Description |
+|----------------------|---------|-------------|
+| `KCAP_REVIEWER_MAX_LIFETIME` | `6h` (`21600`) | Max wall-clock lifetime, **in seconds**, for a hosted review-flow reviewer before the heartbeat reaps it. `0` disables the bound. |
+| `KCAP_REVIEWER_IDLE_TIMEOUT` | `2h` (`7200`)  | Max time, **in seconds**, a reviewer may go without output before the heartbeat reaps it. `0` disables the bound. |
+
 #### Daemon log verbosity
 
 The daemon logs at `Information` by default. Raise the level for transport diagnostics — for example, per-tick `DaemonPing` round-trip times (logged at `Debug`) are useful for telling whether SignalR reconnects are caused by network/proxy latency. Set it either way:

--- a/docs/superpowers/plans/2026-07-17-ai1313-phase-b-cli-daemon-self-defense.md
+++ b/docs/superpowers/plans/2026-07-17-ai1313-phase-b-cli-daemon-self-defense.md
@@ -61,7 +61,7 @@
 - Produces: `record DaemonStatusReport(int ActiveCount, IReadOnlyList<LiveAgentInfo> LiveAgents, IReadOnlyList<QuarantinedAgentInfo> Quarantined)`.
 - Produces: `DaemonConnect` gains trailing `LiveAgentInfo[]? LiveAgents = null` (the existing `string[] LiveAgentIds` stays for back-compat).
 
-- [ ] **Step 1: Write the failing test** — a DTO round-trips through `CapacitorJsonContext` and old-shape JSON (no new fields) still deserializes.
+- [x] **Step 1: Write the failing test** — a DTO round-trips through `CapacitorJsonContext` and old-shape JSON (no new fields) still deserializes.
 
 ```csharp
 using System.Text.Json;

--- a/docs/superpowers/plans/2026-07-17-ai1313-phase-b-cli-daemon-self-defense.md
+++ b/docs/superpowers/plans/2026-07-17-ai1313-phase-b-cli-daemon-self-defense.md
@@ -1,0 +1,504 @@
+# AI-1313 Phase B (kcap-cli) — Daemon self-defense Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the `kcap agent` daemon the self-defense the server's Phase A (PR #1109) can't provide: harden post-spawn launch cleanup, advertise richer per-agent metadata, add a reviewer TTL/idle backstop, and — the core — make hosted-agent processes recoverable after a daemon crash via durable PID records + a startup orphan reap + a scoped env-marker scan, so a survivor never leaks its capacity slot forever.
+
+**Architecture:** All work is in the `kcap-cli` daemon (`Capacitor.Cli.Daemon`), on top of the existing `AgentOrchestrator` (registry `_agents`, `HandleLaunchAgent`/`HandleStopAgent`, `RunHeartbeatLoopAsync`) and the `Pty` spawn layer. Every protocol change is **additive** (an old server ignores unknown JSON fields / unknown one-way hub methods; an old daemon never sets them), so this PR is independently deployable in either order with the Phase A server. Death recovery is **managed-C#** here (write a PID record atomically at spawn → at next boot / on every heartbeat, reap leftover records + env-marked survivors by exact OS-native identity) — no native OS-containment primitive is required for correctness; that (Windows Job Object, Linux `PDEATHSIG`) is a separate follow-on that only makes death *immediate* rather than *next-sweep*.
+
+**Tech Stack:** .NET 10, C#, AOT-published CLI; TUnit test suite (`test/`); `System.Text.Json` source-gen DTOs in `Capacitor.Cli.Core/Models.cs`; SignalR client (`ServerConnection`); existing PTY interop (`Pty/Unix/UnixPtyInterop.cs`, `Pty/Windows/ConPtyInterop.cs`).
+
+## Global Constraints
+
+- **Additive protocol only.** New DTO fields are trailing/optional; new daemon→server messages are one-way `SendAsync` (never `InvokeAsync`) so an unknown method on an old server is a server-side log line, not a client fault. Old daemon ↔ new server and new daemon ↔ old server must both work (spec §7).
+- **No live daemon, no live flows in tests.** Every kill/reap/containment test acts on **isolated dummy processes** the test spawns and owns (spec §2, §8). Never signal a real `kcap-daemon` or a real reviewer.
+- **Ambiguity never kills.** A process is killed only when its identity is proven (exact OS-native start-identity match **plus**, on Unix, the `KCAP_AGENT_ID` env check — the record regime; OR the full env marker triple — the marker regime). If identity/env cannot be read, the process is **spared**, the record quarantined, and a warning logged (spec §6.4(2),(2b)).
+- **A record is deleted only after confirmed death** — exit observed, or the exact identity matches no live process. A failed/timed-out/attempted kill **retains** the record for the next sweep (spec §6.4(2)).
+- **Process identity is the exact OS-native creation stamp**, stored + compared in native units, never round-tripped through `DateTime` (Linux `/proc/{pid}/stat` field 22 `starttime` in clock ticks; macOS `proc_pidinfo`/`kinfo_proc` start `tv_sec`+`tv_usec`; Windows creation `FILETIME`). No tolerance window (spec §6.4(2)).
+- **Reviewer TTL/idle defaults:** lifetime 6h, idle 2h; `0` disables; config keys `daemon.reviewer_max_lifetime`/`daemon.reviewer_idle_timeout` + env `KCAP_REVIEWER_MAX_LIFETIME`/`KCAP_REVIEWER_IDLE_TIMEOUT`. Interactive agents untouched (spec §6.3).
+- **Single-flight teardown:** exactly one teardown runs per agent even when the launch-catch and the read-loop `finally` race (`Interlocked.CompareExchange` flag) (spec §6.1).
+- **`ActiveCount` never changes meaning on the wire:** it stays exactly the `_agents` Starting/Running count. The daemon admission gate becomes `EffectiveCount = ActiveCount + Quarantined.Count` (spec §6.4(2a)).
+
+---
+
+## Scope
+
+**In scope (this PR):** D1 (post-spawn single-flight cleanup), D2 (agent metadata + additive `LiveAgents` on `DaemonConnect` + one-way periodic `DaemonStatusReport` **send**), D3 (reviewer TTL/idle backstop), D4 **managed reaping** — atomic PID records with exact identity, in-memory kill-quarantine, startup orphan reap (`killpg`), scoped env-marker scan (`KCAP_DAEMON_ID`/`KCAP_DAEMON_EPOCH`), and the `HandleStopAgent` PID-record fallback.
+
+**Deferred to follow-on plans** (see the final section — each is an independent subsystem, so a separate plan per the writing-plans scope rule):
+- **Plan B-native — D4 layer 1 OS containment:** Windows creation-time Job Object (`ConPtyProcess`) + Linux `PR_SET_PDEATHSIG` on a dedicated daemon-lifetime spawner thread with an async-signal-safe post-fork shim + `getppid` re-check (`UnixPtyProcess`). Pure hardening on top of this PR's records/scan (makes death immediate; the records/scan already recover survivors), and the only part needing native interop + a C shim.
+- **Plan B2 — sequenced-command settlement (bilateral, server+CLI):** `Epoch`/`Seq`, `StopAgentV2`, `CommandAck`, `AckProcessedPrefix`, `ResolvedStartupCandidates`, generation settlement, and the server-side consumers (S3(b)/(c) untracked-reap + retry-until-gone, S6 daemon-authoritative, the `DaemonStatusReport` **server handler**). This PR only *sends* the report; nothing consumes it yet.
+
+---
+
+## File Structure
+
+- `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` — D1 (single-flight teardown in the launch catch + read-loop finally), D2 (`AgentInstance` metadata; `LiveAgents` snapshot builder; `RunDaemonStatusReportLoopAsync`), D3 (reviewer TTL/idle in `RunHeartbeatLoopAsync`), D4 (write PID record at spawn; kill-quarantine field + heartbeat retry; `HandleStopAgent` PID-record fallback).
+- `src/Capacitor.Cli.Daemon/Services/AgentPidRecordStore.cs` *(new)* — atomic write (temp+rename) / read / delete of `<state-dir>/agents/{agentId}.json`; parse + `.corrupt` quarantine; enumerate leftover records.
+- `src/Capacitor.Cli.Daemon/Services/ProcessIdentity.cs` *(new)* — capture + compare the exact OS-native start-identity for a pid (Linux `/proc/{pid}/stat`, macOS `proc_pidinfo`, Windows `GetProcessTimes`); `IsAlive(pid, identity)`; read a live process's `KCAP_*` env (Linux `/proc/{pid}/environ`, macOS `ps -E -ww`).
+- `src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs` *(new)* — startup record pass (`killpg`→5s→`SIGKILL`, confirmed-death delete) + scoped env-marker scan; both re-runnable from a heartbeat tick.
+- `src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs` *(new)* — in-memory set of unconfirmed-death launch contexts the heartbeat retries; feeds `EffectiveCount` + the status report.
+- `src/Capacitor.Cli.Daemon/DaemonConfig.cs` — `ReviewerMaxLifetime`/`ReviewerIdleTimeout`; the daemon state-dir path + `KCAP_DAEMON_ID`/epoch.
+- `src/Capacitor.Cli.Core/Models.cs` — `LaunchAgentCommand` gains `FlowRunId?`/`FlowRole?`; `DaemonConnect` gains `LiveAgents?`; new `LiveAgentInfo`, `DaemonStatusReport`, `QuarantinedAgentInfo` DTOs + `LaunchKind`-adjacent additions; register all in `CapacitorJsonContext`.
+- `src/Capacitor.Cli.Daemon/Services/ServerConnection.cs` — send `LiveAgents` in `DaemonConnectAsync`; add `DaemonStatusReportAsync` one-way sender.
+- `src/Capacitor.Cli.Daemon/Pty/*` — spawn passes the `KCAP_AGENT_ID`/`KCAP_DAEMON_ID`/`KCAP_DAEMON_EPOCH` env markers to the child (env only — no native containment in this PR).
+- Tests under `test/…Daemon.Tests/` (mirror the existing daemon test project layout): `AgentPidRecordStoreTests`, `ProcessIdentityTests`, `OrphanReaperTests`, `AgentKillQuarantineTests`, `ReviewerTtlTests`, `LaunchCleanupTests`, `DaemonStatusReportTests`.
+
+> **Note (verify at execution time):** confirm the daemon state-dir accessor + `DaemonLock` location the spec cites near `DaemonRunner.cs:380`/`CleanupOrphanedAsync`; `WorktreeManager.CleanupOrphanedAsync` is the sibling boot-cleanup seam. Confirm the exact daemon test project path/namespace (`grep -r "class .*Tests" test/` in the CLI repo) and mirror it — task test paths below use `test/Capacitor.Cli.Daemon.Tests/` as the placeholder to correct on first task.
+
+---
+
+### Task 1: D2a — additive DTOs (`FlowRunId`/`FlowRole`, `LiveAgents`, `DaemonStatusReport`)
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/Models.cs` (`LaunchAgentCommand`, `DaemonConnect`, `CapacitorJsonContext`)
+- Test: `test/Capacitor.Cli.Daemon.Tests/DtoRoundTripTests.cs`
+
+**Interfaces:**
+- Produces: `LaunchAgentCommand` gains trailing `string? FlowRunId = null, string? FlowRole = null`.
+- Produces: `record LiveAgentInfo(string Id, string Kind, DateTimeOffset CreatedAt, string? FlowRunId = null, string? FlowRole = null)`.
+- Produces: `record QuarantinedAgentInfo(string Id, string Kind, DateTimeOffset CreatedAt, string? FlowRunId = null, string? FlowRole = null)`.
+- Produces: `record DaemonStatusReport(int ActiveCount, IReadOnlyList<LiveAgentInfo> LiveAgents, IReadOnlyList<QuarantinedAgentInfo> Quarantined)`.
+- Produces: `DaemonConnect` gains trailing `LiveAgentInfo[]? LiveAgents = null` (the existing `string[] LiveAgentIds` stays for back-compat).
+
+- [ ] **Step 1: Write the failing test** — a DTO round-trips through `CapacitorJsonContext` and old-shape JSON (no new fields) still deserializes.
+
+```csharp
+using System.Text.Json;
+using Capacitor.Cli.Core;
+
+public class DtoRoundTripTests {
+    [Test]
+    public async Task DaemonStatusReport_roundtrips_through_source_gen_context() {
+        var report = new DaemonStatusReport(
+            ActiveCount: 2,
+            LiveAgents: [ new LiveAgentInfo("a1", "ReviewFlow", DateTimeOffset.UtcNow, "flow-1", "reviewer") ],
+            Quarantined: [ new QuarantinedAgentInfo("a2", "Default", DateTimeOffset.UtcNow) ]);
+        var json = JsonSerializer.Serialize(report, CapacitorJsonContext.Default.DaemonStatusReport);
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.DaemonStatusReport)!;
+        await Assert.That(back.ActiveCount).IsEqualTo(2);
+        await Assert.That(back.LiveAgents[0].FlowRunId).IsEqualTo("flow-1");
+    }
+
+    [Test]
+    public async Task LaunchAgentCommand_old_json_without_flow_fields_still_deserializes() {
+        // An old server sends no FlowRunId/FlowRole — must deserialize with nulls, not throw.
+        var oldJson = """{"AgentId":"a1","Model":"default","RepoPath":"/r","Vendor":"codex"}""";
+        var cmd = JsonSerializer.Deserialize(oldJson, CapacitorJsonContext.Default.LaunchAgentCommand)!;
+        await Assert.That(cmd.FlowRunId).IsNull();
+        await Assert.That(cmd.FlowRole).IsNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run → FAIL** (types/context members don't exist).
+
+Run: `dotnet run --project test/Capacitor.Cli.Daemon.Tests -- --treenode-filter "/*/*/DtoRoundTripTests/*"`
+Expected: FAIL — `LiveAgentInfo`/`DaemonStatusReport` undefined.
+
+- [ ] **Step 3: Add the DTOs + trailing fields + `[JsonSerializable]` registrations** in `Models.cs`. Add `FlowRunId`/`FlowRole` as trailing params on `LaunchAgentCommand` (after every existing param, all defaulted `= null`). Add the three new records. Add to `CapacitorJsonContext`:
+
+```csharp
+[JsonSerializable(typeof(LiveAgentInfo))]
+[JsonSerializable(typeof(QuarantinedAgentInfo))]
+[JsonSerializable(typeof(DaemonStatusReport))]
+```
+
+Add `LiveAgentInfo[]? LiveAgents = null` as the final param of `DaemonConnect`.
+
+- [ ] **Step 4: Run → PASS.**
+
+- [ ] **Step 5: Commit** — `git add -A && git commit -m "[AI-1313] Phase B D2a: additive daemon status DTOs (LiveAgents, DaemonStatusReport, LaunchAgentCommand flow identity)"`
+
+---
+
+### Task 2: D2b — `AgentInstance` metadata (Kind + flow identity) + `LiveAgents` snapshot
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (`AgentInstance` record; capture `cmd.Kind`/`cmd.FlowRunId`/`cmd.FlowRole` at construction ~`:508`; add `BuildLiveAgents()`), `src/Capacitor.Cli.Daemon/Services/ServerConnection.cs` (`DaemonConnectAsync` sends `LiveAgents`)
+- Test: `test/Capacitor.Cli.Daemon.Tests/LiveAgentsSnapshotTests.cs`
+
+**Interfaces:**
+- Consumes: `LaunchAgentCommand.FlowRunId`/`FlowRole`/`Kind` (Task 1).
+- Produces: `AgentInstance` gains `public LaunchKind Kind { get; init; } = LaunchKind.Default; public string? FlowRunId { get; init; } public string? FlowRole { get; init; }`.
+- Produces: `AgentOrchestrator.BuildLiveAgents() : IReadOnlyList<LiveAgentInfo>` — one entry per `_agents` value with `Status is "Starting" or "Running"`.
+- Produces: `ServerConnection.GetLiveAgents` callback wired like the existing `GetLiveAgentIds`.
+
+- [ ] **Step 1: Write the failing test** — `BuildLiveAgents` reflects a launched ReviewFlow agent's flow identity + kind, and excludes stopped agents. (Use the daemon test project's existing `AgentOrchestrator` construction helper — locate it: `grep -rn "new AgentOrchestrator(" test/`.)
+
+```csharp
+[Test]
+public async Task BuildLiveAgents_includes_running_reviewflow_identity_excludes_stopped() {
+    var orch = TestOrchestrator.Create(); // existing test helper
+    orch.SeedAgentForTest(id: "a1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-1", flowRole: "reviewer", status: "Running");
+    orch.SeedAgentForTest(id: "a2", kind: LaunchKind.Default, status: "Stopped");
+    var live = orch.BuildLiveAgents();
+    await Assert.That(live.Select(x => x.Id)).IsEquivalentTo(new[] { "a1" });
+    await Assert.That(live[0].FlowRunId).IsEqualTo("flow-1");
+    await Assert.That(live[0].Kind).IsEqualTo("ReviewFlow");
+}
+```
+
+> If no `SeedAgentForTest` helper exists, add a minimal `internal` test seam on `AgentOrchestrator` that inserts a pre-built `AgentInstance` into `_agents` (guarded `[InternalsVisibleTo]` already exists for the daemon test project — verify).
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement** — add the three properties to `AgentInstance`; set them at the `:508` construction (`Kind = cmd.Kind, FlowRunId = cmd.FlowRunId, FlowRole = cmd.FlowRole`); add:
+
+```csharp
+internal IReadOnlyList<LiveAgentInfo> BuildLiveAgents() =>
+    [.. _agents.Values
+        .Where(a => a.Status is "Starting" or "Running")
+        .Select(a => new LiveAgentInfo(a.Id, a.Kind.ToString(), a.CreatedAt, a.FlowRunId, a.FlowRole))];
+```
+
+Wire `_server.GetLiveAgents = BuildLiveAgents;` next to the existing `GetLiveAgentIds` wiring, and in `ServerConnection.DaemonConnectAsync` pass `GetLiveAgents?.Invoke()?.ToArray()` as the new `DaemonConnect.LiveAgents` arg.
+
+- [ ] **Step 4: Run → PASS.**
+
+- [ ] **Step 5: Commit** — `[AI-1313] Phase B D2b: AgentInstance flow identity + LiveAgents on DaemonConnect`
+
+---
+
+### Task 3: D2c — periodic one-way `DaemonStatusReport` send
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (start `RunDaemonStatusReportLoopAsync` next to the existing loops ~`:278`), `src/Capacitor.Cli.Daemon/Services/ServerConnection.cs` (`DaemonStatusReportAsync`)
+- Test: `test/Capacitor.Cli.Daemon.Tests/DaemonStatusReportTests.cs`
+
+**Interfaces:**
+- Consumes: `BuildLiveAgents()` (Task 2), `AgentKillQuarantine.Snapshot()` (Task 8 — until then, empty).
+- Produces: `ServerConnection.DaemonStatusReportAsync(DaemonStatusReport report)` — **one-way `SendAsync`**, wrapped in its own try/catch, never `InvokeAsync`.
+
+- [ ] **Step 1: Write the failing test** — the report loop builds a report with `ActiveCount` = running/starting count and sends via the one-way path; a send exception does not escape.
+
+```csharp
+[Test]
+public async Task StatusReport_sends_active_count_and_live_agents_one_way_swallowing_errors() {
+    var sends = new List<DaemonStatusReport>();
+    var server = new FakeServerConnection { OnStatusReport = r => { sends.Add(r); throw new Exception("boom"); } };
+    var orch = TestOrchestrator.Create(server);
+    orch.SeedAgentForTest("a1", LaunchKind.ReviewFlow, status: "Running");
+    await orch.SendDaemonStatusReportOnceAsync(); // extract the loop body into a testable method
+    await Assert.That(sends).Count().IsEqualTo(1);
+    await Assert.That(sends[0].ActiveCount).IsEqualTo(1);
+    // no throw escaped
+}
+```
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement** — add `ServerConnection.DaemonStatusReportAsync`:
+
+```csharp
+public async Task DaemonStatusReportAsync(DaemonStatusReport report) {
+    try { await _hub.SendAsync("DaemonStatusReport", report, cancellationToken: _ct); }
+    catch (Exception ex) { _logger.LogDebug(ex, "DaemonStatusReport send failed (old server or transient) — ignoring"); }
+}
+```
+
+Add `SendDaemonStatusReportOnceAsync()` (builds `new DaemonStatusReport(ActiveCount, BuildLiveAgents(), _quarantine.Snapshot())` and calls the server) and a 60s `RunDaemonStatusReportLoopAsync(ct)` that calls it each tick inside a total try/catch, started from the same place as `RunHeartbeatLoopAsync`.
+
+- [ ] **Step 4: Run → PASS.**
+
+- [ ] **Step 5: Commit** — `[AI-1313] Phase B D2c: periodic one-way DaemonStatusReport send`
+
+---
+
+### Task 4: D3 — reviewer lifetime/idle backstop
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/DaemonConfig.cs` (config + env), `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (`RunHeartbeatLoopAsync` ~`:1473`)
+- Test: `test/Capacitor.Cli.Daemon.Tests/ReviewerTtlTests.cs`
+
+**Interfaces:**
+- Produces: `DaemonConfig.ReviewerMaxLifetime`/`ReviewerIdleTimeout` (`TimeSpan`, defaults 6h/2h, `TimeSpan.Zero` disables).
+- Consumes: `AgentInstance.Kind` (Task 2), `CreatedAt`/`LastOutputAt` (existing).
+
+- [ ] **Step 1: Write the failing test** — with an injectable clock, a 6h-old Running ReviewFlow agent is reaped with `reviewer_ttl_expired`, a 2h-idle one with `reviewer_idle_expired`, an interactive agent of the same age is untouched, and `0` disables. (Inject a `Func<DateTime> _utcNow` seam into `AgentOrchestrator`; assert `HandleStopAgent` was invoked with the right end reason via a fake.)
+
+```csharp
+[Test]
+public async Task Heartbeat_reaps_reviewflow_past_lifetime_but_not_interactive() {
+    var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+    var orch = TestOrchestrator.Create(clock: () => now, config: c => c.ReviewerMaxLifetime = TimeSpan.FromHours(6));
+    orch.SeedAgentForTest("rev", LaunchKind.ReviewFlow, status: "Running", createdAt: now.AddHours(-7));
+    orch.SeedAgentForTest("int", LaunchKind.Default,    status: "Running", createdAt: now.AddHours(-7));
+    await orch.RunReviewerTtlSweepOnceAsync(); // extract the reviewer-TTL check into a testable method
+    await Assert.That(orch.StoppedAgents).Contains(("rev", "reviewer_ttl_expired"));
+    await Assert.That(orch.StoppedAgents.Select(x => x.Id)).DoesNotContain("int");
+}
+```
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement** — add the config fields + env parsing (`KCAP_REVIEWER_MAX_LIFETIME`/`KCAP_REVIEWER_IDLE_TIMEOUT`, seconds; `0`→`TimeSpan.Zero`); in the heartbeat `foreach`, after the stuck-Starting check, add:
+
+```csharp
+if (agent.Kind == LaunchKind.ReviewFlow && agent.Status == "Running") {
+    if (_config.ReviewerMaxLifetime > TimeSpan.Zero && _utcNow() - agent.CreatedAt > _config.ReviewerMaxLifetime) {
+        agent.PendingEndReason = "reviewer_ttl_expired"; _ = HandleStopAgent(agent.Id); continue;
+    }
+    if (_config.ReviewerIdleTimeout > TimeSpan.Zero && _utcNow() - agent.LastOutputAt > _config.ReviewerIdleTimeout) {
+        agent.PendingEndReason = "reviewer_idle_expired"; _ = HandleStopAgent(agent.Id); continue;
+    }
+}
+```
+
+Route the existing `DateTime.UtcNow` reads in the loop through the `_utcNow()` seam.
+
+- [ ] **Step 4: Run → PASS.**
+
+- [ ] **Step 5: Commit** — `[AI-1313] Phase B D3: reviewer lifetime/idle backstop (6h/2h, 0 disables)`
+
+---
+
+### Task 5: D4a — `ProcessIdentity` (exact OS-native start-identity + liveness + env read)
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/ProcessIdentity.cs`
+- Test: `test/Capacitor.Cli.Daemon.Tests/ProcessIdentityTests.cs`
+
+**Interfaces:**
+- Produces: `readonly record struct ProcessStartIdentity(string Kind, long A, long B)` — `Kind` ∈ `linux-starttime`/`macos-tv`/`windows-filetime`; `(A,B)` the native units (macOS `tv_sec`,`tv_usec`; others in `A`, `B=0`). Serialized as-is (native units, no `DateTime`).
+- Produces: `static ProcessStartIdentity? Capture(int pid)` — null if unreadable.
+- Produces: `static bool Matches(int pid, ProcessStartIdentity expected)` — exact equality against a fresh `Capture(pid)`; false if the pid is gone or identity differs.
+- Produces: `static bool IsAlive(int pid)`.
+- Produces: `static string? ReadAgentEnv(int pid, string key)` — Linux `/proc/{pid}/environ`, macOS `ps -E -ww -o pid=,command=` parse; null if unreadable (→ caller spares).
+
+- [ ] **Step 1: Write the failing test** — capture the identity of a dummy child this test spawns, assert `Matches` is true for the live pid and false after it exits; assert exact serialize round-trip (native units).
+
+```csharp
+[Test]
+public async Task Capture_then_Matches_holds_for_live_process_and_fails_after_exit() {
+    using var dummy = DummyProcess.StartSleep(seconds: 30);   // test-owned isolated process
+    var id = ProcessIdentity.Capture(dummy.Pid)!;
+    await Assert.That(ProcessIdentity.Matches(dummy.Pid, id.Value)).IsTrue();
+    dummy.Kill(); dummy.WaitForExit();
+    await Assert.That(ProcessIdentity.Matches(dummy.Pid, id.Value)).IsFalse();
+}
+
+[Test]
+public async Task Identity_round_trips_in_native_units() {
+    using var dummy = DummyProcess.StartSleep(30);
+    var id = ProcessIdentity.Capture(dummy.Pid)!.Value;
+    var json = JsonSerializer.Serialize(id, CapacitorJsonContext.Default.ProcessStartIdentity);
+    var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.ProcessStartIdentity);
+    await Assert.That(back).IsEqualTo(id);
+    dummy.Kill();
+}
+```
+
+> Add a `DummyProcess` test helper: spawns a real, isolated child (e.g. `/bin/sleep` on Unix, `ping -n` on Windows) the test fully owns; exposes `Pid`, `Kill()`, `WaitForExit()`, and (for Task 7) accepts custom env vars. This is the ONLY thing tests kill.
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement** `ProcessIdentity` with an OS switch: Linux parses `/proc/{pid}/stat` field 22 (`starttime`, careful with the parenthesized comm containing spaces — split on the last `')'`); macOS P/Invokes `proc_pidinfo(PROC_PIDTBSDINFO)` for `pbi_start_tvsec`/`pbi_start_tvusec`; Windows `GetProcessTimes` creation `FILETIME` → `long`. `ReadAgentEnv`: Linux reads NUL-delimited `/proc/{pid}/environ`; macOS runs `ps -E -ww -o pid=,command=` once and parses the appended env for the pid. Register `ProcessStartIdentity` in `CapacitorJsonContext`.
+
+- [ ] **Step 4: Run → PASS** on this host (macOS dev box — the macOS branch runs; Linux/Windows branches are covered by CI runners on those OSes).
+
+- [ ] **Step 5: Commit** — `[AI-1313] Phase B D4a: ProcessIdentity (exact OS-native start-identity, liveness, env read)`
+
+---
+
+### Task 6: D4b — `AgentPidRecordStore` (atomic records + parse + corrupt-quarantine + enumerate)
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/AgentPidRecordStore.cs`
+- Modify: `src/Capacitor.Cli.Daemon/DaemonConfig.cs` (state-dir accessor if not present; `KcapDaemonId` = hash of state-dir path; `KcapDaemonEpoch` = fresh GUID persisted at boot)
+- Test: `test/Capacitor.Cli.Daemon.Tests/AgentPidRecordStoreTests.cs`
+
+**Interfaces:**
+- Produces: `record AgentPidRecord(string AgentId, int Pid, ProcessStartIdentity StartIdentity, string Kind, string Vendor, string? FlowRunId, string? FlowRole, string DaemonId, string DaemonEpoch, DateTimeOffset SpawnedAt)`.
+- Produces: `void Write(AgentPidRecord r)` — temp-file + same-directory `File.Move(overwrite:true)` (atomic); creates `<state-dir>/agents/`.
+- Produces: `bool Delete(string agentId)`.
+- Produces: `IReadOnlyList<AgentPidRecord> ReadAll()` — parses every `*.json`; on parse failure renames `{agentId}.json`→`{agentId}.json.corrupt` and logs, excludes it (never returned, never acted on).
+
+- [ ] **Step 1: Write the failing test** — write→ReadAll returns it with exact identity; a hand-written corrupt file is renamed `.corrupt` and excluded; `Delete` removes it.
+
+```csharp
+[Test]
+public async Task Write_ReadAll_Delete_roundtrip_and_corrupt_is_quarantined() {
+    var dir = TestDir.Create();
+    var store = new AgentPidRecordStore(dir, NullLogger.Instance);
+    var rec = new AgentPidRecord("a1", 123, new("linux-starttime", 999, 0), "ReviewFlow", "codex", "f1", "reviewer", "did", "ep", DateTimeOffset.UtcNow);
+    store.Write(rec);
+    await Assert.That(store.ReadAll().Single().Pid).IsEqualTo(123);
+    File.WriteAllText(Path.Combine(dir, "agents", "bad.json"), "{ not json");
+    await Assert.That(store.ReadAll().Select(r => r.AgentId)).IsEquivalentTo(new[] { "a1" });
+    await Assert.That(File.Exists(Path.Combine(dir, "agents", "bad.json.corrupt"))).IsTrue();
+    store.Delete("a1");
+    await Assert.That(store.ReadAll()).IsEmpty();
+}
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** the store (atomic temp+rename; `try { JsonSerializer.Deserialize } catch { rename .corrupt; log; skip }`). Add `AgentPidRecord` to `CapacitorJsonContext`. Add the state-dir + `KcapDaemonId`/`KcapDaemonEpoch` to config (epoch persisted to `<state-dir>/daemon-epoch` at boot).
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `[AI-1313] Phase B D4b: AgentPidRecordStore (atomic PID records + corrupt quarantine)`
+
+---
+
+### Task 7: D4c — write the record at spawn + pass env markers + `HandleStopAgent` PID-record fallback
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (write record immediately after the runtime spawns, before `RegisterAgentAsync`; delete on confirmed-death teardown; `HandleStopAgent` fallback ~`:906`), `src/Capacitor.Cli.Daemon/Pty/*` + launchers (pass `KCAP_AGENT_ID`/`KCAP_DAEMON_ID`/`KCAP_DAEMON_EPOCH` in the child env)
+- Test: `test/Capacitor.Cli.Daemon.Tests/StopAgentFallbackTests.cs`
+
+**Interfaces:**
+- Consumes: `AgentPidRecordStore` (Task 6), `ProcessIdentity` (Task 5).
+- Produces: env markers on every hosted-agent child; a PID record written at `runtime.Pid` capture time.
+- Produces: `HandleStopAgent(agentId)` for an id absent from `_agents` consults the record → kills by exact `(pid, identity)` + Unix env `KCAP_AGENT_ID` check → confirmed-death delete.
+
+- [ ] **Step 1: Write the failing test** — `HandleStopAgent` for an unknown id whose record points at a live **dummy** (with `KCAP_AGENT_ID` in its env) kills it; an identity-mismatched record leaves the dummy alone and deletes the record.
+
+```csharp
+[Test]
+public async Task StopAgent_unknown_id_kills_by_pid_record_with_env_check() {
+    var dir = TestDir.Create();
+    using var dummy = DummyProcess.StartSleep(30, env: new() { ["KCAP_AGENT_ID"] = "ghost" });
+    var store = new AgentPidRecordStore(dir, NullLogger.Instance);
+    store.Write(new AgentPidRecord("ghost", dummy.Pid, ProcessIdentity.Capture(dummy.Pid)!.Value, "ReviewFlow", "codex", null, null, "did", "ep", DateTimeOffset.UtcNow));
+    var orch = TestOrchestrator.Create(pidStore: store);
+    await orch.HandleStopAgent("ghost");
+    dummy.WaitForExit(TimeSpan.FromSeconds(8));
+    await Assert.That(dummy.HasExited).IsTrue();
+    await Assert.That(store.ReadAll()).IsEmpty(); // confirmed-death delete
+}
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — after the runtime spawns (pid known) write the record before any await; on confirmed-death teardown delete it (retain on unconfirmed — Task 8); thread `KCAP_AGENT_ID`/`KCAP_DAEMON_ID`/`KCAP_DAEMON_EPOCH` into the child env in the launcher/PTY spawn env; extend `HandleStopAgent`'s `!_agents.TryGetValue` branch to the record-based kill (record regime: exact identity **+** Unix env check; `killpg(pid)`→5s→`SIGKILL`; delete only on confirmed death).
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `[AI-1313] Phase B D4c: write PID record at spawn + env markers + StopAgent record fallback`
+
+---
+
+### Task 8: D1 + D4(2a) — single-flight teardown + kill-quarantine + `EffectiveCount`
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs`
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (`AgentInstance.CleanupStarted` flag; single-flight teardown routed from the launch catch `:563` and the read-loop finally; the `:330` admission gate → `EffectiveCount`; heartbeat retry of quarantined kills)
+- Test: `test/Capacitor.Cli.Daemon.Tests/LaunchCleanupTests.cs`, `AgentKillQuarantineTests.cs`
+
+**Interfaces:**
+- Produces: `AgentInstance` gains `int CleanupStarted` (via `Interlocked.CompareExchange(ref CleanupStarted, 1, 0) == 0` gate).
+- Produces: `AgentKillQuarantine` — `Add(context)`, `bool TryRetryAll()` (heartbeat calls; kill+confirm each; remove on confirmed death), `int Count`, `IReadOnlyList<QuarantinedAgentInfo> Snapshot()`.
+- Produces: `AgentOrchestrator.EffectiveCount => ActiveCount + _quarantine.Count`; the `:330` guard uses it.
+
+- [ ] **Step 1: Write the failing test (single-flight)** — a post-`:515`-insert launch failure removes the agent from `_agents`, terminates the runtime, and sends **both** `LaunchFailed` + `AgentUnregistered` even if an intermediate teardown step throws; racing read-loop cleanup + catch cleanup run the teardown exactly once.
+
+```csharp
+[Test]
+public async Task Post_insert_launch_failure_tears_down_once_and_notifies() {
+    var server = new FakeServerConnection();
+    var orch = TestOrchestrator.Create(server, failRegisterAgent: true); // force RegisterAgentAsync to throw
+    await orch.HandleLaunchAgent(new LaunchAgentCommand(AgentId: "a1", Model: "default", RepoPath: TestRepo.Path, Vendor: "codex"));
+    await Assert.That(orch.ContainsAgent("a1")).IsFalse();
+    await Assert.That(server.LaunchFailed).Contains("a1");
+    await Assert.That(server.AgentUnregistered).Contains("a1");
+    await Assert.That(orch.LastRuntimeTerminatedFor("a1")).IsTrue();
+}
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** the single-flight `TeardownAgentAsync(agent, reason, confirmedDeathRequired: true)` — `CleanupStarted` gate; each step (`ReadCts.Cancel`, `Runtime.TerminateAsync(5s)`, token revoke, worktree remove, `_agents.TryRemove`) in its own try/catch; `LaunchFailedAsync` + `AgentUnregisteredAsync` in a `finally`; PID-record delete only on confirmed death, else move the launch context into `_quarantine`. Route the launch catch (`:563`) and the read-loop finally through it.
+- [ ] **Step 4: Write the failing test (quarantine + EffectiveCount)** — an unconfirmed-death teardown adds to `_quarantine`; `EffectiveCount` includes it; the heartbeat retry kills a now-dead dummy and drains it; `Snapshot()` surfaces it.
+
+```csharp
+[Test]
+public async Task Unconfirmed_death_quarantines_counts_and_heartbeat_retry_drains() {
+    using var dummy = DummyProcess.StartSleep(30, env: new(){["KCAP_AGENT_ID"]="q1"});
+    var q = new AgentKillQuarantine(NullLogger.Instance);
+    q.Add(new QuarantineEntry("q1", dummy.Pid, ProcessIdentity.Capture(dummy.Pid)!.Value, "ReviewFlow", DateTimeOffset.UtcNow, null, null));
+    await Assert.That(q.Count).IsEqualTo(1);
+    q.TryRetryAll(); dummy.WaitForExit(TimeSpan.FromSeconds(8));
+    q.TryRetryAll(); // second pass observes confirmed death → drains
+    await Assert.That(q.Count).IsEqualTo(0);
+}
+```
+
+- [ ] **Step 5: Run → PASS**; then wire `_quarantine.TryRetryAll()` into the heartbeat loop and `EffectiveCount` into the `:330` guard.
+- [ ] **Step 6: Commit** — `[AI-1313] Phase B D1+D4(2a): single-flight teardown + kill-quarantine + EffectiveCount admission gate`
+
+---
+
+### Task 9: D4(3) — `OrphanReaper` (startup record pass + scoped env-marker scan)
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs`
+- Modify: `src/Capacitor.Cli.Daemon/Services/DaemonRunner.cs` (call at boot under the daemon lock, next to `WorktreeManager.CleanupOrphanedAsync`), `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (re-run the scan on a heartbeat tick)
+- Test: `test/Capacitor.Cli.Daemon.Tests/OrphanReaperTests.cs`
+
+**Interfaces:**
+- Consumes: `AgentPidRecordStore` (Task 6), `ProcessIdentity` (Task 5), config `KcapDaemonId`/`KcapDaemonEpoch` (Task 6).
+- Produces: `Task ReapOnceAsync()` — (a) record pass: each leftover record whose `(pid, identity)` matches a live process (+ Unix env check) → `killpg`→5s→`SIGKILL`, delete on confirmed death; identity-mismatch → delete record; (b) env-marker scan (Unix): enumerate same-user processes, kill only those with `KCAP_AGENT_ID` **and** `KCAP_DAEMON_ID == this` **and** `KCAP_DAEMON_EPOCH != current` that matched no just-processed record; enumeration failure → logged no-op (retried next tick).
+
+- [ ] **Step 1: Write the failing test (record pass)** — a leftover record pointing at a live dummy (matching identity + env) is killed and its record deleted; an identity-mismatched record is deleted and the dummy spared.
+
+```csharp
+[Test]
+public async Task Startup_record_pass_kills_matching_dummy_and_deletes_record() {
+    var dir = TestDir.Create();
+    using var dummy = DummyProcess.StartSleep(30, env: new(){["KCAP_AGENT_ID"]="orphan"});
+    var store = new AgentPidRecordStore(dir, NullLogger.Instance);
+    store.Write(new AgentPidRecord("orphan", dummy.Pid, ProcessIdentity.Capture(dummy.Pid)!.Value, "ReviewFlow","codex",null,null,"did","old-epoch", DateTimeOffset.UtcNow));
+    var reaper = new OrphanReaper(store, daemonId: "did", currentEpoch: "new-epoch", NullLogger.Instance);
+    await reaper.ReapOnceAsync();
+    dummy.WaitForExit(TimeSpan.FromSeconds(8));
+    await Assert.That(dummy.HasExited).IsTrue();
+    await Assert.That(store.ReadAll()).IsEmpty();
+}
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** the record pass.
+- [ ] **Step 4: Write the failing test (env-marker scan)** — a **recordless** dummy carrying this daemon's `KCAP_DAEMON_ID` + a stale epoch is killed; a dummy with a **different** daemon id is spared; a dummy with the **current** epoch is spared; enumeration failure → logged no-op.
+
+```csharp
+[Test]
+public async Task Env_marker_scan_kills_stale_epoch_of_this_daemon_only() {
+    using var stale = DummyProcess.StartSleep(30, env: new(){["KCAP_AGENT_ID"]="s","KCAP_DAEMON_ID"="did","KCAP_DAEMON_EPOCH"="old"});
+    using var other = DummyProcess.StartSleep(30, env: new(){["KCAP_AGENT_ID"]="o","KCAP_DAEMON_ID"="OTHER","KCAP_DAEMON_EPOCH"="old"});
+    using var mine  = DummyProcess.StartSleep(30, env: new(){["KCAP_AGENT_ID"]="m","KCAP_DAEMON_ID"="did","KCAP_DAEMON_EPOCH"="new"});
+    var reaper = new OrphanReaper(EmptyStore(), daemonId: "did", currentEpoch: "new", NullLogger.Instance);
+    await reaper.ReapOnceAsync();
+    stale.WaitForExit(TimeSpan.FromSeconds(8));
+    await Assert.That(stale.HasExited).IsTrue();
+    await Assert.That(other.HasExited).IsFalse();
+    await Assert.That(mine.HasExited).IsFalse();
+    other.Kill(); mine.Kill();
+}
+```
+
+- [ ] **Step 5: Run → PASS**; wire `ReapOnceAsync` at boot (under the daemon lock) and re-run on a heartbeat tick.
+- [ ] **Step 6: Commit** — `[AI-1313] Phase B D4(3): startup orphan reap + scoped env-marker scan`
+
+---
+
+### Task 10: docs + PR
+
+**Files:** `docs/gotchas/` (a CLI daemon self-defense note if a relevant gotcha file exists), the CLI `README`/daemon docs if they enumerate config keys (add `reviewer_max_lifetime`/`reviewer_idle_timeout`), this plan's checkboxes.
+
+- [ ] **Step 1** — document the new config keys + the PID-record/orphan-reap model where the daemon's other lifecycle behavior is documented.
+- [ ] **Step 2** — full daemon test suite green on this host; note the Linux/Windows-only identity branches are covered by CI runners.
+- [ ] **Step 3** — push the branch; open the PR base `main`, title `[AI-1313] Flow-reviewer capacity reaping — daemon self-defense (Phase B)`, body linking the spec + AI-1313 + noting the two deferred follow-ons (native containment, sequenced settlement).
+- [ ] **Step 4** — Codex review flow (`mode context-only`, full diff inlined) → iterate to clean; address Qodo (all tiers).
+- [ ] **Step 5** — request Alexey; post an AI-1313 Linear comment (do NOT set state); update memory.
+
+---
+
+## Deferred to follow-on plans (independent subsystems — separate plans per the scope rule)
+
+- **Plan B-native (D4 layer 1 — OS containment):** Windows creation-time Job Object via `STARTUPINFOEX` + `PROC_THREAD_ATTRIBUTE_JOB_LIST` in `ConPtyProcess.Spawn` (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, kill-on-close incl. descendants → no survivor class on Windows). Linux `PR_SET_PDEATHSIG(SIGKILL)` on a **single dedicated daemon-lifetime spawner thread** (never pooled; unexpected thread exit fail-fasts the daemon) with an **async-signal-safe post-fork native shim** (`prctl` → `getppid()!=expectedParent ? raise(SIGKILL)` → `execve`; prebuilt argv/envp; no managed re-entry). Pure hardening: this PR's records/scan already recover survivors; layer 1 only makes death immediate. Needs native interop + a C shim + per-OS CI. (Spec §6.4(1); §10 macOS parity remains a follow-up — no OS primitive.)
+- **Plan B2 (sequenced-command settlement — bilateral, server + CLI):** `LaunchAgentCommand`/`StopAgentV2` gain `Epoch`/`Seq`; daemon acks fully-processed watermarks (`AckProcessedPrefix`), emits `CommandAck`/`CommandRejected`/`ResolvedStartupCandidates`; server maintains the generation-settlement ledger, the S5 launch queue, and the S3(b)/(c) untracked-reap + retry-until-gone + S6 daemon-authoritative consumers of `DaemonStatusReport`, all capability-gated on `SupportsSequencedCommands`. This is the hardest, most-tested piece (spec §5.5, §7, §8 "Settlement") and the reason the spec took 14 Codex rounds; it needs its own spec-grounded plan and a paired server PR.
+
+---
+
+## Self-Review
+
+**Spec coverage (this PR's scope):** D1 ✓(T8) · D2 metadata+LiveAgents ✓(T1,T2) + status-report send ✓(T3) · D3 ✓(T4) · D4(2) records+identity ✓(T5,T6,T7) · D4(2a) quarantine+EffectiveCount ✓(T8) · D4(3) startup reap + env scan + StopAgent fallback ✓(T7,T9). **Deferred (own plans):** D4(1) native containment; the sequenced protocol + its server consumers + the `DaemonStatusReport` server handler. Compatibility (§7): all additive — verified by T1's old-JSON test + one-way `SendAsync` in T3.
+
+**Placeholder scan:** the two flagged "verify at execution time" items (daemon test-project path/namespace; the exact state-dir/`DaemonLock` accessor near `DaemonRunner.cs:380`) are real repo-location lookups the implementer resolves in Task 1/Task 6 — not design gaps. `DummyProcess`/`TestDir`/`TestOrchestrator`/`FakeServerConnection` helpers are introduced in T5/T6/T2 and reused; if the daemon test project already has equivalents, use those.
+
+**Type consistency:** `LiveAgentInfo`/`QuarantinedAgentInfo`/`DaemonStatusReport`/`AgentPidRecord`/`ProcessStartIdentity` signatures are defined once (T1/T5/T6) and consumed unchanged (T2/T3/T7/T8/T9). `EffectiveCount = ActiveCount + _quarantine.Count`; `ActiveCount` unchanged. Reviewer end-reasons `reviewer_ttl_expired`/`reviewer_idle_expired` consistent (T4). Env markers `KCAP_AGENT_ID`/`KCAP_DAEMON_ID`/`KCAP_DAEMON_EPOCH` consistent (T7/T9).

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -945,6 +945,7 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(LiveAgentInfo))]
 [JsonSerializable(typeof(QuarantinedAgentInfo))]
 [JsonSerializable(typeof(DaemonStatusReport))]
+[JsonSerializable(typeof(AgentPidRecord))]
 [JsonSerializable(typeof(AgentRegistered))]
 [JsonSerializable(typeof(AgentStatusChanged))]
 [JsonSerializable(typeof(AgentUnregistered))]
@@ -1261,6 +1262,24 @@ public readonly record struct DaemonStatusReport(
         int                  ActiveCount,
         LiveAgentInfo[]      LiveAgents,
         QuarantinedAgentInfo[] Quarantined
+    );
+
+/// <summary>AI-1313 Phase B (D4 §6.4(2)): the durable per-agent PID record written atomically at spawn
+/// to <c>&lt;state-dir&gt;/agents/{agentId}.json</c>, so a restarted daemon can reap a surviving child
+/// by EXACT identity. <see cref="StartIdentity"/> is the AI-839 <c>ProcessStartToken</c> string
+/// (kernel starttime / absolute start ticks — exact, no tolerance). <see cref="DaemonId"/> = hash of
+/// the daemon state-dir path (stable logical identity); <see cref="DaemonEpoch"/> = fresh per boot.</summary>
+public readonly record struct AgentPidRecord(
+        string         AgentId,
+        int            Pid,
+        string         StartIdentity,
+        string         Kind,
+        string         Vendor,
+        string?        FlowRunId,
+        string?        FlowRole,
+        string         DaemonId,
+        string         DaemonEpoch,
+        DateTimeOffset SpawnedAt
     );
 
 public readonly record struct ReviewLaunchInfo(

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1204,7 +1204,7 @@ public readonly record struct LaunchAgentCommand(
         // fields above.
         bool               Borrowed = false,
         string?            BorrowCwd = null,
-        // AI-1313 Phase B (D2): flow identity for a ReviewFlow launch, so the daemon can store it on
+        // Phase B (D2): flow identity for a ReviewFlow launch, so the daemon can store it on
         // the AgentInstance and report it in LiveAgents / DaemonStatusReport (lets a restarted server
         // associate a surviving unassigned reviewer with its role). Appended last, same wire-compat
         // rule as the fields above — old daemons ignore them, old servers never set them.
@@ -1226,9 +1226,9 @@ public enum LaunchKind {
     ReviewFlow = 2
 }
 
-// ── AI-1313 Phase B (D2): daemon self-report DTOs ────────────────────────────────────────────────
+// ── Phase B (D2): daemon self-report DTOs ────────────────────────────────────────────────
 
-/// <summary>AI-1313 Phase B (D2): one live hosted agent in the daemon's self-report. <see cref="Kind"/>
+/// <summary>Phase B (D2): one live hosted agent in the daemon's self-report. <see cref="Kind"/>
 /// is the <see cref="LaunchKind"/> name; <see cref="FlowRunId"/>/<see cref="FlowRole"/> are set only
 /// for a ReviewFlow launch. Carried additively on <see cref="DaemonConnect.LiveAgents"/> and in
 /// <see cref="DaemonStatusReport"/> so the server can associate a surviving unassigned reviewer with
@@ -1241,7 +1241,7 @@ public readonly record struct LiveAgentInfo(
         string?        FlowRole  = null
     );
 
-/// <summary>AI-1313 Phase B (D4 §6.4(2a)): an agent whose death could NOT be confirmed (record-write
+/// <summary>Phase B (D4 §6.4(2a)): an agent whose death could NOT be confirmed (record-write
 /// or kill failure) and is being retried by the daemon heartbeat. Same shape as
 /// <see cref="LiveAgentInfo"/>; reported separately so the server can see it counts against admission
 /// (<c>EffectiveCount = ActiveCount + Quarantined.Count</c>) without changing <c>ActiveCount</c>'s
@@ -1254,7 +1254,7 @@ public readonly record struct QuarantinedAgentInfo(
         string?        FlowRole  = null
     );
 
-/// <summary>AI-1313 Phase B (D2): the periodic (60s) one-way daemon→server self-report. Sent via a
+/// <summary>Phase B (D2): the periodic (60s) one-way daemon→server self-report. Sent via a
 /// one-way <c>SendAsync</c> (never <c>InvokeAsync</c>) so an old server without the handler produces
 /// only a server-side log line, not a client fault. <see cref="ActiveCount"/> is exactly the daemon's
 /// Starting/Running agent count (its wire meaning never changes).</summary>
@@ -1264,9 +1264,9 @@ public readonly record struct DaemonStatusReport(
         QuarantinedAgentInfo[] Quarantined
     );
 
-/// <summary>AI-1313 Phase B (D4 §6.4(2)): the durable per-agent PID record written atomically at spawn
+/// <summary>Phase B (D4 §6.4(2)): the durable per-agent PID record written atomically at spawn
 /// to <c>&lt;state-dir&gt;/agents/{agentId}.json</c>, so a restarted daemon can reap a surviving child
-/// by EXACT identity. <see cref="StartIdentity"/> is the AI-839 <c>ProcessStartToken</c> string
+/// by EXACT identity. <see cref="StartIdentity"/> is the <c>ProcessStartToken</c> string
 /// (kernel starttime / absolute start ticks — exact, no tolerance). <see cref="DaemonId"/> = hash of
 /// the daemon state-dir path (stable logical identity); <see cref="DaemonEpoch"/> = fresh per boot.</summary>
 public readonly record struct AgentPidRecord(
@@ -1359,7 +1359,7 @@ public readonly record struct DaemonConnect(
         string?   Version          = null,
         string[]? SupportedVendors = null,
         string?   MachineId        = null,
-        // AI-1313 Phase B (D2): richer live-agent metadata alongside the existing LiveAgentIds
+        // Phase B (D2): richer live-agent metadata alongside the existing LiveAgentIds
         // (kept for back-compat). Trailing/optional — old servers ignore it, old daemons never set it.
         LiveAgentInfo[]? LiveAgents = null
     );

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -942,6 +942,9 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(EvalRetrospectiveCompleted))]
 [JsonSerializable(typeof(EvalRetrospectiveFailed))]
 [JsonSerializable(typeof(DaemonConnect))]
+[JsonSerializable(typeof(LiveAgentInfo))]
+[JsonSerializable(typeof(QuarantinedAgentInfo))]
+[JsonSerializable(typeof(DaemonStatusReport))]
 [JsonSerializable(typeof(AgentRegistered))]
 [JsonSerializable(typeof(AgentStatusChanged))]
 [JsonSerializable(typeof(AgentUnregistered))]
@@ -1199,7 +1202,13 @@ public readonly record struct LaunchAgentCommand(
         // absolute path to borrow when Borrowed is true. Appended last, same wire-compat rule as the
         // fields above.
         bool               Borrowed = false,
-        string?            BorrowCwd = null
+        string?            BorrowCwd = null,
+        // AI-1313 Phase B (D2): flow identity for a ReviewFlow launch, so the daemon can store it on
+        // the AgentInstance and report it in LiveAgents / DaemonStatusReport (lets a restarted server
+        // associate a surviving unassigned reviewer with its role). Appended last, same wire-compat
+        // rule as the fields above — old daemons ignore them, old servers never set them.
+        string?            FlowRunId = null,
+        string?            FlowRole  = null
     );
 
 /// <summary>
@@ -1215,6 +1224,44 @@ public enum LaunchKind {
     Review     = 1,
     ReviewFlow = 2
 }
+
+// ── AI-1313 Phase B (D2): daemon self-report DTOs ────────────────────────────────────────────────
+
+/// <summary>AI-1313 Phase B (D2): one live hosted agent in the daemon's self-report. <see cref="Kind"/>
+/// is the <see cref="LaunchKind"/> name; <see cref="FlowRunId"/>/<see cref="FlowRole"/> are set only
+/// for a ReviewFlow launch. Carried additively on <see cref="DaemonConnect.LiveAgents"/> and in
+/// <see cref="DaemonStatusReport"/> so the server can associate a surviving unassigned reviewer with
+/// its role instead of a blind grace period. All-optional trailing fields keep it wire-compatible.</summary>
+public readonly record struct LiveAgentInfo(
+        string         Id,
+        string         Kind,
+        DateTimeOffset CreatedAt,
+        string?        FlowRunId = null,
+        string?        FlowRole  = null
+    );
+
+/// <summary>AI-1313 Phase B (D4 §6.4(2a)): an agent whose death could NOT be confirmed (record-write
+/// or kill failure) and is being retried by the daemon heartbeat. Same shape as
+/// <see cref="LiveAgentInfo"/>; reported separately so the server can see it counts against admission
+/// (<c>EffectiveCount = ActiveCount + Quarantined.Count</c>) without changing <c>ActiveCount</c>'s
+/// meaning.</summary>
+public readonly record struct QuarantinedAgentInfo(
+        string         Id,
+        string         Kind,
+        DateTimeOffset CreatedAt,
+        string?        FlowRunId = null,
+        string?        FlowRole  = null
+    );
+
+/// <summary>AI-1313 Phase B (D2): the periodic (60s) one-way daemon→server self-report. Sent via a
+/// one-way <c>SendAsync</c> (never <c>InvokeAsync</c>) so an old server without the handler produces
+/// only a server-side log line, not a client fault. <see cref="ActiveCount"/> is exactly the daemon's
+/// Starting/Running agent count (its wire meaning never changes).</summary>
+public readonly record struct DaemonStatusReport(
+        int                  ActiveCount,
+        LiveAgentInfo[]      LiveAgents,
+        QuarantinedAgentInfo[] Quarantined
+    );
 
 public readonly record struct ReviewLaunchInfo(
         string Owner,
@@ -1292,7 +1339,10 @@ public readonly record struct DaemonConnect(
         string?   InstanceId       = null,
         string?   Version          = null,
         string[]? SupportedVendors = null,
-        string?   MachineId        = null
+        string?   MachineId        = null,
+        // AI-1313 Phase B (D2): richer live-agent metadata alongside the existing LiveAgentIds
+        // (kept for back-compat). Trailing/optional — old servers ignore it, old daemons never set it.
+        LiveAgentInfo[]? LiveAgents = null
     );
 
 public readonly record struct AgentRegistered(

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -10,10 +10,10 @@ public class DaemonConfig {
     /// AI-1313 Phase B (D3): backstop lifetime/idle bounds for a hosted review-flow reviewer, enforced
     /// in the daemon heartbeat. A reviewer whose run went terminal on the server without the daemon
     /// hearing about it (or whose driver vanished) is reaped here so it can't hold a slot forever.
-    /// Defaults 6h lifetime / 2h idle; <see cref="TimeSpan.Zero"/> disables that bound. Config keys
-    /// <c>daemon.reviewer_max_lifetime</c>/<c>daemon.reviewer_idle_timeout</c>; env
-    /// <c>KCAP_REVIEWER_MAX_LIFETIME</c>/<c>KCAP_REVIEWER_IDLE_TIMEOUT</c> (seconds). Interactive
-    /// agents are never touched by these.
+    /// Defaults 6h lifetime / 2h idle; <see cref="TimeSpan.Zero"/> disables that bound. Overridden at
+    /// startup from env <c>KCAP_REVIEWER_MAX_LIFETIME</c>/<c>KCAP_REVIEWER_IDLE_TIMEOUT</c> (seconds);
+    /// a profile config-key form is reserved but not yet wired. Interactive agents are never touched
+    /// by these.
     /// </summary>
     public TimeSpan ReviewerMaxLifetime { get; set; } = TimeSpan.FromHours(6);
     public TimeSpan ReviewerIdleTimeout { get; set; } = TimeSpan.FromHours(2);

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -7,6 +7,18 @@ public class DaemonConfig {
     public int      MaxConcurrentAgents { get; set; } = 5;
 
     /// <summary>
+    /// AI-1313 Phase B (D3): backstop lifetime/idle bounds for a hosted review-flow reviewer, enforced
+    /// in the daemon heartbeat. A reviewer whose run went terminal on the server without the daemon
+    /// hearing about it (or whose driver vanished) is reaped here so it can't hold a slot forever.
+    /// Defaults 6h lifetime / 2h idle; <see cref="TimeSpan.Zero"/> disables that bound. Config keys
+    /// <c>daemon.reviewer_max_lifetime</c>/<c>daemon.reviewer_idle_timeout</c>; env
+    /// <c>KCAP_REVIEWER_MAX_LIFETIME</c>/<c>KCAP_REVIEWER_IDLE_TIMEOUT</c> (seconds). Interactive
+    /// agents are never touched by these.
+    /// </summary>
+    public TimeSpan ReviewerMaxLifetime { get; set; } = TimeSpan.FromHours(6);
+    public TimeSpan ReviewerIdleTimeout { get; set; } = TimeSpan.FromHours(2);
+
+    /// <summary>
     /// Per-process GUID generated at startup, also written to the daemon's
     /// flock-file content. Sent over <c>DaemonConnect</c> so the server
     /// (AI-630) can tell "same daemon reconnecting" from "different daemon

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -19,6 +19,20 @@ public class DaemonConfig {
     public TimeSpan ReviewerIdleTimeout { get; set; } = TimeSpan.FromHours(2);
 
     /// <summary>
+    /// AI-1313 Phase B (D4): root directory under which this daemon writes its per-agent PID records
+    /// (<c>{StateDir}/{name}/agents/{agentId}.json</c>). Null → the shared daemon state dir
+    /// (<c>DaemonLockPaths.Directory</c>); tests point it at a temp dir. The per-name subdir keeps a
+    /// daemon's records "its own" so the startup reap only ever touches this daemon's leftovers.
+    /// </summary>
+    public string? StateDir { get; set; }
+
+    /// <summary>AI-1313 Phase B (D4): a fresh per-boot epoch (GUID). Written into each spawned child's
+    /// <c>KCAP_DAEMON_EPOCH</c> env marker; the startup env-marker scan kills same-daemon children
+    /// whose epoch differs from the current one (i.e. survivors of a prior incarnation). Null → the
+    /// orchestrator generates one at construction.</summary>
+    public string? DaemonEpoch { get; set; }
+
+    /// <summary>
     /// Per-process GUID generated at startup, also written to the daemon's
     /// flock-file content. Sent over <c>DaemonConnect</c> so the server
     /// (AI-630) can tell "same daemon reconnecting" from "different daemon

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -7,7 +7,7 @@ public class DaemonConfig {
     public int      MaxConcurrentAgents { get; set; } = 5;
 
     /// <summary>
-    /// AI-1313 Phase B (D3): backstop lifetime/idle bounds for a hosted review-flow reviewer, enforced
+    /// Phase B (D3): backstop lifetime/idle bounds for a hosted review-flow reviewer, enforced
     /// in the daemon heartbeat. A reviewer whose run went terminal on the server without the daemon
     /// hearing about it (or whose driver vanished) is reaped here so it can't hold a slot forever.
     /// Defaults 6h lifetime / 2h idle; <see cref="TimeSpan.Zero"/> disables that bound. Overridden at
@@ -19,14 +19,14 @@ public class DaemonConfig {
     public TimeSpan ReviewerIdleTimeout { get; set; } = TimeSpan.FromHours(2);
 
     /// <summary>
-    /// AI-1313 Phase B (D4): root directory under which this daemon writes its per-agent PID records
+    /// Phase B (D4): root directory under which this daemon writes its per-agent PID records
     /// (<c>{StateDir}/{name}/agents/{agentId}.json</c>). Null → the shared daemon state dir
     /// (<c>DaemonLockPaths.Directory</c>); tests point it at a temp dir. The per-name subdir keeps a
     /// daemon's records "its own" so the startup reap only ever touches this daemon's leftovers.
     /// </summary>
     public string? StateDir { get; set; }
 
-    /// <summary>AI-1313 Phase B (D4): a fresh per-boot epoch (GUID). Written into each spawned child's
+    /// <summary>Phase B (D4): a fresh per-boot epoch (GUID). Written into each spawned child's
     /// <c>KCAP_DAEMON_EPOCH</c> env marker; the startup env-marker scan kills same-daemon children
     /// whose epoch differs from the current one (i.e. survivors of a prior incarnation). Null → the
     /// orchestrator generates one at construction.</summary>

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -366,6 +366,15 @@ public static partial class DaemonRunner {
         // exactly what this bridge is meant to avoid.
         await host.StartAsync(lifetime.ApplicationStopping);
 
+        // AI-1313 Phase B (D4 §6.4(3)): resolve the orchestrator (which wires OnLaunchAgent +
+        // GetLiveAgents in its ctor) and reap any hosted-agent children that outlived a PRIOR daemon run
+        // — all BEFORE ConnectAsync advertises this daemon and the server can dispatch launches. Doing
+        // it after connect would let new work be admitted while old capacity is still being reclaimed
+        // (those survivors aren't yet in EffectiveCount), and would leave a window where a launch races
+        // an unwired handler. Under the daemon lock; best-effort (swallows its own faults).
+        var orchestrator = host.Services.GetRequiredService<AgentOrchestrator>();
+        await orchestrator.ReapOrphansOnceAsync();
+
         try {
             await connection.ConnectAsync(lifetime.ApplicationStopping);
         } catch (Exception ex) when (nameInUse) {
@@ -383,12 +392,6 @@ public static partial class DaemonRunner {
         var worktreeManager = host.Services.GetRequiredService<WorktreeManager>();
         await worktreeManager.CleanupOrphanedAsync();
 
-        var orchestrator = host.Services.GetRequiredService<AgentOrchestrator>();
-
-        // AI-1313 Phase B (D4 §6.4(3)): reap hosted-agent children that outlived a prior daemon run
-        // (crash/restart) BEFORE we accept new launches — under the daemon lock, next to the worktree
-        // cleanup above. The heartbeat re-runs it thereafter. Best-effort (swallows its own faults).
-        await orchestrator.ReapOrphansOnceAsync();
         // Instantiate EvalRunner so it wires the per-phase eval handlers
         // (PrepareEval / RunQuestion / FinalizeEval / CancelEval) on the
         // ServerConnection. It's stateless beyond the handler assignment —

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -62,6 +62,10 @@ public static partial class DaemonRunner {
             }
         }
 
+        // AI-1313 Phase B (D3): reviewer lifetime/idle backstop overrides from env (seconds; 0 disables).
+        config.ReviewerMaxLifetime = ParseSecondsEnv("KCAP_REVIEWER_MAX_LIFETIME", config.ReviewerMaxLifetime);
+        config.ReviewerIdleTimeout = ParseSecondsEnv("KCAP_REVIEWER_IDLE_TIMEOUT", config.ReviewerIdleTimeout);
+
         // AI-1155: reopen fds 1/2 onto the capture file BEFORE building the host,
         // so even a crash during construction lands somewhere. On the detached
         // launch path the CLI closed our std pipes; without this a runtime/native
@@ -429,6 +433,15 @@ public static partial class DaemonRunner {
         "none"                         => LogLevel.None,
         _                              => null
     };
+
+    /// <summary>AI-1313 Phase B (D3): parse a seconds-valued env var into a <see cref="TimeSpan"/>
+    /// (<c>0</c> → <see cref="TimeSpan.Zero"/>, which disables the bound). Unset/blank/invalid/negative
+    /// → the supplied <paramref name="fallback"/>.</summary>
+    internal static TimeSpan ParseSecondsEnv(string name, TimeSpan fallback) {
+        var raw = Environment.GetEnvironmentVariable(name);
+
+        return int.TryParse(raw, out var secs) && secs >= 0 ? TimeSpan.FromSeconds(secs) : fallback;
+    }
 
     /// <summary>
     /// Parses <c>KCAP_ACP_DEBUG_FRAMES</c> ("1"/"true", case-insensitive, are On; anything else —

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -384,6 +384,11 @@ public static partial class DaemonRunner {
         await worktreeManager.CleanupOrphanedAsync();
 
         var orchestrator = host.Services.GetRequiredService<AgentOrchestrator>();
+
+        // AI-1313 Phase B (D4 §6.4(3)): reap hosted-agent children that outlived a prior daemon run
+        // (crash/restart) BEFORE we accept new launches — under the daemon lock, next to the worktree
+        // cleanup above. The heartbeat re-runs it thereafter. Best-effort (swallows its own faults).
+        await orchestrator.ReapOrphansOnceAsync();
         // Instantiate EvalRunner so it wires the per-phase eval handlers
         // (PrepareEval / RunQuestion / FinalizeEval / CancelEval) on the
         // ServerConnection. It's stateless beyond the handler assignment —

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -62,7 +62,7 @@ public static partial class DaemonRunner {
             }
         }
 
-        // AI-1313 Phase B (D3): reviewer lifetime/idle backstop overrides from env (seconds; 0 disables).
+        // Phase B (D3): reviewer lifetime/idle backstop overrides from env (seconds; 0 disables).
         config.ReviewerMaxLifetime = ParseSecondsEnv("KCAP_REVIEWER_MAX_LIFETIME", config.ReviewerMaxLifetime);
         config.ReviewerIdleTimeout = ParseSecondsEnv("KCAP_REVIEWER_IDLE_TIMEOUT", config.ReviewerIdleTimeout);
 
@@ -366,7 +366,7 @@ public static partial class DaemonRunner {
         // exactly what this bridge is meant to avoid.
         await host.StartAsync(lifetime.ApplicationStopping);
 
-        // AI-1313 Phase B (D4 §6.4(3)): resolve the orchestrator (which wires OnLaunchAgent +
+        // Phase B (D4 §6.4(3)): resolve the orchestrator (which wires OnLaunchAgent +
         // GetLiveAgents in its ctor) and reap any hosted-agent children that outlived a PRIOR daemon run
         // — all BEFORE ConnectAsync advertises this daemon and the server can dispatch launches. Doing
         // it after connect would let new work be admitted while old capacity is still being reclaimed
@@ -442,7 +442,7 @@ public static partial class DaemonRunner {
         _                              => null
     };
 
-    /// <summary>AI-1313 Phase B (D3): parse a seconds-valued env var into a <see cref="TimeSpan"/>
+    /// <summary>Phase B (D3): parse a seconds-valued env var into a <see cref="TimeSpan"/>
     /// (<c>0</c> → <see cref="TimeSpan.Zero"/>, which disables the bound). Unset/blank/invalid/negative
     /// → the supplied <paramref name="fallback"/>.</summary>
     internal static TimeSpan ParseSecondsEnv(string name, TimeSpan fallback) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs
@@ -1,0 +1,48 @@
+using System.Collections.Concurrent;
+using Capacitor.Cli.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// AI-1313 Phase B (D4 §6.4(2a)): the in-memory kill-quarantine — agents whose death could NOT be
+/// confirmed at teardown (kill failed / record write failed while the process is still alive). The
+/// heartbeat retries the kill until it confirms death. While an entry sits here it:
+/// <list type="bullet">
+/// <item>counts against the daemon's admission gate (<c>EffectiveCount = ActiveCount + Quarantined.Count</c>),
+/// so a persistent kill-failure mode FAILS CLOSED — it can never mint unbounded processes;</item>
+/// <item>is reported in <c>DaemonStatusReport.Quarantined</c> (its own field, excluded from
+/// <c>ActiveCount</c>) so the server can see WHY admission is blocked and (Phase B2) treat the id as
+/// physically-live for heal/settlement.</item>
+/// </list>
+/// </summary>
+internal sealed class AgentKillQuarantine(ILogger logger) {
+    /// <summary>A quarantined process — enough to retry the kill by exact identity and to report it.</summary>
+    internal readonly record struct Entry(
+        string AgentId, int Pid, string Identity, string Kind, DateTimeOffset CreatedAt,
+        string? FlowRunId, string? FlowRole);
+
+    readonly ConcurrentDictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+
+    public int Count => _entries.Count;
+
+    /// <summary>Quarantine an agent whose death is unconfirmed (idempotent per agent id).</summary>
+    public void Add(Entry entry) => _entries[entry.AgentId] = entry;
+
+    /// <summary>Snapshot for <c>DaemonStatusReport.Quarantined</c>.</summary>
+    public IReadOnlyList<QuarantinedAgentInfo> Snapshot() =>
+        [.. _entries.Values.Select(e => new QuarantinedAgentInfo(e.AgentId, e.Kind, e.CreatedAt, e.FlowRunId, e.FlowRole))];
+
+    /// <summary>Heartbeat retry: attempt to reap every quarantined process by exact identity and drain
+    /// those confirmed gone. Best-effort per entry — a still-alive one is retained for the next tick.</summary>
+    public async Task RetryAllAsync(CancellationToken ct) {
+        foreach (var entry in _entries.Values) {
+            try {
+                if (await ProcessReaper.ReapByIdentityAsync(entry.Pid, entry.Identity, entry.AgentId, logger, ct))
+                    _entries.TryRemove(new KeyValuePair<string, Entry>(entry.AgentId, entry));
+            } catch (Exception ex) when (ex is not OperationCanceledException) {
+                logger.LogWarning(ex, "AgentKillQuarantine: retry failed for {AgentId} (pid {Pid})", entry.AgentId, entry.Pid);
+            }
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs
@@ -34,15 +34,23 @@ internal sealed class AgentKillQuarantine(ILogger logger) {
         [.. _entries.Values.Select(e => new QuarantinedAgentInfo(e.AgentId, e.Kind, e.CreatedAt, e.FlowRunId, e.FlowRole))];
 
     /// <summary>Heartbeat retry: attempt to reap every quarantined process by exact identity and drain
-    /// those confirmed gone. Best-effort per entry — a still-alive one is retained for the next tick.</summary>
-    public async Task RetryAllAsync(CancellationToken ct) {
+    /// those confirmed gone. Best-effort per entry — a still-alive one is retained for the next tick.
+    /// Returns the agent ids DRAINED this pass (death/recycle confirmed) so the caller deletes their
+    /// durable PID records — a quarantined survivor's record is retained by teardown and, carrying the
+    /// current epoch, would otherwise be skipped by the orphan sweep and leak until restart.</summary>
+    public async Task<IReadOnlyList<string>> RetryAllAsync(CancellationToken ct) {
+        var drained = new List<string>();
+
         foreach (var entry in _entries.Values) {
             try {
-                if (await ProcessReaper.ReapByIdentityAsync(entry.Pid, entry.Identity, entry.AgentId, logger, ct))
-                    _entries.TryRemove(new KeyValuePair<string, Entry>(entry.AgentId, entry));
+                if (await ProcessReaper.ReapByIdentityAsync(entry.Pid, entry.Identity, entry.AgentId, logger, ct)
+                    && _entries.TryRemove(new KeyValuePair<string, Entry>(entry.AgentId, entry)))
+                    drained.Add(entry.AgentId);
             } catch (Exception ex) when (ex is not OperationCanceledException) {
                 logger.LogWarning(ex, "AgentKillQuarantine: retry failed for {AgentId} (pid {Pid})", entry.AgentId, entry.Pid);
             }
         }
+
+        return drained;
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// AI-1313 Phase B (D4 §6.4(2a)): the in-memory kill-quarantine — agents whose death could NOT be
+/// Phase B (D4 §6.4(2a)): the in-memory kill-quarantine — agents whose death could NOT be
 /// confirmed at teardown (kill failed / record write failed while the process is still alive). The
 /// heartbeat retries the kill until it confirms death. While an entry sits here it:
 /// <list type="bullet">

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -470,7 +470,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         if (_quarantine is not { Count: > 0 }) return;
         if (Interlocked.CompareExchange(ref _quarantineSweepRunning, 1, 0) != 0) return;
 
-        try { await _quarantine.RetryAllAsync(ct); }
+        try {
+            // Delete the durable PID record of every agent whose death the retry CONFIRMED — teardown
+            // retained it (with the current epoch) while the child was quarantined, so without this it
+            // would be skipped by the orphan sweep and leak until the next daemon restart.
+            foreach (var agentId in await _quarantine.RetryAllAsync(ct)) DeletePidRecord(agentId);
+        }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
         catch (Exception ex) { _logger.LogWarning(ex, "quarantine retry sweep faulted — continuing"); }
         finally { Interlocked.Exchange(ref _quarantineSweepRunning, 0); }
@@ -2074,6 +2079,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     /// <summary>Test-only entry point to the private cleanup path.</summary>
     internal Task CleanupAgentForTest(string agentId) => CleanupAgentAsync(agentId);
+
+    /// <summary>AI-1313 Phase B (D4 §6.4(2a)): drive one quarantine-retry sweep (drains confirmed-dead
+    /// entries and deletes their durable records) so a test needn't wait for a heartbeat tick.</summary>
+    internal Task RetryQuarantineForTest() => RetryQuarantineOnceAsync(_shutdownCts.Token);
 
     /// <summary>Test-only: number of agents currently tracked (for awaiting cleanup).</summary>
     internal int ActiveAgentCountForTest => _agents.Count;

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -185,6 +185,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // crash-survivor reaping. Initialized in the ctor from config.
     AgentPidRecordStore? _pidRecords;
     AgentKillQuarantine? _quarantine;
+    OrphanReaper?        _orphanReaper;
     string               _daemonId    = "";
     string               _daemonEpoch = "";
     readonly DaemonConfig                                      _config;
@@ -296,6 +297,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _quarantine  = new AgentKillQuarantine(logger);
         _daemonId    = ComputeDaemonId(config.Name);
         _daemonEpoch = config.DaemonEpoch ?? Guid.NewGuid().ToString("N");
+        _orphanReaper = new OrphanReaper(_pidRecords, _daemonId, _daemonEpoch, logger);
 
         // Wire up server commands
         _server.OnLaunchAgent            += HandleLaunchAgent;
@@ -416,6 +418,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         if (confirmedGone) _pidRecords.Delete(agentId); // delete ONLY on confirmed death (spec §6.4(2))
 
         return confirmedGone;
+    }
+
+    /// <summary>AI-1313 Phase B (D4 §6.4(3)): run the startup orphan reap once — called by DaemonRunner
+    /// at boot under the daemon lock (next to WorktreeManager.CleanupOrphanedAsync), and re-run on each
+    /// heartbeat tick. Best-effort: a reaper fault is logged and swallowed, never faulting the caller.</summary>
+    internal async Task ReapOrphansOnceAsync(CancellationToken ct = default) {
+        if (_orphanReaper is null) return;
+        try { await _orphanReaper.ReapOnceAsync(ct); }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+        catch (Exception ex) { _logger.LogWarning(ex, "OrphanReaper sweep faulted — continuing"); }
     }
 
     /// <summary>AI-1313 Phase B (D2): build + send one status report, one-way, swallowing errors (an
@@ -654,7 +666,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 DaemonBridgeUrl: daemonBridgeUrl,
                 CapacitorPath: _config.CapacitorPath,
                 McpAllowlist: effectiveAllowlist,
-                Work: work
+                Work: work,
+                DaemonId: _daemonId,       // AI-1313 Phase B (D4 §6.4(3)): child env markers for the OrphanReaper scan
+                DaemonEpoch: _daemonEpoch
             );
 
             HostedRuntimeStart start;
@@ -1682,6 +1696,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // AI-1313 Phase B (D4 §6.4(2a)): retry killing any unconfirmed-death quarantined process,
             // draining those confirmed gone (frees admission).
             if (_quarantine is { Count: > 0 }) _ = _quarantine.RetryAllAsync(ct);
+
+            // AI-1313 Phase B (D4 §6.4(3)): re-run the orphan reap — record pass is epoch-guarded (never
+            // touches a current-incarnation live agent), env-marker scan reaps a prior incarnation's
+            // recordless survivors. Fire-and-forget; ReapOrphansOnceAsync swallows its own faults.
+            _ = ReapOrphansOnceAsync(ct);
 
             foreach (var (id, reason) in FindReviewersToReap()) {
                 if (_agents.TryGetValue(id, out var reviewer)) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -28,10 +28,18 @@ internal record AgentInstance(
     ) {
     public string?              SessionId         { get; set; }
     public string               Status            { get; set; } = "Starting";
-    public DateTime             CreatedAt         { get; }      = DateTime.UtcNow;
+    public DateTime             CreatedAt         { get; init; } = DateTime.UtcNow;
     public DateTime             LastOutputAt      { get; set; } = DateTime.UtcNow;
     public bool                 HasReceivedOutput { get; set; }
     public TerminalOutputBuffer OutputBuffer      { get; } = new();
+
+    /// <summary>AI-1313 Phase B (D2): the launch kind + (for a ReviewFlow launch) the flow identity,
+    /// captured from <see cref="LaunchAgentCommand"/> at construction. Reported in
+    /// <c>LiveAgents</c>/<c>DaemonStatusReport</c> so a restarted server can associate a surviving
+    /// unassigned reviewer with its role. Defaults preserve pre-D2 behavior for any non-D2 launch path.</summary>
+    public LaunchKind           Kind              { get; init; } = LaunchKind.Default;
+    public string?              FlowRunId         { get; init; }
+    public string?              FlowRole          { get; init; }
 
     /// <summary>Temp MCP config path written for hosted PR reviews; deleted on cleanup.</summary>
     public string? McpConfigPath { get; set; }
@@ -281,6 +289,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 .Select(kvp => kvp.Key)
         ];
 
+        // AI-1313 Phase B (D2): richer live-agent metadata (kind + flow identity) alongside the ids.
+        _server.GetLiveAgents = () => [.. BuildLiveAgents()];
+
         // Start heartbeat loops
         _ = RunHeartbeatLoopAsync(_shutdownCts.Token);
         _ = RunDaemonHeartbeatLoopAsync(_shutdownCts.Token);
@@ -289,6 +300,35 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     }
 
     internal int ActiveCount => _agents.Count(a => a.Value.Status is "Starting" or "Running");
+
+    /// <summary>AI-1313 Phase B (D2): one <see cref="LiveAgentInfo"/> per currently-live (Starting or
+    /// Running), non-private agent, carrying its kind + flow identity. Mirrors the
+    /// <see cref="ServerConnection.GetLiveAgentIds"/> filter (private-local agents excluded).</summary>
+    internal IReadOnlyList<LiveAgentInfo> BuildLiveAgents() =>
+        [.. _agents.Values
+            .Where(a => a.Status is "Starting" or "Running" && !a.IsPrivate)
+            .Select(a => new LiveAgentInfo(a.Id, a.Kind.ToString(), a.CreatedAt, a.FlowRunId, a.FlowRole))];
+
+    /// <summary>AI-1313 Phase B: test-only seam — insert a minimal <see cref="AgentInstance"/> (Noop
+    /// PTY runtime, no real process/worktree) so unit tests can exercise <see cref="BuildLiveAgents"/>
+    /// / status-report / reviewer-TTL logic without a live launch. Never called in production.</summary>
+    internal AgentInstance SeedAgentForTest(
+            string id, LaunchKind kind = LaunchKind.Default, string status = "Running",
+            string? flowRunId = null, string? flowRole = null,
+            DateTime? createdAt = null, DateTime? lastOutputAt = null, bool isPrivate = false) {
+        var agent = new AgentInstance(
+            id, null, "default", null, "/repo", "codex",
+            new PtyHostedAgentRuntime("codex", NoopPtyProcess.Instance),
+            new WorktreeInfo("/repo", "b", "/repo"),
+            new CancellationTokenSource()) {
+            Kind = kind, FlowRunId = flowRunId, FlowRole = flowRole, IsPrivate = isPrivate,
+            CreatedAt = createdAt ?? DateTime.UtcNow
+        };
+        agent.Status = status;
+        if (lastOutputAt is { } lo) agent.LastOutputAt = lo;
+        _agents[id] = agent;
+        return agent;
+    }
 
     async Task HandleLaunchAgent(LaunchAgentCommand cmd) {
         var agentId       = cmd.AgentId;
@@ -518,7 +558,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 CurrentCols         = HostedPtyCols,
                 CurrentRows         = HostedPtyRows,
                 Work                = work,
-                ReviewerBridgeToken = reviewerToken
+                ReviewerBridgeToken = reviewerToken,
+                Kind                = cmd.Kind,       // AI-1313 Phase B (D2): flow identity + kind for LiveAgents/status report
+                FlowRunId           = cmd.FlowRunId,
+                FlowRole            = cmd.FlowRole
             };
             _agents[agentId] = agent;
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -41,6 +41,11 @@ internal record AgentInstance(
     public string?              FlowRunId         { get; init; }
     public string?              FlowRole          { get; init; }
 
+    /// <summary>AI-1313 Phase B (D1): single-flight teardown latch — a plain field (not a property) so
+    /// <see cref="System.Threading.Interlocked.CompareExchange(ref int,int,int)"/> can gate it. Exactly
+    /// one teardown runs even if the launch-catch and the read-loop's finally race.</summary>
+    public int CleanupStarted;
+
     /// <summary>Temp MCP config path written for hosted PR reviews; deleted on cleanup.</summary>
     public string? McpConfigPath { get; set; }
 
@@ -179,6 +184,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // AI-1313 Phase B (D4): durable PID records + this daemon's logical identity/epoch for
     // crash-survivor reaping. Initialized in the ctor from config.
     AgentPidRecordStore? _pidRecords;
+    AgentKillQuarantine? _quarantine;
     string               _daemonId    = "";
     string               _daemonEpoch = "";
     readonly DaemonConfig                                      _config;
@@ -287,6 +293,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         var recordRoot = Path.Combine(
             config.StateDir ?? DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(config.Name));
         _pidRecords  = new AgentPidRecordStore(recordRoot, logger);
+        _quarantine  = new AgentKillQuarantine(logger);
         _daemonId    = ComputeDaemonId(config.Name);
         _daemonEpoch = config.DaemonEpoch ?? Guid.NewGuid().ToString("N");
 
@@ -350,9 +357,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     internal DaemonStatusReport BuildStatusReport() =>
         new(ActiveCount, [.. BuildLiveAgents()], [.. QuarantineSnapshot()]);
 
-    /// <summary>AI-1313 Phase B: the kill-quarantine snapshot for the status report. Empty until D4
-    /// Task 8 wires the real <c>AgentKillQuarantine</c>; kept as a seam so BuildStatusReport is stable.</summary>
-    internal IReadOnlyList<QuarantinedAgentInfo> QuarantineSnapshot() => [];
+    /// <summary>AI-1313 Phase B (D4 §6.4(2a)): the kill-quarantine snapshot for the status report.</summary>
+    internal IReadOnlyList<QuarantinedAgentInfo> QuarantineSnapshot() => _quarantine?.Snapshot() ?? [];
+
+    /// <summary>AI-1313 Phase B (D4 §6.4(2a)): the daemon's admission gate — committed active agents
+    /// PLUS unconfirmed-death quarantined ones, so a persistent kill/record-write failure shrinks
+    /// admission (fails closed) rather than minting processes beyond the budget.</summary>
+    internal int EffectiveCount => ActiveCount + (_quarantine?.Count ?? 0);
 
     /// <summary>AI-1313 Phase B (D4): this daemon's stable logical id = a hash of its name, written
     /// into each child's <c>KCAP_DAEMON_ID</c> marker. Per-name so a different daemon under the same
@@ -437,10 +448,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     internal AgentInstance SeedAgentForTest(
             string id, LaunchKind kind = LaunchKind.Default, string status = "Running",
             string? flowRunId = null, string? flowRole = null,
-            DateTime? createdAt = null, DateTime? lastOutputAt = null, bool isPrivate = false) {
+            DateTime? createdAt = null, DateTime? lastOutputAt = null, bool isPrivate = false,
+            IPtyProcess? pty = null) {
         var agent = new AgentInstance(
             id, null, "default", null, "/repo", "codex",
-            new PtyHostedAgentRuntime("codex", NoopPtyProcess.Instance),
+            new PtyHostedAgentRuntime("codex", pty ?? NoopPtyProcess.Instance),
             new WorktreeInfo("/repo", "b", "/repo"),
             new CancellationTokenSource()) {
             Kind = kind, FlowRunId = flowRunId, FlowRole = flowRole, IsPrivate = isPrivate,
@@ -497,7 +509,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         string? reviewerToken = null;
 
         try {
-            if (ActiveCount >= _config.MaxConcurrentAgents) {
+            if (EffectiveCount >= _config.MaxConcurrentAgents) {
                 await _server.LaunchFailedAsync(agentId, $"At max capacity ({_config.MaxConcurrentAgents} agents)");
 
                 return;
@@ -739,6 +751,20 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             }
         } catch (Exception ex) {
             LogLaunchFailed(ex, agentId);
+
+            // AI-1313 Phase B (D1): if the agent was ALREADY inserted into _agents (a post-insert
+            // failure — e.g. a throwing RegisterAgentAsync at :697), route teardown through the
+            // single-flight CleanupAgentAsync. It owns the full teardown of a live agent: dispose the
+            // runtime (kill the child), remove the owned worktree, confirm-death-or-quarantine, delete
+            // the PID record, revoke the reviewer token, unregister, and drop the registry entry — so
+            // a post-insert throw can never strand an agent whose child process is still alive. Only a
+            // PRE-insert failure (nothing in _agents) falls through to the transient-cleanup path
+            // below, where the reviewer token + owned worktree are not yet owned by any AgentInstance.
+            if (_agents.ContainsKey(agentId)) {
+                await CleanupAgentAsync(agentId);
+                await _server.LaunchFailedAsync(agentId, ex.Message);
+                return;
+            }
 
             // If a reviewer token was minted before the failure and no AgentInstance was created to
             // own it, revoke it here so it can't linger in the bridge's live-token set.
@@ -1653,6 +1679,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // before the per-agent loop so a reaped reviewer isn't also heartbeated this tick. Reason
             // stamped on PendingEndReason so the end attribution is correct even if HandleStopAgent's
             // own end call loses to the read-loop's.
+            // AI-1313 Phase B (D4 §6.4(2a)): retry killing any unconfirmed-death quarantined process,
+            // draining those confirmed gone (frees admission).
+            if (_quarantine is { Count: > 0 }) _ = _quarantine.RetryAllAsync(ct);
+
             foreach (var (id, reason) in FindReviewersToReap()) {
                 if (_agents.TryGetValue(id, out var reviewer)) {
                     _logger.LogInformation(
@@ -1745,9 +1775,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             return;
         }
 
-        // AI-1313 Phase B (D4 §6.4(2)): the agent has been removed from the registry as part of its
-        // termination cleanup — its process is being/has been torn down, so drop the PID record.
-        DeletePidRecord(agentId);
+        // AI-1313 Phase B (D1): single-flight — belt-and-suspenders on top of the TryRemove above, so a
+        // racing launch-catch + read-loop finally can never double-run the teardown for one agent.
+        if (Interlocked.CompareExchange(ref agent.CleanupStarted, 1, 0) != 0) return;
 
         // The reviewer process has exited by the time we get here (this runs off the read-loop's exit
         // path), so revoke its bridge token now — after any final submit_review_result was served.
@@ -1773,6 +1803,21 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // This is the spec's top safety invariant.
         if (agent.Work == WorkLocation.OwnedWorktree) {
             try { await WorktreeManager.RemoveAsync(agent.Worktree); } catch (Exception ex) { LogCleanupStepFailed(ex, "removing worktree", agentId); }
+        }
+
+        // AI-1313 Phase B (D4 §6.4(2)/(2a)): confirm the process is actually gone before dropping its
+        // PID record. If DisposeAsync didn't kill it (a stuck child), QUARANTINE it — retain the record
+        // and count it against admission (fail closed) so the heartbeat retries the kill to confirmed
+        // death. A confirmed-dead process's record is deleted.
+        var pid          = agent.Runtime.Pid;
+        var stillIdentity = ProcessIdentity.Capture(pid);
+        if (stillIdentity is not null && ProcessIdentity.IsAlive(pid)) {
+            _quarantine?.Add(new AgentKillQuarantine.Entry(
+                agent.Id, pid, stillIdentity, agent.Kind.ToString(), agent.CreatedAt, agent.FlowRunId, agent.FlowRole));
+            _logger.LogWarning(
+                "Agent {AgentId} (pid {Pid}) still alive after teardown — quarantined for heartbeat kill-retry", agent.Id, pid);
+        } else {
+            DeletePidRecord(agentId); // confirmed dead
         }
 
         // Skip server unregister during shutdown — _ct is cancelled and the call

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -297,6 +297,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _ = RunDaemonHeartbeatLoopAsync(_shutdownCts.Token);
         _ = RunTokenRefreshLoopAsync(_shutdownCts.Token);
         _ = RunSpoolDrainLoopAsync(_shutdownCts.Token);
+        _ = RunDaemonStatusReportLoopAsync(_shutdownCts.Token); // AI-1313 Phase B (D2): periodic self-report
     }
 
     internal int ActiveCount => _agents.Count(a => a.Value.Status is "Starting" or "Running");
@@ -324,6 +325,32 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         }
 
         return result;
+    }
+
+    /// <summary>AI-1313 Phase B (D2): the daemon's self-report snapshot — its authoritative
+    /// <see cref="ActiveCount"/> plus the live-agent metadata (and, once D4/Task 8 lands, the
+    /// kill-quarantine). Pure; the send loop + tests share it.</summary>
+    internal DaemonStatusReport BuildStatusReport() =>
+        new(ActiveCount, [.. BuildLiveAgents()], [.. QuarantineSnapshot()]);
+
+    /// <summary>AI-1313 Phase B: the kill-quarantine snapshot for the status report. Empty until D4
+    /// Task 8 wires the real <c>AgentKillQuarantine</c>; kept as a seam so BuildStatusReport is stable.</summary>
+    internal IReadOnlyList<QuarantinedAgentInfo> QuarantineSnapshot() => [];
+
+    /// <summary>AI-1313 Phase B (D2): build + send one status report, one-way, swallowing errors (an
+    /// old server has no handler; a transient send failure must not touch the agent loops).</summary>
+    internal async Task SendDaemonStatusReportOnceAsync() {
+        try { await _server.DaemonStatusReportAsync(BuildStatusReport()); }
+        catch (Exception ex) { _logger.LogDebug(ex, "DaemonStatusReport send failed — ignoring"); }
+    }
+
+    async Task RunDaemonStatusReportLoopAsync(CancellationToken ct) {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(60));
+        while (await timer.WaitForNextTickAsync(ct)) {
+            try { await SendDaemonStatusReportOnceAsync(); }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { return; }
+            catch (Exception ex) { _logger.LogWarning(ex, "DaemonStatusReport loop tick faulted — continuing"); }
+        }
     }
 
     /// <summary>AI-1313 Phase B (D2): one <see cref="LiveAgentInfo"/> per currently-live (Starting or

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -175,6 +175,12 @@ public class TerminalOutputBuffer {
 
 internal partial class AgentOrchestrator : IAsyncDisposable {
     readonly ConcurrentDictionary<string, AgentInstance>       _agents = new();
+
+    // AI-1313 Phase B (D4): durable PID records + this daemon's logical identity/epoch for
+    // crash-survivor reaping. Initialized in the ctor from config.
+    AgentPidRecordStore? _pidRecords;
+    string               _daemonId    = "";
+    string               _daemonEpoch = "";
     readonly DaemonConfig                                      _config;
     readonly ServerConnection                                  _server;
     readonly WorktreeManager                                   _worktreeManager;
@@ -273,6 +279,17 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _runtimeFactories  = runtimeFactories;
         _logger            = logger;
 
+        // AI-1313 Phase B (D4): per-daemon PID-record store + this daemon's logical id + boot epoch.
+        // Records live under "{stateDir}/{name}/agents" so they are unambiguously THIS daemon's own
+        // (the startup reap only touches its own leftovers). DaemonId is a stable per-name identity;
+        // DaemonEpoch is fresh per boot so the env-marker scan can tell a prior incarnation's
+        // survivors from the current incarnation's live children.
+        var recordRoot = Path.Combine(
+            config.StateDir ?? DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(config.Name));
+        _pidRecords  = new AgentPidRecordStore(recordRoot, logger);
+        _daemonId    = ComputeDaemonId(config.Name);
+        _daemonEpoch = config.DaemonEpoch ?? Guid.NewGuid().ToString("N");
+
         // Wire up server commands
         _server.OnLaunchAgent            += HandleLaunchAgent;
         _server.OnStopAgent              += HandleStopAgent;
@@ -336,6 +353,59 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <summary>AI-1313 Phase B: the kill-quarantine snapshot for the status report. Empty until D4
     /// Task 8 wires the real <c>AgentKillQuarantine</c>; kept as a seam so BuildStatusReport is stable.</summary>
     internal IReadOnlyList<QuarantinedAgentInfo> QuarantineSnapshot() => [];
+
+    /// <summary>AI-1313 Phase B (D4): this daemon's stable logical id = a hash of its name, written
+    /// into each child's <c>KCAP_DAEMON_ID</c> marker. Per-name so a different daemon under the same
+    /// user is never mistaken for ours by the env-marker scan.</summary>
+    static string ComputeDaemonId(string name) =>
+        Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(name ?? "")))
+        [..16].ToLowerInvariant();
+
+    /// <summary>AI-1313 Phase B (D4 §6.4(2)): write the durable PID record for a just-spawned agent
+    /// (best-effort — a lost record falls to the env-marker scan backstop; D4/Task 8 hardens the
+    /// write-failure path to fail-closed). Captures the EXACT start-identity for the pid.</summary>
+    void WritePidRecordBestEffort(AgentInstance agent, int pid) {
+        if (_pidRecords is null) return;
+
+        var identity = ProcessIdentity.Capture(pid);
+        if (identity is null) return; // unidentifiable pid → skip (env-marker scan backstops it)
+
+        try {
+            _pidRecords.Write(new AgentPidRecord(
+                agent.Id, pid, identity, agent.Kind.ToString(), agent.Vendor,
+                agent.FlowRunId, agent.FlowRole, _daemonId, _daemonEpoch, DateTimeOffset.UtcNow));
+        } catch (Exception ex) {
+            _logger.LogWarning(ex, "Failed to write PID record for agent {AgentId}", agent.Id);
+        }
+    }
+
+    /// <summary>Delete an agent's PID record after its death is confirmed (teardown / confirmed reap).</summary>
+    void DeletePidRecord(string agentId) => _pidRecords?.Delete(agentId);
+
+    /// <summary>Test seams (this daemon's PID-record store) so a unit test can seed/inspect records
+    /// without a real launch. Never used in production.</summary>
+    internal void WritePidRecordForTest(AgentPidRecord record)     => _pidRecords?.Write(record);
+    internal IReadOnlyList<AgentPidRecord> PidRecordsForTest()      => _pidRecords?.ReadAll() ?? [];
+    internal string DaemonIdForTest                                 => _daemonId;
+    internal string DaemonEpochForTest                             => _daemonEpoch;
+
+    /// <summary>AI-1313 Phase B (D4 §6.4(3) StopAgent fallback): the caller had no in-memory agent for
+    /// this id — consult the PID record and, if a live process still matches its EXACT identity (and,
+    /// on Unix, carries the expected <c>KCAP_AGENT_ID</c> env — ambiguity spares), reap it by identity
+    /// and delete the record on confirmed death. This makes the server's registry-independent S2 stop
+    /// effective even against a NEW daemon incarnation that never knew the agent in memory.</summary>
+    async Task<bool> TryStopByPidRecordAsync(string agentId) {
+        if (_pidRecords is null) return false;
+
+        var record = _pidRecords.ReadAll().FirstOrDefault(r => r.AgentId == agentId);
+        if (record.AgentId != agentId) return false; // no record
+
+        var confirmedGone = await ProcessReaper.ReapByRecordAsync(record, _logger, _shutdownCts.Token);
+        if (confirmedGone) _pidRecords.Delete(agentId); // delete ONLY on confirmed death (spec §6.4(2))
+
+        return confirmedGone;
+    }
 
     /// <summary>AI-1313 Phase B (D2): build + send one status report, one-way, swallowing errors (an
     /// old server has no handler; a transient send failure must not touch the agent loops).</summary>
@@ -616,6 +686,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 FlowRole            = cmd.FlowRole
             };
             _agents[agentId] = agent;
+
+            // AI-1313 Phase B (D4 §6.4(2)): write the durable PID record immediately after the process
+            // exists (before registration) so a daemon crash right after this leaves a reapable record.
+            WritePidRecordBestEffort(agent, runtime.Pid);
 
             await RegisterAgentAsync(agent);
 
@@ -1005,8 +1079,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// </summary>
     static readonly TimeSpan GracefulExitWait = TimeSpan.FromSeconds(15);
 
-    async Task HandleStopAgent(string agentId) {
+    internal async Task HandleStopAgent(string agentId) {
         if (!_agents.TryGetValue(agentId, out var agent)) {
+            // AI-1313 Phase B (D4 §6.4(3)): no in-memory agent — this may be a survivor of a PRIOR
+            // daemon incarnation the server is still trying to stop (S2). Fall back to the PID record:
+            // reap by exact identity if a matching live process is still there.
+            await TryStopByPidRecordAsync(agentId);
             return;
         }
 
@@ -1666,6 +1744,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         if (!_agents.TryRemove(agentId, out var agent)) {
             return;
         }
+
+        // AI-1313 Phase B (D4 §6.4(2)): the agent has been removed from the registry as part of its
+        // termination cleanup — its process is being/has been torn down, so drop the PID record.
+        DeletePidRecord(agentId);
 
         // The reviewer process has exited by the time we get here (this runs off the read-loop's exit
         // path), so revoke its bridge token now — after any final submit_review_result was served.

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -301,6 +301,31 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     internal int ActiveCount => _agents.Count(a => a.Value.Status is "Starting" or "Running");
 
+    /// <summary>AI-1313 Phase B (D3): clock seam so the reviewer-TTL heartbeat check is testable with a
+    /// fixed time. Production uses the real UTC clock.</summary>
+    internal Func<DateTime> ClockUtc { get; set; } = () => DateTime.UtcNow;
+
+    /// <summary>AI-1313 Phase B (D3): the ReviewFlow agents the heartbeat should reap now — past
+    /// <see cref="DaemonConfig.ReviewerMaxLifetime"/> (reason <c>reviewer_ttl_expired</c>) or
+    /// <see cref="DaemonConfig.ReviewerIdleTimeout"/> (reason <c>reviewer_idle_expired</c>). Only
+    /// Running ReviewFlow agents; a <see cref="TimeSpan.Zero"/> bound disables it; interactive agents
+    /// are never returned. Pure (no side effects) so the heartbeat and tests share one decision.</summary>
+    internal IReadOnlyList<(string Id, string Reason)> FindReviewersToReap() {
+        var now    = ClockUtc();
+        var result = new List<(string, string)>();
+
+        foreach (var a in _agents.Values) {
+            if (a.Kind != LaunchKind.ReviewFlow || a.Status != "Running") continue;
+
+            if (_config.ReviewerMaxLifetime > TimeSpan.Zero && now - a.CreatedAt > _config.ReviewerMaxLifetime)
+                result.Add((a.Id, "reviewer_ttl_expired"));
+            else if (_config.ReviewerIdleTimeout > TimeSpan.Zero && now - a.LastOutputAt > _config.ReviewerIdleTimeout)
+                result.Add((a.Id, "reviewer_idle_expired"));
+        }
+
+        return result;
+    }
+
     /// <summary>AI-1313 Phase B (D2): one <see cref="LiveAgentInfo"/> per currently-live (Starting or
     /// Running), non-private agent, carrying its kind + flow identity. Mirrors the
     /// <see cref="ServerConnection.GetLiveAgentIds"/> filter (private-local agents excluded).</summary>
@@ -1519,6 +1544,20 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     async Task RunHeartbeatLoopAsync(CancellationToken ct) {
         while (await _heartbeatTimer.WaitForNextTickAsync(ct)) {
+            // AI-1313 Phase B (D3): reap review-flow reviewers past their lifetime/idle backstop. Done
+            // before the per-agent loop so a reaped reviewer isn't also heartbeated this tick. Reason
+            // stamped on PendingEndReason so the end attribution is correct even if HandleStopAgent's
+            // own end call loses to the read-loop's.
+            foreach (var (id, reason) in FindReviewersToReap()) {
+                if (_agents.TryGetValue(id, out var reviewer)) {
+                    _logger.LogInformation(
+                        "Reaping review-flow reviewer {AgentId} ({Reason}); age {AgeHours:F1}h, idle {IdleHours:F1}h",
+                        id, reason, (ClockUtc() - reviewer.CreatedAt).TotalHours, (ClockUtc() - reviewer.LastOutputAt).TotalHours);
+                    reviewer.PendingEndReason = reason;
+                    _ = HandleStopAgent(id);
+                }
+            }
+
             // PrivateLocal agents get no heartbeats and no stuck-Starting auto-stop (deny-all;
             // the local user is present and drives them directly).
             foreach (var agent in _agents.Values.Where(a => (a.Status is "Starting" or "Running") && !a.IsPrivate)) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -33,7 +33,7 @@ internal record AgentInstance(
     public bool                 HasReceivedOutput { get; set; }
     public TerminalOutputBuffer OutputBuffer      { get; } = new();
 
-    /// <summary>AI-1313 Phase B (D2): the launch kind + (for a ReviewFlow launch) the flow identity,
+    /// <summary>Phase B (D2): the launch kind + (for a ReviewFlow launch) the flow identity,
     /// captured from <see cref="LaunchAgentCommand"/> at construction. Reported in
     /// <c>LiveAgents</c>/<c>DaemonStatusReport</c> so a restarted server can associate a surviving
     /// unassigned reviewer with its role. Defaults preserve pre-D2 behavior for any non-D2 launch path.</summary>
@@ -41,16 +41,15 @@ internal record AgentInstance(
     public string?              FlowRunId         { get; init; }
     public string?              FlowRole          { get; init; }
 
-    /// <summary>AI-1313 Phase B (D1): single-flight teardown latch — a plain field (not a property) so
+    /// <summary>Phase B (D1): single-flight teardown latch — a plain field (not a property) so
     /// <see cref="System.Threading.Interlocked.CompareExchange(ref int,int,int)"/> can gate it. Exactly
     /// one teardown runs even if the launch-catch and the read-loop's finally race.</summary>
     public int CleanupStarted;
 
-    /// <summary>AI-1313 Phase B (D4): the child's EXACT start-identity captured ONCE at spawn (the AI-839
-    /// <c>ProcessStartToken</c>). Teardown uses THIS stored token — never a freshly-recaptured one — to
-    /// decide "still ours vs PID reused": if the pid was recycled after the child exited, a re-capture
-    /// would adopt an unrelated process's identity and the heartbeat would then kill it. Null only when
-    /// the pid was never capturable (a non-live/degenerate pid — nothing to track).</summary>
+    /// <summary>Phase B (D4): the child's exact start-identity captured ONCE at spawn (the
+    /// <c>ProcessStartToken</c>). Teardown uses THIS stored token — never a freshly-recaptured one — so a
+    /// pid recycled after the child exited can't be adopted and later killed. Null only when the pid was
+    /// never capturable (a non-live/degenerate pid — nothing to track).</summary>
     public string? StartIdentity { get; set; }
 
     /// <summary>Temp MCP config path written for hosted PR reviews; deleted on cleanup.</summary>
@@ -188,7 +187,7 @@ public class TerminalOutputBuffer {
 internal partial class AgentOrchestrator : IAsyncDisposable {
     readonly ConcurrentDictionary<string, AgentInstance>       _agents = new();
 
-    // AI-1313 Phase B (D4): durable PID records + this daemon's logical identity/epoch for
+    // Phase B (D4): durable PID records + this daemon's logical identity/epoch for
     // crash-survivor reaping. Initialized in the ctor from config.
     AgentPidRecordStore? _pidRecords;
     AgentKillQuarantine? _quarantine;
@@ -196,7 +195,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     string               _daemonId    = "";
     string               _daemonEpoch = "";
 
-    // AI-1313 Phase B (D4 §6.4(2a)/(3)): single-flight latches so a slow sweep (each survivor consumes a
+    // Phase B (D4 §6.4(2a)/(3)): single-flight latches so a slow sweep (each survivor consumes a
     // ~5s TERM grace sequentially) can't overlap itself when the next heartbeat tick fires — otherwise
     // sweeps accumulate, double-signal, and re-scan /proc concurrently. A tick whose prior sweep is still
     // running is simply skipped. 0 = idle, 1 = running (Interlocked-gated).
@@ -300,7 +299,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _runtimeFactories  = runtimeFactories;
         _logger            = logger;
 
-        // AI-1313 Phase B (D4): per-daemon PID-record store + this daemon's logical id + boot epoch.
+        // Phase B (D4): per-daemon PID-record store + this daemon's logical id + boot epoch.
         // Records live under "{stateDir}/{name}/agents" so they are unambiguously THIS daemon's own
         // (the startup reap only touches its own leftovers). DaemonId is a stable per-name identity;
         // DaemonEpoch is fresh per boot so the env-marker scan can tell a prior incarnation's
@@ -329,7 +328,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 .Select(kvp => kvp.Key)
         ];
 
-        // AI-1313 Phase B (D2): richer live-agent metadata (kind + flow identity) alongside the ids.
+        // Phase B (D2): richer live-agent metadata (kind + flow identity) alongside the ids.
         _server.GetLiveAgents = () => [.. BuildLiveAgents()];
 
         // Start heartbeat loops
@@ -337,16 +336,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _ = RunDaemonHeartbeatLoopAsync(_shutdownCts.Token);
         _ = RunTokenRefreshLoopAsync(_shutdownCts.Token);
         _ = RunSpoolDrainLoopAsync(_shutdownCts.Token);
-        _ = RunDaemonStatusReportLoopAsync(_shutdownCts.Token); // AI-1313 Phase B (D2): periodic self-report
+        _ = RunDaemonStatusReportLoopAsync(_shutdownCts.Token); // Phase B (D2): periodic self-report
     }
 
     internal int ActiveCount => _agents.Count(a => a.Value.Status is "Starting" or "Running");
 
-    /// <summary>AI-1313 Phase B (D3): clock seam so the reviewer-TTL heartbeat check is testable with a
+    /// <summary>Phase B (D3): clock seam so the reviewer-TTL heartbeat check is testable with a
     /// fixed time. Production uses the real UTC clock.</summary>
     internal Func<DateTime> ClockUtc { get; set; } = () => DateTime.UtcNow;
 
-    /// <summary>AI-1313 Phase B (D3): the ReviewFlow agents the heartbeat should reap now — past
+    /// <summary>Phase B (D3): the ReviewFlow agents the heartbeat should reap now — past
     /// <see cref="DaemonConfig.ReviewerMaxLifetime"/> (reason <c>reviewer_ttl_expired</c>) or
     /// <see cref="DaemonConfig.ReviewerIdleTimeout"/> (reason <c>reviewer_idle_expired</c>). Only
     /// Running ReviewFlow agents; a <see cref="TimeSpan.Zero"/> bound disables it; interactive agents
@@ -367,16 +366,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         return result;
     }
 
-    /// <summary>AI-1313 Phase B (D2): the daemon's self-report snapshot — its authoritative
+    /// <summary>Phase B (D2): the daemon's self-report snapshot — its authoritative
     /// <see cref="ActiveCount"/> plus the live-agent metadata (and, once D4/Task 8 lands, the
     /// kill-quarantine). Pure; the send loop + tests share it.</summary>
     internal DaemonStatusReport BuildStatusReport() =>
         new(ActiveCount, [.. BuildLiveAgents()], [.. QuarantineSnapshot()]);
 
-    /// <summary>AI-1313 Phase B (D4 §6.4(2a)): the kill-quarantine snapshot for the status report.</summary>
+    /// <summary>Phase B (D4 §6.4(2a)): the kill-quarantine snapshot for the status report.</summary>
     internal IReadOnlyList<QuarantinedAgentInfo> QuarantineSnapshot() => _quarantine?.Snapshot() ?? [];
 
-    /// <summary>AI-1313 Phase B (D4 §6.4(2a)): the daemon's admission gate — EVERY live registry entry
+    /// <summary>Phase B (D4 §6.4(2a)): the daemon's admission gate — EVERY live registry entry
     /// (not just Starting/Running — a Completed/Failed agent still mid-teardown holds its slot until
     /// CleanupAgentAsync's count-preserving remove) PLUS unconfirmed-death quarantined ones. Using the
     /// full <c>_agents.Count</c> (rather than <see cref="ActiveCount"/>, whose Starting/Running meaning is
@@ -385,7 +384,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// admission (fails closed) rather than minting processes beyond the budget.</summary>
     internal int EffectiveCount => _agents.Count + (_quarantine?.Count ?? 0);
 
-    /// <summary>AI-1313 Phase B (D4): this daemon's stable logical id = a hash of its name, written
+    /// <summary>Phase B (D4): this daemon's stable logical id = a hash of its name, written
     /// into each child's <c>KCAP_DAEMON_ID</c> marker. Per-name so a different daemon under the same
     /// user is never mistaken for ours by the env-marker scan.</summary>
     static string ComputeDaemonId(string name) =>
@@ -393,7 +392,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(name ?? "")))
         [..16].ToLowerInvariant();
 
-    /// <summary>AI-1313 Phase B (D4 §6.4(2)/(2a)): capture the child's EXACT start-identity ONCE, store it
+    /// <summary>Phase B (D4 §6.4(2)/(2a)): capture the child's EXACT start-identity ONCE, store it
     /// on the agent (teardown reuses it — never re-captures a possibly-recycled pid), and persist the
     /// durable PID record FAIL-CLOSED. A write failure (I/O) or a live-but-unidentifiable child THROWS —
     /// caught by the post-insert single-flight cleanup, so a spawned child we cannot durably track never
@@ -430,7 +429,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     internal string DaemonIdForTest                                 => _daemonId;
     internal string DaemonEpochForTest                             => _daemonEpoch;
 
-    /// <summary>AI-1313 Phase B (D4 §6.4(3) StopAgent fallback): the caller had no in-memory agent for
+    /// <summary>Phase B (D4 §6.4(3) StopAgent fallback): the caller had no in-memory agent for
     /// this id — consult the PID record and, if a live process still matches its EXACT identity (and,
     /// on Unix, carries the expected <c>KCAP_AGENT_ID</c> env — ambiguity spares), reap it by identity
     /// and delete the record on confirmed death. This makes the server's registry-independent S2 stop
@@ -447,7 +446,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         return confirmedGone;
     }
 
-    /// <summary>AI-1313 Phase B (D4 §6.4(3)): run the startup orphan reap once — called by DaemonRunner
+    /// <summary>Phase B (D4 §6.4(3)): run the startup orphan reap once — called by DaemonRunner
     /// at boot under the daemon lock (next to WorktreeManager.CleanupOrphanedAsync), and re-run on each
     /// heartbeat tick. SINGLE-FLIGHT: if a prior sweep is still running (a long /proc scan + sequential
     /// TERM graces can outlast the 30s heartbeat, and the ctor-started heartbeat can overlap the boot
@@ -463,7 +462,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         finally { Interlocked.Exchange(ref _orphanSweepRunning, 0); }
     }
 
-    /// <summary>AI-1313 Phase B (D4 §6.4(2a)): retry the kill-quarantine once — SINGLE-FLIGHT, mirroring
+    /// <summary>Phase B (D4 §6.4(2a)): retry the kill-quarantine once — SINGLE-FLIGHT, mirroring
     /// <see cref="ReapOrphansOnceAsync"/>, so a slow retry (each entry a ~5s TERM grace) can't overlap the
     /// next heartbeat tick. Skipped when empty or already running.</summary>
     async Task RetryQuarantineOnceAsync(CancellationToken ct) {
@@ -481,7 +480,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         finally { Interlocked.Exchange(ref _quarantineSweepRunning, 0); }
     }
 
-    /// <summary>AI-1313 Phase B (D2): build + send one status report, one-way, swallowing errors (an
+    /// <summary>Phase B (D2): build + send one status report, one-way, swallowing errors (an
     /// old server has no handler; a transient send failure must not touch the agent loops).</summary>
     internal async Task SendDaemonStatusReportOnceAsync() {
         try { await _server.DaemonStatusReportAsync(BuildStatusReport()); }
@@ -497,7 +496,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         }
     }
 
-    /// <summary>AI-1313 Phase B (D2): one <see cref="LiveAgentInfo"/> per currently-live (Starting or
+    /// <summary>Phase B (D2): one <see cref="LiveAgentInfo"/> per currently-live (Starting or
     /// Running), non-private agent, carrying its kind + flow identity. Mirrors the
     /// <see cref="ServerConnection.GetLiveAgentIds"/> filter (private-local agents excluded).</summary>
     internal IReadOnlyList<LiveAgentInfo> BuildLiveAgents() =>
@@ -505,7 +504,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             .Where(a => a.Status is "Starting" or "Running" && !a.IsPrivate)
             .Select(a => new LiveAgentInfo(a.Id, a.Kind.ToString(), a.CreatedAt, a.FlowRunId, a.FlowRole))];
 
-    /// <summary>AI-1313 Phase B: test-only seam — insert a minimal <see cref="AgentInstance"/> (Noop
+    /// <summary>Phase B: test-only seam — insert a minimal <see cref="AgentInstance"/> (Noop
     /// PTY runtime, no real process/worktree) so unit tests can exercise <see cref="BuildLiveAgents"/>
     /// / status-report / reviewer-TTL logic without a live launch. Never called in production.</summary>
     internal AgentInstance SeedAgentForTest(
@@ -718,7 +717,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 CapacitorPath: _config.CapacitorPath,
                 McpAllowlist: effectiveAllowlist,
                 Work: work,
-                DaemonId: _daemonId,       // AI-1313 Phase B (D4 §6.4(3)): child env markers for the OrphanReaper scan
+                DaemonId: _daemonId,       // Phase B (D4 §6.4(3)): child env markers for the OrphanReaper scan
                 DaemonEpoch: _daemonEpoch
             );
 
@@ -758,13 +757,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 CurrentRows         = HostedPtyRows,
                 Work                = work,
                 ReviewerBridgeToken = reviewerToken,
-                Kind                = cmd.Kind,       // AI-1313 Phase B (D2): flow identity + kind for LiveAgents/status report
+                Kind                = cmd.Kind,       // Phase B (D2): flow identity + kind for LiveAgents/status report
                 FlowRunId           = cmd.FlowRunId,
                 FlowRole            = cmd.FlowRole
             };
             _agents[agentId] = agent;
 
-            // AI-1313 Phase B (D4 §6.4(2)): capture the start-identity + write the durable PID record
+            // Phase B (D4 §6.4(2)): capture the start-identity + write the durable PID record
             // immediately after the process exists (before registration) so a daemon crash right after
             // this leaves a reapable record. FAIL-CLOSED: a write/identity failure throws → the catch
             // routes it through the single-flight cleanup (the agent is already in _agents).
@@ -819,14 +818,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         } catch (Exception ex) {
             LogLaunchFailed(ex, agentId);
 
-            // AI-1313 Phase B (D1): if the agent was ALREADY inserted into _agents (a post-insert
-            // failure — e.g. a throwing RegisterAgentAsync at :697), route teardown through the
-            // single-flight CleanupAgentAsync. It owns the full teardown of a live agent: dispose the
-            // runtime (kill the child), remove the owned worktree, confirm-death-or-quarantine, delete
-            // the PID record, revoke the reviewer token, unregister, and drop the registry entry — so
-            // a post-insert throw can never strand an agent whose child process is still alive. Only a
-            // PRE-insert failure (nothing in _agents) falls through to the transient-cleanup path
-            // below, where the reviewer token + owned worktree are not yet owned by any AgentInstance.
+            // Phase B (D1): a post-insert failure (agent already in _agents — e.g. a throwing
+            // RegisterAgentAsync) routes teardown through the single-flight CleanupAgentAsync so it
+            // can't strand a live child; a pre-insert failure falls through to the transient cleanup below.
             if (_agents.ContainsKey(agentId)) {
                 await CleanupAgentAsync(agentId);
                 await _server.LaunchFailedAsync(agentId, ex.Message);
@@ -1174,7 +1168,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     internal async Task HandleStopAgent(string agentId) {
         if (!_agents.TryGetValue(agentId, out var agent)) {
-            // AI-1313 Phase B (D4 §6.4(3)): no in-memory agent — this may be a survivor of a PRIOR
+            // Phase B (D4 §6.4(3)): no in-memory agent — this may be a survivor of a PRIOR
             // daemon incarnation the server is still trying to stop (S2). Fall back to the PID record:
             // reap by exact identity if a matching live process is still there.
             await TryStopByPidRecordAsync(agentId);
@@ -1194,7 +1188,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // Mark this as a user-initiated stop so the read-loop's finally-block
             // EndAgentSessionAsync call uses "agent_stopped" if it ends up being
             // the only successful call (e.g., transient SignalR failure here).
-            // AI-1313 Phase B (D3): but PRESERVE a backstop reason the heartbeat already stamped
+            // Phase B (D3): but PRESERVE a backstop reason the heartbeat already stamped
             // (reviewer_ttl_expired / reviewer_idle_expired) — only overwrite the "agent_exited"
             // default, so server-side attribution can tell a TTL/idle reap from a user stop.
             if (agent.PendingEndReason == "agent_exited") agent.PendingEndReason = "agent_stopped";
@@ -1745,15 +1739,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     async Task RunHeartbeatLoopAsync(CancellationToken ct) {
         while (await _heartbeatTimer.WaitForNextTickAsync(ct)) {
-            // AI-1313 Phase B (D3): reap review-flow reviewers past their lifetime/idle backstop. Done
+            // Phase B (D3): reap review-flow reviewers past their lifetime/idle backstop. Done
             // before the per-agent loop so a reaped reviewer isn't also heartbeated this tick. Reason
             // stamped on PendingEndReason so the end attribution is correct even if HandleStopAgent's
             // own end call loses to the read-loop's.
-            // AI-1313 Phase B (D4 §6.4(2a)): retry killing any unconfirmed-death quarantined process,
+            // Phase B (D4 §6.4(2a)): retry killing any unconfirmed-death quarantined process,
             // draining those confirmed gone (frees admission). Single-flight (skips if a prior retry runs).
             _ = RetryQuarantineOnceAsync(ct);
 
-            // AI-1313 Phase B (D4 §6.4(3)): re-run the orphan reap — record pass is epoch-guarded (never
+            // Phase B (D4 §6.4(3)): re-run the orphan reap — record pass is epoch-guarded (never
             // touches a current-incarnation live agent), env-marker scan reaps a prior incarnation's
             // recordless survivors. Fire-and-forget; single-flight; swallows its own faults.
             _ = ReapOrphansOnceAsync(ct);
@@ -1846,7 +1840,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     }
 
     async Task CleanupAgentAsync(string agentId) {
-        // AI-1313 Phase B (D1): claim the single-flight teardown BEFORE removing the agent from _agents.
+        // Phase B (D1): claim the single-flight teardown BEFORE removing the agent from _agents.
         // TryGetValue (not TryRemove) keeps the agent COUNTED in ActiveCount for the whole teardown, so a
         // concurrent launch can't observe an under-counted EffectiveCount mid-teardown and over-admit
         // (the P2 admission race). The CompareExchange latch on the SAME instance guarantees exactly one
@@ -1880,7 +1874,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             try { await WorktreeManager.RemoveAsync(agent.Worktree); } catch (Exception ex) { LogCleanupStepFailed(ex, "removing worktree", agentId); }
         }
 
-        // AI-1313 Phase B (D4 §6.4(2)/(2a)): confirm the process is actually gone before dropping its PID
+        // Phase B (D4 §6.4(2)/(2a)): confirm the process is actually gone before dropping its PID
         // record. Prove "still ours" with the STORED spawn identity — NEVER a freshly-recaptured token:
         // if the child exited and its pid was recycled, a re-capture would adopt the unrelated process's
         // identity and the heartbeat would later kill it. Quarantine ONLY when the pid is alive AND still
@@ -2080,7 +2074,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <summary>Test-only entry point to the private cleanup path.</summary>
     internal Task CleanupAgentForTest(string agentId) => CleanupAgentAsync(agentId);
 
-    /// <summary>AI-1313 Phase B (D4 §6.4(2a)): drive one quarantine-retry sweep (drains confirmed-dead
+    /// <summary>Phase B (D4 §6.4(2a)): drive one quarantine-retry sweep (drains confirmed-dead
     /// entries and deletes their durable records) so a test needn't wait for a heartbeat tick.</summary>
     internal Task RetryQuarantineForTest() => RetryQuarantineOnceAsync(_shutdownCts.Token);
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -46,6 +46,13 @@ internal record AgentInstance(
     /// one teardown runs even if the launch-catch and the read-loop's finally race.</summary>
     public int CleanupStarted;
 
+    /// <summary>AI-1313 Phase B (D4): the child's EXACT start-identity captured ONCE at spawn (the AI-839
+    /// <c>ProcessStartToken</c>). Teardown uses THIS stored token — never a freshly-recaptured one — to
+    /// decide "still ours vs PID reused": if the pid was recycled after the child exited, a re-capture
+    /// would adopt an unrelated process's identity and the heartbeat would then kill it. Null only when
+    /// the pid was never capturable (a non-live/degenerate pid — nothing to track).</summary>
+    public string? StartIdentity { get; set; }
+
     /// <summary>Temp MCP config path written for hosted PR reviews; deleted on cleanup.</summary>
     public string? McpConfigPath { get; set; }
 
@@ -375,22 +382,31 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(name ?? "")))
         [..16].ToLowerInvariant();
 
-    /// <summary>AI-1313 Phase B (D4 §6.4(2)): write the durable PID record for a just-spawned agent
-    /// (best-effort — a lost record falls to the env-marker scan backstop; D4/Task 8 hardens the
-    /// write-failure path to fail-closed). Captures the EXACT start-identity for the pid.</summary>
-    void WritePidRecordBestEffort(AgentInstance agent, int pid) {
+    /// <summary>AI-1313 Phase B (D4 §6.4(2)/(2a)): capture the child's EXACT start-identity ONCE, store it
+    /// on the agent (teardown reuses it — never re-captures a possibly-recycled pid), and persist the
+    /// durable PID record FAIL-CLOSED. A write failure (I/O) or a live-but-unidentifiable child THROWS —
+    /// caught by the post-insert single-flight cleanup, so a spawned child we cannot durably track never
+    /// stays admitted holding capacity. A non-live/degenerate pid (already gone, or pid&lt;=0) has nothing
+    /// to track, so it returns cleanly rather than failing an already-doomed launch.</summary>
+    void PersistPidRecordOrThrow(AgentInstance agent, int pid) {
         if (_pidRecords is null) return;
 
         var identity = ProcessIdentity.Capture(pid);
-        if (identity is null) return; // unidentifiable pid → skip (env-marker scan backstops it)
+        if (identity is null) {
+            if (ProcessIdentity.IsAlive(pid))
+                throw new InvalidOperationException(
+                    $"Could not capture start-identity for live agent {agent.Id} (pid {pid}) — failing launch closed");
 
-        try {
-            _pidRecords.Write(new AgentPidRecord(
-                agent.Id, pid, identity, agent.Kind.ToString(), agent.Vendor,
-                agent.FlowRunId, agent.FlowRole, _daemonId, _daemonEpoch, DateTimeOffset.UtcNow));
-        } catch (Exception ex) {
-            _logger.LogWarning(ex, "Failed to write PID record for agent {AgentId}", agent.Id);
+            return; // no live capturable process → nothing to record or leak
         }
+
+        agent.StartIdentity = identity;
+
+        // Write throws on I/O failure → propagates → post-insert single-flight cleanup (fail closed):
+        // a spawned, capturable child we cannot durably record must not stay admitted without a record.
+        _pidRecords.Write(new AgentPidRecord(
+            agent.Id, pid, identity, agent.Kind.ToString(), agent.Vendor,
+            agent.FlowRunId, agent.FlowRole, _daemonId, _daemonEpoch, DateTimeOffset.UtcNow));
     }
 
     /// <summary>Delete an agent's PID record after its death is confirmed (teardown / confirmed reap).</summary>
@@ -461,14 +477,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             string id, LaunchKind kind = LaunchKind.Default, string status = "Running",
             string? flowRunId = null, string? flowRole = null,
             DateTime? createdAt = null, DateTime? lastOutputAt = null, bool isPrivate = false,
-            IPtyProcess? pty = null) {
+            IPtyProcess? pty = null, string? startIdentity = null) {
         var agent = new AgentInstance(
             id, null, "default", null, "/repo", "codex",
             new PtyHostedAgentRuntime("codex", pty ?? NoopPtyProcess.Instance),
             new WorktreeInfo("/repo", "b", "/repo"),
             new CancellationTokenSource()) {
             Kind = kind, FlowRunId = flowRunId, FlowRole = flowRole, IsPrivate = isPrivate,
-            CreatedAt = createdAt ?? DateTime.UtcNow
+            CreatedAt = createdAt ?? DateTime.UtcNow, StartIdentity = startIdentity
         };
         agent.Status = status;
         if (lastOutputAt is { } lo) agent.LastOutputAt = lo;
@@ -713,9 +729,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             };
             _agents[agentId] = agent;
 
-            // AI-1313 Phase B (D4 §6.4(2)): write the durable PID record immediately after the process
-            // exists (before registration) so a daemon crash right after this leaves a reapable record.
-            WritePidRecordBestEffort(agent, runtime.Pid);
+            // AI-1313 Phase B (D4 §6.4(2)): capture the start-identity + write the durable PID record
+            // immediately after the process exists (before registration) so a daemon crash right after
+            // this leaves a reapable record. FAIL-CLOSED: a write/identity failure throws → the catch
+            // routes it through the single-flight cleanup (the agent is already in _agents).
+            PersistPidRecordOrThrow(agent, runtime.Pid);
 
             await RegisterAgentAsync(agent);
 
@@ -1141,7 +1159,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // Mark this as a user-initiated stop so the read-loop's finally-block
             // EndAgentSessionAsync call uses "agent_stopped" if it ends up being
             // the only successful call (e.g., transient SignalR failure here).
-            agent.PendingEndReason = "agent_stopped";
+            // AI-1313 Phase B (D3): but PRESERVE a backstop reason the heartbeat already stamped
+            // (reviewer_ttl_expired / reviewer_idle_expired) — only overwrite the "agent_exited"
+            // default, so server-side attribution can tell a TTL/idle reap from a user stop.
+            if (agent.PendingEndReason == "agent_exited") agent.PendingEndReason = "agent_stopped";
             _                      = _server.AgentStatusChangedAsync(agentId, "Completed", agent.SessionId);
             _                      = _server.AppendAgentRunEventAsync(agentId, new AgentRunStopped("user", null));
 
@@ -1790,12 +1811,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     }
 
     async Task CleanupAgentAsync(string agentId) {
-        if (!_agents.TryRemove(agentId, out var agent)) {
-            return;
-        }
-
-        // AI-1313 Phase B (D1): single-flight — belt-and-suspenders on top of the TryRemove above, so a
-        // racing launch-catch + read-loop finally can never double-run the teardown for one agent.
+        // AI-1313 Phase B (D1): claim the single-flight teardown BEFORE removing the agent from _agents.
+        // TryGetValue (not TryRemove) keeps the agent COUNTED in ActiveCount for the whole teardown, so a
+        // concurrent launch can't observe an under-counted EffectiveCount mid-teardown and over-admit
+        // (the P2 admission race). The CompareExchange latch on the SAME instance guarantees exactly one
+        // teardown even if the launch-catch and the read-loop's finally race here.
+        if (!_agents.TryGetValue(agentId, out var agent)) return;
         if (Interlocked.CompareExchange(ref agent.CleanupStarted, 1, 0) != 0) return;
 
         // The reviewer process has exited by the time we get here (this runs off the read-loop's exit
@@ -1824,20 +1845,30 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             try { await WorktreeManager.RemoveAsync(agent.Worktree); } catch (Exception ex) { LogCleanupStepFailed(ex, "removing worktree", agentId); }
         }
 
-        // AI-1313 Phase B (D4 §6.4(2)/(2a)): confirm the process is actually gone before dropping its
-        // PID record. If DisposeAsync didn't kill it (a stuck child), QUARANTINE it — retain the record
-        // and count it against admission (fail closed) so the heartbeat retries the kill to confirmed
-        // death. A confirmed-dead process's record is deleted.
-        var pid          = agent.Runtime.Pid;
-        var stillIdentity = ProcessIdentity.Capture(pid);
-        if (stillIdentity is not null && ProcessIdentity.IsAlive(pid)) {
+        // AI-1313 Phase B (D4 §6.4(2)/(2a)): confirm the process is actually gone before dropping its PID
+        // record. Prove "still ours" with the STORED spawn identity — NEVER a freshly-recaptured token:
+        // if the child exited and its pid was recycled, a re-capture would adopt the unrelated process's
+        // identity and the heartbeat would later kill it. Quarantine ONLY when the pid is alive AND still
+        // matches the stored identity (a stuck child of ours) — retain the record + count it against
+        // admission (fail closed) so the heartbeat retries the kill to confirmed death. A dead pid, a
+        // recycled pid (proven mismatch), or an agent with no captured identity → confirmed gone, delete
+        // the record. Add to quarantine BEFORE removing from _agents so EffectiveCount never dips
+        // (Activeized→quarantined is count-preserving).
+        var pid = agent.Runtime.Pid;
+        if (agent.StartIdentity is { } startIdentity
+            && ProcessIdentity.IsAlive(pid)
+            && ProcessIdentity.Matches(pid, startIdentity)) {
             _quarantine?.Add(new AgentKillQuarantine.Entry(
-                agent.Id, pid, stillIdentity, agent.Kind.ToString(), agent.CreatedAt, agent.FlowRunId, agent.FlowRole));
+                agent.Id, pid, startIdentity, agent.Kind.ToString(), agent.CreatedAt, agent.FlowRunId, agent.FlowRole));
             _logger.LogWarning(
                 "Agent {AgentId} (pid {Pid}) still alive after teardown — quarantined for heartbeat kill-retry", agent.Id, pid);
         } else {
-            DeletePidRecord(agentId); // confirmed dead
+            DeletePidRecord(agentId); // confirmed dead / recycled pid / never-identified
         }
+
+        // Now drop the agent from the live registry — after a surviving child is already in quarantine,
+        // so a concurrent launch never sees EffectiveCount transiently under-count this agent.
+        _agents.TryRemove(agentId, out _);
 
         // Skip server unregister during shutdown — _ct is cancelled and the call
         // would throw TaskCanceledException. The server detects the daemon

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -195,6 +195,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     OrphanReaper?        _orphanReaper;
     string               _daemonId    = "";
     string               _daemonEpoch = "";
+
+    // AI-1313 Phase B (D4 §6.4(2a)/(3)): single-flight latches so a slow sweep (each survivor consumes a
+    // ~5s TERM grace sequentially) can't overlap itself when the next heartbeat tick fires — otherwise
+    // sweeps accumulate, double-signal, and re-scan /proc concurrently. A tick whose prior sweep is still
+    // running is simply skipped. 0 = idle, 1 = running (Interlocked-gated).
+    int _orphanSweepRunning;
+    int _quarantineSweepRunning;
     readonly DaemonConfig                                      _config;
     readonly ServerConnection                                  _server;
     readonly WorktreeManager                                   _worktreeManager;
@@ -369,10 +376,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <summary>AI-1313 Phase B (D4 §6.4(2a)): the kill-quarantine snapshot for the status report.</summary>
     internal IReadOnlyList<QuarantinedAgentInfo> QuarantineSnapshot() => _quarantine?.Snapshot() ?? [];
 
-    /// <summary>AI-1313 Phase B (D4 §6.4(2a)): the daemon's admission gate — committed active agents
-    /// PLUS unconfirmed-death quarantined ones, so a persistent kill/record-write failure shrinks
+    /// <summary>AI-1313 Phase B (D4 §6.4(2a)): the daemon's admission gate — EVERY live registry entry
+    /// (not just Starting/Running — a Completed/Failed agent still mid-teardown holds its slot until
+    /// CleanupAgentAsync's count-preserving remove) PLUS unconfirmed-death quarantined ones. Using the
+    /// full <c>_agents.Count</c> (rather than <see cref="ActiveCount"/>, whose Starting/Running meaning is
+    /// the wire contract) keeps a slot reserved across the whole teardown, so a concurrent launch can't
+    /// observe a transiently-freed slot and over-admit. A persistent kill/record-write failure shrinks
     /// admission (fails closed) rather than minting processes beyond the budget.</summary>
-    internal int EffectiveCount => ActiveCount + (_quarantine?.Count ?? 0);
+    internal int EffectiveCount => _agents.Count + (_quarantine?.Count ?? 0);
 
     /// <summary>AI-1313 Phase B (D4): this daemon's stable logical id = a hash of its name, written
     /// into each child's <c>KCAP_DAEMON_ID</c> marker. Per-name so a different daemon under the same
@@ -438,12 +449,31 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     /// <summary>AI-1313 Phase B (D4 §6.4(3)): run the startup orphan reap once — called by DaemonRunner
     /// at boot under the daemon lock (next to WorktreeManager.CleanupOrphanedAsync), and re-run on each
-    /// heartbeat tick. Best-effort: a reaper fault is logged and swallowed, never faulting the caller.</summary>
+    /// heartbeat tick. SINGLE-FLIGHT: if a prior sweep is still running (a long /proc scan + sequential
+    /// TERM graces can outlast the 30s heartbeat, and the ctor-started heartbeat can overlap the boot
+    /// call), this tick is skipped rather than piling on. Best-effort: a reaper fault is logged and
+    /// swallowed, never faulting the caller.</summary>
     internal async Task ReapOrphansOnceAsync(CancellationToken ct = default) {
         if (_orphanReaper is null) return;
+        if (Interlocked.CompareExchange(ref _orphanSweepRunning, 1, 0) != 0) return; // a sweep is already in flight
+
         try { await _orphanReaper.ReapOnceAsync(ct); }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
         catch (Exception ex) { _logger.LogWarning(ex, "OrphanReaper sweep faulted — continuing"); }
+        finally { Interlocked.Exchange(ref _orphanSweepRunning, 0); }
+    }
+
+    /// <summary>AI-1313 Phase B (D4 §6.4(2a)): retry the kill-quarantine once — SINGLE-FLIGHT, mirroring
+    /// <see cref="ReapOrphansOnceAsync"/>, so a slow retry (each entry a ~5s TERM grace) can't overlap the
+    /// next heartbeat tick. Skipped when empty or already running.</summary>
+    async Task RetryQuarantineOnceAsync(CancellationToken ct) {
+        if (_quarantine is not { Count: > 0 }) return;
+        if (Interlocked.CompareExchange(ref _quarantineSweepRunning, 1, 0) != 0) return;
+
+        try { await _quarantine.RetryAllAsync(ct); }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+        catch (Exception ex) { _logger.LogWarning(ex, "quarantine retry sweep faulted — continuing"); }
+        finally { Interlocked.Exchange(ref _quarantineSweepRunning, 0); }
     }
 
     /// <summary>AI-1313 Phase B (D2): build + send one status report, one-way, swallowing errors (an
@@ -1715,12 +1745,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // stamped on PendingEndReason so the end attribution is correct even if HandleStopAgent's
             // own end call loses to the read-loop's.
             // AI-1313 Phase B (D4 §6.4(2a)): retry killing any unconfirmed-death quarantined process,
-            // draining those confirmed gone (frees admission).
-            if (_quarantine is { Count: > 0 }) _ = _quarantine.RetryAllAsync(ct);
+            // draining those confirmed gone (frees admission). Single-flight (skips if a prior retry runs).
+            _ = RetryQuarantineOnceAsync(ct);
 
             // AI-1313 Phase B (D4 §6.4(3)): re-run the orphan reap — record pass is epoch-guarded (never
             // touches a current-incarnation live agent), env-marker scan reaps a prior incarnation's
-            // recordless survivors. Fire-and-forget; ReapOrphansOnceAsync swallows its own faults.
+            // recordless survivors. Fire-and-forget; single-flight; swallows its own faults.
             _ = ReapOrphansOnceAsync(ct);
 
             foreach (var (id, reason) in FindReviewersToReap()) {
@@ -1855,15 +1885,19 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // the record. Add to quarantine BEFORE removing from _agents so EffectiveCount never dips
         // (Activeized→quarantined is count-preserving).
         var pid = agent.Runtime.Pid;
+        // Quarantine (retain + count) when the child may still be OURS-and-alive: a stored identity that
+        // still matches (true) OR is uncomparable (null — unreadable/foreign token). Delete only on a
+        // proven-gone pid: dead, a conclusive recycle (MatchesTri == false), or an agent that was never
+        // identified. Collapsing the uncomparable case to "gone" would drop a live child's record.
         if (agent.StartIdentity is { } startIdentity
             && ProcessIdentity.IsAlive(pid)
-            && ProcessIdentity.Matches(pid, startIdentity)) {
+            && ProcessIdentity.MatchesTri(pid, startIdentity) != false) {
             _quarantine?.Add(new AgentKillQuarantine.Entry(
                 agent.Id, pid, startIdentity, agent.Kind.ToString(), agent.CreatedAt, agent.FlowRunId, agent.FlowRole));
             _logger.LogWarning(
                 "Agent {AgentId} (pid {Pid}) still alive after teardown — quarantined for heartbeat kill-retry", agent.Id, pid);
         } else {
-            DeletePidRecord(agentId); // confirmed dead / recycled pid / never-identified
+            DeletePidRecord(agentId); // confirmed dead / conclusively recycled pid / never-identified
         }
 
         // Now drop the agent from the live registry — after a surviving child is already in quarantine,

--- a/src/Capacitor.Cli.Daemon/Services/AgentPidRecordStore.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentPidRecordStore.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// AI-1313 Phase B (D4 §6.4(2)): durable per-agent PID records under
+/// <c>&lt;state-dir&gt;/agents/{agentId}.json</c>. Written atomically at spawn (temp-file +
+/// same-directory rename — no fsync needed; a lost record falls to the env-marker scan) so a restarted
+/// daemon can reap a surviving child by exact identity. A record is deleted ONLY after confirmed death
+/// (caller's rule). An unparseable file is quarantined (renamed <c>.corrupt</c>) and excluded — never
+/// acted on.
+/// </summary>
+internal sealed class AgentPidRecordStore(string stateDir, ILogger logger) {
+    readonly string _agentsDir = Path.Combine(stateDir, "agents");
+
+    /// <summary>Atomically write (or overwrite) the record for its agent id. Creates the agents
+    /// directory on first use. Throws on I/O failure — the caller (§6.4(2a)) treats a write failure as
+    /// a launch failure and tears down the child.</summary>
+    public void Write(AgentPidRecord record) {
+        Directory.CreateDirectory(_agentsDir);
+
+        var finalPath = PathFor(record.AgentId);
+        var tempPath  = finalPath + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
+
+        File.WriteAllText(tempPath, JsonSerializer.Serialize(record, CapacitorJsonContext.Default.AgentPidRecord));
+        File.Move(tempPath, finalPath, overwrite: true); // atomic same-directory rename
+    }
+
+    /// <summary>Delete an agent's record (idempotent — false if it wasn't there). Best-effort.</summary>
+    public bool Delete(string agentId) {
+        var path = PathFor(agentId);
+        try {
+            if (!File.Exists(path)) return false;
+            File.Delete(path);
+            return true;
+        } catch (Exception ex) {
+            logger.LogWarning(ex, "AgentPidRecordStore: failed to delete record for {AgentId}", agentId);
+            return false;
+        }
+    }
+
+    /// <summary>All parseable leftover records. An unparseable file is renamed <c>.json.corrupt</c>
+    /// (retained for the operator, never acted on) and excluded from the result.</summary>
+    public IReadOnlyList<AgentPidRecord> ReadAll() {
+        if (!Directory.Exists(_agentsDir)) return [];
+
+        var results = new List<AgentPidRecord>();
+
+        foreach (var path in Directory.EnumerateFiles(_agentsDir, "*.json")) {
+            AgentPidRecord record;
+            try {
+                record = JsonSerializer.Deserialize(File.ReadAllText(path), CapacitorJsonContext.Default.AgentPidRecord);
+            } catch (Exception ex) {
+                logger.LogWarning(ex, "AgentPidRecordStore: unparseable record {Path}; quarantining as .corrupt", path);
+                TryQuarantine(path);
+                continue;
+            }
+
+            // A structurally-valid-JSON-but-empty record (no agent id) is also quarantined — it can
+            // never authorize a kill and shouldn't linger as a live-looking record.
+            if (string.IsNullOrEmpty(record.AgentId)) {
+                logger.LogWarning("AgentPidRecordStore: record {Path} has no agent id; quarantining as .corrupt", path);
+                TryQuarantine(path);
+                continue;
+            }
+
+            results.Add(record);
+        }
+
+        return results;
+    }
+
+    string PathFor(string agentId) => Path.Combine(_agentsDir, agentId + ".json");
+
+    void TryQuarantine(string path) {
+        try { File.Move(path, path + ".corrupt", overwrite: true); }
+        catch (Exception ex) { logger.LogWarning(ex, "AgentPidRecordStore: failed to quarantine {Path}", path); }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/AgentPidRecordStore.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentPidRecordStore.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Capacitor.Cli.Core;
 using Microsoft.Extensions.Logging;
@@ -5,19 +7,18 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// AI-1313 Phase B (D4 §6.4(2)): durable per-agent PID records under
-/// <c>&lt;state-dir&gt;/agents/{agentId}.json</c>. Written atomically at spawn (temp-file +
-/// same-directory rename — no fsync needed; a lost record falls to the env-marker scan) so a restarted
-/// daemon can reap a surviving child by exact identity. A record is deleted ONLY after confirmed death
-/// (caller's rule). An unparseable file is quarantined (renamed <c>.corrupt</c>) and excluded — never
-/// acted on.
+/// Durable per-agent PID records under <c>{state-dir}/agents/</c>, so a restarted daemon can reap a
+/// surviving child by exact identity (spec §6.4(2)). Written atomically (temp file + same-directory
+/// rename). The filename is a SHA-256 of the agent id, NOT the id itself: the id crosses the SignalR
+/// wire unconstrained, so using it directly in a path would let <c>..</c> / separators escape the
+/// directory. The original id is preserved inside the JSON. Deleted only after confirmed death (caller's
+/// rule); an unparseable/empty file is quarantined (renamed <c>.corrupt</c>) and never acted on.
 /// </summary>
 internal sealed class AgentPidRecordStore(string stateDir, ILogger logger) {
     readonly string _agentsDir = Path.Combine(stateDir, "agents");
 
-    /// <summary>Atomically write (or overwrite) the record for its agent id. Creates the agents
-    /// directory on first use. Throws on I/O failure — the caller (§6.4(2a)) treats a write failure as
-    /// a launch failure and tears down the child.</summary>
+    /// <summary>Atomically write (or overwrite) the record. Throws on I/O failure — the caller treats a
+    /// write failure as a launch failure and tears the child down (§6.4(2a)).</summary>
     public void Write(AgentPidRecord record) {
         Directory.CreateDirectory(_agentsDir);
 
@@ -28,7 +29,7 @@ internal sealed class AgentPidRecordStore(string stateDir, ILogger logger) {
         File.Move(tempPath, finalPath, overwrite: true); // atomic same-directory rename
     }
 
-    /// <summary>Delete an agent's record (idempotent — false if it wasn't there). Best-effort.</summary>
+    /// <summary>Delete an agent's record (idempotent — false if absent). Best-effort.</summary>
     public bool Delete(string agentId) {
         var path = PathFor(agentId);
         try {
@@ -41,8 +42,8 @@ internal sealed class AgentPidRecordStore(string stateDir, ILogger logger) {
         }
     }
 
-    /// <summary>All parseable leftover records. An unparseable file is renamed <c>.json.corrupt</c>
-    /// (retained for the operator, never acted on) and excluded from the result.</summary>
+    /// <summary>All parseable leftover records. An unparseable or agent-id-less file is renamed
+    /// <c>.corrupt</c> (retained for the operator, never acted on) and excluded.</summary>
     public IReadOnlyList<AgentPidRecord> ReadAll() {
         if (!Directory.Exists(_agentsDir)) return [];
 
@@ -58,8 +59,6 @@ internal sealed class AgentPidRecordStore(string stateDir, ILogger logger) {
                 continue;
             }
 
-            // A structurally-valid-JSON-but-empty record (no agent id) is also quarantined — it can
-            // never authorize a kill and shouldn't linger as a live-looking record.
             if (string.IsNullOrEmpty(record.AgentId)) {
                 logger.LogWarning("AgentPidRecordStore: record {Path} has no agent id; quarantining as .corrupt", path);
                 TryQuarantine(path);
@@ -72,7 +71,11 @@ internal sealed class AgentPidRecordStore(string stateDir, ILogger logger) {
         return results;
     }
 
-    string PathFor(string agentId) => Path.Combine(_agentsDir, agentId + ".json");
+    // Hash the (untrusted) agent id into the filename so no id can escape _agentsDir via path separators.
+    string PathFor(string agentId) => Path.Combine(_agentsDir, SafeName(agentId) + ".json");
+
+    static string SafeName(string agentId) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(agentId ?? ""))).ToLowerInvariant();
 
     void TryQuarantine(string path) {
         try { File.Move(path, path + ".corrupt", overwrite: true); }

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -93,7 +93,7 @@ internal sealed record RuntimeStartContext(
         // checkout), carried from LaunchAgentCommand.Borrowed through to LauncherContext.Work.
         // Defaults to OwnedWorktree — today's only exercised path — unchanged.
         WorkLocation       Work = WorkLocation.OwnedWorktree,
-        // AI-1313 Phase B (D4 §6.4(3)): daemon-identity env markers stamped into the spawned child so a
+        // Phase B (D4 §6.4(3)): daemon-identity env markers stamped into the spawned child so a
         // RESTARTED daemon's OrphanReaper env-marker scan can recognize a recordless survivor as its
         // own (KCAP_DAEMON_ID == this daemon) from a PRIOR incarnation (KCAP_DAEMON_EPOCH != current)
         // and reap it. Empty when a test/legacy caller omits them — the markers are simply not written.

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -92,5 +92,11 @@ internal sealed record RuntimeStartContext(
         // AI-1207 Phase A: owned worktree (daemon-created) vs borrowed cwd (the user's own
         // checkout), carried from LaunchAgentCommand.Borrowed through to LauncherContext.Work.
         // Defaults to OwnedWorktree — today's only exercised path — unchanged.
-        WorkLocation       Work = WorkLocation.OwnedWorktree
+        WorkLocation       Work = WorkLocation.OwnedWorktree,
+        // AI-1313 Phase B (D4 §6.4(3)): daemon-identity env markers stamped into the spawned child so a
+        // RESTARTED daemon's OrphanReaper env-marker scan can recognize a recordless survivor as its
+        // own (KCAP_DAEMON_ID == this daemon) from a PRIOR incarnation (KCAP_DAEMON_EPOCH != current)
+        // and reap it. Empty when a test/legacy caller omits them — the markers are simply not written.
+        string             DaemonId    = "",
+        string             DaemonEpoch = ""
     );

--- a/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
@@ -73,6 +73,13 @@ internal sealed class OrphanReaper(
             if (handledPids.Contains(pid)) continue;       // already covered by the record pass
             if (!ProcessIdentity.IsAlive(pid)) continue;
 
+            // Capture the start token BEFORE reading the env markers, so the token is bound to the SAME
+            // incarnation whose markers we're about to trust. If the pid is recycled between the marker
+            // reads and the kill, the post-read re-validation (below) catches it — a recapture-after-read
+            // would instead adopt the replacement's identity. Uncapturable → spare.
+            var token = ProcessIdentity.Capture(pid);
+            if (token is null) continue;
+
             // The FULL marker triple must be readable and prove "this daemon, prior incarnation" before
             // we kill. Any missing/unreadable member SPARES (ambiguity never kills) — this covers a
             // process/PID race, a partial read, and a current-incarnation recordless child whose epoch
@@ -86,9 +93,13 @@ internal sealed class OrphanReaper(
             var epoch = ProcessIdentity.ReadAgentEnv(pid, "KCAP_DAEMON_EPOCH");
             if (epoch is null || string.Equals(epoch, currentEpoch, StringComparison.Ordinal)) continue; // unreadable / current incarnation → spare
 
-            // Recordless survivor of a PRIOR incarnation of THIS daemon → reap by marker.
+            // Re-validate the SAME token after all three reads: if the pid was recycled mid-scan, the
+            // markers we just read belong to a different incarnation — the token no longer matches, so spare.
+            if (ProcessIdentity.MatchesTri(pid, token) != true) continue;
+
+            // Recordless survivor of a PRIOR incarnation of THIS daemon → reap by the captured identity.
             try {
-                var gone = await ProcessReaper.ReapByMarkerAsync(pid, agentId, logger, ct);
+                var gone = await ProcessReaper.ReapByMarkerAsync(pid, token, agentId, logger, ct);
                 if (gone)
                     logger.LogInformation(
                         "OrphanReaper: reaped recordless survivor {AgentId} (pid {Pid}) of a prior daemon incarnation", agentId, pid);

--- a/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// AI-1313 Phase B (D4 §6.4(3)): reaps hosted-agent children that OUTLIVED the daemon that spawned
+/// Phase B (D4 §6.4(3)): reaps hosted-agent children that OUTLIVED the daemon that spawned
 /// them — the crash/restart case where the in-memory registry is empty but a review-flow reviewer (or
 /// any hosted child) is still running and holding a slot. Runs once at boot under the daemon lock (next
 /// to <c>WorktreeManager.CleanupOrphanedAsync</c>) and again on a heartbeat tick. Two passes, in order:

--- a/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
@@ -73,15 +73,18 @@ internal sealed class OrphanReaper(
             if (handledPids.Contains(pid)) continue;       // already covered by the record pass
             if (!ProcessIdentity.IsAlive(pid)) continue;
 
-            // Full identity is read from the LIVE process's own env — no native stamp needed.
+            // The FULL marker triple must be readable and prove "this daemon, prior incarnation" before
+            // we kill. Any missing/unreadable member SPARES (ambiguity never kills) — this covers a
+            // process/PID race, a partial read, and a current-incarnation recordless child whose epoch
+            // read momentarily fails (record writes may fail, so such a child can exist).
             var agentId = ProcessIdentity.ReadAgentEnv(pid, "KCAP_AGENT_ID");
             if (agentId is null) continue;                 // not a hosted agent / env unreadable → spare
 
             var did = ProcessIdentity.ReadAgentEnv(pid, "KCAP_DAEMON_ID");
-            if (!string.Equals(did, daemonId, StringComparison.Ordinal)) continue;      // another daemon → spare
+            if (did is null || !string.Equals(did, daemonId, StringComparison.Ordinal)) continue;   // unreadable / another daemon → spare
 
             var epoch = ProcessIdentity.ReadAgentEnv(pid, "KCAP_DAEMON_EPOCH");
-            if (string.Equals(epoch, currentEpoch, StringComparison.Ordinal)) continue; // current incarnation → spare
+            if (epoch is null || string.Equals(epoch, currentEpoch, StringComparison.Ordinal)) continue; // unreadable / current incarnation → spare
 
             // Recordless survivor of a PRIOR incarnation of THIS daemon → reap by marker.
             try {

--- a/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
@@ -1,0 +1,117 @@
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// AI-1313 Phase B (D4 §6.4(3)): reaps hosted-agent children that OUTLIVED the daemon that spawned
+/// them — the crash/restart case where the in-memory registry is empty but a review-flow reviewer (or
+/// any hosted child) is still running and holding a slot. Runs once at boot under the daemon lock (next
+/// to <c>WorktreeManager.CleanupOrphanedAsync</c>) and again on a heartbeat tick. Two passes, in order:
+/// <list type="number">
+/// <item><b>Record pass</b> — every durable PID record this daemon left behind: if a live process still
+/// matches its EXACT <c>(pid, start-identity)</c> (and, on Unix, still carries the expected
+/// <c>KCAP_AGENT_ID</c> env), kill it (killpg→SIGKILL) and delete the record on confirmed death. A
+/// proven identity mismatch (PID reused) deletes the stale record. An unreadable env (macOS 26 redacts
+/// it) SPARES the process and retains the record — ambiguity never kills.</item>
+/// <item><b>Env-marker scan</b> (Unix) — a recordless survivor is found by reading its OWN env: kill
+/// only a process carrying <c>KCAP_AGENT_ID</c> AND <c>KCAP_DAEMON_ID == this daemon</c> AND
+/// <c>KCAP_DAEMON_EPOCH != current</c> (i.e. a prior incarnation of THIS daemon). A different daemon's
+/// child, a current-incarnation child, or any process whose env can't be read is spared. Process
+/// enumeration failure is a logged no-op (retried next tick). On macOS the env redaction makes this
+/// pass find nothing — the record pass is the effective mechanism there; production is Linux.</item>
+/// </list>
+/// </summary>
+internal sealed class OrphanReaper(
+        AgentPidRecordStore store, string daemonId, string currentEpoch, ILogger logger) {
+    /// <summary>Run both passes once. Best-effort throughout — a failure on one process never aborts the
+    /// sweep of the others.</summary>
+    public async Task ReapOnceAsync(CancellationToken ct = default) {
+        var handledPids = new HashSet<int>();
+
+        // ── (1) record pass ──────────────────────────────────────────────────────────────────────
+        foreach (var record in store.ReadAll()) {
+            if (ct.IsCancellationRequested) return;
+            handledPids.Add(record.Pid);
+
+            // Reap ONLY prior-incarnation records. A record stamped with the CURRENT epoch belongs to a
+            // live agent of THIS incarnation (its normal teardown deletes it) — reaping it would kill
+            // our own running agent. This makes the heartbeat RE-RUN safe, not just the boot pass: at
+            // boot every leftover record is prior (this incarnation's epoch is fresh), while mid-life
+            // the store also holds current-epoch records that must be left alone.
+            if (string.Equals(record.DaemonEpoch, currentEpoch, StringComparison.Ordinal)) continue;
+
+            try {
+                var confirmedGone = await ProcessReaper.ReapByRecordAsync(record, logger, ct);
+                if (confirmedGone) {
+                    store.Delete(record.AgentId); // killed+confirmed, already-gone, or proven identity mismatch
+                    logger.LogInformation(
+                        "OrphanReaper: reaped leftover agent {AgentId} (pid {Pid}) from a prior daemon run",
+                        record.AgentId, record.Pid);
+                }
+                // spared (unreadable env) → retain the record for the next tick
+            } catch (Exception ex) when (ex is not OperationCanceledException) {
+                logger.LogWarning(ex, "OrphanReaper: record-pass reap failed for {AgentId} (pid {Pid})", record.AgentId, record.Pid);
+            }
+        }
+
+        // ── (2) env-marker scan (recordless survivors) ───────────────────────────────────────────
+        await ScanEnvMarkersAsync(handledPids, ct);
+    }
+
+    async Task ScanEnvMarkersAsync(HashSet<int> handledPids, CancellationToken ct) {
+        IReadOnlyList<int> pids;
+        try {
+            pids = EnumeratePids();
+        } catch (Exception ex) {
+            logger.LogWarning(ex, "OrphanReaper: process enumeration failed — skipping env-marker scan this tick");
+            return;
+        }
+
+        foreach (var pid in pids) {
+            if (ct.IsCancellationRequested) return;
+            if (handledPids.Contains(pid)) continue;       // already covered by the record pass
+            if (!ProcessIdentity.IsAlive(pid)) continue;
+
+            // Full identity is read from the LIVE process's own env — no native stamp needed.
+            var agentId = ProcessIdentity.ReadAgentEnv(pid, "KCAP_AGENT_ID");
+            if (agentId is null) continue;                 // not a hosted agent / env unreadable → spare
+
+            var did = ProcessIdentity.ReadAgentEnv(pid, "KCAP_DAEMON_ID");
+            if (!string.Equals(did, daemonId, StringComparison.Ordinal)) continue;      // another daemon → spare
+
+            var epoch = ProcessIdentity.ReadAgentEnv(pid, "KCAP_DAEMON_EPOCH");
+            if (string.Equals(epoch, currentEpoch, StringComparison.Ordinal)) continue; // current incarnation → spare
+
+            // Recordless survivor of a PRIOR incarnation of THIS daemon → reap by marker.
+            try {
+                var gone = await ProcessReaper.ReapByMarkerAsync(pid, agentId, logger, ct);
+                if (gone)
+                    logger.LogInformation(
+                        "OrphanReaper: reaped recordless survivor {AgentId} (pid {Pid}) of a prior daemon incarnation", agentId, pid);
+                else
+                    logger.LogWarning(
+                        "OrphanReaper: env-marker kill of {AgentId} (pid {Pid}) not confirmed — retrying next tick", agentId, pid);
+            } catch (Exception ex) when (ex is not OperationCanceledException) {
+                logger.LogWarning(ex, "OrphanReaper: env-marker reap failed for pid {Pid}", pid);
+            }
+        }
+    }
+
+    /// <summary>Enumerate candidate pids for the env-marker scan. Linux lists <c>/proc/[0-9]+</c>;
+    /// per-pid env readability (same-uid) naturally scopes the scan. macOS returns an empty list — its
+    /// env redaction makes the scan a no-op, so there's no point walking every process (the record pass
+    /// covers macOS). Windows has no scan path (layer-1 containment).</summary>
+    static IReadOnlyList<int> EnumeratePids() {
+        if (!OperatingSystem.IsLinux()) return [];
+
+        var pids = new List<int>();
+        foreach (var dir in Directory.EnumerateDirectories("/proc")) {
+            var name = Path.GetFileName(dir);
+            if (int.TryParse(name, NumberStyles.None, CultureInfo.InvariantCulture, out var pid))
+                pids.Add(pid);
+        }
+
+        return pids;
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/ProcessIdentity.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessIdentity.cs
@@ -27,6 +27,15 @@ internal static partial class ProcessIdentity {
     public static bool Matches(int pid, string expectedIdentity) =>
         pid > 0 && ProcessStartToken.Matches(pid, expectedIdentity) == true;
 
+    /// <summary>The AI-839 TRI-STATE identity comparison, preserved for reap decisions that must tell
+    /// "conclusively a different incarnation (recycled pid) — safe to treat as gone" (<c>false</c>) apart
+    /// from "can't compare — token unreadable or foreign scheme, must SPARE and retain" (<c>null</c>).
+    /// A non-positive pid is uncomparable → <c>null</c>. Collapsing <c>null</c> to <c>false</c> (as
+    /// <see cref="Matches"/> does) would drop a still-alive child's record on an unreadable token, so
+    /// callers that delete records / drain quarantine must use THIS, not <see cref="Matches"/>.</summary>
+    public static bool? MatchesTri(int pid, string expectedIdentity) =>
+        pid > 0 ? ProcessStartToken.Matches(pid, expectedIdentity) : null;
+
     /// <summary>Best-effort liveness of <paramref name="pid"/> regardless of identity — only used to
     /// decide whether it's worth probing identity/env. Unix: <c>kill(pid, 0) == 0</c> (ESRCH → dead);
     /// Windows: <see cref="Process.GetProcessById(int)"/> succeeds. A non-positive pid returns false:
@@ -40,7 +49,34 @@ internal static partial class ProcessIdentity {
             catch { return false; }
         }
 
-        return UnixPtyInterop.kill(pid, 0) == 0;
+        if (UnixPtyInterop.kill(pid, 0) != 0) return false; // ESRCH → gone
+
+        // A ZOMBIE (exited but not yet reaped by its parent) still answers kill(pid, 0), but it is
+        // effectively dead — its pid holds a slot only until reaped. Treat it as not-alive so a reaper
+        // confirms death (rather than seeing a live pid whose token is now unreadable → "ambiguous →
+        // spare" → a slot held forever). Linux reads /proc/{pid}/stat state 'Z'. (macOS keeps the
+        // kill(0) answer — its parent-reaping and the retry-next-tick cadence clear the window; a prior
+        // daemon's orphans reparent to init, which reaps promptly.)
+        if (OperatingSystem.IsLinux() && IsLinuxZombie(pid)) return false;
+
+        return true;
+    }
+
+    /// <summary>True if <paramref name="pid"/> is a Linux zombie (state field 'Z' in /proc/{pid}/stat).
+    /// Best-effort: any read/parse failure returns false (fall back to the kill(0) liveness answer).</summary>
+    static bool IsLinuxZombie(int pid) {
+        try {
+            var stat      = File.ReadAllText($"/proc/{pid}/stat");
+            var afterComm = stat.LastIndexOf(')'); // comm can contain spaces/parens; state is the token after the last ')'
+
+            if (afterComm < 0 || afterComm + 2 >= stat.Length) return false;
+
+            var fields = stat[(afterComm + 2)..].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+            return fields.Length > 0 && fields[0].StartsWith('Z');
+        } catch {
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/ProcessIdentity.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessIdentity.cs
@@ -7,8 +7,8 @@ using Capacitor.Cli.Daemon.Pty.Unix;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// AI-1313 Phase B (D4 §6.4(2)): exact process start-identity, liveness, and agent-env read for the
-/// PID-record + env-marker reap. The start-identity REUSES the AI-839 <see cref="ProcessStartToken"/>
+/// Phase B (D4 §6.4(2)): exact process start-identity, liveness, and agent-env read for the
+/// PID-record + env-marker reap. The start-identity REUSES the <see cref="ProcessStartToken"/>
 /// (Linux kernel <c>starttime</c> + <c>boot_id</c>; macOS/Windows absolute <c>StartTime.Ticks</c>) —
 /// exact-equality with NO tolerance window, cross-reader-stable, and PID-reuse-safe — so the spec's
 /// "no fuzzy DateTime comparison" requirement is met by construction. A gone/recycled/uncomparable
@@ -25,13 +25,13 @@ internal static partial class ProcessIdentity {
     public static string? Capture(int pid) => pid > 0 ? ProcessStartToken.ForPid(pid) : null;
 
     /// <summary>True IFF a live process at <paramref name="pid"/> has EXACTLY
-    /// <paramref name="expectedIdentity"/> (AI-839 tri-state == true). A gone pid, a recycled pid
+    /// <paramref name="expectedIdentity"/> (tri-state == true). A gone pid, a recycled pid
     /// (different incarnation), an uncomparable token, or a non-positive pid all return false —
     /// ambiguity never kills.</summary>
     public static bool Matches(int pid, string expectedIdentity) =>
         pid > 0 && ProcessStartToken.Matches(pid, expectedIdentity) == true;
 
-    /// <summary>The AI-839 TRI-STATE identity comparison, preserved for reap decisions that must tell
+    /// <summary>The TRI-STATE identity comparison, preserved for reap decisions that must tell
     /// "conclusively a different incarnation (recycled pid) — safe to treat as gone" (<c>false</c>) apart
     /// from "can't compare — token unreadable or foreign scheme, must SPARE and retain" (<c>null</c>).
     /// A non-positive pid is uncomparable → <c>null</c>. Collapsing <c>null</c> to <c>false</c> (as

--- a/src/Capacitor.Cli.Daemon/Services/ProcessIdentity.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessIdentity.cs
@@ -16,19 +16,25 @@ namespace Capacitor.Cli.Daemon.Services;
 /// </summary>
 internal static partial class ProcessIdentity {
     /// <summary>The exact start-identity token for <paramref name="pid"/>, or null if the process is
-    /// gone or the value can't be read.</summary>
-    public static string? Capture(int pid) => ProcessStartToken.ForPid(pid);
+    /// gone or the value can't be read. A non-positive pid (0 = a degenerate/Noop runtime; negative =
+    /// never a real child) is not a reapable process → null.</summary>
+    public static string? Capture(int pid) => pid > 0 ? ProcessStartToken.ForPid(pid) : null;
 
     /// <summary>True IFF a live process at <paramref name="pid"/> has EXACTLY
     /// <paramref name="expectedIdentity"/> (AI-839 tri-state == true). A gone pid, a recycled pid
-    /// (different incarnation), or an uncomparable token all return false — ambiguity never kills.</summary>
+    /// (different incarnation), an uncomparable token, or a non-positive pid all return false —
+    /// ambiguity never kills.</summary>
     public static bool Matches(int pid, string expectedIdentity) =>
-        ProcessStartToken.Matches(pid, expectedIdentity) == true;
+        pid > 0 && ProcessStartToken.Matches(pid, expectedIdentity) == true;
 
     /// <summary>Best-effort liveness of <paramref name="pid"/> regardless of identity — only used to
     /// decide whether it's worth probing identity/env. Unix: <c>kill(pid, 0) == 0</c> (ESRCH → dead);
-    /// Windows: <see cref="Process.GetProcessById(int)"/> succeeds.</summary>
+    /// Windows: <see cref="Process.GetProcessById(int)"/> succeeds. A non-positive pid returns false:
+    /// <c>kill(0/-1/-pgid, 0)</c> targets a process GROUP (or all processes), never a single child, so
+    /// it must never be treated as "our agent is alive".</summary>
     public static bool IsAlive(int pid) {
+        if (pid <= 0) return false;
+
         if (OperatingSystem.IsWindows()) {
             try { using var _ = Process.GetProcessById(pid); return true; }
             catch { return false; }

--- a/src/Capacitor.Cli.Daemon/Services/ProcessIdentity.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessIdentity.cs
@@ -15,6 +15,10 @@ namespace Capacitor.Cli.Daemon.Services;
 /// process NEVER matches, so an identity mismatch can never authorize a kill.
 /// </summary>
 internal static partial class ProcessIdentity {
+    /// <summary><c>ESRCH</c> ("no such process") — 3 on both Linux and macOS. The only <c>kill(pid, 0)</c>
+    /// errno that proves the process is gone; every other error means present/indeterminate.</summary>
+    const int Esrch = 3;
+
     /// <summary>The exact start-identity token for <paramref name="pid"/>, or null if the process is
     /// gone or the value can't be read. A non-positive pid (0 = a degenerate/Noop runtime; negative =
     /// never a real child) is not a reapable process → null.</summary>
@@ -49,7 +53,13 @@ internal static partial class ProcessIdentity {
             catch { return false; }
         }
 
-        if (UnixPtyInterop.kill(pid, 0) != 0) return false; // ESRCH → gone
+        if (UnixPtyInterop.kill(pid, 0) != 0) {
+            // kill(pid, 0) fails with ESRCH (no such process → gone) OR EPERM (the process EXISTS but we
+            // may not signal it — e.g. it changed credentials). Only ESRCH is "gone"; any other errno
+            // means present-or-indeterminate → treat as ALIVE so we never free capacity or delete a
+            // record for a still-running child (fail closed). ESRCH is 3 on Linux and macOS.
+            return System.Runtime.InteropServices.Marshal.GetLastPInvokeError() != Esrch;
+        }
 
         // A ZOMBIE (exited but not yet reaped by its parent) still answers kill(pid, 0), but it is
         // effectively dead — its pid holds a slot only until reaped. Treat it as not-alive so a reaper

--- a/src/Capacitor.Cli.Daemon/Services/ProcessIdentity.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessIdentity.cs
@@ -1,0 +1,120 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Pty.Unix;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// AI-1313 Phase B (D4 §6.4(2)): exact process start-identity, liveness, and agent-env read for the
+/// PID-record + env-marker reap. The start-identity REUSES the AI-839 <see cref="ProcessStartToken"/>
+/// (Linux kernel <c>starttime</c> + <c>boot_id</c>; macOS/Windows absolute <c>StartTime.Ticks</c>) —
+/// exact-equality with NO tolerance window, cross-reader-stable, and PID-reuse-safe — so the spec's
+/// "no fuzzy DateTime comparison" requirement is met by construction. A gone/recycled/uncomparable
+/// process NEVER matches, so an identity mismatch can never authorize a kill.
+/// </summary>
+internal static partial class ProcessIdentity {
+    /// <summary>The exact start-identity token for <paramref name="pid"/>, or null if the process is
+    /// gone or the value can't be read.</summary>
+    public static string? Capture(int pid) => ProcessStartToken.ForPid(pid);
+
+    /// <summary>True IFF a live process at <paramref name="pid"/> has EXACTLY
+    /// <paramref name="expectedIdentity"/> (AI-839 tri-state == true). A gone pid, a recycled pid
+    /// (different incarnation), or an uncomparable token all return false — ambiguity never kills.</summary>
+    public static bool Matches(int pid, string expectedIdentity) =>
+        ProcessStartToken.Matches(pid, expectedIdentity) == true;
+
+    /// <summary>Best-effort liveness of <paramref name="pid"/> regardless of identity — only used to
+    /// decide whether it's worth probing identity/env. Unix: <c>kill(pid, 0) == 0</c> (ESRCH → dead);
+    /// Windows: <see cref="Process.GetProcessById(int)"/> succeeds.</summary>
+    public static bool IsAlive(int pid) {
+        if (OperatingSystem.IsWindows()) {
+            try { using var _ = Process.GetProcessById(pid); return true; }
+            catch { return false; }
+        }
+
+        return UnixPtyInterop.kill(pid, 0) == 0;
+    }
+
+    /// <summary>
+    /// Read a single <c>KCAP_*</c> variable from a LIVE process's OWN environment (the record/marker
+    /// env check). Linux reads <c>/proc/{pid}/environ</c> (NUL-delimited, same-uid readable); macOS
+    /// uses <c>sysctl(KERN_PROCARGS2)</c> (modern macOS restricts <c>ps -E</c> env visibility entirely,
+    /// so the spec's <c>ps -E</c> is obsolete — <c>KERN_PROCARGS2</c> is the same-uid mechanism <c>ps</c>
+    /// itself used). Returns null when the env can't be read — the caller then SPARES the process
+    /// (ambiguity never kills). Windows returns null (no scan path — layer-1 containment covers it).
+    /// </summary>
+    public static string? ReadAgentEnv(int pid, string key) {
+        try {
+            if (OperatingSystem.IsLinux()) {
+                var raw = File.ReadAllText($"/proc/{pid}/environ");
+                foreach (var entry in raw.Split('\0', StringSplitOptions.RemoveEmptyEntries))
+                    if (entry.StartsWith(key + "=", StringComparison.Ordinal))
+                        return entry[(key.Length + 1)..];
+
+                return null;
+            }
+
+            if (OperatingSystem.IsMacOS())
+                return ReadAgentEnvMacOs(pid, key);
+
+            return null; // Windows: no env scan (layer-1 containment)
+        } catch {
+            return null;
+        }
+    }
+
+    // ── macOS KERN_PROCARGS2 env read ────────────────────────────────────────────────────────────
+
+    const int CtlKern       = 1;
+    const int KernProcArgs2 = 49;
+
+    [LibraryImport("libc", EntryPoint = "sysctl", SetLastError = true)]
+    private static partial int Sysctl(int[] name, uint namelen, byte[]? oldp, ref nuint oldlenp, IntPtr newp, nuint newlen);
+
+    /// <summary>Reads <paramref name="pid"/>'s env via <c>sysctl(KERN_PROCARGS2)</c> and returns
+    /// <paramref name="key"/>'s value. Buffer layout: <c>[int argc][exec_path\0][\0…][argv[0..argc)\0][env…\0]</c>.
+    /// Works for a same-uid process (the daemon's own children); null on any read/parse failure.</summary>
+    static string? ReadAgentEnvMacOs(int pid, string key) {
+        int[] mib  = [CtlKern, KernProcArgs2, pid];
+        nuint size = 0;
+
+        if (Sysctl(mib, (uint) mib.Length, null, ref size, IntPtr.Zero, 0) != 0 || size == 0) return null;
+
+        var buf = new byte[size];
+        if (Sysctl(mib, (uint) mib.Length, buf, ref size, IntPtr.Zero, 0) != 0) return null;
+
+        var len = (int) size;
+        if (len < 4) return null;
+
+        var argc = BitConverter.ToInt32(buf, 0);
+        var p    = 4;
+
+        // exec_path, then its trailing NUL padding
+        while (p < len && buf[p] != 0) p++;
+        while (p < len && buf[p] == 0) p++;
+
+        // skip argc arguments
+        for (var i = 0; i < argc && p < len; i++) {
+            while (p < len && buf[p] != 0) p++;
+            p++;
+        }
+
+        var prefix = key + "=";
+        while (p < len) {
+            var start = p;
+            while (p < len && buf[p] != 0) p++;
+
+            if (p > start) {
+                var entry = Encoding.UTF8.GetString(buf, start, p - start);
+                if (entry.StartsWith(prefix, StringComparison.Ordinal))
+                    return entry[prefix.Length..];
+            }
+
+            p++;
+        }
+
+        return null;
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
@@ -8,42 +8,57 @@ namespace Capacitor.Cli.Daemon.Services;
 /// AI-1313 Phase B (D4 §6.4): the shared "reap by exact identity" primitive used by the
 /// <c>HandleStopAgent</c> PID-record fallback (T7), the kill-quarantine retry (T8), and the startup
 /// <c>OrphanReaper</c> (T9). Kills a leftover child ONLY when its identity is proven — never on
-/// ambiguity — and reports whether death is CONFIRMED (so the caller deletes the record only then, per
-/// spec §6.4(2)).
-/// <para>PID-reuse safety: the expected start-identity token is re-validated before EVERY signal and
-/// after every wait (<see cref="StillTarget"/>). If the target exits and its pid is recycled by an
-/// unrelated process at any point in the TERM→grace→KILL sequence, the mismatch is detected and the
-/// signal is NOT sent — "ours is gone" is reported instead of killing the new occupant.</para>
-/// <para>Two kill regimes (spec §6.4(2b)):</para>
-/// <list type="bullet">
-/// <item><b>Record regime</b> (<see cref="ReapByRecordAsync"/>): exact <c>(pid, start-identity)</c>
-/// match PLUS, on Unix, the <c>KCAP_AGENT_ID</c> env check. If the env can't be read (macOS 26 redacts
-/// it — see <see cref="ProcessIdentity.ReadAgentEnv"/>) the process is SPARED.</item>
-/// <item><b>Marker regime</b> (<see cref="ReapByMarkerAsync"/>): the caller has already validated the
-/// live process's env triple; this captures the process's start-identity and kills by it (so PID reuse
-/// during the kill still can't hit the wrong process). If the identity can't be captured, it SPARES.</item>
-/// </list>
+/// ambiguity — and reports whether death is CONFIRMED (so the caller deletes the record / drains the
+/// quarantine only then, per spec §6.4(2)).
+/// <para><b>Tri-state identity (fail-closed).</b> The leader pid is classified against its expected
+/// start token as one of: <c>Dead</c> (pid gone), <c>Ours</c> (alive, exact match), <c>Recycled</c>
+/// (alive, CONCLUSIVELY a different incarnation — same scheme, different value), or <c>Ambiguous</c>
+/// (alive but token unreadable / foreign scheme). Only <c>Dead</c> and <c>Recycled</c> are "confirmed
+/// gone"; <c>Ambiguous</c> SPARES (returns "not gone") so a still-alive child is never dropped on an
+/// unreadable token.</para>
+/// <para><b>PID-reuse safety.</b> The token is re-classified before EVERY signal and after every wait,
+/// so a pid recycled anywhere in the TERM→grace→KILL window is seen as <c>Recycled</c> and no signal is
+/// sent to the new occupant.</para>
+/// <para><b>Descendant containment.</b> Signals go to the process GROUP (<c>kill(-pid)</c>; a hosted
+/// agent is a forkpty session leader with pgid==pid, so its mcp children are in the group). When the
+/// leader dies (on TERM or otherwise) any orphaned descendants that inherited its group are swept with
+/// an uncatchable group SIGKILL — but only while the leader pid slot is empty, so a reused pid's group
+/// is never touched. (Full group-liveness *confirmation* — distinguishing "group empty" from "not a
+/// group leader" — needs the same OS-primitive work as the deferred native-containment sub-phase; the
+/// uncatchable group SIGKILL already guarantees descendants are cleared.)</para>
 /// </summary>
 internal static class ProcessReaper {
     static readonly TimeSpan GraceBeforeKill = TimeSpan.FromSeconds(5);
 
-    /// <summary>True IFF <paramref name="pid"/> is alive AND (no identity was supplied OR it still
-    /// matches <paramref name="expectedIdentity"/>). Returns false when the target is gone OR the pid
-    /// has been recycled by a different process — the caller then treats it as "ours is gone" and never
-    /// signals.</summary>
-    static bool StillTarget(int pid, string? expectedIdentity) =>
-        ProcessIdentity.IsAlive(pid) && (expectedIdentity is not { } id || ProcessIdentity.Matches(pid, id));
+    enum LeaderState { Dead, Ours, Recycled, Ambiguous }
 
-    /// <summary>Record-regime reap. Returns true when the target is CONFIRMED gone (already dead,
-    /// killed + observed dead, or a proven identity mismatch — i.e. our agent's process is not there),
-    /// false when it may still be alive (kill unconfirmed, or SPARED for unreadable env).</summary>
+    static LeaderState Classify(int pid, string expectedIdentity) {
+        if (!ProcessIdentity.IsAlive(pid)) return LeaderState.Dead;
+
+        return ProcessIdentity.MatchesTri(pid, expectedIdentity) switch {
+            true  => LeaderState.Ours,
+            false => LeaderState.Recycled,   // same scheme, different value → conclusively a different process
+            _     => LeaderState.Ambiguous,  // unreadable / foreign scheme → can't prove → spare
+        };
+    }
+
+    /// <summary>Record-regime reap. Returns true when the target is CONFIRMED gone (dead, killed +
+    /// observed dead, or a proven identity mismatch — our agent's process is not there), false when it
+    /// may still be alive (kill unconfirmed, SPARED for an unreadable env, or an uncomparable token).</summary>
     public static async Task<bool> ReapByRecordAsync(AgentPidRecord record, ILogger logger, CancellationToken ct) {
         var pid = record.Pid;
 
-        if (!ProcessIdentity.IsAlive(pid)) return true;                          // gone
-        if (!ProcessIdentity.Matches(pid, record.StartIdentity)) return true;    // PID reused by an unrelated proc — ours is gone
+        switch (Classify(pid, record.StartIdentity)) {
+            case LeaderState.Dead:      SweepDeadLeaderGroup(pid); return true; // gone — sweep any orphaned descendants
+            case LeaderState.Recycled:  return true;                            // pid reused by an unrelated proc — ours is gone
+            case LeaderState.Ambiguous:
+                logger.LogWarning(
+                    "ProcessReaper: identity uncomparable for pid {Pid} (agent {AgentId}) — sparing (ambiguity never kills)",
+                    pid, record.AgentId);
+                return false;
+        }
 
-        // Unix env guard: only kill if the process still proves it is OUR agent. Unreadable env → spare.
+        // Ours. Unix env guard: only kill if the process still proves it is OUR agent. Unreadable → spare.
         if (!OperatingSystem.IsWindows()) {
             var envAgentId = ProcessIdentity.ReadAgentEnv(pid, "KCAP_AGENT_ID");
             if (envAgentId is null) {
@@ -58,75 +73,97 @@ internal static class ProcessReaper {
         return await KillConfirmAsync(pid, record.StartIdentity, record.AgentId, logger, ct);
     }
 
-    /// <summary>Marker-regime reap of a recordless survivor: the caller has already read + validated the
-    /// env triple from the live process. Captures the process's start-identity so the kill sequence is
-    /// PID-reuse-safe; SPARES (returns false) if the identity can't be captured. Returns true when
-    /// confirmed gone.</summary>
-    public static Task<bool> ReapByMarkerAsync(int pid, string agentId, ILogger logger, CancellationToken ct) {
-        if (!ProcessIdentity.IsAlive(pid)) return Task.FromResult(true);
-
-        var identity = ProcessIdentity.Capture(pid);
-        if (identity is null) {
-            logger.LogWarning(
-                "ProcessReaper: could not capture identity for pid {Pid} (agent {AgentId}) — sparing (ambiguity never kills)",
-                pid, agentId);
-            return Task.FromResult(false);
-        }
-
-        return KillConfirmAsync(pid, identity, agentId, logger, ct);
-    }
+    /// <summary>Marker-regime reap of a recordless survivor. The caller (OrphanReaper) has already
+    /// captured the process's start token BEFORE reading its env-marker triple and re-validated it after,
+    /// so <paramref name="expectedIdentity"/> is bound to the same incarnation whose markers proved
+    /// ownership — no recapture here (which could adopt a replacement after a mid-scan PID reuse).</summary>
+    public static Task<bool> ReapByMarkerAsync(int pid, string expectedIdentity, string agentId, ILogger logger, CancellationToken ct)
+        => KillConfirmAsync(pid, expectedIdentity, agentId, logger, ct);
 
     /// <summary>Kill-quarantine retry (spec §6.4(2a)): the entry is a KNOWN-ours process whose death
-    /// wasn't confirmed at teardown. Kill it by EXACT identity (no env check needed — we already own it,
-    /// and the identity match handles PID reuse) and report confirmed-gone. Gone / PID-reused → true
-    /// (drain it); still alive after SIGKILL → false (retry next tick).</summary>
-    public static Task<bool> ReapByIdentityAsync(int pid, string expectedIdentity, string agentId, ILogger logger, CancellationToken ct) {
-        if (!StillTarget(pid, expectedIdentity)) return Task.FromResult(true); // gone / reused → ours is gone
-        return KillConfirmAsync(pid, expectedIdentity, agentId, logger, ct);
-    }
+    /// wasn't confirmed at teardown. Kill it by EXACT identity and report confirmed-gone (drain) vs
+    /// still-alive/uncomparable (retain for the next tick).</summary>
+    public static Task<bool> ReapByIdentityAsync(int pid, string expectedIdentity, string agentId, ILogger logger, CancellationToken ct)
+        => KillConfirmAsync(pid, expectedIdentity, agentId, logger, ct);
 
-    /// <summary>SIGTERM the process group (Unix; the forkpty child is a session leader so its pgid ==
-    /// pid, taking descendants too), wait <see cref="GraceBeforeKill"/>, then SIGKILL; confirm death.
-    /// The <paramref name="expectedIdentity"/> is re-validated before EACH signal and after each wait,
-    /// so a pid recycled mid-sequence is detected as "ours is gone" and never signalled. Windows falls
-    /// back to a best-effort <see cref="System.Diagnostics.Process"/> kill.</summary>
-    static async Task<bool> KillConfirmAsync(int pid, string? expectedIdentity, string agentId, ILogger logger, CancellationToken ct) {
+    /// <summary>SIGTERM the process group, wait <see cref="GraceBeforeKill"/>, then SIGKILL; confirm the
+    /// leader is gone. Re-classifies before/after each step so a pid recycled mid-sequence is detected as
+    /// "ours is gone" and never signalled; a leader that dies at any point has its orphaned descendants
+    /// swept. Returns true only on confirmed death (or proven recycle), false on unconfirmed/ambiguous.</summary>
+    static async Task<bool> KillConfirmAsync(int pid, string expectedIdentity, string agentId, ILogger logger, CancellationToken ct) {
         try {
-            if (!StillTarget(pid, expectedIdentity)) return true; // exited / recycled before we signal
-
-            if (OperatingSystem.IsWindows()) {
-                try { using var p = System.Diagnostics.Process.GetProcessById(pid); p.Kill(entireProcessTree: true); }
-                catch { /* gone / unkillable */ }
-            } else {
-                // Negative pid → the whole process group (killpg equivalent). Fall back to the pid alone.
-                if (UnixPtyInterop.kill(-pid, UnixPtyInterop.SIGTERM) != 0)
-                    UnixPtyInterop.kill(pid, UnixPtyInterop.SIGTERM);
+            switch (Classify(pid, expectedIdentity)) {
+                case LeaderState.Dead:      SweepDeadLeaderGroup(pid); return true;
+                case LeaderState.Recycled:  return true;
+                case LeaderState.Ambiguous: return false;
             }
+
+            SignalGroup(pid, hard: false); // SIGTERM the group
 
             for (var waited = TimeSpan.Zero; waited < GraceBeforeKill; waited += TimeSpan.FromMilliseconds(250)) {
-                if (!StillTarget(pid, expectedIdentity)) return true;
+                switch (Classify(pid, expectedIdentity)) {
+                    case LeaderState.Dead:      SweepDeadLeaderGroup(pid); return true; // died on TERM → sweep descendants
+                    case LeaderState.Recycled:  return true;
+                    case LeaderState.Ambiguous: return false;
+                }
                 await Task.Delay(250, ct);
             }
 
-            // Re-validate AFTER the grace wait, immediately before the hard kill — the pid may have been
-            // recycled during the 5s window, and SIGKILL to a recycled pid would hit an unrelated process.
-            if (!StillTarget(pid, expectedIdentity)) return true;
-
-            if (!OperatingSystem.IsWindows()) {
-                if (UnixPtyInterop.kill(-pid, UnixPtyInterop.SIGKILL) != 0)
-                    UnixPtyInterop.kill(pid, UnixPtyInterop.SIGKILL);
-                await Task.Delay(250, ct);
+            // Grace elapsed. Re-classify immediately before the hard kill — the pid may have been recycled
+            // during the last wait, and SIGKILL to a recycled group would hit unrelated processes.
+            switch (Classify(pid, expectedIdentity)) {
+                case LeaderState.Dead:      SweepDeadLeaderGroup(pid); return true;
+                case LeaderState.Recycled:  return true;
+                case LeaderState.Ambiguous: return false;
             }
 
-            var gone = !StillTarget(pid, expectedIdentity);
-            if (!gone) logger.LogWarning("ProcessReaper: pid {Pid} (agent {AgentId}) still alive after SIGKILL — retained for next sweep", pid, agentId);
+            SignalGroup(pid, hard: true); // SIGKILL the group
+            await Task.Delay(250, ct);
 
-            return gone;
+            switch (Classify(pid, expectedIdentity)) {
+                case LeaderState.Dead:      SweepDeadLeaderGroup(pid); return true;
+                case LeaderState.Recycled:  return true;
+                case LeaderState.Ambiguous: return false; // became uncomparable → unconfirmed, retain
+                default:
+                    logger.LogWarning("ProcessReaper: pid {Pid} (agent {AgentId}) still alive after SIGKILL — retained for next sweep", pid, agentId);
+                    return false;
+            }
         } catch (OperationCanceledException) {
             return false;
         } catch (Exception ex) {
             logger.LogWarning(ex, "ProcessReaper: kill of pid {Pid} (agent {AgentId}) failed", pid, agentId);
             return false;
         }
+    }
+
+    /// <summary>SIGTERM/SIGKILL the target's process group (Unix; falls back to the bare pid when it
+    /// isn't a group leader). On Windows there are no process groups, so the soft call tree-kills and the
+    /// hard call is a no-op (the tree is already gone).</summary>
+    static void SignalGroup(int pid, bool hard) {
+        if (pid <= 0) return;
+
+        if (OperatingSystem.IsWindows()) {
+            if (!hard) {
+                try { using var p = System.Diagnostics.Process.GetProcessById(pid); p.Kill(entireProcessTree: true); }
+                catch { /* gone / unkillable */ }
+            }
+
+            return;
+        }
+
+        var sig = hard ? UnixPtyInterop.SIGKILL : UnixPtyInterop.SIGTERM;
+        if (UnixPtyInterop.kill(-pid, sig) != 0) UnixPtyInterop.kill(pid, sig); // -pid = the group; fall back to the pid
+    }
+
+    /// <summary>Our leader is confirmed gone → SIGKILL any orphaned descendants that inherited its
+    /// process group. Reuse-safe: only fires while the leader pid slot is EMPTY (a reused pid would be
+    /// alive → skipped), so it can only reach our dead leader's lineage, never a new process's group.
+    /// Best-effort; SIGKILL is uncatchable, so the group is cleared. Unix-only (Windows tree-kill already
+    /// swept the descendants).</summary>
+    static void SweepDeadLeaderGroup(int pid) {
+        if (pid <= 0 || OperatingSystem.IsWindows()) return;
+        if (ProcessIdentity.IsAlive(pid)) return; // pid slot occupied — never signal a possibly-reused leader's group
+
+        UnixPtyInterop.kill(-pid, UnixPtyInterop.SIGKILL);
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// AI-1313 Phase B (D4 §6.4): the shared "reap by exact identity" primitive used by the
+/// Phase B (D4 §6.4): the shared "reap by exact identity" primitive used by the
 /// <c>HandleStopAgent</c> PID-record fallback (T7), the kill-quarantine retry (T8), and the startup
 /// <c>OrphanReaper</c> (T9). Kills a leftover child ONLY when its identity is proven — never on
 /// ambiguity — and reports whether death is CONFIRMED (so the caller deletes the record / drains the

--- a/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
@@ -59,16 +59,20 @@ internal static class ProcessReaper {
                 return false;
         }
 
-        // Ours. Unix env guard: only kill if the process still proves it is OUR agent. Unreadable → spare.
+        // Ours (the EXACT start token already proves this is the same incarnation recorded at spawn).
+        // Unix env guard, defense-in-depth: only kill if the live process ALSO still carries our
+        // KCAP_AGENT_ID. Unreadable OR mismatched env → SPARE and retain the record: it means ownership
+        // can't be proven strongly enough to kill, NOT that the process is gone. Reporting confirmed-gone
+        // here would strand a live child and drop its durable tracking (esp. on macOS, where the marker
+        // scan can't recover it). Only Dead / a conclusive token recycle return confirmed-gone.
         if (!OperatingSystem.IsWindows()) {
             var envAgentId = ProcessIdentity.ReadAgentEnv(pid, "KCAP_AGENT_ID");
-            if (envAgentId is null) {
+            if (envAgentId is null || !string.Equals(envAgentId, record.AgentId, StringComparison.Ordinal)) {
                 logger.LogWarning(
-                    "ProcessReaper: env unreadable for pid {Pid} (agent {AgentId}) — sparing (ambiguity never kills)",
+                    "ProcessReaper: env unreadable/mismatched for pid {Pid} (agent {AgentId}) — sparing (ambiguity never kills)",
                     pid, record.AgentId);
                 return false;
             }
-            if (!string.Equals(envAgentId, record.AgentId, StringComparison.Ordinal)) return true; // not our agent
         }
 
         return await KillConfirmAsync(pid, record.StartIdentity, record.AgentId, logger, ct);

--- a/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
@@ -6,21 +6,33 @@ namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
 /// AI-1313 Phase B (D4 §6.4): the shared "reap by exact identity" primitive used by the
-/// <c>HandleStopAgent</c> PID-record fallback (T7) and the startup <c>OrphanReaper</c> (T9). Kills a
-/// leftover child ONLY when its identity is proven — never on ambiguity — and reports whether death is
-/// CONFIRMED (so the caller deletes the record only then, per spec §6.4(2)).
+/// <c>HandleStopAgent</c> PID-record fallback (T7), the kill-quarantine retry (T8), and the startup
+/// <c>OrphanReaper</c> (T9). Kills a leftover child ONLY when its identity is proven — never on
+/// ambiguity — and reports whether death is CONFIRMED (so the caller deletes the record only then, per
+/// spec §6.4(2)).
+/// <para>PID-reuse safety: the expected start-identity token is re-validated before EVERY signal and
+/// after every wait (<see cref="StillTarget"/>). If the target exits and its pid is recycled by an
+/// unrelated process at any point in the TERM→grace→KILL sequence, the mismatch is detected and the
+/// signal is NOT sent — "ours is gone" is reported instead of killing the new occupant.</para>
 /// <para>Two kill regimes (spec §6.4(2b)):</para>
 /// <list type="bullet">
 /// <item><b>Record regime</b> (<see cref="ReapByRecordAsync"/>): exact <c>(pid, start-identity)</c>
 /// match PLUS, on Unix, the <c>KCAP_AGENT_ID</c> env check. If the env can't be read (macOS 26 redacts
 /// it — see <see cref="ProcessIdentity.ReadAgentEnv"/>) the process is SPARED.</item>
-/// <item><b>Marker regime</b> (<see cref="ReapByMarkerAsync"/>): the full env triple read from the live
-/// process itself (<c>KCAP_AGENT_ID</c> present, <c>KCAP_DAEMON_ID</c> == ours, <c>KCAP_DAEMON_EPOCH</c>
-/// from a prior incarnation). IS full identity for a recordless process; no native stamp needed.</item>
+/// <item><b>Marker regime</b> (<see cref="ReapByMarkerAsync"/>): the caller has already validated the
+/// live process's env triple; this captures the process's start-identity and kills by it (so PID reuse
+/// during the kill still can't hit the wrong process). If the identity can't be captured, it SPARES.</item>
 /// </list>
 /// </summary>
 internal static class ProcessReaper {
     static readonly TimeSpan GraceBeforeKill = TimeSpan.FromSeconds(5);
+
+    /// <summary>True IFF <paramref name="pid"/> is alive AND (no identity was supplied OR it still
+    /// matches <paramref name="expectedIdentity"/>). Returns false when the target is gone OR the pid
+    /// has been recycled by a different process — the caller then treats it as "ours is gone" and never
+    /// signals.</summary>
+    static bool StillTarget(int pid, string? expectedIdentity) =>
+        ProcessIdentity.IsAlive(pid) && (expectedIdentity is not { } id || ProcessIdentity.Matches(pid, id));
 
     /// <summary>Record-regime reap. Returns true when the target is CONFIRMED gone (already dead,
     /// killed + observed dead, or a proven identity mismatch — i.e. our agent's process is not there),
@@ -28,8 +40,8 @@ internal static class ProcessReaper {
     public static async Task<bool> ReapByRecordAsync(AgentPidRecord record, ILogger logger, CancellationToken ct) {
         var pid = record.Pid;
 
-        if (!ProcessIdentity.IsAlive(pid)) return true;                    // gone
-        if (!ProcessIdentity.Matches(pid, record.StartIdentity)) return true; // PID reused by an unrelated proc — ours is gone
+        if (!ProcessIdentity.IsAlive(pid)) return true;                          // gone
+        if (!ProcessIdentity.Matches(pid, record.StartIdentity)) return true;    // PID reused by an unrelated proc — ours is gone
 
         // Unix env guard: only kill if the process still proves it is OUR agent. Unreadable env → spare.
         if (!OperatingSystem.IsWindows()) {
@@ -43,31 +55,45 @@ internal static class ProcessReaper {
             if (!string.Equals(envAgentId, record.AgentId, StringComparison.Ordinal)) return true; // not our agent
         }
 
-        return await KillConfirmAsync(pid, record.AgentId, logger, ct);
+        return await KillConfirmAsync(pid, record.StartIdentity, record.AgentId, logger, ct);
     }
 
     /// <summary>Marker-regime reap of a recordless survivor: the caller has already read + validated the
-    /// env triple from the live process. Returns true when confirmed gone.</summary>
+    /// env triple from the live process. Captures the process's start-identity so the kill sequence is
+    /// PID-reuse-safe; SPARES (returns false) if the identity can't be captured. Returns true when
+    /// confirmed gone.</summary>
     public static Task<bool> ReapByMarkerAsync(int pid, string agentId, ILogger logger, CancellationToken ct) {
         if (!ProcessIdentity.IsAlive(pid)) return Task.FromResult(true);
-        return KillConfirmAsync(pid, agentId, logger, ct);
+
+        var identity = ProcessIdentity.Capture(pid);
+        if (identity is null) {
+            logger.LogWarning(
+                "ProcessReaper: could not capture identity for pid {Pid} (agent {AgentId}) — sparing (ambiguity never kills)",
+                pid, agentId);
+            return Task.FromResult(false);
+        }
+
+        return KillConfirmAsync(pid, identity, agentId, logger, ct);
     }
 
     /// <summary>Kill-quarantine retry (spec §6.4(2a)): the entry is a KNOWN-ours process whose death
-    /// wasn't confirmed at teardown. Kill it by EXACT identity (no env check needed — we already own
-    /// it, and the identity match handles PID reuse) and report confirmed-gone. Gone / PID-reused →
-    /// true (drain it); still alive after SIGKILL → false (retry next tick).</summary>
+    /// wasn't confirmed at teardown. Kill it by EXACT identity (no env check needed — we already own it,
+    /// and the identity match handles PID reuse) and report confirmed-gone. Gone / PID-reused → true
+    /// (drain it); still alive after SIGKILL → false (retry next tick).</summary>
     public static Task<bool> ReapByIdentityAsync(int pid, string expectedIdentity, string agentId, ILogger logger, CancellationToken ct) {
-        if (!ProcessIdentity.IsAlive(pid)) return Task.FromResult(true);
-        if (!ProcessIdentity.Matches(pid, expectedIdentity)) return Task.FromResult(true); // reused → ours is gone
-        return KillConfirmAsync(pid, agentId, logger, ct);
+        if (!StillTarget(pid, expectedIdentity)) return Task.FromResult(true); // gone / reused → ours is gone
+        return KillConfirmAsync(pid, expectedIdentity, agentId, logger, ct);
     }
 
     /// <summary>SIGTERM the process group (Unix; the forkpty child is a session leader so its pgid ==
     /// pid, taking descendants too), wait <see cref="GraceBeforeKill"/>, then SIGKILL; confirm death.
-    /// Windows falls back to a best-effort <see cref="System.Diagnostics.Process"/> kill.</summary>
-    static async Task<bool> KillConfirmAsync(int pid, string agentId, ILogger logger, CancellationToken ct) {
+    /// The <paramref name="expectedIdentity"/> is re-validated before EACH signal and after each wait,
+    /// so a pid recycled mid-sequence is detected as "ours is gone" and never signalled. Windows falls
+    /// back to a best-effort <see cref="System.Diagnostics.Process"/> kill.</summary>
+    static async Task<bool> KillConfirmAsync(int pid, string? expectedIdentity, string agentId, ILogger logger, CancellationToken ct) {
         try {
+            if (!StillTarget(pid, expectedIdentity)) return true; // exited / recycled before we signal
+
             if (OperatingSystem.IsWindows()) {
                 try { using var p = System.Diagnostics.Process.GetProcessById(pid); p.Kill(entireProcessTree: true); }
                 catch { /* gone / unkillable */ }
@@ -78,9 +104,13 @@ internal static class ProcessReaper {
             }
 
             for (var waited = TimeSpan.Zero; waited < GraceBeforeKill; waited += TimeSpan.FromMilliseconds(250)) {
-                if (!ProcessIdentity.IsAlive(pid)) return true;
+                if (!StillTarget(pid, expectedIdentity)) return true;
                 await Task.Delay(250, ct);
             }
+
+            // Re-validate AFTER the grace wait, immediately before the hard kill — the pid may have been
+            // recycled during the 5s window, and SIGKILL to a recycled pid would hit an unrelated process.
+            if (!StillTarget(pid, expectedIdentity)) return true;
 
             if (!OperatingSystem.IsWindows()) {
                 if (UnixPtyInterop.kill(-pid, UnixPtyInterop.SIGKILL) != 0)
@@ -88,7 +118,7 @@ internal static class ProcessReaper {
                 await Task.Delay(250, ct);
             }
 
-            var gone = !ProcessIdentity.IsAlive(pid);
+            var gone = !StillTarget(pid, expectedIdentity);
             if (!gone) logger.LogWarning("ProcessReaper: pid {Pid} (agent {AgentId}) still alive after SIGKILL — retained for next sweep", pid, agentId);
 
             return gone;

--- a/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
@@ -11,21 +11,22 @@ namespace Capacitor.Cli.Daemon.Services;
 /// ambiguity — and reports whether death is CONFIRMED (so the caller deletes the record / drains the
 /// quarantine only then, per spec §6.4(2)).
 /// <para><b>Tri-state identity (fail-closed).</b> The leader pid is classified against its expected
-/// start token as one of: <c>Dead</c> (pid gone), <c>Ours</c> (alive, exact match), <c>Recycled</c>
-/// (alive, CONCLUSIVELY a different incarnation — same scheme, different value), or <c>Ambiguous</c>
-/// (alive but token unreadable / foreign scheme). Only <c>Dead</c> and <c>Recycled</c> are "confirmed
-/// gone"; <c>Ambiguous</c> SPARES (returns "not gone") so a still-alive child is never dropped on an
-/// unreadable token.</para>
+/// start token as one of: <c>Dead</c> (pid gone — or a Linux zombie, treated as gone), <c>Ours</c>
+/// (alive, exact match), <c>Recycled</c> (alive, CONCLUSIVELY a different incarnation — same scheme,
+/// different value), or <c>Ambiguous</c> (alive but token unreadable / foreign scheme). Only <c>Dead</c>
+/// and <c>Recycled</c> are "confirmed gone"; <c>Ambiguous</c> SPARES (returns "not gone") so a
+/// still-alive child is never dropped on an unreadable token.</para>
 /// <para><b>PID-reuse safety.</b> The token is re-classified before EVERY signal and after every wait,
 /// so a pid recycled anywhere in the TERM→grace→KILL window is seen as <c>Recycled</c> and no signal is
 /// sent to the new occupant.</para>
 /// <para><b>Descendant containment.</b> Signals go to the process GROUP (<c>kill(-pid)</c>; a hosted
-/// agent is a forkpty session leader with pgid==pid, so its mcp children are in the group). When the
-/// leader dies (on TERM or otherwise) any orphaned descendants that inherited its group are swept with
-/// an uncatchable group SIGKILL — but only while the leader pid slot is empty, so a reused pid's group
-/// is never touched. (Full group-liveness *confirmation* — distinguishing "group empty" from "not a
-/// group leader" — needs the same OS-primitive work as the deferred native-containment sub-phase; the
-/// uncatchable group SIGKILL already guarantees descendants are cleared.)</para>
+/// agent is a forkpty session leader with pgid==pid, so its mcp children are in the group) WHILE the
+/// live leader still anchors ownership — so a stubborn descendant is SIGKILLed alongside the leader we
+/// have proven is ours. Once the leader is gone we do NOT signal the numeric pgid: an empty leader slot
+/// no longer proves the group is our lineage (the pid could be reused by an unrelated session leader),
+/// and "ambiguity never kills". A descendant that outlives a leader which exited on TERM before the
+/// group SIGKILL is the deferred native-containment concern (Linux PDEATHSIG / Windows Job Object),
+/// which kills descendants with the leader at the OS level.</para>
 /// </summary>
 internal static class ProcessReaper {
     static readonly TimeSpan GraceBeforeKill = TimeSpan.FromSeconds(5);
@@ -33,7 +34,7 @@ internal static class ProcessReaper {
     enum LeaderState { Dead, Ours, Recycled, Ambiguous }
 
     static LeaderState Classify(int pid, string expectedIdentity) {
-        if (!ProcessIdentity.IsAlive(pid)) return LeaderState.Dead;
+        if (!ProcessIdentity.IsAlive(pid)) return LeaderState.Dead; // gone or a zombie (IsAlive is zombie-aware)
 
         return ProcessIdentity.MatchesTri(pid, expectedIdentity) switch {
             true  => LeaderState.Ours,
@@ -49,8 +50,8 @@ internal static class ProcessReaper {
         var pid = record.Pid;
 
         switch (Classify(pid, record.StartIdentity)) {
-            case LeaderState.Dead:      SweepDeadLeaderGroup(pid); return true; // gone — sweep any orphaned descendants
-            case LeaderState.Recycled:  return true;                            // pid reused by an unrelated proc — ours is gone
+            case LeaderState.Dead:      return true;   // our process is gone
+            case LeaderState.Recycled:  return true;   // pid reused by an unrelated proc — ours is gone
             case LeaderState.Ambiguous:
                 logger.LogWarning(
                     "ProcessReaper: identity uncomparable for pid {Pid} (agent {AgentId}) — sparing (ambiguity never kills)",
@@ -88,21 +89,23 @@ internal static class ProcessReaper {
 
     /// <summary>SIGTERM the process group, wait <see cref="GraceBeforeKill"/>, then SIGKILL; confirm the
     /// leader is gone. Re-classifies before/after each step so a pid recycled mid-sequence is detected as
-    /// "ours is gone" and never signalled; a leader that dies at any point has its orphaned descendants
-    /// swept. Returns true only on confirmed death (or proven recycle), false on unconfirmed/ambiguous.</summary>
+    /// "ours is gone" and never signalled. The group signal (TERM then KILL) is only ever sent while the
+    /// leader is alive-and-ours, so a stubborn descendant dies alongside the proven leader; once the
+    /// leader is gone we never signal the pgid. Returns true only on confirmed death (or proven recycle),
+    /// false on unconfirmed/ambiguous.</summary>
     static async Task<bool> KillConfirmAsync(int pid, string expectedIdentity, string agentId, ILogger logger, CancellationToken ct) {
         try {
             switch (Classify(pid, expectedIdentity)) {
-                case LeaderState.Dead:      SweepDeadLeaderGroup(pid); return true;
+                case LeaderState.Dead:      return true;
                 case LeaderState.Recycled:  return true;
                 case LeaderState.Ambiguous: return false;
             }
 
-            SignalGroup(pid, hard: false); // SIGTERM the group
+            SignalGroup(pid, hard: false); // SIGTERM the group (leader is proven ours → group is our lineage)
 
             for (var waited = TimeSpan.Zero; waited < GraceBeforeKill; waited += TimeSpan.FromMilliseconds(250)) {
                 switch (Classify(pid, expectedIdentity)) {
-                    case LeaderState.Dead:      SweepDeadLeaderGroup(pid); return true; // died on TERM → sweep descendants
+                    case LeaderState.Dead:      return true; // leader (and the group it anchored) gone
                     case LeaderState.Recycled:  return true;
                     case LeaderState.Ambiguous: return false;
                 }
@@ -112,16 +115,16 @@ internal static class ProcessReaper {
             // Grace elapsed. Re-classify immediately before the hard kill — the pid may have been recycled
             // during the last wait, and SIGKILL to a recycled group would hit unrelated processes.
             switch (Classify(pid, expectedIdentity)) {
-                case LeaderState.Dead:      SweepDeadLeaderGroup(pid); return true;
+                case LeaderState.Dead:      return true;
                 case LeaderState.Recycled:  return true;
                 case LeaderState.Ambiguous: return false;
             }
 
-            SignalGroup(pid, hard: true); // SIGKILL the group
+            SignalGroup(pid, hard: true); // SIGKILL the group while the leader is still proven ours
             await Task.Delay(250, ct);
 
             switch (Classify(pid, expectedIdentity)) {
-                case LeaderState.Dead:      SweepDeadLeaderGroup(pid); return true;
+                case LeaderState.Dead:      return true;
                 case LeaderState.Recycled:  return true;
                 case LeaderState.Ambiguous: return false; // became uncomparable → unconfirmed, retain
                 default:
@@ -137,8 +140,9 @@ internal static class ProcessReaper {
     }
 
     /// <summary>SIGTERM/SIGKILL the target's process group (Unix; falls back to the bare pid when it
-    /// isn't a group leader). On Windows there are no process groups, so the soft call tree-kills and the
-    /// hard call is a no-op (the tree is already gone).</summary>
+    /// isn't a group leader). Only ever called with the leader proven alive-and-ours, so the group is our
+    /// lineage. On Windows there are no process groups, so the soft call tree-kills and the hard call is a
+    /// no-op (the tree is already gone).</summary>
     static void SignalGroup(int pid, bool hard) {
         if (pid <= 0) return;
 
@@ -153,17 +157,5 @@ internal static class ProcessReaper {
 
         var sig = hard ? UnixPtyInterop.SIGKILL : UnixPtyInterop.SIGTERM;
         if (UnixPtyInterop.kill(-pid, sig) != 0) UnixPtyInterop.kill(pid, sig); // -pid = the group; fall back to the pid
-    }
-
-    /// <summary>Our leader is confirmed gone → SIGKILL any orphaned descendants that inherited its
-    /// process group. Reuse-safe: only fires while the leader pid slot is EMPTY (a reused pid would be
-    /// alive → skipped), so it can only reach our dead leader's lineage, never a new process's group.
-    /// Best-effort; SIGKILL is uncatchable, so the group is cleared. Unix-only (Windows tree-kill already
-    /// swept the descendants).</summary>
-    static void SweepDeadLeaderGroup(int pid) {
-        if (pid <= 0 || OperatingSystem.IsWindows()) return;
-        if (ProcessIdentity.IsAlive(pid)) return; // pid slot occupied — never signal a possibly-reused leader's group
-
-        UnixPtyInterop.kill(-pid, UnixPtyInterop.SIGKILL);
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
@@ -1,0 +1,92 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Pty.Unix;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// AI-1313 Phase B (D4 §6.4): the shared "reap by exact identity" primitive used by the
+/// <c>HandleStopAgent</c> PID-record fallback (T7) and the startup <c>OrphanReaper</c> (T9). Kills a
+/// leftover child ONLY when its identity is proven — never on ambiguity — and reports whether death is
+/// CONFIRMED (so the caller deletes the record only then, per spec §6.4(2)).
+/// <para>Two kill regimes (spec §6.4(2b)):</para>
+/// <list type="bullet">
+/// <item><b>Record regime</b> (<see cref="ReapByRecordAsync"/>): exact <c>(pid, start-identity)</c>
+/// match PLUS, on Unix, the <c>KCAP_AGENT_ID</c> env check. If the env can't be read (macOS 26 redacts
+/// it — see <see cref="ProcessIdentity.ReadAgentEnv"/>) the process is SPARED.</item>
+/// <item><b>Marker regime</b> (<see cref="ReapByMarkerAsync"/>): the full env triple read from the live
+/// process itself (<c>KCAP_AGENT_ID</c> present, <c>KCAP_DAEMON_ID</c> == ours, <c>KCAP_DAEMON_EPOCH</c>
+/// from a prior incarnation). IS full identity for a recordless process; no native stamp needed.</item>
+/// </list>
+/// </summary>
+internal static class ProcessReaper {
+    static readonly TimeSpan GraceBeforeKill = TimeSpan.FromSeconds(5);
+
+    /// <summary>Record-regime reap. Returns true when the target is CONFIRMED gone (already dead,
+    /// killed + observed dead, or a proven identity mismatch — i.e. our agent's process is not there),
+    /// false when it may still be alive (kill unconfirmed, or SPARED for unreadable env).</summary>
+    public static async Task<bool> ReapByRecordAsync(AgentPidRecord record, ILogger logger, CancellationToken ct) {
+        var pid = record.Pid;
+
+        if (!ProcessIdentity.IsAlive(pid)) return true;                    // gone
+        if (!ProcessIdentity.Matches(pid, record.StartIdentity)) return true; // PID reused by an unrelated proc — ours is gone
+
+        // Unix env guard: only kill if the process still proves it is OUR agent. Unreadable env → spare.
+        if (!OperatingSystem.IsWindows()) {
+            var envAgentId = ProcessIdentity.ReadAgentEnv(pid, "KCAP_AGENT_ID");
+            if (envAgentId is null) {
+                logger.LogWarning(
+                    "ProcessReaper: env unreadable for pid {Pid} (agent {AgentId}) — sparing (ambiguity never kills)",
+                    pid, record.AgentId);
+                return false;
+            }
+            if (!string.Equals(envAgentId, record.AgentId, StringComparison.Ordinal)) return true; // not our agent
+        }
+
+        return await KillConfirmAsync(pid, record.AgentId, logger, ct);
+    }
+
+    /// <summary>Marker-regime reap of a recordless survivor: the caller has already read + validated the
+    /// env triple from the live process. Returns true when confirmed gone.</summary>
+    public static Task<bool> ReapByMarkerAsync(int pid, string agentId, ILogger logger, CancellationToken ct) {
+        if (!ProcessIdentity.IsAlive(pid)) return Task.FromResult(true);
+        return KillConfirmAsync(pid, agentId, logger, ct);
+    }
+
+    /// <summary>SIGTERM the process group (Unix; the forkpty child is a session leader so its pgid ==
+    /// pid, taking descendants too), wait <see cref="GraceBeforeKill"/>, then SIGKILL; confirm death.
+    /// Windows falls back to a best-effort <see cref="System.Diagnostics.Process"/> kill.</summary>
+    static async Task<bool> KillConfirmAsync(int pid, string agentId, ILogger logger, CancellationToken ct) {
+        try {
+            if (OperatingSystem.IsWindows()) {
+                try { using var p = System.Diagnostics.Process.GetProcessById(pid); p.Kill(entireProcessTree: true); }
+                catch { /* gone / unkillable */ }
+            } else {
+                // Negative pid → the whole process group (killpg equivalent). Fall back to the pid alone.
+                if (UnixPtyInterop.kill(-pid, UnixPtyInterop.SIGTERM) != 0)
+                    UnixPtyInterop.kill(pid, UnixPtyInterop.SIGTERM);
+            }
+
+            for (var waited = TimeSpan.Zero; waited < GraceBeforeKill; waited += TimeSpan.FromMilliseconds(250)) {
+                if (!ProcessIdentity.IsAlive(pid)) return true;
+                await Task.Delay(250, ct);
+            }
+
+            if (!OperatingSystem.IsWindows()) {
+                if (UnixPtyInterop.kill(-pid, UnixPtyInterop.SIGKILL) != 0)
+                    UnixPtyInterop.kill(pid, UnixPtyInterop.SIGKILL);
+                await Task.Delay(250, ct);
+            }
+
+            var gone = !ProcessIdentity.IsAlive(pid);
+            if (!gone) logger.LogWarning("ProcessReaper: pid {Pid} (agent {AgentId}) still alive after SIGKILL — retained for next sweep", pid, agentId);
+
+            return gone;
+        } catch (OperationCanceledException) {
+            return false;
+        } catch (Exception ex) {
+            logger.LogWarning(ex, "ProcessReaper: kill of pid {Pid} (agent {AgentId}) failed", pid, agentId);
+            return false;
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
@@ -53,6 +53,16 @@ internal static class ProcessReaper {
         return KillConfirmAsync(pid, agentId, logger, ct);
     }
 
+    /// <summary>Kill-quarantine retry (spec §6.4(2a)): the entry is a KNOWN-ours process whose death
+    /// wasn't confirmed at teardown. Kill it by EXACT identity (no env check needed — we already own
+    /// it, and the identity match handles PID reuse) and report confirmed-gone. Gone / PID-reused →
+    /// true (drain it); still alive after SIGKILL → false (retry next tick).</summary>
+    public static Task<bool> ReapByIdentityAsync(int pid, string expectedIdentity, string agentId, ILogger logger, CancellationToken ct) {
+        if (!ProcessIdentity.IsAlive(pid)) return Task.FromResult(true);
+        if (!ProcessIdentity.Matches(pid, expectedIdentity)) return Task.FromResult(true); // reused → ours is gone
+        return KillConfirmAsync(pid, agentId, logger, ct);
+    }
+
     /// <summary>SIGTERM the process group (Unix; the forkpty child is a session leader so its pgid ==
     /// pid, taking descendants too), wait <see cref="GraceBeforeKill"/>, then SIGKILL; confirm death.
     /// Windows falls back to a best-effort <see cref="System.Diagnostics.Process"/> kill.</summary>

--- a/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
@@ -79,7 +79,7 @@ internal sealed partial class PtyHostedAgentRuntimeFactory(
             ["KCAP_AGENT_ID"]       = ctx.AgentId
         };
 
-        // AI-1313 Phase B (D4 §6.4(3)): stamp the daemon-identity markers so a restarted daemon's
+        // Phase B (D4 §6.4(3)): stamp the daemon-identity markers so a restarted daemon's
         // OrphanReaper env-marker scan can reap a recordless survivor of a PRIOR incarnation of THIS
         // daemon (same KCAP_DAEMON_ID, older KCAP_DAEMON_EPOCH) — and never touch another daemon's
         // child or a live agent of the current incarnation.

--- a/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
@@ -79,6 +79,13 @@ internal sealed partial class PtyHostedAgentRuntimeFactory(
             ["KCAP_AGENT_ID"]       = ctx.AgentId
         };
 
+        // AI-1313 Phase B (D4 §6.4(3)): stamp the daemon-identity markers so a restarted daemon's
+        // OrphanReaper env-marker scan can reap a recordless survivor of a PRIOR incarnation of THIS
+        // daemon (same KCAP_DAEMON_ID, older KCAP_DAEMON_EPOCH) — and never touch another daemon's
+        // child or a live agent of the current incarnation.
+        if (!string.IsNullOrEmpty(ctx.DaemonId))    env["KCAP_DAEMON_ID"]    = ctx.DaemonId;
+        if (!string.IsNullOrEmpty(ctx.DaemonEpoch)) env["KCAP_DAEMON_EPOCH"] = ctx.DaemonEpoch;
+
         if (!string.IsNullOrEmpty(ctx.ServerUrl)) {
             env["KCAP_URL"] = ctx.ServerUrl;
         }

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -81,6 +81,10 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// </summary>
     public Func<string[]>? GetLiveAgentIds { get; set; }
 
+    /// <summary>AI-1313 Phase B (D2): richer live-agent metadata (kind + flow identity) sent alongside
+    /// <see cref="GetLiveAgentIds"/> on <c>DaemonConnect</c>. Optional — null when not wired (tests).</summary>
+    public Func<LiveAgentInfo[]>? GetLiveAgents { get; set; }
+
     public ServerConnection(DaemonConfig config, ILoggerFactory loggerFactory, ILogger<ServerConnection> logger) {
         _config = config;
         _logger = logger;
@@ -369,13 +373,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         var platform  = $"{RuntimeInformation.OSDescription} {RuntimeInformation.OSArchitecture}";
         var repoPaths = await MergeRepoPathsAsync();
         var liveIds   = GetLiveAgentIds?.Invoke() ?? [];
+        var liveAgents = GetLiveAgents?.Invoke(); // AI-1313 Phase B (D2): additive; null on an unwired/old path
 
         try {
             await _hub.InvokeAsync(
                 "DaemonConnect",
                 new DaemonConnect(
                     _config.Name, platform, repoPaths, _config.MaxConcurrentAgents, liveIds,
-                    _config.InstanceId, _config.Version, _config.SupportedVendors, MachineId.Get()
+                    _config.InstanceId, _config.Version, _config.SupportedVendors, MachineId.Get(), liveAgents
                 ),
                 cancellationToken: _ct
             );

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -81,11 +81,11 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// </summary>
     public Func<string[]>? GetLiveAgentIds { get; set; }
 
-    /// <summary>AI-1313 Phase B (D2): richer live-agent metadata (kind + flow identity) sent alongside
+    /// <summary>Phase B (D2): richer live-agent metadata (kind + flow identity) sent alongside
     /// <see cref="GetLiveAgentIds"/> on <c>DaemonConnect</c>. Optional — null when not wired (tests).</summary>
     public Func<LiveAgentInfo[]>? GetLiveAgents { get; set; }
 
-    /// <summary>AI-1313 Phase B (D2): send the periodic daemon self-report ONE-WAY (never
+    /// <summary>Phase B (D2): send the periodic daemon self-report ONE-WAY (never
     /// <c>InvokeAsync</c>) — an old server without the <c>DaemonStatusReport</c> handler produces only
     /// a server-side log line, and any send exception is swallowed so the agent loops are untouched.
     /// Virtual so tests can capture the report without a live hub.</summary>
@@ -383,7 +383,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         var platform  = $"{RuntimeInformation.OSDescription} {RuntimeInformation.OSArchitecture}";
         var repoPaths = await MergeRepoPathsAsync();
         var liveIds   = GetLiveAgentIds?.Invoke() ?? [];
-        var liveAgents = GetLiveAgents?.Invoke(); // AI-1313 Phase B (D2): additive; null on an unwired/old path
+        var liveAgents = GetLiveAgents?.Invoke(); // Phase B (D2): additive; null on an unwired/old path
 
         try {
             await _hub.InvokeAsync(

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -85,6 +85,16 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// <see cref="GetLiveAgentIds"/> on <c>DaemonConnect</c>. Optional — null when not wired (tests).</summary>
     public Func<LiveAgentInfo[]>? GetLiveAgents { get; set; }
 
+    /// <summary>AI-1313 Phase B (D2): send the periodic daemon self-report ONE-WAY (never
+    /// <c>InvokeAsync</c>) — an old server without the <c>DaemonStatusReport</c> handler produces only
+    /// a server-side log line, and any send exception is swallowed so the agent loops are untouched.
+    /// Virtual so tests can capture the report without a live hub.</summary>
+    public virtual async Task DaemonStatusReportAsync(DaemonStatusReport report) {
+        if (!IsReady) return;
+        try { await _hub.SendAsync("DaemonStatusReport", report, cancellationToken: _ct); }
+        catch (Exception ex) { _logger.LogDebug(ex, "DaemonStatusReport send failed (old server or transient)"); }
+    }
+
     public ServerConnection(DaemonConfig config, ILoggerFactory loggerFactory, ILogger<ServerConnection> logger) {
         _config = config;
         _logger = logger;

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -58,7 +58,8 @@ public partial class AgentOrchestratorVendorTests {
             IPtyProcessFactory                                  ptyFactory,
             IReadOnlyDictionary<string, IHostedAgentLauncher>   launchers,
             string?                                             allowedRepoPath        = null,
-            IEnumerable<IHostedAgentRuntimeFactory>?            extraRuntimeFactories  = null
+            IEnumerable<IHostedAgentRuntimeFactory>?            extraRuntimeFactories  = null,
+            Action<DaemonConfig>?                               configure              = null
         ) {
         var config = new DaemonConfig {
             Name                = "test",
@@ -71,6 +72,8 @@ public partial class AgentOrchestratorVendorTests {
         if (allowedRepoPath is not null) {
             config.AllowedRepoPaths = [allowedRepoPath];
         }
+
+        configure?.Invoke(config); // AI-1313 Phase B: let a test tweak the config (e.g. reviewer TTL bounds)
 
         var worktreeManager  = new WorktreeManager(config, NullLogger<WorktreeManager>.Instance);
         var repoMatcher      = new RepoMatcher(config, NullLogger<RepoMatcher>.Instance);

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -1091,7 +1091,13 @@ public partial class AgentOrchestratorVendorTests {
         /// CleanupAgentAsync, so a useful signal that local cleanup completed.</summary>
         public Action? OnAgentUnregistered { get; init; }
 
+        /// <summary>Every agent id passed to AgentUnregisteredAsync, in call order. AI-1313 Phase B
+        /// (D1): a single-flight teardown must unregister an agent exactly once even under a racing
+        /// launch-catch + read-loop cleanup.</summary>
+        public List<string> AgentUnregisteredCalls { get; } = [];
+
         public override Task AgentUnregisteredAsync(string agentId) {
+            lock (AgentUnregisteredCalls) AgentUnregisteredCalls.Add(agentId);
             OnAgentUnregistered?.Invoke();
 
             return Task.CompletedTask;

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -896,8 +896,9 @@ public partial class AgentOrchestratorVendorTests {
     }
 
     sealed class SpyPtyProcessFactory : IPtyProcessFactory {
-        public int     SpawnCalls  { get; private set; }
-        public string? LastCommand { get; private set; }
+        public int                         SpawnCalls  { get; private set; }
+        public string?                     LastCommand { get; private set; }
+        public Dictionary<string, string>? LastEnv     { get; private set; }
 
         public IPtyProcess Spawn(
                 string                      command,
@@ -909,6 +910,7 @@ public partial class AgentOrchestratorVendorTests {
             ) {
             SpawnCalls++;
             LastCommand = command;
+            LastEnv     = extraEnv;
 
             return new StubPtyProcess();
         }

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -66,7 +66,10 @@ public partial class AgentOrchestratorVendorTests {
             ServerUrl           = "http://127.0.0.1:1",
             ClaudePath          = "claude",
             MaxConcurrentAgents = 5,
-            WorktreeRoot        = Path.Combine(Path.GetTempPath(), "kcap-orch-wt-" + Guid.NewGuid().ToString("N")[..8])
+            WorktreeRoot        = Path.Combine(Path.GetTempPath(), "kcap-orch-wt-" + Guid.NewGuid().ToString("N")[..8]),
+            // AI-1313 Phase B (D4): isolate the PID-record store to a temp dir so tests never touch the
+            // real ~/.config/kcap/daemons.
+            StateDir            = Path.Combine(Path.GetTempPath(), "kcap-orch-state-" + Guid.NewGuid().ToString("N")[..8])
         };
 
         if (allowedRepoPath is not null) {

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -67,7 +67,7 @@ public partial class AgentOrchestratorVendorTests {
             ClaudePath          = "claude",
             MaxConcurrentAgents = 5,
             WorktreeRoot        = Path.Combine(Path.GetTempPath(), "kcap-orch-wt-" + Guid.NewGuid().ToString("N")[..8]),
-            // AI-1313 Phase B (D4): isolate the PID-record store to a temp dir so tests never touch the
+            // Phase B (D4): isolate the PID-record store to a temp dir so tests never touch the
             // real ~/.config/kcap/daemons.
             StateDir            = Path.Combine(Path.GetTempPath(), "kcap-orch-state-" + Guid.NewGuid().ToString("N")[..8])
         };
@@ -76,7 +76,7 @@ public partial class AgentOrchestratorVendorTests {
             config.AllowedRepoPaths = [allowedRepoPath];
         }
 
-        configure?.Invoke(config); // AI-1313 Phase B: let a test tweak the config (e.g. reviewer TTL bounds)
+        configure?.Invoke(config); // Phase B: let a test tweak the config (e.g. reviewer TTL bounds)
 
         var worktreeManager  = new WorktreeManager(config, NullLogger<WorktreeManager>.Instance);
         var repoMatcher      = new RepoMatcher(config, NullLogger<RepoMatcher>.Instance);
@@ -1093,7 +1093,7 @@ public partial class AgentOrchestratorVendorTests {
         /// CleanupAgentAsync, so a useful signal that local cleanup completed.</summary>
         public Action? OnAgentUnregistered { get; init; }
 
-        /// <summary>Every agent id passed to AgentUnregisteredAsync, in call order. AI-1313 Phase B
+        /// <summary>Every agent id passed to AgentUnregisteredAsync, in call order. Phase B
         /// (D1): a single-flight teardown must unregister an agent exactly once even under a racing
         /// launch-catch + read-loop cleanup.</summary>
         public List<string> AgentUnregisteredCalls { get; } = [];

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/AgentKillQuarantineTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/AgentKillQuarantineTests.cs
@@ -1,0 +1,78 @@
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// AI-1313 Phase B (D4 §6.4(2a)): <see cref="AgentKillQuarantine"/> — the in-memory holding pen for
+/// agents whose death could not be confirmed at teardown. A quarantined entry counts against admission
+/// (via the orchestrator's <c>EffectiveCount</c>) and the heartbeat retries the kill by EXACT identity
+/// until confirmed gone, then drains it. Acts only on a test-owned <see cref="DummyProcess"/>.
+/// </summary>
+public class AgentKillQuarantineTests {
+    [Test]
+    public async Task Add_counts_and_snapshot_carries_flow_identity() {
+        var q = new AgentKillQuarantine(NullLogger.Instance);
+        var created = DateTimeOffset.UtcNow;
+
+        q.Add(new AgentKillQuarantine.Entry("q1", 4242, "ident", "ReviewFlow", created, "flow-9", "reviewer"));
+
+        await Assert.That(q.Count).IsEqualTo(1);
+
+        var snap = q.Snapshot();
+        await Assert.That(snap.Count).IsEqualTo(1);
+        await Assert.That(snap[0].Id).IsEqualTo("q1");
+        await Assert.That(snap[0].Kind).IsEqualTo("ReviewFlow");
+        await Assert.That(snap[0].FlowRunId).IsEqualTo("flow-9");
+        await Assert.That(snap[0].FlowRole).IsEqualTo("reviewer");
+    }
+
+    [Test]
+    public async Task Add_is_idempotent_per_agent_id() {
+        var q = new AgentKillQuarantine(NullLogger.Instance);
+
+        q.Add(new AgentKillQuarantine.Entry("dup", 1, "a", "ReviewFlow", DateTimeOffset.UtcNow, null, null));
+        q.Add(new AgentKillQuarantine.Entry("dup", 2, "b", "ReviewFlow", DateTimeOffset.UtcNow, null, null));
+
+        await Assert.That(q.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task RetryAll_kills_a_live_child_by_identity_then_drains_it() {
+        using var dummy = DummyProcess.StartSleep(
+            30, new Dictionary<string, string> { ["KCAP_AGENT_ID"] = "q1" });
+
+        var identity = ProcessIdentity.Capture(dummy.Pid);
+        await Assert.That(identity).IsNotNull();
+
+        var q = new AgentKillQuarantine(NullLogger.Instance);
+        q.Add(new AgentKillQuarantine.Entry(
+            "q1", dummy.Pid, identity!, "ReviewFlow", DateTimeOffset.UtcNow, null, null));
+
+        await Assert.That(q.Count).IsEqualTo(1);
+
+        // One retry kills the child by exact identity (no env check needed — we own it) and, on
+        // confirmed death, drains the entry so it stops counting against admission.
+        await q.RetryAllAsync(CancellationToken.None);
+
+        await Assert.That(dummy.HasExited).IsTrue();
+        await Assert.That(q.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RetryAll_drains_an_already_gone_process_without_a_kill() {
+        // A process that is already gone (PID reused / exited) is confirmed-gone immediately and
+        // drained — the retry never needs to signal anything.
+        using var dummy = DummyProcess.StartSleep(30);
+        var identity = ProcessIdentity.Capture(dummy.Pid)!;
+        dummy.Kill();
+        dummy.WaitForExit(TimeSpan.FromSeconds(5));
+
+        var q = new AgentKillQuarantine(NullLogger.Instance);
+        q.Add(new AgentKillQuarantine.Entry("gone", dummy.Pid, identity, "ReviewFlow", DateTimeOffset.UtcNow, null, null));
+
+        await q.RetryAllAsync(CancellationToken.None);
+
+        await Assert.That(q.Count).IsEqualTo(0);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/AgentKillQuarantineTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/AgentKillQuarantineTests.cs
@@ -51,11 +51,16 @@ public class AgentKillQuarantineTests {
 
         await Assert.That(q.Count).IsEqualTo(1);
 
-        // One retry kills the child by exact identity (no env check needed — we own it) and, on
-        // confirmed death, drains the entry so it stops counting against admission.
+        // First retry kills the child by exact identity (no env check needed — we own it). The child
+        // dies but, as a direct child of this test process, may linger as an unreaped zombie whose
+        // liveness is momentarily ambiguous — so it is retained (fail closed), exactly as a stuck child
+        // is across heartbeat ticks in production.
         await q.RetryAllAsync(CancellationToken.None);
-
+        dummy.WaitForExit(TimeSpan.FromSeconds(8)); // reap it → liveness is now unambiguous
         await Assert.That(dummy.HasExited).IsTrue();
+
+        // Second retry observes CONFIRMED death and drains the entry so it stops counting against admission.
+        await q.RetryAllAsync(CancellationToken.None);
         await Assert.That(q.Count).IsEqualTo(0);
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/AgentKillQuarantineTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/AgentKillQuarantineTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// AI-1313 Phase B (D4 §6.4(2a)): <see cref="AgentKillQuarantine"/> — the in-memory holding pen for
+/// Phase B (D4 §6.4(2a)): <see cref="AgentKillQuarantine"/> — the in-memory holding pen for
 /// agents whose death could not be confirmed at teardown. A quarantined entry counts against admission
 /// (via the orchestrator's <c>EffectiveCount</c>) and the heartbeat retries the kill by EXACT identity
 /// until confirmed gone, then drains it. Acts only on a test-owned <see cref="DummyProcess"/>.

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/AgentPidRecordStoreTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/AgentPidRecordStoreTests.cs
@@ -1,0 +1,68 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// AI-1313 Phase B (D4 §6.4(2)): <see cref="AgentPidRecordStore"/> — atomic write/read/delete round-trip
+/// (exact identity preserved) and corrupt-record quarantine.
+/// </summary>
+public class AgentPidRecordStoreTests {
+    static string NewStateDir() {
+        var dir = Path.Combine(Path.GetTempPath(), "kcap-pidrec-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    static AgentPidRecord Rec(string agentId, int pid = 123) =>
+        new(agentId, pid, "lx:boot:999", "ReviewFlow", "codex", "flow-1", "reviewer", "daemon-id", "epoch-1", DateTimeOffset.UtcNow);
+
+    [Test]
+    public async Task Write_ReadAll_Delete_roundtrip_preserves_exact_identity() {
+        var dir   = NewStateDir();
+        var store = new AgentPidRecordStore(dir, NullLogger.Instance);
+
+        store.Write(Rec("a1", pid: 4242));
+
+        var all = store.ReadAll();
+        await Assert.That(all).Count().IsEqualTo(1);
+        await Assert.That(all[0].Pid).IsEqualTo(4242);
+        await Assert.That(all[0].StartIdentity).IsEqualTo("lx:boot:999");
+        await Assert.That(all[0].FlowRunId).IsEqualTo("flow-1");
+
+        await Assert.That(store.Delete("a1")).IsTrue();
+        await Assert.That(store.ReadAll()).IsEmpty();
+        await Assert.That(store.Delete("a1")).IsFalse(); // idempotent
+    }
+
+    [Test]
+    public async Task ReadAll_quarantines_a_corrupt_record_and_excludes_it() {
+        var dir   = NewStateDir();
+        var store = new AgentPidRecordStore(dir, NullLogger.Instance);
+        store.Write(Rec("good"));
+
+        var agentsDir = Path.Combine(dir, "agents");
+        File.WriteAllText(Path.Combine(agentsDir, "bad.json"), "{ not valid json");
+
+        var all = store.ReadAll();
+
+        await Assert.That(all.Select(r => r.AgentId)).IsEquivalentTo(new[] { "good" });
+        await Assert.That(File.Exists(Path.Combine(agentsDir, "bad.json.corrupt"))).IsTrue();
+        await Assert.That(File.Exists(Path.Combine(agentsDir, "bad.json"))).IsFalse();
+    }
+
+    [Test]
+    public async Task Write_is_atomic_overwrite_no_temp_files_left() {
+        var dir   = NewStateDir();
+        var store = new AgentPidRecordStore(dir, NullLogger.Instance);
+
+        store.Write(Rec("a1", pid: 1));
+        store.Write(Rec("a1", pid: 2)); // overwrite
+
+        var all = store.ReadAll();
+        await Assert.That(all).Count().IsEqualTo(1);
+        await Assert.That(all[0].Pid).IsEqualTo(2);
+        await Assert.That(Directory.EnumerateFiles(Path.Combine(dir, "agents"), "*.tmp-*")).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/AgentPidRecordStoreTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/AgentPidRecordStoreTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// AI-1313 Phase B (D4 §6.4(2)): <see cref="AgentPidRecordStore"/> — atomic write/read/delete round-trip
+/// Phase B (D4 §6.4(2)): <see cref="AgentPidRecordStore"/> — atomic write/read/delete round-trip
 /// (exact identity preserved) and corrupt-record quarantine.
 /// </summary>
 public class AgentPidRecordStoreTests {
@@ -50,6 +50,24 @@ public class AgentPidRecordStoreTests {
         await Assert.That(all.Select(r => r.AgentId)).IsEquivalentTo(new[] { "good" });
         await Assert.That(File.Exists(Path.Combine(agentsDir, "bad.json.corrupt"))).IsTrue();
         await Assert.That(File.Exists(Path.Combine(agentsDir, "bad.json"))).IsFalse();
+    }
+
+    [Test]
+    public async Task Write_hashes_a_path_traversal_agent_id_inside_the_agents_dir() {
+        var dir   = NewStateDir();
+        var store = new AgentPidRecordStore(dir, NullLogger.Instance);
+        var agentsDir = Path.Combine(dir, "agents");
+
+        // A hostile agent id (path separators / ".." — the id crosses the wire unconstrained) must not
+        // escape the agents directory: the filename is a hash, and the record round-trips by its original id.
+        store.Write(Rec("../../evil", pid: 7));
+
+        var files = Directory.GetFiles(agentsDir, "*.json");
+        await Assert.That(files.Length).IsEqualTo(1);
+        await Assert.That(Path.GetFileName(files[0])).DoesNotContain("evil"); // hashed, not the raw id
+        await Assert.That(store.ReadAll().Any(r => r.AgentId == "../../evil")).IsTrue();
+        await Assert.That(store.Delete("../../evil")).IsTrue();
+        await Assert.That(store.ReadAll()).IsEmpty();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusDtoTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusDtoTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// AI-1313 Phase B (D2): the additive daemon self-report DTOs round-trip through the source-gen
+/// Phase B (D2): the additive daemon self-report DTOs round-trip through the source-gen
 /// <see cref="CapacitorJsonContext"/>, and the new trailing fields on existing wire types stay
 /// backward-compatible (an old server's JSON without them still deserializes).
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusDtoTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusDtoTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// AI-1313 Phase B (D2): the additive daemon self-report DTOs round-trip through the source-gen
+/// <see cref="CapacitorJsonContext"/>, and the new trailing fields on existing wire types stay
+/// backward-compatible (an old server's JSON without them still deserializes).
+/// </summary>
+public class DaemonStatusDtoTests {
+    [Test]
+    public async Task DaemonStatusReport_roundtrips_through_source_gen_context() {
+        var report = new DaemonStatusReport(
+            ActiveCount: 2,
+            LiveAgents:  [new LiveAgentInfo("a1", "ReviewFlow", DateTimeOffset.UtcNow, "flow-1", "reviewer")],
+            Quarantined: [new QuarantinedAgentInfo("a2", "Default", DateTimeOffset.UtcNow)]);
+
+        var json = JsonSerializer.Serialize(report, CapacitorJsonContext.Default.DaemonStatusReport);
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.DaemonStatusReport);
+
+        await Assert.That(back.ActiveCount).IsEqualTo(2);
+        await Assert.That(back.LiveAgents).Count().IsEqualTo(1);
+        await Assert.That(back.LiveAgents[0].FlowRunId).IsEqualTo("flow-1");
+        await Assert.That(back.LiveAgents[0].FlowRole).IsEqualTo("reviewer");
+        await Assert.That(back.Quarantined[0].Id).IsEqualTo("a2");
+    }
+
+    [Test]
+    public async Task LaunchAgentCommand_without_flow_fields_roundtrips_with_nulls() {
+        // An old server builds the command without the new trailing FlowRunId/FlowRole (they default
+        // to null). STJ source-gen binds by name, so the additive trailing params can't break the
+        // wire: a command serialized without them deserializes back with the required fields intact
+        // and the new fields null.
+        var cmd = new LaunchAgentCommand(
+            AgentId: "a1", Prompt: null, Model: "default", Effort: null,
+            RepoPath: "/r", Tools: null, AttachmentIds: null, Vendor: "codex");
+
+        var json = JsonSerializer.Serialize(cmd, CapacitorJsonContext.Default.LaunchAgentCommand);
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.LaunchAgentCommand);
+
+        await Assert.That(back.AgentId).IsEqualTo("a1");
+        await Assert.That(back.Vendor).IsEqualTo("codex");
+        await Assert.That(back.FlowRunId).IsNull();
+        await Assert.That(back.FlowRole).IsNull();
+    }
+
+    [Test]
+    public async Task DaemonConnect_old_json_without_live_agents_still_deserializes() {
+        const string oldJson = """
+                               {"name":"tony","platform":"macOS","repoPaths":[],"maxAgents":5,"liveAgentIds":[]}
+                               """;
+
+        var connect = JsonSerializer.Deserialize(oldJson, CapacitorJsonContext.Default.DaemonConnect);
+
+        await Assert.That(connect.Name).IsEqualTo("tony");
+        await Assert.That(connect.LiveAgents).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusReportTests.cs
@@ -1,0 +1,27 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-1313 Phase B (D2): <see cref="AgentOrchestrator.BuildStatusReport"/> reports the daemon's
+/// authoritative ActiveCount + live-agent metadata (quarantine wired in D4/Task 8).
+/// Partial of <see cref="AgentOrchestratorVendorTests"/> to reuse its test doubles.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task BuildStatusReport_reports_active_count_and_live_agents() {
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        orch.SeedAgentForTest("a1", LaunchKind.ReviewFlow, status: "Running", flowRunId: "f1", flowRole: "reviewer");
+        orch.SeedAgentForTest("a2", LaunchKind.Default,    status: "Running");
+        orch.SeedAgentForTest("a3", LaunchKind.Default,    status: "Stopped");
+
+        var report = orch.BuildStatusReport();
+
+        await Assert.That(report.ActiveCount).IsEqualTo(2); // a1 + a2 (a3 stopped)
+        await Assert.That(report.LiveAgents.Select(x => x.Id)).IsEquivalentTo(new[] { "a1", "a2" });
+        await Assert.That(report.Quarantined).IsEmpty(); // until D4/Task 8
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusReportTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1313 Phase B (D2): <see cref="AgentOrchestrator.BuildStatusReport"/> reports the daemon's
+/// Phase B (D2): <see cref="AgentOrchestrator.BuildStatusReport"/> reports the daemon's
 /// authoritative ActiveCount + live-agent metadata (quarantine wired in D4/Task 8).
 /// Partial of <see cref="AgentOrchestratorVendorTests"/> to reuse its test doubles.
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DummyProcess.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DummyProcess.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// AI-1313 Phase B: a real, isolated child process a test fully owns — the ONLY thing the D4 reap
+/// tests ever signal (spec §2/§8: no live daemon, no live flows). Sleeps for a while so the test can
+/// probe/kill it, and can carry custom <c>KCAP_*</c> env markers for the env-based reap paths.
+/// </summary>
+internal sealed class DummyProcess : IDisposable {
+    readonly Process _proc;
+
+    DummyProcess(Process proc) => _proc = proc;
+
+    public int  Pid       => _proc.Id;
+    public bool HasExited => _proc.HasExited;
+
+    public static DummyProcess StartSleep(int seconds, IDictionary<string, string>? env = null) {
+        var psi = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("cmd.exe", $"/c timeout /t {seconds} >NUL")
+            : new ProcessStartInfo("sleep", seconds.ToString());
+
+        psi.UseShellExecute = false;
+
+        if (env is not null)
+            foreach (var (k, v) in env)
+                psi.Environment[k] = v;
+
+        return new DummyProcess(Process.Start(psi) ?? throw new InvalidOperationException("failed to start dummy process"));
+    }
+
+    public void Kill() {
+        try { _proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+    }
+
+    public bool WaitForExit(TimeSpan timeout) => _proc.WaitForExit((int) timeout.TotalMilliseconds);
+    public void WaitForExit()                 => _proc.WaitForExit();
+
+    public void Dispose() {
+        try { if (!_proc.HasExited) _proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+        _proc.Dispose();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DummyProcess.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DummyProcess.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// AI-1313 Phase B: a real, isolated child process a test fully owns — the ONLY thing the D4 reap
+/// Phase B: a real, isolated child process a test fully owns — the ONLY thing the D4 reap
 /// tests ever signal (spec §2/§8: no live daemon, no live flows). Sleeps for a while so the test can
 /// probe/kill it, and can carry custom <c>KCAP_*</c> env markers for the env-based reap paths.
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LiveAgentsSnapshotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LiveAgentsSnapshotTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1313 Phase B (D2): <see cref="AgentOrchestrator.BuildLiveAgents"/> reflects each live agent's
+/// Phase B (D2): <see cref="AgentOrchestrator.BuildLiveAgents"/> reflects each live agent's
 /// kind + flow identity and mirrors the <c>GetLiveAgentIds</c> filter (Starting/Running, non-private).
 /// Declared as a partial of <see cref="AgentOrchestratorVendorTests"/> to reuse its
 /// <c>BuildOrchestrator</c> + <c>CaptureServerConnection</c> + <c>SpyPtyProcessFactory</c> doubles.

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LiveAgentsSnapshotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LiveAgentsSnapshotTests.cs
@@ -1,0 +1,29 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-1313 Phase B (D2): <see cref="AgentOrchestrator.BuildLiveAgents"/> reflects each live agent's
+/// kind + flow identity and mirrors the <c>GetLiveAgentIds</c> filter (Starting/Running, non-private).
+/// Declared as a partial of <see cref="AgentOrchestratorVendorTests"/> to reuse its
+/// <c>BuildOrchestrator</c> + <c>CaptureServerConnection</c> + <c>SpyPtyProcessFactory</c> doubles.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task BuildLiveAgents_carries_reviewflow_identity_and_excludes_stopped_and_private() {
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        orch.SeedAgentForTest("a1", LaunchKind.ReviewFlow, status: "Running", flowRunId: "flow-1", flowRole: "reviewer");
+        orch.SeedAgentForTest("a2", LaunchKind.Default,    status: "Stopped");
+        orch.SeedAgentForTest("a3", LaunchKind.Default,    status: "Running", isPrivate: true);
+
+        var live = orch.BuildLiveAgents();
+
+        await Assert.That(live.Select(x => x.Id)).IsEquivalentTo(new[] { "a1" });
+        await Assert.That(live[0].Kind).IsEqualTo("ReviewFlow");
+        await Assert.That(live[0].FlowRunId).IsEqualTo("flow-1");
+        await Assert.That(live[0].FlowRole).IsEqualTo("reviewer");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/OrphanReaperTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/OrphanReaperTests.cs
@@ -33,7 +33,10 @@ public class OrphanReaperTests {
         var reaper = new OrphanReaper(store, daemonId: "did", currentEpoch: "new-epoch", NullLogger.Instance);
         await reaper.ReapOnceAsync();
 
-        if (OperatingSystem.IsLinux()) {
+        // Record-pass kills once ownership is provable: Linux confirms via the KCAP_AGENT_ID env,
+        // Windows has no Unix env guard so an exact (pid, start-identity) match suffices. Only macOS 26
+        // spares (env redacted → the Unix env guard can't confirm; ambiguity never kills).
+        if (!OperatingSystem.IsMacOS()) {
             dummy.WaitForExit(TimeSpan.FromSeconds(8));
             await Assert.That(dummy.HasExited).IsTrue();
             await Assert.That(store.ReadAll()).IsEmpty();

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/OrphanReaperTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/OrphanReaperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// AI-1313 Phase B (D4 §6.4(3)): <see cref="OrphanReaper"/> — reaps hosted-agent children that outlived
+/// Phase B (D4 §6.4(3)): <see cref="OrphanReaper"/> — reaps hosted-agent children that outlived
 /// a prior daemon run. Acts only on test-owned <see cref="DummyProcess"/> instances. OS-aware: the
 /// env-dependent reaps confirm-and-kill on Linux (readable <c>/proc/{pid}/environ</c>) but SPARE on
 /// macOS 26 (env redacted — ambiguity never kills); the epoch-guard and gone-process paths are

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/OrphanReaperTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/OrphanReaperTests.cs
@@ -1,0 +1,115 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// AI-1313 Phase B (D4 §6.4(3)): <see cref="OrphanReaper"/> — reaps hosted-agent children that outlived
+/// a prior daemon run. Acts only on test-owned <see cref="DummyProcess"/> instances. OS-aware: the
+/// env-dependent reaps confirm-and-kill on Linux (readable <c>/proc/{pid}/environ</c>) but SPARE on
+/// macOS 26 (env redacted — ambiguity never kills); the epoch-guard and gone-process paths are
+/// OS-independent.
+/// </summary>
+public class OrphanReaperTests {
+    static AgentPidRecordStore NewStore() {
+        var dir = Path.Combine(Path.GetTempPath(), "kcap-orphan-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return new AgentPidRecordStore(dir, NullLogger.Instance);
+    }
+
+    static AgentPidRecord Rec(string agentId, int pid, string identity, string daemonId, string epoch) =>
+        new(agentId, pid, identity, "ReviewFlow", "codex", "flow-1", "reviewer", daemonId, epoch, DateTimeOffset.UtcNow);
+
+    [Test]
+    public async Task Record_pass_reaps_a_prior_incarnation_survivor_and_deletes_the_record() {
+        var store = NewStore();
+        using var dummy = DummyProcess.StartSleep(
+            30, new Dictionary<string, string> { ["KCAP_AGENT_ID"] = "orphan" });
+        var identity = ProcessIdentity.Capture(dummy.Pid)!;
+
+        store.Write(Rec("orphan", dummy.Pid, identity, daemonId: "did", epoch: "old-epoch"));
+
+        var reaper = new OrphanReaper(store, daemonId: "did", currentEpoch: "new-epoch", NullLogger.Instance);
+        await reaper.ReapOnceAsync();
+
+        if (OperatingSystem.IsLinux()) {
+            dummy.WaitForExit(TimeSpan.FromSeconds(8));
+            await Assert.That(dummy.HasExited).IsTrue();
+            await Assert.That(store.ReadAll()).IsEmpty();
+        } else {
+            // macOS: env unreadable → SPARED; process alive, record retained for a later attempt.
+            await Assert.That(dummy.HasExited).IsFalse();
+            await Assert.That(store.ReadAll().Any(r => r.AgentId == "orphan")).IsTrue();
+            dummy.Kill();
+        }
+    }
+
+    [Test]
+    public async Task Record_pass_leaves_a_current_incarnation_record_and_its_live_agent_untouched() {
+        // The epoch guard is the load-bearing safety property for the HEARTBEAT re-run: a record whose
+        // epoch equals the running daemon's must NEVER be reaped — it belongs to a live current agent.
+        var store = NewStore();
+        using var dummy = DummyProcess.StartSleep(
+            30, new Dictionary<string, string> { ["KCAP_AGENT_ID"] = "live" });
+        var identity = ProcessIdentity.Capture(dummy.Pid)!;
+
+        store.Write(Rec("live", dummy.Pid, identity, daemonId: "did", epoch: "cur-epoch"));
+
+        // Same currentEpoch as the record → must be skipped entirely (before any env read).
+        var reaper = new OrphanReaper(store, daemonId: "did", currentEpoch: "cur-epoch", NullLogger.Instance);
+        await reaper.ReapOnceAsync();
+
+        await Assert.That(dummy.HasExited).IsFalse();
+        await Assert.That(store.ReadAll().Any(r => r.AgentId == "live")).IsTrue();
+        dummy.Kill();
+    }
+
+    [Test]
+    public async Task Record_pass_deletes_a_stale_record_whose_process_is_already_gone() {
+        var store = NewStore();
+        using var dummy = DummyProcess.StartSleep(30);
+        var identity = ProcessIdentity.Capture(dummy.Pid)!;
+        var pid = dummy.Pid;
+        dummy.Kill();
+        dummy.WaitForExit(TimeSpan.FromSeconds(5));
+
+        store.Write(Rec("gone", pid, identity, daemonId: "did", epoch: "old-epoch"));
+
+        var reaper = new OrphanReaper(store, daemonId: "did", currentEpoch: "new-epoch", NullLogger.Instance);
+        await reaper.ReapOnceAsync();
+
+        // Process gone (or PID reused → proven identity mismatch) → the stale record is deleted.
+        await Assert.That(store.ReadAll()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Env_marker_scan_reaps_a_stale_epoch_survivor_of_this_daemon_only() {
+        using var stale = DummyProcess.StartSleep(30, new Dictionary<string, string> {
+            ["KCAP_AGENT_ID"] = "s", ["KCAP_DAEMON_ID"] = "did", ["KCAP_DAEMON_EPOCH"] = "old" });
+        using var other = DummyProcess.StartSleep(30, new Dictionary<string, string> {
+            ["KCAP_AGENT_ID"] = "o", ["KCAP_DAEMON_ID"] = "OTHER", ["KCAP_DAEMON_EPOCH"] = "old" });
+        using var mine = DummyProcess.StartSleep(30, new Dictionary<string, string> {
+            ["KCAP_AGENT_ID"] = "m", ["KCAP_DAEMON_ID"] = "did", ["KCAP_DAEMON_EPOCH"] = "new" });
+
+        // Empty store → the record pass is a no-op; only the env-marker scan runs.
+        var reaper = new OrphanReaper(NewStore(), daemonId: "did", currentEpoch: "new", NullLogger.Instance);
+        await reaper.ReapOnceAsync();
+
+        if (OperatingSystem.IsLinux()) {
+            stale.WaitForExit(TimeSpan.FromSeconds(8));
+            await Assert.That(stale.HasExited).IsTrue();  // this daemon, prior epoch → reaped
+            await Assert.That(other.HasExited).IsFalse(); // different daemon → spared
+            await Assert.That(mine.HasExited).IsFalse();  // current epoch → spared
+        } else {
+            // macOS: env of another process can't be read → the scan finds nothing → all spared.
+            await Assert.That(stale.HasExited).IsFalse();
+            await Assert.That(other.HasExited).IsFalse();
+            await Assert.That(mine.HasExited).IsFalse();
+        }
+
+        other.Kill();
+        mine.Kill();
+        stale.Kill();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ProcessIdentityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ProcessIdentityTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// AI-1313 Phase B (D4): <see cref="ProcessIdentity"/> — exact start-identity match against a live
+/// Phase B (D4): <see cref="ProcessIdentity"/> — exact start-identity match against a live
 /// process (and NOT after it exits), plus reading a KCAP_* env marker from a live process. Acts only
 /// on test-owned <see cref="DummyProcess"/> instances.
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ProcessIdentityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ProcessIdentityTests.cs
@@ -1,0 +1,50 @@
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// AI-1313 Phase B (D4): <see cref="ProcessIdentity"/> — exact start-identity match against a live
+/// process (and NOT after it exits), plus reading a KCAP_* env marker from a live process. Acts only
+/// on test-owned <see cref="DummyProcess"/> instances.
+/// </summary>
+public class ProcessIdentityTests {
+    [Test]
+    public async Task Capture_then_Matches_holds_for_live_process_and_fails_after_exit() {
+        using var dummy = DummyProcess.StartSleep(30);
+
+        var identity = ProcessIdentity.Capture(dummy.Pid);
+        await Assert.That(identity).IsNotNull();
+        await Assert.That(ProcessIdentity.Matches(dummy.Pid, identity!)).IsTrue();
+        await Assert.That(ProcessIdentity.IsAlive(dummy.Pid)).IsTrue();
+
+        dummy.Kill();
+        dummy.WaitForExit(TimeSpan.FromSeconds(8));
+
+        await Assert.That(ProcessIdentity.Matches(dummy.Pid, identity!)).IsFalse();
+    }
+
+    [Test]
+    public async Task ReadAgentEnv_reads_a_kcap_marker_where_the_OS_allows_it() {
+        using var dummy = DummyProcess.StartSleep(30, new Dictionary<string, string> {
+            ["KCAP_AGENT_ID"]     = "agent-xyz",
+            ["KCAP_DAEMON_EPOCH"] = "epoch-1",
+        });
+
+        var agentId = ProcessIdentity.ReadAgentEnv(dummy.Pid, "KCAP_AGENT_ID");
+
+        if (OperatingSystem.IsLinux()) {
+            // /proc/{pid}/environ is same-uid readable — the production (Linux) path reads the marker.
+            await Assert.That(agentId).IsEqualTo("agent-xyz");
+            await Assert.That(ProcessIdentity.ReadAgentEnv(dummy.Pid, "KCAP_DAEMON_EPOCH")).IsEqualTo("epoch-1");
+            await Assert.That(ProcessIdentity.ReadAgentEnv(dummy.Pid, "KCAP_NOT_SET")).IsNull();
+        } else {
+            // macOS 26 redacts the env from KERN_PROCARGS2 for a same-user non-root reader (and ps -E),
+            // so cross-process env reading is unavailable — the method degrades to null (callers then
+            // SPARE the process; never a false read). Windows has no scan path. Either way: never a
+            // wrong non-null value.
+            await Assert.That(agentId is null or "agent-xyz").IsTrue();
+        }
+
+        dummy.Kill();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ReviewerTtlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ReviewerTtlTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1313 Phase B (D3): the reviewer lifetime/idle backstop — <see cref="AgentOrchestrator.FindReviewersToReap"/>
+/// Phase B (D3): the reviewer lifetime/idle backstop — <see cref="AgentOrchestrator.FindReviewersToReap"/>
 /// reaps a Running ReviewFlow agent past its lifetime/idle bound and never an interactive agent.
 /// Partial of <see cref="AgentOrchestratorVendorTests"/> to reuse its test doubles.
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ReviewerTtlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ReviewerTtlTests.cs
@@ -1,0 +1,52 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-1313 Phase B (D3): the reviewer lifetime/idle backstop — <see cref="AgentOrchestrator.FindReviewersToReap"/>
+/// reaps a Running ReviewFlow agent past its lifetime/idle bound and never an interactive agent.
+/// Partial of <see cref="AgentOrchestratorVendorTests"/> to reuse its test doubles.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task FindReviewersToReap_flags_lifetime_and_idle_but_not_interactive() {
+        var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.ClockUtc = () => now; // defaults: 6h lifetime / 2h idle
+
+        // 7h-old reviewer → past the 6h lifetime.
+        orch.SeedAgentForTest("rev-old", LaunchKind.ReviewFlow, status: "Running",
+            createdAt: now.AddHours(-7), lastOutputAt: now.AddMinutes(-1));
+        // fresh reviewer, but idle 3h → past the 2h idle bound.
+        orch.SeedAgentForTest("rev-idle", LaunchKind.ReviewFlow, status: "Running",
+            createdAt: now.AddHours(-1), lastOutputAt: now.AddHours(-3));
+        // interactive agent of the same age → never reaped by this backstop.
+        orch.SeedAgentForTest("interactive", LaunchKind.Default, status: "Running",
+            createdAt: now.AddHours(-7), lastOutputAt: now.AddHours(-7));
+        // healthy reviewer → left alone.
+        orch.SeedAgentForTest("rev-fresh", LaunchKind.ReviewFlow, status: "Running",
+            createdAt: now.AddMinutes(-10), lastOutputAt: now.AddMinutes(-1));
+
+        var reap = orch.FindReviewersToReap();
+
+        await Assert.That(reap).Contains(("rev-old", "reviewer_ttl_expired"));
+        await Assert.That(reap).Contains(("rev-idle", "reviewer_idle_expired"));
+        await Assert.That(reap.Select(r => r.Id)).DoesNotContain("interactive");
+        await Assert.That(reap.Select(r => r.Id)).DoesNotContain("rev-fresh");
+    }
+
+    [Test]
+    public async Task FindReviewersToReap_disabled_when_bounds_are_zero() {
+        var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            configure: c => { c.ReviewerMaxLifetime = TimeSpan.Zero; c.ReviewerIdleTimeout = TimeSpan.Zero; });
+        orch.ClockUtc = () => now;
+        orch.SeedAgentForTest("rev", LaunchKind.ReviewFlow, status: "Running",
+            createdAt: now.AddHours(-99), lastOutputAt: now.AddHours(-99));
+
+        await Assert.That(orch.FindReviewersToReap()).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/StopAgentPidFallbackTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/StopAgentPidFallbackTests.cs
@@ -1,0 +1,51 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Tests.Unit.Daemon;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-1313 Phase B (D4 §6.4(3)): <c>HandleStopAgent</c> for an id not in the registry falls back to the
+/// PID record and reaps a matching live process by exact identity. OS-aware: Linux confirms the
+/// <c>KCAP_AGENT_ID</c> env and reaps; macOS 26 can't read the env, so it SPARES (ambiguity never
+/// kills). Partial of <see cref="AgentOrchestratorVendorTests"/> to call the private HandleStopAgent.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task HandleStopAgent_unknown_id_reaps_by_pid_record_where_env_is_readable() {
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        using var dummy = DummyProcess.StartSleep(30, new Dictionary<string, string> { ["KCAP_AGENT_ID"] = "ghost" });
+        var identity = ProcessIdentity.Capture(dummy.Pid);
+        await Assert.That(identity).IsNotNull();
+
+        orch.WritePidRecordForTest(new AgentPidRecord(
+            "ghost", dummy.Pid, identity!, "ReviewFlow", "codex", "f1", "reviewer",
+            orch.DaemonIdForTest, orch.DaemonEpochForTest, DateTimeOffset.UtcNow));
+
+        await orch.HandleStopAgent("ghost");
+
+        if (OperatingSystem.IsLinux()) {
+            // Env-confirmable → reaped by identity, record deleted on confirmed death.
+            dummy.WaitForExit(TimeSpan.FromSeconds(10));
+            await Assert.That(dummy.HasExited).IsTrue();
+            await Assert.That(orch.PidRecordsForTest().Any(r => r.AgentId == "ghost")).IsFalse();
+        } else {
+            // macOS: env unreadable → SPARED; process still alive, record retained for a later sweep.
+            await Assert.That(dummy.HasExited).IsFalse();
+            await Assert.That(orch.PidRecordsForTest().Any(r => r.AgentId == "ghost")).IsTrue();
+            dummy.Kill();
+        }
+    }
+
+    [Test]
+    public async Task HandleStopAgent_unknown_id_with_no_record_is_a_noop() {
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        // No record, no in-memory agent → must not throw.
+        await orch.HandleStopAgent("does-not-exist");
+        await Assert.That(orch.PidRecordsForTest()).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/StopAgentPidFallbackTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/StopAgentPidFallbackTests.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Tests.Unit.Daemon;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1313 Phase B (D4 §6.4(3)): <c>HandleStopAgent</c> for an id not in the registry falls back to the
+/// Phase B (D4 §6.4(3)): <c>HandleStopAgent</c> for an id not in the registry falls back to the
 /// PID record and reaps a matching live process by exact identity. OS-aware: Linux confirms the
 /// <c>KCAP_AGENT_ID</c> env and reaps; macOS 26 can't read the env, so it SPARES (ambiguity never
 /// kills). Partial of <see cref="AgentOrchestratorVendorTests"/> to call the private HandleStopAgent.

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/StopAgentPidFallbackTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/StopAgentPidFallbackTests.cs
@@ -26,8 +26,12 @@ public partial class AgentOrchestratorVendorTests {
 
         await orch.HandleStopAgent("ghost");
 
-        if (OperatingSystem.IsLinux()) {
-            // Env-confirmable → reaped by identity, record deleted on confirmed death.
+        // The record-pass reap kills once ownership is provable: Linux confirms via the KCAP_AGENT_ID
+        // env, Windows has no Unix env guard so an exact (pid, start-identity) match is sufficient. Only
+        // macOS 26 spares — its env is redacted, so the (Unix) env guard can't confirm and ambiguity
+        // never kills.
+        if (!OperatingSystem.IsMacOS()) {
+            // Linux / Windows → reaped by identity, record deleted on confirmed death.
             dummy.WaitForExit(TimeSpan.FromSeconds(10));
             await Assert.That(dummy.HasExited).IsTrue();
             await Assert.That(orch.PidRecordsForTest().Any(r => r.AgentId == "ghost")).IsFalse();

--- a/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
@@ -91,6 +91,31 @@ public partial class AgentOrchestratorVendorTests {
         dummy.Kill();
     }
 
+    [Test]
+    public async Task Launch_stamps_daemon_identity_env_markers_on_the_spawned_child() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new SpyPtyProcessFactory();
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, Launcher("claude"), allowedRepoPath: repoPath);
+
+            await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                AgentId: "env-1", Prompt: "hi", Model: "opus", Effort: null,
+                RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude"));
+
+            // The OrphanReaper env-marker scan (D4 §6.4(3)) recognizes a recordless survivor by these
+            // three markers on the LIVE child's own env — so the spawn must stamp all three.
+            await Assert.That(ptyFactory.LastEnv).IsNotNull();
+            await Assert.That(ptyFactory.LastEnv!["KCAP_AGENT_ID"]).IsEqualTo("env-1");
+            await Assert.That(ptyFactory.LastEnv!["KCAP_DAEMON_ID"]).IsEqualTo(orch.DaemonIdForTest);
+            await Assert.That(ptyFactory.LastEnv!["KCAP_DAEMON_EPOCH"]).IsEqualTo(orch.DaemonEpochForTest);
+        } finally {
+            cleanup();
+        }
+    }
+
     /// <summary>An <see cref="IPtyProcess"/> that reports a real live child's pid but whose disposal
     /// and termination are deliberately no-ops — models a child that survives teardown, so
     /// CleanupAgentAsync's confirm-death step must quarantine it.</summary>

--- a/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
@@ -71,11 +71,13 @@ public partial class AgentOrchestratorVendorTests {
             server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
 
         // A real, live child whose runtime Dispose/Terminate are no-ops — so it is STILL ALIVE after
-        // CleanupAgentAsync's disposal step, exactly like a stuck child that ignored SIGTERM.
+        // CleanupAgentAsync's disposal step, exactly like a stuck child that ignored SIGTERM. Its stored
+        // start-identity is what proves "still ours" at teardown (recycled-pid-safe).
         using var dummy = DummyProcess.StartSleep(
             30, new Dictionary<string, string> { ["KCAP_AGENT_ID"] = "stuck" });
         orch.SeedAgentForTest("stuck", LaunchKind.ReviewFlow, status: "Running",
-            flowRunId: "flow-1", flowRole: "reviewer", pty: new LiveNoKillPtyProcess(dummy.Pid));
+            flowRunId: "flow-1", flowRole: "reviewer", pty: new LiveNoKillPtyProcess(dummy.Pid),
+            startIdentity: ProcessIdentity.Capture(dummy.Pid));
 
         await orch.CleanupAgentForTest("stuck");
 
@@ -114,6 +116,31 @@ public partial class AgentOrchestratorVendorTests {
         } finally {
             cleanup();
         }
+    }
+
+    [Test]
+    public async Task Teardown_does_not_quarantine_or_kill_a_recycled_pid() {
+        var server = new CaptureServerConnection();
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        // A live, unrelated process occupies the pid, but the agent's STORED identity does not match it
+        // (exactly what a recycled pid looks like: our child exited, the pid was reused). Teardown must
+        // treat our agent as gone — never quarantine, never kill the unrelated occupant.
+        using var unrelated = DummyProcess.StartSleep(30);
+        orch.SeedAgentForTest("recycled", LaunchKind.ReviewFlow, status: "Running",
+            pty: new LiveNoKillPtyProcess(unrelated.Pid),
+            startIdentity: "lx:boot0000:0000000000"); // deliberately NOT the live process's identity
+
+        await orch.CleanupAgentForTest("recycled");
+
+        await Assert.That(orch.GetAgentForTest("recycled")).IsNull();
+        await Assert.That(orch.QuarantineSnapshot().Any(q => q.Id == "recycled")).IsFalse();
+        await Assert.That(orch.EffectiveCount).IsEqualTo(0);
+        await Assert.That(unrelated.HasExited).IsFalse(); // the unrelated process was never signalled
+
+        unrelated.Kill();
     }
 
     /// <summary>An <see cref="IPtyProcess"/> that reports a real live child's pid but whose disposal

--- a/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
@@ -170,6 +170,37 @@ public partial class AgentOrchestratorVendorTests {
         dummy.Kill();
     }
 
+    [Test]
+    public async Task Quarantine_drain_deletes_the_retained_pid_record() {
+        var server = new CaptureServerConnection();
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        // A live child with a durable PID record. Teardown quarantines it (still alive) and RETAINS the
+        // record. Once the child is gone, the quarantine retry must both drain the entry AND delete the
+        // record — otherwise the current-epoch record leaks (the orphan sweep skips it until restart).
+        using var dummy = DummyProcess.StartSleep(30, new Dictionary<string, string> { ["KCAP_AGENT_ID"] = "qr" });
+        var identity = ProcessIdentity.Capture(dummy.Pid)!;
+        orch.WritePidRecordForTest(new AgentPidRecord(
+            "qr", dummy.Pid, identity, "ReviewFlow", "codex", "f1", "reviewer",
+            orch.DaemonIdForTest, orch.DaemonEpochForTest, DateTimeOffset.UtcNow));
+        orch.SeedAgentForTest("qr", LaunchKind.ReviewFlow, status: "Running",
+            pty: new LiveNoKillPtyProcess(dummy.Pid), startIdentity: identity);
+
+        await orch.CleanupAgentForTest("qr");
+        await Assert.That(orch.QuarantineSnapshot().Any(q => q.Id == "qr")).IsTrue();
+        await Assert.That(orch.PidRecordsForTest().Any(r => r.AgentId == "qr")).IsTrue(); // retained while quarantined
+
+        // Child is now gone (reaped) → the retry confirms death, drains the entry, and deletes the record.
+        dummy.Kill();
+        dummy.WaitForExit(TimeSpan.FromSeconds(8));
+        await orch.RetryQuarantineForTest();
+
+        await Assert.That(orch.QuarantineSnapshot().Any(q => q.Id == "qr")).IsFalse();
+        await Assert.That(orch.PidRecordsForTest().Any(r => r.AgentId == "qr")).IsFalse();
+    }
+
     /// <summary>An <see cref="IPtyProcess"/> that reports a real live child's pid but whose disposal
     /// and termination are deliberately no-ops — models a child that survives teardown, so
     /// CleanupAgentAsync's confirm-death step must quarantine it.</summary>

--- a/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
@@ -1,0 +1,117 @@
+using System.Runtime.CompilerServices;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Pty;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Tests.Unit.Daemon;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// AI-1313 Phase B (D1 + D4 §6.4(2a)): the single-flight teardown and the kill-quarantine.
+/// <list type="bullet">
+/// <item>A post-insert launch failure (e.g. a throwing RegisterAgentAsync) routes through the same
+/// <c>CleanupAgentAsync</c> teardown, so it can never strand an agent whose child is still live.</item>
+/// <item>Concurrent teardowns of one agent run exactly once (TryRemove + CleanupStarted gate).</item>
+/// <item>A child that survives teardown is QUARANTINED — retained, counted against admission via
+/// <c>EffectiveCount</c>, and reported in <c>QuarantineSnapshot()</c> — so a stuck-kill mode fails
+/// closed rather than minting unbounded processes.</item>
+/// </list>
+/// Partial of <see cref="AgentOrchestratorVendorTests"/> to reuse its BuildOrchestrator/CreateGitRepo/
+/// CaptureServerConnection/SpyPtyProcessFactory harness.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Post_insert_launch_failure_tears_down_via_single_flight_and_unregisters() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            // AgentRegisteredAsync throws on the launch's RegisterAgentAsync call, AFTER the agent was
+            // inserted into _agents — the exact post-insert failure the D1 routing must catch.
+            var server     = new CaptureServerConnection { AgentRegisteredFailTimes = 1 };
+            var ptyFactory = new SpyPtyProcessFactory();
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, Launcher("claude"), allowedRepoPath: repoPath);
+
+            await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                AgentId: "a1", Prompt: "hi", Model: "opus", Effort: null,
+                RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude"));
+
+            // Routed through CleanupAgentAsync: the registry entry is gone, the launch failed on the
+            // server, and — the discriminator vs the pre-insert path — AgentUnregistered was sent.
+            await Assert.That(orch.GetAgentForTest("a1")).IsNull();
+            await Assert.That(server.LaunchFailedCalls.Any(c => c.AgentId == "a1")).IsTrue();
+            await Assert.That(server.AgentUnregisteredCalls).Contains("a1");
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test]
+    public async Task Concurrent_teardown_of_one_agent_unregisters_exactly_once() {
+        var server = new CaptureServerConnection();
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        orch.SeedAgentForTest("s1", LaunchKind.Default, status: "Running");
+
+        // Two racing teardowns (the launch catch and the read-loop finally, in production) must run
+        // the teardown exactly once.
+        await Task.WhenAll(orch.CleanupAgentForTest("s1"), orch.CleanupAgentForTest("s1"));
+
+        await Assert.That(orch.GetAgentForTest("s1")).IsNull();
+        await Assert.That(server.AgentUnregisteredCalls.Count(x => x == "s1")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Teardown_of_a_child_that_survives_disposal_quarantines_and_counts_it() {
+        var server = new CaptureServerConnection();
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        // A real, live child whose runtime Dispose/Terminate are no-ops — so it is STILL ALIVE after
+        // CleanupAgentAsync's disposal step, exactly like a stuck child that ignored SIGTERM.
+        using var dummy = DummyProcess.StartSleep(
+            30, new Dictionary<string, string> { ["KCAP_AGENT_ID"] = "stuck" });
+        orch.SeedAgentForTest("stuck", LaunchKind.ReviewFlow, status: "Running",
+            flowRunId: "flow-1", flowRole: "reviewer", pty: new LiveNoKillPtyProcess(dummy.Pid));
+
+        await orch.CleanupAgentForTest("stuck");
+
+        // Dropped from the live registry but quarantined: it counts against admission (EffectiveCount)
+        // and is surfaced with its flow identity, so the daemon fails closed until the kill confirms.
+        await Assert.That(orch.GetAgentForTest("stuck")).IsNull();
+        await Assert.That(orch.EffectiveCount).IsEqualTo(1);
+
+        var snap = orch.QuarantineSnapshot();
+        await Assert.That(snap.Any(q => q.Id == "stuck" && q.FlowRunId == "flow-1")).IsTrue();
+
+        // dummy is disposed by the using; also drop the quarantine's hold explicitly for hygiene.
+        dummy.Kill();
+    }
+
+    /// <summary>An <see cref="IPtyProcess"/> that reports a real live child's pid but whose disposal
+    /// and termination are deliberately no-ops — models a child that survives teardown, so
+    /// CleanupAgentAsync's confirm-death step must quarantine it.</summary>
+    sealed class LiveNoKillPtyProcess(int pid) : IPtyProcess {
+        public int  Pid       => pid;
+        public bool HasExited => false;
+        public int? ExitCode  => null;
+
+        public ValueTask DisposeAsync() => default;
+        public Task WaitForExitAsync(TimeSpan? _) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan?   _) => Task.CompletedTask; // deliberately does NOT kill
+
+#pragma warning disable CS1998
+        public async IAsyncEnumerable<byte[]> ReadOutputAsync([EnumeratorCancellation] CancellationToken _ = default) {
+            yield break;
+        }
+#pragma warning restore CS1998
+
+        public Task WriteAsync(string _) => Task.CompletedTask;
+        public Task WriteAsync(byte[] _) => Task.CompletedTask;
+        public void Resize(ushort     _, ushort __) { }
+        public void SendInterrupt() { }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
@@ -7,7 +7,7 @@ using Capacitor.Cli.Tests.Unit.Daemon;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1313 Phase B (D1 + D4 §6.4(2a)): the single-flight teardown and the kill-quarantine.
+/// Phase B (D1 + D4 §6.4(2a)): the single-flight teardown and the kill-quarantine.
 /// <list type="bullet">
 /// <item>A post-insert launch failure (e.g. a throwing RegisterAgentAsync) routes through the same
 /// <c>CleanupAgentAsync</c> teardown, so it can never strand an agent whose child is still live.</item>

--- a/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
@@ -125,13 +125,14 @@ public partial class AgentOrchestratorVendorTests {
         await using var orch = BuildOrchestrator(
             server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
 
-        // A live, unrelated process occupies the pid, but the agent's STORED identity is a DIFFERENT real
-        // process's token — same OS token scheme, different value, so it compares CONCLUSIVELY unequal
-        // (exactly what a recycled pid looks like: our child exited, the pid was reused). Teardown must
-        // treat our agent as gone — never quarantine, never kill the unrelated occupant.
+        // A live process occupies the pid, but the agent's STORED identity is a same-scheme token with a
+        // CONCLUSIVELY different value — exactly what a recycled pid looks like (our child exited, the pid
+        // was reused). Derive it from the occupant's OWN token + a suffix so it's guaranteed different yet
+        // same-scheme on every OS. (Deriving it from a second process is not safe: on Linux the start
+        // token is boot-relative clock ticks — two rapidly-started processes can collide on the same
+        // value.) Teardown must treat our agent as gone — never quarantine, never kill the occupant.
         using var occupant = DummyProcess.StartSleep(30);
-        using var other    = DummyProcess.StartSleep(30);
-        var wrongIdentity  = ProcessIdentity.Capture(other.Pid)!; // real, same-scheme, ≠ occupant's identity
+        var wrongIdentity  = ProcessIdentity.Capture(occupant.Pid)! + "9"; // same scheme, ≠ occupant's value
 
         orch.SeedAgentForTest("recycled", LaunchKind.ReviewFlow, status: "Running",
             pty: new LiveNoKillPtyProcess(occupant.Pid), startIdentity: wrongIdentity);
@@ -141,10 +142,9 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(orch.GetAgentForTest("recycled")).IsNull();
         await Assert.That(orch.QuarantineSnapshot().Any(q => q.Id == "recycled")).IsFalse();
         await Assert.That(orch.EffectiveCount).IsEqualTo(0);
-        await Assert.That(occupant.HasExited).IsFalse(); // the unrelated occupant was never signalled
+        await Assert.That(occupant.HasExited).IsFalse(); // the occupant was never signalled
 
         occupant.Kill();
-        other.Kill();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LaunchCleanupTests.cs
@@ -125,22 +125,49 @@ public partial class AgentOrchestratorVendorTests {
         await using var orch = BuildOrchestrator(
             server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
 
-        // A live, unrelated process occupies the pid, but the agent's STORED identity does not match it
+        // A live, unrelated process occupies the pid, but the agent's STORED identity is a DIFFERENT real
+        // process's token — same OS token scheme, different value, so it compares CONCLUSIVELY unequal
         // (exactly what a recycled pid looks like: our child exited, the pid was reused). Teardown must
         // treat our agent as gone — never quarantine, never kill the unrelated occupant.
-        using var unrelated = DummyProcess.StartSleep(30);
+        using var occupant = DummyProcess.StartSleep(30);
+        using var other    = DummyProcess.StartSleep(30);
+        var wrongIdentity  = ProcessIdentity.Capture(other.Pid)!; // real, same-scheme, ≠ occupant's identity
+
         orch.SeedAgentForTest("recycled", LaunchKind.ReviewFlow, status: "Running",
-            pty: new LiveNoKillPtyProcess(unrelated.Pid),
-            startIdentity: "lx:boot0000:0000000000"); // deliberately NOT the live process's identity
+            pty: new LiveNoKillPtyProcess(occupant.Pid), startIdentity: wrongIdentity);
 
         await orch.CleanupAgentForTest("recycled");
 
         await Assert.That(orch.GetAgentForTest("recycled")).IsNull();
         await Assert.That(orch.QuarantineSnapshot().Any(q => q.Id == "recycled")).IsFalse();
         await Assert.That(orch.EffectiveCount).IsEqualTo(0);
-        await Assert.That(unrelated.HasExited).IsFalse(); // the unrelated process was never signalled
+        await Assert.That(occupant.HasExited).IsFalse(); // the unrelated occupant was never signalled
 
-        unrelated.Kill();
+        occupant.Kill();
+        other.Kill();
+    }
+
+    [Test]
+    public async Task Teardown_quarantines_when_the_stored_identity_is_uncomparable() {
+        var server = new CaptureServerConnection();
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        // A live child whose stored identity uses a FOREIGN token scheme ("zz:") — uncomparable on every
+        // OS (tri-state null), so ownership can neither be proven nor disproven. Fail closed: retain +
+        // quarantine (count against admission) rather than dropping a possibly-live child's record.
+        using var dummy = DummyProcess.StartSleep(30);
+        orch.SeedAgentForTest("ambiguous", LaunchKind.ReviewFlow, status: "Running",
+            pty: new LiveNoKillPtyProcess(dummy.Pid), startIdentity: "zz:unknown-scheme-token");
+
+        await orch.CleanupAgentForTest("ambiguous");
+
+        await Assert.That(orch.GetAgentForTest("ambiguous")).IsNull();
+        await Assert.That(orch.QuarantineSnapshot().Any(q => q.Id == "ambiguous")).IsTrue();
+        await Assert.That(orch.EffectiveCount).IsEqualTo(1);
+
+        dummy.Kill();
     }
 
     /// <summary>An <see cref="IPtyProcess"/> that reports a real live child's pid but whose disposal


### PR DESCRIPTION
## What & why

AI-1313 Phase B — the **CLI/daemon** half of flow-reviewer capacity reaping. Phase A (server, kcap-server #1109) makes the *server* reclaim slots from stale/superseded reviewers; this PR makes the **daemon defend its own agent-capacity budget** so a stuck, abandoned, or crash-orphaned hosted reviewer can never wedge a daemon at `N/N` and block every flow.

Design spec (Codex-clean r14): `docs/superpowers/specs/2026-07-16-ai1313-reviewer-capacity-reaping-design.md` (§6 D1–D4). Plan: `docs/superpowers/plans/2026-07-17-ai1313-phase-b-cli-daemon-self-defense.md`.

## Scope (this PR — CLI only, independently deployable)

- **D1 — single-flight teardown.** One `CleanupAgentAsync` path (TryRemove + `CleanupStarted` gate) is the sole teardown; a **post-insert launch failure** (e.g. a throwing `RegisterAgentAsync`) now routes through it, so a failed launch can never strand an agent whose child process is still alive.
- **D2 — daemon self-report.** `AgentInstance` carries kind + flow identity; `DaemonConnect` additively includes `LiveAgents`; a periodic (60s) **one-way** `DaemonStatusReport` is sent (an old server just logs it — no client fault). *(The server-side handler is deferred to B2, below.)*
- **D3 — reviewer lifetime/idle backstop.** The heartbeat reaps a review-flow reviewer past its max lifetime or idle timeout (driver vanished / run went terminal server-side without the daemon hearing). Defaults 6h/2h; `KCAP_REVIEWER_MAX_LIFETIME` / `KCAP_REVIEWER_IDLE_TIMEOUT` (seconds; `0` disables). Interactive agents are never touched.
- **D4 — child containment (records + reaping).**
  - Atomic per-daemon **PID records** (`{state-dir}/{name}/agents/{id}.json`) with an exact OS-native start-identity (reuses AI-839 `ProcessStartToken`; no fuzzy DateTime).
  - **Kill-quarantine**: a child that survives teardown is retained, counted against admission via `EffectiveCount = ActiveCount + Quarantined.Count` (fail closed), and killed by exact identity on the heartbeat retry until confirmed gone.
  - **Startup orphan reap** (boot under the daemon lock + heartbeat): a record pass (**prior-incarnation only** — epoch-guarded, so a heartbeat re-run can never kill a live current agent) plus a Unix **env-marker scan** (`KCAP_AGENT_ID` + `KCAP_DAEMON_ID == this` + `KCAP_DAEMON_EPOCH != current`) for recordless survivors. Every child is stamped with those three env markers at spawn.
  - **StopAgent PID-record fallback**: a stop for an id not in the registry consults the record and reaps by exact identity.

**Safety invariant throughout:** a process is killed only when its identity is *proven*; anything ambiguous is spared. On Linux the env checks read `/proc/{pid}/environ`; **macOS 26 redacts process env**, so the env paths spare there and the record path is the effective mechanism (production is Linux). `ProcessIdentity` is also hardened against non-positive pids so a degenerate/Noop runtime's pid `0` can never make `kill(0,0)` (which targets the daemon's own process group) read as "agent alive".

## Compatibility

All protocol changes are **additive** — an old server ignores the unknown `LiveAgents` field and the unknown `DaemonStatusReport` method (sent one-way via `SendAsync`, never `InvokeAsync`).

## Explicitly deferred (separate follow-on PRs — noted so review scopes correctly)

1. **Native OS containment (D4 layer 1):** Windows creation-time Job Object + Linux `PDEATHSIG` on a dedicated spawner thread with an async-signal-safe post-fork shim. Pure hardening — this PR's records/scan already recover survivors; layer 1 only makes death immediate. Needs native interop + a C shim + per-OS CI.
2. **Sequenced-command settlement (bilateral, server + CLI):** `Epoch`/`Seq`/`CommandAck`/`AckProcessedPrefix`/`ResolvedStartupCandidates`/`StopAgentV2` + the server-side S3(b)/(c) untracked-reap, retry-until-gone, S6 daemon-authoritative, and the `DaemonStatusReport` server handler. Its own spec-grounded plan + paired server PR.

## Testing

TUnit unit tests, **isolated dummy processes only — no real daemon, no live flows** (per spec §2/§8): `AgentKillQuarantineTests`, `LaunchCleanupTests` (post-insert routing, concurrent-teardown-once, survives-disposal quarantine + `EffectiveCount`, spawn env markers), `OrphanReaperTests` (prior-incarnation reap, current-epoch safety guard, gone-process cleanup, env-marker this-daemon-only scan), plus the D2/D3/D4 DTO/TTL/identity/record tests. Env-dependent reaps are OS-aware (Linux kill / macOS spare); the Linux + Windows identity branches are covered by CI runners. Daemon namespace 174/0 and vendor suite 64/0 green locally; full unit suite green apart from a pre-existing bridge-port `NotInParallel` flake (passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)