### PR TITLE
[AI-1389] Routed-import Done-grid double-counts — coherent actual-work signal

### DIFF
--- a/src/Capacitor.Cli/Commands/AntigravityImportSource.cs
+++ b/src/Capacitor.Cli/Commands/AntigravityImportSource.cs
@@ -212,7 +212,12 @@ internal sealed class AntigravityImportSource : IImportSource {
                     BuildSessionStartPayload(c.SessionId, c.Meta.Cwd, c.Meta.FirstTimestamp, ctx.ForcePrivate), ct))
                 return ImportOutcome.Failed;
 
-            await ImportChildrenAsync(ctx.HttpClient, ctx.BaseUrl, c.SessionId, c.SourceMeta!, ct);
+            // Capture whether the repair actually attached new nested-child content — true
+            // iff any child's SendTranscriptBatches sent >0 server-accepted lines. The
+            // lifecycle-only repair path (subagent-start+stop, no content resend) contributes
+            // false. This outcome stays hardcoded Skipped — only SentChildContent is threaded
+            // through below.
+            var sentChildContent = await ImportChildrenAsync(ctx.HttpClient, ctx.BaseUrl, c.SessionId, c.SourceMeta!, ct);
 
             // Explicit gen_metadata usage pass — even though AlreadyLoaded sends zero real
             // transcript lines (the content watermark is already at the tip), a session
@@ -225,7 +230,7 @@ internal sealed class AntigravityImportSource : IImportSource {
                     BuildSessionEndPayload(c.SessionId, c.Meta.Cwd, c.Meta.LastTimestamp), ct))
                 return ImportOutcome.Failed;
 
-            return ImportOutcome.Skipped;
+            return new ImportSessionResult(ImportOutcome.Skipped, sentChildContent);
         }
 
         // Lifecycle-before-transcript (mirrors Gemini): a transcript that advances the
@@ -266,11 +271,20 @@ internal sealed class AntigravityImportSource : IImportSource {
         return startLine > 0 ? ImportOutcome.Resumed : ImportOutcome.Loaded;
     }
 
-    async Task ImportChildrenAsync(
+    /// <summary>
+    /// Returns <c>true</c> iff any child's <see cref="SessionImporter.SendTranscriptBatches"/>
+    /// call sent &gt;0 server-accepted lines during this pass — the <c>SentChildContent</c>
+    /// signal threaded onto the <c>AlreadyLoaded</c> caller's <see cref="ImportSessionResult"/>.
+    /// The lifecycle-only repair branch below (subagent-start+stop, no content resend)
+    /// contributes <c>false</c> — it's a repair, not new content.
+    /// </summary>
+    async Task<bool> ImportChildrenAsync(
             HttpClient client, string baseUrl, string rootId,
             IReadOnlyDictionary<string, object?> sourceMeta, CancellationToken ct) {
         if (!sourceMeta.TryGetValue("Children", out var kidsObj) || kidsObj is not List<string> { Count: > 0 } children)
-            return;
+            return false;
+
+        var anyChildContentSent = false;
 
         foreach (var childId in children) {
             ct.ThrowIfCancellationRequested();
@@ -344,19 +358,28 @@ internal sealed class AntigravityImportSource : IImportSource {
                     BuildSubagentStartPayload(rootId, childAgentId, childTranscript), ct))
                 continue;
 
+            int childSent;
             try {
-                await SessionImporter.SendTranscriptBatches(
+                // failOnError: true — SentChildContent must reflect only server-ACCEPTED
+                // batches; a non-2xx now throws and is caught below, so a rejected batch
+                // never flips the signal (Qodo finding 3).
+                childSent = await SessionImporter.SendTranscriptBatches(
                     httpClient: client, baseUrl: baseUrl, sessionId: rootId,
-                    filePath: childTranscript, agentId: childAgentId, startLine: childStartLine, vendor: Vendor);
+                    filePath: childTranscript, agentId: childAgentId, startLine: childStartLine, vendor: Vendor,
+                    failOnError: true);
             } catch (OperationCanceledException) {
                 throw;
             } catch {
                 continue; // leave subagent-stop unsent; a re-import retries (idempotent)
             }
 
+            if (childSent > 0) anyChildContentSent = true;
+
             await PostHookAsync(client, baseUrl, "subagent-stop",
                 BuildSubagentStopPayload(rootId, childAgentId, childTranscript), ct);
         }
+
+        return anyChildContentSent;
     }
 
     // ── payload builders ────────────────────────────────────────────────────────

--- a/src/Capacitor.Cli/Commands/CursorImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CursorImportSource.cs
@@ -800,10 +800,22 @@ internal sealed class CursorImportSource : IImportSource {
         // new child content would leak on a public session. So probe failure alone is no longer
         // tracked as a reason to suppress SentContent below — the safe default when content was
         // actually posted is to count it, whether or not the watermark was known.
+        //
+        // Before falling open, give a status-bearing 5xx/408 one extra local re-attempt (2
+        // attempts total, fixed, no added backoff) via FetchServerLastLineWithCappedRetryAsync —
+        // a single transient 500 no longer skips straight to fail-open on the first failure.
+        // Statusless transport failures (already retried inside GetWithRetryAsync) and 429 (a
+        // rate-limit signal) are excluded from this outer retry and still fail open on the
+        // first attempt. Cancellation is never treated as a transient failure — it propagates
+        // immediately.
         var startLine = 0;
         try {
-            if (await FetchServerLastLineAsync(ctx.HttpClient, ctx.BaseUrl, parentSessionId, ct, agentId) is { } last)
+            if (await FetchServerLastLineWithCappedRetryAsync(
+                    probeCt => FetchServerLastLineAsync(ctx.HttpClient, ctx.BaseUrl, parentSessionId, probeCt, agentId), ct
+                ) is { } last)
                 startLine = last + 1;
+        } catch (OperationCanceledException) {
+            throw;
         } catch {
             startLine = 0;
         }
@@ -988,7 +1000,10 @@ internal sealed class CursorImportSource : IImportSource {
         using var resp = await http.GetWithRetryAsync(url, ct: ct);
 
         if (resp.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.NoContent) return null;
-        if (!resp.IsSuccessStatusCode) throw new HttpRequestException($"watermark probe returned {(int)resp.StatusCode}");
+        // Construct via the (string?, Exception?, HttpStatusCode?) overload so .StatusCode is
+        // inspectable by FetchServerLastLineWithCappedRetryAsync's status check, rather than
+        // message-string parsing.
+        if (!resp.IsSuccessStatusCode) throw new HttpRequestException($"watermark probe returned {(int)resp.StatusCode}", null, resp.StatusCode);
 
         var       body = await resp.Content.ReadAsStringAsync(ct);
         using var doc  = JsonDocument.Parse(body);
@@ -997,6 +1012,43 @@ internal sealed class CursorImportSource : IImportSource {
             ? ln.GetInt32()
             : null;
     }
+
+    /// <summary>
+    /// A small, fixed 2-attempt cap around a watermark-probe call. Retries ONLY a
+    /// status-bearing 5xx or 408 (Request Timeout) response — a single transient 500 no longer
+    /// skips straight to the caller's fail-open path on the first failure. Two categories are
+    /// explicitly excluded from this outer re-attempt: statusless transport failures (a
+    /// network-level <see cref="HttpRequestException"/> with no <c>.StatusCode</c> — these
+    /// already had their own exponential-backoff retry inside <c>GetWithRetryAsync</c>'s inner
+    /// loop, so a second full retry cycle would double an already-exhausted budget for no
+    /// reason to expect a different outcome), and 429 (Too Many Requests — a rate-limit signal,
+    /// not a transient blip; immediately retrying it is the wrong response). No additional
+    /// backoff is added beyond <c>GetWithRetryAsync</c>'s own per-attempt retry loop. Cancellation
+    /// propagates immediately and is never treated as a transient failure to retry. After both
+    /// attempts are exhausted (or on a non-retryable failure), the exception propagates to the
+    /// caller's existing fail-open handling, unchanged by this cap.
+    ///
+    /// <paramref name="probe"/> is a delegate (rather than concrete HttpClient/url parameters) so
+    /// this pure retry-decision shell is directly, deterministically unit-testable.
+    /// </summary>
+    internal static async Task<int?> FetchServerLastLineWithCappedRetryAsync(
+            Func<CancellationToken, Task<int?>> probe, CancellationToken ct
+        ) {
+        try {
+            return await probe(ct);
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (HttpRequestException ex) when (IsRetryableWatermarkProbeStatus(ex.StatusCode)) {
+            return await probe(ct);
+        }
+    }
+
+    /// <summary>
+    /// True for a status-bearing 5xx or 408 — the only categories the 2-attempt cap retries.
+    /// A null status (statusless transport failure) and 429 both return false.
+    /// </summary>
+    internal static bool IsRetryableWatermarkProbeStatus(HttpStatusCode? statusCode) =>
+        statusCode is { } code && ((int)code >= 500 && (int)code <= 599 || code == HttpStatusCode.RequestTimeout);
 
     static (string? ExcludedRepoKey, string? ExcludedPathKey) ResolveExclusions(
         string? cwd, string? repoKey, ClassifyContext ctx

--- a/src/Capacitor.Cli/Commands/GeminiImportSource.cs
+++ b/src/Capacitor.Cli/Commands/GeminiImportSource.cs
@@ -237,7 +237,15 @@ internal sealed class GeminiImportSource : IImportSource {
         // Import nested subagents (chats/<parentSessionId>/<subId>.jsonl) under the parent,
         // BEFORE session-end so their SubagentStarted/Completed land in the parent stream
         // ahead of SessionEnded. Subagent failures don't fail the (already-imported) parent.
-        await ImportSubagentsAsync(ctx.HttpClient, ctx.BaseUrl, classification.SessionId, transcriptPath, ct);
+        //
+        // Capture whether any subagent actually got new content POSTed and ACCEPTED — the
+        // SentChildContent signal. KNOWN RESIDUAL: ImportSubagentsAsync has no per-child
+        // watermark — it always resends the whole subagent transcript from line 0 on every
+        // re-run, so for a session that HAS a subagent this reads true on essentially every
+        // re-run whether or not anything is actually new. Accepted — still strictly better
+        // than defaulting false (which would risk hiding genuinely-new subagent content
+        // behind the lifecycle-only-replay label).
+        var sentChildContent = await ImportSubagentsAsync(ctx.HttpClient, ctx.BaseUrl, classification.SessionId, transcriptPath, ct);
 
         var endOk = await PostSyntheticHookAsync(
             ctx.HttpClient, ctx.BaseUrl, "session-end/gemini",
@@ -245,9 +253,9 @@ internal sealed class GeminiImportSource : IImportSource {
             ct);
         if (!endOk) return ImportOutcome.Failed;
 
-        if (sent == 0) return startLine > 0 ? ImportOutcome.Resumed : ImportOutcome.Skipped;
+        if (sent == 0) return new ImportSessionResult(startLine > 0 ? ImportOutcome.Resumed : ImportOutcome.Skipped, sentChildContent);
 
-        return startLine > 0 ? ImportOutcome.Resumed : ImportOutcome.Loaded;
+        return new ImportSessionResult(startLine > 0 ? ImportOutcome.Resumed : ImportOutcome.Loaded, sentChildContent);
     }
 
     static JsonObject BuildSessionStartPayload(string sessionId, DateTimeOffset? startedAt) {
@@ -297,8 +305,17 @@ internal sealed class GeminiImportSource : IImportSource {
     /// it. Re-runs are idempotent (deterministic server-side ids). Any descendants beyond the
     /// depth cap, or a descendant directory that couldn't be read, are surfaced (never silent)
     /// via a stderr diagnostic.
+    ///
+    /// Returns <c>true</c> iff any descendant's <see cref="SessionImporter.SendTranscriptBatches"/>
+    /// call sent &gt;0 server-accepted lines — the <c>SentChildContent</c> signal, aggregated
+    /// across the ENTIRE recursive descendant subtree (direct children and every deeper
+    /// grandchild found by the walk above), not just direct children. Unlike Cursor/Antigravity,
+    /// there is no per-descendant watermark here: every re-run resends each descendant's whole
+    /// transcript from line 0, so this reads <c>true</c> on essentially every re-run of a session
+    /// that has any descendant subagent, whether or not anything is actually new (accepted
+    /// residual).
     /// </summary>
-    async Task ImportSubagentsAsync(
+    async Task<bool> ImportSubagentsAsync(
         HttpClient client, string baseUrl, string parentSessionIdDashless, string transcriptPath, CancellationToken ct
     ) {
         // Gemini has no completeness-fingerprint ledger (unlike OpenCode), so the omitted ids
@@ -320,9 +337,10 @@ internal sealed class GeminiImportSource : IImportSource {
                 "(a descendant directory existed but could not be read — its subtree may be incomplete)");
         }
 
-        if (descendants.Count == 0) return;
+        if (descendants.Count == 0) return false;
 
         var typesByParentTranscript = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal);
+        var anySubagentContentSent  = false;
 
         foreach (var d in descendants) {
             ct.ThrowIfCancellationRequested();
@@ -341,19 +359,27 @@ internal sealed class GeminiImportSource : IImportSource {
                 GeminiSubagentDiscovery.BuildStartPayload(parentSessionIdDashless, agentId, agentType, d.File), ct);
             if (!startOk) continue;
 
+            int subSent;
             try {
-                await SessionImporter.SendTranscriptBatches(
+                // failOnError: true — SentChildContent must reflect only server-ACCEPTED
+                // batches; a non-2xx now throws and is caught below, so a rejected batch
+                // never flips the signal (Qodo finding 3).
+                subSent = await SessionImporter.SendTranscriptBatches(
                     httpClient: client, baseUrl: baseUrl,
                     sessionId:  parentSessionIdDashless, filePath: d.File,
-                    agentId:    agentId, startLine: 0, vendor: Vendor);
+                    agentId:    agentId, startLine: 0, vendor: Vendor, failOnError: true);
             } catch {
                 continue; // leave subagent-stop unsent; a re-import retries (idempotent)
             }
+
+            if (subSent > 0) anySubagentContentSent = true;
 
             await PostSyntheticHookAsync(
                 client, baseUrl, "subagent-stop",
                 GeminiSubagentDiscovery.BuildStopPayload(parentSessionIdDashless, agentId, agentType, d.File), ct);
         }
+
+        return anySubagentContentSent;
     }
 
     static DateTimeOffset? TryGetLastWriteUtc(string path) {

--- a/src/Capacitor.Cli/Commands/IImportSource.cs
+++ b/src/Capacitor.Cli/Commands/IImportSource.cs
@@ -47,14 +47,25 @@ internal enum ImportOutcome { Loaded, Resumed, Skipped, Failed }
 
 /// <summary>
 /// Result of <see cref="IImportSource.ImportSessionAsync"/>. <c>SentChildContent</c> is the
-/// real "did new work actually happen" signal (AI-1154 review fix, finding 1): it's true only
-/// when this call POSTed brand-new nested subagent-child transcript bytes (Cursor's inline
-/// child import, under a parent whose own top-level watermark may not have moved at all). The
-/// parent classification/outcome pair alone can't distinguish that from a genuine "nothing to
-/// do" lifecycle/repo-backfill replay — <c>ImportOutcome</c> has no line-0 signal for it, so
-/// this is carried out-of-band instead of inferred. Every non-Cursor source (and Cursor itself
-/// outside the nested-child path) leaves this false via the implicit <c>ImportOutcome</c>
-/// conversion below.
+/// real "did new work actually happen" signal for nested child/subagent streams.
+///
+/// This field concerns ONLY nested child/subagent streams — never the call's own root stream
+/// (an <c>AlreadyLoaded</c> root's own content is by definition already caught up, so
+/// root-level work is always fully conveyed by <c>ImportOutcome</c> alone). It is <c>true</c>
+/// iff, during this call, transcript lines were POSTed to a nested child stream. Where a
+/// reliable per-child watermark is known, <c>true</c> means lines beyond that watermark were
+/// sent. Where the watermark probe fails or no reliable watermark exists, the conservative
+/// default is to attempt a full resend and report <c>true</c> whenever that resend actually
+/// posts lines — this signal deliberately ERRS TOWARD permitting a possibly-duplicate resend
+/// rather than silently suppressing genuinely-new content; it is NOT a claim that the server
+/// was verified to lack that content beforehand.
+///
+/// <para>
+/// <b>This field is meaningful ONLY when the call's own result is non-<c>Failed</c>.</b> On a
+/// <c>Failed</c> result the field's value is UNSPECIFIED and MUST NOT be consulted for any
+/// purpose — see <see cref="ImportCommand.ResolveRoutedOutcomeForCounting"/>, whose resolver
+/// never consults <c>sentChildContent</c> on a <c>Failed</c> outcome.
+/// </para>
 /// </summary>
 internal readonly record struct ImportSessionResult(ImportOutcome Outcome, bool SentChildContent = false) {
     public static implicit operator ImportSessionResult(ImportOutcome outcome) => new(outcome);

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -382,27 +382,67 @@ static class ImportCommand {
     /// </para>
     ///
     /// <para>
-    /// Round-3 finding 2: this gate is CURSOR-ONLY. <c>SentChildContent</c> is populated only by
-    /// <see cref="CursorImportSource"/> — every other routed vendor's <c>ImportSessionResult</c>
-    /// leaves it at its default <c>false</c> via the implicit <c>ImportOutcome</c> conversion,
-    /// including cases (e.g. Antigravity's <c>AlreadyLoaded</c> repair path, which can legitimately
-    /// POST new nested-child content via <c>ImportChildrenAsync</c> before returning
-    /// <see cref="ImportOutcome.Skipped"/>) where that default does NOT mean "no new work". The
-    /// lifecycle-only-replay behavior this models — repo-backfill <c>AlreadyLoaded</c> replays with
-    /// no new content — is specific to Cursor's repo-backfill contract, so gating the whole check on
-    /// the Cursor vendor is what keeps a real import on another vendor from being wrongly suppressed.
+    /// This gate is vendor-NEUTRAL: <c>sentChildContent</c> carries a real signal for Cursor,
+    /// Antigravity, and Gemini alike (Copilot/Kiro/Pi/OpenCode permanently default it
+    /// <c>false</c>, which is already correct for their no-op replay shape).
+    /// </para>
+    ///
+    /// <para>
+    /// This gate alone only decides whether a replay is suppressed — it does NOT decide which
+    /// bucket a non-suppressed call lands in for counting. See
+    /// <see cref="IsSkippedChildContentOverride"/> and <see cref="ResolveRoutedOutcomeForCounting"/>
+    /// for the central aggregation boundary that fixes the case this gate can't: a <c>Skipped</c>
+    /// <c>AlreadyLoaded</c> call (e.g. Antigravity's) that attached genuinely-new nested-child
+    /// content must count as Loaded, even though its own raw outcome is <c>Skipped</c>.
     /// </para>
     /// </summary>
     internal static bool IsLifecycleOnlyRoutedReplay(
-            string                vendor,
             ClassificationStatus  status,
             ImportOutcome         outcome,
             bool                  sentChildContent
         ) =>
-        vendor == "cursor"
-     && status == ClassificationStatus.AlreadyLoaded
+        status == ClassificationStatus.AlreadyLoaded
      && outcome is ImportOutcome.Loaded or ImportOutcome.Resumed or ImportOutcome.Skipped
      && !sentChildContent;
+
+    /// <summary>
+    /// True iff a <c>Skipped</c> <c>AlreadyLoaded</c> call attached genuinely-new nested-child
+    /// content — the only raw outcome whose Done-grid bucket needs
+    /// correcting. <c>Loaded</c>/<c>Resumed</c> already land correctly via the ordinary outcome
+    /// path and are deliberately left untouched (PRESERVED, not reclassified) — this predicate
+    /// does not engage for them. <c>Failed</c> is excluded by the same exact-match: a failed
+    /// lifecycle POST must always surface as Errored, never get reclassified as Loaded just
+    /// because content happened to post first.
+    /// </summary>
+    internal static bool IsSkippedChildContentOverride(
+            ClassificationStatus  status,
+            ImportOutcome         outcome,
+            bool                  sentChildContent
+        ) =>
+        status == ClassificationStatus.AlreadyLoaded
+     && outcome == ImportOutcome.Skipped
+     && sentChildContent;
+
+    /// <summary>
+    /// The single aggregation boundary — what outcome should this routed call count as for
+    /// the Done-grid's counters, per-vendor tracker, and printed line (
+    /// <c>null</c> = suppressed, don't count at all). This is a COUNTING-ONLY boundary: it
+    /// deliberately does NOT drive <c>importedSessionIds</c> / <c>--private</c> membership, which
+    /// stays governed by the pre-existing suppression check and outcome switch, unchanged from
+    /// before this ticket — see the call sites below for the exact membership condition.
+    /// <see cref="IsLifecycleOnlyRoutedReplay"/> requires <c>!sentChildContent</c> and
+    /// <see cref="IsSkippedChildContentOverride"/> requires <c>sentChildContent</c>, so the two
+    /// are mutually exclusive by construction — there's no ordering ambiguity between them.
+    /// </summary>
+    internal static ImportOutcome? ResolveRoutedOutcomeForCounting(
+            ClassificationStatus  status,
+            ImportOutcome         outcome,
+            bool                  sentChildContent
+        ) {
+        if (IsLifecycleOnlyRoutedReplay(status, outcome, sentChildContent))   return null;
+        if (IsSkippedChildContentOverride(status, outcome, sentChildContent)) return ImportOutcome.Loaded;
+        return outcome;
+    }
 
     internal sealed record ClassificationCounts(
             int New,
@@ -1335,61 +1375,57 @@ static class ImportCommand {
                                         privateScopeSessionIds.Add(c.SessionId);
                                     }
 
-                                    // AI-1154 review fix (P2, broadened by the round-2 follow-up):
-                                    // an AlreadyLoaded session's routed call is a lifecycle/repo-
-                                    // backfill replay (or, for a nested child, an inline-handled
-                                    // no-op), not a new import — it must not double-count on top
-                                    // of the classify-time AlreadyLoaded bucket, nor join
-                                    // importedSessionIds (which --private later re-privates).
-                                    // sentChildContent overrides this for an AlreadyLoaded parent
-                                    // that attached a brand-new nested child (round-2 finding 1) —
-                                    // that IS real new work.
-                                    var isLifecycleOnlyReplay = IsLifecycleOnlyRoutedReplay(c.Vendor, c.Status, outcome, result.SentChildContent);
+                                    // An AlreadyLoaded session's routed call is a
+                                    // lifecycle/repo-backfill replay (or, for a nested child, an
+                                    // inline-handled no-op), not a new import — it must not
+                                    // double-count on top of the classify-time AlreadyLoaded
+                                    // bucket. sentChildContent overrides this for an AlreadyLoaded
+                                    // parent that attached a brand-new nested child — that IS
+                                    // real new work.
+                                    //
+                                    // `resolved` — not the raw `outcome` — is the single
+                                    // aggregation boundary that drives every counting/display
+                                    // consumer below (routedLoaded/routedExcluded/routedErrored,
+                                    // routedOutcomesByVendor, and the printed line). This is what
+                                    // fixes a Skipped AlreadyLoaded call (e.g. Antigravity's) that
+                                    // attached genuinely-new child content: it resolves to Loaded
+                                    // for counting even though its own raw outcome stays Skipped.
+                                    //
+                                    // importedSessionIds membership is explicitly EXCLUDED from
+                                    // this — it keeps switching on the raw `outcome`, gated by the
+                                    // same suppression (resolved is not null), so this makes no
+                                    // change to --private visibility for any vendor. See
+                                    // ResolveRoutedOutcomeForCounting's doc comment.
+                                    var resolved = ResolveRoutedOutcomeForCounting(c.Status, outcome, result.SentChildContent);
 
-                                    if (!isLifecycleOnlyReplay) {
+                                    if (resolved is { } resolvedForVendor) {
                                         routedOutcomesByVendor.AddOrUpdate(
                                             c.Vendor,
-                                            addValueFactory: _ => AddRoutedOutcome((0, 0, 0), outcome),
-                                            updateValueFactory: (_, prev) => AddRoutedOutcome(prev, outcome)
+                                            addValueFactory: _ => AddRoutedOutcome((0, 0, 0), resolvedForVendor),
+                                            updateValueFactory: (_, prev) => AddRoutedOutcome(prev, resolvedForVendor)
                                         );
                                     }
 
-                                    switch (outcome) {
+                                    if (resolved is not null && outcome is ImportOutcome.Loaded or ImportOutcome.Resumed) {
+                                        importedSessionIds.Add(c.SessionId);
+                                    }
+
+                                    switch (resolved) {
                                         case ImportOutcome.Loaded:
                                         case ImportOutcome.Resumed:
-                                            if (isLifecycleOnlyReplay) {
-                                                AnsiConsole.MarkupLine(
-                                                    $"[grey]·[/] Refreshed [cyan]{Markup.Escape(c.SessionId)}[/] (repository backfill, already loaded)"
-                                                );
-                                            } else {
-                                                Interlocked.Increment(ref routedLoaded);
-                                                importedSessionIds.Add(c.SessionId);
+                                            Interlocked.Increment(ref routedLoaded);
 
-                                                AnsiConsole.MarkupLine(
-                                                    $"[green]✓[/] Loading [cyan]{Markup.Escape(c.SessionId)}[/] ({Markup.Escape(c.Vendor)})"
-                                                );
-                                            }
+                                            AnsiConsole.MarkupLine(
+                                                $"[green]✓[/] Loading [cyan]{Markup.Escape(c.SessionId)}[/] ({Markup.Escape(c.Vendor)})"
+                                            );
 
                                             break;
                                         case ImportOutcome.Skipped:
-                                            if (isLifecycleOnlyReplay) {
-                                                // Round-2 finding 2: a correlated nested child whose
-                                                // own classification is AlreadyLoaded and whose own
-                                                // routed call short-circuited to Skipped (handled
-                                                // inline by its parent) is NOT excluded work — it
-                                                // already contributes to the classify-time
-                                                // Already-loaded bucket and must not also land in
-                                                // Excluded.
-                                                AnsiConsole.MarkupLine(
-                                                    $"[grey]·[/] Already loaded [cyan]{Markup.Escape(c.SessionId)}[/] (nested under parent)"
-                                                );
-                                            } else {
-                                                Interlocked.Increment(ref routedExcluded);
+                                            Interlocked.Increment(ref routedExcluded);
 
-                                                AnsiConsole.MarkupLine(
-                                                    $"[yellow]~[/] Skipping [cyan]{Markup.Escape(c.SessionId)}[/] (already current)"
-                                                );
-                                            }
+                                            AnsiConsole.MarkupLine(
+                                                $"[yellow]~[/] Skipping [cyan]{Markup.Escape(c.SessionId)}[/] (already current)"
+                                            );
 
                                             break;
                                         case ImportOutcome.Failed:
@@ -1397,6 +1433,22 @@ static class ImportCommand {
 
                                             AnsiConsole.MarkupLine(
                                                 $"[red]✗[/] Failed [cyan]{Markup.Escape(c.SessionId)}[/]"
+                                            );
+
+                                            break;
+                                        case null when outcome is ImportOutcome.Skipped:
+                                            // A suppressed Skipped replay is a plain no-op (could
+                                            // be a Cursor nested child, an Antigravity/OpenCode
+                                            // lifecycle-only repair, etc.), not always "nested
+                                            // under parent".
+                                            AnsiConsole.MarkupLine(
+                                                $"[grey]·[/] Already loaded [cyan]{Markup.Escape(c.SessionId)}[/] (no new content)"
+                                            );
+
+                                            break;
+                                        case null:
+                                            AnsiConsole.MarkupLine(
+                                                $"[grey]·[/] Refreshed [cyan]{Markup.Escape(c.SessionId)}[/] (repository backfill, already loaded)"
                                             );
 
                                             break;
@@ -1421,45 +1473,50 @@ static class ImportCommand {
                             privateScopeSessionIds.Add(c.SessionId);
                         }
 
-                        // AI-1154 review fix (P2, broadened by the round-2 follow-up): see the
-                        // Tty branch above for why an AlreadyLoaded lifecycle-only replay must
-                        // not count as Loaded/Excluded, and why sentChildContent overrides that
-                        // for a parent that attached brand-new nested-child content.
-                        var isLifecycleOnlyReplay = IsLifecycleOnlyRoutedReplay(c.Vendor, c.Status, outcome, result.SentChildContent);
+                        // See the Tty branch above for why an AlreadyLoaded lifecycle-only
+                        // replay must not count as Loaded/Excluded, why sentChildContent
+                        // overrides that for a parent that attached brand-new nested-child
+                        // content, why `resolved` (not the raw `outcome`) drives every
+                        // counting/display consumer, and why importedSessionIds membership is
+                        // explicitly excluded from that and keeps switching on the raw `outcome`.
+                        var resolved = ResolveRoutedOutcomeForCounting(c.Status, outcome, result.SentChildContent);
 
-                        if (!isLifecycleOnlyReplay) {
+                        if (resolved is { } resolvedForVendor) {
                             routedOutcomesByVendor.AddOrUpdate(
                                 c.Vendor,
-                                addValueFactory: _ => AddRoutedOutcome((0, 0, 0), outcome),
-                                updateValueFactory: (_, prev) => AddRoutedOutcome(prev, outcome)
+                                addValueFactory: _ => AddRoutedOutcome((0, 0, 0), resolvedForVendor),
+                                updateValueFactory: (_, prev) => AddRoutedOutcome(prev, resolvedForVendor)
                             );
                         }
 
-                        switch (outcome) {
+                        if (resolved is not null && outcome is ImportOutcome.Loaded or ImportOutcome.Resumed) {
+                            importedSessionIds.Add(c.SessionId);
+                        }
+
+                        switch (resolved) {
                             case ImportOutcome.Loaded:
                             case ImportOutcome.Resumed:
-                                if (isLifecycleOnlyReplay) {
-                                    display.Line($"Refreshed {c.SessionId} (repository backfill, already loaded)");
-                                } else {
-                                    Interlocked.Increment(ref routedLoaded);
-                                    importedSessionIds.Add(c.SessionId);
-                                    display.Line($"Loading {c.SessionId} ({c.Vendor})");
-                                }
+                                Interlocked.Increment(ref routedLoaded);
+                                display.Line($"Loading {c.SessionId} ({c.Vendor})");
 
                                 break;
                             case ImportOutcome.Skipped:
-                                if (isLifecycleOnlyReplay) {
-                                    // Round-2 finding 2: see the Tty branch above.
-                                    display.Line($"Already loaded {c.SessionId} (nested under parent)");
-                                } else {
-                                    Interlocked.Increment(ref routedExcluded);
-                                    display.Line($"Skipping {c.SessionId} (already current)");
-                                }
+                                Interlocked.Increment(ref routedExcluded);
+                                display.Line($"Skipping {c.SessionId} (already current)");
 
                                 break;
                             case ImportOutcome.Failed:
                                 Interlocked.Increment(ref routedErrored);
                                 display.Line($"Failed {c.SessionId}");
+
+                                break;
+                            case null when outcome is ImportOutcome.Skipped:
+                                // See the Tty branch above.
+                                display.Line($"Already loaded {c.SessionId} (no new content)");
+
+                                break;
+                            case null:
+                                display.Line($"Refreshed {c.SessionId} (repository backfill, already loaded)");
 
                                 break;
                         }

--- a/test/Capacitor.Cli.Tests.Integration/AntigravityImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/AntigravityImportTests.cs
@@ -154,9 +154,13 @@ public class AntigravityImportTests : IDisposable {
             CancellationToken.None);
         await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.AlreadyLoaded);
 
-        var outcome = await source.ImportSessionAsync(
+        var result = await source.ImportSessionAsync(
             classified[0], new ImportContext(client, _server.Url!, ForcePrivate: false), CancellationToken.None);
-        await Assert.That(outcome).IsEqualTo(ImportOutcome.Skipped);
+        // Outcome stays hardcoded Skipped, but SentChildContent threads through the repair's
+        // actual work: this repair attaches brand-new child content (the child was previously
+        // missing entirely), so it must report true.
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Skipped);
+        await Assert.That(result.SentChildContent).IsTrue();
 
         var posts = _server.LogEntries.Where(e => e.RequestMessage.Method == "POST")
             .Select(e => e.RequestMessage.Path).ToList();
@@ -173,6 +177,72 @@ public class AntigravityImportTests : IDisposable {
             .Where(e => e.RequestMessage.Path == "/hooks/transcript")
             .Select(e => e.RequestMessage.Body!).Single();
         await Assert.That(childTranscript).Contains($"\"agent_id\":\"{Dashless(Child)}\"");
+    }
+
+    [Test]
+    public async Task ImportSession_AlreadyLoaded_root_child_transcript_rejected_reports_no_sent_child_content_and_suppresses() {
+        WriteTranscript(Root, "build it");
+        WriteTranscript(Child, "sub task");
+        WriteLinkage();
+
+        // Parent (no agentId) fully ingested → AlreadyLoaded; the child (agentId=dashless Child)
+        // was never imported (404), so the repair pass attempts to resend its content — but the
+        // server REJECTS that batch (500). Regression for a Qodo-flagged false positive:
+        // SentChildContent must reflect only server-ACCEPTED batches (failOnError: true), so a
+        // rejected batch must NOT flip the signal to true.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").WithParam("agentId", Dashless(Child)).UsingGet())
+            .AtPriority(1)
+            .RespondWith(Response.Create().WithStatusCode(404));
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .AtPriority(10)
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"last_line_number":99}"""));
+        foreach (var route in new[] {
+            "/hooks/session-start/antigravity",
+            "/hooks/subagent-start", "/hooks/subagent-stop", "/hooks/session-end/antigravity"
+        }) {
+            _server.Given(Request.Create().WithPath(route).UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200));
+        }
+        // The server rejects the child's content batch.
+        _server.Given(Request.Create().WithPath("/hooks/transcript").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(500));
+
+        using var client = new HttpClient();
+        var source = new AntigravityImportSource(home: _home, geminiCliHome: "");
+
+        var discovered = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+        var classified = await source.ClassifyAsync(
+            discovered, new ClassifyContext(client, _server.Url!, MinLines: 0, ExcludedRepos: null, ExcludedPaths: null),
+            CancellationToken.None);
+        await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.AlreadyLoaded);
+
+        var result = await source.ImportSessionAsync(
+            classified[0], new ImportContext(client, _server.Url!, ForcePrivate: false), CancellationToken.None);
+
+        // Outcome stays hardcoded Skipped, but the rejected batch must NOT be reported as
+        // having sent child content — the exact bug under test.
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Skipped);
+        await Assert.That(result.SentChildContent).IsFalse();
+
+        // The walk continues non-fatally past the rejected batch (caught by the surrounding
+        // try/catch): subagent-start was posted, but subagent-stop is left unsent (a re-import
+        // retries), and the parent's own lifecycle (session-start/session-end) still completes.
+        var posts = _server.LogEntries.Where(e => e.RequestMessage.Method == "POST")
+            .Select(e => e.RequestMessage.Path).ToList();
+        await Assert.That(posts.Contains("/hooks/subagent-start")).IsTrue();
+        await Assert.That(posts.Contains("/hooks/subagent-stop")).IsFalse();
+        await Assert.That(posts.Contains("/hooks/session-start/antigravity")).IsTrue();
+        await Assert.That(posts.Contains("/hooks/session-end/antigravity")).IsTrue();
+
+        // A routed AlreadyLoaded+Skipped replay with a false signal is SUPPRESSED for counting,
+        // not reported as Loaded — the false-positive Qodo flagged.
+        var isSuppressed = ImportCommand.IsLifecycleOnlyRoutedReplay(
+            classified[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(isSuppressed).IsTrue();
+
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            classified[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(resolved).IsNull();
     }
 
     [Test]
@@ -206,8 +276,14 @@ public class AntigravityImportTests : IDisposable {
             CancellationToken.None);
         await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.AlreadyLoaded);
 
-        await source.ImportSessionAsync(
+        var result = await source.ImportSessionAsync(
             classified[0], new ImportContext(client, _server.Url!, ForcePrivate: false), CancellationToken.None);
+
+        // The child's only action here is the lifecycle-only repair (start+stop, no content
+        // resend) — that's a repair, not new work, so SentChildContent stays false. (Outcome
+        // stays Skipped.)
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Skipped);
+        await Assert.That(result.SentChildContent).IsFalse();
 
         var posts = _server.LogEntries.Where(e => e.RequestMessage.Method == "POST")
             .Select(e => e.RequestMessage.Path).ToList();

--- a/test/Capacitor.Cli.Tests.Integration/AntigravitySkippedChildOverrideRoutedLoopTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/AntigravitySkippedChildOverrideRoutedLoopTests.cs
@@ -1,0 +1,202 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using Capacitor.Cli.Commands;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// Integration-level regression pinning the routed-loop aggregation boundary in
+/// <c>ImportCommand.HandleImport</c>'s "Importing N routed sessions" phase (the per-session
+/// switch on <see cref="ImportCommand.ResolveRoutedOutcomeForCounting"/>).
+///
+/// <para>
+/// The unit tests in <c>ImportDoneBreakdownTests</c> pin <c>ResolveRoutedOutcomeForCounting</c> /
+/// <c>IsSkippedChildContentOverride</c> in isolation, and separately compute the
+/// <c>importedSessionIds</c> membership expression (<c>resolved is not null &amp;&amp; outcome is
+/// Loaded or Resumed</c>) LOCALLY rather than observing it emerge from the real loop. That leaves
+/// a real regression window open: rewiring the loop's membership check to key off <c>resolved</c>
+/// instead of the raw <c>outcome</c> — or wiring routedLoaded / the Done sub-grid / the printed
+/// line back to the raw outcome instead of <c>resolved</c> — would leave every one of those unit
+/// tests green, because none of them drive <c>HandleImport</c> itself.
+/// </para>
+///
+/// <para>
+/// This test drives the exact "Antigravity shape" the unit tests' comments call out — an
+/// AlreadyLoaded root conversation whose own content is fully ingested, but which attaches a
+/// brand-new correlated child conversation inline during the routed-phase lifecycle repair
+/// (<c>ImportSessionResult(ImportOutcome.Skipped, SentChildContent: true)</c>) — through the REAL
+/// <see cref="ImportCommand.HandleImport"/> orchestrator end-to-end, and asserts all four required
+/// effects move together:
+/// </para>
+/// <list type="number">
+/// <item>Counted as Loaded, not Excluded (<c>routedLoaded</c>, via the "== Done ==" totals).</item>
+/// <item>The per-vendor Done sub-grid shows the "antigravity" row as Loaded, not Excluded (a
+/// second vendor — a Gemini session that hits a probe error — is added so the by-source grid
+/// actually has &gt;1 vendor key and renders at all).</item>
+/// <item>The printed per-session line is the "Loading …" line, not the "Already loaded … (no new
+/// content)" no-op line.</item>
+/// <item>The session does NOT join <c>importedSessionIds</c>: under <c>--private</c>, this
+/// manifests as ZERO <c>PUT .../visibility</c> calls for ANY session, because membership keys off
+/// the raw outcome (Skipped) independent of the Loaded resolution that drives 1–3, and Antigravity
+/// (unlike Cursor) has no separate outcome-independent privatize tracker.</item>
+/// </list>
+/// </summary>
+public class AntigravitySkippedChildOverrideRoutedLoopTests : IDisposable {
+    readonly WireMockServer _server         = WireMockServer.Start();
+    readonly string         _home           = Directory.CreateTempSubdirectory("kcap-ag-routed-loop-it").FullName;
+    readonly string         _geminiTmpDir   = Directory.CreateTempSubdirectory("kcap-ag-routed-loop-gemini-it").FullName;
+
+    const string RootConvId    = "55550000-0000-4000-8000-000000000005";
+    const string ChildConvId   = "66660000-0000-4000-8000-000000000006";
+    const string GeminiConvId  = "77770000-0000-4000-8000-000000000007";
+
+    static string Dashless(string id) => Guid.Parse(id).ToString("N");
+    static readonly string Root  = Dashless(RootConvId);
+    static readonly string Child = Dashless(ChildConvId);
+
+    public void Dispose() {
+        _server.Stop();
+        try { Directory.Delete(_home, recursive: true); } catch { /* best effort */ }
+        try { Directory.Delete(_geminiTmpDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    string BrainDir(string convId) => Path.Combine(_home, ".gemini", "antigravity", "brain", convId);
+
+    void WriteAntigravityTranscript(string convId, string firstUserText) {
+        var dir = Path.Combine(BrainDir(convId), ".system_generated", "logs");
+        Directory.CreateDirectory(dir);
+        File.WriteAllLines(Path.Combine(dir, "transcript_full.jsonl"), new[] {
+            $$"""{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-07-02T19:00:00Z","content":"<USER_REQUEST>{{firstUserText}}</USER_REQUEST>"}""",
+            """{"step_index":1,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","created_at":"2026-07-02T19:00:05Z","content":"done"}"""
+        });
+    }
+
+    // Appends an INVOKE_SUBAGENT step to Root's transcript naming Child as the spawned
+    // conversation — the AI-1218 spawn-time linkage AntigravitySubagents.BuildParentMap reads.
+    void WriteLinkage() {
+        var dir = Path.Combine(BrainDir(RootConvId), ".system_generated", "logs");
+        Directory.CreateDirectory(dir);
+        File.AppendAllLines(Path.Combine(dir, "transcript_full.jsonl"), new[] {
+            $$"""{"type":"INVOKE_SUBAGENT","content":"{\"conversationId\":\"{{ChildConvId}}\"}"}"""
+        });
+    }
+
+    // A second vendor with exactly one classification (ProbeError, from a failing watermark
+    // probe) — just enough for ImportCommand's per-vendor `doneBySource` dictionary to carry 2
+    // keys so the "By source" sub-grid actually renders. ProbeError classifications are excluded
+    // from both the chain and routed import phases, so this session never touches a hook route.
+    void WriteGeminiFixture() {
+        var chats = Path.Combine(_geminiTmpDir, "proj", "chats");
+        Directory.CreateDirectory(chats);
+        File.WriteAllLines(Path.Combine(chats, "session-2026-07-02T19-00-00007777.jsonl"), new[] {
+            $$"""{"sessionId":"{{GeminiConvId}}","projectHash":"h","startTime":"2026-07-02T19:00:00.000Z","lastUpdated":"2026-07-02T19:00:01.000Z","kind":"main"}""",
+            """{"id":"u1","timestamp":"2026-07-02T19:00:01.000Z","type":"user","content":[{"text":"hi"}]}"""
+        });
+    }
+
+    static async Task<string> CaptureStdoutAsync(Func<Task> action) {
+        var original = Console.Out;
+        var sw       = new StringWriter();
+        Console.SetOut(sw);
+        try {
+            await action();
+        } finally {
+            Console.SetOut(original);
+        }
+        return sw.ToString();
+    }
+
+    static bool LineMatches(string text, string label, int value) =>
+        Regex.IsMatch(text, $@"(?m)^\s*{Regex.Escape(label)}\s+{value}\s*$");
+
+    [Test, NotInParallel]
+    public async Task already_loaded_root_with_new_child_content_counts_loaded_but_stays_out_of_private_set() {
+        WriteAntigravityTranscript(RootConvId, "build it");
+        WriteAntigravityTranscript(ChildConvId, "sub task");
+        WriteLinkage();
+        WriteGeminiFixture();
+
+        // Child's own subsession watermark probe (agentId=Child): not yet ingested -> the
+        // AlreadyLoaded-repair path sends its content inline (SentChildContent=true).
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").WithParam("agentId", Child).UsingGet())
+            .AtPriority(1)
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.NotFound));
+        // Root's own top-level probe (no agentId param): already fully ingested (server line 1 ==
+        // the parent's last IMPORT-RELEVANT line, index 1 / PLANNER_RESPONSE) -> AlreadyLoaded.
+        _server.Given(Request.Create().WithPath($"/api/sessions/{Root}/last-line").UsingGet())
+            .AtPriority(5)
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"last_line_number":1}"""));
+        // Fallback for any other session's probe (the Gemini fixture's own session id) -> a hard
+        // failure, so it classifies ProbeError rather than accidentally looking AlreadyLoaded too.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .AtPriority(10)
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.InternalServerError));
+
+        foreach (var route in new[] {
+            "/hooks/session-start/antigravity", "/hooks/transcript",
+            "/hooks/subagent-start", "/hooks/subagent-stop", "/hooks/session-end/antigravity"
+        }) {
+            _server.Given(Request.Create().WithPath(route).UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200));
+        }
+        _server.Given(Request.Create().WithPath("/api/sessions/*/visibility").UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var antigravity = new AntigravityImportSource(home: _home, geminiCliHome: "");
+        var gemini      = new GeminiImportSource(tmpDirOverride: _geminiTmpDir);
+
+        var exitCode = 0;
+        var stdout = await CaptureStdoutAsync(async () => {
+            exitCode = await ImportCommand.HandleImport(
+                baseUrl: _server.Url!,
+                filterCwd: null,
+                minLines: 0,
+                sources: [antigravity, gemini],
+                scope: new ImportScope.All(),
+                skipConfirmation: true,
+                forcePrivate: true
+            );
+        });
+
+        await Assert.That(exitCode).IsEqualTo(0);
+
+        // --- Effect 3: the printed per-session line is the "Loading" line, not the grey
+        // "Already loaded ... (no new content)" no-op line (which is what a raw Skipped outcome
+        // with no override would print instead). ---
+        await Assert.That(stdout).Contains($"Loading {Root} (antigravity)");
+        await Assert.That(stdout).DoesNotContain($"Already loaded {Root}");
+        await Assert.That(stdout).DoesNotContain($"Refreshed {Root}");
+
+        // --- Effects 1 & 2: isolate the "== Done ==" section from the earlier "== Plan ==" one
+        // (which unconditionally prints "Excluded" even at 0) and check both the totals and the
+        // per-vendor "antigravity" sub-grid row show Loaded, not Excluded. ---
+        var doneIdx = stdout.IndexOf("== Done ==", StringComparison.Ordinal);
+        await Assert.That(doneIdx).IsGreaterThanOrEqualTo(0);
+        var doneSection = stdout[doneIdx..];
+
+        // Total row: routedLoaded folded in (chain phase never ran - both sources are routed).
+        await Assert.That(LineMatches(doneSection, "Loaded", 1)).IsTrue();
+        await Assert.That(doneSection).DoesNotContain("Excluded");
+        await Assert.That(doneSection).DoesNotContain("Errored");
+
+        var vendorIdx = doneSection.IndexOf("[antigravity]", StringComparison.Ordinal);
+        await Assert.That(vendorIdx).IsGreaterThanOrEqualTo(0);
+        var nextVendorIdx = doneSection.IndexOf('[', vendorIdx + "[antigravity]".Length);
+        var vendorRow     = nextVendorIdx > 0 ? doneSection[vendorIdx..nextVendorIdx] : doneSection[vendorIdx..];
+
+        await Assert.That(LineMatches(vendorRow, "Loaded", 1)).IsTrue();
+        await Assert.That(LineMatches(vendorRow, "Already loaded", 1)).IsTrue();
+        await Assert.That(vendorRow).DoesNotContain("Excluded");
+
+        // --- Effect 4: the counting-only override must NOT change --private membership. The
+        // RESOLVED outcome is Loaded (drives 1-3 above), but the RAW outcome is still Skipped, so
+        // the root never joins importedSessionIds — and (being a non-Cursor vendor) it has no
+        // separate outcome-independent privatize tracker either — so forcePrivate: true results
+        // in ZERO PUT /visibility calls for this run.
+        var putCalls = _server.LogEntries.Count(e => e.RequestMessage.Method == "PUT");
+        await Assert.That(putCalls).IsEqualTo(0);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Integration/CopilotImportSourceImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CopilotImportSourceImportTests.cs
@@ -1,0 +1,81 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// Copilot has no subagent handling at all on its routed <c>AlreadyLoaded</c> path —
+/// <c>SentChildContent</c> stays at its safe default <c>false</c> via the implicit
+/// <see cref="ImportOutcome"/> conversion. A real Copilot AlreadyLoaded replay must be
+/// recognized by <see cref="ImportCommand.IsLifecycleOnlyRoutedReplay"/> (vendor-neutral) and
+/// suppressed so it doesn't double-count on top of the classify-time AlreadyLoaded bucket.
+/// </summary>
+public class CopilotImportSourceImportTests : IDisposable {
+    readonly WireMockServer _server  = WireMockServer.Start();
+    readonly string         _tempDir = Directory.CreateTempSubdirectory("kcap-copilot-import-it").FullName;
+
+    const string DashedSid = "11111111-2222-3333-4444-555555555555";
+
+    public void Dispose() {
+        _server.Stop();
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    string WriteSession() {
+        var dir = Path.Combine(_tempDir, DashedSid);
+        Directory.CreateDirectory(dir);
+        File.WriteAllLines(Path.Combine(dir, "events.jsonl"), new[] {
+            $$"""{"type":"session.start","data":{"sessionId":"{{DashedSid}}"},"id":"e1","timestamp":"2026-06-10T20:23:49.371Z","parentId":null}""",
+            """{"type":"user.message","data":{"text":"hello"},"id":"e2","timestamp":"2026-06-10T20:23:50.000Z","parentId":"e1"}""",
+            """{"type":"assistant.message","data":{"text":"hi there"},"id":"e3","timestamp":"2026-06-10T20:23:51.000Z","parentId":"e2"}"""
+        });
+        File.WriteAllText(Path.Combine(dir, "workspace.yaml"), "cwd: /work/a\nname: proj\n");
+        return _tempDir;
+    }
+
+    [Test]
+    public async Task ImportSession_AlreadyLoaded_replay_is_a_no_op_suppressed_by_the_vendor_neutral_gate() {
+        var root = WriteSession();
+
+        // Server already covers every importable line → AlreadyLoaded.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"last_line_number":2}"""));
+        foreach (var route in new[] { "/hooks/session-start/copilot", "/hooks/set-title", "/hooks/session-end/copilot" }) {
+            _server.Given(Request.Create().WithPath(route).UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200));
+        }
+
+        using var client = new HttpClient();
+        var source = new CopilotImportSource(
+            sessionStateDirOverride: root,
+            repoDetector: _ => Task.FromResult<RepositoryPayload?>(null));
+
+        var discovered = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+        await Assert.That(discovered.Count).IsEqualTo(1);
+
+        var classified = await source.ClassifyAsync(
+            discovered,
+            new ClassifyContext(client, _server.Url!, MinLines: 0, ExcludedRepos: null, ExcludedPaths: null),
+            CancellationToken.None);
+        await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.AlreadyLoaded);
+
+        var result = await source.ImportSessionAsync(
+            classified[0],
+            new ImportContext(client, _server.Url!, ForcePrivate: false),
+            CancellationToken.None);
+
+        // Copilot never touches a child/subagent stream — SentChildContent stays false.
+        await Assert.That(result.SentChildContent).IsFalse();
+
+        var isSuppressed = ImportCommand.IsLifecycleOnlyRoutedReplay(
+            classified[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(isSuppressed).IsTrue();
+
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            classified[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(resolved).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Integration/CursorPrivatizeLifecycleFailureTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CursorPrivatizeLifecycleFailureTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Text.Json;
 using Capacitor.Cli.Commands;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -185,5 +187,107 @@ public class CursorPrivatizeLifecycleFailureTests : IDisposable {
 
         var (putPaths, _) = VisibilityPuts();
         await Assert.That(putPaths.Length).IsEqualTo(0);
+    }
+
+    // --- The 2-attempt cap on the child watermark probe must never regress the privacy fix
+    // above, even though the cap changes WHEN the fail-open triggers (after 2 attempts instead
+    // of 1). ---
+
+    static string Line(object o) => JsonSerializer.Serialize(o);
+
+    static string ParentTranscriptWithTask(string prompt) => string.Join("\n",
+        Line(new { role = "user", message = new { content = new object[] { new { type = "text", text = "do the thing" } } } }),
+        Line(new {
+            role    = "assistant",
+            message = new {
+                content = new object[] {
+                    new { type = "tool_use", name = "Task", input = new { description = "explore", prompt, subagent_type = "generalPurpose" } }
+                }
+            }
+        })
+    );
+
+    static string ChildTranscriptFromPrompt(string prompt) => string.Join("\n",
+        Line(new { role = "user", message = new { content = new object[] { new { type = "text", text = "<user_query>\n" + prompt + "\n</user_query>" } } } }),
+        Line(new { role = "assistant", message = new { content = new object[] { new { type = "text", text = "exploring" } } } })
+    );
+
+    const string ParentDirSessionId = "33333333-3333-3333-3333-333333333333";
+    const string ChildDirSessionId  = "44444444-4444-4444-4444-444444444444";
+    static readonly string ParentSessionId = CursorImportSource.NormalizeCursorSessionId(ParentDirSessionId);
+    static readonly string ChildSessionId  = CursorImportSource.NormalizeCursorSessionId(ChildDirSessionId);
+
+    /// <summary>
+    /// Writes a real parent+correlated-child pair (same sanitized workspace dir, so
+    /// <see cref="CursorSubagentCorrelator"/> links them) — the only shape that actually
+    /// exercises <c>SendSubagentLifecycleAsync</c>'s watermark probe end-to-end via
+    /// <see cref="ImportCommand.HandleImport"/>.
+    /// </summary>
+    string WriteParentWithCorrelatedChild() {
+        Directory.CreateDirectory(ProjectsDir);
+        const string prompt = "You are exploring the LoanApplicationDemo project. Return an overview.";
+
+        var parentDir = Path.Combine(ProjectsDir, "no-workspace-match", "agent-transcripts", ParentDirSessionId);
+        Directory.CreateDirectory(parentDir);
+        File.WriteAllText(Path.Combine(parentDir, ParentDirSessionId + ".jsonl"), ParentTranscriptWithTask(prompt));
+
+        var childDir = Path.Combine(ProjectsDir, "no-workspace-match", "agent-transcripts", ChildDirSessionId);
+        Directory.CreateDirectory(childDir);
+        File.WriteAllText(Path.Combine(childDir, ChildDirSessionId + ".jsonl"), ChildTranscriptFromPrompt(prompt));
+
+        return ProjectsDir;
+    }
+
+    [Test]
+    public async Task private_run_privatizes_when_child_watermark_probe_fails_both_of_its_2_attempts() {
+        // The child's own SUBSESSION watermark probe (/api/sessions/{parent}/last-line?agentId=
+        // {child}) fails on EVERY call — D3's fixed 2-attempt cap exhausts both attempts, then
+        // falls open (full resend). This must not regress the r6 privacy fix: the parent still
+        // gets privatized, independent of whichever Done-grid bucket the run's outcome lands in.
+        // The classify-time TOP-LEVEL probe (no agentId param) is a separate call shape and must
+        // keep succeeding (404 = fresh) so both sessions actually reach the routed import phase
+        // instead of failing classification outright.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").WithParam("agentId", ChildSessionId).UsingGet())
+            .AtPriority(1)
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.InternalServerError));
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .AtPriority(10)
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.NotFound));
+        foreach (var route in new[] {
+            "/hooks/session-start/cursor", "/hooks/transcript",
+            "/hooks/subagent-start", "/hooks/subagent-stop", "/hooks/session-end/cursor"
+        }) {
+            _server.Given(Request.Create().WithPath(route).UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200));
+        }
+        _server.Given(Request.Create().WithPath("/api/sessions/*/visibility").UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var source = new CursorImportSource(WriteParentWithCorrelatedChild(), WorkspaceStorageDir);
+
+        var exitCode = await ImportCommand.HandleImport(
+            baseUrl: _server.Url!,
+            filterCwd: null,
+            minLines: 0,
+            sources: [source],
+            scope: new ImportScope.All(),
+            skipConfirmation: true,
+            forcePrivate: true
+        );
+
+        await Assert.That(exitCode).IsEqualTo(0);
+
+        // The child's own subsession watermark probe was actually invoked twice (the fixed
+        // 2-attempt cap engaging), not zero and not more — distinct from the classify-time
+        // top-level probes (no agentId param), which succeed on the first attempt.
+        var childProbeCalls = _server.LogEntries.Count(e =>
+            e.RequestMessage.Method == "GET"
+         && e.RequestMessage.Path.EndsWith("/last-line", StringComparison.Ordinal)
+         && e.RequestMessage.Url!.Contains($"agentId={ChildSessionId}", StringComparison.Ordinal));
+        await Assert.That(childProbeCalls).IsEqualTo(2);
+
+        var (putPaths, putBodies) = VisibilityPuts();
+        await Assert.That(putPaths).Contains($"/api/sessions/{ParentSessionId}/visibility");
+        await Assert.That(putBodies.Any(b => b == """{"visibility":"none"}""")).IsTrue();
     }
 }

--- a/test/Capacitor.Cli.Tests.Integration/GeminiSubagentImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/GeminiSubagentImportTests.cs
@@ -78,12 +78,14 @@ public class GeminiSubagentImportTests : IDisposable {
             new ClassifyContext(client, _server.Url!, MinLines: 0, ExcludedRepos: null, ExcludedPaths: null),
             CancellationToken.None);
 
-        var outcome = await source.ImportSessionAsync(
+        var result = await source.ImportSessionAsync(
             classified[0],
             new ImportContext(client, _server.Url!, ForcePrivate: false),
             CancellationToken.None);
 
-        await Assert.That(outcome).IsEqualTo(ImportOutcome.Loaded);
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Loaded);
+        // The subagent DID send real content, so SentChildContent is threaded through as true.
+        await Assert.That(result.SentChildContent).IsTrue();
 
         var posts = _server.LogEntries
             .Where(e => e.RequestMessage.Method == "POST")
@@ -114,6 +116,160 @@ public class GeminiSubagentImportTests : IDisposable {
         var stopBody = _server.LogEntries.Single(e => e.RequestMessage.Path == "/hooks/subagent-stop").RequestMessage.Body!;
         await Assert.That(stopBody).Contains($"\"agent_id\":\"{DashlessSub}\"");
     }
+
+    // --- Gemini's SentChildContent signal, partial-plumbing with a documented residual (no
+    // per-child watermark — see ImportSubagentsAsync's doc comment). ---
+
+    [Test]
+    public async Task ImportSession_AlreadyLoaded_without_a_subagent_reports_no_sent_child_content() {
+        // A subagent-free session's AlreadyLoaded replay never touches a child/subagent stream
+        // at all — SentChildContent correctly reports false.
+        var chats = Path.Combine(_tempDir, "proj", "chats");
+        Directory.CreateDirectory(chats);
+        File.WriteAllLines(Path.Combine(chats, "session-2026-06-22T14-31-0a900001.jsonl"), new[] {
+            $$"""{"sessionId":"{{DashedParent}}","projectHash":"h","startTime":"2026-06-22T14:31:00.000Z","lastUpdated":"2026-06-22T14:31:00.000Z","kind":"main"}""",
+            """{"id":"u1","timestamp":"2026-06-22T14:31:01.000Z","type":"user","content":[{"text":"hi"}]}""",
+            """{"id":"m1","timestamp":"2026-06-22T14:31:05.000Z","type":"gemini","content":"hello"}"""
+        });
+
+        // High watermark → AlreadyLoaded.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"last_line_number":99}"""));
+        foreach (var route in new[] { "/hooks/session-start/gemini", "/hooks/session-end/gemini" }) {
+            _server.Given(Request.Create().WithPath(route).UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200));
+        }
+
+        using var client = new HttpClient();
+        var source = new GeminiImportSource(tmpDirOverride: _tempDir);
+
+        var discovered = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+        var classified = await source.ClassifyAsync(
+            discovered,
+            new ClassifyContext(client, _server.Url!, MinLines: 0, ExcludedRepos: null, ExcludedPaths: null),
+            CancellationToken.None);
+        await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.AlreadyLoaded);
+
+        var result = await source.ImportSessionAsync(
+            classified[0], new ImportContext(client, _server.Url!, ForcePrivate: false), CancellationToken.None);
+
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Resumed);
+        await Assert.That(result.SentChildContent).IsFalse();
+
+        var isSuppressed = ImportCommand.IsLifecycleOnlyRoutedReplay(
+            classified[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(isSuppressed).IsTrue();
+    }
+
+    [Test]
+    public async Task ImportSession_AlreadyLoaded_with_a_subagent_reports_sent_child_content_true() {
+        // Documented residual (D1): ImportSubagentsAsync has no per-child watermark, so it
+        // resends the whole subagent transcript on every re-run — an AlreadyLoaded parent whose
+        // subagent is still present reports SentChildContent=true, whether or not the subagent
+        // content is actually new. That's the accepted, conservative trade-off: this reads true
+        // on essentially every re-run of a subagent-bearing session, closing the common
+        // subagent-free case for free while leaving the subagent-bearing case genuinely
+        // uncounted-as-suppressed (never proven no-work) rather than risking a silently dropped
+        // real subagent update.
+        WriteFixture();
+
+        // High watermark for BOTH the parent and the subagent → AlreadyLoaded, but
+        // ImportSubagentsAsync always resends the subagent transcript regardless.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"last_line_number":99}"""));
+        foreach (var route in new[] {
+            "/hooks/session-start/gemini", "/hooks/transcript",
+            "/hooks/subagent-start", "/hooks/subagent-stop", "/hooks/session-end/gemini"
+        }) {
+            _server.Given(Request.Create().WithPath(route).UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200));
+        }
+
+        using var client = new HttpClient();
+        var source = new GeminiImportSource(tmpDirOverride: _tempDir);
+
+        var discovered = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+        var classified = await source.ClassifyAsync(
+            discovered,
+            new ClassifyContext(client, _server.Url!, MinLines: 0, ExcludedRepos: null, ExcludedPaths: null),
+            CancellationToken.None);
+        await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.AlreadyLoaded);
+
+        var result = await source.ImportSessionAsync(
+            classified[0], new ImportContext(client, _server.Url!, ForcePrivate: false), CancellationToken.None);
+
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Resumed);
+        await Assert.That(result.SentChildContent).IsTrue();
+
+        // No override needed for Gemini — Resumed never engages IsSkippedChildContentOverride
+        // (it requires outcome == Skipped exactly), so this is NOT suppressed: it resolves via
+        // the ordinary outcome path.
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            classified[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(resolved).IsEqualTo(ImportOutcome.Resumed);
+    }
+
+    [Test]
+    public async Task ImportSession_AlreadyLoaded_with_a_subagent_whose_transcript_post_is_rejected_reports_no_sent_child_content() {
+        // Regression for a Qodo-flagged false positive: SendTranscriptBatches returns a
+        // positive line count even when the server REJECTS the batch (failOnError defaults
+        // false), so without failOnError:true here SentChildContent would flip true for a
+        // batch the server never accepted. Mirrors
+        // ImportSession_AlreadyLoaded_with_a_subagent_reports_sent_child_content_true, except
+        // the subagent's /hooks/transcript POST now returns 500.
+        WriteFixture();
+
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"last_line_number":99}"""));
+        foreach (var route in new[] { "/hooks/session-start/gemini", "/hooks/subagent-start", "/hooks/session-end/gemini" }) {
+            _server.Given(Request.Create().WithPath(route).UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200));
+        }
+        // The server rejects the subagent's content batch (the parent, AlreadyLoaded, never
+        // reaches /hooks/transcript at all — its startLine already sits at TotalLines).
+        _server.Given(Request.Create().WithPath("/hooks/transcript").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(500));
+
+        using var client = new HttpClient();
+        var source = new GeminiImportSource(tmpDirOverride: _tempDir);
+
+        var discovered = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+        var classified = await source.ClassifyAsync(
+            discovered,
+            new ClassifyContext(client, _server.Url!, MinLines: 0, ExcludedRepos: null, ExcludedPaths: null),
+            CancellationToken.None);
+        await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.AlreadyLoaded);
+
+        var result = await source.ImportSessionAsync(
+            classified[0], new ImportContext(client, _server.Url!, ForcePrivate: false), CancellationToken.None);
+
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Resumed);
+        // The rejected batch must NOT be reported as having sent child content — the exact
+        // bug under test.
+        await Assert.That(result.SentChildContent).IsFalse();
+
+        // The walk continues non-fatally past the rejected batch (caught by the surrounding
+        // try/catch): subagent-start was posted, but subagent-stop is left unsent (a
+        // re-import retries), and the parent's own lifecycle still completes.
+        var posts = _server.LogEntries.Where(e => e.RequestMessage.Method == "POST")
+            .Select(e => e.RequestMessage.Path).ToList();
+        await Assert.That(posts.Contains("/hooks/subagent-start")).IsTrue();
+        await Assert.That(posts.Contains("/hooks/subagent-stop")).IsFalse();
+        await Assert.That(posts.Contains("/hooks/session-start/gemini")).IsTrue();
+        await Assert.That(posts.Contains("/hooks/session-end/gemini")).IsTrue();
+
+        // A routed AlreadyLoaded replay with a false signal is SUPPRESSED for counting, not
+        // counted Loaded — the false positive Qodo flagged.
+        var isSuppressed = ImportCommand.IsLifecycleOnlyRoutedReplay(
+            classified[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(isSuppressed).IsTrue();
+
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            classified[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(resolved).IsNull();
+    }
+
+    // --- AI-1383 D3: recursive grandchild/descendant discovery. ---
 
     const string DashedGrandsub   = "8c1a2222-3333-4444-5555-666677778888";
     const string DashlessGrandsub = "8c1a2222333344445555666677778888";
@@ -180,12 +336,15 @@ public class GeminiSubagentImportTests : IDisposable {
             new ClassifyContext(client, _server.Url!, MinLines: 0, ExcludedRepos: null, ExcludedPaths: null),
             CancellationToken.None);
 
-        var outcome = await source.ImportSessionAsync(
+        var result = await source.ImportSessionAsync(
             classified[0],
             new ImportContext(client, _server.Url!, ForcePrivate: false),
             CancellationToken.None);
 
-        await Assert.That(outcome).IsEqualTo(ImportOutcome.Loaded);
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Loaded);
+        // Both descendants (Sub + Grandsub) sent real content, aggregated up through the
+        // recursive walk in ImportSubagentsAsync.
+        await Assert.That(result.SentChildContent).IsTrue();
 
         var starts = _server.LogEntries.Where(e => e.RequestMessage.Path == "/hooks/subagent-start")
             .Select(e => e.RequestMessage.Body!).ToList();

--- a/test/Capacitor.Cli.Tests.Integration/KiroImportSourceImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/KiroImportSourceImportTests.cs
@@ -1,0 +1,79 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// Kiro has no subagent handling at all on its routed <c>AlreadyLoaded</c> path —
+/// <c>SentChildContent</c> stays at its safe default <c>false</c> via the implicit
+/// <see cref="ImportOutcome"/> conversion. A real Kiro AlreadyLoaded replay must be recognized
+/// by <see cref="ImportCommand.IsLifecycleOnlyRoutedReplay"/> (vendor-neutral) and suppressed
+/// so it doesn't double-count on top of the classify-time AlreadyLoaded bucket.
+/// </summary>
+public class KiroImportSourceImportTests : IDisposable {
+    readonly WireMockServer _server  = WireMockServer.Start();
+    readonly string         _tempDir = Directory.CreateTempSubdirectory("kcap-kiro-import-it").FullName;
+
+    const string DashedSid = "11111111-2222-3333-4444-555555555555";
+
+    public void Dispose() {
+        _server.Stop();
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    string WriteSession() {
+        var path = Path.Combine(_tempDir, DashedSid + ".jsonl");
+        File.WriteAllLines(path, new[] {
+            """{"version":"v1","kind":"Prompt","data":{"message_id":"m1","content":[{"kind":"text","data":"hi"}]}}""",
+            """{"version":"v1","kind":"AssistantMessage","data":{"message_id":"m2","content":[{"kind":"text","data":"hello back"}]}}"""
+        });
+        File.WriteAllText(Path.Combine(_tempDir, DashedSid + ".json"), """{"cwd":"/work/a","title":"t","created_at":"2026-06-10T20:23:49.371Z","updated_at":"2026-06-10T20:23:50.000Z"}""");
+        return _tempDir;
+    }
+
+    [Test]
+    public async Task ImportSession_AlreadyLoaded_replay_is_a_no_op_suppressed_by_the_vendor_neutral_gate() {
+        var root = WriteSession();
+
+        // Server already covers every importable line → AlreadyLoaded.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"last_line_number":1}"""));
+        foreach (var route in new[] { "/hooks/session-start/kiro", "/hooks/set-title", "/hooks/session-end/kiro" }) {
+            _server.Given(Request.Create().WithPath(route).UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200));
+        }
+
+        using var client = new HttpClient();
+        var source = new KiroImportSource(
+            sessionsDirOverride: root,
+            repoDetector: _ => Task.FromResult<RepositoryPayload?>(null));
+
+        var discovered = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+        await Assert.That(discovered.Count).IsEqualTo(1);
+
+        var classified = await source.ClassifyAsync(
+            discovered,
+            new ClassifyContext(client, _server.Url!, MinLines: 0, ExcludedRepos: null, ExcludedPaths: null),
+            CancellationToken.None);
+        await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.AlreadyLoaded);
+
+        var result = await source.ImportSessionAsync(
+            classified[0],
+            new ImportContext(client, _server.Url!, ForcePrivate: false),
+            CancellationToken.None);
+
+        // Kiro never touches a child/subagent stream — SentChildContent stays false.
+        await Assert.That(result.SentChildContent).IsFalse();
+
+        var isSuppressed = ImportCommand.IsLifecycleOnlyRoutedReplay(
+            classified[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(isSuppressed).IsTrue();
+
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            classified[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(resolved).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Integration/OpenCodeImportSourceImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/OpenCodeImportSourceImportTests.cs
@@ -184,10 +184,27 @@ public class OpenCodeImportSourceImportTests : IDisposable {
         var c2 = await s2.ClassifyAsync(
             await s2.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None), ctx, CancellationToken.None);
         await Assert.That(c2[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.AlreadyLoaded);
-        await Assert.That(await s2.ImportSessionAsync(c2[0], importCtx, CancellationToken.None)).IsEqualTo(ImportOutcome.Skipped);
+
+        var result = await s2.ImportSessionAsync(c2[0], importCtx, CancellationToken.None);
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Skipped);
 
         await Assert.That(_server.LogEntries.Count(e => e.RequestMessage.Path == "/hooks/transcript"))
             .IsEqualTo(transcriptCountAfterRun1);
+
+        // OpenCode's AlreadyLoaded path short-circuits before touching any child/subagent
+        // stream (not even a lifecycle POST), so SentChildContent stays at its safe default
+        // false — trivially correct. This real (AlreadyLoaded, Skipped, false) shape must be
+        // correctly SUPPRESSED by the vendor-neutral gate (a genuine no-op replay), the mirror
+        // case of the Antigravity override — not something newly let through.
+        await Assert.That(result.SentChildContent).IsFalse();
+
+        var isSuppressed = ImportCommand.IsLifecycleOnlyRoutedReplay(
+            c2[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(isSuppressed).IsTrue();
+
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            c2[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(resolved).IsNull();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Integration/PiImportSourceImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/PiImportSourceImportTests.cs
@@ -180,4 +180,53 @@ public class PiImportSourceImportTests : IDisposable {
         await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.Partial);
         await Assert.That(classified[0].ResumeFromLine).IsEqualTo(2);
     }
+
+    // --- Pi's AlreadyLoaded replay is a genuine no-op (no subagent handling in this vendor at
+    // all) — the vendor-neutral gate must suppress this shape. ---
+
+    [Test]
+    public async Task ImportSession_AlreadyLoaded_replay_is_a_no_op_suppressed_by_the_vendor_neutral_gate() {
+        var sessionsDir = WriteSessionFile();
+
+        // Server already covers every importable line → AlreadyLoaded.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"last_line_number":2}"""));
+        _server.Given(Request.Create().WithPath("/hooks/session-start/pi").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200));
+        _server.Given(Request.Create().WithPath("/hooks/session-end/pi").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        using var client = new HttpClient();
+
+        var source = new PiImportSource(
+            sessionsDir,
+            repoDetector: _ => Task.FromResult<RepositoryPayload?>(null));
+
+        var discovered = await source.DiscoverAsync(new DiscoveryFilters(null, null, null, 0), CancellationToken.None);
+        var classified = await source.ClassifyAsync(
+            discovered,
+            new ClassifyContext(client, _server.Url!, MinLines: 0, ExcludedRepos: null, ExcludedPaths: null),
+            CancellationToken.None);
+        await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.AlreadyLoaded);
+
+        var result = await source.ImportSessionAsync(
+            classified[0],
+            new ImportContext(client, _server.Url!, ForcePrivate: false),
+            CancellationToken.None);
+
+        // Pi never touches a child/subagent stream on this path — SentChildContent stays at its
+        // safe default false.
+        await Assert.That(result.SentChildContent).IsFalse();
+
+        // With the vendor parameter dropped, this real (status, outcome, sentChildContent) shape
+        // is recognized as a lifecycle-only replay and must be suppressed — not counted as
+        // Loaded/Resumed on top of the classify-time AlreadyLoaded bucket.
+        var isSuppressed = ImportCommand.IsLifecycleOnlyRoutedReplay(
+            classified[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(isSuppressed).IsTrue();
+
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            classified[0].Status, result.Outcome, result.SentChildContent);
+        await Assert.That(resolved).IsNull();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
@@ -847,6 +847,310 @@ public class CursorImportSourceTests {
         await Assert.That(result.SentChildContent).IsTrue();
     }
 
+    // --- Watermark probe 2-attempt cap ---
+
+    [Test]
+    public async Task cursor_watermark_probe_retries_once_on_transient_500_then_succeeds() {
+        // A single transient 500 no longer skips straight to fail-open on the first failure:
+        // the status-bearing retry engages, the second attempt succeeds with a real watermark,
+        // and only the genuinely-new lines beyond it are sent.
+        using var fx = new ProjectsDirFixture();
+
+        var parentJsonl = fx.AddSession("Users-me-proj", "11111111-1111-1111-1111-111111111111", "{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n");
+        // 3 child lines; watermark (once known) reports last_line_number=0, so lines 1 and 2
+        // are genuinely new.
+        var childJsonl = fx.AddSession("Users-me-proj", "22222222-2222-2222-2222-222222222222", "{\"x\":1}\n{\"y\":2}\n{\"z\":3}\n");
+
+        var src = new CursorImportSource(fx.ProjectsDir, fx.WorkspaceStorageDir);
+
+        var getCalls = 0;
+        var posted   = new List<(string Path, string Body)>();
+
+        using var handler = new StubHandler(
+            getResponse: _ => {
+                getCalls++;
+                return getCalls == 1
+                    ? new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                    : new HttpResponseMessage(HttpStatusCode.OK) {
+                        Content = new StringContent("{\"last_line_number\":0}", System.Text.Encoding.UTF8, "application/json"),
+                    };
+            },
+            postCapture: (req, body) => {
+                posted.Add((req.RequestUri!.AbsolutePath, body));
+
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+        );
+        using var client = new HttpClient(handler);
+
+        var parentClass = new ImportCommand.SessionClassification {
+            SessionId  = "11111111111111111111111111111111",
+            FilePath   = "",
+            EncodedCwd = "",
+            Meta       = new SessionMetadata(),
+            Status     = ImportCommand.ClassificationStatus.AlreadyLoaded,
+            TotalLines = 3,
+            Vendor     = "cursor",
+            SourceMeta = new Dictionary<string, object?> {
+                ["TranscriptPath"]   = parentJsonl,
+                ["SubagentChildren"] = new List<CursorImportSource.CursorSubagentChild> {
+                    new("22222222222222222222222222222222", childJsonl, "generalPurpose"),
+                },
+            },
+        };
+
+        var result = await src.ImportSessionAsync(
+            parentClass, new ImportContext(client, "http://localhost", ForcePrivate: false), CancellationToken.None);
+
+        // Exactly 2 probe attempts: the retryable 500, then the successful retry — no fail-open
+        // triggered (the watermark WAS resolved).
+        await Assert.That(getCalls).IsEqualTo(2);
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Resumed);
+        await Assert.That(result.SentChildContent).IsTrue();
+
+        var transcriptPost = posted.Single(p => p.Path == "/hooks/transcript");
+        var lineNumbers     = JsonNode.Parse(transcriptPost.Body)!["line_numbers"]!.AsArray()
+            .Select(n => n!.GetValue<int>()).ToArray();
+        // The exact startLine used: only lines 1 and 2 (beyond the resolved watermark) were sent.
+        await Assert.That(lineNumbers).IsEquivalentTo(new[] { 1, 2 });
+    }
+
+    [Test]
+    public async Task cursor_watermark_probe_falls_open_after_exactly_2_attempts_on_sustained_500() {
+        // A sustained failure exhausts the fixed 2-attempt cap before falling open — not before,
+        // not after. The fail-open resend still happens (idempotent server-side) and still
+        // conservatively reports SentChildContent=true since lines were actually posted.
+        using var fx = new ProjectsDirFixture();
+
+        var parentJsonl = fx.AddSession("Users-me-proj", "11111111-1111-1111-1111-111111111111", "{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n");
+        var childJsonl  = fx.AddSession("Users-me-proj", "22222222-2222-2222-2222-222222222222", "{\"x\":1}\n{\"y\":2}\n{\"z\":3}\n");
+
+        var src = new CursorImportSource(fx.ProjectsDir, fx.WorkspaceStorageDir);
+
+        var getCalls = 0;
+        var posted   = new List<(string Path, string Body)>();
+
+        using var handler = new StubHandler(
+            getResponse: _ => {
+                getCalls++;
+                return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            },
+            postCapture: (req, body) => {
+                posted.Add((req.RequestUri!.AbsolutePath, body));
+
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+        );
+        using var client = new HttpClient(handler);
+
+        var parentClass = new ImportCommand.SessionClassification {
+            SessionId  = "11111111111111111111111111111111",
+            FilePath   = "",
+            EncodedCwd = "",
+            Meta       = new SessionMetadata(),
+            Status     = ImportCommand.ClassificationStatus.AlreadyLoaded,
+            TotalLines = 3,
+            Vendor     = "cursor",
+            SourceMeta = new Dictionary<string, object?> {
+                ["TranscriptPath"]   = parentJsonl,
+                ["SubagentChildren"] = new List<CursorImportSource.CursorSubagentChild> {
+                    new("22222222222222222222222222222222", childJsonl, "generalPurpose"),
+                },
+            },
+        };
+
+        var result = await src.ImportSessionAsync(
+            parentClass, new ImportContext(client, "http://localhost", ForcePrivate: false), CancellationToken.None);
+
+        // Exactly 2 attempts made — the fixed cap, no more and no less — before falling open.
+        await Assert.That(getCalls).IsEqualTo(2);
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Resumed);
+        await Assert.That(result.SentChildContent).IsTrue();
+
+        var transcriptPost = posted.Single(p => p.Path == "/hooks/transcript");
+        var lineNumbers     = JsonNode.Parse(transcriptPost.Body)!["line_numbers"]!.AsArray()
+            .Select(n => n!.GetValue<int>()).ToArray();
+        // Fail-open: the watermark was never resolved, so the whole child is resent from 0.
+        await Assert.That(lineNumbers).IsEquivalentTo(new[] { 0, 1, 2 });
+    }
+
+    [Test]
+    public async Task cursor_watermark_probe_does_not_retry_a_404() {
+        // A definitive 4xx (here reached via the existing NotFound "no watermark yet" shortcut)
+        // is not retried — the first attempt's result stands, matching today's behavior for a
+        // never-before-imported child.
+        using var fx = new ProjectsDirFixture();
+
+        var parentJsonl = fx.AddSession("Users-me-proj", "11111111-1111-1111-1111-111111111111", "{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n");
+        var childJsonl  = fx.AddSession("Users-me-proj", "22222222-2222-2222-2222-222222222222", "{\"x\":1}\n{\"y\":2}\n{\"z\":3}\n");
+
+        var src = new CursorImportSource(fx.ProjectsDir, fx.WorkspaceStorageDir);
+
+        var getCalls = 0;
+
+        using var handler = new StubHandler(
+            getResponse: _ => {
+                getCalls++;
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            },
+            postCapture: (_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        );
+        using var client = new HttpClient(handler);
+
+        var parentClass = new ImportCommand.SessionClassification {
+            SessionId  = "11111111111111111111111111111111",
+            FilePath   = "",
+            EncodedCwd = "",
+            Meta       = new SessionMetadata(),
+            Status     = ImportCommand.ClassificationStatus.AlreadyLoaded,
+            TotalLines = 3,
+            Vendor     = "cursor",
+            SourceMeta = new Dictionary<string, object?> {
+                ["TranscriptPath"]   = parentJsonl,
+                ["SubagentChildren"] = new List<CursorImportSource.CursorSubagentChild> {
+                    new("22222222222222222222222222222222", childJsonl, "generalPurpose"),
+                },
+            },
+        };
+
+        var result = await src.ImportSessionAsync(
+            parentClass, new ImportContext(client, "http://localhost", ForcePrivate: false), CancellationToken.None);
+
+        await Assert.That(getCalls).IsEqualTo(1); // no second attempt
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Resumed);
+        await Assert.That(result.SentChildContent).IsTrue();
+    }
+
+    [Test]
+    public async Task cursor_watermark_probe_does_not_retry_a_429() {
+        // 429 is explicitly excluded from the outer retry (a rate-limit signal, not a transient
+        // blip) — no second attempt, fail-open triggers immediately, same treatment as a
+        // non-retryable 4xx.
+        using var fx = new ProjectsDirFixture();
+
+        var parentJsonl = fx.AddSession("Users-me-proj", "11111111-1111-1111-1111-111111111111", "{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n");
+        var childJsonl  = fx.AddSession("Users-me-proj", "22222222-2222-2222-2222-222222222222", "{\"x\":1}\n{\"y\":2}\n{\"z\":3}\n");
+
+        var src = new CursorImportSource(fx.ProjectsDir, fx.WorkspaceStorageDir);
+
+        var getCalls = 0;
+
+        using var handler = new StubHandler(
+            getResponse: _ => {
+                getCalls++;
+                return new HttpResponseMessage((HttpStatusCode)429);
+            },
+            postCapture: (_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        );
+        using var client = new HttpClient(handler);
+
+        var parentClass = new ImportCommand.SessionClassification {
+            SessionId  = "11111111111111111111111111111111",
+            FilePath   = "",
+            EncodedCwd = "",
+            Meta       = new SessionMetadata(),
+            Status     = ImportCommand.ClassificationStatus.AlreadyLoaded,
+            TotalLines = 3,
+            Vendor     = "cursor",
+            SourceMeta = new Dictionary<string, object?> {
+                ["TranscriptPath"]   = parentJsonl,
+                ["SubagentChildren"] = new List<CursorImportSource.CursorSubagentChild> {
+                    new("22222222222222222222222222222222", childJsonl, "generalPurpose"),
+                },
+            },
+        };
+
+        var result = await src.ImportSessionAsync(
+            parentClass, new ImportContext(client, "http://localhost", ForcePrivate: false), CancellationToken.None);
+
+        await Assert.That(getCalls).IsEqualTo(1); // no second attempt
+        await Assert.That(result.Outcome).IsEqualTo(ImportOutcome.Resumed);
+        await Assert.That(result.SentChildContent).IsTrue();
+    }
+
+    // The statusless case is tested directly against the pure retry-decision shell
+    // (FetchServerLastLineWithCappedRetryAsync) rather than end-to-end through ImportSessionAsync:
+    // a genuinely statusless HttpRequestException can only come out of GetWithRetryAsync by
+    // exhausting its own real ~30s internal backoff loop (a normally-returned non-2xx status,
+    // used by the four tests above, never enters that loop at all — only a THROWN
+    // HttpRequestException does, and GetWithRetryAsync retries every thrown HttpRequestException
+    // it sees regardless of status). Driving that for real would make this one test take ~30s of
+    // wall-clock time for no extra coverage; testing the shell directly with an injected probe
+    // keeps it instant while still exercising the exact acceptance criterion (finding 4): a
+    // statusless failure gets no second attempt.
+
+    [Test]
+    public async Task fetch_server_last_line_with_capped_retry_does_not_retry_a_statusless_transport_failure() {
+        var probeCalls = 0;
+
+        Task<int?> Probe(CancellationToken _) {
+            probeCalls++;
+
+            throw new HttpRequestException("connection refused"); // no HttpStatusCode — statusless
+        }
+
+        await Assert.That(async () =>
+            await CursorImportSource.FetchServerLastLineWithCappedRetryAsync(Probe, CancellationToken.None)
+        ).Throws<HttpRequestException>();
+
+        await Assert.That(probeCalls).IsEqualTo(1); // no second attempt
+    }
+
+    [Test]
+    public async Task fetch_server_last_line_with_capped_retry_retries_a_status_bearing_5xx_once() {
+        var probeCalls = 0;
+
+        Task<int?> Probe(CancellationToken _) {
+            probeCalls++;
+
+            if (probeCalls == 1)
+                throw new HttpRequestException("boom", null, HttpStatusCode.InternalServerError);
+
+            return Task.FromResult<int?>(7);
+        }
+
+        var result = await CursorImportSource.FetchServerLastLineWithCappedRetryAsync(Probe, CancellationToken.None);
+
+        await Assert.That(result).IsEqualTo(7);
+        await Assert.That(probeCalls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task fetch_server_last_line_with_capped_retry_propagates_cancellation_without_retrying() {
+        var probeCalls = 0;
+        using var cts  = new CancellationTokenSource();
+
+        Task<int?> Probe(CancellationToken _) {
+            probeCalls++;
+            cts.Cancel();
+            throw new OperationCanceledException(cts.Token);
+        }
+
+        await Assert.That(async () =>
+            await CursorImportSource.FetchServerLastLineWithCappedRetryAsync(Probe, cts.Token)
+        ).Throws<OperationCanceledException>();
+
+        await Assert.That(probeCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(500, true)]
+    [Arguments(503, true)]
+    [Arguments(408, true)]
+    [Arguments(404, false)]
+    [Arguments(429, false)]
+    [Arguments(401, false)]
+    public async Task is_retryable_watermark_probe_status_classifies_correctly(int statusCode, bool expected) {
+        var result = CursorImportSource.IsRetryableWatermarkProbeStatus((HttpStatusCode)statusCode);
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task is_retryable_watermark_probe_status_is_false_for_a_null_statusless_code() {
+        var result = CursorImportSource.IsRetryableWatermarkProbeStatus(null);
+        await Assert.That(result).IsFalse();
+    }
+
     [Test]
     public async Task import_session_attaches_repository_from_detected_workspace_repo() {
         // AI-1152: the import/backfill path must attach a `repository` node to the

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportDoneBreakdownTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportDoneBreakdownTests.cs
@@ -155,10 +155,10 @@ public class ImportDoneBreakdownTests {
         await Assert.That(claudeRow.Errored + cursorRow.Errored).IsEqualTo(2);   // 1 + 1
     }
 
-    // --- IsLifecycleOnlyRoutedReplay (AI-1154 review fix, P2; broadened round-2) ---
+    // --- IsLifecycleOnlyRoutedReplay (vendor-NEUTRAL — no per-vendor scoping) ---
     //
     // The routed-phase loop in HandleImport increments routedLoaded/importedSessionIds whenever
-    // ImportOutcome is Loaded/Resumed. For an AlreadyLoaded Cursor classification, ImportSessionAsync
+    // ImportOutcome is Loaded/Resumed. For an AlreadyLoaded classification, ImportSessionAsync
     // re-asserts lifecycle hooks (repository backfill, C2) rather than importing new content, but
     // still returns Loaded/Resumed since there's nothing past the watermark to distinguish it by.
     // IsLifecycleOnlyRoutedReplay is the gate that keeps that replay from being double-counted on
@@ -171,11 +171,14 @@ public class ImportDoneBreakdownTests {
     //   (2) AlreadyLoaded + Skipped (a correlated child whose own routed call short-circuits
     //       to Skipped because its parent imports it inline) is now also recognized, so it
     //       isn't double-counted as both Already-loaded and Excluded.
+    //
+    // Every routed vendor's lifecycle-only replay looks the same shape from here — there's no
+    // `vendor` parameter to scope by.
 
     [Test]
     public async Task already_loaded_plus_loaded_outcome_is_a_lifecycle_only_replay() {
         var result = ImportCommand.IsLifecycleOnlyRoutedReplay(
-            "cursor", ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Loaded, sentChildContent: false);
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Loaded, sentChildContent: false);
 
         await Assert.That(result).IsTrue();
     }
@@ -185,7 +188,7 @@ public class ImportDoneBreakdownTests {
         // The actual shape CursorImportSource.ImportSessionAsync returns for AlreadyLoaded: nothing
         // sent past a non-zero startLine (TotalLines) is classified Resumed, not Loaded.
         var result = ImportCommand.IsLifecycleOnlyRoutedReplay(
-            "cursor", ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Resumed, sentChildContent: false);
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Resumed, sentChildContent: false);
 
         await Assert.That(result).IsTrue();
     }
@@ -194,7 +197,7 @@ public class ImportDoneBreakdownTests {
     public async Task new_plus_loaded_outcome_is_not_a_lifecycle_only_replay() {
         // A genuine first-time import must still count as newly Loaded.
         var result = ImportCommand.IsLifecycleOnlyRoutedReplay(
-            "cursor", ImportCommand.ClassificationStatus.New, ImportOutcome.Loaded, sentChildContent: false);
+            ImportCommand.ClassificationStatus.New, ImportOutcome.Loaded, sentChildContent: false);
 
         await Assert.That(result).IsFalse();
     }
@@ -203,7 +206,7 @@ public class ImportDoneBreakdownTests {
     public async Task partial_plus_resumed_outcome_is_not_a_lifecycle_only_replay() {
         // A genuine resume of a partially-imported session must still count as newly Loaded.
         var result = ImportCommand.IsLifecycleOnlyRoutedReplay(
-            "cursor", ImportCommand.ClassificationStatus.Partial, ImportOutcome.Resumed, sentChildContent: false);
+            ImportCommand.ClassificationStatus.Partial, ImportOutcome.Resumed, sentChildContent: false);
 
         await Assert.That(result).IsFalse();
     }
@@ -212,7 +215,7 @@ public class ImportDoneBreakdownTests {
     public async Task already_loaded_plus_failed_outcome_is_not_a_lifecycle_only_replay() {
         // A failed lifecycle-reassert POST must still surface as Errored, not be swallowed.
         var result = ImportCommand.IsLifecycleOnlyRoutedReplay(
-            "cursor", ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Failed, sentChildContent: false);
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Failed, sentChildContent: false);
 
         await Assert.That(result).IsFalse();
     }
@@ -226,7 +229,7 @@ public class ImportDoneBreakdownTests {
         // the replay gate must not suppress it, so the parent joins importedSessionIds/routedLoaded
         // and a later --private pass correctly re-privates it.
         var result = ImportCommand.IsLifecycleOnlyRoutedReplay(
-            "cursor", ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Resumed, sentChildContent: true);
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Resumed, sentChildContent: true);
 
         await Assert.That(result).IsFalse();
     }
@@ -234,7 +237,7 @@ public class ImportDoneBreakdownTests {
     [Test]
     public async Task already_loaded_plus_loaded_outcome_with_sent_child_content_is_not_a_lifecycle_only_replay() {
         var result = ImportCommand.IsLifecycleOnlyRoutedReplay(
-            "cursor", ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Loaded, sentChildContent: true);
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Loaded, sentChildContent: true);
 
         await Assert.That(result).IsFalse();
     }
@@ -247,7 +250,7 @@ public class ImportDoneBreakdownTests {
         // routed call short-circuits to Skipped because its parent imports it inline. This must
         // not double-count as both Already-loaded (classify time) and Excluded (routed outcome).
         var result = ImportCommand.IsLifecycleOnlyRoutedReplay(
-            "cursor", ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Skipped, sentChildContent: false);
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Skipped, sentChildContent: false);
 
         await Assert.That(result).IsTrue();
     }
@@ -258,49 +261,141 @@ public class ImportDoneBreakdownTests {
         // call is Skipped still rolls up into the Excluded bucket — only the AlreadyLoaded case
         // is a double-count.
         var result = ImportCommand.IsLifecycleOnlyRoutedReplay(
-            "cursor", ImportCommand.ClassificationStatus.New, ImportOutcome.Skipped, sentChildContent: false);
+            ImportCommand.ClassificationStatus.New, ImportOutcome.Skipped, sentChildContent: false);
 
         await Assert.That(result).IsFalse();
     }
 
-    // --- Round-3 finding 2: the gate is CURSOR-ONLY ---
+    // --- ResolveRoutedOutcomeForCounting / IsSkippedChildContentOverride — the aggregation
+    // boundary that decides what a non-suppressed routed call counts as. ---
     //
-    // SentChildContent is populated only by CursorImportSource. Every other routed vendor's
-    // ImportSessionResult leaves it at the default `false` via the implicit ImportOutcome
-    // conversion — including Antigravity's AlreadyLoaded repair path, which can legitimately POST
-    // new nested-child transcript content via ImportChildrenAsync before returning
-    // ImportOutcome.Skipped. Without a vendor scope, the shape
-    // (AlreadyLoaded, Skipped, sentChildContent: false) is indistinguishable from a genuine
-    // Cursor lifecycle-only replay, and a real Antigravity child import gets wrongly suppressed.
+    // IsLifecycleOnlyRoutedReplay only ever says "suppress, don't count at all" — it was never
+    // the thing that decided which bucket a non-suppressed call lands in (that's the raw
+    // `outcome` switch downstream). That's exactly where a Skipped AlreadyLoaded call that
+    // attached genuinely-new nested-child content (e.g. Antigravity's shape) falls through the
+    // cracks: sentChildContent=true correctly stops the gate from suppressing it, but the
+    // downstream switch keys off the literal `outcome`, and Skipped's non-suppressed branch
+    // increments routedExcluded, not routedLoaded. These tests pin the resolver that fixes that.
 
     [Test]
-    public async Task already_loaded_plus_skipped_outcome_for_antigravity_is_not_a_lifecycle_only_replay() {
-        // Same (status, outcome, sentChildContent) shape as the Cursor lifecycle-only-replay case
-        // above, but for Antigravity — whose AlreadyLoaded repair path can attach brand-new nested
-        // child content while still returning Skipped (it never populates SentChildContent). The
-        // gate must not suppress this as lifecycle-only just because the vendor happens to share
-        // the same outcome/status shape as Cursor's genuine no-op replay.
-        var result = ImportCommand.IsLifecycleOnlyRoutedReplay(
-            "antigravity", ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Skipped, sentChildContent: false);
+    public async Task already_loaded_skipped_with_sent_child_content_overrides_to_loaded() {
+        // The exact Antigravity shape: this is the case that was silently wrong before D2, and
+        // the one no per-vendor test alone would catch.
+        var isOverride = ImportCommand.IsSkippedChildContentOverride(
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Skipped, sentChildContent: true);
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Skipped, sentChildContent: true);
 
-        await Assert.That(result).IsFalse();
+        await Assert.That(isOverride).IsTrue();
+        await Assert.That(resolved).IsEqualTo(ImportOutcome.Loaded);
     }
 
     [Test]
-    public async Task already_loaded_plus_resumed_outcome_for_antigravity_is_not_a_lifecycle_only_replay() {
-        var result = ImportCommand.IsLifecycleOnlyRoutedReplay(
-            "antigravity", ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Resumed, sentChildContent: false);
+    public async Task already_loaded_resumed_with_sent_child_content_resolves_unchanged() {
+        // PRESERVED, not reclassified — IsSkippedChildContentOverride requires outcome==Skipped
+        // exactly, so it never engages here; there's no ambiguity for the resolver to resolve.
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Resumed, sentChildContent: true);
 
-        await Assert.That(result).IsFalse();
+        await Assert.That(resolved).IsEqualTo(ImportOutcome.Resumed);
     }
 
     [Test]
-    public async Task already_loaded_plus_loaded_outcome_for_claude_is_not_a_lifecycle_only_replay() {
-        // Sanity check for a non-Cursor, non-Antigravity vendor too — the gate is Cursor-only,
-        // not "every vendor except Antigravity".
-        var result = ImportCommand.IsLifecycleOnlyRoutedReplay(
-            "claude", ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Loaded, sentChildContent: false);
+    public async Task already_loaded_loaded_with_sent_child_content_resolves_unchanged() {
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Loaded, sentChildContent: true);
 
-        await Assert.That(result).IsFalse();
+        await Assert.That(resolved).IsEqualTo(ImportOutcome.Loaded);
+    }
+
+    [Test]
+    public async Task already_loaded_failed_with_sent_child_content_resolves_to_failed_not_loaded() {
+        // Content posting before a lifecycle failure must still surface as Errored — the
+        // override's exact-match on Skipped excludes Failed by construction.
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Failed, sentChildContent: true);
+
+        await Assert.That(resolved).IsEqualTo(ImportOutcome.Failed);
+    }
+
+    [Test]
+    public async Task already_loaded_loaded_without_sent_child_content_resolves_to_null_suppressed() {
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Loaded, sentChildContent: false);
+
+        await Assert.That(resolved).IsNull();
+    }
+
+    [Test]
+    public async Task already_loaded_resumed_without_sent_child_content_resolves_to_null_suppressed() {
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Resumed, sentChildContent: false);
+
+        await Assert.That(resolved).IsNull();
+    }
+
+    [Test]
+    public async Task already_loaded_skipped_without_sent_child_content_resolves_to_null_suppressed() {
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            ImportCommand.ClassificationStatus.AlreadyLoaded, ImportOutcome.Skipped, sentChildContent: false);
+
+        await Assert.That(resolved).IsNull();
+    }
+
+    [Test]
+    public async Task new_plus_skipped_without_sent_child_content_resolves_to_own_raw_outcome() {
+        // Never suppressed, never overridden — both the gate and the override require
+        // AlreadyLoaded.
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            ImportCommand.ClassificationStatus.New, ImportOutcome.Skipped, sentChildContent: false);
+
+        await Assert.That(resolved).IsEqualTo(ImportOutcome.Skipped);
+    }
+
+    [Test]
+    public async Task partial_plus_resumed_without_sent_child_content_resolves_to_own_raw_outcome() {
+        var resolved = ImportCommand.ResolveRoutedOutcomeForCounting(
+            ImportCommand.ClassificationStatus.Partial, ImportOutcome.Resumed, sentChildContent: false);
+
+        await Assert.That(resolved).IsEqualTo(ImportOutcome.Resumed);
+    }
+
+    // --- importedSessionIds membership stays independent of `resolved` ---
+    //
+    // Membership is `resolved is not null && outcome is Loaded or Resumed` — NOT "raw outcome
+    // regardless of sentChildContent", and NOT "resolved outcome". Both negatives below exercise
+    // a different reason that naive phrasing would have been wrong.
+
+    [Test]
+    public async Task already_loaded_resumed_without_sent_child_content_does_not_join_imported_session_ids() {
+        // resolved is null (suppressed by the gate) — even though the raw outcome is Resumed,
+        // membership must be false. The imprecise "raw outcome regardless of sentChildContent"
+        // phrasing would have gotten this wrong: it would have joined, contradicting the truth
+        // table and changing non-Cursor --private behavior.
+        const ImportCommand.ClassificationStatus status = ImportCommand.ClassificationStatus.AlreadyLoaded;
+        const ImportOutcome                       outcome = ImportOutcome.Resumed;
+        const bool                                sentChildContent = false;
+
+        var resolved   = ImportCommand.ResolveRoutedOutcomeForCounting(status, outcome, sentChildContent);
+        var membership = resolved is not null && outcome is ImportOutcome.Loaded or ImportOutcome.Resumed;
+
+        await Assert.That(resolved).IsNull();
+        await Assert.That(membership).IsFalse();
+    }
+
+    [Test]
+    public async Task already_loaded_skipped_with_sent_child_content_does_not_join_imported_session_ids() {
+        // resolved is Loaded (the override fires), but the raw outcome is still Skipped, so
+        // membership must be false — the Skipped-to-Loaded override is counting-only and
+        // deliberately excluded from importedSessionIds / --private membership.
+        const ImportCommand.ClassificationStatus status = ImportCommand.ClassificationStatus.AlreadyLoaded;
+        const ImportOutcome                       outcome = ImportOutcome.Skipped;
+        const bool                                sentChildContent = true;
+
+        var resolved   = ImportCommand.ResolveRoutedOutcomeForCounting(status, outcome, sentChildContent);
+        var membership = resolved is not null && outcome is ImportOutcome.Loaded or ImportOutcome.Resumed;
+
+        await Assert.That(resolved).IsEqualTo(ImportOutcome.Loaded);
+        await Assert.That(membership).IsFalse();
     }
 }


### PR DESCRIPTION
Implements the AI-1389 spec (`docs/superpowers/specs/2026-07-17-ai1389-routed-import-work-signal-design.md` in kcap-server), codex spec-review clean at round 4.

**Stacked on #325** (base = `impl/ai1154-cursor-attribution`) — the AI-1154 CLI baseline this builds on. Retarget to `main` once #325 merges.

## Problem
`kcap import` routes every `AlreadyLoaded` replay into the routed loop for all vendors, but the double-count suppression gate was Cursor-scoped — so non-Cursor no-work replays (Copilot/Gemini/Kiro/Pi `Resumed`; Antigravity/OpenCode `Skipped`) double-counted in the Done grid.

## Change (counting-only — no `--private`/visibility change for any vendor)
- **D1** — generalize `SentChildContent` (child-stream-only, permit-duplicate-send, non-Failed-only); Antigravity `ImportChildrenAsync`→`Task<bool>` and Gemini capture their child-send counts (outcomes unchanged); Copilot/Kiro/Pi/OpenCode need no code.
- **D2** — drop the `vendor` parameter (3-arg `IsLifecycleOnlyRoutedReplay`); add `IsSkippedChildContentOverride` + `ResolveRoutedOutcomeForCounting` driving the three counting/display consumers (counters, per-vendor `AddRoutedOutcome` sub-grid, printed line). `importedSessionIds` membership stays keyed to the raw outcome — **explicitly unchanged**.
- **D3** — Cursor watermark probe: required fixed 2-attempt cap (status-bearing 5xx/408 only; statusless + 429 excluded).
- **D4** — `privateScopeSessionIds` untouched; Cursor `--private` regression pin.

## Tests
Aggregation-boundary suite (incl. both membership negatives), un-vendored gate cases, Antigravity/Gemini signal tests, Copilot/Kiro/Pi/OpenCode suppression, 5 Cursor probe cases, D4 privacy pin. Build + AOT clean; Unit 3157/3159 (2 gated skips), Integration 126/126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)