### PR TITLE
[AI-1391] Daemon sequenced-command settlement (B2-b, daemon half)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-ai1391-b2b-daemon-sequenced-settlement.md
+++ b/docs/superpowers/plans/2026-07-22-ai1391-b2b-daemon-sequenced-settlement.md
@@ -1,0 +1,2775 @@
+# AI-1391 B2-b — Daemon Sequenced-Settlement Implementation Plan (kcap-cli / daemon half)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the daemon (producer) half of AI-1391 B2-b: additive sequenced-command wire DTOs, two serialized sequenced lanes with a contiguous-prefix watermark, a durable resolved-candidates ledger fed by four positive-confirmation hooks, a durable coverage journal / boot-chain attestation driving `RecordlessSurvivorsImpossible`, per-platform `StartupReapComplete` + `StartupDiscovery`, and the daemon-side heal-barrier obligations — all capability-gated on `SupportsSequencedCommands` and advertised-but-inert until the paired server PR consumes it.
+
+**Architecture:** This is PR 2 of the paired B2-b rollout — daemon ships first (capability advertised, unused = inert). The design layers on the shipped AI-1313 Phase B substrate: `AgentPidRecordStore` (atomic temp+rename), `AgentKillQuarantine`, `OrphanReaper`, `ProcessReaper`, `ProcessIdentity`, the per-boot `_daemonEpoch`, and the `DaemonLock` per-name flock. New durable state (`CoverageJournal`, `ResolvedCandidatesLedger`, the marker-candidate source) lives in the daemon's per-name state dir under the same crash-consistency discipline as `AgentPidRecordStore`. Sequenced-command handling is a self-contained `SequencedCommandProcessor` injected with execute/liveness/send delegates so it is unit-testable without a live orchestrator, mirroring how `OrphanReaper`/`AgentKillQuarantine` are tested against isolated `DummyProcess` instances.
+
+**Tech Stack:** .NET 10, C#, System.Text.Json source-gen (`CapacitorJsonContext`, snake_case + string enums), SignalR (`HubConnection`), TUnit on Microsoft Testing Platform.
+
+## Global Constraints
+
+- **.NET 10, TUnit on Microsoft Testing Platform.** Test projects are `OutputType Exe`; NEVER add `Microsoft.NET.Test.Sdk`. Every assertion is `await Assert.That(...)`.
+- **No Linear issue IDs (`AI-<digits>`) in any `.c`/`.h`/`.cs` file.** `scripts/check-linear-ids.sh` (CI job "No Linear issue IDs in C# source") rejects them unconditionally in `src/**/*.cs` and (unless `// linear-id-ok: <reason>`) in `test/**/*.cs`. In code + comments say "Phase B2-b" / "the parent design" / "the sequenced-settlement design", never the issue key. This `.md` plan may reference `AI-1391` freely.
+- **All wire changes are additive** — trailing optional fields with defaults; SignalR's `JsonHubProtocol` binds a single-record argument by snake_case property name, so old servers ignore unknown fields and new daemons get `default` for missing ones.
+- **Everything is capability-gated on `SupportsSequencedCommands`.** Old server + new daemon = legacy unsequenced lane, watermark never advances. New server + old daemon is the server's B2-a degradation (not this PR).
+- **`Epoch` is the shipped Phase B `_daemonEpoch`** (a GUID `"N"` string, fresh per boot, already stamped into children). Reuse it — do NOT mint a second epoch concept. `Seq`/`Generation`/`HighestAcceptedSeq`/`LastProcessedSeq` are `long`; `CommandId` is a GUID string.
+- **Crash-consistency everywhere durable state is written:** atomic temp-file + same-directory rename; for the ledger, ledger-append BEFORE source-deletion; fail-closed I/O (unreadable/corrupt/write-failed ⇒ the safe answer). Every ledger hook and the boot-chain get crash-injection tests; the boot-chain matrix runs through the REAL `DaemonLock` lifecycle, never a hand-edited marker.
+- **No test touches a real daemon or live flows** (parent §2/§8). Tests use isolated `DummyProcess` children and the `CaptureServerConnection` / fake-delegate patterns from Phase B.
+- **Register every new DTO** with `[JsonSerializable(typeof(...))]` on `CapacitorJsonContext` (Models.cs) — the source-gen resolver is inserted first in the SignalR protocol chain, so an unregistered type silently drops the invocation.
+
+## File Structure
+
+**Core (kcap-cli Core — the shared wire contract, producer side):**
+- `src/Capacitor.Cli.Core/Models.cs` — MODIFY: new DTOs + enums (see appendix), additive fields on `DaemonConnect`/`DaemonStatusReport`/`LaunchAgentCommand`, `[JsonSerializable]` registrations.
+
+**Daemon durable-state components (new, in `Daemon.Services`):**
+- `src/Capacitor.Cli.Daemon/Services/CoverageJournal.cs` — CREATE: boot-chain fold → `RecordlessSurvivorsImpossible`.
+- `src/Capacitor.Cli.Daemon/Services/ResolvedCandidatesLedger.cs` — CREATE: durable positive-death-evidence outbox.
+- `src/Capacitor.Cli.Daemon/Services/MarkerCandidateStore.cs` — CREATE: dedicated durable marker-candidate source for recordless survivors.
+- `src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs` — CREATE: two serialized lanes, watermark, identity cache, acks/rejections.
+
+**Daemon wiring (modify):**
+- `src/Capacitor.Cli.Daemon/DaemonLock.cs` — expose `PriorInstanceId` (capture-before-overwrite under the flock).
+- `src/Capacitor.Cli.Daemon/DaemonRunner.cs` — record the coverage boot before `ConnectAsync`; pass durable-state deps to the orchestrator.
+- `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` — own the ledger/marker-store/processor; the four ledger hooks; `ReadLiveness`; `StartupReapComplete`/`StartupDiscovery`/`UnresolvedStartupCandidates` computation; enriched `BuildStatusReport` + `DaemonConnect` payload; route sequenced commands.
+- `src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs` — record-pass + marker-scan confirmation callbacks into the ledger; populate blocked candidates.
+- `src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs` — quarantine-drain confirmation callback.
+- `src/Capacitor.Cli.Daemon/Services/ServerConnection.cs` — `StopAgentV2` / `AckProcessedPrefix` / `AckResolvedCandidates` / `RequestStatusReport` receive handlers; `CommandAckAsync` / `CommandRejectedAsync` one-way sends; enriched `DaemonConnect`.
+
+**Tests (new, `test/Capacitor.Cli.Tests.Unit/Daemon/`):**
+- `SequencedSettlementWireTests.cs`, `CoverageJournalTests.cs`, `DaemonLockPriorInstanceIdTests.cs`, `ResolvedCandidatesLedgerTests.cs`, `LedgerHookTests.cs`, `MarkerCandidateResolutionTests.cs`, `SequencedCommandProcessorTests.cs`, `StartupCompletenessTests.cs`, `HealBarrierReportTests.cs`. Existing `AgentOrchestratorVendorTests` (partial) reused for orchestrator-level assertions.
+
+---
+
+## Appendix — Wire contract (shared; the server plan consumes this verbatim)
+
+All records are `public readonly record struct` in `src/Capacitor.Cli.Core/Models.cs`, registered on `CapacitorJsonContext`, snake_case on the wire. Enums carry `[JsonStringEnumMemberName(...)]` so the wire token is pinned EXACTLY regardless of the global naming policy; the zero value is always the safe default. `using System.Text.Json.Serialization;` is already imported by Models.cs.
+
+**New nested / report DTOs:**
+
+```csharp
+/// Positive per-id death evidence for a prior-incarnation startup candidate.
+/// Generation = daemon-lifetime monotonic ack/ordering id; (AgentId, OldEpoch) = the
+/// crash-reconciliation + server-upsert identity. Flow fields come ONLY from a trusted
+/// record-tracked resolved entry — never from a recordless marker kill (mutable env).
+public readonly record struct ResolvedStartupCandidate(
+        long    Generation,
+        string  AgentId,
+        string  OldEpoch,
+        string? FlowRunId = null,
+        string? FlowRole  = null
+    );
+
+public enum StartupCandidateUnresolvedReason {
+    [JsonStringEnumMemberName("pending_marker")]        PendingMarker        = 0,
+    [JsonStringEnumMemberName("legacy_unresolvable")]   LegacyUnresolvable   = 1,
+    [JsonStringEnumMemberName("identity_unresolvable")] IdentityUnresolvable = 2,
+}
+
+/// A known-id prior-incarnation candidate that is blocked (keeps StartupReapComplete false).
+public readonly record struct UnresolvedStartupCandidate(
+        string                           AgentId,
+        StartupCandidateUnresolvedReason Reason,
+        string?                          FlowRunId = null,
+        string?                          FlowRole  = null
+    );
+
+public enum MarkerScanState {
+    [JsonStringEnumMemberName("pending")]        Pending       = 0, // conservative default (missing field / intermediate daemon)
+    [JsonStringEnumMemberName("complete")]       Complete      = 1,
+    [JsonStringEnumMemberName("failed")]         Failed        = 2,
+    [JsonStringEnumMemberName("not_applicable")] NotApplicable = 3, // Windows (no scan) / macOS (env redacted)
+}
+
+/// Recordless-survivor discovery status; lets the server render WHY StartupReapComplete is false.
+public readonly record struct StartupDiscovery(
+        MarkerScanState MarkerScanState,
+        DateTimeOffset? LastSuccessfulScanAt = null
+    );
+```
+
+**New command / ack DTOs:**
+
+```csharp
+/// Sequenced stop primitive (capability daemons receive this instead of StopAgent).
+public readonly record struct StopAgentV2(
+        string AgentId,
+        string Epoch,
+        long   Seq,
+        string CommandId
+    );
+
+public enum CommandAckState {
+    [JsonStringEnumMemberName("accepted")]  Accepted  = 0, // accepted, not yet terminally processed
+    [JsonStringEnumMemberName("processed")] Processed = 1, // terminal; OutcomeKind + CurrentState set
+}
+
+public enum CommandOutcomeKind {
+    [JsonStringEnumMemberName("launch_executed")]       LaunchExecuted      = 0,
+    [JsonStringEnumMemberName("launch_rejected")]       LaunchRejected      = 1,
+    [JsonStringEnumMemberName("launch_failed_cleaned")] LaunchFailedCleaned = 2,
+    [JsonStringEnumMemberName("stop_executed")]         StopExecuted        = 3,
+    [JsonStringEnumMemberName("internal_error")]        InternalError       = 4,
+}
+
+/// Current liveness read live at ack time (confirmed-death precedence Live>Quarantined>Dead).
+public enum AgentLiveness {
+    [JsonStringEnumMemberName("live")]        Live        = 0,
+    [JsonStringEnumMemberName("quarantined")] Quarantined = 1,
+    [JsonStringEnumMemberName("dead")]        Dead        = 2,
+    [JsonStringEnumMemberName("not_found")]   NotFound    = 3,
+}
+
+/// Answer to an exact-duplicate sequenced command — NO re-execution.
+public readonly record struct CommandAck(
+        string              Epoch,
+        long                Seq,
+        string              CommandId,
+        CommandAckState     State,
+        CommandOutcomeKind? OutcomeKind     = null, // set iff State == Processed
+        AgentLiveness?      CurrentState    = null, // set iff State == Processed
+        string?             AgentId         = null,
+        string?             SessionId       = null,
+        string?             RejectionReason = null
+    );
+
+public enum CommandRejectedReason {
+    [JsonStringEnumMemberName("wrong_next")]           WrongNext          = 0,
+    [JsonStringEnumMemberName("duplicate_collision")]  DuplicateCollision = 1,
+    [JsonStringEnumMemberName("stale_epoch")]          StaleEpoch         = 2,
+    [JsonStringEnumMemberName("daemon_capacity")]      DaemonCapacity     = 3,
+    [JsonStringEnumMemberName("backpressure")]         Backpressure       = 4,
+    [JsonStringEnumMemberName("internal_error")]       InternalError      = 5,
+    [JsonStringEnumMemberName("semantic")]             Semantic           = 6,
+}
+
+/// Terminal rejection of a sequenced command (never advances the old epoch's watermark).
+public readonly record struct CommandRejected(
+        string                Epoch,
+        long                  Seq,
+        string                CommandId,
+        CommandRejectedReason Reason,
+        string?               AgentId = null
+    );
+
+/// Server→daemon retirement proof: may retire identity-cache entries <= UpToSeq for Epoch.
+public readonly record struct AckProcessedPrefix(
+        string Epoch,
+        long   UpToSeq
+    );
+
+/// One resolved-candidate ack entry (sparse, per-entry prune — no head-of-line retention).
+public readonly record struct ResolvedCandidateAck(
+        long   Generation,
+        string AgentId,
+        string OldEpoch
+    );
+
+/// Server→daemon: prune individual resolved-candidate ledger entries.
+public readonly record struct AckResolvedCandidates(
+        ResolvedCandidateAck[] Entries
+    );
+```
+
+**`RequestStatusReport`** is a **zero-argument server→daemon hub invocation** (no DTO), registered like the existing no-arg `_hub.On("AgentInstancesChanged", …)` sinks: `_hub.On("RequestStatusReport", handler)`. It consumes no `Seq`, mutates no state, and is answered by an immediate out-of-band `DaemonStatusReport`.
+
+**Additive fields on existing records (appended last — wire-compat):**
+
+```csharp
+// LaunchAgentCommand — after FlowRole:
+        string? Epoch     = null,  // present ⇒ sequenced lane; absent ⇒ legacy unsequenced lane
+        long?   Seq       = null,
+        string? CommandId = null
+
+// DaemonConnect — after UnattendedVendors:
+        QuarantinedAgentInfo[]?       Quarantined                   = null,
+        string?                       Epoch                         = null,
+        long?                         HighestAcceptedSeq            = null,
+        long?                         LastProcessedSeq              = null,
+        bool?                         StartupReapComplete           = null,
+        ResolvedStartupCandidate[]?   ResolvedStartupCandidates     = null,
+        UnresolvedStartupCandidate[]? UnresolvedStartupCandidates   = null,
+        StartupDiscovery?             StartupDiscovery              = null,
+        bool?                         RecordlessSurvivorsImpossible = null, // absent/false ⇒ has a recordless class
+        bool                          SupportsSequencedCommands     = false // THE capability gate
+
+// DaemonStatusReport — after Quarantined:
+        string?                       Epoch                         = null,
+        long?                         LastProcessedSeq              = null,
+        long?                         HighestAcceptedSeq            = null,
+        bool?                         StartupReapComplete           = null,
+        ResolvedStartupCandidate[]?   ResolvedStartupCandidates     = null,
+        UnresolvedStartupCandidate[]? UnresolvedStartupCandidates   = null,
+        StartupDiscovery?             StartupDiscovery              = null
+```
+
+**Compatibility rules the server plan must honor:** absent `StartupDiscovery` ⇒ treat as `MarkerScanState.Pending` (never `Complete`); absent/false `RecordlessSurvivorsImpossible` ⇒ "has a recordless class" (per-id proof required); `SupportsSequencedCommands == false` ⇒ no watermarks, no sequenced settlement; a new daemon that receives an un-`Seq`'d `LaunchAgentCommand` runs the legacy lane and never advances `LastProcessedSeq`.
+
+**`AgentLiveness` note (intentional):** `AgentLiveness`/`CommandOutcomeKind` stay as defined — nullable on the wire and always explicitly set when `State == Processed`. The daemon's `ReadLiveness` (Task 16) never returns `NotFound`; an agent absent from `_agents ∪ _quarantine` reads `Dead`. `NotFound` collapsing to `Dead` for liveness purposes is deliberate — both satisfy the server's confirmed-absence barriers — while `NotFound` remains a defined wire value a future daemon/path (e.g. a `StopExecuted` outcome, spec §5.5) may still emit distinctly.
+
+---
+
+### Task 1: Wire DTOs — report / connect side
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/Models.cs` (add `ResolvedStartupCandidate`, `UnresolvedStartupCandidate` + reason enum, `StartupDiscovery` + `MarkerScanState` enum near the D2 self-report DTOs ~line 1298; add additive fields to `DaemonConnect` ~line 1401 and `DaemonStatusReport` ~line 1294; add `[JsonSerializable]` lines ~line 961).
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/SequencedSettlementWireTests.cs` (CREATE)
+
+**Interfaces:**
+- Produces: the report/connect DTOs + enums in the appendix; enriched `DaemonConnect` and `DaemonStatusReport` constructors (all new args optional, defaulted).
+- Consumes: nothing (pure Core additions).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using System.Text.Json;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+public class SequencedSettlementWireTests {
+    static readonly JsonSerializerOptions Opts = new() {
+        TypeInfoResolver = CapacitorJsonContext.Default,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    [Test]
+    public async Task StartupDiscovery_pins_exact_wire_tokens_and_defaults_to_pending() {
+        var json = JsonSerializer.Serialize(new StartupDiscovery(MarkerScanState.Complete), Opts);
+        await Assert.That(json).Contains("\"marker_scan_state\":\"complete\"");
+
+        // The zero value (missing field) is the conservative default.
+        await Assert.That(default(MarkerScanState)).IsEqualTo(MarkerScanState.Pending);
+    }
+
+    [Test]
+    public async Task Resolved_and_unresolved_candidates_round_trip() {
+        var resolved = new ResolvedStartupCandidate(7, "a1", "old-epoch", "flow-1", "reviewer");
+        var rt = JsonSerializer.Deserialize<ResolvedStartupCandidate>(JsonSerializer.Serialize(resolved, Opts), Opts);
+        await Assert.That(rt).IsEqualTo(resolved);
+
+        var blockedJson = JsonSerializer.Serialize(
+            new UnresolvedStartupCandidate("a2", StartupCandidateUnresolvedReason.PendingMarker), Opts);
+        await Assert.That(blockedJson).Contains("\"reason\":\"pending_marker\"");
+    }
+
+    [Test]
+    public async Task DaemonStatusReport_new_fields_round_trip_and_default_null() {
+        // Old-shape construction still compiles (all new args optional).
+        var old = new DaemonStatusReport(2, [], []);
+        await Assert.That(old.Epoch).IsNull();
+        await Assert.That(old.StartupDiscovery).IsNull();
+
+        var full = new DaemonStatusReport(
+            2, [], [], Epoch: "e1", LastProcessedSeq: 5, HighestAcceptedSeq: 6,
+            StartupReapComplete: true, ResolvedStartupCandidates: [],
+            UnresolvedStartupCandidates: [], StartupDiscovery: new StartupDiscovery(MarkerScanState.Complete));
+        var rt = JsonSerializer.Deserialize<DaemonStatusReport>(JsonSerializer.Serialize(full, Opts), Opts);
+        await Assert.That(rt.Epoch).IsEqualTo("e1");
+        await Assert.That(rt.StartupReapComplete).IsTrue();
+        await Assert.That(rt.StartupDiscovery!.Value.MarkerScanState).IsEqualTo(MarkerScanState.Complete);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "SequencedSettlementWireTests"`
+Expected: FAIL to COMPILE — `ResolvedStartupCandidate`/`StartupDiscovery`/`MarkerScanState` and the new `DaemonStatusReport` args do not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Models.cs`, add the four report/connect DTOs + two enums from the appendix immediately after the `DaemonStatusReport` record (~line 1298). Append the additive fields to `DaemonStatusReport` (after `Quarantined`) and `DaemonConnect` (after `UnattendedVendors`) exactly as the appendix shows. Add these registrations next to the existing D2 lines (~line 961):
+
+```csharp
+[JsonSerializable(typeof(ResolvedStartupCandidate))]
+[JsonSerializable(typeof(ResolvedStartupCandidate[]))]
+[JsonSerializable(typeof(UnresolvedStartupCandidate))]
+[JsonSerializable(typeof(UnresolvedStartupCandidate[]))]
+[JsonSerializable(typeof(StartupCandidateUnresolvedReason))]
+[JsonSerializable(typeof(StartupDiscovery))]
+[JsonSerializable(typeof(MarkerScanState))]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "SequencedSettlementWireTests"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/Models.cs test/Capacitor.Cli.Tests.Unit/Daemon/SequencedSettlementWireTests.cs
+git commit -m "Add B2-b report/connect wire DTOs (resolved/unresolved candidates, startup discovery)"
+```
+
+---
+
+### Task 2: Wire DTOs — command / ack side
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/Models.cs` (add `StopAgentV2`, `CommandAck` + `CommandAckState`/`CommandOutcomeKind`/`AgentLiveness`, `CommandRejected` + `CommandRejectedReason`, `AckProcessedPrefix`, `ResolvedCandidateAck`, `AckResolvedCandidates`; add `Epoch`/`Seq`/`CommandId` to `LaunchAgentCommand` ~line 1244; register all on `CapacitorJsonContext`).
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/SequencedSettlementWireTests.cs` (extend)
+
+**Interfaces:**
+- Produces: the command/ack DTOs + enums; `LaunchAgentCommand` with `Epoch`/`Seq`/`CommandId`.
+- Consumes: Task 1's `AgentLiveness` reuse in `CommandAck`.
+
+- [ ] **Step 1: Write the failing test** (append to `SequencedSettlementWireTests`)
+
+```csharp
+    [Test]
+    public async Task Command_dtos_pin_wire_tokens_and_round_trip() {
+        var stop = new StopAgentV2("a1", "e1", 9, "cmd-guid");
+        var rt = JsonSerializer.Deserialize<StopAgentV2>(JsonSerializer.Serialize(stop, Opts), Opts);
+        await Assert.That(rt).IsEqualTo(stop);
+
+        var ackJson = JsonSerializer.Serialize(
+            new CommandAck("e1", 9, "cmd", CommandAckState.Processed,
+                CommandOutcomeKind.LaunchExecuted, AgentLiveness.Live, "a1", "sess"), Opts);
+        await Assert.That(ackJson).Contains("\"state\":\"processed\"");
+        await Assert.That(ackJson).Contains("\"outcome_kind\":\"launch_executed\"");
+        await Assert.That(ackJson).Contains("\"current_state\":\"live\"");
+
+        var rejJson = JsonSerializer.Serialize(
+            new CommandRejected("e1", 9, "cmd", CommandRejectedReason.StaleEpoch, "a1"), Opts);
+        await Assert.That(rejJson).Contains("\"reason\":\"stale_epoch\"");
+
+        var pruneJson = JsonSerializer.Serialize(
+            new AckResolvedCandidates([new ResolvedCandidateAck(3, "a1", "old")]), Opts);
+        await Assert.That(pruneJson).Contains("\"generation\":3");
+    }
+
+    [Test]
+    public async Task LaunchAgentCommand_gains_optional_sequencing_fields() {
+        var legacy = new LaunchAgentCommand("a1", "hi", "opus", null, "/repo", null, null, "claude");
+        await Assert.That(legacy.Seq).IsNull(); // absent ⇒ legacy lane
+
+        var seqd = legacy with { Epoch = "e1", Seq = 4, CommandId = "cmd" };
+        var rt = JsonSerializer.Deserialize<LaunchAgentCommand>(JsonSerializer.Serialize(seqd, Opts), Opts);
+        await Assert.That(rt.Seq).IsEqualTo(4L);
+        await Assert.That(rt.CommandId).IsEqualTo("cmd");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "SequencedSettlementWireTests"`
+Expected: FAIL to COMPILE — `StopAgentV2`/`CommandAck`/`CommandRejected` and `LaunchAgentCommand.Seq` do not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the command/ack DTOs + enums from the appendix after the report DTOs in `Models.cs`. Append `Epoch`/`Seq`/`CommandId` to `LaunchAgentCommand` after `FlowRole`. Register each:
+
+```csharp
+[JsonSerializable(typeof(StopAgentV2))]
+[JsonSerializable(typeof(CommandAck))]
+[JsonSerializable(typeof(CommandAckState))]
+[JsonSerializable(typeof(CommandOutcomeKind))]
+[JsonSerializable(typeof(AgentLiveness))]
+[JsonSerializable(typeof(CommandRejected))]
+[JsonSerializable(typeof(CommandRejectedReason))]
+[JsonSerializable(typeof(AckProcessedPrefix))]
+[JsonSerializable(typeof(ResolvedCandidateAck))]
+[JsonSerializable(typeof(AckResolvedCandidates))]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "SequencedSettlementWireTests"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/Models.cs test/Capacitor.Cli.Tests.Unit/Daemon/SequencedSettlementWireTests.cs
+git commit -m "Add B2-b command/ack wire DTOs (StopAgentV2, CommandAck/Rejected, acks) + LaunchAgentCommand sequencing fields"
+```
+
+---
+
+### Task 3: `DaemonLock` captures the prior boot's `InstanceId`
+
+The lock file's `InstanceId` is the persistent per-boot nonce — rewritten by every shipped version at every boot and NOT deleted on clean shutdown (`Dispose` only removes the PID + version files; `Dispose_DoesNotDeleteLockFile` proves the `.lock` survives). The coverage boot-chain needs the PREVIOUS boot's id, captured under the held flock before we overwrite it.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/DaemonLock.cs` (open `FileAccess.ReadWrite`; capture content before `SetLength(0)`; add `PriorInstanceId` property).
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockPriorInstanceIdTests.cs` (CREATE)
+
+**Interfaces:**
+- Produces: `DaemonLock.PriorInstanceId` (`string?` — the previous holder's InstanceId, or null on a genuinely fresh lock / unreadable content).
+- Consumes: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+public class DaemonLockPriorInstanceIdTests {
+    static string Scratch() {
+        var dir = Path.Combine(Path.GetTempPath(), "kcap-lock-prior", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        return dir;
+    }
+
+    [Test]
+    public async Task FreshSlot_has_null_prior_instance_id() {
+        var dir = Scratch();
+        try {
+            using var l = DaemonLock.TryAcquire("alpha");
+            await Assert.That(l!.PriorInstanceId).IsNull();
+        } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); Directory.Delete(dir, true); }
+    }
+
+    [Test]
+    public async Task ReAcquire_sees_the_previous_boots_instance_id() {
+        var dir = Scratch();
+        try {
+            var first = DaemonLock.TryAcquire("alpha")!;
+            var firstId = first.InstanceId;
+            first.Dispose(); // lock file (with firstId) survives Dispose
+
+            using var second = DaemonLock.TryAcquire("alpha");
+            await Assert.That(second!.PriorInstanceId).IsEqualTo(firstId);
+            await Assert.That(second.InstanceId).IsNotEqualTo(firstId);
+        } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); Directory.Delete(dir, true); }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "DaemonLockPriorInstanceIdTests"`
+Expected: FAIL to COMPILE — `PriorInstanceId` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `DaemonLock.cs`: add the field + property, thread it through the private ctor, open `FileAccess.ReadWrite`, and capture before truncation.
+
+```csharp
+    // add near PriorHolderPid:
+    public string? PriorInstanceId { get; }
+
+    // private ctor: add a `string? priorInstanceId` parameter and `PriorInstanceId = priorInstanceId;`
+```
+
+In `TryAcquire`, change the open to `FileAccess.ReadWrite`:
+
+```csharp
+            stream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+```
+
+Immediately after `var (priorUnclean, priorPid) = InspectPriorHolder(pidPath);`, capture the prior lock content (we hold the flock, so the prior holder is provably gone) BEFORE the `stream.SetLength(0)` truncation:
+
+```csharp
+        // Capture the previous holder's InstanceId from the lock-file content BEFORE we overwrite it —
+        // the persistent per-boot nonce the coverage boot-chain uses to detect an intervening
+        // (possibly unaware) boot. Read failures degrade to null (fail-closed downstream).
+        string? priorInstanceId = null;
+        try {
+            if (stream.Length > 0) {
+                stream.Position = 0;
+                var buf = new byte[stream.Length];
+                var n = stream.Read(buf, 0, buf.Length);
+                priorInstanceId = System.Text.Encoding.UTF8.GetString(buf, 0, n)
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .FirstOrDefault();
+            }
+        } catch { priorInstanceId = null; }
+```
+
+Pass `priorInstanceId` into the single `new DaemonLock(...)` call site (`DaemonLock.cs:125`, the final `return`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "DaemonLockPriorInstanceIdTests"`
+Expected: PASS (2 tests). Also re-run `DaemonLockTests` — unchanged behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/DaemonLock.cs test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockPriorInstanceIdTests.cs
+git commit -m "DaemonLock: capture the prior boot's InstanceId under the held flock"
+```
+
+---
+
+### Task 4: `CoverageJournal` — durable boot-chain fold → `RecordlessSurvivorsImpossible`
+
+A durable fold in the daemon's state dir. `cumulative_covered(this boot) = tail.cumulative_covered AND chain_check_passed AND this_epoch_contained`, with a sound genesis base case and fail-closed I/O. Sticky-false by construction (the detecting boot persists `false` in its own tail).
+
+**Single-file atomicity (spec §4.2.3: "`state_dir_initialized` marker + journal in the SAME atomic operation").** The `initialized` flag is folded INTO the journal file itself — the journal is a single JSON document `{ initialized: true, instance_id, cumulative_covered }` written by ONE temp+rename. There is NO separate `state_dir_initialized` marker file (two non-atomic writes would leave a genesis-boot crash with journal-present/marker-absent, which the next boot would read as genesis=false and permanently poison `cumulative_covered` to false — operator-reset-only). **Genesis-eligibility is therefore "the journal file is absent"** (not "a separate marker is absent"): the single atomic rename is the only durable state transition, so a crash is provably either before the rename (no journal ⇒ still genesis-eligible, re-seeds correctly) or after it (a valid, fully-initialized journal). All other pinned semantics are unchanged: genesis needs no prior lock `InstanceId`; a new/deleted dir WITH a prior lock `InstanceId` ⇒ seed false; fail-closed; sticky-false; operator-reset-only `false→true`; downgrade-sandwich detection via the captured-before-overwrite lock `InstanceId`.
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/CoverageJournal.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/CoverageJournalTests.cs` (CREATE — the boot-chain matrix, driven through the REAL `DaemonLock` lifecycle)
+
+**Interfaces:**
+- Produces: `internal sealed class CoverageJournal(string stateDir, ILogger logger)` with `bool RecordBoot(string myInstanceId, string? priorLockInstanceId, bool thisEpochContained)` — writes the new tail atomically and returns `cumulative_covered`.
+- Consumes: `DaemonLock.PriorInstanceId` (Task 3), `DaemonLock.InstanceId`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+public class CoverageJournalTests {
+    // Real DaemonLock lifecycle so the InstanceId chain is genuine, never a hand-edited marker.
+    sealed class Harness : IDisposable {
+        public readonly string LockDir  = Path.Combine(Path.GetTempPath(), "kcap-cov-lock", Guid.NewGuid().ToString("N"));
+        public readonly string StateDir = Path.Combine(Path.GetTempPath(), "kcap-cov-state", Guid.NewGuid().ToString("N"));
+        public Harness() { Directory.CreateDirectory(LockDir); Directory.CreateDirectory(StateDir);
+            DaemonLockPaths.OverrideDirectoryForTesting(LockDir); }
+        // One real boot: acquire the lock, record coverage (aware), dispose.
+        public bool AwareBoot(bool contained = true) {
+            using var l = DaemonLock.TryAcquire("alpha")!;
+            return new CoverageJournal(StateDir, NullLogger.Instance)
+                .RecordBoot(l.InstanceId, l.PriorInstanceId, contained);
+        }
+        // An unaware/old boot: acquires the real lock (mints a fresh InstanceId) but writes NO journal.
+        public void UnawareBoot() { using var l = DaemonLock.TryAcquire("alpha")!; }
+        public void Dispose() { DaemonLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(LockDir, true); } catch { } try { Directory.Delete(StateDir, true); } catch { } }
+    }
+
+    [Test] public async Task Genesis_first_ever_contained_boot_seeds_true() {
+        using var h = new Harness();
+        await Assert.That(h.AwareBoot(contained: true)).IsTrue();
+    }
+
+    [Test] public async Task Genesis_uncontained_epoch_is_false() {
+        using var h = new Harness();
+        await Assert.That(h.AwareBoot(contained: false)).IsFalse();
+    }
+
+    [Test] public async Task Clean_and_crashed_W1_to_W1_keep_the_chain() {
+        using var h = new Harness();
+        await Assert.That(h.AwareBoot()).IsTrue();
+        await Assert.That(h.AwareBoot()).IsTrue(); // prior tail id == prior lock id ⇒ chain intact
+    }
+
+    [Test] public async Task Downgrade_sandwich_breaks_the_chain_permanently() {
+        using var h = new Harness();
+        await Assert.That(h.AwareBoot()).IsTrue();
+        h.UnawareBoot();                             // old boot mints a fresh lock InstanceId, no journal
+        await Assert.That(h.AwareBoot()).IsFalse();  // prior lock id != journal tail id ⇒ broken
+        await Assert.That(h.AwareBoot()).IsFalse();  // sticky: the detecting boot persisted false
+    }
+
+    [Test] public async Task Aware_but_uncontained_epoch_poisons_all_later_boots() {
+        using var h = new Harness();
+        await Assert.That(h.AwareBoot(contained: true)).IsTrue();
+        await Assert.That(h.AwareBoot(contained: false)).IsFalse(); // this_epoch_contained=false
+        await Assert.That(h.AwareBoot(contained: true)).IsFalse();  // folds from false ⇒ still false
+    }
+
+    [Test] public async Task Empty_looking_used_dir_with_prior_lock_is_false() {
+        using var h = new Harness();
+        // A pre-existing (previously-used) state dir with NO journal file + a prior lock InstanceId.
+        // Genesis-eligibility is "journal absent", but a prior lock InstanceId ⇒ un-journaled history ⇒ false.
+        h.UnawareBoot(); // prior lock id exists; state dir has no journal
+        await Assert.That(h.AwareBoot()).IsFalse();
+    }
+
+    [Test] public async Task Corrupt_coverage_state_is_false() {
+        using var h = new Harness();
+        await Assert.That(h.AwareBoot()).IsTrue();
+        File.WriteAllText(Path.Combine(h.StateDir, "coverage.json"), "{ not json");
+        await Assert.That(h.AwareBoot()).IsFalse();
+    }
+
+    [Test] public async Task Genesis_crash_before_the_single_rename_leaves_no_journal_and_reseeds() {
+        using var h = new Harness();
+        // The genesis write is ONE atomic temp+rename of a single {initialized,instance_id,cumulative_covered}
+        // document. A crash BEFORE the rename leaves at most a stray .tmp — never a partial journal and never
+        // a separate marker — so File.Exists(coverage.json) stays false and the next boot is still
+        // genesis-eligible (re-seeds correctly). A COMPLETED rename is a valid, fully-initialized journal.
+        Directory.CreateDirectory(h.StateDir);
+        var journal = Path.Combine(h.StateDir, "coverage.json");
+        File.WriteAllText(journal + ".tmp-deadbeef", "{ partial"); // crash-before-rename residue
+        await Assert.That(File.Exists(journal)).IsFalse();
+
+        await Assert.That(h.AwareBoot(contained: true)).IsTrue();  // journal absent + no prior lock id ⇒ genesis re-seeds
+        await Assert.That(File.Exists(journal)).IsTrue();          // the completed rename is durable
+        await Assert.That(h.AwareBoot(contained: true)).IsTrue();  // a valid initialized journal ⇒ chain intact
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "CoverageJournalTests"`
+Expected: FAIL to COMPILE — `CoverageJournal` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Phase B2-b (sequenced-settlement design §4.2.3): the durable boot-chain attestation that
+/// drives <c>RecordlessSurvivorsImpossible</c>. A boolean alone cannot witness boots by UNAWARE
+/// binaries, so this folds across the lock file's persistent per-boot <c>InstanceId</c> nonce
+/// (the only marker every shipped version rewrites at boot and never deletes):
+///
+///   cumulative_covered(this boot) = tail.cumulative_covered AND chain_check AND this_epoch_contained
+///
+/// where chain_check is "the immediately-preceding boot was our own recorded aware epoch"
+/// (prior lock InstanceId == journal tail's recorded id). Sticky-false by construction: the
+/// detecting boot persists false in its OWN tail, so every later boot inherits it. Fail-closed:
+/// any missing/corrupt/unwritable state evaluates to false. The only false->true path is the
+/// documented operator reset (delete the state dir AND the per-name lock -> next boot is genesis).
+///
+/// The spec's "state_dir_initialized marker + journal in the SAME atomic operation" is satisfied by
+/// folding the <c>Initialized</c> flag INTO the journal document — a single JSON
+/// {initialized, instance_id, cumulative_covered} written by ONE temp+rename. There is deliberately
+/// NO separate marker file (two non-atomic writes would let a genesis-boot crash leave
+/// journal-present/marker-absent → next boot reads genesis=false → permanently poisoned). Genesis
+/// eligibility is therefore "the journal file is absent": the single rename is the only durable state
+/// transition, so a crash is provably either before it (no journal ⇒ re-seed) or after it (a valid
+/// initialized journal).
+/// </summary>
+internal sealed class CoverageJournal(string stateDir, ILogger logger) {
+    readonly string _journalPath = Path.Combine(stateDir, "coverage.json");
+
+    readonly record struct Journal(bool Initialized, string InstanceId, bool CumulativeCovered);
+
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+    [JsonSerializable(typeof(Journal))]
+    partial class Ctx : JsonSerializerContext;
+
+    /// <summary>Fold this boot and persist the new journal atomically BEFORE Connect/spawn. Returns
+    /// cumulative_covered. Never throws — an I/O failure returns false (fail-closed).</summary>
+    public bool RecordBoot(string myInstanceId, string? priorLockInstanceId, bool thisEpochContained) {
+        try {
+            var journalExists = File.Exists(_journalPath);
+            var prior         = journalExists ? ReadJournal() : null; // null ⇒ present-but-corrupt
+
+            bool covered;
+            if (!journalExists) {
+                // Genesis is the ONLY seed-true base case: the journal file is absent (we are about to
+                // atomically initialize it) AND the captured prior lock shows no pre-existing InstanceId
+                // (a genuine first-ever boot for this name). A previously-used dir whose journal is gone
+                // but whose prior lock DOES carry an InstanceId is un-journaled history that re-pointing/
+                // deleting the dir cannot launder ⇒ false.
+                var genesis = priorLockInstanceId is null;
+                covered = genesis && thisEpochContained;
+            } else if (prior is not { Initialized: true } t) {
+                covered = false; // journal present but corrupt / not fully initialized -> fail-closed
+            } else {
+                var chainOk = priorLockInstanceId is { } pid && string.Equals(pid, t.InstanceId, StringComparison.Ordinal);
+                covered = t.CumulativeCovered && chainOk && thisEpochContained;
+            }
+
+            WriteJournalAtomic(new Journal(true, myInstanceId, covered)); // persists the break in THIS entry (sticky)
+            return covered;
+        } catch (Exception ex) {
+            logger.LogWarning(ex, "CoverageJournal: fold/persist failed — advertising RecordlessSurvivorsImpossible=false (fail-closed)");
+            return false;
+        }
+    }
+
+    Journal? ReadJournal() {
+        try {
+            return JsonSerializer.Deserialize(File.ReadAllText(_journalPath), Ctx.Default.Journal);
+        } catch { return null; } // corrupt -> journal present but unparseable => false (never genesis)
+    }
+
+    void WriteJournalAtomic(Journal journal) {
+        Directory.CreateDirectory(stateDir);
+        var tmp = _journalPath + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
+        File.WriteAllText(tmp, JsonSerializer.Serialize(journal, Ctx.Default.Journal));
+        File.Move(tmp, _journalPath, overwrite: true);   // THE single atomic same-directory rename (marker folded in)
+    }
+}
+```
+
+Note on the `Corrupt_coverage_state_is_false` case: after the first aware boot the journal exists with `initialized:true`; a corrupt journal then lands in the `prior is not { Initialized: true } t` branch (journal present, unparseable) ⇒ false — never mistaken for genesis (genesis requires the file to be ABSENT). Correct.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "CoverageJournalTests"`
+Expected: PASS (8 tests — incl. the genesis crash-before-rename case).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/CoverageJournal.cs test/Capacitor.Cli.Tests.Unit/Daemon/CoverageJournalTests.cs
+git commit -m "Add CoverageJournal boot-chain fold (RecordlessSurvivorsImpossible attestation)"
+```
+
+---
+
+### Task 5: Record the coverage boot + advertise `RecordlessSurvivorsImpossible`
+
+Wire `CoverageJournal.RecordBoot` into daemon boot (BEFORE `ConnectAsync`/spawn), pass the result to the orchestrator, and advertise it on `DaemonConnect` + `DaemonStatusReport`. `this_epoch_contained` is true only where OS containment leaves genuinely no recordless survivor class — the Windows Job Object (`OperatingSystem.IsWindows()`); the server consumes `RecordlessSurvivorsImpossible` only on Windows, so a Linux/macOS value is inert.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/DaemonRunner.cs` (compute + record before `ConnectAsync`; stash on `DaemonConfig`).
+- Modify: `src/Capacitor.Cli.Daemon/DaemonConfig.cs` (add `bool RecordlessSurvivorsImpossible { get; set; }`).
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (`BuildStatusReport` + the `DaemonConnect` payload advertise it).
+- Modify: `src/Capacitor.Cli.Daemon/Services/ServerConnection.cs` (`DaemonConnectAsync` passes it).
+- Test: extend `AgentOrchestratorVendorTests` (partial) — the report carries the config value.
+
+**Interfaces:**
+- Consumes: `CoverageJournal.RecordBoot` (Task 4), `DaemonLock.PriorInstanceId`/`InstanceId` (Task 3).
+- Produces: `DaemonConfig.RecordlessSurvivorsImpossible`; the flag on `DaemonStatusReport`/`DaemonConnect`.
+
+- [ ] **Step 1: Write the failing test** (new file `test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs`, partial of the vendor-tests class for the harness)
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Status_report_advertises_recordless_survivors_impossible_from_config() {
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>(),
+            configure: c => c.RecordlessSurvivorsImpossible = true);
+
+        await Assert.That(orch.BuildStatusReport().RecordlessSurvivorsImpossible).IsTrue();
+    }
+}
+```
+
+Wait — `DaemonStatusReport` has no `RecordlessSurvivorsImpossible` field (it is a connect-only capability). Assert via the connect payload instead: expose an internal `BuildConnectRecordlessFlag()` seam OR assert on `orch.RecordlessSurvivorsImpossibleForTest`. Use the latter:
+
+```csharp
+        await Assert.That(orch.RecordlessSurvivorsImpossibleForTest).IsTrue();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "advertises_recordless"`
+Expected: FAIL to COMPILE — `DaemonConfig.RecordlessSurvivorsImpossible` / `RecordlessSurvivorsImpossibleForTest` do not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`DaemonConfig.cs`: add `public bool RecordlessSurvivorsImpossible { get; set; }`.
+
+`AgentOrchestrator.cs`: store it from config in the ctor and expose it (used by the connect payload in Task 17 and the test seam):
+
+```csharp
+    // field near _daemonEpoch:
+    readonly bool _recordlessSurvivorsImpossible;
+    // in ctor, after _daemonEpoch assignment:
+    _recordlessSurvivorsImpossible = config.RecordlessSurvivorsImpossible;
+    // test seam near DaemonEpochForTest:
+    internal bool RecordlessSurvivorsImpossibleForTest => _recordlessSurvivorsImpossible;
+```
+
+`ServerConnection.DaemonConnectAsync`: pass `RecordlessSurvivorsImpossible: _config.RecordlessSurvivorsImpossible` in the `DaemonConnect` ctor (see Task 17 for the full enriched payload; for now add just this named arg).
+
+`DaemonRunner.cs`: after `config.InstanceId = daemonLock.InstanceId;` (~line 198), record the coverage boot before the services are built:
+
+```csharp
+        // Phase B2-b (sequenced-settlement §4.2.3): fold the durable coverage boot-chain BEFORE any
+        // Connect/spawn. this_epoch_contained is true only where OS containment leaves NO recordless
+        // survivor class (the Windows Job Object). Fail-closed inside RecordBoot.
+        var coverageStateDir = Path.Combine(
+            config.StateDir ?? DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(config.Name));
+        config.RecordlessSurvivorsImpossible = new CoverageJournal(coverageStateDir, /*logger*/ NullLogger.Instance)
+            .RecordBoot(daemonLock.InstanceId, daemonLock.PriorInstanceId, thisEpochContained: OperatingSystem.IsWindows());
+```
+
+(Use the DaemonRunner's available logger factory rather than `NullLogger` if one is in scope at that point; `NullLogger.Instance` is acceptable this early in boot — add `using Microsoft.Extensions.Logging.Abstractions;`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "advertises_recordless"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/DaemonRunner.cs src/Capacitor.Cli.Daemon/DaemonConfig.cs src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs src/Capacitor.Cli.Daemon/Services/ServerConnection.cs test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
+git commit -m "Record coverage boot at startup and advertise RecordlessSurvivorsImpossible"
+```
+
+---
+
+### Task 6: `ResolvedCandidatesLedger` — durable positive-death-evidence outbox
+
+Durable, state-dir, atomic temp+rename (same discipline as `AgentPidRecordStore`). Daemon-lifetime monotonic `Generation` persisted WITH the ledger. Idempotent upsert keyed on the source-stable `(AgentId, OldEpoch)` — NOT `Generation` (which the pre-append source lacks). Per-entry `Ack` prunes independently (no head-of-line retention). Re-reported until acked.
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/ResolvedCandidatesLedger.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/ResolvedCandidatesLedgerTests.cs` (CREATE)
+
+**Interfaces:**
+- Produces:
+  - `internal sealed class ResolvedCandidatesLedger(string stateDir, ILogger logger)`
+  - `ResolvedStartupCandidate Upsert(string agentId, string oldEpoch, string? flowRunId, string? flowRole)` — assigns/returns the entry (idempotent on `(agentId, oldEpoch)`; allocates a new `Generation` only for a genuinely new key), persisted atomically before returning.
+  - `IReadOnlyList<ResolvedStartupCandidate> Snapshot()` — all un-acked entries, in `Generation` order.
+  - `void Ack(IEnumerable<ResolvedCandidateAck> entries)` — prune matching `(Generation, AgentId, OldEpoch)`; unknown/already-pruned keys are idempotent no-ops.
+- Consumes: `ResolvedStartupCandidate`/`ResolvedCandidateAck` (Task 1/2).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+public class ResolvedCandidatesLedgerTests {
+    static ResolvedCandidatesLedger New(out string dir) {
+        dir = Path.Combine(Path.GetTempPath(), "kcap-ledger-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return new ResolvedCandidatesLedger(dir, NullLogger.Instance);
+    }
+
+    [Test] public async Task Upsert_is_idempotent_on_agent_and_epoch_and_monotonic_generation() {
+        var l = New(out _);
+        var a = l.Upsert("a1", "e0", null, null);
+        var b = l.Upsert("a2", "e0", null, null);
+        var aAgain = l.Upsert("a1", "e0", null, null); // same key -> same generation, no new entry
+        await Assert.That(a.Generation).IsEqualTo(1L);
+        await Assert.That(b.Generation).IsEqualTo(2L);
+        await Assert.That(aAgain.Generation).IsEqualTo(1L);
+        await Assert.That(l.Snapshot().Count).IsEqualTo(2);
+    }
+
+    [Test] public async Task Snapshot_and_generation_survive_restart() {
+        var l = New(out var dir);
+        l.Upsert("a1", "e0", "flow", "reviewer");
+        var reopened = new ResolvedCandidatesLedger(dir, NullLogger.Instance);
+        await Assert.That(reopened.Snapshot().Single().AgentId).IsEqualTo("a1");
+        // A new key after restart must not reuse generation 1.
+        await Assert.That(reopened.Upsert("a2", "e0", null, null).Generation).IsEqualTo(2L);
+    }
+
+    [Test] public async Task Ack_prunes_sparsely_without_head_of_line_blocking() {
+        var l = New(out _);
+        var g1 = l.Upsert("a1", "e0", null, null);
+        var g2 = l.Upsert("a2", "e0", null, null);
+        var g3 = l.Upsert("a3", "e0", null, null);
+        l.Ack([new ResolvedCandidateAck(g1.Generation, "a1", "e0"),
+               new ResolvedCandidateAck(g3.Generation, "a3", "e0")]);
+        await Assert.That(l.Snapshot().Select(x => x.AgentId)).IsEquivalentTo(new[] { "a2" });
+        l.Ack([new ResolvedCandidateAck(g2.Generation, "a2", "e0")]); // idempotent for already-pruned too
+        l.Ack([new ResolvedCandidateAck(99, "nope", "e0")]);          // unknown -> no-op
+        await Assert.That(l.Snapshot()).IsEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "ResolvedCandidatesLedgerTests"`
+Expected: FAIL to COMPILE — `ResolvedCandidatesLedger` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```csharp
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Capacitor.Cli.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Phase B2-b (sequenced-settlement design §4.2.4): the durable outbox of positive per-id death
+/// evidence. Persisted atomically (temp+rename) in the daemon state dir; the monotonic
+/// <c>Generation</c> counter persists WITH it (spans epochs + restarts). Upsert is idempotent on the
+/// source-stable <c>(AgentId, OldEpoch)</c> key — the same key never mints a second entry, so a
+/// crash-reconciled re-append (source leftover matched by <c>(AgentId, OldEpoch)</c>) collapses onto
+/// the committed entry. <c>Generation</c> is the server-facing ack/ordering id only. Entries are
+/// re-reported every connect/report until <see cref="Ack"/> prunes them sparsely.
+/// </summary>
+internal sealed class ResolvedCandidatesLedger {
+    readonly string _path;
+    readonly ILogger _logger;
+    readonly object _lock = new();
+    readonly Dictionary<(string AgentId, string OldEpoch), ResolvedStartupCandidate> _entries = new();
+    long _nextGeneration = 1;
+
+    public ResolvedCandidatesLedger(string stateDir, ILogger logger) {
+        Directory.CreateDirectory(stateDir);
+        _path = Path.Combine(stateDir, "resolved-candidates.json");
+        _logger = logger;
+        Load();
+    }
+
+    public ResolvedStartupCandidate Upsert(string agentId, string oldEpoch, string? flowRunId, string? flowRole) {
+        lock (_lock) {
+            var key = (agentId, oldEpoch);
+            if (_entries.TryGetValue(key, out var existing)) return existing; // idempotent — no new generation
+            var entry = new ResolvedStartupCandidate(_nextGeneration++, agentId, oldEpoch, flowRunId, flowRole);
+            _entries[key] = entry;
+            Persist();
+            return entry;
+        }
+    }
+
+    public IReadOnlyList<ResolvedStartupCandidate> Snapshot() {
+        lock (_lock) return [.. _entries.Values.OrderBy(e => e.Generation)];
+    }
+
+    public void Ack(IEnumerable<ResolvedCandidateAck> entries) {
+        lock (_lock) {
+            var changed = false;
+            foreach (var a in entries) {
+                var key = (a.AgentId, a.OldEpoch);
+                if (_entries.TryGetValue(key, out var e) && e.Generation == a.Generation)
+                    changed |= _entries.Remove(key);
+            }
+            if (changed) Persist();
+        }
+    }
+
+    // ── durable state (persist the entries AND the generation high-water together) ────────────────
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+    [JsonSerializable(typeof(Persisted))]
+    partial class Ctx : JsonSerializerContext;
+
+    readonly record struct Persisted(long NextGeneration, ResolvedStartupCandidate[] Entries);
+
+    void Load() {
+        try {
+            if (!File.Exists(_path)) return;
+            var p = JsonSerializer.Deserialize(File.ReadAllText(_path), Ctx.Default.Persisted);
+            _nextGeneration = Math.Max(1, p.NextGeneration);
+            foreach (var e in p.Entries ?? []) _entries[(e.AgentId, e.OldEpoch)] = e;
+        } catch (Exception ex) {
+            _logger.LogWarning(ex, "ResolvedCandidatesLedger: unreadable ledger — starting empty (re-derived from sources next boot)");
+        }
+    }
+
+    void Persist() {
+        var tmp = _path + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
+        File.WriteAllText(tmp, JsonSerializer.Serialize(
+            new Persisted(_nextGeneration, [.. _entries.Values]), Ctx.Default.Persisted));
+        File.Move(tmp, _path, overwrite: true); // atomic same-directory rename
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "ResolvedCandidatesLedgerTests"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/ResolvedCandidatesLedger.cs test/Capacitor.Cli.Tests.Unit/Daemon/ResolvedCandidatesLedgerTests.cs
+git commit -m "Add ResolvedCandidatesLedger durable positive-death-evidence outbox"
+```
+
+---
+
+### Task 7: Hook A — `OrphanReaper` record-pass confirmed-gone → ledger (append-before-delete)
+
+The record pass confirms a prior-incarnation record's process gone (killed, already-exited, or proven identity mismatch — `ReapByRecordAsync == true`). Emit the resolved entry to the ledger BEFORE deleting the source record. On a crash between append and delete, the restart's record pass re-derives the leftover source, `Upsert` collapses onto the committed entry (idempotent on `(AgentId, OldEpoch)`), and the delete is retried. Flow fields come from the TRUSTED record.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs` (add an optional `onRecordResolved` callback; invoke it before `store.Delete` in the record pass).
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/LedgerHookTests.cs` (CREATE)
+
+**Interfaces:**
+- Consumes: `ResolvedCandidatesLedger.Upsert` (Task 6), `AgentPidRecord.DaemonEpoch`/`FlowRunId`/`FlowRole`.
+- Produces: `OrphanReaper` ctor gains a trailing `Action<string agentId, string oldEpoch, string? flowRunId, string? flowRole>? onRecordResolved = null` (existing 4-arg call sites/tests unaffected).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+public class LedgerHookTests {
+    static (AgentPidRecordStore store, ResolvedCandidatesLedger ledger, string dir) NewPair() {
+        var dir = Path.Combine(Path.GetTempPath(), "kcap-hook-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return (new AgentPidRecordStore(dir, NullLogger.Instance), new ResolvedCandidatesLedger(dir, NullLogger.Instance), dir);
+    }
+
+    [Test]
+    public async Task Record_pass_appends_resolved_evidence_before_deleting_the_source() {
+        var (store, ledger, _) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5)); // process gone -> confirmed absent
+
+        store.Write(new AgentPidRecord("gone", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-1", "reviewer", "did", "old-epoch", DateTimeOffset.UtcNow));
+
+        var reaper = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await reaper.ReapOnceAsync();
+
+        var entry = ledger.Snapshot().Single();
+        await Assert.That(entry.AgentId).IsEqualTo("gone");
+        await Assert.That(entry.OldEpoch).IsEqualTo("old-epoch");
+        await Assert.That(entry.FlowRole).IsEqualTo("reviewer"); // from the trusted record
+        await Assert.That(store.ReadAll()).IsEmpty();            // source deleted after the append
+    }
+
+    [Test]
+    public async Task Crash_between_append_and_delete_reconciles_idempotently_on_restart() {
+        var (store, ledger, dir) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        store.Write(new AgentPidRecord("gone", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-1", "reviewer", "did", "old-epoch", DateTimeOffset.UtcNow));
+
+        // Simulate crash-after-append-before-delete: append, but skip the delete this pass.
+        var crashing = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => { ledger.Upsert(a, e, fr, role); throw new IOException("crash before delete"); });
+        try { await crashing.ReapOnceAsync(); } catch { /* the reaper swallows per-record faults */ }
+        await Assert.That(store.ReadAll()).IsNotEmpty();          // leftover source
+        var gen = ledger.Snapshot().Single().Generation;
+
+        // Restart: re-derive from the leftover source; Upsert collapses onto the committed entry.
+        var restarted = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await restarted.ReapOnceAsync();
+        await Assert.That(store.ReadAll()).IsEmpty();             // leftover source now deleted
+        await Assert.That(ledger.Snapshot().Single().Generation).IsEqualTo(gen); // single emit, no new generation
+    }
+
+    [Test]
+    public async Task Crash_before_append_re_derives_the_record_pass_evidence_next_boot() {
+        // Parent §8: crash BEFORE the durable append leaves the source only → re-derived next boot
+        // (at-least-once, deduped). The record pass confirms death but the daemon dies before Upsert.
+        var (store, ledger, _) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        store.Write(new AgentPidRecord("gone", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-1", "reviewer", "did", "old-epoch", DateTimeOffset.UtcNow));
+
+        // Crash before the append: the confirmed-gone branch throws before touching the ledger.
+        var crashing = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (_, _, _, _) => throw new IOException("crash before append"));
+        try { await crashing.ReapOnceAsync(); } catch { /* per-record faults swallowed */ }
+        await Assert.That(ledger.Snapshot()).IsEmpty();          // nothing committed
+        await Assert.That(store.ReadAll()).IsNotEmpty();         // source persists
+
+        // Next boot re-derives from the on-disk pre-append source shape (keyed (AgentId, OldEpoch)).
+        var restarted = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await restarted.ReapOnceAsync();
+        var entry = ledger.Snapshot().Single();
+        await Assert.That(entry.AgentId).IsEqualTo("gone");
+        await Assert.That(entry.OldEpoch).IsEqualTo("old-epoch");
+        await Assert.That(store.ReadAll()).IsEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "LedgerHookTests"`
+Expected: FAIL to COMPILE — the `onRecordResolved` ctor parameter does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `OrphanReaper.cs`, add the trailing ctor parameter and invoke it before deletion in the record pass:
+
+```csharp
+internal sealed class OrphanReaper(
+        AgentPidRecordStore store, string daemonId, string currentEpoch, ILogger logger,
+        Action<string, string, string?, string?>? onRecordResolved = null) {
+```
+
+In `ReapOnceAsync`, the confirmed-gone branch of the record pass — invoke the callback BEFORE `store.Delete`:
+
+```csharp
+                if (confirmedGone) {
+                    // Phase B2-b (§4.2.4): ledger-append BEFORE source-deletion. A crash between the two
+                    // leaves a committed entry + leftover source; the next boot re-derives it and Upsert
+                    // (idempotent on (AgentId, OldEpoch)) collapses onto the committed entry, then deletes.
+                    onRecordResolved?.Invoke(record.AgentId, record.DaemonEpoch, record.FlowRunId, record.FlowRole);
+                    store.Delete(record.AgentId);
+                    logger.LogInformation(
+                        "OrphanReaper: reaped leftover agent {AgentId} (pid {Pid}) from a prior daemon run",
+                        record.AgentId, record.Pid);
+                }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "LedgerHookTests"`
+Expected: PASS (3 tests — happy path + crash between-append-delete + crash before-append). Re-run `OrphanReaperTests` — unaffected (callback defaults null).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs test/Capacitor.Cli.Tests.Unit/Daemon/LedgerHookTests.cs
+git commit -m "Hook OrphanReaper record-pass into the resolved-candidates ledger (append-before-delete)"
+```
+
+---
+
+### Task 8: Hooks B & C — quarantine drain + StopAgent-fallback → ledger
+
+Both live in the orchestrator. The **quarantine drain** (`RetryQuarantineOnceAsync`) confirms death of a current-incarnation agent; emit `(agentId, _daemonEpoch, flow…)` before deleting its record (harmless per outbox idempotency for a same-epoch id; gives the server id-level absence proof). The **StopAgent-fallback** (`TryStopByPidRecordAsync`) confirms a record's process gone; emit `(agentId, record.DaemonEpoch, record.Flow…)` before deleting.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs` (`RetryAllAsync` returns the drained *entries* — not just ids — so their flow identity is available; or expose a lookup). Simpler: change the drained return to `IReadOnlyList<Entry>`.
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (own the `ResolvedCandidatesLedger`; emit in `RetryQuarantineOnceAsync` and `TryStopByPidRecordAsync`).
+- Test: extend `test/Capacitor.Cli.Tests.Unit/Daemon/LedgerHookTests.cs` (quarantine drain) + an orchestrator-level assertion in `AgentOrchestratorVendorTests`.
+
+**Interfaces:**
+- Consumes: `ResolvedCandidatesLedger.Upsert`; `AgentKillQuarantine.Entry` (now returned by `RetryAllAsync`).
+- Produces: `AgentKillQuarantine.RetryAllAsync` returns `IReadOnlyList<Entry>`; `AgentOrchestrator._resolvedLedger` field + test seam `ResolvedLedgerSnapshotForTest`.
+
+- [ ] **Step 1: Write the failing test** (append to `LedgerHookTests`)
+
+```csharp
+    [Test]
+    public async Task Quarantine_drain_returns_entries_and_confirmed_ones_are_emittable() {
+        var q = new AgentKillQuarantine(NullLogger.Instance);
+        using var dummy = DummyProcess.StartSleep(30);
+        var id = ProcessIdentity.Capture(dummy.Pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5)); // confirmed dead -> will drain
+
+        q.Add(new AgentKillQuarantine.Entry("q1", dummy.Pid, id, "ReviewFlow", DateTimeOffset.UtcNow, "flow-1", "reviewer"));
+        var drained = await q.RetryAllAsync(CancellationToken.None);
+
+        await Assert.That(drained.Select(e => e.AgentId)).IsEquivalentTo(new[] { "q1" });
+        await Assert.That(drained.Single().FlowRole).IsEqualTo("reviewer");
+    }
+
+    // ── Quarantine-drain hook — crash both sides (parent §8). The drain's durable source is the RETAINED
+    // AgentPidRecord (teardown quarantines AND keeps the record); the drain emits (AgentId, epoch-at-drain,
+    // flow…) then deletes the record. After a crash the record's DaemonEpoch == that same epoch, so the
+    // next boot's OrphanReaper record pass reconciles on the source-stable (AgentId, OldEpoch) key (NOT
+    // Generation, which the pre-append source lacks).
+    [Test]
+    public async Task Quarantine_drain_crash_between_append_and_delete_reconciles_single_emit() {
+        var (store, ledger, _) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        store.Write(new AgentPidRecord("qr", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-1", "reviewer", "did", "drain-epoch", DateTimeOffset.UtcNow));
+        var committed = ledger.Upsert("qr", "drain-epoch", "flow-1", "reviewer"); // drain appended
+        // crash before DeletePidRecord → committed entry + leftover record
+
+        var reaper = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await reaper.ReapOnceAsync();
+        await Assert.That(store.ReadAll()).IsEmpty();
+        await Assert.That(ledger.Snapshot().Single().Generation).IsEqualTo(committed.Generation); // single emit
+    }
+
+    [Test]
+    public async Task Quarantine_drain_crash_before_append_re_derives_next_boot() {
+        var (store, ledger, _) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        store.Write(new AgentPidRecord("qr", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-1", "reviewer", "did", "drain-epoch", DateTimeOffset.UtcNow));
+        await Assert.That(ledger.Snapshot()).IsEmpty(); // crash before append → record only
+
+        var reaper = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await reaper.ReapOnceAsync();
+        await Assert.That(ledger.Snapshot().Single().AgentId).IsEqualTo("qr");
+        await Assert.That(store.ReadAll()).IsEmpty();
+    }
+
+    // ── StopAgent-fallback hook — crash both sides (parent §8). TryStopByPidRecordAsync emits
+    // (agentId, record.DaemonEpoch, record.flow…) before deleting the record; same durable source +
+    // (AgentId, OldEpoch) reconciliation as the drain hook.
+    [Test]
+    public async Task Stop_fallback_crash_between_append_and_delete_reconciles_single_emit() {
+        var (store, ledger, _) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        store.Write(new AgentPidRecord("sf", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-2", "reviewer", "did", "stop-epoch", DateTimeOffset.UtcNow));
+        var committed = ledger.Upsert("sf", "stop-epoch", "flow-2", "reviewer"); // stop-fallback appended
+        // crash before _pidRecords.Delete → committed entry + leftover record
+
+        var reaper = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await reaper.ReapOnceAsync();
+        await Assert.That(store.ReadAll()).IsEmpty();
+        await Assert.That(ledger.Snapshot().Single().Generation).IsEqualTo(committed.Generation);
+    }
+
+    [Test]
+    public async Task Stop_fallback_crash_before_append_re_derives_next_boot() {
+        var (store, ledger, _) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        store.Write(new AgentPidRecord("sf", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-2", "reviewer", "did", "stop-epoch", DateTimeOffset.UtcNow));
+        await Assert.That(ledger.Snapshot()).IsEmpty(); // crash before append
+
+        var reaper = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await reaper.ReapOnceAsync();
+        await Assert.That(ledger.Snapshot().Single().AgentId).IsEqualTo("sf");
+        await Assert.That(store.ReadAll()).IsEmpty();
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "Quarantine_drain OR Stop_fallback"`
+Expected: FAIL to COMPILE — `RetryAllAsync` returns `IReadOnlyList<string>`, not `Entry`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `AgentKillQuarantine.cs`, change `RetryAllAsync` to return the drained entries:
+
+```csharp
+    public async Task<IReadOnlyList<Entry>> RetryAllAsync(CancellationToken ct) {
+        var drained = new List<Entry>();
+        foreach (var entry in _entries.Values) {
+            try {
+                if (await ProcessReaper.ReapByIdentityAsync(entry.Pid, entry.Identity, entry.AgentId, logger, ct)
+                    && _entries.TryRemove(new KeyValuePair<string, Entry>(entry.AgentId, entry)))
+                    drained.Add(entry);
+            } catch (Exception ex) when (ex is not OperationCanceledException) {
+                logger.LogWarning(ex, "AgentKillQuarantine: retry failed for {AgentId} (pid {Pid})", entry.AgentId, entry.Pid);
+            }
+        }
+        return drained;
+    }
+```
+
+In `AgentOrchestrator.cs`: add a `ResolvedCandidatesLedger? _resolvedLedger;` field, construct it in the ctor next to `_pidRecords` (`_resolvedLedger = new ResolvedCandidatesLedger(recordRoot, logger);`). Then in `RetryQuarantineOnceAsync`, emit before deleting:
+
+```csharp
+            foreach (var e in await _quarantine.RetryAllAsync(ct)) {
+                _resolvedLedger?.Upsert(e.AgentId, _daemonEpoch, e.FlowRunId, e.FlowRole); // append before delete
+                DeletePidRecord(e.AgentId);
+            }
+```
+
+And in `TryStopByPidRecordAsync`, emit before delete:
+
+```csharp
+        var confirmedGone = await ProcessReaper.ReapByRecordAsync(record, _logger, _shutdownCts.Token);
+        if (confirmedGone) {
+            _resolvedLedger?.Upsert(agentId, record.DaemonEpoch, record.FlowRunId, record.FlowRole); // append before delete
+            _pidRecords.Delete(agentId);
+        }
+        return confirmedGone;
+```
+
+Wire the OrphanReaper's `onRecordResolved` (Task 7) to `_resolvedLedger` in the ctor:
+
+```csharp
+        _orphanReaper = new OrphanReaper(_pidRecords, _daemonId, _daemonEpoch, logger,
+            onRecordResolved: (a, e, fr, role) => _resolvedLedger?.Upsert(a, e, fr, role));
+```
+
+Add the test seam: `internal IReadOnlyList<ResolvedStartupCandidate> ResolvedLedgerSnapshotForTest => _resolvedLedger?.Snapshot() ?? [];`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "Quarantine_drain OR Stop_fallback"`
+Expected: PASS (drain-returns-entries + the four crash-injection tests — quarantine-drain and StopAgent-fallback, both sides each). Re-run `AgentKillQuarantineTests` — update the one existing assertion that expected `IReadOnlyList<string>` (now `.Select(e => e.AgentId)`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs test/Capacitor.Cli.Tests.Unit/Daemon/LedgerHookTests.cs
+git commit -m "Hook quarantine drain + StopAgent-fallback into the resolved-candidates ledger"
+```
+
+---
+
+### Task 9: Hook D — marker-candidate source + env-marker recordless resolution matrix
+
+The env-marker scan can confirm-kill a fully **recordless** prior-epoch survivor. For crash-consistency it does NOT mint a spawn-bound `AgentPidRecord` (that would violate the capture-binding rule); it writes a dedicated durable **marker-candidate source** `{AgentId, DaemonId, OldEpoch, pid}` (marker-based kill authority; NO trusted flow identity from mutable env), then resolves: **(a)** pid dead per `ProcessIdentity.IsAlive` (ESRCH or Linux zombie) ⇒ resolved + emit; **(b)** alive + triple still matches ⇒ kill → on confirmed death, resolved; **(c)** alive + mismatch/unreadable ⇒ spare, source stays PENDING, NO ledger entry (surfaces as `pending_marker`). Ledger-append BEFORE source-deletion; crash re-reads the source and re-runs (a)/(b)/(c) — re-reading the live triple so a reused pid is spared.
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/MarkerCandidateStore.cs`
+- Modify: `src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs` (write the source before the marker kill; emit before `store.Delete` on confirmed death; leave the source pending on spare; add an optional `MarkerCandidateStore` + `onMarkerResolved` callback; a boot reconciliation pass over persisted sources).
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/MarkerCandidateResolutionTests.cs` (CREATE)
+
+**Interfaces:**
+- Produces: `MarkerCandidateStore` (`Write`/`Delete`/`ReadAll` over `internal readonly record struct MarkerCandidate(string AgentId, string DaemonId, string OldEpoch, int Pid)`); `OrphanReaper` gains trailing optional `MarkerCandidateStore? markerStore = null, Action<string,string>? onMarkerResolved = null` (`(agentId, oldEpoch)` — no flow identity, for a fully **recordless** survivor). A resolution that finds a co-existing durable record for the same id (the Linux `identity_unavailable` case) routes the trusted flow via the Task 7 `onRecordResolved` sink instead (record epoch + record flow), never null — see `EmitAndClear`.
+- Consumes: `ProcessIdentity.IsAlive`/`MatchesTri`/`Capture`/`ReadAgentEnv`, `ProcessReaper.ReapByMarkerAsync`, `AgentPidRecordStore.ReadAll`, the Task 7 `onRecordResolved` sink.
+
+- [ ] **Step 1: Write the failing test** (Linux-gated, mirroring `OrphanReaperTests`)
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+public class MarkerCandidateResolutionTests {
+    static (AgentPidRecordStore store, MarkerCandidateStore markers, string dir) New() {
+        var dir = Path.Combine(Path.GetTempPath(), "kcap-mk-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return (new AgentPidRecordStore(dir, NullLogger.Instance), new MarkerCandidateStore(dir, NullLogger.Instance), dir);
+    }
+
+    [Test]
+    public async Task Recordless_marker_kill_emits_resolved_and_deletes_the_source() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, markers, _) = New();
+        using var dummy = DummyProcess.StartSleep(30, new Dictionary<string, string> {
+            ["KCAP_AGENT_ID"] = "rec-less", ["KCAP_DAEMON_ID"] = "did", ["KCAP_DAEMON_EPOCH"] = "old" });
+
+        var resolved = new List<(string, string)>();
+        var reaper = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            markerStore: markers, onMarkerResolved: (a, e) => resolved.Add((a, e)));
+        await reaper.ReapOnceAsync();
+
+        dummy.WaitForExit(TimeSpan.FromSeconds(8));
+        await Assert.That(dummy.HasExited).IsTrue();
+        await Assert.That(resolved).Contains(("rec-less", "old"));
+        await Assert.That(markers.ReadAll()).IsEmpty();          // source deleted after the emit
+    }
+
+    [Test]
+    public async Task Alive_mismatch_spares_and_leaves_the_marker_candidate_pending() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, markers, _) = New();
+        // A persisted marker-candidate whose pid is now occupied by an UNRELATED process (no triple).
+        using var occupant = DummyProcess.StartSleep(30); // no KCAP_* env
+        markers.Write(new MarkerCandidate("stale", "did", "old", occupant.Pid));
+
+        var resolved = new List<(string, string)>();
+        var reaper = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            markerStore: markers, onMarkerResolved: (a, e) => resolved.Add((a, e)));
+        await reaper.ReapOnceAsync(); // boot reconciliation re-reads the source, re-runs (a)/(b)/(c)
+
+        await Assert.That(occupant.HasExited).IsFalse();          // reused pid spared
+        await Assert.That(resolved).IsEmpty();                    // (c) never emits
+        await Assert.That(markers.ReadAll().Single().AgentId).IsEqualTo("stale"); // stays pending
+        occupant.Kill();
+    }
+
+    [Test]
+    public async Task Confirmed_dead_persisted_candidate_resolves_incl_zombie_path() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, markers, _) = New();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5)); // dead per IsAlive
+        markers.Write(new MarkerCandidate("dead1", "did", "old", pid));
+
+        var resolved = new List<(string, string)>();
+        var reaper = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            markerStore: markers, onMarkerResolved: (a, e) => resolved.Add((a, e)));
+        await reaper.ReapOnceAsync();
+
+        await Assert.That(resolved).Contains(("dead1", "old")); // (a) dead -> resolved+emit
+        await Assert.That(markers.ReadAll()).IsEmpty();
+    }
+
+    // ── Marker-scan kill hook — crash both sides (parent §8; recordless→marker-candidate case). ──
+    [Test]
+    public async Task Marker_kill_crash_before_append_re_derives_from_the_persisted_source() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, markers, _) = New();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5)); // dead per IsAlive (branch a)
+        markers.Write(new MarkerCandidate("mk-gone", "did", "old", pid));
+
+        // Crash BEFORE the emit: onMarkerResolved throws before the ledger append -> no entry, source persists.
+        var crashing = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            markerStore: markers, onMarkerResolved: (_, _) => throw new IOException("crash before append"));
+        try { await crashing.ReapOnceAsync(); } catch { /* per-source faults swallowed */ }
+        await Assert.That(markers.ReadAll()).IsNotEmpty(); // source persists (never a source-less window)
+
+        // Next boot reconciles: re-read the on-disk source, (a) dead -> single emit + delete.
+        var resolved = new List<(string, string)>();
+        var restarted = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            markerStore: markers, onMarkerResolved: (a, e) => resolved.Add((a, e)));
+        await restarted.ReapOnceAsync();
+        await Assert.That(resolved).IsEquivalentTo(new[] { ("mk-gone", "old") });
+        await Assert.That(markers.ReadAll()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Marker_kill_crash_between_append_and_source_delete_reconciles_idempotently() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, markers, dir) = New();
+        var ledger = new ResolvedCandidatesLedger(dir, NullLogger.Instance);
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        markers.Write(new MarkerCandidate("mk-gone", "did", "old", pid));
+        var committed = ledger.Upsert("mk-gone", "old", null, null); // append happened
+        // crash before markerStore.Delete -> committed entry + leftover marker source
+
+        // Next boot: reconciliation re-reads the source, (a) dead -> idempotent Upsert (key (AgentId,OldEpoch)) + delete.
+        var restarted = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            markerStore: markers, onMarkerResolved: (a, e) => ledger.Upsert(a, e, null, null));
+        await restarted.ReapOnceAsync();
+        await Assert.That(ledger.Snapshot().Single().Generation).IsEqualTo(committed.Generation); // single emit
+        await Assert.That(markers.ReadAll()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Identity_unavailable_record_resolved_via_marker_scan_emits_trusted_flow() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, markers, _) = New();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5)); // dead per IsAlive (branch a)
+        // A Linux identity_unavailable RECORD (capture failed) co-existing with a marker-candidate source.
+        store.Write(new AgentPidRecord("iu", pid, "", PidIdentityKind.IdentityUnavailable, "ReviewFlow",
+            "codex", "flow-9", "reviewer", "did", "old", DateTimeOffset.UtcNow));
+        markers.Write(new MarkerCandidate("iu", "did", "old", pid));
+
+        var recordResolved = new List<(string a, string e, string? fr, string? role)>();
+        var markerResolved = new List<(string, string)>();
+        var reaper = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => recordResolved.Add((a, e, fr, role)),
+            markerStore: markers, onMarkerResolved: (a, e) => markerResolved.Add((a, e)));
+        await reaper.ReapOnceAsync();
+
+        // The trusted record's flow is emitted (via onRecordResolved), NOT null (via onMarkerResolved).
+        await Assert.That(recordResolved.Single().role).IsEqualTo("reviewer");
+        await Assert.That(recordResolved.Single().fr).IsEqualTo("flow-9");
+        await Assert.That(markerResolved).IsEmpty();
+        await Assert.That(store.ReadAll()).IsEmpty();       // identity_unavailable record cleared
+        await Assert.That(markers.ReadAll()).IsEmpty();     // marker source cleared
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "MarkerCandidateResolutionTests"`
+Expected: FAIL to COMPILE — `MarkerCandidateStore` + the new `OrphanReaper` params do not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `MarkerCandidateStore.cs`:
+
+```csharp
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>Phase B2-b (§4.2.4): durable marker-candidate sources for RECORDLESS prior-epoch
+/// survivors. Kill authority is marker-based (the live env triple, re-read at kill time); there is NO
+/// spawn-bound start-identity and NO trusted flow identity (the env is mutable). Same atomic
+/// temp+rename + hashed-filename discipline as <see cref="AgentPidRecordStore"/>.</summary>
+internal sealed class MarkerCandidateStore(string stateDir, ILogger logger) {
+    readonly string _dir = Path.Combine(stateDir, "marker-candidates");
+
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+    [JsonSerializable(typeof(MarkerCandidate))]
+    partial class Ctx : JsonSerializerContext;
+
+    public void Write(MarkerCandidate c) {
+        Directory.CreateDirectory(_dir);
+        var final = PathFor(c.AgentId);
+        var tmp   = final + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
+        File.WriteAllText(tmp, JsonSerializer.Serialize(c, Ctx.Default.MarkerCandidate));
+        File.Move(tmp, final, overwrite: true);
+    }
+
+    public bool Delete(string agentId) {
+        try { var p = PathFor(agentId); if (!File.Exists(p)) return false; File.Delete(p); return true; }
+        catch (Exception ex) { logger.LogWarning(ex, "MarkerCandidateStore: delete failed for {AgentId}", agentId); return false; }
+    }
+
+    public IReadOnlyList<MarkerCandidate> ReadAll() {
+        if (!Directory.Exists(_dir)) return [];
+        var r = new List<MarkerCandidate>();
+        foreach (var p in Directory.EnumerateFiles(_dir, "*.json")) {
+            try {
+                var c = JsonSerializer.Deserialize(File.ReadAllText(p), Ctx.Default.MarkerCandidate);
+                if (!string.IsNullOrEmpty(c.AgentId)) r.Add(c);
+            } catch (Exception ex) { logger.LogWarning(ex, "MarkerCandidateStore: unparseable source {Path}", p); }
+        }
+        return r;
+    }
+
+    string PathFor(string agentId) => Path.Combine(_dir,
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(agentId ?? ""))).ToLowerInvariant() + ".json");
+}
+
+internal readonly record struct MarkerCandidate(string AgentId, string DaemonId, string OldEpoch, int Pid);
+```
+
+In `OrphanReaper.cs`, add the trailing ctor params and restructure the env-marker scan. First the signature:
+
+```csharp
+internal sealed class OrphanReaper(
+        AgentPidRecordStore store, string daemonId, string currentEpoch, ILogger logger,
+        Action<string, string, string?, string?>? onRecordResolved = null,
+        MarkerCandidateStore? markerStore = null,
+        Action<string, string>? onMarkerResolved = null) {
+```
+
+At the start of `ScanEnvMarkersAsync`, first RECONCILE any persisted sources (crash recovery), applying (a)/(b)/(c) by re-reading the live pid — a source outlives one pass, so this covers the crash-before-kill window:
+
+```csharp
+        // Boot/heartbeat reconciliation of persisted marker-candidate sources (crash recovery). Re-read
+        // the LIVE triple so a pid reused since the source was written is spared, never mis-killed.
+        if (markerStore is not null) {
+            foreach (var c in markerStore.ReadAll()) {
+                if (ct.IsCancellationRequested) return;
+                await ResolveMarkerCandidateAsync(c, ct);
+            }
+        }
+```
+
+In the live scan loop, when a recordless prior-incarnation survivor is positively identified (after the existing triple checks + `MatchesTri(pid, token) == true`), replace the direct `ReapByMarkerAsync`/`store.Delete` block with: write the source, then resolve it:
+
+```csharp
+            // Recordless survivor of a PRIOR incarnation of THIS daemon. Persist a durable
+            // marker-candidate source BEFORE the kill (crash-consistency: a crash before the kill
+            // re-runs the resolution next boot; never a source-less window, never a retroactive mint).
+            var candidate = new MarkerCandidate(agentId, daemonId, epoch, pid);
+            markerStore?.Write(candidate);
+            await ResolveMarkerCandidateAsync(candidate, ct);
+```
+
+Add the resolution method (the matrix), keeping the record-store cleanup for the identity_unavailable case:
+
+```csharp
+    async Task ResolveMarkerCandidateAsync(MarkerCandidate c, CancellationToken ct) {
+        // (a) dead per the shipped zombie-aware IsAlive (ESRCH or Linux 'Z') -> conclusively resolved.
+        if (!ProcessIdentity.IsAlive(c.Pid)) { EmitAndClear(c); return; }
+
+        // Re-read the live triple: (c) mismatch/unreadable -> SPARE, stay pending, NO emit (a triple
+        // mismatch cannot distinguish PID-reuse from the process mutating its own env).
+        var agentId = ProcessIdentity.ReadAgentEnv(c.Pid, "KCAP_AGENT_ID");
+        var did     = ProcessIdentity.ReadAgentEnv(c.Pid, "KCAP_DAEMON_ID");
+        var epoch   = ProcessIdentity.ReadAgentEnv(c.Pid, "KCAP_DAEMON_EPOCH");
+        var token   = ProcessIdentity.Capture(c.Pid);
+        var tripleMatches = agentId == c.AgentId && did == c.DaemonId && epoch == c.OldEpoch && token is not null;
+        if (!tripleMatches) return; // (c) pending
+
+        // (b) alive + triple still matches -> kill; on CONFIRMED death, resolve.
+        if (await ProcessReaper.ReapByMarkerAsync(c.Pid, token!, c.AgentId, logger, ct)) EmitAndClear(c);
+        else logger.LogWarning("OrphanReaper: marker kill of {AgentId} (pid {Pid}) not confirmed — retry next tick", c.AgentId, c.Pid);
+    }
+
+    void EmitAndClear(MarkerCandidate c) {
+        // Ledger-append BEFORE source-deletion (crash reconciled next boot; idempotent). Trust boundary:
+        // a fully RECORDLESS survivor's env is untrusted, so it maps to NO role (onMarkerResolved, null
+        // flow). But a Linux identity_unavailable RECORD resolved via the marker scan carries TRUSTED flow
+        // identity — written from the daemon's own AgentInstance into the durable record at spawn — so pull
+        // FlowRunId/FlowRole (and the trusted DaemonEpoch) FROM THAT RECORD via the record-resolved sink,
+        // so its role can be individually healed. Never trust flow from the mutable env.
+        var record = store.ReadAll().FirstOrDefault(r => string.Equals(r.AgentId, c.AgentId, StringComparison.Ordinal));
+        if (!string.IsNullOrEmpty(record.AgentId))
+            onRecordResolved?.Invoke(record.AgentId, record.DaemonEpoch, record.FlowRunId, record.FlowRole);
+        else
+            onMarkerResolved?.Invoke(c.AgentId, c.OldEpoch);
+        store.Delete(c.AgentId);   // clears the identity_unavailable record (no-op for a pure recordless survivor)
+        markerStore?.Delete(c.AgentId);
+    }
+```
+
+Wire the orchestrator ctor (extend the Task 8 `_orphanReaper` construction): construct a `MarkerCandidateStore _markerCandidates = new(recordRoot, logger);` field and pass `markerStore: _markerCandidates, onMarkerResolved: (a, e) => _resolvedLedger?.Upsert(a, e, null, null)`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "MarkerCandidateResolutionTests"`
+Expected: PASS (6 tests on Linux — the 3 resolution-matrix cases + marker crash-injection both sides + the identity_unavailable trusted-flow case; no-ops on macOS/Windows). Re-run `OrphanReaperTests` — unaffected (new params default null; the identity_unavailable record-clear path still works via `EmitAndClear`'s `store.Delete`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/MarkerCandidateStore.cs src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs test/Capacitor.Cli.Tests.Unit/Daemon/MarkerCandidateResolutionTests.cs
+git commit -m "Add marker-candidate source + env-marker recordless resolution matrix into the ledger"
+```
+
+---
+
+### Task 10: Advertise `ResolvedStartupCandidates` + honor `AckResolvedCandidates`
+
+The ledger's `Snapshot()` is re-reported on every `DaemonConnect` + `DaemonStatusReport` until acked; the server's `AckResolvedCandidates` prunes per-entry.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (`BuildStatusReport` includes `ResolvedStartupCandidates`; `GetLiveAgents`-style seam feeding the connect payload; an `OnAckResolvedCandidates` handler routes to `_resolvedLedger.Ack`).
+- Modify: `src/Capacitor.Cli.Daemon/Services/ServerConnection.cs` (register the `AckResolvedCandidates` receive handler; expose a `GetResolvedStartupCandidates` snapshot func for the connect payload).
+- Test: extend `AgentOrchestratorVendorTests` (report carries ledger entries; ack prunes).
+
+**Interfaces:**
+- Consumes: `ResolvedCandidatesLedger.Snapshot`/`Ack` (Task 6).
+- Produces: `AgentOrchestrator.HandleAckResolvedCandidates(AckResolvedCandidates)`; `ServerConnection.OnAckResolvedCandidates` event + `GetResolvedStartupCandidates` func.
+
+- [ ] **Step 1: Write the failing test** (append to `StartupCompletenessTests` partial)
+
+```csharp
+    [Test]
+    public async Task Status_report_carries_resolved_candidates_and_ack_prunes_them() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+
+        var g = orch.SeedResolvedCandidateForTest("a1", "old-epoch");   // test seam over the ledger
+        await Assert.That(orch.BuildStatusReport().ResolvedStartupCandidates!.Single().AgentId).IsEqualTo("a1");
+
+        // The seam + the underlying ledger Ack are SYNCHRONOUS (void) — no await (would be CS4008).
+        orch.HandleAckResolvedCandidatesForTest(
+            new AckResolvedCandidates([new ResolvedCandidateAck(g.Generation, "a1", "old-epoch")]));
+        await Assert.That(orch.BuildStatusReport().ResolvedStartupCandidates).IsEmpty();
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "carries_resolved_candidates"`
+Expected: FAIL to COMPILE — `SeedResolvedCandidateForTest`/`HandleAckResolvedCandidatesForTest` and the report field wiring do not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `AgentOrchestrator.cs`, enrich `BuildStatusReport` (keep the existing positional args, add the new named ones):
+
+```csharp
+    internal DaemonStatusReport BuildStatusReport() =>
+        new(ActiveCount, [.. BuildLiveAgents()], [.. QuarantineSnapshot()],
+            Epoch: _daemonEpoch,                                   // (Epoch/counters finalized in Task 16)
+            ResolvedStartupCandidates: [.. _resolvedLedger?.Snapshot() ?? []]);
+```
+
+Add the ack handler + test seams:
+
+```csharp
+    internal void HandleAckResolvedCandidates(AckResolvedCandidates ack) => _resolvedLedger?.Ack(ack.Entries ?? []);
+
+    internal ResolvedStartupCandidate SeedResolvedCandidateForTest(string agentId, string oldEpoch)
+        => _resolvedLedger!.Upsert(agentId, oldEpoch, null, null);
+    internal void HandleAckResolvedCandidatesForTest(AckResolvedCandidates ack) => HandleAckResolvedCandidates(ack);
+```
+
+In the ctor, wire the receive handler + connect snapshot func:
+
+```csharp
+        _server.OnAckResolvedCandidates += HandleAckResolvedCandidates;
+        _server.GetResolvedStartupCandidates = () => [.. _resolvedLedger?.Snapshot() ?? []];
+```
+
+In `ServerConnection.cs`, add the event + func + hub registration (one-way receive):
+
+```csharp
+    public event Action<AckResolvedCandidates>? OnAckResolvedCandidates;
+    public Func<ResolvedStartupCandidate[]>? GetResolvedStartupCandidates { get; set; }
+    // in the ctor, next to the other _hub.On registrations:
+    _hub.On<AckResolvedCandidates>("AckResolvedCandidates", ack => { OnAckResolvedCandidates?.Invoke(ack); return Task.CompletedTask; });
+```
+
+Include the snapshot in the `DaemonConnect` payload (finalized in Task 16; add the named arg now):
+`ResolvedStartupCandidates: GetResolvedStartupCandidates?.Invoke()`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "carries_resolved_candidates"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs src/Capacitor.Cli.Daemon/Services/ServerConnection.cs test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
+git commit -m "Advertise ResolvedStartupCandidates and honor AckResolvedCandidates prune"
+```
+
+---
+
+### Task 11: `StartupReapComplete` (per-platform) + `StartupDiscovery` + `UnresolvedStartupCandidates`
+
+Compute the three completeness signals and advertise them on `DaemonConnect` + `DaemonStatusReport`.
+
+- **`StartupDiscovery`**: Linux = `pending` until one clean env-marker-scan pass, then `complete` (`failed` on enumeration error); Windows + macOS = `not_applicable` (no scan).
+- **`UnresolvedStartupCandidates`**: known-id blocked candidates = leftover records that can't resolve (identity_unavailable / cross-scheme legacy) + pending marker-candidate sources (`pending_marker`). Reason mapping: pending marker source ⇒ `pending_marker`; identity_unavailable record ⇒ `identity_unresolvable`; macOS cross-scheme (`Present`+alive+ambiguous) legacy record ⇒ `legacy_unresolvable`. Flow fields from the trusted record where available.
+- **`StartupReapComplete`**: Linux = no blocked candidates AND one clean marker-scan pass succeeded; Windows-with-`RecordlessSurvivorsImpossible` = trivially true; pre-W1 Windows + macOS = record-pass-only (no blocked record-tracked candidates).
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs` (track `LastScanState`/`LastSuccessfulScanAt`; expose blocked candidates from the record pass + marker store).
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (compute the three signals from the reaper + marker store + ledger; add to `BuildStatusReport` + the connect payload).
+- Test: extend `StartupCompletenessTests`.
+
+**Interfaces:**
+- Produces: `OrphanReaper.CurrentDiscovery` (`StartupDiscovery`), `OrphanReaper.BlockedCandidates()` (`IReadOnlyList<UnresolvedStartupCandidate>`); `AgentOrchestrator.ComputeStartupReapComplete()` (bool) feeding the report/connect.
+- Consumes: `MarkerCandidateStore.ReadAll` (Task 9), `AgentPidRecordStore.ReadAll`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+    [Test]
+    public async Task Startup_discovery_is_not_applicable_off_linux_and_pending_before_a_scan() {
+        await using var orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        var report = orch.BuildStatusReport();
+        var expected = OperatingSystem.IsLinux() ? MarkerScanState.Complete : MarkerScanState.NotApplicable;
+        // A clean boot with no candidates: after ReapOrphansOnceAsync the Linux scan is complete.
+        await orch.ReapOrphansOnceAsync();
+        await Assert.That(orch.BuildStatusReport().StartupDiscovery!.Value.MarkerScanState)
+            .IsEqualTo(OperatingSystem.IsLinux() ? MarkerScanState.Complete : MarkerScanState.NotApplicable);
+    }
+
+    [Test]
+    public async Task Pending_marker_candidate_blocks_completion_and_surfaces_reason() {
+        if (!OperatingSystem.IsLinux()) return;
+        await using var orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedPendingMarkerCandidateForTest("blocked", "old"); // occupant with no matching triple
+        var report = orch.BuildStatusReport();
+        await Assert.That(report.StartupReapComplete).IsFalse();
+        await Assert.That(report.UnresolvedStartupCandidates!.Single().Reason)
+            .IsEqualTo(StartupCandidateUnresolvedReason.PendingMarker);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "Startup_discovery_is_not_applicable OR Pending_marker_candidate_blocks"`
+Expected: FAIL to COMPILE / assert — the signals are not computed yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `OrphanReaper.cs`, track discovery state and expose blocked candidates:
+
+```csharp
+    public StartupDiscovery CurrentDiscovery { get; private set; } =
+        new(OperatingSystem.IsLinux() ? MarkerScanState.Pending : MarkerScanState.NotApplicable);
+
+    // Wrap the whole env-marker scan (the Task 9 persisted-source reconciliation loop + the live-scan loop)
+    // in a try/catch and set the discovery state at BOTH exit points. Linux only — Windows/macOS have no
+    // scan and CurrentDiscovery stays NotApplicable. A clean enumeration pass is Complete even if it left a
+    // spared `pending_marker` candidate (that blocks completion via BlockedCandidates, not via the pass state).
+    async Task ScanEnvMarkersAsync(CancellationToken ct) {
+        if (!OperatingSystem.IsLinux()) return; // no scan off Linux; CurrentDiscovery stays NotApplicable
+        try {
+            if (markerStore is not null)
+                foreach (var c in markerStore.ReadAll()) {
+                    if (ct.IsCancellationRequested) return;
+                    await ResolveMarkerCandidateAsync(c, ct);   // crash-recovery reconciliation (Task 9)
+                }
+            // ... existing live-enumeration + recordless-survivor resolution loop (Task 9) ...
+            CurrentDiscovery = new StartupDiscovery(MarkerScanState.Complete, DateTimeOffset.UtcNow); // one clean pass
+        } catch (Exception ex) {
+            // Enumeration failure → Failed, retried on the next heartbeat; keep the last successful scan time.
+            logger.LogWarning(ex, "OrphanReaper: env-marker scan failed — StartupDiscovery=failed, retry next heartbeat");
+            CurrentDiscovery = new StartupDiscovery(MarkerScanState.Failed, CurrentDiscovery.LastSuccessfulScanAt);
+        }
+    }
+
+    /// <summary>Known-id prior-incarnation candidates that block completion.</summary>
+    public IReadOnlyList<UnresolvedStartupCandidate> BlockedCandidates(MarkerCandidateStore? markerStore) {
+        var list = new List<UnresolvedStartupCandidate>();
+        foreach (var r in store.ReadAll()) {
+            if (string.Equals(r.DaemonEpoch, currentEpoch, StringComparison.Ordinal)) continue; // current-incarnation
+            if (r.IdentityKind == PidIdentityKind.IdentityUnavailable)
+                list.Add(new(r.AgentId, StartupCandidateUnresolvedReason.IdentityUnresolvable, r.FlowRunId, r.FlowRole));
+            else if (OperatingSystem.IsMacOS() && ProcessIdentity.IsAlive(r.Pid) && ProcessIdentity.MatchesTri(r.Pid, r.StartIdentity) is null)
+                list.Add(new(r.AgentId, StartupCandidateUnresolvedReason.LegacyUnresolvable, r.FlowRunId, r.FlowRole));
+        }
+        foreach (var m in markerStore?.ReadAll() ?? [])
+            list.Add(new(m.AgentId, StartupCandidateUnresolvedReason.PendingMarker));
+        return list;
+    }
+```
+
+In `AgentOrchestrator.cs`, compute the signals and add to `BuildStatusReport`:
+
+```csharp
+    internal bool ComputeStartupReapComplete() {
+        var blocked = _orphanReaper?.BlockedCandidates(_markerCandidates).Count ?? 0;
+        if (blocked > 0) return false;
+        if (OperatingSystem.IsLinux())
+            return _orphanReaper?.CurrentDiscovery.MarkerScanState == MarkerScanState.Complete;
+        if (OperatingSystem.IsWindows() && _recordlessSurvivorsImpossible) return true;
+        return true; // pre-W1 Windows / macOS: record-pass-only completion (no blocked record-tracked candidates)
+    }
+```
+
+Extend `BuildStatusReport`:
+
+```csharp
+    internal DaemonStatusReport BuildStatusReport() =>
+        new(ActiveCount, [.. BuildLiveAgents()], [.. QuarantineSnapshot()],
+            Epoch: _daemonEpoch,
+            StartupReapComplete: ComputeStartupReapComplete(),
+            ResolvedStartupCandidates: [.. _resolvedLedger?.Snapshot() ?? []],
+            UnresolvedStartupCandidates: [.. _orphanReaper?.BlockedCandidates(_markerCandidates) ?? []],
+            StartupDiscovery: _orphanReaper?.CurrentDiscovery);
+```
+
+Add the test seam:
+
+```csharp
+    internal void SeedPendingMarkerCandidateForTest(string agentId, string oldEpoch) =>
+        _markerCandidates.Write(new MarkerCandidate(agentId, _daemonId, oldEpoch, 999_999)); // pid value is irrelevant to this seam
+```
+
+(The `999_999` pid is fine: `BlockedCandidates` lists every persisted marker-candidate source as `pending_marker` **without** a liveness check, and the test asserts the blocked/reason surface directly via `BuildStatusReport` — it never runs a scan, so a dead pid is never resolved away. No live-pid/`DummyProcess` plumbing is needed for this test.)
+
+Mirror the three fields into the `DaemonConnect` payload via `ServerConnection` getters (`GetStartupReapComplete`, `GetUnresolvedStartupCandidates`, `GetStartupDiscovery`), wired in the ctor and read in `DaemonConnectAsync` (finalized alongside the counters in Task 16).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "Startup_discovery_is_not_applicable OR Pending_marker_candidate_blocks"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs src/Capacitor.Cli.Daemon/Services/ServerConnection.cs test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
+git commit -m "Compute per-platform StartupReapComplete + StartupDiscovery + UnresolvedStartupCandidates"
+```
+
+---
+
+### Task 12: `SequencedCommandProcessor` core — exact-next accept, serial lane, contiguous watermark, synthesized-error item
+
+The heart of the daemon side: a self-contained, delegate-injected processor (unit-tested without a live orchestrator). Under one lock it accepts only the exact-next `Seq`, records a cache entry, and enqueues to a single-reader ordered lane; a background consumer executes strictly serially and advances the contiguous `LastProcessedSeq` on each terminal outcome. If lane-item creation fails after the counter is reserved, a synthesized errored terminal item advances the watermark anyway (an advertised-accepted `Seq` with no processable item is impossible).
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs` (CREATE)
+
+**Interfaces:**
+- Produces:
+  - `internal enum SequencedKind { Launch, Stop }`
+  - `internal readonly record struct SequencedItem(SequencedKind Kind, string Epoch, long Seq, string CommandId, string AgentId)`
+  - `internal readonly record struct CommandOutcome(CommandOutcomeKind Kind, string? AgentId = null, string? SessionId = null, CommandRejectedReason? RejectReason = null)`
+  - `internal sealed class SequencedCommandProcessor : IAsyncDisposable` with `Task SubmitAsync(SequencedItem, Func<Task<CommandOutcome>> execute)`, `void AckPrefix(AckProcessedPrefix)` (Task 14), `string Epoch`/`long HighestAcceptedSeq`/`long LastProcessedSeq`, the private contiguity-safe `AdvanceWatermarkLocked()` (shared by the lane consumer and `SynthesizeErrorLocked`), and the `internal void CompleteLaneForTest()` seam.
+- Consumes: `CommandAck`/`CommandRejected`/`AgentLiveness`/`CommandOutcomeKind`/`CommandRejectedReason` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using System.Collections.Concurrent;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+public class SequencedCommandProcessorTests {
+    sealed class Harness {
+        public readonly List<CommandAck> Acks = [];
+        public readonly List<CommandRejected> Rejects = [];
+        public readonly ConcurrentQueue<long> ExecOrder = new();
+        public SequencedCommandProcessor P(string epoch = "e1", int bound = 256) => new(
+            epoch, _ => AgentLiveness.Live,
+            a => { lock (Acks) Acks.Add(a); return Task.CompletedTask; },
+            r => { lock (Rejects) Rejects.Add(r); return Task.CompletedTask; },
+            NullLogger.Instance, bound);
+        public SequencedItem Launch(long seq, string epoch = "e1", string id = "cmd", string agent = "a")
+            => new(SequencedKind.Launch, epoch, seq, id + seq, agent + seq);
+    }
+
+    [Test] public async Task Exact_next_commands_execute_serially_and_advance_the_watermark() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => { h.ExecOrder.Enqueue(1); return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)); });
+        await p.SubmitAsync(h.Launch(2), () => { h.ExecOrder.Enqueue(2); return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)); });
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(2L);
+        await Assert.That(h.ExecOrder.ToArray()).IsEquivalentTo(new[] { 1L, 2L });
+    }
+
+    [Test] public async Task Out_of_order_command_is_not_accepted() {
+        var h = new Harness(); await using var p = h.P();
+        var ran = false;
+        await p.SubmitAsync(h.Launch(2), () => { ran = true; return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)); });
+        await Assert.That(p.HighestAcceptedSeq).IsEqualTo(0L); // Seq 2 while next is 1 -> not accepted
+        await Assert.That(ran).IsFalse();
+    }
+
+    [Test] public async Task Execute_fault_becomes_internal_error_and_still_advances_the_watermark() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => throw new InvalidOperationException("boom"));
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(1L);
+        await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.InternalError);
+    }
+
+    [Test] public async Task Forced_item_creation_failure_synthesizes_a_terminal_item_and_advances_monotonically() {
+        // Parent §8: forced item-creation failure AFTER counter reservation -> synthesized errored terminal
+        // item at N, watermark advances. AND the monotonicity hazard: when the lane is completing while an
+        // earlier accepted item is still draining, the synthesized advance must NOT jump past it (which the
+        // draining item's later advance would then regress below).
+        var h = new Harness(); await using var p = h.P();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var gate    = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Item 1 accepted + enqueued; its execute BLOCKS mid-flight (still draining).
+        var t1 = p.SubmitAsync(h.Launch(1),
+            async () => { started.SetResult(); await gate.Task; return new CommandOutcome(CommandOutcomeKind.LaunchExecuted); });
+        await started.Task;                 // item 1 is dequeued and executing
+
+        // Complete the lane while item 1 drains, then submit item 2 -> TryWrite fails -> SynthesizeErrorLocked.
+        p.CompleteLaneForTest();
+        var t2 = p.SubmitAsync(h.Launch(2), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await t2;                           // the synthesized terminal completes immediately
+        var afterSynth = p.LastProcessedSeq;
+        await Assert.That(afterSynth).IsEqualTo(0L);   // synth at N=2 did NOT skip past the still-draining N=1
+
+        gate.SetResult();                   // item 1 drains; contiguous prefix now reaches 1 then 2
+        await t1;
+        await Assert.That(afterSynth).IsLessThanOrEqualTo(p.LastProcessedSeq); // monotonic — never regressed
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(2L);                    // contiguous prefix reaches 2
+        await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.InternalError); // synth emitted the reject
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "SequencedCommandProcessorTests"`
+Expected: FAIL to COMPILE — the type does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```csharp
+using System.Threading.Channels;
+using Capacitor.Cli.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+internal enum SequencedKind { Launch, Stop }
+
+internal readonly record struct SequencedItem(
+    SequencedKind Kind, string Epoch, long Seq, string CommandId, string AgentId);
+
+internal readonly record struct CommandOutcome(
+    CommandOutcomeKind Kind, string? AgentId = null, string? SessionId = null, CommandRejectedReason? RejectReason = null);
+
+/// <summary>
+/// Phase B2-b (sequenced-settlement design §4.2.2; parent §5.5): the daemon's two-lane sequenced
+/// command handler. Exactly two command types are sequenced (Seq'd LaunchAgentCommand + StopAgentV2),
+/// executed strictly serially per epoch. Acceptance (bump HighestAcceptedSeq + cache entry + enqueue)
+/// is one atomic operation under <c>_lock</c>; LastProcessedSeq is the contiguous terminal prefix
+/// (advances only on a terminal outcome). Self-contained + delegate-injected so it is unit-testable
+/// with no live orchestrator (mirrors OrphanReaper/AgentKillQuarantine).
+/// </summary>
+internal sealed class SequencedCommandProcessor : IAsyncDisposable {
+    sealed class CacheEntry { public required string CommandId; public bool Processed; public CommandOutcome Outcome; }
+    readonly record struct LaneItem(SequencedItem Item, Func<Task<CommandOutcome>> Execute, TaskCompletionSource Done);
+
+    readonly string _epoch;
+    readonly Func<string, AgentLiveness> _readLiveness;
+    readonly Func<CommandAck, Task> _sendAck;
+    readonly Func<CommandRejected, Task> _sendRejected;
+    readonly ILogger _logger;
+    readonly int _cacheBound;
+
+    readonly object _lock = new();
+    long _highestAcceptedSeq;
+    long _lastProcessedSeq;
+    long _lastAckedPrefix;
+    readonly Dictionary<long, CacheEntry> _cache = new();
+    readonly Channel<LaneItem> _lane = Channel.CreateUnbounded<LaneItem>(new UnboundedChannelOptions { SingleReader = true });
+    readonly Task _laneTask;
+
+    public SequencedCommandProcessor(
+            string epoch, Func<string, AgentLiveness> readLiveness,
+            Func<CommandAck, Task> sendAck, Func<CommandRejected, Task> sendRejected,
+            ILogger logger, int cacheBound = 256) {
+        _epoch = epoch; _readLiveness = readLiveness; _sendAck = sendAck; _sendRejected = sendRejected;
+        _logger = logger; _cacheBound = cacheBound;
+        _laneTask = Task.Run(RunLaneAsync);
+    }
+
+    public string Epoch => _epoch;
+    public long HighestAcceptedSeq { get { lock (_lock) return _highestAcceptedSeq; } }
+    public long LastProcessedSeq   { get { lock (_lock) return _lastProcessedSeq; } }
+
+    public Task SubmitAsync(SequencedItem item, Func<Task<CommandOutcome>> execute) {
+        lock (_lock) {
+            if (!string.Equals(item.Epoch, _epoch, StringComparison.Ordinal))
+                return RejectLocked(item, CommandRejectedReason.StaleEpoch);   // never touches THIS epoch's lane
+
+            if (_cache.TryGetValue(item.Seq, out var existing))
+                return HandleDuplicateLocked(item, existing);                   // Task 13 answers with CommandAck
+
+            if (item.Seq != _highestAcceptedSeq + 1)
+                return HandleNonNextLocked(item);                              // Task 15 sends wrong_next
+
+            // ACCEPT + lane-item, atomically under _lock.
+            _highestAcceptedSeq = item.Seq;
+            _cache[item.Seq] = new CacheEntry { CommandId = item.CommandId, Processed = false };
+            var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (!_lane.Writer.TryWrite(new LaneItem(item, execute, done))) {
+                SynthesizeErrorLocked(item); // shutdown/allocation race: watermark must still advance
+                done.SetResult();
+            }
+            return done.Task;
+        }
+    }
+
+    // Task 12 stubs (replaced in later tasks):
+    Task HandleDuplicateLocked(SequencedItem item, CacheEntry existing) => Task.CompletedTask;
+    Task HandleNonNextLocked(SequencedItem item) => Task.CompletedTask;
+
+    Task RejectLocked(SequencedItem item, CommandRejectedReason reason) {
+        _ = _sendRejected(new CommandRejected(item.Epoch, item.Seq, item.CommandId, reason, item.AgentId));
+        return Task.CompletedTask;
+    }
+
+    void SynthesizeErrorLocked(SequencedItem item) {
+        // Lane-item creation failed AFTER acceptance (shutdown/allocation race) — an advertised-accepted
+        // Seq with no processable item is impossible, so mark this Seq terminally errored and advance the
+        // watermark THROUGH THE CONTIGUOUS PREFIX only. NEVER set _lastProcessedSeq = item.Seq directly:
+        // if the lane is completing while an earlier accepted item is still draining, a direct jump to N
+        // would (a) advertise a non-contiguous prefix and (b) be regressed below when the earlier item's
+        // consumer later advances to N-1. AdvanceWatermarkLocked is monotonic + contiguous by construction.
+        _cache[item.Seq] = new CacheEntry {
+            CommandId = item.CommandId, Processed = true,
+            Outcome = new CommandOutcome(CommandOutcomeKind.InternalError, item.AgentId) };
+        AdvanceWatermarkLocked();
+        _ = _sendRejected(new CommandRejected(item.Epoch, item.Seq, item.CommandId, CommandRejectedReason.InternalError, item.AgentId));
+    }
+
+    /// <summary>The watermark is the contiguous terminal-processed prefix. Walk forward through Processed
+    /// cache entries from _lastProcessedSeq+1 so a synthesized out-of-order terminal (a shutdown race)
+    /// never advances past a still-draining earlier item, and no advance can ever regress the watermark
+    /// (monotonic by construction). Retired seqs are always &lt;= _lastProcessedSeq, so the walk is safe.</summary>
+    void AdvanceWatermarkLocked() {
+        while (_cache.TryGetValue(_lastProcessedSeq + 1, out var next) && next.Processed)
+            _lastProcessedSeq++;
+    }
+
+    /// <summary>Test seam: complete the lane writer so a subsequent accepted Submit's TryWrite fails,
+    /// forcing the SynthesizeErrorLocked path deterministically (mirrors a shutdown race).</summary>
+    internal void CompleteLaneForTest() => _lane.Writer.TryComplete();
+
+    async Task RunLaneAsync() {
+        await foreach (var li in _lane.Reader.ReadAllAsync()) {
+            CommandOutcome outcome;
+            try {
+                outcome = await li.Execute();
+            } catch (Exception ex) {
+                _logger.LogWarning(ex, "SequencedCommandProcessor: execution faulted for seq {Seq} — internal_error", li.Item.Seq);
+                outcome = new CommandOutcome(CommandOutcomeKind.InternalError, li.Item.AgentId);
+                _ = _sendRejected(new CommandRejected(li.Item.Epoch, li.Item.Seq, li.Item.CommandId, CommandRejectedReason.InternalError, li.Item.AgentId));
+            }
+
+            // Task 15: an execution-time terminal rejection (daemon_capacity / semantic) emits CommandRejected.
+            if (outcome.Kind == CommandOutcomeKind.LaunchRejected && outcome.RejectReason is { } r)
+                _ = _sendRejected(new CommandRejected(li.Item.Epoch, li.Item.Seq, li.Item.CommandId, r, li.Item.AgentId));
+
+            lock (_lock) {
+                if (_cache.TryGetValue(li.Item.Seq, out var e)) { e.Processed = true; e.Outcome = outcome; }
+                AdvanceWatermarkLocked(); // contiguous terminal prefix — serial lane => normally == prior + 1,
+                                          // but shared with SynthesizeErrorLocked so a race can never regress it
+            }
+            li.Done.SetResult();
+        }
+    }
+
+    public void AckPrefix(AckProcessedPrefix ack) { /* Task 14 */ }
+
+    public async ValueTask DisposeAsync() {
+        _lane.Writer.TryComplete();
+        try { await _laneTask; } catch { /* best-effort */ }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "SequencedCommandProcessorTests"`
+Expected: PASS (4 tests — incl. the forced-item-creation-failure synthesized-terminal case).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
+git commit -m "Add SequencedCommandProcessor core (exact-next accept, serial lane, contiguous watermark, synthesized-error item)"
+```
+
+---
+
+### Task 13: Duplicate → `CommandAck`; different-CommandId → `duplicate_collision`
+
+An exact duplicate `(Epoch, Seq, CommandId)` is answered — never re-executed — with a `CommandAck`: `Accepted` while still processing, or `Processed` with the cached `OutcomeKind` + a LIVE `CurrentState` read (confirmed-death precedence). A different `CommandId` at an already-accepted `Seq` is a protocol violation → `CommandRejected(duplicate_collision)`.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs` (replace the `HandleDuplicateLocked` stub).
+- Test: extend `SequencedCommandProcessorTests`.
+
+**Interfaces:**
+- Consumes: the injected `readLiveness`/`sendAck`/`sendRejected`.
+- Produces: no new public surface (behavior change).
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```csharp
+    [Test] public async Task Duplicate_of_a_processed_command_is_acked_with_outcome_and_live_state_not_reexecuted() {
+        var h = new Harness(); await using var p = h.P();
+        var runs = 0;
+        var item = h.Launch(1);
+        await p.SubmitAsync(item, () => { runs++; return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted, "a", "sess")); });
+        await p.SubmitAsync(item, () => { runs++; return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)); });
+        await Assert.That(runs).IsEqualTo(1);                                    // no re-execution
+        var ack = h.Acks.Single();
+        await Assert.That(ack.State).IsEqualTo(CommandAckState.Processed);
+        await Assert.That(ack.OutcomeKind).IsEqualTo(CommandOutcomeKind.LaunchExecuted);
+        await Assert.That(ack.CurrentState).IsEqualTo(AgentLiveness.Live);       // read live at ack time
+    }
+
+    [Test] public async Task Different_command_id_at_an_accepted_seq_is_a_duplicate_collision() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        // Same Seq, different CommandId:
+        await p.SubmitAsync(new SequencedItem(SequencedKind.Launch, "e1", 1, "OTHER", "a1"),
+            () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.DuplicateCollision);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "Duplicate_of_a_processed OR Different_command_id"`
+Expected: FAIL — the stub sends nothing.
+
+- [ ] **Step 3: Write minimal implementation** (replace the `HandleDuplicateLocked` stub)
+
+```csharp
+    Task HandleDuplicateLocked(SequencedItem item, CacheEntry existing) {
+        if (!string.Equals(existing.CommandId, item.CommandId, StringComparison.Ordinal)) {
+            // A DIFFERENT command claiming an accepted Seq — protocol invariant violation.
+            _ = _sendRejected(new CommandRejected(item.Epoch, item.Seq, item.CommandId, CommandRejectedReason.DuplicateCollision, item.AgentId));
+            return Task.CompletedTask;
+        }
+
+        if (!existing.Processed) {
+            _ = _sendAck(new CommandAck(_epoch, item.Seq, item.CommandId, CommandAckState.Accepted));
+        } else {
+            // CurrentState is read LIVE at ack time (immutable execution fact vs current liveness);
+            // the readLiveness delegate reads the daemon lifecycle collections with confirmed-death precedence.
+            var live = _readLiveness(existing.Outcome.AgentId ?? item.AgentId);
+            _ = _sendAck(new CommandAck(_epoch, item.Seq, item.CommandId, CommandAckState.Processed,
+                existing.Outcome.Kind, live, existing.Outcome.AgentId ?? item.AgentId, existing.Outcome.SessionId));
+        }
+        return Task.CompletedTask;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "Duplicate_of_a_processed OR Different_command_id"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
+git commit -m "SequencedCommandProcessor: answer duplicates with CommandAck; reject collisions"
+```
+
+---
+
+### Task 14: `AckProcessedPrefix` retirement + backpressure (never evict unacked identity)
+
+The identity cache is retired ONLY by a validated `AckProcessedPrefix` (current epoch, `UpToSeq <= LastProcessedSeq`, strictly monotonic). If the cache reaches its bound before an ack, further sequenced accepts are rejected with `backpressure` — an unacked entry is NEVER evicted.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs` (implement `AckPrefix`; add the backpressure check to `SubmitAsync`'s accept path).
+- Test: extend `SequencedCommandProcessorTests`.
+
+**Interfaces:**
+- Consumes: `AckProcessedPrefix` (Task 2).
+- Produces: `AckPrefix` behavior; `CommandRejectedReason.Backpressure` emission.
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```csharp
+    [Test] public async Task Backpressure_rejects_when_the_cache_is_full_and_ack_prefix_reopens_capacity() {
+        var h = new Harness(); await using var p = h.P(bound: 2);
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await p.SubmitAsync(h.Launch(2), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await p.SubmitAsync(h.Launch(3), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.Backpressure);
+        await Assert.That(p.HighestAcceptedSeq).IsEqualTo(2L);       // 3 not accepted (unacked identity kept)
+
+        p.AckPrefix(new AckProcessedPrefix("e1", 2));                // retire <= 2
+        await p.SubmitAsync(h.Launch(3), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(3L);
+    }
+
+    [Test] public async Task AckPrefix_rejects_over_ahead_regressing_and_stale_epoch_without_eviction() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        p.AckPrefix(new AckProcessedPrefix("e1", 5));   // over-ahead (> LastProcessedSeq) -> ignored
+        p.AckPrefix(new AckProcessedPrefix("WRONG", 1));// stale epoch -> ignored
+        // A duplicate is still answerable (identity not evicted):
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(h.Acks.Count).IsEqualTo(1);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "Backpressure_rejects OR AckPrefix_rejects"`
+Expected: FAIL — `AckPrefix` is a no-op and no backpressure check exists.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the backpressure guard in `SubmitAsync`, immediately before the accept block (after the exact-next check passes):
+
+```csharp
+            if (item.Seq != _highestAcceptedSeq + 1)
+                return HandleNonNextLocked(item);
+
+            if (_cache.Count >= _cacheBound)                                   // never evict unacked identity
+                return RejectLocked(item, CommandRejectedReason.Backpressure);
+
+            // ACCEPT + lane-item, atomically under _lock.
+```
+
+Implement `AckPrefix`:
+
+```csharp
+    public void AckPrefix(AckProcessedPrefix ack) {
+        lock (_lock) {
+            if (!string.Equals(ack.Epoch, _epoch, StringComparison.Ordinal)) return; // stale epoch
+            if (ack.UpToSeq > _lastProcessedSeq) return;                              // over-ahead of processed prefix
+            if (ack.UpToSeq <= _lastAckedPrefix) return;                             // regressing / duplicate
+            _lastAckedPrefix = ack.UpToSeq;
+            foreach (var seq in _cache.Keys.Where(k => k <= ack.UpToSeq).ToList()) _cache.Remove(seq);
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "Backpressure_rejects OR AckPrefix_rejects"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
+git commit -m "SequencedCommandProcessor: AckProcessedPrefix retirement + backpressure (no unacked eviction)"
+```
+
+---
+
+### Task 15: `CommandRejected` per-reason — `wrong_next`, `stale_epoch`, `daemon_capacity`, `semantic`
+
+Replace the `HandleNonNextLocked` stub with a `wrong_next` emission (a too-far-ahead `Seq` — the transport must resync; the accept/watermark are untouched). `stale_epoch` already emits (Task 12). Execution-time terminal rejections (`daemon_capacity`, `semantic`) flow via the `execute` delegate's `CommandOutcome{ Kind = LaunchRejected, RejectReason = … }` and advance the watermark (rejected-as-item), which the lane already maps to a `CommandRejected` (Task 12 lane code).
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs` (replace `HandleNonNextLocked`).
+- Test: extend `SequencedCommandProcessorTests`.
+
+**Interfaces:**
+- Consumes: `CommandRejectedReason` (Task 2).
+- Produces: `wrong_next` on a non-next Seq; `daemon_capacity`/`semantic` via `CommandOutcome.RejectReason`.
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```csharp
+    [Test] public async Task Non_next_future_seq_is_rejected_wrong_next_without_accepting() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await p.SubmitAsync(h.Launch(3), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted))); // gap
+        await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.WrongNext);
+        await Assert.That(p.HighestAcceptedSeq).IsEqualTo(1L);
+    }
+
+    [Test] public async Task Execution_time_daemon_capacity_rejection_advances_watermark_and_emits_reject() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(
+            new CommandOutcome(CommandOutcomeKind.LaunchRejected, "a", RejectReason: CommandRejectedReason.DaemonCapacity)));
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(1L);        // rejected-as-item is terminal
+        await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.DaemonCapacity);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "Non_next_future_seq OR Execution_time_daemon_capacity"`
+Expected: FAIL — `HandleNonNextLocked` is a silent stub.
+
+- [ ] **Step 3: Write minimal implementation** (replace the `HandleNonNextLocked` stub)
+
+```csharp
+    Task HandleNonNextLocked(SequencedItem item) {
+        // A future Seq with a gap (Seq > HighestAcceptedSeq + 1). Never accepted out of order; the
+        // server's transport sequencer resyncs (nudge -> observe -> retransmit). A too-LOW uncached Seq
+        // (already retired) is also wrong_next — the sender is behind the retirement frontier.
+        return RejectLocked(item, CommandRejectedReason.WrongNext);
+    }
+```
+
+The `daemon_capacity`/`semantic` path needs no processor change — the lane's Task 12 mapping already emits `CommandRejected` for a `LaunchRejected` outcome carrying a `RejectReason`. (The orchestrator's launch execute-closure returns that outcome; Task 16.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "Non_next_future_seq OR Execution_time_daemon_capacity"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
+git commit -m "SequencedCommandProcessor: wrong_next + execution-time daemon_capacity/semantic rejections"
+```
+
+---
+
+### Task 16: Wire the processor into `ServerConnection` + `AgentOrchestrator` (routing, legacy lane, counters, `SupportsSequencedCommands`, `RequestStatusReport`)
+
+Route sequenced commands through the processor; keep the legacy unsequenced lane for un-`Seq`'d commands (old server). Advertise `Epoch`/`HighestAcceptedSeq`/`LastProcessedSeq` + `SupportsSequencedCommands = true` on the report/connect. Serve `AckProcessedPrefix` and `RequestStatusReport`, and send `CommandAck`/`CommandRejected` one-way.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/ServerConnection.cs` (receive handlers `StopAgentV2`/`AckProcessedPrefix`/`RequestStatusReport`; one-way sends `CommandAckAsync`/`CommandRejectedAsync`; the full enriched `DaemonConnect` payload).
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (own the processor; refactor `HandleLaunchAgent` into a router + `HandleLaunchAgentCore`; add `HandleStopAgentV2`; add `ReadLiveness`; finalize `BuildStatusReport` counters + the connect getters).
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/HealBarrierReportTests.cs` (CREATE — a `partial class AgentOrchestratorVendorTests`, namespace `Capacitor.Cli.Tests.Unit`, reusing the existing `BuildOrchestrator`/`CaptureServerConnection`/`SeedAgentForTest` harness; Task 17 MODIFYs this same file).
+
+**Interfaces:**
+- Consumes: `SequencedCommandProcessor` (Tasks 12–15), `StopAgentV2`/`AckProcessedPrefix`/`CommandAck`/`CommandRejected` (Task 2).
+- Produces:
+  - `ServerConnection`: `event Func<StopAgentV2, Task>? OnStopAgentV2`, `event Action<AckProcessedPrefix>? OnAckProcessedPrefix`, `event Func<Task>? OnRequestStatusReport`, `Task CommandAckAsync(CommandAck)`, `Task CommandRejectedAsync(CommandRejected)`, connect-payload getters `Func<long?>? GetHighestAcceptedSeq`/`GetLastProcessedSeq`, `Func<bool>? GetStartupReapComplete`, `Func<UnresolvedStartupCandidate[]>? GetUnresolvedStartupCandidates`, `Func<StartupDiscovery?>? GetStartupDiscovery`.
+  - `AgentOrchestrator`: `AgentLiveness ReadLiveness(string agentId)`; `HandleLaunchAgentCore`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Report_advertises_sequencing_capability_and_counters() {
+        await using var orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        var report = orch.BuildStatusReport();
+        await Assert.That(report.Epoch).IsNotNull();
+        await Assert.That(report.HighestAcceptedSeq).IsEqualTo(0L); // fresh epoch, nothing accepted yet
+        await Assert.That(report.LastProcessedSeq).IsEqualTo(0L);
+    }
+
+    [Test]
+    public async Task ReadLiveness_follows_confirmed_death_precedence() {
+        await using var orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("live", LaunchKind.ReviewFlow, status: "Running");
+        await Assert.That(orch.ReadLiveness("live")).IsEqualTo(AgentLiveness.Live);
+        await Assert.That(orch.ReadLiveness("never")).IsEqualTo(AgentLiveness.Dead);
+    }
+
+    [Test]
+    public async Task ReadLiveness_racing_transitions_never_yields_a_transient_false_dead() {
+        // Parent §8: CommandAck.CurrentState racing live->quarantine / quarantine->dead transitions must
+        // never surface a transient false Dead. Hammer ReadLiveness while the agent moves live -> quarantine
+        // (teardown of a surviving child) -> dead (drain after the child exits). The shipped ordering
+        // invariant (CleanupAgentAsync adds to _quarantine BEFORE removing from _agents) keeps the id
+        // continuously in _agents ∪ _quarantine until the drain, so deadness is monotonic.
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        using var dummy = DummyProcess.StartSleep(30);
+        orch.SeedAgentForTest("rev", LaunchKind.ReviewFlow, status: "Running", flowRunId: "f", flowRole: "reviewer",
+            pty: new LivePtyDouble(dummy.Pid), startIdentity: ProcessIdentity.Capture(dummy.Pid));
+
+        var observed = new System.Collections.Concurrent.ConcurrentQueue<AgentLiveness>();
+        using var stop = new CancellationTokenSource();
+        var hammer = Task.Run(() => { while (!stop.IsCancellationRequested) observed.Enqueue(orch.ReadLiveness("rev")); });
+
+        await orch.CleanupAgentForTest("rev");                        // live -> quarantine (child still alive)
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        await orch.RetryQuarantineForTest();                          // quarantine -> dead (drain confirms death)
+        stop.Cancel(); await hammer;
+
+        // No transient false Dead: once Dead is observed it is never followed by a non-Dead reading.
+        var seq = observed.ToArray();
+        var firstDead = Array.IndexOf(seq, AgentLiveness.Dead);
+        if (firstDead >= 0)
+            await Assert.That(seq.Skip(firstDead).All(s => s == AgentLiveness.Dead)).IsTrue();
+        await Assert.That(orch.ReadLiveness("rev")).IsEqualTo(AgentLiveness.Dead); // genuinely dead at the end
+    }
+
+    /// <summary>A live-pid-backed pty double whose TerminateAsync deliberately does NOT kill (so teardown
+    /// quarantines the "surviving" child). Mirrors LaunchCleanupTests' private LiveNoKillPtyProcess.</summary>
+    sealed class LivePtyDouble(int pid) : IPtyProcess {
+        public int  Pid       => pid;
+        public bool HasExited => false;
+        public int? ExitCode  => null;
+        public ValueTask DisposeAsync() => default;
+        public Task WaitForExitAsync(TimeSpan? _) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan?   _) => Task.CompletedTask; // deliberately does NOT kill
+#pragma warning disable CS1998
+        public async IAsyncEnumerable<byte[]> ReadOutputAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken _ = default) { yield break; }
+#pragma warning restore CS1998
+        public Task WriteAsync(string _) => Task.CompletedTask;
+        public Task WriteAsync(byte[] _) => Task.CompletedTask;
+        public void Resize(ushort     _, ushort __) { }
+        public void SendInterrupt() { }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "advertises_sequencing_capability OR ReadLiveness"`
+Expected: FAIL to COMPILE — `report.HighestAcceptedSeq`/`ReadLiveness` do not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`ServerConnection.cs` — events, sends, hub registrations (add in the ctor next to the existing `_hub.On` calls):
+
+```csharp
+    public event Func<StopAgentV2, Task>? OnStopAgentV2;
+    public event Action<AckProcessedPrefix>? OnAckProcessedPrefix;
+    public event Func<Task>? OnRequestStatusReport;
+
+    public virtual async Task CommandAckAsync(CommandAck ack) {
+        if (!IsReady) return;
+        try { await _hub.SendAsync("CommandAck", ack, cancellationToken: _ct); }
+        catch (Exception ex) { _logger.LogDebug(ex, "CommandAck send failed (old server or transient)"); }
+    }
+    public virtual async Task CommandRejectedAsync(CommandRejected rej) {
+        if (!IsReady) return;
+        try { await _hub.SendAsync("CommandRejected", rej, cancellationToken: _ct); }
+        catch (Exception ex) { _logger.LogDebug(ex, "CommandRejected send failed (old server or transient)"); }
+    }
+
+    // ctor registrations:
+    _hub.On<StopAgentV2>("StopAgentV2", cmd => SafeInvoke("StopAgentV2", () => OnStopAgentV2?.Invoke(cmd)));
+    _hub.On<AckProcessedPrefix>("AckProcessedPrefix", ack => { OnAckProcessedPrefix?.Invoke(ack); return Task.CompletedTask; });
+    _hub.On("RequestStatusReport", () => OnRequestStatusReport?.Invoke() ?? Task.CompletedTask);
+```
+
+Add the connect getters (fields) and pass the FULL enriched payload in `DaemonConnectAsync`:
+
+```csharp
+    public Func<long?>? GetHighestAcceptedSeq { get; set; }
+    public Func<long?>? GetLastProcessedSeq { get; set; }
+    public Func<bool>? GetStartupReapComplete { get; set; }
+    public Func<UnresolvedStartupCandidate[]>? GetUnresolvedStartupCandidates { get; set; }
+    public Func<StartupDiscovery?>? GetStartupDiscovery { get; set; }
+    public Func<QuarantinedAgentInfo[]>? GetQuarantined { get; set; }
+
+    // in DaemonConnectAsync, replace the DaemonConnect ctor call with the enriched payload:
+    new DaemonConnect(
+        _config.Name, platform, repoPaths, _config.MaxConcurrentAgents, liveIds,
+        _config.InstanceId, _config.Version, _config.SupportedVendors, MachineId.Get(), liveAgents,
+        _config.UnattendedVendors,
+        Quarantined:                   GetQuarantined?.Invoke(),
+        Epoch:                         _config.DaemonEpoch,
+        HighestAcceptedSeq:            GetHighestAcceptedSeq?.Invoke(),
+        LastProcessedSeq:              GetLastProcessedSeq?.Invoke(),
+        StartupReapComplete:           GetStartupReapComplete?.Invoke(),
+        ResolvedStartupCandidates:     GetResolvedStartupCandidates?.Invoke(),
+        UnresolvedStartupCandidates:   GetUnresolvedStartupCandidates?.Invoke(),
+        StartupDiscovery:              GetStartupDiscovery?.Invoke(),
+        RecordlessSurvivorsImpossible: _config.RecordlessSurvivorsImpossible,
+        SupportsSequencedCommands:     true)
+```
+
+(`_config.DaemonEpoch` must be set — `DaemonRunner` currently leaves it null and the orchestrator mints it. Make `DaemonRunner` set `config.DaemonEpoch ??= Guid.NewGuid().ToString("N");` before building services, so the connect epoch and the orchestrator's `_daemonEpoch` agree.)
+
+`AgentOrchestrator.cs`:
+
+Add the processor field + `ReadLiveness` + construct the processor in the ctor:
+
+```csharp
+    SequencedCommandProcessor? _processor;
+
+    // in ctor, after _resolvedLedger/_markerCandidates/_orphanReaper set up:
+    _processor = new SequencedCommandProcessor(
+        _daemonEpoch, ReadLiveness, _server.CommandAckAsync, _server.CommandRejectedAsync, logger);
+
+    // wire receive handlers + connect getters:
+    _server.OnStopAgentV2          += HandleStopAgentV2;
+    _server.OnAckProcessedPrefix   += ack => _processor?.AckPrefix(ack);
+    _server.OnRequestStatusReport  += SendDaemonStatusReportOnceAsync;
+    _server.GetHighestAcceptedSeq          = () => _processor?.HighestAcceptedSeq;
+    _server.GetLastProcessedSeq            = () => _processor?.LastProcessedSeq;
+    _server.GetStartupReapComplete         = ComputeStartupReapComplete;
+    _server.GetUnresolvedStartupCandidates = () => [.. _orphanReaper?.BlockedCandidates(_markerCandidates) ?? []];
+    _server.GetStartupDiscovery            = () => _orphanReaper?.CurrentDiscovery;
+    _server.GetQuarantined                 = () => [.. QuarantineSnapshot()];
+
+    /// <summary>Phase B2-b (spec §5.5/§4.2.2): the single lifecycle-state read (confirmed-death precedence
+    /// Live>Quarantined>Dead) over the same collections CleanupAgentAsync + AgentKillQuarantine mutate. The
+    /// spec mandates that a duplicate CommandAck's CurrentState be read so a teardown racing the read can
+    /// NEVER surface a transient false Dead. This read is lock-free (it does not take the per-agent lifecycle
+    /// lock) and is SOUND ONLY BECAUSE OF THE SHIPPED CleanupAgentAsync ORDERING INVARIANT: the confirmed-
+    /// death teardown adds the surviving child to `_quarantine` BEFORE removing it from `_agents`
+    /// (AgentOrchestrator.cs — "Add to quarantine BEFORE removing from _agents so EffectiveCount never dips"),
+    /// so an agent is CONTINUOUSLY present in `_agents ∪ _quarantine` from spawn until its quarantine entry
+    /// is drained (RetryQuarantineOnceAsync) — there is no window where a live/tearing-down agent is absent
+    /// from both, hence no transient false Dead. Dead is returned only after the genuine drain (confirmed
+    /// death). If that ordering invariant is ever broken, this must instead take the per-agent lifecycle lock.
+    /// NotFound collapses to Dead here (see the appendix note) — both satisfy confirmed-absence.</summary>
+    internal AgentLiveness ReadLiveness(string agentId) {
+        // Order matters: check _agents first (Live/Quarantined-by-status), then _quarantine, then Dead.
+        // The add-to-quarantine-before-remove-from-_agents invariant makes this ordering false-Dead-free.
+        if (_agents.TryGetValue(agentId, out var a)) return a.Status is "Starting" or "Running" ? AgentLiveness.Live : AgentLiveness.Quarantined;
+        if (_quarantine?.Snapshot().Any(q => q.Id == agentId) == true) return AgentLiveness.Quarantined;
+        return AgentLiveness.Dead;
+    }
+```
+
+Refactor the launch handler into a router + core, and add the V2 stop router:
+
+```csharp
+    // Rename the existing HandleLaunchAgent body to HandleLaunchAgentCore, and make HandleLaunchAgent route:
+    async Task HandleLaunchAgent(LaunchAgentCommand cmd) {
+        if (_processor is { } proc && cmd.Seq is { } seq && cmd.Epoch is { } epoch && cmd.CommandId is { } cmdId) {
+            await proc.SubmitAsync(
+                new SequencedItem(SequencedKind.Launch, epoch, seq, cmdId, cmd.AgentId),
+                async () => {
+                    await HandleLaunchAgentCore(cmd);
+                    return _agents.TryGetValue(cmd.AgentId, out var a)
+                        ? new CommandOutcome(CommandOutcomeKind.LaunchExecuted, cmd.AgentId, a.SessionId)
+                        : new CommandOutcome(CommandOutcomeKind.LaunchFailedCleaned, cmd.AgentId);
+                });
+            return;
+        }
+        await HandleLaunchAgentCore(cmd); // legacy unsequenced lane (old server) — never advances the watermark
+    }
+
+    async Task HandleStopAgentV2(StopAgentV2 cmd) {
+        if (_processor is { } proc) {
+            await proc.SubmitAsync(
+                new SequencedItem(SequencedKind.Stop, cmd.Epoch, cmd.Seq, cmd.CommandId, cmd.AgentId),
+                async () => { await HandleStopAgent(cmd.AgentId); return new CommandOutcome(CommandOutcomeKind.StopExecuted, cmd.AgentId); });
+            return;
+        }
+        await HandleStopAgent(cmd.AgentId);
+    }
+```
+
+Finalize `BuildStatusReport` counters:
+
+```csharp
+    internal DaemonStatusReport BuildStatusReport() =>
+        new(ActiveCount, [.. BuildLiveAgents()], [.. QuarantineSnapshot()],
+            Epoch: _daemonEpoch,
+            LastProcessedSeq: _processor?.LastProcessedSeq,
+            HighestAcceptedSeq: _processor?.HighestAcceptedSeq,
+            StartupReapComplete: ComputeStartupReapComplete(),
+            ResolvedStartupCandidates: [.. _resolvedLedger?.Snapshot() ?? []],
+            UnresolvedStartupCandidates: [.. _orphanReaper?.BlockedCandidates(_markerCandidates) ?? []],
+            StartupDiscovery: _orphanReaper?.CurrentDiscovery);
+```
+
+Dispose the processor in `DisposeAsync` (add `if (_processor is not null) await _processor.DisposeAsync();`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "advertises_sequencing_capability OR ReadLiveness"`
+Expected: PASS (counters + `ReadLiveness_follows_confirmed_death_precedence` + the racing-transition test). Run the full Unit suite once to catch the `SafeInvoke`/handler-wiring regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/ServerConnection.cs src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs src/Capacitor.Cli.Daemon/DaemonRunner.cs test/Capacitor.Cli.Tests.Unit/Daemon/HealBarrierReportTests.cs
+git commit -m "Wire SequencedCommandProcessor into daemon: routing, counters, capability, RequestStatusReport"
+```
+
+---
+
+### Task 17: Heal-barrier obligations — post-stop report proves absence; `SupportsSequencedCommands` gating
+
+Verify the daemon-side heal-barrier contract end to end through the orchestrator: after a `StopAgentV2` at `Seq = M` terminally processes, a subsequent `DaemonStatusReport` carries `LastProcessedSeq >= M` and omits the stopped id from `LiveAgents ∪ Quarantined` once confirmed dead; a still-unconfirmed-death stop keeps the id in `Quarantined` (physical-liveness set), so absence is NOT proven (the shipped CleanupAgentAsync unconfirmed-death move already guarantees this). Also confirm `RequestStatusReport` triggers an immediate report and the legacy lane never advances the watermark.
+
+**Files:**
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/HealBarrierReportTests.cs` (MODIFY — Task 16 CREATEd it as a `partial class AgentOrchestratorVendorTests`; add these two heal-barrier tests to the same partial) — orchestrator-level, using `SeedAgentForTest` + the `SequencedCommandProcessor` via `HandleStopAgentV2ForTest`, and the **existing shipped** `HandleLaunchAgentForTest` seam (`AgentOrchestrator.cs:2103`, already routes through `HandleLaunchAgent`) for the legacy-lane launch.
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (add the one new test seam `HandleStopAgentV2ForTest`; `HandleLaunchAgentForTest` already exists and needs no change).
+
+**Interfaces:**
+- Consumes: everything above; the **existing** `AgentOrchestrator.HandleLaunchAgentForTest(LaunchAgentCommand)` seam (shipped at `AgentOrchestrator.cs:2103`) — the Task 16 refactor makes it route an un-`Seq`'d command down the legacy lane.
+- Produces: `AgentOrchestrator.HandleStopAgentV2ForTest(StopAgentV2)` (the only new seam); the `CaptureServerConnection` capture lists as needed (extend the existing double).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Stop_via_v2_advances_watermark_and_a_later_report_omits_the_confirmed_dead_id() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        var agent = orch.SeedAgentForTest("rev", LaunchKind.ReviewFlow, status: "Running", flowRunId: "f", flowRole: "reviewer");
+        var epoch = orch.DaemonEpochForTest;
+
+        await orch.HandleStopAgentV2ForTest(new StopAgentV2("rev", epoch, 1, "cmd-1"));
+
+        var report = orch.BuildStatusReport();
+        await Assert.That(report.LastProcessedSeq).IsEqualTo(1L);                          // stop at M=1 terminally processed
+        await Assert.That(report.LiveAgents.Select(x => x.Id)).DoesNotContain("rev");      // confirmed dead (Noop pty) -> absent
+        await Assert.That(report.Quarantined.Select(x => x.Id)).DoesNotContain("rev");
+    }
+
+    [Test]
+    public async Task Legacy_unsequenced_launch_never_advances_the_watermark() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        // No Epoch/Seq/CommandId -> legacy lane.
+        await orch.HandleLaunchAgentForTest(new LaunchAgentCommand("x", "hi", "opus", null, "/tmp", null, null, "bogus"));
+        await Assert.That(orch.BuildStatusReport().HighestAcceptedSeq).IsEqualTo(0L);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "Stop_via_v2_advances OR Legacy_unsequenced_launch"`
+Expected: FAIL to COMPILE — `HandleStopAgentV2ForTest` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the ONE new test seam in `AgentOrchestrator.cs` (the launch seam `HandleLaunchAgentForTest` already exists at `AgentOrchestrator.cs:2103` — the `Legacy_unsequenced_launch...` test reuses it, and the Task 16 refactor makes it route an un-`Seq`'d command down the legacy lane; no new launch seam):
+
+```csharp
+    internal Task HandleStopAgentV2ForTest(StopAgentV2 cmd) => HandleStopAgentV2(cmd);
+```
+
+(The seeded agent uses `NoopPtyProcess` — pid 0 / not-alive — so `HandleStopAgent` → `CleanupAgentAsync` confirms death immediately, removing it from `_agents` without quarantining. The stop terminally processes at `Seq = 1`, so `LastProcessedSeq == 1` and the id is absent from both collections. No production change is needed beyond the one seam; this task is verification that Tasks 12–16 compose correctly.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --filter "Stop_via_v2_advances OR Legacy_unsequenced_launch"`
+Expected: PASS. Then run the FULL Unit suite (`dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj`) and the Linear-ID guard (`bash scripts/check-linear-ids.sh`) — both green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs test/Capacitor.Cli.Tests.Unit/Daemon/HealBarrierReportTests.cs
+git commit -m "Verify heal-barrier post-stop report proves absence; legacy lane never advances watermark"
+```
+
+---
+
+## Self-Review — spec-requirement → task coverage
+
+**AI-1391 §4.2 (B2-b), daemon-side requirements:**
+
+| Spec requirement | Task(s) |
+| --- | --- |
+| §4.2.1 wire: `DaemonConnect`/`DaemonStatusReport`/`LaunchAgentCommand` additive fields; `StopAgentV2`/`CommandAck`/`CommandRejected`/`AckProcessedPrefix`/`AckResolvedCandidates`/`RequestStatusReport`; `ResolvedStartupCandidate` shape; `UnresolvedStartupCandidate` reason enum `{pending_marker,legacy_unresolvable,identity_unresolvable}`; `StartupDiscovery` `{MarkerScanState∈{complete,pending,failed,not_applicable}, LastSuccessfulScanAt?}`; CapacitorJsonContext + snake_case + additive-compat | 1, 2 (appendix) |
+| §4.2.1 `Epoch` = shipped `_daemonEpoch`; old server → legacy lane | 16 (routing + DaemonRunner epoch pinning) |
+| §4.2.2 exactly two sequenced lanes, strictly serial per epoch | 12 |
+| §4.2.2 `LastProcessedSeq` contiguous terminal prefix; exact-next acceptance | 12 |
+| §4.2.2 accept + lane-item atomic under one lock; synthesized `internal_error` item + `CommandRejected(internal_error)` | 12 |
+| §4.2.2 per-epoch identity cache retired only by validated `AckProcessedPrefix` (monotonic, ≤ LastProcessedSeq, current epoch); backpressure, never evict unacked | 14 |
+| §4.2.2 duplicate → `CommandAck {Accepted\|Processed(+outcome)}` with `Outcome.CurrentState` (confirmed-death precedence, invariant-sound lock-free read documented in Task 16; racing-transition test proves no transient false `Dead`) | 13, 16 (`ReadLiveness` + racing test) |
+| §4.2.2 `Epoch` reuse (no second epoch) | 5, 16 |
+| §4.2.4 durable ledger, atomic temp+rename, daemon-lifetime monotonic `Generation` persisted with it | 6 |
+| §4.2.4 four positive-confirmation hooks: record-pass / quarantine drain / StopAgent-fallback / env-marker kill (incl. recordless→marker-candidate) | 7, 8, 9 |
+| §4.2.4 dedicated marker-candidate source `{AgentId,DaemonId,OldEpoch,pid}`, marker-based authority, no spawn-bound record, no trusted flow identity from env | 9 |
+| §4.2.4 write ordering ledger-append-BEFORE-source-deletion; crash reconciliation on `(AgentId,OldEpoch)`; idempotent upsert; re-report until `AckResolvedCandidates` prunes per-entry | 6 (upsert/ack), 7 (record crash-inject both sides), 8 (quarantine-drain + StopAgent-fallback crash-inject both sides), 9 (marker crash-inject both sides), 10 (prune) |
+| §4.2.4 marker resolution matrix (a) dead/zombie→resolved (b) alive+match→kill→resolved (c) alive+mismatch/unreadable→spare/`pending_marker` | 9 |
+| §4.2.3 coverage journal, `cumulative_covered` fold, genesis rule (single-file `{initialized,…}` — marker folded into the journal, ONE atomic temp+rename; genesis-eligibility = journal absent), downgrade/unaware-boot detection via lock `InstanceId`, fail-closed, sticky-false, operator-reset-only | 3, 4 |
+| §4.2.3 `RecordlessSurvivorsImpossible` = journal tail's `cumulative_covered`, re-derived at every DaemonConnect | 5 |
+| §4.2.5 `StartupReapComplete` per-platform (Linux marker-scan-complete; Windows-with-RecordlessSurvivorsImpossible trivial; pre-W1 Windows + macOS record-pass-only) + `StartupDiscovery` + `UnresolvedStartupCandidates` population | 11 |
+| §4.2.6 heal-barrier: serve `RequestStatusReport`; post-stop report carries `LastProcessedSeq ≥ M` omitting the id; `CommandRejected` per-reason (`wrong_next`/`duplicate_collision`/`stale_epoch`/`daemon_capacity`/semantic) | 12 (stale_epoch/internal_error), 13 (duplicate_collision), 15 (wrong_next/daemon_capacity/semantic), 16 (RequestStatusReport), 17 (post-stop report) |
+| §5 compat: additive, `SupportsSequencedCommands`-gated, legacy lane never advances watermark | 16, 17 |
+
+**Parent §8 "Settlement" acceptance list (daemon-observable items):**
+
+| Parent §8 Settlement item | Task |
+| --- | --- |
+| contiguous-prefix watermark: slow launch at N + fast stop at N+1 → watermark stays < N until N processes | 12 (serial lane ⇒ N+1 can't process before N) |
+| exact-next acceptance; send-fails-before-accept then N+1 → rejected, no permanent hole | 15 (`wrong_next`) |
+| accept+enqueue atomicity — forced item-creation failure → synthesized errored terminal item at N, watermark advances (monotonically, via the contiguity-safe `AdvanceWatermarkLocked`; tested with an earlier item still draining) | 12 |
+| duplicate before/during/after execution → `CommandAck` `Accepted` vs `Processed(+outcome)`; no re-execution | 13 |
+| `CommandAck.CurrentState` racing live→quarantine/quarantine→dead → no transient false `Dead` (invariant-sound lock-free read: `CleanupAgentAsync` quarantines BEFORE removing from `_agents`; asserted by the racing-transition test) | 13, 16 (`ReadLiveness` precedence + racing test) |
+| `AckProcessedPrefix` validation — over-ahead/regressing/stale-epoch rejected without eviction | 14 |
+| backpressure with cache pressure → reject, never evict unacked identity | 14 |
+| `CommandRejected` per-reason — wrong_next resync, duplicate_collision alarm, stale_epoch, daemon_capacity, semantic | 12, 13, 15 |
+| generation-identity: `Generation` persistence across restarts | 6 |
+| ledger entries at the four hooks, not for spared/ambiguous; crash-injection **both sides of each hook** (before-append re-derives next boot; between-append-delete reconciles single-emit); `(AgentId,OldEpoch)` reconciliation key (NOT `Generation`) | 7 (record-pass), 8 (quarantine-drain + StopAgent-fallback), 9 (marker-scan incl. recordless) — before-append + between-append-delete tests in each |
+| marker-candidate exit+PID-reuse race → re-read triple spares the reused occupant | 9 |
+| `StartupReapComplete` per-platform matrix; identity_unavailable/legacy/pending detail in `UnresolvedStartupCandidates` | 11 |
+| `ResolvedStartupCandidates` (single name) + `UnresolvedStartupCandidates` round-trips + old-server-ignores-unknown | 1, 10 |
+| explicit `StartupDiscovery` cases — each `MarkerScanState` + `LastSuccessfulScanAt` round-trip | 1, 11 |
+| `RecordlessSurvivorsImpossible` round-trip + default; boot-chain matrix through the REAL `DaemonLock` (clean/crashed W1→W1, downgrade sandwich, aware-uncontained, durable stickiness, empty-dir-with-prior-lock, corrupt, **genesis crash-before-the-single-rename re-seeds**) | 3, 4, 5 |
+| macOS/pre-W1-Windows per-id-only override (flag never sufficient alone) | 11 (`ComputeStartupReapComplete` platform arms) + **server-side** (below) |
+| `AgentUnregistered` / retired-generation dedup; teardown-with-unconfirmed-death → id moves to Quarantined, watermark advances, absence NOT satisfied | 17 (post-stop report) + shipped Phase B `CleanupAgentAsync` |
+| no test touches a real daemon or live flows | all (DummyProcess / delegate fakes / real DaemonLock) |
+
+**Gaps / server-owned items intentionally out of this daemon PR (flagged):**
+1. **Tombstone eviction / `EffectiveStartupComplete` predicate / heal-barrier clear / settlement paths (a)/(b)/(c) / the macOS per-id-only override CONSUMPTION** are **server-side** (parent §5.5, B2-b §4.2.3). This daemon PR only *produces* the signals (`StartupReapComplete`, `StartupDiscovery`, `RecordlessSurvivorsImpossible`, `ResolvedStartupCandidates`, counters). The server-plan author consumes them per the appendix. **Not a gap in this plan.**
+2. **The server transport sequencer** (allocate Seq + transmit, pause-nudge-retransmit, `AckProcessedPrefix` emission, `AckResolvedCandidates` emission, `RequestStatusReport` nudge) is server-side. The daemon *receives* these; sending them is the server plan.
+3. **`LaunchRejected` as a `CommandAck` outcome** (spec §5.5 lists it): resolved as a spec ambiguity — see below. The daemon emits capacity/semantic rejections via `CommandRejected` (Task 15), and `CommandAck` uses `LaunchExecuted`/`LaunchFailedCleaned`. `LaunchRejected` remains a defined wire value the server may still receive on the `CommandAck` path from a future daemon; no daemon-side gap.
+
+**Spec ambiguities resolved (with resolution):**
+- **`Epoch` wire type.** Parent §5.5 pins `HighestAcceptedSeq` as `Int64` but never types `Epoch`; the shipped `_daemonEpoch` is a GUID `"N"` **string**. Resolved: `Epoch` is `string` on every DTO (`LaunchAgentCommand`, `StopAgentV2`, `CommandAck`, `CommandRejected`, `AckProcessedPrefix`, reports) to match `_daemonEpoch` and `AgentPidRecord.DaemonEpoch`.
+- **Enum wire tokens vs the global naming policy.** `CapacitorJsonContext` sets `UseStringEnumConverter=true` + `SnakeCaseLower`, but the existing DEV-1665 note describes camelCase enum output — ambiguous. Resolved: every new enum pins its exact wire token with `[JsonStringEnumMemberName("…")]` and the round-trip tests (Tasks 1/2) assert the raw JSON substring, so the cross-repo contract is exact regardless of the converter's default casing. Zero values are the safe defaults (`MarkerScanState.Pending = 0`).
+- **`CommandAck` outcome richness.** §5.5 describes a discriminated `LaunchExecuted{metadata}` / `LaunchRejected{code}` / `LaunchFailedCleaned` / `StopExecuted` union. Resolved to a flat, AOT-friendly `CommandAck` (`OutcomeKind` + `CurrentState` + optional `AgentId`/`SessionId`/`RejectionReason`); the daemon determines a launch's `OutcomeKind` by a post-execution `_agents.ContainsKey` check (`LaunchExecuted` vs `LaunchFailedCleaned`), and emits capacity/semantic rejections via `CommandRejected` rather than a `CommandAck` `LaunchRejected` (kept as a defined-but-daemon-unused value).
+- **Quarantine-drain hook `OldEpoch`.** The shipped `_quarantine` is in-memory kill-quarantine (current-incarnation only), so a drain's `OldEpoch` is the *current* epoch. Resolved: emit the resolved-candidate anyway (idempotent, harmless for a same-epoch id, and it gives the server id-level absence proof); the prior-epoch resolutions come from the record pass + marker scan.
+- **`this_epoch_contained`.** Only the Windows Job Object leaves genuinely no recordless survivor class (Linux keeps records+scan as the descendant backstop per parent §6.4). Resolved: production `thisEpochContained = OperatingSystem.IsWindows()`; the server consumes `RecordlessSurvivorsImpossible` only on Windows, so the Linux/macOS value is inert. Tests inject both to exercise the aware-uncontained branch.
+- **`RequestStatusReport` shape.** Listed as a "message" but carries no payload. Resolved: a zero-argument hub invocation (`_hub.On("RequestStatusReport", …)`), matching the shipped no-arg broadcast-sink pattern — no DTO.
+
+## Locked wire-contract record shapes (hand to the server-plan author)
+
+Exactly as in the Appendix. Summary of the daemon→server / server→daemon split:
+- **server→daemon (received):** `LaunchAgentCommand` (+`Epoch`/`Seq`/`CommandId`), `StopAgentV2`, `AckProcessedPrefix`, `AckResolvedCandidates`, `RequestStatusReport` (0-arg).
+- **daemon→server (produced):** `DaemonConnect` (+`Quarantined`/`Epoch`/`HighestAcceptedSeq`/`LastProcessedSeq`/`StartupReapComplete`/`ResolvedStartupCandidates`/`UnresolvedStartupCandidates`/`StartupDiscovery`/`RecordlessSurvivorsImpossible`/`SupportsSequencedCommands`), `DaemonStatusReport` (+`Epoch`/`LastProcessedSeq`/`HighestAcceptedSeq`/`StartupReapComplete`/`ResolvedStartupCandidates`/`UnresolvedStartupCandidates`/`StartupDiscovery`), `CommandAck`, `CommandRejected`.
+- **enums:** `MarkerScanState`, `StartupCandidateUnresolvedReason`, `CommandAckState`, `CommandOutcomeKind`, `AgentLiveness`, `CommandRejectedReason` — each with `[JsonStringEnumMemberName]`-pinned snake_case tokens.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-22-ai1391-b2b-daemon-sequenced-settlement.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?
+
+---
+
+## Revision log (adversarial review round 1)
+
+Each finding → the change applied. Tasks touched are noted.
+
+**CRITICAL**
+1. **CoverageJournal genesis atomicity (Task 4; and every reader of the journal).** The plan wrote the journal via temp+rename and then wrote `state_dir_initialized` as a *separate* `File.WriteAllText` — two non-atomic ops, violating the spec's pinned "marker + journal in the SAME atomic operation" (a genesis-boot crash between them left journal-present/marker-absent → next boot computed genesis=false → permanently poisoned `cumulative_covered`). **Fix:** folded the `initialized` flag INTO the journal document (`{ initialized, instance_id, cumulative_covered }`) written by ONE temp+rename; there is no separate marker file. Genesis-eligibility is now "journal file absent". Rewrote the class doc, `RecordBoot` (journal-absent vs present-but-uninitialized/corrupt vs present-initialized branches), `ReadJournal`/`WriteJournalAtomic`, and the Task 4 preamble. Renamed `Empty_looking_used_dir_without_marker_is_false` → `..._with_prior_lock_is_false` (updated comment), and **added** `Genesis_crash_before_the_single_rename_leaves_no_journal_and_reseeds` (crash before the single rename ⇒ no journal ⇒ still genesis-eligible; a completed rename ⇒ valid initialized journal). Test count 7→8. All pinned semantics preserved.
+
+**IMPORTANT**
+2. **Task 17 undefined test seam (Tasks 16, 17).** The Task 17 test calls `orch.HandleLaunchAgentForTest(...)`, which **already exists** as a shipped seam (`AgentOrchestrator.cs:2103`, routes through `HandleLaunchAgent`); the Interfaces named a phantom `HandleLaunchAgentSequencedForTest`. **Fix:** reconciled to the existing `HandleLaunchAgentForTest` (only the new `HandleStopAgentV2ForTest` is added); removed the phantom from the Files/Interfaces/Step-3 text. Also reconciled `HealBarrierReportTests.cs` — Task 16 CREATEs it (a `partial class AgentOrchestratorVendorTests`), Task 17 MODIFYs it (fixed the commit `git add` paths on both tasks; dropped the stale `AgentOrchestratorVendorTests.cs`).
+3. **Task 10 `await` on a `void` seam (CS4008).** The test did `await orch.HandleAckResolvedCandidatesForTest(...)`, but the seam and the underlying ledger `Ack` are synchronous (`void`). **Fix:** dropped the `await` (matches the synchronous shipped ledger `Ack`), with a clarifying comment.
+4. **Missing crash-injection matrix (Tasks 7, 8, 9).** Parent §8 + B2-b §6 pin crash-injection on BOTH sides for ALL FOUR ledger hooks. **Fix:** added before-append + between-append-delete tests for each: Task 7 (record-pass — added the before-append case), Task 8 (quarantine-drain + StopAgent-fallback — 4 new tests), Task 9 (marker-scan kill incl. recordless→marker-candidate — 2 new tests). Each asserts single-emit reconciliation from the actual on-disk pre-append source via the source-stable `(AgentId, OldEpoch)` key (NOT `Generation`) using DummyProcess/real-store. Updated per-task pass counts.
+5. **Synthesized-item path + monotonicity hazard (Task 12).** Added the forced-item-creation-failure test (completes the lane via a new `CompleteLaneForTest()` seam so an accepted Submit's `TryWrite` fails → `SynthesizeErrorLocked`). Fixed the hazard: `SynthesizeErrorLocked` no longer sets `_lastProcessedSeq = item.Seq` unconditionally — both it and the lane consumer now call a shared contiguity-safe `AdvanceWatermarkLocked()` that walks the contiguous terminal prefix, so a synthesize during lane-completion can neither jump past a still-draining earlier item nor be regressed below by it. The test asserts monotonicity + the final contiguous watermark.
+6. **Task 16 lock-free `ReadLiveness` + missing racing test.** The read probes `_agents`/quarantine lock-free. **Fix (option b):** documented — in both the task text and a code comment — that the lock-free read is SOUND only because of the shipped `CleanupAgentAsync` ordering invariant (quarantine `Add` BEFORE `_agents.TryRemove`), so an agent is continuously in `_agents ∪ _quarantine` until the drain ⇒ no transient false `Dead` (and a note that it must otherwise take the per-agent lifecycle lock). Added `ReadLiveness_racing_transitions_never_yields_a_transient_false_dead` (hammers `ReadLiveness` across live→quarantine→dead using the shipped `DummyProcess` + a pid-backed pty double; asserts deadness is monotonic).
+
+**MINORs**
+- Task 3: "both `new DaemonLock(...)` call sites" → corrected to the single call site (`DaemonLock.cs:125`, the final `return`).
+- Task 9: an `identity_unavailable` record carries TRUSTED flow — fixed `EmitAndClear` to look up a co-existing durable record and route its trusted `FlowRunId`/`FlowRole` (and record `DaemonEpoch`) via the `onRecordResolved` sink; a fully recordless survivor still maps to null flow via `onMarkerResolved`. Added `Identity_unavailable_record_resolved_via_marker_scan_emits_trusted_flow`. Updated the Interfaces note.
+- Task 11: replaced the prose/inline-comment `CurrentDiscovery` Complete/Failed transitions with complete `ScanEnvMarkersAsync` try/catch code; dropped the confusing "use a live pid" parenthetical in `SeedPendingMarkerCandidateForTest` (the `999_999` pid is fine — `BlockedCandidates` lists marker sources as `pending_marker` without a liveness check).
+- Tasks 16/17: `HealBarrierReportTests.cs` — Task 17 marked MODIFY (Task 16 CREATEs); names kept consistent.
+- Appendix: added the one-line note that the daemon's `ReadLiveness` collapses `NotFound` to `Dead` intentionally (both satisfy absence), while `NotFound` stays a defined wire value a future `StopExecuted`-path daemon may emit distinctly.
+
+**Structure preserved.** No tasks added or removed (still 17); every task keeps the 5-step TDD shape (failing test → run-red → minimal impl → run-green → commit); all additions are new test methods within existing Step 1 blocks and impl/seam changes within Step 3, with exact paths and complete code retained.

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -967,6 +967,17 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(StartupCandidateUnresolvedReason))]
 [JsonSerializable(typeof(StartupDiscovery))]
 [JsonSerializable(typeof(MarkerScanState))]
+// Phase B2-b (sequenced-settlement design): command / ack side wire DTOs.
+[JsonSerializable(typeof(StopAgentV2))]
+[JsonSerializable(typeof(CommandAck))]
+[JsonSerializable(typeof(CommandAckState))]
+[JsonSerializable(typeof(CommandOutcomeKind))]
+[JsonSerializable(typeof(AgentLiveness))]
+[JsonSerializable(typeof(CommandRejected))]
+[JsonSerializable(typeof(CommandRejectedReason))]
+[JsonSerializable(typeof(AckProcessedPrefix))]
+[JsonSerializable(typeof(ResolvedCandidateAck))]
+[JsonSerializable(typeof(AckResolvedCandidates))]
 [JsonSerializable(typeof(AgentPidRecord))]
 [JsonSerializable(typeof(PidIdentityKind))]
 [JsonSerializable(typeof(AgentRegistered))]
@@ -1250,7 +1261,15 @@ public readonly record struct LaunchAgentCommand(
         // associate a surviving unassigned reviewer with its role). Appended last, same wire-compat
         // rule as the fields above — old daemons ignore them, old servers never set them.
         string?            FlowRunId = null,
-        string?            FlowRole  = null
+        string?            FlowRole  = null,
+        // Phase B2-b (sequenced-settlement design): additive per-command sequencing fields. Present
+        // Epoch ⇒ the sequenced lane (the daemon serializes + watermarks against the shipped per-boot
+        // _daemonEpoch); absent ⇒ the legacy unsequenced lane (never advances LastProcessedSeq).
+        // CommandId is a GUID string. Appended last, same wire-compat rule as the fields above —
+        // old daemons ignore them, old servers never set them.
+        string?            Epoch     = null,
+        long?              Seq       = null,
+        string?            CommandId = null
     );
 
 /// <summary>
@@ -1363,6 +1382,107 @@ public enum MarkerScanState {
 public readonly record struct StartupDiscovery(
         MarkerScanState MarkerScanState,
         DateTimeOffset? LastSuccessfulScanAt = null
+    );
+
+// ── Phase B2-b (sequenced-settlement design): command / ack side wire DTOs ──
+
+/// <summary>Phase B2-b (sequenced-settlement design): the sequenced stop primitive. A capability
+/// daemon receives this instead of the legacy <c>StopAgent</c>; <see cref="Epoch"/> is the shipped
+/// per-boot <c>_daemonEpoch</c>, <see cref="Seq"/> the lane sequence number, <see cref="CommandId"/>
+/// a GUID string.</summary>
+public readonly record struct StopAgentV2(
+        string AgentId,
+        string Epoch,
+        long   Seq,
+        string CommandId
+    );
+
+/// <summary>Phase B2-b (sequenced-settlement design): ack lifecycle state. The zero value
+/// <see cref="Accepted"/> is the conservative default (accepted, not yet terminally processed);
+/// <see cref="Processed"/> is terminal and carries <c>OutcomeKind</c> + <c>CurrentState</c>.</summary>
+public enum CommandAckState {
+    [JsonStringEnumMemberName("accepted")]  Accepted  = 0, // accepted, not yet terminally processed
+    [JsonStringEnumMemberName("processed")] Processed = 1, // terminal; OutcomeKind + CurrentState set
+}
+
+/// <summary>Phase B2-b (sequenced-settlement design): terminal outcome of a processed sequenced
+/// command. The zero value <see cref="LaunchExecuted"/> is the conservative default.</summary>
+public enum CommandOutcomeKind {
+    [JsonStringEnumMemberName("launch_executed")]       LaunchExecuted      = 0,
+    [JsonStringEnumMemberName("launch_rejected")]       LaunchRejected      = 1,
+    [JsonStringEnumMemberName("launch_failed_cleaned")] LaunchFailedCleaned = 2,
+    [JsonStringEnumMemberName("stop_executed")]         StopExecuted        = 3,
+    [JsonStringEnumMemberName("internal_error")]        InternalError       = 4,
+}
+
+/// <summary>Phase B2-b (sequenced-settlement design): current liveness read live at ack time
+/// (confirmed-death precedence Live &gt; Quarantined &gt; Dead). The zero value <see cref="Live"/> is
+/// the conservative default. <see cref="NotFound"/> is a defined wire value the daemon's liveness read
+/// collapses to <see cref="Dead"/>, but a future path may still emit distinctly.</summary>
+public enum AgentLiveness {
+    [JsonStringEnumMemberName("live")]        Live        = 0,
+    [JsonStringEnumMemberName("quarantined")] Quarantined = 1,
+    [JsonStringEnumMemberName("dead")]        Dead        = 2,
+    [JsonStringEnumMemberName("not_found")]   NotFound    = 3,
+}
+
+/// <summary>Phase B2-b (sequenced-settlement design): the daemon's answer to a sequenced command
+/// (including an exact-duplicate — NO re-execution). <c>OutcomeKind</c>/<c>CurrentState</c> are set
+/// iff <see cref="State"/> == <see cref="CommandAckState.Processed"/>.</summary>
+public readonly record struct CommandAck(
+        string              Epoch,
+        long                Seq,
+        string              CommandId,
+        CommandAckState     State,
+        CommandOutcomeKind? OutcomeKind     = null, // set iff State == Processed
+        AgentLiveness?      CurrentState    = null, // set iff State == Processed
+        string?             AgentId         = null,
+        string?             SessionId       = null,
+        string?             RejectionReason = null
+    );
+
+/// <summary>Phase B2-b (sequenced-settlement design): why a sequenced command was terminally
+/// rejected (never advances the old epoch's watermark). The zero value <see cref="WrongNext"/> is
+/// the conservative default.</summary>
+public enum CommandRejectedReason {
+    [JsonStringEnumMemberName("wrong_next")]           WrongNext          = 0,
+    [JsonStringEnumMemberName("duplicate_collision")]  DuplicateCollision = 1,
+    [JsonStringEnumMemberName("stale_epoch")]          StaleEpoch         = 2,
+    [JsonStringEnumMemberName("daemon_capacity")]      DaemonCapacity     = 3,
+    [JsonStringEnumMemberName("backpressure")]         Backpressure       = 4,
+    [JsonStringEnumMemberName("internal_error")]       InternalError      = 5,
+    [JsonStringEnumMemberName("semantic")]             Semantic           = 6,
+}
+
+/// <summary>Phase B2-b (sequenced-settlement design): terminal rejection of a sequenced command
+/// (never advances the old epoch's watermark).</summary>
+public readonly record struct CommandRejected(
+        string                Epoch,
+        long                  Seq,
+        string                CommandId,
+        CommandRejectedReason Reason,
+        string?               AgentId = null
+    );
+
+/// <summary>Phase B2-b (sequenced-settlement design): server→daemon retirement proof — the daemon
+/// may retire identity-cache entries &lt;= <see cref="UpToSeq"/> for <see cref="Epoch"/>.</summary>
+public readonly record struct AckProcessedPrefix(
+        string Epoch,
+        long   UpToSeq
+    );
+
+/// <summary>Phase B2-b (sequenced-settlement design): one resolved-candidate ack entry (sparse,
+/// per-entry prune — no head-of-line retention).</summary>
+public readonly record struct ResolvedCandidateAck(
+        long   Generation,
+        string AgentId,
+        string OldEpoch
+    );
+
+/// <summary>Phase B2-b (sequenced-settlement design): server→daemon prune of individual
+/// resolved-candidate ledger entries.</summary>
+public readonly record struct AckResolvedCandidates(
+        ResolvedCandidateAck[] Entries
     );
 
 /// <summary>M1-A (spec §4.3): distinguishes a record with a comparable start-identity

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -959,6 +959,14 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(LiveAgentInfo))]
 [JsonSerializable(typeof(QuarantinedAgentInfo))]
 [JsonSerializable(typeof(DaemonStatusReport))]
+// Phase B2-b (sequenced-settlement design): report / connect side wire DTOs.
+[JsonSerializable(typeof(ResolvedStartupCandidate))]
+[JsonSerializable(typeof(ResolvedStartupCandidate[]))]
+[JsonSerializable(typeof(UnresolvedStartupCandidate))]
+[JsonSerializable(typeof(UnresolvedStartupCandidate[]))]
+[JsonSerializable(typeof(StartupCandidateUnresolvedReason))]
+[JsonSerializable(typeof(StartupDiscovery))]
+[JsonSerializable(typeof(MarkerScanState))]
 [JsonSerializable(typeof(AgentPidRecord))]
 [JsonSerializable(typeof(PidIdentityKind))]
 [JsonSerializable(typeof(AgentRegistered))]
@@ -1294,7 +1302,67 @@ public readonly record struct QuarantinedAgentInfo(
 public readonly record struct DaemonStatusReport(
         int                  ActiveCount,
         LiveAgentInfo[]      LiveAgents,
-        QuarantinedAgentInfo[] Quarantined
+        QuarantinedAgentInfo[] Quarantined,
+        // Phase B2-b (sequenced-settlement design): additive heal-barrier / startup-completeness
+        // fields. All trailing/optional — an old server ignores them, an old daemon never sets them.
+        // Epoch is the shipped per-boot _daemonEpoch (reused, never a second epoch concept).
+        string?                       Epoch                         = null,
+        long?                         LastProcessedSeq              = null,
+        long?                         HighestAcceptedSeq            = null,
+        bool?                         StartupReapComplete           = null,
+        ResolvedStartupCandidate[]?   ResolvedStartupCandidates     = null,
+        UnresolvedStartupCandidate[]? UnresolvedStartupCandidates   = null,
+        StartupDiscovery?             StartupDiscovery              = null
+    );
+
+// ── Phase B2-b (sequenced-settlement design): startup-completeness / heal-barrier report DTOs ──
+
+/// <summary>Phase B2-b (sequenced-settlement design): positive per-id death evidence for a
+/// prior-incarnation startup candidate. <see cref="Generation"/> is a daemon-lifetime monotonic
+/// ack/ordering id; <c>(AgentId, OldEpoch)</c> is the crash-reconciliation + server-upsert identity.
+/// Flow fields come ONLY from a trusted record-tracked resolved entry — never from a recordless
+/// marker kill (mutable env).</summary>
+public readonly record struct ResolvedStartupCandidate(
+        long    Generation,
+        string  AgentId,
+        string  OldEpoch,
+        string? FlowRunId = null,
+        string? FlowRole  = null
+    );
+
+/// <summary>Phase B2-b (sequenced-settlement design): why a known-id prior-incarnation candidate is
+/// still blocked (keeps <c>StartupReapComplete</c> false). The zero value <see cref="PendingMarker"/>
+/// is the conservative default.</summary>
+public enum StartupCandidateUnresolvedReason {
+    [JsonStringEnumMemberName("pending_marker")]        PendingMarker        = 0,
+    [JsonStringEnumMemberName("legacy_unresolvable")]   LegacyUnresolvable   = 1,
+    [JsonStringEnumMemberName("identity_unresolvable")] IdentityUnresolvable = 2,
+}
+
+/// <summary>Phase B2-b (sequenced-settlement design): a known-id prior-incarnation candidate that is
+/// blocked (keeps <c>StartupReapComplete</c> false).</summary>
+public readonly record struct UnresolvedStartupCandidate(
+        string                           AgentId,
+        StartupCandidateUnresolvedReason Reason,
+        string?                          FlowRunId = null,
+        string?                          FlowRole  = null
+    );
+
+/// <summary>Phase B2-b (sequenced-settlement design): recordless-survivor marker-scan status. The
+/// zero value <see cref="Pending"/> is the conservative default — a missing field or an intermediate
+/// daemon reads as <see cref="Pending"/> (never <see cref="Complete"/>).</summary>
+public enum MarkerScanState {
+    [JsonStringEnumMemberName("pending")]        Pending       = 0, // conservative default (missing field / intermediate daemon)
+    [JsonStringEnumMemberName("complete")]       Complete      = 1,
+    [JsonStringEnumMemberName("failed")]         Failed        = 2,
+    [JsonStringEnumMemberName("not_applicable")] NotApplicable = 3, // Windows (no scan) / macOS (env redacted)
+}
+
+/// <summary>Phase B2-b (sequenced-settlement design): recordless-survivor discovery status; lets the
+/// server render WHY <c>StartupReapComplete</c> is false.</summary>
+public readonly record struct StartupDiscovery(
+        MarkerScanState MarkerScanState,
+        DateTimeOffset? LastSuccessfulScanAt = null
     );
 
 /// <summary>M1-A (spec §4.3): distinguishes a record with a comparable start-identity
@@ -1415,7 +1483,21 @@ public readonly record struct DaemonConnect(
         // subset of SupportedVendors — every entry here MUST also appear there). Null from a daemon
         // build that predates this field — that daemon is simply not an override-eligible target for
         // ANY vendor. There is deliberately no fallback that widens a null to anything non-null.
-        string[]? UnattendedVendors = null
+        string[]? UnattendedVendors = null,
+        // Phase B2-b (sequenced-settlement design): additive startup-completeness / heal-barrier
+        // capability payload. All trailing/optional — old servers ignore it, old daemons never set
+        // it. Advertised-but-inert until the paired server PR consumes it (gated on
+        // SupportsSequencedCommands). Epoch is the shipped per-boot _daemonEpoch (reused).
+        QuarantinedAgentInfo[]?       Quarantined                   = null,
+        string?                       Epoch                         = null,
+        long?                         HighestAcceptedSeq            = null,
+        long?                         LastProcessedSeq              = null,
+        bool?                         StartupReapComplete           = null,
+        ResolvedStartupCandidate[]?   ResolvedStartupCandidates     = null,
+        UnresolvedStartupCandidate[]? UnresolvedStartupCandidates   = null,
+        StartupDiscovery?             StartupDiscovery              = null,
+        bool?                         RecordlessSurvivorsImpossible = null, // absent/false ⇒ has a recordless class
+        bool                          SupportsSequencedCommands     = false // THE capability gate
     );
 
 public readonly record struct AgentRegistered(

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1331,7 +1331,11 @@ public readonly record struct DaemonStatusReport(
         bool?                         StartupReapComplete           = null,
         ResolvedStartupCandidate[]?   ResolvedStartupCandidates     = null,
         UnresolvedStartupCandidate[]? UnresolvedStartupCandidates   = null,
-        StartupDiscovery?             StartupDiscovery              = null
+        StartupDiscovery?             StartupDiscovery              = null,
+        // Phase B2-b (sequenced-settlement design §5.5): the daemon-lifetime monotonic high-water of the
+        // resolved-candidates ledger, advertised alongside ResolvedStartupCandidates so that once sparse
+        // acks prune entries the server still knows the generation frontier. Additive/optional.
+        long?                         HighestResolutionGeneration   = null
     );
 
 // ── Phase B2-b (sequenced-settlement design): startup-completeness / heal-barrier report DTOs ──
@@ -1617,7 +1621,11 @@ public readonly record struct DaemonConnect(
         UnresolvedStartupCandidate[]? UnresolvedStartupCandidates   = null,
         StartupDiscovery?             StartupDiscovery              = null,
         bool?                         RecordlessSurvivorsImpossible = null, // absent/false ⇒ has a recordless class
-        bool                          SupportsSequencedCommands     = false // THE capability gate
+        bool                          SupportsSequencedCommands     = false, // THE capability gate
+        // Phase B2-b (sequenced-settlement design §5.5): the daemon-lifetime monotonic high-water of the
+        // resolved-candidates ledger, advertised alongside ResolvedStartupCandidates so that once sparse
+        // acks prune entries the server still knows the generation frontier. Additive/optional.
+        long?                         HighestResolutionGeneration   = null
     );
 
 public readonly record struct AgentRegistered(

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -29,8 +29,20 @@ public class DaemonConfig {
     /// <summary>Phase B (D4): a fresh per-boot epoch (GUID). Written into each spawned child's
     /// <c>KCAP_DAEMON_EPOCH</c> env marker; the startup env-marker scan kills same-daemon children
     /// whose epoch differs from the current one (i.e. survivors of a prior incarnation). Null → the
-    /// orchestrator generates one at construction.</summary>
+    /// orchestrator generates one at construction. <c>DaemonRunner</c> pins this before building
+    /// services (Phase B2-b) so the advertised connect epoch and the orchestrator's own boot epoch
+    /// agree.</summary>
     public string? DaemonEpoch { get; set; }
+
+    /// <summary>
+    /// Phase B2-b (sequenced-settlement design §4.2.3): the durable coverage boot-chain verdict,
+    /// folded by <c>CoverageJournal.RecordBoot</c> in <c>DaemonRunner</c> BEFORE any Connect/spawn and
+    /// advertised on <c>DaemonConnect</c>. True only where OS containment leaves genuinely no recordless
+    /// survivor class (the Windows Job Object); absent/false ⇒ "has a recordless class" (the server
+    /// requires per-id death proof). The server consumes it only on Windows, so a Linux/macOS value is
+    /// inert. Fail-closed to false when the fold/persist fails.
+    /// </summary>
+    public bool RecordlessSurvivorsImpossible { get; set; }
 
     /// <summary>
     /// Per-process GUID generated at startup, also written to the daemon's

--- a/src/Capacitor.Cli.Daemon/DaemonLock.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonLock.cs
@@ -49,8 +49,19 @@ internal sealed class DaemonLock : IDisposable {
     /// </summary>
     public int? PriorHolderPid { get; }
 
+    /// <summary>
+    /// The previous holder's <see cref="InstanceId"/>, read from the lock-file content
+    /// under the held flock BEFORE we overwrote it — or null on a genuinely fresh lock
+    /// (empty file) or unreadable content. Unlike the PID file (deleted on clean
+    /// shutdown), the lock file's InstanceId is the persistent per-boot nonce every
+    /// shipped version rewrites at boot and never deletes, so it witnesses the
+    /// immediately-preceding boot even one by an unaware binary. Phase B2-b
+    /// (sequenced-settlement design) uses it as the coverage boot-chain's chain-check.
+    /// </summary>
+    public string? PriorInstanceId { get; }
+
     DaemonLock(FileStream stream, string lockPath, string pidPath, string versionPath, string instanceId,
-               bool priorExitWasUnclean, int? priorHolderPid) {
+               bool priorExitWasUnclean, int? priorHolderPid, string? priorInstanceId) {
         _stream             = stream;
         _lockPath           = lockPath;
         _pidPath            = pidPath;
@@ -58,6 +69,7 @@ internal sealed class DaemonLock : IDisposable {
         InstanceId          = instanceId;
         PriorExitWasUnclean = priorExitWasUnclean;
         PriorHolderPid      = priorHolderPid;
+        PriorInstanceId     = priorInstanceId;
     }
 
     /// <summary>
@@ -80,11 +92,12 @@ internal sealed class DaemonLock : IDisposable {
 
         try {
             // FileShare.None maps to flock(LOCK_EX) on POSIX. Open with
-            // FileAccess.Write so we can rewrite the instance id into the
-            // file content below. FileMode.OpenOrCreate keeps a stale
+            // FileAccess.ReadWrite so we can both read the previous holder's
+            // instance id (captured below, before truncation) and rewrite our
+            // own into the file content. FileMode.OpenOrCreate keeps a stale
             // lockfile on disk from blocking acquisition — flock semantics
             // mean kernel-managed liveness, not file presence.
-            stream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
+            stream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
         } catch (IOException) {
             return null;
         }
@@ -97,6 +110,21 @@ internal sealed class DaemonLock : IDisposable {
         // deletes it) — i.e. it died via an uncatchable SIGKILL / crash. Capture
         // that for the successor's startup breadcrumb.
         var (priorUnclean, priorPid) = InspectPriorHolder(pidPath);
+
+        // Capture the previous holder's InstanceId from the lock-file content BEFORE we overwrite it —
+        // the persistent per-boot nonce the coverage boot-chain uses to detect an intervening
+        // (possibly unaware) boot. Read failures degrade to null (fail-closed downstream).
+        string? priorInstanceId = null;
+        try {
+            if (stream.Length > 0) {
+                stream.Position = 0;
+                var buf = new byte[stream.Length];
+                var n = stream.Read(buf, 0, buf.Length);
+                priorInstanceId = System.Text.Encoding.UTF8.GetString(buf, 0, n)
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .FirstOrDefault();
+            }
+        } catch { priorInstanceId = null; }
 
         try {
             // Rewrite the file content with the fresh instance id. Truncate
@@ -122,7 +150,7 @@ internal sealed class DaemonLock : IDisposable {
             try { DaemonVersionMarker.Write(daemonName, version); } catch { /* best-effort */ }
         }
 
-        return new DaemonLock(stream, lockPath, pidPath, versionPath, instanceId, priorUnclean, priorPid);
+        return new DaemonLock(stream, lockPath, pidPath, versionPath, instanceId, priorUnclean, priorPid, priorInstanceId);
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/DaemonLock.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonLock.cs
@@ -60,16 +60,24 @@ internal sealed class DaemonLock : IDisposable {
     /// </summary>
     public string? PriorInstanceId { get; }
 
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.3): true iff the lock file was NON-EMPTY
+    /// but its content could not be read into a prior InstanceId (a read fault, or blank/garbage
+    /// content). Distinguishes an unreadable prior lock from a genuinely empty first-ever/genesis slot
+    /// (where this is false and <see cref="PriorInstanceId"/> is null): the coverage boot-chain treats
+    /// an indeterminate prior as fail-closed, NEVER as genesis.</summary>
+    public bool PriorLockIndeterminate { get; }
+
     DaemonLock(FileStream stream, string lockPath, string pidPath, string versionPath, string instanceId,
-               bool priorExitWasUnclean, int? priorHolderPid, string? priorInstanceId) {
-        _stream             = stream;
-        _lockPath           = lockPath;
-        _pidPath            = pidPath;
-        _versionPath        = versionPath;
-        InstanceId          = instanceId;
-        PriorExitWasUnclean = priorExitWasUnclean;
-        PriorHolderPid      = priorHolderPid;
-        PriorInstanceId     = priorInstanceId;
+               bool priorExitWasUnclean, int? priorHolderPid, string? priorInstanceId, bool priorLockIndeterminate) {
+        _stream                = stream;
+        _lockPath              = lockPath;
+        _pidPath               = pidPath;
+        _versionPath           = versionPath;
+        InstanceId             = instanceId;
+        PriorExitWasUnclean    = priorExitWasUnclean;
+        PriorHolderPid         = priorHolderPid;
+        PriorInstanceId        = priorInstanceId;
+        PriorLockIndeterminate = priorLockIndeterminate;
     }
 
     /// <summary>
@@ -113,18 +121,28 @@ internal sealed class DaemonLock : IDisposable {
 
         // Capture the previous holder's InstanceId from the lock-file content BEFORE we overwrite it —
         // the persistent per-boot nonce the coverage boot-chain uses to detect an intervening
-        // (possibly unaware) boot. Read failures degrade to null (fail-closed downstream).
+        // (possibly unaware) boot. A genuinely EMPTY file is a first-ever/genesis slot (priorInstanceId
+        // stays null, NOT indeterminate). A non-empty file we cannot read into an id — a read fault OR
+        // blank/garbage content — is INDETERMINATE: the coverage boot-chain must fail-closed there and
+        // never conflate it with genesis. The read is bounded (the content is a 32-char GUID + newline),
+        // so a corrupt/oversized lock file can't drive an unbounded allocation.
         string? priorInstanceId = null;
+        var priorLockIndeterminate = false;
         try {
             if (stream.Length > 0) {
                 stream.Position = 0;
-                var buf = new byte[stream.Length];
+                var len = (int)Math.Min(stream.Length, 4096);
+                var buf = new byte[len];
                 var n = stream.Read(buf, 0, buf.Length);
                 priorInstanceId = System.Text.Encoding.UTF8.GetString(buf, 0, n)
                     .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                     .FirstOrDefault();
+                priorLockIndeterminate = string.IsNullOrEmpty(priorInstanceId); // non-empty file, no id ⇒ indeterminate
             }
-        } catch { priorInstanceId = null; }
+        } catch {
+            priorInstanceId = null;
+            priorLockIndeterminate = true; // non-empty-but-unreadable ⇒ fail-closed, never genesis
+        }
 
         try {
             // Rewrite the file content with the fresh instance id. Truncate
@@ -150,7 +168,7 @@ internal sealed class DaemonLock : IDisposable {
             try { DaemonVersionMarker.Write(daemonName, version); } catch { /* best-effort */ }
         }
 
-        return new DaemonLock(stream, lockPath, pidPath, versionPath, instanceId, priorUnclean, priorPid, priorInstanceId);
+        return new DaemonLock(stream, lockPath, pidPath, versionPath, instanceId, priorUnclean, priorPid, priorInstanceId, priorLockIndeterminate);
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -10,6 +10,7 @@ using Capacitor.Cli.Core.Config;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Daemon;
 
@@ -196,6 +197,20 @@ public static partial class DaemonRunner {
         }
 
         config.InstanceId = daemonLock.InstanceId;
+
+        // Phase B2-b (sequenced-settlement design): pin the per-boot epoch here, before any service is
+        // built, so the epoch advertised on DaemonConnect and the orchestrator's own _daemonEpoch (which
+        // falls back to config.DaemonEpoch) are provably the same value.
+        config.DaemonEpoch ??= Guid.NewGuid().ToString("N");
+
+        // Phase B2-b (sequenced-settlement design §4.2.3): fold the durable coverage boot-chain BEFORE any
+        // Connect/spawn. this_epoch_contained is true only where OS containment leaves NO recordless
+        // survivor class (the Windows Job Object). Fail-closed inside RecordBoot. NullLogger is acceptable
+        // this early — the host's logging pipeline isn't built yet.
+        var coverageStateDir = Path.Combine(
+            config.StateDir ?? DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(config.Name));
+        config.RecordlessSurvivorsImpossible = new CoverageJournal(coverageStateDir, NullLogger.Instance)
+            .RecordBoot(daemonLock.InstanceId, daemonLock.PriorInstanceId, thisEpochContained: OperatingSystem.IsWindows());
 
         builder.Services.AddSingleton(config);
         builder.Services.AddSingleton(daemonLock);

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -210,7 +210,8 @@ public static partial class DaemonRunner {
         var coverageStateDir = Path.Combine(
             config.StateDir ?? DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(config.Name));
         config.RecordlessSurvivorsImpossible = new CoverageJournal(coverageStateDir, NullLogger.Instance)
-            .RecordBoot(daemonLock.InstanceId, daemonLock.PriorInstanceId, thisEpochContained: OperatingSystem.IsWindows());
+            .RecordBoot(daemonLock.InstanceId, daemonLock.PriorInstanceId,
+                priorLockReadFailed: daemonLock.PriorLockIndeterminate, thisEpochContained: OperatingSystem.IsWindows());
 
         builder.Services.AddSingleton(config);
         builder.Services.AddSingleton(daemonLock);

--- a/src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentKillQuarantine.cs
@@ -35,17 +35,19 @@ internal sealed class AgentKillQuarantine(ILogger logger) {
 
     /// <summary>Heartbeat retry: attempt to reap every quarantined process by exact identity and drain
     /// those confirmed gone. Best-effort per entry — a still-alive one is retained for the next tick.
-    /// Returns the agent ids DRAINED this pass (death/recycle confirmed) so the caller deletes their
-    /// durable PID records — a quarantined survivor's record is retained by teardown and, carrying the
-    /// current epoch, would otherwise be skipped by the orphan sweep and leak until restart.</summary>
-    public async Task<IReadOnlyList<string>> RetryAllAsync(CancellationToken ct) {
-        var drained = new List<string>();
+    /// Returns the ENTRIES drained this pass (death/recycle confirmed) so the caller can both delete
+    /// their durable PID records — a quarantined survivor's record is retained by teardown and, carrying
+    /// the current epoch, would otherwise be skipped by the orphan sweep and leak until restart — AND
+    /// (Phase B2-b, sequenced-settlement design §4.2.4) emit their flow identity as positive per-id
+    /// death evidence to the resolved-candidates ledger before that delete.</summary>
+    public async Task<IReadOnlyList<Entry>> RetryAllAsync(CancellationToken ct) {
+        var drained = new List<Entry>();
 
         foreach (var entry in _entries.Values) {
             try {
                 if (await ProcessReaper.ReapByIdentityAsync(entry.Pid, entry.Identity, entry.AgentId, logger, ct)
                     && _entries.TryRemove(new KeyValuePair<string, Entry>(entry.AgentId, entry)))
-                    drained.Add(entry.AgentId);
+                    drained.Add(entry);
             } catch (Exception ex) when (ex is not OperationCanceledException) {
                 logger.LogWarning(ex, "AgentKillQuarantine: retry failed for {AgentId} (pid {Pid})", entry.AgentId, entry.Pid);
             }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -195,6 +195,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     string               _daemonId    = "";
     string               _daemonEpoch = "";
 
+    // Phase B2-b (sequenced-settlement design §4.2.3): the durable coverage boot-chain verdict,
+    // folded in DaemonRunner (before Connect) and stashed on config. Advertised on the enriched
+    // DaemonConnect payload; a Linux/macOS value is inert (the server consumes it only on Windows).
+    readonly bool        _recordlessSurvivorsImpossible;
+
     // Phase B (D4 §6.4(2a)/(3)): single-flight latches so a slow sweep (each survivor consumes a
     // ~5s TERM grace sequentially) can't overlap itself when the next heartbeat tick fires — otherwise
     // sweeps accumulate, double-signal, and re-scan /proc concurrently. A tick whose prior sweep is still
@@ -310,6 +315,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _quarantine  = new AgentKillQuarantine(logger);
         _daemonId    = ComputeDaemonId(config.Name);
         _daemonEpoch = config.DaemonEpoch ?? Guid.NewGuid().ToString("N");
+        _recordlessSurvivorsImpossible = config.RecordlessSurvivorsImpossible;
         _orphanReaper = new OrphanReaper(_pidRecords, _daemonId, _daemonEpoch, logger);
 
         // Wire up server commands
@@ -466,6 +472,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     internal IReadOnlyList<AgentPidRecord> PidRecordsForTest()      => _pidRecords?.ReadAll() ?? [];
     internal string DaemonIdForTest                                 => _daemonId;
     internal string DaemonEpochForTest                             => _daemonEpoch;
+    internal bool   RecordlessSurvivorsImpossibleForTest           => _recordlessSurvivorsImpossible;
 
     /// <summary>Phase B (D4 §6.4(3) StopAgent fallback): the caller had no in-memory agent for
     /// this id — consult the PID record and, if a live process still matches its EXACT identity (and,

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -203,6 +203,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // state dir as _pidRecords, under the same atomic temp+rename discipline.
     ResolvedCandidatesLedger? _resolvedLedger;
 
+    // Phase B2-b (sequenced-settlement design §4.2.4): the durable marker-candidate source store for a
+    // RECORDLESS prior-epoch survivor (Hook D). The env-marker scan persists a source BEFORE the kill and
+    // resolves it through the (a)/(b)/(c) matrix; on confirmed death it emits into _resolvedLedger with a
+    // NULL flow (the env is untrusted) unless a co-existing durable RECORD supplies a trusted flow.
+    MarkerCandidateStore? _markerCandidates;
+
     // Phase B2-b (sequenced-settlement design §4.2.3): the durable coverage boot-chain verdict,
     // folded in DaemonRunner (before Connect) and stashed on config. Advertised on the enriched
     // DaemonConnect payload; a Linux/macOS value is inert (the server consumes it only on Windows).
@@ -330,8 +336,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // callback (Hook A) emits into it before the source delete; the drain (Hook B) and StopAgent
         // fallback (Hook C) below emit directly. All three are append-before-delete + idempotent.
         _resolvedLedger = new ResolvedCandidatesLedger(recordRoot, logger);
+        // Phase B2-b (sequenced-settlement design §4.2.4): the marker-candidate source store (Hook D)
+        // shares the same record root. A recordless survivor resolves with a NULL flow (env untrusted);
+        // a co-existing durable record's TRUSTED flow is routed through onRecordResolved by EmitAndClear.
+        _markerCandidates = new MarkerCandidateStore(recordRoot, logger);
         _orphanReaper = new OrphanReaper(_pidRecords, _daemonId, _daemonEpoch, logger,
-            onRecordResolved: (a, e, fr, role) => _resolvedLedger?.Upsert(a, e, fr, role));
+            onRecordResolved: (a, e, fr, role) => _resolvedLedger?.Upsert(a, e, fr, role),
+            markerStore: _markerCandidates,
+            onMarkerResolved: (a, e) => _resolvedLedger?.Upsert(a, e, null, null));
 
         // Wire up server commands
         _server.OnLaunchAgent            += HandleLaunchAgent;

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -355,6 +355,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _server.FindRepoForRemoteHandler      =  HandleFindRepoForRemote;
         _server.ProbeBorrowSourceHandler      =  HandleProbeBorrowSource;
 
+        // Phase B2-b (sequenced-settlement design §4.2.4): the server prunes the resolved-candidates
+        // ledger per-entry via AckResolvedCandidates (synchronous void handler); the connect payload
+        // re-advertises the un-acked snapshot alongside the periodic DaemonStatusReport.
+        _server.OnAckResolvedCandidates       += HandleAckResolvedCandidates;
+        _server.GetResolvedStartupCandidates  =  () => [.. _resolvedLedger?.Snapshot() ?? []];
+
         _server.GetLiveAgentIds = () => [
             .. _agents
                 .Where(kvp => (kvp.Value.Status is "Starting" or "Running") && !kvp.Value.IsPrivate)
@@ -403,7 +409,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <see cref="ActiveCount"/> plus the live-agent metadata (and, once D4/Task 8 lands, the
     /// kill-quarantine). Pure; the send loop + tests share it.</summary>
     internal DaemonStatusReport BuildStatusReport() =>
-        new(ActiveCount, [.. BuildLiveAgents()], [.. QuarantineSnapshot()]);
+        new(ActiveCount, [.. BuildLiveAgents()], [.. QuarantineSnapshot()],
+            // Phase B2-b (sequenced-settlement design §4.2.4): re-advertise the durable resolved-
+            // candidates ledger on every self-report until the server prunes it per-entry via
+            // AckResolvedCandidates. Epoch is the shipped per-boot _daemonEpoch (Epoch/counters
+            // finalized in a later task); the field is additive/inert until the paired server PR reads it.
+            Epoch: _daemonEpoch,
+            ResolvedStartupCandidates: [.. _resolvedLedger?.Snapshot() ?? []]);
 
     /// <summary>Phase B (D4 §6.4(2a)): the kill-quarantine snapshot for the status report.</summary>
     internal IReadOnlyList<QuarantinedAgentInfo> QuarantineSnapshot() => _quarantine?.Snapshot() ?? [];
@@ -505,6 +517,20 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// un-acked snapshot, so a test can assert the confirmed-gone hooks (quarantine drain / StopAgent
     /// fallback / record pass) emitted positive per-id death evidence. Never used in production.</summary>
     internal IReadOnlyList<ResolvedStartupCandidate> ResolvedLedgerSnapshotForTest => _resolvedLedger?.Snapshot() ?? [];
+
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.4): honor the server's per-entry
+    /// AckResolvedCandidates prune (sparse, deliver-once). SYNCHRONOUS — the ledger's <c>Ack</c> is a
+    /// synchronous void, so this stays void (a <c>void</c> event/receive seam is never awaited).</summary>
+    internal void HandleAckResolvedCandidates(AckResolvedCandidates ack) => _resolvedLedger?.Ack(ack.Entries ?? []);
+
+    /// <summary>Test seam: seed a resolved-candidate ledger entry so a test can drive the advertise/ack
+    /// prune path without a real confirmed-death hook. Never used in production.</summary>
+    internal ResolvedStartupCandidate SeedResolvedCandidateForTest(string agentId, string oldEpoch)
+        => _resolvedLedger!.Upsert(agentId, oldEpoch, null, null);
+
+    /// <summary>Test seam: route an ack through the SYNCHRONOUS <see cref="HandleAckResolvedCandidates"/>
+    /// handler (no await — the ledger Ack is void). Never used in production.</summary>
+    internal void HandleAckResolvedCandidatesForTest(AckResolvedCandidates ack) => HandleAckResolvedCandidates(ack);
 
     /// <summary>Test seam: seed a kill-quarantine entry so a test can drive the drain hook without a
     /// real launch+teardown. Mirrors <see cref="WritePidRecordForTest"/>; never used in production.</summary>

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -361,6 +361,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _server.OnAckResolvedCandidates       += HandleAckResolvedCandidates;
         _server.GetResolvedStartupCandidates  =  () => [.. _resolvedLedger?.Snapshot() ?? []];
 
+        // Phase B2-b (sequenced-settlement design): mirror the per-platform startup-completeness signals
+        // into the DaemonConnect payload (the periodic DaemonStatusReport carries them via
+        // BuildStatusReport). Additive/inert until the paired server PR consumes them; finalized
+        // alongside the sequenced counters in a later task.
+        _server.GetStartupReapComplete         =  ComputeStartupReapComplete;
+        _server.GetUnresolvedStartupCandidates =  () => [.. _orphanReaper?.BlockedCandidates() ?? []];
+        _server.GetStartupDiscovery            =  () => _orphanReaper?.CurrentDiscovery;
+
         _server.GetLiveAgentIds = () => [
             .. _agents
                 .Where(kvp => (kvp.Value.Status is "Starting" or "Running") && !kvp.Value.IsPrivate)
@@ -415,7 +423,38 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // AckResolvedCandidates. Epoch is the shipped per-boot _daemonEpoch (Epoch/counters
             // finalized in a later task); the field is additive/inert until the paired server PR reads it.
             Epoch: _daemonEpoch,
-            ResolvedStartupCandidates: [.. _resolvedLedger?.Snapshot() ?? []]);
+            // Phase B2-b (sequenced-settlement design): the per-platform startup-completeness signals.
+            // StartupReapComplete is a computed roll-up; UnresolvedStartupCandidates always lists the
+            // blocked known-id set so a completion-false report carries its reason; StartupDiscovery
+            // surfaces the recordless-survivor marker-scan state (Pending/Complete/Failed on Linux,
+            // NotApplicable off it). Additive/inert until the paired server PR consumes them.
+            StartupReapComplete: ComputeStartupReapComplete(),
+            ResolvedStartupCandidates: [.. _resolvedLedger?.Snapshot() ?? []],
+            UnresolvedStartupCandidates: [.. _orphanReaper?.BlockedCandidates() ?? []],
+            StartupDiscovery: _orphanReaper?.CurrentDiscovery);
+
+    /// <summary>Phase B2-b (sequenced-settlement design): the per-platform startup-reap-complete
+    /// roll-up. A blocked known-id candidate (pending_marker / legacy_unresolvable /
+    /// identity_unresolvable) always keeps it false. Otherwise completion is platform-specific:
+    /// <list type="bullet">
+    /// <item><b>Linux</b> — needs BOTH no blocked candidates AND one clean env-marker-scan pass
+    /// (<see cref="MarkerScanState.Complete"/>): the scan is the only proof a recordless survivor was
+    /// enumerated.</item>
+    /// <item><b>Windows with <c>RecordlessSurvivorsImpossible</c></b> — trivially complete once the
+    /// record pass leaves nothing blocked (the boot-chain attestation proves no recordless class
+    /// exists).</item>
+    /// <item><b>pre-W1 Windows + macOS</b> — record-pass-only completion (a weakened proof: there is no
+    /// scan and no boot-chain guarantee, so "no blocked record-tracked candidates" is the best available
+    /// signal).</item>
+    /// </list></summary>
+    internal bool ComputeStartupReapComplete() {
+        var blocked = _orphanReaper?.BlockedCandidates().Count ?? 0;
+        if (blocked > 0) return false;
+        if (OperatingSystem.IsLinux())
+            return _orphanReaper?.CurrentDiscovery.MarkerScanState == MarkerScanState.Complete;
+        if (OperatingSystem.IsWindows() && _recordlessSurvivorsImpossible) return true;
+        return true; // pre-W1 Windows / macOS: record-pass-only completion (no blocked record-tracked candidates)
+    }
 
     /// <summary>Phase B (D4 §6.4(2a)): the kill-quarantine snapshot for the status report.</summary>
     internal IReadOnlyList<QuarantinedAgentInfo> QuarantineSnapshot() => _quarantine?.Snapshot() ?? [];
@@ -535,6 +574,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <summary>Test seam: seed a kill-quarantine entry so a test can drive the drain hook without a
     /// real launch+teardown. Mirrors <see cref="WritePidRecordForTest"/>; never used in production.</summary>
     internal void QuarantineForTest(AgentKillQuarantine.Entry entry) => _quarantine?.Add(entry);
+
+    /// <summary>Phase B2-b (sequenced-settlement design): test seam — persist a marker-candidate source
+    /// so a test can assert it surfaces as a <c>pending_marker</c> blocked candidate (keeping
+    /// <see cref="ComputeStartupReapComplete"/> false) without a real recordless survivor. The pid is
+    /// irrelevant: <see cref="OrphanReaper.BlockedCandidates"/> lists every persisted source WITHOUT a
+    /// liveness check, and the assertion reads the blocked surface directly via
+    /// <see cref="BuildStatusReport"/> (no scan runs, so the dead pid is never resolved away). Never used
+    /// in production.</summary>
+    internal void SeedPendingMarkerCandidateForTest(string agentId, string oldEpoch) =>
+        _markerCandidates!.Write(new MarkerCandidate(agentId, _daemonId, oldEpoch, 999_999));
 
     /// <summary>Phase B (D4 §6.4(3) StopAgent fallback): the caller had no in-memory agent for
     /// this id — consult the PID record and, if a live process still matches its EXACT identity (and,

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -756,13 +756,22 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         return agent;
     }
 
-    /// <summary>Phase B2-b (sequenced-settlement design §4.2.2): route a launch. A fully-Seq'd command
-    /// (Epoch + Seq + CommandId present) goes through the processor's serial lane — accepted exactly-in-order,
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.2/§5.5): route a launch. A fully-Seq'd command
+    /// (Epoch + Seq + CommandId ALL present) goes through the processor's serial lane — accepted exactly-in-order,
     /// executed once, and turned into a terminal CommandAck/CommandRejected from the <see cref="CommandOutcome"/>
-    /// the core returns. An un-Seq'd command (old server) runs the legacy unsequenced lane directly and never
-    /// advances the watermark. The processor being null (never happens in production — always constructed in
-    /// the ctor) also falls back to the legacy lane.</summary>
+    /// the core returns. An un-Seq'd command (NONE of the three — old server) runs the legacy unsequenced lane
+    /// directly and never advances the watermark. Anything in between (a PARTIAL tuple, or the processor somehow
+    /// missing) is a malformed sequenced command and FAILS CLOSED with a LaunchFailed — never the legacy lane,
+    /// whose retry could be re-accepted on the sequenced lane and double-create the generation.</summary>
     async Task HandleLaunchAgent(LaunchAgentCommand cmd) {
+        var anySeq = cmd.Epoch is not null || cmd.Seq is not null || cmd.CommandId is not null;
+        if (!anySeq) { await HandleLaunchAgentCore(cmd); return; } // old server — legacy unsequenced lane
+
+        // Phase B2-b (sequenced-settlement design §5.5): a capable server sends ALL of
+        // Epoch/Seq/CommandId. Anything less (a partial tuple, or the processor somehow missing) is a
+        // malformed sequenced command and must FAIL CLOSED — never the unwatermarked legacy lane, whose
+        // retry could be re-accepted on the sequenced lane and double-create the generation
+        // (at-most-once-per-generation).
         if (_processor is { } proc && cmd.Epoch is { } epoch && cmd.Seq is { } seq && cmd.CommandId is { } cmdId) {
             await proc.SubmitAsync(
                 new SequencedItem(SequencedKind.Launch, epoch, seq, cmdId, cmd.AgentId),
@@ -770,7 +779,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             return;
         }
 
-        await HandleLaunchAgentCore(cmd); // legacy unsequenced lane (old server) — never advances the watermark
+        await _server.LaunchFailedAsync(cmd.AgentId, "Malformed sequenced launch: partial Epoch/Seq/CommandId");
     }
 
     /// <summary>Phase B2-b (sequenced-settlement design §4.2.2): the shipped launch body, now returning the

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -214,6 +214,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // DaemonConnect payload; a Linux/macOS value is inert (the server consumes it only on Windows).
     readonly bool        _recordlessSurvivorsImpossible;
 
+    // Phase B2-b (sequenced-settlement design §4.2.2): the epoch-scoped sequenced-command handler.
+    // Owns the two serialized lanes + the contiguous-prefix watermark; injected with this orchestrator's
+    // ReadLiveness / the server's CommandAck+CommandRejected sends so it stays unit-testable without a
+    // live hub. Only Seq'd LaunchAgentCommand + StopAgentV2 route through it; un-Seq'd commands stay on
+    // the legacy unsequenced lane (old-server compat) and never advance the watermark.
+    SequencedCommandProcessor? _processor;
+
     // Phase B (D4 §6.4(2a)/(3)): single-flight latches so a slow sweep (each survivor consumes a
     // ~5s TERM grace sequentially) can't overlap itself when the next heartbeat tick fires — otherwise
     // sweeps accumulate, double-signal, and re-scan /proc concurrently. A tick whose prior sweep is still
@@ -345,6 +352,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             markerStore: _markerCandidates,
             onMarkerResolved: (a, e) => _resolvedLedger?.Upsert(a, e, null, null));
 
+        // Phase B2-b (sequenced-settlement design §4.2.2): the epoch-scoped sequenced-command processor.
+        // Scoped to the shipped per-boot _daemonEpoch; ReadLiveness gives it the confirmed-death-precedence
+        // liveness read a duplicate CommandAck needs, and the two server sends are its ack/reject channels.
+        _processor = new SequencedCommandProcessor(
+            _daemonEpoch, ReadLiveness, _server.CommandAckAsync, _server.CommandRejectedAsync, logger);
+
         // Wire up server commands
         _server.OnLaunchAgent            += HandleLaunchAgent;
         _server.OnStopAgent              += HandleStopAgent;
@@ -368,6 +381,17 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _server.GetStartupReapComplete         =  ComputeStartupReapComplete;
         _server.GetUnresolvedStartupCandidates =  () => [.. _orphanReaper?.BlockedCandidates() ?? []];
         _server.GetStartupDiscovery            =  () => _orphanReaper?.CurrentDiscovery;
+
+        // Phase B2-b (sequenced-settlement design §4.2.2): route the sequenced-command receive seams and
+        // mirror the watermark counters + kill-quarantine snapshot onto the connect payload. StopAgentV2
+        // goes through the processor's serial lane; AckProcessedPrefix retires identity-cache entries;
+        // RequestStatusReport is answered by an immediate out-of-band DaemonStatusReport.
+        _server.OnStopAgentV2          += HandleStopAgentV2;
+        _server.OnAckProcessedPrefix   += ack => _processor?.AckPrefix(ack);
+        _server.OnRequestStatusReport  += SendDaemonStatusReportOnceAsync;
+        _server.GetHighestAcceptedSeq  =  () => _processor?.HighestAcceptedSeq;
+        _server.GetLastProcessedSeq    =  () => _processor?.LastProcessedSeq;
+        _server.GetQuarantined         =  () => [.. QuarantineSnapshot()];
 
         _server.GetLiveAgentIds = () => [
             .. _agents
@@ -420,9 +444,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         new(ActiveCount, [.. BuildLiveAgents()], [.. QuarantineSnapshot()],
             // Phase B2-b (sequenced-settlement design §4.2.4): re-advertise the durable resolved-
             // candidates ledger on every self-report until the server prunes it per-entry via
-            // AckResolvedCandidates. Epoch is the shipped per-boot _daemonEpoch (Epoch/counters
-            // finalized in a later task); the field is additive/inert until the paired server PR reads it.
+            // AckResolvedCandidates. Epoch is the shipped per-boot _daemonEpoch.
             Epoch: _daemonEpoch,
+            // Phase B2-b (sequenced-settlement design §4.2.2): the sequenced-command watermark counters
+            // from the processor (LastProcessedSeq = contiguous terminal prefix; HighestAcceptedSeq =
+            // highest accepted). Null before the processor exists; 0 on a fresh epoch (nothing accepted).
+            LastProcessedSeq: _processor?.LastProcessedSeq,
+            HighestAcceptedSeq: _processor?.HighestAcceptedSeq,
             // Phase B2-b (sequenced-settlement design): the per-platform startup-completeness signals.
             // StartupReapComplete is a computed roll-up; UnresolvedStartupCandidates always lists the
             // blocked known-id set so a completion-false report carries its reason; StartupDiscovery
@@ -454,6 +482,28 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             return _orphanReaper?.CurrentDiscovery.MarkerScanState == MarkerScanState.Complete;
         if (OperatingSystem.IsWindows() && _recordlessSurvivorsImpossible) return true;
         return true; // pre-W1 Windows / macOS: record-pass-only completion (no blocked record-tracked candidates)
+    }
+
+    /// <summary>Phase B2-b (sequenced-settlement design §5.5/§4.2.2): the single lifecycle-state read
+    /// (confirmed-death precedence Live &gt; Quarantined &gt; Dead) over the same collections
+    /// <see cref="CleanupAgentAsync"/> + <see cref="AgentKillQuarantine"/> mutate. The design mandates that a
+    /// duplicate CommandAck's CurrentState be read so a teardown racing the read can NEVER surface a transient
+    /// false Dead. This read is lock-free (it does not take the per-agent lifecycle lock) and is SOUND ONLY
+    /// BECAUSE OF THE SHIPPED CleanupAgentAsync ORDERING INVARIANT: the confirmed-death teardown adds the
+    /// surviving child to <c>_quarantine</c> BEFORE removing it from <c>_agents</c> (AgentOrchestrator.cs —
+    /// "Add to quarantine BEFORE removing from _agents so EffectiveCount never dips"), so an agent is
+    /// CONTINUOUSLY present in <c>_agents ∪ _quarantine</c> from spawn until its quarantine entry is drained
+    /// (RetryQuarantineOnceAsync) — there is no window where a live/tearing-down agent is absent from both,
+    /// hence no transient false Dead. Dead is returned only after the genuine drain (confirmed death). If that
+    /// ordering invariant is ever broken, this must instead take the per-agent lifecycle lock. NotFound
+    /// collapses to Dead here (see the appendix note) — both satisfy confirmed-absence.</summary>
+    internal AgentLiveness ReadLiveness(string agentId) {
+        // Order matters: check _agents first (Live/Quarantined-by-status), then _quarantine, then Dead.
+        // The add-to-quarantine-before-remove-from-_agents invariant makes this ordering false-Dead-free.
+        if (_agents.TryGetValue(agentId, out var a))
+            return a.Status is "Starting" or "Running" ? AgentLiveness.Live : AgentLiveness.Quarantined;
+        if (_quarantine?.Snapshot().Any(q => q.Id == agentId) == true) return AgentLiveness.Quarantined;
+        return AgentLiveness.Dead;
     }
 
     /// <summary>Phase B (D4 §6.4(2a)): the kill-quarantine snapshot for the status report.</summary>
@@ -702,7 +752,31 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         return agent;
     }
 
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.2): route a launch. A fully-Seq'd command
+    /// (Epoch + Seq + CommandId present) goes through the processor's serial lane — accepted exactly-in-order,
+    /// executed once, and turned into a terminal CommandAck/CommandRejected from the <see cref="CommandOutcome"/>
+    /// the core returns. An un-Seq'd command (old server) runs the legacy unsequenced lane directly and never
+    /// advances the watermark. The processor being null (never happens in production — always constructed in
+    /// the ctor) also falls back to the legacy lane.</summary>
     async Task HandleLaunchAgent(LaunchAgentCommand cmd) {
+        if (_processor is { } proc && cmd.Epoch is { } epoch && cmd.Seq is { } seq && cmd.CommandId is { } cmdId) {
+            await proc.SubmitAsync(
+                new SequencedItem(SequencedKind.Launch, epoch, seq, cmdId, cmd.AgentId),
+                () => HandleLaunchAgentCore(cmd));
+            return;
+        }
+
+        await HandleLaunchAgentCore(cmd); // legacy unsequenced lane (old server) — never advances the watermark
+    }
+
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.2): the shipped launch body, now returning the
+    /// terminal <see cref="CommandOutcome"/> the sequenced lane needs (the legacy caller ignores it). Every
+    /// shipped pre-flight rejection maps to <c>LaunchRejected</c> — capacity to <c>daemon_capacity</c>, all
+    /// other validations to <c>semantic</c> — so the sequenced lane emits a CommandRejected alongside the
+    /// unchanged LaunchFailed; a spawn/registration failure that was cleaned up maps to
+    /// <c>launch_failed_cleaned</c>; a registered agent maps to <c>launch_executed</c>. The shipped
+    /// LaunchFailed / worktree-teardown / cleanup side effects are UNCHANGED — only the return value is added.</summary>
+    async Task<CommandOutcome> HandleLaunchAgentCore(LaunchAgentCommand cmd) {
         var agentId       = cmd.AgentId;
         var prompt        = cmd.Prompt;
         var model         = cmd.Model;
@@ -721,7 +795,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         if (string.IsNullOrWhiteSpace(cmd.Vendor) || !_runtimeFactories.TryGetValue(cmd.Vendor, out var runtimeFactory)) {
             await _server.LaunchFailedAsync(cmd.AgentId, $"Unknown vendor: {cmd.Vendor}");
 
-            return;
+            return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
         }
 
         // fail an unattended (review-flow) launch fast when the selected vendor's
@@ -731,7 +805,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         if (UnattendedLaunchPolicy.RejectionReason(cmd.Vendor, runtimeFactory.SupportsUnattended, isReviewFlow) is { } unattendedRejection) {
             await _server.LaunchFailedAsync(cmd.AgentId, unattendedRejection);
 
-            return;
+            return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
         }
 
         WorktreeInfo? worktree      = null;
@@ -750,26 +824,26 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             if (EffectiveCount >= _config.MaxConcurrentAgents) {
                 await _server.LaunchFailedAsync(agentId, $"At max capacity ({_config.MaxConcurrentAgents} agents)");
 
-                return;
+                return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.DaemonCapacity);
             }
 
             if (!_config.IsRepoAllowed(repoPath)) {
                 await _server.LaunchFailedAsync(agentId, $"Repo path not allowed: {repoPath}");
 
-                return;
+                return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
             }
 
             if (!Directory.Exists(repoPath)) {
                 await _server.LaunchFailedAsync(agentId, $"Repo path does not exist: {repoPath}");
 
-                return;
+                return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
             }
 
             if (isReview) {
                 if (cmd.Review is not { } review) {
                     await _server.LaunchFailedAsync(agentId, "Review launch missing PR info");
 
-                    return;
+                    return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
                 }
 
                 // Final guard: re-validate that the chosen path's origin really
@@ -780,7 +854,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 if (actual is null) {
                     await _server.LaunchFailedAsync(agentId, $"No origin remote at {repoPath}");
 
-                    return;
+                    return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
                 }
 
                 var expected = $"github.com/{review.Owner}/{review.Repo}";
@@ -788,7 +862,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 if (!string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase)) {
                     await _server.LaunchFailedAsync(agentId, $"Repo at {repoPath} no longer matches {review.Owner}/{review.Repo} (origin: {actual})");
 
-                    return;
+                    return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
                 }
             }
 
@@ -801,7 +875,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             if (!string.IsNullOrEmpty(effort) && !ValidEffortLevels.Contains(effort)) {
                 await _server.LaunchFailedAsync(agentId, $"Invalid effort level: {effort}");
 
-                return;
+                return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
             }
 
             LogLaunching(agentId, repoPath, effort ?? "default", model);
@@ -866,7 +940,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                         try { await WorktreeManager.RemoveAsync(worktree); } catch { /* best-effort */ }
                     }
 
-                    return;
+                    return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
                 }
 
                 daemonBridgeUrl    = _permissionBridge.RegisterReviewerToken(reviewerServers);
@@ -922,7 +996,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     }
                 }
 
-                return;
+                return new CommandOutcome(CommandOutcomeKind.LaunchFailedCleaned, agentId);
             }
 
             mcpConfigPath = start.McpConfigPath;
@@ -1008,6 +1082,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             if (string.Equals(cmd.Vendor, "codex", StringComparison.OrdinalIgnoreCase)) {
                 ReportResolvedModel(agentId, cmd.Vendor, model);
             }
+
+            // Phase B2-b (sequenced-settlement design §4.2.2): the launch executed — the agent is registered.
+            // The sequenced lane turns this into a terminal CommandAck(Processed) with a LIVE CurrentState read
+            // at ack time; a fire-and-forget read loop that already finalized+cleaned the agent (e.g. an
+            // immediate-exit runtime) reads as launch_failed_cleaned instead. Legacy callers ignore the value.
+            return _agents.TryGetValue(agentId, out var launched)
+                ? new CommandOutcome(CommandOutcomeKind.LaunchExecuted, agentId, launched.SessionId)
+                : new CommandOutcome(CommandOutcomeKind.LaunchFailedCleaned, agentId);
         } catch (Exception ex) {
             LogLaunchFailed(ex, agentId);
 
@@ -1017,7 +1099,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             if (_agents.ContainsKey(agentId)) {
                 await CleanupAgentAsync(agentId);
                 await _server.LaunchFailedAsync(agentId, ex.Message);
-                return;
+                return new CommandOutcome(CommandOutcomeKind.LaunchFailedCleaned, agentId);
             }
 
             // If a reviewer token was minted before the failure and no AgentInstance was created to
@@ -1059,6 +1141,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             }
 
             await _server.LaunchFailedAsync(agentId, ex.Message);
+
+            // Phase B2-b (sequenced-settlement design §4.2.2): a pre-insert failure — the worktree (if any)
+            // was torn down and no agent was ever registered; terminal for the sequenced lane.
+            return new CommandOutcome(CommandOutcomeKind.LaunchFailedCleaned, agentId);
         }
     }
 
@@ -1358,6 +1444,24 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// session-end POST + watcher drain on a healthy connection.
     /// </summary>
     static readonly TimeSpan GracefulExitWait = TimeSpan.FromSeconds(15);
+
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.2): the sequenced stop. Routes through the
+    /// processor's serial lane (accepted exactly-in-order, executed once, terminal StopExecuted outcome →
+    /// CommandAck). Falls back to the legacy <see cref="HandleStopAgent"/> path if the processor is absent
+    /// (never happens in production — always constructed in the ctor).</summary>
+    async Task HandleStopAgentV2(StopAgentV2 cmd) {
+        if (_processor is { } proc) {
+            await proc.SubmitAsync(
+                new SequencedItem(SequencedKind.Stop, cmd.Epoch, cmd.Seq, cmd.CommandId, cmd.AgentId),
+                async () => {
+                    await HandleStopAgent(cmd.AgentId);
+                    return new CommandOutcome(CommandOutcomeKind.StopExecuted, cmd.AgentId);
+                });
+            return;
+        }
+
+        await HandleStopAgent(cmd.AgentId); // legacy unsequenced fallback
+    }
 
     internal async Task HandleStopAgent(string agentId) {
         if (!_agents.TryGetValue(agentId, out var agent)) {
@@ -2194,6 +2298,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _daemonHeartbeat.Dispose();
         _tokenRefresh.Dispose();
         _spoolDrain.Dispose();
+
+        // Phase B2-b (sequenced-settlement design §4.2.2): complete the processor's serial lane so an
+        // in-flight execution drains before the daemon exits.
+        if (_processor is not null) await _processor.DisposeAsync();
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -195,6 +195,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     string               _daemonId    = "";
     string               _daemonEpoch = "";
 
+    // Phase B2-b (sequenced-settlement design §4.2.4): the durable positive-death-evidence outbox.
+    // Fed at every CONFIRMED-gone seam — the OrphanReaper record pass (Hook A), the quarantine drain
+    // (Hook B), and the StopAgent-fallback reap (Hook C) — always ledger-append BEFORE source-delete so
+    // a crash between the two re-derives from the leftover source and Upsert (idempotent on the
+    // source-stable (AgentId, OldEpoch) key) collapses onto the committed entry. Lives in the same
+    // state dir as _pidRecords, under the same atomic temp+rename discipline.
+    ResolvedCandidatesLedger? _resolvedLedger;
+
     // Phase B2-b (sequenced-settlement design §4.2.3): the durable coverage boot-chain verdict,
     // folded in DaemonRunner (before Connect) and stashed on config. Advertised on the enriched
     // DaemonConnect payload; a Linux/macOS value is inert (the server consumes it only on Windows).
@@ -316,7 +324,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _daemonId    = ComputeDaemonId(config.Name);
         _daemonEpoch = config.DaemonEpoch ?? Guid.NewGuid().ToString("N");
         _recordlessSurvivorsImpossible = config.RecordlessSurvivorsImpossible;
-        _orphanReaper = new OrphanReaper(_pidRecords, _daemonId, _daemonEpoch, logger);
+
+        // Phase B2-b (sequenced-settlement design §4.2.4): the resolved-candidates ledger shares the PID
+        // record root so all durable per-daemon state lives together. The OrphanReaper's record-pass
+        // callback (Hook A) emits into it before the source delete; the drain (Hook B) and StopAgent
+        // fallback (Hook C) below emit directly. All three are append-before-delete + idempotent.
+        _resolvedLedger = new ResolvedCandidatesLedger(recordRoot, logger);
+        _orphanReaper = new OrphanReaper(_pidRecords, _daemonId, _daemonEpoch, logger,
+            onRecordResolved: (a, e, fr, role) => _resolvedLedger?.Upsert(a, e, fr, role));
 
         // Wire up server commands
         _server.OnLaunchAgent            += HandleLaunchAgent;
@@ -474,6 +489,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     internal string DaemonEpochForTest                             => _daemonEpoch;
     internal bool   RecordlessSurvivorsImpossibleForTest           => _recordlessSurvivorsImpossible;
 
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.4): the resolved-candidates ledger's
+    /// un-acked snapshot, so a test can assert the confirmed-gone hooks (quarantine drain / StopAgent
+    /// fallback / record pass) emitted positive per-id death evidence. Never used in production.</summary>
+    internal IReadOnlyList<ResolvedStartupCandidate> ResolvedLedgerSnapshotForTest => _resolvedLedger?.Snapshot() ?? [];
+
+    /// <summary>Test seam: seed a kill-quarantine entry so a test can drive the drain hook without a
+    /// real launch+teardown. Mirrors <see cref="WritePidRecordForTest"/>; never used in production.</summary>
+    internal void QuarantineForTest(AgentKillQuarantine.Entry entry) => _quarantine?.Add(entry);
+
     /// <summary>Phase B (D4 §6.4(3) StopAgent fallback): the caller had no in-memory agent for
     /// this id — consult the PID record and, if a live process still matches its EXACT identity (and,
     /// on Unix, carries the expected <c>KCAP_AGENT_ID</c> env — ambiguity spares), reap it by identity
@@ -486,7 +510,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         if (record.AgentId != agentId) return false; // no record
 
         var confirmedGone = await ProcessReaper.ReapByRecordAsync(record, _logger, _shutdownCts.Token);
-        if (confirmedGone) _pidRecords.Delete(agentId); // delete ONLY on confirmed death (spec §6.4(2))
+        if (confirmedGone) {
+            // Phase B2-b (sequenced-settlement design §4.2.4) Hook C: ledger-append the positive per-id
+            // death evidence (from the TRUSTED record — its epoch + flow identity) BEFORE deleting the
+            // source record. A crash between the two leaves a committed entry + leftover record; the next
+            // boot's OrphanReaper record pass re-derives it and Upsert (idempotent on the source-stable
+            // (AgentId, OldEpoch) key) collapses onto the committed entry, then completes the delete.
+            _resolvedLedger?.Upsert(agentId, record.DaemonEpoch, record.FlowRunId, record.FlowRole);
+            _pidRecords.Delete(agentId); // delete ONLY on confirmed death (spec §6.4(2))
+        }
 
         return confirmedGone;
     }
@@ -518,7 +550,19 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // Delete the durable PID record of every agent whose death the retry CONFIRMED — teardown
             // retained it (with the current epoch) while the child was quarantined, so without this it
             // would be skipped by the orphan sweep and leak until the next daemon restart.
-            foreach (var agentId in await _quarantine.RetryAllAsync(ct)) DeletePidRecord(agentId);
+            //
+            // Phase B2-b (sequenced-settlement design §4.2.4) Hook B: for each drained (confirmed-dead)
+            // entry, ledger-append its positive per-id death evidence BEFORE deleting the record. The
+            // shipped _quarantine is current-incarnation only, so its entries carry the CURRENT epoch —
+            // emit (AgentId, _daemonEpoch, flow…). That same-epoch id is harmless per outbox idempotency
+            // (prior-epoch proofs come from the record pass + marker scan) and gives the server id-level
+            // absence proof. Append-before-delete: a crash between the two leaves a committed entry + the
+            // retained record (its DaemonEpoch == _daemonEpoch), which the next boot's OrphanReaper record
+            // pass reconciles on the source-stable (AgentId, OldEpoch) key (single emit) then deletes.
+            foreach (var e in await _quarantine.RetryAllAsync(ct)) {
+                _resolvedLedger?.Upsert(e.AgentId, _daemonEpoch, e.FlowRunId, e.FlowRole);
+                DeletePidRecord(e.AgentId);
+            }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
         catch (Exception ex) { _logger.LogWarning(ex, "quarantine retry sweep faulted — continuing"); }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2460,6 +2460,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <summary>Test-only entry point to the private stop handler (mirrors <see cref="HandleLaunchAgentForTest"/>).</summary>
     internal Task HandleStopAgentForTest(string agentId) => HandleStopAgent(agentId);
 
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.6): test-only entry point to the sequenced
+    /// stop handler so a heal-barrier test can drive a Seq'd <see cref="StopAgentV2"/> through the
+    /// processor's serial lane (advances the watermark; the confirmed-dead id then falls out of both
+    /// LiveAgents and Quarantined). Mirrors <see cref="HandleStopAgentForTest"/>.</summary>
+    internal Task HandleStopAgentV2ForTest(StopAgentV2 cmd) => HandleStopAgentV2(cmd);
+
     /// <summary>Test-only entry point to the private send-input handler (bracketed-paste submit).</summary>
     internal Task HandleSendInputForTest(SendInputCommand cmd) => HandleSendInput(cmd);
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -201,13 +201,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // a crash between the two re-derives from the leftover source and Upsert (idempotent on the
     // source-stable (AgentId, OldEpoch) key) collapses onto the committed entry. Lives in the same
     // state dir as _pidRecords, under the same atomic temp+rename discipline.
-    ResolvedCandidatesLedger? _resolvedLedger;
+    readonly ResolvedCandidatesLedger? _resolvedLedger;
 
     // Phase B2-b (sequenced-settlement design §4.2.4): the durable marker-candidate source store for a
     // RECORDLESS prior-epoch survivor (Hook D). The env-marker scan persists a source BEFORE the kill and
     // resolves it through the (a)/(b)/(c) matrix; on confirmed death it emits into _resolvedLedger with a
     // NULL flow (the env is untrusted) unless a co-existing durable RECORD supplies a trusted flow.
-    MarkerCandidateStore? _markerCandidates;
+    readonly MarkerCandidateStore? _markerCandidates;
 
     // Phase B2-b (sequenced-settlement design §4.2.3): the durable coverage boot-chain verdict,
     // folded in DaemonRunner (before Connect) and stashed on config. Advertised on the enriched
@@ -219,7 +219,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // ReadLiveness / the server's CommandAck+CommandRejected sends so it stays unit-testable without a
     // live hub. Only Seq'd LaunchAgentCommand + StopAgentV2 route through it; un-Seq'd commands stay on
     // the legacy unsequenced lane (old-server compat) and never advance the watermark.
-    SequencedCommandProcessor? _processor;
+    readonly SequencedCommandProcessor? _processor;
 
     // Phase B (D4 §6.4(2a)/(3)): single-flight latches so a slow sweep (each survivor consumes a
     // ~5s TERM grace sequentially) can't overlap itself when the next heartbeat tick fires — otherwise
@@ -392,6 +392,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _server.GetHighestAcceptedSeq  =  () => _processor?.HighestAcceptedSeq;
         _server.GetLastProcessedSeq    =  () => _processor?.LastProcessedSeq;
         _server.GetQuarantined         =  () => [.. QuarantineSnapshot()];
+        // Phase B2-b (sequenced-settlement design): the DaemonConnect epoch reads THIS orchestrator's
+        // per-boot _daemonEpoch (the same source the processor is scoped to), so the advertised epoch
+        // can't diverge from it even if config.DaemonEpoch were left unpinned (tests).
+        _server.GetDaemonEpoch         =  () => _daemonEpoch;
 
         _server.GetLiveAgentIds = () => [
             .. _agents

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -373,6 +373,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // re-advertises the un-acked snapshot alongside the periodic DaemonStatusReport.
         _server.OnAckResolvedCandidates       += HandleAckResolvedCandidates;
         _server.GetResolvedStartupCandidates  =  () => [.. _resolvedLedger?.Snapshot() ?? []];
+        // Phase B2-b (sequenced-settlement design §5.5): advertise the ledger's monotonic high-water on
+        // the connect payload (BuildStatusReport carries it on the periodic self-report) so the server
+        // learns the generation frontier even after sparse acks prune entries.
+        _server.GetHighestResolutionGeneration =  () => _resolvedLedger?.HighestResolutionGeneration;
 
         // Phase B2-b (sequenced-settlement design): mirror the per-platform startup-completeness signals
         // into the DaemonConnect payload (the periodic DaemonStatusReport carries them via
@@ -463,7 +467,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             StartupReapComplete: ComputeStartupReapComplete(),
             ResolvedStartupCandidates: [.. _resolvedLedger?.Snapshot() ?? []],
             UnresolvedStartupCandidates: [.. _orphanReaper?.BlockedCandidates() ?? []],
-            StartupDiscovery: _orphanReaper?.CurrentDiscovery);
+            StartupDiscovery: _orphanReaper?.CurrentDiscovery,
+            // Phase B2-b (sequenced-settlement design §5.5): the resolved-candidates ledger's monotonic
+            // high-water, so once sparse acks prune entries the server still knows the generation frontier.
+            HighestResolutionGeneration: _resolvedLedger?.HighestResolutionGeneration);
 
     /// <summary>Phase B2-b (sequenced-settlement design): the per-platform startup-reap-complete
     /// roll-up. A blocked known-id candidate (pending_marker / legacy_unresolvable /

--- a/src/Capacitor.Cli.Daemon/Services/CoverageJournal.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CoverageJournal.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Phase B2-b (sequenced-settlement design §4.2.3): the durable boot-chain attestation that
+/// drives <c>RecordlessSurvivorsImpossible</c>. A boolean alone cannot witness boots by UNAWARE
+/// binaries, so this folds across the lock file's persistent per-boot <c>InstanceId</c> nonce
+/// (the only marker every shipped version rewrites at boot and never deletes):
+///
+///   cumulative_covered(this boot) = tail.cumulative_covered AND chain_check AND this_epoch_contained
+///
+/// where chain_check is "the immediately-preceding boot was our own recorded aware epoch"
+/// (prior lock InstanceId == journal tail's recorded id). Sticky-false by construction: the
+/// detecting boot persists false in its OWN tail, so every later boot inherits it. Fail-closed:
+/// any missing/corrupt/unwritable state evaluates to false. The only false->true path is the
+/// documented operator reset (delete the state dir AND the per-name lock -> next boot is genesis).
+///
+/// The spec's "state_dir_initialized marker + journal in the SAME atomic operation" is satisfied by
+/// folding the <c>Initialized</c> flag INTO the journal document — a single JSON
+/// {initialized, instance_id, cumulative_covered} written by ONE temp+rename. There is deliberately
+/// NO separate marker file (two non-atomic writes would let a genesis-boot crash leave
+/// journal-present/marker-absent → next boot reads genesis=false → permanently poisoned). Genesis
+/// eligibility is therefore "the journal file is absent": the single rename is the only durable state
+/// transition, so a crash is provably either before it (no journal ⇒ re-seed) or after it (a valid
+/// initialized journal).
+/// </summary>
+internal sealed partial class CoverageJournal(string stateDir, ILogger logger) {
+    readonly string _journalPath = Path.Combine(stateDir, "coverage.json");
+
+    readonly record struct Journal(bool Initialized, string InstanceId, bool CumulativeCovered);
+
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+    [JsonSerializable(typeof(Journal))]
+    partial class Ctx : JsonSerializerContext;
+
+    /// <summary>Fold this boot and persist the new journal atomically BEFORE Connect/spawn. Returns
+    /// cumulative_covered. Never throws — an I/O failure returns false (fail-closed).</summary>
+    public bool RecordBoot(string myInstanceId, string? priorLockInstanceId, bool thisEpochContained) {
+        try {
+            var journalExists = File.Exists(_journalPath);
+            var prior         = journalExists ? ReadJournal() : null; // null ⇒ present-but-corrupt
+
+            bool covered;
+            if (!journalExists) {
+                // Genesis is the ONLY seed-true base case: the journal file is absent (we are about to
+                // atomically initialize it) AND the captured prior lock shows no pre-existing InstanceId
+                // (a genuine first-ever boot for this name). A previously-used dir whose journal is gone
+                // but whose prior lock DOES carry an InstanceId is un-journaled history that re-pointing/
+                // deleting the dir cannot launder ⇒ false.
+                var genesis = priorLockInstanceId is null;
+                covered = genesis && thisEpochContained;
+            } else if (prior is not { Initialized: true } t) {
+                covered = false; // journal present but corrupt / not fully initialized -> fail-closed
+            } else {
+                var chainOk = priorLockInstanceId is { } pid && string.Equals(pid, t.InstanceId, StringComparison.Ordinal);
+                covered = t.CumulativeCovered && chainOk && thisEpochContained;
+            }
+
+            WriteJournalAtomic(new Journal(true, myInstanceId, covered)); // persists the break in THIS entry (sticky)
+            return covered;
+        } catch (Exception ex) {
+            logger.LogWarning(ex, "CoverageJournal: fold/persist failed — advertising RecordlessSurvivorsImpossible=false (fail-closed)");
+            return false;
+        }
+    }
+
+    Journal? ReadJournal() {
+        try {
+            return JsonSerializer.Deserialize(File.ReadAllText(_journalPath), Ctx.Default.Journal);
+        } catch { return null; } // corrupt -> journal present but unparseable => false (never genesis)
+    }
+
+    void WriteJournalAtomic(Journal journal) {
+        Directory.CreateDirectory(stateDir);
+        var tmp = _journalPath + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
+        File.WriteAllText(tmp, JsonSerializer.Serialize(journal, Ctx.Default.Journal));
+        File.Move(tmp, _journalPath, overwrite: true);   // THE single atomic same-directory rename (marker folded in)
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/CoverageJournal.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CoverageJournal.cs
@@ -38,7 +38,7 @@ internal sealed partial class CoverageJournal(string stateDir, ILogger logger) {
 
     /// <summary>Fold this boot and persist the new journal atomically BEFORE Connect/spawn. Returns
     /// cumulative_covered. Never throws — an I/O failure returns false (fail-closed).</summary>
-    public bool RecordBoot(string myInstanceId, string? priorLockInstanceId, bool thisEpochContained) {
+    public bool RecordBoot(string myInstanceId, string? priorLockInstanceId, bool priorLockReadFailed, bool thisEpochContained) {
         try {
             var journalExists = File.Exists(_journalPath);
             var prior         = journalExists ? ReadJournal() : null; // null ⇒ present-but-corrupt
@@ -49,8 +49,10 @@ internal sealed partial class CoverageJournal(string stateDir, ILogger logger) {
                 // atomically initialize it) AND the captured prior lock shows no pre-existing InstanceId
                 // (a genuine first-ever boot for this name). A previously-used dir whose journal is gone
                 // but whose prior lock DOES carry an InstanceId is un-journaled history that re-pointing/
-                // deleting the dir cannot launder ⇒ false.
-                var genesis = priorLockInstanceId is null;
+                // deleting the dir cannot launder ⇒ false. An INDETERMINATE prior lock (non-empty but
+                // unreadable/garbage) is NOT genesis either — an unreadable prior could hide an intervening
+                // boot, so it must fail-closed (never conflate "unreadable" with "genuinely empty").
+                var genesis = !priorLockReadFailed && priorLockInstanceId is null;
                 covered = genesis && thisEpochContained;
             } else if (prior is not { Initialized: true } t) {
                 covered = false; // journal present but corrupt / not fully initialized -> fail-closed

--- a/src/Capacitor.Cli.Daemon/Services/MarkerCandidateStore.cs
+++ b/src/Capacitor.Cli.Daemon/Services/MarkerCandidateStore.cs
@@ -1,0 +1,53 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>Phase B2-b (sequenced-settlement design §4.2.4): durable marker-candidate sources for
+/// RECORDLESS prior-epoch survivors. Kill authority is marker-based (the live env triple, re-read at
+/// kill time); there is NO spawn-bound start-identity and NO trusted flow identity (the env is
+/// mutable). Same atomic temp+rename + hashed-filename discipline as
+/// <see cref="AgentPidRecordStore"/>.</summary>
+internal sealed partial class MarkerCandidateStore(string stateDir, ILogger logger) {
+    readonly string _dir = Path.Combine(stateDir, "marker-candidates");
+
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+    [JsonSerializable(typeof(MarkerCandidate))]
+    partial class MarkerCandidateJsonCtx : JsonSerializerContext;
+
+    public void Write(MarkerCandidate c) {
+        Directory.CreateDirectory(_dir);
+        var final = PathFor(c.AgentId);
+        var tmp   = final + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
+        File.WriteAllText(tmp, JsonSerializer.Serialize(c, MarkerCandidateJsonCtx.Default.MarkerCandidate));
+        File.Move(tmp, final, overwrite: true);
+    }
+
+    public bool Delete(string agentId) {
+        try { var p = PathFor(agentId); if (!File.Exists(p)) return false; File.Delete(p); return true; }
+        catch (Exception ex) { logger.LogWarning(ex, "MarkerCandidateStore: delete failed for {AgentId}", agentId); return false; }
+    }
+
+    public IReadOnlyList<MarkerCandidate> ReadAll() {
+        if (!Directory.Exists(_dir)) return [];
+        var r = new List<MarkerCandidate>();
+        foreach (var p in Directory.EnumerateFiles(_dir, "*.json")) {
+            try {
+                var c = JsonSerializer.Deserialize(File.ReadAllText(p), MarkerCandidateJsonCtx.Default.MarkerCandidate);
+                if (!string.IsNullOrEmpty(c.AgentId)) r.Add(c);
+            } catch (Exception ex) { logger.LogWarning(ex, "MarkerCandidateStore: unparseable source {Path}", p); }
+        }
+        return r;
+    }
+
+    string PathFor(string agentId) => Path.Combine(_dir,
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(agentId ?? ""))).ToLowerInvariant() + ".json");
+}
+
+/// <summary>Phase B2-b (sequenced-settlement design §4.2.4): the durable marker-candidate source
+/// tuple. Marker-based kill authority for a fully recordless prior-epoch survivor — no start-identity
+/// token, no trusted flow identity.</summary>
+internal readonly record struct MarkerCandidate(string AgentId, string DaemonId, string OldEpoch, int Pid);

--- a/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
@@ -28,14 +28,25 @@ internal sealed class OrphanReaper(
         Action<string, string, string?, string?>? onRecordResolved = null,
         MarkerCandidateStore? markerStore = null,
         Action<string, string>? onMarkerResolved = null) {
+    // Phase B2-b (sequenced-settlement design): CurrentDiscovery is a multi-field struct
+    // ({enum, DateTimeOffset?}) written on the reap thread and read on the report/connect thread, so an
+    // unguarded read could tear. A dedicated gate around just the field's get/set makes each access
+    // atomic; the sweep is single-flight (only the reap thread ever writes), so the read-modify-write at
+    // the enumeration-failure seam needs no wider critical section.
+    readonly object _discoveryGate = new();
+    StartupDiscovery _currentDiscovery =
+        new(OperatingSystem.IsLinux() ? MarkerScanState.Pending : MarkerScanState.NotApplicable);
+
     /// <summary>Phase B2-b (sequenced-settlement design): the recordless-survivor env-marker-scan
     /// status, advertised on the daemon's startup-completeness signals. Seeded per-platform:
     /// <c>Pending</c> on Linux (a scan runs and must complete one clean pass), <c>NotApplicable</c> on
     /// Windows (no scan — layer-1 containment) and macOS (env redaction makes the scan find nothing).
     /// The Linux scan flips it to <c>Complete</c> after one clean enumeration pass or <c>Failed</c> on an
     /// enumeration error (retried next heartbeat); off Linux it stays <c>NotApplicable</c> forever.</summary>
-    public StartupDiscovery CurrentDiscovery { get; private set; } =
-        new(OperatingSystem.IsLinux() ? MarkerScanState.Pending : MarkerScanState.NotApplicable);
+    public StartupDiscovery CurrentDiscovery {
+        get { lock (_discoveryGate) { return _currentDiscovery; } }
+        private set { lock (_discoveryGate) { _currentDiscovery = value; } }
+    }
 
     /// <summary>Phase B2-b (sequenced-settlement design): the known-id prior-incarnation candidates
     /// that are BLOCKED — each keeps <c>StartupReapComplete</c> false until resolved. Three sources,

--- a/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
@@ -187,6 +187,11 @@ internal sealed class OrphanReaper(
             return;
         }
 
+        // Phase B2-b (sequenced-settlement design §5.5): track a marker-candidate source-WRITE failure
+        // (a survivor we could neither durably record nor kill) so the pass does not falsely report
+        // Complete below — such a survivor is invisible to BlockedCandidates AND still alive.
+        var captureFailed = false;
+
         foreach (var pid in pids) {
             if (ct.IsCancellationRequested) return;
             if (handledPids.Contains(pid)) continue;       // already covered by the record pass
@@ -220,24 +225,41 @@ internal sealed class OrphanReaper(
             // marker-candidate source BEFORE the kill (crash-consistency: a crash before the kill
             // re-runs the resolution next boot; never a source-less window, never a retroactive mint),
             // then resolve it through the same matrix as the reconciliation pass.
+            // Persist a durable source BEFORE the kill, and split the write from the resolution so a
+            // WRITE failure is distinguishable from a post-write resolution failure. A write failure
+            // means no source was committed: the survivor is invisible to BlockedCandidates AND still
+            // unkilled, so it must NOT let this pass report Complete. A failure AFTER a successful write
+            // leaves a pending_marker source that BlockedCandidates already treats as blocking, so that
+            // case does not fail the pass (the next boot re-derives + retries the kill from the source).
+            var candidate = new MarkerCandidate(agentId, daemonId, epoch, pid);
             try {
-                var candidate = new MarkerCandidate(agentId, daemonId, epoch, pid);
                 markerStore?.Write(candidate);
+            } catch (Exception ex) when (ex is not OperationCanceledException) {
+                captureFailed = true;
+                logger.LogWarning(ex, "OrphanReaper: marker-candidate source write failed for pid {Pid} — discovery stays incomplete this pass (retried next heartbeat)", pid);
+                continue; // never resolve/kill without a durable source first
+            }
+            try {
                 await ResolveMarkerCandidateAsync(candidate, ct);
             } catch (Exception ex) when (ex is not OperationCanceledException) {
-                logger.LogWarning(ex, "OrphanReaper: env-marker reap failed for pid {Pid}", pid);
+                logger.LogWarning(ex, "OrphanReaper: env-marker reap failed for pid {Pid} — source retained, retried next boot", pid);
             }
         }
 
-        // Phase B2-b (sequenced-settlement design): one clean env-marker-scan pass completed —
-        // enumeration succeeded and every candidate was walked (never cancelled mid-pass; a cancel
-        // returns early above, leaving discovery unchanged). On Linux this is the completeness proof, so
-        // flip to Complete and stamp the scan time. A pass that merely SPARED a pending_marker candidate
-        // is still clean here — that spared source blocks completion via BlockedCandidates, not via the
-        // pass state. Off Linux there is no scan (EnumeratePids returns empty), so CurrentDiscovery stays
+        // Phase B2-b (sequenced-settlement design §5.5): a clean env-marker-scan pass = enumeration
+        // succeeded AND every discovered survivor was durably captured (its pending_marker source now
+        // blocks via BlockedCandidates) or resolved — never cancelled mid-pass (a cancel returns early
+        // above, leaving discovery unchanged). Only then is the pass a completeness proof → flip to
+        // Complete and stamp the scan time. A pass that merely SPARED a pending_marker candidate is still
+        // clean (that spared source blocks via BlockedCandidates, not the pass state). But if ANY
+        // candidate's durable source WRITE failed, that survivor is untracked + unkilled, so the pass is
+        // NOT a proof — leave discovery Failed (retried next heartbeat), keeping the last successful scan
+        // time. Off Linux there is no scan (EnumeratePids returns empty), so CurrentDiscovery stays
         // NotApplicable.
         if (OperatingSystem.IsLinux())
-            CurrentDiscovery = new StartupDiscovery(MarkerScanState.Complete, DateTimeOffset.UtcNow);
+            CurrentDiscovery = captureFailed
+                ? new StartupDiscovery(MarkerScanState.Failed, CurrentDiscovery.LastSuccessfulScanAt)
+                : new StartupDiscovery(MarkerScanState.Complete, DateTimeOffset.UtcNow);
     }
 
     /// <summary>Resolve a marker-candidate source through the asymmetric matrix. Because a recordless

--- a/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
@@ -252,14 +252,30 @@ internal sealed class OrphanReaper(
     /// via the marker scan carries TRUSTED flow identity — written from the daemon's own AgentInstance
     /// into the durable record at spawn — so pull FlowRunId/FlowRole (and the trusted DaemonEpoch) FROM
     /// THAT RECORD via the record-resolved sink, so its role can be individually healed. Never trust flow
-    /// from the mutable env.</summary>
+    /// from the mutable env.
+    /// <para>The env agentId is UNTRUSTED for role authority — a prior-epoch DESCENDANT can inherit a
+    /// still-live leader's <c>KCAP_AGENT_ID</c> env triple (the descendant-outlives-leader residual) and
+    /// be reaped under a DIFFERENT pid. Matching a durable record on agentId ALONE would then emit a false
+    /// trusted-flow death proof for the LIVE leader AND delete its record. So only trust a record that
+    /// ALSO corroborates the reaped pid AND the prior epoch (<c>r.Pid == c.Pid &amp;&amp; r.DaemonEpoch ==
+    /// c.OldEpoch</c>): the live leader's record (its own pid, a different/current epoch) then can't be
+    /// matched by a descendant killed under another pid, and the resolution falls back to the recordless
+    /// null-flow path — NO record delete. The legitimate identity_unavailable case is unaffected: there
+    /// the record genuinely IS the reaped pid, so pid + epoch + agentId all corroborate.</para></summary>
     void EmitAndClear(MarkerCandidate c) {
-        var record = store.ReadAll().FirstOrDefault(r => string.Equals(r.AgentId, c.AgentId, StringComparison.Ordinal));
-        if (!string.IsNullOrEmpty(record.AgentId))
+        var record = store.ReadAll().FirstOrDefault(r =>
+            string.Equals(r.AgentId, c.AgentId, StringComparison.Ordinal)
+            && r.Pid == c.Pid
+            && string.Equals(r.DaemonEpoch, c.OldEpoch, StringComparison.Ordinal));
+        if (!string.IsNullOrEmpty(record.AgentId)) {
+            // Corroborated identity_unavailable record: emit its TRUSTED flow and clear the record.
             onRecordResolved?.Invoke(record.AgentId, record.DaemonEpoch, record.FlowRunId, record.FlowRole);
-        else
+            store.Delete(c.AgentId);
+        } else {
+            // Pure recordless survivor, OR a non-corroborating record that belongs to a LIVE leader: the
+            // env is untrusted -> null flow, and NEVER delete a record we didn't corroborate.
             onMarkerResolved?.Invoke(c.AgentId, c.OldEpoch);
-        store.Delete(c.AgentId);   // clears the identity_unavailable record (no-op for a pure recordless survivor)
+        }
         markerStore?.Delete(c.AgentId);
         logger.LogInformation(
             "OrphanReaper: resolved marker-candidate {AgentId} (pid {Pid}) of a prior daemon incarnation", c.AgentId, c.Pid);

--- a/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
@@ -25,11 +25,33 @@ namespace Capacitor.Cli.Daemon.Services;
 /// </summary>
 internal sealed class OrphanReaper(
         AgentPidRecordStore store, string daemonId, string currentEpoch, ILogger logger,
-        Action<string, string, string?, string?>? onRecordResolved = null) {
-    /// <summary>Run both passes once. Best-effort throughout — a failure on one process never aborts the
+        Action<string, string, string?, string?>? onRecordResolved = null,
+        MarkerCandidateStore? markerStore = null,
+        Action<string, string>? onMarkerResolved = null) {
+    /// <summary>Run all passes once. Best-effort throughout — a failure on one process never aborts the
     /// sweep of the others.</summary>
     public async Task ReapOnceAsync(CancellationToken ct = default) {
         var handledPids = new HashSet<int>();
+
+        // ── (0) marker-candidate reconciliation (crash recovery) ───────────────────────────────────
+        // Phase B2-b (sequenced-settlement design §4.2.4): re-derive any persisted marker-candidate
+        // source BEFORE the record pass. A source outlives one pass, so this covers the crash-before-kill
+        // window: re-read the LIVE triple so a pid reused since the source was written is spared, never
+        // mis-killed. It runs FIRST so a source co-existing with an identity_unavailable RECORD is
+        // resolved by EmitAndClear (which routes the TRUSTED record flow via onRecordResolved) before the
+        // record pass could independently resolve+delete that record — no double emit.
+        if (markerStore is not null) {
+            foreach (var c in markerStore.ReadAll()) {
+                if (ct.IsCancellationRequested) return;
+                try {
+                    await ResolveMarkerCandidateAsync(c, ct);
+                } catch (Exception ex) when (ex is not OperationCanceledException) {
+                    // Per-source fault (e.g. a sink throwing before the append): the source is left on
+                    // disk (append-before-delete), so the next boot re-derives it. Never abort the sweep.
+                    logger.LogWarning(ex, "OrphanReaper: marker-candidate reconciliation faulted for {AgentId} (pid {Pid}) — retained for next boot", c.AgentId, c.Pid);
+                }
+            }
+        }
 
         // ── (1) record pass ──────────────────────────────────────────────────────────────────────
         foreach (var record in store.ReadAll()) {
@@ -126,27 +148,66 @@ internal sealed class OrphanReaper(
             // markers we just read belong to a different incarnation — the token no longer matches, so spare.
             if (ProcessIdentity.MatchesTri(pid, token) != true) continue;
 
-            // Recordless survivor of a PRIOR incarnation of THIS daemon → reap by the captured identity.
+            // Recordless survivor of a PRIOR incarnation of THIS daemon. Persist a durable
+            // marker-candidate source BEFORE the kill (crash-consistency: a crash before the kill
+            // re-runs the resolution next boot; never a source-less window, never a retroactive mint),
+            // then resolve it through the same matrix as the reconciliation pass.
             try {
-                var gone = await ProcessReaper.ReapByMarkerAsync(pid, token, agentId, logger, ct);
-                if (gone) {
-                    // Positive, PID-independent resolution: delete any record for THIS agent id (a
-                    // no-op if none exists — the ordinary recordless-survivor case). This is what
-                    // makes the "identity_unavailable record + live-env-triple confirms it" case
-                    // self-heal WITHOUT ever keying off the numeric pid alone (a reused pid between
-                    // this kill and any later record pass can't act on the wrong occupant, because the
-                    // record is already gone by then).
-                    store.Delete(agentId);
-                    logger.LogInformation(
-                        "OrphanReaper: reaped recordless survivor {AgentId} (pid {Pid}) of a prior daemon incarnation", agentId, pid);
-                } else {
-                    logger.LogWarning(
-                        "OrphanReaper: env-marker kill of {AgentId} (pid {Pid}) not confirmed — retrying next tick", agentId, pid);
-                }
+                var candidate = new MarkerCandidate(agentId, daemonId, epoch, pid);
+                markerStore?.Write(candidate);
+                await ResolveMarkerCandidateAsync(candidate, ct);
             } catch (Exception ex) when (ex is not OperationCanceledException) {
                 logger.LogWarning(ex, "OrphanReaper: env-marker reap failed for pid {Pid}", pid);
             }
         }
+    }
+
+    /// <summary>Resolve a marker-candidate source through the asymmetric matrix. Because a recordless
+    /// survivor has NO spawn-bound start-identity, a triple mismatch is spare-only — never positive death
+    /// evidence — since a mismatch can't distinguish PID-reuse from the original mutating its own env.
+    /// <list type="bullet">
+    /// <item><b>(a)</b> pid dead per the shipped zombie-aware <see cref="ProcessIdentity.IsAlive"/> (ESRCH
+    /// or Linux 'Z') ⇒ conclusively resolved → emit + delete the source.</item>
+    /// <item><b>(b)</b> alive (non-zombie) + the LIVE triple still matches ⇒ kill; on CONFIRMED death,
+    /// resolve as (a).</item>
+    /// <item><b>(c)</b> alive (non-zombie) + triple mismatch/unreadable ⇒ SPARE, the source stays PENDING,
+    /// NO emit — a reused pid no longer carrying our triple is left untouched (PID-reuse safe).</item>
+    /// </list></summary>
+    async Task ResolveMarkerCandidateAsync(MarkerCandidate c, CancellationToken ct) {
+        // (a) dead per the shipped zombie-aware IsAlive (ESRCH or Linux 'Z') -> conclusively resolved.
+        if (!ProcessIdentity.IsAlive(c.Pid)) { EmitAndClear(c); return; }
+
+        // Re-read the LIVE triple: (c) mismatch/unreadable -> SPARE, stay pending, NO emit (a triple
+        // mismatch cannot distinguish PID-reuse from the process mutating its own env).
+        var agentId = ProcessIdentity.ReadAgentEnv(c.Pid, "KCAP_AGENT_ID");
+        var did     = ProcessIdentity.ReadAgentEnv(c.Pid, "KCAP_DAEMON_ID");
+        var epoch   = ProcessIdentity.ReadAgentEnv(c.Pid, "KCAP_DAEMON_EPOCH");
+        var token   = ProcessIdentity.Capture(c.Pid);
+        var tripleMatches = agentId == c.AgentId && did == c.DaemonId && epoch == c.OldEpoch && token is not null;
+        if (!tripleMatches) return; // (c) pending
+
+        // (b) alive + triple still matches -> kill; on CONFIRMED death, resolve.
+        if (await ProcessReaper.ReapByMarkerAsync(c.Pid, token!, c.AgentId, logger, ct)) EmitAndClear(c);
+        else logger.LogWarning("OrphanReaper: marker kill of {AgentId} (pid {Pid}) not confirmed — retry next tick", c.AgentId, c.Pid);
+    }
+
+    /// <summary>Ledger-append BEFORE source-deletion (crash reconciled next boot; idempotent). Trust
+    /// boundary: a fully RECORDLESS survivor's env is untrusted, so it maps to NO role
+    /// (<paramref name="onMarkerResolved"/>, null flow). But a Linux identity_unavailable RECORD resolved
+    /// via the marker scan carries TRUSTED flow identity — written from the daemon's own AgentInstance
+    /// into the durable record at spawn — so pull FlowRunId/FlowRole (and the trusted DaemonEpoch) FROM
+    /// THAT RECORD via the record-resolved sink, so its role can be individually healed. Never trust flow
+    /// from the mutable env.</summary>
+    void EmitAndClear(MarkerCandidate c) {
+        var record = store.ReadAll().FirstOrDefault(r => string.Equals(r.AgentId, c.AgentId, StringComparison.Ordinal));
+        if (!string.IsNullOrEmpty(record.AgentId))
+            onRecordResolved?.Invoke(record.AgentId, record.DaemonEpoch, record.FlowRunId, record.FlowRole);
+        else
+            onMarkerResolved?.Invoke(c.AgentId, c.OldEpoch);
+        store.Delete(c.AgentId);   // clears the identity_unavailable record (no-op for a pure recordless survivor)
+        markerStore?.Delete(c.AgentId);
+        logger.LogInformation(
+            "OrphanReaper: resolved marker-candidate {AgentId} (pid {Pid}) of a prior daemon incarnation", c.AgentId, c.Pid);
     }
 
     /// <summary>Enumerate candidate pids for the env-marker scan. Linux lists <c>/proc/[0-9]+</c>;

--- a/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
@@ -28,6 +28,46 @@ internal sealed class OrphanReaper(
         Action<string, string, string?, string?>? onRecordResolved = null,
         MarkerCandidateStore? markerStore = null,
         Action<string, string>? onMarkerResolved = null) {
+    /// <summary>Phase B2-b (sequenced-settlement design): the recordless-survivor env-marker-scan
+    /// status, advertised on the daemon's startup-completeness signals. Seeded per-platform:
+    /// <c>Pending</c> on Linux (a scan runs and must complete one clean pass), <c>NotApplicable</c> on
+    /// Windows (no scan — layer-1 containment) and macOS (env redaction makes the scan find nothing).
+    /// The Linux scan flips it to <c>Complete</c> after one clean enumeration pass or <c>Failed</c> on an
+    /// enumeration error (retried next heartbeat); off Linux it stays <c>NotApplicable</c> forever.</summary>
+    public StartupDiscovery CurrentDiscovery { get; private set; } =
+        new(OperatingSystem.IsLinux() ? MarkerScanState.Pending : MarkerScanState.NotApplicable);
+
+    /// <summary>Phase B2-b (sequenced-settlement design): the known-id prior-incarnation candidates
+    /// that are BLOCKED — each keeps <c>StartupReapComplete</c> false until resolved. Three sources,
+    /// each with its reason:
+    /// <list type="bullet">
+    /// <item><c>identity_unresolvable</c> — a prior-epoch <see cref="PidIdentityKind.IdentityUnavailable"/>
+    /// record the record pass can never resolve (no comparable token); the Linux env-marker scan may
+    /// still reap it, macOS requires a manual kill.</item>
+    /// <item><c>legacy_unresolvable</c> — a macOS prior-epoch <see cref="PidIdentityKind.Present"/> record
+    /// whose live pid is still alive but whose token is ambiguous (a cross-scheme mismatch spared every
+    /// pass).</item>
+    /// <item><c>pending_marker</c> — any persisted marker-candidate source (a recordless prior-epoch
+    /// survivor whose live triple no longer matches, so it stays pending). Listed WITHOUT a liveness
+    /// check — a source on disk is a blocking candidate until the resolution matrix clears it. Flow
+    /// identity is unknown for a recordless survivor (the env is untrusted), so it is omitted.</item>
+    /// </list>
+    /// Flow fields for the record-tracked reasons come from the TRUSTED durable record. Uses the
+    /// ctor-injected <c>markerStore</c>/<c>store</c>/<c>currentEpoch</c>.</summary>
+    public IReadOnlyList<UnresolvedStartupCandidate> BlockedCandidates() {
+        var list = new List<UnresolvedStartupCandidate>();
+        foreach (var r in store.ReadAll()) {
+            if (string.Equals(r.DaemonEpoch, currentEpoch, StringComparison.Ordinal)) continue; // current-incarnation
+            if (r.IdentityKind == PidIdentityKind.IdentityUnavailable)
+                list.Add(new(r.AgentId, StartupCandidateUnresolvedReason.IdentityUnresolvable, r.FlowRunId, r.FlowRole));
+            else if (OperatingSystem.IsMacOS() && ProcessIdentity.IsAlive(r.Pid) && ProcessIdentity.MatchesTri(r.Pid, r.StartIdentity) is null)
+                list.Add(new(r.AgentId, StartupCandidateUnresolvedReason.LegacyUnresolvable, r.FlowRunId, r.FlowRole));
+        }
+        foreach (var m in markerStore?.ReadAll() ?? [])
+            list.Add(new(m.AgentId, StartupCandidateUnresolvedReason.PendingMarker));
+        return list;
+    }
+
     /// <summary>Run all passes once. Best-effort throughout — a failure on one process never aborts the
     /// sweep of the others.</summary>
     public async Task ReapOnceAsync(CancellationToken ct = default) {
@@ -116,6 +156,11 @@ internal sealed class OrphanReaper(
             pids = EnumeratePids();
         } catch (Exception ex) {
             logger.LogWarning(ex, "OrphanReaper: process enumeration failed — skipping env-marker scan this tick");
+            // Phase B2-b (sequenced-settlement design): an enumeration failure leaves discovery FAILED on
+            // Linux (retried next heartbeat); keep the last successful scan time so a prior clean pass is
+            // still remembered. Off Linux there is no scan, so CurrentDiscovery stays NotApplicable.
+            if (OperatingSystem.IsLinux())
+                CurrentDiscovery = new StartupDiscovery(MarkerScanState.Failed, CurrentDiscovery.LastSuccessfulScanAt);
             return;
         }
 
@@ -160,6 +205,16 @@ internal sealed class OrphanReaper(
                 logger.LogWarning(ex, "OrphanReaper: env-marker reap failed for pid {Pid}", pid);
             }
         }
+
+        // Phase B2-b (sequenced-settlement design): one clean env-marker-scan pass completed —
+        // enumeration succeeded and every candidate was walked (never cancelled mid-pass; a cancel
+        // returns early above, leaving discovery unchanged). On Linux this is the completeness proof, so
+        // flip to Complete and stamp the scan time. A pass that merely SPARED a pending_marker candidate
+        // is still clean here — that spared source blocks completion via BlockedCandidates, not via the
+        // pass state. Off Linux there is no scan (EnumeratePids returns empty), so CurrentDiscovery stays
+        // NotApplicable.
+        if (OperatingSystem.IsLinux())
+            CurrentDiscovery = new StartupDiscovery(MarkerScanState.Complete, DateTimeOffset.UtcNow);
     }
 
     /// <summary>Resolve a marker-candidate source through the asymmetric matrix. Because a recordless

--- a/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
@@ -24,7 +24,8 @@ namespace Capacitor.Cli.Daemon.Services;
 /// </list>
 /// </summary>
 internal sealed class OrphanReaper(
-        AgentPidRecordStore store, string daemonId, string currentEpoch, ILogger logger) {
+        AgentPidRecordStore store, string daemonId, string currentEpoch, ILogger logger,
+        Action<string, string, string?, string?>? onRecordResolved = null) {
     /// <summary>Run both passes once. Best-effort throughout — a failure on one process never aborts the
     /// sweep of the others.</summary>
     public async Task ReapOnceAsync(CancellationToken ct = default) {
@@ -54,6 +55,13 @@ internal sealed class OrphanReaper(
             try {
                 var confirmedGone = await ProcessReaper.ReapByRecordAsync(record, logger, ct);
                 if (confirmedGone) {
+                    // Phase B2-b (sequenced-settlement design §4.2.4): ledger-append BEFORE
+                    // source-deletion. A crash between the two leaves a committed entry + leftover
+                    // source; the next boot re-derives it and Upsert (idempotent on the source-stable
+                    // (AgentId, OldEpoch) key) collapses onto the committed entry, then deletes the
+                    // leftover. Flow fields come from the TRUSTED record. Emitted ONLY for this
+                    // positive confirmed-gone branch — never for spared/ambiguous records.
+                    onRecordResolved?.Invoke(record.AgentId, record.DaemonEpoch, record.FlowRunId, record.FlowRole);
                     store.Delete(record.AgentId); // killed+confirmed, already-gone, or proven identity mismatch
                     logger.LogInformation(
                         "OrphanReaper: reaped leftover agent {AgentId} (pid {Pid}) from a prior daemon run",

--- a/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/OrphanReaper.cs
@@ -63,8 +63,11 @@ internal sealed class OrphanReaper(
     /// check — a source on disk is a blocking candidate until the resolution matrix clears it. Flow
     /// identity is unknown for a recordless survivor (the env is untrusted), so it is omitted.</item>
     /// </list>
-    /// Flow fields for the record-tracked reasons come from the TRUSTED durable record. Uses the
-    /// ctor-injected <c>markerStore</c>/<c>store</c>/<c>currentEpoch</c>.</summary>
+    /// A THIRD arm catches EVERY OTHER prior-epoch record still on disk (a Present record the record pass
+    /// SPARED — a transient ambiguous identity read on Linux, or a record-pass fault): confirmed-dead
+    /// records are deleted at reap time, so any survivor is unresolved and blocks (identity_unresolvable),
+    /// never silently omitted. Flow fields for the record-tracked reasons come from the TRUSTED durable
+    /// record. Uses the ctor-injected <c>markerStore</c>/<c>store</c>/<c>currentEpoch</c>.</summary>
     public IReadOnlyList<UnresolvedStartupCandidate> BlockedCandidates() {
         var list = new List<UnresolvedStartupCandidate>();
         foreach (var r in store.ReadAll()) {
@@ -73,6 +76,15 @@ internal sealed class OrphanReaper(
                 list.Add(new(r.AgentId, StartupCandidateUnresolvedReason.IdentityUnresolvable, r.FlowRunId, r.FlowRole));
             else if (OperatingSystem.IsMacOS() && ProcessIdentity.IsAlive(r.Pid) && ProcessIdentity.MatchesTri(r.Pid, r.StartIdentity) is null)
                 list.Add(new(r.AgentId, StartupCandidateUnresolvedReason.LegacyUnresolvable, r.FlowRunId, r.FlowRole));
+            else
+                // Phase B2-b (sequenced-settlement design §5.5): any OTHER prior-epoch record still on disk
+                // was SPARED by the record pass (a transient ambiguous identity read on Linux, or a
+                // record-pass fault) — NOT confirmed dead. The spec requires completion to stay false until
+                // every record is confirmed dead, so it blocks (identity_unresolvable). Confirmed-dead
+                // records are already deleted, so this never fires for a resolved one; a record whose
+                // process died between passes blocks only until the next reap tick deletes it (safe — a
+                // false-incomplete only delays relaunch, never mints a duplicate).
+                list.Add(new(r.AgentId, StartupCandidateUnresolvedReason.IdentityUnresolvable, r.FlowRunId, r.FlowRole));
         }
         foreach (var m in markerStore?.ReadAll() ?? [])
             list.Add(new(m.AgentId, StartupCandidateUnresolvedReason.PendingMarker));

--- a/src/Capacitor.Cli.Daemon/Services/ResolvedCandidatesLedger.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ResolvedCandidatesLedger.cs
@@ -32,9 +32,17 @@ internal sealed partial class ResolvedCandidatesLedger {
         lock (_lock) {
             var key = (agentId, oldEpoch);
             if (_entries.TryGetValue(key, out var existing)) return existing; // idempotent — no new generation
-            var entry = new ResolvedStartupCandidate(_nextGeneration++, agentId, oldEpoch, flowRunId, flowRole);
+            var entry = new ResolvedStartupCandidate(_nextGeneration, agentId, oldEpoch, flowRunId, flowRole);
             _entries[key] = entry;
-            Persist();
+            // Phase B2-b (sequenced-settlement design §5.5): persist the PROSPECTIVE state (with the
+            // post-increment high-water) BEFORE committing the counter in memory, and roll back the
+            // in-memory entry if the durable write throws — so memory never leads disk. A leftover
+            // in-memory-only entry would otherwise satisfy the next sweep's idempotent short-circuit above
+            // WITHOUT persisting, and the caller would then delete the durable source (append-before-delete
+            // is the invariant that keeps a crash re-derivable).
+            try { PersistState(_nextGeneration + 1); }
+            catch { _entries.Remove(key); throw; }
+            _nextGeneration++; // commit the counter only after a durable write succeeded
             return entry;
         }
     }
@@ -73,10 +81,15 @@ internal sealed partial class ResolvedCandidatesLedger {
         }
     }
 
-    void Persist() {
+    // Ack removes an entry then persists. A persist failure there leaves memory BEHIND disk, which is
+    // benign: the entry re-loads + re-reports on the next restart and the server re-acks it idempotently.
+    // So this direction needs NO rollback (only Upsert's memory-leads-disk direction does).
+    void Persist() => PersistState(_nextGeneration);
+
+    void PersistState(long nextGeneration) {
         var tmp = _path + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
         File.WriteAllText(tmp, JsonSerializer.Serialize(
-            new Persisted(_nextGeneration, [.. _entries.Values]), LedgerJsonCtx.Default.Persisted));
+            new Persisted(nextGeneration, [.. _entries.Values]), LedgerJsonCtx.Default.Persisted));
         File.Move(tmp, _path, overwrite: true); // atomic same-directory rename
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/ResolvedCandidatesLedger.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ResolvedCandidatesLedger.cs
@@ -51,6 +51,12 @@ internal sealed partial class ResolvedCandidatesLedger {
         lock (_lock) return [.. _entries.Values.OrderBy(e => e.Generation)];
     }
 
+    /// <summary>Phase B2-b (sequenced-settlement design §5.5): the daemon-lifetime monotonic high-water
+    /// of minted generations — 0 before any mint, N after N distinct Upserts. Persists across prunes and
+    /// restarts (<see cref="_nextGeneration"/> is never decremented and Load restores it), so once sparse
+    /// acks prune entries the server still learns the generation frontier.</summary>
+    public long HighestResolutionGeneration { get { lock (_lock) return _nextGeneration - 1; } }
+
     public void Ack(IEnumerable<ResolvedCandidateAck> entries) {
         lock (_lock) {
             var changed = false;

--- a/src/Capacitor.Cli.Daemon/Services/ResolvedCandidatesLedger.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ResolvedCandidatesLedger.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Capacitor.Cli.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Phase B2-b (sequenced-settlement design §4.2.4): the durable outbox of positive per-id death
+/// evidence. Persisted atomically (temp+rename) in the daemon state dir; the monotonic
+/// <c>Generation</c> counter persists WITH it (spans epochs + restarts). Upsert is idempotent on the
+/// source-stable <c>(AgentId, OldEpoch)</c> key — the same key never mints a second entry, so a
+/// crash-reconciled re-append (source leftover matched by <c>(AgentId, OldEpoch)</c>) collapses onto
+/// the committed entry. <c>Generation</c> is the server-facing ack/ordering id only. Entries are
+/// re-reported every connect/report until <see cref="Ack"/> prunes them sparsely.
+/// </summary>
+internal sealed partial class ResolvedCandidatesLedger {
+    readonly string _path;
+    readonly ILogger _logger;
+    readonly object _lock = new();
+    readonly Dictionary<(string AgentId, string OldEpoch), ResolvedStartupCandidate> _entries = new();
+    long _nextGeneration = 1;
+
+    public ResolvedCandidatesLedger(string stateDir, ILogger logger) {
+        Directory.CreateDirectory(stateDir);
+        _path = Path.Combine(stateDir, "resolved-candidates.json");
+        _logger = logger;
+        Load();
+    }
+
+    public ResolvedStartupCandidate Upsert(string agentId, string oldEpoch, string? flowRunId, string? flowRole) {
+        lock (_lock) {
+            var key = (agentId, oldEpoch);
+            if (_entries.TryGetValue(key, out var existing)) return existing; // idempotent — no new generation
+            var entry = new ResolvedStartupCandidate(_nextGeneration++, agentId, oldEpoch, flowRunId, flowRole);
+            _entries[key] = entry;
+            Persist();
+            return entry;
+        }
+    }
+
+    public IReadOnlyList<ResolvedStartupCandidate> Snapshot() {
+        lock (_lock) return [.. _entries.Values.OrderBy(e => e.Generation)];
+    }
+
+    public void Ack(IEnumerable<ResolvedCandidateAck> entries) {
+        lock (_lock) {
+            var changed = false;
+            foreach (var a in entries) {
+                var key = (a.AgentId, a.OldEpoch);
+                if (_entries.TryGetValue(key, out var e) && e.Generation == a.Generation)
+                    changed |= _entries.Remove(key);
+            }
+            if (changed) Persist();
+        }
+    }
+
+    // ── durable state (persist the entries AND the generation high-water together) ────────────────
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+    [JsonSerializable(typeof(Persisted))]
+    partial class LedgerJsonCtx : JsonSerializerContext;
+
+    readonly record struct Persisted(long NextGeneration, ResolvedStartupCandidate[] Entries);
+
+    void Load() {
+        try {
+            if (!File.Exists(_path)) return;
+            var p = JsonSerializer.Deserialize(File.ReadAllText(_path), LedgerJsonCtx.Default.Persisted);
+            _nextGeneration = Math.Max(1, p.NextGeneration);
+            foreach (var e in p.Entries ?? []) _entries[(e.AgentId, e.OldEpoch)] = e;
+        } catch (Exception ex) {
+            _logger.LogWarning(ex, "ResolvedCandidatesLedger: unreadable ledger — starting empty (re-derived from sources next boot)");
+        }
+    }
+
+    void Persist() {
+        var tmp = _path + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
+        File.WriteAllText(tmp, JsonSerializer.Serialize(
+            new Persisted(_nextGeneration, [.. _entries.Values]), LedgerJsonCtx.Default.Persisted));
+        File.Move(tmp, _path, overwrite: true); // atomic same-directory rename
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
@@ -63,6 +63,9 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
             if (item.Seq != _highestAcceptedSeq + 1)
                 return HandleNonNextLocked(item);                              // Task 15 sends wrong_next
 
+            if (_cache.Count >= _cacheBound)                                   // never evict unacked identity
+                return RejectLocked(item, CommandRejectedReason.Backpressure); // reopens only via a validated AckProcessedPrefix
+
             // ACCEPT + lane-item, atomically under _lock.
             _highestAcceptedSeq = item.Seq;
             _cache[item.Seq] = new CacheEntry { CommandId = item.CommandId, Processed = false };
@@ -157,7 +160,23 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
         }
     }
 
-    public void AckPrefix(AckProcessedPrefix ack) { /* Task 14 */ }
+    /// <summary>Phase B2-b (sequenced-settlement design): retire per-epoch identity-cache entries through a
+    /// VALIDATED <c>AckProcessedPrefix</c> — current epoch, not over-ahead of the processed prefix, strictly
+    /// monotonic. An unacked entry is NEVER evicted (that is the backpressure contract's other half). Called
+    /// off the hub, so it takes <c>_lock</c> itself.</summary>
+    public void AckPrefix(AckProcessedPrefix ack) {
+        lock (_lock) {
+            if (!string.Equals(ack.Epoch, _epoch, StringComparison.Ordinal)) return; // stale epoch — not our lane
+            if (ack.UpToSeq > _lastProcessedSeq) return;                              // over-ahead of the processed prefix
+            if (ack.UpToSeq <= _lastAckedPrefix) return;                              // regressing / duplicate ack
+            _lastAckedPrefix = ack.UpToSeq;
+            List<long>? toRemove = null;
+            foreach (var seq in _cache.Keys)
+                if (seq <= ack.UpToSeq) (toRemove ??= []).Add(seq);
+            if (toRemove is not null)
+                foreach (var seq in toRemove) _cache.Remove(seq);
+        }
+    }
 
     public async ValueTask DisposeAsync() {
         _lane.Writer.TryComplete();

--- a/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Threading.Channels;
 using Capacitor.Cli.Core;
 using Microsoft.Extensions.Logging;
@@ -95,11 +96,25 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
             // CurrentState is read LIVE at ack time (immutable execution fact vs current liveness);
             // the readLiveness delegate reads the daemon lifecycle collections with confirmed-death precedence.
             var live = _readLiveness(existing.Outcome.AgentId ?? item.AgentId);
+            // Phase B2-b (sequenced-settlement design §5.5): carry the CACHED rejection reason so a
+            // retransmitted duplicate of a rejected launch is still distinguishable as daemon_capacity
+            // (requeue) vs semantic (fail) — the exact lost-rejection case the identity cache answers.
+            var reason = existing.Outcome.RejectReason is { } r ? RejectReasonWireToken(r) : null;
             _ = _sendAck(new CommandAck(_epoch, item.Seq, item.CommandId, CommandAckState.Processed,
-                existing.Outcome.Kind, live, existing.Outcome.AgentId ?? item.AgentId, existing.Outcome.SessionId));
+                existing.Outcome.Kind, live, existing.Outcome.AgentId ?? item.AgentId, existing.Outcome.SessionId, reason));
         }
         return Task.CompletedTask;
     }
+
+    /// <summary>Phase B2-b (sequenced-settlement design §5.5): the wire token a cached
+    /// <see cref="CommandRejectedReason"/> carries on a processed-duplicate <see cref="CommandAck"/> —
+    /// serialized through the SAME context the SignalR hub uses for <c>CommandRejected.Reason</c>, so a
+    /// retransmitted duplicate reads <c>daemon_capacity</c>/<c>semantic</c> identically to the first
+    /// rejection (the ack's <c>RejectionReason</c> is a STRING; the outcome's <c>RejectReason</c> is the
+    /// enum). NEVER <c>.ToString()</c> — that emits the C# name, not the <c>[JsonStringEnumMemberName]</c>
+    /// snake_case token.</summary>
+    static string RejectReasonWireToken(CommandRejectedReason reason) =>
+        JsonSerializer.Serialize(reason, CapacitorJsonContext.Default.CommandRejectedReason).Trim('"');
 
     /// <summary>Phase B2-b (sequenced-settlement design): a non-next Seq (a gap — Seq &gt; HighestAcceptedSeq+1,
     /// or a too-low already-retired Seq below the frontier) is NEVER accepted out of order. Emit wrong_next so

--- a/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
@@ -101,8 +101,10 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
         return Task.CompletedTask;
     }
 
-    // Task 12 stub (replaced in a later task):
-    Task HandleNonNextLocked(SequencedItem item) => Task.CompletedTask;
+    /// <summary>Phase B2-b (sequenced-settlement design): a non-next Seq (a gap — Seq &gt; HighestAcceptedSeq+1,
+    /// or a too-low already-retired Seq below the frontier) is NEVER accepted out of order. Emit wrong_next so
+    /// the server's transport sequencer resyncs (nudge → observe → retransmit); accept path + watermark untouched.</summary>
+    Task HandleNonNextLocked(SequencedItem item) => RejectLocked(item, CommandRejectedReason.WrongNext);
 
     Task RejectLocked(SequencedItem item, CommandRejectedReason reason) {
         _ = _sendRejected(new CommandRejected(item.Epoch, item.Seq, item.CommandId, reason, item.AgentId));

--- a/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
@@ -75,8 +75,30 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
         }
     }
 
-    // Task 12 stubs (replaced in later tasks):
-    Task HandleDuplicateLocked(SequencedItem item, CacheEntry existing) => Task.CompletedTask;
+    /// <summary>Phase B2-b (sequenced-settlement design): an exact-duplicate <c>(Epoch, Seq, CommandId)</c>
+    /// is ANSWERED, never re-executed — <c>Accepted</c> while still processing, or <c>Processed</c> with the
+    /// cached <c>OutcomeKind</c> + a LIVE <c>CurrentState</c> read. A DIFFERENT CommandId at an already-accepted
+    /// Seq is a protocol-invariant violation → <c>duplicate_collision</c>. Called under <c>_lock</c>.</summary>
+    Task HandleDuplicateLocked(SequencedItem item, CacheEntry existing) {
+        if (!string.Equals(existing.CommandId, item.CommandId, StringComparison.Ordinal)) {
+            // A DIFFERENT command claiming an accepted Seq — protocol invariant violation.
+            _ = _sendRejected(new CommandRejected(item.Epoch, item.Seq, item.CommandId, CommandRejectedReason.DuplicateCollision, item.AgentId));
+            return Task.CompletedTask;
+        }
+
+        if (!existing.Processed) {
+            _ = _sendAck(new CommandAck(_epoch, item.Seq, item.CommandId, CommandAckState.Accepted));
+        } else {
+            // CurrentState is read LIVE at ack time (immutable execution fact vs current liveness);
+            // the readLiveness delegate reads the daemon lifecycle collections with confirmed-death precedence.
+            var live = _readLiveness(existing.Outcome.AgentId ?? item.AgentId);
+            _ = _sendAck(new CommandAck(_epoch, item.Seq, item.CommandId, CommandAckState.Processed,
+                existing.Outcome.Kind, live, existing.Outcome.AgentId ?? item.AgentId, existing.Outcome.SessionId));
+        }
+        return Task.CompletedTask;
+    }
+
+    // Task 12 stub (replaced in a later task):
     Task HandleNonNextLocked(SequencedItem item) => Task.CompletedTask;
 
     Task RejectLocked(SequencedItem item, CommandRejectedReason reason) {

--- a/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
@@ -1,0 +1,144 @@
+using System.Threading.Channels;
+using Capacitor.Cli.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+internal enum SequencedKind { Launch, Stop }
+
+internal readonly record struct SequencedItem(
+    SequencedKind Kind, string Epoch, long Seq, string CommandId, string AgentId);
+
+internal readonly record struct CommandOutcome(
+    CommandOutcomeKind Kind, string? AgentId = null, string? SessionId = null, CommandRejectedReason? RejectReason = null);
+
+/// <summary>
+/// Phase B2-b (sequenced-settlement design §4.2.2; parent §5.5): the daemon's two-lane sequenced
+/// command handler. Exactly two command types are sequenced (Seq'd LaunchAgentCommand + StopAgentV2),
+/// executed strictly serially per epoch. Acceptance (bump HighestAcceptedSeq + cache entry + enqueue)
+/// is one atomic operation under <c>_lock</c>; LastProcessedSeq is the contiguous terminal prefix
+/// (advances only on a terminal outcome). Self-contained + delegate-injected so it is unit-testable
+/// with no live orchestrator (mirrors OrphanReaper/AgentKillQuarantine).
+/// </summary>
+internal sealed class SequencedCommandProcessor : IAsyncDisposable {
+    sealed class CacheEntry { public required string CommandId; public bool Processed; public CommandOutcome Outcome; }
+    readonly record struct LaneItem(SequencedItem Item, Func<Task<CommandOutcome>> Execute, TaskCompletionSource Done);
+
+    readonly string _epoch;
+    readonly Func<string, AgentLiveness> _readLiveness;
+    readonly Func<CommandAck, Task> _sendAck;
+    readonly Func<CommandRejected, Task> _sendRejected;
+    readonly ILogger _logger;
+    readonly int _cacheBound;
+
+    readonly object _lock = new();
+    long _highestAcceptedSeq;
+    long _lastProcessedSeq;
+    long _lastAckedPrefix;
+    readonly Dictionary<long, CacheEntry> _cache = new();
+    readonly Channel<LaneItem> _lane = Channel.CreateUnbounded<LaneItem>(new UnboundedChannelOptions { SingleReader = true });
+    readonly Task _laneTask;
+
+    public SequencedCommandProcessor(
+            string epoch, Func<string, AgentLiveness> readLiveness,
+            Func<CommandAck, Task> sendAck, Func<CommandRejected, Task> sendRejected,
+            ILogger logger, int cacheBound = 256) {
+        _epoch = epoch; _readLiveness = readLiveness; _sendAck = sendAck; _sendRejected = sendRejected;
+        _logger = logger; _cacheBound = cacheBound;
+        _laneTask = Task.Run(RunLaneAsync);
+    }
+
+    public string Epoch => _epoch;
+    public long HighestAcceptedSeq { get { lock (_lock) return _highestAcceptedSeq; } }
+    public long LastProcessedSeq   { get { lock (_lock) return _lastProcessedSeq; } }
+
+    public Task SubmitAsync(SequencedItem item, Func<Task<CommandOutcome>> execute) {
+        lock (_lock) {
+            if (!string.Equals(item.Epoch, _epoch, StringComparison.Ordinal))
+                return RejectLocked(item, CommandRejectedReason.StaleEpoch);   // never touches THIS epoch's lane
+
+            if (_cache.TryGetValue(item.Seq, out var existing))
+                return HandleDuplicateLocked(item, existing);                   // Task 13 answers with CommandAck
+
+            if (item.Seq != _highestAcceptedSeq + 1)
+                return HandleNonNextLocked(item);                              // Task 15 sends wrong_next
+
+            // ACCEPT + lane-item, atomically under _lock.
+            _highestAcceptedSeq = item.Seq;
+            _cache[item.Seq] = new CacheEntry { CommandId = item.CommandId, Processed = false };
+            var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (!_lane.Writer.TryWrite(new LaneItem(item, execute, done))) {
+                SynthesizeErrorLocked(item); // shutdown/allocation race: watermark must still advance
+                done.SetResult();
+            }
+            return done.Task;
+        }
+    }
+
+    // Task 12 stubs (replaced in later tasks):
+    Task HandleDuplicateLocked(SequencedItem item, CacheEntry existing) => Task.CompletedTask;
+    Task HandleNonNextLocked(SequencedItem item) => Task.CompletedTask;
+
+    Task RejectLocked(SequencedItem item, CommandRejectedReason reason) {
+        _ = _sendRejected(new CommandRejected(item.Epoch, item.Seq, item.CommandId, reason, item.AgentId));
+        return Task.CompletedTask;
+    }
+
+    void SynthesizeErrorLocked(SequencedItem item) {
+        // Lane-item creation failed AFTER acceptance (shutdown/allocation race) — an advertised-accepted
+        // Seq with no processable item is impossible, so mark this Seq terminally errored and advance the
+        // watermark THROUGH THE CONTIGUOUS PREFIX only. NEVER set _lastProcessedSeq = item.Seq directly:
+        // if the lane is completing while an earlier accepted item is still draining, a direct jump to N
+        // would (a) advertise a non-contiguous prefix and (b) be regressed below when the earlier item's
+        // consumer later advances to N-1. AdvanceWatermarkLocked is monotonic + contiguous by construction.
+        _cache[item.Seq] = new CacheEntry {
+            CommandId = item.CommandId, Processed = true,
+            Outcome = new CommandOutcome(CommandOutcomeKind.InternalError, item.AgentId) };
+        AdvanceWatermarkLocked();
+        _ = _sendRejected(new CommandRejected(item.Epoch, item.Seq, item.CommandId, CommandRejectedReason.InternalError, item.AgentId));
+    }
+
+    /// <summary>The watermark is the contiguous terminal-processed prefix. Walk forward through Processed
+    /// cache entries from _lastProcessedSeq+1 so a synthesized out-of-order terminal (a shutdown race)
+    /// never advances past a still-draining earlier item, and no advance can ever regress the watermark
+    /// (monotonic by construction). Retired seqs are always &lt;= _lastProcessedSeq, so the walk is safe.</summary>
+    void AdvanceWatermarkLocked() {
+        while (_cache.TryGetValue(_lastProcessedSeq + 1, out var next) && next.Processed)
+            _lastProcessedSeq++;
+    }
+
+    /// <summary>Test seam: complete the lane writer so a subsequent accepted Submit's TryWrite fails,
+    /// forcing the SynthesizeErrorLocked path deterministically (mirrors a shutdown race).</summary>
+    internal void CompleteLaneForTest() => _lane.Writer.TryComplete();
+
+    async Task RunLaneAsync() {
+        await foreach (var li in _lane.Reader.ReadAllAsync()) {
+            CommandOutcome outcome;
+            try {
+                outcome = await li.Execute();
+            } catch (Exception ex) {
+                _logger.LogWarning(ex, "SequencedCommandProcessor: execution faulted for seq {Seq} — internal_error", li.Item.Seq);
+                outcome = new CommandOutcome(CommandOutcomeKind.InternalError, li.Item.AgentId);
+                _ = _sendRejected(new CommandRejected(li.Item.Epoch, li.Item.Seq, li.Item.CommandId, CommandRejectedReason.InternalError, li.Item.AgentId));
+            }
+
+            // Task 15: an execution-time terminal rejection (daemon_capacity / semantic) emits CommandRejected.
+            if (outcome.Kind == CommandOutcomeKind.LaunchRejected && outcome.RejectReason is { } r)
+                _ = _sendRejected(new CommandRejected(li.Item.Epoch, li.Item.Seq, li.Item.CommandId, r, li.Item.AgentId));
+
+            lock (_lock) {
+                if (_cache.TryGetValue(li.Item.Seq, out var e)) { e.Processed = true; e.Outcome = outcome; }
+                AdvanceWatermarkLocked(); // contiguous terminal prefix — serial lane => normally == prior + 1,
+                                          // but shared with SynthesizeErrorLocked so a race can never regress it
+            }
+            li.Done.SetResult();
+        }
+    }
+
+    public void AckPrefix(AckProcessedPrefix ack) { /* Task 14 */ }
+
+    public async ValueTask DisposeAsync() {
+        _lane.Writer.TryComplete();
+        try { await _laneTask; } catch { /* best-effort */ }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -112,6 +112,13 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public Func<UnresolvedStartupCandidate[]>? GetUnresolvedStartupCandidates { get; set; }
     public Func<StartupDiscovery?>?            GetStartupDiscovery            { get; set; }
 
+    /// <summary>Phase B2-b (sequenced-settlement design §5.5): the resolved-candidates ledger's
+    /// daemon-lifetime monotonic high-water, re-advertised on <c>DaemonConnect</c> alongside
+    /// <see cref="GetResolvedStartupCandidates"/> so that once sparse acks prune entries the server still
+    /// knows the generation frontier. Null when unwired (tests / early startup) ⇒ the additive field
+    /// stays null, wire-compatible with old servers.</summary>
+    public Func<long?>?                        GetHighestResolutionGeneration { get; set; }
+
     /// <summary>Phase B2-b (sequenced-settlement design §4.2.2): the sequenced-command watermark counters
     /// (the processor's HighestAcceptedSeq / LastProcessedSeq) and the kill-quarantine snapshot, mirrored
     /// onto the enriched <c>DaemonConnect</c> payload alongside the periodic <c>DaemonStatusReport</c>. Set
@@ -489,7 +496,10 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                     Epoch: GetDaemonEpoch?.Invoke() ?? _config.DaemonEpoch,
                     HighestAcceptedSeq: GetHighestAcceptedSeq?.Invoke(),
                     LastProcessedSeq: GetLastProcessedSeq?.Invoke(),
-                    SupportsSequencedCommands: true
+                    SupportsSequencedCommands: true,
+                    // Phase B2-b (sequenced-settlement design §5.5): the resolved-candidates ledger's
+                    // monotonic high-water alongside the re-advertised snapshot above.
+                    HighestResolutionGeneration: GetHighestResolutionGeneration?.Invoke()
                 ),
                 cancellationToken: _ct
             );

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -90,6 +90,15 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// handler (<see cref="AgentOrchestrator"/>) is SYNCHRONOUS (the ledger Ack is void).</summary>
     public event Action<AckResolvedCandidates>? OnAckResolvedCandidates;
 
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.2/§5.5): the sequenced-command receive seams.
+    /// <see cref="OnStopAgentV2"/> is the Seq'd stop primitive a capability daemon receives instead of the
+    /// legacy <c>StopAgent</c>; <see cref="OnAckProcessedPrefix"/> is the server's identity-cache retirement
+    /// proof (SYNCHRONOUS — the processor's <c>AckPrefix</c> is void); <see cref="OnRequestStatusReport"/> is
+    /// a zero-argument server→daemon nudge answered by an immediate out-of-band <c>DaemonStatusReport</c>.</summary>
+    public event Func<StopAgentV2, Task>?    OnStopAgentV2;
+    public event Action<AckProcessedPrefix>? OnAckProcessedPrefix;
+    public event Func<Task>?                 OnRequestStatusReport;
+
     /// <summary>Phase B2-b (sequenced-settlement design §4.2.4): snapshot of the un-acked resolved-
     /// candidates ledger, re-advertised on <c>DaemonConnect</c> (mirrors <see cref="GetLiveAgents"/>).
     /// Optional — null when not wired (tests / early startup) ⇒ no candidates advertised.</summary>
@@ -103,6 +112,15 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public Func<UnresolvedStartupCandidate[]>? GetUnresolvedStartupCandidates { get; set; }
     public Func<StartupDiscovery?>?            GetStartupDiscovery            { get; set; }
 
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.2): the sequenced-command watermark counters
+    /// (the processor's HighestAcceptedSeq / LastProcessedSeq) and the kill-quarantine snapshot, mirrored
+    /// onto the enriched <c>DaemonConnect</c> payload alongside the periodic <c>DaemonStatusReport</c>. Set
+    /// by <see cref="AgentOrchestrator"/> at startup; null (tests / early startup) ⇒ the additive fields
+    /// stay at their defaults, wire-compatible with old servers.</summary>
+    public Func<long?>?                  GetHighestAcceptedSeq { get; set; }
+    public Func<long?>?                  GetLastProcessedSeq   { get; set; }
+    public Func<QuarantinedAgentInfo[]>? GetQuarantined        { get; set; }
+
     /// <summary>Phase B (D2): send the periodic daemon self-report ONE-WAY (never
     /// <c>InvokeAsync</c>) — an old server without the <c>DaemonStatusReport</c> handler produces only
     /// a server-side log line, and any send exception is swallowed so the agent loops are untouched.
@@ -111,6 +129,22 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         if (!IsReady) return;
         try { await _hub.SendAsync("DaemonStatusReport", report, cancellationToken: _ct); }
         catch (Exception ex) { _logger.LogDebug(ex, "DaemonStatusReport send failed (old server or transient)"); }
+    }
+
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.2): answer a sequenced command ONE-WAY (never
+    /// <c>InvokeAsync</c>) — an old server without the <c>CommandAck</c>/<c>CommandRejected</c> handler
+    /// produces only a server-side log line, and any send exception is swallowed so the agent loops are
+    /// untouched. Virtual so tests can capture the sends without a live hub.</summary>
+    public virtual async Task CommandAckAsync(CommandAck ack) {
+        if (!IsReady) return;
+        try { await _hub.SendAsync("CommandAck", ack, cancellationToken: _ct); }
+        catch (Exception ex) { _logger.LogDebug(ex, "CommandAck send failed (old server or transient)"); }
+    }
+
+    public virtual async Task CommandRejectedAsync(CommandRejected rej) {
+        if (!IsReady) return;
+        try { await _hub.SendAsync("CommandRejected", rej, cancellationToken: _ct); }
+        catch (Exception ex) { _logger.LogDebug(ex, "CommandRejected send failed (old server or transient)"); }
     }
 
     public ServerConnection(DaemonConfig config, ILoggerFactory loggerFactory, ILogger<ServerConnection> logger) {
@@ -166,6 +200,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         // resolved-candidates ledger per-entry. The handler is SYNCHRONOUS (the ledger Ack is void), so
         // invoke it inline and return a completed task — no work is awaited.
         _hub.On<AckResolvedCandidates>("AckResolvedCandidates", ack => { OnAckResolvedCandidates?.Invoke(ack); return Task.CompletedTask; });
+
+        // Phase B2-b (sequenced-settlement design §4.2.2): the sequenced-command receive seams. StopAgentV2
+        // routes through SafeInvoke like every other command handler; AckProcessedPrefix + RequestStatusReport
+        // are synchronous/no-arg (the prefix ack is a void state mutation; the status-report nudge is answered
+        // out-of-band), so they invoke inline and return a completed task.
+        _hub.On<StopAgentV2>("StopAgentV2", cmd => SafeInvoke("StopAgentV2", () => OnStopAgentV2?.Invoke(cmd)));
+        _hub.On<AckProcessedPrefix>("AckProcessedPrefix", ack => { OnAckProcessedPrefix?.Invoke(ack); return Task.CompletedTask; });
+        _hub.On("RequestStatusReport", () => OnRequestStatusReport?.Invoke() ?? Task.CompletedTask);
 
         // Client-result invocations for per-phase eval dispatch.
         _hub.On<PrepareEvalCommand, PrepareResult>("PrepareEval",
@@ -428,7 +470,17 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                     // defaults, wire-compatible with old servers.
                     StartupReapComplete: GetStartupReapComplete?.Invoke(),
                     UnresolvedStartupCandidates: GetUnresolvedStartupCandidates?.Invoke(),
-                    StartupDiscovery: GetStartupDiscovery?.Invoke()
+                    StartupDiscovery: GetStartupDiscovery?.Invoke(),
+                    // Phase B2-b (sequenced-settlement design §4.2.2): the sequenced-settlement capability
+                    // + its epoch/watermark counters + the kill-quarantine snapshot. SupportsSequencedCommands
+                    // is THE gate: advertised true here but inert until the paired server PR consumes it. Epoch
+                    // is the shipped per-boot _daemonEpoch (set by DaemonRunner before services build, so the
+                    // connect epoch and the orchestrator's _daemonEpoch agree).
+                    Quarantined: GetQuarantined?.Invoke(),
+                    Epoch: _config.DaemonEpoch,
+                    HighestAcceptedSeq: GetHighestAcceptedSeq?.Invoke(),
+                    LastProcessedSeq: GetLastProcessedSeq?.Invoke(),
+                    SupportsSequencedCommands: true
                 ),
                 cancellationToken: _ct
             );

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -391,7 +391,11 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                 new DaemonConnect(
                     _config.Name, platform, repoPaths, _config.MaxConcurrentAgents, liveIds,
                     _config.InstanceId, _config.Version, _config.SupportedVendors, MachineId.Get(), liveAgents,
-                    _config.UnattendedVendors
+                    _config.UnattendedVendors,
+                    // Phase B2-b (sequenced-settlement design §4.2.3): advertise the durable coverage
+                    // boot-chain verdict. The full enriched sequenced-settlement payload lands in a
+                    // later task; for now this single additive field is wire-compatible with old servers.
+                    RecordlessSurvivorsImpossible: _config.RecordlessSurvivorsImpossible
                 ),
                 cancellationToken: _ct
             );

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -121,6 +121,13 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public Func<long?>?                  GetLastProcessedSeq   { get; set; }
     public Func<QuarantinedAgentInfo[]>? GetQuarantined        { get; set; }
 
+    /// <summary>Phase B2-b (sequenced-settlement design): the daemon's per-boot epoch, advertised on
+    /// <c>DaemonConnect</c>. Set by <see cref="AgentOrchestrator"/> to return its own <c>_daemonEpoch</c>
+    /// so the connect epoch and the orchestrator/processor epoch read ONE source (no test-divergence
+    /// footgun). Null when unwired (tests / early startup) ⇒ falls back to <c>_config.DaemonEpoch</c>,
+    /// which <c>DaemonRunner</c> pins before services build, so prod behaviour is unchanged.</summary>
+    public Func<string?>?                GetDaemonEpoch        { get; set; }
+
     /// <summary>Phase B (D2): send the periodic daemon self-report ONE-WAY (never
     /// <c>InvokeAsync</c>) — an old server without the <c>DaemonStatusReport</c> handler produces only
     /// a server-side log line, and any send exception is swallowed so the agent loops are untouched.
@@ -202,12 +209,12 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         _hub.On<AckResolvedCandidates>("AckResolvedCandidates", ack => { OnAckResolvedCandidates?.Invoke(ack); return Task.CompletedTask; });
 
         // Phase B2-b (sequenced-settlement design §4.2.2): the sequenced-command receive seams. StopAgentV2
-        // routes through SafeInvoke like every other command handler; AckProcessedPrefix + RequestStatusReport
-        // are synchronous/no-arg (the prefix ack is a void state mutation; the status-report nudge is answered
-        // out-of-band), so they invoke inline and return a completed task.
+        // and RequestStatusReport route through SafeInvoke like every other command handler (so a throwing
+        // handler is logged, not surfaced to the hub); AckProcessedPrefix is a synchronous void state
+        // mutation, so it invokes inline and returns a completed task.
         _hub.On<StopAgentV2>("StopAgentV2", cmd => SafeInvoke("StopAgentV2", () => OnStopAgentV2?.Invoke(cmd)));
         _hub.On<AckProcessedPrefix>("AckProcessedPrefix", ack => { OnAckProcessedPrefix?.Invoke(ack); return Task.CompletedTask; });
-        _hub.On("RequestStatusReport", () => OnRequestStatusReport?.Invoke() ?? Task.CompletedTask);
+        _hub.On("RequestStatusReport", () => SafeInvoke("RequestStatusReport", () => OnRequestStatusReport?.Invoke()));
 
         // Client-result invocations for per-phase eval dispatch.
         _hub.On<PrepareEvalCommand, PrepareResult>("PrepareEval",
@@ -474,10 +481,12 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                     // Phase B2-b (sequenced-settlement design §4.2.2): the sequenced-settlement capability
                     // + its epoch/watermark counters + the kill-quarantine snapshot. SupportsSequencedCommands
                     // is THE gate: advertised true here but inert until the paired server PR consumes it. Epoch
-                    // is the shipped per-boot _daemonEpoch (set by DaemonRunner before services build, so the
-                    // connect epoch and the orchestrator's _daemonEpoch agree).
+                    // is read from the orchestrator's own per-boot _daemonEpoch via GetDaemonEpoch — the SINGLE
+                    // source the orchestrator + processor use — so the connect epoch can't diverge from it.
+                    // Unwired (tests / early startup) falls back to _config.DaemonEpoch, which DaemonRunner
+                    // pins before services build, so prod behaviour is unchanged.
                     Quarantined: GetQuarantined?.Invoke(),
-                    Epoch: _config.DaemonEpoch,
+                    Epoch: GetDaemonEpoch?.Invoke() ?? _config.DaemonEpoch,
                     HighestAcceptedSeq: GetHighestAcceptedSeq?.Invoke(),
                     LastProcessedSeq: GetLastProcessedSeq?.Invoke(),
                     SupportsSequencedCommands: true

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -85,6 +85,16 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// <see cref="GetLiveAgentIds"/> on <c>DaemonConnect</c>. Optional — null when not wired (tests).</summary>
     public Func<LiveAgentInfo[]>? GetLiveAgents { get; set; }
 
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.4): the server prunes the daemon's durable
+    /// resolved-candidates ledger per-entry (sparse, deliver-once). One-way server→daemon receive; the
+    /// handler (<see cref="AgentOrchestrator"/>) is SYNCHRONOUS (the ledger Ack is void).</summary>
+    public event Action<AckResolvedCandidates>? OnAckResolvedCandidates;
+
+    /// <summary>Phase B2-b (sequenced-settlement design §4.2.4): snapshot of the un-acked resolved-
+    /// candidates ledger, re-advertised on <c>DaemonConnect</c> (mirrors <see cref="GetLiveAgents"/>).
+    /// Optional — null when not wired (tests / early startup) ⇒ no candidates advertised.</summary>
+    public Func<ResolvedStartupCandidate[]>? GetResolvedStartupCandidates { get; set; }
+
     /// <summary>Phase B (D2): send the periodic daemon self-report ONE-WAY (never
     /// <c>InvokeAsync</c>) — an old server without the <c>DaemonStatusReport</c> handler produces only
     /// a server-side log line, and any send exception is swallowed so the agent loops are untouched.
@@ -143,6 +153,11 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         // instead of resizing the PTY to 0×0 — graceful degradation during a non-atomic CLI/server
         // rollout.
         _hub.On<ResizeTerminalCommand>("ResizeTerminalAggregate", cmd => SafeInvoke("ResizeTerminalAggregate", () => OnResizeTerminal?.Invoke(cmd)));
+
+        // Phase B2-b (sequenced-settlement design §4.2.4): one-way server→daemon receive that prunes the
+        // resolved-candidates ledger per-entry. The handler is SYNCHRONOUS (the ledger Ack is void), so
+        // invoke it inline and return a completed task — no work is awaited.
+        _hub.On<AckResolvedCandidates>("AckResolvedCandidates", ack => { OnAckResolvedCandidates?.Invoke(ack); return Task.CompletedTask; });
 
         // Client-result invocations for per-phase eval dispatch.
         _hub.On<PrepareEvalCommand, PrepareResult>("PrepareEval",
@@ -392,10 +407,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                     _config.Name, platform, repoPaths, _config.MaxConcurrentAgents, liveIds,
                     _config.InstanceId, _config.Version, _config.SupportedVendors, MachineId.Get(), liveAgents,
                     _config.UnattendedVendors,
-                    // Phase B2-b (sequenced-settlement design §4.2.3): advertise the durable coverage
-                    // boot-chain verdict. The full enriched sequenced-settlement payload lands in a
-                    // later task; for now this single additive field is wire-compatible with old servers.
-                    RecordlessSurvivorsImpossible: _config.RecordlessSurvivorsImpossible
+                    // Phase B2-b (sequenced-settlement design §4.2.3/§4.2.4): advertise the durable
+                    // coverage boot-chain verdict plus the un-acked resolved-candidates ledger snapshot,
+                    // re-reported on every connect until the server prunes it via AckResolvedCandidates.
+                    // The full enriched sequenced-settlement payload lands in a later task; these
+                    // additive fields are wire-compatible with old servers (ignored) and inert until the
+                    // paired server PR consumes them.
+                    RecordlessSurvivorsImpossible: _config.RecordlessSurvivorsImpossible,
+                    ResolvedStartupCandidates: GetResolvedStartupCandidates?.Invoke()
                 ),
                 cancellationToken: _ct
             );

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -95,6 +95,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// Optional — null when not wired (tests / early startup) ⇒ no candidates advertised.</summary>
     public Func<ResolvedStartupCandidate[]>? GetResolvedStartupCandidates { get; set; }
 
+    /// <summary>Phase B2-b (sequenced-settlement design): the per-platform startup-completeness signals,
+    /// re-advertised on <c>DaemonConnect</c> alongside the periodic <c>DaemonStatusReport</c>. Set by
+    /// <see cref="AgentOrchestrator"/> at startup; optional — null when not wired (tests / early startup)
+    /// ⇒ the additive field defaults (StartupReapComplete/StartupDiscovery null, no blocked candidates).</summary>
+    public Func<bool>?                         GetStartupReapComplete         { get; set; }
+    public Func<UnresolvedStartupCandidate[]>? GetUnresolvedStartupCandidates { get; set; }
+    public Func<StartupDiscovery?>?            GetStartupDiscovery            { get; set; }
+
     /// <summary>Phase B (D2): send the periodic daemon self-report ONE-WAY (never
     /// <c>InvokeAsync</c>) — an old server without the <c>DaemonStatusReport</c> handler produces only
     /// a server-side log line, and any send exception is swallowed so the agent loops are untouched.
@@ -414,7 +422,13 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                     // additive fields are wire-compatible with old servers (ignored) and inert until the
                     // paired server PR consumes them.
                     RecordlessSurvivorsImpossible: _config.RecordlessSurvivorsImpossible,
-                    ResolvedStartupCandidates: GetResolvedStartupCandidates?.Invoke()
+                    ResolvedStartupCandidates: GetResolvedStartupCandidates?.Invoke(),
+                    // Phase B2-b (sequenced-settlement design): the per-platform startup-completeness
+                    // signals. Null getters (tests / early startup) leave the additive fields at their
+                    // defaults, wire-compatible with old servers.
+                    StartupReapComplete: GetStartupReapComplete?.Invoke(),
+                    UnresolvedStartupCandidates: GetUnresolvedStartupCandidates?.Invoke(),
+                    StartupDiscovery: GetStartupDiscovery?.Invoke()
                 ),
                 cancellationToken: _ct
             );

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/CoverageJournalTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/CoverageJournalTests.cs
@@ -1,0 +1,89 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+public class CoverageJournalTests {
+    // Real DaemonLock lifecycle so the InstanceId chain is genuine, never a hand-edited marker.
+    sealed class Harness : IDisposable {
+        public readonly string LockDir  = Path.Combine(Path.GetTempPath(), "kcap-cov-lock", Guid.NewGuid().ToString("N"));
+        public readonly string StateDir = Path.Combine(Path.GetTempPath(), "kcap-cov-state", Guid.NewGuid().ToString("N"));
+        public Harness() { Directory.CreateDirectory(LockDir); Directory.CreateDirectory(StateDir);
+            DaemonLockPaths.OverrideDirectoryForTesting(LockDir); }
+        // One real boot: acquire the lock, record coverage (aware), dispose.
+        public bool AwareBoot(bool contained = true) {
+            using var l = DaemonLock.TryAcquire("alpha")!;
+            return new CoverageJournal(StateDir, NullLogger.Instance)
+                .RecordBoot(l.InstanceId, l.PriorInstanceId, contained);
+        }
+        // An unaware/old boot: acquires the real lock (mints a fresh InstanceId) but writes NO journal.
+        public void UnawareBoot() { using var l = DaemonLock.TryAcquire("alpha")!; }
+        public void Dispose() { DaemonLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(LockDir, true); } catch { } try { Directory.Delete(StateDir, true); } catch { } }
+    }
+
+    [Test] public async Task Genesis_first_ever_contained_boot_seeds_true() {
+        using var h = new Harness();
+        await Assert.That(h.AwareBoot(contained: true)).IsTrue();
+    }
+
+    [Test] public async Task Genesis_uncontained_epoch_is_false() {
+        using var h = new Harness();
+        await Assert.That(h.AwareBoot(contained: false)).IsFalse();
+    }
+
+    [Test] public async Task Clean_and_crashed_W1_to_W1_keep_the_chain() {
+        using var h = new Harness();
+        await Assert.That(h.AwareBoot()).IsTrue();
+        await Assert.That(h.AwareBoot()).IsTrue(); // prior tail id == prior lock id ⇒ chain intact
+    }
+
+    [Test] public async Task Downgrade_sandwich_breaks_the_chain_permanently() {
+        using var h = new Harness();
+        await Assert.That(h.AwareBoot()).IsTrue();
+        h.UnawareBoot();                             // old boot mints a fresh lock InstanceId, no journal
+        await Assert.That(h.AwareBoot()).IsFalse();  // prior lock id != journal tail id ⇒ broken
+        await Assert.That(h.AwareBoot()).IsFalse();  // sticky: the detecting boot persisted false
+    }
+
+    [Test] public async Task Aware_but_uncontained_epoch_poisons_all_later_boots() {
+        using var h = new Harness();
+        await Assert.That(h.AwareBoot(contained: true)).IsTrue();
+        await Assert.That(h.AwareBoot(contained: false)).IsFalse(); // this_epoch_contained=false
+        await Assert.That(h.AwareBoot(contained: true)).IsFalse();  // folds from false ⇒ still false
+    }
+
+    [Test] public async Task Empty_looking_used_dir_with_prior_lock_is_false() {
+        using var h = new Harness();
+        // A pre-existing (previously-used) state dir with NO journal file + a prior lock InstanceId.
+        // Genesis-eligibility is "journal absent", but a prior lock InstanceId ⇒ un-journaled history ⇒ false.
+        h.UnawareBoot(); // prior lock id exists; state dir has no journal
+        await Assert.That(h.AwareBoot()).IsFalse();
+    }
+
+    [Test] public async Task Corrupt_coverage_state_is_false() {
+        using var h = new Harness();
+        await Assert.That(h.AwareBoot()).IsTrue();
+        File.WriteAllText(Path.Combine(h.StateDir, "coverage.json"), "{ not json");
+        await Assert.That(h.AwareBoot()).IsFalse();
+    }
+
+    [Test] public async Task Genesis_crash_before_the_single_rename_leaves_no_journal_and_reseeds() {
+        using var h = new Harness();
+        // The genesis write is ONE atomic temp+rename of a single {initialized,instance_id,cumulative_covered}
+        // document. A crash BEFORE the rename leaves at most a stray .tmp — never a partial journal and never
+        // a separate marker — so File.Exists(coverage.json) stays false and the next boot is still
+        // genesis-eligible (re-seeds correctly). A COMPLETED rename is a valid, fully-initialized journal.
+        Directory.CreateDirectory(h.StateDir);
+        var journal = Path.Combine(h.StateDir, "coverage.json");
+        File.WriteAllText(journal + ".tmp-deadbeef", "{ partial"); // crash-before-rename residue
+        await Assert.That(File.Exists(journal)).IsFalse();
+
+        await Assert.That(h.AwareBoot(contained: true)).IsTrue();  // journal absent + no prior lock id ⇒ genesis re-seeds
+        await Assert.That(File.Exists(journal)).IsTrue();          // the completed rename is durable
+        await Assert.That(h.AwareBoot(contained: true)).IsTrue();  // a valid initialized journal ⇒ chain intact
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/CoverageJournalTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/CoverageJournalTests.cs
@@ -17,7 +17,7 @@ public class CoverageJournalTests {
         public bool AwareBoot(bool contained = true) {
             using var l = DaemonLock.TryAcquire("alpha")!;
             return new CoverageJournal(StateDir, NullLogger.Instance)
-                .RecordBoot(l.InstanceId, l.PriorInstanceId, contained);
+                .RecordBoot(l.InstanceId, l.PriorInstanceId, priorLockReadFailed: l.PriorLockIndeterminate, contained);
         }
         // An unaware/old boot: acquires the real lock (mints a fresh InstanceId) but writes NO journal.
         public void UnawareBoot() { using var l = DaemonLock.TryAcquire("alpha")!; }
@@ -62,6 +62,21 @@ public class CoverageJournalTests {
         // Genesis-eligibility is "journal absent", but a prior lock InstanceId ⇒ un-journaled history ⇒ false.
         h.UnawareBoot(); // prior lock id exists; state dir has no journal
         await Assert.That(h.AwareBoot()).IsFalse();
+    }
+
+    [Test] public async Task Indeterminate_prior_lock_is_not_genesis_even_with_absent_journal() {
+        using var h = new Harness();
+        // A read-failed / blank prior lock (priorLockReadFailed = true) with an absent journal must NOT be
+        // treated as genesis — an unreadable prior lock could hide an intervening boot, so it fails closed
+        // (regression: previously null priorLockInstanceId alone drove genesis, conflating empty-vs-unreadable).
+        var covered = new CoverageJournal(h.StateDir, NullLogger.Instance)
+            .RecordBoot("me", priorLockInstanceId: null, priorLockReadFailed: true, thisEpochContained: true);
+        await Assert.That(covered).IsFalse();
+        // A genuinely empty prior lock (readFailed = false, id = null) with an absent journal is still genesis.
+        using var h2 = new Harness();
+        var genesis = new CoverageJournal(h2.StateDir, NullLogger.Instance)
+            .RecordBoot("me", priorLockInstanceId: null, priorLockReadFailed: false, thisEpochContained: true);
+        await Assert.That(genesis).IsTrue();
     }
 
     [Test] public async Task Corrupt_coverage_state_is_false() {

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockPriorInstanceIdTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockPriorInstanceIdTests.cs
@@ -1,0 +1,37 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+public class DaemonLockPriorInstanceIdTests {
+    static string Scratch() {
+        var dir = Path.Combine(Path.GetTempPath(), "kcap-lock-prior", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        return dir;
+    }
+
+    [Test]
+    public async Task FreshSlot_has_null_prior_instance_id() {
+        var dir = Scratch();
+        try {
+            using var l = DaemonLock.TryAcquire("alpha");
+            await Assert.That(l!.PriorInstanceId).IsNull();
+        } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); Directory.Delete(dir, true); }
+    }
+
+    [Test]
+    public async Task ReAcquire_sees_the_previous_boots_instance_id() {
+        var dir = Scratch();
+        try {
+            var first = DaemonLock.TryAcquire("alpha")!;
+            var firstId = first.InstanceId;
+            first.Dispose(); // lock file (with firstId) survives Dispose
+
+            using var second = DaemonLock.TryAcquire("alpha");
+            await Assert.That(second!.PriorInstanceId).IsEqualTo(firstId);
+            await Assert.That(second.InstanceId).IsNotEqualTo(firstId);
+        } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); Directory.Delete(dir, true); }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockPriorInstanceIdTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockPriorInstanceIdTests.cs
@@ -22,6 +22,36 @@ public class DaemonLockPriorInstanceIdTests {
     }
 
     [Test]
+    public async Task NonEmpty_unreadable_prior_lock_is_indeterminate_not_a_fresh_slot() {
+        var dir = Scratch();
+        try {
+            var first = DaemonLock.TryAcquire("alpha")!;
+            var firstId = first.InstanceId;
+            first.Dispose(); // lock file (with firstId) survives Dispose
+
+            // Corrupt the lock file to non-empty blank content: a re-acquire must read it as INDETERMINATE
+            // (priorInstanceId null AND PriorLockIndeterminate true) — NOT a genesis-eligible empty slot.
+            var lockFile = Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories)
+                .First(f => File.ReadAllText(f).Contains(firstId));
+            File.WriteAllText(lockFile, "   \n");
+
+            using var second = DaemonLock.TryAcquire("alpha");
+            await Assert.That(second!.PriorInstanceId).IsNull();
+            await Assert.That(second.PriorLockIndeterminate).IsTrue();
+        } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); Directory.Delete(dir, true); }
+    }
+
+    [Test]
+    public async Task FreshSlot_is_not_indeterminate() {
+        var dir = Scratch();
+        try {
+            using var l = DaemonLock.TryAcquire("alpha");
+            await Assert.That(l!.PriorInstanceId).IsNull();
+            await Assert.That(l.PriorLockIndeterminate).IsFalse(); // genuinely empty ⇒ genesis-eligible, not indeterminate
+        } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); Directory.Delete(dir, true); }
+    }
+
+    [Test]
     public async Task ReAcquire_sees_the_previous_boots_instance_id() {
         var dir = Scratch();
         try {

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/HealBarrierReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/HealBarrierReportTests.cs
@@ -87,6 +87,40 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(orch.BuildStatusReport().LastProcessedSeq).IsEqualTo(1L);
     }
 
+    // Phase B2-b (sequenced-settlement design §4.2.6): the daemon-side heal-barrier contract. A
+    // StopAgentV2 at Seq = M that terminally processes advances LastProcessedSeq to M; once the agent's
+    // death is confirmed it is absent from BOTH LiveAgents and Quarantined, so a later report PROVES the
+    // id's absence at watermark M. The seeded agent uses NoopPtyProcess (pid 0 / not-alive), so
+    // HandleStopAgent -> CleanupAgentAsync confirms death immediately (no quarantine), removing it from
+    // _agents. This is verification that Tasks 12–16 compose into the barrier obligation.
+    [Test]
+    public async Task Stop_via_v2_advances_watermark_and_a_later_report_omits_the_confirmed_dead_id() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        var agent = orch.SeedAgentForTest("rev", LaunchKind.ReviewFlow, status: "Running", flowRunId: "f", flowRole: "reviewer");
+        var epoch = orch.DaemonEpochForTest;
+
+        await orch.HandleStopAgentV2ForTest(new StopAgentV2("rev", epoch, 1, "cmd-1"));
+
+        var report = orch.BuildStatusReport();
+        await Assert.That(report.LastProcessedSeq).IsEqualTo(1L);                          // stop at M=1 terminally processed
+        await Assert.That(report.LiveAgents.Select(x => x.Id)).DoesNotContain("rev");      // confirmed dead (Noop pty) -> absent
+        await Assert.That(report.Quarantined.Select(x => x.Id)).DoesNotContain("rev");
+    }
+
+    // Phase B2-b (sequenced-settlement design §5): an un-Seq'd launch (old server) runs the legacy
+    // unsequenced lane and must NEVER advance the sequenced watermark.
+    [Test]
+    public async Task Legacy_unsequenced_launch_never_advances_the_watermark() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        // No Epoch/Seq/CommandId -> legacy lane.
+        await orch.HandleLaunchAgentForTest(new LaunchAgentCommand("x", "hi", "opus", null, "/tmp", null, null, "bogus"));
+        await Assert.That(orch.BuildStatusReport().HighestAcceptedSeq).IsEqualTo(0L);
+    }
+
     /// <summary>A live-pid-backed pty double whose TerminateAsync deliberately does NOT kill (so teardown
     /// quarantines the "surviving" child). Mirrors LaunchCleanupTests' private LiveNoKillPtyProcess.</summary>
     sealed class LivePtyDouble(int pid) : IPtyProcess {

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/HealBarrierReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/HealBarrierReportTests.cs
@@ -121,6 +121,34 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(orch.BuildStatusReport().HighestAcceptedSeq).IsEqualTo(0L);
     }
 
+    // Phase B2-b (sequenced-settlement design §5.5): a PARTIAL sequencing tuple (some but not all of
+    // Epoch/Seq/CommandId present) is a malformed sequenced command and must FAIL CLOSED (LaunchFailed) —
+    // never fall through to the unwatermarked legacy lane, whose retry could be re-accepted on the
+    // sequenced lane and double-create the generation (at-most-once-per-generation). It must not spawn and
+    // must not advance the watermark.
+    [Test]
+    public async Task Partial_sequencing_tuple_fails_closed_without_spawning_or_advancing_the_watermark() {
+        var server = new SeqCaptureServerConnection();
+        // A VALID vendor so the fail-closed reason can ONLY be the malformed-tuple route, not the legacy
+        // lane's unknown-vendor rejection (which would mask a missing fix).
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher> { ["claude"] = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude") });
+
+        // Epoch + Seq present, CommandId ABSENT -> malformed.
+        await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+            AgentId: "partial", Prompt: "hi", Model: "opus", Effort: null,
+            RepoPath: "/tmp/does-not-matter", Tools: null, AttachmentIds: null, Vendor: "claude",
+            Epoch: orch.DaemonEpochForTest, Seq: 1, CommandId: null));
+
+        await Assert.That(server.LaunchFaileds.Count).IsEqualTo(1);
+        await Assert.That(server.LaunchFaileds[0].AgentId).IsEqualTo("partial");
+        await Assert.That(server.LaunchFaileds[0].Reason).Contains("Malformed sequenced launch"); // the fix's route
+        await Assert.That(orch.GetAgentForTest("partial")).IsNull();                    // never spawned
+        var report = orch.BuildStatusReport();
+        await Assert.That(report.HighestAcceptedSeq).IsEqualTo(0L);                     // watermark untouched
+        await Assert.That(report.LastProcessedSeq).IsEqualTo(0L);
+    }
+
     /// <summary>A live-pid-backed pty double whose TerminateAsync deliberately does NOT kill (so teardown
     /// quarantines the "surviving" child). Mirrors LaunchCleanupTests' private LiveNoKillPtyProcess.</summary>
     sealed class LivePtyDouble(int pid) : IPtyProcess {
@@ -148,10 +176,11 @@ public partial class AgentOrchestratorVendorTests {
         NullLogger<ServerConnection>.Instance
     ) {
         internal override bool IsReady => true;
-        public List<CommandRejected> Rejects { get; } = [];
-        public List<CommandAck>      Acks    { get; } = [];
+        public List<CommandRejected> Rejects       { get; } = [];
+        public List<CommandAck>      Acks          { get; } = [];
+        public List<(string AgentId, string Reason)> LaunchFaileds { get; } = [];
 
-        public override Task LaunchFailedAsync(string agentId, string reason) => Task.CompletedTask;
+        public override Task LaunchFailedAsync(string agentId, string reason) { lock (LaunchFaileds) LaunchFaileds.Add((agentId, reason)); return Task.CompletedTask; }
         public override Task CommandRejectedAsync(CommandRejected rej) { lock (Rejects) Rejects.Add(rej); return Task.CompletedTask; }
         public override Task CommandAckAsync(CommandAck ack)           { lock (Acks)    Acks.Add(ack);    return Task.CompletedTask; }
     }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/HealBarrierReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/HealBarrierReportTests.cs
@@ -1,0 +1,124 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Pty;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Tests.Unit.Daemon;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+// Phase B2-b (sequenced-settlement design): the orchestrator now owns an epoch-scoped
+// SequencedCommandProcessor, advertises its Epoch/HighestAcceptedSeq/LastProcessedSeq counters on the
+// self-report + connect payload, and exposes the single confirmed-death-precedence liveness read
+// (ReadLiveness) the processor uses to answer duplicate CommandAcks. This partial reuses the vendor
+// test class's BuildOrchestrator/CaptureServerConnection/SpyPtyProcessFactory/SeedAgentForTest harness.
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Report_advertises_sequencing_capability_and_counters() {
+        await using var orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        var report = orch.BuildStatusReport();
+        await Assert.That(report.Epoch).IsNotNull();
+        await Assert.That(report.HighestAcceptedSeq).IsEqualTo(0L); // fresh epoch, nothing accepted yet
+        await Assert.That(report.LastProcessedSeq).IsEqualTo(0L);
+    }
+
+    [Test]
+    public async Task ReadLiveness_follows_confirmed_death_precedence() {
+        await using var orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("live", LaunchKind.ReviewFlow, status: "Running");
+        await Assert.That(orch.ReadLiveness("live")).IsEqualTo(AgentLiveness.Live);
+        await Assert.That(orch.ReadLiveness("never")).IsEqualTo(AgentLiveness.Dead);
+    }
+
+    [Test]
+    public async Task ReadLiveness_racing_transitions_never_yields_a_transient_false_dead() {
+        // Parent §8: CommandAck.CurrentState racing live->quarantine / quarantine->dead transitions must
+        // never surface a transient false Dead. Hammer ReadLiveness while the agent moves live -> quarantine
+        // (teardown of a surviving child) -> dead (drain after the child exits). The shipped ordering
+        // invariant (CleanupAgentAsync adds to _quarantine BEFORE removing from _agents) keeps the id
+        // continuously in _agents ∪ _quarantine until the drain, so deadness is monotonic.
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        using var dummy = DummyProcess.StartSleep(30);
+        orch.SeedAgentForTest("rev", LaunchKind.ReviewFlow, status: "Running", flowRunId: "f", flowRole: "reviewer",
+            pty: new LivePtyDouble(dummy.Pid), startIdentity: ProcessIdentity.Capture(dummy.Pid));
+
+        var observed = new System.Collections.Concurrent.ConcurrentQueue<AgentLiveness>();
+        using var stop = new CancellationTokenSource();
+        var hammer = Task.Run(() => { while (!stop.IsCancellationRequested) observed.Enqueue(orch.ReadLiveness("rev")); });
+
+        await orch.CleanupAgentForTest("rev");                        // live -> quarantine (child still alive)
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        await orch.RetryQuarantineForTest();                          // quarantine -> dead (drain confirms death)
+        stop.Cancel(); await hammer;
+
+        // No transient false Dead: once Dead is observed it is never followed by a non-Dead reading.
+        var seq = observed.ToArray();
+        var firstDead = Array.IndexOf(seq, AgentLiveness.Dead);
+        if (firstDead >= 0)
+            await Assert.That(seq.Skip(firstDead).All(s => s == AgentLiveness.Dead)).IsTrue();
+        await Assert.That(orch.ReadLiveness("rev")).IsEqualTo(AgentLiveness.Dead); // genuinely dead at the end
+    }
+
+    // Phase B2-b (sequenced-settlement design §4.2.2/§5.5): a Seq'd LaunchAgentCommand the shipped launch
+    // would reject at capacity flows through the processor as a terminal LaunchRejected(daemon_capacity)
+    // CommandOutcome, so the sequenced lane emits a CommandRejected (in addition to the legacy
+    // LaunchFailed) and the watermark still advances. MaxConcurrentAgents=0 makes the very first admission
+    // check reject with no launcher/worktree side effects.
+    [Test]
+    public async Task Sequenced_launch_over_capacity_emits_daemon_capacity_rejection() {
+        var server = new SeqCaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher> { ["claude"] = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude") },
+            configure: c => c.MaxConcurrentAgents = 0);
+
+        await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+            AgentId: "cap", Prompt: "hi", Model: "opus", Effort: null,
+            RepoPath: "/tmp/does-not-matter", Tools: null, AttachmentIds: null, Vendor: "claude",
+            Epoch: orch.DaemonEpochForTest, Seq: 1, CommandId: "cmd-1"));
+
+        await Assert.That(server.Rejects.Count).IsEqualTo(1);
+        await Assert.That(server.Rejects[0].Reason).IsEqualTo(CommandRejectedReason.DaemonCapacity);
+        await Assert.That(server.Rejects[0].Seq).IsEqualTo(1L);
+        // The terminal (daemon_capacity) processing advanced the watermark through the accepted prefix.
+        await Assert.That(orch.BuildStatusReport().LastProcessedSeq).IsEqualTo(1L);
+    }
+
+    /// <summary>A live-pid-backed pty double whose TerminateAsync deliberately does NOT kill (so teardown
+    /// quarantines the "surviving" child). Mirrors LaunchCleanupTests' private LiveNoKillPtyProcess.</summary>
+    sealed class LivePtyDouble(int pid) : IPtyProcess {
+        public int  Pid       => pid;
+        public bool HasExited => false;
+        public int? ExitCode  => null;
+        public ValueTask DisposeAsync() => default;
+        public Task WaitForExitAsync(TimeSpan? _) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan?   _) => Task.CompletedTask; // deliberately does NOT kill
+#pragma warning disable CS1998
+        public async IAsyncEnumerable<byte[]> ReadOutputAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken _ = default) { yield break; }
+#pragma warning restore CS1998
+        public Task WriteAsync(string _) => Task.CompletedTask;
+        public Task WriteAsync(byte[] _) => Task.CompletedTask;
+        public void Resize(ushort     _, ushort __) { }
+        public void SendInterrupt() { }
+    }
+
+    /// <summary>Captures the one-way sequenced CommandAck/CommandRejected sends (synchronously, so an
+    /// awaited SubmitAsync has already recorded them) and no-ops everything else the capacity-reject path
+    /// touches. IsReady is forced true so the base sends aren't short-circuited before our override.</summary>
+    sealed class SeqCaptureServerConnection() : ServerConnection(
+        new() { Name = "test", ServerUrl = "http://127.0.0.1:1" },
+        NullLoggerFactory.Instance,
+        NullLogger<ServerConnection>.Instance
+    ) {
+        internal override bool IsReady => true;
+        public List<CommandRejected> Rejects { get; } = [];
+        public List<CommandAck>      Acks    { get; } = [];
+
+        public override Task LaunchFailedAsync(string agentId, string reason) => Task.CompletedTask;
+        public override Task CommandRejectedAsync(CommandRejected rej) { lock (Rejects) Rejects.Add(rej); return Task.CompletedTask; }
+        public override Task CommandAckAsync(CommandAck ack)           { lock (Acks)    Acks.Add(ack);    return Task.CompletedTask; }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LedgerHookOrchestratorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LedgerHookOrchestratorTests.cs
@@ -1,0 +1,39 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Tests.Unit.Daemon;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+// Phase B2-b (sequenced-settlement design §4.2.4): orchestrator-level proof that the quarantine-drain
+// hook emits positive per-id death evidence into the real ResolvedCandidatesLedger owned by the
+// orchestrator (append BEFORE the durable PID-record delete). Reuses the vendor test class's
+// BuildOrchestrator/CaptureServerConnection/SpyPtyProcessFactory harness + the shared test seams.
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Quarantine_drain_via_orchestrator_emits_resolved_evidence_before_deleting_the_record() {
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid      = dummy.Pid;
+        var identity = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5)); // confirmed dead -> the drain confirms + emits
+
+        // Teardown retains the PID record (current epoch) of a quarantined survivor, so the drain deletes
+        // it. Seed both the record and the quarantine entry to mirror that post-teardown state exactly.
+        orch.WritePidRecordForTest(new AgentPidRecord(
+            "q1", pid, identity, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-1", "reviewer", orch.DaemonIdForTest, orch.DaemonEpochForTest, DateTimeOffset.UtcNow));
+        orch.QuarantineForTest(new AgentKillQuarantine.Entry(
+            "q1", pid, identity, "ReviewFlow", DateTimeOffset.UtcNow, "flow-1", "reviewer"));
+
+        await orch.RetryQuarantineForTest();
+
+        var entry = orch.ResolvedLedgerSnapshotForTest.Single();
+        await Assert.That(entry.AgentId).IsEqualTo("q1");
+        await Assert.That(entry.OldEpoch).IsEqualTo(orch.DaemonEpochForTest); // drain emits the current epoch
+        await Assert.That(entry.FlowRole).IsEqualTo("reviewer");
+        await Assert.That(orch.PidRecordsForTest()).IsEmpty(); // record deleted after the append
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LedgerHookTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LedgerHookTests.cs
@@ -83,4 +83,96 @@ public class LedgerHookTests {
         await Assert.That(entry.OldEpoch).IsEqualTo("old-epoch");
         await Assert.That(store.ReadAll()).IsEmpty();
     }
+
+    [Test]
+    public async Task Quarantine_drain_returns_entries_and_confirmed_ones_are_emittable() {
+        var q = new AgentKillQuarantine(NullLogger.Instance);
+        using var dummy = DummyProcess.StartSleep(30);
+        var id = ProcessIdentity.Capture(dummy.Pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5)); // confirmed dead -> will drain
+
+        q.Add(new AgentKillQuarantine.Entry("q1", dummy.Pid, id, "ReviewFlow", DateTimeOffset.UtcNow, "flow-1", "reviewer"));
+        var drained = await q.RetryAllAsync(CancellationToken.None);
+
+        await Assert.That(drained.Select(e => e.AgentId)).IsEquivalentTo(new[] { "q1" });
+        await Assert.That(drained.Single().FlowRole).IsEqualTo("reviewer");
+    }
+
+    // ── Quarantine-drain hook — crash both sides (parent §8). The drain's durable source is the RETAINED
+    // AgentPidRecord (teardown quarantines AND keeps the record); the drain emits (AgentId, epoch-at-drain,
+    // flow…) then deletes the record. After a crash the record's DaemonEpoch == that same epoch, so the
+    // next boot's OrphanReaper record pass reconciles on the source-stable (AgentId, OldEpoch) key (NOT
+    // Generation, which the pre-append source lacks).
+    [Test]
+    public async Task Quarantine_drain_crash_between_append_and_delete_reconciles_single_emit() {
+        var (store, ledger, _) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        store.Write(new AgentPidRecord("qr", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-1", "reviewer", "did", "drain-epoch", DateTimeOffset.UtcNow));
+        var committed = ledger.Upsert("qr", "drain-epoch", "flow-1", "reviewer"); // drain appended
+        // crash before DeletePidRecord → committed entry + leftover record
+
+        var reaper = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await reaper.ReapOnceAsync();
+        await Assert.That(store.ReadAll()).IsEmpty();
+        await Assert.That(ledger.Snapshot().Single().Generation).IsEqualTo(committed.Generation); // single emit
+    }
+
+    [Test]
+    public async Task Quarantine_drain_crash_before_append_re_derives_next_boot() {
+        var (store, ledger, _) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        store.Write(new AgentPidRecord("qr", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-1", "reviewer", "did", "drain-epoch", DateTimeOffset.UtcNow));
+        await Assert.That(ledger.Snapshot()).IsEmpty(); // crash before append → record only
+
+        var reaper = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await reaper.ReapOnceAsync();
+        await Assert.That(ledger.Snapshot().Single().AgentId).IsEqualTo("qr");
+        await Assert.That(store.ReadAll()).IsEmpty();
+    }
+
+    // ── StopAgent-fallback hook — crash both sides (parent §8). TryStopByPidRecordAsync emits
+    // (agentId, record.DaemonEpoch, record.flow…) before deleting the record; same durable source +
+    // (AgentId, OldEpoch) reconciliation as the drain hook.
+    [Test]
+    public async Task Stop_fallback_crash_between_append_and_delete_reconciles_single_emit() {
+        var (store, ledger, _) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        store.Write(new AgentPidRecord("sf", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-2", "reviewer", "did", "stop-epoch", DateTimeOffset.UtcNow));
+        var committed = ledger.Upsert("sf", "stop-epoch", "flow-2", "reviewer"); // stop-fallback appended
+        // crash before _pidRecords.Delete → committed entry + leftover record
+
+        var reaper = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await reaper.ReapOnceAsync();
+        await Assert.That(store.ReadAll()).IsEmpty();
+        await Assert.That(ledger.Snapshot().Single().Generation).IsEqualTo(committed.Generation);
+    }
+
+    [Test]
+    public async Task Stop_fallback_crash_before_append_re_derives_next_boot() {
+        var (store, ledger, _) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        store.Write(new AgentPidRecord("sf", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-2", "reviewer", "did", "stop-epoch", DateTimeOffset.UtcNow));
+        await Assert.That(ledger.Snapshot()).IsEmpty(); // crash before append
+
+        var reaper = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await reaper.ReapOnceAsync();
+        await Assert.That(ledger.Snapshot().Single().AgentId).IsEqualTo("sf");
+        await Assert.That(store.ReadAll()).IsEmpty();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LedgerHookTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LedgerHookTests.cs
@@ -1,0 +1,86 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+public class LedgerHookTests {
+    static (AgentPidRecordStore store, ResolvedCandidatesLedger ledger, string dir) NewPair() {
+        var dir = Path.Combine(Path.GetTempPath(), "kcap-hook-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return (new AgentPidRecordStore(dir, NullLogger.Instance), new ResolvedCandidatesLedger(dir, NullLogger.Instance), dir);
+    }
+
+    [Test]
+    public async Task Record_pass_appends_resolved_evidence_before_deleting_the_source() {
+        var (store, ledger, _) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5)); // process gone -> confirmed absent
+
+        store.Write(new AgentPidRecord("gone", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-1", "reviewer", "did", "old-epoch", DateTimeOffset.UtcNow));
+
+        var reaper = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await reaper.ReapOnceAsync();
+
+        var entry = ledger.Snapshot().Single();
+        await Assert.That(entry.AgentId).IsEqualTo("gone");
+        await Assert.That(entry.OldEpoch).IsEqualTo("old-epoch");
+        await Assert.That(entry.FlowRole).IsEqualTo("reviewer"); // from the trusted record
+        await Assert.That(store.ReadAll()).IsEmpty();            // source deleted after the append
+    }
+
+    [Test]
+    public async Task Crash_between_append_and_delete_reconciles_idempotently_on_restart() {
+        var (store, ledger, dir) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        store.Write(new AgentPidRecord("gone", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-1", "reviewer", "did", "old-epoch", DateTimeOffset.UtcNow));
+
+        // Simulate crash-after-append-before-delete: append, but skip the delete this pass.
+        var crashing = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => { ledger.Upsert(a, e, fr, role); throw new IOException("crash before delete"); });
+        try { await crashing.ReapOnceAsync(); } catch { /* the reaper swallows per-record faults */ }
+        await Assert.That(store.ReadAll()).IsNotEmpty();          // leftover source
+        var gen = ledger.Snapshot().Single().Generation;
+
+        // Restart: re-derive from the leftover source; Upsert collapses onto the committed entry.
+        var restarted = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await restarted.ReapOnceAsync();
+        await Assert.That(store.ReadAll()).IsEmpty();             // leftover source now deleted
+        await Assert.That(ledger.Snapshot().Single().Generation).IsEqualTo(gen); // single emit, no new generation
+    }
+
+    [Test]
+    public async Task Crash_before_append_re_derives_the_record_pass_evidence_next_boot() {
+        // Parent §8: crash BEFORE the durable append leaves the source only → re-derived next boot
+        // (at-least-once, deduped). The record pass confirms death but the daemon dies before Upsert.
+        var (store, ledger, _) = NewPair();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; var id = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        store.Write(new AgentPidRecord("gone", pid, id, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-1", "reviewer", "did", "old-epoch", DateTimeOffset.UtcNow));
+
+        // Crash before the append: the confirmed-gone branch throws before touching the ledger.
+        var crashing = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (_, _, _, _) => throw new IOException("crash before append"));
+        try { await crashing.ReapOnceAsync(); } catch { /* per-record faults swallowed */ }
+        await Assert.That(ledger.Snapshot()).IsEmpty();          // nothing committed
+        await Assert.That(store.ReadAll()).IsNotEmpty();         // source persists
+
+        // Next boot re-derives from the on-disk pre-append source shape (keyed (AgentId, OldEpoch)).
+        var restarted = new OrphanReaper(store, "did", "new-epoch", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => ledger.Upsert(a, e, fr, role));
+        await restarted.ReapOnceAsync();
+        var entry = ledger.Snapshot().Single();
+        await Assert.That(entry.AgentId).IsEqualTo("gone");
+        await Assert.That(entry.OldEpoch).IsEqualTo("old-epoch");
+        await Assert.That(store.ReadAll()).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/MarkerCandidateResolutionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/MarkerCandidateResolutionTests.cs
@@ -108,6 +108,49 @@ public class MarkerCandidateResolutionTests {
         await Assert.That(markers.ReadAll()).IsEmpty();
     }
 
+    // Phase B2-b (sequenced-settlement design): the env agentId on a marker candidate is UNTRUSTED for
+    // role authority. A prior-epoch DESCENDANT that inherited a still-live leader X's KCAP_AGENT_ID env
+    // triple (the descendant-outlives-leader residual) and is reaped under a DIFFERENT pid must NOT be
+    // corroborated against X's still-on-disk leader record: matching on agentId ALONE would emit a FALSE
+    // trusted-flow death proof for the LIVE leader AND delete its durable record (stranding it).
+    // EmitAndClear must also corroborate the reaped pid + the prior epoch. Cross-platform: the marker
+    // resolves via branch (a) (!IsAlive of the reaped pid), which needs no env-marker scan.
+    [Test]
+    public async Task Marker_resolution_does_not_delete_or_falsely_resolve_a_non_corroborating_live_leader_record() {
+        var (store, markers, _) = New();
+
+        // The reaped descendant: a real, test-owned process, killed so branch (a) (!IsAlive) resolves it.
+        using var descendant = DummyProcess.StartSleep(30);
+        var reapedPid = descendant.Pid;
+        descendant.Kill();
+        descendant.WaitForExit(TimeSpan.FromSeconds(5));
+
+        // The LIVE leader X's durable record: X's OWN pid (alive, != the reaped pid) and the CURRENT
+        // epoch (a live current-incarnation leader). Neither the reaped pid nor the marker's prior epoch
+        // corroborates — the record pass skips a current-epoch record, so the live process is untouched.
+        var leaderPid = Environment.ProcessId; // alive, distinct from the reaped pid, carries no KCAP_* env
+        store.Write(new AgentPidRecord("leader-x", leaderPid, "tok", PidIdentityKind.Present,
+            "ReviewFlow", "codex", "flow-x", "leader", "did", "cur", DateTimeOffset.UtcNow));
+
+        // The marker candidate carries the descendant's INHERITED agentId (leader-x), the PRIOR epoch,
+        // and the reaped (dead) pid.
+        markers.Write(new MarkerCandidate("leader-x", "did", "old", reapedPid));
+
+        var recordResolved = new List<(string a, string e, string? fr, string? role)>();
+        var markerResolved = new List<(string, string)>();
+        var reaper = new OrphanReaper(store, "did", "cur", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => recordResolved.Add((a, e, fr, role)),
+            markerStore: markers, onMarkerResolved: (a, e) => markerResolved.Add((a, e)));
+        await reaper.ReapOnceAsync();
+
+        // The live leader's record is UNTOUCHED — not deleted, no trusted-flow death proof emitted for it.
+        await Assert.That(store.ReadAll().Any(r => r.AgentId == "leader-x")).IsTrue();
+        await Assert.That(recordResolved).IsEmpty();
+        // The resolution falls back to the recordless (null-flow) path and still clears the marker source.
+        await Assert.That(markerResolved).IsEquivalentTo(new[] { ("leader-x", "old") });
+        await Assert.That(markers.ReadAll()).IsEmpty();
+    }
+
     [Test]
     public async Task Identity_unavailable_record_resolved_via_marker_scan_emits_trusted_flow() {
         if (!OperatingSystem.IsLinux()) return;

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/MarkerCandidateResolutionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/MarkerCandidateResolutionTests.cs
@@ -1,0 +1,136 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+public class MarkerCandidateResolutionTests {
+    static (AgentPidRecordStore store, MarkerCandidateStore markers, string dir) New() {
+        var dir = Path.Combine(Path.GetTempPath(), "kcap-mk-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return (new AgentPidRecordStore(dir, NullLogger.Instance), new MarkerCandidateStore(dir, NullLogger.Instance), dir);
+    }
+
+    [Test]
+    public async Task Recordless_marker_kill_emits_resolved_and_deletes_the_source() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, markers, _) = New();
+        using var dummy = DummyProcess.StartSleep(30, new Dictionary<string, string> {
+            ["KCAP_AGENT_ID"] = "rec-less", ["KCAP_DAEMON_ID"] = "did", ["KCAP_DAEMON_EPOCH"] = "old" });
+
+        var resolved = new List<(string, string)>();
+        var reaper = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            markerStore: markers, onMarkerResolved: (a, e) => resolved.Add((a, e)));
+        await reaper.ReapOnceAsync();
+
+        dummy.WaitForExit(TimeSpan.FromSeconds(8));
+        await Assert.That(dummy.HasExited).IsTrue();
+        await Assert.That(resolved).Contains(("rec-less", "old"));
+        await Assert.That(markers.ReadAll()).IsEmpty();          // source deleted after the emit
+    }
+
+    [Test]
+    public async Task Alive_mismatch_spares_and_leaves_the_marker_candidate_pending() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, markers, _) = New();
+        // A persisted marker-candidate whose pid is now occupied by an UNRELATED process (no triple).
+        using var occupant = DummyProcess.StartSleep(30); // no KCAP_* env
+        markers.Write(new MarkerCandidate("stale", "did", "old", occupant.Pid));
+
+        var resolved = new List<(string, string)>();
+        var reaper = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            markerStore: markers, onMarkerResolved: (a, e) => resolved.Add((a, e)));
+        await reaper.ReapOnceAsync(); // boot reconciliation re-reads the source, re-runs (a)/(b)/(c)
+
+        await Assert.That(occupant.HasExited).IsFalse();          // reused pid spared
+        await Assert.That(resolved).IsEmpty();                    // (c) never emits
+        await Assert.That(markers.ReadAll().Single().AgentId).IsEqualTo("stale"); // stays pending
+        occupant.Kill();
+    }
+
+    [Test]
+    public async Task Confirmed_dead_persisted_candidate_resolves_incl_zombie_path() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, markers, _) = New();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5)); // dead per IsAlive
+        markers.Write(new MarkerCandidate("dead1", "did", "old", pid));
+
+        var resolved = new List<(string, string)>();
+        var reaper = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            markerStore: markers, onMarkerResolved: (a, e) => resolved.Add((a, e)));
+        await reaper.ReapOnceAsync();
+
+        await Assert.That(resolved).Contains(("dead1", "old")); // (a) dead -> resolved+emit
+        await Assert.That(markers.ReadAll()).IsEmpty();
+    }
+
+    // ── Marker-scan kill hook — crash both sides (parent §8; recordless→marker-candidate case). ──
+    [Test]
+    public async Task Marker_kill_crash_before_append_re_derives_from_the_persisted_source() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, markers, _) = New();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5)); // dead per IsAlive (branch a)
+        markers.Write(new MarkerCandidate("mk-gone", "did", "old", pid));
+
+        // Crash BEFORE the emit: onMarkerResolved throws before the ledger append -> no entry, source persists.
+        var crashing = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            markerStore: markers, onMarkerResolved: (_, _) => throw new IOException("crash before append"));
+        try { await crashing.ReapOnceAsync(); } catch { /* per-source faults swallowed */ }
+        await Assert.That(markers.ReadAll()).IsNotEmpty(); // source persists (never a source-less window)
+
+        // Next boot reconciles: re-read the on-disk source, (a) dead -> single emit + delete.
+        var resolved = new List<(string, string)>();
+        var restarted = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            markerStore: markers, onMarkerResolved: (a, e) => resolved.Add((a, e)));
+        await restarted.ReapOnceAsync();
+        await Assert.That(resolved).IsEquivalentTo(new[] { ("mk-gone", "old") });
+        await Assert.That(markers.ReadAll()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Marker_kill_crash_between_append_and_source_delete_reconciles_idempotently() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, markers, dir) = New();
+        var ledger = new ResolvedCandidatesLedger(dir, NullLogger.Instance);
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5));
+        markers.Write(new MarkerCandidate("mk-gone", "did", "old", pid));
+        var committed = ledger.Upsert("mk-gone", "old", null, null); // append happened
+        // crash before markerStore.Delete -> committed entry + leftover marker source
+
+        // Next boot: reconciliation re-reads the source, (a) dead -> idempotent Upsert (key (AgentId,OldEpoch)) + delete.
+        var restarted = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            markerStore: markers, onMarkerResolved: (a, e) => ledger.Upsert(a, e, null, null));
+        await restarted.ReapOnceAsync();
+        await Assert.That(ledger.Snapshot().Single().Generation).IsEqualTo(committed.Generation); // single emit
+        await Assert.That(markers.ReadAll()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Identity_unavailable_record_resolved_via_marker_scan_emits_trusted_flow() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, markers, _) = New();
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid = dummy.Pid; dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5)); // dead per IsAlive (branch a)
+        // A Linux identity_unavailable RECORD (capture failed) co-existing with a marker-candidate source.
+        store.Write(new AgentPidRecord("iu", pid, "", PidIdentityKind.IdentityUnavailable, "ReviewFlow",
+            "codex", "flow-9", "reviewer", "did", "old", DateTimeOffset.UtcNow));
+        markers.Write(new MarkerCandidate("iu", "did", "old", pid));
+
+        var recordResolved = new List<(string a, string e, string? fr, string? role)>();
+        var markerResolved = new List<(string, string)>();
+        var reaper = new OrphanReaper(store, "did", "new", NullLogger.Instance,
+            onRecordResolved: (a, e, fr, role) => recordResolved.Add((a, e, fr, role)),
+            markerStore: markers, onMarkerResolved: (a, e) => markerResolved.Add((a, e)));
+        await reaper.ReapOnceAsync();
+
+        // The trusted record's flow is emitted (via onRecordResolved), NOT null (via onMarkerResolved).
+        await Assert.That(recordResolved.Single().role).IsEqualTo("reviewer");
+        await Assert.That(recordResolved.Single().fr).IsEqualTo("flow-9");
+        await Assert.That(markerResolved).IsEmpty();
+        await Assert.That(store.ReadAll()).IsEmpty();       // identity_unavailable record cleared
+        await Assert.That(markers.ReadAll()).IsEmpty();     // marker source cleared
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/MarkerCandidateResolutionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/MarkerCandidateResolutionTests.cs
@@ -151,6 +151,35 @@ public class MarkerCandidateResolutionTests {
         await Assert.That(markers.ReadAll()).IsEmpty();
     }
 
+    // Phase B2-b (sequenced-settlement design §5.5): if a discovered recordless survivor's durable
+    // marker-candidate source WRITE fails, the survivor is neither recorded (invisible to
+    // BlockedCandidates) nor killed — so the scan must NOT report Complete this pass, or
+    // StartupReapComplete could go true beside a live prior-epoch survivor and the server would launch a
+    // duplicate. Discovery must stay Failed (retried next heartbeat).
+    [Test]
+    public async Task Marker_scan_stays_incomplete_when_a_candidate_source_write_fails() {
+        if (!OperatingSystem.IsLinux()) return;
+        var (store, _, dir) = New();
+        // A MarkerCandidateStore whose Write ALWAYS throws: its state dir is actually a FILE, so
+        // Directory.CreateDirectory(_dir) fails for every Write.
+        var badBase = Path.Combine(dir, "not-a-dir");
+        File.WriteAllText(badBase, "x");
+        var failingMarkers = new MarkerCandidateStore(badBase, NullLogger.Instance);
+
+        // A live prior-epoch recordless survivor the scan discovers and tries (and fails) to capture.
+        using var dummy = DummyProcess.StartSleep(30, new Dictionary<string, string> {
+            ["KCAP_AGENT_ID"] = "surv", ["KCAP_DAEMON_ID"] = "did", ["KCAP_DAEMON_EPOCH"] = "old" });
+
+        var reaper = new OrphanReaper(store, "did", "new", NullLogger.Instance, markerStore: failingMarkers);
+        await reaper.ReapOnceAsync();
+
+        // The source write failed, so the pass is not a completeness proof.
+        await Assert.That(reaper.CurrentDiscovery.MarkerScanState).IsEqualTo(MarkerScanState.Failed);
+        // The survivor was never killed (we never resolve without a durable source first).
+        await Assert.That(dummy.HasExited).IsFalse();
+        dummy.Kill();
+    }
+
     [Test]
     public async Task Identity_unavailable_record_resolved_via_marker_scan_emits_trusted_flow() {
         if (!OperatingSystem.IsLinux()) return;

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ResolvedCandidatesLedgerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ResolvedCandidatesLedgerTests.cs
@@ -1,0 +1,46 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+public class ResolvedCandidatesLedgerTests {
+    static ResolvedCandidatesLedger New(out string dir) {
+        dir = Path.Combine(Path.GetTempPath(), "kcap-ledger-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return new ResolvedCandidatesLedger(dir, NullLogger.Instance);
+    }
+
+    [Test] public async Task Upsert_is_idempotent_on_agent_and_epoch_and_monotonic_generation() {
+        var l = New(out _);
+        var a = l.Upsert("a1", "e0", null, null);
+        var b = l.Upsert("a2", "e0", null, null);
+        var aAgain = l.Upsert("a1", "e0", null, null); // same key -> same generation, no new entry
+        await Assert.That(a.Generation).IsEqualTo(1L);
+        await Assert.That(b.Generation).IsEqualTo(2L);
+        await Assert.That(aAgain.Generation).IsEqualTo(1L);
+        await Assert.That(l.Snapshot().Count).IsEqualTo(2);
+    }
+
+    [Test] public async Task Snapshot_and_generation_survive_restart() {
+        var l = New(out var dir);
+        l.Upsert("a1", "e0", "flow", "reviewer");
+        var reopened = new ResolvedCandidatesLedger(dir, NullLogger.Instance);
+        await Assert.That(reopened.Snapshot().Single().AgentId).IsEqualTo("a1");
+        // A new key after restart must not reuse generation 1.
+        await Assert.That(reopened.Upsert("a2", "e0", null, null).Generation).IsEqualTo(2L);
+    }
+
+    [Test] public async Task Ack_prunes_sparsely_without_head_of_line_blocking() {
+        var l = New(out _);
+        var g1 = l.Upsert("a1", "e0", null, null);
+        var g2 = l.Upsert("a2", "e0", null, null);
+        var g3 = l.Upsert("a3", "e0", null, null);
+        l.Ack([new ResolvedCandidateAck(g1.Generation, "a1", "e0"),
+               new ResolvedCandidateAck(g3.Generation, "a3", "e0")]);
+        await Assert.That(l.Snapshot().Select(x => x.AgentId)).IsEquivalentTo(new[] { "a2" });
+        l.Ack([new ResolvedCandidateAck(g2.Generation, "a2", "e0")]); // idempotent for already-pruned too
+        l.Ack([new ResolvedCandidateAck(99, "nope", "e0")]);          // unknown -> no-op
+        await Assert.That(l.Snapshot()).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ResolvedCandidatesLedgerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ResolvedCandidatesLedgerTests.cs
@@ -53,6 +53,25 @@ public class ResolvedCandidatesLedgerTests {
         await Assert.That(reopened.Snapshot().Single().AgentId).IsEqualTo("a1");
     }
 
+    // Phase B2-b (sequenced-settlement design §5.5): the daemon-lifetime monotonic high-water — 0 before
+    // any mint, N after N distinct Upserts — and unchanged by an Ack that prunes entries (so once sparse
+    // acks prune the ledger the server still learns the generation frontier). Survives restart because
+    // _nextGeneration is never decremented and Load restores it.
+    [Test] public async Task HighestResolutionGeneration_reports_the_monotonic_high_water() {
+        var l = New(out var dir);
+        await Assert.That(l.HighestResolutionGeneration).IsEqualTo(0L); // nothing minted yet
+        var g1 = l.Upsert("a1", "e0", null, null);
+        l.Upsert("a2", "e0", null, null);
+        l.Upsert("a3", "e0", null, null);
+        await Assert.That(l.HighestResolutionGeneration).IsEqualTo(3L);
+
+        l.Ack([new ResolvedCandidateAck(g1.Generation, "a1", "e0")]); // prune a1
+        await Assert.That(l.HighestResolutionGeneration).IsEqualTo(3L); // unchanged by a prune
+
+        var reopened = new ResolvedCandidatesLedger(dir, NullLogger.Instance);
+        await Assert.That(reopened.HighestResolutionGeneration).IsEqualTo(3L); // survives restart
+    }
+
     [Test] public async Task Ack_prunes_sparsely_without_head_of_line_blocking() {
         var l = New(out _);
         var g1 = l.Upsert("a1", "e0", null, null);

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ResolvedCandidatesLedgerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ResolvedCandidatesLedgerTests.cs
@@ -31,6 +31,28 @@ public class ResolvedCandidatesLedgerTests {
         await Assert.That(reopened.Upsert("a2", "e0", null, null).Generation).IsEqualTo(2L);
     }
 
+    // Phase B2-b (sequenced-settlement design §5.5): Upsert must be transactional with its durable write.
+    // If the atomic write fails, the in-memory entry AND the generation counter must roll back so memory
+    // never leads disk — otherwise the next sweep's idempotent short-circuit returns the unpersisted entry
+    // without persisting, and the caller then deletes the durable source (violating append-before-delete).
+    [Test] public async Task Upsert_rolls_back_entry_and_generation_when_the_durable_write_fails() {
+        var l = New(out var dir);
+        // Force the durable write to throw: remove the state dir so PersistState's temp write fails.
+        Directory.Delete(dir, recursive: true);
+
+        await Assert.That(() => { l.Upsert("a1", "e0", null, null); }).Throws<Exception>();
+        await Assert.That(l.Snapshot()).IsEmpty(); // no phantom in-memory entry
+
+        // The failed mint did NOT consume a generation: after the dir is restored, the SAME key mints
+        // generation 1 (not 2).
+        Directory.CreateDirectory(dir);
+        await Assert.That(l.Upsert("a1", "e0", null, null).Generation).IsEqualTo(1L);
+
+        // No partial/leftover file leads a fresh reload to a phantom entry.
+        var reopened = new ResolvedCandidatesLedger(dir, NullLogger.Instance);
+        await Assert.That(reopened.Snapshot().Single().AgentId).IsEqualTo("a1");
+    }
+
     [Test] public async Task Ack_prunes_sparsely_without_head_of_line_blocking() {
         var l = New(out _);
         var g1 = l.Upsert("a1", "e0", null, null);

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
@@ -91,4 +91,27 @@ public class SequencedCommandProcessorTests {
             () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
         await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.DuplicateCollision);
     }
+
+    [Test] public async Task Backpressure_rejects_when_the_cache_is_full_and_ack_prefix_reopens_capacity() {
+        var h = new Harness(); await using var p = h.P(bound: 2);
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await p.SubmitAsync(h.Launch(2), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await p.SubmitAsync(h.Launch(3), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.Backpressure);
+        await Assert.That(p.HighestAcceptedSeq).IsEqualTo(2L);       // 3 not accepted (unacked identity kept)
+
+        p.AckPrefix(new AckProcessedPrefix("e1", 2));                // retire <= 2
+        await p.SubmitAsync(h.Launch(3), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(3L);
+    }
+
+    [Test] public async Task AckPrefix_rejects_over_ahead_regressing_and_stale_epoch_without_eviction() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        p.AckPrefix(new AckProcessedPrefix("e1", 5));   // over-ahead (> LastProcessedSeq) -> ignored
+        p.AckPrefix(new AckProcessedPrefix("WRONG", 1));// stale epoch -> ignored
+        // A duplicate is still answerable (identity not evicted):
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(h.Acks.Count).IsEqualTo(1);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
@@ -130,4 +130,38 @@ public class SequencedCommandProcessorTests {
         await Assert.That(p.LastProcessedSeq).IsEqualTo(1L);        // rejected-as-item is terminal
         await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.DaemonCapacity);
     }
+
+    // Phase B2-b (sequenced-settlement design §5.5): a retransmitted duplicate of a LaunchRejected command
+    // must carry the CACHED rejection reason on its processed CommandAck, as the SAME wire token
+    // CommandRejected.Reason serializes to, so the server can tell daemon_capacity (requeue) from semantic
+    // (fail) for exactly the lost-rejection case the identity cache exists to answer.
+    [Test] public async Task Duplicate_of_a_capacity_rejected_launch_carries_the_daemon_capacity_wire_token() {
+        var h = new Harness(); await using var p = h.P();
+        var item = h.Launch(1);
+        await p.SubmitAsync(item, () => Task.FromResult(
+            new CommandOutcome(CommandOutcomeKind.LaunchRejected, "a", RejectReason: CommandRejectedReason.DaemonCapacity)));
+        await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        var ack = h.Acks.Single();
+        await Assert.That(ack.State).IsEqualTo(CommandAckState.Processed);
+        await Assert.That(ack.OutcomeKind).IsEqualTo(CommandOutcomeKind.LaunchRejected);
+        await Assert.That(ack.RejectionReason).IsEqualTo("daemon_capacity");
+    }
+
+    [Test] public async Task Duplicate_of_a_semantically_rejected_launch_carries_the_semantic_wire_token() {
+        var h = new Harness(); await using var p = h.P();
+        var item = h.Launch(1);
+        await p.SubmitAsync(item, () => Task.FromResult(
+            new CommandOutcome(CommandOutcomeKind.LaunchRejected, "a", RejectReason: CommandRejectedReason.Semantic)));
+        await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(h.Acks.Single().RejectionReason).IsEqualTo("semantic");
+    }
+
+    // A duplicate of a non-rejected (executed) command has no cached reject reason -> null RejectionReason.
+    [Test] public async Task Duplicate_of_an_executed_launch_has_no_rejection_reason() {
+        var h = new Harness(); await using var p = h.P();
+        var item = h.Launch(1);
+        await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted, "a", "sess")));
+        await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(h.Acks.Single().RejectionReason).IsNull();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+public class SequencedCommandProcessorTests {
+    sealed class Harness {
+        public readonly List<CommandAck> Acks = [];
+        public readonly List<CommandRejected> Rejects = [];
+        public readonly ConcurrentQueue<long> ExecOrder = new();
+        public SequencedCommandProcessor P(string epoch = "e1", int bound = 256) => new(
+            epoch, _ => AgentLiveness.Live,
+            a => { lock (Acks) Acks.Add(a); return Task.CompletedTask; },
+            r => { lock (Rejects) Rejects.Add(r); return Task.CompletedTask; },
+            NullLogger.Instance, bound);
+        public SequencedItem Launch(long seq, string epoch = "e1", string id = "cmd", string agent = "a")
+            => new(SequencedKind.Launch, epoch, seq, id + seq, agent + seq);
+    }
+
+    [Test] public async Task Exact_next_commands_execute_serially_and_advance_the_watermark() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => { h.ExecOrder.Enqueue(1); return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)); });
+        await p.SubmitAsync(h.Launch(2), () => { h.ExecOrder.Enqueue(2); return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)); });
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(2L);
+        await Assert.That(h.ExecOrder.ToArray()).IsEquivalentTo(new[] { 1L, 2L });
+    }
+
+    [Test] public async Task Out_of_order_command_is_not_accepted() {
+        var h = new Harness(); await using var p = h.P();
+        var ran = false;
+        await p.SubmitAsync(h.Launch(2), () => { ran = true; return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)); });
+        await Assert.That(p.HighestAcceptedSeq).IsEqualTo(0L); // Seq 2 while next is 1 -> not accepted
+        await Assert.That(ran).IsFalse();
+    }
+
+    [Test] public async Task Execute_fault_becomes_internal_error_and_still_advances_the_watermark() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => throw new InvalidOperationException("boom"));
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(1L);
+        await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.InternalError);
+    }
+
+    [Test] public async Task Forced_item_creation_failure_synthesizes_a_terminal_item_and_advances_monotonically() {
+        // Parent §8: forced item-creation failure AFTER counter reservation -> synthesized errored terminal
+        // item at N, watermark advances. AND the monotonicity hazard: when the lane is completing while an
+        // earlier accepted item is still draining, the synthesized advance must NOT jump past it (which the
+        // draining item's later advance would then regress below).
+        var h = new Harness(); await using var p = h.P();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var gate    = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Item 1 accepted + enqueued; its execute BLOCKS mid-flight (still draining).
+        var t1 = p.SubmitAsync(h.Launch(1),
+            async () => { started.SetResult(); await gate.Task; return new CommandOutcome(CommandOutcomeKind.LaunchExecuted); });
+        await started.Task;                 // item 1 is dequeued and executing
+
+        // Complete the lane while item 1 drains, then submit item 2 -> TryWrite fails -> SynthesizeErrorLocked.
+        p.CompleteLaneForTest();
+        var t2 = p.SubmitAsync(h.Launch(2), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await t2;                           // the synthesized terminal completes immediately
+        var afterSynth = p.LastProcessedSeq;
+        await Assert.That(afterSynth).IsEqualTo(0L);   // synth at N=2 did NOT skip past the still-draining N=1
+
+        gate.SetResult();                   // item 1 drains; contiguous prefix now reaches 1 then 2
+        await t1;
+        await Assert.That(afterSynth).IsLessThanOrEqualTo(p.LastProcessedSeq); // monotonic — never regressed
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(2L);                    // contiguous prefix reaches 2
+        await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.InternalError); // synth emitted the reject
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
@@ -69,4 +69,26 @@ public class SequencedCommandProcessorTests {
         await Assert.That(p.LastProcessedSeq).IsEqualTo(2L);                    // contiguous prefix reaches 2
         await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.InternalError); // synth emitted the reject
     }
+
+    [Test] public async Task Duplicate_of_a_processed_command_is_acked_with_outcome_and_live_state_not_reexecuted() {
+        var h = new Harness(); await using var p = h.P();
+        var runs = 0;
+        var item = h.Launch(1);
+        await p.SubmitAsync(item, () => { runs++; return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted, "a", "sess")); });
+        await p.SubmitAsync(item, () => { runs++; return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)); });
+        await Assert.That(runs).IsEqualTo(1);                                    // no re-execution
+        var ack = h.Acks.Single();
+        await Assert.That(ack.State).IsEqualTo(CommandAckState.Processed);
+        await Assert.That(ack.OutcomeKind).IsEqualTo(CommandOutcomeKind.LaunchExecuted);
+        await Assert.That(ack.CurrentState).IsEqualTo(AgentLiveness.Live);       // read live at ack time
+    }
+
+    [Test] public async Task Different_command_id_at_an_accepted_seq_is_a_duplicate_collision() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        // Same Seq, different CommandId:
+        await p.SubmitAsync(new SequencedItem(SequencedKind.Launch, "e1", 1, "OTHER", "a1"),
+            () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.DuplicateCollision);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
@@ -114,4 +114,20 @@ public class SequencedCommandProcessorTests {
         await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
         await Assert.That(h.Acks.Count).IsEqualTo(1);
     }
+
+    [Test] public async Task Non_next_future_seq_is_rejected_wrong_next_without_accepting() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await p.SubmitAsync(h.Launch(3), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted))); // gap
+        await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.WrongNext);
+        await Assert.That(p.HighestAcceptedSeq).IsEqualTo(1L);
+    }
+
+    [Test] public async Task Execution_time_daemon_capacity_rejection_advances_watermark_and_emits_reject() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(
+            new CommandOutcome(CommandOutcomeKind.LaunchRejected, "a", RejectReason: CommandRejectedReason.DaemonCapacity)));
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(1L);        // rejected-as-item is terminal
+        await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.DaemonCapacity);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedSettlementWireTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedSettlementWireTests.cs
@@ -68,6 +68,25 @@ public class SequencedSettlementWireTests {
         await Assert.That(pruneJson).Contains("\"generation\":3");
     }
 
+    // Phase B2-b (sequenced-settlement design §5.5): the report/connect payloads advertise
+    // HighestResolutionGeneration (the daemon-lifetime monotonic high-water) alongside the resolved-
+    // candidates array, so once sparse acks prune entries the server still knows the generation frontier.
+    // Additive/optional — old-shape construction leaves it null.
+    [Test]
+    public async Task HighestResolutionGeneration_round_trips_on_report_and_connect() {
+        var reportRt = JsonSerializer.Deserialize<DaemonStatusReport>(JsonSerializer.Serialize(
+            new DaemonStatusReport(1, [], [], HighestResolutionGeneration: 7), Opts), Opts);
+        await Assert.That(reportRt.HighestResolutionGeneration).IsEqualTo(7L);
+
+        // Old-shape construction still leaves it null.
+        await Assert.That(new DaemonStatusReport(1, [], []).HighestResolutionGeneration).IsNull();
+
+        var connectRt = JsonSerializer.Deserialize<DaemonConnect>(JsonSerializer.Serialize(
+            new DaemonConnect("d", "linux", [], 5, [], HighestResolutionGeneration: 9), Opts), Opts);
+        await Assert.That(connectRt.HighestResolutionGeneration).IsEqualTo(9L);
+        await Assert.That(new DaemonConnect("d", "linux", [], 5, []).HighestResolutionGeneration).IsNull();
+    }
+
     [Test]
     public async Task LaunchAgentCommand_gains_optional_sequencing_fields() {
         var legacy = new LaunchAgentCommand("a1", "hi", "opus", null, "/repo", null, null, "claude");

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedSettlementWireTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedSettlementWireTests.cs
@@ -45,4 +45,37 @@ public class SequencedSettlementWireTests {
         await Assert.That(rt.StartupReapComplete).IsTrue();
         await Assert.That(rt.StartupDiscovery!.Value.MarkerScanState).IsEqualTo(MarkerScanState.Complete);
     }
+
+    [Test]
+    public async Task Command_dtos_pin_wire_tokens_and_round_trip() {
+        var stop = new StopAgentV2("a1", "e1", 9, "cmd-guid");
+        var rt = JsonSerializer.Deserialize<StopAgentV2>(JsonSerializer.Serialize(stop, Opts), Opts);
+        await Assert.That(rt).IsEqualTo(stop);
+
+        var ackJson = JsonSerializer.Serialize(
+            new CommandAck("e1", 9, "cmd", CommandAckState.Processed,
+                CommandOutcomeKind.LaunchExecuted, AgentLiveness.Live, "a1", "sess"), Opts);
+        await Assert.That(ackJson).Contains("\"state\":\"processed\"");
+        await Assert.That(ackJson).Contains("\"outcome_kind\":\"launch_executed\"");
+        await Assert.That(ackJson).Contains("\"current_state\":\"live\"");
+
+        var rejJson = JsonSerializer.Serialize(
+            new CommandRejected("e1", 9, "cmd", CommandRejectedReason.StaleEpoch, "a1"), Opts);
+        await Assert.That(rejJson).Contains("\"reason\":\"stale_epoch\"");
+
+        var pruneJson = JsonSerializer.Serialize(
+            new AckResolvedCandidates([new ResolvedCandidateAck(3, "a1", "old")]), Opts);
+        await Assert.That(pruneJson).Contains("\"generation\":3");
+    }
+
+    [Test]
+    public async Task LaunchAgentCommand_gains_optional_sequencing_fields() {
+        var legacy = new LaunchAgentCommand("a1", "hi", "opus", null, "/repo", null, null, "claude");
+        await Assert.That(legacy.Seq).IsNull(); // absent ⇒ legacy lane
+
+        var seqd = legacy with { Epoch = "e1", Seq = 4, CommandId = "cmd" };
+        var rt = JsonSerializer.Deserialize<LaunchAgentCommand>(JsonSerializer.Serialize(seqd, Opts), Opts);
+        await Assert.That(rt.Seq).IsEqualTo(4L);
+        await Assert.That(rt.CommandId).IsEqualTo("cmd");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedSettlementWireTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedSettlementWireTests.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+public class SequencedSettlementWireTests {
+    static readonly JsonSerializerOptions Opts = new() {
+        TypeInfoResolver = CapacitorJsonContext.Default,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    [Test]
+    public async Task StartupDiscovery_pins_exact_wire_tokens_and_defaults_to_pending() {
+        var json = JsonSerializer.Serialize(new StartupDiscovery(MarkerScanState.Complete), Opts);
+        await Assert.That(json).Contains("\"marker_scan_state\":\"complete\"");
+
+        // The zero value (missing field) is the conservative default.
+        await Assert.That(default(MarkerScanState)).IsEqualTo(MarkerScanState.Pending);
+    }
+
+    [Test]
+    public async Task Resolved_and_unresolved_candidates_round_trip() {
+        var resolved = new ResolvedStartupCandidate(7, "a1", "old-epoch", "flow-1", "reviewer");
+        var rt = JsonSerializer.Deserialize<ResolvedStartupCandidate>(JsonSerializer.Serialize(resolved, Opts), Opts);
+        await Assert.That(rt).IsEqualTo(resolved);
+
+        var blockedJson = JsonSerializer.Serialize(
+            new UnresolvedStartupCandidate("a2", StartupCandidateUnresolvedReason.PendingMarker), Opts);
+        await Assert.That(blockedJson).Contains("\"reason\":\"pending_marker\"");
+    }
+
+    [Test]
+    public async Task DaemonStatusReport_new_fields_round_trip_and_default_null() {
+        // Old-shape construction still compiles (all new args optional).
+        var old = new DaemonStatusReport(2, [], []);
+        await Assert.That(old.Epoch).IsNull();
+        await Assert.That(old.StartupDiscovery).IsNull();
+
+        var full = new DaemonStatusReport(
+            2, [], [], Epoch: "e1", LastProcessedSeq: 5, HighestAcceptedSeq: 6,
+            StartupReapComplete: true, ResolvedStartupCandidates: [],
+            UnresolvedStartupCandidates: [], StartupDiscovery: new StartupDiscovery(MarkerScanState.Complete));
+        var rt = JsonSerializer.Deserialize<DaemonStatusReport>(JsonSerializer.Serialize(full, Opts), Opts);
+        await Assert.That(rt.Epoch).IsEqualTo("e1");
+        await Assert.That(rt.StartupReapComplete).IsTrue();
+        await Assert.That(rt.StartupDiscovery!.Value.MarkerScanState).IsEqualTo(MarkerScanState.Complete);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
@@ -25,8 +25,6 @@ public partial class AgentOrchestratorVendorTests {
     public async Task Startup_discovery_is_not_applicable_off_linux_and_pending_before_a_scan() {
         await using var orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(),
             new Dictionary<string, IHostedAgentLauncher>());
-        var report = orch.BuildStatusReport();
-        var expected = OperatingSystem.IsLinux() ? MarkerScanState.Complete : MarkerScanState.NotApplicable;
         // A clean boot with no candidates: after ReapOrphansOnceAsync the Linux scan is complete.
         await orch.ReapOrphansOnceAsync();
         await Assert.That(orch.BuildStatusReport().StartupDiscovery!.Value.MarkerScanState)

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
@@ -1,0 +1,20 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+// Phase B2-b (sequenced-settlement design): the orchestrator surfaces the durable coverage
+// boot-chain verdict (DaemonConfig.RecordlessSurvivorsImpossible, folded in DaemonRunner before
+// Connect) so the enriched DaemonConnect payload can advertise it. This partial reuses the vendor
+// test class's BuildOrchestrator/CaptureServerConnection/SpyPtyProcessFactory harness.
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Status_report_advertises_recordless_survivors_impossible_from_config() {
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>(),
+            configure: c => c.RecordlessSurvivorsImpossible = true);
+
+        await Assert.That(orch.RecordlessSurvivorsImpossibleForTest).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
@@ -17,4 +17,22 @@ public partial class AgentOrchestratorVendorTests {
 
         await Assert.That(orch.RecordlessSurvivorsImpossibleForTest).IsTrue();
     }
+
+    // Phase B2-b (sequenced-settlement design §4.2.4): the ledger's un-acked snapshot is re-reported on
+    // every status report until the server prunes it per-entry via AckResolvedCandidates. The seam and
+    // the underlying ledger Ack are SYNCHRONOUS (void) — no await (would be CS4008).
+    [Test]
+    public async Task Status_report_carries_resolved_candidates_and_ack_prunes_them() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+
+        var g = orch.SeedResolvedCandidateForTest("a1", "old-epoch");   // test seam over the ledger
+        await Assert.That(orch.BuildStatusReport().ResolvedStartupCandidates!.Single().AgentId).IsEqualTo("a1");
+
+        // The seam + the underlying ledger Ack are SYNCHRONOUS (void) — no await (would be CS4008).
+        orch.HandleAckResolvedCandidatesForTest(
+            new AckResolvedCandidates([new ResolvedCandidateAck(g.Generation, "a1", "old-epoch")]));
+        await Assert.That(orch.BuildStatusReport().ResolvedStartupCandidates).IsEmpty();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
@@ -18,6 +18,37 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(orch.RecordlessSurvivorsImpossibleForTest).IsTrue();
     }
 
+    // Phase B2-b (sequenced-settlement design): StartupDiscovery.MarkerScanState is NotApplicable off
+    // Linux (Windows has no scan, macOS env is redacted) and — on Linux — flips to Complete after one
+    // clean env-marker-scan pass. A clean boot with no candidates completes the pass on the first reap.
+    [Test]
+    public async Task Startup_discovery_is_not_applicable_off_linux_and_pending_before_a_scan() {
+        await using var orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        var report = orch.BuildStatusReport();
+        var expected = OperatingSystem.IsLinux() ? MarkerScanState.Complete : MarkerScanState.NotApplicable;
+        // A clean boot with no candidates: after ReapOrphansOnceAsync the Linux scan is complete.
+        await orch.ReapOrphansOnceAsync();
+        await Assert.That(orch.BuildStatusReport().StartupDiscovery!.Value.MarkerScanState)
+            .IsEqualTo(OperatingSystem.IsLinux() ? MarkerScanState.Complete : MarkerScanState.NotApplicable);
+    }
+
+    // Phase B2-b (sequenced-settlement design): a persisted marker-candidate source (a recordless
+    // prior-epoch survivor with no matching live triple) surfaces as a PendingMarker blocked candidate
+    // and keeps StartupReapComplete false. Linux-only — the blocked-candidate surface is asserted
+    // directly via BuildStatusReport (no scan runs), so the seeded dead pid is never resolved away.
+    [Test]
+    public async Task Pending_marker_candidate_blocks_completion_and_surfaces_reason() {
+        if (!OperatingSystem.IsLinux()) return;
+        await using var orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedPendingMarkerCandidateForTest("blocked", "old"); // occupant with no matching triple
+        var report = orch.BuildStatusReport();
+        await Assert.That(report.StartupReapComplete).IsFalse();
+        await Assert.That(report.UnresolvedStartupCandidates!.Single().Reason)
+            .IsEqualTo(StartupCandidateUnresolvedReason.PendingMarker);
+    }
+
     // Phase B2-b (sequenced-settlement design §4.2.4): the ledger's un-acked snapshot is re-reported on
     // every status report until the server prunes it per-entry via AckResolvedCandidates. The seam and
     // the underlying ledger Ack are SYNCHRONOUS (void) — no await (would be CS4008).

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/StartupCompletenessTests.cs
@@ -47,6 +47,29 @@ public partial class AgentOrchestratorVendorTests {
             .IsEqualTo(StartupCandidateUnresolvedReason.PendingMarker);
     }
 
+    // Phase B2-b (sequenced-settlement design §5.5): a PRESENT prior-epoch record that the record pass
+    // spared (a transient ambiguous identity read on Linux, or a record-pass fault) is still on disk and
+    // therefore UNRESOLVED — confirmed-dead records are deleted. It must keep completion FALSE (surfaced as
+    // identity_unresolvable), never be silently omitted (the paired server would treat omission as proof of
+    // death and launch a duplicate). Deterministic: BlockedCandidates() just reads the store, so seed it
+    // directly with a dead pid (so the macOS legacy-live arm can't catch it) — the else arm must.
+    [Test]
+    public async Task Spared_prior_epoch_present_record_blocks_completion_as_identity_unresolvable() {
+        await using var orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        orch.WritePidRecordForTest(new AgentPidRecord(
+            "spared", 999_999, "mac:boot:uid", PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-1", "reviewer", orch.DaemonIdForTest, "old-epoch", DateTimeOffset.UtcNow));
+
+        var report = orch.BuildStatusReport();
+        await Assert.That(report.StartupReapComplete).IsFalse();
+        var blocked = report.UnresolvedStartupCandidates!.Single(c => c.AgentId == "spared");
+        await Assert.That(blocked.Reason).IsEqualTo(StartupCandidateUnresolvedReason.IdentityUnresolvable);
+        await Assert.That(blocked.FlowRunId).IsEqualTo("flow-1");   // from the TRUSTED record
+        await Assert.That(blocked.FlowRole).IsEqualTo("reviewer");
+        await Assert.That(orch.ComputeStartupReapComplete()).IsFalse();
+    }
+
     // Phase B2-b (sequenced-settlement design §4.2.4): the ledger's un-acked snapshot is re-reported on
     // every status report until the server prunes it per-entry via AckResolvedCandidates. The seam and
     // the underlying ledger Ack are SYNCHRONOUS (void) — no await (would be CS4008).


### PR DESCRIPTION
## What & why

Part of **AI-1391 B2-b** — the bilateral **sequenced daemon-command settlement** protocol (parent AI-1313 §5.5/§6/§7/§8). This is the **daemon (producer) half**; the paired kcap-server PR consumes the wire. Rollout is **daemon-first**: everything here is advertised-but-inert — the `SupportsSequencedCommands` capability is `true` on `DaemonConnect`, but no behaviour changes until the server PR lands and starts sending sequenced commands. All wire changes are **additive** (an old server ignores unknown fields/methods), so either merge order is safe.

Spec: `docs/superpowers/specs/2026-07-17-ai1391-sequenced-settlement-design.md`. Plan (in this PR): `docs/superpowers/plans/2026-07-22-ai1391-b2b-daemon-sequenced-settlement.md`.

## Scope (daemon producer side)

- **Additive wire DTOs** (`Cli.Core/Models.cs`) — `StopAgentV2` / `CommandAck` / `CommandRejected` / `AckProcessedPrefix` / `AckResolvedCandidates` / `RequestStatusReport`; `ResolvedStartupCandidate` / `UnresolvedStartupCandidate` / `StartupDiscovery`; and additive fields on `LaunchAgentCommand` (Epoch/Seq/CommandId) + `DaemonConnect`/`DaemonStatusReport` (watermark + startup-completeness + `SupportsSequencedCommands`). Enums pinned with `[JsonStringEnumMemberName]` and zero = safe default.
- **`SequencedCommandProcessor`** — two sequenced lanes (Seq'd `LaunchAgentCommand` + `StopAgentV2`) executed strictly serially per epoch; exact-next acceptance is one atomic op under lock; `LastProcessedSeq` is the contiguous terminal-processed prefix; duplicates answered with `CommandAck` (never re-executed); `wrong_next` / `duplicate_collision` / `backpressure` / `stale_epoch` / `internal_error` rejections; `AckProcessedPrefix` retires identity-cache entries (never evicts an unacked entry). Un-Seq'd commands stay on the legacy unsequenced lane (old-server compat) and never advance the watermark.
- **`ResolvedCandidatesLedger`** — durable positive-death-evidence outbox in the daemon state dir (atomic temp+rename, monotonic `Generation`, append-before-source-delete, `(AgentId, OldEpoch)` reconcile key). Four hooks feed it: OrphanReaper record-pass, quarantine drain, StopAgent PID-record fallback, and the env-marker recordless resolution matrix. Pruned by a validated `AckResolvedCandidates`.
- **Coverage boot-chain attestation** — `CoverageJournal` (single-atomic-write genesis, `cumulative_covered` fold) + `DaemonLock.PriorInstanceId` chain-check → the fail-closed, sticky-false `RecordlessSurvivorsImpossible` flag advertised on connect.
- **Per-platform startup discovery** — `StartupReapComplete` + `StartupDiscovery` (marker-scan state) + `UnresolvedStartupCandidates`; the daemon heal-barrier serves `RequestStatusReport` and emits `CommandRejected` per reason.

## Deferred (noted seams, not in this PR)

- Wait-at-capacity `DaemonLaunchQueue` (FIFO ticket state machine) — the spec frames it as a separate layer; an `OnLaunchRequeue` seam is provided.

## Marker-path safety (review follow-up)

`OrphanReaper.EmitAndClear` now corroborates the **reaped pid AND prior epoch** (`r.Pid == c.Pid && r.DaemonEpoch == c.OldEpoch`) before trusting/deleting a durable record on the marker path — the env agentId is untrusted for role authority, so a prior-epoch descendant that inherited a still-live leader's env can no longer emit a false trusted-flow death proof for (or delete the record of) the live leader. Non-corroborating matches fall back to the recordless null-flow path with no record delete.

## Testing

`Capacitor.Cli.Tests.Unit` full suite green — **total 3663, failed 0**, 2 skipped (a gated live-ACP E2E). New coverage across the processor, ledger + 4 hooks, coverage journal, DaemonLock prior-instance chain, heal-barrier report, marker-candidate resolution matrix, startup completeness, and the wire DTOs. Tests use isolated dummy processes only — no real daemon, no live flows. The Linux-only marker-scan matrix is exercised under Linux CI.

## Compatibility

Fully additive; `SupportsSequencedCommands` is the single gate. An old server ignores the new fields/methods and the daemon behaves exactly as before. No projection or read-model changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
