### PR TITLE
[AI-1398] Capture Cursor ACP native session title (daemon)

### DIFF
--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1134,6 +1134,7 @@ public static class AcpEventKind {
     public const string AssistantThinking  = "assistant_thinking";
     public const string ToolCall           = "tool_call";
     public const string ToolResult         = "tool_result";
+    public const string SessionTitle       = "session_title";
     public const string SessionEnded       = "session_ended";
 }
 

--- a/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
@@ -45,6 +45,9 @@ internal static partial class AcpEventTranslator {
     /// <see cref="AcpSessionUpdate.ToolResultText"/> is non-null — a status-only update (non-terminal,
     /// or terminal with no extractable content) returns <see langword="null"/> rather than an empty
     /// <c>ToolResultReceived</c>.</description></item>
+    /// <item><description><see cref="AcpUpdateKind.SessionInfo"/> → <see cref="AcpEventKind.SessionTitle"/>
+    /// when the update carries a non-blank <see cref="AcpSessionUpdate.Title"/> (the agent's
+    /// auto-generated session title), else <see langword="null"/>.</description></item>
     /// <item><description><see cref="AcpUpdateKind.Plan"/>/<see cref="AcpUpdateKind.AvailableCommands"/>
     /// → always <see langword="null"/> (not transcript content; deferred to future work).</description></item>
     /// <item><description><see cref="AcpUpdateKind.Unknown"/> → <see langword="null"/>, but
@@ -100,6 +103,18 @@ internal static partial class AcpEventTranslator {
                     ToolResult: update.ToolResultText,
                     ToolIsError: update.ToolIsError,
                     TimestampIso: timestampIso);
+
+            case AcpUpdateKind.SessionInfo:
+                // session_info_update carries the agent's auto-generated session title. Emit a
+                // SessionTitle envelope only when a non-blank title is present; a title-less info
+                // update has nothing to surface, so it is dropped like the other content-free kinds.
+                return string.IsNullOrWhiteSpace(update.Title)
+                    ? null
+                    : new AcpEventEnvelope(
+                        Seq: seq,
+                        Kind: AcpEventKind.SessionTitle,
+                        Text: update.Title,
+                        TimestampIso: timestampIso);
 
             case AcpUpdateKind.Plan:
             case AcpUpdateKind.AvailableCommands:

--- a/src/Capacitor.Cli.Daemon/Acp/AcpSessionUpdate.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpSessionUpdate.cs
@@ -5,12 +5,12 @@ namespace Capacitor.Cli.Daemon.Acp;
 
 /// <summary>
 /// Discriminator for <see cref="AcpSessionUpdate.Kind"/>, mirroring the <c>sessionUpdate</c> string
-/// values documented in <c>docs/acp-probe-findings.md</c>. Only <see cref="AgentMessageChunk"/> and
-/// <see cref="AvailableCommands"/> are probe-confirmed; <see cref="AgentThoughtChunk"/>,
-/// <see cref="ToolCall"/>, <see cref="ToolCallUpdate"/>, and <see cref="Plan"/> are spec-derived but
-/// not yet observed on the wire (see the probe doc's "Recommended follow-up"). <see cref="Unknown"/>
-/// covers any future/unrecognized discriminator so the reducer never throws on an unfamiliar
-/// variant.
+/// values documented in <c>docs/acp-probe-findings.md</c>. <see cref="AgentMessageChunk"/>,
+/// <see cref="AvailableCommands"/>, and <see cref="SessionInfo"/> are probe-confirmed;
+/// <see cref="AgentThoughtChunk"/>, <see cref="ToolCall"/>, <see cref="ToolCallUpdate"/>, and
+/// <see cref="Plan"/> are spec-derived but not yet observed on the wire (see the probe doc's
+/// "Recommended follow-up"). <see cref="Unknown"/> covers any future/unrecognized discriminator so
+/// the reducer never throws on an unfamiliar variant.
 /// </summary>
 internal enum AcpUpdateKind {
     AgentMessageChunk,
@@ -19,6 +19,7 @@ internal enum AcpUpdateKind {
     ToolCallUpdate,
     Plan,
     AvailableCommands,
+    SessionInfo,
     Unknown,
 }
 
@@ -42,6 +43,7 @@ internal enum AcpUpdateKind {
 internal sealed record AcpSessionUpdate(
     AcpUpdateKind Kind,
     string?       Text           = null,
+    string?       Title          = null, // session_info_update's agent-authored session title
     string?       ToolCallId     = null,
     string?       ToolTitle      = null,
     string?       ToolKind       = null,

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -686,7 +686,11 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             : null;
 
     static string? GetStringOrNull(JsonElement element, string propertyName) =>
-        element.TryGetProperty(propertyName, out var value) ? value.GetString() : null;
+        element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null; // guard the ValueKind: GetString() THROWS on a non-string value (number/object/
+                    // array), which would let a schema-drift frame bubble an exception up and skip
+                    // the entire notification. A wrong-typed field is treated as absent instead.
 
     /// <summary>
     /// Verbatim JSON text of <paramref name="propertyName"/> when it's a JSON object (e.g. a

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -757,6 +757,18 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                     }
                     break;
 
+                case AcpUpdateKind.SessionInfo:
+                    // Session-title metadata is not transcript content: it must NOT close an open
+                    // chunk run. A session_info_update interleaved between two message/thought
+                    // chunks would otherwise flush the run mid-stream and split one contiguous
+                    // assistant message into two envelopes. Emit it standalone, leaving
+                    // _openRunKind/_openRunText untouched so the surrounding chunks still aggregate
+                    // into one run (the title is orderless metadata — its relative seq is immaterial).
+                    var titleEnvelope = AcpEventTranslator.Translate(update, seq: 0, NowIso(), logger: _logger, debugFrames: _debugFrames);
+                    if (titleEnvelope is { } t)
+                        EmitEnvelope(t);
+                    break;
+
                 default:
                     FlushOpenRunLocked(); // kind-transition — the open run (if any) ends here
                     var envelope = AcpEventTranslator.Translate(update, seq: 0, NowIso(), logger: _logger, debugFrames: _debugFrames);

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -671,6 +671,11 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
             "available_commands_update" => new AcpSessionUpdate(AcpUpdateKind.AvailableCommands, Raw: update),
 
+            "session_info_update" => new AcpSessionUpdate(
+                AcpUpdateKind.SessionInfo,
+                Title: GetStringOrNull(update, "title"),
+                Raw: update),
+
             _ => new AcpSessionUpdate(AcpUpdateKind.Unknown, Raw: update),
         };
     }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpEventEnvelopeWireCompatTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpEventEnvelopeWireCompatTests.cs
@@ -89,6 +89,7 @@ public class AcpEventEnvelopeWireCompatTests {
         await Assert.That(AcpEventKind.AssistantThinking).IsEqualTo("assistant_thinking");
         await Assert.That(AcpEventKind.ToolCall).IsEqualTo("tool_call");
         await Assert.That(AcpEventKind.ToolResult).IsEqualTo("tool_result");
+        await Assert.That(AcpEventKind.SessionTitle).IsEqualTo("session_title");
         await Assert.That(AcpEventKind.SessionEnded).IsEqualTo("session_ended");
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpEventTranslatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpEventTranslatorTests.cs
@@ -142,6 +142,29 @@ public class AcpEventTranslatorTests {
         await Assert.That(AcpEventTranslator.Translate(new AcpSessionUpdate(AcpUpdateKind.Unknown), 1, TimestampIso)).IsNull();
     }
 
+    [Test]
+    public async Task SessionInfo_with_title_translates_to_SessionTitle_envelope_carrying_the_title() {
+        var update = new AcpSessionUpdate(AcpUpdateKind.SessionInfo, Title: "Shell Reporter");
+
+        var env = AcpEventTranslator.Translate(update, seq: 3, timestampIso: TimestampIso);
+
+        await Assert.That(env).IsNotNull();
+        await Assert.That(env!.Value.Kind).IsEqualTo(AcpEventKind.SessionTitle);
+        await Assert.That(env.Value.Text).IsEqualTo("Shell Reporter");
+        await Assert.That(env.Value.Seq).IsEqualTo(3L);
+        await Assert.That(env.Value.TimestampIso).IsEqualTo(TimestampIso);
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task SessionInfo_with_blank_title_translates_to_null(string? title) {
+        var update = new AcpSessionUpdate(AcpUpdateKind.SessionInfo, Title: title);
+
+        await Assert.That(AcpEventTranslator.Translate(update, 1, TimestampIso)).IsNull();
+    }
+
     // ── KCAP_ACP_DEBUG_FRAMES gate: Unknown-kind raw-JSON dump ──────────────────────────────────
 
     static AcpSessionUpdate UnknownUpdateWithSecretMarker() {

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
@@ -199,6 +199,27 @@ public class AcpHostedAgentRuntimeTests {
         await Assert.That(received.Title).IsEqualTo("Shell Reporter");
     }
 
+    [Test]
+    public async Task SessionInfo_update_with_a_non_string_title_reduces_to_null_title_without_dropping_the_frame() {
+        await using var h = new Harness();
+
+        // A schema-drift session_info_update whose title is a NUMBER, not a string. GetStringOrNull
+        // must treat it as absent (Title=null) rather than throwing — a thrown GetString() would
+        // bubble up and make the read loop skip the whole notification frame.
+        var badTitle     = System.Text.Json.JsonDocument.Parse("""{"sessionUpdate":"session_info_update","title":123}""").RootElement.Clone();
+        var notification = FakeAcpAgent.BuildSessionUpdateNotification(FakeAcpAgent.FixedSessionId, badTitle);
+        var result       = System.Text.Json.JsonDocument.Parse("""{"stopReason":"end_turn"}""").RootElement.Clone();
+        h.Fake.EnqueuePromptScript(new[] { notification }, result);
+
+        h.StartFakeAgentLoop();
+        await h.Runtime.StartAsync("/abs/worktree", "prompt", h.Cts.Token).WaitAsync(HangGuard);
+
+        var received = await h.Runtime.Updates.ReadAsync().AsTask().WaitAsync(HangGuard);
+
+        await Assert.That(received.Kind).IsEqualTo(AcpUpdateKind.SessionInfo);
+        await Assert.That(received.Title).IsNull();
+    }
+
     // ── Option B task 1: Reduce() tool-call/tool-result field capture ──────────────
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
@@ -181,6 +181,24 @@ public class AcpHostedAgentRuntimeTests {
         await Assert.That(received.Raw!.Value.GetProperty("foo").GetString()).IsEqualTo("bar");
     }
 
+    [Test]
+    public async Task SessionInfo_update_is_reduced_to_SessionInfo_with_the_captured_title() {
+        await using var h = new Harness();
+
+        var infoUpdate   = FakeAcpAgent.BuildSessionInfoUpdate("Shell Reporter");
+        var notification = FakeAcpAgent.BuildSessionUpdateNotification(FakeAcpAgent.FixedSessionId, infoUpdate);
+        var result       = System.Text.Json.JsonDocument.Parse("""{"stopReason":"end_turn"}""").RootElement.Clone();
+        h.Fake.EnqueuePromptScript(new[] { notification }, result);
+
+        h.StartFakeAgentLoop();
+        await h.Runtime.StartAsync("/abs/worktree", "prompt", h.Cts.Token).WaitAsync(HangGuard);
+
+        var received = await h.Runtime.Updates.ReadAsync().AsTask().WaitAsync(HangGuard);
+
+        await Assert.That(received.Kind).IsEqualTo(AcpUpdateKind.SessionInfo);
+        await Assert.That(received.Title).IsEqualTo("Shell Reporter");
+    }
+
     // ── Option B task 1: Reduce() tool-call/tool-result field capture ──────────────
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpTranscriptAggregationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpTranscriptAggregationTests.cs
@@ -183,6 +183,35 @@ public class AcpTranscriptAggregationTests {
     }
 
     [Test]
+    public async Task A_session_info_update_mid_run_does_not_split_the_message_run() {
+        // A native session-title update (session_info_update) interleaved between two message
+        // chunks must NOT flush the open run: the title is orderless metadata, not transcript
+        // content. It is emitted standalone and the surrounding chunks still coalesce into ONE
+        // AssistantText envelope (regression for the aggregation-split bug).
+        await using var h = new Harness();
+
+        var chunk1    = FakeAcpAgent.BuildSessionUpdateNotification(FakeAcpAgent.FixedSessionId, FakeAcpAgent.BuildAgentMessageChunkUpdate("Hello "));
+        var infoTitle = FakeAcpAgent.BuildSessionUpdateNotification(FakeAcpAgent.FixedSessionId, FakeAcpAgent.BuildSessionInfoUpdate("Shell Reporter"));
+        var chunk2    = FakeAcpAgent.BuildSessionUpdateNotification(FakeAcpAgent.FixedSessionId, FakeAcpAgent.BuildAgentMessageChunkUpdate("world"));
+        h.Fake.EnqueuePromptScript(new[] { chunk1, infoTitle, chunk2 }, EndTurnResult);
+
+        h.StartFakeAgentLoop();
+        await h.Runtime.StartAsync("/abs/worktree", "hi", h.Cts.Token).WaitAsync(HangGuard);
+
+        await ReadEnvelopeAsync(h.Runtime); // UserMessage
+
+        // The title is emitted standalone (it did NOT flush the open run)...
+        var title = await ReadEnvelopeAsync(h.Runtime);
+        await Assert.That(title.Kind).IsEqualTo(AcpEventKind.SessionTitle);
+        await Assert.That(title.Text).IsEqualTo("Shell Reporter");
+
+        // ...and the two message chunks still coalesce into ONE AssistantText run.
+        var message = await ReadEnvelopeAsync(h.Runtime);
+        await Assert.That(message.Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(message.Text).IsEqualTo("Hello world");
+    }
+
+    [Test]
     public async Task UserMessage_envelope_is_emitted_once_per_turn_before_that_turns_assistant_envelopes() {
         await using var h = new Harness();
 

--- a/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
@@ -577,6 +577,17 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
         return JsonDocument.Parse(stream.ToArray()).RootElement.Clone();
     }
 
+    /// <summary>
+    /// Probe-confirmed <c>session_info_update</c> variant (agent session auto-titling):
+    /// <c>{"sessionUpdate":"session_info_update","title":"..."}</c> — captured verbatim in
+    /// docs/ai-688-cursor-prototype-findings.md.
+    /// </summary>
+    public static JsonElement BuildSessionInfoUpdate(string title) {
+        var escaped = JsonEncodedText.Encode(title);
+        return JsonDocument.Parse($$$"""{"sessionUpdate":"session_info_update","title":"{{{escaped}}}"}""")
+            .RootElement.Clone();
+    }
+
     // ---- spec-derived (NOT probe-confirmed) helper builders ----
     //
     // The probe account was plan-gated before any tool-call turn completed, so none of the

--- a/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
@@ -579,8 +579,8 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
 
     /// <summary>
     /// Probe-confirmed <c>session_info_update</c> variant (agent session auto-titling):
-    /// <c>{"sessionUpdate":"session_info_update","title":"..."}</c> — captured verbatim in
-    /// docs/ai-688-cursor-prototype-findings.md.
+    /// <c>{"sessionUpdate":"session_info_update","title":"..."}</c> — the shape captured verbatim
+    /// from a real <c>cursor-agent acp</c> session in the Cursor prototype findings doc.
     /// </summary>
     public static JsonElement BuildSessionInfoUpdate(string title) {
         var escaped = JsonEncodedText.Encode(title);


### PR DESCRIPTION
## Problem

When dogfooding a **hosted Cursor** agent, the session title always showed as a random 8-char hex id. `cursor-agent acp` auto-titles its session and emits a `session_info_update` sessionUpdate carrying `{title}` (e.g. `{"sessionUpdate":"session_info_update","title":"Shell Reporter"}`), but the daemon dropped it as `AcpUpdateKind.Unknown`, so the title never reached the server.

## Change (daemon half)

- `AcpHostedAgentRuntime.Reduce()` maps `session_info_update` → a new `AcpUpdateKind.SessionInfo` carrying the title on a new `AcpSessionUpdate.Title` field.
- `AcpEventTranslator.Translate()` emits a `SessionTitle` envelope (new `AcpEventKind`, string value `session_title`) when a non-blank title is present; a title-less info update is dropped.
- Adds `AcpEventKind.SessionTitle` to the daemon-local Core contract, mirrored to the server-side `Capacitor.Server.Core.Acp.AcpEventKind` (kcap-server companion PR).

## Tests

- `AcpHostedAgentRuntimeTests` — `session_info_update` reduces to `SessionInfo` with the captured title.
- `AcpEventTranslatorTests` — `SessionInfo` + title → `SessionTitle` envelope; blank/null/whitespace title → null.
- `AcpEventEnvelopeWireCompatTests` — locks the `session_title` wire value.
- `FakeAcpAgent.BuildSessionInfoUpdate` helper (probe-confirmed shape).

Full CLI unit suite green (3349/3351, 2 gated live E2E skipped).

## Companion PR

kcap-server #1123: applies the `SessionTitle` envelope to the hosted-agent UI (durable title event + live agent-card prompt sync). Safe to merge in either order — an unknown kind is ignored by whichever side is behind.
