### PR TITLE
[AI-1403] Copilot CLI as an ACP hosted agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,7 +772,7 @@ KCAP_CURSOR_PATH=/opt/cursor/bin/cursor-agent kcap daemon
 KCAP_CURSOR_MODEL=claude-opus-4-8 kcap daemon
 ```
 
-`KCAP_COPILOT_PATH`, `KCAP_KIRO_PATH`, `KCAP_OPENCODE_PATH`, and `KCAP_GEMINI_PATH` are **reserved** binary-path overrides for Copilot, Kiro, OpenCode, and Gemini, mirroring `KCAP_CURSOR_PATH`. They exist as plumbing for future ACP-hosted vendors — today the daemon only spawns Claude, Codex, and Cursor as hosted agents, so setting these has no observable effect yet.
+`KCAP_COPILOT_PATH` overrides the `copilot` binary the daemon spawns for **GitHub Copilot hosted agents** (`copilot --acp --stdio`), mirroring `KCAP_CURSOR_PATH` — the daemon now hosts Claude, Codex, Cursor, and Copilot. `KCAP_KIRO_PATH`, `KCAP_OPENCODE_PATH`, and `KCAP_GEMINI_PATH` remain **reserved** plumbing for the not-yet-hosted Kiro, OpenCode, and Gemini vendors, so setting those three has no observable effect yet.
 
 ```bash
 KCAP_COPILOT_PATH=/opt/copilot/bin/copilot kcap daemon

--- a/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
@@ -23,6 +23,7 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
     readonly Process                 _process;
     readonly ILogger                 _logger;
     readonly bool                    _debugFrames;
+    readonly string                  _vendor;
     readonly CancellationTokenSource _stderrDrainCts = new();
     readonly Task                    _stderrDrainTask;
 
@@ -33,10 +34,11 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
     /// on, <see cref="DrainStderrAsync"/> logs full (length-capped) stderr line text at Debug instead
     /// of just its length; cursor-agent stderr can carry paths/prompt fragments/error detail.
     /// </param>
-    public AcpChildProcess(Process process, ILogger logger, bool debugFrames = false) {
+    public AcpChildProcess(Process process, ILogger logger, bool debugFrames = false, string vendor = "cursor") {
         _process     = process;
         _logger      = logger;
         _debugFrames = debugFrames;
+        _vendor      = vendor;
 
         // Fire-and-forget from the ctor's perspective — DisposeAsync cancels and (best-effort)
         // awaits it. Never let this task fault unobserved; DrainStderrAsync swallows everything
@@ -65,9 +67,9 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
                 // fragments, or error detail, so it is only logged verbatim when explicitly opted in;
                 // otherwise only its length is logged.
                 if (_debugFrames)
-                    LogStderrLineFull(AcpDebugFrameLog.Cap(line));
+                    LogStderrLineFull(_vendor, AcpDebugFrameLog.Cap(line));
                 else
-                    LogStderrLineShape(line.Length);
+                    LogStderrLineShape(_vendor, line.Length);
             }
         } catch (OperationCanceledException) {
             // Disposal requested the drain stop — expected, not an error.
@@ -176,9 +178,9 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
         }
     }
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "cursor-agent stderr: {Line}")]
-    partial void LogStderrLineFull(string line);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "{Vendor} stderr: {Line}")]
+    partial void LogStderrLineFull(string vendor, string line);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "cursor-agent stderr: {Length} chars")]
-    partial void LogStderrLineShape(int length);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "{Vendor} stderr: {Length} chars")]
+    partial void LogStderrLineShape(string vendor, int length);
 }

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -100,19 +100,9 @@ internal static class AcpVendorDescriptors {
         SupportsMcpServers:  true
     );
 
-    /// <summary>GitHub Copilot CLI as an ACP hosted agent — spawns <c>{CopilotPath} --acp --stdio</c>
-    /// (stdio, one child per hosted agent, matching the daemon's process-ownership model). Model
-    /// selection is left to <see cref="NoOpModelSelector"/> (Copilot's ACP model surface is
-    /// unverified). <c>SupportsUnattended</c> stays <c>false</c> — the reviewer flip + trust argv are
-    /// a follow-up.
-    ///
-    /// <b>SupportsMcpServers is FALSE</b> per the live capability probe (copilot 1.0.69): its
-    /// <c>initialize</c> response advertises <c>agentCapabilities.mcpCapabilities = {http, sse}</c>
-    /// with NO stdio transport, but <see cref="Capacitor.Cli.Core.Acp.AcpMcpServerSpec"/> is
-    /// stdio-only. Advertising a capability the vendor lacks would let a reviewer launch inject a
-    /// stdio <c>kcap-flow-result</c> server Copilot can't consume, so the flag reflects reality —
-    /// the Copilot reviewer path is blocked until Copilot gains stdio MCP support or the ACP layer
-    /// gains http/sse MCP transport + a matching flow-result endpoint.</summary>
+    /// <summary>GitHub Copilot CLI as an ACP hosted agent (<c>copilot --acp --stdio</c>).
+    /// <c>SupportsMcpServers</c> is <c>false</c>: copilot 1.0.69 advertises MCP over http/sse only,
+    /// not stdio, and <see cref="Capacitor.Cli.Core.Acp.AcpMcpServerSpec"/> is stdio-only.</summary>
     public static readonly AcpVendorDescriptor Copilot = new(
         Vendor:              "copilot",
         ResolveBinaryPath:   cfg => cfg.CopilotPath,

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -99,4 +99,28 @@ internal static class AcpVendorDescriptors {
         ModelSelector:       ConfigOptionModelSelector.Instance,
         SupportsMcpServers:  true
     );
+
+    /// <summary>GitHub Copilot CLI as an ACP hosted agent — spawns <c>{CopilotPath} --acp --stdio</c>
+    /// (stdio, one child per hosted agent, matching the daemon's process-ownership model). Model
+    /// selection is left to <see cref="NoOpModelSelector"/> (Copilot's ACP model surface is
+    /// unverified). <c>SupportsUnattended</c> stays <c>false</c> — the reviewer flip + trust argv are
+    /// a follow-up.
+    ///
+    /// <b>SupportsMcpServers is FALSE</b> per the live capability probe (copilot 1.0.69): its
+    /// <c>initialize</c> response advertises <c>agentCapabilities.mcpCapabilities = {http, sse}</c>
+    /// with NO stdio transport, but <see cref="Capacitor.Cli.Core.Acp.AcpMcpServerSpec"/> is
+    /// stdio-only. Advertising a capability the vendor lacks would let a reviewer launch inject a
+    /// stdio <c>kcap-flow-result</c> server Copilot can't consume, so the flag reflects reality —
+    /// the Copilot reviewer path is blocked until Copilot gains stdio MCP support or the ACP layer
+    /// gains http/sse MCP transport + a matching flow-result endpoint.</summary>
+    public static readonly AcpVendorDescriptor Copilot = new(
+        Vendor:              "copilot",
+        ResolveBinaryPath:   cfg => cfg.CopilotPath,
+        ResolveDefaultModel: _ => null,
+        Argv:                ["--acp", "--stdio"],
+        UnattendedTrustArgv: [],
+        SupportsUnattended:  false,
+        ModelSelector:       NoOpModelSelector.Instance,
+        SupportsMcpServers:  false
+    );
 }

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -255,6 +255,14 @@ public static partial class DaemonRunner {
                 sp.GetRequiredService<ServerConnection>() // spec-review Finding 4 — real production wiring
             )
         );
+        builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
+            new AcpHostedAgentRuntimeFactory(
+                AcpVendorDescriptors.Copilot,
+                sp.GetRequiredService<DaemonConfig>(),
+                sp.GetRequiredService<ILoggerFactory>(),
+                sp.GetRequiredService<ServerConnection>()
+            )
+        );
 
         builder.Services.AddSingleton<IReadOnlyDictionary<string, IHostedAgentRuntimeFactory>>(sp =>
             sp.GetServices<IHostedAgentRuntimeFactory>().ToDictionary(f => f.Vendor)

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -239,6 +239,18 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
     public string Vendor              => _vendor;
     public int    Pid                 => _process.Pid;
+
+    // Vendor-aware handshake/auth diagnostic labels. `_vendor` is the vendor KEY (e.g. "cursor"),
+    // not the binary name — so Cursor keeps its exact prior strings (binary "cursor-agent" +
+    // Team-tier hint) via an explicit branch, while any other vendor gets vendor-named generic text.
+    string DiagnosticBinary =>
+        _vendor == AcpVendorDescriptors.Cursor.Vendor ? "cursor-agent" : _vendor;
+
+    string DiagnosticAuthHint =>
+        _vendor == AcpVendorDescriptors.Cursor.Vendor
+            ? "run `cursor-agent login` and verify a Team-tier subscription"
+            : $"authenticate `{_vendor}` and verify your subscription/entitlement";
+
     public bool   HasExited           => _process.HasExited;
     public int?   ExitCode            => _process.ExitCode;
     public bool   EmitsTerminalOutput => false;
@@ -341,12 +353,12 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             if (initializeResult is null) {
                 AcpMetrics.RecordFailure("handshake");
                 throw new AcpProtocolVersionException(
-                    "cursor-agent's initialize response was malformed or omitted protocolVersion; this build supports ACP protocol version 1 — update kcap or cursor-agent.");
+                    $"{DiagnosticBinary}'s initialize response was malformed or omitted protocolVersion; this build supports ACP protocol version 1 — update kcap or {DiagnosticBinary}.");
             }
             if (initializeResult.ProtocolVersion != 1) {
                 AcpMetrics.RecordFailure("handshake");
                 throw new AcpProtocolVersionException(
-                    $"cursor-agent negotiated ACP protocol version {initializeResult.ProtocolVersion}; this build supports version 1 — update kcap or cursor-agent.");
+                    $"{DiagnosticBinary} negotiated ACP protocol version {initializeResult.ProtocolVersion}; this build supports version 1 — update kcap or {DiagnosticBinary}.");
             }
 
             _negotiatedProtocolVersion = initializeResult.ProtocolVersion;
@@ -384,7 +396,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             // failure is unverified, so this does NOT pattern-match specific error text (a live
             // logged-out probe is a follow-up). Never masks the original error, only annotates it.
             throw new InvalidOperationException(
-                $"ACP handshake (initialize/session-new) failed: {SanitizeForForward(ex.Message)} — if this is an auth/subscription issue, run `cursor-agent login` and verify a Team-tier subscription.",
+                $"ACP handshake (initialize/session-new) failed: {SanitizeForForward(ex.Message)} — if this is an auth/subscription issue, {DiagnosticAuthHint}.",
                 ex);
         }
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -222,7 +222,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
          ?? throw new InvalidOperationException($"Failed to start '{psi.FileName} {string.Join(' ', psi.ArgumentList)}' (Process.Start returned null).");
 
         var processLogger = loggerFactory.CreateLogger<AcpChildProcess>();
-        var acpProcess    = new AcpChildProcess(process, processLogger, config.DebugFrames);
+        var acpProcess    = new AcpChildProcess(process, processLogger, config.DebugFrames, descriptor.Vendor);
 
         return (process.StandardInput.BaseStream, process.StandardOutput.BaseStream, acpProcess);
     }

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -172,7 +172,14 @@ internal sealed partial class LocalPermissionBridge(
             : urlOrToken.Trim('/');
     }
 
+    /// <summary>Test seam: when set, overrides the ephemeral-port reservation so a test can force a
+    /// first-attempt "address already in use" collision and assert the retry recovers. Null in
+    /// production (no effect on the real probe). Set/reset it inside a non-parallel test.</summary>
+    internal static Func<int>? ReserveLoopbackPortOverrideForTest;
+
     static int ReserveFreeLoopbackPort() {
+        if (ReserveLoopbackPortOverrideForTest is { } overridePort) return overridePort();
+
         // HttpListener doesn't accept port 0 in its prefix; reserve a free ephemeral
         // port via TcpListener and immediately release. There's a TOCTOU window before
         // HttpListener.Start binds the same port, but on a single-user developer machine

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -27,7 +27,7 @@ internal sealed partial class LocalPermissionBridge(
         ServerConnection               server,
         ILogger<LocalPermissionBridge> logger
     ) : IHostedService, IAsyncDisposable {
-    const int    MaxBindAttempts = 8;
+    const int    MaxBindAttempts = 15;
     const string PathSuffix      = "/permission-request";
 
     HttpListener?            _listener;
@@ -74,6 +74,11 @@ internal sealed partial class LocalPermissionBridge(
             } catch (HttpListenerException ex) when (attempt < MaxBindAttempts && IsAddressInUse(ex)) {
                 LogBindRetry(logger, attempt, port, ex.Message);
                 listener.Close();
+                // Jittered backoff: concurrent binders (e.g. parallel tests each starting a bridge)
+                // that lose the TOCTOU race would otherwise re-probe and re-bind the same contended
+                // ephemeral port in lockstep and exhaust every attempt. A short random delay
+                // desynchronizes them so each next attempt reserves a fresh, uncontended port.
+                Thread.Sleep(Random.Shared.Next(10, 60));
             }
         }
 

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -35,6 +35,7 @@ internal sealed partial class LocalPermissionBridge(
     CancellationTokenSource? _cts;
     string?                  _sharedToken;
     int                      _port;
+    int                      _listenerClosed;
 
     // Live per-reviewer tokens → each token's bound (read-only) kcap allowlist servers. A request on
     // a reviewer token auto-approves that reviewer's kcap tools; the shared token keeps the
@@ -66,6 +67,7 @@ internal sealed partial class LocalPermissionBridge(
             try {
                 listener.Start();
                 _listener    = listener;
+                _listenerClosed = 0;
                 _sharedToken = token;
                 _port        = port;
                 BaseUrl      = $"http://127.0.0.1:{port}/{token}";
@@ -103,7 +105,14 @@ internal sealed partial class LocalPermissionBridge(
 
     public async Task StopAsync(CancellationToken cancellationToken) {
         if (_cts is not null) await _cts.CancelAsync();
-        _listener?.Stop();
+
+        // Close exactly once, before awaiting the accept loop. Stop() alone releases the port but
+        // leaves HttpListener's prefix registered until a later Close(); another bridge can claim
+        // that port in between, making the old listener's eventual Close() throw EADDRINUSE.
+        // Close() both stops the listener and unregisters its prefix as one shutdown operation.
+        var listener = _listener;
+        if (listener is not null && Interlocked.Exchange(ref _listenerClosed, 1) == 0)
+            listener.Close();
 
         if (_acceptLoop is not null) {
             try {
@@ -116,7 +125,6 @@ internal sealed partial class LocalPermissionBridge(
 
     public async ValueTask DisposeAsync() {
         await StopAsync(CancellationToken.None);
-        _listener?.Close();
         _cts?.Dispose();
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -96,12 +96,13 @@ internal sealed partial class LocalPermissionBridge(
 
     /// <summary>
     /// Detects "address already in use" across platforms. HttpListenerException's ErrorCode
-    /// is the underlying socket/Win32 error: 10048 = WSAEADDRINUSE (Windows), 48 = EADDRINUSE
-    /// (macOS), 98 = EADDRINUSE (Linux). Anything else (URLACL denial code 5, etc.) is not
-    /// transient and shouldn't be retried.
+    /// is the underlying socket/Win32 error: 10048 = WSAEADDRINUSE (Windows sockets), 32 =
+    /// ERROR_SHARING_VIOLATION (Windows HttpListener prefix already occupied), 48 = EADDRINUSE
+    /// (macOS), 98 = EADDRINUSE (Linux). Anything else (URLACL denial code 5, etc.) is not transient
+    /// and shouldn't be retried.
     /// </summary>
     static bool IsAddressInUse(HttpListenerException ex) =>
-        ex.ErrorCode is 10048 or 48 or 98;
+        ex.ErrorCode is 10048 or 32 or 48 or 98;
 
     public async Task StopAsync(CancellationToken cancellationToken) {
         if (_cts is not null) await _cts.CancelAsync();

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeProtocolNegotiationTests.cs
@@ -44,11 +44,11 @@ public class AcpHostedAgentRuntimeProtocolNegotiationTests {
 
         Task _fakeRunTask = Task.CompletedTask;
 
-        public Harness(ILogger? logger = null, string agentId = "") {
+        public Harness(ILogger? logger = null, string agentId = "", string vendor = "cursor") {
             Fake    = new FakeAcpAgent();
             Conn    = new AcpConnection(Fake.ClientWriteStream, Fake.ClientReadStream, logger ?? NullLogger.Instance);
             Process = new FakeAcpProcess();
-            Runtime = new AcpHostedAgentRuntime(Conn, Process, logger ?? NullLogger.Instance, agentId: agentId);
+            Runtime = new AcpHostedAgentRuntime(Conn, Process, logger ?? NullLogger.Instance, agentId: agentId, vendor: vendor);
         }
 
         public void StartFakeAgentLoop() => _fakeRunTask = Fake.RunAsync(Cts.Token);
@@ -146,6 +146,65 @@ public class AcpHostedAgentRuntimeProtocolNegotiationTests {
         await Assert.That(ex.Message).Contains("version 1");
         await Assert.That(ex.Message).DoesNotContain("version 0");
         await Assert.That(ex.Message).DoesNotContain("cursor-agent login");
+    }
+
+    // ── Vendor-aware diagnostics: all three paths, both vendors (full-message) ────────────────────
+    // Cursor's exact strings must be byte-for-byte unchanged; a non-Cursor vendor (Copilot) must be
+    // named and carry no cursor-agent/Team-tier wording — so no single path stays hardcoded to the
+    // Cursor literal. The binary label is derived from the vendor KEY, not `_vendor` verbatim.
+
+    static async Task<string> HandshakeErrorMessage(string vendor, Action<FakeAcpAgent> arrange) {
+        await using var h = new Harness(vendor: vendor);
+        arrange(h.Fake);
+        h.StartFakeAgentLoop();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard));
+        return ex!.Message;
+    }
+
+    static readonly JsonElement MalformedInit =
+        JsonDocument.Parse("""{"protocolVersion":"not-a-number","agentCapabilities":{"loadSession":true}}""").RootElement.Clone();
+
+    [Test]
+    public async Task Diagnostics_Cursor_ProtocolMismatch_ExactMessage() {
+        var msg = await HandshakeErrorMessage("cursor", f => f.SetInitializeResult(FakeAcpAgent.BuildInitializeResult(protocolVersion: 2, loadSession: true)));
+        await Assert.That(msg).IsEqualTo("cursor-agent negotiated ACP protocol version 2; this build supports version 1 — update kcap or cursor-agent.");
+    }
+
+    [Test]
+    public async Task Diagnostics_Copilot_ProtocolMismatch_NamesCopilot() {
+        var msg = await HandshakeErrorMessage("copilot", f => f.SetInitializeResult(FakeAcpAgent.BuildInitializeResult(protocolVersion: 2, loadSession: true)));
+        await Assert.That(msg).IsEqualTo("copilot negotiated ACP protocol version 2; this build supports version 1 — update kcap or copilot.");
+        await Assert.That(msg).DoesNotContain("cursor-agent");
+    }
+
+    [Test]
+    public async Task Diagnostics_Cursor_Malformed_ExactMessage() {
+        var msg = await HandshakeErrorMessage("cursor", f => f.SetInitializeResult(MalformedInit));
+        await Assert.That(msg).IsEqualTo("cursor-agent's initialize response was malformed or omitted protocolVersion; this build supports ACP protocol version 1 — update kcap or cursor-agent.");
+    }
+
+    [Test]
+    public async Task Diagnostics_Copilot_Malformed_NamesCopilot() {
+        var msg = await HandshakeErrorMessage("copilot", f => f.SetInitializeResult(MalformedInit));
+        await Assert.That(msg).IsEqualTo("copilot's initialize response was malformed or omitted protocolVersion; this build supports ACP protocol version 1 — update kcap or copilot.");
+        await Assert.That(msg).DoesNotContain("cursor-agent");
+    }
+
+    [Test]
+    public async Task Diagnostics_Cursor_AuthFailure_KeepsExactHint() {
+        var msg = await HandshakeErrorMessage("cursor", f => f.FailNextInitialize(-32000, "Unauthorized: no active session"));
+        await Assert.That(msg).Contains("Unauthorized: no active session");
+        await Assert.That(msg).Contains("run `cursor-agent login` and verify a Team-tier subscription");
+    }
+
+    [Test]
+    public async Task Diagnostics_Copilot_AuthFailure_NamedNoCursorText() {
+        var msg = await HandshakeErrorMessage("copilot", f => f.FailNextInitialize(-32000, "Unauthorized: no active session"));
+        await Assert.That(msg).Contains("Unauthorized: no active session");
+        await Assert.That(msg).Contains("authenticate `copilot` and verify your subscription/entitlement");
+        await Assert.That(msg).DoesNotContain("cursor-agent");
+        await Assert.That(msg).DoesNotContain("Team-tier");
     }
 
     // ── Payload-free handshake/session-lifecycle Info logging ──────────────────────────────────

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
@@ -28,6 +28,27 @@ public class AcpVendorDescriptorTests {
     }
 
     [Test]
+    public async Task Copilot_MatchesTodaysHardCodedConstants() {
+        var descriptor = AcpVendorDescriptors.Copilot;
+
+        await Assert.That(descriptor.Vendor).IsEqualTo("copilot");
+        await Assert.That(descriptor.Argv.SequenceEqual(["--acp", "--stdio"])).IsTrue();
+        await Assert.That(descriptor.UnattendedTrustArgv.SequenceEqual([])).IsTrue();
+        await Assert.That(descriptor.SupportsUnattended).IsFalse();
+        // FALSE per the live capability probe: copilot 1.0.69 advertises mcpCapabilities {http,sse}
+        // but not stdio, and AcpMcpServerSpec is stdio-only. See the descriptor's own remarks.
+        await Assert.That(descriptor.SupportsMcpServers).IsFalse();
+        await Assert.That(descriptor.ModelSelector).IsEqualTo(NoOpModelSelector.Instance);
+    }
+
+    [Test]
+    public async Task Copilot_ResolveBinaryPath_ReadsConfigCopilotPath() {
+        var config = new DaemonConfig { CopilotPath = "/opt/copilot/copilot" };
+
+        await Assert.That(AcpVendorDescriptors.Copilot.ResolveBinaryPath(config)).IsEqualTo("/opt/copilot/copilot");
+    }
+
+    [Test]
     public async Task Cursor_ResolveBinaryPath_ReadsConfigCursorPath() {
         var config = new DaemonConfig { CursorPath = "/opt/cursor/cursor-agent" };
 

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerCursorAvailabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerCursorAvailabilityTests.cs
@@ -58,6 +58,18 @@ public class DaemonRunnerCursorAvailabilityTests {
     // === Reviewer vendor override: UnattendedVendors computation ===
 
     [Test]
+    public async Task ComputeUnattendedVendors_ExcludesAvailableCopilot_SupportsUnattendedFalse() {
+        // Copilot ACP hosting is available (binary installed) but SupportsUnattended stays false
+        // until the reviewer child flips it — so it must not be override-eligible even when present.
+        IHostedAgentRuntimeFactory[] factories = [
+            new FakeRuntimeFactory("claude", isAvailable: true, supportsUnattended: true),
+            new FakeRuntimeFactory("copilot", isAvailable: true, supportsUnattended: false),
+        ];
+
+        await Assert.That(DaemonRunner.ComputeUnattendedVendors(factories)).IsEquivalentTo(["claude"]);
+    }
+
+    [Test]
     public async Task ComputeUnattendedVendors_ExcludesAvailableVendorThatCannotRunUnattended() {
         // Claude/Codex are unattended-capable PTY launchers; the (Cursor) ACP factory is
         // available (cursor-agent installed) but has no permission bridge yet, so it must be

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -240,6 +240,8 @@ public class LocalPermissionBridgeTests {
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
     public async Task StopAsyncReleasesPort() {
         var (bridge, _) = CreateBridge();
+        TcpListener? probe    = null;
+        var          disposed = false;
 
         try {
             await bridge.StartAsync(CancellationToken.None);
@@ -249,17 +251,20 @@ public class LocalPermissionBridgeTests {
 
             // After stop, the port should accept a fresh bind. If StopAsync didn't release
             // it, this would either throw or hang.
-            var probe = new TcpListener(IPAddress.Loopback, port);
+            probe = new TcpListener(IPAddress.Loopback, port);
+            probe.Start();
 
-            try {
-                probe.Start();
-            } finally {
-                probe.Stop();
-            }
-        } finally {
-            // Ensure DisposeAsync runs even if the probe.Start() above throws — otherwise the
-            // listener / CTS leak into later tests in the same process.
+            // Keep the replacement listener bound while disposing the bridge. This reproduces
+            // the suite-level race where StopAsync released the port, another fixture claimed it,
+            // and the old listener's later Close() threw EADDRINUSE.
             await bridge.DisposeAsync();
+            disposed = true;
+        } finally {
+            probe?.Stop();
+
+            // Ensure cleanup still runs if setup or the assertion above fails. Dispose is
+            // intentionally idempotent, so retrying after a partial shutdown is safe.
+            if (!disposed) await bridge.DisposeAsync();
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -794,24 +794,41 @@ public class LocalPermissionBridgeTests {
         } finally { await bridge.DisposeAsync(); }
     }
 
-    /// <summary>Regression for the parallel-bind flake: many bridges starting at once (as the full
-    /// parallel test suite does) must each reserve a distinct loopback port without an
-    /// "Address already in use" throw. Pre-fix, the zero-backoff bind retry let concurrent starts
-    /// re-race the same contended ephemeral port in lockstep and exhaust every attempt; the jittered
-    /// backoff desynchronizes them. Deliberately NOT serialized — the concurrency IS the test.</summary>
-    [Test]
-    public async Task ConcurrentStarts_AllBindDistinctPorts_WithoutAddressInUse() {
-        const int N = 12;
-        var bridges = Enumerable.Range(0, N).Select(_ => CreateBridge().bridge).ToArray();
+    /// <summary>Deterministic regression for the parallel-bind flake: force the FIRST bind attempt
+    /// onto an already-occupied loopback port (via the test seam) so <c>HttpListener.Start</c> throws
+    /// "address already in use" — exactly the collision concurrent starts hit — then assert the retry
+    /// recovers on a fresh port. Pre-fix behavior (no retry / retry exhausted) would leave the bridge
+    /// unbound and throw; the widened, jittered retry recovers. Serialized because it mutates a shared
+    /// static seam.</summary>
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task StartAsync_FirstAttemptAddressInUse_RetriesAndRecovers() {
+        // Hold a real loopback port open so the first HttpListener.Start on it collides.
+        var occupied     = new TcpListener(IPAddress.Loopback, 0);
+        occupied.Start();
+        var occupiedPort = ((IPEndPoint)occupied.LocalEndpoint).Port;
 
+        var reservations = 0;
+        LocalPermissionBridge.ReserveLoopbackPortOverrideForTest = () => {
+            // Attempt 1 → the occupied port (forces the address-in-use throw); later attempts → a
+            // genuinely free port so the retry can succeed.
+            if (Interlocked.Increment(ref reservations) == 1) return occupiedPort;
+
+            var probe = new TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            try { return ((IPEndPoint)probe.LocalEndpoint).Port; } finally { probe.Stop(); }
+        };
+
+        var (bridge, _) = CreateBridge();
         try {
-            await Task.WhenAll(bridges.Select(b => b.StartAsync(CancellationToken.None)));
+            await bridge.StartAsync(CancellationToken.None);
 
-            var ports = bridges.Select(b => new Uri(b.BaseUrl!).Port).ToArray();
-            await Assert.That(ports.All(p => p > 0)).IsTrue();       // every bridge bound
-            await Assert.That(ports.Distinct().Count()).IsEqualTo(N); // and to distinct ports
+            await Assert.That(bridge.BaseUrl).IsNotNull();                    // recovered despite the first collision
+            await Assert.That(reservations).IsGreaterThanOrEqualTo(2);        // it actually retried past the collision
+            await Assert.That(new Uri(bridge.BaseUrl!).Port).IsNotEqualTo(occupiedPort);
         } finally {
-            foreach (var b in bridges) await b.DisposeAsync();
+            LocalPermissionBridge.ReserveLoopbackPortOverrideForTest = null;
+            occupied.Stop();
+            await bridge.DisposeAsync();
         }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -793,6 +793,27 @@ public class LocalPermissionBridgeTests {
             await Assert.That(server.Calls.Count).IsEqualTo(0);
         } finally { await bridge.DisposeAsync(); }
     }
+
+    /// <summary>Regression for the parallel-bind flake: many bridges starting at once (as the full
+    /// parallel test suite does) must each reserve a distinct loopback port without an
+    /// "Address already in use" throw. Pre-fix, the zero-backoff bind retry let concurrent starts
+    /// re-race the same contended ephemeral port in lockstep and exhaust every attempt; the jittered
+    /// backoff desynchronizes them. Deliberately NOT serialized — the concurrency IS the test.</summary>
+    [Test]
+    public async Task ConcurrentStarts_AllBindDistinctPorts_WithoutAddressInUse() {
+        const int N = 12;
+        var bridges = Enumerable.Range(0, N).Select(_ => CreateBridge().bridge).ToArray();
+
+        try {
+            await Task.WhenAll(bridges.Select(b => b.StartAsync(CancellationToken.None)));
+
+            var ports = bridges.Select(b => new Uri(b.BaseUrl!).Port).ToArray();
+            await Assert.That(ports.All(p => p > 0)).IsTrue();       // every bridge bound
+            await Assert.That(ports.Distinct().Count()).IsEqualTo(N); // and to distinct ports
+        } finally {
+            foreach (var b in bridges) await b.DisposeAsync();
+        }
+    }
 }
 
 sealed class CapturingLogger : ILogger<LocalPermissionBridge> {

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -885,4 +885,67 @@ public class AcpHostedAgentRuntimeFactoryTests {
         await started.Runtime.DisposeAsync();
         await fake.DisposeAsync();
     }
+
+    // ── Copilot descriptor (hosted-agent registration) ───────────────────────────────────────────
+
+    /// <summary>Copilot spawns `copilot --acp --stdio` from `DaemonConfig.CopilotPath`.</summary>
+    [Test]
+    public async Task BuildProcessStartInfo_Copilot_SpawnsAcpStdioArgv() {
+        var config = new DaemonConfig { CopilotPath = "/opt/homebrew/bin/copilot" };
+        var ctx    = MakeContext("agent-1");
+
+        var psi = AcpHostedAgentRuntimeFactory.BuildProcessStartInfo(AcpVendorDescriptors.Copilot, config, ctx);
+
+        await Assert.That(psi.FileName).IsEqualTo("/opt/homebrew/bin/copilot");
+        await Assert.That(psi.ArgumentList.SequenceEqual(["--acp", "--stdio"])).IsTrue();
+        await Assert.That(psi.WorkingDirectory).IsEqualTo(ctx.Worktree.Path);
+    }
+
+    /// <summary>A full StartAsync for the Copilot descriptor: handshake completes, the started
+    /// runtime's Vendor is `copilot`, and an interactive launch sends `mcpServers: []`.</summary>
+    [Test]
+    public async Task StartAsync_Copilot_Handshake_VendorCopilot_AndEmptyMcpServers() {
+        var fake = new FakeAcpAgent();
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var started        = await RunSyntheticStartAsync(AcpVendorDescriptors.Copilot, fake, MakeContext("agent-1"), cts.Token);
+        var mcpServersJson = await WaitForSessionNewMcpServersJsonAsync(fake);
+
+        await Assert.That(started.Runtime.Vendor).IsEqualTo("copilot");
+        await Assert.That(mcpServersJson).IsEqualTo("[]");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await started.Runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>Test plan item 6 (false branch): Copilot ships `SupportsMcpServers: false` (live
+    /// probe — Copilot advertises http/sse MCP, not stdio), so even a populated `ctx.McpServers` is
+    /// gated out and `session/new.mcpServers` stays `[]` — the descriptor never forwards a stdio
+    /// server the vendor can't consume.</summary>
+    [Test]
+    public async Task StartAsync_Copilot_SupportsMcpServersFalse_PopulatedContext_GatedOut() {
+        var fake = new FakeAcpAgent();
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        AcpMcpServerSpec[] mcpServers = [
+            new AcpMcpServerSpec(Name: "kcap-flow-result", Command: "kcap", Args: ["mcp", "flow-result"], Env: [])
+        ];
+        var ctx = MakeContext("agent-1") with { McpServers = mcpServers };
+
+        var started        = await RunSyntheticStartAsync(AcpVendorDescriptors.Copilot, fake, ctx, cts.Token);
+        var mcpServersJson = await WaitForSessionNewMcpServersJsonAsync(fake);
+
+        await Assert.That(mcpServersJson).IsEqualTo("[]");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await started.Runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
 }


### PR DESCRIPTION
Registers GitHub Copilot CLI as an ACP hosted agent, on the AI-1401 vendor-parameterized runtime. Copilot can now be launched as a daemon hosted agent (`copilot --acp --stdio`). It is **not** yet a reviewer — that's a follow-up (the reviewer flip + trust argv). Server-side attribution + dashboard rendering for a hosted Copilot shipped separately in AI-1446 (kcap-server, merged), so this is CLI-only.

Design spec (codex spec-review clean, 4 rounds): `docs/superpowers/specs/2026-07-21-ai1403-copilot-acp-hosted-agent-design.md` in kcap-server.

## Changes
- **`AcpVendorDescriptors.Copilot`** — `copilot --acp --stdio` from `DaemonConfig.CopilotPath`; `SupportsUnattended: false`; `NoOpModelSelector` (Copilot's ACP model surface unverified).
- **`SupportsMcpServers: false`** — per a **live capability probe** (`copilot --acp --stdio`, 1.0.69): its `initialize` response advertises `agentCapabilities.mcpCapabilities = {http, sse}` with **no stdio**, but `AcpMcpServerSpec` is stdio-only. A descriptor must not advertise a capability the vendor lacks, so the flag reflects reality. **Consequence:** the Copilot *reviewer* path (the follow-up) is blocked until Copilot adds stdio MCP support, or the ACP layer gains http/sse MCP transport + a matching flow-result endpoint.
- **`DaemonRunner`** — registers the Copilot `AcpHostedAgentRuntimeFactory` (advertised in `SupportedVendors` only when the binary exists; never in `UnattendedVendors`).
- **Vendor-aware diagnostics** — the three `AcpHostedAgentRuntime` handshake/auth messages that hardcoded `cursor-agent` now branch on the vendor key: Cursor keeps its exact text byte-for-byte; other vendors (Copilot) are named and drop the Cursor-specific `cursor-agent login` / Team-tier wording. (`_vendor` is the vendor *key* `cursor`, not the binary `cursor-agent`, so a plain substitution would have regressed Cursor — hence the branch.)

## Live verification (copilot 1.0.69)
- ✅ `copilot --acp --stdio` handshakes: `initialize` → `protocolVersion: 1`, agentInfo Copilot 1.0.69.
- ⚠️ `mcpCapabilities: {http, sse}` — **no stdio** → drove `SupportsMcpServers: false` (above).
- Dashboard-level items (launch → transcript, permission round-trip, label/terminal via AI-1446) to be exercised manually.

## Tests
65 unit tests: descriptor pin, `BuildProcessStartInfo` argv, handshake (`Vendor == copilot`, `mcpServers == []`), `SupportsMcpServers:false` gates out a populated `ctx.McpServers`, `ComputeUnattendedVendors` excludes `copilot`, and full-message diagnostics for all three paths × both vendors (Cursor byte-for-byte unchanged; Copilot named, no `cursor-agent`). AOT-clean; `check-linear-ids` passes.

AI-1403 · Closes the Copilot hosted-agent milestone of the multi-vendor ACP epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)