### PR TITLE
[AI-1392] Strip Linear IDs from code comments + CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
         if: runner.os == 'Linux'
         run: dotnet run --project test/Capacitor.Cli.Tests.Integration/Capacitor.Cli.Tests.Integration.csproj
 
+  lint-linear-ids:
+    name: No Linear issue IDs in C# source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for Linear issue ID tokens in src/**/*.cs and test/**/*.cs
+        run: bash scripts/check-linear-ids.sh
+
   aot-check:
     name: AOT publish check
     runs-on: ubuntu-latest

--- a/scripts/check-linear-ids.sh
+++ b/scripts/check-linear-ids.sh
@@ -19,47 +19,89 @@ set -u
 ID_RE='(^|[^A-Za-z0-9_])AI-[0-9]+($|[^A-Za-z0-9_])'
 SUPPRESS_RE='//[[:space:]]*linear-id-ok:[[:space:]]*[^[:space:]]'
 
-# Pathspecs need `:(glob)` magic: git's default (non-magic) pathspec matching
-# for a `**` pattern only matches files nested at least one directory below
-# the anchor and silently excludes files sitting directly in src/ or test/
-# (verified empirically -- 'src/**/*.cs' misses a top-level src/Foo.cs but
-# finds src/Commands/Nested.cs; ':(glob)src/**/*.cs' finds both).
-# git grep exit codes: 0 = matches, 1 = no matches, >1 = error.
-matches="$(git grep -n -E "$ID_RE" -- ':(glob)src/**/*.cs' ':(glob)test/**/*.cs')"
-rc=$?
-[ "$rc" -gt 1 ] && { echo "::error::git grep failed (exit $rc) — treating as failure." >&2; exit 2; }
-[ "$rc" -eq 1 ] && exit 0   # no AI-\d+ tokens anywhere in scope
+# src/ and test/ are each checked with their OWN pathspec-scoped `git grep`
+# invocation, rather than one combined grep whose DISPLAY output is then
+# reparsed for a leading `src/`/`test/` prefix to decide which hits may be
+# suppressed. `git grep`'s presentation output is not a stable data format
+# to reparse: it can carry ANSI color escapes (if color leaks in from
+# user/CI config, e.g. a `color.grep=always` in a global gitconfig) and,
+# independent of color, git C-quotes any path containing whitespace or
+# non-ASCII bytes in double quotes with backslash escapes (e.g. a file
+# literally named `src/weird name.cs` prints as `"src/weird name.cs"`). A
+# genuine src/ violation living at such a path could therefore begin with
+# an escape byte or a literal `"` rather than `s`, matching NEITHER a
+# `^src/` nor a `^test/` regex against the combined display text — silently
+# dropped from both partitions, and the checker would exit 0 despite an
+# in-scope violation. This was a real fail-open bug in an earlier revision
+# of this script (see Guard design below for the empirical regression case
+# that proves it and the fix).
+#
+# Scoping by pathspec instead means git itself resolves which tree a match
+# came from — no path string is ever parsed, quoted or not, to make the
+# src-vs-test decision, so this class of bug cannot recur.
+#
+# Pathspecs need `:(glob)` magic (unchanged from before): git's default
+# (non-magic) pathspec matching for a `**` pattern only matches files
+# nested at least one directory below the anchor and silently excludes
+# files sitting directly in src/ or test/ (verified empirically —
+# 'src/**/*.cs' misses a top-level src/Foo.cs but finds
+# src/Commands/Nested.cs; ':(glob)src/**/*.cs' finds both).
+#
+# `--no-color` on both invocations forecloses the ANSI-escape half of the
+# bug outright (belt-and-braces — pathspec scoping already means neither
+# invocation's output is reparsed for a path prefix, so nothing depends on
+# `--no-color`, but it costs nothing and removes the escape-sequence risk
+# from the picture entirely rather than relying solely on "we don't parse
+# this anyway").
+#
+# git grep exit codes throughout: 0 = matches, 1 = no matches (not an
+# error — just an empty result for that tree), >1 = error. Each invocation
+# reports and is checked against its OWN status; a failure in either one
+# fails closed (exit 2), never falls through to "clean".
 
-# Suppression (// linear-id-ok: <reason>) may ONLY drop a test/ hit — it exists
-# for synthetic ID-shaped test data, never for a genuine internal reference.
-# Any hit under src/ is ALWAYS a violation, suppression marker or not: partition
-# matches by path first, then apply the suppression filter to the test/ half
-# only. (git grep prefixes each hit with the pathspec-relative path, so a
-# leading `src/` / `test/` on the match line is exactly the partition key.)
-# grep exit codes throughout: 0 = something matched, 1 = nothing matched
-# (not an error — just an empty partition/empty remainder), >1 = error.
-src_matches="$(printf '%s\n' "$matches" | grep -E '^src/')"
+src_matches="$(git grep --no-color -nE "$ID_RE" -- ':(glob)src/**/*.cs')"
 src_rc=$?
-[ "$src_rc" -gt 1 ] && { echo "::error::grep failed (exit $src_rc) partitioning src/ matches — treating as failure." >&2; exit 2; }
+[ "$src_rc" -gt 1 ] && { echo "::error::git grep failed (exit $src_rc) scanning src/ — treating as failure." >&2; exit 2; }
 
-test_matches="$(printf '%s\n' "$matches" | grep -E '^test/')"
+test_matches="$(git grep --no-color -nE "$ID_RE" -- ':(glob)test/**/*.cs')"
 test_rc=$?
-[ "$test_rc" -gt 1 ] && { echo "::error::grep failed (exit $test_rc) partitioning test/ matches — treating as failure." >&2; exit 2; }
+[ "$test_rc" -gt 1 ] && { echo "::error::git grep failed (exit $test_rc) scanning test/ — treating as failure." >&2; exit 2; }
 
+# src/ hits are UNCONDITIONAL violations: suppression may NEVER apply there,
+# so there is no filter to run — a match in src/ is a violation, full stop.
+src_violations=""
+[ "$src_rc" -eq 0 ] && src_violations="$src_matches"
+
+# test/ hits are eligible for suppression: a line matching SUPPRESS_RE (the
+# `// linear-id-ok: <reason>` marker) is dropped; whatever remains is a
+# violation. The marker match is against line CONTENT only — the src-vs-test
+# decision was already made above by which pathspec-scoped grep produced the
+# line, not by inspecting the line's leading path text.
+#
+# The filter only runs when test_rc is 0 (i.e. test_matches is guaranteed
+# non-empty — at least one real match line). This sidesteps a genuine
+# empty-input edge case in `grep -v`: piping a truly empty (0-byte) stream
+# into `grep -vE` exits 1 with no output (verified empirically — see Guard
+# design), which already reads as "no violations" and is NOT an error, but
+# gating on test_rc means production behavior never has to depend on that
+# nuance in the first place — when there's nothing to filter, we simply
+# don't invoke the filter.
 test_violations=""
 if [ "$test_rc" -eq 0 ]; then
-    test_violations="$(printf '%s\n' "$test_matches" | grep -vE "$SUPPRESS_RE")"
+    test_violations="$(printf '%s' "$test_matches" | grep -vE "$SUPPRESS_RE")"
     tv_rc=$?
-    [ "$tv_rc" -gt 1 ] && { echo "::error::grep failed (exit $tv_rc) applying the suppression filter — treating as failure." >&2; exit 2; }
+    [ "$tv_rc" -gt 1 ] && { echo "::error::grep failed (exit $tv_rc) applying the suppression filter to test/ matches — treating as failure." >&2; exit 2; }
     [ "$tv_rc" -eq 1 ] && test_violations=""  # every test/ hit was correctly suppressed
 fi
 
-# src/ hits are unconditional violations (no suppression filter applied above);
-# test/ hits only survive if grep -v didn't strip them as suppressed.
-if [ "$src_rc" -eq 0 ] && [ -n "$test_violations" ]; then
-    violations="$(printf '%s\n%s' "$src_matches" "$test_violations")"
-elif [ "$src_rc" -eq 0 ]; then
-    violations="$src_matches"
+# Aggregate: any src/ hit (always a violation) plus any unsuppressed test/
+# hit. Both are independently gathered above by pathspec, not by reparsing
+# combined output — the two invocations' results are simply concatenated
+# here for reporting.
+if [ -n "$src_violations" ] && [ -n "$test_violations" ]; then
+    violations="$(printf '%s\n%s' "$src_violations" "$test_violations")"
+elif [ -n "$src_violations" ]; then
+    violations="$src_violations"
 else
     violations="$test_violations"
 fi

--- a/scripts/check-linear-ids.sh
+++ b/scripts/check-linear-ids.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# scripts/check-linear-ids.sh — see docs/superpowers/specs/2026-07-17-ai1392-linear-id-comment-sweep-design.md
+# Exit: 0 clean, 1 = violation found, 2 = checker failure (never "clean").
+# Portable POSIX ERE only — no PCRE, no `grep -P`, no `git grep -P` anywhere in
+# this script. Verified on BSD grep (macOS stock /usr/bin/grep, BSD grep
+# 2.6.0-FreeBSD, which rejects -P outright with "invalid option -- P", exit 2)
+# and GNU grep (Linux CI runners) — see Guard design below for the exact test
+# matrix. This is what makes "run identically on a laptop" actually true.
+set -u
+
+# Word-bounded AI-<digits> without \b (POSIX ERE has none): a left guard that
+# rejects a directly-preceding identifier char, and a right guard that rejects
+# a directly-following one. Both character classes are IDENTICAL — letters,
+# digits, and `_` only, no hyphen on either side — matching \b's word/non-word
+# transition exactly (a hyphen is a non-word character in \w/\b semantics, so
+# a hyphen-preceded token like `prefix-AI-1382` has a real boundary and must
+# match; excluding hyphen from the left guard was a bug, not a deliberate
+# widening — see the case table's hyphen-preceded rows).
+ID_RE='(^|[^A-Za-z0-9_])AI-[0-9]+($|[^A-Za-z0-9_])'
+SUPPRESS_RE='//[[:space:]]*linear-id-ok:[[:space:]]*[^[:space:]]'
+
+# Pathspecs need `:(glob)` magic: git's default (non-magic) pathspec matching
+# for a `**` pattern only matches files nested at least one directory below
+# the anchor and silently excludes files sitting directly in src/ or test/
+# (verified empirically -- 'src/**/*.cs' misses a top-level src/Foo.cs but
+# finds src/Commands/Nested.cs; ':(glob)src/**/*.cs' finds both).
+# git grep exit codes: 0 = matches, 1 = no matches, >1 = error.
+matches="$(git grep -n -E "$ID_RE" -- ':(glob)src/**/*.cs' ':(glob)test/**/*.cs')"
+rc=$?
+[ "$rc" -gt 1 ] && { echo "::error::git grep failed (exit $rc) — treating as failure." >&2; exit 2; }
+[ "$rc" -eq 1 ] && exit 0   # no AI-\d+ tokens anywhere in scope
+
+# grep -v exit codes: 0 = something remains (violation), 1 = all filtered
+# (every hit was correctly suppressed), >1 = error.
+violations="$(printf '%s\n' "$matches" | grep -vE "$SUPPRESS_RE")"
+grc=$?
+[ "$grc" -gt 1 ] && { echo "::error::grep failed (exit $grc) applying the suppression filter — treating as failure." >&2; exit 2; }
+[ "$grc" -eq 1 ] && exit 0  # every hit was on a correctly-suppressed line
+
+echo "$violations"
+echo "::error::Linear issue ID token found in tracked C# source. Rewrite per docs/superpowers/specs/2026-07-17-ai1392-linear-id-comment-sweep-design.md. Suppression (// linear-id-ok: <reason>) is for synthetic ID-shaped test data ONLY — a genuine internal reference must be escalated to an owner before merge, never suppressed."
+exit 1

--- a/scripts/check-linear-ids.sh
+++ b/scripts/check-linear-ids.sh
@@ -30,13 +30,42 @@ rc=$?
 [ "$rc" -gt 1 ] && { echo "::error::git grep failed (exit $rc) — treating as failure." >&2; exit 2; }
 [ "$rc" -eq 1 ] && exit 0   # no AI-\d+ tokens anywhere in scope
 
-# grep -v exit codes: 0 = something remains (violation), 1 = all filtered
-# (every hit was correctly suppressed), >1 = error.
-violations="$(printf '%s\n' "$matches" | grep -vE "$SUPPRESS_RE")"
-grc=$?
-[ "$grc" -gt 1 ] && { echo "::error::grep failed (exit $grc) applying the suppression filter — treating as failure." >&2; exit 2; }
-[ "$grc" -eq 1 ] && exit 0  # every hit was on a correctly-suppressed line
+# Suppression (// linear-id-ok: <reason>) may ONLY drop a test/ hit — it exists
+# for synthetic ID-shaped test data, never for a genuine internal reference.
+# Any hit under src/ is ALWAYS a violation, suppression marker or not: partition
+# matches by path first, then apply the suppression filter to the test/ half
+# only. (git grep prefixes each hit with the pathspec-relative path, so a
+# leading `src/` / `test/` on the match line is exactly the partition key.)
+# grep exit codes throughout: 0 = something matched, 1 = nothing matched
+# (not an error — just an empty partition/empty remainder), >1 = error.
+src_matches="$(printf '%s\n' "$matches" | grep -E '^src/')"
+src_rc=$?
+[ "$src_rc" -gt 1 ] && { echo "::error::grep failed (exit $src_rc) partitioning src/ matches — treating as failure." >&2; exit 2; }
+
+test_matches="$(printf '%s\n' "$matches" | grep -E '^test/')"
+test_rc=$?
+[ "$test_rc" -gt 1 ] && { echo "::error::grep failed (exit $test_rc) partitioning test/ matches — treating as failure." >&2; exit 2; }
+
+test_violations=""
+if [ "$test_rc" -eq 0 ]; then
+    test_violations="$(printf '%s\n' "$test_matches" | grep -vE "$SUPPRESS_RE")"
+    tv_rc=$?
+    [ "$tv_rc" -gt 1 ] && { echo "::error::grep failed (exit $tv_rc) applying the suppression filter — treating as failure." >&2; exit 2; }
+    [ "$tv_rc" -eq 1 ] && test_violations=""  # every test/ hit was correctly suppressed
+fi
+
+# src/ hits are unconditional violations (no suppression filter applied above);
+# test/ hits only survive if grep -v didn't strip them as suppressed.
+if [ "$src_rc" -eq 0 ] && [ -n "$test_violations" ]; then
+    violations="$(printf '%s\n%s' "$src_matches" "$test_violations")"
+elif [ "$src_rc" -eq 0 ]; then
+    violations="$src_matches"
+else
+    violations="$test_violations"
+fi
+
+[ -z "$violations" ] && exit 0
 
 echo "$violations"
-echo "::error::Linear issue ID token found in tracked C# source. Rewrite per docs/superpowers/specs/2026-07-17-ai1392-linear-id-comment-sweep-design.md. Suppression (// linear-id-ok: <reason>) is for synthetic ID-shaped test data ONLY — a genuine internal reference must be escalated to an owner before merge, never suppressed."
+echo "::error::Linear issue ID token found in tracked C# source. Rewrite per docs/superpowers/specs/2026-07-17-ai1392-linear-id-comment-sweep-design.md. Suppression (// linear-id-ok: <reason>) is for synthetic ID-shaped test data under test/ ONLY — any hit under src/ is always a violation regardless of the marker, and a genuine internal reference must be escalated to an owner before merge, never suppressed."
 exit 1

--- a/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
+++ b/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
@@ -6,7 +6,7 @@ namespace Capacitor.Cli.Core.Acp;
 
 /// <summary>
 /// Typed <c>params</c> payloads for the ACP methods <see cref="Daemon.Acp.AcpConnection"/> callers
-/// (<c>AcpHostedAgentRuntime</c>, AI-684 Task 9) send. These exist only so request construction can
+/// (<c>AcpHostedAgentRuntime</c>, Task 9) send. These exist only so request construction can
 /// go through source-gen (<see cref="JsonSerializer.SerializeToElement{T}(T, System.Text.Json.Serialization.Metadata.JsonTypeInfo{T})"/>
 /// against <see cref="CapacitorJsonContext"/>) instead of the reflection-based overloads, which are
 /// unsafe under NativeAOT. Field names/shapes are pinned to the probe-confirmed wire shapes in
@@ -17,7 +17,7 @@ namespace Capacitor.Cli.Core.Acp;
 
 /// <summary>
 /// <c>initialize</c> params. Deliberately advertises MINIMAL client capabilities (no <c>fs</c>, no
-/// <c>terminal</c>) — AI-687 decides those from the AI-688 findings; AI-684 does not implement
+/// <c>terminal</c>) — decides those from the findings; does not implement
 /// either capability.
 /// </summary>
 public sealed record InitializeParams(
@@ -125,8 +125,8 @@ public sealed record AvailableModelDto(
 
 /// <summary>
 /// <c>session/request_permission</c> params sent BY THE AGENT (server-initiated request, handled
-/// via <see cref="Daemon.Acp.AcpConnection.OnServerRequest"/>) — AI-686. Spec-derived, NOT
-/// probe-confirmed: the AI-684 probe never observed a real <c>session/request_permission</c> frame
+/// via <see cref="Daemon.Acp.AcpConnection.OnServerRequest"/>). Spec-derived, NOT
+/// probe-confirmed: the probe never observed a real <c>session/request_permission</c> frame
 /// (the probe account's turn ended before any tool call — see
 /// <c>docs/acp-probe-findings.md</c> §"Permission / elicitation requests"). Mirrors the shape
 /// <see cref="Capacitor.Cli.Tests.Unit.Acp.FakeAcpAgent.BuildRequestPermissionFrame"/> already
@@ -170,7 +170,7 @@ public sealed record PermissionOutcomeDto(
 /// <summary>
 /// Capability-gated, NOT part of the core ACP spec — modeled defensively on the same
 /// request/response shape as <see cref="SessionRequestPermissionParams"/> since no confirmed
-/// elicitation schema exists for Cursor (AI-682 R3's open question: "Does Cursor use the ACP
+/// elicitation schema exists for Cursor (R3's open question: "Does Cursor use the ACP
 /// elicitation RFD shape or a vendor extension?" is unanswered). The daemon never advertises
 /// support for this method in <c>initialize</c> (see <c>AcpHostedAgentRuntime.StartAsync</c>'s
 /// existing minimal-capabilities <c>ClientCapabilities</c>, unchanged by this plan) — if a real

--- a/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
+++ b/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
@@ -17,8 +17,8 @@ namespace Capacitor.Cli.Core.Acp;
 
 /// <summary>
 /// <c>initialize</c> params. Deliberately advertises MINIMAL client capabilities (no <c>fs</c>, no
-/// <c>terminal</c>) — decides those from the findings; does not implement
-/// either capability.
+/// <c>terminal</c>) — those get decided later based on ACP probe findings; this type implements
+/// neither capability.
 /// </summary>
 public sealed record InitializeParams(
     [property: JsonPropertyName("protocolVersion")]  int                     ProtocolVersion,

--- a/src/Capacitor.Cli.Core/Acp/AcpRpc.cs
+++ b/src/Capacitor.Cli.Core/Acp/AcpRpc.cs
@@ -8,7 +8,7 @@ namespace Capacitor.Cli.Core.Acp;
 /// JSON-RPC 2.0 request frame for the ACP stdio transport (client → agent, or agent → client for
 /// server-initiated requests like <c>session/request_permission</c> / <c>fs/*</c>). <see cref="Params"/>
 /// stays a <see cref="JsonElement"/> so this layer is non-polymorphic and AOT/trim-safe — the
-/// connection layer (AI-684 Task 7) parses it into a typed shape once the method is known. Wire
+/// connection layer parses it into a typed shape once the method is known. Wire
 /// shape confirmed by the probe in <c>docs/acp-probe-findings.md</c>:
 /// <c>{"jsonrpc":"2.0","id":1,"method":"initialize","params":{...}}</c>.
 /// </summary>

--- a/src/Capacitor.Cli.Core/Antigravity/AntigravityGenMetadata.cs
+++ b/src/Capacitor.Cli.Core/Antigravity/AntigravityGenMetadata.cs
@@ -12,7 +12,7 @@ public readonly record struct AntigravityUsageRow(
 );
 
 /// <summary>
-/// Decoder for Antigravity's <c>gen_metadata.data</c> protobuf blob (AI-1158). Antigravity
+/// Decoder for Antigravity's <c>gen_metadata.data</c> protobuf blob. Antigravity
 /// keeps per-generation tokens/model in the sibling SQLite db, not the JSONL transcript, and
 /// ships NO <c>.proto</c>, so field numbers are pinned EMPIRICALLY against real Antigravity
 /// 2.2.1 blobs (verified across many rows / conversations):
@@ -72,7 +72,7 @@ public static class AntigravityGenMetadata {
     /// re-emitted row dedupes while a new row adds. <paramref name="createdAt"/> anchors the
     /// event timestamp to the conversation's most-recent transcript step (the row is decoded
     /// right after the generation that produced that step), so the backfill's recency reflects
-    /// the turn rather than the event-store write time (AI-1157 review, S4).
+    /// the turn rather than the event-store write time (review, S4).
     /// </summary>
     public static string ToUsageLine(AntigravityUsageRow row, long genRow, string? createdAt = null) {
         var o = new JsonObject {

--- a/src/Capacitor.Cli.Core/Antigravity/AntigravityHooks.cs
+++ b/src/Capacitor.Cli.Core/Antigravity/AntigravityHooks.cs
@@ -3,13 +3,13 @@ using System.Text.Json.Nodes;
 namespace Capacitor.Cli.Core.Antigravity;
 
 /// <summary>
-/// Builder + detection for kcap's hook block inside Antigravity's <c>hooks.json</c>
-/// (AI-1158). Antigravity's config nests differently from Gemini's shared
+/// Builder + detection for kcap's hook block inside Antigravity's <c>hooks.json</c>.
+/// Antigravity's config nests differently from Gemini's shared
 /// <c>settings.json</c>: <c>hooks.json</c> is a map of user-named blocks →
 /// <c>{ event → entries }</c>, so kcap owns exactly one block (<see cref="BlockName"/>)
 /// and never disturbs user blocks.
 ///
-/// Two entry shapes (verified against Antigravity 2.2.1, AI-1150 spike): tool events
+/// Two entry shapes (verified against Antigravity 2.2.1, spike): tool events
 /// (<c>PreToolUse</c>/<c>PostToolUse</c>) use <c>[{ matcher, hooks:[…] }]</c>; lifecycle
 /// events (<c>PreInvocation</c>/<c>PostInvocation</c>/<c>Stop</c>) use a DIRECT handler
 /// list <c>[{ type, command, timeout }]</c> (a matcher there is silently ignored / can
@@ -39,7 +39,7 @@ public static class AntigravityHooks {
 
     /// <summary>Semver of the kcap plugin's manifest/hook layout (NOT the kcap build version —
     /// that's tracked by the sibling <c>.kcap-hooks-version</c> marker). Kept a plain dotted
-    /// triple: the GUI was only verified to accept a simple <c>x.y.z</c> (AI-1158 GUI re-test),
+    /// triple: the GUI was only verified to accept a simple <c>x.y.z</c> (GUI re-test),
     /// so we avoid prerelease/build-metadata suffixes that a stricter loader might reject.</summary>
     public const string PluginVersion = "1.0.0";
 
@@ -47,7 +47,7 @@ public static class AntigravityHooks {
     /// The plugin manifest (<c>plugin.json</c>) the Antigravity GUI REQUIRES to recognize a
     /// directory under <c>config/plugins/</c> as a loadable plugin. Without this marker the GUI
     /// silently ignores the dir and never loads the sibling <c>hooks.json</c> — the reason the
-    /// CLI-dir install shipped in #256 was invisible to the running IDE (AI-1158 GUI re-test).
+    /// CLI-dir install shipped in #256 was invisible to the running IDE (GUI re-test).
     /// <c>name</c> is optional (the GUI defaults it to the dir name) but we set it explicitly.
     /// </summary>
     public static JsonObject BuildPluginManifest() =>

--- a/src/Capacitor.Cli.Core/Antigravity/AntigravityHooksInstaller.cs
+++ b/src/Capacitor.Cli.Core/Antigravity/AntigravityHooksInstaller.cs
@@ -28,7 +28,7 @@ public static class AntigravityHooksInstaller {
         // plugin.json is REQUIRED for the GUI to load the dir — write it FIRST and let a
         // failure propagate so the install aborts (it is NOT best-effort like the version
         // marker). Otherwise a written hooks.json is dead weight the GUI ignores — the exact
-        // AI-1158 false-success mode this fix exists to prevent.
+        // false-success mode this fix exists to prevent.
         WritePluginManifest(hooksPath);
 
         var root = LoadOrBackup(hooksPath);
@@ -100,7 +100,7 @@ public static class AntigravityHooksInstaller {
 
     /// <summary>Writes the REQUIRED plugin.json manifest. Unlike the version marker this is
     /// deliberately NOT best-effort: a failure propagates so <see cref="Install"/> fails
-    /// rather than leaving a hooks.json the GUI can never load (AI-1158).</summary>
+    /// rather than leaving a hooks.json the GUI can never load.</summary>
     static void WritePluginManifest(string hooksPath) {
         var dir = Path.GetDirectoryName(hooksPath);
         if (string.IsNullOrEmpty(dir))

--- a/src/Capacitor.Cli.Core/Antigravity/AntigravityPaths.cs
+++ b/src/Capacitor.Cli.Core/Antigravity/AntigravityPaths.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Core.Gemini;
 namespace Capacitor.Cli.Core.Antigravity;
 
 /// <summary>
-/// Filesystem layout for Google Antigravity (AI-1157/AI-1158). Antigravity is a
+/// Filesystem layout for Google Antigravity. Antigravity is a
 /// GUI IDE (VS Code fork, Windsurf/Codeium lineage) whose agent state lives under
 /// the SHARED <c>~/.gemini</c> home in an <c>antigravity</c> subdir (so paths reuse
 /// <see cref="GeminiPaths.Root"/> and honor <c>GEMINI_CLI_HOME</c>). Each conversation
@@ -16,7 +16,7 @@ namespace Capacitor.Cli.Core.Antigravity;
 /// kcap control hooks. Per-workspace installs live under <c>&lt;root&gt;/.agents/plugins/kcap/</c>.
 /// ⚠️ The <c>~/.gemini/antigravity-cli/</c> dir is the <c>agy</c> CLI's config root — the
 /// GUI does NOT read it, so installing hooks there (as #256 originally did) is invisible
-/// to the running IDE (AI-1158 GUI re-test).
+/// to the running IDE (GUI re-test).
 ///
 /// ⚠️ <c>~/.gemini</c> is shared with the Gemini CLI — <see cref="GeminiPaths.IsInstalled"/>
 /// must require a Gemini-specific marker so an Antigravity-only home doesn't read as
@@ -79,7 +79,7 @@ public static class AntigravityPaths {
     public static string? ConversationDbFromTranscript(string transcriptPath) {
         // Require the EXACT shape …/brain/<id>/.system_generated/logs/transcript_full.jsonl —
         // validate each segment so an unexpected path fails open (returns null) instead of
-        // being mapped to a guessed <root>/conversations/<derived>.db (AI-1157 review).
+        // being mapped to a guessed <root>/conversations/<derived>.db.
         if (!string.Equals(Path.GetFileName(transcriptPath), "transcript_full.jsonl", StringComparison.Ordinal))
             return null;
 

--- a/src/Capacitor.Cli.Core/Antigravity/AntigravitySubagents.cs
+++ b/src/Capacitor.Cli.Core/Antigravity/AntigravitySubagents.cs
@@ -106,7 +106,7 @@ public static class AntigravitySubagents {
     }
 
     /// <summary>
-    /// redesign — the authoritative spawn-time parent→child signal. A parent's transcript
+    /// The authoritative spawn-time parent→child signal. A parent's transcript
     /// records an INVOKE_SUBAGENT step whose <c>content</c> embeds JSON listing the child
     /// conversation(s) it spawned (<c>{ "conversationId": "&lt;child&gt;", … }</c>, one object or an
     /// array). Returns the child ids for a single transcript line — empty for any non-INVOKE_SUBAGENT,

--- a/src/Capacitor.Cli.Core/Antigravity/AntigravitySubagents.cs
+++ b/src/Capacitor.Cli.Core/Antigravity/AntigravitySubagents.cs
@@ -4,10 +4,10 @@ namespace Capacitor.Cli.Core.Antigravity;
 
 /// <summary>
 /// Resolves Antigravity's subagent → parent conversation linkage for historical import. A
-/// subagent is a SEPARATE conversation; AI-1218 redesign: the linkage is derived from the
+/// subagent is a SEPARATE conversation; the linkage is derived from the
 /// parent transcript's <c>INVOKE_SUBAGENT</c> steps (the spawn-time signal — same source the
 /// live watcher now uses, see <see cref="ChildConversationIdsFromLine"/>), which is available
-/// even for a child that never reports back. This replaces the pre-AI-1218 (AI-1160)
+/// even for a child that never reports back. This replaces the
 /// child-reports-back scan of <c>brain/&lt;parent&gt;/.system_generated/messages/*.json</c>,
 /// which silently dropped errored/never-reporting children (see d9956b89) and had the
 /// sender/recipient direction inverted in some captures (see 7f8d9d93 → a1204f98). Roots are
@@ -106,7 +106,7 @@ public static class AntigravitySubagents {
     }
 
     /// <summary>
-    /// AI-1218 redesign — the authoritative spawn-time parent→child signal. A parent's transcript
+    /// redesign — the authoritative spawn-time parent→child signal. A parent's transcript
     /// records an INVOKE_SUBAGENT step whose <c>content</c> embeds JSON listing the child
     /// conversation(s) it spawned (<c>{ "conversationId": "&lt;child&gt;", … }</c>, one object or an
     /// array). Returns the child ids for a single transcript line — empty for any non-INVOKE_SUBAGENT,

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -461,7 +461,7 @@ public static class OAuthLoginFlow {
 
     /// <summary>
     /// Builds OidcClient options for the WorkOS AuthKit authorization-code-with-PKCE flow.
-    /// Authorize + token both on the API domain (AI-958 — never the AuthKit UI domain). WorkOS is a
+    /// Authorize + token both on the API domain (never the AuthKit UI domain). WorkOS is a
     /// public client (no secret) with non-standard endpoints, no discovery, and no id_token, so
     /// discovery/keyset/userinfo are disabled and the response is mapped by hand.
     /// </summary>
@@ -475,7 +475,7 @@ public static class OAuthLoginFlow {
             DisablePushedAuthorization = true,
             ProviderInformation = new ProviderInformation {
                 IssuerName        = apiBase,
-                AuthorizeEndpoint = $"{apiBase}/user_management/authorize",     // AI-958: always the API domain
+                AuthorizeEndpoint = $"{apiBase}/user_management/authorize",     // always the API domain
                 TokenEndpoint     = $"{apiBase}/user_management/authenticate",
             },
         };

--- a/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
+++ b/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
@@ -482,7 +482,7 @@ static class ClaudeCliRunner {
     /// Rejects responses with <c>is_error: true</c> — the CLI signals API
     /// failures (overload, rate limit, auth) by setting this flag and writing
     /// the error text into <c>result</c>. Treating that text as a valid title
-    /// caused, where API error messages surfaced as session titles.
+    /// caused a regression where API error messages surfaced as session titles.
     /// </para>
     /// </summary>
     static ClaudeCliResult? ParseJsonResponseOnly(string stdout) {

--- a/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
+++ b/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
@@ -79,7 +79,7 @@ static class ClaudeCliRunner {
     /// on in both modes — strict-mcp-config is what keeps the user's global
     /// or plugin MCP servers (e.g. <c>kcap-sessions</c> from the kcap Claude
     /// Code plugin) from leaking in and getting permission-blocked under
-    /// the allowlist (AI-803). Leaving both null preserves the text-only
+    /// the allowlist. Leaving both null preserves the text-only
     /// behaviour every other caller relies on.
     /// </para>
     ///
@@ -199,9 +199,9 @@ static class ClaudeCliRunner {
         psi.Environment.Remove("CLAUDECODE");
         psi.Environment.Remove("CLAUDE_CODE_ENTRYPOINT");
         // A globally-set ANTHROPIC_API_KEY overrides subscription auth in `claude -p`,
-        // which surfaced as AI-755 (API error text leaking into session titles).
+        // which surfaced as (API error text leaking into session titles).
         // Users on PAYG/API-key auth opt back in via profile flag or
-        // KCAP_USE_PROVIDER_API_KEY=1 (AI-776).
+        // KCAP_USE_PROVIDER_API_KEY=1.
         if (!ProviderApiKeyPolicy.ShouldKeepProviderKey()) {
             psi.Environment.Remove("ANTHROPIC_API_KEY");
         }
@@ -388,7 +388,7 @@ static class ClaudeCliRunner {
         //     others) into the headless judge; the judge then reaches for
         //     those un-allowlisted tools and every call is blocked by
         //     permission restrictions, degrading verdicts to "unable to
-        //     investigate" (AI-803).
+        //     investigate".
         args.Add("--strict-mcp-config");
 
         // Lock down the built-in tool surface in BOTH modes:
@@ -482,7 +482,7 @@ static class ClaudeCliRunner {
     /// Rejects responses with <c>is_error: true</c> — the CLI signals API
     /// failures (overload, rate limit, auth) by setting this flag and writing
     /// the error text into <c>result</c>. Treating that text as a valid title
-    /// caused AI-755, where API error messages surfaced as session titles.
+    /// caused, where API error messages surfaced as session titles.
     /// </para>
     /// </summary>
     static ClaudeCliResult? ParseJsonResponseOnly(string stdout) {
@@ -514,7 +514,7 @@ static class ClaudeCliRunner {
     /// Skipped when the envelope has <c>is_error: true</c>: the transcript's
     /// last assistant text on a failed turn can be a partial reply or stale
     /// auto-memory content, and surfacing that as a successful result is the
-    /// AI-755 regression vector the <see cref="ParseJsonResponseOnly"/>
+    /// regression vector the <see cref="ParseJsonResponseOnly"/>
     /// guard exists to close.
     /// </para>
     /// </summary>

--- a/src/Capacitor.Cli.Core/CodexCliRunner.cs
+++ b/src/Capacitor.Cli.Core/CodexCliRunner.cs
@@ -82,7 +82,7 @@ static class CodexCliRunner {
         };
         // A globally-set OPENAI_API_KEY overrides ChatGPT subscription auth in `codex exec`.
         // Users on PAYG/API-key auth opt back in via profile flag or
-        // KCAP_USE_PROVIDER_API_KEY=1 (AI-776).
+        // KCAP_USE_PROVIDER_API_KEY=1.
         if (!ProviderApiKeyPolicy.ShouldKeepProviderKey()) {
             psi.Environment.Remove("OPENAI_API_KEY");
         }
@@ -100,7 +100,7 @@ static class CodexCliRunner {
         psi.ArgumentList.Add($"model_reasoning_effort=\"{reasoning}\"");
         // Only pin a model when the caller explicitly asks. Letting codex pick its
         // own default keeps title generation working for ChatGPT-account auth
-        // (which rejects model names like "gpt-5.3-codex" with a 400 — AI-757).
+        // (which rejects model names like "gpt-5.3-codex" with a 400 —).
         // Empty/whitespace is treated the same as null to match CodexLauncher's
         // argv-building behaviour — passing `-m ""` to codex is never useful.
         if (!string.IsNullOrWhiteSpace(model)) {
@@ -155,7 +155,7 @@ static class CodexCliRunner {
             if (process.ExitCode != 0) {
                 // Tail-truncate: codex prints a multi-line session header before any
                 // error message lands on stderr, so head-truncation discarded the
-                // useful part (AI-757). Keep the last 800 chars so 4xx/5xx bodies
+                // useful part. Keep the last 800 chars so 4xx/5xx bodies
                 // and skill-loader warnings further down still make it into the log.
                 var stderrTail = stderr.Length > 800 ? "…" + stderr[^800..] : stderr;
                 log($"Codex exited with code {process.ExitCode}, stderr: {SanitizeForLog(stderrTail)}");

--- a/src/Capacitor.Cli.Core/CodexCliRunner.cs
+++ b/src/Capacitor.Cli.Core/CodexCliRunner.cs
@@ -100,7 +100,7 @@ static class CodexCliRunner {
         psi.ArgumentList.Add($"model_reasoning_effort=\"{reasoning}\"");
         // Only pin a model when the caller explicitly asks. Letting codex pick its
         // own default keeps title generation working for ChatGPT-account auth
-        // (which rejects model names like "gpt-5.3-codex" with a 400 —).
+        // (which rejects model names like "gpt-5.3-codex" with a 400).
         // Empty/whitespace is treated the same as null to match CodexLauncher's
         // argv-building behaviour — passing `-m ""` to codex is never useful.
         if (!string.IsNullOrWhiteSpace(model)) {

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -26,7 +26,7 @@ public static class CodexConfigToml {
     static string DefaultConfigPath => Path.Combine(CodexPaths.Home(), "config.toml");
 
     /// <summary>
-    /// AI-794 — enable network access for Codex's <c>workspace-write</c> sandbox so
+    /// enable network access for Codex's <c>workspace-write</c> sandbox so
     /// kcap skills (which shell out to <c>kcap …</c>) can reach the Capacitor server.
     /// Codex blocks all sandbox network by default; a constrained
     /// <c>network_proxy</c> allowlist keeps everything else closed.

--- a/src/Capacitor.Cli.Core/Commands/PrRefParser.cs
+++ b/src/Capacitor.Cli.Core/Commands/PrRefParser.cs
@@ -42,7 +42,7 @@ public static partial class PrRefParser {
     [GeneratedRegex(@"^https?://[^/]+/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$")]
     private static partial Regex GitHubUrlPattern();
 
-    // GitLab MR URL. Nested groups supported (§6b /): owner is the full
+    // GitLab MR URL. Nested groups supported (§6b): owner is the full
     // namespace path before the project, project is the last segment. The literal
     // "/-/merge_requests/" delimiter disambiguates the greedy owner from the project.
     // Same trailing-suffix tolerance so /diffs, /commits, ?query, #note parse.

--- a/src/Capacitor.Cli.Core/Commands/PrRefParser.cs
+++ b/src/Capacitor.Cli.Core/Commands/PrRefParser.cs
@@ -42,7 +42,7 @@ public static partial class PrRefParser {
     [GeneratedRegex(@"^https?://[^/]+/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$")]
     private static partial Regex GitHubUrlPattern();
 
-    // GitLab MR URL. Nested groups supported (§6b / AI-1121): owner is the full
+    // GitLab MR URL. Nested groups supported (§6b /): owner is the full
     // namespace path before the project, project is the last segment. The literal
     // "/-/merge_requests/" delimiter disambiguates the greedy owner from the project.
     // Same trailing-suffix tolerance so /diffs, /commits, ?query, #note parse.

--- a/src/Capacitor.Cli.Core/Config/AppConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/AppConfig.cs
@@ -225,8 +225,8 @@ public static class AppConfig {
     public static string NormalizeUrl(string url) => url.TrimEnd('/');
 
     /// <summary>The full set of accepted <c>default_visibility</c> values, server-agnostic
-    /// (a server that gates Projects off simply treats <c>project</c> as owner-only — see
-    ///). Internal (not private) so other CLI-side surfaces that validate or offer this
+    /// (a server that gates Projects off simply treats <c>project</c> as owner-only).
+    /// Internal (not private) so other CLI-side surfaces that validate or offer this
     /// value — e.g. <c>SetupCommand</c>'s <c>--default-visibility</c> flag and interactive
     /// wizard choice list — can't drift out of sync with what config actually accepts.</summary>
     internal static readonly string[] ValidVisibilities = ["private", "project", "org_public", "public"];

--- a/src/Capacitor.Cli.Core/Config/AppConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/AppConfig.cs
@@ -226,7 +226,7 @@ public static class AppConfig {
 
     /// <summary>The full set of accepted <c>default_visibility</c> values, server-agnostic
     /// (a server that gates Projects off simply treats <c>project</c> as owner-only — see
-    /// AI-1206). Internal (not private) so other CLI-side surfaces that validate or offer this
+    ///). Internal (not private) so other CLI-side surfaces that validate or offer this
     /// value — e.g. <c>SetupCommand</c>'s <c>--default-visibility</c> flag and interactive
     /// wizard choice list — can't drift out of sync with what config actually accepts.</summary>
     internal static readonly string[] ValidVisibilities = ["private", "project", "org_public", "public"];

--- a/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
@@ -26,7 +26,7 @@ public record ProfileConfig {
     [JsonPropertyName("cwd_remap")]
     public CwdRemap[] CwdRemap { get; init; } = [];
 
-    // AI-1134: stable machine identity for machine-tagged memories. Generated once by
+    // stable machine identity for machine-tagged memories. Generated once by
     // MachineIdProvider; never rotated (rotation orphans previously tagged memories).
     [JsonPropertyName("machine_id")]
     public string? MachineId { get; init; }
@@ -54,7 +54,7 @@ public record Profile {
     public bool? DisableSessionGuidelines { get; init; }
 
     /// <summary>
-    /// AI-1165 — when true, kcap skips injecting the team-memory index at SessionStart.
+    /// when true, kcap skips injecting the team-memory index at SessionStart.
     /// Independent of <see cref="DisableSessionGuidelines"/> so the recurring-lessons and
     /// memory-index injections can be toggled separately.
     /// </summary>
@@ -65,7 +65,7 @@ public record Profile {
     /// When true, kcap keeps <c>ANTHROPIC_API_KEY</c> / <c>OPENAI_API_KEY</c>
     /// in the spawn environment for headless agent CLIs (title generation,
     /// summaries, judges). Default <c>false</c> scrubs them so subscription
-    /// auth (claude.ai / ChatGPT account) is used instead — see AI-755.
+    /// auth (claude.ai / ChatGPT account) is used instead.
     /// Override at runtime with <c>KCAP_USE_PROVIDER_API_KEY=1</c>.
     /// </summary>
     [JsonPropertyName("use_provider_api_key")]

--- a/src/Capacitor.Cli.Core/Cursor/CursorPaths.cs
+++ b/src/Capacitor.Cli.Core/Cursor/CursorPaths.cs
@@ -27,7 +27,7 @@ public sealed record CursorPaths(string UserDir, string WorkspaceStorageDir) {
     /// <summary>
     /// True when any of the OS-specific Cursor user dirs exists. Detection by
     /// directory presence — Cursor IDE users without the <c>cursor</c> shell
-    /// command on PATH must still be detected (AI-730 design, Q7).
+    /// command on PATH must still be detected (design, Q7).
     /// </summary>
     public static bool IsInstalled(string? home = null, OsPlatform? platform = null, string? appData = null) {
         home     ??= PathHelpers.HomeDirectory;

--- a/src/Capacitor.Cli.Core/Cursor/CursorPromptCanonicalizer.cs
+++ b/src/Capacitor.Cli.Core/Cursor/CursorPromptCanonicalizer.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace Capacitor.Cli.Core.Cursor;
 
-/// <summary>CLI side of the pinned Cursor prompt canonicalization contract (AI-1154/1156).
+/// <summary>CLI side of the pinned Cursor prompt canonicalization contract.
 /// Body MUST stay byte-identical to the server's Capacitor.Cursor.CursorPromptCanonicalizer.</summary>
 public static class CursorPromptCanonicalizer {
     const string TsOpen = "<timestamp>", TsClose = "</timestamp>";

--- a/src/Capacitor.Cli.Core/CursorAppendOnlyProbe.cs
+++ b/src/Capacitor.Cli.Core/CursorAppendOnlyProbe.cs
@@ -3,7 +3,7 @@ using System.Security.Cryptography;
 namespace Capacitor.Cli.Core;
 
 /// <summary>
-/// AI-1382 D0. Pure prefix-hash comparison used by both the phase-0 empirical verification harness
+/// D0. Pure prefix-hash comparison used by both the phase-0 empirical verification harness
 /// (<c>kcap cursor-verify-appendonly</c>) and the runtime two-zone rewrite guard
 /// (<see cref="Capacitor.Cli.Commands.CursorRewriteGuard"/>). Append-only ⇔ length is monotonically
 /// non-decreasing AND re-hashing the first L_earlier bytes at the later time reproduces the

--- a/src/Capacitor.Cli.Core/DaemonLockPaths.cs
+++ b/src/Capacitor.Cli.Core/DaemonLockPaths.cs
@@ -12,7 +12,7 @@ namespace Capacitor.Cli.Core;
 /// <c>~/.config/kcap</c>) wrote to different singletons and never saw
 /// each other, allowing two daemons under the same name to authenticate as
 /// the same GitHub ID and oscillate the server-side <c>DaemonRegistry</c>
-/// slot. The staging incident that motivated was exactly that.</para>
+/// slot. The staging incident that motivated this fix was exactly that.</para>
 ///
 /// <para>This helper uses a <b>fixed location</b> under the home directory
 /// (<c>~/.config/kcap/daemons/</c>) regardless of <c>KCAP_CONFIG_DIR</c>,

--- a/src/Capacitor.Cli.Core/DaemonLockPaths.cs
+++ b/src/Capacitor.Cli.Core/DaemonLockPaths.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 namespace Capacitor.Cli.Core;
 
 /// <summary>
-/// Path layout for per-name daemon lock + PID + start-lock files (AI-630).
+/// Path layout for per-name daemon lock + PID + start-lock files.
 ///
 /// <para>The previous layout used singletons at <c>PathHelpers.ConfigPath("agent.pid")</c>
 /// and <c>PathHelpers.ConfigPath("agent.start.lock")</c>. Two daemons with
@@ -12,7 +12,7 @@ namespace Capacitor.Cli.Core;
 /// <c>~/.config/kcap</c>) wrote to different singletons and never saw
 /// each other, allowing two daemons under the same name to authenticate as
 /// the same GitHub ID and oscillate the server-side <c>DaemonRegistry</c>
-/// slot. The staging incident that motivated AI-630 was exactly that.</para>
+/// slot. The staging incident that motivated was exactly that.</para>
 ///
 /// <para>This helper uses a <b>fixed location</b> under the home directory
 /// (<c>~/.config/kcap/daemons/</c>) regardless of <c>KCAP_CONFIG_DIR</c>,
@@ -121,7 +121,7 @@ public static partial class DaemonLockPaths {
     /// derived from <c>*.lock</c>, <c>*.pid</c>, <c>*.restart-pending</c>, and
     /// <c>*.version</c> files. Used by <c>daemon doctor</c> to classify held vs
     /// stale entries; covers orphan PID files that have no matching lock (e.g. a
-    /// pre-AI-630 daemon whose migration ran for the PID file but not the start
+    /// legacy daemon whose migration ran for the PID file but not the start
     /// lock, or a stop that removed the lock but left the PID behind) and
     /// marker-only leftovers (a crash between queueing a restart and applying it,
     /// or a version marker left after an unclean exit).

--- a/src/Capacitor.Cli.Core/DaemonNameResolver.cs
+++ b/src/Capacitor.Cli.Core/DaemonNameResolver.cs
@@ -19,9 +19,9 @@ namespace Capacitor.Cli.Core;
 /// <item>The literal string <c>"daemon"</c>.</item>
 /// </list>
 ///
-/// <para>Note: pre-AI-630 <c>DaemonRunner.RunAsync</c> had the env var
+/// <para>Note: <c>DaemonRunner.RunAsync</c> previously had the env var
 /// unconditionally override <c>--name</c>. That was an unintentional
-/// inversion of the usual CLI convention (explicit flag wins). AI-630
+/// inversion of the usual CLI convention (explicit flag wins). This
 /// fixes it so <c>--name</c> is the strongest signal as users expect.</para>
 /// </summary>
 public static class DaemonNameResolver {

--- a/src/Capacitor.Cli.Core/Eval/EvalCatalogClient.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalCatalogClient.cs
@@ -4,8 +4,8 @@ namespace Capacitor.Cli.Core.Eval;
 
 /// <summary>
 /// Fetches the full eval catalog (server-rendered per-question prompts +
-/// retrospective prompt + versions) from <c>GET /api/eval/catalog</c> (
-/// Phase 3). Returns <c>null</c> on HTTP failure, deserialization error, or a
+/// retrospective prompt + versions) from <c>GET /api/eval/catalog</c>
+/// (Phase 3). Returns <c>null</c> on HTTP failure, deserialization error, or a
 /// failed integrity check so callers abort the run BEFORE expensive judge work
 /// (SF#4) -- the catalog is non-optional, so there is no safe fallback. Fetched
 /// once per run and threaded through <see cref="EvalService.EvalContext"/>.

--- a/src/Capacitor.Cli.Core/Eval/EvalCatalogClient.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalCatalogClient.cs
@@ -4,7 +4,7 @@ namespace Capacitor.Cli.Core.Eval;
 
 /// <summary>
 /// Fetches the full eval catalog (server-rendered per-question prompts +
-/// retrospective prompt + versions) from <c>GET /api/eval/catalog</c> (AI-9
+/// retrospective prompt + versions) from <c>GET /api/eval/catalog</c> (
 /// Phase 3). Returns <c>null</c> on HTTP failure, deserialization error, or a
 /// failed integrity check so callers abort the run BEFORE expensive judge work
 /// (SF#4) -- the catalog is non-optional, so there is no safe fallback. Fetched

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -403,7 +403,7 @@ public static class EvalService {
         // chain. Accepted here because the alternative for an oversized chained
         // trace is the embed path's hard 400 (no verdict at all). Full
         // chain-aware tools require server-side chain support on
-        // eval-summary/search/transcript — tracked in.
+        // eval-summary/search/transcript — tracked separately for future work.
         var tokenBudget = TraceTokenBudget();
         var forceTools  = ShouldForceTools(traceJson.Length, tokenBudget);
         if (forceTools) {

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -33,7 +33,7 @@ public static class EvalService {
     // level keeps retrospectives cheap and prevents the model from padding
     // lists with low-signal bullets just because the schema would let it.
     //
-    // AI-795: suggestions.items is an object with {text, audience} — NOT a
+    // suggestions.items is an object with {text, audience} — NOT a
     // bare string. The previous string-items schema forced the model to
     // ignore the prompt's {text, audience} instruction, which meant every
     // suggestion landed as audience="human" and no agent_guidance was ever
@@ -87,7 +87,7 @@ public static class EvalService {
     // --mcp-config we pass to claude; the key becomes the `mcp__<key>__<tool>`
     // prefix claude uses. Named after `kcap mcp judge`'s own serverInfo so it
     // never collides with the plugin-registered `kcap-review` (`kcap mcp
-    // review`) server when both load (AI-803).
+    // review`) server when both load.
     internal const string JudgeMcpServerName = "kcap-judge";
 
     // Shared between RunRetrospectiveAsync and the tools-enabled per-question
@@ -278,7 +278,7 @@ public static class EvalService {
                 return null;
             }
 
-            // AI-9 Phase 3 — fetch the full catalog (rendered prompts + raw text +
+            // Phase 3 — fetch the full catalog (rendered prompts + raw text +
             // versions) so PrepareAsync can reconcile the run question list from it.
             var catalog = await EvalCatalogClient.FetchAsync(baseUrl, httpClient, observer, ct);
             if (catalog is null) return null;   // FetchAsync already emitted OnFailed
@@ -394,7 +394,7 @@ public static class EvalService {
         // session through the tools path (no embedded trace) instead of the
         // text-only path. See ShouldForceTools / DefaultTraceTokenBudget.
         //
-        // Known limitation (AI-966 review): the judge MCP tools for
+        // Known limitation: the judge MCP tools for
         // summary/search/transcript/tool-result are single-session — only
         // recap/errors follow the continuation chain (and the server endpoints
         // they back have no chain support). So a chained eval (`--chain`) whose
@@ -403,7 +403,7 @@ public static class EvalService {
         // chain. Accepted here because the alternative for an oversized chained
         // trace is the embed path's hard 400 (no verdict at all). Full
         // chain-aware tools require server-side chain support on
-        // eval-summary/search/transcript — tracked in AI-968.
+        // eval-summary/search/transcript — tracked in.
         var tokenBudget = TraceTokenBudget();
         var forceTools  = ShouldForceTools(traceJson.Length, tokenBudget);
         if (forceTools) {
@@ -420,7 +420,7 @@ public static class EvalService {
         // "stable" trends). FactsUsed snapshots persist as empty for new
         // evals; the read-side projection + UI panel stay in place so
         // historical eval audit views keep working.
-        // AI-9 Phase 3 — reconcile the run question list FROM the catalog (rendered
+        // Phase 3 — reconcile the run question list FROM the catalog (rendered
         // prompts + raw text + versions). The text path uses each question's rendered
         // Prompt directly; the tools path keeps the embedded wrapper + raw text.
         var selectedIds = questions.Select(q => q.Id).ToList();
@@ -486,7 +486,7 @@ public static class EvalService {
             // on demand. ctx.ForceTools additionally routes EVERY question
             // here (not just the NeedsTools four) when the session's trace is
             // too large to embed — see PrepareAsync's size gate.
-            // AI-9 Phase 3 — the reconciled question's Prompt is the RENDERED
+            // Phase 3 — the reconciled question's Prompt is the RENDERED
             // text-path prompt; the tools template substitutes {QUESTION_TEXT}
             // from question.Prompt, so feed it the RAW catalog text instead.
             var prompt = BuildToolsQuestionPrompt(
@@ -510,7 +510,7 @@ public static class EvalService {
                 ct:             ct
             );
         } else {
-            // Text-only path (default). AI-9 Phase 3: the prompt is the catalog's
+            // Text-only path (default). Phase 3: the prompt is the catalog's
             // server-RENDERED prompt carried on the reconciled question — fill the
             // runtime placeholders and strip any residual {CACHE_BOUNDARY}.
             var prompt = BuildTextQuestionPrompt(question, ctx.SessionId, ctx.EvalRunId, ctx.TraceJson);
@@ -591,7 +591,7 @@ public static class EvalService {
             return null;
         }
 
-        // 4. Aggregate per-category + overall scores. AI-9 Phase 3: V3 payload —
+        // 4. Aggregate per-category + overall scores. Phase 3: V3 payload —
         //    each verdict is stamped with its catalog prompt version; the
         //    retrospective prompt version is stamped below from ctx.
         var aggregate = Aggregate(verdicts, ctx.EvalRunId, model, ctx.Questions);
@@ -626,7 +626,7 @@ public static class EvalService {
         );
         aggregate = aggregate with { Retrospective = retrospective };
 
-        // AI-9 Phase 3 — stamp the catalog retrospective prompt version.
+        // Phase 3 — stamp the catalog retrospective prompt version.
         aggregate = aggregate with { RetrospectivePromptVersion = ctx.RetrospectivePromptVersion };
 
         // 6. Persist the aggregate to the server via the V3 route.
@@ -682,7 +682,7 @@ public static class EvalService {
 
     /// <summary>
     /// Persists a V3 aggregate to <c>POST /api/sessions/{id}/evals/v3</c>
-    /// (AI-9 Phase 3 — carries per-question + retrospective prompt versions).
+    /// (Phase 3 — carries per-question + retrospective prompt versions).
     /// Public seam for the daemon's wire-format contract test, mirroring
     /// <see cref="PersistAggregateV2Async"/>.
     /// </summary>
@@ -715,7 +715,7 @@ public static class EvalService {
     // ── Prompt construction ────────────────────────────────────────────────
 
     /// <summary>
-    /// AI-9 Phase 3 — build the run question list FROM the catalog, preserving the
+    /// Phase 3 — build the run question list FROM the catalog, preserving the
     /// order of <paramref name="selectedIds"/>. Each result carries the catalog's
     /// rendered <see cref="EvalQuestionDto.Prompt"/> (text path), raw
     /// <see cref="EvalQuestionDto.RawText"/> (tools path), <see cref="EvalQuestionDto.PromptVersion"/>,
@@ -781,7 +781,7 @@ public static class EvalService {
 
     /// <summary>
     /// Builds the retrospective synthesis prompt from the catalog-rendered
-    /// template (AI-9 Phase 3 — was a static embedded field) and the
+    /// template (Phase 3 — was a static embedded field) and the
     /// placeholders the judge needs: session metadata, per-question verdicts,
     /// retained patterns from prior evals in this repo, and the compacted trace.
     ///
@@ -794,7 +794,7 @@ public static class EvalService {
     /// </para>
     /// </summary>
     public static string BuildRetrospectivePrompt(
-            string template,           // AI-9 Phase 3 — from catalog (was static embedded field)
+            string template,           // Phase 3 — from catalog (was static embedded field)
             string sessionMeta,
             string verdictsJson,
             string knownPatterns,
@@ -1109,7 +1109,7 @@ public static class EvalService {
             string                             model,
             IReadOnlyList<EvalQuestionDto>     questions
         ) {
-        // AI-9 Phase 3 — stamp each verdict with its catalog prompt version
+        // Phase 3 — stamp each verdict with its catalog prompt version
         // (from the reconciled questions) before grouping, so the V3 payload
         // carries per-question prompt provenance.
         var versionByQuestion = questions
@@ -1208,7 +1208,7 @@ public static class EvalService {
         // Soft-drop of {KNOWN_PATTERNS}: template no longer has the
         // placeholder, so the retrospective prompt builder receives an
         // empty knownPatterns string and the replace becomes a no-op.
-        // AI-9 Phase 3: template comes from the catalog and {TRACE_JSON} is
+        // Phase 3: template comes from the catalog and {TRACE_JSON} is
         // filled with the daemon's already-fetched trace (SF#1).
         var prompt = BuildRetrospectivePrompt(
             retrospectivePrompt, sessionMeta, verdictsJson, knownPatterns: "", traceJson);
@@ -1242,7 +1242,7 @@ public static class EvalService {
                 return null;
             }
 
-            // AI-795 T18: V2 parser — tolerant of bare-string suggestion items
+            // T18: V2 parser — tolerant of bare-string suggestion items
             // and missing audience field (coerces to "human"). Server-side V2
             // route accepts both shapes.
             var retrospective = ParseRetrospectiveV2(result.Result);

--- a/src/Capacitor.Cli.Core/HookSpool.cs
+++ b/src/Capacitor.Cli.Core/HookSpool.cs
@@ -20,7 +20,7 @@ public enum DrainOutcome {
 /// <c>.draining</c> temp before reading, so concurrent appends never collide
 /// with an in-flight drain.
 ///
-/// <para>Moved to <c>Capacitor.Cli.Core</c> (AI-1357 Task 12) so both the CLI
+/// <para>Moved to <c>Capacitor.Cli.Core</c> so both the CLI
 /// (<c>Capacitor.Cli</c>, an AOT exe) and the daemon (<c>Capacitor.Cli.Daemon</c>,
 /// a separate AOT exe) can share the ordered-drain primitives without either
 /// project referencing the other's exe as a library.</para>
@@ -102,7 +102,7 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     }
 
     // Recovered temps (oldest first) then the rotated live file. Returns true => stop the whole pass.
-    // NOTE (AI-1357 Task 12 / BLOCKER-1): only ever recovers ITS OWN ".draining" temps — never the
+    // NOTE: only ever recovers ITS OWN ".draining" temps — never the
     // ordered drain's ".ordered-*" temps (see DrainRoutesAsync below). The ordered drain deliberately
     // WITHHOLDS a phase's remainder mid-pass (e.g. a session-end held back until the transcript tail
     // and the leading non-terminal run are done); if this route-agnostic FIFO recovered that withheld
@@ -191,7 +191,7 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     /// that entry — is preserved for the caller's next phase. Used by <see cref="LifecycleSpoolDrain"/>
     /// to enforce cross-spool ordering (lifecycle start &#8594; transcript tail &#8594; lifecycle end).
     ///
-    /// <para><b>Distinct temp namespace (AI-1357 Task 12 / BLOCKER-1).</b> Rotates the live file to a
+    /// <para><b>Distinct temp namespace.</b> Rotates the live file to a
     /// <c>{sid}.ordered-{pid}-{seq}</c> temp — NOT the <c>{sid}.{pid}-{seq}.draining</c> shape
     /// <see cref="DrainAllAsync"/> (route-agnostic FIFO, still used by Claude/Cursor) uses — so a
     /// deliberately-withheld phase can never be recovered and redelivered out of order by the
@@ -278,7 +278,7 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     /// <summary>
     /// True if a terminal (session-end) entry for this session has already been durably delivered
     /// (or permanently dropped) by a previous ordered-drain pass — see <see cref="MarkEnded"/>.
-    /// AI-1357 Task 12 / BLOCKER-3: once true, <see cref="LifecycleSpoolDrain"/> must never attempt
+    /// Task 12 / BLOCKER-3: once true, <see cref="LifecycleSpoolDrain"/> must never attempt
     /// to deliver a straggler non-terminal entry for this session, even one that arrives (or is
     /// discovered) in a later pass — that would be a real cross-pass ordering violation, not just a
     /// same-pass one (the same-pass case is already prevented by <see cref="DrainRoutesAsync"/>'s
@@ -302,7 +302,7 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     /// <summary>
     /// Deletes any lifecycle entries remaining for a session already <see cref="MarkEnded"/> —
     /// a post-end straggler (e.g. a subagent-stop that arrived after session-end was already
-    /// delivered) must be dropped, never delivered out of order (AI-1357 Task 12 / BLOCKER-3).
+    /// delivered) must be dropped, never delivered out of order.
     /// </summary>
     public void DiscardRemainder(string sessionId) {
         if (!SafeSessionId.IsMatch(sessionId)) return;

--- a/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
+++ b/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
@@ -1,6 +1,6 @@
 namespace Capacitor.Cli.Core;
 
-/// <summary>AI-1126 D-c: the kcap-owned MCP server registry — the ONLY source a flow
+/// <summary> D-c: the kcap-owned MCP server registry — the ONLY source a flow
 /// definition's mcp: allowlist resolves against (never user config). StartsFlows marks
 /// servers that can start flows; they are stripped from every allowlist regardless of
 /// listing (the recursion guard — the server strips too, this is the authoritative layer).

--- a/src/Capacitor.Cli.Core/Kiro/KiroUsage.cs
+++ b/src/Capacitor.Cli.Core/Kiro/KiroUsage.cs
@@ -15,7 +15,7 @@ namespace Capacitor.Cli.Core.Kiro;
 /// stamps a <c>_kcap_usage</c> object on that transcript line;
 /// <c>KiroTranscriptNormalizer</c> lifts credits/context% onto
 /// <c>extensions.kiro</c> and, when the token counts are non-zero, stamps a
-/// canonical <c>$usage</c> (the AI-1196 hedge: dormant now, auto-lights if a
+/// canonical <c>$usage</c> (the hedge: dormant now, auto-lights if a
 /// future kiro-cli release populates them). The session <c>model_id</c> rides
 /// alongside the token counts so that <c>$usage</c> has a model. Import-only today
 /// (the live path would key off Kiro's per-turn <c>stop</c> hook).
@@ -70,7 +70,7 @@ public static class KiroUsage {
 
                 double? ctx = t["context_usage_percentage"] is JsonValue c && c.TryGetValue<double>(out var cp) ? cp : null;
 
-                // Token-count hedge (AI-1196): Kiro persists these as 0 today (upstream
+                // Token-count hedge: Kiro persists these as 0 today (upstream
                 // aws#2397 — the CLI discards the API's TokenUsage). Carry them ONLY when
                 // non-zero, so the hedge stays dormant now and lights up automatically if
                 // a future kiro-cli release starts populating them.
@@ -112,7 +112,7 @@ public static class KiroUsage {
 
             // bool/int/double/long/string assign to JsonObject is AOT-reflection-free,
             // so no JsonNode.Parse dance. Credits/context% are doubles; token counts are
-            // longs and only present when non-zero (AI-1196 hedge); model rides with them.
+            // longs and only present when non-zero (hedge); model rides with them.
             var usage = new JsonObject { ["credits"] = u.Credits };
             if (u.ContextPct is { } pct)          usage["context_usage_percentage"] = pct;
             if (u.InputTokens is { } inTok)       usage["input_token_count"]        = inTok;

--- a/src/Capacitor.Cli.Core/LifecycleSpoolDrain.cs
+++ b/src/Capacitor.Cli.Core/LifecycleSpoolDrain.cs
@@ -6,7 +6,7 @@ namespace Capacitor.Cli.Core;
 /// (+ needs-import marker) → spooled session-end. Idempotent under repeated/partial passes via
 /// deterministic server ids. Stdout-contract hooks (Codex) run this in the BACKGROUND / AFTER stdout.
 ///
-/// <para>Moved to <c>Capacitor.Cli.Core</c> (AI-1357 Task 12) so the daemon's periodic drain can share
+/// <para>Moved to <c>Capacitor.Cli.Core</c> so the daemon's periodic drain can share
 /// this exact ordering logic without referencing the CLI's exe project.</para>
 /// </summary>
 public static class LifecycleSpoolDrain {
@@ -23,7 +23,7 @@ public static class LifecycleSpoolDrain {
         foreach (var sid in OrderedSessions(lifecycle, transcript, currentSessionId)) {
             if (Expired()) return;
 
-            // AI-1357 Task 12 / BLOCKER-3: a session whose terminal (session-end) route was already
+            // Task 12 / BLOCKER-3: a session whose terminal (session-end) route was already
             // durably delivered by a PRIOR pass must never have a straggler non-terminal entry
             // (e.g. a late subagent-stop) delivered after it — that would be a real ordering
             // violation, reachable now that session-start/subagent-stop/session-end share one spool
@@ -67,7 +67,7 @@ public static class LifecycleSpoolDrain {
     /// Production wrapper: real HTTP posters that map status → DrainOutcome (mirrors ClaudeHookCommand's
     /// ClaudePoster / CursorHookCommand's PostOnce-based poster).
     ///
-    /// <para><b>generate_whats_done (AI-1357 Task 12 / BLOCKER-2).</b> <paramref name="onWhatsDoneRequested"/>
+    /// <para><b>generate_whats_done.</b> <paramref name="onWhatsDoneRequested"/>
     /// is invoked with <c>(sessionId, vendor)</c> whenever a terminal (session-end) entry this drain
     /// delivers comes back with <c>generate_whats_done: true</c> — the exact side effect
     /// <c>ClaudeHookCommand.ClaudePoster</c> performs for Claude's own session-end replay. Without this,
@@ -114,7 +114,7 @@ public static class LifecycleSpoolDrain {
     }
 
     static Task<DrainOutcome> PostTranscript(HttpClient client, string baseUrl, string body, CancellationToken ct) {
-        // AI-1382 review fix #1/#8 — a Cursor batch already quarantined by the runtime rewrite
+        // review fix #1/#8 — a Cursor batch already quarantined by the runtime rewrite
         // guard must never be replayed from the shutdown transcript spool: the tail spooled at
         // shutdown could predate the quarantine (a batch queued before the guard tripped on a
         // later poll), and this is the ONLY delivery-time check the spool-replay path has, since

--- a/src/Capacitor.Cli.Core/MachineId.cs
+++ b/src/Capacitor.Cli.Core/MachineId.cs
@@ -3,14 +3,14 @@ using System.Text.Json;
 namespace Capacitor.Cli.Core;
 
 /// <summary>
-/// Stable per-machine identifier (AI-1207): lets the server prove that a daemon reconnecting
+/// Stable per-machine identifier: lets the server prove that a daemon reconnecting
 /// under a given repo path is actually running on the machine it claims, rather than trusting a
 /// path string alone. Persisted once to <c>machine.json</c> in the CLI's config directory
 /// (<see cref="PathHelpers.ConfigPath"/> — the same resolution <c>Auth.TokenStore</c> uses,
 /// honouring <c>KCAP_CONFIG_DIR</c>) so every process on this machine — hooks, watcher, daemon,
 /// MCP — resolves the same file and reports the same id.
 ///
-/// Distinct from <see cref="MachineIdProvider"/> (AI-1134), which tags memories with a
+/// Distinct from <see cref="MachineIdProvider"/>, which tags memories with a
 /// separately-generated id stored inside the profile config (<c>config.json</c>'s
 /// <c>machine_id</c>); the two are not reconciled. This one is a standalone file so reading/
 /// writing it can never race a concurrent <c>ProfileConfig</c> save.

--- a/src/Capacitor.Cli.Core/Mcp/KcapMcpServers.cs
+++ b/src/Capacitor.Cli.Core/Mcp/KcapMcpServers.cs
@@ -26,13 +26,13 @@ public static class KcapMcpServers {
             "Attach the current session to a work item (issue, PR, or a brand-new item), and list what a session is attached to."),
     ];
 
-    /// <summary>Codex omits `kcap-flows` (AI-1056: paid hosted reviewer, Claude-only) and
-    /// `kcap-workitems` (AI-1264: Claude Code plugin only, not yet exposed to Codex).</summary>
+    /// <summary>Codex omits `kcap-flows` (paid hosted reviewer, Claude-only) and
+    /// `kcap-workitems` (Claude Code plugin only, not yet exposed to Codex).</summary>
     public static IReadOnlyList<KcapMcpServer> ForCodex =>
         All.Where(s => s.Name is not ("kcap-flows" or "kcap-workitems")).ToArray();
 
     /// <summary>The shared set for every non-Claude JSON harness (Cursor, Copilot, OpenCode,
-    /// Kiro, Gemini, Antigravity) — omits `kcap-workitems` (AI-1264: Claude Code plugin only;
+    /// Kiro, Gemini, Antigravity) — omits `kcap-workitems` (Claude Code plugin only;
     /// its session-id default rides the Claude hook env). Unlike Codex, these still get
     /// `kcap-flows`.</summary>
     public static IReadOnlyList<KcapMcpServer> ForCursor =>

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -139,7 +139,7 @@ class WatchState {
     public int          LinesReadAhead      { get; set; } // file position while buffering
     public bool         ThresholdReached    { get; set; }
 
-    // AI-1357 task 7: set by the shutdown final drain (isFinalDrain) when it held back an
+    // task 7: set by the shutdown final drain (isFinalDrain) when it held back an
     // unterminated/unparseable final line rather than consuming it. RunWatch reads it right after
     // the final drain to flag the session needs-import (never drop a truncated tail).
     public bool FinalDrainHeldIncompleteLine { get; set; }
@@ -149,7 +149,7 @@ class WatchState {
     // Initialized when the watcher starts; updated in DrainNewLines on new lines.
     public DateTimeOffset LastActivityAt { get; set; } = DateTimeOffset.UtcNow;
 
-    // AI-1359: idle-clock freeze while disconnected. DisconnectedSince is set when the SignalR
+    // idle-clock freeze while disconnected. DisconnectedSince is set when the SignalR
     // connection drops and cleared when it returns; AccumulatedDisconnected sums the disconnected
     // durations SINCE the last transcript activity (reset to zero when LastActivityAt advances).
     // ShouldEndOnIdle subtracts it so a transient outage isn't counted as idleness, while a
@@ -183,12 +183,12 @@ class WatchState {
     // the Codex PendingCodexToolCalls guard).
     public int PendingAntigravityToolCalls { get; set; }
 
-    // Antigravity live subagent nesting (AI-1218): child conversation ids already POSTed to
+    // Antigravity live subagent nesting: child conversation ids already POSTed to
     // /hooks/antigravity/subagent-link for this parent watcher. A child stays OUT of this set
     // until its link POST succeeds, so a failed POST retries on the next scan (fail-open).
     public HashSet<string> PostedSubagentLinks { get; } = new(StringComparer.Ordinal);
 
-    // AI-1357 task 10: Kiro turn anchors (the turn's final message_id) already streamed as a
+    // task 10: Kiro turn anchors (the turn's final message_id) already streamed as a
     // synthetic KiroUsageBackfilled line, so a later drain never re-emits the same anchor. Mirrors
     // LastAntigravityGenIdx above, but keyed on the anchor string rather than a row index because
     // Kiro's sidecar has no stable ordinal — committed ONLY after a successful send (see
@@ -201,7 +201,7 @@ class WatchState {
     // re-staged) fresh on the next drain, so nothing is lost.
     public List<string> KiroUsagePendingAnchors { get; } = [];
 
-    // AI-1382 Task 11 (D0/D3) — byte offset (end of the last batch the runtime rewrite guard
+    // Task 11 (D0/D3) — byte offset (end of the last batch the runtime rewrite guard
     // verified and the server acked) the Cursor watcher's guard checks resume from each poll.
     // Distinct from LinesProcessed (a LINE-number cursor set from the server's acked frontier,
     // which can differ from the raw count of lines sent when a line was disposed differently
@@ -209,7 +209,7 @@ class WatchState {
     // range it last verified. Only ever set for vendor == "cursor".
     public long CursorByteOffset { get; set; }
 
-    // AI-1382 review fix #2 — poll counter driving the periodic full-prefix re-hash cadence
+    // poll counter driving the periodic full-prefix re-hash cadence
     // (WatchCommand.CursorFullPrefixVerifyEveryNPolls). Incremented once per poll for vendor ==
     // "cursor" only; a plain counter (not wall-clock time) so the cadence is exact regardless of
     // how long any individual poll takes.
@@ -349,13 +349,13 @@ public record EvalQuestionDto {
     [JsonPropertyName("needs_tools")]
     public bool NeedsTools { get; init; }
 
-    // AI-9 Phase 3 — the catalog prompt version this question's rendered prompt
+    // Phase 3 — the catalog prompt version this question's rendered prompt
     // ran against. Null on the back-compat /api/eval/questions alias (which does
     // not emit it) and on older servers; populated only by /api/eval/catalog.
     [JsonPropertyName("prompt_version")]
     public string? PromptVersion { get; init; }
 
-    // AI-9 Phase 3 — RAW question text from the catalog, used by the tools path
+    // Phase 3 — RAW question text from the catalog, used by the tools path
     // (the embedded tools template substitutes this into {QUESTION_TEXT}). Null on
     // the alias / older servers. Distinct from Prompt, which on a reconciled
     // text-path question holds the server-RENDERED prompt.
@@ -364,7 +364,7 @@ public record EvalQuestionDto {
 }
 
 /// <summary>
-/// Wire-format DTO for <c>GET /api/eval/catalog</c> (AI-9 Phase 3). Carries the
+/// Wire-format DTO for <c>GET /api/eval/catalog</c>. Carries the
 /// server-rendered retrospective prompt + its version, and the active questions
 /// with raw text + server-rendered prompt + per-question prompt version +
 /// needs_tools. There is NO top-level question template — the daemon uses each
@@ -444,7 +444,7 @@ public record EvalQuestionVerdict {
     [JsonPropertyName("tools_used")]
     public int? ToolsUsed { get; init; }
 
-    // AI-9 Phase 3 — catalog prompt version stamped at aggregation time before
+    // Phase 3 — catalog prompt version stamped at aggregation time before
     // POSTing the V3 payload. Null until Aggregate fills it from the catalog.
     [JsonPropertyName("prompt_version")]
     public string? PromptVersion { get; init; }
@@ -625,7 +625,7 @@ public record SessionEvalCompletedPayloadV2 {
     public List<EvalFactSnapshotPayload> FactsUsed { get; init; } = [];
 }
 
-// Posted to POST /api/sessions/{id}/evals/v3 (AI-9 Phase 3). Differs from V2 by
+// Posted to POST /api/sessions/{id}/evals/v3. Differs from V2 by
 // adding retrospective_prompt_version; the per-question version rides on each
 // EvalQuestionVerdict.PromptVersion. Wire shape must stay 1:1 with the server's
 // SessionEvalCompletedPayloadV3 in Capacitor.Server.
@@ -692,7 +692,7 @@ static partial class GitUrlParser {
     }
 
     // owner is greedy (`.+`) so a nested GitLab namespace (group/subgroup/...) is
-    // captured whole, with repo as the final path segment. AI-1121 / §6b.
+    // captured whole, with repo as the final path segment. / §6b.
     [GeneratedRegex(@"https?://[^/]+/(?<owner>.+)/(?<repo>[^/]+?)(?:\.git)?$")]
     internal static partial Regex HttpsRegex();
 
@@ -832,7 +832,7 @@ public sealed record CliProjectError {
 
 /// <summary>
 /// One discovered plan/spec/design/checklist artifact returned by
-/// <c>GET /api/sessions/{id}/plan-artifacts</c> (AI-701). Mirrors the server's
+/// <c>GET /api/sessions/{id}/plan-artifacts</c>. Mirrors the server's
 /// <c>Capacitor.Plans.PlanArtifact</c> record field-for-field; string fields
 /// (<see cref="Kind"/>, <see cref="Source"/>, <see cref="ContentState"/>,
 /// <see cref="Confidence"/>) carry the server's snake_case enum values verbatim
@@ -869,7 +869,7 @@ public sealed record PlanArtifactDto {
     [JsonPropertyName("is_primary")]      public bool IsPrimary { get; init; }
 }
 
-/// <summary>Body of <c>GET /api/sessions/{id}/plan-artifacts</c> (AI-701).</summary>
+/// <summary>Body of <c>GET /api/sessions/{id}/plan-artifacts</c>.</summary>
 public sealed record PlanArtifactsResponseDto {
     [JsonPropertyName("primary")]     public PlanArtifactDto? Primary { get; init; }
     [JsonPropertyName("artifacts")]   public List<PlanArtifactDto> Artifacts { get; init; } = [];
@@ -1043,7 +1043,7 @@ public readonly record struct PermissionDecision(
     );
 
 /// <summary>
-/// Single-argument payload for the <c>RequestPermission2</c> hub invocation (AI-864). SignalR
+/// Single-argument payload for the <c>RequestPermission2</c> hub invocation. SignalR
 /// binds hub-method arguments by count, so a record keeps the arity fixed at 1 and lets the wire
 /// contract gain fields without breaking mixed-version servers. Mirrors the server-side record of
 /// the same name in Capacitor.Server; property names must stay in sync (snake_case on the wire).
@@ -1056,7 +1056,7 @@ public readonly record struct HostedPermissionRequest(
     );
 
 /// <summary>
-/// Payload of the <c>PermissionResolved</c> server→client push (AI-864): the user's decision for a
+/// Payload of the <c>PermissionResolved</c> server→client push: the user's decision for a
 /// hosted-agent permission request, correlated by <see cref="RequestId"/>. A single record (not
 /// positional args) so the push contract can gain fields without breaking mixed-version daemons —
 /// SignalR binds by argument count. Mirrors the server-side record of the same name.
@@ -1067,7 +1067,7 @@ public readonly record struct PermissionResolution(
     );
 
 /// <summary>
-/// Single-argument payload for the <c>AcpRequestInteraction</c> hub invocation (AI-686). Mirrors
+/// Single-argument payload for the <c>AcpRequestInteraction</c> hub invocation. Mirrors
 /// the server-side record of the same name in <c>Capacitor.Server.Core</c> (<c>src/Capacitor.Server.Core/AcpInteraction.cs</c>);
 /// property names must stay in sync (snake_case on the wire via this context's naming policy).
 /// <b>Spec-review Finding 1:</b> <see cref="RequestedSchema"/> is a new OPTIONAL trailing field,
@@ -1090,14 +1090,14 @@ public readonly record struct AcpInteractionRequest(
     );
 
 /// <summary>
-/// One selectable option for an ACP permission or elicitation interaction (AI-686). Spec-review
+/// One selectable option for an ACP permission or elicitation interaction. Spec-review
 /// Finding 6: <see cref="OptionId"/> is the stable resolution key (mirrors
 /// <c>Acp.PermissionOptionDto.OptionId</c>) — <see cref="Label"/> is display-only.
 /// </summary>
 public readonly record struct AcpInteractionOption(string OptionId, string Label, string? Description, string? Kind = null);
 
 /// <summary>
-/// Decision for an ACP interaction (AI-686), pushed from the server. Mirrors the server-side
+/// Decision for an ACP interaction, pushed from the server. Mirrors the server-side
 /// record of the same name. Spec-review Finding 6: <see cref="SelectedOptionId"/> is what
 /// <c>AcpInteractionBridge.MapPermissionDecision</c> (Task B3) matches against — never
 /// <see cref="SelectedOptionLabel"/>, which is retained for display/attribution only.
@@ -1112,7 +1112,7 @@ public readonly record struct AcpInteractionDecision(
     );
 
 /// <summary>
-/// Payload of the <c>AcpInteractionResolved</c> server→client push (AI-686), correlated by
+/// Payload of the <c>AcpInteractionResolved</c> server→client push, correlated by
 /// <see cref="RequestId"/>. Mirrors the server-side record of the same name.
 /// </summary>
 public readonly record struct AcpInteractionResolution(
@@ -1194,7 +1194,7 @@ public readonly record struct AcpEventEnvelope(
 public readonly record struct AcpBatchAck(long AcceptedSeq, long PersistedSeq, long? ExpectedNextSeq = null);
 
 /// <summary>
-/// Ack returned from the server's <c>SendTranscriptBatchAcked</c> hub method (AI-1382 D3).
+/// Ack returned from the server's <c>SendTranscriptBatchAcked</c> hub method (D3).
 /// Field-for-field mirror of the server-side <c>Capacitor.TranscriptBatchAck</c> record.
 /// <see cref="NextLineNumber"/> is the source-acknowledgement frontier — the first line number
 /// the server has NOT fully disposed of (emitted or deliberately ignored). The Cursor watcher
@@ -1218,13 +1218,13 @@ public readonly record struct LaunchAgentCommand(
         LaunchKind        Kind            = LaunchKind.Default,
         ReviewLaunchInfo? Review          = null,
         string?           BaseRef         = null,
-        // AI-1126 D-c: for a review-flow launch, the flow definition's MCP allowlist — server-owned
+        // D-c: for a review-flow launch, the flow definition's MCP allowlist — server-owned
         // names the daemon resolves against the kcap-owned KcapMcpRegistry and materializes into the
         // launcher's MCP config (flow-starting servers are stripped regardless of listing). Appended
         // last as an optional field so the SignalR positional binding stays wire-compatible with
         // older daemons/servers.
         string[]?         McpAllowlist = null,
-        // AI-1207 Phase A: launch against the user's own checkout instead of a fresh daemon-owned
+        // Phase A: launch against the user's own checkout instead of a fresh daemon-owned
         // worktree. A bool on the wire (not the WorkLocation enum) — WorkLocation's numeric values
         // are BorrowedCwd=0/OwnedWorktree=1, the reverse of what you'd guess, so a raw enum int
         // would be a footgun; the daemon maps Borrowed -> WorkLocation internally. BorrowCwd is the
@@ -1244,7 +1244,7 @@ public readonly record struct LaunchAgentCommand(
 /// Discriminator for daemon launch commands. <see cref="Default"/> preserves
 /// the existing prompt-driven launch; <see cref="Review"/> uses
 /// <see cref="ReviewLaunchInfo"/> + <c>BaseRef</c> to drive a hosted PR review;
-/// <see cref="ReviewFlow"/> (AI-1089) marks a durable agent-review-flow reviewer, which the
+/// <see cref="ReviewFlow"/> marks a durable agent-review-flow reviewer, which the
 /// daemon runs unattended (never approval + no MCP). The value crosses the CLI↔server wire, so
 /// it MUST stay Default=0, Review=1, ReviewFlow=2.
 /// </summary>
@@ -1329,7 +1329,7 @@ public readonly record struct FindRepoForRemoteRequest(
     );
 
 /// <summary>
-/// Daemon reply to the server's <c>ProbeBorrowSource</c> client-result invocation (AI-1207 Phase A,
+/// Daemon reply to the server's <c>ProbeBorrowSource</c> client-result invocation (Phase A,
 /// task A3): "can you borrow this path?". <see cref="CanBorrow"/> mirrors
 /// <c>BorrowAuthResult.Allowed</c>; <see cref="CanonicalCwd"/>/<see cref="CanonicalGitRoot"/> are the
 /// daemon-computed canonical paths (non-null only when the path exists), and <see cref="Reason"/>
@@ -1363,7 +1363,7 @@ public readonly record struct ResizeTerminalCommand(
 /// file content for diagnostics). The server uses it to distinguish a
 /// legitimate reconnect of the same daemon (new SignalR connectionId, same
 /// instance) from a different daemon process claiming the same
-/// <c>(owner, name)</c> slot. Pre-AI-630 daemons sent no <c>InstanceId</c>;
+/// <c>(owner, name)</c> slot. Legacy daemons sent no <c>InstanceId</c>;
 /// the server still accepts them under a legacy-displacement fallback.</para>
 ///
 /// <para><c>Version</c> is the daemon binary's
@@ -1371,7 +1371,7 @@ public readonly record struct ResizeTerminalCommand(
 /// the server's <c>DaemonInfo</c> so the dashboard can show what version
 /// each connected daemon is running.</para>
 ///
-/// <para><c>MachineId</c> (AI-1207) is this machine's stable id (see
+/// <para><c>MachineId</c> is this machine's stable id (see
 /// <see cref="MachineId"/>), reported so the server can later prove a daemon
 /// claiming a given repo path is actually running on the requester's
 /// machine. Trailing/optional so an older daemon that doesn't send it (or a

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -139,7 +139,7 @@ class WatchState {
     public int          LinesReadAhead      { get; set; } // file position while buffering
     public bool         ThresholdReached    { get; set; }
 
-    // task 7: set by the shutdown final drain (isFinalDrain) when it held back an
+    // Task 7: set by the shutdown final drain (isFinalDrain) when it held back an
     // unterminated/unparseable final line rather than consuming it. RunWatch reads it right after
     // the final drain to flag the session needs-import (never drop a truncated tail).
     public bool FinalDrainHeldIncompleteLine { get; set; }
@@ -188,7 +188,7 @@ class WatchState {
     // until its link POST succeeds, so a failed POST retries on the next scan (fail-open).
     public HashSet<string> PostedSubagentLinks { get; } = new(StringComparer.Ordinal);
 
-    // task 10: Kiro turn anchors (the turn's final message_id) already streamed as a
+    // Task 10: Kiro turn anchors (the turn's final message_id) already streamed as a
     // synthetic KiroUsageBackfilled line, so a later drain never re-emits the same anchor. Mirrors
     // LastAntigravityGenIdx above, but keyed on the anchor string rather than a row index because
     // Kiro's sidecar has no stable ordinal — committed ONLY after a successful send (see

--- a/src/Capacitor.Cli.Core/OpenCode/OpenCodeExtensionInstaller.cs
+++ b/src/Capacitor.Cli.Core/OpenCode/OpenCodeExtensionInstaller.cs
@@ -1,7 +1,7 @@
 namespace Capacitor.Cli.Core.OpenCode;
 
 /// <summary>
-/// Installs / removes kcap's live-ingest plugin for SST OpenCode (AI-919).
+/// Installs / removes kcap's live-ingest plugin for SST OpenCode.
 /// OpenCode has no shell hooks, so — like Pi — kcap ships a TypeScript plugin
 /// file (<c>~/.config/opencode/plugins/kcap.ts</c>) that OpenCode auto-discovers
 /// and loads in-process. The plugin bridges OpenCode's event bus to the kcap CLI:
@@ -28,7 +28,7 @@ public static class OpenCodeExtensionInstaller {
     /// </summary>
     public const string ExtensionContent =
         """
-        // kcap.ts — Kurrent Capacitor live-ingest plugin for SST OpenCode (AI-919).
+        // kcap.ts — Kurrent Capacitor live-ingest plugin for SST OpenCode.
         //
         // Installed by `kcap setup` / `kcap plugin install --opencode` into
         // ~/.config/opencode/plugins/kcap.ts, which OpenCode auto-loads in-process.
@@ -54,7 +54,7 @@ public static class OpenCodeExtensionInstaller {
           const file = (sid: string) => join(dir, sid + ".jsonl")
           // Subagents run as child sessions; their {info,parts} go in a nested dir beside
           // the parent file (<dir>/<parent>/<child>.jsonl) that the kcap watcher scans and
-          // streams with the child's agent_id → AgentSubsession-* (AI-919 phase 2).
+          // streams with the child's agent_id → AgentSubsession-*.
           const childFile = (parent: string, child: string) => join(dir, parent, child + ".jsonl")
           const started = new Set<string>()
           const children = new Set<string>()           // known subagent (child) session ids — skip top-level

--- a/src/Capacitor.Cli.Core/OpenCode/OpenCodeSubagentDiscovery.cs
+++ b/src/Capacitor.Cli.Core/OpenCode/OpenCodeSubagentDiscovery.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Core; // JsonElement Str/Obj extensions
 namespace Capacitor.Cli.Core.OpenCode;
 
 /// <summary>
-/// Discovery + lifecycle-payload glue for OpenCode subagents (AI-919 phase 2).
+/// Discovery + lifecycle-payload glue for OpenCode subagents.
 /// OpenCode runs a subagent as a child session (<c>session.parentID</c>) stored in its
 /// SQLite db — not on disk as JSONL — so the kcap plugin (which holds the in-process SDK
 /// <c>client</c>) fetches each child's messages and writes them as native

--- a/src/Capacitor.Cli.Core/ProcessStartToken.cs
+++ b/src/Capacitor.Cli.Core/ProcessStartToken.cs
@@ -6,7 +6,7 @@ namespace Capacitor.Cli.Core;
 /// A machine-local token identifying a specific process <i>incarnation</i>,
 /// stable across separate reader processes. Stored on the second line of the
 /// daemon PID file and compared to tell a live daemon apart from a recycled
-/// PID (AI-630 liveness check, AI-839 fix).
+/// PID (liveness check, fix).
 ///
 /// <para><b>Why not just <see cref="Process.StartTime"/>?</b> On Linux that
 /// value is NOT stable across processes: .NET derives it from a per-call
@@ -15,7 +15,7 @@ namespace Capacitor.Cli.Core;
 /// drift as the realtime clock is adjusted (NTP). The daemon wrote its own
 /// start time, and the CLI's <c>status</c>/<c>stop</c>/<c>doctor</c> — separate
 /// processes — recomputed a slightly different value, so an exact-tick equality
-/// check classified every <i>live</i> daemon as a stale PID file (AI-839).</para>
+/// check classified every <i>live</i> daemon as a stale PID file.</para>
 ///
 /// <para>On Linux the token is <c>lx:&lt;boot_id&gt;:&lt;starttime&gt;</c> where
 /// <c>starttime</c> is field 22 of <c>/proc/&lt;pid&gt;/stat</c> (clock ticks
@@ -30,7 +30,7 @@ namespace Capacitor.Cli.Core;
 ///
 /// <para>The <c>scheme:</c> prefix lets <see cref="Matches"/> distinguish "a
 /// different incarnation" (same scheme, different value — conclusive) from "a
-/// token I can't compare" (a legacy pre-AI-839 PID file that stored bare
+/// token I can't compare" (a legacy PID file that stored bare
 /// <see cref="Process.StartTime"/> ticks with no prefix, encountered mid-upgrade
 /// while the old daemon is still running). The latter returns null so callers
 /// fall back to a weaker image-name check instead of stranding a live daemon.</para>

--- a/src/Capacitor.Cli.Core/ProcessStartToken.cs
+++ b/src/Capacitor.Cli.Core/ProcessStartToken.cs
@@ -6,7 +6,7 @@ namespace Capacitor.Cli.Core;
 /// A machine-local token identifying a specific process <i>incarnation</i>,
 /// stable across separate reader processes. Stored on the second line of the
 /// daemon PID file and compared to tell a live daemon apart from a recycled
-/// PID (liveness check, fix).
+/// PID.
 ///
 /// <para><b>Why not just <see cref="Process.StartTime"/>?</b> On Linux that
 /// value is NOT stable across processes: .NET derives it from a per-call

--- a/src/Capacitor.Cli.Core/ProviderApiKeyPolicy.cs
+++ b/src/Capacitor.Cli.Core/ProviderApiKeyPolicy.cs
@@ -10,7 +10,7 @@ namespace Capacitor.Cli.Core;
 /// Default behaviour scrubs them so subscription auth (claude.ai login,
 /// ChatGPT account login) is used by <c>claude -p</c> / <c>codex exec</c>;
 /// a globally-set key would otherwise override subscription auth and break
-/// title generation / summaries (AI-755).
+/// title generation / summaries.
 /// </para>
 ///
 /// <para>

--- a/src/Capacitor.Cli.Core/TranscriptSpool.cs
+++ b/src/Capacitor.Cli.Core/TranscriptSpool.cs
@@ -10,7 +10,7 @@ namespace Capacitor.Cli.Core;
 /// <c>needs-import</c> marker so the session is surfaced as requiring `kcap import` rather than
 /// truncated. Per-session JSONL of transcript batch JSON, one per line, arrival order.
 ///
-/// <para>Moved to <c>Capacitor.Cli.Core</c> (AI-1357 Task 12) alongside <see cref="HookSpool"/> and
+/// <para>Moved to <c>Capacitor.Cli.Core</c> alongside <see cref="HookSpool"/> and
 /// <see cref="LifecycleSpoolDrain"/> so both the CLI and the daemon can share the ordered-drain
 /// primitives.</para>
 /// </summary>

--- a/src/Capacitor.Cli.Core/WatcherHeartbeat.cs
+++ b/src/Capacitor.Cli.Core/WatcherHeartbeat.cs
@@ -4,7 +4,7 @@ namespace Capacitor.Cli.Core;
 
 /// <summary>
 /// Pure heartbeat read/write + staleness policy backing the watcher wedge-detection
-/// probe (AI-1357 task 9). Today <c>WatcherManager.IsWatcherAlive</c> only checks that
+/// probe. Today <c>WatcherManager.IsWatcherAlive</c> only checks that
 /// the PID exists, so a <b>wedged</b> watcher — main loop hung but the process still
 /// alive — is never restarted; the hook self-heal only recovers dead/absent watchers.
 ///

--- a/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
@@ -5,7 +5,7 @@ namespace Capacitor.Cli.Daemon.Acp;
 
 /// <summary>
 /// <see cref="IAcpProcess"/> over a real <see cref="Process"/> — the <c>cursor-agent acp</c> child
-/// spawned by <see cref="Services.AcpHostedAgentRuntimeFactory"/> (AI-684 Task 10). Mirrors the
+/// spawned by <see cref="Services.AcpHostedAgentRuntimeFactory"/>. Mirrors the
 /// terminate/wait semantics of <c>Pty.Unix.UnixPtyProcess</c>/<c>WinPtyProcess</c> (SIGTERM-then-kill
 /// via <see cref="Process.Kill(bool)"/>, bounded waits that return silently on timeout) but owns no
 /// terminal I/O — stdin/stdout carry ACP JSON-RPC frames, consumed by <see cref="AcpConnection"/>.

--- a/src/Capacitor.Cli.Daemon/Acp/AcpConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpConnection.cs
@@ -24,7 +24,7 @@ internal sealed class AcpRpcException : Exception {
 }
 
 /// <summary>
-/// Newline-delimited JSON-RPC 2.0 stdio transport for <c>cursor-agent acp</c> (AI-684 Task 7).
+/// Newline-delimited JSON-RPC 2.0 stdio transport for <c>cursor-agent acp</c>.
 /// Owns framing (one JSON object per line, UTF-8), outbound request/response correlation, and
 /// routing of inbound notifications and server→client requests. Decoupled from <see cref="System.Diagnostics.Process"/>
 /// — the ctor takes plain <see cref="Stream"/>s so tests can drive it over in-memory pipes; the
@@ -43,7 +43,7 @@ internal sealed class AcpRpcException : Exception {
 ///   exit early on a single bad line (a wire hiccup would otherwise silently wedge every pending
 ///   and future <see cref="RequestAsync"/> call).
 ///
-/// Per the AI-684 probe (<c>docs/acp-probe-findings.md</c>), ACP has no per-request
+/// Per the probe (<c>docs/acp-probe-findings.md</c>), ACP has no per-request
 /// <c>$/cancelRequest</c> frame — cancellation is session-level via the <c>session/cancel</c>
 /// notification, which the runtime sends through <see cref="NotifyAsync"/>. Cancelling the
 /// <see cref="CancellationToken"/> passed to <see cref="RequestAsync"/> only abandons the pending
@@ -82,7 +82,7 @@ internal sealed partial class AcpConnection : IAsyncDisposable {
     /// <c>fs/*</c>, <c>terminal/*</c>). The read loop echoes the request's id verbatim in the
     /// response it writes back, with this delegate's return value as the JSON-RPC <c>result</c>.
     /// If unset, every inbound server request is answered with a method-not-found error — a safe
-    /// default-decline posture. AI-684 leaves this unset; AI-686 wires it to the permission bridge.
+    /// default-decline posture. leaves this unset; wires it to the permission bridge.
     ///
     /// A handler returning <see langword="null"/> signals the method is unhandled: the connection
     /// answers <c>-32601 Method not found</c>, the SAME response a fully unset handler produces —
@@ -340,7 +340,7 @@ internal sealed partial class AcpConnection : IAsyncDisposable {
         }
 
         try {
-            // AI-686: the final response write deliberately uses CancellationToken.None, not `ct` —
+            // the final response write deliberately uses CancellationToken.None, not `ct` —
             // this method's own doc comment guarantees exactly one response frame is written "no
             // matter what happens", and `ct` is the SAME token AcpHostedAgentRuntime.DisposeAsync
             // cancels to unblock a pending OnServerRequest handler (e.g. AcpInteractionBridge

--- a/src/Capacitor.Cli.Daemon/Acp/AcpConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpConnection.cs
@@ -82,7 +82,7 @@ internal sealed partial class AcpConnection : IAsyncDisposable {
     /// <c>fs/*</c>, <c>terminal/*</c>). The read loop echoes the request's id verbatim in the
     /// response it writes back, with this delegate's return value as the JSON-RPC <c>result</c>.
     /// If unset, every inbound server request is answered with a method-not-found error — a safe
-    /// default-decline posture. leaves this unset; wires it to the permission bridge.
+    /// default-decline posture. This constructor leaves it unset; permission-bridge wiring assigns it.
     ///
     /// A handler returning <see langword="null"/> signals the method is unhandled: the connection
     /// answers <c>-32601 Method not found</c>, the SAME response a fully unset handler produces —

--- a/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
@@ -46,7 +46,7 @@ internal static partial class AcpEventTranslator {
     /// or terminal with no extractable content) returns <see langword="null"/> rather than an empty
     /// <c>ToolResultReceived</c>.</description></item>
     /// <item><description><see cref="AcpUpdateKind.Plan"/>/<see cref="AcpUpdateKind.AvailableCommands"/>
-    /// → always <see langword="null"/> (not transcript content; deferred to).</description></item>
+    /// → always <see langword="null"/> (not transcript content; deferred to future work).</description></item>
     /// <item><description><see cref="AcpUpdateKind.Unknown"/> → <see langword="null"/>, but
     /// logged via <paramref name="logger"/> (when supplied) at debug level — never silently
     /// swallowed. <see cref="AcpSessionUpdate.Raw"/> itself is only logged verbatim when

--- a/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
@@ -46,7 +46,7 @@ internal static partial class AcpEventTranslator {
     /// or terminal with no extractable content) returns <see langword="null"/> rather than an empty
     /// <c>ToolResultReceived</c>.</description></item>
     /// <item><description><see cref="AcpUpdateKind.Plan"/>/<see cref="AcpUpdateKind.AvailableCommands"/>
-    /// → always <see langword="null"/> (not transcript content; deferred to AI-689).</description></item>
+    /// → always <see langword="null"/> (not transcript content; deferred to).</description></item>
     /// <item><description><see cref="AcpUpdateKind.Unknown"/> → <see langword="null"/>, but
     /// logged via <paramref name="logger"/> (when supplied) at debug level — never silently
     /// swallowed. <see cref="AcpSessionUpdate.Raw"/> itself is only logged verbatim when

--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -9,7 +9,7 @@ namespace Capacitor.Cli.Daemon.Acp;
 /// <summary>
 /// Bridges ACP server→client interaction requests (<c>session/request_permission</c>, and a
 /// capability-gated, defensive <c>elicitation/create</c>) to the Capacitor server's
-/// <c>AcpRequestInteraction</c> hub method (AI-686), and maps the returned decision back to the
+/// <c>AcpRequestInteraction</c> hub method, and maps the returned decision back to the
 /// ACP JSON-RPC result shape. Wired as (a closure over) <see cref="AcpConnection.OnServerRequest"/>
 /// by <see cref="Capacitor.Cli.Daemon.Services.AcpHostedAgentRuntime"/> (Task B4).
 ///
@@ -35,7 +35,7 @@ internal sealed partial class AcpInteractionBridge(
     /// Handles one inbound <see cref="AcpRequest"/>. Returns <see langword="null"/> for any method
     /// this bridge doesn't recognize (letting <see cref="AcpConnection.HandleServerRequestAsync"/>'s
     /// existing default-decline posture answer with a JSON-RPC "Method not found" error, unchanged
-    /// from AI-684's behavior for every method except the two this bridge now claims).
+    /// from the prior behavior for every method except the two this bridge now claims).
     ///
     /// <b>Qodo daemon-review Q2:</b> takes NO caller-supplied session id — the ACP session id used to
     /// correlate this interaction server-side comes ONLY from the request's OWN

--- a/src/Capacitor.Cli.Daemon/Acp/AcpSessionUpdate.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpSessionUpdate.cs
@@ -24,12 +24,12 @@ internal enum AcpUpdateKind {
 
 /// <summary>
 /// Reduced, AOT-friendly internal DTO for one <c>session/update</c> notification's inner
-/// <c>update</c> object. Flat and non-polymorphic by design (AI-684 scope: reduce the wire shape to
-/// something AI-685's mapper can turn into canonical events, without modeling every field of every
+/// <c>update</c> object. Flat and non-polymorphic by design (scope: reduce the wire shape to
+/// something the mapper can turn into canonical events, without modeling every field of every
 /// variant). <see cref="Raw"/> always carries the full <c>update</c> object (not the outer
 /// notification envelope) so the mapper can reach into fields this DTO doesn't surface yet —
 /// notably the untyped <c>plan</c> entries and any fields on spec-derived variants that drift once
-/// AI-684's probe follow-up re-verifies them against a non-plan-gated account.
+/// a follow-up probe re-verifies them against a non-plan-gated account.
 ///
 /// <see cref="ToolInputJson"/> carries the tool_call's
 /// <c>rawInput</c>, feeding <c>AcpEventEnvelope.ToolInputJson</c>, and

--- a/src/Capacitor.Cli.Daemon/Acp/IAcpProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/IAcpProcess.cs
@@ -5,7 +5,7 @@ namespace Capacitor.Cli.Daemon.Acp;
 /// Minimal process-lifecycle abstraction for the <c>cursor-agent acp</c> child process, mirroring
 /// the shape of <see cref="Pty.IPtyProcess"/> but without any terminal I/O (ACP stdio carries
 /// JSON-RPC protocol traffic, not terminal bytes — that goes through <see cref="AcpConnection"/>
-/// instead). Exists so <c>AcpHostedAgentRuntime</c> (AI-684 Task 9) is testable without spawning a
+/// instead). Exists so <c>AcpHostedAgentRuntime</c> is testable without spawning a
 /// real process; Task 10's factory implements this over <see cref="System.Diagnostics.Process"/>.
 /// </summary>
 internal interface IAcpProcess : IAsyncDisposable {

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -35,7 +35,7 @@ public class DaemonConfig {
     /// <summary>
     /// Per-process GUID generated at startup, also written to the daemon's
     /// flock-file content. Sent over <c>DaemonConnect</c> so the server
-    /// (AI-630) can tell "same daemon reconnecting" from "different daemon
+    /// can tell "same daemon reconnecting" from "different daemon
     /// claiming the same name". Set in <c>DaemonRunner.RunAsync</c> once
     /// the lock has been acquired; <c>null</c> in tests that bypass lock
     /// acquisition.
@@ -54,7 +54,7 @@ public class DaemonConfig {
     /// Vendor tokens this daemon can actually spawn — populated in
     /// <c>DaemonRunner.RunAsync</c> by probing each registered
     /// <c>IHostedAgentLauncher.IsAvailable()</c>. Sent over
-    /// <c>DaemonConnect</c> (AI-652) so the server's launch dialog only
+    /// <c>DaemonConnect</c> so the server's launch dialog only
     /// offers vendors this daemon has installed. <c>null</c> when the
     /// host hasn't been built yet or in tests that bypass the runner.
     /// </summary>
@@ -71,7 +71,7 @@ public class DaemonConfig {
 
     /// <summary>
     /// Path or bare command for the Cursor CLI's ACP entry point, spawned as
-    /// <c>{CursorPath} acp</c> by <c>AcpHostedAgentRuntimeFactory</c> (AI-684 Task 10). Overridable
+    /// <c>{CursorPath} acp</c> by <c>AcpHostedAgentRuntimeFactory</c>. Overridable
     /// via <c>KCAP_CURSOR_PATH</c>, mirroring <see cref="ClaudePath"/>/<see cref="CodexPath"/>.
     /// </summary>
     public string CursorPath { get; set; } = "cursor-agent";

--- a/src/Capacitor.Cli.Daemon/DaemonLock.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonLock.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Daemon;
 
 /// <summary>
-/// Per-daemon-name exclusive lock and PID file (AI-630). Acquired by the
+/// Per-daemon-name exclusive lock and PID file. Acquired by the
 /// daemon process for its lifetime; release happens automatically when the
 /// <see cref="FileStream"/> handle closes (process exit, including
 /// <c>SIGKILL</c> / power-off — the kernel releases <c>flock</c>).
@@ -16,7 +16,7 @@ namespace Capacitor.Cli.Daemon;
 /// <c>kcap daemon doctor</c> reads it to surface human-friendly
 /// "instance=<i>prefix</i>" output without needing a live SignalR session.</para>
 ///
-/// <para>The acquisition guards against the AI-630 scenario: two daemons
+/// <para>The acquisition guards against the scenario: two daemons
 /// under the same name on the same machine (regardless of
 /// <c>KCAP_CONFIG_DIR</c> — <see cref="DaemonLockPaths"/> uses a fixed
 /// directory). Two daemons with <i>different</i> names are allowed to
@@ -33,7 +33,7 @@ internal sealed class DaemonLock : IDisposable {
 
     /// <summary>
     /// True when a PID file for this name was still on disk at the moment we
-    /// acquired the exclusive flock (AI-1155). A graceful shutdown deletes the
+    /// acquired the exclusive flock. A graceful shutdown deletes the
     /// PID file in <see cref="Dispose"/>, so a leftover one means the previous
     /// holder exited WITHOUT running its cleanup — the signature of an
     /// uncatchable termination (external <c>SIGKILL</c> from macOS jetsam/OOM
@@ -91,7 +91,7 @@ internal sealed class DaemonLock : IDisposable {
 
         var instanceId = Guid.NewGuid().ToString("N");
 
-        // AI-1155: inspect any leftover PID file BEFORE WritePidFile overwrites
+        // inspect any leftover PID file BEFORE WritePidFile overwrites
         // it. Now that we hold the exclusive flock the prior holder is provably
         // gone, so a still-present PID file means it never ran Dispose (which
         // deletes it) — i.e. it died via an uncatchable SIGKILL / crash. Capture
@@ -176,7 +176,7 @@ internal sealed class DaemonLock : IDisposable {
     }
 
     static void WritePidFile(string pidPath) {
-        // The second line is a cross-process-stable start token (AI-839): on
+        // The second line is a cross-process-stable start token: on
         // Linux Process.StartTime differs between the daemon that writes it and
         // the CLI that later reads it, so we persist the kernel's boot-relative
         // starttime instead. Best-effort — a null token falls back to PID-only,
@@ -190,7 +190,7 @@ internal sealed class DaemonLock : IDisposable {
         if (_disposed) return;
         _disposed = true;
 
-        // AI-1155: delete the PID file (and version marker) BEFORE releasing the
+        // delete the PID file (and version marker) BEFORE releasing the
         // flock, not after. A successor waiting on the lock (`--await-lock`
         // restart-after-update) can't acquire it until we release below, so by
         // then our PID file is already gone — it can never observe a leftover PID
@@ -212,7 +212,7 @@ internal sealed class DaemonLock : IDisposable {
         // Release the kernel-level flock last. Do NOT delete the lock file: the
         // kernel flock is what enforces exclusion, file presence on disk is
         // irrelevant, and unlinking it here would race a daemon that acquired the
-        // path between our unlink and a re-create — reopening the AI-630 hole.
+        // path between our unlink and a re-create — reopening the hole.
         // `kcap daemon doctor --clean` removes truly stale files.
         try { _stream.Dispose(); } catch { /* best-effort */ }
     }

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -66,7 +66,7 @@ public static partial class DaemonRunner {
         config.ReviewerMaxLifetime = ParseSecondsEnv("KCAP_REVIEWER_MAX_LIFETIME", config.ReviewerMaxLifetime);
         config.ReviewerIdleTimeout = ParseSecondsEnv("KCAP_REVIEWER_IDLE_TIMEOUT", config.ReviewerIdleTimeout);
 
-        // AI-1155: reopen fds 1/2 onto the capture file BEFORE building the host,
+        // reopen fds 1/2 onto the capture file BEFORE building the host,
         // so even a crash during construction lands somewhere. On the detached
         // launch path the CLI closed our std pipes; without this a runtime/native
         // fatal message would go to a broken pipe and vanish. No-op under launchd
@@ -168,7 +168,7 @@ public static partial class DaemonRunner {
         // running under the same name on this machine. The lock content is
         // a fresh instance id that we'll also send over DaemonConnect so
         // the server can refuse a second daemon claiming the same
-        // (owner, name) slot (AI-630).
+        // (owner, name) slot.
         var daemonLock = awaitLock
             ? DaemonLock.TryAcquire(config.Name, TimeSpan.FromSeconds(5), config.Version)
             : DaemonLock.TryAcquire(config.Name, config.Version);
@@ -213,7 +213,7 @@ public static partial class DaemonRunner {
             sp.GetServices<IHostedAgentLauncher>().ToDictionary(l => l.Vendor)
         );
 
-        // Runtime-selection seam (AI-684 Task 10): one IHostedAgentRuntimeFactory per vendor.
+        // Runtime-selection seam: one IHostedAgentRuntimeFactory per vendor.
         // AgentOrchestrator selects by vendor from the resulting dictionary instead of driving
         // Prepare/BuildArgs/Spawn inline. PtyHostedAgentRuntimeFactory wraps each registered PTY
         // launcher (Claude, Codex); AcpHostedAgentRuntimeFactory speaks ACP JSON-RPC over stdio for
@@ -283,7 +283,7 @@ public static partial class DaemonRunner {
         // Set by the supervised restart strategy so we exit non-zero for a supervisor relaunch.
         var restartState = host.Services.GetRequiredService<RestartState>();
 
-        // AI-652 (extended by AI-684 Task 10): probe each registered runtime factory's CLI binary
+        // probe each registered runtime factory's CLI binary
         // so the DaemonConnect payload only advertises vendors this daemon can actually spawn —
         // now via IHostedAgentRuntimeFactory.IsAvailable() rather than IHostedAgentLauncher, so
         // Cursor (which has no IHostedAgentLauncher) is advertised once cursor-agent is installed.
@@ -312,7 +312,7 @@ public static partial class DaemonRunner {
 
         LogDaemonStarting(logger, config.Name, config.ServerUrl);
 
-        // AI-1155: if the previous daemon under this name vanished without
+        // if the previous daemon under this name vanished without
         // releasing its lock, it was SIGKILLed (macOS jetsam/OOM, `kill -9`),
         // lost power, or crashed hard — none of which the dying process can
         // log. Emit a breadcrumb now so the otherwise-silent death is on the
@@ -349,7 +349,7 @@ public static partial class DaemonRunner {
             LogLifetimeStopped(logger);
         });
 
-        // AI-630: if the server rejects our DaemonConnect because another
+        // if the server rejects our DaemonConnect because another
         // live daemon owns the (owner, name) slot, signal host shutdown
         // and remember to return exit code 3 instead of 0. Subscribe
         // before ConnectAsync so the initial-connect path is covered.
@@ -418,7 +418,7 @@ public static partial class DaemonRunner {
         // failure-restart policy relaunches the now-updated binary.
         if (restartState.SupervisedRestart) return ExitCodes.RestartRequested;
 
-        // AI-630: if the daemon was shut down because the server told us
+        // if the daemon was shut down because the server told us
         // our (owner, name) slot is contested mid-run (heartbeat-triggered
         // path), exit with code 3 so wrappers (systemd, npm, CI) can tell
         // this apart from a normal Ctrl+C exit.

--- a/src/Capacitor.Cli.Daemon/Pty/IPtyProcessFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/IPtyProcessFactory.cs
@@ -3,7 +3,7 @@ namespace Capacitor.Cli.Daemon.Pty;
 /// <summary>
 /// Single source of truth for the fixed size hosted-agent PTYs are spawned at.
 /// Hosted PTYs are never resized; the daemon reports these dims to the server so
-/// read-only viewers lock their xterm to exactly the width Claude drew for (AI-884).
+/// read-only viewers lock their xterm to exactly the width Claude drew for.
 /// Referenced by both <see cref="IPtyProcessFactory.Spawn"/>'s defaults and the
 /// orchestrator's spawn + dimension-report calls so the two can never drift.
 /// </summary>

--- a/src/Capacitor.Cli.Daemon/Pty/IPtyProcessFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/IPtyProcessFactory.cs
@@ -3,7 +3,7 @@ namespace Capacitor.Cli.Daemon.Pty;
 /// <summary>
 /// Single source of truth for the fixed size hosted-agent PTYs are spawned at.
 /// Hosted PTYs are never resized; the daemon reports these dims to the server so
-/// read-only viewers lock their xterm to exactly the width Claude drew for.
+/// read-only viewers lock their xterm to exactly the width Claude's output assumes.
 /// Referenced by both <see cref="IPtyProcessFactory.Spawn"/>'s defaults and the
 /// orchestrator's spawn + dimension-report calls so the two can never drift.
 /// </summary>

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -538,7 +538,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
     /// <summary>
     /// Never yields a byte — ACP stdout is protocol traffic, never terminal output (no terminal
-    /// capability until). Crucially, this must NOT complete until the process exits or
+    /// capability yet). Crucially, this must NOT complete until the process exits or
     /// <paramref name="ct"/> cancels (Fix B/E): <see cref="AgentOrchestrator.ReadAgentOutputAsync"/>
     /// treats the enumerable ending as "the agent's output stream ended" and finalizes the agent —
     /// for a PTY that's a real signal (the CLI exited), but the old implementation here

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -12,14 +12,14 @@ namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
 /// <see cref="IHostedAgentRuntime"/> that drives an ACP (Agent Client Protocol) session over
-/// <see cref="AcpConnection"/> for Cursor (AI-684 Task 9). Owns the <c>initialize</c> →
+/// <see cref="AcpConnection"/> for Cursor. Owns the <c>initialize</c> →
 /// <c>session/new</c> → <c>session/prompt</c> handshake and reduces inbound <c>session/update</c>
 /// notifications to <see cref="AcpSessionUpdate"/> DTOs, surfaced via <see cref="Updates"/> for
-/// AI-685's mapper to turn into canonical events. AI-684 scope stops there — no canonical events, no
+/// the mapper to turn into canonical events. Scope stops there — no canonical events, no
 /// permission bridge (<c>OnServerRequest</c> stays unset, so the connection's default-decline
-/// posture answers any inbound server request with a method-not-found error; AI-686 wires the real
-/// bridge). Local-attach (raw byte input) and terminal output are PTY-only surfaces the ACP runtime
-/// does not support until AI-687 adds a terminal capability.
+/// posture answers any inbound server request with a method-not-found error; a follow-up wires
+/// the real bridge). Local-attach (raw byte input) and terminal output are PTY-only surfaces the
+/// ACP runtime does not support until a follow-up adds a terminal capability.
 ///
 /// Also owns a serialized, single-flight prompt-turn worker (<see cref="RunTurnWorkerAsync"/>/
 /// <see cref="ProcessTurnAsync"/>) and a chunk aggregator (<see cref="AggregateUpdate"/>) that
@@ -166,7 +166,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     }
 
     /// <summary>
-    /// <paramref name="requestInteraction"/> is optional (AI-686) — when null, matches AI-684's
+    /// <paramref name="requestInteraction"/> is optional — when null, matches the
     /// original behavior exactly: <see cref="AcpConnection.OnServerRequest"/> stays unset, and any
     /// <c>session/request_permission</c>/<c>elicitation/create</c> the agent sends gets the
     /// connection's default JSON-RPC "Method not found" response. When provided, it is forwarded
@@ -538,8 +538,8 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
     /// <summary>
     /// Never yields a byte — ACP stdout is protocol traffic, never terminal output (no terminal
-    /// capability until AI-687). Crucially, this must NOT complete until the process exits or
-    /// <paramref name="ct"/> cancels (AI-684 Fix B/E): <see cref="AgentOrchestrator.ReadAgentOutputAsync"/>
+    /// capability until). Crucially, this must NOT complete until the process exits or
+    /// <paramref name="ct"/> cancels (Fix B/E): <see cref="AgentOrchestrator.ReadAgentOutputAsync"/>
     /// treats the enumerable ending as "the agent's output stream ended" and finalizes the agent —
     /// for a PTY that's a real signal (the CLI exited), but the old implementation here
     /// (<c>yield break</c> on the first call) made a LIVE ACP agent look like it had already
@@ -597,7 +597,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         throw new NotSupportedException("Local-attach raw input is a PTY-only surface; the ACP runtime has no equivalent channel.");
 
     public void Resize(ushort cols, ushort rows) {
-        // No terminal capability until AI-687 — no-op.
+        // No terminal capability until — no-op.
     }
 
     public async Task RequestGracefulStopAsync() {

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -5,14 +5,14 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// <see cref="IHostedAgentRuntimeFactory"/> for Cursor (AI-684 Task 10): spawns
+/// <see cref="IHostedAgentRuntimeFactory"/> for Cursor: spawns
 /// <c>{DaemonConfig.CursorPath} acp</c> as a child process, wraps its stdio in an
 /// <see cref="AcpConnection"/> + <see cref="AcpChildProcess"/>, and drives the ACP handshake via
 /// <see cref="AcpHostedAgentRuntime.StartAsync"/>. Cursor has no unattended mode yet (no permission
-/// bridge until AI-686), so <see cref="SupportsUnattended"/> is <c>false</c> — the orchestrator's
+/// bridge until), so <see cref="SupportsUnattended"/> is <c>false</c> — the orchestrator's
 /// <c>UnattendedLaunchPolicy</c> refuses a review-flow launch for this vendor.
 ///
-/// <b>Spec-review Finding 4 (AI-686):</b> gained a <see cref="ServerConnection"/> constructor
+/// <b>Spec-review Finding 4:</b> gained a <see cref="ServerConnection"/> constructor
 /// dependency so every runtime this factory produces has the real permission/elicitation bridge
 /// wired — <see cref="StartAsync"/> passes <c>ctx.AgentId</c> and
 /// <see cref="ServerConnection.RequestAcpInteractionAsync"/> into <see cref="AcpHostedAgentRuntime"/>'s
@@ -52,7 +52,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         var acpConnection = new AcpConnection(input, output, connLogger, config.DebugFrames);
 
         // Spec-review Finding 4: real production wiring — every Cursor launch now gets the
-        // permission/elicitation bridge, not AI-684's default MethodNotFound/decline.
+        // permission/elicitation bridge, not the default MethodNotFound/decline.
         var runtime = new AcpHostedAgentRuntime(
             acpConnection,
             acpProcess,

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -9,7 +9,7 @@ namespace Capacitor.Cli.Daemon.Services;
 /// <c>{DaemonConfig.CursorPath} acp</c> as a child process, wraps its stdio in an
 /// <see cref="AcpConnection"/> + <see cref="AcpChildProcess"/>, and drives the ACP handshake via
 /// <see cref="AcpHostedAgentRuntime.StartAsync"/>. Cursor has no unattended mode yet (no permission
-/// bridge until), so <see cref="SupportsUnattended"/> is <c>false</c> — the orchestrator's
+/// bridge yet), so <see cref="SupportsUnattended"/> is <c>false</c> — the orchestrator's
 /// <c>UnattendedLaunchPolicy</c> refuses a review-flow launch for this vendor.
 ///
 /// <b>Spec-review Finding 4:</b> gained a <see cref="ServerConnection"/> constructor

--- a/src/Capacitor.Cli.Daemon/Services/AcpTranscriptForwarder.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpTranscriptForwarder.cs
@@ -48,7 +48,7 @@ namespace Capacitor.Cli.Daemon.Services;
 /// resends that make no progress (with a small backoff) and, once the cap is hit, treats the binding
 /// as terminal (stop + clear + <see cref="IsTerminal"/>) rather than spinning. A legitimate gap
 /// advances its <c>ExpectedNextSeq</c> each round and so never trips the guard. Deeper reconnect
-/// resilience beyond this remains AI-689.
+/// resilience beyond this remains.
 ///
 /// Out of scope here: building/emitting the <c>SessionStarted</c> envelope (it is passed
 /// in pre-built as <paramref name="initialEnvelope"/>) or calling <c>AcpSessionStarted</c> — the bind

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -59,7 +59,7 @@ internal partial class AgentOrchestrator {
             if (!isPrivate) {
                 // Register like a UI-launched agent: hosted env so it's visible/drivable from the
                 // owner's web UI, the session links via KCAP_AGENT_ID, and permissions route
-                // through the daemon bridge (Slice 1, AI-972). --private omits all of this.
+                // through the daemon bridge. --private omits all of this.
                 env["KCAP_RENDERED_AGENT"] = "1";
                 env["KCAP_AGENT_ID"]       = agentId;
                 if (_permissionBridge.BaseUrl is { } bridgeUrl) env["KCAP_DAEMON_URL"] = bridgeUrl;

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -216,15 +216,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // reports these dims to the server right after the agent registers (and on
     // reconnect) so the read-only viewers (web/desktop xterm) lock to exactly the
     // width Claude drew for — otherwise the viewer auto-fits its panel and the
-    // mismatched columns garble the TUI (AI-884). PtyDefaults is the single source
+    // mismatched columns garble the TUI. PtyDefaults is the single source
     // of truth, shared with IPtyProcessFactory.Spawn's defaults so they can't drift.
     const ushort HostedPtyCols = PtyDefaults.Cols;
     const ushort HostedPtyRows = PtyDefaults.Rows;
 
     readonly PeriodicTimer _heartbeatTimer = new(TimeSpan.FromSeconds(30));
 
-    // AI-79: heartbeat tightened from 60 s SendAsync to round-trip Ping.
-    // AI-642: tick halved (15 → 7 s) and deadline halved (10 → 5 s) so a
+    // heartbeat tightened from 60 s SendAsync to round-trip Ping.
+    // tick halved (15 → 7 s) and deadline halved (10 → 5 s) so a
     // displaced-slot mismatch or a hung transport is caught within ~10 s
     // instead of ~25 s. This is independent of SignalR's transport timeout
     // (which stays at the 30 s default) — the heartbeat is the daemon's
@@ -233,7 +233,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     static readonly TimeSpan PingDeadline = TimeSpan.FromSeconds(5);
 
-    // AI-992: proactively refresh the active profile's auth token ahead of expiry so a
+    // proactively refresh the active profile's auth token ahead of expiry so a
     // continuously-running daemon keeps a WorkOS sliding-inactivity session alive (up to its
     // absolute lifetime) rather than forcing a `kcap login` after an idle period. The tick is
     // cheap (a token-file read + expiry compare) and only calls the refresh endpoint when the
@@ -242,7 +242,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // even for a failing refresh or a short-lived token that keeps re-entering the window.
     readonly PeriodicTimer _tokenRefresh = new(TimeSpan.FromSeconds(60));
 
-    // AI-1357 Task 12: periodic sweep of the cross-vendor lifecycle + transcript spools. Covers
+    // Task 12: periodic sweep of the cross-vendor lifecycle + transcript spools. Covers
     // backlogs left behind by vendors whose session-end never fires another `kcap` hook process
     // (Kiro/OpenCode watcher-owned session-end, Antigravity/Codex-desktop GUI idle/parent-exit) —
     // see SpoolDrainLoop's doc comment. 60s mirrors the reaper-style cadence of the other timers;
@@ -548,7 +548,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             return;
         }
 
-        // AI-1124: fail an unattended (review-flow) launch fast when the selected vendor's
+        // fail an unattended (review-flow) launch fast when the selected vendor's
         // runtime can't run unattended — before creating a worktree, so there's nothing to
         // clean up. Both shipped PTY launchers support it; this guards future vendors (and the
         // ACP/Cursor runtime, which does not).
@@ -774,7 +774,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // A runtime with no terminal output (ACP/cursor) has no output-chunk signal to flip
             // Starting→Running on — ReadAgentOutputAsync's read loop never yields a byte for such
             // a runtime, so without this the agent would sit in "Starting" until the heartbeat's
-            // StartupTimeout auto-stops it as stuck (AI-684 Fix B/E). Flip to Running immediately:
+            // StartupTimeout auto-stops it as stuck (Fix B/E). Flip to Running immediately:
             // the runtime factory's StartAsync already completed the ACP initialize/session-new
             // handshake by the time we get here, so the session really is established. PTY
             // runtimes are unaffected — they keep the existing on-first-chunk flip in
@@ -958,7 +958,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // full. Tie that await to BOTH this agent's stop (ReadCts) and daemon shutdown
         // so HandleStopAgent releasing ReadCts unblocks the read loop — otherwise a
         // stop mid-outage would leave the finally-block finalization/cleanup stalled
-        // until the whole daemon exits (AI-846).
+        // until the whole daemon exits.
         using var sendCts = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
 
         try {
@@ -994,8 +994,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     } else {
                         // Hosted: the server is the only consumer, so back-pressure here when the
                         // queue is full (slow/down transport) — a chunk is never dropped, since
-                        // losing one byte garbles the whole redraw-TUI mirror (AI-844). sendCts
-                        // releases this await on agent stop or daemon shutdown (AI-846).
+                        // losing one byte garbles the whole redraw-TUI mirror. sendCts
+                        // releases this await on agent stop or daemon shutdown.
                         await _server.SendTerminalOutputAsync(agent.Id, base64, sendCts.Token);
                     }
                 }
@@ -1047,7 +1047,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 // whose ReadOutputAsync yields real terminal bytes (PTY). A no-terminal runtime
                 // (ACP/cursor) never has output to key off, so gate the check on
                 // EmitsTerminalOutput — such a runtime is Completed/Failed purely by exit code
-                // (AI-684 Fix B/E), never misclassified as a startup failure just for having
+                // (Fix B/E), never misclassified as a startup failure just for having
                 // produced no output.
                 if (agent.Runtime.EmitsTerminalOutput && IsStartupFailure(agent.CreatedAt, agent.LastOutputAt, agent.HasReceivedOutput)) {
                     var output = ExtractTerminalText(agent.OutputBuffer);
@@ -1313,7 +1313,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             }
         }
 
-        // AI-30: PtyHostedAgentRuntime.SendUserInputAsync delivers this as a bracketed paste so
+        // PtyHostedAgentRuntime.SendUserInputAsync delivers this as a bracketed paste so
         // the CLI's TUI treats it as one pasted block and the following Enter is an unambiguous
         // submit keypress (see its doc comment for why a naive text-then-CR write mishandles
         // large multi-line input). The ACP runtime sends a structured session/prompt instead, so
@@ -1417,7 +1417,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         => _repoMatcher.FindAsync(req.Owner, req.Repo, req.CandidatePaths ?? [], _shutdownCts.Token);
 
     /// <summary>
-    /// Handles the server's <c>ProbeBorrowSource</c> client-result invocation (AI-1207 Phase A, task
+    /// Handles the server's <c>ProbeBorrowSource</c> client-result invocation (Phase A, task
     /// A3): "can you borrow this path?". Delegates the actual policy (allowlist, git-root resolution,
     /// symlink canonicalization) to <see cref="BorrowAuthorizer"/> — constructed fresh over the
     /// daemon's current <see cref="DaemonConfig"/> so a config reload is picked up on the next probe —
@@ -1662,7 +1662,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// AgentStatusChanged) so per-session ownership is restored after a (re-)connect. Wired into
     /// <see cref="ServerConnection.ReRegisterAgentsHook"/> and awaited inside
     /// <see cref="ServerConnection.RegisterDaemon"/> BEFORE readiness is restored — so a
-    /// permission invoke gated on <c>IsReady</c> can't fire before ownership recovery (AI-864).
+    /// permission invoke gated on <c>IsReady</c> can't fire before ownership recovery.
     ///
     /// Each agent's re-registration is retried a bounded number of times before giving up, so a
     /// transient blip doesn't leave that agent's ownership unrestored while the daemon still
@@ -1683,7 +1683,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     // Re-send the fixed PTY dims. The server stores them in memory, so a
                     // server restart (not just a daemon blip) wipes them — without this
                     // resend the read-only viewers never re-lock and the TUI garbles
-                    // again exactly as before the fix (AI-884). Best-effort: its own
+                    // again exactly as before the fix. Best-effort: its own
                     // catch keeps a dims-send failure from escaping to the retry handler
                     // (which would re-register the agent) or withholding readiness.
                     try {
@@ -1692,7 +1692,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                         LogTerminalDimsSendFailed(ex, agent.Id);
                     }
 
-                    // AI-842: do NOT replay the full output buffer here. The old
+                    // do NOT replay the full output buffer here. The old
                     // replay re-sent the entire 2 MB ring on every reconnect, which
                     // the server appended to its own buffer and live-broadcast on
                     // top of the current screen — duplicated, and interleaved with
@@ -2084,10 +2084,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <summary>Test-only entry point to the private stop handler (mirrors <see cref="HandleLaunchAgentForTest"/>).</summary>
     internal Task HandleStopAgentForTest(string agentId) => HandleStopAgent(agentId);
 
-    /// <summary>Test-only entry point to the private send-input handler (AI-30 bracketed-paste submit).</summary>
+    /// <summary>Test-only entry point to the private send-input handler (bracketed-paste submit).</summary>
     internal Task HandleSendInputForTest(SendInputCommand cmd) => HandleSendInput(cmd);
 
-    /// <summary>Test-only entry point to the private probe-borrow-source handler (AI-1207 task A3).</summary>
+    /// <summary>Test-only entry point to the private probe-borrow-source handler.</summary>
     internal Task<BorrowProbeResult> HandleProbeBorrowSourceForTest(string path) => HandleProbeBorrowSource(path);
 
     internal Task RegisterAgentForTestAsync(AgentInstance agent) => RegisterAgentAsync(agent);

--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -94,7 +94,7 @@ internal sealed partial class ClaudeLauncher(
                 // Skip it for BorrowedCwd; the --disallowedTools deny-list below removes the
                 // write/execute surface instead. Deliberately NOT --permission-mode plan —
                 // that reshapes tool use more broadly and can block/reshape the injected
-                // flow-result MCP tool too (AI-1207).
+                // flow-result MCP tool too.
                 if (ctx.Work != WorkLocation.BorrowedCwd) {
                     args.Add("--permission-mode");
                     args.Add("bypassPermissions");
@@ -102,7 +102,7 @@ internal sealed partial class ClaudeLauncher(
 
                 args.Add("--strict-mcp-config");
                 args.Add("--mcp-config");
-                // AI-1139: the strict config now whitelists exactly the kcap-flow-result
+                // the strict config now whitelists exactly the kcap-flow-result
                 // submission server; the empty map remains the fallback when the daemon has
                 // no server URL / kcap path configured.
                 args.Add(BuildReviewFlowMcpConfig(ctx));
@@ -117,7 +117,7 @@ internal sealed partial class ClaudeLauncher(
                 // Write/MultiEdit/NotebookEdit/Bash — composed into the SAME --disallowedTools
                 // value: the Claude CLI takes one comma-or-space-separated list per flag, not
                 // repeated flags, so both denials must be merged into a single argument
-                // (AI-1207). Read/Grep/Glob and the flow-result MCP tool stay available.
+                // Read/Grep/Glob and the flow-result MCP tool stay available.
                 args.Add("--disallowedTools");
                 args.Add(ctx.Work == WorkLocation.BorrowedCwd
                     ? "Agent,Edit,Write,MultiEdit,NotebookEdit,Bash"
@@ -143,12 +143,12 @@ internal sealed partial class ClaudeLauncher(
         return new LaunchArgs(args.ToArray(), mcpConfigPath);
     }
 
-    /// <summary>AI-1139: strict whitelist for review-flow reviewers — exactly the
+    /// <summary>: strict whitelist for review-flow reviewers — exactly the
     /// kcap-flow-result submission server, or the empty map when the daemon has no server
     /// URL / kcap path (zero servers is the recursion-safe default). Built via JsonNode
     /// string casts — JsonValue.Create / collection expressions lower to generic Add&lt;T&gt;
     /// and trip NativeAOT (IL3050).
-    /// AI-1126 D-c: on the non-empty path, also materializes the flow definition's
+    /// D-c: on the non-empty path, also materializes the flow definition's
     /// <see cref="LauncherContext.McpAllowlist"/> into the same mcpServers object — each name
     /// resolved against the kcap-owned <see cref="KcapMcpRegistry"/> (never ambient user
     /// config), unknown names skipped, flow-starting servers stripped regardless of listing.

--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -143,7 +143,7 @@ internal sealed partial class ClaudeLauncher(
         return new LaunchArgs(args.ToArray(), mcpConfigPath);
     }
 
-    /// <summary>: strict whitelist for review-flow reviewers — exactly the
+    /// <summary>Strict whitelist for review-flow reviewers — exactly the
     /// kcap-flow-result submission server, or the empty map when the daemon has no server
     /// URL / kcap path (zero servers is the recursion-safe default). Built via JsonNode
     /// string casts — JsonValue.Create / collection expressions lower to generic Add&lt;T&gt;

--- a/src/Capacitor.Cli.Daemon/Services/CliResolver.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CliResolver.cs
@@ -6,7 +6,7 @@ namespace Capacitor.Cli.Daemon.Services;
 /// <c>PATH</c> (plus <c>PATHEXT</c> on Windows). On Unix, requires at least
 /// one execute bit (mirrors <c>AgentDetector.IsExecutable</c> in the CLI
 /// project — keep the two in sync). Used by
-/// <see cref="IHostedAgentLauncher.IsAvailable"/> at daemon startup (AI-652)
+/// <see cref="IHostedAgentLauncher.IsAvailable"/> at daemon startup
 /// to decide which vendor launchers to advertise over <c>DaemonConnect</c>.
 ///
 /// <para>This intentionally does NOT execute the binary — startup must stay

--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -77,7 +77,7 @@ internal sealed partial class CodexLauncher(
             // A borrowed reviewer runs in the user's REAL checkout (not a daemon-owned,
             // throwaway worktree) — workspace-write would let it mutate that real repo.
             // read-only is already proven in the headless runner (CodexCliRunner), including
-            // with MCP injection, so the flow-result MCP tool still works (AI-1207).
+            // with MCP injection, so the flow-result MCP tool still works.
             ctx.Work == WorkLocation.BorrowedCwd ? "read-only" : "workspace-write",
             // Review-flow reviewers (LaunchKind.ReviewFlow) run unattended → never pause for
             // approval (writes stay confined by the workspace-write sandbox). Interactive rendered
@@ -86,7 +86,7 @@ internal sealed partial class CodexLauncher(
             ctx.IsReviewFlow ? "never" : "on-request"
         };
 
-        // Review-flow reviewers get exactly ONE MCP server: kcap-flow-result (AI-1139), which can
+        // Review-flow reviewers get exactly ONE MCP server: kcap-flow-result, which can
         // only submit a result — never start a flow. Clear-then-whitelist, in this order:
         // the bare `mcp_servers={}` FIRST replaces the entire [mcp_servers] table from
         // ~/.codex/config.toml; the dotted overrides then insert into the now-empty table.
@@ -120,7 +120,7 @@ internal sealed partial class CodexLauncher(
         return new([.. args], McpConfigPath: null);
     }
 
-    /// <summary>AI-1139: registers the reviewer-side result-submission server. Skipped (zero
+    /// <summary>: registers the reviewer-side result-submission server. Skipped (zero
     /// servers — the recursion-safe default) when the daemon has no server URL or kcap path;
     /// the reviewer then falls back to the transcript marker per the prompt contract.</summary>
     void AddFlowResultServer(List<string> args, LauncherContext ctx) {
@@ -136,7 +136,7 @@ internal sealed partial class CodexLauncher(
         args.Add($"mcp_servers.{name}.env={{KCAP_URL={TomlString(config.ServerUrl)},KCAP_FLOW_AGENT_ID={TomlString(ctx.AgentId)}}}");
     }
 
-    /// <summary>AI-1126 D-c: materializes the flow definition's <see cref="LauncherContext.McpAllowlist"/>
+    /// <summary> D-c: materializes the flow definition's <see cref="LauncherContext.McpAllowlist"/>
     /// as additional dotted overrides, in the same clear-then-whitelist style as
     /// <see cref="AddFlowResultServer"/>. Each name resolves against the kcap-owned
     /// <see cref="KcapMcpRegistry"/> — never ambient user config — unknown names are skipped,

--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -120,7 +120,7 @@ internal sealed partial class CodexLauncher(
         return new([.. args], McpConfigPath: null);
     }
 
-    /// <summary>: registers the reviewer-side result-submission server. Skipped (zero
+    /// <summary>Registers the reviewer-side result-submission server. Skipped (zero
     /// servers — the recursion-safe default) when the daemon has no server URL or kcap path;
     /// the reviewer then falls back to the transcript marker per the prompt contract.</summary>
     void AddFlowResultServer(List<string> args, LauncherContext ctx) {

--- a/src/Capacitor.Cli.Daemon/Services/ConnectionRetry.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ConnectionRetry.cs
@@ -25,7 +25,7 @@ namespace Capacitor.Cli.Daemon.Services;
 ///
 /// A caller may additionally supply <paramref name="isRetriableServerError"/> +
 /// <paramref name="maxServerErrorRetries"/> to retry a BOUNDED number of times on specific
-/// server-rejection exceptions (AI-864: the "Caller is not the daemon owning session"
+/// server-rejection exceptions (the "Caller is not the daemon owning session"
 /// <c>HubException</c> that can appear briefly after a reconnect, before per-agent
 /// re-registration has restored ownership — retrying past that window avoids a spurious deny).
 /// Unlike transient disconnects, these retries are capped so a genuinely-permanent server error

--- a/src/Capacitor.Cli.Daemon/Services/DaemonHeartbeatLoop.cs
+++ b/src/Capacitor.Cli.Daemon/Services/DaemonHeartbeatLoop.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// Daemon-driven liveness probe — replaces the pre-AI-79 fire-and-forget
+/// Daemon-driven liveness probe — replaces the previous fire-and-forget
 /// <c>SendHeartbeatAsync</c>. The server-side <c>DaemonPing</c> hub method
 /// returns <c>true</c> if the calling connection is still the registered
 /// daemon for its <c>(owner, name)</c> slot, and <c>false</c> if it isn't —
@@ -31,7 +31,7 @@ internal sealed class DaemonHeartbeatLoop(
     ) {
     /// <summary>
     /// Round-trip time at or above which a <c>DaemonPing</c> is logged as a
-    /// warning rather than at debug (AI-840 diagnostics). Defaults to half the
+    /// warning rather than at debug (diagnostics). Defaults to half the
     /// per-tick deadline: pings that take this long aren't yet failing, but the
     /// transport latency is climbing toward the deadline that triggers a forced
     /// reconnect, so surfacing them shows degradation building up *before* the
@@ -101,7 +101,7 @@ internal sealed class DaemonHeartbeatLoop(
         try {
             await port.ReRegisterAsync();
         } catch (HubException ex) when (ex.Message.StartsWith(ServerConnection.NameInUseErrorCode, StringComparison.Ordinal)) {
-            // AI-630: the server explicitly told us our (owner, name) slot
+            // the server explicitly told us our (owner, name) slot
             // is held by another live daemon. Force-reconnecting would just
             // re-trigger the same rejection. ServerConnection already fired
             // OnNameInUse — DaemonRunner has called lifetime.StopApplication()

--- a/src/Capacitor.Cli.Daemon/Services/EvalRunner.cs
+++ b/src/Capacitor.Cli.Daemon/Services/EvalRunner.cs
@@ -51,7 +51,7 @@ internal sealed class EvalRunner {
         var       observer   = new DaemonEvalObserver(_connection, cmd.EvalRunId, cmd.SessionId, _logger);
 
         try {
-            // AI-9 Phase 3 — fetch the catalog (rendered prompts + raw text +
+            // Phase 3 — fetch the catalog (rendered prompts + raw text +
             // versions) so PrepareAsync reconciles the run question list from it.
             var catalog = await EvalCatalogClient.FetchAsync(_baseUrl, httpClient, observer, _shutdownToken);
             if (catalog is null) return new(false, "catalog load failed", null, 0, 0, 0, 0, 0);
@@ -100,7 +100,7 @@ internal sealed class EvalRunner {
         var       observer   = new DaemonEvalObserver(_connection, cmd.EvalRunId, ctx.SessionId, _logger);
 
         try {
-            // AI-9 Phase 3 — the SignalR-supplied cmd.Question carries raw text
+            // Phase 3 — the SignalR-supplied cmd.Question carries raw text
             // and a null prompt version; the RECONCILED question from the cached
             // context (matched by id) carries the catalog's rendered Prompt, RawText,
             // and PromptVersion. Judge the reconciled item, not the wire DTO.
@@ -147,7 +147,7 @@ internal sealed class EvalRunner {
         try {
             // FinalizeAsync signature was updated in Task 6.5 — the taxonomy is
             // carried on ctx.Questions, not passed separately.
-            // AI-9 Phase 3: FinalizeAsync now returns SessionEvalCompletedPayloadV3;
+            // Phase 3: FinalizeAsync now returns SessionEvalCompletedPayloadV3;
             // FinalizeResult.Aggregate is the V1 wire DTO held by the server
             // orchestrator, which only inspects Success on this result so we
             // pass null for Aggregate. The V3 payload is already persisted to

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs
@@ -19,7 +19,7 @@ internal interface IHostedAgentLauncher {
 
     /// <summary>
     /// Reports whether <see cref="CliPath"/> resolves to an executable that
-    /// looks installed. Used at daemon startup (AI-652) to build the list of
+    /// looks installed. Used at daemon startup to build the list of
     /// supported vendors advertised over <c>DaemonConnect</c>, so the launch
     /// dialog only offers vendors the daemon can actually spawn.
     /// </summary>
@@ -30,8 +30,8 @@ internal interface IHostedAgentLauncher {
     /// (LaunchKind.ReviewFlow): one that runs to completion with no human in
     /// the loop — no tool-permission prompts — and cannot recursively invoke
     /// flow-starting MCP tools. The orchestrator refuses an unattended launch
-    /// for a vendor that returns <c>false</c> (AI-1124). Both shipped launchers
-    /// support it; a future vendor (e.g. Gemini, AI-899) may not.
+    /// for a vendor that returns <c>false</c>. Both shipped launchers
+    /// support it; a future vendor (e.g. Gemini,) may not.
     /// </summary>
     bool SupportsUnattended { get; }
 
@@ -82,7 +82,7 @@ internal sealed record LauncherContext(
     /// Borrowed-cwd launches skip repo-mutating <c>Prepare()</c> steps.</summary>
     public WorkLocation Work { get; init; } = WorkLocation.OwnedWorktree;
 
-    /// <summary>AI-1126 D-c: the review-flow definition's MCP allowlist, carried verbatim from
+    /// <summary> D-c: the review-flow definition's MCP allowlist, carried verbatim from
     /// <see cref="Capacitor.Cli.Core.LaunchAgentCommand.McpAllowlist"/>. Launchers resolve each
     /// name against the kcap-owned MCP registry and materialize matching servers into the vendor's
     /// MCP config, stripping any flow-starting server regardless of listing. Null/local-spawn

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs
@@ -31,7 +31,7 @@ internal interface IHostedAgentLauncher {
     /// the loop — no tool-permission prompts — and cannot recursively invoke
     /// flow-starting MCP tools. The orchestrator refuses an unattended launch
     /// for a vendor that returns <c>false</c>. Both shipped launchers
-    /// support it; a future vendor (e.g. Gemini,) may not.
+    /// support it; a future vendor (e.g. Gemini) may not.
     /// </summary>
     bool SupportsUnattended { get; }
 

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs
@@ -38,7 +38,7 @@ internal interface IHostedAgentRuntime : IAsyncDisposable {
 
     /// <summary>
     /// Terminal byte stream consumed by the orchestrator read loop. PTY runtimes yield real
-    /// terminal output; the ACP runtime yields an empty stream until adds a terminal
+    /// terminal output; the ACP runtime yields an empty stream until a follow-up adds a terminal
     /// capability (ACP stdout is protocol traffic, never terminal output).
     /// </summary>
     IAsyncEnumerable<byte[]> ReadOutputAsync(CancellationToken ct = default);
@@ -63,7 +63,7 @@ internal interface IHostedAgentRuntime : IAsyncDisposable {
     Task SendRawInputAsync(byte[] data);
 
     /// <summary>Viewer resize. PTY runtimes resize the winsize; the ACP runtime no-ops until
-    /// adds a terminal capability.</summary>
+    /// a follow-up adds a terminal capability.</summary>
     void Resize(ushort cols, ushort rows);
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs
@@ -6,7 +6,7 @@ namespace Capacitor.Cli.Daemon.Services;
 /// cleanup, heartbeats); the runtime owns the vendor-specific process and I/O.
 ///
 /// <see cref="PtyHostedAgentRuntime"/> wraps an <see cref="Pty.IPtyProcess"/> for the interactive
-/// CLIs (Claude, Codex). <c>AcpHostedAgentRuntime</c> (AI-684) speaks ACP JSON-RPC over stdio for
+/// CLIs (Claude, Codex). <c>AcpHostedAgentRuntime</c> speaks ACP JSON-RPC over stdio for
 /// Cursor. The orchestrator only ever touches this interface, never a raw PTY.
 /// </summary>
 internal interface IHostedAgentRuntime : IAsyncDisposable {
@@ -38,7 +38,7 @@ internal interface IHostedAgentRuntime : IAsyncDisposable {
 
     /// <summary>
     /// Terminal byte stream consumed by the orchestrator read loop. PTY runtimes yield real
-    /// terminal output; the ACP runtime yields an empty stream until AI-687 adds a terminal
+    /// terminal output; the ACP runtime yields an empty stream until adds a terminal
     /// capability (ACP stdout is protocol traffic, never terminal output).
     /// </summary>
     IAsyncEnumerable<byte[]> ReadOutputAsync(CancellationToken ct = default);
@@ -63,7 +63,7 @@ internal interface IHostedAgentRuntime : IAsyncDisposable {
     Task SendRawInputAsync(byte[] data);
 
     /// <summary>Viewer resize. PTY runtimes resize the winsize; the ACP runtime no-ops until
-    /// AI-687 adds a terminal capability.</summary>
+    /// adds a terminal capability.</summary>
     void Resize(ushort cols, ushort rows);
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Core.LocalIpc;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// Runtime-selection seam (AI-684 Task 10): one implementation per vendor family, chosen by
+/// Runtime-selection seam: one implementation per vendor family, chosen by
 /// <see cref="AgentOrchestrator.HandleLaunchAgent"/> via <c>cmd.Vendor</c> instead of the orchestrator
 /// itself building the vendor-specific runtime inline. <see cref="PtyHostedAgentRuntimeFactory"/>
 /// wraps an <see cref="IHostedAgentLauncher"/> + <see cref="Pty.IPtyProcessFactory"/> for the
@@ -84,12 +84,12 @@ internal sealed record RuntimeStartContext(
         string?           ServerUrl,
         string?           DaemonBridgeUrl,
         string            CapacitorPath,
-        // AI-1126 D-c: the review-flow definition's MCP allowlist, carried verbatim from
+        // D-c: the review-flow definition's MCP allowlist, carried verbatim from
         // LaunchAgentCommand.McpAllowlist through to LauncherContext.McpAllowlist for the PTY
         // launchers to materialize. Unused by the ACP factory (Cursor has no MCP-allowlist
         // materialization yet).
         string[]?         McpAllowlist = null,
-        // AI-1207 Phase A: owned worktree (daemon-created) vs borrowed cwd (the user's own
+        // Phase A: owned worktree (daemon-created) vs borrowed cwd (the user's own
         // checkout), carried from LaunchAgentCommand.Borrowed through to LauncherContext.Work.
         // Defaults to OwnedWorktree — today's only exercised path — unchanged.
         WorkLocation       Work = WorkLocation.OwnedWorktree,

--- a/src/Capacitor.Cli.Daemon/Services/LocalSocketSink.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalSocketSink.cs
@@ -6,7 +6,7 @@ namespace Capacitor.Cli.Daemon.Services;
 /// calls <see cref="TryEnqueue"/>, which never blocks: if the bounded queue is full, the
 /// client is too slow, so we mark it <see cref="Detached"/> and drop it rather than (a)
 /// silently losing a chunk mid-stream — which desyncs Claude's cursor-addressing redraw
-/// (AI-844) — or (b) back-pressuring the shared loop and stalling every other client. A
+/// or (b) back-pressuring the shared loop and stalling every other client. A
 /// dropped client reattaches for a fresh <c>OutputBuffer</c> replay, recovering from a
 /// clean frame.
 internal sealed class LocalSocketSink : ITerminalSink {
@@ -19,7 +19,7 @@ internal sealed class LocalSocketSink : ITerminalSink {
         _send = send;
         // Wait mode: TryWrite never blocks but returns false when the queue is full — that
         // false is our overflow signal (force-detach). DropOldest/DropWrite would silently
-        // lose a chunk and always return true, reintroducing the AI-844 corruption.
+        // lose a chunk and always return true, reintroducing the corruption.
         _ch = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(capacity) {
             FullMode     = BoundedChannelFullMode.Wait,
             SingleReader = true

--- a/src/Capacitor.Cli.Daemon/Services/PendingAcpInteractionRegistry.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PendingAcpInteractionRegistry.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// Correlates an ACP interaction request (AI-686) with the server's later
+/// Correlates an ACP interaction request with the server's later
 /// <c>AcpInteractionResolved</c> push. Copy-shape of <see cref="PendingPermissionRegistry"/>
 /// parameterized on <see cref="AcpInteractionDecision"/> instead of <see cref="PermissionDecision"/>
 /// — kept as a separate small class (matching this codebase's existing style of small,

--- a/src/Capacitor.Cli.Daemon/Services/PendingPermissionRegistry.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PendingPermissionRegistry.cs
@@ -5,7 +5,7 @@ namespace Capacitor.Cli.Daemon.Services;
 /// <summary>
 /// Correlates a hosted-agent permission request with the server's later decision push.
 ///
-/// Background (AI-864): the daemon used to obtain a permission decision as the return value of
+/// Background: the daemon used to obtain a permission decision as the return value of
 /// a <c>RequestPermission</c> hub invocation that stayed pending for the entire elicitation
 /// wait. Under SignalR's default <c>MaximumParallelInvocationsPerClient = 1</c> that single
 /// in-flight invocation starved the daemon's <c>DaemonPing</c>, tripped the 5s ping deadline,

--- a/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntime.cs
@@ -28,7 +28,7 @@ internal sealed class PtyHostedAgentRuntime(string vendor, IPtyProcess pty) : IH
     /// <summary>
     /// Delivers <paramref name="text"/> as a bracketed paste (ESC[200~ … ESC[201~) so the agent's
     /// TUI treats it as one pasted block and the following Enter is an unambiguous submit
-    /// keypress. Without the paste markers a large multi-line message is mis-handled (AI-30):
+    /// keypress. Without the paste markers a large multi-line message is mis-handled:
     /// Codex never submits it at all, and Claude only submits it ~50% of the time — the CR races
     /// the still-ingesting paste and is folded in as a literal newline, so the text sits in the
     /// composer until a later, isolated keystroke finishes it. Both hosted CLIs enable

--- a/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
@@ -6,7 +6,7 @@ namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
 /// <see cref="IHostedAgentRuntimeFactory"/> for the interactive PTY-backed CLIs (Claude, Codex).
-/// Moved verbatim from the body of <see cref="AgentOrchestrator.HandleLaunchAgent"/> (AI-684 Task
+/// Moved verbatim from the body of <see cref="AgentOrchestrator.HandleLaunchAgent"/> (Task
 /// 10): builds the <see cref="LauncherContext"/> (including the review-launch
 /// <see cref="ReviewLaunchBuilder.BuildAsync"/> call), runs <see cref="IHostedAgentLauncher.Prepare"/>
 /// then <see cref="IHostedAgentLauncher.BuildArgs"/>, assembles the daemon-injected env vars, spawns

--- a/src/Capacitor.Cli.Daemon/Services/RegistrationGate.cs
+++ b/src/Capacitor.Cli.Daemon/Services/RegistrationGate.cs
@@ -34,7 +34,7 @@ internal sealed class RegistrationGate {
     /// returned — before the server re-established per-session ownership via the separate agent
     /// re-registration path. A permission invoke gated on <see cref="IsReady"/> could then fire
     /// into that gap and get a "Caller is not the daemon owning session" HubException, which the
-    /// retry layer treats as fatal → a spurious deny (the residual half of the AI-864 bug).
+    /// retry layer treats as fatal → a spurious deny (the residual half of the bug).
     ///
     /// If <paramref name="daemonConnect"/> throws (e.g. name-in-use), the exception propagates
     /// and readiness stays cleared — re-registration is skipped and MarkRegistered never runs.

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -835,7 +835,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         ) => _hub.InvokeAsync<AcpBatchAck>("AcpSessionEvents", agentId, acpSessionId, envelopes, cancellationToken: ct);
 
     /// <summary>
-    /// Queues a base64 PTY chunk for the hosted-agent terminal mirror.:
+    /// Queues a base64 PTY chunk for the hosted-agent terminal mirror:
     /// chunks are drained by <see cref="TerminalOutputSender"/>'s single ordered loop
     /// instead of being fired at <c>SendAsync</c> fire-and-forget, so they reach the
     /// server in PTY order. The enqueue awaits when the queue is full — the caller

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -65,7 +65,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public Func<FindRepoForRemoteRequest, Task<string[]>>? FindRepoForRemoteHandler { get; set; }
 
     /// <summary>
-    /// Handler for the server's <c>ProbeBorrowSource</c> client-result invocation (AI-1207 Phase A,
+    /// Handler for the server's <c>ProbeBorrowSource</c> client-result invocation (Phase A,
     /// task A3): "can you borrow this path?". Receives a filesystem path and returns the
     /// daemon-computed authorization + canonical paths. Set by <see cref="AgentOrchestrator"/> at
     /// startup; when null, returns <c>BorrowProbeResult(false, null, null, "no handler")</c>.
@@ -167,7 +167,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         _hub.On<FindRepoForRemoteRequest, string[]>("FindRepoForRemote",
             req => FindRepoForRemoteHandler?.Invoke(req) ?? Task.FromResult(Array.Empty<string>()));
 
-        // Client-result invocation: "can you borrow this path?" (AI-1207 Phase A, task A3). Lets the
+        // Client-result invocation: "can you borrow this path?". Lets the
         // server prove co-location before offering a borrow-cwd launch target. "no handler" is
         // returned when the orchestrator hasn't wired the handler yet (e.g. early startup).
         _hub.On<string, BorrowProbeResult>("ProbeBorrowSource",
@@ -175,7 +175,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                 ?? Task.FromResult(new BorrowProbeResult(false, null, null, "no handler")));
 
         // Server→client push carrying the user's decision for a hosted-agent permission request
-        // (AI-864). Paired with the RequestPermission2 invocation in RequestPermissionAsync: that
+        // Paired with the RequestPermission2 invocation in RequestPermissionAsync: that
         // invocation returns a requestId immediately (so it can't occupy the connection's single
         // parallel-invocation slot and starve DaemonPing), and the decision arrives later via
         // this message. Resolve() completes the awaiting RequestPermissionAsync call, or buffers
@@ -185,7 +185,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             res => _pendingPermissions.Resolve(res.RequestId, res.Decision));
 
         // Server→client push carrying the user's decision for an ACP permission/elicitation
-        // interaction (AI-686). Mirrors the PermissionResolved registration above — a separate
+        // interaction. Mirrors the PermissionResolved registration above — a separate
         // registry (AcpInteractionDecision-typed) rather than reusing _pendingPermissions, since
         // the decision payload shape differs (ACP interactions carry SelectedOptionLabel/
         // SelectedIndex/FreeText that Claude Code's PermissionDecision has no equivalent for).
@@ -207,7 +207,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
 
     /// <summary>
     /// Registers no-op client handlers for the UI-only broadcasts a daemon can
-    /// receive on its hub connection (AI-841). The server adds every
+    /// receive on its hub connection. The server adds every
     /// authenticated connection — daemons included — to its <c>org-members</c>
     /// UI group in <c>CapacitorHub.OnConnectedAsync</c>, and only removes the
     /// daemon again inside <c>DaemonConnect</c>. In the window between the
@@ -252,7 +252,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// connected+registered state. Logged as connection uptime in
     /// <see cref="OnClosed"/> so the daemon log shows how long each connection
     /// survived — the cadence that distinguishes a steady transport from one
-    /// flapping every few seconds (AI-840 diagnostics). Zero until the first
+    /// flapping every few seconds (diagnostics). Zero until the first
     /// successful connect.
     /// </summary>
     long _connectedTimestamp;
@@ -306,7 +306,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
                 throw;
             } catch (Exception ex) when (IsNameInUse(ex)) {
-                // AI-630: server explicitly rejected this daemon because
+                // server explicitly rejected this daemon because
                 // another live daemon owns the (owner, name) slot. Don't
                 // retry — retrying would just thrash the incumbent.
                 // RegisterDaemon already fired OnNameInUse before re-throwing
@@ -352,7 +352,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// followed by the ACP re-bind (<see cref="ReRegisterAgentsAndAcpBindingsAsync"/>), and only THEN
     /// restores readiness. Folding agent re-registration into the readiness bracket closes the
     /// window where a permission invoke could fire after <c>DaemonConnect</c> but before the server
-    /// re-established per-session ownership (AI-864); folding the ACP re-bind in right after it
+    /// re-established per-session ownership; folding the ACP re-bind in right after it
     /// closes the equivalent window for <see cref="SendAcpEventsAsync"/> — that call is
     /// <see cref="IsReady"/>-gated, so it can never
     /// reach the server before <see cref="ReBindAcpSessionsAsync"/> has re-established every active
@@ -395,7 +395,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                 cancellationToken: _ct
             );
         } catch (Exception ex) when (IsNameInUse(ex)) {
-            // AI-630: server refused our (owner, name) slot because another
+            // server refused our (owner, name) slot because another
             // live daemon owns it. Surface to DaemonRunner before re-throwing
             // so the host can shut down cleanly; the heartbeat loop's
             // SafeReRegisterAsync filters this exception out so we don't
@@ -463,7 +463,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     }
 
     /// <summary>
-    /// Round-trip liveness probe (AI-566). Calls <c>DaemonPing</c> on the server
+    /// Round-trip liveness probe. Calls <c>DaemonPing</c> on the server
     /// and returns whether this connection is still the registered daemon for
     /// its <c>(owner, name)</c> slot. <c>false</c> means the slot was displaced
     /// — usually by an auto-reconnect Register from a different conn id —
@@ -488,7 +488,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// <see cref="RegisterDaemon"/>. Used when the heartbeat ping times out
     /// or throws — the WebSocket is hung and only a fresh connection
     /// recovers it. StopAsync is capped at 5 s so a wedged transport
-    /// can't stall the heartbeat loop indefinitely (Qodo AI-642).
+    /// can't stall the heartbeat loop indefinitely (Qodo).
     /// </summary>
     public async Task ForceReconnectAsync() {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(_ct);
@@ -599,7 +599,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         // RequestPermission2 is a SHORT invocation: the server tracks the request, broadcasts the
         // prompt to the UI, and returns a requestId right away — it does NOT stay pending for the
         // whole elicitation wait. That keeps the connection's single parallel-invocation slot free
-        // so DaemonPing isn't starved (the AI-864 reconnect-storm / spurious-deny bug). The user's
+        // so DaemonPing isn't starved (the reconnect-storm / spurious-deny bug). The user's
         // decision arrives later via the "PermissionResolved" push, correlated by requestId.
         //
         // The invoke is still wrapped in ConnectionRetry: a SignalR blip while obtaining the
@@ -631,7 +631,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
 
     /// <summary>
     /// Forwards an ACP permission/elicitation interaction to the server's
-    /// <c>AcpRequestInteraction</c> hub method and returns the user's decision (AI-686). Mirrors
+    /// <c>AcpRequestInteraction</c> hub method and returns the user's decision. Mirrors
     /// <see cref="RequestPermissionAsync"/>'s non-blocking-invoke-then-await-push pattern exactly —
     /// see that method's remarks for why the invoke returns a requestId immediately rather than
     /// blocking the connection's parallel-invocation slot for the whole interaction wait.
@@ -655,7 +655,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
 
     /// <summary>
     /// Max bounded retries for the post-reconnect "Caller is not the daemon owning session"
-    /// HubException (AI-864). ≈ this × <see cref="PermissionRetryPollInterval"/> of grace for
+    /// HubException. ≈ this × <see cref="PermissionRetryPollInterval"/> of grace for
     /// per-agent re-registration to restore ownership before the request falls through to a deny.
     /// </summary>
     const int OwnershipNotReadyMaxRetries = 6;
@@ -835,7 +835,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         ) => _hub.InvokeAsync<AcpBatchAck>("AcpSessionEvents", agentId, acpSessionId, envelopes, cancellationToken: ct);
 
     /// <summary>
-    /// Queues a base64 PTY chunk for the hosted-agent terminal mirror. AI-842/AI-844:
+    /// Queues a base64 PTY chunk for the hosted-agent terminal mirror.:
     /// chunks are drained by <see cref="TerminalOutputSender"/>'s single ordered loop
     /// instead of being fired at <c>SendAsync</c> fire-and-forget, so they reach the
     /// server in PTY order. The enqueue awaits when the queue is full — the caller
@@ -846,7 +846,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// Cancels a blocked (back-pressured) enqueue. The read loop passes a token tied
     /// to BOTH the per-agent stop (<c>ReadCts</c>) and daemon shutdown, so stopping a
     /// single agent releases its read loop even mid-outage — otherwise the loop's
-    /// finally-block finalization/cleanup would stall until daemon shutdown (AI-846).
+    /// finally-block finalization/cleanup would stall until daemon shutdown.
     /// </param>
     public virtual Task SendTerminalOutputAsync(string agentId, string base64Data, CancellationToken ct = default) =>
         _terminalSender.EnqueueAsync(agentId, base64Data, ct).AsTask();

--- a/src/Capacitor.Cli.Daemon/Services/SpoolDrainLoop.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SpoolDrainLoop.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// Daemon-side periodic drain of the cross-vendor lifecycle + transcript spools (AI-1357 Task 12).
+/// Daemon-side periodic drain of the cross-vendor lifecycle + transcript spools.
 ///
 /// <para>Complements the per-invocation drain wired into the CLI's <c>case "hook":</c> entry point
 /// (<c>AgentHookPoster.DrainSpoolsAsync</c>): that only runs when a `kcap` process is invoked at all.

--- a/src/Capacitor.Cli.Daemon/Services/TerminalOutputSender.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TerminalOutputSender.cs
@@ -6,19 +6,19 @@ namespace Capacitor.Cli.Daemon.Services;
 /// <summary>
 /// Serialises hosted-agent terminal output onto a single ordered channel so the
 /// stream the web "Terminal" tab renders is delivered in PTY order and survives a
-/// flapping SignalR connection <em>without losing bytes</em> (AI-842, AI-844).
+/// flapping SignalR connection <em>without losing bytes</em>.
 ///
-/// The pre-AI-842 path fired every PTY chunk at <c>HubConnection.SendAsync</c>
+/// The previous path fired every PTY chunk at <c>HubConnection.SendAsync</c>
 /// with a discarded task. While the hub was disconnected those sends faulted
 /// silently — dropping bytes mid-ANSI-escape-sequence — and the read loop's
 /// concurrent fire-and-forget sends could interleave out of order. A single
 /// consumer draining one channel fixes the ordering and the silent-fault problem.
 ///
-/// AI-842 capped that channel with <c>DropOldest</c>, which re-introduced silent
+/// capped that channel with <c>DropOldest</c>, which re-introduced silent
 /// loss: under back-pressure (a slow/flapping tunnel) it discarded the oldest
 /// queued chunks. Claude Code's TUI is a cursor-addressing redraw stream — a
 /// single dropped or reordered chunk desyncs every later repaint, so the
-/// "Terminal" tab rendered garbled output with lost history (AI-844). The queue
+/// "Terminal" tab rendered garbled output with lost history. The queue
 /// is therefore loss-free:
 /// <list type="bullet">
 ///   <item>The bounded channel uses <see cref="BoundedChannelFullMode.Wait"/>, so

--- a/src/Capacitor.Cli.Daemon/Services/TokenRefreshLoop.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TokenRefreshLoop.cs
@@ -26,7 +26,7 @@ internal sealed class TokenStoreRefreshPort(TimeSpan window) : IProactiveTokenRe
 }
 
 /// <summary>
-/// Daemon-driven proactive auth-token refresh (AI-992). Auth tokens are otherwise refreshed
+/// Daemon-driven proactive auth-token refresh. Auth tokens are otherwise refreshed
 /// lazily — only once a hook hits an expired access token — so after an idle period the user
 /// sees a 401 and must re-run <c>kcap login</c>. This loop keeps the active profile's token
 /// warm by refreshing it <em>ahead</em> of expiry while the daemon runs, which for WorkOS's

--- a/src/Capacitor.Cli.Daemon/Services/UnattendedLaunchPolicy.cs
+++ b/src/Capacitor.Cli.Daemon/Services/UnattendedLaunchPolicy.cs
@@ -1,7 +1,7 @@
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// AI-1124: gate for unattended (LaunchKind.ReviewFlow) launches. A vendor whose
+/// gate for unattended (LaunchKind.ReviewFlow) launches. A vendor whose
 /// launcher can't run without a human in the loop must be refused BEFORE a worktree
 /// is created — otherwise the agent spawns and hangs forever on a permission prompt
 /// no one will answer. Pure so it's unit-testable without the full orchestrator.
@@ -13,7 +13,7 @@ internal static class UnattendedLaunchPolicy {
         RejectionReason(launcher.Vendor, launcher.SupportsUnattended, isReviewFlow);
 
     /// <summary>
-    /// Vendor-agnostic overload (AI-684 Task 10): the orchestrator now selects by
+    /// Vendor-agnostic overload: the orchestrator now selects by
     /// <see cref="IHostedAgentRuntimeFactory"/> rather than <see cref="IHostedAgentLauncher"/>, so
     /// this takes the vendor token and its <c>SupportsUnattended</c> flag directly instead of a
     /// launcher instance.

--- a/src/Capacitor.Cli.Daemon/StdErrCapture.cs
+++ b/src/Capacitor.Cli.Daemon/StdErrCapture.cs
@@ -10,7 +10,7 @@ namespace Capacitor.Cli.Daemon;
 ///
 /// <para>The detached launch path (<c>kcap daemon start -d</c> / <c>kcap
 /// agent</c>) redirects the child's std streams to a pipe and immediately
-/// closes it (, to avoid a pipe-leak hang), so without this those fatal
+/// closes it (to avoid a pipe-leak hang), so without this those fatal
 /// messages are written to a broken pipe and lost — which is exactly why a
 /// hard daemon death currently leaves no trace. The CLI therefore passes
 /// <c>--stderr-file &lt;path&gt;</c> on the detached path; the daemon reopens

--- a/src/Capacitor.Cli.Daemon/StdErrCapture.cs
+++ b/src/Capacitor.Cli.Daemon/StdErrCapture.cs
@@ -3,14 +3,14 @@ using System.Runtime.InteropServices;
 namespace Capacitor.Cli.Daemon;
 
 /// <summary>
-/// AI-1155: redirect the daemon's OS-level stdout/stderr (fds 1 and 2) onto a
+/// redirect the daemon's OS-level stdout/stderr (fds 1 and 2) onto a
 /// file so output that BYPASSES the ILogger pipeline is still captured — the
 /// runtime's "Fatal error." dump on an unhandled native exception, an
 /// <c>abort()</c> message, or a <see cref="Environment.FailFast(string)"/>.
 ///
 /// <para>The detached launch path (<c>kcap daemon start -d</c> / <c>kcap
 /// agent</c>) redirects the child's std streams to a pipe and immediately
-/// closes it (AI-839, to avoid a pipe-leak hang), so without this those fatal
+/// closes it (, to avoid a pipe-leak hang), so without this those fatal
 /// messages are written to a broken pipe and lost — which is exactly why a
 /// hard daemon death currently leaves no trace. The CLI therefore passes
 /// <c>--stderr-file &lt;path&gt;</c> on the detached path; the daemon reopens

--- a/src/Capacitor.Cli/Commands/AgentHookPoster.cs
+++ b/src/Capacitor.Cli/Commands/AgentHookPoster.cs
@@ -36,7 +36,7 @@ internal enum HookPostOutcome {
 /// and POSTed blindly. When auth has lapsed that meant a guaranteed-to-401 POST plus a
 /// misleading per-turn <c>HTTP 401</c> stderr line; this helper instead reports
 /// <see cref="HookPostOutcome.AuthLapsed"/> so the caller can skip the doomed work and exit
-/// cleanly — carrying the Claude hook's #183 behaviour to the other hooks (AI-993).
+/// cleanly — carrying the Claude hook's #183 behaviour to the other hooks.
 ///
 /// These agents have no user-facing stdout notice channel (stdout is either unused or a JSON
 /// decision/context channel), so no re-login nudge is surfaced here — the expired state is
@@ -94,7 +94,7 @@ internal static class AgentHookPoster {
     }
 
     /// <summary>
-    /// AI-1357: spawn-before-post variant. Like <see cref="PostAsync(string,string,string,string)"/>,
+    /// spawn-before-post variant. Like <see cref="PostAsync(string,string,string,string)"/>,
     /// but on a lapsed-auth or transient (5xx/408/429/unreachable) failure it durably spools the
     /// lifecycle payload to <paramref name="spool"/> and returns <see cref="HookPostOutcome.Spooled"/>
     /// (a global drain pass replays it after recovery). Callers treat <c>Posted</c> OR <c>Spooled</c>
@@ -107,7 +107,7 @@ internal static class AgentHookPoster {
                             baseUrl, endpoint, body, agentTag, spool, sessionId, route);
 
     /// <summary>
-    /// AI-1357: spawn-before-post decision. Capture must start regardless of whether the lifecycle
+    /// spawn-before-post decision. Capture must start regardless of whether the lifecycle
     /// POST was actually <em>delivered</em> — both <c>Posted</c> (delivered) and <c>Spooled</c>
     /// (durably persisted for a later drain) proceed to <c>WatcherManager.EnsureWatcherRunning</c>,
     /// because a spooled <c>SessionStarted</c> will still reach the server on the next drain pass.
@@ -125,7 +125,7 @@ internal static class AgentHookPoster {
     static readonly TimeSpan DrainThrottle = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// AI-1357 Task 4 (Task 12: centralized): bounded, best-effort drain of the cross-vendor
+    /// Task 4 (Task 12: centralized): bounded, best-effort drain of the cross-vendor
     /// lifecycle + transcript spools. Introduced in Task 4 as a per-vendor call from each
     /// JSON-payload dispatcher's <c>Handle</c>; Task 12 centralized the call site into
     /// <c>Program.cs</c>'s <c>case "hook":</c> (before dispatch, non-Codex) so it runs exactly once
@@ -136,7 +136,7 @@ internal static class AgentHookPoster {
     /// <see cref="LifecycleSpoolDrain.RunAsync(HttpClient,string,HookSpool,TranscriptSpool,string?,TimeSpan,CancellationToken,Action{string,string}?)"/>
     /// directly instead.
     ///
-    /// <para><b>Throttled (AI-1357 review #1).</b> Several vendors fire their lifecycle hook on
+    /// <para><b>Throttled.</b> Several vendors fire their lifecycle hook on
     /// EVERY prompt (Kiro's <c>agentSpawn</c>, OpenCode's <c>session.idle</c>-driven re-fire), so an
     /// un-throttled drain would attempt a ~1.5s network round-trip per prompt during a server outage.
     /// A cross-vendor on-disk stamp (<c>{spoolDir}/.last-drain</c>) caps attempts to one per
@@ -150,7 +150,7 @@ internal static class AgentHookPoster {
     /// <see cref="LifecycleSpoolDrain"/>'s production poster treats a non-timeout/non-5xx status as a
     /// permanent drop — which would silently discard the very backlog this protects.</para>
     ///
-    /// <para><b>Fresh client (AI-1357 review #3 — documented deviation).</b> The brief's Step 3
+    /// <para><b>Fresh client (review #3 — documented deviation).</b> The brief's Step 3
     /// suggested reusing the vendor's authenticated client, but the drain runs at the top of the
     /// dispatcher BEFORE any lifecycle POST, and the vendors never hold a reusable client — each
     /// <see cref="PostOrSpoolAsync(string,string,string,string,HookSpool,string,string)"/> builds and
@@ -176,7 +176,7 @@ internal static class AgentHookPoster {
             using (client) {
                 if (IsAuthLapsed(status)) return;
 
-                // AI-1357 Task 12 / BLOCKER-2: a generically-drained session-end (any vendor — the
+                // Task 12 / BLOCKER-2: a generically-drained session-end (any vendor — the
                 // server's generate_whats_done signal is vendor-agnostic, see WatchCommand's
                 // parent-exit path) must still trigger the what's-done generator, mirroring
                 // ClaudeHookCommand.ClaudePoster's own session-end replay side effect.

--- a/src/Capacitor.Cli/Commands/AntigravityGenMetadataDb.cs
+++ b/src/Capacitor.Cli/Commands/AntigravityGenMetadataDb.cs
@@ -6,15 +6,15 @@ namespace Capacitor.Cli.Commands;
 /// <summary>
 /// Read-only reader over an Antigravity conversation's SQLite db
 /// (<c>~/.gemini/antigravity/conversations/&lt;id&gt;.db</c>), yielding the synthetic
-/// <c>USAGE</c> transcript lines the server maps to <c>AntigravityUsageBackfilledEvent</c>
-/// (AI-1158). Antigravity keeps per-generation tokens/model in the <c>gen_metadata</c>
+/// <c>USAGE</c> transcript lines the server maps to <c>AntigravityUsageBackfilledEvent</c>.
+/// Antigravity keeps per-generation tokens/model in the <c>gen_metadata</c>
 /// table's protobuf <c>data</c> blob, not the JSONL transcript, so the watcher polls this
 /// alongside tailing <c>transcript_full.jsonl</c> and streams the decoded rows.
 ///
 /// Lives in the CLI project (not Core) so the Microsoft.Data.Sqlite native bundle never
 /// reaches the AOT-published daemon — same rationale as <see cref="OpenCodeDb"/>. Opened
 /// read-only, WAL-tolerant. Every step is best-effort: a missing db / table / undecodable
-/// row is skipped, never thrown (cost is always fail-open — see AI-728).
+/// row is skipped, never thrown (cost is always fail-open —).
 /// </summary>
 internal sealed class AntigravityGenMetadataDb : IDisposable {
     readonly SqliteConnection _conn;

--- a/src/Capacitor.Cli/Commands/AntigravityGenMetadataDb.cs
+++ b/src/Capacitor.Cli/Commands/AntigravityGenMetadataDb.cs
@@ -14,7 +14,7 @@ namespace Capacitor.Cli.Commands;
 /// Lives in the CLI project (not Core) so the Microsoft.Data.Sqlite native bundle never
 /// reaches the AOT-published daemon — same rationale as <see cref="OpenCodeDb"/>. Opened
 /// read-only, WAL-tolerant. Every step is best-effort: a missing db / table / undecodable
-/// row is skipped, never thrown (cost is always fail-open —).
+/// row is skipped, never thrown (cost is always fail-open).
 /// </summary>
 internal sealed class AntigravityGenMetadataDb : IDisposable {
     readonly SqliteConnection _conn;

--- a/src/Capacitor.Cli/Commands/AntigravityHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/AntigravityHookCommand.cs
@@ -6,7 +6,7 @@ using Capacitor.Cli.Core.Config;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Dispatcher for Google Antigravity's control hooks (AI-1158). Antigravity is a GUI
+/// Dispatcher for Google Antigravity's control hooks. Antigravity is a GUI
 /// IDE with no shell hooks; the kcap plugin (a block in Antigravity's <c>hooks.json</c>)
 /// registers one command per lifecycle/tool event. Because the JSON payload carries NO
 /// event-name field, the event is passed as a positional arg:
@@ -24,13 +24,13 @@ namespace Capacitor.Cli.Commands;
 /// are no-ops here (the watcher already tails the transcript continuously).
 ///
 /// Fail-open throughout — a kcap/server problem must never disrupt the Antigravity IDE. The
-/// session-start POST goes through <see cref="AgentHookPoster.PostOrSpoolAsync"/> (AI-1357 Task
+/// session-start POST goes through <see cref="AgentHookPoster.PostOrSpoolAsync"/> (Task
 /// 6): a lapsed/outage POST is durably spooled for a later drain, and the watcher still spawns
 /// (<see cref="SpawnGateForTest"/>) — capture must not depend on lifecycle-POST delivery.
 /// Antigravity conversation ids are dashed UUIDs; kcap canonicalizes them to the DASHLESS form
 /// for BOTH the session-start payload and the watcher key so they resolve to one stream (the
 /// dashed id lives on only in the transcript file path). Historical import canonicalizes the
-/// same way, so a conversation captured live and later re-imported dedupes to one stream (AI-1238).
+/// same way, so a conversation captured live and later re-imported dedupes to one stream.
 /// </summary>
 static class AntigravityHookCommand {
     public static Task<int> Handle(string baseUrl, string[] args) =>
@@ -105,7 +105,7 @@ static class AntigravityHookCommand {
         if (cwd is not null) {
             forwarded["cwd"] = cwd;
 
-            // AI-701: best-effort git-root discovery, fail-open (omitted when no repo is found).
+            // best-effort git-root discovery, fail-open (omitted when no repo is found).
             if (GitRepository.FindRoot(cwd) is { } workspaceRoot) forwarded["workspace_root"] = workspaceRoot;
         }
         if (Str(payload, "antigravityVersion") is { } version)
@@ -128,7 +128,7 @@ static class AntigravityHookCommand {
             return 0;
         }
 
-        // AI-1357 Task 6: spawn-before-post. Route through the shared spool-aware poster (which
+        // Task 6: spawn-before-post. Route through the shared spool-aware poster (which
         // replaced this dispatcher's former bespoke poster) — a lapse/outage durably spools the
         // payload for a later drain AND still proceeds to spawn the watcher, so capture never
         // depends on lifecycle-POST delivery. Only a permanent Failed withholds the watcher.

--- a/src/Capacitor.Cli/Commands/AntigravityImportSource.cs
+++ b/src/Capacitor.Cli/Commands/AntigravityImportSource.cs
@@ -250,7 +250,7 @@ internal sealed class AntigravityImportSource : IImportSource {
 
         // Explicit gen_metadata usage pass — decodes the sibling conversation .db and posts the
         // synthetic USAGE lines the live watcher would have streamed, so a content-only import
-        // still gains cost. Best-effort (cost is never load-bearing,); always before
+        // still gains cost. Best-effort (cost is never load-bearing); always before
         // session-end.
         await PostUsageLinesAsync(ctx, c.SessionId, transcriptPath, c.Meta.FirstTimestamp, ct);
 

--- a/src/Capacitor.Cli/Commands/AntigravityImportSource.cs
+++ b/src/Capacitor.Cli/Commands/AntigravityImportSource.cs
@@ -9,7 +9,7 @@ using Capacitor.Cli.Core.Antigravity;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Discover + classify + import historical Google Antigravity conversations (AI-1160).
+/// Discover + classify + import historical Google Antigravity conversations.
 /// Each conversation is a brain dir under
 /// <c>~/.gemini/antigravity/brain/&lt;id&gt;/.system_generated/logs/transcript_full.jsonl</c> —
 /// the same lines the live watcher tails — so historical and live import converge on the
@@ -19,7 +19,7 @@ namespace Capacitor.Cli.Commands;
 /// is its DASHLESS canonical form — matching live capture (the Antigravity hook and
 /// <c>kcap watch</c> strip dashes) so a session captured live and later re-imported dedupes to
 /// one stream, and so <c>kcap import --antigravity --session &lt;id&gt;</c> filtering is
-/// format-insensitive (AI-1238). The dashed conversation id is kept only for filesystem paths
+/// format-insensitive. The dashed conversation id is kept only for filesystem paths
 /// (the brain-dir transcript). Subagents are separate conversations linked via
 /// <c>INVOKE_SUBAGENT</c> steps in the parent's transcript (the spawn-time signal;
 /// see <see cref="AntigravitySubagents"/>); roots are conversations
@@ -74,7 +74,7 @@ internal sealed class AntigravityImportSource : IImportSource {
         }
         var byRoot    = AntigravitySubagents.BuildRootDescendants(convIds, parentMap);
 
-        // AI-1218 drift observability: surface format drift without a messages fallback.
+        // drift observability: surface format drift without a messages fallback.
         // HashSet membership so the counters stay O(n), not O(n²), on large brain trees (qodo #285).
         var allConversationIds = convIds.ToHashSet(StringComparer.Ordinal);
         var linkedChildIds     = parentMap.Values.ToHashSet(StringComparer.Ordinal);
@@ -87,7 +87,7 @@ internal sealed class AntigravityImportSource : IImportSource {
 
         // Normalize the --session filter to the dashless canonical form so it matches the
         // dashless session id we surface, whether the user passed a dashed or dashless id
-        // (mirrors GeminiImportSource) (AI-1238).
+        // (mirrors GeminiImportSource).
         var sessionFilter = filters.FilterSession is { } fs ? ImportCommand.NormalizeGuid(fs) : null;
 
         var sinceUtc = filters.Since is { } since
@@ -206,7 +206,7 @@ internal sealed class AntigravityImportSource : IImportSource {
         // once-skipped subagent would otherwise be lost forever), then re-post session-end — all
         // idempotent server-side (deterministic lifecycle ids → no-ops when they already
         // succeeded). If either lifecycle POST fails, return Failed so a re-run retries the repair
-        // instead of reporting a falsely-complete Skipped (mirrors Cursor) (AI-1160 review).
+        // instead of reporting a falsely-complete Skipped (mirrors Cursor).
         if (c.Status == ImportCommand.ClassificationStatus.AlreadyLoaded) {
             if (!await PostHookAsync(ctx.HttpClient, ctx.BaseUrl, "session-start/antigravity",
                     BuildSessionStartPayload(c.SessionId, c.Meta.Cwd, c.Meta.FirstTimestamp, ctx.ForcePrivate), ct))
@@ -218,7 +218,7 @@ internal sealed class AntigravityImportSource : IImportSource {
             // transcript lines (the content watermark is already at the tip), a session
             // re-imported after this feature shipped may still be missing its USAGE lines
             // (they were never emitted on the original import). Always attempted, always
-            // before session-end (AI-1358 item 7).
+            // before session-end.
             await PostUsageLinesAsync(ctx, c.SessionId, transcriptPath, c.Meta.FirstTimestamp, ct);
 
             if (!await PostHookAsync(ctx.HttpClient, ctx.BaseUrl, "session-end/antigravity",
@@ -250,8 +250,8 @@ internal sealed class AntigravityImportSource : IImportSource {
 
         // Explicit gen_metadata usage pass — decodes the sibling conversation .db and posts the
         // synthetic USAGE lines the live watcher would have streamed, so a content-only import
-        // still gains cost. Best-effort (cost is never load-bearing, AI-728); always before
-        // session-end (AI-1358 item 7).
+        // still gains cost. Best-effort (cost is never load-bearing,); always before
+        // session-end.
         await PostUsageLinesAsync(ctx, c.SessionId, transcriptPath, c.Meta.FirstTimestamp, ct);
 
         // Children as subagents — BEFORE session-end so SubagentCompleted precedes SessionEnded.
@@ -279,7 +279,7 @@ internal sealed class AntigravityImportSource : IImportSource {
             // resolves the transcript path. The server-facing agent_id is its DASHLESS canonical
             // form: the server canonicalizes agent_id on both ingest and watermark read, so this
             // matches live routing/correlation and the dashless session ids used everywhere else
-            // (mirrors GeminiImportSource) (AI-1238).
+            // (mirrors GeminiImportSource).
             var childTranscript = AntigravityPaths.TranscriptFullPath(childId, _home, _geminiCliHome);
             if (!File.Exists(childTranscript)) continue;
 
@@ -316,15 +316,14 @@ internal sealed class AntigravityImportSource : IImportSource {
                 // a server restart between the failed stop and this re-import. Re-posting start
                 // restores the active mark (idempotent: deterministic SubagentStarted id, and
                 // already-active is a no-op) so the following stop clears it and appends the
-                // (idempotent, deterministic) SubagentCompleted. Child content is not re-sent
-                // (AI-1160 review).
+                // (idempotent, deterministic) SubagentCompleted. Child content is not re-sent.
                 //
                 // strict=true on BOTH: the server's start endpoint returns a fail-open 200 even
                 // when RecordAgentStartAsync throws and rolls back the active mark, so a non-strict
                 // start would be treated as success and the following stop would silently no-op
                 // (no active agent → no SubagentCompleted). strict surfaces the failure as non-2xx,
                 // so we only post stop when start truly re-marked the agent, and a re-import retries
-                // otherwise (AI-1160 review).
+                // otherwise.
                 if (await PostHookAsync(client, baseUrl, "subagent-start",
                         BuildSubagentStartPayload(rootId, childAgentId, childTranscript, strict: true), ct))
                     await PostHookAsync(client, baseUrl, "subagent-stop",
@@ -364,7 +363,7 @@ internal sealed class AntigravityImportSource : IImportSource {
     static JsonObject BuildSessionStartPayload(string sid, string? cwd, DateTimeOffset? startedAt, bool forcePrivate) {
         var p = new JsonObject { ["hook_event_name"] = "sessionStart", ["session_id"] = sid };
         if (cwd is not null) p["cwd"] = cwd;
-        // AI-701 (finding 4): fail-open git-root discovery, mirroring ImportChainsAsync
+        // fail-open git-root discovery, mirroring ImportChainsAsync
         // so routed imports carry the same workspace_root the file-based path does.
         if (cwd is not null && GitRepository.FindRoot(cwd) is { } workspaceRoot) p["workspace_root"] = workspaceRoot;
         if (startedAt is { } ts) p["started_at"] = ts.ToString("O");
@@ -383,7 +382,7 @@ internal sealed class AntigravityImportSource : IImportSource {
 
     // strict=true makes the server return non-2xx when the lifecycle write itself fails, rather
     // than a fail-open 200 — so a caller that gates on the POST result learns the server actually
-    // recorded the event (AI-1160 review).
+    // recorded the event.
 
     static JsonObject BuildSubagentStartPayload(string parentSid, string agentId, string transcriptPath, bool strict = false) {
         var p = new JsonObject {
@@ -402,7 +401,7 @@ internal sealed class AntigravityImportSource : IImportSource {
     // agent_transcript_path, and last_assistant_message. Omitting them makes the server reject the
     // body at binding (before HandleSubagentStop runs), so strict is never honored and PostHookAsync
     // returns false — the repair would then loop start→failed-stop forever. Send the full shape,
-    // mirroring GeminiSubagentDiscovery.BuildStopPayload (AI-1160 review).
+    // mirroring GeminiSubagentDiscovery.BuildStopPayload.
     static JsonObject BuildSubagentStopPayload(string parentSid, string agentId, string transcriptPath, bool strict = false) {
         var p = new JsonObject {
             ["hook_event_name"]        = "subagent_stop",
@@ -425,7 +424,7 @@ internal sealed class AntigravityImportSource : IImportSource {
     // three are pinned to the same literal (grepped: WatchCommand.cs:1692,
     // SessionWriter.TranscriptPipeline.cs:21) since the server derives the USAGE event id from
     // line CONTENT (gen_row), not the line number, so the number is only a non-colliding
-    // ordering hint (AI-1358 item 7).
+    // ordering hint.
     const long AntigravityUsageLineBase = 1_000_000_000L;
 
     /// <summary>
@@ -436,8 +435,8 @@ internal sealed class AntigravityImportSource : IImportSource {
     /// band). Deterministic USAGE event ids (keyed on gen_row) dedupe server-side, so re-posting
     /// on every re-import is safe. Called for every classification (New/Partial AND
     /// AlreadyLoaded) so a session imported before this feature shipped — content but no cost —
-    /// gains usage on a bare re-import even though zero physical transcript lines are (re)sent
-    /// (AI-1358 item 7). Best-effort: cost is never load-bearing (AI-728) — a decode/post failure
+    /// gains usage on a bare re-import even though zero physical transcript lines are (re)sent.
+    /// Best-effort: cost is never load-bearing — a decode/post failure
     /// here must never fail the import.
     /// </summary>
     static async Task<bool> PostUsageLinesAsync(
@@ -475,7 +474,7 @@ internal sealed class AntigravityImportSource : IImportSource {
         } catch (OperationCanceledException) {
             throw;
         } catch {
-            return false; // cost is always best-effort (AI-728) — never let a post failure surface
+            return false; // cost is always best-effort — never let a post failure surface
         }
     }
 

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -365,7 +365,7 @@ public static class ClaudeHookCommand {
                         // Clamp the pre-drain cap so it cannot consume the entire remaining budget
                         // that the bounded POST needs (mirrors the session-end fix). Reserve at
                         // least Safety (1.5s) for the bounded POST so a slow drain doesn't starve
-                        // it entirely. Use whichever is smallest (AI-1005).
+                        // it entirely. Use whichever is smallest.
                         var remaining    = HookBudget.Remaining(processStart, "subagent-stop");
                         var effectiveCap = TimeSpan.FromMilliseconds(
                             Math.Max(0, Math.Min(PreHookDrainCap.TotalMilliseconds,
@@ -426,7 +426,7 @@ public static class ClaudeHookCommand {
             // plan_content onto the enriched body before the POST.
             body = await deferredRepoTask!;
 
-            // AI-701: best-effort git-root discovery for the session's cwd, fed to the server's
+            // best-effort git-root discovery for the session's cwd, fed to the server's
             // plan-artifact discovery so a repo-file plan/spec found at the workspace root can be
             // attributed even when cwd is a subdirectory. Fail-open: GitRepository.FindRoot swallows
             // I/O errors and returns null when no repo is found, in which case the field is simply
@@ -491,7 +491,7 @@ public static class ClaudeHookCommand {
                 return 0;
             }
 
-            // AI-1165 — kick off the team-memory index fetch in PARALLEL with the hook POST so
+            // kick off the team-memory index fetch in PARALLEL with the hook POST so
             // it adds no latency to the critical path. Fully best-effort / fail-open: any failure,
             // a 401, or a budget overrun yields a null fragment and nothing is injected. Started
             // after the ordering-guard / backlog returns above so a spooled session-start doesn't
@@ -551,7 +551,7 @@ public static class ClaudeHookCommand {
                     var disabled        = AppConfig.ResolvedProfile?.Profile?.DisableSessionGuidelines is true;
                     var lessonsFragment = SessionGuidelinesEmitter.BuildFragment(responseNode, disabled);
                     var nudgeFragment   = VersionNudgeEmitter.BuildFragment(responseNode, CapacitorVersion.CurrentDisplay());
-                    // AI-1165 — join the parallel memory-index fetch, bounded by the remaining
+                    // join the parallel memory-index fetch, bounded by the remaining
                     // hook budget so a slow fetch can't delay the hook (fail-open → null).
                     var memoryFragment  = MemoryIndexEmitter.BuildFragment(
                         await AwaitMemoryIndexAsync(memoryIndexTask, processStart), memoryDisabled);
@@ -634,7 +634,7 @@ public static class ClaudeHookCommand {
 
         // Dedicated bounded POST for the per-agent subagent-stop: a single attempt clamped to the
         // remaining hook budget that spools on transient failure, so a dropped SubagentCompleted is
-        // replayed on the next hook (AI-1005). Only the stop carrying agent_id maps to a completion;
+        // replayed on the next hook. Only the stop carrying agent_id maps to a completion;
         // without it, fall through to the shared best-effort path (behavior unchanged).
         if (command == "subagent-stop") {
             string? sessionId = null, agentId = null;
@@ -646,7 +646,7 @@ public static class ClaudeHookCommand {
 
             if (sessionId is not null && agentId is not null) {
                 // Ordering guard: if this session's backlog couldn't fully drain, spool the fresh
-                // subagent-stop so a stranded session-start reaches the server before it (AI-1005).
+                // subagent-stop so a stranded session-start reaches the server before it.
                 if (CurrentSessionHasBacklog(spool, sessionId)) {
                     spool.Append(sessionId, "subagent-stop", body);
                     await Console.Error.WriteLineAsync($"[kcap] subagent-stop spooled (ordering guard); will retry on the next kcap hook ({sessionId}/{agentId})");
@@ -777,7 +777,7 @@ public static class ClaudeHookCommand {
         }
     }
 
-    // ── AI-1165: SessionStart team-memory index injection ────────────────────────
+    // ──: SessionStart team-memory index injection ────────────────────────
     //
     // Best-effort fetch of GET /api/memories/index for the current repo + machine.
     // Fail-open on a failure / non-2xx / timeout → null, and
@@ -893,7 +893,7 @@ public static class ClaudeHookCommand {
     /// Returns true if the given session still has undelivered spool entries. Used as an ordering
     /// guard so a stranded session-start always reaches the server before its session-end.
     ///
-    /// <para>Delegates to the public <see cref="HookSpool.HasBacklog"/> (AI-1357 Task 12) rather than
+    /// <para>Delegates to the public <see cref="HookSpool.HasBacklog"/> rather than
     /// re-implementing the file checks: the ordered drain (now running on every non-Codex hook,
     /// including <c>--claude</c>) can WITHHOLD a spooled session-end in the <c>.ordered-*</c> temp
     /// namespace pending the transcript tail. A stale private check that only looked at

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -777,7 +777,7 @@ public static class ClaudeHookCommand {
         }
     }
 
-    // ──: SessionStart team-memory index injection ────────────────────────
+    // ── SessionStart team-memory index injection ────────────────────────
     //
     // Best-effort fetch of GET /api/memories/index for the current repo + machine.
     // Fail-open on a failure / non-2xx / timeout → null, and

--- a/src/Capacitor.Cli/Commands/CleanupCommand.cs
+++ b/src/Capacitor.Cli/Commands/CleanupCommand.cs
@@ -33,7 +33,7 @@ static class CleanupCommand {
         // Sweep any leftover per-key auxiliary files (heartbeat/started/spawnlock). KillWatcher
         // removes the heartbeat/started markers per key but deliberately leaves spawn locks
         // behind (unlink-race safety); cleanup holds no lock, so it's the safe place to purge
-        // them, and this also mops up orphans whose .pid was already gone (AI-1357 task 9).
+        // them, and this also mops up orphans whose .pid was already gone.
         var purged = WatcherManager.PurgeAuxiliaryFiles();
 
         await Console.Out.WriteLineAsync(

--- a/src/Capacitor.Cli/Commands/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CodexHookCommand.cs
@@ -36,7 +36,7 @@ static class CodexHookCommand {
     // `stop.command.output` / `session-start.command.output` JSON schema and
     // reject empty bodies with "hook returned invalid stop hook JSON output".
     // `continue: true` is the schema default; emitting it explicitly satisfies
-    // the parser without altering behavior..
+    // the parser without altering behavior.
     const string SessionScopedOutputJson = """{"continue":true}""";
 
     /// <summary>

--- a/src/Capacitor.Cli/Commands/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CodexHookCommand.cs
@@ -16,9 +16,9 @@ namespace Capacitor.Cli.Commands;
 /// Wire contract (Codex event → server route):
 ///   SessionStart      → POST /hooks/session-start/codex
 ///   Stop              → POST /hooks/stop (best-effort, 2s cap, swallow-all).
-///                       Codex fires Stop at every turn end, not session end
-///                       (AI-648); session-end stays owned by the watcher's
-///                       parent-PID monitor (AI-647). The POST lets the server
+///                       Codex fires Stop at every turn end, not session end;
+///                       session-end stays owned by the watcher's
+///                       parent-PID monitor. The POST lets the server
 ///                       emit the idle-wait marker that clears the chat
 ///                       "working" indicator. HandleStop also refreshes watcher
 ///                       liveness and emits {"continue":true} for Codex's parser.
@@ -36,7 +36,7 @@ static class CodexHookCommand {
     // `stop.command.output` / `session-start.command.output` JSON schema and
     // reject empty bodies with "hook returned invalid stop hook JSON output".
     // `continue: true` is the schema default; emitting it explicitly satisfies
-    // the parser without altering behavior. See AI-635.
+    // the parser without altering behavior..
     const string SessionScopedOutputJson = """{"continue":true}""";
 
     /// <summary>
@@ -48,7 +48,7 @@ static class CodexHookCommand {
     internal static void WriteSessionScopedOutput(TextWriter writer) => writer.Write(SessionScopedOutputJson);
 
     /// <summary>
-    /// AI-1357 Task 5: enforces the Codex stdout-first contract — <paramref name="writeStdout"/>
+    /// Task 5: enforces the Codex stdout-first contract — <paramref name="writeStdout"/>
     /// (the synchronous handshake write) always completes before <paramref name="postStdoutWork"/>
     /// (the best-effort watcher-ensure + background spool drain) even starts. The parent Codex
     /// process blocks on the hook's stdout, so a large/unreachable spool backlog sitting behind
@@ -163,7 +163,7 @@ static class CodexHookCommand {
             // PermissionRequest response hangs it. If a handler throws (e.g. an
             // IO/permission fault while building the authenticated client), the
             // CLI's top-level guard would exit 0 with empty stdout and Codex would
-            // report "invalid hook output" (AI-1168 review). Emit the
+            // report "invalid hook output". Emit the
             // event-appropriate fallback here first, and record for diagnosis.
             CrashReporter.Record("hook", ex);
             EmitFallbackOutput(eventName);
@@ -202,7 +202,7 @@ static class CodexHookCommand {
             node["default_visibility"] = visibility;
         }
 
-        // AI-701: best-effort git-root discovery, fail-open (omitted when cwd is absent or no
+        // best-effort git-root discovery, fail-open (omitted when cwd is absent or no
         // repo is found) — see the mirrored ClaudeHookCommand comment for rationale.
         if (TryGetString(node, "cwd") is { } startCwd && GitRepository.FindRoot(startCwd) is { } workspaceRoot) {
             node["workspace_root"] = workspaceRoot;
@@ -230,7 +230,7 @@ static class CodexHookCommand {
         var enrichedNode = JsonNode.Parse(enriched);
         var sessionId    = TryGetString(enrichedNode, "session_id");
 
-        // AI-1357: spawn-before-post. A lapsed-auth or transient/unreachable failure durably
+        // spawn-before-post. A lapsed-auth or transient/unreachable failure durably
         // spools the payload instead of dropping it (Spooled) — never AuthLapsed here, unlike the
         // legacy PostAsync path, so ShouldSpawnAfter below can safely spawn on Spooled too.
         var spool = new HookSpool(PathHelpers.ConfigPath("spool"));
@@ -257,8 +257,8 @@ static class CodexHookCommand {
     // global lifecycle/transcript spool drain in the background. Neither may precede or block on
     // the stdout write in HandleSessionStart. The drain is fire-and-forget (never awaited) — its
     // own internal throttle/budget/try-catch make it safe to abandon if the process exits first;
-    // reliable delivery for Codex sessions is carried by the daemon's periodic drain pass
-    // (AI-1357 Task 12), not by this opportunistic best-effort attempt.
+    // reliable delivery for Codex sessions is carried by the daemon's periodic drain pass,
+    // not by this opportunistic best-effort attempt.
     static Task RunPostStdoutWork(
             string baseUrl, HookSpool spool, JsonNode? enrichedNode, string? sessionId, HookPostOutcome outcome) {
         var transcriptSpool = new TranscriptSpool(PathHelpers.ConfigPath("transcript-spool"));
@@ -281,7 +281,7 @@ static class CodexHookCommand {
     static async Task<int> HandleStop(string baseUrl, JsonNode node) {
         // Codex 'Stop' fires at every turn end, NOT session end. Session-end
         // is fired by the watcher's parent-PID monitor in WatchCommand.cs
-        // (AI-647) when the codex process actually exits — that path POSTs
+        // when the codex process actually exits — that path POSTs
         // /hooks/session-end/codex with reason: "parent_exited" and handles
         // generate_whats_done. Treating Stop as session-end here would kill
         // the watcher after turn 1 and mismark multi-turn sessions as ended
@@ -305,7 +305,7 @@ static class CodexHookCommand {
             await PostBestEffortAsync(baseUrl, "stop", node, TimeSpan.FromSeconds(2));
         }
 
-        // AI-635: Codex's stop-hook output parser rejects empty stdout as
+        // Codex's stop-hook output parser rejects empty stdout as
         // "invalid stop hook JSON output". Emit the schema default explicitly.
         WriteSessionScopedOutput(Console.Out);
         return 0;
@@ -328,7 +328,7 @@ static class CodexHookCommand {
         // Do NOT post to /hooks/permission-request/{vendor} — that route runs
         // RunPermissionFlow which long-polls up to 10 hours waiting for a
         // hosted-agent UI decision. With Codex's 30 s hook timeout, the hook
-        // process is killed long before the server returns (AI-636).
+        // process is killed long before the server returns.
         //
         // Single 2 s deadline covers BOTH the /auth/config discovery and the
         // /hooks/permission-record POST inside PostBestEffortAsync.

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -12,9 +12,8 @@ namespace Capacitor.Cli.Commands;
 /// </summary>
 internal static class CodingAgentsStep {
     // New-vendor fields are appended with defaults so existing (named-arg) call
-    // sites and the broad CodingAgentsStep test suite compile unchanged. Gemini
-    // (AI-887), Kiro (AI-888), and Pi (AI-886) were all added after the original
-    // four vendors.
+    // sites and the broad CodingAgentsStep test suite compile unchanged. Gemini,
+    // Kiro, and Pi were all added after the original four vendors.
     internal record Options(bool SkipClaude, bool SkipCodex, bool SkipCursor, bool SkipCopilot, bool NoPrompt, bool SkipGemini = false, bool SkipKiro = false, bool SkipPi = false, bool SkipOpenCode = false, bool SkipCodexNetworkAccess = false, bool SkipAntigravity = false, bool SkipCursorMcp = false, bool SkipCopilotMcp = false, bool SkipCopilotInstructions = false, bool SkipGeminiMcp = false, bool SkipGeminiInstructions = false, bool SkipAntigravityMcp = false, bool SkipAntigravityInstructions = false, bool SkipAntigravitySkills = false, bool SkipOpenCodeMcp = false, bool SkipOpenCodeInstructions = false, bool SkipKiroMcp = false, bool SkipKiroSkills = false, bool SkipPiMcp = false, bool SkipPiInstructions = false);
 
     internal record DetectedAgents(bool Claude, bool Codex, bool Cursor, bool Copilot, bool Gemini = false, bool Kiro = false, bool Pi = false, bool OpenCode = false, bool Antigravity = false);
@@ -168,7 +167,7 @@ internal static class CodingAgentsStep {
         var antigravityInstructionsInstalled = HandleAntigravityInstructions(options, paths, installers, writeLine, antigravitySelected);
         var antigravitySkillsInstalled = HandleAntigravitySkills(options, paths, installers, writeLine, antigravitySelected);
 
-        // AI-1285 — the shared ~/.agents/skills/ install is decoupled from Codex: run it
+        // the shared ~/.agents/skills/ install is decoupled from Codex: run it
         // once when any non-Claude agent is detected, independent of that agent's hook
         // install. Placed last so the single skills prompt follows the per-agent steps.
         var agentSkillsInstalled  = HandleAgentSkills(options, detected, paths, installers, prompt, writeLine);
@@ -820,7 +819,7 @@ internal static class CodingAgentsStep {
     }
 
     /// <summary>
-    /// AI-1285 — installs the agent-agnostic kcap skills to <c>~/.agents/skills/</c>,
+    /// installs the agent-agnostic kcap skills to <c>~/.agents/skills/</c>,
     /// decoupled from Codex. Every non-Claude coding agent reads (or may read) the
     /// cross-agent skills tree, so install once when any is detected — independent of
     /// whether that agent's hooks were installed. Claude is excluded: it gets skills
@@ -894,7 +893,7 @@ internal static class CodingAgentsStep {
     }
 
     /// <summary>
-    /// AI-1285 — Codex-specific: removes the legacy <c>~/.codex/skills/kcap-*</c> folders
+    /// Codex-specific: removes the legacy <c>~/.codex/skills/kcap-*</c> folders
     /// left by pre-migration installer versions (Codex reads <c>~/.agents/skills</c> now).
     /// Runs only when Codex is detected <em>and</em> the shared skills are in place this
     /// run (freshly installed or already current) — never on the declined / copy-failed /
@@ -950,7 +949,7 @@ internal static class CodingAgentsStep {
     }
 
     /// <summary>
-    /// AI-794 — Codex runs the agent's shell tool in a network-blocked sandbox, so kcap
+    /// Codex runs the agent's shell tool in a network-blocked sandbox, so kcap
     /// skills (which shell out to <c>kcap …</c>) can't reach the Capacitor server. After
     /// Codex hooks install, offer to enable sandbox network access for the configured
     /// server(s) via <see cref="Installers.EnableCodexNetworkAccess"/>. Gated on hooks
@@ -1007,7 +1006,7 @@ internal static class CodingAgentsStep {
     /// CLI picks them up with no manual TOML edit. Gated on Codex hooks installing — the
     /// same "full Codex integration" trigger as skills. No prompt: registration is
     /// non-destructive (only adds missing kcap servers) and mirrors how the Claude plugin
-    /// auto-registers its MCP servers. <c>kcap-flows</c> stays Claude-only (AI-1056).
+    /// auto-registers its MCP servers. <c>kcap-flows</c> stays Claude-only.
     /// </summary>
     static bool HandleCodexMcp(
             Paths          paths,

--- a/src/Capacitor.Cli/Commands/CopilotFinalizeDrainCommand.cs
+++ b/src/Capacitor.Cli/Commands/CopilotFinalizeDrainCommand.cs
@@ -5,7 +5,7 @@ namespace Capacitor.Cli.Commands;
 
 /// <summary>
 /// Detached post-<c>sessionEnd</c> "finalize drain" for GitHub Copilot CLI
-/// sessions (AI-897).
+/// sessions.
 /// </summary>
 /// <remarks>
 /// Copilot appends <c>session.shutdown</c> — the per-model input/cache token

--- a/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
@@ -7,7 +7,7 @@ using Capacitor.Cli.Core.Copilot;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Single-binary dispatcher for GitHub Copilot CLI hooks (AI-815). Copilot
+/// Single-binary dispatcher for GitHub Copilot CLI hooks. Copilot
 /// command-hook payloads carry no uniform event-name field (sessionStart's
 /// payload is just <c>{sessionId, timestamp, cwd, source, initialPrompt}</c>),
 /// so the kcap hooks installer writes one entry per event with the event name
@@ -23,11 +23,11 @@ namespace Capacitor.Cli.Commands;
 ///                  --resume — the server's deterministic lifecycle event ids
 ///                  make the re-POST idempotent and the watcher resumes from
 ///                  the server watermark.
-///   sessionEnd   → spawn the detached copilot-finalize drainer FIRST (AI-897:
-///                  it must be created before — and outlive — the rest of the
+///   sessionEnd   → spawn the detached copilot-finalize drainer FIRST (it
+///                  must be created before — and outlive — the rest of the
 ///                  hook to capture the session.shutdown tail Copilot writes
 ///                  after the hook returns), then kill watcher + capped inline
-///                  drain (mirrors Claude's AI-813 pre-drain cap), then POST
+///                  drain (mirrors Claude's pre-drain cap), then POST
 ///                  /hooks/session-end/copilot.
 ///   agentStop    → no server POST. Fires at every turn end; used only to
 ///                  re-enliven a crashed watcher (mirrors Codex's Stop).
@@ -37,7 +37,7 @@ namespace Capacitor.Cli.Commands;
 /// Copilot treats hook stdout as optional, so this dispatcher emits nothing.
 /// </remarks>
 static class CopilotHookCommand {
-    // Mirror of ClaudeHookCommand.PreHookDrainCap (AI-813): Copilot kills the
+    // Mirror of ClaudeHookCommand.PreHookDrainCap: Copilot kills the
     // sessionEnd hook at its configured timeout (default 30s, but kcap.json
     // entries set 30 and users can lower it) — the drain must never starve the
     // session-end POST, or the session sticks "Active" forever.
@@ -97,7 +97,7 @@ static class CopilotHookCommand {
             return 0;
         }
 
-        // AI-1357 Task 12: the cross-vendor backlog drain now runs centrally in Program.cs's
+        // Task 12: the cross-vendor backlog drain now runs centrally in Program.cs's
         // `case "hook":` before dispatch — no longer wired here (removes the double-wire).
         var spool = new HookSpool(PathHelpers.ConfigPath("spool"));
 
@@ -143,7 +143,7 @@ static class CopilotHookCommand {
         if (cwd is not null) {
             forwarded["cwd"] = cwd;
 
-            // AI-701: best-effort git-root discovery, fail-open (omitted when no repo is found).
+            // best-effort git-root discovery, fail-open (omitted when no repo is found).
             if (GitRepository.FindRoot(cwd) is { } workspaceRoot) forwarded["workspace_root"] = workspaceRoot;
         }
 
@@ -153,7 +153,7 @@ static class CopilotHookCommand {
 
         // Copilot stamps hook payloads with a unix-ms timestamp; forward it as
         // started_at so canonical SessionStarted carries the real start time
-        // (the server falls back to UtcNow when absent — AI-739 precedent).
+        // (the server falls back to UtcNow when absent — precedent).
         if (TryGetUnixMillis(node, "timestamp") is { } startedAt) {
             forwarded["started_at"] = startedAt.ToString("O");
         }
@@ -178,7 +178,7 @@ static class CopilotHookCommand {
             return 0;
         }
 
-        // Spawn-before-post (AI-1357): capture must start on Posted OR Spooled (auth lapse /
+        // Spawn-before-post: capture must start on Posted OR Spooled (auth lapse /
         // outage) — a doomed/delayed lifecycle POST must never withhold the watcher. Only a
         // permanent failure keeps the prior non-zero exit and skips the watcher.
         var outcome = await AgentHookPoster.PostOrSpoolAsync(
@@ -200,7 +200,7 @@ static class CopilotHookCommand {
         ) {
         var transcriptPath = TranscriptPathFor(dashedSessionId);
 
-        // AI-897: Copilot appends `session.shutdown` (per-model input/cache token
+        // Copilot appends `session.shutdown` (per-model input/cache token
         // aggregates) — and sometimes the final assistant turn — to events.jsonl
         // only AFTER this hook returns, by which point the live watcher is dead
         // (KillWatcher below) and the server's session-end StopAndDrain has run,
@@ -216,7 +216,7 @@ static class CopilotHookCommand {
 
         // Kill watcher + inline-drain BEFORE the POST so the server computes
         // stats over the full transcript — capped so a slow drain can't starve
-        // the session-end POST (mirror of ClaudeHookCommand / AI-813).
+        // the session-end POST (mirror of ClaudeHookCommand /).
         try {
             var drained = await TimeBudget.RunCappedAsync(
                 async () => {

--- a/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
@@ -216,7 +216,7 @@ static class CopilotHookCommand {
 
         // Kill watcher + inline-drain BEFORE the POST so the server computes
         // stats over the full transcript — capped so a slow drain can't starve
-        // the session-end POST (mirror of ClaudeHookCommand /).
+        // the session-end POST (mirror of ClaudeHookCommand's pre-drain cap).
         try {
             var drained = await TimeBudget.RunCappedAsync(
                 async () => {

--- a/src/Capacitor.Cli/Commands/CopilotImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CopilotImportSource.cs
@@ -189,7 +189,7 @@ internal sealed class CopilotImportSource : IImportSource {
             // workspace.yaml's updated_at is stamped when Copilot assigns the
             // session name (near session START), not at session end. The
             // truthful end time is the session-final `session.shutdown`
-            // record's own timestamp (AI-1358 A3) — read directly off the raw
+            // record's own timestamp — read directly off the raw
             // transcript, NOT through IsImportRelevantLine, which deliberately
             // skips session.* records for a different purpose (watermark
             // comparison against the server's normalized line count above).
@@ -325,7 +325,7 @@ internal sealed class CopilotImportSource : IImportSource {
             ["source"]          = "startup",
         };
         if (cwd is not null) payload["cwd"] = cwd;
-        // AI-701 (finding 4): fail-open git-root discovery, mirroring ImportChainsAsync
+        // fail-open git-root discovery, mirroring ImportChainsAsync
         // so routed imports carry the same workspace_root the file-based path does.
         if (cwd is not null && GitRepository.FindRoot(cwd) is { } workspaceRoot) payload["workspace_root"] = workspaceRoot;
         if (startedAt is { } ts) payload["started_at"] = ts.ToString("O");

--- a/src/Capacitor.Cli/Commands/CursorHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CursorHookCommand.cs
@@ -134,7 +134,7 @@ public static class CursorHookCommand {
 
             if (sessionId is not null && DisabledSessions.IsDisabled(sessionId)) return 0;
 
-            // AI-1151 (live): bring CursorSubagentCorrelator into the live hook/backfill
+            // bring CursorSubagentCorrelator into the live hook/backfill
             // path. Cursor is NOT watcher-backed, so the correlation must run right here in
             // the per-hook CLI dispatcher rather than in a background watcher. The decision
             // (linked to a parent, or not) is made once — at the child's own sessionStart —
@@ -168,7 +168,7 @@ public static class CursorHookCommand {
             }
             var isSubagentChild = subagentParentId is not null;
 
-            // AI-1152: attach a `repository` node on sessionStart so the session groups
+            // attach a `repository` node on sessionStart so the session groups
             // under its repo in the sidebar. Cursor payloads carry `workspace_roots`
             // rather than `cwd`, so the generic EnrichWithRepositoryInfo (which reads
             // `cwd`) can't be used — detect from workspace_roots[0] instead. Bounded by
@@ -183,7 +183,7 @@ public static class CursorHookCommand {
                  && roots[0] is JsonValue wv && wv.TryGetValue<string>(out var wr))
                     workspaceRoot = wr;
 
-                // AI-1382 Task 9: spawn (or heal) this session's tailing Cursor watcher FIRST —
+                // Task 9: spawn (or heal) this session's tailing Cursor watcher FIRST —
                 // live transcript capture must never be lost even if the repo-enrichment call
                 // below (or the eventual POST) is slow or fails. Idempotent; a no-op once alive.
                 if (sessionId is not null && !string.IsNullOrEmpty(transcriptPath)) {
@@ -209,11 +209,11 @@ public static class CursorHookCommand {
                         using var content = new StringContent(entryBody, Encoding.UTF8, "application/json");
                         using var resp    = await client.PostOnceAsync($"{baseUrl}/hooks/{route}", content, HookPostTimeout, ct);
                         if (resp.IsSuccessStatusCode) {
-                            // AI-1382 Task 8: a spooled beforeSubmitPrompt (user-prompt/cursor)
+                            // Task 8: a spooled beforeSubmitPrompt (user-prompt/cursor)
                             // finally being delivered here means the side-effect barrier this
                             // session may be holding on can now be cleared.
                             if (route == "user-prompt/cursor") CursorMarkers.ClearBarrier(sessionId);
-                            // AI-1382 Task 12: this IS "a later invocation whose spool drain
+                            // Task 12: this IS "a later invocation whose spool drain
                             // delivers the start" — a subagent-start that failed its first live
                             // POST (see HandleSubagentChildEventAsync) just got acknowledged here
                             // instead. Perform the deferred child-watcher spawn now.
@@ -226,7 +226,7 @@ public static class CursorHookCommand {
                 }, budgetTotal, ct);
             }
 
-            // AI-1382 review fix #4 — capture whether this session STILL has spool backlog after
+            // capture whether this session STILL has spool backlog after
             // the drain attempt above. A TransientStop mid-drain (or budget expiry) can leave
             // entries undelivered — including an earlier canonical lifecycle event like
             // sessionStart — and the ordering guard below only early-returns for mappings whose
@@ -236,7 +236,7 @@ public static class CursorHookCommand {
             // before the still-backlogged earlier event ever reaches the server.
             var hasRemainingSpoolBacklog = sessionId is not null && spool.HasBacklog(sessionId);
 
-            // AI-1151 (live): a linked subagent child takes over entirely from here — it never
+            // a linked subagent child takes over entirely from here — it never
             // gets the normal mapping.RouteSegment POST (mirroring CursorImportSource.
             // SendSubagentLifecycleAsync, which never gives a correlated child its own top-level
             // lifecycle either). See HandleSubagentChildEventAsync for the divert.
@@ -276,7 +276,7 @@ public static class CursorHookCommand {
                                && !string.IsNullOrEmpty(transcriptPath);
 
             if (drainBeforePost && !BudgetExpired()) {
-                // AI-1382 Task 10 (D2): this IS the sessionEnd pre-end drain — the hook is the
+                // Task 10 (D2): this IS the sessionEnd pre-end drain — the hook is the
                 // last component that will ever observe this transcript, so a valid
                 // newline-less final record must be consumed rather than held forever.
                 await CursorTranscriptBackfill.RunAsync(
@@ -297,18 +297,18 @@ public static class CursorHookCommand {
             if (!posted && mapping.SpoolOnFailure && sessionId is not null) {
                 spool.Append(sessionId, mapping.RouteSegment, normalized);
             }
-            // AI-1382 Task 8: the ordering-sensitive beforeSubmitPrompt's own live POST just
+            // Task 8: the ordering-sensitive beforeSubmitPrompt's own live POST just
             // succeeded — clear the barrier it created above.
             if (posted && eventName == "beforeSubmitPrompt" && sessionId is not null) {
                 CursorMarkers.ClearBarrier(sessionId);
             }
 
-            // AI-1382 Task 9: recovery spawn from a non-start hook — ONLY once this
+            // Task 9: recovery spawn from a non-start hook — ONLY once this
             // invocation's own lifecycle POST has actually landed (never race a fresh watcher
             // ahead of the metadata the server needs to attribute its lines to). sessionStart
             // already spawned before its POST above; ShouldSpawnWatcher is false for sessionEnd
             // regardless, so this is safe to reach unconditionally for every other event.
-            // AI-1382 review fix #4 — additionally require no remaining spool backlog: this
+            // additionally require no remaining spool backlog: this
             // invocation's own POST landing is not enough if an EARLIER queued event for this
             // session is still stuck undelivered (hasRemainingSpoolBacklog, captured above).
             if (posted && eventName != "sessionStart" && sessionId is not null && !string.IsNullOrEmpty(transcriptPath)
@@ -332,7 +332,7 @@ public static class CursorHookCommand {
     }
 
     /// <summary>
-    /// AI-1151 (live): the divert path for a Cursor hook belonging to a subagent child
+    /// the divert path for a Cursor hook belonging to a subagent child
     /// already linked to a parent (<see cref="CursorLiveSubagentLinker"/>). Mirrors
     /// <c>CursorImportSource.SendSubagentLifecycleAsync</c> — only three things ever happen
     /// for a linked child, regardless of which Cursor hook fired: <c>subagent-start</c>
@@ -384,7 +384,7 @@ public static class CursorHookCommand {
             return 0;
         }
 
-        // AI-1382 review fix #5 — a non-start hook for a child whose subagent-start was never
+        // a non-start hook for a child whose subagent-start was never
         // acknowledged (2xx) must not let ANY child transcript flow, nor its own subagent-stop
         // POST. The backlog check above only catches a start that's still PENDING retry; a start
         // that hit a non-transient 4xx is permanently DROPPED by the generic drain (HandleCore's
@@ -401,7 +401,7 @@ public static class CursorHookCommand {
         // replay, so that's all we do (plus a self-heal spawn — see below).
         if (!isLifecycle) {
             if (!string.IsNullOrEmpty(transcriptPath) && !budgetExpired()) {
-                // AI-1382 review fix #5 — self-heal. HasSubagentStartAck (above) only proves
+                // self-heal. HasSubagentStartAck (above) only proves
                 // subagent-start was acknowledged (2xx) AT SOME POINT — the child watcher process
                 // itself may since have exited (the newly-enabled idle ceiling), crashed, or never
                 // actually spawned at all (e.g. its acked sessionStart hook carried no transcript
@@ -423,7 +423,7 @@ public static class CursorHookCommand {
 
         // sessionEnd: drain the transcript before the terminal hook — same ordering rationale
         // as the top-level path, and mirrors SendSubagentLifecycleAsync (its transcript batch
-        // always precedes subagent-stop too). AI-1382 Task 10 (D2): this is the child's own
+        // always precedes subagent-stop too). Task 10 (D2): this is the child's own
         // pre-end drain, so consume a complete-but-unterminated final line rather than holding it.
         if (isStop && !string.IsNullOrEmpty(transcriptPath) && !budgetExpired()) {
             await CursorTranscriptBackfill.RunAsync(
@@ -438,7 +438,7 @@ public static class CursorHookCommand {
 
         var posted = await TryPostHookAsync(client, baseUrl, route, body!, ct);
         if (!posted) {
-            // AI-1382 Task 12 — subagent-start POST failed (spooled): the child watcher must
+            // Task 12 — subagent-start POST failed (spooled): the child watcher must
             // NOT spawn here. Spawning now would let the watcher's own poll deliver child
             // transcript lines before SubagentStarted is ever appended (the server has no
             // AgentSubsession stream open yet to receive them). Spool it and STOP; running the
@@ -450,12 +450,12 @@ public static class CursorHookCommand {
             return 0;
         }
 
-        // AI-1382 review fix #5 — persist the positive ack so HandleSubagentChildEventAsync's
+        // persist the positive ack so HandleSubagentChildEventAsync's
         // no-ack gate (above) is satisfied for every subsequent hook invocation for this child
         // (a fresh process each time, so nothing survives in memory).
         if (isStart) CursorMarkers.MarkSubagentStartAcked(childSessionId);
 
-        // AI-1382 Task 12 — subagent-start is ACKNOWLEDGED (2xx) via this live POST. Only now
+        // Task 12 — subagent-start is ACKNOWLEDGED (2xx) via this live POST. Only now
         // may the child's own tailing watcher be spawned — the invariant this task exists for
         // is that no child transcript line ever reaches the server before SubagentStarted.
         if (isStart && !string.IsNullOrEmpty(transcriptPath)) {
@@ -474,7 +474,7 @@ public static class CursorHookCommand {
     }
 
     /// <summary>
-    /// AI-1382 Task 12 — spawns (or heals) the child (subagent) Cursor watcher, keyed
+    /// Task 12 — spawns (or heals) the child (subagent) Cursor watcher, keyed
     /// <c>{parentSessionId}-{childSessionId}</c> so it never collides with the parent's own
     /// top-level watcher key. Tails the CHILD's own transcript file and routes every batch it
     /// sends under <paramref name="parentSessionId"/> with <c>agentId = childSessionId</c>
@@ -507,7 +507,7 @@ public static class CursorHookCommand {
     }
 
     /// <summary>
-    /// AI-1382 Task 12 — the generic spool-drain callback (<see cref="HandleCore"/>'s top-of-method
+    /// Task 12 — the generic spool-drain callback (<see cref="HandleCore"/>'s top-of-method
     /// drain, which runs for every session BEFORE the <c>isSubagentChild</c> divert) has just
     /// delivered a previously-spooled <c>subagent-start</c> entry. Parses the parent/child/
     /// transcript-path triple back out of its own payload shape
@@ -526,7 +526,7 @@ public static class CursorHookCommand {
             if (parentSessionId is null || childSessionId is null || string.IsNullOrEmpty(transcriptPath)) {
                 return Task.CompletedTask;
             }
-            // AI-1382 review fix #5 — this delivery IS the 2xx ack for a previously-spooled
+            // this delivery IS the 2xx ack for a previously-spooled
             // subagent-start; persist it so the no-ack gate in HandleSubagentChildEventAsync is
             // satisfied for this child from here on.
             CursorMarkers.MarkSubagentStartAcked(childSessionId);
@@ -535,7 +535,7 @@ public static class CursorHookCommand {
     }
 
     /// <summary>
-    /// AI-1382 Task 9 — pure precedence predicate for whether THIS hook invocation should
+    /// Task 9 — pure precedence predicate for whether THIS hook invocation should
     /// spawn (or heal) the per-session top-level Cursor watcher. Precedence, from the D1
     /// design: ① a terminal hook (<c>sessionEnd</c>) never spawns — only the pre-end drain and
     /// the terminal POST matter there, and spawning a watcher moments before killing the
@@ -551,7 +551,7 @@ public static class CursorHookCommand {
     }
 
     /// <summary>
-    /// AI-1382 Task 9 — spawns (or heals, via <see cref="WatcherManager.EnsureWatcherRunning"/>'s
+    /// Task 9 — spawns (or heals, via <see cref="WatcherManager.EnsureWatcherRunning"/>'s
     /// existing idempotent PID+heartbeat check) the per-session top-level Cursor watcher for
     /// <paramref name="sessionId"/>, unless: the session is quarantined (a runtime rewrite-guard
     /// trip — Task 7 — must not keep resurrecting a watcher for a session already given up on),

--- a/src/Capacitor.Cli/Commands/CursorImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CursorImportSource.cs
@@ -494,7 +494,7 @@ internal sealed class CursorImportSource : IImportSource {
         // (next run sees AlreadyLoaded and never re-emits). Treat lifecycle
         // POST failure as a hard import failure; the orchestrator surfaces
         // Errored and the user re-runs, which is idempotent on the server
-        // (canonical event ids are deterministic —).
+        // (canonical event ids are deterministic).
         var startOk = await PostSyntheticHookAsync(
             ctx.HttpClient, ctx.BaseUrl, "session-start/cursor",
             BuildSessionStartPayload(classification.SessionId, workspaceFolder, transcriptPath, createdUtc, repositoryNode),

--- a/src/Capacitor.Cli/Commands/CursorImportSource.cs
+++ b/src/Capacitor.Cli/Commands/CursorImportSource.cs
@@ -34,7 +34,7 @@ internal sealed class CursorImportSource : IImportSource {
     readonly Lazy<IReadOnlyDictionary<string, string?>>  _sanitizedToFolder;
     readonly Func<string, Task<RepositoryPayload?>>      _repoDetector;
 
-    // AI-1358 (item 5): per-cwd cache of the detected repo payload, populated during
+    // per-cwd cache of the detected repo payload, populated during
     // ImportSessionAsync. Historical import can walk many sessions that share one workspace
     // folder — without this, each session would re-run repo detection for the same cwd. Keyed
     // by the resolved workspace folder (Ordinal — the same string ImportSessionAsync already
@@ -53,9 +53,9 @@ internal sealed class CursorImportSource : IImportSource {
         _projectsDir         = projectsDirOverride         ?? CursorPaths.ProjectsDir();
         _workspaceStorageDir = workspaceStorageDirOverride ?? CursorPaths.Resolve().WorkspaceStorageDir;
         _sanitizedToFolder   = new Lazy<IReadOnlyDictionary<string, string?>>(BuildSanitizedToFolderMap);
-        // AI-1358 (item 5): historical import must never attach a live PR to an old session —
+        // historical import must never attach a live PR to an old session —
         // stamping today's open PR onto a transcript from weeks ago is an anachronism, and it's
-        // exactly the wasted `gh pr view` / `glab api` round-trip per cwd that AI-1122 already
+        // exactly the wasted `gh pr view` / `glab api` round-trip per cwd that already
         // skips for the other import sources. detectPullRequest:false still resolves
         // owner/repo/branch (BuildRepositoryNode's non-PR fields), so imported sessions keep
         // grouping under their repo — they just never carry pr_number/pr_title/pr_url/pr_head_ref.
@@ -79,7 +79,7 @@ internal sealed class CursorImportSource : IImportSource {
     // Path.GetFullPath: on Windows GetFullPath rebases a driveless rooted path
     // (e.g. "/Users/me/dev/foo") onto the current drive ("C:\Users\me\dev\foo"),
     // which neither Cursor's sanitized project-dir naming nor a caller-supplied
-    // --cwd ever carries — breaking the sanitized-key match (AI-820). Must stay
+    // cwd ever carries — breaking the sanitized-key match. Must stay
     // byte-identical to BuildSanitizedToFolderMap's normalization.
     static string NormalizeForComparison(string path) {
         var p = path.Replace('\\', '/').TrimEnd('/');
@@ -225,7 +225,7 @@ internal sealed class CursorImportSource : IImportSource {
         var repoCache    = new Dictionary<string, string?>(StringComparer.Ordinal); // cwd → "owner/repo" or null
         var hasExcludes  = ctx.ExcludedRepos is { Count: > 0 };
 
-        // AI-1153: correlate subagent (child) sessions to their parent by prompt-hash across
+        // correlate subagent (child) sessions to their parent by prompt-hash across
         // all discovered transcripts. A child is ingested under the parent's AgentSubsession
         // stream *by the parent's own import* (subagent-start → transcript-with-agent_id →
         // subagent-stop, before the parent's session-end) rather than as a separate top-level
@@ -233,7 +233,7 @@ internal sealed class CursorImportSource : IImportSource {
         // the last event on its stream — a subagent-start posted after a parallel parent's
         // session-end would reactivate the ended parent (SubagentStarted is a reactivation event).
         //
-        // AI-1156 (D5): the correlator's INPUT is widened to every session under the SAME
+        // the correlator's INPUT is widened to every session under the SAME
         // workspace's agent-transcripts/ dir — ignoring --session/--cwd/--since/scope for this
         // internal step (cheap local file reads only). Without this, a `--session <child>`
         // (or --cwd/--since-narrowed) import only ever sees the child in `sessions`, so it can
@@ -357,7 +357,7 @@ internal sealed class CursorImportSource : IImportSource {
                 continue;
             }
 
-            // Ended-at contract (AI-1358 A3): unlike Copilot (session.shutdown record) or
+            // Ended-at contract: unlike Copilot (session.shutdown record) or
             // Gemini/Pi (per-record "timestamp" field), Cursor's Anthropic content-block
             // transcript carries no authoritative session-end record to tail-scan. The
             // fallback is: the last parsed user-wrapper timestamp when the normalizer
@@ -428,10 +428,10 @@ internal sealed class CursorImportSource : IImportSource {
             ImportContext                       ctx,
             CancellationToken                   ct
         ) {
-        // AI-1153: a correlated subagent child is imported by its parent (below), under the
+        // a correlated subagent child is imported by its parent (below), under the
         // parent's AgentSubsession stream — never as a standalone top-level session.
         //
-        // AI-1156 (D5): this flag is no longer unconditional. ImportCommand reconciles `routed`
+        // this flag is no longer unconditional. ImportCommand reconciles `routed`
         // right after building it — an ORPHANED child (its correlated parent isn't itself part
         // of this run's plan) has IsSubagentChild/ParentSessionId cleared before reaching here,
         // so this check only still fires for a child whose parent IS about to run its own
@@ -441,7 +441,7 @@ internal sealed class CursorImportSource : IImportSource {
             return ImportOutcome.Skipped;
         }
 
-        // AI-1382 review fix #6 — re-check quarantine FRESH, before ANY lifecycle/transcript
+        // re-check quarantine FRESH, before ANY lifecycle/transcript
         // delivery. ClassifyAsync's own check (at classification time, above in this file) can be
         // stale by the time this runs: repo probing, an interactive confirmation prompt, or simply
         // queueing behind other sessions in the same import run all give the live watcher's
@@ -467,12 +467,12 @@ internal sealed class CursorImportSource : IImportSource {
 
         var (createdUtc, modifiedUtc) = TryGetTranscriptTimes(transcriptPath);
 
-        // AI-1152: detect the repo from the workspace folder so the synthetic
+        // detect the repo from the workspace folder so the synthetic
         // sessionStart carries a `repository` node → server emits RepositoryDetected
         // and the (historical/backfilled) session groups under its repo. Fail-open:
         // a non-git workspace or detection error leaves it null and unattributed.
         //
-        // AI-1358 (item 5): cached per cwd — a historical import walks every session under a
+        // cached per cwd — a historical import walks every session under a
         // workspace, and many share one cwd, so this only runs detection once per distinct
         // folder for the whole import rather than once per session.
         JsonObject? repositoryNode = null;
@@ -494,7 +494,7 @@ internal sealed class CursorImportSource : IImportSource {
         // (next run sees AlreadyLoaded and never re-emits). Treat lifecycle
         // POST failure as a hard import failure; the orchestrator surfaces
         // Errored and the user re-runs, which is idempotent on the server
-        // (canonical event ids are deterministic — AI-731).
+        // (canonical event ids are deterministic —).
         var startOk = await PostSyntheticHookAsync(
             ctx.HttpClient, ctx.BaseUrl, "session-start/cursor",
             BuildSessionStartPayload(classification.SessionId, workspaceFolder, transcriptPath, createdUtc, repositoryNode),
@@ -512,7 +512,7 @@ internal sealed class CursorImportSource : IImportSource {
             _                                                => 0,
         };
 
-        // AI-1382 review fix #6 — re-check again at the transcript boundary: the sessionStart POST
+        // re-check again at the transcript boundary: the sessionStart POST
         // that just landed gave the runtime guard another window to trip. Unlike the pre-flight
         // check above (nothing posted yet, so Skipped there is exactly right), the session now
         // legitimately exists server-side — best-effort close it with session-end so it doesn't
@@ -530,7 +530,7 @@ internal sealed class CursorImportSource : IImportSource {
             return ImportOutcome.Failed;
         }
 
-        // AI-1382 review fix (r4, finding #2) — the best-effort close-and-fail contract shared by
+        // the best-effort close-and-fail contract shared by
         // EVERY quarantine-abort seam below (the parent's own mid-transcript trip AND a child's):
         // best-effort session-end so the session doesn't hang open "active" forever (subagent-start
         // may already have posted for a child — this closes the parent/subsession the SAME way
@@ -550,7 +550,7 @@ internal sealed class CursorImportSource : IImportSource {
 
         int sent;
         try {
-            // AI-1382 review fix (r3, finding #4) — abortDelivery re-checks the ALREADY-resolved
+            // abortDelivery re-checks the ALREADY-resolved
             // quarantineIdentity (a cheap marker-file read, no correlator re-run) before every
             // 100-line batch. Without this, a quarantine written by the live watcher's runtime
             // rewrite guard between batch 1 and batch 2 (or later) still let every remaining batch
@@ -572,18 +572,18 @@ internal sealed class CursorImportSource : IImportSource {
             return ImportOutcome.Failed;
         }
 
-        // AI-1153: import this parent's subagent children BEFORE its session-end, so the
+        // import this parent's subagent children BEFORE its session-end, so the
         // parent's SessionEnded remains the last event on its stream. A subagent-start
         // (reactivation event) appended after the parent's SessionEnded would flip the
         // ended parent back to Active. Hard-fail on child failure (same contract as the
         // parent lifecycle) so a re-run — idempotent via deterministic ids — repairs it.
         //
-        // AI-1154 review fix (P1): track whether any child ACTUALLY sent new transcript bytes,
+        // track whether any child ACTUALLY sent new transcript bytes,
         // independent of the parent's own `sent`/`startLine`. An AlreadyLoaded parent (nothing
         // past its own watermark) can still attach a previously-unloaded child here — that's
         // real new work, and ImportCommand's IsLifecycleOnlyRoutedReplay must not suppress it.
         //
-        // AI-1382 review fix (r4, finding #2) — a child-transcript quarantine trip is surfaced as
+        // a child-transcript quarantine trip is surfaced as
         // the SAME typed TranscriptDeliveryAbortedException the parent's own delivery throws (see
         // SendSubagentLifecycleAsync below); catching it here routes it through CloseAndFailAsync
         // instead of letting SendSubagentLifecycleAsync's old catch-all swallow it into a bare
@@ -632,10 +632,10 @@ internal sealed class CursorImportSource : IImportSource {
     /// <summary>
     /// Stamps subagent correlation onto a session's SourceMeta (SourceMeta is read-only, so every
     /// session gets a fresh copy). Children carry <c>IsSubagentChild</c> + <c>ParentSessionId</c>
-    /// (AI-1156 D5 — the parent id lets <see cref="ImportCommand"/> reconcile an orphaned child
+    /// (D5 — the parent id lets <see cref="ImportCommand"/> reconcile an orphaned child
     /// to standalone when the parent isn't itself part of this run's plan) so their own import
     /// no-ops (unless reconciled); parents carry <c>SubagentChildren</c> so they import them inline.
-    /// Every classification also carries <c>QuarantineIdentity</c> — AI-1382 review fix #6 — so
+    /// Every classification also carries <c>QuarantineIdentity</c> — review fix #6 — so
     /// <see cref="ImportSessionAsync"/> can re-check <see cref="CursorMarkers.IsQuarantined"/>
     /// FRESH immediately before any lifecycle/transcript delivery (the family identity itself is
     /// stable for the run; only the quarantine STATE needs a live re-check, since the live
@@ -694,7 +694,7 @@ internal sealed class CursorImportSource : IImportSource {
     }
 
     /// <summary>
-    /// AI-1382 review fix #7 — resolves the FAMILY (quarantine) identity for <paramref name="sessionId"/>:
+    /// resolves the FAMILY (quarantine) identity for <paramref name="sessionId"/>:
     /// its correlated parent's id when <paramref name="subagentLinks"/> (computed from THIS batch's
     /// discovered sessions) has a link, falling back to the persisted
     /// <see cref="CursorLiveSubagentLinker"/> marker — written independently by the LIVE hook
@@ -717,7 +717,7 @@ internal sealed class CursorImportSource : IImportSource {
     }
 
     /// <summary>
-    /// AI-1153: ingest one Cursor subagent child under its parent's <c>AgentSubsession</c>
+    /// ingest one Cursor subagent child under its parent's <c>AgentSubsession</c>
     /// stream. Mirrors <c>SessionImporter.SendAgentLifecycle</c>: <c>subagent-start</c>
     /// (session_id=parent, agent_id=child) → transcript batches routed with <c>agent_id</c>=child
     /// (resumed from the subsession watermark so re-imports don't repost the whole child) →
@@ -728,14 +728,14 @@ internal sealed class CursorImportSource : IImportSource {
     /// session card.
     ///
     /// <para>
-    /// AI-1154 review fix (P1): also reports whether this call actually POSTed new transcript
+    /// also reports whether this call actually POSTed new transcript
     /// bytes for the child (<c>SentContent</c>) — the caller needs that to know real new work
     /// happened even when the PARENT's own <c>sent</c> count is zero (e.g. an AlreadyLoaded
     /// parent attaching a previously-unloaded child).
     /// </para>
     ///
     /// <para>
-    /// AI-1154 review fix (P1, round-4): a fail-open resend — the child subsession watermark
+    /// a fail-open resend — the child subsession watermark
     /// probe itself threw, so <c>startLine</c> resets to 0 and the whole child is reposted — is
     /// INDETERMINATE, not proof of "no new content". The round-3 fix treated a probe failure as
     /// "definitely a duplicate resend" and forced <c>SentContent = false</c>; but when the child
@@ -761,7 +761,7 @@ internal sealed class CursorImportSource : IImportSource {
         if (string.IsNullOrEmpty(child.TranscriptPath) || !File.Exists(child.TranscriptPath))
             return (true, false); // missing child transcript — skip, non-fatal
 
-        // AI-1382 review fix (r4, finding #2a) — never start a NEW child under a family that is
+        // never start a NEW child under a family that is
         // ALREADY quarantined by the time its turn comes up in the parent's loop. Without this, a
         // quarantine tripped by some earlier child's own delivery (or any other concurrent trip —
         // the live watcher runs alongside this import) still let every LATER child's subagent-start
@@ -790,7 +790,7 @@ internal sealed class CursorImportSource : IImportSource {
         // Resume from the subsession watermark (AgentSubsession-{parent}-{child}) so a re-import
         // doesn't repost the full child transcript every time. Fail-open to a full send.
         //
-        // AI-1154 review fix (P1, round-4): a fail-open resend (the probe itself threw — e.g. a
+        // a fail-open resend (the probe itself threw — e.g. a
         // transient 5xx) resets startLine to 0 and reposts the WHOLE child. That resend is
         // INDETERMINATE — it MAY be a duplicate of an already-complete child, or it MAY be
         // genuinely new content that a transient probe failure prevented us from resuming
@@ -814,7 +814,7 @@ internal sealed class CursorImportSource : IImportSource {
             // transcript POST must abort so the parent import fails and a re-run repairs it,
             // rather than leaving an empty completed subagent while reporting success.
             //
-            // AI-1382 review fix (r3, finding #4) — abortDelivery closes over the SAME
+            // abortDelivery closes over the SAME
             // already-resolved quarantineIdentity as the parent's own send (no extra correlator
             // work), so a quarantine tripping mid-child-transcript also aborts the remaining
             // child batches, not just the parent's.
@@ -829,7 +829,7 @@ internal sealed class CursorImportSource : IImportSource {
                 failOnError:   true,
                 abortDelivery: () => CursorMarkers.IsQuarantined(quarantineIdentity));
         } catch (SessionImporter.TranscriptDeliveryAbortedException) {
-            // AI-1382 review fix (r4, finding #2b) — a quarantine trip during THIS child's own
+            // a quarantine trip during THIS child's own
             // transcript delivery must propagate to the caller's close-and-fail path, not collapse
             // into the same bare `false` an ordinary POST failure returns below. A `false` here
             // returned Failed from ImportSessionAsync WITHOUT ever posting the parent's best-effort
@@ -879,12 +879,12 @@ internal sealed class CursorImportSource : IImportSource {
         if (workspaceFolder is not null) {
             payload["workspace_roots"] = new JsonArray(workspaceFolder);
         }
-        // AI-1152: git-detected repo (owner/repo/branch/...) so the server emits
+        // git-detected repo (owner/repo/branch/...) so the server emits
         // RepositoryDetected for historical/backfilled Cursor sessions.
         if (repository is not null) {
             payload["repository"] = repository;
         }
-        // AI-739: server prefers started_at over UtcNow when present, so
+        // server prefers started_at over UtcNow when present, so
         // historical sessions surface with their real start time. Use an
         // ISO-8601 round-trip ("O") string — DateTimeOffset? on the server
         // record deserialises that shape directly.
@@ -981,7 +981,7 @@ internal sealed class CursorImportSource : IImportSource {
     }
 
     static async Task<int?> FetchServerLastLineAsync(HttpClient http, string baseUrl, string sessionId, CancellationToken ct, string? agentId = null) {
-        // agentId set → probe the AgentSubsession-{sessionId}-{agentId} watermark (AI-1153).
+        // agentId set → probe the AgentSubsession-{sessionId}-{agentId} watermark.
         var url = string.IsNullOrEmpty(agentId)
             ? $"{baseUrl}/api/sessions/{sessionId}/last-line"
             : $"{baseUrl}/api/sessions/{sessionId}/last-line?agentId={Uri.EscapeDataString(agentId)}";

--- a/src/Capacitor.Cli/Commands/CursorLiveSubagentLinker.cs
+++ b/src/Capacitor.Cli/Commands/CursorLiveSubagentLinker.cs
@@ -4,11 +4,11 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Live-flow wrapper over <see cref="CursorSubagentCorrelator"/> (AI-1151).
+/// Live-flow wrapper over <see cref="CursorSubagentCorrelator"/>.
 ///
 /// <see cref="CursorSubagentCorrelator"/> only runs on the historical <c>import</c> path
 /// today, so a live Cursor <c>Task</c>/<c>Agent</c> subagent is ingested as its own
-/// top-level session instead of nesting under its parent — the same problem AI-1153 fixed
+/// top-level session instead of nesting under its parent — the same problem fixed
 /// for import. Cursor is NOT watcher-backed (<see cref="CursorHookCommand"/> backfills each
 /// session's transcript over HTTP as hooks arrive), so the correlation has to run inline in
 /// that per-hook dispatcher rather than in a background watcher.
@@ -19,7 +19,7 @@ namespace Capacitor.Cli.Commands;
 /// (<c>agentId = child session id</c>, mirroring <c>CursorImportSource.cs:468</c>) — so a
 /// live-then-import of the same session converges on the same deterministic
 /// <c>AgentSubsession-{parent}-{child}</c> stream instead of duplicating the subagent's
-/// lifecycle/content (ties to AI-1358 A1).
+/// lifecycle/content (ties to A1).
 /// </summary>
 public static class CursorLiveSubagentLinker {
     // Bounds the sibling-transcript scan so a workspace with a very long history can't blow

--- a/src/Capacitor.Cli/Commands/CursorSubagentCorrelator.cs
+++ b/src/Capacitor.Cli/Commands/CursorSubagentCorrelator.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core.Cursor;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Correlates Cursor subagent sessions to their parent (AI-1153).
+/// Correlates Cursor subagent sessions to their parent.
 ///
 /// Cursor runs a subagent (a <c>Task</c>/<c>Agent</c> tool call) as its OWN
 /// top-level session with its own transcript — and provides NO explicit

--- a/src/Capacitor.Cli/Commands/CursorTranscriptBackfill.cs
+++ b/src/Capacitor.Cli/Commands/CursorTranscriptBackfill.cs
@@ -21,14 +21,14 @@ public static class CursorTranscriptBackfill {
     public readonly record struct Stats(int LinesPosted, bool Failed);
 
     /// <param name="agentId">
-    /// AI-1151 (live subagent linking): when set, <paramref name="sessionId"/> is the
+    /// when set, <paramref name="sessionId"/> is the
     /// PARENT session and the batch is routed to its <c>AgentSubsession-{sessionId}-{agentId}</c>
     /// stream instead of the top-level <c>AgentSession-{sessionId}</c> — mirroring the watermark
     /// probe + transcript POST shape <c>CursorImportSource.SendSubagentLifecycleAsync</c> uses for
     /// historical import, so live and import converge on the same subsession watermark.
     /// </param>
     /// <param name="finalDrain">
-    /// AI-1382 Task 10 (D2) — set ONLY by the <c>sessionEnd</c> pre-end drain. Selects
+    /// Task 10 (D2) — set ONLY by the <c>sessionEnd</c> pre-end drain. Selects
     /// <see cref="WatchCommand.IncompleteFinalLinePolicy.ConsumeIfComplete"/> instead of the
     /// default <see cref="WatchCommand.IncompleteFinalLinePolicy.Hold"/>: at session end the
     /// hook (not the live watcher) is the last component that can ever observe this transcript,
@@ -48,13 +48,13 @@ public static class CursorTranscriptBackfill {
             return new Stats(0, false);
         }
 
-        // AI-1382 D0 — a session already quarantined by the runtime rewrite guard must never
+        // a session already quarantined by the runtime rewrite guard must never
         // have more transcript lines delivered; the watcher has already given up on it.
         if (CursorMarkers.IsQuarantined(sessionId)) {
             return new Stats(0, false);
         }
 
-        // AI-1382 D1 — an ordering-sensitive hook (beforeSubmitPrompt) may have queued an
+        // an ordering-sensitive hook (beforeSubmitPrompt) may have queued an
         // attachment the Cursor normalizer needs to see BEFORE the matching user transcript line
         // is normalized. While the barrier is pending, hold delivery entirely (retry next
         // invocation) rather than risk normalizing ahead of the attachment.
@@ -93,7 +93,7 @@ public static class CursorTranscriptBackfill {
         } catch { return new Stats(0, Failed: true); }
 
         // Read every line past the watermark into the batch, via the same length-capped,
-        // concurrent-append-safe primitive the live watcher uses (AI-1382 Task 10 — replaces
+        // concurrent-append-safe primitive the live watcher uses (Task 10 — replaces
         // the prior ad-hoc StreamReader loop, which held nothing back for a still-being-written
         // final line and so risked truncating it). Cursor's JSONL is bounded by the agent turn
         // count — practical sizes are dozens of lines, not thousands; the server's
@@ -114,7 +114,7 @@ public static class CursorTranscriptBackfill {
 
         if (lines.Count == 0 || budget()) return new(0, Failed: false);
 
-        // AI-1382 review fix #8 — re-check both markers IMMEDIATELY at the delivery boundary,
+        // re-check both markers IMMEDIATELY at the delivery boundary,
         // not only before the watermark GET + file read above. A concurrent beforeSubmitPrompt
         // (creating its barrier) or a guard trip on the live watcher (quarantining the session)
         // landing in that window — between the early check and this POST — must still be caught

--- a/src/Capacitor.Cli/Commands/CursorVerifyAppendOnlyCommand.cs
+++ b/src/Capacitor.Cli/Commands/CursorVerifyAppendOnlyCommand.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// AI-1382 D0 — hidden diagnostic: the phase-0 empirical verification harness. Samples
+/// hidden diagnostic: the phase-0 empirical verification harness. Samples
 /// <c>(length, sha256(prefix))</c> off a live Cursor transcript file at ~1s cadence for a bounded
 /// duration and checks every earlier/later sample pair with
 /// <see cref="CursorAppendOnlyProbe.PrefixStable"/>, printing a PASS/FAIL report.

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -121,7 +121,7 @@ public static class DaemonCommands {
             return 1;
         }
 
-        // The daemon owns its PID file end to end (AI-1155): it writes it inside
+        // The daemon owns its PID file end to end: it writes it inside
         // the flock during startup (DaemonLock.TryAcquire) and deletes it under
         // the flock in Dispose. The supervisor neither writes nor deletes it.
         //
@@ -173,13 +173,13 @@ public static class DaemonCommands {
         }
 
         // Redirect ALL three standard streams so the detached daemon does not
-        // inherit our stdout/stderr (AI-839). Left un-redirected, the daemon
+        // inherit our stdout/stderr. Left un-redirected, the daemon
         // keeps the terminal — or a capturing parent's pipe — open for its
         // whole lifetime, so `kcap daemon start -d` appears to hang: it returns
         // and the daemon reparents to init, but anything reading our piped
         // output blocks on EOF that never comes. The daemon logs to --log-file,
         // so it has no use for these streams. (Same pipe-leak hazard and fix as
-        // the AI-820 watcher / what's-done spawns.)
+        // the watcher / what's-done spawns.)
         var psi = new ProcessStartInfo {
             FileName               = daemonPath,
             UseShellExecute        = false,
@@ -191,7 +191,7 @@ public static class DaemonCommands {
         psi.ArgumentList.Add("--log-file");
         psi.ArgumentList.Add(LogPath);
 
-        // AI-1155: we close the daemon's std pipes just below (anti-hang), which
+        // we close the daemon's std pipes just below (anti-hang), which
         // means a runtime/native fatal message written straight to fd 2 would be
         // lost — the reason hard daemon deaths currently leave no trace. Point the
         // daemon's fds at a sibling capture file so those messages survive. Same
@@ -204,7 +204,7 @@ public static class DaemonCommands {
         }
 
         // Windows: clear HANDLE_FLAG_INHERIT on our own std handles so the child
-        // doesn't inherit a capturing parent's pipe handles (AI-820). No-op on Unix.
+        // doesn't inherit a capturing parent's pipe handles. No-op on Unix.
         ProcessHelpers.PreventInheritedStdHandles();
 
         var process = new Process { StartInfo = psi };
@@ -216,7 +216,7 @@ public static class DaemonCommands {
         process.StandardOutput.Close();
         process.StandardError.Close();
 
-        // AI-630: the daemon binary acquires its own per-name flock at
+        // the daemon binary acquires its own per-name flock at
         // startup and exits with code 2 if another live daemon already
         // holds it (the race we couldn't catch via the PID-file guard
         // alone, e.g. when the previous daemon's PID file got wiped but
@@ -238,7 +238,7 @@ public static class DaemonCommands {
             return process.ExitCode == 0 ? 1 : process.ExitCode;
         }
 
-        // No supervisor PID-file write here (AI-1155): the daemon wrote its own
+        // No supervisor PID-file write here: the daemon wrote its own
         // inside the flock during startup — which the readiness wait above just
         // confirmed it survived — and owns its deletion. A redundant out-of-flock
         // write could recreate the file after a clean daemon exit and trip the
@@ -320,7 +320,7 @@ public static class DaemonCommands {
         if (ReadPidFile(name) is not { } entry) {
             // ReadPidFile returns null for BOTH an absent file and a present-but-
             // unparseable one (empty/partial — e.g. a mid-write SIGKILL; it no
-            // longer unlinks the latter, AI-1155).
+            // longer unlinks the latter,).
             if (!File.Exists(DaemonLockPaths.PidPath(name))) {
                 Console.Error.WriteLine($"No daemon '{name}' running (no PID file found).");
 
@@ -385,8 +385,8 @@ public static class DaemonCommands {
     /// PID afterward. Every daemon (supervisor-started, foreground, or
     /// self-respawned) takes this flock before writing its PID, so this is the
     /// race-free way for the CLI to clean up markers without unlinking a live
-    /// daemon's PID file (AI-1155). The lock file itself is never deleted
-    /// (AI-630); <c>doctor --clean</c> owns that. Returns false if a live daemon
+    /// daemon's PID file. The lock file itself is never deleted;
+    /// <c>doctor --clean</c> owns that. Returns false if a live daemon
     /// holds the flock (caller should treat the name as running).
     /// </summary>
     static bool TryCleanupMarkersUnderLock(string name) {
@@ -521,7 +521,7 @@ public static class DaemonCommands {
                 if (DaemonRestartMarker.TryRead(name) is { } marker)
                     await Console.Out.WriteLineAsync($"  {marker.Describe()}");
             } else {
-                // AI-1155: report the stale PID file but do NOT delete it. Its
+                // report the stale PID file but do NOT delete it. Its
                 // presence is now the durable hard-death signal the next daemon
                 // reads to log the unclean-exit breadcrumb (DaemonLock); a passive
                 // `status` read that removed it would give that breadcrumb a false
@@ -644,12 +644,12 @@ public static class DaemonCommands {
 
                     if (clean) {
                         // Delete the daemon-owned markers WHILE still holding the
-                        // probe's flock (AI-1155): a concurrent `daemon start` must
+                        // probe's flock: a concurrent `daemon start` must
                         // take this same flock, so it can't slip a live daemon in
                         // and have us unlink its fresh PID. Do NOT delete the lock
                         // file — unlinking it (even while holding it) lets a later
                         // start create a new lock inode and acquire a SECOND
-                        // independent flock at the same path (AI-630). Leave it;
+                        // independent flock at the same path. Leave it;
                         // it's inert and the next start reuses it.
                         try { File.Delete(pidPath); } catch {
                             /* best-effort */
@@ -693,7 +693,7 @@ public static class DaemonCommands {
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         if (lines.Length == 0 || !int.TryParse(lines[0], out var pid)) {
-            // AI-1155: report "no usable PID" but do NOT delete the file. The
+            // report "no usable PID" but do NOT delete the file. The
             // daemon writes it with File.WriteAllText (truncate+write) under the
             // flock, so a SIGKILL/native abort mid-write can leave a present but
             // empty/partial/unparseable file — which is itself a hard-death
@@ -720,7 +720,7 @@ public static class DaemonCommands {
     ///
     /// The name fallback applies only when the token can't be compared at all:
     /// no token recorded, the live token is unreadable, or the recorded token is
-    /// a legacy/foreign scheme — notably a pre-AI-839 PID file that stored bare
+    /// a legacy/foreign scheme — notably a PID file that stored bare
     /// <c>Process.StartTime</c> ticks. Falling back there keeps a still-running
     /// old daemon manageable across an upgrade instead of stranding it.
     /// </summary>

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -320,7 +320,7 @@ public static class DaemonCommands {
         if (ReadPidFile(name) is not { } entry) {
             // ReadPidFile returns null for BOTH an absent file and a present-but-
             // unparseable one (empty/partial — e.g. a mid-write SIGKILL; it no
-            // longer unlinks the latter,).
+            // longer unlinks the latter).
             if (!File.Exists(DaemonLockPaths.PidPath(name))) {
                 Console.Error.WriteLine($"No daemon '{name}' running (no PID file found).");
 

--- a/src/Capacitor.Cli/Commands/EndedAtResolvers.cs
+++ b/src/Capacitor.Cli/Commands/EndedAtResolvers.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Per-vendor `ended_at` resolution (AI-1358 A3). The rule is NOT one blanket helper:
+/// Per-vendor `ended_at` resolution. The rule is NOT one blanket helper:
 /// vendors whose records carry durable timestamps use a tail-scan; Copilot's best end is the
 /// final `session.shutdown` record (which the import-relevance helper deliberately skips —
 /// this resolver must NOT inherit that skip contract); Cursor has no durable record timestamp

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -8,7 +8,7 @@ using Capacitor.Cli.Core.Gemini;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Single-binary dispatcher for Google Gemini CLI hooks (AI-887). Unlike
+/// Single-binary dispatcher for Google Gemini CLI hooks. Unlike
 /// Copilot, Gemini's command-hook stdin payload carries a uniform
 /// <c>hook_event_name</c> (PascalCase: <c>SessionStart</c> / <c>SessionEnd</c> /
 /// <c>Notification</c>), so this dispatcher self-routes on it like Claude — the
@@ -24,13 +24,13 @@ namespace Capacitor.Cli.Commands;
 ///                  so the server's deterministic lifecycle ids make the re-POST
 ///                  idempotent and the watcher resumes from the server watermark.
 ///   SessionEnd   → kill watcher + capped inline drain (mirror of the Copilot /
-///                  Claude AI-813 pre-drain cap), then POST /hooks/session-end/gemini.
+///                  Claude pre-drain cap), then POST /hooks/session-end/gemini.
 ///   Notification → best-effort forward to the Claude-shaped /hooks/notification.
 /// Gemini treats hook stdout as a JSON decision channel; this dispatcher emits
 /// nothing (no stdout) so every action is allowed.
 /// </remarks>
 static class GeminiHookCommand {
-    // Mirror of CopilotHookCommand.PreHookDrainCap (AI-813): the drain must
+    // Mirror of CopilotHookCommand.PreHookDrainCap: the drain must
     // never starve the session-end POST, or the session sticks "Active".
     static readonly TimeSpan PreHookDrainCap = TimeSpan.FromSeconds(8);
 
@@ -68,7 +68,7 @@ static class GeminiHookCommand {
             return 0;
         }
 
-        // AI-1357 Task 12: the cross-vendor backlog drain now runs centrally in Program.cs's
+        // Task 12: the cross-vendor backlog drain now runs centrally in Program.cs's
         // `case "hook":` before dispatch — no longer wired here (removes the double-wire).
         var spool = new HookSpool(PathHelpers.ConfigPath("spool"));
 
@@ -108,7 +108,7 @@ static class GeminiHookCommand {
         if (cwd is not null) {
             forwarded["cwd"] = cwd;
 
-            // AI-701: best-effort git-root discovery, fail-open (omitted when no repo is found).
+            // best-effort git-root discovery, fail-open (omitted when no repo is found).
             if (GitRepository.FindRoot(cwd) is { } workspaceRoot) forwarded["workspace_root"] = workspaceRoot;
         }
 
@@ -137,7 +137,7 @@ static class GeminiHookCommand {
             return 0;
         }
 
-        // Spawn-before-post (AI-1357 Task 6): capture must start on Posted OR Spooled (auth lapse /
+        // Spawn-before-post: capture must start on Posted OR Spooled (auth lapse /
         // outage) — a doomed/delayed lifecycle POST must never withhold the watcher. On a real
         // failure PostOrSpoolAsync already logged to stderr; a lapse or transient outage instead
         // durably spools the payload for a later drain pass. Only a permanent failure keeps the
@@ -148,7 +148,7 @@ static class GeminiHookCommand {
 
         if (!AgentHookPoster.ShouldSpawnAfter(outcome)) return outcome == HookPostOutcome.Failed ? 1 : 0;
 
-        // AI-1357 Task 6: await (was fire-and-forget) so a spawn failure is observed here rather
+        // Task 6: await (was fire-and-forget) so a spawn failure is observed here rather
         // than silently swallowed, and the process isn't torn down before the spawn completes.
         await EnsureWatcher(baseUrl, sessionId, node, cwd, source);
         return 0;
@@ -156,7 +156,7 @@ static class GeminiHookCommand {
 
     /// <summary>Test seam mirroring <see cref="AgentHookPoster.ShouldSpawnAfter"/> — session-start
     /// capture must start on <c>Posted</c> OR <c>Spooled</c>, never gated behind lifecycle-POST
-    /// delivery (AI-1357 Task 6).</summary>
+    /// delivery.</summary>
     internal static bool SpawnGateForTest(HookPostOutcome o) => AgentHookPoster.ShouldSpawnAfter(o);
 
     static async Task<int> HandleSessionEnd(string baseUrl, JsonNode node, string sessionId, string? cwd) {
@@ -176,7 +176,7 @@ static class GeminiHookCommand {
                         // teardown: kill each live child watcher, drain its tail, and finalize
                         // it (subagent-stop). Restart-safe — driven off the on-disk files,
                         // not an in-memory set. Shared with the watcher's parent-exit fallback
-                        // so a crash that bypasses this hook still finalizes subagents (AI-900).
+                        // so a crash that bypasses this hook still finalizes subagents.
                         await GeminiSubagentTeardown.DrainAsync(baseUrl, sessionId, transcriptPath);
                     },
                     PreHookDrainCap
@@ -259,7 +259,7 @@ static class GeminiHookCommand {
         // one and resume appends to the same transcript.
         var skipTitle = source is "resume" or "clear";
 
-        // AI-1357 Task 6: awaited (was fire-and-forget `_ =`) so a spawn failure surfaces to the
+        // Task 6: awaited (was fire-and-forget `_ =`) so a spawn failure surfaces to the
         // caller instead of being silently dropped, and the host process doesn't exit before the
         // spawn completes.
         await WatcherManager.EnsureWatcherRunning(

--- a/src/Capacitor.Cli/Commands/GeminiSubagentTeardown.cs
+++ b/src/Capacitor.Cli/Commands/GeminiSubagentTeardown.cs
@@ -6,7 +6,7 @@ using Capacitor.Cli.Core.Gemini;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Shared session-end teardown for live Gemini subagents (AI-900). Gemini fires no
+/// Shared session-end teardown for live Gemini subagents. Gemini fires no
 /// subagent-stop hook, and the child watchers the parent spawns carry no parent-pid
 /// watchdog, so the parent session-end is the ONLY thing that finalizes them: for each
 /// nested subagent transcript, kill its child watcher (no-op if already gone), drain its

--- a/src/Capacitor.Cli/Commands/GuardedDiscovery.cs
+++ b/src/Capacitor.Cli/Commands/GuardedDiscovery.cs
@@ -1,7 +1,7 @@
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Shared symlink/cycle/depth-guarded file enumeration for import discovery (AI-1358 A4).
+/// Shared symlink/cycle/depth-guarded file enumeration for import discovery.
 /// Only Claude previously resolved link targets + deduped by real path; every routed source
 /// now shares this so a symlinked/large session tree can't loop, explode, or abort a pass.
 /// </summary>

--- a/src/Capacitor.Cli/Commands/IImportSource.cs
+++ b/src/Capacitor.Cli/Commands/IImportSource.cs
@@ -47,7 +47,7 @@ internal enum ImportOutcome { Loaded, Resumed, Skipped, Failed }
 
 /// <summary>
 /// Result of <see cref="IImportSource.ImportSessionAsync"/>. <c>SentChildContent</c> is the
-/// real "did new work actually happen" signal (AI-1154 review fix, finding 1): it's true only
+/// real "did new work actually happen" signal: it's true only
 /// when this call POSTed brand-new nested subagent-child transcript bytes (Cursor's inline
 /// child import, under a parent whose own top-level watermark may not have moved at all). The
 /// parent classification/outcome pair alone can't distinguish that from a genuine "nothing to

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -358,7 +358,7 @@ static class ImportCommand {
     }
 
     /// <summary>
-    /// AI-1154 review fix (P2, broadened by the round-2 follow-up findings): a routed-phase
+    /// a routed-phase
     /// <c>AlreadyLoaded</c> classification (Cursor) is included in `routed` solely so its
     /// <c>ImportSessionAsync</c> call can re-assert lifecycle hooks and backfill the
     /// <c>repository</c> node on an already-fully-ingested session (the C2 suppressed-repo-import
@@ -992,7 +992,7 @@ static class ImportCommand {
         // contract was New/Partial only — but if a previous import advanced
         // the transcript watermark while a lifecycle POST failed, the session
         // is forever lifecycle-less under the old filter. Server-side
-        // idempotency (canonical event ids per AI-731) makes re-emission safe;
+        // idempotency (canonical event ids per) makes re-emission safe;
         // CursorImportSource.ImportSessionAsync short-circuits the transcript
         // batch when there's nothing past the watermark and just fires the
         // lifecycle hooks.
@@ -1003,7 +1003,7 @@ static class ImportCommand {
             )
             .ToList();
 
-        // AI-1156 (D5): a Cursor subagent child whose correlated parent isn't itself among
+        // a Cursor subagent child whose correlated parent isn't itself among
         // `routed` (e.g. `--session <child>` excluded the parent from this run's classify slice,
         // or the parent was classified but excluded from import for any other reason) must import
         // standalone rather than being silently dropped by CursorImportSource.ImportSessionAsync's
@@ -1127,9 +1127,9 @@ static class ImportCommand {
         // sub-grid attributes Skipped-at-import to Excluded (not Errored).
         var routedOutcomesByVendor = new ConcurrentDictionary<string, (int Loaded, int Skipped, int Failed)>(StringComparer.Ordinal);
 
-        // AI-1154 review fix (r6, P1): a SEPARATE tracker from `importedSessionIds`, used
+        // a SEPARATE tracker from `importedSessionIds`, used
         // ONLY to decide what gets privatized under --private — never fed into the Done-grid
-        // counting (`importedSessionIds`/`doneBySource` stay exactly as they were; the AI-1389
+        // counting (`importedSessionIds`/`doneBySource` stay exactly as they were; the
         // cosmetic double-count concern is intentionally left alone). `importedSessionIds`
         // only gains a Cursor session id when this run did "real new work" by the
         // Loaded/Failed/AlreadyLoaded + SentChildContent accounting — but privacy must NOT
@@ -1174,7 +1174,7 @@ static class ImportCommand {
                             // lines are posted: MaxValue is the session's sendable-line count and
                             // Value advances per flushed batch via OnSessionProgress. A slot that
                             // has no batch yet (or whose total couldn't be counted) draws an
-                            // indeterminate stripe rather than a stuck 0% (AI-907).
+                            // indeterminate stripe rather than a stuck 0%.
                             var slots = new ProgressTask[ImportWorkerCount];
 
                             for (var i = 0; i < ImportWorkerCount; i++) {
@@ -1326,7 +1326,7 @@ static class ImportCommand {
                                     var result  = await ImportOne(c);
                                     var outcome = result.Outcome;
 
-                                    // AI-1154 review fix (r6, P1): capture for privatization BEFORE
+                                    // capture for privatization BEFORE
                                     // any Loaded/Failed/AlreadyLoaded classification below — see the
                                     // declaration comment on privateScopeSessionIds. Deliberately
                                     // unconditional: even a Failed outcome (lifecycle POST failed
@@ -1335,7 +1335,7 @@ static class ImportCommand {
                                         privateScopeSessionIds.Add(c.SessionId);
                                     }
 
-                                    // AI-1154 review fix (P2, broadened by the round-2 follow-up):
+                                    // review fix (P2, broadened by the round-2 follow-up):
                                     // an AlreadyLoaded session's routed call is a lifecycle/repo-
                                     // backfill replay (or, for a nested child, an inline-handled
                                     // no-op), not a new import — it must not double-count on top
@@ -1415,13 +1415,13 @@ static class ImportCommand {
                         var result  = await ImportOne(c);
                         var outcome = result.Outcome;
 
-                        // AI-1154 review fix (r6, P1): see the Tty branch above — unconditional
+                        // see the Tty branch above — unconditional
                         // privatization capture, independent of the outcome classification below.
                         if (forcePrivate && c.Vendor == "cursor") {
                             privateScopeSessionIds.Add(c.SessionId);
                         }
 
-                        // AI-1154 review fix (P2, broadened by the round-2 follow-up): see the
+                        // see the
                         // Tty branch above for why an AlreadyLoaded lifecycle-only replay must
                         // not count as Loaded/Excluded, and why sentChildContent overrides that
                         // for a parent that attached brand-new nested-child content.
@@ -1470,7 +1470,7 @@ static class ImportCommand {
 
         // --- --private: mark all imported sessions owner-only ---
         //
-        // AI-1154 review fix (r6, P1): the privatize set is importedSessionIds (chain-phase +
+        // the privatize set is importedSessionIds (chain-phase +
         // routed-phase "real new work") UNIONED with privateScopeSessionIds (every Cursor
         // routed classification touched this run under --private, regardless of outcome — see
         // its declaration above). The union — not a replacement — keeps chain-phase and
@@ -1732,7 +1732,7 @@ static class ImportCommand {
                 }
             }
 
-            // Scan from the end. Confirmed (AI-1358 A3.3) that Codex rollout
+            // Scan from the end. Confirmed that Codex rollout
             // records also key their per-record timestamp under root-level
             // "timestamp" (same envelope shape session_meta/response_item/
             // event_msg all share) — verified against
@@ -1986,7 +1986,7 @@ static class ImportCommand {
     /// <summary>
     /// Build a SessionId → repo lookup for every discovered transcript. Repo
     /// detection (git + `gh pr view`) is the slow part of the discovery phase
-    /// and ran sequentially per-session pre-AI-692, making `kcap import`
+    /// and previously ran sequentially per-session, making `kcap import`
     /// look frozen on large histories. This version deduplicates by cwd
     /// (transcripts in the same project share a repo) and runs detection in
     /// parallel, surfacing progress via a Spectre status spinner on a TTY and
@@ -2095,7 +2095,7 @@ static class ImportCommand {
             // segment). Trim the last separator-delimited segment ourselves
             // instead of Path.GetDirectoryName, which on Windows normalizes
             // '/' → '\' and would break the Ordinal set comparison for
-            // forward-slash transcript cwds (AI-820). Both '/' and '\' are
+            // forward-slash transcript cwds. Both '/' and '\' are
             // honored so mixed-style paths collapse consistently on every OS.
             var parent = TrimLastSegment(path);
 
@@ -2533,7 +2533,7 @@ static class ImportCommand {
         // Denominator for the per-slot progress bar: the number of parent-transcript
         // lines this import will POST. For a resume, only the lines past the server's
         // watermark are sent. 0 when the file is missing/unreadable — the slot then
-        // stays indeterminate instead of stuck at 0% (AI-907). Skipped entirely when
+        // stays indeterminate instead of stuck at 0%. Skipped entirely when
         // no live bar consumes it (non-TTY) so we don't pre-scan every transcript.
         var sendableTotal = events.TrackPerSessionProgress
             ? SessionImporter.CountSendableLines(
@@ -2624,7 +2624,7 @@ static class ImportCommand {
         if (session.PreviousSessionId is not null) startHook["previous_session_id"] = session.PreviousSessionId;
         if (meta.Slug is not null) startHook["slug"]                                = meta.Slug;
 
-        // AI-701: best-effort git-root discovery from the (already remap-resolved) cwd, so
+        // best-effort git-root discovery from the (already remap-resolved) cwd, so
         // historical imports carry the same workspace_root the live hooks do. Fail-open:
         // GitRepository.FindRoot swallows I/O errors and returns null when no repo is found
         // on this machine (e.g. the recorded path no longer exists), in which case the field

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -358,7 +358,7 @@ static class ImportCommand {
     }
 
     /// <summary>
-    /// a routed-phase
+    /// A routed-phase
     /// <c>AlreadyLoaded</c> classification (Cursor) is included in `routed` solely so its
     /// <c>ImportSessionAsync</c> call can re-assert lifecycle hooks and backfill the
     /// <c>repository</c> node on an already-fully-ingested session (the C2 suppressed-repo-import
@@ -992,7 +992,7 @@ static class ImportCommand {
         // contract was New/Partial only — but if a previous import advanced
         // the transcript watermark while a lifecycle POST failed, the session
         // is forever lifecycle-less under the old filter. Server-side
-        // idempotency (canonical event ids per) makes re-emission safe;
+        // idempotency (canonical event ids) makes re-emission safe;
         // CursorImportSource.ImportSessionAsync short-circuits the transcript
         // batch when there's nothing past the watermark and just fires the
         // lifecycle hooks.

--- a/src/Capacitor.Cli/Commands/KiroHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/KiroHookCommand.cs
@@ -6,7 +6,7 @@ using Capacitor.Cli.Core.Kiro;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Single-binary dispatcher for AWS Kiro CLI hooks (AI-888). Kiro (the rebranded
+/// Single-binary dispatcher for AWS Kiro CLI hooks. Kiro (the rebranded
 /// Amazon Q Developer CLI) delivers each hook as JSON on STDIN; the kcap
 /// installer writes one entry per event with the event name embedded in the
 /// command: <c>kcap hook --kiro --event agentSpawn</c>.
@@ -70,7 +70,7 @@ static class KiroHookCommand {
         // disable` must stop every POST and watcher restart for the session.
         if (DisabledSessions.IsDisabled(sessionId)) return 0;
 
-        // AI-1357 Task 12: the cross-vendor backlog drain now runs centrally in Program.cs's
+        // Task 12: the cross-vendor backlog drain now runs centrally in Program.cs's
         // `case "hook":` before dispatch — no longer wired here (removes the double-wire).
         var spool = new HookSpool(PathHelpers.ConfigPath("spool"));
 
@@ -106,7 +106,7 @@ static class KiroHookCommand {
         if (cwd is not null) {
             forwarded["cwd"] = cwd;
 
-            // AI-701: best-effort git-root discovery, fail-open (omitted when no repo is found).
+            // best-effort git-root discovery, fail-open (omitted when no repo is found).
             if (GitRepository.FindRoot(cwd) is { } workspaceRoot) forwarded["workspace_root"] = workspaceRoot;
         }
 
@@ -137,7 +137,7 @@ static class KiroHookCommand {
             return 0;
         }
 
-        // Spawn-before-post (AI-1357): capture must start on Posted OR Spooled (auth lapse /
+        // Spawn-before-post: capture must start on Posted OR Spooled (auth lapse /
         // outage) — a doomed/delayed lifecycle POST must never withhold the watcher. On a real
         // failure PostOrSpoolAsync already logged to stderr; a lapse or transient outage instead
         // durably spools the payload for a later drain pass. Only a permanent failure skips the

--- a/src/Capacitor.Cli/Commands/KiroImportSource.cs
+++ b/src/Capacitor.Cli/Commands/KiroImportSource.cs
@@ -309,7 +309,7 @@ internal sealed class KiroImportSource : IImportSource {
             ["session_id"]      = sessionId,
         };
         if (cwd is not null) payload["cwd"] = cwd;
-        // AI-701 (finding 4): fail-open git-root discovery, mirroring ImportChainsAsync
+        // fail-open git-root discovery, mirroring ImportChainsAsync
         // so routed imports carry the same workspace_root the file-based path does.
         if (cwd is not null && GitRepository.FindRoot(cwd) is { } workspaceRoot) payload["workspace_root"] = workspaceRoot;
         if (model is not null) payload["model"] = model;

--- a/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
@@ -12,8 +12,8 @@ using Capacitor.Cli.Core.Auth;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// AI-1139: reviewer/participant-side MCP server injected into hosted review-flow launches.
-/// Exposes submit_review_result (POSTs to /api/flows/reviewer/result) and, as of AI-1127 E-c,
+/// reviewer/participant-side MCP server injected into hosted review-flow launches.
+/// Exposes submit_review_result (POSTs to /api/flows/reviewer/result) and, as of E-c,
 /// send_flow_message (POSTs to /api/flows/participant/message) — the only two tools a hosted
 /// participant needs. Deliberately a SEPARATE command from `kcap mcp flows` — a hard security
 /// boundary so no flag regression can ever expose start_review_flow to an unattended reviewer.
@@ -24,7 +24,7 @@ static class McpFlowResultServer {
     const int MaxAttempts = 5;
     static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(3);
 
-    // AI-1127 E-0 (AI-1190): the server no longer reads the transcript — markers deliver
+    // E-0: the server no longer reads the transcript — markers deliver
     // nothing, so the only useful guidance on failure is to retry the tool itself.
     const string FallbackHint =
         "Retry this tool call — it is the ONLY delivery channel. Do NOT fall back to FINDINGS:/NO FINDINGS markers in your reply: the server does not read the transcript, so a marker delivers nothing.";
@@ -204,7 +204,7 @@ static class McpFlowResultServer {
             if (code == "stale_round_token")
                 // Deliberately NO retry hint: a stale round token means this round is already
                 // closed — the result must be discarded, never redelivered (spec-review round 2
-                // finding; the AI-1139 round-token guard).
+                // finding; the round-token guard).
                 return ($"Error: {message}", true);
 
             if (code == "server_catching_up")
@@ -222,7 +222,7 @@ static class McpFlowResultServer {
         }
     }
 
-    /// <summary>AI-1127 E-c: validation + POST + retry policy for the participant's out-of-band
+    /// <summary> E-c: validation + POST + retry policy for the participant's out-of-band
     /// note to the driver. Mirrors SubmitCoreAsync's structure. <paramref name="messageId"/> is
     /// generated ONCE per tool call (by the caller's default) and reused across every retry
     /// attempt below, so the server can dedupe a redelivered POST instead of recording the same
@@ -383,7 +383,7 @@ record SubmitReviewerResultDto(
     [property: JsonPropertyName("text")]        string? Text
 );
 
-/// <summary>CLI-side DTO for POST /api/flows/participant/message — mirrors the server's request shape (AI-1127 E-c).</summary>
+/// <summary>CLI-side DTO for POST /api/flows/participant/message — mirrors the server's request shape (E-c).</summary>
 record SendFlowMessageDto(
     [property: JsonPropertyName("agent_id")]   string AgentId,
     [property: JsonPropertyName("message_id")] string MessageId,

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -29,7 +29,7 @@ static class McpFlowsServer {
         var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
 
         // The authenticated client is created on the first tools/call, not at startup: kcap-flows
-        // auto-registers (AI-1056), so Claude Code spawns `kcap mcp flows` for every session —
+        // auto-registers, so Claude Code spawns `kcap mcp flows` for every session —
         // deferring keeps startup local-only (no GET /auth/config, token load, or stderr re-auth
         // hint) for sessions that never invoke a flows tool. Created on demand into a nullable
         // field (rather than a Lazy<Task>) so a transient creation failure leaves it null and the
@@ -49,7 +49,7 @@ static class McpFlowsServer {
             try {
                 if (client is null) {
                     client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
-                    // AI-1061: the review-flow endpoints long-poll (start_review_flow /
+                    // the review-flow endpoints long-poll (start_review_flow /
                     // submit_review_round block server-side up to ~10 min while the reviewer runs).
                     // The default 100s timeout would abort the POST, which the server sees as a
                     // cancel and tears the reviewer down — so disable the client-side deadline and
@@ -182,13 +182,13 @@ static class McpFlowsServer {
             if (toolName is "get_review_flow_status" or "get_flow_status") {
                 statusPayload = FormatStatusResponse(body, out var pendingIds);
 
-                // AI-1127 E-c: ack exactly the ids that were actually rendered into the text
+                // E-c: ack exactly the ids that were actually rendered into the text
                 // above, after the text is fully built — never before, never a superset.
                 var flowRunId = arguments?["flow_run_id"]?.GetValue<string>();
                 if (flowRunId is not null)
                     await AckRenderedMessagesAsync(client, apiRoot, flowRunId, pendingIds, Task.Delay);
             } else if (toolName is "close_review_flow" or "close_flow") {
-                // AI-1127 E-c: render pending_messages but never ack them — the server delivers
+                // E-c: render pending_messages but never ack them — the server delivers
                 // them atomically with the close, so there is nothing left to redeliver.
                 statusPayload = FormatCloseResponse(body, out _);
             } else {
@@ -231,7 +231,7 @@ static class McpFlowsServer {
     /// <summary>
     /// Posts to POST /api/flows/review/start. Shared by start_review_flow (reads the flow
     /// kind from the "kind" arg) and its generic alias start_flow (reads it from
-    /// "definition_id" — the server treats kind == definition id, AI-1126 phase C).
+    /// "definition_id" — the server treats kind == definition id, phase C).
     /// start_flow additionally accepts an inline "definition_yaml" (dynamic flows): the MCP
     /// schema can't express the xor, so exactly-one is enforced here, BEFORE any HTTP call;
     /// start_review_flow stays catalog-only (kind remains required there).
@@ -268,7 +268,7 @@ static class McpFlowsServer {
 
         var sessionId = ArgParsing.ResolveSessionIdFromEnv();
 
-        // AI-1207 B2: this machine's stable id, matched server-side against each connected daemon's
+        // B2: this machine's stable id, matched server-side against each connected daemon's
         // registration id to prove the reviewer would run on the SAME host as this requester. Same
         // call the daemon reports at registration (ServerConnection), so the ids are identical — the
         // last piece that lets the server pick the borrow path instead of a mirrored worktree.
@@ -354,7 +354,7 @@ static class McpFlowsServer {
     static readonly TimeSpan PollCap        = TimeSpan.FromMinutes(8);   // safely below MCP_TOOL_TIMEOUT
     static readonly TimeSpan PerGetTimeout  = TimeSpan.FromSeconds(20);
     static readonly TimeSpan NotFoundGrace  = TimeSpan.FromSeconds(10);
-    // AI-1127 E-c final review, Important: the shared client has Timeout = InfiniteTimeSpan (the
+    // E-c final review, Important: the shared client has Timeout = InfiniteTimeSpan (the
     // review-flow endpoints long-poll), so without a per-attempt bound a hung ack POST would block
     // indefinitely — stalling the tool response the driver is waiting on. Mirrors PerGetTimeout's
     // per-attempt bounding of PollUntilTerminalAsync's GETs.
@@ -369,7 +369,7 @@ static class McpFlowsServer {
     // Maximum consecutive transient failures (5xx / network / TLS) before giving up.
     const int MaxTransientRetries = 5;
 
-    /// <summary>AI-1127 E-c: a multi-participant start records the run only — no round exists to
+    /// <summary> E-c: a multi-participant start records the run only — no round exists to
     /// poll, so the old poll path must not run. Returns null unless the body is exactly that shape
     /// (round-full starts and old servers fall through to the existing logic unchanged). Today's
     /// server never puts pending_messages on a round-less start (a brand-new run has no
@@ -437,7 +437,7 @@ static class McpFlowsServer {
     }
 
     /// <summary>If the POST already carries a terminal result (old/blocking server), return it.
-    /// Otherwise poll GET /api/flows/{id} until the started round is terminal (AI-1061).
+    /// Otherwise poll GET /api/flows/{id} until the started round is terminal.
     /// <paramref name="toolName"/> is the tool that initiated the round (one of
     /// start_review_flow/submit_review_round/start_flow/send_to_participant) — threaded through
     /// so the graceful-cap timeout message can point back at the matching status tool.</summary>
@@ -572,7 +572,7 @@ static class McpFlowsServer {
     internal static string FormatPolledRoundResult(JsonObject node, string flowRunId) =>
         FormatPolledRoundResult(node, flowRunId, out _);
 
-    /// <summary>AI-1127 E-c: id-exposing overload — see <see cref="AppendPendingMessages"/>.</summary>
+    /// <summary> E-c: id-exposing overload — see <see cref="AppendPendingMessages"/>.</summary>
     internal static string FormatPolledRoundResult(JsonObject node, string flowRunId, out IReadOnlyList<string> pendingIds) {
         var roundNumber = node["round_number"]?.GetValue<int>();
         var resultKind  = node["round_result_kind"]?.GetValue<string>() ?? node["round_status"]?.GetValue<string>() ?? "";
@@ -595,7 +595,7 @@ static class McpFlowsServer {
     /// </summary>
     internal static string FormatRoundResponse(string body) => FormatRoundResponse(body, out _);
 
-    /// <summary>AI-1127 E-c: id-exposing overload — see <see cref="AppendPendingMessages"/>.</summary>
+    /// <summary> E-c: id-exposing overload — see <see cref="AppendPendingMessages"/>.</summary>
     internal static string FormatRoundResponse(string body, out IReadOnlyList<string> pendingIds) {
         try {
             var node = JsonNode.Parse(body)?.AsObject();
@@ -628,7 +628,7 @@ static class McpFlowsServer {
 
     internal static string FormatStatusResponse(string body) => FormatStatusResponse(body, out _);
 
-    /// <summary>AI-1127 E-c: id-exposing overload — see <see cref="AppendPendingMessages"/>.</summary>
+    /// <summary> E-c: id-exposing overload — see <see cref="AppendPendingMessages"/>.</summary>
     internal static string FormatStatusResponse(string body, out IReadOnlyList<string> pendingIds) {
         try {
             var node = JsonNode.Parse(body)?.AsObject();
@@ -676,7 +676,7 @@ static class McpFlowsServer {
     /// </summary>
     internal static string FormatCloseResponse(string body) => FormatCloseResponse(body, out _);
 
-    /// <summary>AI-1127 E-c: id-exposing overload — see <see cref="AppendPendingMessages"/>.</summary>
+    /// <summary> E-c: id-exposing overload — see <see cref="AppendPendingMessages"/>.</summary>
     internal static string FormatCloseResponse(string body, out IReadOnlyList<string> pendingIds) {
         try {
             var node = JsonNode.Parse(body)?.AsObject();
@@ -697,7 +697,7 @@ static class McpFlowsServer {
         }
     }
 
-    /// <summary>AI-1127 E-c: renders the fold-computed undelivered sidecar messages carried on a
+    /// <summary> E-c: renders the fold-computed undelivered sidecar messages carried on a
     /// status/round/close response. Returns the rendered ids so the caller can ack exactly what
     /// the driver will actually see (never more).</summary>
     internal static IReadOnlyList<string> AppendPendingMessages(StringBuilder sb, JsonObject node) {
@@ -705,7 +705,7 @@ static class McpFlowsServer {
 
         // Render entries into a scratch buffer first so the header count reflects what actually
         // got rendered, not the raw array length — a malformed (non-object) entry is skipped
-        // below, and the header must not overcount past what the driver will see (AI-1127 E-c
+        // below, and the header must not overcount past what the driver will see (E-c
         // final review, Minor: header used arr.Count while entries were filtered).
         var ids     = new List<string>();
         var entries = new StringBuilder();
@@ -740,7 +740,7 @@ static class McpFlowsServer {
     static string StringField(JsonObject o, string name) =>
         o[name] is JsonValue v && v.TryGetValue<string>(out var s) ? s : "";
 
-    /// <summary>AI-1127 E-c: deliver-once ack for pending messages. Callers must invoke this
+    /// <summary> E-c: deliver-once ack for pending messages. Callers must invoke this
     /// AFTER the response text has been fully formatted, passing only the ids that were actually
     /// rendered into that text — never before, never a superset. No-op (no HTTP call at all) when
     /// <paramref name="messageIds"/> is empty, which keeps this byte-compatible with servers that
@@ -762,7 +762,7 @@ static class McpFlowsServer {
 
         async Task<bool> TryPostAsync() {
             try {
-                // AI-1127 E-c final review, Important: bound each attempt — the shared client has
+                // E-c final review, Important: bound each attempt — the shared client has
                 // no client-side deadline (Timeout = InfiniteTimeSpan, needed for the long-polling
                 // round endpoints), so an unbounded ack POST could hang the tool response the
                 // driver is waiting on. A timeout surfaces as OperationCanceledException, which
@@ -994,7 +994,7 @@ record StartReviewFlowDto(
 
 /// <summary>
 /// CLI-side DTO for POST /api/flows/{flowRunId}/rounds — mirrors the server's SubmitReviewRoundRequest.
-/// Participant is optional (AI-1126 D-b): the review alias (submit_review_round) always leaves it
+/// Participant is optional (D-b): the review alias (submit_review_round) always leaves it
 /// null, which the WhenWritingNull context config omits from the wire entirely, keeping the alias
 /// byte-compatible with servers that predate the field. The generic alias (send_to_participant)
 /// always supplies it; the server validates it against the flow definition.
@@ -1006,7 +1006,7 @@ record SubmitReviewRoundDto(
     [property: JsonPropertyName("participant")]  string? Participant = null
 );
 
-/// <summary>CLI-side DTO for POST /api/flows/{flowRunId}/messages/ack — AI-1127 E-c deliver-once ack.</summary>
+/// <summary>CLI-side DTO for POST /api/flows/{flowRunId}/messages/ack — E-c deliver-once ack.</summary>
 record AckFlowMessagesDto(
     [property: JsonPropertyName("message_ids")] IReadOnlyList<string> MessageIds
 );

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -231,7 +231,7 @@ static class McpMemoryServer {
     }
 
     // NOTE: request bodies use snake_case keys (repo_hash, machine_tag, source_session_id) —
-    // the server's global JSON policy is JsonNamingPolicy.SnakeCaseLower (see AI-1134 task 9).
+    // the server's global JSON policy is JsonNamingPolicy.SnakeCaseLower.
     // Responses are passed through as raw text, so only these request-body builders are affected.
     internal static JsonObject BuildSaveBody(JsonObject? args, string? cwdRepoHash, string? machineId) {
         string Req(string name) =>

--- a/src/Capacitor.Cli/Commands/McpProtocol.cs
+++ b/src/Capacitor.Cli/Commands/McpProtocol.cs
@@ -7,7 +7,7 @@ namespace Capacitor.Cli.Commands;
 /// Shared MCP protocol plumbing so every kcap MCP server answers the standard capability
 /// probes (<c>resources/list</c>, <c>prompts/list</c>, <c>ping</c>) and negotiates the
 /// protocol version — instead of returning <c>-32601</c>, which some clients treat as fatal
-/// and drop the server (the likely root of). JsonNode DOM only → AOT-safe.
+/// and drop the server. JsonNode DOM only → AOT-safe.
 /// </summary>
 static class McpProtocol {
     /// The version we advertise when we don't recognise the client's request.

--- a/src/Capacitor.Cli/Commands/McpProtocol.cs
+++ b/src/Capacitor.Cli/Commands/McpProtocol.cs
@@ -7,7 +7,7 @@ namespace Capacitor.Cli.Commands;
 /// Shared MCP protocol plumbing so every kcap MCP server answers the standard capability
 /// probes (<c>resources/list</c>, <c>prompts/list</c>, <c>ping</c>) and negotiates the
 /// protocol version — instead of returning <c>-32601</c>, which some clients treat as fatal
-/// and drop the server (the likely root of AI-1132). JsonNode DOM only → AOT-safe.
+/// and drop the server (the likely root of). JsonNode DOM only → AOT-safe.
 /// </summary>
 static class McpProtocol {
     /// The version we advertise when we don't recognise the client's request.

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -291,7 +291,7 @@ static class McpWorkItemsServer {
         new("declare_work_item",
             "Attach the CURRENT session (and its continuation chain) to a work item on the Capacitor server. Provide exactly one of issue_key, pr_number, work_item_id, or new_title.",
             new("object", new() {
-                ["issue_key"]    = new("string", "Attach to the work item for this issue key (e.g. 'AI-1234'), creating it if none exists yet."),
+                ["issue_key"]    = new("string", "Attach to the work item for this issue key (e.g. 'PROJ-1234'), creating it if none exists yet."),
                 ["pr_number"]    = new("integer", "Attach to the work item for this PR number, creating it if none exists yet."),
                 ["work_item_id"] = new("string", "Attach directly to this work item id."),
                 ["new_title"]    = new("string", "Create a brand-new work item with this title and attach to it."),

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -9,7 +9,7 @@ using Capacitor.Cli.Core.Auth;
 
 namespace Capacitor.Cli.Commands;
 
-/// <summary>AI-1264 P2 task 17: MCP tools for the work-items correlation surface — attach the
+/// <summary> P2 task 17: MCP tools for the work-items correlation surface — attach the
 /// current session (and its continuation chain) to a work item, and list what a session is
 /// already attached to. Cloned from <see cref="McpMemoryServer"/>'s stdio JSON-RPC loop; unlike
 /// memory this server has no repo/machine context to resolve — the only per-call input is the
@@ -195,7 +195,7 @@ static class McpWorkItemsServer {
     }
 
     // NOTE: request bodies use snake_case keys — the server's global JSON policy is
-    // JsonNamingPolicy.SnakeCaseLower (see AI-1134 task 9). Responses are passed through as raw
+    // JsonNamingPolicy.SnakeCaseLower. Responses are passed through as raw
     // text, so only this request-body builder is affected. The server enforces "exactly one of
     // issue_key/pr_number/work_item_id/new_title" (400 on violation) — this builder passes
     // through whichever selector(s) were supplied and lets that validation surface as a tool

--- a/src/Capacitor.Cli/Commands/OpenCodeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/OpenCodeHookCommand.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Core.Config;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Dispatcher for the SST OpenCode live-ingest plugin (AI-919). OpenCode has no
+/// Dispatcher for the SST OpenCode live-ingest plugin. OpenCode has no
 /// shell hooks; the shipped <c>kcap.ts</c> plugin invokes:
 ///   <c>kcap hook --opencode --event session-start --session &lt;id&gt; --file &lt;path&gt; [--cwd &lt;cwd&gt;] [--model &lt;m&gt;] [--provider &lt;p&gt;] [--version &lt;v&gt;]</c>
 ///
@@ -47,7 +47,7 @@ static class OpenCodeHookCommand {
         // and watcher restart for the session.
         if (DisabledSessions.IsDisabled(sessionId)) return 0;
 
-        // AI-1357 Task 12: the cross-vendor backlog drain now runs centrally in Program.cs's
+        // Task 12: the cross-vendor backlog drain now runs centrally in Program.cs's
         // `case "hook":` before dispatch — no longer wired here (removes the double-wire).
         var spool = new HookSpool(PathHelpers.ConfigPath("spool"));
 
@@ -84,7 +84,7 @@ static class OpenCodeHookCommand {
         if (cwd is not null) {
             forwarded["cwd"] = cwd;
 
-            // AI-701: best-effort git-root discovery, fail-open (omitted when no repo is found).
+            // best-effort git-root discovery, fail-open (omitted when no repo is found).
             if (GitRepository.FindRoot(cwd) is { } workspaceRoot) forwarded["workspace_root"] = workspaceRoot;
         }
         if (GetArg(args, "--model")    is { } model)    forwarded["model"]            = model;
@@ -110,7 +110,7 @@ static class OpenCodeHookCommand {
             return 0;
         }
 
-        // Spawn-before-post (AI-1357): capture must start on Posted OR Spooled (auth lapse /
+        // Spawn-before-post: capture must start on Posted OR Spooled (auth lapse /
         // outage) — a doomed/delayed lifecycle POST must never withhold the watcher. On a real
         // failure PostOrSpoolAsync already logged to stderr; a lapse or transient outage instead
         // durably spools the payload for a later drain pass. Only a permanent failure skips the

--- a/src/Capacitor.Cli/Commands/OpenCodeSubagentTeardown.cs
+++ b/src/Capacitor.Cli/Commands/OpenCodeSubagentTeardown.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Core.OpenCode;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Shared session-end teardown for live OpenCode subagents (AI-919 phase 2). OpenCode
+/// Shared session-end teardown for live OpenCode subagents. OpenCode
 /// fires no subagent-stop hook and the child watchers the parent spawns carry no
 /// parent-pid watchdog, so the parent session-end is the ONLY thing that finalizes them:
 /// for each nested child transcript the plugin wrote, kill its child watcher (no-op if

--- a/src/Capacitor.Cli/Commands/PiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/PiHookCommand.cs
@@ -29,7 +29,7 @@ namespace Capacitor.Cli.Commands;
 static class PiHookCommand {
     // Pi's extension shells out with a 10s pi.exec timeout (see kcap.ts), so the
     // session-end drain must finish well inside that or the session-end POST is
-    // starved and the session sticks "Active" (mirror of).
+    // starved and the session sticks "Active" (same drain-cap pattern as ClaudeHookCommand's).
     static readonly TimeSpan PreHookDrainCap = TimeSpan.FromSeconds(6);
 
     public static async Task<int> Handle(string baseUrl, string[] args) {
@@ -141,7 +141,7 @@ static class PiHookCommand {
     static async Task<int> HandleSessionEnd(string baseUrl, string sessionId, string file, string? cwd, string? reason) {
         // Kill watcher + inline-drain BEFORE the POST so the server computes
         // stats over the full transcript — capped so a slow drain can't starve
-        // the session-end POST (mirror of ClaudeHookCommand /).
+        // the session-end POST (mirror of ClaudeHookCommand).
         try {
             var drained = await TimeBudget.RunCappedAsync(
                 async () => {

--- a/src/Capacitor.Cli/Commands/PiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/PiHookCommand.cs
@@ -7,7 +7,7 @@ using Capacitor.Cli.Core.Config;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Dispatcher for the Pi (badlogic/pi-mono) live-ingest extension (AI-886). Pi
+/// Dispatcher for the Pi (badlogic/pi-mono) live-ingest extension. Pi
 /// has no shell hooks; the shipped <c>kcap.ts</c> extension invokes this on
 /// Pi's in-process lifecycle events:
 ///   <c>kcap hook --pi --event session-start --file &lt;path&gt; --cwd &lt;cwd&gt; --reason &lt;reason&gt;</c>
@@ -29,7 +29,7 @@ namespace Capacitor.Cli.Commands;
 static class PiHookCommand {
     // Pi's extension shells out with a 10s pi.exec timeout (see kcap.ts), so the
     // session-end drain must finish well inside that or the session-end POST is
-    // starved and the session sticks "Active" (mirror of AI-813).
+    // starved and the session sticks "Active" (mirror of).
     static readonly TimeSpan PreHookDrainCap = TimeSpan.FromSeconds(6);
 
     public static async Task<int> Handle(string baseUrl, string[] args) {
@@ -63,7 +63,7 @@ static class PiHookCommand {
             return 0;
         }
 
-        // AI-1357 Task 12: the cross-vendor backlog drain now runs centrally in Program.cs's
+        // Task 12: the cross-vendor backlog drain now runs centrally in Program.cs's
         // `case "hook":` before dispatch — no longer wired here (removes the double-wire).
         var spool = new HookSpool(PathHelpers.ConfigPath("spool"));
 
@@ -103,7 +103,7 @@ static class PiHookCommand {
         if (cwd is not null) {
             forwarded["cwd"] = cwd;
 
-            // AI-701: best-effort git-root discovery, fail-open (omitted when no repo is found).
+            // best-effort git-root discovery, fail-open (omitted when no repo is found).
             if (GitRepository.FindRoot(cwd) is { } workspaceRoot) forwarded["workspace_root"] = workspaceRoot;
         }
         if (startedAt is { } ts) forwarded["started_at"] = ts.ToString("O");
@@ -121,7 +121,7 @@ static class PiHookCommand {
             return 0;
         }
 
-        // Spawn-before-post (AI-1357): capture must start on Posted OR Spooled (auth lapse /
+        // Spawn-before-post: capture must start on Posted OR Spooled (auth lapse /
         // outage) — a doomed/delayed lifecycle POST must never withhold the watcher. Only a
         // permanent failure keeps the prior non-zero exit and skips the watcher.
         var outcome = await AgentHookPoster.PostOrSpoolAsync(
@@ -141,7 +141,7 @@ static class PiHookCommand {
     static async Task<int> HandleSessionEnd(string baseUrl, string sessionId, string file, string? cwd, string? reason) {
         // Kill watcher + inline-drain BEFORE the POST so the server computes
         // stats over the full transcript — capped so a slow drain can't starve
-        // the session-end POST (mirror of ClaudeHookCommand / AI-813).
+        // the session-end POST (mirror of ClaudeHookCommand /).
         try {
             var drained = await TimeBudget.RunCappedAsync(
                 async () => {

--- a/src/Capacitor.Cli/Commands/PiImportSource.cs
+++ b/src/Capacitor.Cli/Commands/PiImportSource.cs
@@ -165,7 +165,7 @@ internal sealed class PiImportSource : IImportSource {
                 continue;
             }
 
-            // Pi transcript records carry a per-record "timestamp" field (AI-1358 A3);
+            // Pi transcript records carry a per-record "timestamp" field;
             // prefer the tail-scanned last one over file mtime, which can be skewed
             // by unrelated later writes to the same session-scoped file.
             meta.LastTimestamp = EndedAtResolvers.LastTimestampFromJsonl(transcriptPath) ?? TryGetLastWriteUtc(transcriptPath);
@@ -282,7 +282,7 @@ internal sealed class PiImportSource : IImportSource {
             ["source"]          = "startup",
         };
         if (cwd is not null) payload["cwd"] = cwd;
-        // AI-701 (finding 4): fail-open git-root discovery, mirroring ImportChainsAsync
+        // fail-open git-root discovery, mirroring ImportChainsAsync
         // so routed imports carry the same workspace_root the file-based path does.
         if (cwd is not null && GitRepository.FindRoot(cwd) is { } workspaceRoot) payload["workspace_root"] = workspaceRoot;
         if (startedAt is { } ts) payload["started_at"] = ts.ToString("O");
@@ -375,9 +375,9 @@ internal sealed class PiImportSource : IImportSource {
     /// <summary>
     /// True when the line maps to at least one canonical event under the
     /// server's <c>PiTranscriptNormalizer</c>: the <c>session</c> header always
-    /// emits; <c>compaction</c> emits a <c>ContextCompacted</c> (AI-892);
+    /// emits; <c>compaction</c> emits a <c>ContextCompacted</c>;
     /// <c>branch_summary</c> emits an <c>AssistantTextGenerated</c> with Pi metadata
-    /// (AI-892);
+    ///;
     /// <c>message</c> emits for roles user/assistant (non-empty content),
     /// toolResult (has toolCallId), bashExecution (has command). Everything else
     /// (model_change / thinking_level_change / label / session_info / custom*) is

--- a/src/Capacitor.Cli/Commands/PiImportSource.cs
+++ b/src/Capacitor.Cli/Commands/PiImportSource.cs
@@ -376,8 +376,7 @@ internal sealed class PiImportSource : IImportSource {
     /// True when the line maps to at least one canonical event under the
     /// server's <c>PiTranscriptNormalizer</c>: the <c>session</c> header always
     /// emits; <c>compaction</c> emits a <c>ContextCompacted</c>;
-    /// <c>branch_summary</c> emits an <c>AssistantTextGenerated</c> with Pi metadata
-    ///;
+    /// <c>branch_summary</c> emits an <c>AssistantTextGenerated</c> with Pi metadata;
     /// <c>message</c> emits for roles user/assistant (non-empty content),
     /// toolResult (has toolCallId), bashExecution (has command). Everything else
     /// (model_change / thinking_level_change / label / session_info / custom*) is

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -132,7 +132,7 @@ public static class PluginCommand {
                     : $"Plugin installed ({scope}: {settingsPath})"
             );
 
-            // AI-836: Claude Code only loads hooks at session start. A fresh install from
+            // Claude Code only loads hooks at session start. A fresh install from
             // inside a running session won't record it live until the user restarts. The
             // refresh path (npm postinstall) is silent — it isn't an interactive moment and
             // existing sessions already had hooks, so the reminder would be noise.
@@ -378,7 +378,7 @@ public static class PluginCommand {
         // Per-skill preflight runs BEFORE writing hooks so a packaging defect
         // (top-level skills/ present but an individual skill folder missing)
         // can't leave the user with hooks installed and skills not. This is the
-        // atomicity guarantee from AI-676 — either everything installs or nothing.
+        // atomicity guarantee from — either everything installs or nothing.
         var missingSkills = AgentsSkillsInstaller.SourceNames
             .Where(name => !Directory.Exists(Path.Combine(skillsSource, name)))
             .ToList();
@@ -418,7 +418,7 @@ public static class PluginCommand {
 
         AgentsSkillsInstaller.CleanLegacyCodexSkills(env.LegacyCodexSkills);
 
-        // AI-794 — enable Codex sandbox network access so the skills just installed can
+        // enable Codex sandbox network access so the skills just installed can
         // reach the Capacitor server. Opt out with --skip-codex-network-access. The
         // --if-installed refresh path returns earlier, so npm postinstall never flips this.
         if (!args.Contains("--skip-codex-network-access"))
@@ -427,7 +427,7 @@ public static class PluginCommand {
         // Register the kcap MCP servers in ~/.codex/config.toml so Codex CLI picks them up
         // with no manual TOML edit (the plugin descriptor path alone isn't enough — many
         // users never run `codex plugin add`). Non-destructive + idempotent. `kcap-flows`
-        // stays Claude-only (AI-1056). The --if-installed refresh returns earlier, so npm
+        // stays Claude-only. The --if-installed refresh returns earlier, so npm
         // postinstall never touches config.toml here.
         await RegisterCodexMcpServersAsync(env);
 
@@ -442,7 +442,7 @@ public static class PluginCommand {
     }
 
     /// <summary>
-    /// AI-794 — turn on Codex's <c>workspace-write</c> sandbox network access, constrained
+    /// turn on Codex's <c>workspace-write</c> sandbox network access, constrained
     /// to the Capacitor server(s) of every configured profile, so kcap skills can reach the
     /// server. Never fails the install: a write error is a warning, not an error code.
     /// </summary>
@@ -974,7 +974,7 @@ public static class PluginCommand {
         return failed ? 1 : 0;
     }
 
-    // ── OpenCode (SST): a TypeScript plugin, not a hooks.json (AI-919) ───────
+    // ── OpenCode (SST): a TypeScript plugin, not a hooks.json ───────
 
     static async Task<int> InstallOpenCode(string[] args, PluginEnvironment env) {
         var pluginPath = GetArg(args, "--opencode-plugin-path") ?? env.OpenCodeKcapPlugin;
@@ -1119,7 +1119,7 @@ public static class PluginCommand {
         return pluginFailed || mcpFailed || instrFailed ? 1 : 0;
     }
 
-    // ── Antigravity (AI-1158) — a named block in Antigravity's hooks.json ────────
+    // ── Antigravity — a named block in Antigravity's hooks.json ────────
     static async Task<int> InstallAntigravity(string[] args, PluginEnvironment env) {
         var hooksPath = GetArg(args, "--antigravity-hooks-path") ?? env.AntigravityHooksJson;
 

--- a/src/Capacitor.Cli/Commands/PluginEnvironment.cs
+++ b/src/Capacitor.Cli/Commands/PluginEnvironment.cs
@@ -13,7 +13,7 @@ namespace Capacitor.Cli.Commands;
 /// Process-state seam for <see cref="PluginCommand"/>. Captures the values that
 /// <c>kcap plugin install/remove</c> would otherwise read from
 /// <see cref="Environment"/> / <see cref="Console"/>, so tests can supply
-/// fakes without mutating shared process state (see AI-741).
+/// fakes without mutating shared process state.
 ///
 /// <see cref="ResolvePluginPath"/> is a delegate (not a string) so the
 /// filesystem probing in <see cref="SetupCommand.ResolvePluginPath(string?)"/>

--- a/src/Capacitor.Cli/Commands/SessionImporter.cs
+++ b/src/Capacitor.Cli/Commands/SessionImporter.cs
@@ -461,7 +461,7 @@ static class SessionImporter {
     /// <see cref="TranscriptBatch"/> so the server picks the matching normalizer.
     /// </param>
     /// <param name="abortDelivery">
-    /// AI-1382 review fix (r3, finding #4; extended r4, finding #3) — checked immediately BEFORE
+    /// checked immediately BEFORE
     /// every batch POST (including the very first) AND immediately AFTER it. When it returns true,
     /// delivery aborts by throwing <see cref="TranscriptDeliveryAbortedException"/> — a pre-POST trip
     /// skips the pending batch entirely; a post-POST trip has already sent that batch but stops
@@ -526,7 +526,7 @@ static class SessionImporter {
                 batchLines.Clear();
                 batchLineNumbers.Clear();
 
-                // AI-1382 review fix (r4, finding #3) — re-check IMMEDIATELY after the POST too, not
+                // re-check IMMEDIATELY after the POST too, not
                 // only before the NEXT one. Before this, a marker written while THIS batch's POST was
                 // in flight was only ever caught by the pre-POST check ahead of a batch that might
                 // never come (see below) — for a transcript with no further lines to send (this was
@@ -544,7 +544,7 @@ static class SessionImporter {
             totalSent += flushed;
             progress?.Report(new BatchFlushed(agentId, flushed));
 
-            // AI-1382 review fix (r4, finding #3) — same post-POST re-check for the trailing/only
+            // same post-POST re-check for the trailing/only
             // batch (a transcript of <=100 lines never enters the loop branch above at all, so
             // WITHOUT this check here specifically, a marker written while this — the ONLY — POST was
             // in flight was never observed anywhere: SendTranscriptBatches returned normally and the
@@ -556,7 +556,7 @@ static class SessionImporter {
     }
 
     /// <summary>
-    /// AI-1382 review fix (r3, finding #4) — thrown by <see cref="SendTranscriptBatches"/> when its
+    /// thrown by <see cref="SendTranscriptBatches"/> when its
     /// <c>abortDelivery</c> predicate trips mid-delivery (between batches). Distinct from a generic
     /// send failure so a caller that wants to react specially (Cursor's best-effort session-end —
     /// see <see cref="CursorImportSource.ImportSessionAsync"/>) can catch it before a broader

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -265,7 +265,7 @@ public static class SetupCommand {
             SkipPiMcp: skipPiMcpFlag,
             SkipPiInstructions: skipPiInstructionsFlag);
 
-        // AI-794 — allowlist the Capacitor server(s) Codex skills need to reach. A single
+        // allowlist the Capacitor server(s) Codex skills need to reach. A single
         // **.kcap.ai wildcard covers every SaaS tenant (current + future) and the auth
         // proxy; self-hosted servers are added as exact hosts. Derived from the active
         // server URL plus every configured profile so switching profiles still works.
@@ -317,7 +317,7 @@ public static class SetupCommand {
             InstallAntigravityHooks:  PluginCommand.InstallAntigravityHooks,
             EnableCodexNetworkAccess: () => CodexConfigToml.EnableNetworkAccess(codexAllowDomains),
             RegisterCodexMcp:         () => CodexConfigToml.RegisterKcapMcpServers(),
-            // AI-1264: every non-Claude JSON harness registers the ForCursor subset — kcap-workitems
+            // every non-Claude JSON harness registers the ForCursor subset — kcap-workitems
             // is a Claude Code plugin-only tool (its session-id default rides the Claude hook env).
             RegisterCursorMcp:        () => JsonMcpConfigWriter.Register(
                 CursorPaths.UserMcpJson(), KcapMcpServers.ForCursor, McpConfigShape.Standard, cwd: null, new McpMarker("cursor")),
@@ -358,7 +358,7 @@ public static class SetupCommand {
             stepOptions, detected, stepPaths, stepInstallers, PromptYesNo, WriteLine);
 
         // Provider API key handling. kcap scrubs ANTHROPIC_API_KEY / OPENAI_API_KEY
-        // from headless agent CLI spawns by default (AI-755) so subscription auth
+        // from headless agent CLI spawns by default so subscription auth
         // wins. PAYG users with the keys set in their environment can opt back in
         // here; the rest never see this prompt.
         var anthropicSet     = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY"));
@@ -440,7 +440,7 @@ public static class SetupCommand {
 
         var finalTokens = await TokenStore.LoadAsync();
 
-        // AI-752: tell the server this user has finished CLI setup, so the dashboard
+        // tell the server this user has finished CLI setup, so the dashboard
         // can flip the new-tenant welcome modal from "Waiting for CLI to register"
         // to "Registered". Best-effort — never block setup completion on this.
         await PingCliSetupAsync(serverUrl);
@@ -464,7 +464,7 @@ public static class SetupCommand {
 
         AnsiConsole.Write(grid);
 
-        // AI-836: hooks only load at coding-agent session start. The common case is a user
+        // hooks only load at coding-agent session start. The common case is a user
         // running `kcap setup` from inside an already-running session, which won't stream
         // live until it restarts — so tell them, but only when something was actually
         // installed (no point promising recording we never wired up).
@@ -592,7 +592,7 @@ public static class SetupCommand {
         return Directory.Exists(repoPlugin) ? repoPlugin : null;
     }
 
-    // AI-752 — best-effort signal to the server that this user has completed CLI setup.
+    // best-effort signal to the server that this user has completed CLI setup.
     // Silently swallows network/auth/server errors: the welcome-modal nudge is a UX
     // affordance, not part of the contract of `kcap setup`.
     //
@@ -661,7 +661,7 @@ public static class SetupCommand {
     }
 
     /// <summary>
-    /// AI-836 — the end-of-setup reminder that live recording only starts on a
+    /// the end-of-setup reminder that live recording only starts on a
     /// <em>new</em> coding-agent session. Claude Code (and the other agents) load hooks
     /// at session start, so a session that was already running when setup installed the
     /// hooks keeps running without them and never streams live. Returns the Spectre-markup

--- a/src/Capacitor.Cli/Commands/StatusCommand.cs
+++ b/src/Capacitor.Cli/Commands/StatusCommand.cs
@@ -69,8 +69,8 @@ public static class StatusCommand {
 
         await Console.Out.WriteLineAsync(line);
 
-        // Daemon — AI-630: read per-name PID files under
-        // ~/.config/kcap/daemons/ instead of the pre-AI-630 singleton
+        // Daemon: read per-name PID files under
+        // ~/.config/kcap/daemons/ instead of the legacy singleton
         // at ~/.config/kcap/agent.pid. The top-level `kcap status`
         // must agree with `kcap daemon status`; previously this
         // command kept saying "not running" while `daemon status` reported

--- a/src/Capacitor.Cli/Commands/ValidatePlanCommand.cs
+++ b/src/Capacitor.Cli/Commands/ValidatePlanCommand.cs
@@ -14,7 +14,7 @@ static class ValidatePlanCommand {
 
     /// <summary>
     /// Test-friendly core: caller owns the <see cref="HttpClient"/> (mirrors
-    /// <see cref="ClaudeHookCommand.HandleCore"/>'s seam). Two-call flow (AI-701):
+    /// <see cref="ClaudeHookCommand.HandleCore"/>'s seam). Two-call flow:
     /// <c>GET /api/sessions/{id}/plan-artifacts?chain=true</c> for the discovered plan
     /// artifact set, then the existing <c>GET /api/sessions/{id}/recap?chain=true</c> for
     /// current-session work rows and AI-generated "what's done" summaries. A 404 on the
@@ -22,7 +22,7 @@ static class ValidatePlanCommand {
     /// to <see cref="RenderLegacyAsync"/> — the original recap-only behavior, unchanged.
     /// Exit codes: 0 for a normal render or "no plan found" (absence is a valid answer); 2
     /// when the PRIMARY artifact's content is unavailable (validation genuinely isn't
-    /// possible); 1 for transport/HTTP errors (AI-701 review finding 3).
+    /// possible); 1 for transport/HTTP errors.
     /// </summary>
     internal static async Task<int> HandleCore(HttpClient httpClient, string baseUrl, string sessionId) {
         HttpResponseMessage artifactsResp;
@@ -101,7 +101,7 @@ static class ValidatePlanCommand {
         var primaryUnavailable = await RenderPlanArtifacts(primary, artifacts);
         await RenderWhatsDoneAndInstructions(summaries, work);
 
-        // AI-701 review finding 3: an unavailable PRIMARY means validation genuinely couldn't
+        // review finding 3: an unavailable PRIMARY means validation genuinely couldn't
         // happen — distinct from both success (0, including the "no plan found" case above,
         // where absence of a plan is itself a valid answer) and a generic error (1).
         return primaryUnavailable ? 2 : 0;
@@ -112,7 +112,7 @@ static class ValidatePlanCommand {
     /// exists but hasn't resolved yet, so this is the last known complete text. Single-sourced
     /// here (rather than referenced from the server) because the CLI has no dependency on
     /// <c>Capacitor.Server</c>; text and spacing must stay byte-for-byte identical to the
-    /// server's <c>PlanRowRendering.DegradedText</c> (AI-701 review finding).
+    /// server's <c>PlanRowRendering.DegradedText</c>.
     /// </summary>
     const string DegradedMarker = "[plan state: unresolved newer revision — last known complete text]";
 
@@ -130,7 +130,7 @@ static class ValidatePlanCommand {
     /// <returns>
     /// <c>true</c> when the PRIMARY artifact's content could not be retrieved
     /// (<c>content_state == "unavailable"</c>) — the caller uses this to exit 2 instead of 0
-    /// (AI-701 review finding 3): distinguishable from success (0) and from a generic error (1).
+    /// distinguishable from success (0) and from a generic error (1).
     /// </returns>
     static async Task<bool> RenderPlanArtifacts(PlanArtifactDto? primary, IReadOnlyList<PlanArtifactDto> artifacts) {
         var ordered = primary is null
@@ -151,7 +151,7 @@ static class ValidatePlanCommand {
                 await Console.Out.WriteLineAsync(DegradedMarker);
             }
 
-            // "truncated" with null Content is treated like "unavailable" (AI-701 review
+            // "truncated" with null Content is treated like "unavailable" (review
             // finding 2): the server contract pairs content_state=="truncated" with non-null
             // Content, but a malformed/edge response with Content == null must not render the
             // nonsensical "first 0 of ... bytes" — fall through to the unavailable placeholder.
@@ -164,7 +164,7 @@ static class ValidatePlanCommand {
                     var n = Encoding.UTF8.GetByteCount(artifact.Content!);
                     // OriginalBytes is nullable — a well-formed truncated artifact always
                     // carries it, but fall back to "?" rather than emit "of  bytes" if it's
-                    // ever missing (AI-701 review finding 2).
+                    // ever missing.
                     var total = artifact.OriginalBytes?.ToString() ?? "?";
                     await Console.Out.WriteLineAsync($"[plan truncated: first {n} of {total} bytes]");
                     await Console.Out.WriteLineAsync(artifact.Content!);
@@ -238,7 +238,7 @@ static class ValidatePlanCommand {
     }
 
     /// <summary>
-    /// Original (pre-AI-701) recap-only behavior, preserved byte-for-byte for old servers that
+    /// Original recap-only behavior, preserved byte-for-byte for old servers that
     /// don't yet expose <c>GET /api/sessions/{id}/plan-artifacts</c> (or a session/candidate the
     /// route can't resolve). Plans come from <c>recap</c> entries of type "plan" across the
     /// session chain; work/summaries are filtered exactly as before.

--- a/src/Capacitor.Cli/Commands/VendorSelection.cs
+++ b/src/Capacitor.Cli/Commands/VendorSelection.cs
@@ -32,8 +32,8 @@ public static class VendorSelection {
         }
 
         // Reject unknown vendor-prefixed flags. The legacy SQLite-era options
-        // (--cursor-workspace, --cursor-all-workspaces) were dropped in
-        // AI-737; the JSONL walkers don't need workspace filtering since the
+        // (--cursor-workspace, --cursor-all-workspaces) were dropped;
+        // the JSONL walkers don't need workspace filtering since the
         // transcript path already encodes the workspace.
         foreach (var a in args) {
             if (!a.StartsWith("--")) continue;

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -2395,7 +2395,7 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// redesign: link subagents from the parent transcript's INVOKE_SUBAGENT steps (the
+    /// Links subagents from the parent transcript's INVOKE_SUBAGENT steps (the
     /// spawn-time signal), replacing the messages/*.json scan. For each child id not already
     /// posted, POST the link once via <paramref name="post"/> (returns true on success); a failed
     /// POST is left un-posted so a later scan retries. Pure over its inputs for unit testing.

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -97,7 +97,7 @@ static partial class WatchCommand {
     /// empty, newline-terminated, OR its last (newline-less) line parses as JSON. Length-stability
     /// is NOT proof of completion — a large write can pause mid-record for longer than any bounded
     /// wait, so a static-but-unparseable tail is still incomplete. Pure so it is unit-testable
-    /// without a real file (AI-1357 task 7).
+    /// without a real file.
     /// </summary>
     internal static bool IsFinalLineComplete(string fileText) {
         if (fileText.Length == 0 || fileText[^1] == '\n') return true;
@@ -136,14 +136,14 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// Maximum single wait between heartbeat touches (AI-1357 task 9). Comfortably below the
+    /// Maximum single wait between heartbeat touches. Comfortably below the
     /// <c>WatcherHeartbeat.Threshold</c> so no chunked wait can ever look stale, and matches the
     /// main loop's disconnected-branch poll cadence.
     /// </summary>
     internal static readonly TimeSpan HeartbeatSlice = TimeSpan.FromSeconds(5);
 
     /// <summary>
-    /// AI-1382 review fix #2 — cadence for the periodic full-prefix re-hash
+    /// cadence for the periodic full-prefix re-hash
     /// (<see cref="CursorRewriteGuard.VerifyFullPrefix"/>), the coarser-grained safety net beyond
     /// the per-poll two-zone checks: every Nth poll (~1s cadence — roughly once a minute), the
     /// whole file is re-read from byte 0 and its prefix hash compared to the last sample, so a
@@ -157,7 +157,7 @@ static partial class WatchCommand {
     /// caller can refresh the heartbeat between each — keeping a reconnecting-but-alive watcher
     /// from ever crossing the staleness threshold while it waits out a long connect-retry backoff.
     /// Pure so the "no chunk exceeds the slice" guarantee is unit-testable without spawning a
-    /// watcher or a real server (AI-1357 task 9). A non-positive total yields no chunks.
+    /// watcher or a real server. A non-positive total yields no chunks.
     /// </summary>
     internal static IReadOnlyList<TimeSpan> HeartbeatSlices(TimeSpan total, TimeSpan maxSlice) {
         var slices    = new List<TimeSpan>();
@@ -191,7 +191,7 @@ static partial class WatchCommand {
         Console.SetOut(logWriter);
         Console.SetError(logWriter);
 
-        // AI-1357 task 9: `logKey` is already the same `{sessionId}` / `{sessionId}-{agentId}`
+        // task 9: `logKey` is already the same `{sessionId}` / `{sessionId}-{agentId}`
         // key WatcherManager uses for the pid file, so it doubles as the heartbeat key. Touch
         // once here (startup) and then every main-loop iteration below so a hook-side
         // staleness probe can distinguish a wedged (hung-but-alive) watcher from a healthy
@@ -223,7 +223,7 @@ static partial class WatchCommand {
         // backoff grows to 30s — longer than the ~20s staleness threshold — so a single Task.Delay
         // would let the heartbeat go stale mid-wait and get a healthy-but-reconnecting watcher
         // falsely reaped. Chunk the wait into ≤5s slices (the same cadence as the main loop's
-        // disconnected branch), touching before each slice. Returns false if cancelled (AI-1357 task 9).
+        // disconnected branch), touching before each slice. Returns false if cancelled.
         async Task<bool> DelayWithHeartbeatAsync(TimeSpan total) {
             foreach (var chunk in HeartbeatSlices(total, HeartbeatSlice)) {
                 TouchHeartbeat();
@@ -248,7 +248,7 @@ static partial class WatchCommand {
         // guarantees the write is observed even though awaits already act as memory
         // barriers in practice.
         var parentExited = 0;
-        // AI-1359: set by the staged parent-dead recovery loop when it ends a wedged watcher on the ceiling.
+        // set by the staged parent-dead recovery loop when it ends a wedged watcher on the ceiling.
         var wedgedCeilingExit = 0;
 
         // Handle SIGTERM/SIGINT for graceful shutdown.
@@ -284,18 +284,18 @@ static partial class WatchCommand {
             ctx.Cancel = true;
         });
 
-        // AI-1359: declared before the parent-watchdog block so the staged parent-dead recovery
+        // declared before the parent-watchdog block so the staged parent-dead recovery
         // task can read state.LastActivityAt as its no-progress clock.
         var state = new WatchState();
         state.LastActivityAt = DateTimeOffset.UtcNow;
 
-        // AI-1382 Task 11 (D0) — one runtime rewrite-guard instance for this watcher's whole
+        // Task 11 (D0) — one runtime rewrite-guard instance for this watcher's whole
         // lifetime (its checkpoint/pending-range state is meant to persist poll-to-poll). Null
         // for every non-Cursor vendor — DrainNewLines only exercises guard/ack logic when both
         // vendor == "cursor" AND this is non-null.
         var cursorGuard = vendor == "cursor" ? new CursorRewriteGuard(sessionId) : null;
 
-        // AI-1382 review fix (r3, finding #1) — serializes a reconnect-discovered rewind
+        // serializes a reconnect-discovered rewind
         // (ApplyReconnectRewindAsync, run from the Reconnected handler) against DrainNewLines'
         // own guard/state mutations (main loop + final drain). Both mutate WatchState's
         // CursorByteOffset/LinesProcessed and CursorRewriteGuard's checkpoint; without this a
@@ -306,7 +306,7 @@ static partial class WatchCommand {
         // with a guard/rewind interplay); null — and never awaited — for every other vendor.
         var cursorRewindGate = vendor == "cursor" ? new SemaphoreSlim(1, 1) : null;
 
-        // AI-1382 Task 11 (D0) — a rewrite trip discards the unsent batch (DrainNewLines already
+        // Task 11 (D0) — a rewrite trip discards the unsent batch (DrainNewLines already
         // returned without advancing state) and quarantines the session (the guard itself writes
         // the marker); this just triggers the same clean-exit path StopWatcher uses.
         void OnCursorRewriteDetected() {
@@ -314,7 +314,7 @@ static partial class WatchCommand {
             cts.Cancel();
         }
 
-        // AI-1357 task 8: the dedicated undelivered-transcript-tail spool, shared by the final-drain
+        // task 8: the dedicated undelivered-transcript-tail spool, shared by the final-drain
         // needs-import marker below and the shutdown-during-outage tail spool.
         var transcriptSpool = new TranscriptSpool(PathHelpers.ConfigPath("transcript-spool"));
 
@@ -413,7 +413,7 @@ static partial class WatchCommand {
         // (otherwise a <10-line conversation would never reach threshold, never idle-end, and
         // leave the session Active with the watcher lingering — the IDE process outlives it).
         //
-        // AI-1382 review fix #4 — Cursor's own sessionStart hook ALSO posts (and spawns this very
+        // Cursor's own sessionStart hook ALSO posts (and spawns this very
         // watcher) before any transcript line is ever read, so the same reasoning applies: the
         // generic 10-line buffer exists only to avoid polluting the server with a session it has
         // never heard of, which isn't true for Cursor either. Without this, a top-level Cursor
@@ -433,7 +433,7 @@ static partial class WatchCommand {
         // can tune the two GUIs independently.
         var idleTimeout = vendor switch {
             "antigravity" => ResolveCodexIdleTimeout(Environment.GetEnvironmentVariable("KCAP_ANTIGRAVITY_IDLE_MINUTES")),
-            // AI-1382 Task 11 (D1): Cursor's own idle-ceiling knob — see ResolveCursorIdleCeiling.
+            // Task 11 (D1): Cursor's own idle-ceiling knob — see ResolveCursorIdleCeiling.
             "cursor"      => ResolveCursorIdleCeiling(Environment.GetEnvironmentVariable("KCAP_CURSOR_IDLE_CEILING_MINUTES")),
             _             => ResolveCodexIdleTimeout(Environment.GetEnvironmentVariable("KCAP_CODEX_IDLE_MINUTES")),
         };
@@ -477,7 +477,7 @@ static partial class WatchCommand {
         // ServerTimeout stays at the 30s default for rollout safety.
         hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(7);
 
-        // AI-1382 review fix (r3, finding #1) — runs DrainNewLines under cursorRewindGate when one
+        // runs DrainNewLines under cursorRewindGate when one
         // exists, so it can never observe a half-applied reconnect rewind (see cursorRewindGate's
         // declaration above). Thin wrapper over the directly-testable GatedDrainNewLinesAsync (see
         // its doc — RunWatch itself can't be driven without a live SignalR reconnect).
@@ -511,7 +511,7 @@ static partial class WatchCommand {
                 if (serverPosition < state.LinesProcessed) {
                     Log($"Server behind ({serverPosition} vs {state.LinesProcessed}), rewinding to resend gap");
 
-                    // AI-1382 review fix (r3, finding #1) — hold cursorRewindGate for the whole
+                    // hold cursorRewindGate for the whole
                     // rewind so a concurrently-running DrainNewLines (main loop or final drain)
                     // can never interleave with it (see cursorRewindGate's declaration above).
                     // Thin wrapper over the directly-testable GatedApplyReconnectRewindAsync.
@@ -519,7 +519,7 @@ static partial class WatchCommand {
                         cursorRewindGate, state, serverPosition, sessionId, vendor, transcriptPath, cursorGuard, cts.Token);
 
                     if (!rewound) {
-                        // AI-1382 review fix (r4, finding #5) — the server's frontier couldn't be
+                        // the server's frontier couldn't be
                         // resolved to an exact local byte offset (the local transcript has fewer
                         // lines than the server acknowledged — truncated/replaced while this watcher
                         // was disconnected). SeedCursorByteOffsetAsync already quarantined the
@@ -547,7 +547,7 @@ static partial class WatchCommand {
         var connectRetryDelay = TimeSpan.FromSeconds(1);
 
         while (!cts.Token.IsCancellationRequested) {
-            // AI-1357 task 9: touch every connect-retry iteration too. A server outage at
+            // task 9: touch every connect-retry iteration too. A server outage at
             // startup (backoff up to 30s) that lasts longer than grace+threshold (~50s) is a
             // healthy-but-reconnecting watcher, NOT a wedged one — without a heartbeat here
             // the hook probe would judge it stale and reap+respawn it repeatedly for the
@@ -565,7 +565,7 @@ static partial class WatchCommand {
                 Log($"SignalR connect failed, retrying in {connectRetryDelay.TotalSeconds}s: {ex.Message}");
 
                 // Heartbeat-aware wait: the backoff caps at 30s > the staleness threshold, so a
-                // plain Task.Delay here would falsely mark a reconnecting watcher stale (AI-1357).
+                // plain Task.Delay here would falsely mark a reconnecting watcher stale.
                 if (!await DelayWithHeartbeatAsync(connectRetryDelay)) {
                     break;
                 }
@@ -586,7 +586,7 @@ static partial class WatchCommand {
         Log($"Connected via SignalR, resuming from line {state.LinesProcessed}");
         TouchHeartbeat();
 
-        // AI-1382 review fix (r3, finding #2) — seed the Cursor byte frontier to the TRUE byte
+        // seed the Cursor byte frontier to the TRUE byte
         // offset of the resumed line on this INITIAL registration too, not only on a later
         // reconnect rewind (ApplyReconnectRewindAsync already does this for reconnects, via the
         // SAME SeedCursorByteOffsetAsync helper — see below). Without this, a watcher resuming at
@@ -596,7 +596,7 @@ static partial class WatchCommand {
         // true offset plus M — a permanent, silent line/byte-frontier misalignment that made the
         // guard re-scan/re-hash old history forever.
         //
-        // AI-1382 review fix (r4, finding #5) — this resumed line number N is the server's own
+        // this resumed line number N is the server's own
         // acknowledged frontier, which can legitimately exceed the local transcript's line count
         // when it was truncated/replaced while this watcher was offline (e.g. across a restart).
         // SeedCursorByteOffsetAsync quarantines the session and returns false in that case rather
@@ -608,13 +608,13 @@ static partial class WatchCommand {
         }
 
         // Gemini fires no subagent hooks, so the parent watcher discovers nested subagent
-        // transcripts itself and spawns a child watcher per subagent (AI-900). Tracks the
+        // transcripts itself and spawns a child watcher per subagent. Tracks the
         // files already registered + spawned so each is handled exactly once across ticks.
         var seenSubagents = new HashSet<string>(StringComparer.Ordinal);
 
         try {
             while (!cts.Token.IsCancellationRequested) {
-                // AI-1357 task 9: touch every iteration — including no-content drains and
+                // task 9: touch every iteration — including no-content drains and
                 // while disconnected/reconnecting below — so staleness unambiguously means
                 // the loop itself is wedged, not merely idle or mid-reconnect.
                 TouchHeartbeat();
@@ -623,7 +623,7 @@ static partial class WatchCommand {
                 // No point re-reading the file or attempting sends that will fail.
                 if (hubConnection.State != HubConnectionState.Connected) {
                     // Freeze the idle clock: record when we went offline so the reconnect path can
-                    // subtract the outage from the idle measure (AI-1359).
+                    // subtract the outage from the idle measure.
                     state.DisconnectedSince ??= DateTimeOffset.UtcNow;
 
                     try {
@@ -649,16 +649,16 @@ static partial class WatchCommand {
                     state.LastRepoDetection = DateTimeOffset.UtcNow;
                 }
 
-                // AI-1382 review fix (r3, finding #1) — gated so this can never interleave with a
+                // gated so this can never interleave with a
                 // concurrently-running reconnect rewind (see cursorRewindGate's declaration above).
                 var drained = await DrainNewLinesGatedAsync(isFinalDrainLocal: false, cts.Token);
 
                 // Live subagent discovery: only the parent (agentId == null) watcher scans;
                 // child subagent watchers (agentId != null) just stream their file. Gemini
                 // scans its native nested chat files; OpenCode scans the nested dir the
-                // kcap plugin writes child {info,parts} into (AI-919 phase 2); Antigravity
+                // kcap plugin writes child {info,parts} into; Antigravity
                 // links subagents from the parent transcript's INVOKE_SUBAGENT steps — the
-                // spawn-time signal — drained this tick (AI-1218 — nesting only, subagents are
+                // spawn-time signal — drained this tick (nesting only, subagents are
                 // captured standalone already).
                 if (agentId is null && vendor == "gemini") {
                     await ScanGeminiSubagents(baseUrl, sessionId, transcriptPath, seenSubagents, cts.Token);
@@ -668,7 +668,7 @@ static partial class WatchCommand {
                     await ScanAntigravitySubagentLinks(baseUrl, sessionId, drained, state.PostedSubagentLinks, cts.Token);
                 }
 
-                // AI-1382 review fix #6 — the Cursor idle clock must be the LATER of transcript
+                // the Cursor idle clock must be the LATER of transcript
                 // activity AND the hook heartbeat mtime. Keyed on the CHILD's own session id for
                 // a child watcher (agentId), matching how CursorHookCommand actually writes the
                 // heartbeat (each hook touches its OWN raw session_id, never remapped to the
@@ -686,7 +686,7 @@ static partial class WatchCommand {
                         DateTimeOffset.UtcNow,
                         idleTimeout,
                         // A tool awaiting its result suppresses idle-end: Codex tracks call_ids,
-                        // Antigravity counts PLANNER_RESPONSE calls vs result steps (AI-1157 review).
+                        // Antigravity counts PLANNER_RESPONSE calls vs result steps.
                         toolInFlight: vendor == "antigravity"
                             ? state.PendingAntigravityToolCalls > 0
                             : state.PendingCodexToolCalls.Count > 0,
@@ -716,7 +716,7 @@ static partial class WatchCommand {
         } else {
             Log("Draining remaining lines...");
 
-            // Shutdown completion signal (AI-1357 task 7): the outage/idle-timeout final drain used
+            // Shutdown completion signal: the outage/idle-timeout final drain used
             // to disable the half-written-line holdback unconditionally, which could consume a line
             // the agent was still mid-write on. Instead:
             //   1. Bounded-wait (≤2s) to give the writer a chance to finish the final record — a
@@ -729,7 +729,7 @@ static partial class WatchCommand {
             // `kcap import` can recover the tail rather than dropping a truncated line.
             await WaitForFinalLineCompletionAsync(transcriptPath);
 
-            // AI-1382 review fix (r3, finding #1) — gated for the same reason as the main loop's
+            // gated for the same reason as the main loop's
             // drain call above (a reconnect right at shutdown is unlikely but not impossible).
             var finalDrained = await DrainNewLinesGatedAsync(isFinalDrainLocal: true, CancellationToken.None);
 
@@ -741,7 +741,7 @@ static partial class WatchCommand {
                 transcriptSpool.MarkNeedsImport(sessionId, "shutdown final drain: last transcript line never completed (no newline, unparseable)");
             }
 
-            // AI-1357 task 8: shutdown-during-outage. DrainNewLines above only advances
+            // task 8: shutdown-during-outage. DrainNewLines above only advances
             // state.LinesProcessed past lines the hub actually CONFIRMED — a failed final-drain send
             // (hub down, OR a HubException while the connection stays Connected — the generic catch
             // below does not change connection state) leaves LinesProcessed unchanged, so any lines
@@ -755,7 +755,7 @@ static partial class WatchCommand {
 
             // One last subagent-link scan on the way out — the parent may have emitted an
             // INVOKE_SUBAGENT step after the main loop's last tick but before exit, and this is
-            // the watcher's final chance to link it (AI-1218).
+            // the watcher's final chance to link it.
             if (agentId is null && vendor == "antigravity") {
                 await ScanAntigravitySubagentLinks(baseUrl, sessionId, finalDrained, state.PostedSubagentLinks, CancellationToken.None);
             }
@@ -795,7 +795,7 @@ static partial class WatchCommand {
                       : idleExit                                  ? "idle_timeout"
                       :                                             null;
 
-        // AI-1382 Task 11 (D1): Cursor's idle-ceiling exit must NOT synthesize session-end here —
+        // Task 11 (D1): Cursor's idle-ceiling exit must NOT synthesize session-end here —
         // unlike Codex/Antigravity, end synthesis for Cursor has exactly one owner (the
         // sessionEnd hook, or the server-side lease-gated sweep as a backstop). The watcher only
         // exits and final-drains; posting here would race/duplicate whichever of those two
@@ -818,7 +818,7 @@ static partial class WatchCommand {
     /// sight of a file it registers the subagent (<c>subagent-start</c>, fail-closed) then
     /// spawns a detached child watcher that streams it with the subagent's canonical agentId
     /// (→ <c>AgentSubsession-*</c>). Idempotent across ticks via <paramref name="seen"/>;
-    /// deterministic server-side lifecycle ids make re-registration safe. AI-900.
+    /// deterministic server-side lifecycle ids make re-registration safe..
     /// </summary>
     static async Task ScanGeminiSubagents(
             string          baseUrl,
@@ -888,7 +888,7 @@ static partial class WatchCommand {
     /// that streams it with the canonical agentId (= childSid) → <c>AgentSubsession-*</c>, which
     /// lines up with the agentId the server surfaced from the parent's <c>task</c> tool call.
     /// Idempotent across ticks via <paramref name="seen"/>; deterministic server-side lifecycle
-    /// ids make re-registration safe. AI-919 phase 2.
+    /// ids make re-registration safe. phase 2.
     /// </summary>
     static async Task ScanOpenCodeSubagents(
             string            baseUrl,
@@ -982,7 +982,7 @@ static partial class WatchCommand {
             : DefaultCodexIdleTimeout;
 
     /// <summary>
-    /// AI-1382 Task 11 (D1) — Cursor has no shell hooks that reliably fire a per-conversation
+    /// Task 11 (D1) — Cursor has no shell hooks that reliably fire a per-conversation
     /// parent-exit signal (the same class of gap Codex/Antigravity have), so an idle transcript
     /// is likewise the fallback session-end signal. Its own knob (default 60 min, mirroring
     /// <see cref="DefaultCodexIdleTimeout"/>) so tenants can tune it independently of the two
@@ -1005,10 +1005,10 @@ static partial class WatchCommand {
     /// idle. Pure so the policy is unit-testable. Gated to: the vendors whose parent-exit
     /// watchdog can't fire per-conversation — codex (the desktop app's shared app-server never
     /// exits per session), antigravity (the IDE process outlives any one conversation), and
-    /// cursor (AI-1382: no shell hooks fire a reliable per-conversation parent-exit signal
+    /// cursor (no shell hooks fire a reliable per-conversation parent-exit signal
     /// either — its own idle ceiling is the fallback). Session watchers additionally require
     /// threshold-reached (below-threshold short-lived sessions have no server session to end);
-    /// Cursor CHILD (subagent) watchers are eligible too (AI-1382 review fix #6) WITHOUT the
+    /// Cursor CHILD (subagent) watchers are eligible too WITHOUT the
     /// threshold gate — they never buffer, so ThresholdReached never flips true for them; see
     /// <see cref="RunWatch"/>'s call site for the same fix's heartbeat-aware idle clock. Uses
     /// strictly-greater-than so the boundary tick is not yet considered idle. Also
@@ -1036,7 +1036,7 @@ static partial class WatchCommand {
         ) {
         if (vendor != "codex" && vendor != "antigravity" && vendor != "cursor") return false;
 
-        // AI-1382 review fix #6 — a Cursor CHILD (subagent) watcher never buffers and so never
+        // a Cursor CHILD (subagent) watcher never buffers and so never
         // sets ThresholdReached (WatchState.ThresholdReached only ever flips true on the
         // agentId==null buffering-flush branch in DrainNewLines) — requiring it here would make
         // child watchers permanently ineligible for the idle ceiling. Session watchers keep the
@@ -1055,7 +1055,7 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// AI-1382 Task 13 — pure extraction of the end-synthesis suppression <see cref="RunWatch"/>
+    /// Task 13 — pure extraction of the end-synthesis suppression <see cref="RunWatch"/>
     /// applies to its own idle-ceiling exit. Cursor's end-of-session synthesis has exactly one
     /// owner (the <c>sessionEnd</c> hook, or the server-side lease-gated sweep as a backstop);
     /// unlike Codex/Antigravity, the watcher posting <c>session-end</c> itself on an idle-ceiling
@@ -1066,7 +1066,7 @@ static partial class WatchCommand {
     internal static bool CursorSuppressesEndPost(string vendor, bool idleExit) => vendor == "cursor" && idleExit;
 
     /// <summary>
-    /// AI-1382 review fix #4 — vendors whose sessionStart hook (or, for Antigravity, an
+    /// vendors whose sessionStart hook (or, for Antigravity, an
     /// equivalent pre-spawn POST) commits the session server-side BEFORE the tailing watcher
     /// itself ever reads a transcript line, so the generic below-threshold buffer (which exists
     /// solely to avoid polluting the server with a session it has never heard of) does not apply.
@@ -1082,7 +1082,7 @@ static partial class WatchCommand {
     internal static bool SkipsThresholdBuffering(string vendor) => vendor is "antigravity" or "cursor";
 
     /// <summary>
-    /// AI-1382 review fix #6 — the idle clock <see cref="ShouldEndOnIdle"/> measures against for
+    /// the idle clock <see cref="ShouldEndOnIdle"/> measures against for
     /// Cursor must be the LATER of transcript activity (<paramref name="lastActivityAt"/>) and the
     /// hook heartbeat mtime (<paramref name="hookHeartbeatAt"/>): every Cursor hook invocation —
     /// including telemetry-only ones — touches <c>CursorMarkers.HeartbeatPath</c> independent of
@@ -1159,7 +1159,7 @@ static partial class WatchCommand {
         // hook this is the only place that finalizes live subagents. Mirror the hook path: kill
         // each child watcher, drain its tail, POST subagent-stop — capped so a slow drain can't
         // block the watchdog's self-termination, and run BEFORE the session-end POST so
-        // SubagentCompleted lands ahead of SessionEnded. No-op when none were spawned (AI-900).
+        // SubagentCompleted lands ahead of SessionEnded. No-op when none were spawned.
         if (vendor == "gemini") {
             try {
                 var finalized = await TimeBudget.RunCappedAsync(
@@ -1179,7 +1179,7 @@ static partial class WatchCommand {
         // discovered + streamed by ScanOpenCodeSubagents, with no parent-pid watchdog on the
         // child watchers), so the parent exit is the only place that finalizes them. Same
         // shape as the Gemini teardown; runs BEFORE the session-end POST so SubagentCompleted
-        // lands ahead of SessionEnded. No-op when none were spawned (AI-919 phase 2).
+        // lands ahead of SessionEnded. No-op when none were spawned.
         if (vendor == "opencode") {
             // DrainAsync is self-bounding (per-step caps + a shared cleanup deadline + a hard
             // overall ceiling), so it needs no outer time cap here — wrapping it in one risked
@@ -1255,7 +1255,7 @@ static partial class WatchCommand {
     static readonly Regex CommandNameRegex = CommandNameRx();
     static          bool  parseErrorLogged;
 
-    // AI-1382 review fix #2/#3 — internal (not private) so the Cursor rewrite-guard wiring
+    // review fix #2/#3 — internal (not private) so the Cursor rewrite-guard wiring
     // (shrink detection, the periodic full-prefix cadence, and the acked-byte-offset checkpoint)
     // is directly regression-testable: every path exercised by those tests trips the guard and
     // returns BEFORE ever touching `hubConnection`, so an unconnected/never-started HubConnection
@@ -1277,7 +1277,7 @@ static partial class WatchCommand {
                 return [];
             }
 
-            // AI-1382 Task 11 (D1) — a Cursor session already given up on (quarantined by the
+            // Task 11 (D1) — a Cursor session already given up on (quarantined by the
             // runtime rewrite guard) must never have more transcript lines delivered by the
             // watcher either; and while an ordering-sensitive hook's side-effect barrier is
             // pending, HOLD delivery entirely this poll (retry next tick) rather than risk
@@ -1293,7 +1293,7 @@ static partial class WatchCommand {
                 }
             }
 
-            // AI-1382 Task 11 (D0/D3) — the runtime two-zone rewrite guard (Task 7) verifies the
+            // Task 11 (D0/D3) — the runtime two-zone rewrite guard (Task 7) verifies the
             // byte range this poll is about to send hasn't been rewritten underneath the watcher.
             // Record the new range's hash NOW (right after the line-based read snapshot below) and
             // re-verify the SAME range, freshly re-read from disk, immediately before send below —
@@ -1303,7 +1303,7 @@ static partial class WatchCommand {
             var cursorGuardOldOffset    = state.CursorByteOffset;
             var priorLineCursorForGuard = state.LinesProcessed;
 
-            // AI-1382 review fix (r3, finding #3) — decide BEFORE reading whether this poll needs
+            // decide BEFORE reading whether this poll needs
             // the (rare, amortized) periodic full-prefix re-hash, which genuinely needs the whole
             // file, or can use a BOUNDED read starting near the guard's own prior-tail zone. Moved
             // ahead of the read (previously decided only after) so ReadNewCompleteLinesAsync can be
@@ -1323,7 +1323,7 @@ static partial class WatchCommand {
                 // baseline to be caught against until poll N seeds the ALREADY-rewritten file as if
                 // it were the original, valid one. Every Nth poll after that still compares.
                 //
-                // AI-1382 review fix (r4, finding #4) — PEEK the would-be next count for this
+                // PEEK the would-be next count for this
                 // poll's cadence decision WITHOUT committing it to state yet. The old code
                 // incremented state.CursorGuardPollCount right here, unconditionally — if the
                 // guarded read below then hit a transient IOException (caught by this method's
@@ -1344,21 +1344,21 @@ static partial class WatchCommand {
 
             // Read only newline-TERMINATED lines. A final line still being written by the agent
             // (no trailing '\n' yet) is held back — sending its truncated prefix and advancing the
-            // position past it permanently drops the completed line (AI-1243: dropped Read results;
+            // position past it permanently drops the completed line (dropped Read results;
             // large tool_result lines are slow to flush and get caught mid-write). The next drain
             // re-reads it once complete.
             NewTranscriptLines drainRead;
             await using (var stream = new FileStream(
                     transcriptPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) {
-                // Shutdown final drain (AI-1357 task 7): consume an unterminated final line only if
+                // Shutdown final drain: consume an unterminated final line only if
                 // the exact bytes read parse as a complete JSON record (re-validated at consume time,
                 // so no TOCTOU with the bounded pre-wait); a still-growing/unparseable tail is held.
-                // Every live drain always holds an unterminated final line (AI-1243).
+                // Every live drain always holds an unterminated final line.
                 //
-                // AI-1382 review fix #1 — Cursor additionally captures the raw byte buffer this
+                // Cursor additionally captures the raw byte buffer this
                 // read decodes from (captureRawBytes), so the rewrite guard below can hash the
                 // EXACT bytes that produced `newLines` instead of a separately reopened read.
-                // AI-1382 review fix (r3, finding #3) — rawBytesReadFrom/newRangeByteOffset bound
+                // rawBytesReadFrom/newRangeByteOffset bound
                 // that capture instead of always reading the whole file (see above).
                 drainRead = await ReadNewCompleteLinesAsync(
                     stream, state.LinesProcessed,
@@ -1368,7 +1368,7 @@ static partial class WatchCommand {
                     newRangeByteOffset: vendor == "cursor" ? cursorGuardOldOffset : null);
             }
 
-            // AI-1382 review fix (r4, finding #4) — commit the cadence counter now that the guarded
+            // commit the cadence counter now that the guarded
             // read above actually completed without throwing. A failure never reaches this line, so
             // the next poll re-peeks from the SAME starting count — if THIS poll was full-prefix-due
             // but failed before reading, the next successful poll is still due (nothing was skipped).
@@ -1383,7 +1383,7 @@ static partial class WatchCommand {
                 state.FinalDrainHeldIncompleteLine = drainRead.HeldIncompleteFinalLine;
             }
 
-            // AI-1382 review fix #3 — cursorGuardNewLength is the SAME capped byte length
+            // cursorGuardNewLength is the SAME capped byte length
             // ReadNewCompleteLinesAsync sampled while building drainRead above
             // (drainRead.SnapshotByteLength), NOT a fresh FileInfo.Length re-sample. Re-sampling
             // here raced an append between that line-based read and this call: any bytes appended
@@ -1397,7 +1397,7 @@ static partial class WatchCommand {
             byte[]? cursorGuardVerifiedRange = null;
 
             if (vendor == "cursor" && cursorGuard is not null && cursorGuardSnapshot is not null) {
-                // AI-1382 review fix #1 — every hash below is derived from cursorGuardSnapshot, the
+                // every hash below is derived from cursorGuardSnapshot, the
                 // raw byte buffer ReadNewCompleteLinesAsync captured during the SAME capped read
                 // that decoded drainRead.Lines (above) — never from a separate file reopen. The
                 // previous wiring reopened the file HERE to hash the prior zone and record the new
@@ -1476,7 +1476,7 @@ static partial class WatchCommand {
                 antigravityGenMax = AppendAntigravityUsageLines(state, newLines, newLineNumbers, transcriptPath, state.LastAntigravityCreatedAt);
             }
 
-            // AI-1357 task 10: Kiro's per-turn credits/context% live in the sibling {id}.json, not
+            // task 10: Kiro's per-turn credits/context% live in the sibling {id}.json, not
             // the .jsonl (see KiroUsage docs) — by the time Kiro flushes that sidecar, a live drain
             // has usually already sent the anchor's AssistantMessage line, so import-style inline
             // enrichment can't reach it. Backfill it instead as a synthetic KiroUsageBackfilled line
@@ -1642,7 +1642,7 @@ static partial class WatchCommand {
                 ? state.Repository
                 : null;
 
-            // AI-1382 review fix (r4, findings #1 + the repo-only-failed branch below) — keep the
+            // keep the
             // BYTE frontier in lockstep with the LINE frontier on EVERY path that advances
             // state.LinesProcessed past blank/whitespace-only lines WITHOUT a send that returns an
             // ack. Before this, such a poll (newLines.Count == 0, but linesRead — the new
@@ -1681,7 +1681,7 @@ static partial class WatchCommand {
             }
 
             if (newLines.Count == 0 && repoToSend is null) {
-                // AI-1382 review fix (r4, finding #1) — advance the byte frontier together with the
+                // advance the byte frontier together with the
                 // line frontier (see AdvanceCursorBlankByteFrontierInLockstep above).
                 AdvanceCursorBlankByteFrontierInLockstep();
 
@@ -1692,7 +1692,7 @@ static partial class WatchCommand {
             }
 
             try {
-                // AI-1382 Task 11 (D0) — pre-send re-verify: re-read the SAME byte range fresh
+                // Task 11 (D0) — pre-send re-verify: re-read the SAME byte range fresh
                 // from disk immediately before this call and compare to the hash recorded above.
                 // A rewrite racing between the read (above) and this send is exactly what this
                 // last check catches; a length shrink or hash mismatch discards the unsent batch
@@ -1713,7 +1713,7 @@ static partial class WatchCommand {
                         }
                     }
 
-                    // AI-1382 review fix #3 — this is the freshest, just-re-verified copy of the
+                    // this is the freshest, just-re-verified copy of the
                     // exact bytes about to be sent; stash it so the checkpoint logic below can map
                     // the server's acked LINE count to a precise byte offset within it, instead of
                     // assuming the whole range was delivered.
@@ -1725,10 +1725,10 @@ static partial class WatchCommand {
                 // defaults (PR #576 / v0.4.0 incident), so a parameter object keeps the
                 // contract stable: adding a field stays backward-compatible (this client
                 // omits a null vendor; servers ignore unknown fields). This calls the
-                // record-based `SendTranscriptBatch2` added in AI-850 (the legacy
+                // record-based `SendTranscriptBatch2` added in (the legacy
                 // positional `SendTranscriptBatch` stays on the server for older CLIs),
                 // so it requires a server deployed with that method — server-before-CLI.
-                // AI-1382 D3: Cursor uses the ACKED variant instead — its return carries the
+                // Cursor uses the ACKED variant instead — its return carries the
                 // server's source-acknowledgement frontier, which the watcher's local cursor
                 // tracks (see below) rather than the raw count of lines just sent.
                 var batch = new TranscriptBatch {
@@ -1743,7 +1743,7 @@ static partial class WatchCommand {
                 int? cursorAckNextLine = null;
 
                 if (vendor == "cursor") {
-                    // AI-1382 review fix #8 — re-check both markers IMMEDIATELY at the delivery
+                    // re-check both markers IMMEDIATELY at the delivery
                     // boundary. The early checks at the top of this method ran before the guard's
                     // file reads/re-verification above (which can take real, if small, wall-clock
                     // time), so a beforeSubmitPrompt barrier created — or a quarantine written by
@@ -1779,7 +1779,7 @@ static partial class WatchCommand {
                 state.LinesProcessed = cursorAckNextLine ?? linesRead;
 
                 if (cursorAckNextLine is not null) {
-                    // AI-1382 review fix #3 — checkpoint only the bytes the ack actually covers.
+                    // checkpoint only the bytes the ack actually covers.
                     // A partially-disposed batch (D3's "halt-at-the-gap" policy) acks fewer lines
                     // than were sent; the previous code advanced CursorByteOffset to the full
                     // capped snapshot length regardless, silently checkpointing the unacked tail
@@ -1797,7 +1797,7 @@ static partial class WatchCommand {
                     state.CursorByteOffset = ackedByteOffset;
 
                     if (cursorGuard is not null) {
-                        // AI-1382 review fix #1 — derive the checkpoint's trailing hash from
+                        // derive the checkpoint's trailing hash from
                         // cursorGuardSnapshot, the bytes captured during THIS poll's single capped
                         // read (already re-verified against fresh disk re-reads at both the guard
                         // check above and the pre-send VerifyNewRange step), instead of reopening
@@ -1805,7 +1805,7 @@ static partial class WatchCommand {
                         // the RPC had already returned — a rewrite landing while the ack was in
                         // flight would be blessed as the new checkpoint baseline instead of caught
                         // (this is the same TOCTOU class review fix #1 closes for the read side).
-                        // AI-1382 review fix (r3, finding #3) — cursorGuardSnapshot may now start at
+                        // cursorGuardSnapshot may now start at
                         // cursorGuardSnapshotAt (a bounded, non-zero offset) rather than always byte
                         // 0; the slice below is relative to the snapshot buffer, so subtract it.
                         var trailingLength = (int)Math.Min(cursorGuard.TrailingBytes, ackedByteOffset);
@@ -1841,7 +1841,7 @@ static partial class WatchCommand {
                     // Repo-only batch failed — no transcript lines at risk, so advance
                     // position and defer retry to the next 60s repo detection cycle.
                     //
-                    // AI-1382 review fix (r4) — this branch reaches the send path only because a
+                    // this branch reaches the send path only because a
                     // repo change was pending (repoToSend != null); newLines.Count == 0 here means
                     // any lines this poll DID read were blank/whitespace-only. Advancing
                     // LinesProcessed alone would leave CursorByteOffset/checkpoint behind exactly as
@@ -1869,7 +1869,7 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// Pure builder (AI-1357 task 8) for the JSON payload spooled into <see cref="TranscriptSpool"/>
+    /// Pure builder for the JSON payload spooled into <see cref="TranscriptSpool"/>
     /// at shutdown when the hub is down and the final drain's still-undelivered tail cannot be sent
     /// live. Mirrors the <see cref="TranscriptBatch"/> construction in <see cref="DrainNewLines"/>
     /// (the live SignalR send) so the shape the global drain (task 3) later POSTs to
@@ -1892,7 +1892,7 @@ static partial class WatchCommand {
             CapacitorJsonContext.Default.TranscriptBatch);
 
     /// <summary>
-    /// AI-1357 task 8: called from the shutdown path only when the hub is NOT connected at the point
+    /// task 8: called from the shutdown path only when the hub is NOT connected at the point
     /// the final drain finishes. Re-reads the transcript from <paramref name="linesProcessed"/> (the
     /// last line the server actually confirmed, per <see cref="DrainNewLines"/>'s
     /// "only advance position after successful send" rule) to EOF, using the same
@@ -1915,7 +1915,7 @@ static partial class WatchCommand {
         ) {
         if (!File.Exists(transcriptPath)) return null;
 
-        // AI-1382 review fix #1 — a Cursor session already quarantined by the runtime rewrite
+        // a Cursor session already quarantined by the runtime rewrite
         // guard must never have its tail re-read and spooled here either: the bytes past
         // `linesProcessed` ARE the exact corrupted batch the guard just discarded (the discard
         // never advanced state.LinesProcessed), so without this check a later global drain
@@ -2140,7 +2140,7 @@ static partial class WatchCommand {
             _          => TryExtractClaudeUserText(line)
         };
 
-    // ── OpenCode extractors (AI-919) ───────────────────────────────────────────
+    // ── OpenCode extractors ───────────────────────────────────────────
     //
     // OpenCode transcript lines are {info,parts} with info.role user/assistant. Title
     // text is the joined non-hidden text parts — mirrors the server's
@@ -2172,7 +2172,7 @@ static partial class WatchCommand {
         return pieces.Count > 0 ? string.Join("\n", pieces) : null;
     }
 
-    // ── Antigravity extractors (AI-1158) ────────────────────────────────────────
+    // ── Antigravity extractors ────────────────────────────────────────
     //
     // Antigravity writes brain/<id>/.system_generated/logs/transcript_full.jsonl as
     // {step_index, source, type, status, content, thinking, tool_calls, …} lines.
@@ -2237,13 +2237,13 @@ static partial class WatchCommand {
                 if (idx > maxIdx) maxIdx = idx;
             }
         } catch (Exception ex) {
-            // Cost is always best-effort (AI-728) — never let a db read break the drain.
+            // Cost is always best-effort — never let a db read break the drain.
             Log($"Antigravity usage poll failed: {ex.Message}");
         }
         return maxIdx;
     }
 
-    // AI-1357 task 10: Kiro's per-turn credits/context% live in the sidecar {id}.json, not the
+    // task 10: Kiro's per-turn credits/context% live in the sidecar {id}.json, not the
     // .jsonl the live watcher tails (see KiroUsage docs) — the import path enriches the anchor
     // AssistantMessage line inline because it reads the whole file up front, but a live drain has
     // already sent that line by the time Kiro flushes the sidecar. So the live path emits a
@@ -2280,7 +2280,7 @@ static partial class WatchCommand {
     /// send (mirrors <see cref="AppendAntigravityUsageLines"/>'s watermark-after-send contract, but
     /// keyed on anchor strings rather than a monotonic row index). Returns the count staged (0 on a
     /// missing/malformed sidecar or when every turn's anchor is already emitted) — never throws;
-    /// usage is always best-effort (AI-728/AI-1196).
+    /// usage is always best-effort.
     /// </summary>
     internal static long AppendKiroUsageBackfillLines(WatchState state, List<string> newLines, List<int> newLineNumbers, string transcriptPath) {
         state.KiroUsagePendingAnchors.Clear();
@@ -2295,7 +2295,7 @@ static partial class WatchCommand {
             foreach (var (anchor, usage) in anchors) {
                 if (state.KiroUsageEmittedAnchors.Contains(anchor)) { offset++; continue; }
 
-                // Task 10 scope is credits/context% only — tokens stay upstream-blocked (AI-1196),
+                // Task 10 scope is credits/context% only — tokens stay upstream-blocked,
                 // so a turn with only (dormant, zero) token counts has nothing to backfill yet.
                 if (usage.Credits == 0 && usage.ContextPct is null) { offset++; continue; }
 
@@ -2306,7 +2306,7 @@ static partial class WatchCommand {
                 offset++;
             }
         } catch (Exception ex) {
-            // Usage is always best-effort (AI-728) — never let a sidecar read break the drain.
+            // Usage is always best-effort — never let a sidecar read break the drain.
             Log($"Kiro usage backfill poll failed: {ex.Message}");
         }
         return staged;
@@ -2350,7 +2350,7 @@ static partial class WatchCommand {
     /// produce a decrement step, so counting them as "in flight" would pin
     /// <see cref="WatchState.PendingAntigravityToolCalls"/> above zero forever and permanently
     /// suppress the parent's idle-end — a subagent-invoking conversation would only end when
-    /// Antigravity quits (AI-1218). They do not block the parent's idleness, so they are excluded
+    /// Antigravity quits. They do not block the parent's idleness, so they are excluded
     /// from the pending count.
     /// </summary>
     static readonly HashSet<string> AsyncAntigravityToolCalls =
@@ -2395,7 +2395,7 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// AI-1218 redesign: link subagents from the parent transcript's INVOKE_SUBAGENT steps (the
+    /// redesign: link subagents from the parent transcript's INVOKE_SUBAGENT steps (the
     /// spawn-time signal), replacing the messages/*.json scan. For each child id not already
     /// posted, POST the link once via <paramref name="post"/> (returns true on success); a failed
     /// POST is left un-posted so a later scan retries. Pure over its inputs for unit testing.
@@ -2417,7 +2417,7 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// Live subagent nesting (AI-1218): links a subagent from its parent transcript's
+    /// Live subagent nesting: links a subagent from its parent transcript's
     /// INVOKE_SUBAGENT steps — the spawn-time signal — rather than waiting for the child to
     /// report back. <paramref name="drainedLines"/> are the lines the watcher just drained from
     /// the parent transcript this tick. Each newly-seen child is POSTed to
@@ -2453,7 +2453,7 @@ static partial class WatchCommand {
         }
     }
 
-    // ── Kiro extractors (AI-888) ───────────────────────────────────────────
+    // ── Kiro extractors ───────────────────────────────────────────
     //
     // Kiro CLI writes ~/.kiro/sessions/cli/{id}.jsonl as {"version","kind","data"}
     // lines: kind "Prompt" (user) / "AssistantMessage" / "ToolResults", whose
@@ -2483,7 +2483,7 @@ static partial class WatchCommand {
         return null;
     }
 
-    // ── Copilot extractors (AI-815) ────────────────────────────────────────
+    // ── Copilot extractors ────────────────────────────────────────
     //
     // Copilot's events.jsonl envelope: {type, data, id, timestamp, parentId,
     // agentId?}. Subagent-tagged events (agentId set) are skipped — a
@@ -2524,7 +2524,7 @@ static partial class WatchCommand {
         }
     }
 
-    // ── Pi extractors (AI-886) ─────────────────────────────────────────────
+    // ── Pi extractors ─────────────────────────────────────────────
     //
     // Pi emits type:"message" with message.role user/assistant — NOT Claude's
     // top-level type:"user"/"assistant" — so the watcher title path needs its
@@ -2783,10 +2783,10 @@ static partial class WatchCommand {
     /// <see cref="SnapshotByteLength"/> - <see cref="SnapshotStartOffset"/> bytes — populated only
     /// when the caller opts in via <c>captureRawBytes</c> (<see cref="ReadNewCompleteLinesAsync"/>)
     /// — so the Cursor rewrite guard can hash the EXACT bytes that decoded <see cref="Lines"/>
-    /// instead of a later, separately-reopened disk read (AI-1382 review fix #1: the previous
+    /// instead of a later, separately-reopened disk read (review fix #1: the previous
     /// two-read wiring left a TOCTOU window between decoding the batch and hashing it).
     ///
-    /// AI-1382 review fix (r3, finding #3) — <see cref="SnapshotStartOffset"/> is non-zero whenever
+    /// <see cref="SnapshotStartOffset"/> is non-zero whenever
     /// the caller asked for a BOUNDED capture (<c>rawBytesReadFrom</c> on
     /// <see cref="ReadNewCompleteLinesAsync"/>): <see cref="SnapshotBytes"/> then only spans the
     /// guard's prior-tail zone plus the new range, not the whole file, so a poll with little/no new
@@ -2807,10 +2807,10 @@ static partial class WatchCommand {
     public enum IncompleteFinalLinePolicy {
         /// <summary>Every normal live drain: ALWAYS hold an unterminated final line — the agent is
         /// mid-write of it, and consuming its truncated prefix would permanently drop the completed
-        /// line (AI-1243).</summary>
+        /// line.</summary>
         Hold,
 
-        /// <summary>The shutdown final drain (AI-1357 task 7): consume the unterminated final line
+        /// <summary>The shutdown final drain: consume the unterminated final line
         /// ONLY IF the exact bytes read parse as a complete JSON record; otherwise hold it. The
         /// parseable-JSON check runs on the SAME bytes being consumed, so there is no TOCTOU with a
         /// separate pre-read completeness probe — a line that resumed growing into an incomplete
@@ -2824,7 +2824,7 @@ static partial class WatchCommand {
     /// means the agent is mid-write of it: it is held back — excluded from the batch AND from
     /// <see cref="NewTranscriptLines.NextPosition"/> — so a later drain re-reads it once complete.
     /// Consuming it would send a truncated line that fails to normalize server-side and permanently
-    /// drop the completed line (AI-1243, the "endless reads" bug; large Read tool_result lines were
+    /// drop the completed line (, the "endless reads" bug; large Read tool_result lines were
     /// the common victim). Blank lines are skipped from the output but still advance the position,
     /// matching the long-standing drain behaviour.
     /// </summary>
@@ -2850,7 +2850,7 @@ static partial class WatchCommand {
             lineIndex++;
         }
 
-        // AI-1382 review fix #3: this string-based helper has no independent byte-length sample
+        // this string-based helper has no independent byte-length sample
         // of its own (its caller already materialized the whole file into `fileText` elsewhere),
         // so SnapshotByteLength stays at its default (0, unused here) — only
         // ReadNewCompleteLinesAsync below (the Cursor watcher's actual read path) populates it.
@@ -2859,7 +2859,7 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// AI-1382 Task 11 (D0/D3) — reads exactly <paramref name="buffer"/>'s length worth of bytes
+    /// Task 11 (D0/D3) — reads exactly <paramref name="buffer"/>'s length worth of bytes
     /// from <paramref name="stream"/>'s CURRENT position, looping until the buffer is full or EOF
     /// is hit. Used by the Cursor watcher's runtime rewrite-guard byte-range checks, which need
     /// a definite byte count (a single <see cref="Stream.ReadAsync(Memory{byte},CancellationToken)"/>
@@ -2878,7 +2878,7 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// AI-1382 review fix #3 — maps a server-acknowledged LINE count within the Cursor guard's
+    /// maps a server-acknowledged LINE count within the Cursor guard's
     /// freshly-verified new-range byte buffer to the byte offset immediately after that many
     /// lines' terminating newlines. <paramref name="range"/> spans file bytes starting at
     /// <paramref name="rangeStartOffset"/>; <paramref name="ackedLineCount"/> is how many of the
@@ -2907,10 +2907,10 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// AI-1382 review fix #2 — scans <paramref name="transcriptPath"/> from byte 0 to find the byte
+    /// scans <paramref name="transcriptPath"/> from byte 0 to find the byte
     /// offset immediately after the <paramref name="lineNumber"/>-th newline. Returns 0 for a
     /// non-positive <paramref name="lineNumber"/> (nothing to resolve). Returns null when the file
-    /// is missing, or has fewer lines than requested — <b>AI-1382 review fix (r4, finding #5)</b>:
+    /// is missing, or has fewer lines than requested — <b> review fix (r4, finding #5)</b>:
     /// this used to silently CLAMP to EOF instead, on the stated assumption that the reconnect path
     /// only ever rewinds to a line count the server itself acknowledged, which "by construction"
     /// can't exceed what the file has ever contained. That assumption breaks on an initial resume
@@ -2924,7 +2924,7 @@ static partial class WatchCommand {
     /// exactly" and quarantine rather than seed a bogus baseline.
     ///
     /// <para>
-    /// AI-1382 review fix (r5) — finding #5's guard was slightly too strict: a COMPLETE final
+    /// finding #5's guard was slightly too strict: a COMPLETE final
     /// record with no trailing newline yet (exactly what this watcher's own shutdown final drain,
     /// <see cref="IncompleteFinalLinePolicy.ConsumeIfComplete"/>, sends — and what historical
     /// import's <c>StreamReader</c>-based line splitting also sends for a file with no final
@@ -2942,7 +2942,7 @@ static partial class WatchCommand {
     /// </para>
     ///
     /// <para>
-    /// AI-1382 review fix (r6) — the C + 1 case no longer resolves to EOF paired with the
+    /// the C + 1 case no longer resolves to EOF paired with the
     /// unchanged <paramref name="lineNumber"/>. Seeding <see cref="WatchState.CursorByteOffset"/>
     /// at EOF while <see cref="WatchState.LinesProcessed"/> stayed at C + 1 (the r5 behaviour) put
     /// the byte cursor exactly where Cursor's OWN later-arriving terminator for this SAME
@@ -3002,7 +3002,7 @@ static partial class WatchCommand {
 
         if (trailingRead != trailingLength) return null; // file shrank underneath us — don't guess
 
-        // AI-1382 review fix (r6) — rewind to the record's own start (lastNewlineEnd) and drop
+        // rewind to the record's own start (lastNewlineEnd) and drop
         // LineNumber by one (not yet "processed" — it will be re-read/re-sent) instead of
         // resolving at EOF with LineNumber unchanged. See the method doc for why the EOF seed
         // drifted line numbering once Cursor's own terminator for this record later arrived.
@@ -3012,7 +3012,7 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// AI-1382 review fix #2 — applies a reconnect-discovered rewind (the server's acknowledged
+    /// applies a reconnect-discovered rewind (the server's acknowledged
     /// line frontier, <paramref name="serverPosition"/>, is behind <paramref name="state"/>'s own
     /// <see cref="WatchState.LinesProcessed"/>) atomically: for Cursor, resolves and rewinds
     /// <see cref="WatchState.CursorByteOffset"/> to the TRUE byte offset of
@@ -3023,7 +3023,7 @@ static partial class WatchCommand {
     /// reconnect. A no-op byte-side rewind for every non-Cursor vendor (no guard to keep in sync).
     ///
     /// <para>
-    /// AI-1382 review fix (r4, finding #5) — returns false, WITHOUT touching
+    /// returns false, WITHOUT touching
     /// <see cref="WatchState.LinesProcessed"/> or <see cref="WatchState.CursorByteOffset"/> at all,
     /// when <paramref name="serverPosition"/> cannot be resolved to an exact local byte offset (the
     /// session has already been quarantined by <see cref="SeedCursorByteOffsetAsync"/> in that case).
@@ -3033,7 +3033,7 @@ static partial class WatchCommand {
     /// </para>
     ///
     /// <para>
-    /// AI-1382 review fix (r6) — <see cref="WatchState.LinesProcessed"/> is no longer set to
+    /// <see cref="WatchState.LinesProcessed"/> is no longer set to
     /// <paramref name="serverPosition"/> unconditionally here; <see cref="SeedCursorByteOffsetAsync"/>
     /// now owns that assignment (for every vendor) so it can substitute a REWOUND line count for
     /// the r5 complete-unterminated-final-record case, keeping it in lockstep with the byte offset
@@ -3049,17 +3049,17 @@ static partial class WatchCommand {
             CursorRewriteGuard? cursorGuard,
             CancellationToken   ct
         ) {
-        // AI-1382 review fix (r3, finding #2) — shares the byte-side seed with RunWatch's INITIAL
+        // shares the byte-side seed with RunWatch's INITIAL
         // WatcherConnect registration (see SeedCursorByteOffsetAsync's own doc) so both paths that
         // resume at a server-given line number map it to the true byte offset identically.
         //
-        // AI-1382 review fix (r6) — SeedCursorByteOffsetAsync now sets state.LinesProcessed itself
+        // SeedCursorByteOffsetAsync now sets state.LinesProcessed itself
         // (possibly rewound), so this no longer duplicates that assignment afterward.
         return await SeedCursorByteOffsetAsync(state, serverPosition, sessionId, vendor, transcriptPath, cursorGuard, ct);
     }
 
     /// <summary>
-    /// AI-1382 review fix (r3, finding #2) — resolves <paramref name="lineNumber"/> to its TRUE
+    /// resolves <paramref name="lineNumber"/> to its TRUE
     /// byte offset in <paramref name="transcriptPath"/> and seeds <see cref="WatchState.CursorByteOffset"/>
     /// with it, resetting the guard's checkpoint so the two-zone checks start clean from that
     /// offset (exactly as if this were the guard's very first poll). A no-op byte-side seed for
@@ -3077,7 +3077,7 @@ static partial class WatchCommand {
     /// N but counted their bytes from 0 — a permanent, silent line/byte-frontier misalignment.
     ///
     /// <para>
-    /// AI-1382 review fix (r4, finding #5) — <paramref name="lineNumber"/> is the server's own
+    /// <paramref name="lineNumber"/> is the server's own
     /// acknowledged frontier, so it is normally exactly resolvable; when it is NOT (fewer local
     /// lines exist than the server claims — a transcript truncated/replaced while the watcher was
     /// offline), seeding CursorByteOffset to a clamped EOF offset would establish the rewrite
@@ -3089,7 +3089,7 @@ static partial class WatchCommand {
     /// </para>
     ///
     /// <para>
-    /// AI-1382 review fix (r6) — <see cref="ResolveByteOffsetForLineAsync"/> now returns a
+    /// <see cref="ResolveByteOffsetForLineAsync"/> now returns a
     /// (byte offset, line number) PAIR rather than a bare byte offset, because the r5
     /// complete-unterminated-final-record case resolves to a REWOUND pair (the record's own start,
     /// paired with <paramref name="lineNumber"/> - 1) instead of EOF paired with
@@ -3138,7 +3138,7 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// AI-1382 review fix (r3, finding #1) — runs <see cref="ApplyReconnectRewindAsync"/> under
+    /// runs <see cref="ApplyReconnectRewindAsync"/> under
     /// <paramref name="gate"/> (RunWatch's <c>cursorRewindGate</c> — null for every non-Cursor
     /// vendor) so it can never interleave with a concurrently-running <see cref="DrainNewLines"/>
     /// (see <see cref="GatedDrainNewLinesAsync"/>, held under the SAME gate instance). Both mutate
@@ -3151,7 +3151,7 @@ static partial class WatchCommand {
     /// itself — not just <see cref="ApplyReconnectRewindAsync"/>'s own atomicity — is directly
     /// unit-testable without a live SignalR reconnect.
     ///
-    /// Returns false (AI-1382 review fix r4, finding #5) when the rewind could not resolve the
+    /// Returns false (review fix r4, finding #5) when the rewind could not resolve the
     /// server's frontier exactly and quarantined the session instead — the caller must exit the
     /// same way it would for a runtime rewrite detection.
     /// </summary>
@@ -3178,7 +3178,7 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// AI-1382 review fix (r3, finding #1) — runs <see cref="DrainNewLines"/> under
+    /// runs <see cref="DrainNewLines"/> under
     /// <paramref name="gate"/> (RunWatch's <c>cursorRewindGate</c> — null for every non-Cursor
     /// vendor), the exact counterpart to <see cref="GatedApplyReconnectRewindAsync"/>: the SAME
     /// gate instance serializes both, so a drain can never observe a half-applied reconnect
@@ -3218,18 +3218,18 @@ static partial class WatchCommand {
     /// the whole file (Qodo #291 #2): only lines beyond <paramref name="linesProcessed"/> are retained.
     /// The file length is sampled once and the end-of-file newline is read from the last byte, then the
     /// read is CAPPED at that length — so a concurrent append after the sample can't make an as-yet
-    /// unterminated final line look complete and get consumed (which would re-drop it — AI-1243).
+    /// unterminated final line look complete and get consumed (which would re-drop it —).
     /// Opened by the caller with FileShare.ReadWrite (Qodo #291 #1) so the writing agent is never blocked.
     /// </summary>
     /// <param name="rawBytesReadFrom">
-    /// AI-1382 review fix (r3, finding #3) — only meaningful when <paramref name="captureRawBytes"/>
+    /// only meaningful when <paramref name="captureRawBytes"/>
     /// is true: the absolute file offset the captured buffer starts at. 0 (the default) captures
     /// the whole file, exactly as before. A caller that knows it only needs a bounded window (the
     /// Cursor guard's prior-tail zone plus the new range) passes the true start offset instead, so
     /// the buffer allocated is bounded by how much is actually new/relevant, not file size.
     /// </param>
     /// <param name="newRangeByteOffset">
-    /// AI-1382 review fix (r3, finding #3) — only meaningful when <paramref name="captureRawBytes"/>
+    /// only meaningful when <paramref name="captureRawBytes"/>
     /// is true: the absolute file offset of the first NEW line (line number <paramref name="linesProcessed"/>).
     /// Bytes in the captured buffer before this offset (the prior-tail zone, present only for the
     /// guard's hash) are never decoded as lines. When null (the default), the legacy behaviour
@@ -3264,7 +3264,7 @@ static partial class WatchCommand {
         byte[]? rawBytes       = null;
         var     snapshotStart  = 0L;
 
-        // AI-1382 review fix #1 — when the caller (the Cursor watcher) needs it, capture the raw
+        // when the caller (the Cursor watcher) needs it, capture the raw
         // bytes of this SAME capped read into a buffer and decode lines from THAT buffer, rather
         // than streaming lines directly off `stream`. This is what lets the runtime rewrite guard
         // hash the EXACT bytes that produced `newLines` below — the previous wiring decoded lines
@@ -3273,7 +3273,7 @@ static partial class WatchCommand {
         // and the pre-send re-verify would see the same, but stale, later snapshot). Every other
         // vendor keeps the original zero-buffering streaming path (captureRawBytes defaults false).
         if (captureRawBytes) {
-            // AI-1382 review fix (r3, finding #3) — bound the capture to [rawBytesReadFrom, EOF)
+            // bound the capture to [rawBytesReadFrom, EOF)
             // instead of always materializing the whole file. The caller (DrainNewLines) only ever
             // passes a non-zero rawBytesReadFrom on a poll that doesn't need the periodic
             // full-prefix re-hash, so an idle/small poll allocates a buffer sized to the guard's
@@ -3340,7 +3340,7 @@ static partial class WatchCommand {
             }
         }
 
-        // AI-1382 review fix #3: `length` is the exact byte boundary this read was capped at
+        // `length` is the exact byte boundary this read was capped at
         // (sampled once, above, before any concurrent append could grow the file further) —
         // threaded through as SnapshotByteLength so the Cursor rewrite guard can use THIS value
         // instead of re-sampling FileInfo.Length later and risking a race with an append that
@@ -3353,8 +3353,8 @@ static partial class WatchCommand {
     // Decide the fate of a still-being-written final line (no trailing newline yet). Under
     // Hold (every live drain) it is always held back: the position stays before it and it is dropped
     // from this batch, so a later drain re-reads it once newline-terminated — consuming its truncated
-    // prefix would permanently drop the completed line (AI-1243). Under ConsumeIfComplete (the
-    // shutdown final drain — AI-1357 task 7) it is consumed ONLY IF the exact bytes read parse as a
+    // prefix would permanently drop the completed line. Under ConsumeIfComplete (the
+    // shutdown final drain — task 7) it is consumed ONLY IF the exact bytes read parse as a
     // complete JSON record; a still-growing/unparseable tail is held (never sent-and-advanced) and
     // signalled via HeldIncompleteFinalLine so the caller can flag needs-import. Because the parse
     // check runs on the bytes actually being consumed here, there is no TOCTOU with any earlier

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -355,7 +355,7 @@ static partial class WatchCommand {
             case ParentWatchdog.ParentAlreadyDead:
                 Log($"Parent pid {parentPid} already dead at watcher startup; entering staged recovery — "
                   + "will periodically re-resolve + re-arm the watchdog, and only end after a long ceiling "
-                  + "with no transcript progress and continued resolution failure (AI-1359).");
+                  + "with no transcript progress and continued resolution failure.");
 
                 // Staged recovery: re-resolve the durable agent (using the vendor alias) and re-arm if
                 // found; otherwise end ONLY after `ceiling` of no transcript progress. Any new progress

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -191,7 +191,7 @@ static partial class WatchCommand {
         Console.SetOut(logWriter);
         Console.SetError(logWriter);
 
-        // task 9: `logKey` is already the same `{sessionId}` / `{sessionId}-{agentId}`
+        // Task 9: `logKey` is already the same `{sessionId}` / `{sessionId}-{agentId}`
         // key WatcherManager uses for the pid file, so it doubles as the heartbeat key. Touch
         // once here (startup) and then every main-loop iteration below so a hook-side
         // staleness probe can distinguish a wedged (hung-but-alive) watcher from a healthy
@@ -314,7 +314,7 @@ static partial class WatchCommand {
             cts.Cancel();
         }
 
-        // task 8: the dedicated undelivered-transcript-tail spool, shared by the final-drain
+        // Task 8: the dedicated undelivered-transcript-tail spool, shared by the final-drain
         // needs-import marker below and the shutdown-during-outage tail spool.
         var transcriptSpool = new TranscriptSpool(PathHelpers.ConfigPath("transcript-spool"));
 
@@ -547,7 +547,7 @@ static partial class WatchCommand {
         var connectRetryDelay = TimeSpan.FromSeconds(1);
 
         while (!cts.Token.IsCancellationRequested) {
-            // task 9: touch every connect-retry iteration too. A server outage at
+            // Task 9: touch every connect-retry iteration too. A server outage at
             // startup (backoff up to 30s) that lasts longer than grace+threshold (~50s) is a
             // healthy-but-reconnecting watcher, NOT a wedged one — without a heartbeat here
             // the hook probe would judge it stale and reap+respawn it repeatedly for the
@@ -614,7 +614,7 @@ static partial class WatchCommand {
 
         try {
             while (!cts.Token.IsCancellationRequested) {
-                // task 9: touch every iteration — including no-content drains and
+                // Task 9: touch every iteration — including no-content drains and
                 // while disconnected/reconnecting below — so staleness unambiguously means
                 // the loop itself is wedged, not merely idle or mid-reconnect.
                 TouchHeartbeat();
@@ -741,7 +741,7 @@ static partial class WatchCommand {
                 transcriptSpool.MarkNeedsImport(sessionId, "shutdown final drain: last transcript line never completed (no newline, unparseable)");
             }
 
-            // task 8: shutdown-during-outage. DrainNewLines above only advances
+            // Task 8: shutdown-during-outage. DrainNewLines above only advances
             // state.LinesProcessed past lines the hub actually CONFIRMED — a failed final-drain send
             // (hub down, OR a HubException while the connection stays Connected — the generic catch
             // below does not change connection state) leaves LinesProcessed unchanged, so any lines
@@ -818,7 +818,7 @@ static partial class WatchCommand {
     /// sight of a file it registers the subagent (<c>subagent-start</c>, fail-closed) then
     /// spawns a detached child watcher that streams it with the subagent's canonical agentId
     /// (→ <c>AgentSubsession-*</c>). Idempotent across ticks via <paramref name="seen"/>;
-    /// deterministic server-side lifecycle ids make re-registration safe..
+    /// deterministic server-side lifecycle ids make re-registration safe.
     /// </summary>
     static async Task ScanGeminiSubagents(
             string          baseUrl,
@@ -888,7 +888,7 @@ static partial class WatchCommand {
     /// that streams it with the canonical agentId (= childSid) → <c>AgentSubsession-*</c>, which
     /// lines up with the agentId the server surfaced from the parent's <c>task</c> tool call.
     /// Idempotent across ticks via <paramref name="seen"/>; deterministic server-side lifecycle
-    /// ids make re-registration safe. phase 2.
+    /// ids make re-registration safe.
     /// </summary>
     static async Task ScanOpenCodeSubagents(
             string            baseUrl,
@@ -1476,7 +1476,7 @@ static partial class WatchCommand {
                 antigravityGenMax = AppendAntigravityUsageLines(state, newLines, newLineNumbers, transcriptPath, state.LastAntigravityCreatedAt);
             }
 
-            // task 10: Kiro's per-turn credits/context% live in the sibling {id}.json, not
+            // Task 10: Kiro's per-turn credits/context% live in the sibling {id}.json, not
             // the .jsonl (see KiroUsage docs) — by the time Kiro flushes that sidecar, a live drain
             // has usually already sent the anchor's AssistantMessage line, so import-style inline
             // enrichment can't reach it. Backfill it instead as a synthetic KiroUsageBackfilled line
@@ -1892,7 +1892,7 @@ static partial class WatchCommand {
             CapacitorJsonContext.Default.TranscriptBatch);
 
     /// <summary>
-    /// task 8: called from the shutdown path only when the hub is NOT connected at the point
+    /// Task 8: called from the shutdown path only when the hub is NOT connected at the point
     /// the final drain finishes. Re-reads the transcript from <paramref name="linesProcessed"/> (the
     /// last line the server actually confirmed, per <see cref="DrainNewLines"/>'s
     /// "only advance position after successful send" rule) to EOF, using the same
@@ -2243,7 +2243,7 @@ static partial class WatchCommand {
         return maxIdx;
     }
 
-    // task 10: Kiro's per-turn credits/context% live in the sidecar {id}.json, not the
+    // Task 10: Kiro's per-turn credits/context% live in the sidecar {id}.json, not the
     // .jsonl the live watcher tails (see KiroUsage docs) — the import path enriches the anchor
     // AssistantMessage line inline because it reads the whole file up front, but a live drain has
     // already sent that line by the time Kiro flushes the sidecar. So the live path emits a
@@ -2824,7 +2824,7 @@ static partial class WatchCommand {
     /// means the agent is mid-write of it: it is held back — excluded from the batch AND from
     /// <see cref="NewTranscriptLines.NextPosition"/> — so a later drain re-reads it once complete.
     /// Consuming it would send a truncated line that fails to normalize server-side and permanently
-    /// drop the completed line (, the "endless reads" bug; large Read tool_result lines were
+    /// drop the completed line (the "endless reads" bug; large Read tool_result lines were
     /// the common victim). Blank lines are skipped from the output but still advance the position,
     /// matching the long-standing drain behaviour.
     /// </summary>
@@ -3218,7 +3218,7 @@ static partial class WatchCommand {
     /// the whole file (Qodo #291 #2): only lines beyond <paramref name="linesProcessed"/> are retained.
     /// The file length is sampled once and the end-of-file newline is read from the last byte, then the
     /// read is CAPPED at that length — so a concurrent append after the sample can't make an as-yet
-    /// unterminated final line look complete and get consumed (which would re-drop it —).
+    /// unterminated final line look complete and get consumed (which would re-drop it).
     /// Opened by the caller with FileShare.ReadWrite (Qodo #291 #1) so the writing agent is never blocked.
     /// </summary>
     /// <param name="rawBytesReadFrom">

--- a/src/Capacitor.Cli/CrashReporter.cs
+++ b/src/Capacitor.Cli/CrashReporter.cs
@@ -9,7 +9,7 @@ namespace Capacitor.Cli;
 /// spawns — that lets an exception escape its command handler would otherwise
 /// reach the NativeAOT runtime, which <b>aborts the process (SIGABRT) and writes
 /// a macOS crash report</b>. That was happening dozens of times a day in the
-/// wild (same class as, which fixed two specific <c>Process.Start</c>
+/// wild (the same class as a prior fix that patched two specific <c>Process.Start</c>
 /// sites but not the structural gap). This records the exception to a rolling
 /// crash log and maps the command to a fail-open exit, so the abort class
 /// disappears <i>and</i> the exact exception is captured for follow-up.

--- a/src/Capacitor.Cli/CrashReporter.cs
+++ b/src/Capacitor.Cli/CrashReporter.cs
@@ -4,12 +4,12 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli;
 
 /// <summary>
-/// AI-1168: last-resort guard for the CLI's top-level command dispatch. A `kcap`
+/// last-resort guard for the CLI's top-level command dispatch. A `kcap`
 /// invocation — especially a hook or a detached generator the coding agent
 /// spawns — that lets an exception escape its command handler would otherwise
 /// reach the NativeAOT runtime, which <b>aborts the process (SIGABRT) and writes
 /// a macOS crash report</b>. That was happening dozens of times a day in the
-/// wild (same class as AI-848, which fixed two specific <c>Process.Start</c>
+/// wild (same class as, which fixed two specific <c>Process.Start</c>
 /// sites but not the structural gap). This records the exception to a rolling
 /// crash log and maps the command to a fail-open exit, so the abort class
 /// disappears <i>and</i> the exact exception is captured for follow-up.

--- a/src/Capacitor.Cli/MemoryIndexEmitter.cs
+++ b/src/Capacitor.Cli/MemoryIndexEmitter.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Nodes;
 namespace Capacitor.Cli;
 
 /// <summary>
-/// AI-1165 (Agent Memories Phase 2) — builds the SessionStart "team memory" index
+/// builds the SessionStart "team memory" index
 /// fragment from the <c>GET /api/memories/index</c> response body: a JSON array of
 /// <c>{memory_id, slug, audience, description, kind}</c>, already capped and
 /// most-recently-updated first by the server.

--- a/src/Capacitor.Cli/ProcessHelpers.cs
+++ b/src/Capacitor.Cli/ProcessHelpers.cs
@@ -144,7 +144,7 @@ static partial class ProcessHelpers {
     /// the transcript watcher.
     /// </summary>
     /// <remarks>
-    /// Background (AI-820): hooks are invoked by the coding agent (Claude/Codex) with their
+    /// Background: hooks are invoked by the coding agent (Claude/Codex) with their
     /// stdio wired to pipes the agent reads. .NET's <see cref="System.Diagnostics.Process"/>
     /// always passes <c>bInheritHandles: true</c> to <c>CreateProcess</c> when any stream is
     /// redirected, so a watcher spawned from inside a hook inherits the hook process's own
@@ -189,7 +189,7 @@ static partial class ProcessHelpers {
                 return;
             }
 
-            // SetHandleInformation genuinely failed on a valid handle: the AI-820
+            // SetHandleInformation genuinely failed on a valid handle: the
             // mitigation did not apply, so a spawned watcher may still inherit this
             // pipe and reintroduce the hang/leak. Surface one diagnostic per process
             // (don't spam the agent's hook output) and never throw.
@@ -269,7 +269,7 @@ static partial class ProcessHelpers {
             // Walk the ppid ancestry by process name to skip the transient per-hook
             // executor. GetParentPidWindows() alone returns that executor, which has
             // usually already exited by the time the watcher boots — so the parent-PID
-            // watchdog saw a dead PID at startup and silently never armed (AI-822).
+            // watchdog saw a dead PID at startup and silently never armed.
             // Falls back to the immediate parent when no agent is found on the chain
             // (preserving prior behaviour for the no-vendor / unmatched cases). PID reuse
             // is a known Windows hazard for ppid walks, but the by-name match means a
@@ -345,7 +345,7 @@ static partial class ProcessHelpers {
     /// Returns <c>(ppid, comm)</c> for an arbitrary live PID, or null if the process
     /// can't be inspected (gone, access denied, or unsupported platform). Feeds the
     /// ancestry walk in <see cref="ResolveCodingAgentPid"/> on every platform — the
-    /// Windows implementation (AI-822) reads the parent PID via
+    /// Windows implementation reads the parent PID via
     /// <c>NtQueryInformationProcess</c> and the image name via
     /// <c>QueryFullProcessImageName</c>.
     /// </summary>
@@ -585,7 +585,7 @@ static partial class ProcessHelpers {
 
         // Match the vendor token OR `{vendor}-cli`. The bounded `-cli` tolerance fixes the Kiro
         // watchdog, whose durable process image is `kiro-cli` while its vendor token is `kiro`
-        // (AI-1359); the clean-stem gate above keeps it from over-matching unrelated processes.
+        // The clean-stem gate above keeps it from over-matching unrelated processes.
         return stem.Equals(vendor, StringComparison.OrdinalIgnoreCase)
             || stem.Equals($"{vendor}-cli", StringComparison.OrdinalIgnoreCase);
     }

--- a/src/Capacitor.Cli/ProcessHelpers.cs
+++ b/src/Capacitor.Cli/ProcessHelpers.cs
@@ -197,7 +197,7 @@ static partial class ProcessHelpers {
                 stdHandleInheritWarned = true;
                 Console.Error.WriteLine(
                     $"[kcap] warning: could not clear HANDLE_FLAG_INHERIT on {streamName} "
-                  + $"(win32 error {Marshal.GetLastPInvokeError()}); a spawned watcher may inherit std handles (AI-820).");
+                  + $"(win32 error {Marshal.GetLastPInvokeError()}); a spawned watcher may inherit std handles.");
             }
         } catch {
             // Best effort — handle hygiene must never crash the spawn path.

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -559,7 +559,7 @@ switch (command) {
             ? allSources.Where(s => vsel.Vendors.Contains(s.Vendor)).ToList()
             : allSources;
 
-        // Scope resolution ---
+        // --- Scope resolution ---
         var profileConfig = await AppConfig.LoadProfileConfig();
         var activeProfile = string.IsNullOrEmpty(profileConfig.ActiveProfile) ? "default" : profileConfig.ActiveProfile;
         var storedOrg     = profileConfig.Profiles.GetValueOrDefault(activeProfile)?.ImportOrg;

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -93,7 +93,7 @@ if (baseUrl is null && !offlineCommands.Contains(command)) {
     return 1;
 }
 
-// AI-1168: last-resort guard around the whole command dispatch. Without it, any
+// last-resort guard around the whole command dispatch. Without it, any
 // exception a handler doesn't swallow escapes to the NativeAOT runtime, which
 // aborts the process (SIGABRT + a macOS crash report). For a ~1s hook/generator
 // the agent spawns, that was happening dozens of times a day. Record the
@@ -559,7 +559,7 @@ switch (command) {
             ? allSources.Where(s => vsel.Vendors.Contains(s.Vendor)).ToList()
             : allSources;
 
-        // --- Scope resolution (AI-613) ---
+        // Scope resolution ---
         var profileConfig = await AppConfig.LoadProfileConfig();
         var activeProfile = string.IsNullOrEmpty(profileConfig.ActiveProfile) ? "default" : profileConfig.ActiveProfile;
         var storedOrg     = profileConfig.Profiles.GetValueOrDefault(activeProfile)?.ImportOrg;
@@ -638,7 +638,7 @@ switch (command) {
     }
     // Internal: spawned detached by the Copilot sessionEnd hook to deliver the
     // post-hook `session.shutdown` tail Copilot writes after the hook returns
-    // (AI-897). Not a user-facing command.
+    // Not a user-facing command.
     case "copilot-finalize" when args.Length < 3:
         Console.Error.WriteLine("Usage: kcap copilot-finalize <sessionId> <transcriptPath>");
 
@@ -698,7 +698,7 @@ switch (command) {
         return 0;
     }
     case "hook": {
-        // AI-1357 Task 12: global, session-agnostic drain pass run early in EVERY non-Codex hook
+        // Task 12: global, session-agnostic drain pass run early in EVERY non-Codex hook
         // invocation — centralizes the per-vendor AgentHookPoster.DrainSpoolsAsync calls Tasks 4-6
         // added (removed from their Handle methods so this runs exactly once per invocation) and
         // additionally covers Claude/Cursor, which never called it (they only drain their OWN
@@ -748,7 +748,7 @@ switch (command) {
         await Console.Error.WriteLineAsync(
             "kcap cursor import has been removed. Use 'kcap import --cursor' instead.");
         return 2;
-    // Internal: AI-1382 D0 phase-0 empirical append-only verification harness. Hidden —
+    // Internal: D0 phase-0 empirical append-only verification harness. Hidden —
     // not in help-usage.txt — run manually against a live Cursor transcript while gathering
     // the D0 evidence; not part of the normal watch/hook/import surface.
     case "cursor-verify-appendonly":

--- a/src/Capacitor.Cli/RepositoryDetection.cs
+++ b/src/Capacitor.Cli/RepositoryDetection.cs
@@ -12,7 +12,7 @@ namespace Capacitor.Cli;
 static class RepositoryDetection {
     // Bump whenever the cached shape/derivation changes so stale entries are ignored.
     // v2: added Host + provider-aware parsing.
-    // v3: multi-segment owner parsing (nested GitLab groups,) — v2 entries for
+    // v3: multi-segment owner parsing (nested GitLab groups) — v2 entries for
     //     nested repos have owner=null and must re-derive.
     internal const int CacheSchemaVersion = 3;
 

--- a/src/Capacitor.Cli/RepositoryDetection.cs
+++ b/src/Capacitor.Cli/RepositoryDetection.cs
@@ -12,7 +12,7 @@ namespace Capacitor.Cli;
 static class RepositoryDetection {
     // Bump whenever the cached shape/derivation changes so stale entries are ignored.
     // v2: added Host + provider-aware parsing.
-    // v3: multi-segment owner parsing (nested GitLab groups, AI-1121) — v2 entries for
+    // v3: multi-segment owner parsing (nested GitLab groups,) — v2 entries for
     //     nested repos have owner=null and must re-derive.
     internal const int CacheSchemaVersion = 3;
 
@@ -57,7 +57,7 @@ static class RepositoryDetection {
     }
 
     /// <summary>
-    /// cwd-explicit enrichment (AI-1152). Same as <see cref="EnrichWithRepositoryInfo"/> but the
+    /// cwd-explicit enrichment. Same as <see cref="EnrichWithRepositoryInfo"/> but the
     /// working directory is supplied by the caller rather than read from a <c>cwd</c> field —
     /// used by the Cursor hook path, whose payloads carry <c>workspace_roots</c> instead of
     /// <c>cwd</c>. Always attaches when a repo is detected (no last-emitted dedup): callers use
@@ -119,7 +119,7 @@ static class RepositoryDetection {
     // detectPullRequest=false skips the live PR/MR provider detection (the `gh pr view` / `glab api`
     // round-trip) while still resolving base repo info (owner/repo/user/branch/host). Bulk import
     // passes false: it never emits PR fields, so that per-cwd round-trip is pure wasted latency
-    // (AI-1122). `run` is an injectable command runner (defaults to the real process spawner) so the
+    // `run` is an injectable command runner (defaults to the real process spawner) so the
     // git/provider spawns are unit-testable.
     public static async Task<RepositoryPayload?> DetectRepositoryAsync(
             string cwd, TimeSpan? budget = null, bool detectPullRequest = true, CommandRunner? run = null) {

--- a/src/Capacitor.Cli/SecretRedactor.cs
+++ b/src/Capacitor.Cli/SecretRedactor.cs
@@ -6,7 +6,7 @@ static partial class SecretRedactor {
     // Above this length, lines are replaced with an opaque placeholder instead of being scanned
     // by the regex pipeline. Real conversation turns and small tool results stay well under this;
     // lines above it are almost always truncated dumps (mid-key secret blobs, base64 blobs) that
-    // would trip regex alternation paths into catastrophic backtracking (see AI-783 / line 953
+    // would trip regex alternation paths into catastrophic backtracking (the line 953
     // incident where an unterminated `-----BEGIN RSA PRIVATE KEY-----` blob wedged the watcher
     // main loop at 100% CPU). UTF-16 code units, not bytes — the redaction cost is dominated by
     // regex stepping over chars, and the limit is a coarse defense-in-depth bound, not a wire-size
@@ -73,7 +73,7 @@ static partial class SecretRedactor {
     // Each prefix is specific enough to avoid false positives — EXCEPT the bare `sk-` (OpenAI)
     // prefix, which is short enough to appear mid-word: it matched the `sk-notification` substring
     // inside "ta·sk-notification", redacting Claude Code's injected background-task blocks to
-    // `<ta[REDACTED]> … </ta[REDACTED]>` (AI-1162). Gate the `sk-` branch on a non-alphanumeric
+    // `<ta[REDACTED]> … </ta[REDACTED]>`. Gate the `sk-` branch on a non-alphanumeric
     // lookbehind so it only fires at a token boundary; real keys (`sk-proj-…`, `sk-live_…`,
     // preceded by whitespace/quote/punctuation) still redact, while `disk-`, `task-`, `kiosk-` etc.
     // pass through. The other prefixes carry `_`/distinctive spellings and don't collide mid-word.
@@ -133,7 +133,7 @@ static partial class SecretRedactor {
     // Known limitation: header values that embed escaped quotes (e.g. `Set-Cookie: a=\"b\"; …`
     // inside JSON-encoded content) capture only up to the first `\`. Fixing this properly
     // requires JSON-tree-aware redaction (parse → walk strings → redact decoded → re-serialize),
-    // tracked as a follow-up — see AI-649.
+    // tracked as a follow-up.
     //
     // group 1 = header name + colon + optional opening quote, group 2 = value
     [GeneratedRegex(

--- a/src/Capacitor.Cli/WatcherManager.cs
+++ b/src/Capacitor.Cli/WatcherManager.cs
@@ -136,7 +136,7 @@ static class WatcherManager {
 
             await File.WriteAllTextAsync(GetPidFilePath(key), process.Id.ToString());
 
-            // task 9: record this instance's start time so a later staleness probe
+            // Task 9: record this instance's start time so a later staleness probe
             // knows whether it's still within the startup grace window — written here (not
             // by the watcher itself) so it exists even if the child never gets far enough to
             // touch its own heartbeat.
@@ -538,7 +538,7 @@ static class WatcherManager {
                     // Redact like WatchCommand.DrainNewLines — the live watcher
                     // path already redacts, and this inline-drain can carry real
                     // assistant/tool content (e.g. the Copilot final turn the
-                    // finalize drain delivers,).
+                    // finalize drain delivers).
                     newLines.Add(SecretRedactor.RedactLine(line));
                     newLineNumbers.Add(lineIndex);
                 }

--- a/src/Capacitor.Cli/WatcherManager.cs
+++ b/src/Capacitor.Cli/WatcherManager.cs
@@ -18,7 +18,7 @@ static class WatcherManager {
     /// <summary>
     /// Per-key heartbeat file (touched every main-loop iteration by the watcher itself —
     /// see <c>WatchCommand.RunWatch</c>) used by <see cref="IsWatcherAlive"/> to tell a
-    /// wedged (hung-but-alive) watcher from a healthy one (AI-1357 task 9).
+    /// wedged (hung-but-alive) watcher from a healthy one.
     /// </summary>
     internal static string GetHeartbeatFilePath(string key) => WatcherHeartbeat.HeartbeatPath(GetWatcherDir(), key);
 
@@ -35,7 +35,7 @@ static class WatcherManager {
     /// (<c>FileShare.None</c> maps to <c>flock(LOCK_EX)</c> on POSIX and a real exclusive
     /// lock on Windows) — guarding every spawn decision in <see cref="EnsureWatcherRunning"/>
     /// (both "no watcher yet" and "reap a wedged one first") so concurrent hooks racing the
-    /// same key can't double-spawn (AI-1357 task 9).
+    /// same key can't double-spawn.
     /// </summary>
     static string GetSpawnLockFilePath(string key) => Path.Combine(GetWatcherDir(), $"{key}.spawnlock");
 
@@ -119,7 +119,7 @@ static class WatcherManager {
 
             // Stop the watcher from inheriting the coding agent's std handles on Windows;
             // otherwise it holds the agent's hook-stdout pipe open for its whole lifetime,
-            // hanging synchronous subagent hooks and orphaning the watcher (AI-820).
+            // hanging synchronous subagent hooks and orphaning the watcher.
             ProcessHelpers.PreventInheritedStdHandles();
 
             var process = Process.Start(psi);
@@ -136,7 +136,7 @@ static class WatcherManager {
 
             await File.WriteAllTextAsync(GetPidFilePath(key), process.Id.ToString());
 
-            // AI-1357 task 9: record this instance's start time so a later staleness probe
+            // task 9: record this instance's start time so a later staleness probe
             // knows whether it's still within the startup grace window — written here (not
             // by the watcher itself) so it exists even if the child never gets far enough to
             // touch its own heartbeat.
@@ -151,7 +151,7 @@ static class WatcherManager {
     }
 
     /// <summary>
-    /// Deletes the per-key heartbeat + started markers (AI-1357 task 9) so they don't leak
+    /// Deletes the per-key heartbeat + started markers so they don't leak
     /// per-session the way the pid file never did. Deliberately does NOT touch the
     /// <c>{key}.spawnlock</c> file: <see cref="KillWatcher"/> can run from inside
     /// <see cref="WithSpawnLock"/> (the wedged-watcher reap path), and unlinking a held lock
@@ -168,7 +168,7 @@ static class WatcherManager {
     /// Removes every leftover per-key auxiliary file (<c>*.heartbeat</c>/<c>*.started</c>/
     /// <c>*.spawnlock</c>) in the watcher directory. Called by <c>kcap cleanup</c> after all
     /// watchers are killed — the one place it is safe to unlink spawn-lock files, since cleanup
-    /// holds no spawn lock. Returns the number of files removed (AI-1357 task 9).
+    /// holds no spawn lock. Returns the number of files removed.
     /// </summary>
     public static int PurgeAuxiliaryFiles() {
         var dir = GetWatcherDir();
@@ -196,7 +196,7 @@ static class WatcherManager {
     /// <summary>
     /// Kills the watcher process for the given key. Returns true if the watcher was running and was killed,
     /// false if it was already dead or no PID file existed. Always removes the per-key
-    /// heartbeat/started markers (AI-1357 task 9); see <see cref="DeleteHeartbeatFiles"/> for
+    /// heartbeat/started markers; see <see cref="DeleteHeartbeatFiles"/> for
     /// why the spawn lock is intentionally left behind here.
     /// </summary>
     public static async Task<bool> KillWatcher(string key) {
@@ -286,7 +286,7 @@ static class WatcherManager {
     /// <summary>
     /// True when the watcher's PID exists AND its heartbeat isn't stale (after the startup
     /// grace) — i.e. the process is alive AND its main loop is provably still turning, not
-    /// wedged (AI-1357 task 9). A PID-only check (the old behavior, still available via
+    /// wedged. A PID-only check (the old behavior, still available via
     /// <see cref="PidAlive"/>) can't tell a hung watcher from a healthy one.
     /// </summary>
     internal static bool IsWatcherAlive(string key) {
@@ -309,7 +309,7 @@ static class WatcherManager {
     /// <see cref="GetSpawnLockFilePath"/>). If another process already holds it, returns
     /// immediately WITHOUT running <paramref name="body"/> — the current holder is either
     /// already reaping + respawning this key, or about to, so there is nothing for the
-    /// loser to do but skip (AI-1357 task 9: prevents two concurrent hooks from
+    /// loser to do but skip (task 9: prevents two concurrent hooks from
     /// double-spawning a watcher for the same key).
     /// </summary>
     internal static async Task WithSpawnLock(string key, Func<Task> body) {
@@ -368,7 +368,7 @@ static class WatcherManager {
         // would leave a race: KillWatcher deletes the pid file before releasing the lock, so
         // a second hook arriving in that window would see "no pid" and take an unguarded
         // plain-spawn path, double-spawning anyway. Locking the whole decision — including
-        // the plain "no watcher yet" spawn — closes that window (AI-1357 task 9).
+        // the plain "no watcher yet" spawn — closes that window.
         await WithSpawnLock(key, async () => {
             // Re-check under the lock: another hook may have already reaped + respawned (or
             // spawned from scratch) this key while we were waiting to acquire it.
@@ -412,7 +412,7 @@ static class WatcherManager {
             }
 
             // Don't let this detached child inherit the agent's std handles on Windows
-            // (AI-820) — same pipe-leak hazard as the watcher spawn above.
+            // same pipe-leak hazard as the watcher spawn above.
             ProcessHelpers.PreventInheritedStdHandles();
 
             var process = Process.Start(psi);
@@ -438,7 +438,7 @@ static class WatcherManager {
     /// Spawns a detached, short-lived <c>kcap copilot-finalize</c> process that
     /// delivers the Copilot <c>session.shutdown</c> tail (and any final assistant
     /// turn) which Copilot writes to events.jsonl only AFTER the sessionEnd hook
-    /// returns (AI-897). The hook calls this as its FIRST action — before killing
+    /// returns. The hook calls this as its FIRST action — before killing
     /// the live watcher and POSTing session-end — so the drainer is guaranteed to
     /// exist even if the POST hangs and Copilot SIGKILLs the hook; being detached
     /// it survives that kill and is the only thing left to read the file. Fire-
@@ -462,7 +462,7 @@ static class WatcherManager {
             psi.ArgumentList.Add(transcriptPath);
 
             // Don't let this detached child inherit the agent's std handles on
-            // Windows (AI-820) — same pipe-leak hazard as the spawns above.
+            // Windows — same pipe-leak hazard as the spawns above.
             ProcessHelpers.PreventInheritedStdHandles();
 
             var process = Process.Start(psi);
@@ -538,7 +538,7 @@ static class WatcherManager {
                     // Redact like WatchCommand.DrainNewLines — the live watcher
                     // path already redacts, and this inline-drain can carry real
                     // assistant/tool content (e.g. the Copilot final turn the
-                    // finalize drain delivers, AI-897).
+                    // finalize drain delivers,).
                     newLines.Add(SecretRedactor.RedactLine(line));
                     newLineNumbers.Add(lineIndex);
                 }

--- a/test/Capacitor.Cli.Tests.Integration/AntigravityImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/AntigravityImportTests.cs
@@ -186,7 +186,7 @@ public class AntigravityImportTests : IDisposable {
         // server's stop no-ops without an active mark, and that mark is lost on a restart, so the
         // start re-establishes it before the stop appends the completion event. Without this a
         // prior run's stop that failed after content leaves the subagent uncompleted forever
-        // (review, findings at :240 / :249).
+        // (see the resume-from-line-position tests below for the exact edge cases).
         _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"last_line_number":99}"""));
         foreach (var route in new[] {

--- a/test/Capacitor.Cli.Tests.Integration/AntigravityImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/AntigravityImportTests.cs
@@ -6,10 +6,10 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// Wire-contract test for Antigravity historical import (AI-1160). Drives the full
+/// Wire-contract test for Antigravity historical import. Drives the full
 /// discover → classify → import path over an on-disk brain tree (a root conversation plus
 /// a subagent conversation linked via an INVOKE_SUBAGENT step in the parent's
-/// transcript_full.jsonl — the AI-1218 spawn-time signal, see
+/// transcript_full.jsonl — the spawn-time signal, see
 /// <c>AntigravitySubagents.BuildParentMap</c>) and asserts the lifecycle the server expects:
 /// session-start/antigravity → parent transcript → subagent-start → child transcript (routed
 /// by agent_id) → subagent-stop → session-end/antigravity, all tagged vendor=antigravity.
@@ -23,7 +23,7 @@ public class AntigravityImportTests : IDisposable {
 
     // The brain-dir conversation id is dashed on disk, but the id surfaced to the server
     // (session id + subagent agent_id) is the dashless canonical form — matching live capture
-    // so live + imported captures of one conversation land on the same stream (AI-1238).
+    // so live + imported captures of one conversation land on the same stream.
     static string Dashless(string id) => Guid.Parse(id).ToString("N");
 
     public void Dispose() {
@@ -43,7 +43,7 @@ public class AntigravityImportTests : IDisposable {
     }
 
     // Appends an INVOKE_SUBAGENT step to Root's transcript naming Child as the spawned
-    // conversation — the AI-1218 spawn-time linkage BuildParentMap reads (messages/*.json is
+    // conversation — the spawn-time linkage BuildParentMap reads (messages/*.json is
     // no longer consulted). Root's transcript must already exist (WriteTranscript(Root, ...)
     // is called before this at every call site).
     void WriteLinkage() {
@@ -130,7 +130,7 @@ public class AntigravityImportTests : IDisposable {
 
         // Parent (no agentId) fully ingested → AlreadyLoaded; the child (agentId=dashless Child)
         // was never imported (404). The AlreadyLoaded branch must STILL run the child-repair pass,
-        // else a once-skipped subagent is lost forever (AI-1160 review, finding 1).
+        // else a once-skipped subagent is lost forever.
         _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").WithParam("agentId", Dashless(Child)).UsingGet())
             .AtPriority(1)
             .RespondWith(Response.Create().WithStatusCode(404));
@@ -163,7 +163,7 @@ public class AntigravityImportTests : IDisposable {
 
         // The parent transcript is not re-sent, but lifecycle IS re-asserted (repair — a prior
         // run may have failed session-end) and the missing child is repaired: session-start →
-        // subagent-start → child transcript → subagent-stop → session-end (AI-1160 review, finding 1).
+        // subagent-start → child transcript → subagent-stop → session-end.
         await Assert.That(posts.Contains("/hooks/subagent-start")).IsTrue();
         await Assert.That(posts.Contains("/hooks/subagent-stop")).IsTrue();
         await Assert.That(posts.Contains("/hooks/session-start/antigravity")).IsTrue();
@@ -186,7 +186,7 @@ public class AntigravityImportTests : IDisposable {
         // server's stop no-ops without an active mark, and that mark is lost on a restart, so the
         // start re-establishes it before the stop appends the completion event. Without this a
         // prior run's stop that failed after content leaves the subagent uncompleted forever
-        // (AI-1160 review, findings at :240 / :249).
+        // (review, findings at :240 / :249).
         _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"last_line_number":99}"""));
         foreach (var route in new[] {
@@ -242,7 +242,7 @@ public class AntigravityImportTests : IDisposable {
 
         // Parent not yet imported (404) → New; child partially imported up to line 0 → resume from
         // file line 1, numbered by TRUE position (1). The pre-fix code fed the HWM as
-        // lineNumberOffset and re-sent the whole file as [1,2] (AI-1160 review, finding 2).
+        // lineNumberOffset and re-sent the whole file as [1,2].
         _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").WithParam("agentId", Dashless(Child)).UsingGet())
             .AtPriority(1)
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"last_line_number":0}"""));

--- a/test/Capacitor.Cli.Tests.Integration/AntigravityImportUsagePassTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/AntigravityImportUsagePassTests.cs
@@ -7,7 +7,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// Wire-contract test for the AI-1358 (item 7.1) explicit gen_metadata usage pass on
+/// Wire-contract test for the (item 7.1) explicit gen_metadata usage pass on
 /// Antigravity historical import: the source must decode the sibling conversation
 /// <c>.db</c>'s <c>gen_metadata</c> row(s) into synthetic USAGE transcript lines and POST
 /// them via <c>/hooks/transcript</c> BEFORE <c>/hooks/session-end/antigravity</c> — for every

--- a/test/Capacitor.Cli.Tests.Integration/AntigravitySessionStartTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/AntigravitySessionStartTests.cs
@@ -9,7 +9,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// CLI→server integration for the Antigravity hook dispatcher (AI-1158/AI-1159):
+/// CLI→server integration for the Antigravity hook dispatcher:
 /// a PreInvocation drives a POST to /hooks/session-start/antigravity carrying the
 /// enriched payload (session id, version, profile default visibility), and an
 /// excluded-repo PreInvocation is skipped and marks the session disabled.

--- a/test/Capacitor.Cli.Tests.Integration/AntigravitySkippedChildOverrideRoutedLoopTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/AntigravitySkippedChildOverrideRoutedLoopTests.cs
@@ -75,7 +75,7 @@ public class AntigravitySkippedChildOverrideRoutedLoopTests : IDisposable {
     }
 
     // Appends an INVOKE_SUBAGENT step to Root's transcript naming Child as the spawned
-    // conversation — the AI-1218 spawn-time linkage AntigravitySubagents.BuildParentMap reads.
+    // conversation — the spawn-time linkage AntigravitySubagents.BuildParentMap reads.
     void WriteLinkage() {
         var dir = Path.Combine(BrainDir(RootConvId), ".system_generated", "logs");
         Directory.CreateDirectory(dir);

--- a/test/Capacitor.Cli.Tests.Integration/ClaudeHookStdoutTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/ClaudeHookStdoutTests.cs
@@ -11,7 +11,7 @@ namespace Capacitor.Cli.Tests.Integration;
 /// WireMock server and captures stdout to validate the SessionStart
 /// <c>hookSpecificOutput</c> envelope shape — including the
 /// single-envelope invariant when both <c>top_clusters</c> and
-/// <c>version</c> are present (AI-768).
+/// <c>version</c> are present.
 ///
 /// Test payloads deliberately OMIT <c>transcript_path</c> so the
 /// session-start path short-circuits before
@@ -31,7 +31,7 @@ namespace Capacitor.Cli.Tests.Integration;
 /// A group key is insufficient: another file's test whose SUT writes to
 /// <c>Console.Out</c> (e.g. <c>CodexHookCommand</c> emitting
 /// <c>{"continue":true}</c>) can run under a DIFFERENT key and leak into the
-/// capture (AI-737). Do not re-add a group key here.
+/// capture. Do not re-add a group key here.
 /// </summary>
 public class ClaudeHookStdoutTests : IDisposable {
     readonly WireMockServer _server = WireMockServer.Start();

--- a/test/Capacitor.Cli.Tests.Integration/CodexSessionStartVisibilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CodexSessionStartVisibilityTests.cs
@@ -9,7 +9,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// AI-782 — Codex sessions must honor the active V2 profile's
+/// Codex sessions must honor the active V2 profile's
 /// <c>default_visibility</c> and <c>excluded_repos</c> settings, the
 /// same way the Claude hook does. Without this, Codex sessions
 /// silently default to org-visible (the server treats null as the

--- a/test/Capacitor.Cli.Tests.Integration/CursorImportPrTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CursorImportPrTests.cs
@@ -7,7 +7,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// AI-1358 Task 5.1: Cursor historical import must attach owner/repo but never a stale PR
+/// Task 5.1: Cursor historical import must attach owner/repo but never a stale PR
 /// (importing an old session shouldn't stamp today's PR onto it — an anachronism), and repo
 /// detection for a given workspace must run at most once per <c>import</c> invocation even
 /// when many sessions share the same cwd. Drives the real discover → classify → import path

--- a/test/Capacitor.Cli.Tests.Integration/CursorPrivatizeLifecycleFailureTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CursorPrivatizeLifecycleFailureTests.cs
@@ -6,7 +6,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// AI-1154 review fix (r6, P1) — a lifecycle failure (subagent-stop/session-end) or a no-new-
+/// a lifecycle failure (subagent-stop/session-end) or a no-new-
 /// content retry AFTER a Cursor session's content has already been posted must not permanently
 /// bypass <c>--private</c>. Drives the real <c>ImportCommand.HandleImport</c> orchestrator (not
 /// just <see cref="CursorImportSource.ImportSessionAsync"/> in isolation) against a stub server,
@@ -28,7 +28,7 @@ namespace Capacitor.Cli.Tests.Integration;
 /// The fix adds a separate, outcome-independent tracker
 /// (<c>privateScopeSessionIds</c> in <c>ImportCommand.cs</c>) that captures every Cursor routed
 /// classification touched under <c>--private</c> regardless of outcome, and unions it into the
-/// privatize set — without touching <c>importedSessionIds</c>/the Done-grid counting (AI-1389
+/// privatize set — without touching <c>importedSessionIds</c>/the Done-grid counting (
 /// stays deferred, untouched).
 /// </para>
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Integration/CursorPrivatizeLifecycleFailureTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CursorPrivatizeLifecycleFailureTests.cs
@@ -28,7 +28,7 @@ namespace Capacitor.Cli.Tests.Integration;
 /// The fix adds a separate, outcome-independent tracker
 /// (<c>privateScopeSessionIds</c> in <c>ImportCommand.cs</c>) that captures every Cursor routed
 /// classification touched under <c>--private</c> regardless of outcome, and unions it into the
-/// privatize set — without touching <c>importedSessionIds</c>/the Done-grid counting (
+/// privatize set — without touching <c>importedSessionIds</c>/the Done-grid counting (that
 /// stays deferred, untouched).
 /// </para>
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Integration/CursorSuppressedRepoImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CursorSuppressedRepoImportTests.cs
@@ -7,7 +7,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// AI-1154 Task C2 (D1, CLI side) — the CLI already posts <c>session-start/cursor</c> (carrying
+/// Task C2 (D1, CLI side) — the CLI already posts <c>session-start/cursor</c> (carrying
 /// <c>repository</c> when detected) before ever branching on classification status, so an
 /// <c>AlreadyLoaded</c> (suppression-simulating) re-import still ships the repository payload the
 /// server's D1 suppressed-path handler (Task C1) needs to backfill attribution. This pins that

--- a/test/Capacitor.Cli.Tests.Integration/CursorTailingWatcherTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CursorTailingWatcherTests.cs
@@ -8,7 +8,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// AI-1382 Task 13 — end-to-end acceptance tests for the Cursor tailing-watcher promotion,
+/// Task 13 — end-to-end acceptance tests for the Cursor tailing-watcher promotion,
 /// composing the pure/HTTP seams Tasks 7-12 already built (mirroring
 /// <see cref="LiveWatchHardeningAcceptanceTests"/>'s style: thin tests proving the contract from
 /// a fresh vantage point, not re-deriving coverage an earlier task's unit tests already own).
@@ -241,7 +241,7 @@ public class CursorTailingWatcherTests {
     // ── 5. Resume at an unterminated final line, then its terminator arrives → no line drift (r6) ──
 
     /// <summary>
-    /// AI-1382 review fix (r6) — end-to-end regression for the P1 finding: a watcher resumes at a
+    /// end-to-end regression for the P1 finding: a watcher resumes at a
     /// server frontier that lands exactly on a COMPLETE-but-unterminated final record (the r5
     /// scenario — a prior process's shutdown final drain already sent and the server already
     /// acked that record), then Cursor appends the record's own trailing newline before writing

--- a/test/Capacitor.Cli.Tests.Integration/EvalQuestionsAliasRawTextTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/EvalQuestionsAliasRawTextTests.cs
@@ -7,7 +7,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// AI-9 Phase 3: the /api/eval/questions alias returns RAW question text in `prompt`
+/// Phase 3: the /api/eval/questions alias returns RAW question text in `prompt`
 /// (no prompt_version). An old released daemon substitutes that raw text into its OWN
 /// embedded {QUESTION_TEXT} template; a rendered value would double-wrap. This guards
 /// the CLI client's view of the alias contract.

--- a/test/Capacitor.Cli.Tests.Integration/EvalRunnerV2PostTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/EvalRunnerV2PostTests.cs
@@ -7,7 +7,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// AI-795 Task 18: locks in the daemon's V2 wire-format migration. After
+/// Task 18: locks in the daemon's V2 wire-format migration. After
 /// migrating <see cref="EvalService.Aggregate"/> to return
 /// <see cref="SessionEvalCompletedPayloadV2"/>, the persistence step must
 /// POST to <c>/api/sessions/{id}/evals/v2</c> (not the legacy V1 route)

--- a/test/Capacitor.Cli.Tests.Integration/EvalRunnerV3PostTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/EvalRunnerV3PostTests.cs
@@ -7,7 +7,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// AI-9 Phase 3: locks the daemon's V3 wire-format migration. The persistence
+/// Phase 3: locks the daemon's V3 wire-format migration. The persistence
 /// step must POST to /api/sessions/{id}/evals/v3 (not v2) and the body must
 /// carry per-question prompt_version and retrospective_prompt_version.
 /// Drives PersistAggregateV3Async directly (same seam as EvalRunnerV2PostTests).

--- a/test/Capacitor.Cli.Tests.Integration/GeminiSubagentImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/GeminiSubagentImportTests.cs
@@ -7,7 +7,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// Wire-contract test for Gemini subagent import (AI-900). Gemini records subagents
+/// Wire-contract test for Gemini subagent import. Gemini records subagents
 /// in nested files (<c>chats/&lt;parentSessionId&gt;/&lt;subId&gt;.jsonl</c>); the parent's
 /// <c>invoke_agent</c> tool call persists <c>agentId == subId</c> + <c>args.agent_name</c>.
 /// This drives the full discover → classify → import path and asserts the subagent
@@ -120,7 +120,7 @@ public class GeminiSubagentImportTests : IDisposable {
 
     // Root (invoke_agent → Sub) + Sub's OWN chats/<sub>/ dir with a grandsub file whose
     // invocation is recorded in SUB's own transcript (a DIFFERENT agent_name than the root's
-    // call) — matches EnumerateDescendantFiles' context-carrying walk (AI-1383 D3).
+    // call) — matches EnumerateDescendantFiles' context-carrying walk (D3).
     void WriteThreeLevelFixture() {
         var chats = Path.Combine(_tempDir, "proj", "chats");
         Directory.CreateDirectory(chats);
@@ -153,7 +153,7 @@ public class GeminiSubagentImportTests : IDisposable {
 
     [Test]
     public async Task ImportSession_imports_a_grandchild_subagent_as_direct_subagent_of_root_with_correct_type() {
-        // AI-1383 D3: a subagent's own subagent (chats/<sub>/<grandsub>.jsonl) must import —
+        // a subagent's own subagent (chats/<sub>/<grandsub>.jsonl) must import —
         // previously silently dropped by the single-level EnumerateSubagentFiles scan — as a
         // DIRECT subagent of the top-level root, with its type resolved from its IMMEDIATE
         // parent (Sub's own transcript), not the root's, and not falling back to "subagent".

--- a/test/Capacitor.Cli.Tests.Integration/GeminiSubagentImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/GeminiSubagentImportTests.cs
@@ -269,7 +269,7 @@ public class GeminiSubagentImportTests : IDisposable {
         await Assert.That(resolved).IsNull();
     }
 
-    // --- AI-1383 D3: recursive grandchild/descendant discovery. ---
+    // --- D3: recursive grandchild/descendant discovery. ---
 
     const string DashedGrandsub   = "8c1a2222-3333-4444-5555-666677778888";
     const string DashlessGrandsub = "8c1a2222333344445555666677778888";

--- a/test/Capacitor.Cli.Tests.Integration/ImportEndReassertTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/ImportEndReassertTests.cs
@@ -6,7 +6,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// AI-1358 Task A2.1: the Partial-resume branch must post exactly one
+/// Task A2.1: the Partial-resume branch must post exactly one
 /// <c>session-end/{vendor}</c> AFTER a successful fail-closed transcript tail — end-only
 /// reassert, since SessionStarted uses random ids (re-asserting start would duplicate it)
 /// while session-end has server-side idempotency — and must NEVER finalize when the tail

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -223,7 +223,7 @@ public class McpFlowsServerTests : IDisposable {
     }
 
     /// <summary>
-    /// Handshake probe (AI-1233): clients that send <c>resources/list</c> / <c>prompts/list</c> /
+    /// Handshake probe: clients that send <c>resources/list</c> / <c>prompts/list</c> /
     /// <c>ping</c> before treating the server as ready must get empty-but-successful responses,
     /// not <c>-32601 Method not found</c> — and the negotiated protocolVersion must echo back a
     /// client-requested version we support, not always the hardcoded baseline.
@@ -268,7 +268,7 @@ public class McpFlowsServerTests : IDisposable {
     }
 
     /// <summary>
-    /// Malformed-initialize survival probe (AI-1233): a client sending a non-string
+    /// Malformed-initialize survival probe: a client sending a non-string
     /// <c>protocolVersion</c> (e.g. a bare JSON number) must not crash <c>McpProtocol.NegotiateVersion</c> —
     /// the initialize dispatch arm has no try/catch, so an uncaught exception there would kill the
     /// whole stdio server. The server must fall back to the baseline version and stay responsive.
@@ -323,7 +323,7 @@ public class McpFlowsServerTests : IDisposable {
     /// <summary>
     /// Pins the four review-tool schemas byte-stably: definition_id/participant/message must
     /// NEVER leak into these schemas — old clients (and old skills) depend on the exact
-    /// property/required sets that shipped before the generic tools were added (AI-1126 D-b).
+    /// property/required sets that shipped before the generic tools were added (D-b).
     /// </summary>
     [Test]
     public async Task Review_tool_schemas_are_unchanged() {
@@ -376,7 +376,7 @@ public class McpFlowsServerTests : IDisposable {
 
     /// <summary>
     /// Generic alias for start_review_flow: definition_id maps onto the wire "kind" field so the
-    /// server (which treats kind == definition id, AI-1126 phase C) doesn't need to know about
+    /// server (which treats kind == definition id, phase C) doesn't need to know about
     /// the generic tool name at all.
     /// </summary>
     [Test]
@@ -544,7 +544,7 @@ public class McpFlowsServerTests : IDisposable {
     /// A non-boolean JSON "async" (e.g. an LLM caller passing the string "yes") must NOT crash
     /// the request with an uncaught GetValue&lt;bool&gt;() exception — it must surface as a clean
     /// isError:true tool result, and the stdio loop must stay alive for the next request (Qodo
-    /// finding, AI-1126 D-b). No WireMock stub is needed: the bad arg is rejected before any HTTP
+    /// finding, D-b). No WireMock stub is needed: the bad arg is rejected before any HTTP
     /// call is made, mirroring Submit_review_round_without_flow_run_id_returns_error above.
     /// </summary>
     [Test]
@@ -735,7 +735,7 @@ public class McpFlowsServerTests : IDisposable {
     }
 
     /// <summary>
-    /// Regression (AI-1056): kcap-flows auto-registers via the Claude plugin, so Claude Code
+    /// Regression: kcap-flows auto-registers via the Claude plugin, so Claude Code
     /// spawns `kcap mcp flows` for every session. initialize / tools/list must stay local-only —
     /// the authenticated client (and its GET /auth/config round-trip + re-auth stderr hint) is
     /// created lazily on the first tools/call, so sessions that never use a flows tool pay

--- a/test/Capacitor.Cli.Tests.Integration/OpenCodeDbFixtureIt.cs
+++ b/test/Capacitor.Cli.Tests.Integration/OpenCodeDbFixtureIt.cs
@@ -38,7 +38,7 @@ internal sealed class OpenCodeDbFixtureIt : IDisposable {
 
     // Nullable-timestamp variant of AddSession — real OpenCode rows can carry a NULL
     // time_created/time_updated (session never touched after creation, or a schema
-    // that predates the column), which must map to "unknown", not epoch (AI-1358).
+    // that predates the column), which must map to "unknown", not epoch.
     public void AddSessionRaw(string id, string? parent, string? dir, string title, long? timeCreated, long? timeUpdated) {
         using var c = Open(); using var cmd = c.CreateCommand();
         cmd.CommandText = "INSERT INTO session(id,parent_id,directory,title,version,time_created,time_updated) VALUES($i,$p,$d,$t,'1.17',$tc,$tu)";

--- a/test/Capacitor.Cli.Tests.Integration/OpenCodeImportSourceImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/OpenCodeImportSourceImportTests.cs
@@ -192,7 +192,7 @@ public class OpenCodeImportSourceImportTests : IDisposable {
 
     [Test]
     public async Task ImportSession_imports_a_three_level_chain_flattened_as_direct_subagents_of_root() {
-        // AI-1383 D3: a grandchild (parent_id → child → grandchild) must NOT be silently
+        // a grandchild (parent_id → child → grandchild) must NOT be silently
         // dropped — both descendants import as DIRECT subagents of the top-level root (the
         // existing flatten shape; Model A's stream key can't express deeper nesting).
         _fix.AddSession("ses_root", null, "/work/a", "Root", 100);
@@ -237,7 +237,7 @@ public class OpenCodeImportSourceImportTests : IDisposable {
 
     [Test]
     public async Task ImportSession_posts_session_end_even_when_a_descendant_subagent_start_fails() {
-        // AI-1383 D3 item 4 (finally-style re-close): a subagent-start posted against this
+        // D3 item 4 (finally-style re-close): a subagent-start posted against this
         // root may reactivate it if it was already Ended — so the session-end re-assertion
         // must run regardless of a descendant lifecycle failure. Previously OpenCode's early
         // `Failed` return here bailed before ever posting session-end.
@@ -303,7 +303,7 @@ public class OpenCodeImportSourceImportTests : IDisposable {
 
     [Test]
     public async Task ledger_version_bump_invalidates_a_pre_upgrade_direct_only_fingerprint() {
-        // AI-1383 D3: a ledger entry recorded before recursive descendant discovery shipped
+        // a ledger entry recorded before recursive descendant discovery shipped
         // covered only the parent + direct children. Simulate that stale entry directly (any
         // fingerprint computed under the OLD scheme differs from the new one, which always
         // carries the version marker) and confirm re-classification picks up the grandchild
@@ -393,7 +393,7 @@ public class OpenCodeImportSourceImportTests : IDisposable {
 
     [Test]
     public async Task ImportSession_reasserts_session_end_and_still_propagates_cancellation_after_a_descendant_reactivates_root() {
-        // AI-1383 D3 review fix #1: cancellation arriving AFTER a descendant lifecycle already
+        // cancellation arriving AFTER a descendant lifecycle already
         // reactivated the root must NOT skip the finally-style re-close, or the root is left
         // stuck Active. Two descendants: once the FIRST one's subagent-start/content/stop fully
         // lands (any of which could reactivate an already-Ended root server-side), cancellation
@@ -436,7 +436,7 @@ public class OpenCodeImportSourceImportTests : IDisposable {
 
     [Test]
     public async Task ImportSession_propagates_cancellation_arriving_during_title_cleanup_and_never_marks_ledger_complete() {
-        // AI-1383 D3 review fix #4: the round-1 fix (above) only recorded a cancellation THROWN
+        // the round-1 fix (above) only recorded a cancellation THROWN
         // BY ImportDescendantsAsync. A cancellation arriving AFTER descendants finish — while
         // step 4's PostSetTitleAsync is awaited, which swallows OperationCanceledException
         // internally — used to be silently lost: session-end always runs with
@@ -492,10 +492,10 @@ public class OpenCodeImportSourceImportTests : IDisposable {
     // NotInParallel with NO group key — globally sequential, mirroring
     // ClaudeHookStdoutTests: this test redirects the process-global Console.Error, and a group
     // key alone wouldn't stop an unrelated test under a different key from writing to stderr
-    // concurrently and leaking into the capture (AI-737).
+    // concurrently and leaking into the capture.
     [Test, NotInParallel]
     public async Task new_depth_9_descendant_invalidates_the_fingerprint_and_reimports_with_omitted_warning() {
-        // AI-1383 D3 review fix #2: the completeness fingerprint used to hash only the IN-CAP
+        // the completeness fingerprint used to hash only the IN-CAP
         // descendant list, so a descendant added BELOW the depth cap (which never changes the
         // in-cap set) left the fingerprint unchanged and the ledger stuck AlreadyLoaded forever
         // — even though the new descendant should at least be surfaced via descendants_omitted.

--- a/test/Capacitor.Cli.Tests.Integration/PiImportSourceImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/PiImportSourceImportTests.cs
@@ -7,7 +7,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// Routed-import wire-contract tests for <see cref="PiImportSource"/> (AI-886).
+/// Routed-import wire-contract tests for <see cref="PiImportSource"/>.
 /// Pi classifications carry <c>FilePath = ""</c>, so they run through the
 /// routed phase (<c>ImportSessionAsync</c>) rather than the chain worker. These
 /// drive the full discover → classify → import path against a stub server and

--- a/test/Capacitor.Cli.Tests.Integration/WatcherHeartbeatStalenessTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/WatcherHeartbeatStalenessTests.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// Covers the hook-side staleness probe (AI-1357 task 9): <c>WatcherManager.IsWatcherAlive</c>
+/// Covers the hook-side staleness probe: <c>WatcherManager.IsWatcherAlive</c>
 /// now requires BOTH a live PID and a non-stale heartbeat, and <c>EnsureWatcherRunning</c>
 /// reaps + respawns a wedged (alive-but-stale) watcher under the cross-platform spawn lock so
 /// two concurrent hooks racing the same key can't double-spawn. Mirrors <see cref="WatcherLifecycleTests"/> —
@@ -173,7 +173,7 @@ public class WatcherHeartbeatStalenessTests {
 
     [Test]
     public async Task KillWatcher_RemovesHeartbeatAndStartedFiles() {
-        // AI-1357 task 9 (review issue 2): the new sidecar files must not leak per-session the
+        // task 9 (review issue 2): the new sidecar files must not leak per-session the
         // way the pid file never did. KillWatcher removes the heartbeat + started markers.
         var (key, transcriptPath, pidFile) = NewKey("kill-cleanup");
         using var dummy = StartDummyProcess();

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpConnectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpConnectionTests.cs
@@ -328,7 +328,7 @@ public class AcpConnectionTests {
         using var       cts     = new CancellationTokenSource();
         var              runTask = harness.Connection.RunAsync(cts.Token);
 
-        // OnServerRequest intentionally left unset (AI-684 default-decline posture).
+        // OnServerRequest intentionally left unset (default-decline posture).
         await harness.WriteFrameToConnectionAsync(
             """{"jsonrpc":"2.0","id":99,"method":"session/request_permission","params":{}}"""
         );

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpEventEnvelopeWireCompatTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpEventEnvelopeWireCompatTests.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// AI-688 Option B task 1 wire-compat guard: <see cref="AcpEventEnvelope"/>/<see cref="AcpBatchAck"/>
+/// Option B task 1 wire-compat guard: <see cref="AcpEventEnvelope"/>/<see cref="AcpBatchAck"/>
 /// are daemon-local mirrors of the server's <c>Capacitor.Server.Core.Acp.AcpEventEnvelope</c> /
 /// <c>AcpBatchAck</c> (read from the ai-686 server worktree,
 /// <c>src/Capacitor.Server.Core/Acp/AcpEventEnvelope.cs</c>) — they cross the SignalR wire to the

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpEventTranslatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpEventTranslatorTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// AI-688 Option B task 1: pure unit tests for <see cref="AcpEventTranslator.Translate"/> and its
+/// Option B task 1: pure unit tests for <see cref="AcpEventTranslator.Translate"/> and its
 /// synthesized-lifecycle builders — no ACP wire/process/runtime involved (see
 /// <see cref="AcpHostedAgentRuntimeTests"/> for the <see cref="AcpSessionUpdate"/> reduction this
 /// translator consumes). Every case is constructed directly against a hand-built

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeModelSelectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeModelSelectionTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// gap 1: exercises <see cref="AcpHostedAgentRuntime.StartAsync"/>'s model-selection step —
+/// Model-selection gap 1: exercises <see cref="AcpHostedAgentRuntime.StartAsync"/>'s model-selection step —
 /// <c>session/set_config_option</c>, sent AFTER <c>session/new</c> resolves and BEFORE the first
 /// <c>session/prompt</c> fires — end-to-end against <see cref="FakeAcpAgent"/>. Mirrors the
 /// <c>AcpHostedAgentRuntimeTests</c> harness pattern; no real <c>cursor-agent acp</c> process.

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeModelSelectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeModelSelectionTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// AI-688 gap 1: exercises <see cref="AcpHostedAgentRuntime.StartAsync"/>'s model-selection step —
+/// gap 1: exercises <see cref="AcpHostedAgentRuntime.StartAsync"/>'s model-selection step —
 /// <c>session/set_config_option</c>, sent AFTER <c>session/new</c> resolves and BEFORE the first
 /// <c>session/prompt</c> fires — end-to-end against <see cref="FakeAcpAgent"/>. Mirrors the
 /// <c>AcpHostedAgentRuntimeTests</c> harness pattern; no real <c>cursor-agent acp</c> process.

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimePermissionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimePermissionTests.cs
@@ -8,12 +8,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// AI-686 end-to-end: <see cref="FakeAcpAgent"/> sends a real
+/// end-to-end: <see cref="FakeAcpAgent"/> sends a real
 /// <c>session/request_permission</c> server→client request mid-turn; the runtime's wired
 /// <see cref="AcpInteractionBridge"/> forwards it to an injected "ask the server" delegate and
 /// writes the JSON-RPC response back to the wire only once that delegate resolves — proving the
 /// agent's request genuinely blocks on the human decision rather than getting an immediate
-/// default-decline (AI-684's prior behavior, since <c>OnServerRequest</c> was unset).
+/// default-decline ('s prior behavior, since <c>OnServerRequest</c> was unset).
 /// </summary>
 public class AcpHostedAgentRuntimePermissionTests {
     static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
@@ -91,7 +91,7 @@ public class AcpHostedAgentRuntimePermissionTests {
     [Test]
     public async Task PermissionRequest_NoInteractionDelegateWired_DefaultsToMethodNotFound() {
         // Backward-compat: a runtime constructed WITHOUT the new optional delegate (matching every
-        // pre-AI-686 call site) keeps AI-684's exact default-decline posture — OnServerRequest
+        // call site before this change) keeps the original exact default-decline posture — OnServerRequest
         // stays effectively unset for permission requests, so AcpConnection answers with a
         // JSON-RPC "Method not found" error, not a crash or hang.
         var fake    = new FakeAcpAgent();

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimePermissionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimePermissionTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// end-to-end: <see cref="FakeAcpAgent"/> sends a real
+/// End-to-end: <see cref="FakeAcpAgent"/> sends a real
 /// <c>session/request_permission</c> server→client request mid-turn; the runtime's wired
 /// <see cref="AcpInteractionBridge"/> forwards it to an injected "ask the server" delegate and
 /// writes the JSON-RPC response back to the wire only once that delegate resolves — proving the

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimePermissionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimePermissionTests.cs
@@ -13,7 +13,7 @@ namespace Capacitor.Cli.Tests.Unit.Acp;
 /// <see cref="AcpInteractionBridge"/> forwards it to an injected "ask the server" delegate and
 /// writes the JSON-RPC response back to the wire only once that delegate resolves — proving the
 /// agent's request genuinely blocks on the human decision rather than getting an immediate
-/// default-decline ('s prior behavior, since <c>OnServerRequest</c> was unset).
+/// default-decline (the runtime's prior behavior, since <c>OnServerRequest</c> was unset).
 /// </summary>
 public class AcpHostedAgentRuntimePermissionTests {
     static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// AI-689 Workstream A: exercises <see cref="AcpHostedAgentRuntime.StartAsync"/>'s handling of the
+/// Workstream A: exercises <see cref="AcpHostedAgentRuntime.StartAsync"/>'s handling of the
 /// <c>initialize</c> response — protocol-version validation (A1), captured
 /// <c>agentCapabilities</c> (A2), and the auth/subscription hint appended to a handshake failure
 /// without masking the original error (A4). Mirrors the <c>AcpHostedAgentRuntimeTests</c> harness

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
@@ -18,7 +18,7 @@ public class AcpHostedAgentRuntimeTests {
     /// <summary>
     /// <see cref="IAcpProcess"/> fake whose <see cref="WaitForExitAsync"/> genuinely blocks (like
     /// the real <c>AcpChildProcess</c> over a live child process) until <see cref="SignalExited"/>
-    /// is called or the process is <see cref="TerminateAsync"/>d — needed to exercise AI-684 Fix
+    /// is called or the process is <see cref="TerminateAsync"/>d — needed to exercise Fix
     /// E's "stay open until the process exits" contract on <c>AcpHostedAgentRuntime.ReadOutputAsync</c>.
     /// The un-signalled default (used by every pre-existing test in this file, which never calls
     /// <see cref="SignalExited"/>) matches the OLD <c>Task.CompletedTask</c> behavior closely enough
@@ -95,7 +95,7 @@ public class AcpHostedAgentRuntimeTests {
 
         await h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard);
 
-        // AI-684 Fix E: StartAsync returns once session/new resolves — it fires the initial
+        // Fix E: StartAsync returns once session/new resolves — it fires the initial
         // session/prompt as untracked background work rather than awaiting it, so the fake may not
         // have received (or recorded) it yet at this exact instant. Poll rather than asserting
         // immediately.
@@ -181,7 +181,7 @@ public class AcpHostedAgentRuntimeTests {
         await Assert.That(received.Raw!.Value.GetProperty("foo").GetString()).IsEqualTo("bar");
     }
 
-    // ── AI-688 Option B task 1: Reduce() tool-call/tool-result field capture ──────────────
+    // ── Option B task 1: Reduce() tool-call/tool-result field capture ──────────────
 
     [Test]
     public async Task ToolCall_update_captures_ToolInputJson_from_rawInput() {
@@ -305,7 +305,7 @@ public class AcpHostedAgentRuntimeTests {
 
         await h.Runtime.StartAsync("/abs/worktree", "", h.Cts.Token).WaitAsync(HangGuard);
 
-        // AI-684 Fix E: SendUserInputAsync fires the session/prompt as untracked background work
+        // Fix E: SendUserInputAsync fires the session/prompt as untracked background work
         // and returns as soon as it's queued, NOT once the fake has received/answered it — so poll
         // for the call to land instead of asserting immediately after the await returns.
         await h.Runtime.SendUserInputAsync("more").WaitAsync(HangGuard);
@@ -346,7 +346,7 @@ public class AcpHostedAgentRuntimeTests {
 
         await Assert.ThrowsAsync<NotSupportedException>(() => h.Runtime.SendRawInputAsync(new byte[] { 1 }));
 
-        // ReadOutputAsync never yields a byte, but (AI-684 Fix E) it also must not complete on its
+        // ReadOutputAsync never yields a byte, but (Fix E) it also must not complete on its
         // own — it stays open until the process exits or ct cancels (see the dedicated
         // ReadOutputAsync_* tests below for that contract). Cancel to end the enumeration here,
         // since this test's focus is "yields nothing", not "when does it end".
@@ -365,7 +365,7 @@ public class AcpHostedAgentRuntimeTests {
         await Assert.That(any).IsFalse();
     }
 
-    // ── AI-684 Fix E: ReadOutputAsync must stay open (not complete immediately) ──────────
+    // ── Fix E: ReadOutputAsync must stay open (not complete immediately) ──────────
 
     [Test]
     public async Task ReadOutputAsync_stays_open_until_the_process_exits() {
@@ -418,7 +418,7 @@ public class AcpHostedAgentRuntimeTests {
         await readTask.WaitAsync(HangGuard);
     }
 
-    // ── AI-684 Fix E: StartAsync/SendUserInputAsync must not block on turn completion ───────
+    // ── Fix E: StartAsync/SendUserInputAsync must not block on turn completion ───────
 
     [Test]
     public async Task StartAsync_does_not_await_the_initial_prompt_turn_to_completion() {

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// AI-686: <see cref="AcpInteractionBridge"/> parses an inbound <c>session/request_permission</c>
+/// <see cref="AcpInteractionBridge"/> parses an inbound <c>session/request_permission</c>
 /// (spec-derived shape, NOT probe-confirmed — see <c>docs/acp-probe-findings.md</c>) or capability-
 /// gated <c>elicitation/create</c> server request, forwards it to an injected
 /// "ask the server" delegate (standing in for <see cref="Capacitor.Cli.Daemon.Services.ServerConnection.RequestAcpInteractionAsync"/>),

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionMessagesTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionMessagesTests.cs
@@ -6,7 +6,7 @@ using Capacitor.Cli.Core.Acp;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// Round-trip / wire-shape tests for the AI-686 Task B1 ACP permission + elicitation DTOs — proves
+/// Round-trip / wire-shape tests for the Task B1 ACP permission + elicitation DTOs — proves
 /// the source-gen <see cref="CapacitorJsonContext"/> registrations exist and serialize with the
 /// exact camelCase wire vocabulary (<see cref="Acp.PermissionOutcomeDto"/>'s <c>"selected"</c> /
 /// <c>"cancelled"</c> spellings, distinct from the server-internal <c>"cancel"</c>) and snake_case

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpModelResolverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpModelResolverTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core.Acp;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// gap 1: pure unit tests for <see cref="AcpModelResolver.Resolve"/>'s match precedence
+/// Model-selection gap 1: pure unit tests for <see cref="AcpModelResolver.Resolve"/>'s match precedence
 /// (exact <c>modelId</c> -&gt; prefix <c>modelId</c> -&gt; <c>name</c> equals/contains -&gt;
 /// <see langword="null"/>). No ACP wire/process involved — see
 /// <see cref="AcpHostedAgentRuntimeModelSelectionTests"/> for the end-to-end

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpModelResolverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpModelResolverTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core.Acp;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// AI-688 gap 1: pure unit tests for <see cref="AcpModelResolver.Resolve"/>'s match precedence
+/// gap 1: pure unit tests for <see cref="AcpModelResolver.Resolve"/>'s match precedence
 /// (exact <c>modelId</c> -&gt; prefix <c>modelId</c> -&gt; <c>name</c> equals/contains -&gt;
 /// <see langword="null"/>). No ACP wire/process involved — see
 /// <see cref="AcpHostedAgentRuntimeModelSelectionTests"/> for the end-to-end

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpServerConnectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpServerConnectionTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// AI-688 Option B task 3: covers <see cref="ServerConnection"/>'s two new gated ACP hub-invoke
+/// Option B task 3: covers <see cref="ServerConnection"/>'s two new gated ACP hub-invoke
 /// methods (<see cref="ServerConnection.AcpSessionStartedAsync"/>/<see cref="ServerConnection.SendAcpEventsAsync"/>)
 /// and the reconnect re-bind mechanism (<see cref="ServerConnection.RegisterAcpBinding"/>/
 /// <see cref="ServerConnection.UnregisterAcpBinding"/>/<see cref="ServerConnection.ReBindAcpSessionsAsync"/>).
@@ -42,7 +42,7 @@ public class AcpServerConnectionTests {
         /// observe ordering/gating state at the exact moment the (re-)bind call happens.</summary>
         public Action? OnRawSessionStartedInvoked { get; set; }
 
-        /// <summary>AI-688 reliability fix (Codex P1 #1): how many MORE times the raw
+        /// <summary> reliability fix (Codex P1 #1): how many MORE times the raw
         /// AcpSessionStarted invoke should throw for a given agentId before it starts succeeding —
         /// drives <see cref="ReBindAcpSessionsAsyncBoundedRetryTests"/>'s bounded-retry-then-give-up
         /// and transient-failure-then-recover cases. Absent/zero entries always succeed.</summary>

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpTranscriptAggregationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpTranscriptAggregationTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// AI-688 Option B task 2: exercises <see cref="AcpHostedAgentRuntime"/>'s chunk aggregation +
+/// Option B task 2: exercises <see cref="AcpHostedAgentRuntime"/>'s chunk aggregation +
 /// serialized single-flight prompt-turn worker end-to-end against <see cref="FakeAcpAgent"/>, via the
 /// ordered <see cref="AcpHostedAgentRuntime.Envelopes"/> transcript (§2.1 of
 /// <c>docs/ai688-option-b-canonical-surfacing-design.md</c>). Mirrors the
@@ -47,7 +47,7 @@ public class AcpTranscriptAggregationTests {
 
         Task _fakeRunTask = Task.CompletedTask;
 
-        /// <summary>AI-688 reliability fix (Qodo #6): <paramref name="logger"/>/<paramref name="transcriptCapacity"/>
+        /// <summary> reliability fix (Qodo #6): <paramref name="logger"/>/<paramref name="transcriptCapacity"/>
         /// let the bounded-channel drop test inject a capturing logger and a tiny cap without every
         /// other <c>Harness()</c> call site having to care.</summary>
         public Harness(ILogger? logger = null, int? transcriptCapacity = null) {
@@ -288,7 +288,7 @@ public class AcpTranscriptAggregationTests {
         await h.Runtime.StartAsync("/abs/worktree", "go", h.Cts.Token).WaitAsync(HangGuard);
         await WaitForPromptCallCountAsync(h.Fake, minCount: 1);
 
-        // The crux of the cancellation contract (AI-688 task 2): a turn stuck awaiting a stopReason
+        // The crux of the cancellation contract: a turn stuck awaiting a stopReason
         // that will NEVER arrive (the fake holds the response forever) must not pin DisposeAsync.
         await h.Runtime.DisposeAsync().AsTask().WaitAsync(HangGuard);
 
@@ -332,7 +332,7 @@ public class AcpTranscriptAggregationTests {
         h.Fake.HoldPromptResponses.TrySetResult();
     }
 
-    // ── Bounded transcript channel (AI-688 PR #301 review, Qodo #6) ────────────────────────────
+    // ── Bounded transcript channel (PR #301 review, Qodo #6) ────────────────────────────
 
     /// <summary>Records every log call — mirrors <c>TokenRefreshLoopTests.CaptureLogger</c>'s
     /// established pattern for asserting on a warning without a real logging sink.</summary>

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpTranscriptForwarderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpTranscriptForwarderTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
-/// AI-688 Option B task 3: exercises <see cref="AcpTranscriptForwarder"/>'s seq assignment, unacked
+/// Option B task 3: exercises <see cref="AcpTranscriptForwarder"/>'s seq assignment, unacked
 /// buffer, and ack state machine (gap-resend, terminal-drop, send-throw-then-recover) against a fake
 /// send delegate and a fake transcript channel — no real <c>ServerConnection</c>/SignalR involved.
 /// The ack rules under test are transcribed EXACTLY from
@@ -163,7 +163,7 @@ public class AcpTranscriptForwarderTests {
         await Assert.That(callCount).IsEqualTo(2); // never retried/resent once terminal
     }
 
-    // ── Hot-loop guard (AI-688 review): stalled gap → terminal ─────────────────────────────────────
+    // ── Hot-loop guard: stalled gap → terminal ─────────────────────────────────────
 
     [Test]
     public async Task Stalled_gap_with_no_progress_stops_and_marks_terminal_after_the_cap() {

--- a/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
@@ -406,7 +406,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     }
 
     /// <summary>
-    /// gap 1: answers a <c>session/set_config_option</c> request — either the scripted
+    /// Model-selection gap 1: answers a <c>session/set_config_option</c> request — either the scripted
     /// JSON-RPC error (see <see cref="FailNextSetConfigOption"/>) or a probe-shaped success result
     /// echoing back the requested <c>value</c> as the <c>model</c> config option's
     /// <c>currentValue</c>, mirroring the real agent's confirmed response shape

--- a/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
@@ -101,9 +101,9 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     /// <c>session/prompt</c> turn's response, awaiting and recording the connection's reply before
     /// answering the prompt itself with the default <c>end_turn</c> result. This finally wires the
     /// builder helpers <see cref="BuildRequestPermissionFrame"/>/<see cref="PermissionOutcomeSelected"/>/
-    /// <see cref="PermissionOutcomeCancelled"/> into the fake's active dispatch loop — AI-684 Task 8
+    /// <see cref="PermissionOutcomeCancelled"/> into the fake's active dispatch loop — Task 8
     /// built them but deliberately left them unwired (see this file's original remarks), since the
-    /// permission bridge itself was AI-686's job.
+    /// permission bridge itself was Task 9's job.
     /// </summary>
     public void EnqueuePermissionRequestDuringNextPrompt(string toolCallJson, string optionsJson) {
         _pendingServerRequestToolCallJson = toolCallJson;
@@ -162,7 +162,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     /// <summary>
     /// Overrides the <c>session/new</c> response this fake returns for every subsequent
     /// <c>session/new</c> request (default: <see cref="ProbeConfirmedSessionNewResult"/>, a single
-    /// <c>composer-2.5[fast=true]</c> model) — AI-688 gap 1 model-selection tests use this to script
+    /// <c>composer-2.5[fast=true]</c> model) — gap 1 model-selection tests use this to script
     /// a richer <c>models.availableModels</c> list + <c>currentModelId</c>.
     /// <see cref="BuildSessionNewResult"/> is the easiest way to build a well-formed override.
     /// </summary>
@@ -170,7 +170,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
 
     /// <summary>
     /// Arranges the NEXT <c>session/set_config_option</c> request to be answered with a JSON-RPC
-    /// error instead of a success result (AI-688 gap 1) — models a real agent rejecting the
+    /// error instead of a success result — models a real agent rejecting the
     /// resolved model id, exercising <c>AcpHostedAgentRuntime</c>'s non-fatal "log a warning and
     /// continue with Cursor's default model" handling.
     /// </summary>
@@ -179,7 +179,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     /// <summary>
     /// Overrides the <c>initialize</c> response this fake returns for every subsequent
     /// <c>initialize</c> request (default: <see cref="ProbeConfirmedInitializeResult"/>, protocol
-    /// version 1 with <c>loadSession: true</c>) — AI-689 protocol-negotiation tests use this to
+    /// version 1 with <c>loadSession: true</c>) — protocol-negotiation tests use this to
     /// script a mismatched <c>protocolVersion</c> or a missing/false <c>agentCapabilities</c>.
     /// <see cref="BuildInitializeResult"/> is the easiest way to build a well-formed override.
     /// </summary>
@@ -187,13 +187,13 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
 
     /// <summary>
     /// Arranges the NEXT <c>initialize</c> request to be answered with a JSON-RPC error instead of
-    /// a success result (AI-689) — models a logged-out/unsubscribed <c>cursor-agent</c> rejecting
+    /// a success result — models a logged-out/unsubscribed <c>cursor-agent</c> rejecting
     /// the handshake, exercising <c>AcpHostedAgentRuntime.StartAsync</c>'s auth/subscription hint.
     /// </summary>
     public void FailNextInitialize(int code, string message) => _failNextInitialize = (code, message);
 
     /// <summary>
-    /// Convenience builder for a caller-controlled <c>initialize</c> result (AI-689) — narrower than
+    /// Convenience builder for a caller-controlled <c>initialize</c> result — narrower than
     /// the full <see cref="ProbeConfirmedInitializeResult"/> fixture, carrying only the two fields
     /// <c>AcpHostedAgentRuntime.StartAsync</c> actually reads: <paramref name="protocolVersion"/>
     /// and, when non-null, an <c>agentCapabilities.loadSession</c> flag. Passing
@@ -217,7 +217,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     }
 
     /// <summary>
-    /// Convenience builder for a probe-shaped <c>session/new</c> result (AI-688 gap 1) with a
+    /// Convenience builder for a probe-shaped <c>session/new</c> result with a
     /// caller-controlled <c>models.availableModels</c> list + <c>currentModelId</c>.
     /// <paramref name="availableModels"/> entries are <c>(modelId, name)</c> pairs.
     /// </summary>
@@ -252,7 +252,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     /// When set, every <c>session/prompt</c> request's RESPONSE (not the queued updates, if any) is
     /// held back until <paramref name="gate"/> completes — the fake still records the call
     /// immediately (so <see cref="ReceivedCalls"/> observes it right away), it just doesn't answer.
-    /// Models a real agent mid-turn: used by AI-684 Fix E tests to prove
+    /// Models a real agent mid-turn: used by Fix E tests to prove
     /// <c>AcpHostedAgentRuntime.StartAsync</c>/<c>SendUserInputAsync</c> return promptly WITHOUT
     /// waiting for the turn's <c>stopReason</c> response, instead of the pre-fix behavior where
     /// both awaited the full round trip. Set to <see langword="null"/> (the default) to answer
@@ -280,7 +280,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
                 if (string.IsNullOrWhiteSpace(line))
                     continue;
 
-                // AI-686: dispatched as untracked background work rather than awaited in-loop.
+                // dispatched as untracked background work rather than awaited in-loop.
                 // EnqueuePermissionRequestDuringNextPrompt's session/request_permission send-and-await
                 // (SendServerRequestAndAwaitResponseAsync) is itself triggered from a session/prompt's
                 // dispatch — its TaskCompletionSource can only be completed by THIS SAME loop reading
@@ -324,8 +324,8 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
         if (!hasMethod) {
             // A frame with no "method" is either the connection's reply to one of THIS fake's own
             // session/request_permission sends (id in _pendingFakeRequests), or an unrelated
-            // response the fake doesn't care about — never expected in AI-684/686's scripts other
-            // than this new path, but guarded defensively.
+            // response the fake doesn't care about — never expected in this fixture's scripts
+            // other than this new path, but guarded defensively.
             if (hasId && idElement.TryGetInt64(out var replyId)) {
                 TaskCompletionSource<(JsonElement?, JsonElement?)>? pending;
                 lock (_sentServerRequestsLock) _pendingFakeRequests.Remove(replyId, out pending);
@@ -406,7 +406,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     }
 
     /// <summary>
-    /// AI-688 gap 1: answers a <c>session/set_config_option</c> request — either the scripted
+    /// gap 1: answers a <c>session/set_config_option</c> request — either the scripted
     /// JSON-RPC error (see <see cref="FailNextSetConfigOption"/>) or a probe-shaped success result
     /// echoing back the requested <c>value</c> as the <c>model</c> config option's
     /// <c>currentValue</c>, mirroring the real agent's confirmed response shape
@@ -579,7 +579,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
 
     // ---- spec-derived (NOT probe-confirmed) helper builders ----
     //
-    // The AI-684 probe account was plan-gated before any tool-call turn completed, so none of the
+    // The probe account was plan-gated before any tool-call turn completed, so none of the
     // variants below were ever observed on the wire (see docs/acp-probe-findings.md, "sessionUpdate
     // variants observed" and "Recommended follow-up"). They are built from the published ACP spec
     // only. Re-verify each against docs/acp-probe-findings.md's "Recommended follow-up" once a
@@ -601,7 +601,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     /// Spec-derived, NOT yet verified against cursor-agent (the probe account was plan-gated before
     /// any tool-call turn completed) — re-verify against docs/acp-probe-findings.md "Recommended
     /// follow-up" once available. Shape: <c>{"sessionUpdate":"tool_call","toolCallId":"...","title":"...","kind":"...","status":"...","rawInput":{...}}</c>
-    /// (<c>rawInput</c> only when <paramref name="rawInputJson"/> is non-null — AI-688 task 1's
+    /// (<c>rawInput</c> only when <paramref name="rawInputJson"/> is non-null — task 1's
     /// <c>AcpSessionUpdate.Reduce()</c> extraction target for <c>ToolInputJson</c>).
     /// <paramref name="status"/> is one of <c>pending</c> / <c>in_progress</c> / <c>completed</c> / <c>failed</c>.
     /// </summary>
@@ -630,7 +630,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     /// any tool-call turn completed) — re-verify against docs/acp-probe-findings.md "Recommended
     /// follow-up" once available. Shape: <c>{"sessionUpdate":"tool_call_update","toolCallId":"...","status":"...","content":[{"type":"content","content":{"type":"text","text":"..."}}],"rawOutput":{...}}</c>
     /// — <c>content</c>/<c>rawOutput</c> are included only when <paramref name="resultText"/>/
-    /// <paramref name="rawOutputJson"/> are non-null (AI-688 task 1's
+    /// <paramref name="rawOutputJson"/> are non-null (task 1's
     /// <c>AcpSessionUpdate.Reduce()</c> extraction targets for <c>ToolResultText</c>: the ACP-spec
     /// <c>ToolCallContent</c> text-block shape, falling back to <c>rawOutput</c> verbatim).
     /// </summary>
@@ -685,7 +685,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     /// <paramref name="toolCallJson"/> and <paramref name="optionsJson"/> are raw JSON text for the
     /// nested objects, left as caller-supplied strings since their exact shape is unconfirmed.
     /// Task 8 does not wire this into <see cref="RunAsync"/>'s dispatch loop — a documented builder
-    /// is sufficient for this fixture's scope; Task 9 (AI-686) wires the actual permission bridge.
+    /// is sufficient for this fixture's scope; Task 9 wires the actual permission bridge.
     /// The two possible client response shapes are documented on
     /// <see cref="PermissionOutcomeSelected"/> / <see cref="PermissionOutcomeCancelled"/>.
     /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/AgentHookPosterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentHookPosterTests.cs
@@ -7,7 +7,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Tests for the shared agent-hook recording POST (AI-993). This is the seam the non-Claude
+/// Tests for the shared agent-hook recording POST. This is the seam the non-Claude
 /// hooks (Codex, Gemini, Copilot, Pi, Kiro, OpenCode) delegate to. Its job is to SKIP a POST
 /// that would 401 because auth has lapsed — reporting <see cref="HookPostOutcome.AuthLapsed"/>
 /// without touching stderr or the server — while leaving the authenticated success path and

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorAcpForwardingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorAcpForwardingTests.cs
@@ -7,7 +7,7 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-688 Option B task 4: covers the orchestrator wiring that ties tasks 1–3 into the launch/
+/// Option B task 4: covers the orchestrator wiring that ties tasks 1–3 into the launch/
 /// teardown lifecycle — <see cref="AgentOrchestrator.HandleLaunchAgent"/>'s post-registration ACP
 /// bind + forwarder start, and <see cref="AgentOrchestrator"/>'s teardown path's bounded final-drain
 /// before <c>EndAgentSession</c>. Reuses the shared <see cref="AgentOrchestratorVendorTests"/> test
@@ -257,7 +257,7 @@ public partial class AgentOrchestratorVendorTests {
         }
     }
 
-    // ── Reliability fixes (AI-688 PR #301 review: per-agent CTS) ───────────────────────────────
+    // ── Reliability fixes (PR #301 review: per-agent CTS) ───────────────────────────────
 
     /// <summary>
     /// Qodo #4: a drain that misses its budget must not leave the forwarder's <c>RunTask</c> running

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorBorrowLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorBorrowLaunchTests.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1207 Phase A (tasks A5 + A6): the borrowed-launch branch in
+/// Phase A (tasks A5 + A6): the borrowed-launch branch in
 /// <see cref="AgentOrchestrator.HandleLaunchAgent"/> and — the reason A5 and A6 ship together —
 /// the failed-launch cleanup guard.
 ///

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorBracketedPasteTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorBracketedPasteTests.cs
@@ -7,7 +7,7 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-30: a pasted (large, multi-line) message written to a hosted agent's PTY as raw bytes
+/// a pasted (large, multi-line) message written to a hosted agent's PTY as raw bytes
 /// followed by a carriage return often fails to submit — the CR races the still-ingesting
 /// paste and is folded into it as a literal newline, so the text sits in the composer until a
 /// later, isolated keystroke finishes it (Codex never submits at all; Claude ~50% of the time).

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorProbeBorrowSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorProbeBorrowSourceTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1207 Phase A (task A3): covers <see cref="AgentOrchestrator.HandleProbeBorrowSourceForTest"/>,
+/// Phase A (task A3): covers <see cref="AgentOrchestrator.HandleProbeBorrowSourceForTest"/>,
 /// the handler behind the server→daemon <c>ProbeBorrowSource</c> hub method. The handler is a thin
 /// mapping from <see cref="BorrowAuthorizer.AuthorizeBorrowAsync"/>'s <see cref="BorrowAuthResult"/>
 /// onto the wire-facing <see cref="BorrowProbeResult"/> — the policy itself (allowlist, git-root,

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -966,8 +966,8 @@ public partial class AgentOrchestratorVendorTests {
             return Task.CompletedTask;
         }
 
-        /// <summary>Number of times to fail AgentRegisteredAsync before succeeding (:
-        /// drives the bounded per-agent re-registration retry test).</summary>
+        /// <summary>Number of times to fail AgentRegisteredAsync before succeeding (drives
+        /// the bounded per-agent re-registration retry test).</summary>
         public int AgentRegisteredFailTimes { get; init; }
         public int AgentRegisteredCallCount { get; private set; }
 

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -115,7 +115,7 @@ public partial class AgentOrchestratorVendorTests {
         public void StopApplication() { }
     }
 
-    // AI-864: re-registration is awaited inside RegisterDaemon before readiness is restored.
+    // re-registration is awaited inside RegisterDaemon before readiness is restored.
     // A transient per-agent failure must be retried (not swallowed on first try), so the agent's
     // ownership is restored before the daemon flips ready — narrowing the "ready despite reregister
     // failure" window qodo flagged.
@@ -195,7 +195,7 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(ptyFactory.SpawnCalls).IsEqualTo(0);
     }
 
-    // AI-1124: the orchestrator's unattended-launch guard (UnattendedLaunchPolicy.RejectionReason)
+    // the orchestrator's unattended-launch guard (UnattendedLaunchPolicy.RejectionReason)
     // must actually be wired into HandleLaunchAgent — reject a review-flow launch whose vendor
     // can't run unattended, and do it before any worktree/PTY side effects.
     [Test]
@@ -317,7 +317,7 @@ public partial class AgentOrchestratorVendorTests {
         }
     }
 
-    // AI-684 Task 10: a "cursor" launch must route to its registered IHostedAgentRuntimeFactory
+    // Task 10: a "cursor" launch must route to its registered IHostedAgentRuntimeFactory
     // (the ACP seam) rather than falling through to a PTY launcher/factory. This is a pure unit
     // test — SpyHostedAgentRuntimeFactory never spawns a real cursor-agent process.
     [Test]
@@ -365,7 +365,7 @@ public partial class AgentOrchestratorVendorTests {
         }
     }
 
-    // AI-684 Fix B/E (PR #244 review, BLOCKER): a runtime whose ReadOutputAsync never yields a byte
+    // Fix B/E (PR #244 review, BLOCKER): a runtime whose ReadOutputAsync never yields a byte
     // (ACP/cursor) must NOT wait for the orchestrator's on-first-chunk Starting→Running flip — that
     // flip lives in ReadAgentOutputAsync and only fires on an output CHUNK, which never arrives for
     // such a runtime. Before the fix this left the agent stuck in "Starting" (eventually auto-
@@ -592,7 +592,7 @@ public partial class AgentOrchestratorVendorTests {
 
             // Stopping the agent cancels ReadCts. The blocked enqueue MUST be released by
             // that cancellation; otherwise the read loop (and its finally-block cleanup)
-            // stalls until daemon shutdown (AI-846). Before the fix the enqueue awaited the
+            // stalls until daemon shutdown. Before the fix the enqueue awaited the
             // daemon-lifetime token instead, so this never completes.
             await orch.HandleStopAgentForTest("agent-bp");
 
@@ -782,7 +782,7 @@ public partial class AgentOrchestratorVendorTests {
     }
 
     /// <summary>
-    /// Test double for the AI-684 Task 10 runtime-selection seam: records that <see cref="StartAsync"/>
+    /// Test double for the Task 10 runtime-selection seam: records that <see cref="StartAsync"/>
     /// was called (and with what agent id) and returns a no-op <see cref="FakeHostedAgentRuntime"/>,
     /// without ever spawning a real process — proves the orchestrator routes a launch to the correct
     /// <see cref="IHostedAgentRuntimeFactory"/> by vendor.
@@ -819,7 +819,7 @@ public partial class AgentOrchestratorVendorTests {
     /// harmless stand-in instead of a real PTY or ACP connection. <see cref="ReadOutputAsync"/>
     /// blocks until <see cref="ExitGate"/> is released (or <c>ct</c> cancels) rather than completing
     /// immediately, mirroring the real ACP runtime's "stay open until the process exits" contract —
-    /// this lets AI-684 Fix B/E tests observe orchestrator state (e.g. Status flips to "Running")
+    /// this lets Fix B/E tests observe orchestrator state (e.g. Status flips to "Running")
     /// WHILE the agent is still live, before ever driving it to completion.</summary>
     sealed class FakeHostedAgentRuntime(string vendor, bool emitsTerminalOutput) : IHostedAgentRuntime {
         public string Vendor              => vendor;
@@ -966,7 +966,7 @@ public partial class AgentOrchestratorVendorTests {
             return Task.CompletedTask;
         }
 
-        /// <summary>Number of times to fail AgentRegisteredAsync before succeeding (AI-864:
+        /// <summary>Number of times to fail AgentRegisteredAsync before succeeding (:
         /// drives the bounded per-agent re-registration retry test).</summary>
         public int AgentRegisteredFailTimes { get; init; }
         public int AgentRegisteredCallCount { get; private set; }
@@ -980,7 +980,7 @@ public partial class AgentOrchestratorVendorTests {
                 : Task.CompletedTask;
         }
 
-        // ── AI-688 Option B task 4: ACP bind/forward capture ────────────────────────────────────
+        // ── Option B task 4: ACP bind/forward capture ────────────────────────────────────
         // Overrides the RAW hub-invoke seams (mirroring AcpServerConnectionTests' TestServerConnection)
         // rather than the higher-level gated AcpSessionStartedAsync/SendAcpEventsAsync, so every call
         // still goes through the REAL ConnectionRetry/IsReady gating the production wiring relies on.
@@ -1018,7 +1018,7 @@ public partial class AgentOrchestratorVendorTests {
 
         /// <summary>One-shot gate: when set, the NEXT raw AcpSessionStarted invoke awaits this task
         /// before returning (then the field is cleared) — models a bind call still in flight across
-        /// a reconnect outage (AI-688 reliability fix's stale-binding-race test), independent of
+        /// a reconnect outage (reliability fix's stale-binding-race test), independent of
         /// <paramref name="ct"/> so the test controls exactly when the "late bind" resolves.</summary>
         public TaskCompletionSource? PendingAcpBindGate { get; set; }
 
@@ -1051,7 +1051,7 @@ public partial class AgentOrchestratorVendorTests {
             if (AcpEventsBlockUntil is { } blockCts) {
                 // Linked with ct (unlike a bare blockCts.Token wait) so a per-agent CTS cancellation
                 // propagates through exactly like a real _hub.InvokeAsync(..., cancellationToken: ct)
-                // call would (AI-688 reliability fix: forwarder-cancel-on-drain-timeout relies on
+                // call would (reliability fix: forwarder-cancel-on-drain-timeout relies on
                 // this). A ct-driven cancellation PROPAGATES (mirrors the real hub); blockCts alone
                 // is purely test cleanup (releases an otherwise-abandoned background call) and falls
                 // through to a normal successful return.
@@ -1080,7 +1080,7 @@ public partial class AgentOrchestratorVendorTests {
 
         /// <summary>(AgentId, Status) pairs passed to every AgentStatusChangedAsync call, in
         /// call order — lets a test assert on the exact lifecycle transitions the orchestrator
-        /// drove (e.g. AI-684 Fix B/E's immediate Running flip for a no-terminal runtime).</summary>
+        /// drove (e.g. Fix B/E's immediate Running flip for a no-terminal runtime).</summary>
         public List<(string AgentId, string Status)> StatusChangedCalls { get; } = [];
 
         public override Task AgentStatusChangedAsync(string agentId, string status, string? sessionId) {
@@ -1109,7 +1109,7 @@ public partial class AgentOrchestratorVendorTests {
             => Task.CompletedTask;
 
         /// <summary>Set both to make the send block (simulating a full/down terminal
-        /// queue) until its <c>ct</c> is cancelled — used by the AI-846 back-pressure
+        /// queue) until its <c>ct</c> is cancelled — used by the back-pressure
         /// test. Left null for every other test, where the send is a no-op.</summary>
         public TaskCompletionSource? SendEntered   { get; init; }
         public TaskCompletionSource? SendUnblocked { get; init; }

--- a/test/Capacitor.Cli.Tests.Unit/AgentStartupFailureTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentStartupFailureTests.cs
@@ -7,7 +7,7 @@ namespace Capacitor.Cli.Tests.Unit;
 /// between a process that exited before establishing a real session (auth
 /// error, missing config, immediate crash) and a real session that ended.
 ///
-/// Regression for AI-572: a user who types <c>/exit</c> shortly after starting
+/// Regression for: a user who types <c>/exit</c> shortly after starting
 /// the agent was being mislabeled as "failed during startup" because the prior
 /// implementation used wall-clock time since spawn instead of output flow.
 /// </summary>
@@ -57,7 +57,7 @@ public class AgentStartupFailureTests {
 
     [Test]
     public async Task UserExitedAfterShortInteractiveSession_IsNotStartupFailure() {
-        // AI-572 scenario: agent ran for ~27 seconds, user typed /exit. The
+        // scenario: agent ran for ~27 seconds, user typed /exit. The
         // 30-second wall-clock window misclassified this as a startup failure.
         // Output flowed throughout, so the spawn → last-output gap is large.
         var result = AgentOrchestrator.IsStartupFailure(

--- a/test/Capacitor.Cli.Tests.Unit/AgentStartupFailureTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentStartupFailureTests.cs
@@ -57,7 +57,7 @@ public class AgentStartupFailureTests {
 
     [Test]
     public async Task UserExitedAfterShortInteractiveSession_IsNotStartupFailure() {
-        // scenario: agent ran for ~27 seconds, user typed /exit. The
+        // Scenario: agent ran for ~27 seconds, user typed /exit. The
         // 30-second wall-clock window misclassified this as a startup failure.
         // Output flowed throughout, so the spawn → last-output gap is large.
         var result = AgentOrchestrator.IsStartupFailure(

--- a/test/Capacitor.Cli.Tests.Unit/AntigravityGenMetadataTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravityGenMetadataTests.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Core.Antigravity;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Unit tests for <see cref="AntigravityGenMetadata"/> (AI-1158): the empirically-pinned
+/// Unit tests for <see cref="AntigravityGenMetadata"/>: the empirically-pinned
 /// protobuf field walk (top.1 → 4 → {2 input, 3 output, 5 cacheRead}; 19 model id, 21
 /// label) and the synthetic USAGE line it produces. Uses hand-built protobuf vectors so
 /// the decoder is verified without a real .db (the shapes match Antigravity 2.2.1 blobs).
@@ -70,7 +70,7 @@ public class AntigravityGenMetadataTests {
         await Assert.That(AntigravityGenMetadata.TryDecode(Blob(0, 0, null, "m", null))).IsNull();
     }
 
-    // AI-1158 review (C4): an over-large varint must not surface as a negative token count
+    // an over-large varint must not surface as a negative token count
     // via an unchecked ulong→long cast.
     [Test]
     public async Task Overlarge_token_varint_does_not_produce_a_negative_count() {

--- a/test/Capacitor.Cli.Tests.Unit/AntigravityHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravityHookCommandTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Unit tests for <see cref="AntigravityHookCommand"/> (AI-1158): event-arg parsing and
+/// Unit tests for <see cref="AntigravityHookCommand"/>: event-arg parsing and
 /// the fail-open routing paths that must NOT touch the network (non-PreInvocation events,
 /// malformed / incomplete payloads). The session-start POST path is exercised by the
 /// WireMock integration suite.

--- a/test/Capacitor.Cli.Tests.Unit/AntigravityHooksInstallerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravityHooksInstallerTests.cs
@@ -5,7 +5,7 @@ namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
 /// Unit tests for <see cref="AntigravityHooksInstaller"/> / <see cref="AntigravityHooks"/>
-/// (AI-1158): the kcap block is installed with the two shape variants, user blocks are
+/// the kcap block is installed with the two shape variants, user blocks are
 /// preserved, remove strips only kcap's block, and malformed JSON is backed up (never
 /// silently clobbered).
 /// </summary>
@@ -44,7 +44,7 @@ public class AntigravityHooksInstallerTests {
         } finally { Directory.Delete(dir, recursive: true); }
     }
 
-    // AI-1158 GUI re-test: the GUI only loads a plugin dir that contains a plugin.json
+    // GUI re-test: the GUI only loads a plugin dir that contains a plugin.json
     // manifest — without it, hooks.json is never read. Install must write it; Remove must
     // clean it up.
     [Test]
@@ -65,7 +65,7 @@ public class AntigravityHooksInstallerTests {
         } finally { Directory.Delete(dir, recursive: true); }
     }
 
-    // AI-1158 review (F1): plugin.json is load-bearing, so a failure to write it must fail the
+    // plugin.json is load-bearing, so a failure to write it must fail the
     // install rather than silently leaving a hooks.json the GUI ignores. Simulate the failure by
     // making the manifest PATH an existing directory (WriteAllText can't overwrite a dir).
     [Test]
@@ -81,7 +81,7 @@ public class AntigravityHooksInstallerTests {
         } finally { Directory.Delete(dir, recursive: true); }
     }
 
-    // AI-1158 review (F2): removing kcap must not neuter user-authored blocks by deleting the
+    // removing kcap must not neuter user-authored blocks by deleting the
     // manifest — while a hooks.json remains for the GUI to load, plugin.json is kept.
     [Test]
     public async Task Remove_keeps_plugin_manifest_when_user_blocks_remain() {

--- a/test/Capacitor.Cli.Tests.Unit/AntigravityImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravityImportSourceTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Unit tests for <see cref="AntigravityImportSource"/> discovery. AI-1218 redesign: roots are
+/// Unit tests for <see cref="AntigravityImportSource"/> discovery. redesign: roots are
 /// conversations that are never invoked as a child (per the parent transcript's
 /// INVOKE_SUBAGENT steps — see <c>AntigravitySubagents.BuildParentMap</c>), children are
 /// attached for subagent import, and IsImportRelevantLine matches the normalizer's
@@ -18,7 +18,7 @@ public class AntigravityImportSourceTests {
     const string SessB = "bbbbbbbb-0000-0000-0000-00000000b00b";
 
     // The brain-dir conversation id is dashed on disk, but the surfaced session id is the
-    // dashless canonical form (matching live capture — AI-1238). Children stay dashed because
+    // dashless canonical form (matching live capture —). Children stay dashed because
     // they resolve on-disk brain-dir transcript paths.
     static string Dashless(string id) => Guid.Parse(id).ToString("N");
 
@@ -38,7 +38,7 @@ public class AntigravityImportSourceTests {
     }
 
     // Appends an INVOKE_SUBAGENT step to convId's transcript naming childId as the spawned
-    // conversation — the AI-1218 spawn-time linkage BuildParentMap now reads instead of
+    // conversation — the spawn-time linkage BuildParentMap now reads instead of
     // messages/*.json.
     static void AppendInvoke(string home, string convId, string childId) {
         var dir = Path.Combine(BrainDir(home, convId), ".system_generated", "logs");
@@ -124,7 +124,7 @@ public class AntigravityImportSourceTests {
         // discovered session id must be the DASHLESS canonical form — matching live capture
         // (the Antigravity hook + `kcap watch` strip dashes) so a session captured live and
         // later re-imported dedupes to one stream, and so `--session` filtering is
-        // format-insensitive (AI-1238).
+        // format-insensitive.
         const string dashed = "11110000-0000-4000-8000-000000000001";
         var dashless = Guid.Parse(dashed).ToString("N");
 

--- a/test/Capacitor.Cli.Tests.Unit/AntigravityImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravityImportSourceTests.cs
@@ -18,7 +18,7 @@ public class AntigravityImportSourceTests {
     const string SessB = "bbbbbbbb-0000-0000-0000-00000000b00b";
 
     // The brain-dir conversation id is dashed on disk, but the surfaced session id is the
-    // dashless canonical form (matching live capture —). Children stay dashed because
+    // dashless canonical form (matching live capture). Children stay dashed because
     // they resolve on-disk brain-dir transcript paths.
     static string Dashless(string id) => Guid.Parse(id).ToString("N");
 

--- a/test/Capacitor.Cli.Tests.Unit/AntigravityImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravityImportSourceTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Unit tests for <see cref="AntigravityImportSource"/> discovery. redesign: roots are
+/// Unit tests for <see cref="AntigravityImportSource"/> discovery: roots are
 /// conversations that are never invoked as a child (per the parent transcript's
 /// INVOKE_SUBAGENT steps — see <c>AntigravitySubagents.BuildParentMap</c>), children are
 /// attached for subagent import, and IsImportRelevantLine matches the normalizer's

--- a/test/Capacitor.Cli.Tests.Unit/AntigravityPathsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravityPathsTests.cs
@@ -3,9 +3,9 @@ using Capacitor.Cli.Core.Antigravity;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Unit tests for <see cref="AntigravityPaths"/> (AI-1158). Antigravity data lives
+/// Unit tests for <see cref="AntigravityPaths"/>. Antigravity data lives
 /// under the shared <c>~/.gemini</c> home in an <c>antigravity</c> subdir; paths are
-/// asserted against the captured on-disk layout (AI-1150 spike). Parallel-safe: the
+/// asserted against the captured on-disk layout (spike). Parallel-safe: the
 /// <c>geminiCliHome</c> override is non-null, so no env var is read.
 /// </summary>
 public class AntigravityPathsTests {
@@ -18,7 +18,7 @@ public class AntigravityPathsTests {
             .IsEqualTo(Path.Combine(GeminiRoot, "antigravity"));
     }
 
-    // AI-1158 GUI re-test: the plugin must land under the GUI config root
+    // GUI re-test: the plugin must land under the GUI config root
     // (~/.gemini/config/plugins/kcap/), NOT the agy CLI dir (~/.gemini/antigravity-cli/),
     // which the running IDE never reads.
     [Test]
@@ -90,7 +90,7 @@ public class AntigravityPathsTests {
         }
     }
 
-    // AI-1158 review (C2): the watcher sees a dashless session id but must resolve the
+    // the watcher sees a dashless session id but must resolve the
     // real (dashed) conversation's sibling gen_metadata db from the transcript path.
     [Test]
     public async Task ConversationDbFromTranscript_resolves_the_sibling_db() {

--- a/test/Capacitor.Cli.Tests.Unit/AntigravitySpawnBeforePostTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravitySpawnBeforePostTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1357 Task 6: Antigravity is routed through <see cref="AgentHookPoster.PostOrSpoolAsync"/>
+/// Task 6: Antigravity is routed through <see cref="AgentHookPoster.PostOrSpoolAsync"/>
 /// (its own bespoke poster previously gated the watcher on <c>exit == 0</c>, which never spawned
 /// on a lapse/outage). <see cref="AntigravityHookCommand.SpawnGateForTest"/> exposes the same
 /// spawn decision as <see cref="AgentHookPoster.ShouldSpawnAfter"/> so a spooled outcome still

--- a/test/Capacitor.Cli.Tests.Unit/AntigravityStatusLineTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravityStatusLineTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// The `kcap status` hooks line reports Antigravity alongside the other vendors (AI-1158).
+/// The `kcap status` hooks line reports Antigravity alongside the other vendors.
 /// </summary>
 public class AntigravityStatusLineTests {
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/AntigravitySubagentLinkScanTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravitySubagentLinkScanTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Unit tests for <see cref="WatchCommand.ExtractAndPostSubagentLinks"/> (AI-1218 redesign): the
+/// Unit tests for <see cref="WatchCommand.ExtractAndPostSubagentLinks"/> (redesign): the
 /// live-watcher scan that links Antigravity subagents from the parent transcript's
 /// INVOKE_SUBAGENT steps (the spawn-time signal) instead of the child-reports-back
 /// <c>messages/*.json</c> scan. Drives the extraction+POST composition directly since

--- a/test/Capacitor.Cli.Tests.Unit/AntigravitySubagentsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravitySubagentsTests.cs
@@ -3,9 +3,9 @@ using Capacitor.Cli.Core.Antigravity;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Unit tests for <see cref="AntigravitySubagents"/>. AI-1218 redesign: the child→parent map is
+/// Unit tests for <see cref="AntigravitySubagents"/>. The child→parent map is
 /// built from the parent transcript's <c>INVOKE_SUBAGENT</c> steps (the spawn-time signal) rather
-/// than the child-reports-back <c>messages/*.json</c> scan used pre-AI-1218 (AI-1160), which
+/// than the child-reports-back <c>messages/*.json</c> scan used previously, which
 /// missed children that never reported back.
 /// </summary>
 public class AntigravitySubagentsTests {
@@ -18,7 +18,7 @@ public class AntigravitySubagentsTests {
     static void MakeBrainDir(string home, string convId) =>
         Directory.CreateDirectory(Path.Combine(home, ".gemini", "antigravity", "brain", convId, ".system_generated", "logs"));
 
-    // AI-1218: on-disk brain layout for the INVOKE_SUBAGENT-based BuildParentMap, one temp
+    // on-disk brain layout for the INVOKE_SUBAGENT-based BuildParentMap, one temp
     // home per test, auto-cleaned on dispose (mirrors the NewHome/MakeBrainDir pattern above,
     // but for transcript-based fixtures rather than messages/*.json).
     sealed class TempBrain : IDisposable {
@@ -35,8 +35,8 @@ public class AntigravitySubagentsTests {
         }
     }
 
-    // AI-1160 review (finding 3): the discovery scan is O(history) IO and must be interruptible.
-    // Still valid under the AI-1218 transcript-based rewrite (scan is still O(history) IO).
+    // the discovery scan is O(history) IO and must be interruptible.
+    // Still valid under the transcript-based rewrite (scan is still O(history) IO).
     [Test]
     public async Task BuildParentMap_honors_cancellation() {
         var home = NewHome();
@@ -49,10 +49,10 @@ public class AntigravitySubagentsTests {
         } finally { Directory.Delete(home, recursive: true); }
     }
 
-    // AI-1218: BuildParentMap now derives child→parent from the parent transcript's
+    // BuildParentMap now derives child→parent from the parent transcript's
     // INVOKE_SUBAGENT steps (spawn-time signal) instead of the child-reports-back
     // messages/*.json scan (the old signal was unreliable for children that never reported back —
-    // see AI-1218's d9956b89 case below).
+    // see the d9956b89 case below).
     [Test]
     public async Task BuildParentMap_from_invoke_maps_children_to_the_invoking_parent() {
         using var tmp = new TempBrain();

--- a/test/Capacitor.Cli.Tests.Unit/AntigravityWatchExtractorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravityWatchExtractorTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Unit tests for the Antigravity watcher extractors (AI-1158): title-text extraction
+/// Unit tests for the Antigravity watcher extractors: title-text extraction
 /// from transcript_full.jsonl lines, the &lt;USER_REQUEST&gt; envelope strip, the
 /// title-event gate (<see cref="WatchCommand.IsEvent"/>), and the idle-timeout policy
 /// generalized to the antigravity GUI vendor (<see cref="WatchCommand.ShouldEndOnIdle"/>).
@@ -80,7 +80,7 @@ public class AntigravityWatchExtractorTests {
 
     [Test]
     public async Task PendingToolCalls_excludes_async_subagent_orchestration_so_a_parent_can_idle_end() {
-        // AI-1218: define_subagent/invoke_subagent resolve via a SEPARATE conversation (the child
+        // define_subagent/invoke_subagent resolve via a SEPARATE conversation (the child
         // reports back through brain/<parent>/messages), never as a result step in this transcript.
         // Counting them would pin the count > 0 forever and suppress idle-end, so a subagent-invoking
         // parent would only end when Antigravity quits. They must be excluded from the in-flight count.

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
@@ -124,7 +124,7 @@ public class ClaudeCliRunnerTests {
 
     // DEV-1484 contract: when a caller opts into MCP mode, they must name the
     // tools they want exposed. `--strict-mcp-config` already limits which MCP
-    // *servers* load to just the caller's inline config (AI-803), and the
+    // *servers* load to just the caller's inline config, and the
     // built-in lockdown (`--tools ""` / `--disallowedTools LSP`) stays on, so
     // an MCP config with no allowlist would load a server whose tools are never
     // permitted — the judge can't call anything, which is a silent
@@ -153,7 +153,7 @@ public class ClaudeCliRunnerTests {
         await Assert.That(ex?.ParamName).IsEqualTo("allowedTools");
     }
 
-    // AI-803: the tool-using (MCP) judge branch must keep `--strict-mcp-config`
+    // the tool-using (MCP) judge branch must keep `--strict-mcp-config`
     // on so claude loads ONLY the caller's inline session-scoped judge server.
     // Without it, a client machine with the `kcap` Claude Code plugin installed
     // leaks its global `kcap-sessions` server into the headless judge; the judge
@@ -281,7 +281,7 @@ public class ClaudeCliRunnerTests {
         return i >= 0 && i + 1 < args.Count ? args[i + 1] : null;
     }
 
-    // AI-755: the CLI returns is_error:true with the API failure text in
+    // the CLI returns is_error:true with the API failure text in
     // `result` when the upstream call fails (overload, rate limit, auth).
     // Surfacing that text as a title produced session titles like
     // "Claude API error: Overloaded". Treat it as a failure instead.
@@ -332,7 +332,7 @@ public class ClaudeCliRunnerTests {
         await Assert.That(result!.Result).IsEqualTo("ok");
     }
 
-    // AI-755 follow-up: if the envelope says is_error:true, the parser
+    // follow-up: if the envelope says is_error:true, the parser
     // returns null but RunCoreAsync still tries TryReadTranscriptFallback.
     // The transcript's last assistant block on a failed turn can be a
     // partial reply or stale auto-memory content, so converting that into

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeCliRunnerTests.cs
@@ -332,7 +332,7 @@ public class ClaudeCliRunnerTests {
         await Assert.That(result!.Result).IsEqualTo("ok");
     }
 
-    // follow-up: if the envelope says is_error:true, the parser
+    // Follow-up: if the envelope says is_error:true, the parser
     // returns null but RunCoreAsync still tries TryReadTranscriptFallback.
     // The transcript's last assistant block on a failed turn can be a
     // partial reply or stale auto-memory content, so converting that into

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
@@ -16,7 +16,7 @@ public class ClaudeHookCommandTests {
         await Assert.That(fx.RouteOrder).Contains("session-start");
     }
 
-    // AI-701: the session-start payload gains a best-effort workspace_root (the git repo root
+    // the session-start payload gains a best-effort workspace_root (the git repo root
     // for cwd), used server-side by plan-artifact discovery. Fail-open: a cwd with no
     // discoverable .git entry (e.g. "/tmp") must omit the field entirely rather than send null.
     [Test]
@@ -306,7 +306,7 @@ public class ClaudeHookCommandTests {
         await Assert.That(all).Contains("\"route\":\"subagent-stop\"");
     }
 
-    // AI-1357 Task 12 / BLOCKER-1+3 regression: the centralized ordered drain (now running on every
+    // Task 12 / BLOCKER-1+3 regression: the centralized ordered drain (now running on every
     // non-Codex hook, incl. --claude) can WITHHOLD a spooled session-end in the ".ordered-*" temp
     // namespace pending the transcript tail. ClaudeHookCommand.CurrentSessionHasBacklog must see that
     // withheld terminal (it now delegates to HookSpool.HasBacklog, which covers ".ordered-*") so a

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherReviewFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherReviewFlowTests.cs
@@ -99,7 +99,7 @@ public class ClaudeLauncherReviewFlowTests {
         await Assert.That(NewLauncher().SupportsUnattended).IsTrue();
     }
 
-    // === AI-1126 D-c: definition MCP allowlist materialization ===
+    // === D-c: definition MCP allowlist materialization ===
 
     [Test]
     public async Task ReviewFlow_with_allowlist_merges_servers_into_mcp_config() {
@@ -203,7 +203,7 @@ public class ClaudeLauncherReviewFlowTests {
         await Assert.That(argsEmpty).IsEquivalentTo(argsNull, CollectionOrdering.Matching);
     }
 
-    // === AI-1207 Phase A: read-only argv for a borrowed reviewer ===
+    // === Phase A: read-only argv for a borrowed reviewer ===
 
     [Test]
     public async Task Review_flow_borrowed_cwd_denies_write_and_exec_tools_instead_of_bypass() {

--- a/test/Capacitor.Cli.Tests.Unit/CliResolverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CliResolverTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Covers the daemon-startup vendor probe (AI-652). The resolver is the
+/// Covers the daemon-startup vendor probe. The resolver is the
 /// only place the daemon decides whether to advertise <c>claude</c> /
 /// <c>codex</c> over <c>DaemonConnect</c>, so the launch dialog's vendor
 /// filter is only ever as accurate as this lookup.
@@ -30,7 +30,7 @@ public class CliResolverTests {
 
     /// <summary>
     /// A non-executable file on disk must NOT be advertised as a spawnable
-    /// CLI. The original AI-652 resolver missed this and would have shipped
+    /// CLI. The original resolver missed this and would have shipped
     /// "claude" as supported on hosts where the binary existed but couldn't
     /// be executed (e.g. wrong owner, stripped exec bit).
     /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
@@ -224,7 +224,7 @@ public class CodexConfigTomlTests {
         await Assert.That(ArgsOf(review)).IsEquivalentTo(new[] { "mcp", "review" });
         await Assert.That((string)sessions["command"]).IsEqualTo("kcap");
         await Assert.That(ArgsOf(sessions)).IsEquivalentTo(new[] { "mcp", "sessions" });
-        // AI-1146: kcap-memory is now auto-registered for Codex too.
+        // kcap-memory is now auto-registered for Codex too.
         await Assert.That((string)memory["command"]).IsEqualTo("kcap");
         await Assert.That(ArgsOf(memory)).IsEquivalentTo(new[] { "mcp", "memory" });
     }

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs
@@ -98,7 +98,7 @@ public class CodexHookCommandTests : IDisposable {
             var endRequests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-end/codex").UsingPost());
             await Assert.That(endRequests.Count).IsEqualTo(0);
 
-            // invariant: valid JSON object on stdout, no chatter.
+            // Invariant: valid JSON object on stdout, no chatter.
             var stdout = stdoutWriter.ToString();
             var doc    = JsonDocument.Parse(stdout);
             await Assert.That(doc.RootElement.GetProperty("continue").GetBoolean()).IsTrue();
@@ -227,7 +227,7 @@ public class CodexHookCommandTests : IDisposable {
         // the request server-side via /hooks/permission-record (the same
         // fire-and-forget endpoint Claude's terminal path uses) and emits an
         // empty hookSpecificOutput so Codex's normal in-CLI approval prompt
-        // asks the user. Regression for.
+        // asks the user. Regression test for this behavior.
         var previousEnv = Environment.GetEnvironmentVariable("KCAP_DAEMON_URL");
         Environment.SetEnvironmentVariable("KCAP_DAEMON_URL", null);
 
@@ -314,12 +314,12 @@ public class CodexHookCommandTests : IDisposable {
         await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
     }
 
-    // / Qodo finding: bounding only the POST left auth discovery
+    // Qodo finding: bounding only the POST left auth discovery
     // (GET /auth/config) running on HttpClient's 100 s default. Stub
     // /auth/config slow and assert the hook still returns under 5 s — the
     // shared 2 s CTS in CodexHookCommand covers discovery too.
     //
-    // follow-up: this test redirects Console.Out, so it must share
+    // Separately, this test redirects Console.Out, so it must share
     // ConsoleSerialGroup with every other Console.Out-redirecting test in
     // the suite. Previously it lived in its own "CodexPermissionRequestStdout"
     // group and raced against the ConsoleSerialGroup tests, occasionally
@@ -422,10 +422,10 @@ public class CodexHookCommandTests : IDisposable {
         await Assert.That(_server.LogEntries.Count).IsEqualTo(0);
     }
 
-    // Fix #3 /: non-string session_id in a Stop payload must not crash.
+    // Fix #3: non-string session_id in a Stop payload must not crash.
     // session_id falls to null via the safe TryGetString helper, so HandleStop
     // short-circuits before EnsureWatcherRunning. No server POST is expected
-    // (removed Stop's session-end POST), but we still stub
+    // (Stop's session-end POST was removed), but we still stub
     // /hooks/session-end/codex so a regression that reintroduces the POST
     // surfaces as a test failure via the WireMock log assertion below.
     [Test]
@@ -444,7 +444,7 @@ public class CodexHookCommandTests : IDisposable {
         await Assert.That(endRequests.Count).IsEqualTo(0);
     }
 
-    // when the user runs `kcap disable`, the marker file
+    // When the user runs `kcap disable`, the marker file
     // under PathHelpers.ConfigPath("disabled") must short-circuit the Codex
     // hook the same way it does for Claude. Without this guard, the next
     // Codex Stop hook restarts the watcher (HandleStop calls
@@ -507,7 +507,7 @@ public class CodexHookCommandTests : IDisposable {
     // PermissionRequest_records_event_and_yields_decision_to_codex above; it
     // asserts the new record-and-yield contract (no in-CLI decision, fall back
     // to Codex's own approval prompt). The tests below cover the new
-    // daemon-bridge branch added in.
+    // daemon-bridge branch added since then.
 
     [Test, NotInParallel]
     public async Task PermissionRequest_with_daemon_url_set_posts_to_bridge_and_forwards_response_to_stdout() {

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs
@@ -12,7 +12,7 @@ public class CodexHookCommandTests : IDisposable {
     // A group key was insufficient: parallel tests in *other* files (e.g.
     // ImportDisplayGridTests / CliResolverTests) still mutate the same
     // process-global state under different group keys, and the cross-group
-    // race nondeterministically corrupted Console captures (AI-737 CI).
+    // race nondeterministically corrupted Console captures (CI).
 
     readonly WireMockServer _server = WireMockServer.Start();
 
@@ -44,7 +44,7 @@ public class CodexHookCommandTests : IDisposable {
         await Assert.That(root.GetProperty("session_id").GetString()).IsEqualTo("019e032205fc7570be6575719c3ea861");
         await Assert.That(root.GetProperty("home_dir").GetString()).IsNotNull();
 
-        // AI-635: SessionStart also writes Codex's required JSON output to stdout.
+        // SessionStart also writes Codex's required JSON output to stdout.
         // We can't reliably capture stdout here because the test path spawns a
         // real watcher child process via Process.Start, which under TUnit's
         // Console capture corrupts subsequent stdout reads. The Stop test covers
@@ -57,7 +57,7 @@ public class CodexHookCommandTests : IDisposable {
     // POSTs to /hooks/stop so the server can emit the idle-wait marker that
     // clears the chat "working" indicator — but it must NOT POST session-end
     // (that path is reserved for the watcher's parent-exit fallback), and must
-    // still emit {"continue":true} on stdout (AI-635) with no watcher chatter.
+    // still emit {"continue":true} on stdout with no watcher chatter.
     //
     // Globally sequential: captures Console.Out for the duration.
     [Test, NotInParallel]
@@ -98,7 +98,7 @@ public class CodexHookCommandTests : IDisposable {
             var endRequests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-end/codex").UsingPost());
             await Assert.That(endRequests.Count).IsEqualTo(0);
 
-            // AI-635 invariant: valid JSON object on stdout, no chatter.
+            // invariant: valid JSON object on stdout, no chatter.
             var stdout = stdoutWriter.ToString();
             var doc    = JsonDocument.Parse(stdout);
             await Assert.That(doc.RootElement.GetProperty("continue").GetBoolean()).IsTrue();
@@ -227,7 +227,7 @@ public class CodexHookCommandTests : IDisposable {
         // the request server-side via /hooks/permission-record (the same
         // fire-and-forget endpoint Claude's terminal path uses) and emits an
         // empty hookSpecificOutput so Codex's normal in-CLI approval prompt
-        // asks the user. Regression for AI-636.
+        // asks the user. Regression for.
         var previousEnv = Environment.GetEnvironmentVariable("KCAP_DAEMON_URL");
         Environment.SetEnvironmentVariable("KCAP_DAEMON_URL", null);
 
@@ -277,7 +277,7 @@ public class CodexHookCommandTests : IDisposable {
         await Assert.That(wrong.Count).IsEqualTo(0);
     }
 
-    // AI-636: the hook must return well under Codex's 30 s timeout even when
+    // the hook must return well under Codex's 30 s timeout even when
     // the recording endpoint is slow. We cap the HTTP client at 2 s and
     // swallow the resulting TaskCanceledException — guard against future
     // regressions where someone reintroduces an unbounded await.
@@ -314,12 +314,12 @@ public class CodexHookCommandTests : IDisposable {
         await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
     }
 
-    // AI-636 / Qodo finding: bounding only the POST left auth discovery
+    // / Qodo finding: bounding only the POST left auth discovery
     // (GET /auth/config) running on HttpClient's 100 s default. Stub
     // /auth/config slow and assert the hook still returns under 5 s — the
     // shared 2 s CTS in CodexHookCommand covers discovery too.
     //
-    // AI-628 follow-up: this test redirects Console.Out, so it must share
+    // follow-up: this test redirects Console.Out, so it must share
     // ConsoleSerialGroup with every other Console.Out-redirecting test in
     // the suite. Previously it lived in its own "CodexPermissionRequestStdout"
     // group and raced against the ConsoleSerialGroup tests, occasionally
@@ -422,10 +422,10 @@ public class CodexHookCommandTests : IDisposable {
         await Assert.That(_server.LogEntries.Count).IsEqualTo(0);
     }
 
-    // Fix #3 / AI-648: non-string session_id in a Stop payload must not crash.
+    // Fix #3 /: non-string session_id in a Stop payload must not crash.
     // session_id falls to null via the safe TryGetString helper, so HandleStop
     // short-circuits before EnsureWatcherRunning. No server POST is expected
-    // (AI-648 removed Stop's session-end POST), but we still stub
+    // (removed Stop's session-end POST), but we still stub
     // /hooks/session-end/codex so a regression that reintroduces the POST
     // surfaces as a test failure via the WireMock log assertion below.
     [Test]
@@ -439,12 +439,12 @@ public class CodexHookCommandTests : IDisposable {
 
         await Assert.That(exit).IsEqualTo(0);
 
-        // AI-648: Stop must never POST session-end, even with a malformed payload.
+        // Stop must never POST session-end, even with a malformed payload.
         var endRequests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-end/codex").UsingPost());
         await Assert.That(endRequests.Count).IsEqualTo(0);
     }
 
-    // AI-676 P1: when the user runs `kcap disable`, the marker file
+    // when the user runs `kcap disable`, the marker file
     // under PathHelpers.ConfigPath("disabled") must short-circuit the Codex
     // hook the same way it does for Claude. Without this guard, the next
     // Codex Stop hook restarts the watcher (HandleStop calls
@@ -503,11 +503,11 @@ public class CodexHookCommandTests : IDisposable {
 
     // ---- PermissionRequest daemon-bridge tests ----
     //
-    // The no-daemon-URL "stub" branch is covered by the AI-636 regression test
+    // The no-daemon-URL "stub" branch is covered by the regression test
     // PermissionRequest_records_event_and_yields_decision_to_codex above; it
     // asserts the new record-and-yield contract (no in-CLI decision, fall back
     // to Codex's own approval prompt). The tests below cover the new
-    // daemon-bridge branch added in AI-68.
+    // daemon-bridge branch added in.
 
     [Test, NotInParallel]
     public async Task PermissionRequest_with_daemon_url_set_posts_to_bridge_and_forwards_response_to_stdout() {

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexImportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexImportTests.cs
@@ -37,7 +37,7 @@ public class CodexImportTests {
 
     [Test]
     public async Task ExtractCodexSessionMetadata_prefers_turn_context_model_over_model_provider() {
-        // AI-194 (CLI half): session_meta only carries model_provider ("openai"),
+        // session_meta only carries model_provider ("openai"),
         // not the actual model. The real model name lives on turn_context.payload.model
         // (e.g. "gpt-5.5"). Prefer that over the provider so the session card and
         // details show "gpt-5.5" instead of "openai".

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -343,7 +343,7 @@ public class CodexLauncherTests {
             var configToml = File.ReadAllText(Path.Combine(home, ".codex", "config.toml"));
             // The TOML writer emits the path as a basic (double-quoted) key, so
             // backslashes are escaped per spec (\ → \\). Match the escaped form
-            // so the assertion holds on Windows too (no-op on POSIX paths)..
+            // so the assertion holds on Windows too (no-op on POSIX paths).
             var escapedWorktree = worktree.Replace("\\", "\\\\");
             await Assert.That(configToml).Contains($"\"{escapedWorktree}\"");
             await Assert.That(configToml).Contains("trust_level = \"trusted\"");

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -114,7 +114,7 @@ public class CodexLauncherTests {
     public async Task BuildArgs_omits_model_when_default_sentinel(string model) {
         // "default" is a vendor-neutral sentinel meaning "use the vendor's own default
         // model". Codex has no such model — `-m default` fails on ChatGPT accounts
-        // (AI-1114). Omit -m so Codex falls back to its configured default.
+        // Omit -m so Codex falls back to its configured default.
         var args = NewLauncher().BuildArgs(NewCtx(model: model)).Args;
         await Assert.That(args).DoesNotContain("-m");
         await Assert.That(args).DoesNotContain(model);
@@ -343,7 +343,7 @@ public class CodexLauncherTests {
             var configToml = File.ReadAllText(Path.Combine(home, ".codex", "config.toml"));
             // The TOML writer emits the path as a basic (double-quoted) key, so
             // backslashes are escaped per spec (\ → \\). Match the escaped form
-            // so the assertion holds on Windows too (no-op on POSIX paths). AI-820.
+            // so the assertion holds on Windows too (no-op on POSIX paths)..
             var escapedWorktree = worktree.Replace("\\", "\\\\");
             await Assert.That(configToml).Contains($"\"{escapedWorktree}\"");
             await Assert.That(configToml).Contains("trust_level = \"trusted\"");
@@ -457,7 +457,7 @@ public class CodexLauncherTests {
         await Assert.That(NewLauncher().SupportsUnattended).IsTrue();
     }
 
-    // === AI-1126 D-c: definition MCP allowlist materialization ===
+    // === D-c: definition MCP allowlist materialization ===
 
     static CodexLauncher NewFlowResultLauncher() =>
         new(new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" }, NullLogger<CodexLauncher>.Instance);
@@ -552,7 +552,7 @@ public class CodexLauncherTests {
         await Assert.That(argsEmpty).IsEquivalentTo(argsNull, CollectionOrdering.Matching);
     }
 
-    // === AI-1207 Phase A: read-only sandbox for a borrowed reviewer ===
+    // === Phase A: read-only sandbox for a borrowed reviewer ===
 
     [Test]
     public async Task BuildArgs_borrowed_cwd_uses_read_only_sandbox() {

--- a/test/Capacitor.Cli.Tests.Unit/CodexStdoutContractTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodexStdoutContractTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1357 Task 5: Codex's SessionStart hook must satisfy Codex's blocking stdout handshake
+/// Task 5: Codex's SessionStart hook must satisfy Codex's blocking stdout handshake
 /// BEFORE any best-effort post-stdout work (watcher-ensure, global spool drain) runs — a
 /// large/unreachable spool backlog must never stall the handshake. These tests exercise
 /// <see cref="CodexHookCommand.RunSessionStartHandshakeForTest"/> directly, the seam

--- a/test/Capacitor.Cli.Tests.Unit/CodingAgentPidResolverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodingAgentPidResolverTests.cs
@@ -120,7 +120,7 @@ public class CodingAgentPidResolverTests {
         // On Windows the per-PID lookup (GetProcessInfo) returns the full image path
         // from QueryFullProcessImageNameW, e.g. "C:\...\claude.exe". The walk must match
         // it by basename plus a single ".exe" extension so the Windows parent-PID
-        // watchdog can resolve the durable agent past the transient hook executor (AI-822).
+        // watchdog can resolve the durable agent past the transient hook executor.
         // hook(100) -> cmd(90) -> claude.exe(50) -> explorer(20)
         var lookup = ProcTable.Of(
             (90, 50, @"C:\Windows\System32\cmd.exe"),
@@ -186,7 +186,7 @@ public class CodingAgentPidResolverTests {
     public async Task Resolves_kiro_when_process_is_kiro_cli() {
         // Kiro's process image is `kiro-cli`, but the vendor token is `kiro`. The by-name ancestry
         // walk must match a bounded `-cli` suffix so the parent-exit watchdog identifies the durable
-        // process instead of falling back to the fragile pgid heuristic (AI-1359).
+        // process instead of falling back to the fragile pgid heuristic.
         // hook(100) -> sh(90) -> kiro-cli(50) -> zsh(20)
         var lookup = ProcTable.Of((90, 50, "sh"), (50, 20, "kiro-cli"), (20, 1, "-zsh"));
 

--- a/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodingAgentsStepTests.cs
@@ -228,7 +228,7 @@ public class CodingAgentsStepTests {
         await Assert.That(sink.Lines).Contains(l => l.Contains("/hooks") && l.Contains("trust"));
     }
 
-    // ── Agent skills decoupled from Codex (AI-1285) ──────────────────────────
+    // ── Agent skills decoupled from Codex ──────────────────────────
 
     [Test]
     public async Task Agent_skills_installed_when_only_cursor_detected() {
@@ -479,7 +479,7 @@ public class CodingAgentsStepTests {
         await Assert.That(prompts).DoesNotContain(p => p.Contains("agent skills", StringComparison.OrdinalIgnoreCase) && p.Contains("Codex"));
     }
 
-    // ── Codex sandbox network access (AI-794) ────────────────────────────────
+    // ── Codex sandbox network access ────────────────────────────────
 
     [Test]
     public async Task Codex_network_access_enabled_when_hooks_installed_and_accepted() {
@@ -1994,7 +1994,7 @@ public class CodingAgentsStepTests {
         await Assert.That(sink.Lines).Contains(l => l.Contains("Could not write the Pi extension"));
     }
 
-    // ── OpenCode (SST): a plugin file, like Pi (AI-919) ──────────────────────
+    // ── OpenCode (SST): a plugin file, like Pi ──────────────────────
 
     [Test]
     public async Task OpenCode_detected_and_accepted_installs_plugin() {

--- a/test/Capacitor.Cli.Tests.Unit/ConfigCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ConfigCommandTests.cs
@@ -169,7 +169,7 @@ public class ConfigCommandTests {
         await Assert.That(updated.ServerUrl).IsEqualTo("https://example.com");
     }
 
-    // ── default_visibility (AI-1206: "project" added to the ladder) ────────────
+    // ── default_visibility ("project" added to the ladder) ────────────
 
     [Test]
     [Arguments("private")]

--- a/test/Capacitor.Cli.Tests.Unit/ConfigMigrationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ConfigMigrationTests.cs
@@ -170,7 +170,7 @@ public class ConfigMigrationTests {
         await Assert.That(config.DisableSessionGuidelines).IsNull();
     }
 
-    // update_check migration-default quirk ---
+    // --- update_check migration-default quirk ---
     //
     // STJ source-gen does not apply a record member-initializer default (`= true`)
     // for a JSON property absent from the payload, so deserializing a v1 config

--- a/test/Capacitor.Cli.Tests.Unit/ConfigMigrationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ConfigMigrationTests.cs
@@ -170,7 +170,7 @@ public class ConfigMigrationTests {
         await Assert.That(config.DisableSessionGuidelines).IsNull();
     }
 
-    // --- update_check migration-default quirk (AI-1168 / #268) ---
+    // update_check migration-default quirk ---
     //
     // STJ source-gen does not apply a record member-initializer default (`= true`)
     // for a JSON property absent from the payload, so deserializing a v1 config

--- a/test/Capacitor.Cli.Tests.Unit/ConnectionRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ConnectionRetryTests.cs
@@ -127,7 +127,7 @@ public class ConnectionRetryTests {
         await Assert.That(invokeCalls).IsEqualTo(2);
     }
 
-    // AI-864: a HubException matching the retriable-server-error predicate is retried up to a
+    // a HubException matching the retriable-server-error predicate is retried up to a
     // BOUND (unlike transient disconnects, which retry until the daemon shuts down). Used for the
     // "Caller is not the daemon owning session" error that can appear briefly after a reconnect
     // before per-agent re-registration restores ownership — retrying past that window avoids a

--- a/test/Capacitor.Cli.Tests.Unit/CopilotFinalizeDrainTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CopilotFinalizeDrainTests.cs
@@ -7,7 +7,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Pure detection logic for the Copilot finalize drain (AI-897): the drainer
+/// Pure detection logic for the Copilot finalize drain: the drainer
 /// treats a terminal <c>session.shutdown</c> line as "the tail is complete".
 /// </summary>
 public class CopilotFinalizeDrainLastLineTests {
@@ -65,7 +65,7 @@ public class CopilotFinalizeDrainLastLineTests {
 }
 
 /// <summary>
-/// End-to-end timing behaviour of the Copilot finalize drain (AI-897), driven
+/// End-to-end timing behaviour of the Copilot finalize drain, driven
 /// through the testable <see cref="CopilotFinalizeDrainCommand.RunAsync"/> seam
 /// against a mock server. Mirrors the existing InlineDrain WireMock harness:
 /// auth discovery degrades to "None" (no live server at the resolved default),
@@ -185,7 +185,7 @@ public class CopilotFinalizeDrainRunTests : IDisposable {
     public async Task TimeoutFallback_DrainsExistingTail_WhenShutdownNeverArrives() {
         // Copilot crash / shutdown never written: the budget elapses but the
         // finalizer must still deliver the final assistant turn it can see
-        // (the secondary AI-897 risk — a dropped final turn).
+        // (the secondary risk — a dropped final turn).
         const string sessionId = "test-finalize-timeout";
         StubServer(sessionId);
 

--- a/test/Capacitor.Cli.Tests.Unit/CrashReporterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CrashReporterTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1168: the CLI's top-level guard converts an otherwise-uncaught exception
+/// the CLI's top-level guard converts an otherwise-uncaught exception
 /// (which NativeAOT turns into a SIGABRT + crash report on a ~1s hook/generator
 /// process) into a logged, clean exit. These cover the pure decisions —
 /// which commands fail open, the resulting exit code, and the crash-log entry

--- a/test/Capacitor.Cli.Tests.Unit/CrossProcessRefreshTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CrossProcessRefreshTests.cs
@@ -7,7 +7,7 @@ namespace Capacitor.Cli.Tests.Unit;
 /// Tests for TokenStore.RefreshWithCrossProcessLockAsync — the profile-scoped lock that both the
 /// reactive (GetValidTokensAsync) and proactive (RefreshIfExpiringAsync) paths refresh through.
 ///
-/// Covers two review findings on the proactive-refresh PR (#257 / AI-992):
+/// Covers two review findings on the proactive-refresh PR:
 ///   1. The refreshed token must be persisted under the SAME profile the lock was taken on, not
 ///      the (possibly since-switched) active profile — the refresh delegates no longer self-save.
 ///   2. A refresh that a peer already performed while we waited for the lock must NOT be repeated,

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorGuardWiringTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorGuardWiringTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace Capacitor.Cli.Tests.Unit.Cursor;
 
 /// <summary>
-/// AI-1382 review fix #2 — regression tests for the Cursor runtime rewrite-guard WIRING inside
+/// regression tests for the Cursor runtime rewrite-guard WIRING inside
 /// <see cref="WatchCommand.DrainNewLines"/> (as distinct from <see cref="CursorRewriteGuardTests"/>,
 /// which pins the guard's own pure hash-comparison logic in isolation). Both scenarios here trip
 /// the guard and return BEFORE <c>DrainNewLines</c> ever touches its <see cref="HubConnection"/>
@@ -119,7 +119,7 @@ public class CursorGuardWiringTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1382 review fix #3 — VerifyFullPrefix's only production call site (the periodic cadence
+    // VerifyFullPrefix's only production call site (the periodic cadence
     // check) used to seed lazily on its OWN first invocation, which — before this fix — never
     // happened until poll N (CursorFullPrefixVerifyEveryNPolls). The two OTHER full-prefix tests
     // above manually pre-seed the guard via a direct guard.VerifyFullPrefix(...) call to isolate
@@ -176,7 +176,7 @@ public class CursorGuardWiringTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1382 review fix (r3, finding #3) — the guard's checks (prior-zone hash, shrink, new-range
+    // the guard's checks (prior-zone hash, shrink, new-range
     // record) must still work correctly on a NON-cadence poll, where DrainNewLines now captures
     // only a BOUNDED window (the guard's own trailing-tail zone plus the new range) instead of
     // materializing the whole file. Before this fix, this poll would have re-allocated/re-read the
@@ -269,7 +269,7 @@ public class CursorGuardWiringTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1382 review fix (r4, finding #1) — a poll that reads ONLY blank/whitespace lines
+    // a poll that reads ONLY blank/whitespace lines
     // (newLines.Count == 0, but the line frontier still advanced past them) must move
     // CursorByteOffset in LOCKSTEP with LinesProcessed. Before the fix, only LinesProcessed
     // advanced here, leaving CursorByteOffset (and the guard's own checkpoint) pointed at the OLD
@@ -332,7 +332,7 @@ public class CursorGuardWiringTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1382 review fix (r4, finding #4) — CursorGuardPollCount (the full-prefix cadence counter)
+    // CursorGuardPollCount (the full-prefix cadence counter)
     // must only be committed once the guarded read it fed actually completes. Before the fix, the
     // counter incremented UNCONDITIONALLY before opening the file — a transient IOException on that
     // open/read (e.g. a concurrent writer briefly holding an exclusive lock) still "used up" the
@@ -378,7 +378,7 @@ public class CursorGuardWiringTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1382 review fix (r4, the repo-only-failed drain branch) — the SAME byte/line-lockstep the
+    // the SAME byte/line-lockstep the
     // finding-#1 blank-only early-return got must also hold on the OTHER path that advances
     // LinesProcessed past blank lines without an acked send: the "repo-only batch failed" catch
     // branch. That branch is only reached when a repo change was pending (repoToSend != null) AND

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
@@ -95,7 +95,7 @@ public class CursorHookCommandTests {
         await Assert.That(fx.RouteOrder).IsEquivalentTo(["session-start/cursor", "session-end/cursor"]);
     }
 
-    // AI-1382 review fix #4 — a telemetry-only mapping (postToolUse, SpoolOnFailure=false) must
+    // a telemetry-only mapping (postToolUse, SpoolOnFailure=false) must
     // NOT let the recovery-spawn watcher start while an EARLIER queued canonical event (here:
     // sessionStart) is still stuck undelivered. Simulate: sessionStart is already spooled from a
     // prior failed invocation; THIS invocation's generic top-of-method drain retries it and hits
@@ -212,7 +212,7 @@ public class CursorHookCommandTests {
 
     [Test]
     public async Task telemetry_only_hook_touches_the_heartbeat_file() {
-        // AI-1382 Task 8: even a telemetry-only hook (never spooled, lossy on failure) must
+        // Task 8: even a telemetry-only hook (never spooled, lossy on failure) must
         // touch the per-session heartbeat — it reflects "Cursor is still firing hooks",
         // independent of whatever the transcript/spool machinery is doing.
         using var fx = new Fixture();
@@ -248,7 +248,7 @@ public class CursorHookCommandTests {
 
     [Test]
     public async Task sessionEnd_drains_the_hook_spool_before_the_pre_end_transcript_drain_and_clears_the_barrier() {
-        // AI-1382 Task 8: a beforeSubmitPrompt whose live POST previously failed left a barrier
+        // Task 8: a beforeSubmitPrompt whose live POST previously failed left a barrier
         // + a spooled user-prompt/cursor entry behind. sessionEnd must deliver that spooled
         // entry (clearing the barrier) BEFORE running its pre-end transcript drain, so a
         // transcript line depending on the attachment is never normalized ahead of it.
@@ -397,7 +397,7 @@ public class CursorHookCommandTests {
         public HttpClient Client                { get; }
         public string     TranscriptPathEscaped => _transcriptPath.Replace(@"\", @"\\");
 
-        // AI-1382 Task 10: the backfill now holds a non-newline-terminated final line on every
+        // Task 10: the backfill now holds a non-newline-terminated final line on every
         // mid-session (Hold-policy) call — a real Cursor transcript line is newline-terminated
         // once flushed, so tests write content the same way rather than exercising the
         // holdback edge case incidentally.

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorLiveSubagentIntegrationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorLiveSubagentIntegrationTests.cs
@@ -6,7 +6,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit.Cursor;
 
 /// <summary>
-/// AI-1151 (live): end-to-end coverage of CursorHookCommand's subagent-linking divert —
+/// end-to-end coverage of CursorHookCommand's subagent-linking divert —
 /// CursorLiveSubagentLinkerTests covers the pure ResolveParent/marker/discovery pieces in
 /// isolation; these tests exercise the actual hook dispatcher wiring (subagent-start/-stop
 /// instead of the top-level lifecycle, transcript routed with agent_id, mid-lifecycle hooks
@@ -137,7 +137,7 @@ public class CursorLiveSubagentIntegrationTests {
     }
 
     /// <summary>
-    /// AI-1151/AI-1358 A1: the agent_id the LIVE path uses (child session id, dashless) must
+    /// the agent_id the LIVE path uses (child session id, dashless) must
     /// be byte-identical to what the IMPORT path (CursorImportSource.SendSubagentLifecycleAsync)
     /// would use for the same child — otherwise a live-then-import of the same session would
     /// duplicate the subagent's AgentSubsession stream instead of converging on it.

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorMarkersTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorMarkersTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit.Cursor;
 
 /// <summary>
-/// AI-1382 D0/D1 — round-trips CursorMarkers' quarantine/barrier/heartbeat path helpers and the
+/// D0/D1 — round-trips CursorMarkers' quarantine/barrier/heartbeat path helpers and the
 /// quarantine read/write cycle. Shares the KCAP_CONFIG_DIR temp dir RepoPathStoreGlobalSetup pins
 /// before PathHelpers' static ConfigDir field is first touched (see that class's doc comment); a
 /// fresh GUID session id per test keeps these from colliding with each other or with the other
@@ -127,7 +127,7 @@ public class CursorMarkersTests {
         await Assert.That(WatcherHeartbeat.Read(CursorMarkers.HeartbeatPath(sid))).IsEqualTo(now);
     }
 
-    // AI-1382 review fix #5 — the durable per-child subagent-start-acknowledgement marker.
+    // the durable per-child subagent-start-acknowledgement marker.
     [Test]
     public async Task HasSubagentStartAck_false_before_any_ack_is_recorded() {
         var childSid = NewSessionId();

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorReconnectRewindTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorReconnectRewindTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.SignalR.Client;
 namespace Capacitor.Cli.Tests.Unit.Cursor;
 
 /// <summary>
-/// AI-1382 review fix #2 — a reconnect that discovers the server's acknowledged line frontier is
+/// a reconnect that discovers the server's acknowledged line frontier is
 /// behind the watcher's own <see cref="WatchState.LinesProcessed"/> must rewind the Cursor byte
 /// guard's checkpoint ATOMICALLY with the line cursor. Before the fix, only
 /// <see cref="WatchState.LinesProcessed"/> rewound — <see cref="WatchState.CursorByteOffset"/> and
@@ -27,7 +27,7 @@ public class CursorReconnectRewindTests {
             var path = Path.Combine(dir, "t.jsonl");
             await File.WriteAllTextAsync(path, "line1\nline2\nline3\n");
 
-            // AI-1382 review fix (r6): the method now returns a (ByteOffset, LineNumber) pair —
+            // the method now returns a (ByteOffset, LineNumber) pair —
             // trivial for a non-positive request, LineNumber just carries the input through.
             var zero = await WatchCommand.ResolveByteOffsetForLineAsync(path, 0, CancellationToken.None);
             await Assert.That(zero!.Value.ByteOffset).IsEqualTo(0L);
@@ -39,7 +39,7 @@ public class CursorReconnectRewindTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1382 review fix (r4, finding #5) — a missing file with a POSITIVE requested line number is
+    // a missing file with a POSITIVE requested line number is
     // exactly "fewer lines on disk than requested" (zero, in this case) — the caller must quarantine
     // rather than clamp to a byte offset of 0, which used to look like a perfectly valid (if empty)
     // resume baseline.
@@ -57,7 +57,7 @@ public class CursorReconnectRewindTests {
             // Deliberately uneven line lengths so a naive "count * avg-length" guess would be wrong.
             await File.WriteAllTextAsync(path, "a\nbbbb\ncc\n"); // offsets: line0 ends at 2, line1 ends at 7, line2 ends at 10
 
-            // AI-1382 review fix (r6): unchanged mid-file case — the returned pair's LineNumber is
+            // unchanged mid-file case — the returned pair's LineNumber is
             // always the requested lineNumber unchanged; only the r5 unterminated-final-record case
             // (covered below) rewinds it.
             var r1 = await WatchCommand.ResolveByteOffsetForLineAsync(path, 1, CancellationToken.None);
@@ -74,7 +74,7 @@ public class CursorReconnectRewindTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1382 review fix (r4, finding #5) — the pre-fix behaviour silently clamped to EOF here; this
+    // the pre-fix behaviour silently clamped to EOF here; this
     // is exactly the truncated-transcript scenario the fix closes, so the method must now signal
     // "cannot resolve exactly" (null) instead of handing back a bogus baseline offset.
     [Test]
@@ -88,7 +88,7 @@ public class CursorReconnectRewindTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1382 review fix (r5) — a COMPLETE final record with no trailing newline yet must resolve,
+    // a COMPLETE final record with no trailing newline yet must resolve,
     // not quarantine. This is exactly what the watcher's own shutdown final drain
     // (IncompleteFinalLinePolicy.ConsumeIfComplete) and historical import's StreamReader-based
     // splitting both send as the last line of a file. Before this fix, the round-4 guard treated
@@ -96,7 +96,7 @@ public class CursorReconnectRewindTests {
     // watcher restart resuming at that same final line (server frontier == local line count) would
     // permanently quarantine an otherwise-healthy, append-only session.
     //
-    // AI-1382 review fix (r6) — the r5 fix originally resolved this case at EOF, unchanged
+    // the r5 fix originally resolved this case at EOF, unchanged
     // LineNumber. That seeded CursorByteOffset exactly where Cursor's OWN later-arriving
     // terminator for this SAME already-acked record lands; when it arrived, the bounded reader
     // (seeding its own line index from LinesProcessed, left at the record's line number) misread
@@ -126,7 +126,7 @@ public class CursorReconnectRewindTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1382 review fix (r5) — the completeness gate matters: an unterminated tail that ISN'T a
+    // the completeness gate matters: an unterminated tail that ISN'T a
     // parseable JSON record (still being written, or genuinely truncated mid-record) must still
     // quarantine — only a demonstrably COMPLETE trailing record is allowed to resolve at EOF.
     [Test]
@@ -140,7 +140,7 @@ public class CursorReconnectRewindTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1382 review fix (r4, finding #5), preserved under r5 — a request for a line further beyond
+    // review fix (r4, finding #5), preserved under r5 — a request for a line further beyond
     // the local file than "the final unterminated record" is a genuine shortfall (truncation/rewrite)
     // and must still quarantine, never resolve. (No trailing content at all here — both requested
     // lines are already accounted for by the two newlines, and line 5 is nowhere close.)
@@ -179,7 +179,7 @@ public class CursorReconnectRewindTests {
         await Assert.That(CursorMarkers.IsQuarantined(sid)).IsFalse();
     }
 
-    // ---- AI-1382 review fix (r3, finding #2) — WatchCommand.SeedCursorByteOffsetAsync ----
+    // review fix (r3, finding #2) — WatchCommand.SeedCursorByteOffsetAsync ----
     //
     // Shared by ApplyReconnectRewindAsync (already covered above) and RunWatch's INITIAL
     // WatcherConnect registration, which — before this fix — left CursorByteOffset at its default
@@ -215,13 +215,13 @@ public class CursorReconnectRewindTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1382 review fix (r5) — reproduces the actual failure scenario: a final drain
+    // reproduces the actual failure scenario: a final drain
     // (IncompleteFinalLinePolicy.ConsumeIfComplete) sends a complete but unterminated final record,
     // the watcher exits (idle), and a LATER hook restarts the watcher with the server resuming it at
     // that exact same final line (server frontier == local line count, file STILL lacks the trailing
     // newline). SeedCursorByteOffsetAsync must seed a valid byte offset and NOT quarantine.
     //
-    // AI-1382 review fix (r6) — reproduces the P1 finding this seeds against: the r5 fix seeded
+    // reproduces the P1 finding this seeds against: the r5 fix seeded
     // CursorByteOffset at EOF while leaving LinesProcessed at the (already-acked) final record's own
     // line number. That put the byte cursor exactly where Cursor's OWN later-arriving terminator
     // for this SAME record lands; when it arrived, the bounded reader — seeding its line index from
@@ -260,7 +260,7 @@ public class CursorReconnectRewindTests {
 
     [Test]
     public async Task SeedCursorByteOffsetAsync_is_a_byte_only_no_op_for_non_cursor_vendors() {
-        // AI-1382 review fix (r6): SeedCursorByteOffsetAsync now sets state.LinesProcessed for
+        // SeedCursorByteOffsetAsync now sets state.LinesProcessed for
         // EVERY vendor (previously only its callers did) — the "no-op" is byte-side only.
         var dir = Directory.CreateTempSubdirectory("kcap-seed-initial-resume-noncursor").FullName;
         try {
@@ -311,7 +311,7 @@ public class CursorReconnectRewindTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1382 review fix (r4, finding #5) — the server-acknowledged resume frontier can legitimately
+    // the server-acknowledged resume frontier can legitimately
     // exceed the local transcript's line count (truncated/replaced while the watcher was offline).
     // SeedCursorByteOffsetAsync must quarantine and refuse to seed rather than clamp to EOF.
     [Test]
@@ -438,7 +438,7 @@ public class CursorReconnectRewindTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // ---- AI-1382 review fix (r3, finding #1) — GatedApplyReconnectRewindAsync/GatedDrainNewLinesAsync ----
+    // review fix (r3, finding #1) — GatedApplyReconnectRewindAsync/GatedDrainNewLinesAsync ----
     //
     // RunWatch's own cursorRewindGate/Reconnected handler can't be driven without a live SignalR
     // reconnect (same constraint CursorGuardWiringTests' class doc states), so these tests drive
@@ -546,7 +546,7 @@ public class CursorReconnectRewindTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // ---- AI-1382 review fix (r4, finding #5) — GatedApplyReconnectRewindAsync propagates a refused rewind ----
+    // review fix (r4, finding #5) — GatedApplyReconnectRewindAsync propagates a refused rewind ----
 
     [Test]
     public async Task GatedApplyReconnectRewindAsync_returns_false_and_leaves_state_untouched_when_the_server_frontier_exceeds_local_lines() {

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorReconnectRewindTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorReconnectRewindTests.cs
@@ -179,7 +179,7 @@ public class CursorReconnectRewindTests {
         await Assert.That(CursorMarkers.IsQuarantined(sid)).IsFalse();
     }
 
-    // review fix (r3, finding #2) — WatchCommand.SeedCursorByteOffsetAsync ----
+    // ---- review fix (r3, finding #2) — WatchCommand.SeedCursorByteOffsetAsync ----
     //
     // Shared by ApplyReconnectRewindAsync (already covered above) and RunWatch's INITIAL
     // WatcherConnect registration, which — before this fix — left CursorByteOffset at its default
@@ -438,7 +438,7 @@ public class CursorReconnectRewindTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // review fix (r3, finding #1) — GatedApplyReconnectRewindAsync/GatedDrainNewLinesAsync ----
+    // ---- review fix (r3, finding #1) — GatedApplyReconnectRewindAsync/GatedDrainNewLinesAsync ----
     //
     // RunWatch's own cursorRewindGate/Reconnected handler can't be driven without a live SignalR
     // reconnect (same constraint CursorGuardWiringTests' class doc states), so these tests drive
@@ -546,7 +546,7 @@ public class CursorReconnectRewindTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // review fix (r4, finding #5) — GatedApplyReconnectRewindAsync propagates a refused rewind ----
+    // ---- review fix (r4, finding #5) — GatedApplyReconnectRewindAsync propagates a refused rewind ----
 
     [Test]
     public async Task GatedApplyReconnectRewindAsync_returns_false_and_leaves_state_untouched_when_the_server_frontier_exceeds_local_lines() {

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorRewriteGuardTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorRewriteGuardTests.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit.Cursor;
 
 /// <summary>
-/// AI-1382 D0 — the runtime two-zone rewrite guard. Each test uses a fresh GUID session id (see
+/// the runtime two-zone rewrite guard. Each test uses a fresh GUID session id (see
 /// CursorMarkersTests) so asserting CursorMarkers.IsQuarantined after a detected rewrite doesn't
 /// collide with the other marker/guard tests sharing the same KCAP_CONFIG_DIR temp dir.
 /// </summary>
@@ -114,7 +114,7 @@ public class CursorRewriteGuardTests {
         await Assert.That(CursorMarkers.IsQuarantined(sid)).IsTrue();
     }
 
-    // AI-1382 review fix #2 — a shrink is unambiguous evidence of a rewrite on its own; the
+    // a shrink is unambiguous evidence of a rewrite on its own; the
     // watcher's original wiring gated the whole zone check behind "did the file grow", so a
     // shrink slipped through entirely undetected.
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorTopLevelStreamingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorTopLevelStreamingTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.SignalR.Client;
 namespace Capacitor.Cli.Tests.Unit.Cursor;
 
 /// <summary>
-/// AI-1382 review fix #4 — a top-level Cursor watcher must stream new transcript lines
+/// a top-level Cursor watcher must stream new transcript lines
 /// immediately rather than accumulating them in <see cref="WatchState.BufferedLines"/> (the
 /// generic below-threshold buffer every other vendor without a pre-spawn commit still uses).
 /// <see cref="WatchCommand.SkipsThresholdBuffering"/> is the pure decision (see

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorTranscriptBackfillTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorTranscriptBackfillTests.cs
@@ -91,7 +91,7 @@ public class CursorTranscriptBackfillTests {
         await Assert.That(postCount).IsEqualTo(0);
     }
 
-    // AI-1382 review fix #8 — the markers must be re-checked IMMEDIATELY at the delivery
+    // the markers must be re-checked IMMEDIATELY at the delivery
     // boundary (right before the POST), not only before the watermark GET. Simulate a
     // concurrent quarantine landing DURING the watermark probe — after the early check already
     // passed, but before the POST — by setting the marker as a side effect of the GET call

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorWatcherSpawnTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorWatcherSpawnTests.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit.Cursor;
 
 /// <summary>
-/// AI-1382 Task 9 — the precedence-ordered per-session Cursor watcher spawn.
+/// Task 9 — the precedence-ordered per-session Cursor watcher spawn.
 /// <see cref="CursorHookCommand.ShouldSpawnWatcher"/> is pure (no I/O); the
 /// <see cref="CursorHookCommand.MaybeSpawnWatcherAsync"/> tests use
 /// <see cref="WatcherManager.SpawnOverrideForTesting"/> so no real OS process is ever spawned.
@@ -94,7 +94,7 @@ public class CursorWatcherSpawnTests {
         } finally { WatcherManager.SpawnOverrideForTesting = null; }
     }
 
-    // AI-1382 Task 12 — the child (subagent) watcher must never be spawned before the server
+    // Task 12 — the child (subagent) watcher must never be spawned before the server
     // has acknowledged the diverted subagent-start (2xx). A spooled start (POST failure) defers
     // the spawn entirely; a later invocation whose spool drain finally delivers the start is
     // what performs it. Invariant under test: no child transcript line — and here, no child
@@ -182,7 +182,7 @@ public class CursorWatcherSpawnTests {
         }
     }
 
-    // AI-1382 Task 12 — the deferred half of the acked-start gate: a subagent-start that failed
+    // Task 12 — the deferred half of the acked-start gate: a subagent-start that failed
     // its first live POST (spooled by HandleSubagentChildEventAsync) must still spawn the child
     // watcher once a LATER hook invocation's generic spool drain (HandleCore, top of method —
     // runs before the isSubagentChild divert) finally delivers it. Exercises the real dispatcher
@@ -244,7 +244,7 @@ public class CursorWatcherSpawnTests {
         }
     }
 
-    // AI-1382 review fix #5 — a subagent-start that hits a non-transient 4xx on retry (via
+    // a subagent-start that hits a non-transient 4xx on retry (via
     // HandleCore's generic top-of-method spool drain) is permanently DROPPED — HookSpool removes
     // the entry, so HasBacklog goes false even though no AgentSubsession stream was ever opened
     // server-side. Before the fix, that emptied backlog let the child's own content-less hooks
@@ -323,7 +323,7 @@ public class CursorWatcherSpawnTests {
         }
     }
 
-    // AI-1382 review fix #5 — once subagent-start is acked, every LATER NONTERMINAL hook for the
+    // once subagent-start is acked, every LATER NONTERMINAL hook for the
     // same child must attempt to (re)spawn its watcher — not just the child's own sessionStart.
     // Before the fix, only sessionStart ever called MaybeSpawnChildWatcherAsync, so a child
     // watcher that later exited (the newly-enabled idle ceiling), crashed, or never actually

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockEnumerationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockEnumerationTests.cs
@@ -3,10 +3,10 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// AI-630 review fix #4: <see cref="DaemonLockPaths.EnumerateNames"/> must
+/// <see cref="DaemonLockPaths.EnumerateNames"/> must
 /// union <c>*.lock</c> and <c>*.pid</c> filenames, not just <c>*.lock</c>.
 /// An orphan PID file (no matching lock, e.g. a daemon that stopped via
-/// the AI-78 path before the per-name layout existed) needs to be visible
+/// the path before the per-name layout existed) needs to be visible
 /// to <c>kcap daemon doctor --clean</c>; previously it was invisible.
 /// </summary>
 [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
@@ -20,7 +20,7 @@ public class DaemonLockEnumerationTests {
         try {
             // alpha has both lock and pid (held daemon).
             // beta has only a lock (e.g. doctor just cleaned the pid).
-            // gamma has only a pid (orphan from before AI-630 migration).
+            // gamma has only a pid (orphan from before migration).
             File.WriteAllText(Path.Combine(dir, "alpha.lock"), "instance-1");
             File.WriteAllText(Path.Combine(dir, "alpha.pid"),  "12345");
             File.WriteAllText(Path.Combine(dir, "beta.lock"),  "instance-2");

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockPathsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockPathsTests.cs
@@ -5,7 +5,7 @@ namespace Capacitor.Cli.Tests.Unit.Daemon;
 /// <summary>
 /// Tests for <see cref="DaemonLockPaths"/> — the name-sanitization rules and
 /// the per-name path layout that prevents two daemons under the same name
-/// from racing on the AI-630 lock.
+/// from racing on the lock.
 /// </summary>
 public class DaemonLockPathsTests {
     [Test]
@@ -42,7 +42,7 @@ public class DaemonLockPathsTests {
     [Test]
     public async Task Directory_LivesUnderDaemonsFolder() {
         // Verify the PRODUCTION fallback (no KCAP_DAEMONS_DIR set) uses the renamed
-        // ~/.config/kcap/daemons/ path, not the pre-AI-644 agents/ path. Asserted against the pure
+        // ~/.config/kcap/daemons/ path, not the legacy agents/ path. Asserted against the pure
         // ResolveDefaultDir(null) rather than by clearing the process-global env var — clearing it
         // would race any parallel test that reads DaemonLockPaths.Directory and briefly re-expose the
         // real daemons dir (Qodo #289 finding 2/3). This is deterministic and touches no shared state.

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockTests.cs
@@ -5,7 +5,7 @@ namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
 /// Tests for <see cref="DaemonLock"/> — the per-name flock the daemon binary
-/// holds for its lifetime. Verifies the AI-630 protection: a second daemon
+/// holds for its lifetime. Verifies the protection: a second daemon
 /// acquiring the same name on the same machine fails fast.
 ///
 /// All tests redirect <see cref="DaemonLockPaths"/> to a temp directory so
@@ -113,7 +113,7 @@ public class DaemonLockTests {
     }
 
     /// <summary>
-    /// AI-630 review fix: <see cref="DaemonLock.Dispose"/> must not delete the
+    /// <see cref="DaemonLock.Dispose"/> must not delete the
     /// lock file on disk. If it did, a daemon B that acquired the path between
     /// our flock release and the unlink would have its inode unlinked under
     /// it, and a daemon C could then create a fresh file and acquire a SECOND
@@ -139,7 +139,7 @@ public class DaemonLockTests {
     }
 
     /// <summary>
-    /// AI-630 review fix: when a successor daemon has already overwritten
+    /// when a successor daemon has already overwritten
     /// the PID file with its own PID, the disposing daemon must not delete
     /// it — that would orphan the successor's entry and `agent stop` would
     /// no longer find the live daemon.
@@ -168,7 +168,7 @@ public class DaemonLockTests {
     }
 
     /// <summary>
-    /// AI-839: the daemon must write a PID file whose first line is its PID and
+    /// the daemon must write a PID file whose first line is its PID and
     /// whose second line is the cross-process-stable start token, so the CLI's
     /// <c>status</c>/<c>stop</c>/<c>doctor</c> (separate processes) can confirm
     /// the live daemon instead of misreading it as a stale entry. The PID file
@@ -304,7 +304,7 @@ public class DaemonLockTests {
     }
 
     /// <summary>
-    /// AI-1155: a daemon that is SIGKILLed (macOS jetsam/OOM, `kill -9`), loses
+    /// a daemon that is SIGKILLed (macOS jetsam/OOM, `kill -9`), loses
     /// power, or crashes natively never runs <see cref="DaemonLock.Dispose"/>, so
     /// its PID file is left on disk. Once we hold the exclusive flock (proving the
     /// prior holder is gone), a leftover PID file is the signature of that unclean

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLogLevelTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLogLevelTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// Covers the daemon log-verbosity toggle (AI-840 diagnostics): the
+/// Covers the daemon log-verbosity toggle (diagnostics): the
 /// <c>--log-level</c> / <c>KCAP_DAEMON_LOG_LEVEL</c> string parse, and that the
 /// rolling file logger actually honours the configured minimum level — the
 /// per-tick DaemonPing RTT line logs at Debug, which the pre-toggle hardcoded

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonNameResolverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonNameResolverTests.cs
@@ -7,7 +7,7 @@ namespace Capacitor.Cli.Tests.Unit.Daemon;
 /// helper used by both the CLI supervisor and the daemon binary. Keeping
 /// these paths in lockstep is critical: a mismatch would mean the CLI
 /// checks one PID file while the daemon writes to a different one, and
-/// the AI-78 PID-file guard would be bypassable again.
+/// the PID-file guard would be bypassable again.
 /// </summary>
 [NotInParallel("KCAP_DAEMON_NAME")]
 public class DaemonNameResolverTests {
@@ -53,7 +53,7 @@ public class DaemonNameResolverTests {
 
     [Test]
     public async Task Resolve_NameArgOverridesEnvVar() {
-        // AI-630 fix: pre-AI-630 DaemonRunner had the env var trump --name,
+        // DaemonRunner previously had the env var trump --name,
         // which inverted the usual CLI convention (explicit flag is the
         // strongest signal). The new precedence puts --name first so the
         // user's explicit choice always wins.

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerCursorAvailabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerCursorAvailabilityTests.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// AI-689 A3: <c>DaemonRunner.RunAsync</c> silently omits an unavailable vendor from
+/// <c>DaemonRunner.RunAsync</c> silently omits an unavailable vendor from
 /// <c>DaemonConfig.SupportedVendors</c> (correct — the launch dialog just won't offer it), but gave
 /// operators no clue WHY when that vendor is Cursor. <see cref="DaemonRunner.ShouldWarnCursorUnavailable"/>
 /// is the pure predicate extracted from that startup seam so it's testable without spinning up the

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ProcessStartTokenTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ProcessStartTokenTests.cs
@@ -6,7 +6,7 @@ namespace Capacitor.Cli.Tests.Unit.Daemon;
 /// <summary>
 /// Tests for <see cref="ProcessStartToken"/> — the cross-process-stable start
 /// token that the daemon PID file uses to tell a live daemon from a recycled
-/// PID. The bug it fixes (AI-839) only manifests <i>across processes</i>: on
+/// PID. The bug it fixes only manifests <i>across processes</i>: on
 /// Linux <see cref="Process.StartTime"/> is recomputed per process from a
 /// boot-time estimate, so the daemon and a later <c>status</c> invocation
 /// disagreed and every live daemon looked "stale". The cross-process test
@@ -39,7 +39,7 @@ public class ProcessStartTokenTests {
     }
 
     /// <summary>
-    /// The core AI-839 guarantee on Linux: the token is built from the kernel's
+    /// The core guarantee on Linux: the token is built from the kernel's
     /// boot-relative <c>starttime</c> (field 22 of <c>/proc/&lt;pid&gt;/stat</c>)
     /// plus the per-boot id, NOT <see cref="Process.StartTime"/>. The kernel
     /// value is byte-identical for every reader and never recomputed, which is
@@ -83,7 +83,7 @@ public class ProcessStartTokenTests {
     }
 
     /// <summary>
-    /// A pre-AI-839 PID file stored a bare <see cref="Process.StartTime"/> tick
+    /// A legacy PID file stored a bare <see cref="Process.StartTime"/> tick
     /// count (no <c>scheme:</c> prefix). It must compare as "can't tell" (null)
     /// so the daemon-identity check falls back to the name match instead of
     /// stranding a still-running old daemon across an upgrade.

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/StdErrCaptureTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/StdErrCaptureTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Daemon;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// AI-1155: on the detached launch path the CLI closes the daemon's std pipes,
+/// on the detached launch path the CLI closes the daemon's std pipes,
 /// so any output that bypasses the ILogger pipeline — the runtime's
 /// "Fatal error." dump, an abort() message, a FailFast — is written to a broken
 /// pipe and lost. The daemon reopens fds 1/2 onto a capture file when the CLI

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/TerminalOutputSenderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/TerminalOutputSenderTests.cs
@@ -5,12 +5,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-842 / AI-844: the hosted-agent terminal mirror must reach the server in PTY
+/// the hosted-agent terminal mirror must reach the server in PTY
 /// order and survive a flapping SignalR connection <em>without dropping bytes</em>.
-/// AI-842 routed the stream through a single ordered drain loop but capped it with a
+/// routed the stream through a single ordered drain loop but capped it with a
 /// <c>DropOldest</c> channel — under back-pressure that silently discarded the
 /// oldest chunks, severing a redraw-TUI stream mid-escape-sequence (the garbled
-/// "Terminal" tab). AI-844 makes the queue loss-free: a full channel back-pressures
+/// "Terminal" tab). makes the queue loss-free: a full channel back-pressures
 /// the producer instead of dropping, and the only remaining drop — a send that keeps
 /// throwing while the hub reports Connected — is bounded-retried, then counted and
 /// logged rather than silently lost. These tests pin those guarantees without

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/TerminalOutputSenderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/TerminalOutputSenderTests.cs
@@ -5,12 +5,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// the hosted-agent terminal mirror must reach the server in PTY
+/// The hosted-agent terminal mirror must reach the server in PTY
 /// order and survive a flapping SignalR connection <em>without dropping bytes</em>.
-/// routed the stream through a single ordered drain loop but capped it with a
+/// An earlier version routed the stream through a single ordered drain loop but capped it with a
 /// <c>DropOldest</c> channel — under back-pressure that silently discarded the
 /// oldest chunks, severing a redraw-TUI stream mid-escape-sequence (the garbled
-/// "Terminal" tab). makes the queue loss-free: a full channel back-pressures
+/// "Terminal" tab). A later fix makes the queue loss-free: a full channel back-pressures
 /// the producer instead of dropping, and the only remaining drop — a send that keeps
 /// throwing while the hub reports Connected — is bounded-retried, then counted and
 /// logged rather than silently lost. These tests pin those guarantees without

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/TokenRefreshLoopTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/TokenRefreshLoopTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// Unit tests for the daemon-side proactive token-refresh tick (AI-992). The loop wakes on a
+/// Unit tests for the daemon-side proactive token-refresh tick. The loop wakes on a
 /// low-frequency timer and asks the port to refresh the active profile's token if it is inside
 /// the expiry window. Like the daemon heartbeat loop, it runs as an unobserved background Task,
 /// so <see cref="TokenRefreshLoop.TickAsync"/> must be total — a throwing refresh must not kill

--- a/test/Capacitor.Cli.Tests.Unit/Eval/EvalCatalogClientTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Eval/EvalCatalogClientTests.cs
@@ -10,7 +10,7 @@ public class EvalCatalogClientTests {
             Task.FromResult(new HttpResponseMessage(code) { Content = new StringContent(body) });
     }
 
-    // AI-9 Phase 3 (Task 5) — IEvalObserver.OnFinished now takes V3.
+    // Phase 3 (Task 5) — IEvalObserver.OnFinished now takes V3.
     sealed class CapturingObserver : IEvalObserver {
         public string? FailReason;
         public void OnFailed(string reason) => FailReason = reason;

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceJsonSchemaTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceJsonSchemaTests.cs
@@ -7,7 +7,7 @@ namespace Capacitor.Cli.Tests.Unit;
 /// Validates that <see cref="EvalService.GetRetrospectiveJsonSchema()"/> encodes
 /// the structured <c>{text, audience}</c> suggestion shape so that the
 /// Claude CLI judge is actually constrained to emit objects — not bare
-/// strings — for every suggestion item. Regression guard for.
+/// strings — for every suggestion item. Regression guard for that shape.
 /// </summary>
 public class EvalServiceJsonSchemaTests {
     // EvalService is internal; Capacitor.Cli.Core ships InternalsVisibleTo

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceJsonSchemaTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceJsonSchemaTests.cs
@@ -7,7 +7,7 @@ namespace Capacitor.Cli.Tests.Unit;
 /// Validates that <see cref="EvalService.GetRetrospectiveJsonSchema()"/> encodes
 /// the structured <c>{text, audience}</c> suggestion shape so that the
 /// Claude CLI judge is actually constrained to emit objects — not bare
-/// strings — for every suggestion item. Regression guard for AI-795.
+/// strings — for every suggestion item. Regression guard for.
 /// </summary>
 public class EvalServiceJsonSchemaTests {
     // EvalService is internal; Capacitor.Cli.Core ships InternalsVisibleTo

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
@@ -14,7 +14,7 @@ public class EvalServiceTests {
 
     // ── Judge MCP config ───────────────────────────────────────────────────
 
-    // AI-803 follow-up: the inline judge server is named `kcap-judge` (not
+    // follow-up: the inline judge server is named `kcap-judge` (not
     // `kcap-review`) so it never collides with the plugin-registered
     // `kcap-review` (`kcap mcp review`) server, and the allowlist prefix must
     // track that server key exactly — otherwise every judge tool call lands
@@ -382,7 +382,7 @@ public class EvalServiceTests {
         await Assert.That(agg.OverallScore).IsEqualTo(1);
     }
 
-    // ── BuildTextQuestionPrompt (AI-9 Phase 3) ─────────────────────────────
+    // ── BuildTextQuestionPrompt ─────────────────────────────
     //
     // The legacy embedded-template BuildQuestionPrompt was removed in Phase 3.
     // The text path now uses the catalog's server-RENDERED prompt carried on
@@ -554,7 +554,7 @@ public class EvalServiceTests {
 
     [Test]
     public async Task BuildRetrospectivePrompt_substitutes_all_placeholders() {
-        // AI-9 Phase 3: the template now comes from the catalog (passed in) and
+        // Phase 3: the template now comes from the catalog (passed in) and
         // carries a {TRACE_JSON} placeholder the daemon fills with its already-
         // fetched trace (SF#1).
         var template = "meta={SESSION_META} verdicts={VERDICTS_JSON} patterns={KNOWN_PATTERNS} trace={TRACE_JSON}";

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
@@ -14,7 +14,7 @@ public class EvalServiceTests {
 
     // ── Judge MCP config ───────────────────────────────────────────────────
 
-    // follow-up: the inline judge server is named `kcap-judge` (not
+    // Follow-up: the inline judge server is named `kcap-judge` (not
     // `kcap-review`) so it never collides with the plugin-registered
     // `kcap-review` (`kcap mcp review`) server, and the allowlist prefix must
     // track that server key exactly — otherwise every judge tool call lands

--- a/test/Capacitor.Cli.Tests.Unit/GeminiHooksTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiHooksTests.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Core.Gemini;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-887: kcap merges its command hooks into Gemini's SHARED
+/// kcap merges its command hooks into Gemini's SHARED
 /// <c>~/.gemini/settings.json</c> (nested <c>{hooks:[{command}]}</c> entries),
 /// so the merge must preserve user-authored hooks AND every other settings key.
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/GeminiImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiImportSourceTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-887: discovery walks <c>~/.gemini/tmp/&lt;project&gt;/chats/session-*.jsonl</c>
+/// discovery walks <c>~/.gemini/tmp/&lt;project&gt;/chats/session-*.jsonl</c>
 /// and reads the FULL dashed session id from the file's header record (the
 /// filename only carries the 8-char shortId). <see cref="GeminiImportSource.IsImportRelevantLine"/>
 /// must mirror the server normalizer's skip rules so the import watermark

--- a/test/Capacitor.Cli.Tests.Unit/GeminiPathsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiPathsTests.cs
@@ -52,7 +52,7 @@ public class GeminiPathsTests {
             .IsEqualTo(Path.Combine("/foo", ".gemini", "GEMINI.md"));
     }
 
-    // AI-1158: ~/.gemini is shared with Google Antigravity — an Antigravity-only
+    // ~/.gemini is shared with Google Antigravity — an Antigravity-only
     // home must NOT read as a Gemini install, but a real Gemini marker still must.
     [Test]
     public async Task IsInstalled_false_when_only_antigravity_present() {

--- a/test/Capacitor.Cli.Tests.Unit/GeminiSpawnBeforePostTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiSpawnBeforePostTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1357 Task 6: Gemini's session-start is routed through <see cref="AgentHookPoster.PostOrSpoolAsync"/>
+/// Task 6: Gemini's session-start is routed through <see cref="AgentHookPoster.PostOrSpoolAsync"/>
 /// (was the POST-only <c>PostAsync</c>, which returned WITHOUT spawning on anything but <c>Posted</c>).
 /// <see cref="GeminiHookCommand.SpawnGateForTest"/> exposes the same spawn decision as
 /// <see cref="AgentHookPoster.ShouldSpawnAfter"/> so a spooled outcome (auth lapse / outage) still

--- a/test/Capacitor.Cli.Tests.Unit/GeminiSubagentDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiSubagentDiscoveryTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Core.Gemini;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Unit tests for <see cref="GeminiSubagentDiscovery"/> (AI-900) — the shared discovery
+/// Unit tests for <see cref="GeminiSubagentDiscovery"/> — the shared discovery
 /// used by both the import path and the live watcher: locate nested subagent files under
 /// <c>chats/&lt;dashedParent&gt;/</c>, resolve each subagent's type from the parent's
 /// <c>invoke_agent</c> call, and canonicalize the (dashed) subId for the server.
@@ -82,7 +82,7 @@ public class GeminiSubagentDiscoveryTests {
         await Assert.That(GeminiSubagentDiscovery.CanonicalAgentId(input)).IsEqualTo(expected);
     }
 
-    // ── EnumerateDescendantFiles (AI-1383 D3: recursive grandchild discovery) ──────────────
+    // ── EnumerateDescendantFiles (D3: recursive grandchild discovery) ──────────────
 
     const string DashedGrandsub = "8c1a2222-3333-4444-5555-666677778888";
 
@@ -216,7 +216,7 @@ public class GeminiSubagentDiscoveryTests {
         }
     }
 
-    // AI-1383 D3 review fix #3: the walker used to stop AT the boundary child (depth 9) and
+    // the walker used to stop AT the boundary child (depth 9) and
     // never look below it, so a chain continuing to depth 10 was still counted as ONE omitted
     // descendant. The walk must now continue (never importing) below the cap to count the
     // WHOLE omitted subtree.
@@ -254,7 +254,7 @@ public class GeminiSubagentDiscoveryTests {
         }
     }
 
-    // ── MaxCountingNodes scope (AI-1383 D3 review fix #4) ───────────────────────────────────
+    // ── MaxCountingNodes scope (D3 review fix #4) ───────────────────────────────────
     //
     // The counting ceiling used to gate the WHOLE unified traversal via the shared visited-id
     // set's total size, so a root with a wide IN-CAP fan-out (well within MaxDescendantDepth)
@@ -347,7 +347,7 @@ public class GeminiSubagentDiscoveryTests {
         }
     }
 
-    // AI-1383 D3 review fix #5: the ceiling used to bound the RETURNED omitted count/ids, but
+    // the ceiling used to bound the RETURNED omitted count/ids, but
     // not the actual WORK — every below-cap node already enqueued before the ceiling was hit
     // (up to MaxCountingNodes of them) still got individually dequeued and directory-enumerated
     // afterward. Once truncation is established, the below-cap frontier must be abandoned
@@ -403,7 +403,7 @@ public class GeminiSubagentDiscoveryTests {
         }
     }
 
-    // AI-1383 D3 review fix #6: a below-cap parent's single directory read used to always
+    // a below-cap parent's single directory read used to always
     // enumerate (and OrderBy-sort) the WHOLE directory before CountTruncated could even be
     // detected — a depth-8 node with (say) a million depth-9 subagent files would list and sort
     // all million entries in one call. The per-parent read must instead be capped to (remaining
@@ -457,7 +457,7 @@ public class GeminiSubagentDiscoveryTests {
         }
     }
 
-    // AI-1383 D3 review fix #7 (P2): a below-cap parent's bounded directory read caps RAW files
+    // a below-cap parent's bounded directory read caps RAW files
     // via Take(), but non-GUID filtering happens AFTER that — so a junk (non-GUID) *.jsonl file
     // landing inside the sentinel window used to silently consume the sole sentinel slot, filling
     // omittedIds to exactly MaxCountingNodes valid ids while CountTruncated stayed false: a false

--- a/test/Capacitor.Cli.Tests.Unit/GitLabPrDetectorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GitLabPrDetectorTests.cs
@@ -33,7 +33,7 @@ public class GitLabPrDetectorTests {
 
     [Test]
     public async Task Nested_group_encodes_full_project_path() {
-        // AI-1121: a nested namespace owner ("group/sub") must be URL-encoded whole
+        // a nested namespace owner ("group/sub") must be URL-encoded whole
         // into the glab project path (group%2Fsub%2Fproj), not left with a raw slash.
         string? seen = null;
         CommandRunner fake = (_, args, _, _) => { seen = args; return Task.FromResult<string?>("[]"); };

--- a/test/Capacitor.Cli.Tests.Unit/HookSpoolTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/HookSpoolTests.cs
@@ -115,7 +115,7 @@ public class HookSpoolTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1357 Task 12 / BLOCKER-1: the ordered drain (LifecycleSpoolDrain / DrainRoutesAsync) uses a
+    // Task 12 / BLOCKER-1: the ordered drain (LifecycleSpoolDrain / DrainRoutesAsync) uses a
     // distinct ".ordered-*" temp namespace precisely so it can deliberately WITHHOLD a phase's
     // remainder mid-pass (e.g. a session-end held back until the transcript tail is done) without
     // the unrelated route-agnostic FIFO drain (DrainAllAsync, still used by Claude/Cursor) sweeping

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
@@ -6,7 +6,7 @@ using Capacitor.Cli.Core;
 
 namespace Capacitor.Cli.Tests.Unit.Import;
 
-// AI-1382 review fix (r2) — several tests here share hardcoded session ids ("11111111-…",
+// several tests here share hardcoded session ids ("11111111-…",
 // "22222222-…") across BOTH ClassifyAsync and ImportSessionAsync calls, and CursorMarkers writes
 // a REAL, non-per-test quarantine marker file (no DI seam to isolate it). ImportSessionAsync now
 // also reads that marker (review fix #6) in addition to ClassifyAsync's existing check, widening
@@ -33,9 +33,9 @@ public class CursorImportSourceTests {
     [Test]
     public async Task session_start_payload_carries_pr_fields_when_repo_has_a_pr() {
         // Cursor is the one import source whose synthetic session-start carries a `repository`
-        // node (AI-1152) via BuildRepositoryNode — including pr_* when a PR is detected. Guard
+        // node via BuildRepositoryNode — including pr_* when a PR is detected. Guard
         // that the payload propagates those fields (a regression dropped them when Cursor's repo
-        // detector was switched to skip PR detection during the import-latency work — AI-1122).
+        // detector was switched to skip PR detection during the import-latency work —).
         var repo = new RepositoryPayload {
             Owner = "o", RepoName = "r", Host = "github.com", Branch = "main",
             PrNumber = 7, PrTitle = "t", PrUrl = "https://github.com/o/r/pull/7", PrHeadRef = "main"
@@ -305,7 +305,7 @@ public class CursorImportSourceTests {
         await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.ProbeError);
     }
 
-    // AI-1382 review fix #7 — a session already quarantined by the live watcher's runtime rewrite
+    // a session already quarantined by the live watcher's runtime rewrite
     // guard must never be fed back through `kcap import` either.
     [Test]
     public async Task classify_skips_a_quarantined_standalone_session() {
@@ -357,7 +357,7 @@ public class CursorImportSourceTests {
         await Assert.That(classified[0].Status).IsEqualTo(ImportCommand.ClassificationStatus.New);
     }
 
-    // AI-1382 review fix #7 — quarantine is always keyed on the FAMILY (parent) identity, since
+    // quarantine is always keyed on the FAMILY (parent) identity, since
     // CursorRewriteGuard is constructed from the watcher process's own sessionId argument, which
     // for a spawned child watcher IS the parent id (WatcherManager.BuildSpawnArgs). A correlated
     // child must therefore be filtered under its PARENT's quarantine marker, not its own — an
@@ -462,7 +462,7 @@ public class CursorImportSourceTests {
 
     [Test]
     public async Task import_session_populates_started_at_and_ended_at_from_file_times() {
-        // AI-739: synthetic lifecycle hooks must carry the JSONL file's
+        // synthetic lifecycle hooks must carry the JSONL file's
         // creation/last-write time so the server records canonical
         // SessionStarted/SessionEnded with the real timestamps, not
         // import-time wall clock.
@@ -643,7 +643,7 @@ public class CursorImportSourceTests {
         await Assert.That(posted).DoesNotContain("/hooks/transcript");
     }
 
-    // --- AI-1154 round-2 review fix (finding 1): SentChildContent signal ---
+    // round-2 review fix (finding 1): SentChildContent signal ---
 
     [Test]
     public async Task already_loaded_parent_reports_sent_child_content_when_attaching_a_new_child() {
@@ -735,7 +735,7 @@ public class CursorImportSourceTests {
         await Assert.That(result.SentChildContent).IsFalse();
     }
 
-    // --- AI-1154 round-4 review fix (P1): probe failure is indeterminate, defaults privacy-safe ---
+    // round-4 review fix (P1): probe failure is indeterminate, defaults privacy-safe ---
 
     [Test]
     public async Task already_loaded_parent_with_failing_child_watermark_probe_conservatively_reports_sent_child_content_to_preserve_privacy() {
@@ -849,7 +849,7 @@ public class CursorImportSourceTests {
 
     [Test]
     public async Task import_session_attaches_repository_from_detected_workspace_repo() {
-        // AI-1152: the import/backfill path must attach a `repository` node to the
+        // the import/backfill path must attach a `repository` node to the
         // synthetic sessionStart so historical Cursor sessions emit RepositoryDetected
         // server-side and group under their repo (not just "All repos"). Detected from
         // the workspace folder via the repo detector (git remote parse).
@@ -967,7 +967,7 @@ public class CursorImportSourceTests {
 
     [Test]
     public async Task parent_import_nests_subagent_child_before_its_own_session_end() {
-        // AI-1153: the PARENT's import ingests its subagent child under the parent's
+        // the PARENT's import ingests its subagent child under the parent's
         // AgentSubsession stream (subagent-start + transcript-with-agent_id + subagent-stop),
         // and — critically — BEFORE the parent's own session-end, so a late subagent-start
         // can't reactivate the ended parent (review finding on ordering).
@@ -1080,7 +1080,7 @@ public class CursorImportSourceTests {
         await Assert.That(posted.Count).IsEqualTo(0); // nothing posted — the parent owns this child
     }
 
-    // AI-1382 review fix #6 — ImportSessionAsync must re-check quarantine FRESH, before ANY
+    // ImportSessionAsync must re-check quarantine FRESH, before ANY
     // lifecycle/transcript delivery, rather than trusting only ClassifyAsync's earlier check. This
     // simulates the runtime rewrite guard tripping SOMETIME AFTER classification (repo probing, an
     // interactive confirmation prompt, or simply queueing behind other sessions in the same
@@ -1164,7 +1164,7 @@ public class CursorImportSourceTests {
         await Assert.That(posted).Contains("/hooks/session-end/cursor");
     }
 
-    // AI-1382 review fix #6 (the second checkpoint) — a quarantine that appears WHILE the
+    // a quarantine that appears WHILE the
     // sessionStart POST is in flight must still be caught before any transcript content is sent;
     // the session already legitimately exists server-side by then, so it's best-effort closed
     // with session-end rather than left hanging "active" forever, and the outcome signals Failed
@@ -1211,7 +1211,7 @@ public class CursorImportSourceTests {
         } finally { try { File.Delete(CursorMarkers.QuarantinePath(sessionId)); } catch { } }
     }
 
-    // AI-1382 review fix (r3, finding #4) — the round-2 fix above only re-checked quarantine
+    // the round-2 fix above only re-checked quarantine
     // immediately BEFORE SendTranscriptBatches; that method itself streamed the (mutable) file and
     // posted one request per 100 lines with NO quarantine check at all, so a quarantine written by
     // the live watcher's runtime rewrite guard AFTER the first transcript POST still let every
@@ -1271,7 +1271,7 @@ public class CursorImportSourceTests {
         } finally { try { File.Delete(CursorMarkers.QuarantinePath(sessionId)); } catch { } }
     }
 
-    // AI-1382 review fix (r4, finding #3) — the round-3 fix above only proved the SECOND of TWO
+    // the round-3 fix above only proved the SECOND of TWO
     // batches gets aborted; it never exercised a transcript that is a SINGLE (final and only)
     // batch, which is exactly the gap SendTranscriptBatches' round-3 wiring left open (no "next"
     // pre-POST check ever runs for a one-batch send). This drives a transcript of 30 lines
@@ -1327,7 +1327,7 @@ public class CursorImportSourceTests {
         } finally { try { File.Delete(CursorMarkers.QuarantinePath(sessionId)); } catch { } }
     }
 
-    // AI-1382 review fix (r4, finding #2) — a quarantine trip during a CHILD's own transcript
+    // a quarantine trip during a CHILD's own transcript
     // delivery must propagate to the parent's best-effort close-and-fail path — the same contract
     // as a trip during the parent's OWN transcript. Before the fix, SendSubagentLifecycleAsync's
     // catch-all swallowed the typed TranscriptDeliveryAbortedException into a bare `false`, so
@@ -1396,7 +1396,7 @@ public class CursorImportSourceTests {
         } finally { try { File.Delete(CursorMarkers.QuarantinePath(parentId)); } catch { } }
     }
 
-    // AI-1382 review fix (r4, finding #2a) — never START a NEW child once the family is found
+    // never START a NEW child once the family is found
     // quarantined, even when that quarantine was NOT tripped by this child's own delivery (a
     // concurrent trip — the live watcher runs alongside this import — discovered only when it's
     // this child's turn in the loop). Two children are configured in a fixed, known order; the
@@ -1472,7 +1472,7 @@ public class CursorImportSourceTests {
         } finally { try { File.Delete(CursorMarkers.QuarantinePath(parentId)); } catch { } }
     }
 
-    // AI-1382 review fix #7 — subagentLinks is only ever computed from the sessions THIS batch
+    // subagentLinks is only ever computed from the sessions THIS batch
     // discovered. A --session <child> filter excludes the parent from that batch entirely, so the
     // in-batch correlator can never produce the family link. The persisted CursorLiveSubagentLinker
     // marker (written by the live hook dispatcher, independent of any one CLI invocation's

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
@@ -35,7 +35,7 @@ public class CursorImportSourceTests {
         // Cursor is the one import source whose synthetic session-start carries a `repository`
         // node via BuildRepositoryNode — including pr_* when a PR is detected. Guard
         // that the payload propagates those fields (a regression dropped them when Cursor's repo
-        // detector was switched to skip PR detection during the import-latency work —).
+        // detector was switched to skip PR detection during the import-latency work).
         var repo = new RepositoryPayload {
             Owner = "o", RepoName = "r", Host = "github.com", Branch = "main",
             PrNumber = 7, PrTitle = "t", PrUrl = "https://github.com/o/r/pull/7", PrHeadRef = "main"

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorImportSourceTests.cs
@@ -643,7 +643,7 @@ public class CursorImportSourceTests {
         await Assert.That(posted).DoesNotContain("/hooks/transcript");
     }
 
-    // round-2 review fix (finding 1): SentChildContent signal ---
+    // --- round-2 review fix (finding 1): SentChildContent signal ---
 
     [Test]
     public async Task already_loaded_parent_reports_sent_child_content_when_attaching_a_new_child() {
@@ -735,7 +735,7 @@ public class CursorImportSourceTests {
         await Assert.That(result.SentChildContent).IsFalse();
     }
 
-    // round-4 review fix (P1): probe failure is indeterminate, defaults privacy-safe ---
+    // --- round-4 review fix (P1): probe failure is indeterminate, defaults privacy-safe ---
 
     [Test]
     public async Task already_loaded_parent_with_failing_child_watermark_probe_conservatively_reports_sent_child_content_to_preserve_privacy() {

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorOrphanedChildStandaloneTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorOrphanedChildStandaloneTests.cs
@@ -6,7 +6,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit.Import;
 
 /// <summary>
-/// AI-1156 Task F1/F2 (D5, CLI side): the subagent correlator's INPUT is widened to
+/// Task F1/F2 (D5, CLI side): the subagent correlator's INPUT is widened to
 /// same-workspace discovery (ignoring --session/--cwd/--since/scope), so a filtered/scoped
 /// import still stamps a correlated child even when its parent falls outside this run's slice —
 /// and such an orphaned child must import STANDALONE rather than being silently dropped.
@@ -139,7 +139,7 @@ public class CursorOrphanedChildStandaloneTests {
 
     [Test]
     public async Task reconciliation_prunes_a_child_excluded_from_the_routed_plan_off_the_parents_subagent_children() {
-        // AI-1154 review fix (P1): the reverse direction of F1/F2. `--session <parent>` puts the
+        // the reverse direction of F1/F2. `--session <parent>` puts the
         // PARENT in this run's routed plan but never classifies the child (excluded by the
         // --session filter) — yet ClassifyAsync's widened same-workspace scan still correlates and
         // stamps SubagentChildren=[child] onto the parent. Attaching that child in

--- a/test/Capacitor.Cli.Tests.Unit/Import/CursorSubagentCorrelatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/CursorSubagentCorrelatorTests.cs
@@ -6,7 +6,7 @@ namespace Capacitor.Cli.Tests.Unit.Import;
 public class CursorSubagentCorrelatorTests {
     // Cursor runs a subagent as its OWN session/transcript. The only in-data link is that
     // the child's first user_query (minus the <user_query> wrapper) is byte-identical to the
-    // parent's `Task`/`Agent` tool_use `prompt`. The correlator recovers that link (AI-1153).
+    // parent's `Task`/`Agent` tool_use `prompt`. The correlator recovers that link.
 
     static string Line(object o) => JsonSerializer.Serialize(o);
 

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportChainsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportChainsTests.cs
@@ -100,7 +100,7 @@ public class ImportChainsTests : IDisposable {
 
     [Test]
     public async Task ImportChainsAsync_reports_per_session_progress() {
-        // Regression (AI-907): per-session slot rows always showed 0% because
+        // Regression: per-session slot rows always showed 0% because
         // BatchFlushed events were never wired to the slot bar. OnSessionProgress
         // must now fire once per flushed parent batch, carrying the batch size and
         // the session's full sendable-line total.
@@ -299,7 +299,7 @@ public class ImportChainsTests : IDisposable {
 
     [Test]
     public async Task ImportChainsAsync_derives_workspace_root_from_the_remapped_cwd_not_the_raw_meta_cwd() {
-        // Regression (AI-701 review): workspace_root discovery used to run
+        // Regression: workspace_root discovery used to run
         // GitRepository.FindRoot against the RAW transcript cwd (session.Meta.Cwd)
         // instead of the already remap-/worktree-resolved path the import flow
         // computes up front into sessionCwds. A historical transcript whose recorded

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportDoneBreakdownTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportDoneBreakdownTests.cs
@@ -155,7 +155,7 @@ public class ImportDoneBreakdownTests {
         await Assert.That(claudeRow.Errored + cursorRow.Errored).IsEqualTo(2);   // 1 + 1
     }
 
-    // --- IsLifecycleOnlyRoutedReplay (AI-1154 review fix, P2; broadened round-2) ---
+    // IsLifecycleOnlyRoutedReplay (review fix, P2; broadened round-2) ---
     //
     // The routed-phase loop in HandleImport increments routedLoaded/importedSessionIds whenever
     // ImportOutcome is Loaded/Resumed. For an AlreadyLoaded Cursor classification, ImportSessionAsync

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportDoneBreakdownTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportDoneBreakdownTests.cs
@@ -155,7 +155,7 @@ public class ImportDoneBreakdownTests {
         await Assert.That(claudeRow.Errored + cursorRow.Errored).IsEqualTo(2);   // 1 + 1
     }
 
-    // IsLifecycleOnlyRoutedReplay (review fix, P2; broadened round-2) ---
+    // --- IsLifecycleOnlyRoutedReplay (review fix, P2; broadened round-2) ---
     //
     // The routed-phase loop in HandleImport increments routedLoaded/importedSessionIds whenever
     // ImportOutcome is Loaded/Resumed. For an AlreadyLoaded Cursor classification, ImportSessionAsync

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportMissingCwdsReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportMissingCwdsReportTests.cs
@@ -180,7 +180,7 @@ public class ImportMissingCwdsReportTests {
             Console.SetOut(prevOut);
         }
         // Normalize CRLF→LF so line-anchored assertions (e.g. Contains("…\n"))
-        // hold on Windows, where the writer emits Environment.NewLine. AI-820.
+        // hold on Windows, where the writer emits Environment.NewLine..
         return sw.ToString().Replace("\r\n", "\n");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportMissingCwdsReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportMissingCwdsReportTests.cs
@@ -180,7 +180,7 @@ public class ImportMissingCwdsReportTests {
             Console.SetOut(prevOut);
         }
         // Normalize CRLF→LF so line-anchored assertions (e.g. Contains("…\n"))
-        // hold on Windows, where the writer emits Environment.NewLine..
+        // hold on Windows, where the writer emits Environment.NewLine.
         return sw.ToString().Replace("\r\n", "\n");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Import/VendorSelectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/VendorSelectionTests.cs
@@ -70,7 +70,7 @@ public class VendorSelectionTests {
 
     [Test]
     public async Task legacy_cursor_workspace_flag_is_rejected() {
-        // --cursor-workspace and --cursor-all-workspaces were dropped in AI-737
+        // cursor-workspace and --cursor-all-workspaces were dropped in
         // when the SQLite import path was retired. The JSONL walker doesn't need
         // workspace filtering, so these flags now surface as unknown source options.
         var r = VendorSelection.Parse(["--cursor-workspace", "/some/path"]);

--- a/test/Capacitor.Cli.Tests.Unit/ImportProviderDetectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ImportProviderDetectionTests.cs
@@ -5,7 +5,7 @@ namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
 /// Import discards PR/MR fields on every path, so running the live `gh pr view` / `glab api`
-/// provider round-trip per cwd during a bulk import is wasted latency (AI-1122). These tests pin
+/// provider round-trip per cwd during a bulk import is wasted latency. These tests pin
 /// the `detectPullRequest` switch on RepositoryDetection.DetectRepositoryAsync via an injected
 /// command runner: import (false) resolves owner/repo with git only and never spawns a provider
 /// CLI, while the default (live) path still does.

--- a/test/Capacitor.Cli.Tests.Unit/KiroLiveUsageBackfillTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/KiroLiveUsageBackfillTests.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Nodes;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Covers the live-watch Kiro usage-backfill synthetic line (AI-1357 task 10):
+/// Covers the live-watch Kiro usage-backfill synthetic line:
 /// <see cref="WatchCommand.BuildKiroUsageBackfillLine"/> builds the JSONL the server
 /// recognizes, and <see cref="WatchCommand.AppendKiroUsageBackfillLines"/> reads the
 /// sidecar <c>{id}.json</c> via <see cref="Capacitor.Cli.Core.Kiro.KiroUsage.AnchorMap"/>

--- a/test/Capacitor.Cli.Tests.Unit/KiroUsageTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/KiroUsageTests.cs
@@ -57,7 +57,7 @@ public class KiroUsageTests {
         await Assert.That(KiroUsage.AnchorMap(json).Count).IsEqualTo(0);
     }
 
-    // ── token-count hedge (AI-1196) ──────────────────────────────────────────
+    // ── token-count hedge ──────────────────────────────────────────
     // Kiro's schema carries input/output_token_count per turn and a session model
     // id, but the CLI persists them as 0 today (upstream aws#2397). When a future
     // release populates them, the CLI must forward the (non-zero) counts + model so

--- a/test/Capacitor.Cli.Tests.Unit/LaunchAgentCommandWireFormatTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LaunchAgentCommandWireFormatTests.cs
@@ -90,7 +90,7 @@ public class LaunchAgentCommandWireFormatTests {
 
     [Test]
     public async Task Mcp_allowlist_round_trips_snake_case() {
-        // AI-1126 D-c: the server sends the flow definition's MCP allowlist so the daemon can
+        // D-c: the server sends the flow definition's MCP allowlist so the daemon can
         // thread it to the launcher (Task 6 materializes it). Appended last after
         // BaseRef so older daemons/servers stay wire-compatible.
         var cmd = new LaunchAgentCommand(
@@ -115,7 +115,7 @@ public class LaunchAgentCommandWireFormatTests {
 
     [Test]
     public async Task Legacy_payload_without_mcp_allowlist_deserializes_null() {
-        // Version skew: a server predating AI-1126 D-c never sends mcp_allowlist. The daemon
+        // Version skew: a server predating D-c never sends mcp_allowlist. The daemon
         // must still bind the command (positional SignalR binding) and default the field to
         // null — i.e. no allowlist materialization — rather than failing to invoke LaunchAgent.
         const string legacyWire =
@@ -132,7 +132,7 @@ public class LaunchAgentCommandWireFormatTests {
 
     [Test]
     public async Task Old_reader_ignores_mcp_allowlist() {
-        // AI-1126 D-c: a new server sends mcp_allowlist to an old daemon that predates this
+        // D-c: a new server sends mcp_allowlist to an old daemon that predates this
         // task. The old reader must ignore the unknown field and still bind everything else —
         // launches must not break just because the server got the new field first.
         var cmd = new LaunchAgentCommand(
@@ -157,7 +157,7 @@ public class LaunchAgentCommandWireFormatTests {
 
     [Test]
     public async Task Borrowed_and_BorrowCwd_round_trip_snake_case() {
-        // AI-1207 Phase A: the server tells the daemon to launch against the user's own checkout
+        // Phase A: the server tells the daemon to launch against the user's own checkout
         // (skip worktree creation) instead of a fresh daemon-owned worktree. Appended last after
         // McpAllowlist, same wire-compat rule as the fields before it.
         var cmd = new LaunchAgentCommand(
@@ -184,7 +184,7 @@ public class LaunchAgentCommandWireFormatTests {
 
     [Test]
     public async Task Legacy_payload_without_borrowed_fields_deserializes_defaults() {
-        // Version skew: an older server that predates AI-1207 never sends borrowed/borrow_cwd. The
+        // Version skew: an older server that predates never sends borrowed/borrow_cwd. The
         // daemon must still bind the command (positional SignalR binding) and default Borrowed to
         // false / BorrowCwd to null — i.e. behave exactly as an owned-worktree launch.
         const string legacyWire =
@@ -236,7 +236,7 @@ public class LaunchAgentCommandWireFormatTests {
 }
 
 /// <summary>
-/// Frozen snapshot of <see cref="LaunchAgentCommand"/>'s shape from BEFORE AI-1126 D-c added
+/// Frozen snapshot of <see cref="LaunchAgentCommand"/>'s shape from BEFORE D-c added
 /// <c>McpAllowlist</c> — used by <see cref="LaunchAgentCommandWireFormatTests.Old_reader_ignores_mcp_allowlist"/>
 /// to prove an old daemon build tolerates the new wire field rather than failing to bind.
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/LaunchAgentCommandWireFormatTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LaunchAgentCommandWireFormatTests.cs
@@ -184,7 +184,7 @@ public class LaunchAgentCommandWireFormatTests {
 
     [Test]
     public async Task Legacy_payload_without_borrowed_fields_deserializes_defaults() {
-        // Version skew: an older server that predates never sends borrowed/borrow_cwd. The
+        // Version skew: an older server that predates the borrow feature never sends borrowed/borrow_cwd. The
         // daemon must still bind the command (positional SignalR binding) and default Borrowed to
         // false / BorrowCwd to null — i.e. behave exactly as an owned-worktree launch.
         const string legacyWire =

--- a/test/Capacitor.Cli.Tests.Unit/LifecycleSpoolDrainTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LifecycleSpoolDrainTests.cs
@@ -7,7 +7,7 @@ public class LifecycleSpoolDrainTests {
     static string TmpDir() => Path.Combine(Path.GetTempPath(), $"kcap-drain-{Guid.NewGuid():N}");
     const string Sid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
-    // AI-1382 review fix #1/#8 — the HttpClient-backed RunAsync overload's transcript poster
+    // review fix #1/#8 — the HttpClient-backed RunAsync overload's transcript poster
     // (PostTranscript) must enforce the Cursor quarantine marker itself: a batch spooled BEFORE
     // a runtime rewrite-guard trip (or one that simply never got checked anywhere else) must
     // still never reach `/hooks/transcript` once its session is quarantined — this is the ONLY
@@ -150,7 +150,7 @@ public class LifecycleSpoolDrainTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // AI-1357 Task 12 / BLOCKER-3: session-start/subagent-stop/session-end now share one spool
+    // Task 12 / BLOCKER-3: session-start/subagent-stop/session-end now share one spool
     // file in prod, so a subagent-stop that arrives (or is only discovered) AFTER session-end was
     // already delivered is reachable. Same-pass, DrainRoutesAsync's phase-mismatch break already
     // withholds it correctly — but a bare re-run of RunAsync on a FRESH file containing only that

--- a/test/Capacitor.Cli.Tests.Unit/LifecycleSpoolDrainWhatsDoneTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LifecycleSpoolDrainWhatsDoneTests.cs
@@ -6,7 +6,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1357 Task 12 / BLOCKER-2: <c>LifecycleSpoolDrain.PostOnce</c>'s (HttpClient/production
+/// Task 12 / BLOCKER-2: <c>LifecycleSpoolDrain.PostOnce</c>'s (HttpClient/production
 /// overload's) job in Task 3 didn't carry <c>ClaudeHookCommand.ClaudePoster</c>'s
 /// <c>generate_whats_done</c> side effect (spawning the what's-done generator). Once this drain
 /// runs centrally (Task 12's Program.cs wiring + the daemon-periodic sweep) it can be the one that

--- a/test/Capacitor.Cli.Tests.Unit/LiveWatchHardeningAcceptanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LiveWatchHardeningAcceptanceTests.cs
@@ -6,7 +6,7 @@ using WireMock.Server;
 
 namespace Capacitor.Cli.Tests.Unit;
 
-// AI-1357 Task 15 — acceptance tests encoding the spec's Testing section (Step 1), reusing the
+// Task 15 — acceptance tests encoding the spec's Testing section (Step 1), reusing the
 // pure/HTTP seams Tasks 1-14 already built. Where a criterion is already fully covered by an
 // existing unit test from an earlier task, the test below is deliberately THIN — it asserts the
 // end-to-end contract from a different vantage point (a real HTTP round trip, a combined
@@ -46,7 +46,7 @@ public class LiveWatchHardeningAcceptanceTests {
     /// watcher-backed non-Claude vendor's lifecycle POST reports <see cref="HookPostOutcome.Spooled"/>
     /// (never the legacy <see cref="HookPostOutcome.AuthLapsed"/>, which spools nothing) — and
     /// <see cref="AgentHookPoster.ShouldSpawnAfter"/> says the watcher should STILL spawn.
-    /// Capture must never depend on lifecycle-POST delivery (AI-1357 Tasks 4-6).
+    /// Capture must never depend on lifecycle-POST delivery.
     ///
     /// <para>Exercises the real per-vendor route strings (not just the generic outcome), so a
     /// wrong/missing route on any one vendor's call site would show up here. Antigravity and

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -432,7 +432,7 @@ public class LocalPermissionBridgeTests {
         }
     }
 
-    // AI-1139 follow-up: a review-flow reviewer's own result-submission tool must be auto-approved
+    // follow-up: a review-flow reviewer's own result-submission tool must be auto-approved
     // by the bridge WITHOUT surfacing a user prompt. Codex fires a PermissionRequest for the MCP
     // tool call even under `--ask-for-approval never`, and its hook bridges here; without this the
     // unattended reviewer blocks on a decision it can never get.

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -432,7 +432,7 @@ public class LocalPermissionBridgeTests {
         }
     }
 
-    // follow-up: a review-flow reviewer's own result-submission tool must be auto-approved
+    // Follow-up: a review-flow reviewer's own result-submission tool must be auto-approved
     // by the bridge WITHOUT surfacing a user prompt. Codex fires a PermissionRequest for the MCP
     // tool call even under `--ask-for-approval never`, and its hook bridges here; without this the
     // unattended reviewer blocks on a decision it can never get.

--- a/test/Capacitor.Cli.Tests.Unit/MachineIdFileTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/MachineIdFileTests.cs
@@ -3,8 +3,8 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Tests for <see cref="MachineId"/> — the AI-1207 stable per-machine id the daemon reports at
-/// registration (distinct from <see cref="MachineIdProvider"/>'s AI-1134 memory-tagging id; see
+/// Tests for <see cref="MachineId"/> — the stable per-machine id the daemon reports at
+/// registration (distinct from <see cref="MachineIdProvider"/>'s memory-tagging id; see
 /// MachineIdTests.cs for that one).
 ///
 /// PathHelpers.ConfigDir is static readonly — captured once at class-load time from

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsServerTests.cs
@@ -236,7 +236,7 @@ public class McpFlowsServerTests {
 
     [Test]
     public async Task Ack_attempt_times_out_and_is_swallowed() {
-        // AI-1127 E-c final review, Important: the shared MCP client normally has
+        // E-c final review, Important: the shared MCP client normally has
         // Timeout = InfiniteTimeSpan (the review-flow endpoints long-poll), so
         // AckRenderedMessagesAsync now bounds each POST attempt itself (PerAckPostTimeout, 15s).
         // Driving the real 15s bound here would make this test slow without adding coverage —

--- a/test/Capacitor.Cli.Tests.Unit/McpWorkItemsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpWorkItemsServerTests.cs
@@ -67,10 +67,10 @@ public class McpWorkItemsServerTests {
 
     [Test]
     public async Task Declare_body_carries_session_id_and_issue_key() {
-        var body = McpWorkItemsServer.BuildDeclareBody(Args("""{"session_id":"s1","issue_key":"AI-1234"}"""));
+        var body = McpWorkItemsServer.BuildDeclareBody(Args("""{"session_id":"s1","issue_key":"PROJ-1234"}"""));
 
         await Assert.That(body["session_id"]!.GetValue<string>()).IsEqualTo("s1");
-        await Assert.That(body["issue_key"]!.GetValue<string>()).IsEqualTo("AI-1234");
+        await Assert.That(body["issue_key"]!.GetValue<string>()).IsEqualTo("PROJ-1234");
         await Assert.That(body["pr_number"]).IsNull();
         await Assert.That(body["work_item_id"]).IsNull();
         await Assert.That(body["new_title"]).IsNull();
@@ -120,7 +120,7 @@ public class McpWorkItemsServerTests {
         // dropping the wrong-shaped selector would let the server's exactly-one rule pass and
         // perform an attach the caller never validly requested.
         var ex = Assert.Throws<ArgumentException>(
-            () => McpWorkItemsServer.BuildDeclareBody(Args("""{"session_id":"s1","issue_key":"AI-1","pr_number":"123"}""")));
+            () => McpWorkItemsServer.BuildDeclareBody(Args("""{"session_id":"s1","issue_key":"PROJ-1","pr_number":"123"}""")));
 
         await Assert.That(ex!.Message).Contains("pr_number");
     }

--- a/test/Capacitor.Cli.Tests.Unit/OpenCodeDbTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OpenCodeDbTests.cs
@@ -89,7 +89,7 @@ public class OpenCodeDbTests {
         await Assert.That(string.Join(",", kids.Select(k => k.Id))).IsEqualTo("ses_c1,ses_c2");
     }
 
-    // ── QueryDescendants (AI-1383 D3: recursive grandchild discovery) ──────────────────────
+    // ── QueryDescendants (D3: recursive grandchild discovery) ──────────────────────
 
     [Test]
     public async Task QueryDescendants_walks_a_multi_level_parent_chain() {
@@ -136,7 +136,7 @@ public class OpenCodeDbTests {
         await Assert.That(truncated).IsFalse();
     }
 
-    // AI-1383 D3 review fix #3: the walker used to stop AT the boundary child (depth 9) and
+    // the walker used to stop AT the boundary child (depth 9) and
     // never look below it, so a chain continuing to depth 10 was still counted as ONE omitted
     // descendant — undercounting the true size of the omitted subtree. The walk must now
     // continue (never importing) below the cap to count the WHOLE subtree.
@@ -186,7 +186,7 @@ public class OpenCodeDbTests {
         await Assert.That(truncated).IsFalse();
     }
 
-    // ── MaxCountingNodes scope (AI-1383 D3 review fix #4) ───────────────────────────────────
+    // ── MaxCountingNodes scope (D3 review fix #4) ───────────────────────────────────
     //
     // The counting ceiling used to gate the WHOLE unified traversal via the shared visited-id
     // set's total size, so a root with a wide IN-CAP fan-out (well within MaxDescendantDepth)
@@ -252,7 +252,7 @@ public class OpenCodeDbTests {
         await Assert.That(omittedIds.Count).IsEqualTo(OpenCodeDb.MaxCountingNodes);
     }
 
-    // AI-1383 D3 review fix #5: the ceiling used to bound the RETURNED omitted count/ids, but
+    // the ceiling used to bound the RETURNED omitted count/ids, but
     // not the actual WORK — every below-cap node already enqueued before the ceiling was hit
     // (up to MaxCountingNodes of them) still got individually dequeued and queried afterward.
     // Once truncation is established, the below-cap frontier must be abandoned outright rather
@@ -293,7 +293,7 @@ public class OpenCodeDbTests {
         await Assert.That(ocdb.QueryChildrenCallCount).IsLessThanOrEqualTo(9);
     }
 
-    // AI-1383 D3 review fix #6: a below-cap parent's single QueryChildren call used to
+    // a below-cap parent's single QueryChildren call used to
     // materialize its ENTIRE child row set before CountTruncated could even be detected — a
     // depth-8 parent with (say) a million depth-9 children would read/allocate all million rows
     // in one call. The per-parent fetch must instead be capped to (remaining counting capacity +
@@ -328,7 +328,7 @@ public class OpenCodeDbTests {
         await Assert.That(ocdb.QueryChildrenMaxRowsReturned).IsLessThanOrEqualTo(OpenCodeDb.MaxCountingNodes + 1);
     }
 
-    // AI-1383 D3 review fix #7 (P2): a below-cap parent's bounded row fetch caps RAW SQL rows via
+    // a below-cap parent's bounded row fetch caps RAW SQL rows via
     // `LIMIT`, but QuerySessions's per-row try/catch skip of a malformed row happens AFTER that —
     // so a malformed row landing inside the sentinel window used to silently consume the sole
     // sentinel slot, filling omittedIds to exactly MaxCountingNodes valid ids while CountTruncated

--- a/test/Capacitor.Cli.Tests.Unit/OpenCodeExtensionInstallerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OpenCodeExtensionInstallerTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core.OpenCode;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Covers the OpenCode plugin installer (AI-919): kcap.ts write/remove + the
+/// Covers the OpenCode plugin installer: kcap.ts write/remove + the
 /// version-marker helpers. OpenCode has no hooks.json — kcap ships a dependency-free
 /// TypeScript plugin OpenCode auto-loads from <c>~/.config/opencode/plugins/</c>.
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/OpenCodeExtractorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OpenCodeExtractorTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-919 (review follow-up): the watcher must read OpenCode's <c>{info,parts}</c> shape for
+/// the watcher must read OpenCode's <c>{info,parts}</c> shape for
 /// title/event extraction (info.role + text parts) rather than falling through to the Claude
 /// <c>type:"user"|"assistant"</c> shape — otherwise OpenCode sessions get no titles. Mirrors
 /// the server normalizer's text rules (joined non-hidden text parts; synthetic/ignored skipped).

--- a/test/Capacitor.Cli.Tests.Unit/OpenCodeImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OpenCodeImportSourceTests.cs
@@ -191,7 +191,7 @@ public class OpenCodeImportSourceTests {
 
     [Test]
     public async Task import_session_derives_workspace_root_from_cwd_when_a_git_repo_is_present() {
-        // AI-701 review finding 4: routed imports (OpenCode/Pi/Copilot/Kiro/Antigravity) went
+        // review finding 4: routed imports (OpenCode/Pi/Copilot/Kiro/Antigravity) went
         // straight to ImportSessionAsync and never derived workspace_root — only the file-based
         // chain path (ImportChainsAsync) did. Mirrors ImportChainsTests'
         // ImportChainsAsync_derives_workspace_root_from_the_remapped_cwd_not_the_raw_meta_cwd.

--- a/test/Capacitor.Cli.Tests.Unit/OpenCodeSubagentDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OpenCodeSubagentDiscoveryTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Core.OpenCode;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Unit tests for <see cref="OpenCodeSubagentDiscovery"/> (AI-919 phase 2): the nested
+/// Unit tests for <see cref="OpenCodeSubagentDiscovery"/>: the nested
 /// child-file convention the kcap plugin writes + the parent watcher scans, the agent-name
 /// resolution, and the vendor-agnostic <c>/hooks/subagent-{start,stop}</c> payload shapes
 /// (whose required-field set the server's HookBase enforces).

--- a/test/Capacitor.Cli.Tests.Unit/PendingPermissionRegistryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PendingPermissionRegistryTests.cs
@@ -8,7 +8,7 @@ namespace Capacitor.Cli.Tests.Unit;
 /// hosted-agent permission request (the daemon gets a requestId back from RequestPermission2)
 /// and the server's later "PermissionResolved" push carrying the user's decision. Replaces the
 /// old model where the decision was the return value of a hub invocation held open for the whole
-/// wait (which starved DaemonPing — see AI-864). The registry must:
+/// wait (which starved DaemonPing —). The registry must:
 ///   - complete the awaiting call when the matching push arrives,
 ///   - handle a push that races ahead of the await (buffered, returned on registration),
 ///   - propagate cancellation (daemon shutdown) and not leak the pending entry,

--- a/test/Capacitor.Cli.Tests.Unit/PendingPermissionRegistryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PendingPermissionRegistryTests.cs
@@ -8,7 +8,7 @@ namespace Capacitor.Cli.Tests.Unit;
 /// hosted-agent permission request (the daemon gets a requestId back from RequestPermission2)
 /// and the server's later "PermissionResolved" push carrying the user's decision. Replaces the
 /// old model where the decision was the return value of a hub invocation held open for the whole
-/// wait (which starved DaemonPing —). The registry must:
+/// wait (which starved DaemonPing). The registry must:
 ///   - complete the awaiting call when the matching push arrives,
 ///   - handle a push that races ahead of the await (buffered, returned on registration),
 ///   - propagate cancellation (daemon shutdown) and not leak the pending entry,

--- a/test/Capacitor.Cli.Tests.Unit/PiExtensionInstallerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PiExtensionInstallerTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core.Pi;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Covers the Pi extension installer (AI-886): kcap.ts write/remove + the
+/// Covers the Pi extension installer: kcap.ts write/remove + the
 /// version-marker helpers. Pi has no hooks.json — kcap ships a TypeScript
 /// extension Pi auto-loads from <c>~/.pi/agent/extensions/</c>.
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/PiImportSourceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PiImportSourceTests.cs
@@ -4,7 +4,7 @@ namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
 /// Discovery-phase + import-relevance tests for <see cref="PiImportSource"/>
-/// against fake <c>~/.pi/agent/sessions</c> trees (AI-886). Pi stores one
+/// against fake <c>~/.pi/agent/sessions</c> trees. Pi stores one
 /// tree-structured JSONL per session; discovery reads the <c>session</c> header
 /// line for the id/cwd/timestamp and walks the tree recursively.
 /// </summary>
@@ -139,8 +139,8 @@ public class PiImportSourceTests {
     [Arguments("""{"type":"message","id":"a","message":{"role":"toolResult","toolCallId":"c1","content":[]}}""", true)]
     [Arguments("""{"type":"message","id":"a","message":{"role":"bashExecution","command":"ls"}}""", true)]
     [Arguments("""{"type":"model_change","id":"a","modelId":"gpt-5"}""", false)]
-    [Arguments("""{"type":"compaction","id":"a","summary":"x"}""", true)]  // AI-892: compaction → ContextCompacted
-    [Arguments("""{"type":"branch_summary","id":"a","summary":"branch","fromId":"b"}""", true)] // AI-892: branch_summary → AssistantTextGenerated
+    [Arguments("""{"type":"compaction","id":"a","summary":"x"}""", true)]  // compaction → ContextCompacted
+    [Arguments("""{"type":"branch_summary","id":"a","summary":"branch","fromId":"b"}""", true)] // branch_summary → AssistantTextGenerated
     [Arguments("""{"type":"branch_summary","id":"a","summary":""}""", false)]
     [Arguments("""{"type":"branch_summary","id":"a","summary":"   "}""", false)]
     [Arguments("""{"type":"label","id":"a","label":"x"}""", false)]

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
@@ -534,7 +534,7 @@ public class PluginCommandCodexInstallIntegrationTests {
         await Assert.That(stdout).Contains("trust");
     }
 
-    // regression: when the top-level skills/ folder is present but one
+    // Regression: when the top-level skills/ folder is present but one
     // or more individual skill sub-folders are missing (packaging defect),
     // `plugin install --codex` must fail BEFORE writing hooks. The per-skill
     // preflight must run before InstallCodexHooks to maintain the atomicity

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
@@ -606,7 +606,7 @@ public class PluginCommandCodexInstallIntegrationTests {
         var toml       = await File.ReadAllTextAsync(configPath);
         await Assert.That(toml).Contains("[mcp_servers.kcap-review]");
         await Assert.That(toml).Contains("[mcp_servers.kcap-sessions]");
-        await Assert.That(toml).Contains("[mcp_servers.kcap-memory]"); //
+        await Assert.That(toml).Contains("[mcp_servers.kcap-memory]");
     }
 
     [Test]
@@ -621,7 +621,7 @@ public class PluginCommandCodexInstallIntegrationTests {
         var toml = await File.ReadAllTextAsync(configPath);
         await Assert.That(toml).DoesNotContain("kcap-review");
         await Assert.That(toml).DoesNotContain("kcap-sessions");
-        await Assert.That(toml).DoesNotContain("kcap-memory"); //
+        await Assert.That(toml).DoesNotContain("kcap-memory");
         await Assert.That(toml).Contains("my-tool"); // user's server preserved
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCodexTests.cs
@@ -534,11 +534,11 @@ public class PluginCommandCodexInstallIntegrationTests {
         await Assert.That(stdout).Contains("trust");
     }
 
-    // AI-698 regression: when the top-level skills/ folder is present but one
+    // regression: when the top-level skills/ folder is present but one
     // or more individual skill sub-folders are missing (packaging defect),
     // `plugin install --codex` must fail BEFORE writing hooks. The per-skill
     // preflight must run before InstallCodexHooks to maintain the atomicity
-    // guarantee from AI-676 — either everything installs or nothing does.
+    // guarantee from — either everything installs or nothing does.
     [Test]
     public async Task InstallCodex_fails_before_writing_hooks_when_individual_skill_folder_missing() {
         using var fakeHome   = new TempDir();
@@ -567,7 +567,7 @@ public class PluginCommandCodexInstallIntegrationTests {
         await Assert.That(stderr).Contains("Cannot install Codex plugin");
     }
 
-    // AI-676 P2: when the kcap plugin folder cannot be resolved (e.g.,
+    // when the kcap plugin folder cannot be resolved (e.g.,
     // the binary was hand-copied and the sibling `kcap/` tree is gone),
     // `plugin install --codex` must fail BEFORE writing hooks. Otherwise the
     // user ends up with hook entries pointing at a kcap binary whose
@@ -606,7 +606,7 @@ public class PluginCommandCodexInstallIntegrationTests {
         var toml       = await File.ReadAllTextAsync(configPath);
         await Assert.That(toml).Contains("[mcp_servers.kcap-review]");
         await Assert.That(toml).Contains("[mcp_servers.kcap-sessions]");
-        await Assert.That(toml).Contains("[mcp_servers.kcap-memory]"); // AI-1146
+        await Assert.That(toml).Contains("[mcp_servers.kcap-memory]"); //
     }
 
     [Test]
@@ -621,7 +621,7 @@ public class PluginCommandCodexInstallIntegrationTests {
         var toml = await File.ReadAllTextAsync(configPath);
         await Assert.That(toml).DoesNotContain("kcap-review");
         await Assert.That(toml).DoesNotContain("kcap-sessions");
-        await Assert.That(toml).DoesNotContain("kcap-memory"); // AI-1146
+        await Assert.That(toml).DoesNotContain("kcap-memory"); //
         await Assert.That(toml).Contains("my-tool"); // user's server preserved
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
@@ -69,7 +69,7 @@ public class PluginCommandCursorTests {
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-flows");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-memory");
-        // AI-1264: kcap-workitems is Claude Code plugin only — not auto-registered for Cursor.
+        // kcap-workitems is Claude Code plugin only — not auto-registered for Cursor.
         await Assert.That(servers.Select(kv => kv.Key)).DoesNotContain("kcap-workitems");
         await Assert.That(servers["my-tool"]).IsNotNull(); // user server preserved
     }

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandOpenCodeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandOpenCodeTests.cs
@@ -8,7 +8,7 @@ using Capacitor.Cli.Core.OpenCode;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Plugin-dispatch tests for the OpenCode live-ingest plugin (AI-919): install
+/// Plugin-dispatch tests for the OpenCode live-ingest plugin: install
 /// (+ <c>--if-installed</c> refresh) and remove via <c>kcap plugin --opencode</c>.
 /// The npm refresh path (refresh.js) runs the <c>--if-installed</c> form on every
 /// upgrade, so it MUST no-op for users who never opted in — these tests guard that

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandPiTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandPiTests.cs
@@ -5,7 +5,7 @@ using Capacitor.Cli.Core.Pi;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Plugin-dispatch tests for the Pi live-ingest extension (AI-886). Pi has no
+/// Plugin-dispatch tests for the Pi live-ingest extension. Pi has no
 /// hook file — its integration is the <c>~/.pi/agent/extensions/kcap.ts</c>
 /// extension, installed by <c>kcap plugin install --pi</c>, refreshed via
 /// <c>--if-installed</c>, removed by <c>kcap plugin remove --pi</c>. The npm

--- a/test/Capacitor.Cli.Tests.Unit/PrRefParserTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PrRefParserTests.cs
@@ -102,7 +102,7 @@ public class PrRefParserTests {
 
     [Test]
     public async Task Gitlab_nested_group_mr_url_is_parsed() {
-        // Nested groups supported (§6b /): owner is the full namespace path.
+        // Nested groups supported (§6b): owner is the full namespace path.
         var ok = PrRefParser.TryParse("https://gitlab.com/group/sub/project/-/merge_requests/42",
                                       out var owner, out var repo, out var pr);
         await Assert.That(ok).IsTrue();

--- a/test/Capacitor.Cli.Tests.Unit/PrRefParserTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PrRefParserTests.cs
@@ -102,7 +102,7 @@ public class PrRefParserTests {
 
     [Test]
     public async Task Gitlab_nested_group_mr_url_is_parsed() {
-        // Nested groups supported (§6b / AI-1121): owner is the full namespace path.
+        // Nested groups supported (§6b /): owner is the full namespace path.
         var ok = PrRefParser.TryParse("https://gitlab.com/group/sub/project/-/merge_requests/42",
                                       out var owner, out var repo, out var pr);
         await Assert.That(ok).IsTrue();

--- a/test/Capacitor.Cli.Tests.Unit/ProactiveTokenRefreshDecisionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProactiveTokenRefreshDecisionTests.cs
@@ -7,7 +7,7 @@ namespace Capacitor.Cli.Tests.Unit;
 /// daemon's proactive-refresh tick makes each time it wakes. It answers "should we
 /// refresh the active profile's token ahead of expiry, and via which provider path?"
 /// without touching the network or the filesystem, so every branch is unit-testable
-/// in isolation (AI-992).
+/// in isolation.
 /// </summary>
 public class ProactiveTokenRefreshDecisionTests {
     static readonly TimeSpan Window = TimeSpan.FromMinutes(5);

--- a/test/Capacitor.Cli.Tests.Unit/ProcessHelpersHandleInheritanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProcessHelpersHandleInheritanceTests.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Covers the AI-820 fix: <see cref="ProcessHelpers.PreventInheritedStdHandles"/> /
+/// Covers the fix: <see cref="ProcessHelpers.PreventInheritedStdHandles"/> /
 /// <see cref="ProcessHelpers.TryClearInheritFlag"/> stop a hook-spawned watcher from
 /// inheriting the coding agent's std handles on Windows (which otherwise holds the
 /// agent's hook-stdout pipe open, hanging synchronous subagent hooks and orphaning

--- a/test/Capacitor.Cli.Tests.Unit/ProcessHelpersTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProcessHelpersTests.cs
@@ -126,7 +126,7 @@ public class ProcessHelpersTests {
     public async Task GetProcessInfo_returns_ppid_and_name_for_current_process() {
         // Backs the ancestry walk: it must report a process's real parent PID and a
         // non-empty executable name so the walk can match the coding agent by name.
-        // Runs on every platform now that Windows has a native implementation (AI-822):
+        // Runs on every platform now that Windows has a native implementation:
         // the Windows branch previously returned null, so the parent-PID watchdog had no
         // way to resolve the durable coding-agent process and silently never armed.
         var info = ProcessHelpers.GetProcessInfo(Environment.ProcessId);

--- a/test/Capacitor.Cli.Tests.Unit/ProviderBudgetSplitTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ProviderBudgetSplitTests.cs
@@ -8,7 +8,7 @@ namespace Capacitor.Cli.Tests.Unit;
 /// Guards the effective-provider-budget split added in #229: the probe (GitProviderRouter) and the
 /// PR/MR detector share one ceiling, and the detector must run within the budget the probe LEFT
 /// BEHIND — not the full cap. This is timing-dependent in production; an injected timestamp makes
-/// it deterministic so a regression (handing the detector the full cap) is caught in CI (AI-1120).
+/// it deterministic so a regression (handing the detector the full cap) is caught in CI.
 /// </summary>
 public class ProviderBudgetSplitTests {
     [Before(Test)]

--- a/test/Capacitor.Cli.Tests.Unit/PtyHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PtyHostedAgentRuntimeTests.cs
@@ -38,7 +38,7 @@ public class PtyHostedAgentRuntimeTests {
 
         await runtime.SendUserInputAsync("hello world");
 
-        // AI-30: the text is delivered as one bracketed-paste block (ESC[200~ … ESC[201~) so the
+        // the text is delivered as one bracketed-paste block (ESC[200~ … ESC[201~) so the
         // CLI's TUI treats it as a single paste and the following Enter is an unambiguous submit
         // keypress, rather than racing the still-ingesting text.
         await Assert.That(pty.StringWrites.Count).IsEqualTo(2);

--- a/test/Capacitor.Cli.Tests.Unit/ReadNewCompleteLinesAsyncTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ReadNewCompleteLinesAsyncTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Capacitor.Cli.Tests.Unit;
 
-// / Qodo #291: the streaming drain reader (ReadNewCompleteLinesAsync) replaces
+// Qodo #291: the streaming drain reader (ReadNewCompleteLinesAsync) replaces
 // File.ReadAllTextAsync in DrainNewLines. It must (1) open with FileShare.ReadWrite so a
 // concurrently-writing agent is never blocked (#291 #1), (2) NOT materialize the whole file
 // (#291 #2), and (3) stay byte-for-byte behaviour-equivalent to the string helper

--- a/test/Capacitor.Cli.Tests.Unit/ReadNewCompleteLinesAsyncTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ReadNewCompleteLinesAsyncTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Capacitor.Cli.Tests.Unit;
 
-// AI-1243 / Qodo #291: the streaming drain reader (ReadNewCompleteLinesAsync) replaces
+// / Qodo #291: the streaming drain reader (ReadNewCompleteLinesAsync) replaces
 // File.ReadAllTextAsync in DrainNewLines. It must (1) open with FileShare.ReadWrite so a
 // concurrently-writing agent is never blocked (#291 #1), (2) NOT materialize the whole file
 // (#291 #2), and (3) stay byte-for-byte behaviour-equivalent to the string helper
@@ -24,7 +24,7 @@ public class ReadNewCompleteLinesAsyncTests {
         return await WatchCommand.ReadNewCompleteLinesAsync(stream, linesProcessed, policy, default);
     }
 
-    // AI-1382 review fix #1 — the Cursor watcher's captureRawBytes: true path.
+    // the Cursor watcher's captureRawBytes: true path.
     static async Task<WatchCommand.NewTranscriptLines> ReadViaStreamRaw(
             string path, int linesProcessed, WatchCommand.IncompleteFinalLinePolicy policy) {
         await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
@@ -170,7 +170,7 @@ public class ReadNewCompleteLinesAsyncTests {
     public async Task Cap_stops_reading_at_the_sampled_length() {
         // The wrapper mirrors a length sampled BEFORE a concurrent append: bytes past `limit`
         // exist in `inner` but must never be surfaced, so an as-yet unterminated final line can't
-        // be made to look complete and get consumed (the AI-1243 bug this PR fixes).
+        // be made to look complete and get consumed (the bug this PR fixes).
         var full  = Encoding.UTF8.GetBytes("a\nb\nc\n");   // 6 bytes
         var limit = 4L;                                     // "a\nb\n" only
         using var inner = new MemoryStream(full);
@@ -232,7 +232,7 @@ public class ReadNewCompleteLinesAsyncTests {
         await Assert.That(Encoding.UTF8.GetString(buffer, 0, total)).IsEqualTo("hello");
     }
 
-    // ---- 5. AI-1382 review fix #1: captureRawBytes threads the EXACT decode-read bytes back to
+    // 5. review fix #1: captureRawBytes threads the EXACT decode-read bytes back to
     // the caller. This is the mechanism the fix relies on to close the TOCTOU the round-2 review
     // found: the runtime rewrite guard used to decode lines from one read, then reopen the file
     // SEPARATELY to hash "the new range" — a rewrite landing between those two reads meant the
@@ -292,7 +292,7 @@ public class ReadNewCompleteLinesAsyncTests {
         }
     }
 
-    // ---- 6. AI-1382 review fix (r3, finding #3): rawBytesReadFrom/newRangeByteOffset bound the
+    // 6. review fix (r3, finding #3): rawBytesReadFrom/newRangeByteOffset bound the
     // captureRawBytes buffer instead of always materializing the whole file. A large, mostly-
     // unchanged Cursor transcript must NOT be re-read/re-allocated in full on every poll — only the
     // guard's own small trailing-tail zone plus whatever's actually new. The periodic full-prefix

--- a/test/Capacitor.Cli.Tests.Unit/RepoMatcherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RepoMatcherTests.cs
@@ -155,7 +155,7 @@ public class RepoMatcherTests {
 
     [Test]
     public async Task FindAsync_MatchingNestedGitlabGroupOrigin_ReturnsRoot() {
-        // AI-1121: a nested namespace owner ("group/sub") must match the full
+        // a nested namespace owner ("group/sub") must match the full
         // owner/repo suffix of the normalized remote.
         var repo = MakeTempRepo("git@gitlab.com:group/sub/project.git");
         try {

--- a/test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RepositoryDetectionCacheTests.cs
@@ -16,7 +16,7 @@ public class RepositoryDetectionCacheTests {
 
     [Test]
     public async Task GitCacheEntry_v2_is_stale_after_nested_group_bump() {
-        // v2 pre-dates multi-segment owner parsing (AI-1121); a nested repo cached under
+        // v2 pre-dates multi-segment owner parsing; a nested repo cached under
         // v2 has owner=null and must be re-derived, not served stale, after the bump.
         const string v2 = """{"schema_version":2,"host":"gitlab.com","owner":null,"repo_name":null,"cached_at":"2020-01-01T00:00:00+00:00"}""";
         var entry = JsonSerializer.Deserialize(v2, CapacitorJsonContext.Default.GitCacheEntry);
@@ -25,7 +25,7 @@ public class RepositoryDetectionCacheTests {
     }
 
     // Exercises the real detection path end-to-end for a nested namespace, proving the
-    // greedy owner parse (AI-1121) flows through DetectRepositoryAsync (glab-independent).
+    // greedy owner parse flows through DetectRepositoryAsync (glab-independent).
     [Test]
     public async Task Detects_nested_gitlab_repo_base_info() {
         var repo = MakeTempRepo("git@gitlab.com:group/sub/project.git");

--- a/test/Capacitor.Cli.Tests.Unit/RunAgentArgsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RunAgentArgsTests.cs
@@ -35,7 +35,7 @@ public class RunAgentArgsTests {
 
     [Test]
     public async Task Share_is_not_a_flag_sharing_is_a_ui_action() {
-        // Sharing is server/UI-authoritative (AI-861 tracks a future `kcap share` command),
+        // Sharing is server/UI-authoritative (tracks a future `kcap share` command),
         // so --share is just an unknown run-agent flag and is rejected.
         await Assert.That(RunAgentArgs.Parse(["claude", "--share"]).Error).IsNotNull();
     }

--- a/test/Capacitor.Cli.Tests.Unit/SecretRedactorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SecretRedactorTests.cs
@@ -10,7 +10,7 @@ public class SecretRedactorTests {
         // `\n`-escaped key body lines, then truncated WITHOUT a matching `-----END` marker, used
         // to wedge the watcher: the `(?:\\n|[\s\S])*?` alternation in PemBlockRegex had two paths
         // for every `\n` pair, producing ~2^N backtracking on the failed-to-find-END search.
-        // Observed in prod (AI-783): watcher main loop at 100% CPU for 50s+ on a 5KB line.
+        // Observed in prod: watcher main loop at 100% CPU for 50s+ on a 5KB line.
         var keyBody = new StringBuilder();
 
         // Synthetic base64-like body — NOT a real key. The redactor's backtracking shape only
@@ -128,7 +128,7 @@ public class SecretRedactorTests {
 
     [Test]
     public async Task DoesNotRedact_TaskNotificationTag_MidWordSkMatch() {
-        // AI-1162: the OpenAI `sk-` vendor-token branch matched the `sk-notification` substring
+        // the OpenAI `sk-` vendor-token branch matched the `sk-notification` substring
         // inside "ta·sk-notification", turning Claude Code's injected background-task blocks into
         // `<ta[REDACTED]> … </ta[REDACTED]>`. The tag is not a secret and must survive verbatim.
         var line = """
@@ -434,7 +434,7 @@ public class SecretRedactorTests {
         await Assert.That(content[0].GetProperty("is_error").GetBoolean()).IsFalse();
     }
 
-    // AI-50 — auth headers recorded as-is
+    // auth headers recorded as-is
 
     [Test]
     public async Task RedactsLine_AuthorizationBearer_InCurlToolResult() {
@@ -579,7 +579,7 @@ public class SecretRedactorTests {
         await Assert.That(result).Contains("https://alice:[REDACTED]@github.com");
     }
 
-    // AI-53 — labeled secrets with no colon separator (e.g. `hcloud:token  <value>`)
+    // labeled secrets with no colon separator (e.g. `hcloud:token  <value>`)
 
     [Test]
     public async Task RedactsLine_LabeledSecret_HcloudToken_InToolResult() {

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryLiveTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryLiveTests.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Services;
 
 /// <summary>
-/// AI-688 gap 1 — GATED live end-to-end test that drives the REAL <see cref="AcpHostedAgentRuntimeFactory"/>
+/// gap 1 — GATED live end-to-end test that drives the REAL <see cref="AcpHostedAgentRuntimeFactory"/>
 /// against a REAL <c>cursor-agent acp</c> child process (no <c>FakeAcpAgent</c>, no in-memory pipe —
 /// see <see cref="AcpHostedAgentRuntimeFactoryTests"/> for that coverage of the same code path) to
 /// prove that model selection (<c>session/set_config_option</c>, sent from
@@ -87,7 +87,7 @@ public class AcpHostedAgentRuntimeFactoryLiveTests {
                 config: new DaemonConfig(), // CursorPath="cursor-agent", CursorModel="claude-sonnet-4-5"
                 loggerFactory: liveLoggerFactory,
                 connection: connection,
-                connectionSource: null // real cursor-agent acp spawn — AI-688 gap 1's production path
+                connectionSource: null // real cursor-agent acp spawn — gap 1's production path
             );
 
             var ctx = new RuntimeStartContext(
@@ -135,7 +135,7 @@ public class AcpHostedAgentRuntimeFactoryLiveTests {
 
     /// <summary>
     /// Drains <paramref name="updates"/> until an <c>agent_message_chunk</c> (concatenated across
-    /// however many chunks Cursor streams the answer in — the AI-688 probe observed the reply
+    /// however many chunks Cursor streams the answer in — the probe observed the reply
     /// arriving split across multiple chunks) contains "HELLO" (case-insensitive), or
     /// <paramref name="timeout"/> elapses.
     /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Services;
 
 /// <summary>
-/// 4, Finding 3: proves <see cref="AcpHostedAgentRuntimeFactory"/> — constructed for
+/// Round-4 review finding 3: proves <see cref="AcpHostedAgentRuntimeFactory"/> — constructed for
 /// real, driven through its REAL <see cref="AcpHostedAgentRuntimeFactory.StartAsync"/> — actually
 /// wires the ACP interaction bridge into the runtime it produces, by observing an inbound
 /// <c>session/request_permission</c> genuinely dispatch to the injected <c>requestInteraction</c>
@@ -18,8 +18,8 @@ namespace Capacitor.Cli.Tests.Unit.Services;
 /// process-spawning is swapped out via its <c>connectionSource</c> constructor seam for one backed
 /// by <see cref="FakeAcpAgent"/>'s existing in-memory pipe streams, the same fake this project
 /// already uses for <c>AcpHostedAgentRuntimeTests</c>/<c>AcpHostedAgentRuntimePermissionTests</c>.
-/// A regression that left <c>StartAsync</c> passing <c>requestInteraction: null</c> ('s
-/// original default-decline posture) would make this test's <c>session/request_permission</c>
+/// A regression that left <c>StartAsync</c> passing <c>requestInteraction: null</c> (reverting to
+/// the runtime's original default-decline posture) would make this test's <c>session/request_permission</c>
 /// resolve with a JSON-RPC "Method not found" error instead of the well-formed <c>cancelled</c>
 /// outcome asserted below — i.e. this test FAILS on that regression, unlike the pre-round-4 test it
 /// replaces.
@@ -122,7 +122,7 @@ public class AcpHostedAgentRuntimeFactoryTests {
     }
 
     /// <summary>
-    /// gap 1: <c>ctx.Model</c> (the launch's own model override) must take precedence over
+    /// Model-precedence gap: <c>ctx.Model</c> (the launch's own model override) must take precedence over
     /// <c>DaemonConfig.CursorModel</c> (the daemon-wide family-prefix default) — proves the full
     /// chain (factory merges the two, runtime resolves against `session/new`'s `availableModels`,
     /// sends `session/set_config_option`) picks the PER-LAUNCH model, not the daemon default.
@@ -178,7 +178,7 @@ public class AcpHostedAgentRuntimeFactoryTests {
     public async Task StartAsync_IfRequestInteractionWereNull_PermissionRequestWouldGetMethodNotFound() {
         var fake = new FakeAcpAgent();
         var conn = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
-        var runtime = new AcpHostedAgentRuntime(conn, new FakeAcpProcess(), NullLogger.Instance); // no requestInteraction — default
+        var runtime = new AcpHostedAgentRuntime(conn, new FakeAcpProcess(), NullLogger.Instance); // no requestInteraction — default behavior
 
         using var cts = new CancellationTokenSource();
         var fakeRunTask = fake.RunAsync(cts.Token);

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Services;
 
 /// <summary>
-/// AI-686 round-4, Finding 3: proves <see cref="AcpHostedAgentRuntimeFactory"/> — constructed for
+/// 4, Finding 3: proves <see cref="AcpHostedAgentRuntimeFactory"/> — constructed for
 /// real, driven through its REAL <see cref="AcpHostedAgentRuntimeFactory.StartAsync"/> — actually
 /// wires the ACP interaction bridge into the runtime it produces, by observing an inbound
 /// <c>session/request_permission</c> genuinely dispatch to the injected <c>requestInteraction</c>
@@ -18,7 +18,7 @@ namespace Capacitor.Cli.Tests.Unit.Services;
 /// process-spawning is swapped out via its <c>connectionSource</c> constructor seam for one backed
 /// by <see cref="FakeAcpAgent"/>'s existing in-memory pipe streams, the same fake this project
 /// already uses for <c>AcpHostedAgentRuntimeTests</c>/<c>AcpHostedAgentRuntimePermissionTests</c>.
-/// A regression that left <c>StartAsync</c> passing <c>requestInteraction: null</c> (AI-684's
+/// A regression that left <c>StartAsync</c> passing <c>requestInteraction: null</c> ('s
 /// original default-decline posture) would make this test's <c>session/request_permission</c>
 /// resolve with a JSON-RPC "Method not found" error instead of the well-formed <c>cancelled</c>
 /// outcome asserted below — i.e. this test FAILS on that regression, unlike the pre-round-4 test it
@@ -122,7 +122,7 @@ public class AcpHostedAgentRuntimeFactoryTests {
     }
 
     /// <summary>
-    /// AI-688 gap 1: <c>ctx.Model</c> (the launch's own model override) must take precedence over
+    /// gap 1: <c>ctx.Model</c> (the launch's own model override) must take precedence over
     /// <c>DaemonConfig.CursorModel</c> (the daemon-wide family-prefix default) — proves the full
     /// chain (factory merges the two, runtime resolves against `session/new`'s `availableModels`,
     /// sends `session/set_config_option`) picks the PER-LAUNCH model, not the daemon default.
@@ -178,7 +178,7 @@ public class AcpHostedAgentRuntimeFactoryTests {
     public async Task StartAsync_IfRequestInteractionWereNull_PermissionRequestWouldGetMethodNotFound() {
         var fake = new FakeAcpAgent();
         var conn = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
-        var runtime = new AcpHostedAgentRuntime(conn, new FakeAcpProcess(), NullLogger.Instance); // no requestInteraction — AI-684 default
+        var runtime = new AcpHostedAgentRuntime(conn, new FakeAcpProcess(), NullLogger.Instance); // no requestInteraction — default
 
         using var cts = new CancellationTokenSource();
         var fakeRunTask = fake.RunAsync(cts.Token);

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryToolUseLiveTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryToolUseLiveTests.cs
@@ -178,7 +178,7 @@ public class AcpHostedAgentRuntimeFactoryToolUseLiveTests {
                 if (toolResults.Count > 0)
                     Console.WriteLine("[ai-688-task5-live] turn produced a ToolResult envelope — a tool_call_update reached a terminal status with extractable content.");
 
-                Console.WriteLine($"[ai-688-task5-live] AI-686 permission path fired: {connection.Requests.Count > 0}");
+                Console.WriteLine($"[ai-688-task5-live] PROJ-686 permission path fired: {connection.Requests.Count > 0}");
             } finally {
                 startCts.Cancel();
                 await started.Runtime.DisposeAsync();

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryToolUseLiveTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryToolUseLiveTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Services;
 
 /// <summary>
-/// AI-688 Option B task 5 (the capstone) — GATED live E2E that drives a REAL TOOL-USING turn
+/// Option B task 5 (the capstone) — GATED live E2E that drives a REAL TOOL-USING turn
 /// against a REAL <c>cursor-agent acp</c> process, through the FULL daemon pipeline built by tasks
 /// 1–4: <see cref="AcpHostedAgentRuntimeFactory"/> (real process spawn, no <c>FakeAcpAgent</c>) →
 /// <see cref="AcpHostedAgentRuntime"/>'s ACP handshake + chunk aggregation (task 2) →
@@ -17,8 +17,8 @@ namespace Capacitor.Cli.Tests.Unit.Services;
 /// 2/4's bind-handoff shape) — the same shape task 3/4's orchestrator wiring reads from, just read
 /// directly here instead of through the (SignalR-backed) forwarder.
 ///
-/// Also exercises the AI-686 permission bridge for real: the python probe backing
-/// <c>docs/ai-688-cursor-prototype-findings.md</c>'s "Tool-using turn (AI-688 task 5)" section
+/// Also exercises the permission bridge for real: the python probe backing
+/// <c>docs/ai-688-cursor-prototype-findings.md</c>'s "Tool-using turn" section
 /// showed Cursor DOES send a real <c>session/request_permission</c> before running an
 /// un-allowlisted shell command, so this test's <see cref="AutoApproveServerConnection"/> answers
 /// it with a genuine "selected" decision (unlike <c>AcpHostedAgentRuntimeFactoryLiveTests</c>'s
@@ -70,7 +70,7 @@ public class AcpHostedAgentRuntimeFactoryToolUseLiveTests {
             if (chosen.OptionId is null && options.Length > 0)
                 chosen = options[0];
 
-            // AcpInteractionBridge.MapPermissionDecision (AI-686) fails closed unless BOTH (a)
+            // AcpInteractionBridge.MapPermissionDecision fails closed unless BOTH (a)
             // Outcome is on its AffirmativeOutcomes allowlist AND (b) SelectedOptionId matches one
             // of the OFFERED options' OptionId. "allow_once" is always on that allowlist, so it's
             // used as Outcome regardless of the chosen option's own Kind string — what actually
@@ -110,7 +110,7 @@ public class AcpHostedAgentRuntimeFactoryToolUseLiveTests {
                 config: new DaemonConfig(), // CursorPath="cursor-agent"
                 loggerFactory: liveLoggerFactory,
                 connection: connection,
-                connectionSource: null // real cursor-agent acp spawn — AI-688 gap 1/task 5's production path
+                connectionSource: null // real cursor-agent acp spawn — gap 1/task 5's production path
             );
 
             var ctx = new RuntimeStartContext(

--- a/test/Capacitor.Cli.Tests.Unit/Services/PendingAcpInteractionRegistryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PendingAcpInteractionRegistryTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Tests.Unit.Services;
 
 /// <summary>
-/// AI-686: <see cref="PendingAcpInteractionRegistry"/> is a straight copy-shape of the already-
+/// <see cref="PendingAcpInteractionRegistry"/> is a straight copy-shape of the already-
 /// tested <see cref="PendingPermissionRegistry"/> parameterized on <see cref="AcpInteractionDecision"/>
 /// — these tests mirror that class's own test coverage for the early-arrival race and cancellation.
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/SessionImporterProgressTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionImporterProgressTests.cs
@@ -56,7 +56,7 @@ public class SessionImporterProgressTests : IDisposable {
         }
     }
 
-    // AI-1382 review fix (r4, finding #3) — abortDelivery must be re-checked immediately AFTER a
+    // abortDelivery must be re-checked immediately AFTER a
     // POST too, not only before the next one. A transcript small enough to be a SINGLE (final and
     // only) batch never reaches a "next" pre-POST check at all, so before this fix a quarantine
     // marker that appeared while that one-and-only POST was "in flight" was never observed anywhere
@@ -96,7 +96,7 @@ public class SessionImporterProgressTests : IDisposable {
 
     [Test]
     public async Task CountSendableLines_counts_non_blank_lines_from_start() {
-        // The per-session progress denominator (AI-907): must equal the number of
+        // The per-session progress denominator: must equal the number of
         // lines SendTranscriptBatches/ImportSessionAsync actually POST — non-blank
         // lines from startLine to EOF.
         var path = Path.GetTempFileName();

--- a/test/Capacitor.Cli.Tests.Unit/ShutdownTranscriptSpoolTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ShutdownTranscriptSpoolTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1357 task 8: at shutdown (idle-timeout / parent-exit) with the hub down, the final drain's
+/// task 8: at shutdown (idle-timeout / parent-exit) with the hub down, the final drain's
 /// undelivered transcript tail (state.LinesProcessed → EOF) must not be silently dropped — it is
 /// spooled into the dedicated <see cref="TranscriptSpool"/> so the global drain (task 3) replays it
 /// after recovery, without a manual `kcap import`.
@@ -137,7 +137,7 @@ public class ShutdownTranscriptSpoolTests {
     }
 
     /// <summary>
-    /// AI-1382 review fix #1: a Cursor session already quarantined by the runtime rewrite guard
+    /// a Cursor session already quarantined by the runtime rewrite guard
     /// must never have its tail re-read and spooled here — the bytes past `linesProcessed` ARE
     /// the exact corrupted batch the guard just discarded (the discard never advances
     /// LinesProcessed), so without this check the shutdown path would re-read and spool

--- a/test/Capacitor.Cli.Tests.Unit/ShutdownTranscriptSpoolTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ShutdownTranscriptSpoolTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// task 8: at shutdown (idle-timeout / parent-exit) with the hub down, the final drain's
+/// Task 8: at shutdown (idle-timeout / parent-exit) with the hub down, the final drain's
 /// undelivered transcript tail (state.LinesProcessed → EOF) must not be silently dropped — it is
 /// spooled into the dedicated <see cref="TranscriptSpool"/> so the global drain (task 3) replays it
 /// after recovery, without a manual `kcap import`.

--- a/test/Capacitor.Cli.Tests.Unit/SpawnBeforePostTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SpawnBeforePostTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-1357 Task 4: the spawn-before-post decision for the JSON-payload vendor dispatchers
+/// Task 4: the spawn-before-post decision for the JSON-payload vendor dispatchers
 /// (Kiro, OpenCode, Pi, Copilot). Capture must start on <c>Posted</c> OR <c>Spooled</c> — never
 /// gated behind lifecycle-POST delivery. Only a permanent <c>Failed</c> withholds the watcher.
 /// </summary>
@@ -13,7 +13,7 @@ public class SpawnBeforePostTests {
         await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Posted)).IsTrue();
         await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Spooled)).IsTrue();
         // AuthLapsed (legacy PostAsync path) spools NOTHING, so spawning there would tail a session
-        // whose SessionStarted was permanently dropped — must NOT spawn (AI-1357 review #2).
+        // whose SessionStarted was permanently dropped — must NOT spawn.
         await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.AuthLapsed)).IsFalse();
         await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Failed)).IsFalse();
     }

--- a/test/Capacitor.Cli.Tests.Unit/SplitNewCompleteLinesTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SplitNewCompleteLinesTests.cs
@@ -2,7 +2,7 @@ using Capacitor.Cli.Commands;
 
 namespace Capacitor.Cli.Tests.Unit;
 
-// AI-1243 ("endless reads in chat"): the live watcher drain must NOT consume a transcript
+// the live watcher drain must NOT consume a transcript
 // line that is not yet newline-terminated — the agent is mid-write of it. Sending the
 // truncated prefix and advancing the position past it permanently drops the completed line
 // (its truncated JSON fails to normalize server-side, and the next drain starts after it).
@@ -32,7 +32,7 @@ public class SplitNewCompleteLinesTests {
 
     [Test]
     public async Task Dropped_read_result_is_delivered_once_complete() {
-        // Reproduces AI-1243: a tool_use line (complete) followed by its tool_result line
+        // Reproduces: a tool_use line (complete) followed by its tool_result line
         // caught mid-write (no trailing newline yet).
         var first = WatchCommand.SplitNewCompleteLines("tool_use_A\ntool_result_A", 0);
 
@@ -84,7 +84,7 @@ public class SplitNewCompleteLinesTests {
 
     [Test]
     public async Task Final_drain_consumes_a_parseable_unterminated_final_line() {
-        // AI-1357 task 7: the shutdown final drain (ConsumeIfComplete) delivers an unterminated
+        // task 7: the shutdown final drain (ConsumeIfComplete) delivers an unterminated
         // final line ONLY when it is a complete JSON record. Here the last line parses, so it is
         // consumed and the position advances past it.
         var r = WatchCommand.SplitNewCompleteLines(

--- a/test/Capacitor.Cli.Tests.Unit/SplitNewCompleteLinesTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SplitNewCompleteLinesTests.cs
@@ -84,7 +84,7 @@ public class SplitNewCompleteLinesTests {
 
     [Test]
     public async Task Final_drain_consumes_a_parseable_unterminated_final_line() {
-        // task 7: the shutdown final drain (ConsumeIfComplete) delivers an unterminated
+        // Task 7: the shutdown final drain (ConsumeIfComplete) delivers an unterminated
         // final line ONLY when it is a complete JSON record. Here the last line parses, so it is
         // consumed and the position advances past it.
         var r = WatchCommand.SplitNewCompleteLines(

--- a/test/Capacitor.Cli.Tests.Unit/StatusCommandHooksTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/StatusCommandHooksTests.cs
@@ -104,7 +104,7 @@ public class StatusCommandHooksTests {
         // status must surface every supported agent so an install of any one can be
         // verified from `kcap status`. Gemini and Kiro were each previously absent
         // from the line entirely (added in PR #169); OpenCode was likewise missing
-        // until the AI-919 status surface was wired up.
+        // until the status surface was wired up.
         var line = StatusCommand.BuildHooksStatusLine(
             claude: true, codex: false, cursor: false, copilot: false, gemini: true, kiro: true, pi: true, opencode: true);
 

--- a/test/Capacitor.Cli.Tests.Unit/TokenStoreProfileTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TokenStoreProfileTests.cs
@@ -190,7 +190,7 @@ public class TokenStoreProfileTests {
     [NotInParallel(nameof(TokenStoreProfileTests))]
     public async Task LoadAsync_corrupt_active_profile_does_not_fall_back_to_legacy() {
         // A present-but-corrupt active profile means "not authenticated" — it must NOT
-        // resurrect stale credentials from a surviving legacy tokens.json (AI-1082 review).
+        // resurrect stale credentials from a surviving legacy tokens.json.
         Directory.CreateDirectory(TokensDir);
         Directory.CreateDirectory(Path.GetDirectoryName(LegacyPath)!);
         await File.WriteAllTextAsync(
@@ -222,7 +222,7 @@ public class TokenStoreProfileTests {
     [NotInParallel(nameof(TokenStoreProfileTests))]
     public async Task DeleteAsync_removes_leaked_temp_files() {
         // Logout must remove ALL token material, including temps leaked by a crash
-        // between write and move (AI-1082 review).
+        // between write and move.
         Directory.CreateDirectory(TokensDir);
         await File.WriteAllTextAsync(Path.Combine(TokensDir, "default.json"), "{}");
         await File.WriteAllTextAsync(Path.Combine(TokensDir, "default.json.999.deadbeef.tmp"), "secret");

--- a/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -141,7 +141,7 @@ public class UninstallCommandTests {
 
     [Test]
     public async Task User_level_uninstall_removes_pi_extension() {
-        // AI-886: Pi has no hook file — its live-ingest integration is the
+        // Pi has no hook file — its live-ingest integration is the
         // ~/.pi/agent/extensions/kcap.ts extension. uninstall must delete it
         // (+ the version marker) or pi keeps auto-loading kcap.ts after the user
         // removed kcap. A user-authored sibling extension must survive.

--- a/test/Capacitor.Cli.Tests.Unit/ValidatePlanCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ValidatePlanCommandTests.cs
@@ -7,7 +7,7 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// AI-701: <see cref="ValidatePlanCommand"/>'s two-call flow — <c>GET .../plan-artifacts?chain=true</c>
+/// <see cref="ValidatePlanCommand"/>'s two-call flow — <c>GET .../plan-artifacts?chain=true</c>
 /// for the discovered plan set, then the existing <c>GET .../recap?chain=true</c> for current-session
 /// work rows and "what's done" summaries. A 404 on the artifacts route (old server / non-visible
 /// session) falls back to the original recap-only rendering unchanged.
@@ -227,13 +227,13 @@ public class ValidatePlanCommandTests : IDisposable {
 
         await Assert.That(stdout).Contains("[plan content unavailable due to size bounds]");
         await Assert.That(stdout).Contains("Validation is not possible");
-        // AI-701 review finding 3: distinguishable from success (0) and from a generic error (1).
+        // review finding 3: distinguishable from success (0) and from a generic error (1).
         await Assert.That(exitCode).IsEqualTo(2);
     }
 
     [Test, NotInParallel]
     public async Task Truncated_primary_with_null_original_bytes_falls_back_to_unknown_total_marker() {
-        // AI-701 review finding 2: OriginalBytes is nullable — a malformed/edge response could
+        // review finding 2: OriginalBytes is nullable — a malformed/edge response could
         // omit it even on a "truncated" artifact. The marker must stay well-formed ("of ? bytes"),
         // never "of  bytes".
         const string content = "Truncated prefix with no known original size...";
@@ -281,7 +281,7 @@ public class ValidatePlanCommandTests : IDisposable {
 
     [Test, NotInParallel]
     public async Task Truncated_primary_with_null_content_renders_like_unavailable() {
-        // AI-701 review finding 2: content_state=="truncated" with Content == null is an edge
+        // review finding 2: content_state=="truncated" with Content == null is an edge
         // shape the server contract doesn't normally produce, but the CLI must not print
         // "first 0 of {n} bytes" — treat it like "unavailable" (placeholder + exit 2 since this
         // is the primary).
@@ -327,7 +327,7 @@ public class ValidatePlanCommandTests : IDisposable {
 
     [Test, NotInParallel]
     public async Task Degraded_primary_prefixes_the_plan_section_with_the_degraded_marker() {
-        // CRITICAL (AI-701 review): is_complete == false on the primary — a newer
+        // CRITICAL: is_complete == false on the primary — a newer
         // revision exists but hasn't resolved yet — must render the
         // "unresolved newer revision" marker before the content. This mirrors the
         // server's PlanRowRendering.DegradedText byte-for-byte (em-dash, spacing).
@@ -423,7 +423,7 @@ public class ValidatePlanCommandTests : IDisposable {
 
     [Test, NotInParallel]
     public async Task Primary_not_first_in_artifacts_array_still_renders_first_then_others_in_server_order() {
-        // MINOR (AI-701 review): the primary artifact can appear anywhere in the
+        // MINOR: the primary artifact can appear anywhere in the
         // "artifacts" array (the server's discovery order is newest-first, not
         // primary-first). Rendering must still put the primary's section first,
         // followed by the OTHER artifacts in the order the server returned them.

--- a/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
@@ -740,7 +740,7 @@ public class CodexTranscriptExtractionTests {
     }
 }
 
-// / PR #162: Pi emits type:"message" with message.role (not Claude's
+// PR #162: Pi emits type:"message" with message.role (not Claude's
 // top-level user/assistant), so the watcher title helpers need a Pi branch —
 // otherwise live Pi sessions never get the initial/LLM title.
 public class PiTitleHelperTests {

--- a/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
@@ -391,7 +391,7 @@ public class WatchCommandTests {
         await Assert.That(should).IsFalse();
     }
 
-    // AI-1382 Task 11 (D1) — Cursor joins the idle-ceiling vendor set (D1/D3): no shell hooks
+    // Task 11 (D1) — Cursor joins the idle-ceiling vendor set (D1/D3): no shell hooks
     // fire per-conversation the way a parent-exit watchdog needs, so an idle transcript (no file
     // growth AND heartbeat gone stale) is the fallback signal a Cursor session has ended. Unlike
     // Codex/Antigravity, the watcher itself must NOT synthesize session-end on this path — end
@@ -411,7 +411,7 @@ public class WatchCommandTests {
             lastActivityAt: now.AddMinutes(-5), now: now, idleTimeout: TimeSpan.FromMinutes(60))).IsFalse();
     }
 
-    // AI-1382 review fix #6 — a Cursor CHILD (subagent) watcher never buffers, so
+    // a Cursor CHILD (subagent) watcher never buffers, so
     // WatchState.ThresholdReached never flips true for it; excluding non-session-watchers from
     // the idle ceiling (the pre-fix behavior) made every Cursor child watcher permanently
     // ineligible to idle-exit. The exemption is Cursor-only.
@@ -445,7 +445,7 @@ public class WatchCommandTests {
             lastActivityAt: idle, now: now, idleTimeout: TimeSpan.FromMinutes(60))).IsFalse();
     }
 
-    // AI-1382 review fix #6 — ResolveCursorIdleClock: the idle clock is the LATER of transcript
+    // ResolveCursorIdleClock: the idle clock is the LATER of transcript
     // activity and the hook heartbeat, for Cursor only.
     [Test]
     public async Task ResolveCursorIdleClock_prefers_the_later_hook_heartbeat_for_cursor() {
@@ -501,7 +501,7 @@ public class WatchCommandTests {
         await Assert.That(ack.NextLineNumber).IsEqualTo(7);
     }
 
-    // AI-1382 review fix #3 — ByteOffsetForAckedLines: maps a server-acked LINE count to the byte
+    // ByteOffsetForAckedLines: maps a server-acked LINE count to the byte
     // offset within the guard's verified range, so the checkpoint advances only as far as the ack
     // actually covers (a partially-disposed D3 "halt-at-the-gap" batch must not have its unacked
     // tail bytes checkpointed as if delivered).
@@ -567,7 +567,7 @@ public class WatchCommandTests {
         await Assert.That(result).IsEqualTo(TimeSpan.FromMinutes(expectedMinutes));
     }
 
-    // AI-1382 review fix #4 — Cursor's own sessionStart hook posts (and spawns this very watcher)
+    // Cursor's own sessionStart hook posts (and spawns this very watcher)
     // before any transcript line is ever read, exactly like Antigravity — so the generic
     // below-threshold buffer must not apply to it either.
     [Test]
@@ -740,7 +740,7 @@ public class CodexTranscriptExtractionTests {
     }
 }
 
-// AI-886 / PR #162: Pi emits type:"message" with message.role (not Claude's
+// / PR #162: Pi emits type:"message" with message.role (not Claude's
 // top-level user/assistant), so the watcher title helpers need a Pi branch —
 // otherwise live Pi sessions never get the initial/LLM title.
 public class PiTitleHelperTests {

--- a/test/Capacitor.Cli.Tests.Unit/WatcherHeartbeatTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatcherHeartbeatTests.cs
@@ -76,7 +76,7 @@ public class WatcherHeartbeatTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // Connect-retry / reconnect heartbeat freshness ---
+    // --- Connect-retry / reconnect heartbeat freshness ---
     // The connect-retry backoff grows to 30s, longer than the 20s staleness threshold. The wait
     // is chunked via HeartbeatSlices so the heartbeat is refreshed between slices; if any single
     // chunk could exceed the threshold, a healthy-but-reconnecting watcher would be falsely reaped.

--- a/test/Capacitor.Cli.Tests.Unit/WatcherHeartbeatTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatcherHeartbeatTests.cs
@@ -76,7 +76,7 @@ public class WatcherHeartbeatTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
-    // --- Connect-retry / reconnect heartbeat freshness (AI-1357 task 9, review issue 1) ---
+    // Connect-retry / reconnect heartbeat freshness ---
     // The connect-retry backoff grows to 30s, longer than the 20s staleness threshold. The wait
     // is chunked via HeartbeatSlices so the heartbeat is refreshed between slices; if any single
     // chunk could exceed the threshold, a healthy-but-reconnecting watcher would be falsely reaped.


### PR DESCRIPTION
Implements the AI-1392 spec (`docs/superpowers/specs/2026-07-17-ai1392-linear-id-comment-sweep-design.md` in kcap-server), codex spec-review clean at round 6. Unblocked now that #324/#325/#326 have all merged to main.

## What
kcap-cli's CLAUDE.md prohibits Linear issue IDs in code comments (this is a public repo). The rule wasn't enforced and drifted repo-wide (~1038 `AI-####` tokens in `src/`+`test/` comments). This PR sweeps them and adds a CI guard so it can't regrow.

## Change
- **Guard** (`scripts/check-linear-ids.sh` + `lint-linear-ids` CI job): portable POSIX ERE (no PCRE — runs on stock macOS BSD grep and GNU alike), pattern `(^|[^A-Za-z0-9_])AI-[0-9]+($|[^A-Za-z0-9_])` over `:(glob)src/**/*.cs` + `:(glob)test/**/*.cs`, exit contract **0 clean / 1 violation / 2 checker-failure** (git-grep/grep errors never silently pass). Suppression only for synthetic ID-shaped test data via `// linear-id-ok: <reason>`; a genuine Linear reference can never be suppressed.
- **Sweep** (270 files, comment-only): removed every in-scope `AI-####` comment token per the spec's rewrite rules (drop provenance tokens keeping substance; cross-references reworded to self-contained behavioral phrases; TODO/FIXME preserved).
- **Renames** (7 string-literal edits across 5 files): `AI-####`-shaped values in test fixtures / a tool-description example / a debug tag / two in-string log citations → non-Linear placeholders (arbitrary values).

## Verification
Diff is **trivia-only** (verified by a line-pairing script: every changed line is inside a comment or one of the 7 string edits — no logic changed). Guard exits 0 on the swept tree. All 7 spec acceptance cases pass (violation→1, empty-reason→1, valid suppression→0, out-of-scope→0, near-miss `OPENAI-2`→0, stub-git→2, stub-grep→2). Build 0 errors (Cli + Daemon), AOT clean, McpWorkItems 15/15 + Import 298/298 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)