### PR TITLE
[AI-1407] ACP unattended reviewer foundation: flow-result MCP over ACP + owned-worktree-gated auto-approve

### DIFF
--- a/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
+++ b/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
@@ -41,6 +41,13 @@ public static class KcapMcpRegistry {
     public static readonly IReadOnlySet<string> ReviewFlowAutoApprovableServers =
         new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "kcap-review", "kcap-sessions" };
 
+    /// <summary>The reserved result-submission server every review-flow reviewer is launched with,
+    /// injected by the launcher independent of the allowlist. It is intentionally NOT a registry
+    /// entry, so <see cref="TryResolveReviewFlowAllowlist"/> treats it as an already-satisfied no-op
+    /// (never a rejection, never re-emitted) — the server's dynamic-flow policy legitimately lists
+    /// it, and every reviewer runtime must agree on that.</summary>
+    public const string ReservedResultChannelId = "kcap-flow-result";
+
     /// <summary>Explicit, reviewed classification: each auto-approvable server → the exact tool
     /// names it exposes that are unattended-safe (read / result-submit). The single source of
     /// truth the contract guard test cross-checks against each server's live <c>tools/list</c>;
@@ -78,6 +85,11 @@ public static class KcapMcpRegistry {
         var seen   = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var name in names) {
+            // The reserved result channel is always injected by the launcher, so it is a no-op here
+            // (satisfied, never re-emitted, never rejected) — consistent across every reviewer runtime.
+            if (string.Equals(name?.Trim(), ReservedResultChannelId, StringComparison.OrdinalIgnoreCase))
+                continue;
+
             var d = Resolve(name);
 
             if (d is null || d.StartsFlows || !ReviewFlowAutoApprovableServers.Contains(d.Id)) {

--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -29,7 +29,8 @@ namespace Capacitor.Cli.Daemon.Acp;
 internal sealed partial class AcpInteractionBridge(
         Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> requestInteraction,
         string                                                                       agentId,
-        ILogger                                                                      logger
+        ILogger                                                                      logger,
+        bool                                                                         autoApproveUnattended = false
     ) {
     /// <summary>
     /// Handles one inbound <see cref="AcpRequest"/>. Returns <see langword="null"/> for any method
@@ -95,6 +96,29 @@ internal sealed partial class AcpInteractionBridge(
         // separate null-checks that could drift.
         var options = parsed.Options?.Where(o => o is not null).ToArray() ?? [];
 
+        // Unattended review-flow reviewer: never route a permission request to a human. This is an
+        // unconditional TRUST decision — it selects a least-privilege allow option and does NOT
+        // inspect or confine the tool or its target (there is no OS sandbox; the owned-worktree gate
+        // is a launch precondition, not a per-operation boundary — see AcpReviewFlowMcp / the factory).
+        // Fail closed (cancelled) when there is no unambiguous allow option to select.
+        if (autoApproveUnattended) {
+            var chosen = TrySelectLeastPrivilegeAllow(options);
+
+            if (chosen is not null) {
+                // Audit fields are pinned: agentId + the selected allow Kind, plus the tool title
+                // as EXPLICITLY-untrusted, agent-supplied context. No path is logged — the bridge
+                // has no trustworthy path field (ToolCall is opaque), so a path would be a
+                // fabricated assurance of what the operation touched.
+                LogUnattendedAutoApproved(agentId, chosen.Kind ?? "", TryGetToolTitle(parsed.ToolCall) ?? "(untitled)");
+
+                return SelectedResult(chosen);
+            }
+
+            LogUnattendedAutoApproveDeclined(agentId, "no unambiguous allow option offered");
+
+            return CancelledResult();
+        }
+
         var interactionRequest = new AcpInteractionRequest(
             AgentId: agentId,
             AcpSessionId: parsed.SessionId,
@@ -154,6 +178,15 @@ internal sealed partial class AcpInteractionBridge(
     }
 
     async Task<JsonElement?> HandleElicitationAsync(AcpRequest request, CancellationToken ct) {
+        // Unattended review-flow reviewer: there is no human to answer an elicitation, and a reviewer
+        // should proceed on its own assumptions (and state them in its findings) rather than block.
+        // Decline deterministically without routing anywhere.
+        if (autoApproveUnattended) {
+            LogUnattendedElicitationDeclined(agentId);
+
+            return CancelledResult();
+        }
+
         // Never advertised in `initialize` (see AcpHostedAgentRuntime.StartAsync's minimal
         // ClientCapabilities, unchanged by this plan) — handled defensively in case a real agent
         // sends it unprompted, per R3's open question on whether Cursor uses a vendor-specific
@@ -309,6 +342,34 @@ internal sealed partial class AcpInteractionBridge(
         return matched is not null ? SelectedResult(matched) : CancelledResult()!.Value;
     }
 
+    /// <summary>
+    /// Auto-selects the least-privilege ALLOW option among the request's OFFERED options, by exact
+    /// <see cref="PermissionOptionDto.Kind"/> — never by <see cref="PermissionOptionDto.Name"/>/label,
+    /// which a hostile agent controls. Least-privilege = prefer a single <c>allow_once</c> over
+    /// <c>allow_always</c>; exactly one <c>allow_once</c> wins even when <c>allow_always</c> options
+    /// are also offered. Returns <see langword="null"/> (→ caller returns <c>cancelled</c>) when there
+    /// is no allow option, the allow set is ambiguous (≥2 <c>allow_once</c>, or 0 <c>allow_once</c>
+    /// with ≥2 <c>allow_always</c>), or the chosen option's <see cref="PermissionOptionDto.OptionId"/>
+    /// is blank or not unique across the offered options. <c>OptionId</c> is non-nullable in C# but
+    /// the wire deserializer enforces neither non-null nor uniqueness, so both are validated here — a
+    /// blank or colliding id can't address an unambiguous option and echoing it risks selecting the
+    /// wrong one server-side.
+    /// </summary>
+    static PermissionOptionDto? TrySelectLeastPrivilegeAllow(IReadOnlyList<PermissionOptionDto> options) {
+        var once   = options.Where(o => o.Kind == "allow_once").ToArray();
+        var always = options.Where(o => o.Kind == "allow_always").ToArray();
+
+        var chosen =
+            once.Length   == 1                          ? once[0]   :
+            once.Length   == 0 && always.Length == 1    ? always[0] :
+            null;
+
+        if (chosen is null || string.IsNullOrWhiteSpace(chosen.OptionId)) return null;
+        if (options.Count(o => o.OptionId == chosen.OptionId) != 1)       return null;
+
+        return chosen;
+    }
+
     static JsonElement SelectedResult(PermissionOptionDto chosen) =>
         JsonSerializer.SerializeToElement(
             new PermissionOutcomeResult(new PermissionOutcomeDto("selected", chosen.OptionId)),
@@ -346,4 +407,18 @@ internal sealed partial class AcpInteractionBridge(
 
     [LoggerMessage(Level = LogLevel.Information, Message = "ACP blocking request resolved: agentId={AgentId} kind={Kind} decision={Decision}")]
     partial void LogInteractionResolved(string agentId, string kind, string decision);
+
+    // ── Unattended review-flow auto-approve audit ───────────────────────────────────────────────
+    // Pinned fields only: agentId + the selected allow Kind, plus the tool title as EXPLICITLY
+    // untrusted, agent-supplied context. Deliberately NO path field — the bridge has no trustworthy
+    // path (ToolCall is opaque), so a path would be a fabricated assurance of what was touched.
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ACP unattended review-flow: auto-approved '{Kind}' permission for agent {AgentId} (tool title, untrusted: {ToolTitle})")]
+    partial void LogUnattendedAutoApproved(string agentId, string kind, string toolTitle);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ACP unattended review-flow: declined permission for agent {AgentId} ({Reason}); returning cancelled")]
+    partial void LogUnattendedAutoApproveDeclined(string agentId, string reason);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ACP unattended review-flow: declined elicitation for agent {AgentId} (reviewers state assumptions in findings); returning cancelled")]
+    partial void LogUnattendedElicitationDeclined(string agentId);
 }

--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -96,19 +96,13 @@ internal sealed partial class AcpInteractionBridge(
         // separate null-checks that could drift.
         var options = parsed.Options?.Where(o => o is not null).ToArray() ?? [];
 
-        // Unattended review-flow reviewer: never route a permission request to a human. This is an
-        // unconditional TRUST decision — it selects a least-privilege allow option and does NOT
-        // inspect or confine the tool or its target (there is no OS sandbox; the owned-worktree gate
-        // is a launch precondition, not a per-operation boundary — see AcpReviewFlowMcp / the factory).
-        // Fail closed (cancelled) when there is no unambiguous allow option to select.
+        // Unattended reviewer: auto-approve a least-privilege allow option without a human, fail
+        // closed when there's no unambiguous one. A trust decision — it does not inspect the tool.
         if (autoApproveUnattended) {
             var chosen = TrySelectLeastPrivilegeAllow(options);
 
             if (chosen is not null) {
-                // Audit fields are pinned: agentId + the selected allow Kind, plus the tool title
-                // as EXPLICITLY-untrusted, agent-supplied context. No path is logged — the bridge
-                // has no trustworthy path field (ToolCall is opaque), so a path would be a
-                // fabricated assurance of what the operation touched.
+                // Pinned audit fields; tool title is untrusted (ToolCall is opaque). No path logged.
                 LogUnattendedAutoApproved(agentId, chosen.Kind ?? "", TryGetToolTitle(parsed.ToolCall) ?? "(untitled)");
 
                 return SelectedResult(chosen);

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -199,7 +199,8 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             int?                                                                           pendingTurnsCapacity = null,
             bool                                                                           debugFrames = false,
             string                                                                         vendor = "cursor",
-            IAcpModelSelector?                                                             modelSelector = null
+            IAcpModelSelector?                                                             modelSelector = null,
+            bool                                                                           autoApproveUnattended = false
         ) {
         _connection    = connection;
         _process       = process;
@@ -231,7 +232,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         _connection.OnNotification += HandleNotification;
 
         if (requestInteraction is not null) {
-            _interactionBridge = new AcpInteractionBridge(requestInteraction, agentId, logger);
+            _interactionBridge = new AcpInteractionBridge(requestInteraction, agentId, logger, autoApproveUnattended);
             _connection.OnServerRequest = (request, ct) => _interactionBridge.HandleAsync(request, ct);
         }
     }

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon.Acp;
@@ -50,18 +51,10 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         LogLaunching(ctx.AgentId, Vendor, ctx.Worktree.Path);
         AcpMetrics.Launches.Add(1);
 
-        // Validate + build the review-flow result channel BEFORE anything spawns. _connectionSource
-        // spawns the child process for the default (real) source, so validation placed near
-        // runtime.StartAsync below would throw AFTER spawn and leak a child; a non-default
-        // connectionSource never reaches BuildProcessStartInfo at all. This is the primary gate:
-        // it fails closed (throws) for an IsReviewFlow launch that isn't unattended-capable, isn't
-        // an owned worktree, has no ACP mcpServers support, or can't build a deliverable result
-        // channel. Returns null for a non-review launch (mcpServers stay exactly as before).
+        // Fail closed BEFORE _connectionSource spawns a child (a later gate would leak one). Null for
+        // a non-review launch; the built MCP list for a valid review flow.
         var reviewMcp = ValidateAndBuildReviewFlowMcp(ctx, descriptor);
 
-        // Auto-approve is enabled only for an owned-worktree, unattended-capable review flow. The
-        // pre-spawn validation above already refuses the other IsReviewFlow rows, so this predicate
-        // is a belt-and-suspenders recomputation of the same conditions.
         var autoApproveUnattended =
             ctx.IsReviewFlow && ctx.Work == WorkLocation.OwnedWorktree && descriptor.SupportsUnattended;
 
@@ -85,9 +78,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             autoApproveUnattended: autoApproveUnattended
         );
 
-        // A review flow sends the injected result channel + resolved allowlist; every other launch
-        // keeps the prior behavior (ctx.McpServers when the descriptor supports it, else null —
-        // null for every launch today, since no non-review caller populates ctx.McpServers).
+        // Review flow: the injected result channel + allowlist. Otherwise unchanged (null today).
         var mcpServers = ctx.IsReviewFlow
             ? reviewMcp
             : descriptor.SupportsMcpServers ? ctx.McpServers : null;
@@ -115,17 +106,13 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     }
 
     /// <summary>
-    /// Fail-closed validation + build of the review-flow result channel, run as the FIRST thing in
-    /// <see cref="StartAsync"/> (before any spawn). Returns <see langword="null"/> for a non-review
-    /// launch (leaving mcpServers untouched); for an <see cref="RuntimeStartContext.IsReviewFlow"/>
-    /// launch it throws unless the launch is safe to run unattended AND has a deliverable result
-    /// channel, then returns the built MCP list.
-    ///
-    /// The owned-worktree requirement is a launch precondition, NOT a filesystem sandbox: an ACP
-    /// reviewer performs its own file/shell operations with no OS containment, so confining what an
-    /// auto-approved tool can touch is a per-vendor property each reviewer child must verify live.
-    /// This gate only guarantees the reviewer's cwd is a daemon-owned throwaway, and that the
-    /// trust-at-spawn argv (appended for IsReviewFlow) is never handed to a borrowed-cwd launch.
+    /// Fail-closed validation + build of the review-flow MCP list, run as the FIRST thing in
+    /// <see cref="StartAsync"/> — before <c>_connectionSource</c> can spawn a child. Returns
+    /// <see langword="null"/> for a non-review launch; for a review flow it throws unless the launch
+    /// is safe to run unattended AND has a deliverable result channel AND every allowlist entry is an
+    /// auto-approvable read-only server, then returns the built list. Owned-worktree is a launch
+    /// precondition (a daemon-owned throwaway cwd + no trust-at-spawn on a borrowed cwd), NOT a
+    /// filesystem sandbox — containment is a per-vendor concern (see the design spec).
     /// </summary>
     static IReadOnlyList<AcpMcpServerSpec>? ValidateAndBuildReviewFlowMcp(
             RuntimeStartContext ctx, AcpVendorDescriptor descriptor) {
@@ -143,14 +130,22 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             throw new InvalidOperationException(
                 $"Vendor '{descriptor.Vendor}' cannot host a review-flow reviewer: no ACP mcpServers support (needed for the kcap-flow-result channel).");
 
-        // All three inputs the result channel needs must be present and non-blank, or the reviewer
-        // would start with a dead channel and wedge the round. A blank agent id in particular would
-        // still yield a non-empty server list and slip past a count-only guard, so it is checked here.
+        // A blank agent id would still yield a non-empty server list and slip past a count-only guard,
+        // so all three result-channel inputs are checked (a dead channel wedges the round).
         if (string.IsNullOrWhiteSpace(ctx.ServerUrl) || string.IsNullOrWhiteSpace(ctx.CapacitorPath) || string.IsNullOrWhiteSpace(ctx.AgentId))
             throw new InvalidOperationException(
                 "Review-flow launch cannot inject the kcap-flow-result channel (missing server url / kcap path / agent id).");
 
-        return AcpReviewFlowMcp.Build(ctx);
+        // The reviewer runs under the auto-approve bridge, so the injected MCP set IS its capability
+        // boundary: resolve the allowlist through the SAME authoritative read-only reviewer policy the
+        // orchestrator applies to Codex — an unknown, flow-starting, or non-auto-approvable entry
+        // (e.g. a write server) fails the launch fast rather than being handed to an auto-approving
+        // reviewer or silently dropped.
+        if (!KcapMcpRegistry.TryResolveReviewFlowAllowlist(ctx.McpAllowlist, out var allowlistServerIds, out var rejected))
+            throw new InvalidOperationException(
+                $"Review-flow reviewer MCP allowlist contains a server that is not auto-approvable: '{rejected}'.");
+
+        return AcpReviewFlowMcp.Build(ctx, allowlistServerIds);
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon.Acp;
 using Microsoft.Extensions.Logging;
 
@@ -48,6 +50,21 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         LogLaunching(ctx.AgentId, Vendor, ctx.Worktree.Path);
         AcpMetrics.Launches.Add(1);
 
+        // Validate + build the review-flow result channel BEFORE anything spawns. _connectionSource
+        // spawns the child process for the default (real) source, so validation placed near
+        // runtime.StartAsync below would throw AFTER spawn and leak a child; a non-default
+        // connectionSource never reaches BuildProcessStartInfo at all. This is the primary gate:
+        // it fails closed (throws) for an IsReviewFlow launch that isn't unattended-capable, isn't
+        // an owned worktree, has no ACP mcpServers support, or can't build a deliverable result
+        // channel. Returns null for a non-review launch (mcpServers stay exactly as before).
+        var reviewMcp = ValidateAndBuildReviewFlowMcp(ctx, descriptor);
+
+        // Auto-approve is enabled only for an owned-worktree, unattended-capable review flow. The
+        // pre-spawn validation above already refuses the other IsReviewFlow rows, so this predicate
+        // is a belt-and-suspenders recomputation of the same conditions.
+        var autoApproveUnattended =
+            ctx.IsReviewFlow && ctx.Work == WorkLocation.OwnedWorktree && descriptor.SupportsUnattended;
+
         var runtimeLogger = loggerFactory.CreateLogger<AcpHostedAgentRuntime>();
         var connLogger    = loggerFactory.CreateLogger<AcpConnection>();
 
@@ -64,8 +81,16 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             requestInteraction: connection.RequestAcpInteractionAsync,
             debugFrames: config.DebugFrames,
             vendor: descriptor.Vendor,
-            modelSelector: descriptor.ModelSelector
+            modelSelector: descriptor.ModelSelector,
+            autoApproveUnattended: autoApproveUnattended
         );
+
+        // A review flow sends the injected result channel + resolved allowlist; every other launch
+        // keeps the prior behavior (ctx.McpServers when the descriptor supports it, else null —
+        // null for every launch today, since no non-review caller populates ctx.McpServers).
+        var mcpServers = ctx.IsReviewFlow
+            ? reviewMcp
+            : descriptor.SupportsMcpServers ? ctx.McpServers : null;
 
         try {
             await runtime.StartAsync(
@@ -73,7 +98,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
                 ctx.Prompt,
                 ct,
                 ResolveRequestedModel(descriptor, config, ctx),
-                descriptor.SupportsMcpServers ? ctx.McpServers : null
+                mcpServers
             ).ConfigureAwait(false);
         } catch {
             // The runtime owns both the connection and the process; dispose on a failed handshake
@@ -87,6 +112,45 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         // IAcpTranscriptSource directly) — hand it back on HostedRuntimeStart so the orchestrator can
         // bind + forward without downcasting Runtime.
         return new HostedRuntimeStart(runtime, McpConfigPath: null, Transcript: runtime);
+    }
+
+    /// <summary>
+    /// Fail-closed validation + build of the review-flow result channel, run as the FIRST thing in
+    /// <see cref="StartAsync"/> (before any spawn). Returns <see langword="null"/> for a non-review
+    /// launch (leaving mcpServers untouched); for an <see cref="RuntimeStartContext.IsReviewFlow"/>
+    /// launch it throws unless the launch is safe to run unattended AND has a deliverable result
+    /// channel, then returns the built MCP list.
+    ///
+    /// The owned-worktree requirement is a launch precondition, NOT a filesystem sandbox: an ACP
+    /// reviewer performs its own file/shell operations with no OS containment, so confining what an
+    /// auto-approved tool can touch is a per-vendor property each reviewer child must verify live.
+    /// This gate only guarantees the reviewer's cwd is a daemon-owned throwaway, and that the
+    /// trust-at-spawn argv (appended for IsReviewFlow) is never handed to a borrowed-cwd launch.
+    /// </summary>
+    static IReadOnlyList<AcpMcpServerSpec>? ValidateAndBuildReviewFlowMcp(
+            RuntimeStartContext ctx, AcpVendorDescriptor descriptor) {
+        if (!ctx.IsReviewFlow) return null;
+
+        if (!descriptor.SupportsUnattended)
+            throw new InvalidOperationException(
+                $"Vendor '{descriptor.Vendor}' cannot host an unattended (review-flow) agent.");
+
+        if (ctx.Work != WorkLocation.OwnedWorktree)
+            throw new InvalidOperationException(
+                $"Unattended review-flow launch for '{descriptor.Vendor}' requires an owned worktree, not a borrowed cwd.");
+
+        if (!descriptor.SupportsMcpServers)
+            throw new InvalidOperationException(
+                $"Vendor '{descriptor.Vendor}' cannot host a review-flow reviewer: no ACP mcpServers support (needed for the kcap-flow-result channel).");
+
+        // All three inputs the result channel needs must be present and non-blank, or the reviewer
+        // would start with a dead channel and wedge the round. A blank agent id in particular would
+        // still yield a non-empty server list and slip past a count-only guard, so it is checked here.
+        if (string.IsNullOrWhiteSpace(ctx.ServerUrl) || string.IsNullOrWhiteSpace(ctx.CapacitorPath) || string.IsNullOrWhiteSpace(ctx.AgentId))
+            throw new InvalidOperationException(
+                "Review-flow launch cannot inject the kcap-flow-result channel (missing server url / kcap path / agent id).");
+
+        return AcpReviewFlowMcp.Build(ctx);
     }
 
     /// <summary>
@@ -121,6 +185,14 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         if (ctx.IsReviewFlow && !descriptor.SupportsUnattended)
             throw new InvalidOperationException(
                 $"Vendor '{descriptor.Vendor}' does not support unattended (review-flow) launches.");
+
+        // Defense-in-depth for the trust-at-spawn argv appended just below: a borrowed-cwd reviewer
+        // would run in the requester's live checkout, so this refuses it here too. StartAsync's
+        // pre-spawn validation is the primary gate; this backstops the default spawn path (a
+        // non-default connectionSource never reaches this builder).
+        if (ctx.IsReviewFlow && ctx.Work != WorkLocation.OwnedWorktree)
+            throw new InvalidOperationException(
+                $"Unattended review-flow launch for '{descriptor.Vendor}' requires an owned worktree, not a borrowed cwd.");
 
         var argv = ctx.IsReviewFlow
             ? [.. descriptor.Argv, .. descriptor.UnattendedTrustArgv]

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -138,15 +138,9 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
 
         // The reviewer runs under the auto-approve bridge, so the injected MCP set IS its capability
         // boundary: resolve the allowlist through the SAME authoritative read-only reviewer policy the
-        // orchestrator applies to Codex — an unknown, flow-starting, or non-auto-approvable entry
-        // (e.g. a write server) fails the launch fast rather than being handed to an auto-approving
-        // reviewer or silently dropped. The reserved kcap-flow-result id (always injected by Build,
-        // and legitimately listed by the server's dynamic-flow policy) is a no-op, not a rejection.
-        var reviewerAllowlist = ctx.McpAllowlist?
-            .Where(n => !string.Equals(n?.Trim(), AcpReviewFlowMcp.ResultChannelId, StringComparison.OrdinalIgnoreCase))
-            .ToArray();
-
-        if (!KcapMcpRegistry.TryResolveReviewFlowAllowlist(reviewerAllowlist, out var allowlistServerIds, out var rejected))
+        // orchestrator applies to Codex (TryResolveReviewFlowAllowlist — reserved result channel is a
+        // no-op, unknown/flow-starting/non-auto-approvable write servers fail the launch fast).
+        if (!KcapMcpRegistry.TryResolveReviewFlowAllowlist(ctx.McpAllowlist, out var allowlistServerIds, out var rejected))
             throw new InvalidOperationException(
                 $"Review-flow reviewer MCP allowlist contains a server that is not auto-approvable: '{rejected}'.");
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -140,8 +140,13 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         // boundary: resolve the allowlist through the SAME authoritative read-only reviewer policy the
         // orchestrator applies to Codex — an unknown, flow-starting, or non-auto-approvable entry
         // (e.g. a write server) fails the launch fast rather than being handed to an auto-approving
-        // reviewer or silently dropped.
-        if (!KcapMcpRegistry.TryResolveReviewFlowAllowlist(ctx.McpAllowlist, out var allowlistServerIds, out var rejected))
+        // reviewer or silently dropped. The reserved kcap-flow-result id (always injected by Build,
+        // and legitimately listed by the server's dynamic-flow policy) is a no-op, not a rejection.
+        var reviewerAllowlist = ctx.McpAllowlist?
+            .Where(n => !string.Equals(n?.Trim(), AcpReviewFlowMcp.ResultChannelId, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (!KcapMcpRegistry.TryResolveReviewFlowAllowlist(reviewerAllowlist, out var allowlistServerIds, out var rejected))
             throw new InvalidOperationException(
                 $"Review-flow reviewer MCP allowlist contains a server that is not auto-approvable: '{rejected}'.");
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
@@ -14,11 +14,16 @@ namespace Capacitor.Cli.Daemon.Services;
 /// <c>ctx</c> fields (validated non-blank) rather than <c>DaemonConfig</c>, matching the factory.
 /// </summary>
 internal static class AcpReviewFlowMcp {
+    /// <summary>The reserved result-channel server id. Always injected here, so it is NOT a
+    /// <see cref="KcapMcpRegistry"/> entry — callers drop it from the reviewer allowlist as a no-op
+    /// before validating the rest (the server's dynamic-flow policy may list it explicitly).</summary>
+    internal const string ResultChannelId = "kcap-flow-result";
+
     internal static IReadOnlyList<AcpMcpServerSpec> Build(RuntimeStartContext ctx, IReadOnlyList<string> allowlistServerIds) {
         // The result channel: both env vars are mandatory (the flow-result MCP server exits when
         // KCAP_FLOW_AGENT_ID is absent). KCAP_FLOW_AGENT_ID is exclusive to it.
         var servers = new List<AcpMcpServerSpec> {
-            new("kcap-flow-result", ctx.CapacitorPath, ["mcp", "flow-result"],
+            new(ResultChannelId, ctx.CapacitorPath, ["mcp", "flow-result"],
                 [new("KCAP_URL", ctx.ServerUrl!), new("KCAP_FLOW_AGENT_ID", ctx.AgentId)])
         };
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
@@ -4,49 +4,28 @@ using Capacitor.Cli.Core.Acp;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// Builds the <see cref="AcpMcpServerSpec"/> list a review-flow reviewer's <c>session/new</c> must
-/// carry — the ACP-layer analogue of <see cref="ClaudeLauncher"/>'s PTY <c>BuildReviewFlowMcpConfig</c>,
-/// reproducing it exactly: the <c>kcap-flow-result</c> submission channel (the ONLY way a reviewer
-/// returns its verdict) plus the flow definition's MCP allowlist resolved against the kcap-owned
-/// <see cref="KcapMcpRegistry"/> (never ambient user config), with flow-starting servers stripped
-/// (the recursion guard).
+/// Builds the review-flow reviewer's <c>session/new</c> <see cref="AcpMcpServerSpec"/> list — the
+/// ACP analogue of <see cref="ClaudeLauncher"/>'s PTY <c>BuildReviewFlowMcpConfig</c>: the
+/// <c>kcap-flow-result</c> submit channel plus the reviewer allowlist.
 ///
-/// Called ONLY after <see cref="AcpHostedAgentRuntimeFactory"/>'s pre-spawn validation has confirmed
-/// <see cref="RuntimeStartContext.ServerUrl"/>, <see cref="RuntimeStartContext.CapacitorPath"/>, and
-/// <see cref="RuntimeStartContext.AgentId"/> are all non-blank, so this builder never emits a server
-/// with a blank command or a dead result channel.
-///
-/// Reads the launch's own <c>ctx</c> fields (not <c>DaemonConfig</c>) so there is a single source of
-/// truth with the rest of the ACP factory, which already stamps <c>KCAP_URL</c> from
-/// <see cref="RuntimeStartContext.ServerUrl"/>.
+/// Caller (<see cref="AcpHostedAgentRuntimeFactory"/>) supplies <paramref name="allowlistServerIds"/>
+/// already resolved and validated via <see cref="KcapMcpRegistry.TryResolveReviewFlowAllowlist"/>,
+/// so every id here is a canonical, auto-approvable read-only server. Reads the launch's own
+/// <c>ctx</c> fields (validated non-blank) rather than <c>DaemonConfig</c>, matching the factory.
 /// </summary>
 internal static class AcpReviewFlowMcp {
-    internal static IReadOnlyList<AcpMcpServerSpec> Build(RuntimeStartContext ctx) {
+    internal static IReadOnlyList<AcpMcpServerSpec> Build(RuntimeStartContext ctx, IReadOnlyList<string> allowlistServerIds) {
+        // The result channel: both env vars are mandatory (the flow-result MCP server exits when
+        // KCAP_FLOW_AGENT_ID is absent). KCAP_FLOW_AGENT_ID is exclusive to it.
         var servers = new List<AcpMcpServerSpec> {
-            // The result channel. Both env vars are mandatory — the flow-result MCP server
-            // Environment.Exit(2)s when KCAP_FLOW_AGENT_ID is absent.
             new("kcap-flow-result", ctx.CapacitorPath, ["mcp", "flow-result"],
                 [new("KCAP_URL", ctx.ServerUrl!), new("KCAP_FLOW_AGENT_ID", ctx.AgentId)])
         };
 
-        // Dedup by canonical id (case-insensitive): ClaudeLauncher writes into a JsonObject keyed
-        // by descriptor.Id, so ["kcap-sessions","KCAP-SESSIONS"] collapses to one server there. A
-        // list-append helper must match, or duplicate AcpMcpServerSpec.Name entries would make the
-        // session/new payload's behavior undefined (a vendor may reject it or pick arbitrarily).
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var name in ctx.McpAllowlist ?? []) {
-            var descriptor = KcapMcpRegistry.Resolve(name);
-
-            // Skip unknown (unresolvable) names and flow-starting servers (recursion guard — a
-            // reviewer can never be handed kcap-flows, incl. case-variants the registry canonicalizes).
-            if (descriptor is null || descriptor.StartsFlows) continue;
-            if (!seen.Add(descriptor.Id)) continue;
-
-            // Allowlist servers get KCAP_URL only — never KCAP_FLOW_AGENT_ID, which is exclusive to
-            // the result channel.
-            servers.Add(new(descriptor.Id, ctx.CapacitorPath, descriptor.Args,
-                [new("KCAP_URL", ctx.ServerUrl!)]));
+        foreach (var id in allowlistServerIds) {
+            // id is a validated canonical id, so Resolve is non-null. Allowlist servers get KCAP_URL only.
+            var descriptor = KcapMcpRegistry.Resolve(id)!;
+            servers.Add(new(descriptor.Id, ctx.CapacitorPath, descriptor.Args, [new("KCAP_URL", ctx.ServerUrl!)]));
         }
 
         return servers;

--- a/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
@@ -1,0 +1,54 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Acp;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Builds the <see cref="AcpMcpServerSpec"/> list a review-flow reviewer's <c>session/new</c> must
+/// carry — the ACP-layer analogue of <see cref="ClaudeLauncher"/>'s PTY <c>BuildReviewFlowMcpConfig</c>,
+/// reproducing it exactly: the <c>kcap-flow-result</c> submission channel (the ONLY way a reviewer
+/// returns its verdict) plus the flow definition's MCP allowlist resolved against the kcap-owned
+/// <see cref="KcapMcpRegistry"/> (never ambient user config), with flow-starting servers stripped
+/// (the recursion guard).
+///
+/// Called ONLY after <see cref="AcpHostedAgentRuntimeFactory"/>'s pre-spawn validation has confirmed
+/// <see cref="RuntimeStartContext.ServerUrl"/>, <see cref="RuntimeStartContext.CapacitorPath"/>, and
+/// <see cref="RuntimeStartContext.AgentId"/> are all non-blank, so this builder never emits a server
+/// with a blank command or a dead result channel.
+///
+/// Reads the launch's own <c>ctx</c> fields (not <c>DaemonConfig</c>) so there is a single source of
+/// truth with the rest of the ACP factory, which already stamps <c>KCAP_URL</c> from
+/// <see cref="RuntimeStartContext.ServerUrl"/>.
+/// </summary>
+internal static class AcpReviewFlowMcp {
+    internal static IReadOnlyList<AcpMcpServerSpec> Build(RuntimeStartContext ctx) {
+        var servers = new List<AcpMcpServerSpec> {
+            // The result channel. Both env vars are mandatory — the flow-result MCP server
+            // Environment.Exit(2)s when KCAP_FLOW_AGENT_ID is absent.
+            new("kcap-flow-result", ctx.CapacitorPath, ["mcp", "flow-result"],
+                [new("KCAP_URL", ctx.ServerUrl!), new("KCAP_FLOW_AGENT_ID", ctx.AgentId)])
+        };
+
+        // Dedup by canonical id (case-insensitive): ClaudeLauncher writes into a JsonObject keyed
+        // by descriptor.Id, so ["kcap-sessions","KCAP-SESSIONS"] collapses to one server there. A
+        // list-append helper must match, or duplicate AcpMcpServerSpec.Name entries would make the
+        // session/new payload's behavior undefined (a vendor may reject it or pick arbitrarily).
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var name in ctx.McpAllowlist ?? []) {
+            var descriptor = KcapMcpRegistry.Resolve(name);
+
+            // Skip unknown (unresolvable) names and flow-starting servers (recursion guard — a
+            // reviewer can never be handed kcap-flows, incl. case-variants the registry canonicalizes).
+            if (descriptor is null || descriptor.StartsFlows) continue;
+            if (!seen.Add(descriptor.Id)) continue;
+
+            // Allowlist servers get KCAP_URL only — never KCAP_FLOW_AGENT_ID, which is exclusive to
+            // the result channel.
+            servers.Add(new(descriptor.Id, ctx.CapacitorPath, descriptor.Args,
+                [new("KCAP_URL", ctx.ServerUrl!)]));
+        }
+
+        return servers;
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
@@ -14,16 +14,11 @@ namespace Capacitor.Cli.Daemon.Services;
 /// <c>ctx</c> fields (validated non-blank) rather than <c>DaemonConfig</c>, matching the factory.
 /// </summary>
 internal static class AcpReviewFlowMcp {
-    /// <summary>The reserved result-channel server id. Always injected here, so it is NOT a
-    /// <see cref="KcapMcpRegistry"/> entry — callers drop it from the reviewer allowlist as a no-op
-    /// before validating the rest (the server's dynamic-flow policy may list it explicitly).</summary>
-    internal const string ResultChannelId = "kcap-flow-result";
-
     internal static IReadOnlyList<AcpMcpServerSpec> Build(RuntimeStartContext ctx, IReadOnlyList<string> allowlistServerIds) {
         // The result channel: both env vars are mandatory (the flow-result MCP server exits when
         // KCAP_FLOW_AGENT_ID is absent). KCAP_FLOW_AGENT_ID is exclusive to it.
         var servers = new List<AcpMcpServerSpec> {
-            new(ResultChannelId, ctx.CapacitorPath, ["mcp", "flow-result"],
+            new(KcapMcpRegistry.ReservedResultChannelId, ctx.CapacitorPath, ["mcp", "flow-result"],
                 [new("KCAP_URL", ctx.ServerUrl!), new("KCAP_FLOW_AGENT_ID", ctx.AgentId)])
         };
 

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
@@ -619,4 +619,156 @@ public class AcpInteractionBridgeTests {
         await Assert.That(infoEntries).Contains(e => e.Message.Contains("resolved") && e.Message.Contains("elicitation") && e.Message.Contains("selected"));
         await Assert.That(infoEntries).DoesNotContain(e => e.Message.Contains("Proceed?")); // never the prompt text
     }
+
+    // ── Unattended review-flow auto-approve (AcpInteractionBridge autoApproveUnattended) ─────────
+    //
+    // A bridge built with autoApproveUnattended:true selects the least-privilege ALLOW option by
+    // exact Kind WITHOUT ever routing to a human, and fails closed (cancelled) when there is no
+    // unambiguous allow option. Every case below uses a delegate that INCREMENTS a counter (never
+    // throws — the bridge would swallow a throw and return cancelled, masking the assertion) so each
+    // test can prove requestInteraction was invoked exactly zero times.
+
+    static JsonElement PermissionParamsWithOptions(string optionsJson) {
+        var json = $$"""{"sessionId":"{{AcpSessionId}}","toolCall":{"toolCallId":"call-1","title":"Run ls"},"options":{{optionsJson}}}""";
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    static (AcpInteractionBridge Bridge, Func<int> Calls) AutoApproveBridge(ILogger? logger = null) {
+        var calls = 0;
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => { Interlocked.Increment(ref calls); return Task.FromResult(new AcpInteractionDecision("cancel", null, null, null, null, null)); },
+            agentId: AgentId,
+            logger: logger ?? NullLogger.Instance,
+            autoApproveUnattended: true);
+
+        return (bridge, () => Volatile.Read(ref calls));
+    }
+
+    static async Task<(string Outcome, string? OptionId)> RunAutoApprovePermissionAsync(string optionsJson) {
+        var (bridge, calls) = AutoApproveBridge();
+        var request = new AcpRequest(1, "session/request_permission", PermissionParamsWithOptions(optionsJson));
+        var result  = await bridge.HandleAsync(request, CancellationToken.None);
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(calls()).IsEqualTo(0); // never routed to a human
+        return (outcome.GetProperty("outcome").GetString()!, outcome.TryGetProperty("optionId", out var id) ? id.GetString() : null);
+    }
+
+    [Test]
+    public async Task AutoApprove_PrefersAllowOnce_OverAllowAlways() {
+        var (outcome, optionId) = await RunAutoApprovePermissionAsync(
+            """[{"optionId":"r","name":"Reject","kind":"reject_once"},{"optionId":"ao","name":"Allow once","kind":"allow_once"},{"optionId":"aa","name":"Allow always","kind":"allow_always"}]""");
+
+        await Assert.That(outcome).IsEqualTo("selected");
+        await Assert.That(optionId).IsEqualTo("ao");
+    }
+
+    [Test]
+    public async Task AutoApprove_OneAllowOnce_WithMultipleAllowAlways_SelectsTheOnce() {
+        var (outcome, optionId) = await RunAutoApprovePermissionAsync(
+            """[{"optionId":"r","name":"Reject","kind":"reject_once"},{"optionId":"ao","name":"Allow once","kind":"allow_once"},{"optionId":"aa1","name":"Allow always","kind":"allow_always"},{"optionId":"aa2","name":"Allow always project","kind":"allow_always"}]""");
+
+        await Assert.That(outcome).IsEqualTo("selected");
+        await Assert.That(optionId).IsEqualTo("ao");
+    }
+
+    [Test]
+    public async Task AutoApprove_OnlyAllowAlways_SelectsIt() {
+        var (outcome, optionId) = await RunAutoApprovePermissionAsync(
+            """[{"optionId":"aa","name":"Allow always","kind":"allow_always"}]""");
+
+        await Assert.That(outcome).IsEqualTo("selected");
+        await Assert.That(optionId).IsEqualTo("aa");
+    }
+
+    [Test]
+    public async Task AutoApprove_NoAllowOption_MapsToCancelled() {
+        var (outcome, _) = await RunAutoApprovePermissionAsync(
+            """[{"optionId":"r","name":"Reject","kind":"reject_once"},{"optionId":"ra","name":"Reject always","kind":"reject_always"}]""");
+
+        await Assert.That(outcome).IsEqualTo("cancelled");
+    }
+
+    [Test]
+    public async Task AutoApprove_EmptyOptions_MapsToCancelled() {
+        var (outcome, _) = await RunAutoApprovePermissionAsync("[]");
+
+        await Assert.That(outcome).IsEqualTo("cancelled");
+    }
+
+    [Test]
+    public async Task AutoApprove_AmbiguousTwoAllowOnce_MapsToCancelled() {
+        var (outcome, _) = await RunAutoApprovePermissionAsync(
+            """[{"optionId":"ao1","name":"Allow once","kind":"allow_once"},{"optionId":"ao2","name":"Allow once too","kind":"allow_once"}]""");
+
+        await Assert.That(outcome).IsEqualTo("cancelled");
+    }
+
+    [Test]
+    public async Task AutoApprove_AmbiguousTwoAllowAlways_NoOnce_MapsToCancelled() {
+        var (outcome, _) = await RunAutoApprovePermissionAsync(
+            """[{"optionId":"aa1","name":"Allow always","kind":"allow_always"},{"optionId":"aa2","name":"Allow always project","kind":"allow_always"}]""");
+
+        await Assert.That(outcome).IsEqualTo("cancelled");
+    }
+
+    [Test]
+    public async Task AutoApprove_BlankOptionId_MapsToCancelled() {
+        var (outcome, _) = await RunAutoApprovePermissionAsync(
+            """[{"optionId":"   ","name":"Allow once","kind":"allow_once"}]""");
+
+        await Assert.That(outcome).IsEqualTo("cancelled");
+    }
+
+    [Test]
+    public async Task AutoApprove_DuplicateOptionId_MapsToCancelled() {
+        // The chosen allow_once shares its OptionId with another offered option — echoing it could
+        // select the wrong option server-side, so fail closed.
+        var (outcome, _) = await RunAutoApprovePermissionAsync(
+            """[{"optionId":"dup","name":"Reject","kind":"reject_once"},{"optionId":"dup","name":"Allow once","kind":"allow_once"}]""");
+
+        await Assert.That(outcome).IsEqualTo("cancelled");
+    }
+
+    [Test]
+    public async Task AutoApprove_DeceptiveAllowName_ButRejectKind_MapsToCancelled() {
+        // Kind wins over Name — a hostile agent labeling a reject option "Allow" must not be approved.
+        var (outcome, _) = await RunAutoApprovePermissionAsync(
+            """[{"optionId":"x","name":"Allow","kind":"reject_once"}]""");
+
+        await Assert.That(outcome).IsEqualTo("cancelled");
+    }
+
+    [Test]
+    public async Task AutoApprove_Elicitation_DeclinedWithoutRoutingToHuman() {
+        var (bridge, calls) = AutoApproveBridge();
+
+        var json    = $$"""{"sessionId":"{{AcpSessionId}}","message":"Proceed?","options":[{"optionId":"yes","name":"Yes","kind":"allow_once"}]}""";
+        var request = new AcpRequest(1, "elicitation/create", JsonDocument.Parse(json).RootElement.Clone());
+        var result  = await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(result!.Value.GetProperty("outcome").GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+        await Assert.That(calls()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task AutoApprove_AuditLog_PinsAgentIdAndKind_NoPathField() {
+        var logger = new CaptureLogger();
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => { throw new InvalidOperationException("must not be called"); },
+            agentId: AgentId,
+            logger: logger,
+            autoApproveUnattended: true);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionParamsWithOptions(
+            """[{"optionId":"ao","name":"Allow once","kind":"allow_once"}]"""));
+        await bridge.HandleAsync(request, CancellationToken.None);
+
+        var infoEntries = logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        await Assert.That(infoEntries).Contains(e =>
+            e.Message.Contains("auto-approved")
+            && e.Message.Contains(AgentId)
+            && e.Message.Contains("allow_once"));
+        // No path field is ever logged — the bridge has no trustworthy path (ToolCall is opaque).
+        await Assert.That(infoEntries).DoesNotContain(e => e.Message.Contains("path"));
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/KcapMcpRegistryReviewFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/KcapMcpRegistryReviewFlowTests.cs
@@ -50,6 +50,19 @@ public class KcapMcpRegistryReviewFlowTests {
     }
 
     [Test]
+    public async Task Resolve_treats_reserved_flow_result_id_as_a_satisfied_no_op() {
+        // kcap-flow-result is always injected by the launcher and is not a registry entry; the
+        // server's dynamic-flow policy legitimately lists it, so it must be accepted (not rejected)
+        // and NOT re-emitted in the resolved servers. Every reviewer runtime shares this.
+        var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(
+            ["kcap-flow-result", "KCAP-FLOW-RESULT", "kcap-review"], out var servers, out var rejected);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(rejected).IsNull();
+        await Assert.That(servers).IsEquivalentTo(["kcap-review"]);
+    }
+
+    [Test]
     public async Task Resolve_null_or_empty_is_ok_empty() {
         var ok1 = KcapMcpRegistry.TryResolveReviewFlowAllowlist(null, out var s1, out var r1);
         await Assert.That(ok1).IsTrue();

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -1,5 +1,6 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
@@ -646,6 +647,196 @@ public class AcpHostedAgentRuntimeFactoryTests {
         await Assert.That(calls[1].Method).IsEqualTo("session/new");
         await Assert.That(calls[2].Method).IsEqualTo("session/set_config_option");
         await Assert.That(calls[3].Method).IsEqualTo("session/prompt");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await started.Runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    // ── Review-flow reviewer foundation: result-channel MCP + fail-closed pre-spawn validation ───
+
+    /// <summary>A review-flow launch context: unattended-capable synthetic vendor, owned worktree
+    /// (the default), a resolvable server url + kcap path, plus an optional MCP allowlist.</summary>
+    static RuntimeStartContext ReviewContext(string[]? allowlist = null) =>
+        MakeContext("agent-1") with {
+            IsReviewFlow = true,
+            ServerUrl    = "http://kcap.test",
+            McpAllowlist = allowlist
+        };
+
+    /// <summary>A factory whose connectionSource INCREMENTS a counter (never throws — a throw would
+    /// be swallowed by StartAsync's own handshake catch and mask the assertion) so a test can prove
+    /// the child process was never spawned when pre-spawn validation refuses a launch.</summary>
+    static (AcpHostedAgentRuntimeFactory Factory, Func<int> SpawnCount) CountingSpawnFactory(AcpVendorDescriptor descriptor) {
+        var spawns = 0;
+        var fake   = new FakeAcpAgent();
+        var factory = new AcpHostedAgentRuntimeFactory(
+            descriptor: descriptor,
+            config: new DaemonConfig(),
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: new CaptureServerConnection(),
+            connectionSource: _ => { Interlocked.Increment(ref spawns); return (fake.ClientWriteStream, fake.ClientReadStream, new FakeAcpProcess()); });
+
+        return (factory, () => Volatile.Read(ref spawns));
+    }
+
+    /// <summary>Test plan 2: session/new carries kcap-flow-result (both env vars) + one server per
+    /// resolvable non-flow allowlist name (KCAP_URL only), with pinned command/args, exact JSON.</summary>
+    [Test]
+    public async Task ReviewFlow_SessionNew_CarriesFlowResultAndAllowlistServers_ExactJson() {
+        var descriptor = SyntheticDescriptor(supportsMcpServers: true);
+        var fake        = new FakeAcpAgent();
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var started = await RunSyntheticStartAsync(descriptor, fake, ReviewContext(["kcap-review"]), cts.Token);
+        var mcpServersJson = await WaitForSessionNewMcpServersJsonAsync(fake);
+
+        await Assert.That(mcpServersJson).IsEqualTo(
+            """[{"name":"kcap-flow-result","command":"/usr/local/bin/kcap","args":["mcp","flow-result"],"env":[{"name":"KCAP_URL","value":"http://kcap.test"},{"name":"KCAP_FLOW_AGENT_ID","value":"agent-1"}]},{"name":"kcap-review","command":"/usr/local/bin/kcap","args":["mcp","review"],"env":[{"name":"KCAP_URL","value":"http://kcap.test"}]}]""");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await started.Runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>Test plan 3: kcap-flows (and a case-variant) are stripped, unknown names skipped, and
+    /// a repeated/case-varied canonical id collapses to a single server (JsonObject-keying parity).</summary>
+    [Test]
+    public async Task ReviewFlow_RecursionGuard_StripsFlows_SkipsUnknown_AndDedupsByCanonicalId() {
+        var descriptor = SyntheticDescriptor(supportsMcpServers: true);
+        var fake        = new FakeAcpAgent();
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var allowlist = new[] { "kcap-flows", "KCAP-FLOWS", "kcap-sessions", "KCAP-SESSIONS", "totally-unknown" };
+        var started = await RunSyntheticStartAsync(descriptor, fake, ReviewContext(allowlist), cts.Token);
+        var mcpServersJson = await WaitForSessionNewMcpServersJsonAsync(fake);
+
+        await Assert.That(mcpServersJson).IsEqualTo(
+            """[{"name":"kcap-flow-result","command":"/usr/local/bin/kcap","args":["mcp","flow-result"],"env":[{"name":"KCAP_URL","value":"http://kcap.test"},{"name":"KCAP_FLOW_AGENT_ID","value":"agent-1"}]},{"name":"kcap-sessions","command":"/usr/local/bin/kcap","args":["mcp","sessions"],"env":[{"name":"KCAP_URL","value":"http://kcap.test"}]}]""");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await started.Runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>Test plan 4: a review flow missing the server url or kcap path can't build a result
+    /// channel — StartAsync throws BEFORE the connectionSource is ever invoked (no leaked child).</summary>
+    [Test]
+    public async Task ReviewFlow_MissingServerUrl_ThrowsBeforeSpawn() {
+        var (factory, spawns) = CountingSpawnFactory(SyntheticDescriptor(supportsMcpServers: true));
+
+        await Assert.That(async () => await factory.StartAsync(ReviewContext() with { ServerUrl = null }, CancellationToken.None))
+            .Throws<InvalidOperationException>();
+        await Assert.That(spawns()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ReviewFlow_WhitespaceCapacitorPath_ThrowsBeforeSpawn() {
+        var (factory, spawns) = CountingSpawnFactory(SyntheticDescriptor(supportsMcpServers: true));
+
+        await Assert.That(async () => await factory.StartAsync(ReviewContext() with { CapacitorPath = "   " }, CancellationToken.None))
+            .Throws<InvalidOperationException>();
+        await Assert.That(spawns()).IsEqualTo(0);
+    }
+
+    /// <summary>Test plan 5: an unattended-capable vendor with no ACP mcpServers support can't carry
+    /// the result channel — throws before spawn.</summary>
+    [Test]
+    public async Task ReviewFlow_NoMcpServerSupport_ThrowsBeforeSpawn() {
+        var (factory, spawns) = CountingSpawnFactory(SyntheticDescriptor(supportsMcpServers: false));
+
+        await Assert.That(async () => await factory.StartAsync(ReviewContext(), CancellationToken.None))
+            .Throws<InvalidOperationException>();
+        await Assert.That(spawns()).IsEqualTo(0);
+    }
+
+    /// <summary>Test plan 6: a borrowed cwd, and separately a non-unattended vendor, both fail closed
+    /// before spawn. Plus BuildProcessStartInfo's defense-in-depth borrowed-cwd refusal.</summary>
+    [Test]
+    public async Task ReviewFlow_BorrowedCwd_ThrowsBeforeSpawn() {
+        var (factory, spawns) = CountingSpawnFactory(SyntheticDescriptor(supportsMcpServers: true));
+
+        await Assert.That(async () => await factory.StartAsync(ReviewContext() with { Work = WorkLocation.BorrowedCwd }, CancellationToken.None))
+            .Throws<InvalidOperationException>();
+        await Assert.That(spawns()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ReviewFlow_NotUnattended_ThrowsBeforeSpawn() {
+        // Cursor's SupportsUnattended is false.
+        var (factory, spawns) = CountingSpawnFactory(AcpVendorDescriptors.Cursor);
+
+        await Assert.That(async () => await factory.StartAsync(ReviewContext(), CancellationToken.None))
+            .Throws<InvalidOperationException>();
+        await Assert.That(spawns()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task BuildProcessStartInfo_Throws_ForReviewFlow_WhenBorrowedCwd_NoTrustArgvBuilt() {
+        var descriptor = SyntheticDescriptor(supportsMcpServers: true); // SupportsUnattended: true
+        var config     = new DaemonConfig();
+
+        await Assert.That(() => AcpHostedAgentRuntimeFactory.BuildProcessStartInfo(
+            descriptor, config, MakeContext("agent-1") with { IsReviewFlow = true, Work = WorkLocation.BorrowedCwd }
+        )).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>Test plan 7: a blank/whitespace agent id would still yield a non-empty MCP list and
+    /// slip past a count-only guard — it must fail closed before spawn.</summary>
+    [Test]
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task ReviewFlow_BlankAgentId_ThrowsBeforeSpawn(string agentId) {
+        var (factory, spawns) = CountingSpawnFactory(SyntheticDescriptor(supportsMcpServers: true));
+
+        await Assert.That(async () => await factory.StartAsync(ReviewContext() with { AgentId = agentId }, CancellationToken.None))
+            .Throws<InvalidOperationException>();
+        await Assert.That(spawns()).IsEqualTo(0);
+    }
+
+    /// <summary>Test plan 11: for an owned-worktree unattended review flow, the factory computes
+    /// autoApprove=true and threads it to the bridge — an inbound permission request is auto-approved
+    /// (least-privilege allow) WITHOUT ever routing to the injected server connection (no human).</summary>
+    [Test]
+    public async Task ReviewFlow_OwnedWorktree_Unattended_AutoApprovesPermission_WithoutRoutingToHuman() {
+        var descriptor = SyntheticDescriptor(supportsMcpServers: true); // SupportsUnattended: true
+        var fake        = new FakeAcpAgent();
+        var connection  = new CaptureServerConnection();
+
+        var factory = new AcpHostedAgentRuntimeFactory(
+            descriptor: descriptor,
+            config: new DaemonConfig(),
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: connection,
+            connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, new FakeAcpProcess()));
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var started = await factory.StartAsync(ReviewContext(), cts.Token).WaitAsync(HangGuard);
+
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Read file"}""",
+            optionsJson: """[{"optionId":"ao","name":"Allow once","kind":"allow_once"},{"optionId":"d","name":"Deny","kind":"reject_once"}]""");
+
+        await started.Runtime.SendUserInputAsync("review").WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (fake.LastServerRequestResponse is null && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        var outcome = fake.LastServerRequestResponse!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("selected");
+        await Assert.That(outcome.GetProperty("optionId").GetString()).IsEqualTo("ao");
+        // The bridge auto-approved locally: the server connection was never consulted.
+        await Assert.That(connection.RequestAcpInteractionAsyncCalled).IsFalse();
 
         cts.Cancel();
         try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -703,18 +703,17 @@ public class AcpHostedAgentRuntimeFactoryTests {
         await fake.DisposeAsync();
     }
 
-    /// <summary>Test plan 3: kcap-flows (and a case-variant) are stripped, unknown names skipped, and
-    /// a repeated/case-varied canonical id collapses to a single server (JsonObject-keying parity).</summary>
+    /// <summary>Test plan 3a: a repeated/case-varied auto-approvable id collapses to a single server
+    /// (JsonObject-keying parity).</summary>
     [Test]
-    public async Task ReviewFlow_RecursionGuard_StripsFlows_SkipsUnknown_AndDedupsByCanonicalId() {
+    public async Task ReviewFlow_DedupsAllowlistByCanonicalId() {
         var descriptor = SyntheticDescriptor(supportsMcpServers: true);
         var fake        = new FakeAcpAgent();
 
         using var cts = new CancellationTokenSource();
         var fakeRunTask = fake.RunAsync(cts.Token);
 
-        var allowlist = new[] { "kcap-flows", "KCAP-FLOWS", "kcap-sessions", "KCAP-SESSIONS", "totally-unknown" };
-        var started = await RunSyntheticStartAsync(descriptor, fake, ReviewContext(allowlist), cts.Token);
+        var started = await RunSyntheticStartAsync(descriptor, fake, ReviewContext(["kcap-sessions", "KCAP-SESSIONS"]), cts.Token);
         var mcpServersJson = await WaitForSessionNewMcpServersJsonAsync(fake);
 
         await Assert.That(mcpServersJson).IsEqualTo(
@@ -724,6 +723,25 @@ public class AcpHostedAgentRuntimeFactoryTests {
         try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
         await started.Runtime.DisposeAsync();
         await fake.DisposeAsync();
+    }
+
+    /// <summary>Test plan 3b: an allowlist entry that is flow-starting (recursion guard), unknown, or a
+    /// non-auto-approvable write server (kcap-memory) fails the launch BEFORE spawn — the reviewer
+    /// runs under the auto-approve bridge, so a write server must never reach it. Matches the
+    /// authoritative read-only reviewer policy the orchestrator enforces for Codex.</summary>
+    [Test]
+    [Arguments("kcap-flows")]
+    [Arguments("KCAP-FLOWS")]
+    [Arguments("kcap-memory")]
+    [Arguments("kcap-workitems")]
+    [Arguments("totally-unknown")]
+    public async Task ReviewFlow_NonAutoApprovableAllowlistEntry_ThrowsBeforeSpawn(string entry) {
+        var (factory, spawns) = CountingSpawnFactory(SyntheticDescriptor(supportsMcpServers: true));
+
+        // kcap-sessions is auto-approvable; the offending entry must still fail the whole launch.
+        await Assert.That(async () => await factory.StartAsync(ReviewContext(["kcap-sessions", entry]), CancellationToken.None))
+            .Throws<InvalidOperationException>();
+        await Assert.That(spawns()).IsEqualTo(0);
     }
 
     /// <summary>Test plan 4: a review flow missing the server url or kcap path can't build a result

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -725,6 +725,30 @@ public class AcpHostedAgentRuntimeFactoryTests {
         await fake.DisposeAsync();
     }
 
+    /// <summary>The reserved `kcap-flow-result` id (always injected separately; the server's
+    /// dynamic-flow policy legitimately lists it) is a no-op in the allowlist — not a rejection —
+    /// and is not double-injected.</summary>
+    [Test]
+    public async Task ReviewFlow_ReservedFlowResultIdInAllowlist_IsNoOp_NotRejected() {
+        var descriptor = SyntheticDescriptor(supportsMcpServers: true);
+        var fake        = new FakeAcpAgent();
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var started = await RunSyntheticStartAsync(descriptor, fake, ReviewContext(["kcap-flow-result", "KCAP-FLOW-RESULT", "kcap-review"]), cts.Token);
+        var mcpServersJson = await WaitForSessionNewMcpServersJsonAsync(fake);
+
+        // Exactly one flow-result server + kcap-review; the redundant allowlist entries are dropped.
+        await Assert.That(mcpServersJson).IsEqualTo(
+            """[{"name":"kcap-flow-result","command":"/usr/local/bin/kcap","args":["mcp","flow-result"],"env":[{"name":"KCAP_URL","value":"http://kcap.test"},{"name":"KCAP_FLOW_AGENT_ID","value":"agent-1"}]},{"name":"kcap-review","command":"/usr/local/bin/kcap","args":["mcp","review"],"env":[{"name":"KCAP_URL","value":"http://kcap.test"}]}]""");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await started.Runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
     /// <summary>Test plan 3b: an allowlist entry that is flow-starting (recursion guard), unknown, or a
     /// non-auto-approvable write server (kcap-memory) fails the launch BEFORE spawn — the reviewer
     /// runs under the auto-approve bridge, so a write server must never reach it. Matches the


### PR DESCRIPTION
Vendor-neutral CLI/daemon plumbing so a per-vendor child (AI-1409 Copilot, AI-1408 Cursor, …) can flip `SupportsUnattended` and become an unattended **review-flow reviewer over ACP**. Foundation only — **flips nothing**: every real vendor stays `SupportsUnattended:false`, so all new paths are unreachable in production and hosted-Cursor is pinned byte-for-byte. Epic **AI-1400**. Design spec (codex spec-review clean, 4 rounds): `docs/superpowers/specs/2026-07-20-ai1407-acp-reviewer-foundation-design.md` in kcap-server.

## What blocks an ACP vendor from being an unattended reviewer (both handled here)
1. **Result channel** — a reviewer returns its verdict ONLY via the injected `kcap-flow-result` MCP server. AI-1401 added `RuntimeStartContext.McpServers` → `session/new`, but no caller populated it.
2. **Permissions** — unattended = never ask a human, but ACP vendors surface `session/request_permission` and the bridge routes it to a human → timeout → wedged round.

## Changes
- **`AcpReviewFlowMcp.Build`** (new) — the `AcpMcpServerSpec` analogue of `ClaudeLauncher.BuildReviewFlowMcpConfig`: `kcap-flow-result` (`KCAP_URL` + `KCAP_FLOW_AGENT_ID`) plus the flow's MCP allowlist resolved through `KcapMcpRegistry` (flow-starting servers stripped = recursion guard; unknown skipped; **deduped by canonical `d.Id`** to match ClaudeLauncher's `JsonObject` keying).
- **`AcpHostedAgentRuntimeFactory`** — `ValidateAndBuildReviewFlowMcp` runs as the **first statement of `StartAsync`, before `_connectionSource` spawns** (the primary gate; a later seam would leak a child). Fails closed for a review-flow launch that isn't unattended-capable, isn't an owned worktree, has no ACP `mcpServers` support, or can't build a deliverable channel (nonblank url/path/agent id). `BuildProcessStartInfo` gains the matching owned-worktree refusal as defense-in-depth (it's where the trust-at-spawn argv is decided).
- **`AcpInteractionBridge`** — `autoApproveUnattended` selects the least-privilege allow option **by `Kind`** (nonblank + unique `OptionId`) without routing to a human, declines elicitations, and fails closed otherwise. Audit log pins `agentId` + selected `kind` + the **untrusted** tool title; never a path (`ToolCall` is opaque).

## Security framing
Owned-worktree is a launch **precondition** (the reviewer's cwd is a daemon-owned throwaway, and trust-at-spawn never reaches a borrowed cwd) — **not** filesystem confinement. There is no OS sandbox; the vendor does its own file/shell ops. Real containment (absolute-path escape, shell escape, ambient MCP/network) is a **blocking per-vendor acceptance criterion** each reviewer child must verify live — documented in the spec's "Per-vendor containment gate".

## Tests
62 tests across `AcpHostedAgentRuntimeFactoryTests` + `AcpInteractionBridgeTests`: flow-result JSON (pinned command/args/env), recursion-guard + dedup, fail-closed-before-spawn (connectionSource never invoked) for missing channel / no-mcp / borrowed-cwd / not-unattended / blank agent id, the least-privilege selector's full case table (ambiguity, blank/duplicate OptionId, deceptive name), elicitation decline, audit-log field pinning, and an owned-worktree end-to-end auto-approve. AOT-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)