### PR TITLE
AI-1458: add shared SessionStart memory foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,23 @@ Once set up, Capacitor runs silently in the background. Every Claude Code (and C
 - **SessionStart team-memory index** — at every session start (Claude Code) `kcap` also fetches a compact index of durable [team memories](#memory-mcp-server-for-agents) visible for the current repo/machine and appends a `## Team memory` block to `additionalContext`: one `slug: description` line per memory, grouped **Org / Team / Yours**, with a nudge to call `get_memory` / `search_memories` for full content. Only the index is injected — never the bodies — so the cost stays roughly flat as the pool grows (mirrors a local `MEMORY.md`). Best-effort and fail-open (a slow or failed fetch injects nothing, never blocking the hook). Opt out with `disable_memory_index: true` in `~/.config/kcap/config.json` or `kcap config set disable_memory_index true`.
 - **Crash resilience** — if a `kcap` command hits an unexpected error it records the exception (with stack trace) to `~/.config/kcap/crash.log` (honours `KCAP_CONFIG_DIR`; size-capped) and exits cleanly instead of aborting. Hook and detached-generator commands the coding agent spawns **fail open** (exit 0, nothing surfaced to the agent); other commands exit non-zero with a one-line stderr message pointing at the log.
 
+The SessionStart memory foundation is deliberately separate from harness activation. Every row uses
+the same typed fetch/render, lifecycle, fenced lease, and golden output contracts; only Claude is
+wired in this foundation release. Each remaining adapter is activated and live-certified by its own
+AI-1456 child issue.
+
+| Harness | Shared foundation | Hook/extension wired | Live receipt | Upstream status |
+|---------|-------------------|----------------------|--------------|-----------------|
+| Claude Code | yes | yes | existing baseline | available |
+| Codex CLI | yes | no | pending | available |
+| Cursor CLI / IDE | yes | no | pending | CLI available; IDE context delivery degraded upstream |
+| GitHub Copilot CLI | yes | no | pending | available |
+| Gemini CLI | yes | no | pending | available |
+| Kiro CLI | yes | no | pending | available |
+| Pi | yes | no | pending | extension bridge required |
+| OpenCode | yes | no | pending | extension bridge required |
+| Antigravity | yes | no | pending | `PreInvocation` adapter required |
+
 ## CLI commands
 
 At a glance — each links to its section below:

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -94,7 +94,7 @@ public static class TokenStore {
         return tokens;
     }
 
-    public static async Task SaveAsync(string profile, StoredTokens tokens) {
+    public static async Task SaveAsync(string profile, StoredTokens tokens, CancellationToken ct = default) {
         Directory.CreateDirectory(TokenDir);
         var path     = ProfileTokenPath(profile);
         // Unique per write so concurrent writers (hooks/watcher/daemon/MCP/login share this
@@ -115,9 +115,10 @@ public static class TokenStore {
         try {
             await using (var stream = new FileStream(tempPath, options))
             await using (var writer = new StreamWriter(stream)) {
-                await writer.WriteAsync(JsonSerializer.Serialize(tokens, CapacitorJsonContext.Default.StoredTokens));
+                await writer.WriteAsync(
+                    JsonSerializer.Serialize(tokens, CapacitorJsonContext.Default.StoredTokens).AsMemory(), ct);
             }
-            await ReplaceWithRetryAsync(tempPath, path);
+            await ReplaceWithRetryAsync(tempPath, path, ct);
         } finally {
             // Success renames the temp away; only a failed write/move leaves it. Unlike the
             // old shared name, a leaked unique temp never gets reused, so clean it up.
@@ -148,15 +149,16 @@ public static class TokenStore {
     const int ReplaceMaxAttempts   = 5;
     const int ReplaceBackoffBaseMs = 20;
 
-    static async Task ReplaceWithRetryAsync(string tempPath, string path) {
+    static async Task ReplaceWithRetryAsync(string tempPath, string path, CancellationToken ct = default) {
         for (var attempt = 1; ; attempt++) {
+            ct.ThrowIfCancellationRequested();
             try {
                 File.Move(tempPath, path, overwrite: true);
                 return;
             } catch (Exception ex) when ((ex is UnauthorizedAccessException or IOException)
                                          && attempt < ReplaceMaxAttempts) {
                 // Linear backoff (20/40/60/80ms) to let the peer holding the target close it.
-                await Task.Delay(ReplaceBackoffBaseMs * attempt);
+                await Task.Delay(ReplaceBackoffBaseMs * attempt, ct);
             }
         }
     }
@@ -233,8 +235,8 @@ public static class TokenStore {
         return Task.CompletedTask;
     }
 
-    static async Task<string> ResolveActiveProfileAsync() {
-        var cfg = await AppConfig.LoadProfileConfig();
+    static async Task<string> ResolveActiveProfileAsync(CancellationToken ct = default) {
+        var cfg = await AppConfig.LoadProfileConfig(ct);
         return string.IsNullOrEmpty(cfg.ActiveProfile) ? "default" : cfg.ActiveProfile;
     }
 
@@ -265,6 +267,28 @@ public static class TokenStore {
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Forces one provider refresh even when the locally cached access token has not expired.
+    /// Used only after a server 401 proves that the otherwise-valid token is no longer accepted.
+    /// The existing profile-scoped lock still serializes rotating credentials across processes.
+    /// </summary>
+    public static async Task<StoredTokens?> ForceRefreshAsync(CancellationToken ct = default) {
+        var profile = await ResolveActiveProfileAsync(ct);
+        var tokens = await LoadWithLegacyFallbackAsync(profile);
+        if (tokens is null) return null;
+
+        Func<StoredTokens, Task<StoredTokens?>> refresh = tokens.Provider switch {
+            AuthProvider.WorkOS when tokens.RefreshToken is not null && tokens.ClientId is not null
+                => value => RefreshWorkOSAsync(value, ct),
+            AuthProvider.GitHubApp => value => RefreshGitHubAsync(value, ct),
+            _ => _ => Task.FromResult<StoredTokens?>(null)
+        };
+        if (tokens.Provider is not (AuthProvider.WorkOS or AuthProvider.GitHubApp)) return null;
+
+        return await RefreshWithCrossProcessLockAsync(
+            profile, tokens, refresh, needsRefresh: static _ => true, cancellationToken: ct);
     }
 
     // The decision the daemon's proactive-refresh tick makes each time it wakes. Kept a
@@ -357,7 +381,8 @@ public static class TokenStore {
             StoredTokens                            current,
             Func<StoredTokens, Task<StoredTokens?>> refresh,
             Func<StoredTokens, bool>?               needsRefresh    = null,
-            Action?                                 onLockContended = null
+            Action?                                 onLockContended = null,
+            CancellationToken                       cancellationToken = default
         ) {
         // Default predicate: refresh a token GetValidTokensAsync already found expired. The
         // proactive path (RefreshIfExpiringAsync) passes a wider "within N minutes of expiry"
@@ -375,6 +400,7 @@ public static class TokenStore {
         var         deadline   = DateTime.UtcNow.AddSeconds(15);
 
         while (lockStream is null) {
+            cancellationToken.ThrowIfCancellationRequested();
             try {
                 lockStream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
             } catch (IOException) {
@@ -393,7 +419,7 @@ public static class TokenStore {
                     return null;
                 }
 
-                await Task.Delay(100);
+                await Task.Delay(100, cancellationToken);
             }
         }
 
@@ -421,7 +447,7 @@ public static class TokenStore {
             // a different profile's file (without that profile's lock). Saving here, under the lock,
             // with the profile we locked, closes that hole for both callers.
             if (refreshed is not null) {
-                await SaveAsync(profile, refreshed);
+                await SaveAsync(profile, refreshed, cancellationToken);
             }
 
             return refreshed;
@@ -465,7 +491,10 @@ public static class TokenStore {
     // Kept short so a hook never blocks for the default 30s budget when the server is down.
     static readonly TimeSpan RefreshRetryBudget = TimeSpan.FromSeconds(5);
 
-    static async Task<StoredTokens?> RefreshGitHubAsync(StoredTokens tokens) {
+    static Task<StoredTokens?> RefreshGitHubAsync(StoredTokens tokens) =>
+        RefreshGitHubAsync(tokens, CancellationToken.None);
+
+    static async Task<StoredTokens?> RefreshGitHubAsync(StoredTokens tokens, CancellationToken ct) {
         var baseUrl = AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KCAP_URL") ?? "http://localhost:5108";
         var url     = $"{baseUrl}/auth/refresh";
 
@@ -487,13 +516,14 @@ public static class TokenStore {
         var payload = new StringContent(requestBody, System.Text.Encoding.UTF8, "application/json");
 
         try {
-            var response = await http.PostWithRetryAsync(url, payload, RefreshRetryBudget);
+            var response = await http.PostWithRetryAsync(url, payload, RefreshRetryBudget, ct);
 
             if (!response.IsSuccessStatusCode) {
                 return null;
             }
 
-            var json = await response.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.TokenExchangeResponse);
+            var json = await response.Content.ReadFromJsonAsync(
+                CapacitorJsonContext.Default.TokenExchangeResponse, ct);
 
             if (json is null) {
                 return null;
@@ -511,7 +541,10 @@ public static class TokenStore {
         }
     }
 
-    static async Task<StoredTokens?> RefreshWorkOSAsync(StoredTokens tokens) {
+    static Task<StoredTokens?> RefreshWorkOSAsync(StoredTokens tokens) =>
+        RefreshWorkOSAsync(tokens, CancellationToken.None);
+
+    static async Task<StoredTokens?> RefreshWorkOSAsync(StoredTokens tokens, CancellationToken ct) {
         // Mirror RefreshGitHubAsync: network/parse failures return null (caller surfaces
         // "run kcap login") rather than throwing out of GetValidTokensAsync and crashing.
         try {
@@ -532,14 +565,16 @@ public static class TokenStore {
                         ["refresh_token"] = tokens.RefreshToken!
                     }
                 ),
-                RefreshRetryBudget
+                RefreshRetryBudget,
+                ct
             );
 
             if (!response.IsSuccessStatusCode) {
                 return null;
             }
 
-            var json = await response.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse);
+            var json = await response.Content.ReadFromJsonAsync(
+                CapacitorJsonContext.Default.WorkOSAuthResponse, ct);
 
             if (json is null) {
                 return null;

--- a/src/Capacitor.Cli.Core/Config/AppConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/AppConfig.cs
@@ -249,14 +249,14 @@ public static class AppConfig {
         ResolvedProfile   = new ResolvedProfile(serverUrl, profileName, profile, null);
     }
 
-    public static async Task<ProfileConfig> LoadProfileConfig() {
+    public static async Task<ProfileConfig> LoadProfileConfig(CancellationToken ct = default) {
         if (!File.Exists(ConfigPath))
             return new() { Profiles = new() { ["default"] = new() } };
 
         string json;
 
         try {
-            json = await File.ReadAllTextAsync(ConfigPath);
+            json = await File.ReadAllTextAsync(ConfigPath, ct);
         } catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) {
             await Console.Error.WriteLineAsync($"Warning: could not read config at {ConfigPath}: {ex.Message}");
 
@@ -296,7 +296,7 @@ public static class AppConfig {
             }
 
             try {
-                await SaveProfileConfig(result.Config);
+                await SaveProfileConfig(result.Config, ct);
             } catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) {
                 await Console.Error.WriteLineAsync($"Warning: could not persist migrated config at {ConfigPath}: {ex.Message}");
             }
@@ -332,15 +332,17 @@ public static class AppConfig {
         return rebuilt is null ? config : config with { Profiles = rebuilt };
     }
 
-    public static async Task SaveProfileConfig(ProfileConfig config) {
+    public static async Task SaveProfileConfig(ProfileConfig config, CancellationToken ct = default) {
         var dir = Path.GetDirectoryName(ConfigPath)!;
         Directory.CreateDirectory(dir);
         var tempPath = $"{ConfigPath}.tmp";
 
         await File.WriteAllBytesAsync(
             tempPath,
-            JsonSerializer.SerializeToUtf8Bytes(config, ProfileConfigJsonContextIndented.Default.ProfileConfig)
+            JsonSerializer.SerializeToUtf8Bytes(config, ProfileConfigJsonContextIndented.Default.ProfileConfig),
+            ct
         );
+        ct.ThrowIfCancellationRequested();
         File.Move(tempPath, ConfigPath, overwrite: true);
     }
 

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -35,7 +35,8 @@ public static class HttpClientExtensions {
     /// so they can stay quiet on high-frequency events and exit cleanly instead of erroring per-turn.
     /// </summary>
     public static async Task<(HttpClient Client, AuthStatus Status)> CreateClientWithAuthStatusAsync(
-        string? baseUrl = null, CancellationToken ct = default, bool allowAutoRedirect = true) {
+        string? baseUrl = null, CancellationToken ct = default, bool allowAutoRedirect = true,
+        bool forceRefresh = false) {
         var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = allowAutoRedirect });
 
         baseUrl ??= AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KCAP_URL") ?? "http://localhost:5108";
@@ -45,7 +46,9 @@ public static class HttpClientExtensions {
             return (client, AuthStatus.NoAuthRequired); // No auth needed
         }
 
-        var tokens = await TokenStore.GetValidTokensAsync();
+        var tokens = forceRefresh
+            ? await TokenStore.ForceRefreshAsync(ct)
+            : await TokenStore.GetValidTokensAsync();
 
         if (tokens is not null) {
             client.DefaultRequestHeaders.Authorization = new("Bearer", tokens.AccessToken);

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -34,8 +34,9 @@ public static class HttpClientExtensions {
     /// surface it. Hook callers should prefer this over <see cref="CreateAuthenticatedClientAsync"/>
     /// so they can stay quiet on high-frequency events and exit cleanly instead of erroring per-turn.
     /// </summary>
-    public static async Task<(HttpClient Client, AuthStatus Status)> CreateClientWithAuthStatusAsync(string? baseUrl = null, CancellationToken ct = default) {
-        var client = new HttpClient();
+    public static async Task<(HttpClient Client, AuthStatus Status)> CreateClientWithAuthStatusAsync(
+        string? baseUrl = null, CancellationToken ct = default, bool allowAutoRedirect = true) {
+        var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = allowAutoRedirect });
 
         baseUrl ??= AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KCAP_URL") ?? "http://localhost:5108";
         var provider = await DiscoverProviderAsync(baseUrl, ct);

--- a/src/Capacitor.Cli.Core/MachineIdProvider.cs
+++ b/src/Capacitor.Cli.Core/MachineIdProvider.cs
@@ -6,12 +6,12 @@ public static class MachineIdProvider {
     public static string Generate() => "mach-" + Guid.NewGuid().ToString("N")[..12];
 
     /// <summary>Returns the persisted machine id, generating + saving one on first use.</summary>
-    public static async Task<string> GetOrCreateAsync() {
-        var config = await AppConfig.LoadProfileConfig();
+    public static async Task<string> GetOrCreateAsync(CancellationToken ct = default) {
+        var config = await AppConfig.LoadProfileConfig(ct);
         if (!string.IsNullOrWhiteSpace(config.MachineId)) return config.MachineId;
 
         var id = Generate();
-        await AppConfig.SaveProfileConfig(config with { MachineId = id });
+        await AppConfig.SaveProfileConfig(config with { MachineId = id }, ct);
         return id;
     }
 }

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.SessionStartMemory;
 
 namespace Capacitor.Cli.Commands;
 
@@ -32,11 +33,14 @@ public static class ClaudeHookCommand {
 
     static Task<int> HandleWithDeps(HookSpool spool, long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask)
         => HandleWithDeps(spool, processStart, baseUrl, stdin, updateCheckTask,
-            () => HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl));
+            () => HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl),
+            async ct => (await HttpClientExtensions.CreateClientWithAuthStatusAsync(
+                baseUrl, ct, allowAutoRedirect: false)).Client);
 
     internal static async Task<int> HandleWithDeps(
             HookSpool spool, long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask,
-            Func<Task<(HttpClient Client, AuthStatus Status)>> clientFactory) {
+            Func<Task<(HttpClient Client, AuthStatus Status)>> clientFactory,
+            Func<CancellationToken, Task<HttpClient>>? memoryClientFactory = null) {
         string body;
         try { body = await stdin.ReadToEndAsync(); } catch { return 0; }
 
@@ -82,7 +86,8 @@ public static class ClaudeHookCommand {
 
         var (client, authStatus) = created.Value;
         try {
-            return await HandleCore(client, authStatus, spool, processStart, baseUrl, new StringReader(body), updateCheckTask);
+            return await HandleCore(client, authStatus, spool, processStart, baseUrl, new StringReader(body),
+                updateCheckTask, memoryClientFactory);
         } catch (Exception ex) {
             await Console.Error.WriteLineAsync($"[kcap] claude hook failed (fail-open): {ex.Message}");
             return 0;
@@ -170,10 +175,15 @@ public static class ClaudeHookCommand {
         return false;
     }
 
-    internal static async Task<int> HandleCore(HttpClient client, AuthStatus authStatus, HookSpool spool, long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask = null) {
+    internal static async Task<int> HandleCore(HttpClient client, AuthStatus authStatus, HookSpool spool,
+        long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask = null,
+        Func<CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
+        Func<SessionStartMemoryLeaseStore>? memoryStoreFactory = null) {
         var body = await stdin.ReadToEndAsync();
 
         var eventName = ExtractEventName(body);
+        string? nativeSessionId = null;
+        try { nativeSessionId = JsonNode.Parse(body)?["session_id"]?.GetValue<string>(); } catch { }
 
         if (eventName is null) {
             Console.Error.WriteLine("kcap hook --claude: missing hook_event_name in payload");
@@ -496,10 +506,28 @@ public static class ClaudeHookCommand {
             // a 401, or a budget overrun yields a null fragment and nothing is injected. Started
             // after the ordering-guard / backlog returns above so a spooled session-start doesn't
             // pay for a fetch it won't use.
-            var memoryDisabled  = AppConfig.ResolvedProfile?.Profile?.DisableMemoryIndex is true;
-            var memoryIndexTask = memoryDisabled
-                ? Task.FromResult<JsonNode?>(null)
-                : TryFetchMemoryIndexAsync(client, baseUrl, sessionCwd, processStart);
+            var memoryDisabled = AppConfig.ResolvedProfile?.Profile?.DisableMemoryIndex is true;
+            var lifecycleReason = source?.ToLowerInvariant() switch {
+                "resume" => SessionLifecycleReason.Resume,
+                "reopen" => SessionLifecycleReason.Reopen,
+                "fork" => SessionLifecycleReason.Fork,
+                "compact" => SessionLifecycleReason.Compact,
+                _ => SessionLifecycleReason.New
+            };
+            Task<string?> memoryIndexTask = string.IsNullOrEmpty(nativeSessionId)
+                ? Task.FromResult<string?>(null)
+                : new SessionStartMemoryOrchestrator(
+                        memoryStoreFactory?.Invoke() ?? new SessionStartMemoryLeaseStore(),
+                        new SessionStartMemoryContextProvider(
+                            new SessionStartMemoryScopeResolver(),
+                            memoryClientFactory ?? (_ => Task.FromResult(client)),
+                            disposeClients: memoryClientFactory is not null))
+                    .GetFragmentAsync(
+                        new SessionMemoryLifecycle(SessionStartHarness.Claude, nativeSessionId, null,
+                            IsTopLevel: true, ClassificationAuthoritative: true, lifecycleReason,
+                            CallbackMayRepeat: false),
+                        new SessionStartMemoryContextRequest(baseUrl, sessionCwd, memoryDisabled,
+                            HookBudget.Remaining(processStart, "session-start"), CancellationToken.None));
 
             // 2. Single bounded POST — keep resp alive to read the response body for the
             //    context-envelope emission and plan-content POST on success.
@@ -553,8 +581,7 @@ public static class ClaudeHookCommand {
                     var nudgeFragment   = VersionNudgeEmitter.BuildFragment(responseNode, CapacitorVersion.CurrentDisplay());
                     // join the parallel memory-index fetch, bounded by the remaining
                     // hook budget so a slow fetch can't delay the hook (fail-open → null).
-                    var memoryFragment  = MemoryIndexEmitter.BuildFragment(
-                        await AwaitMemoryIndexAsync(memoryIndexTask, processStart), memoryDisabled);
+                    var memoryFragment = await AwaitMemoryFragmentAsync(memoryIndexTask, processStart);
 
                     var envelope = SessionStartAdditionalContext.BuildEnvelope(lessonsFragment, nudgeFragment, memoryFragment);
 
@@ -777,73 +804,16 @@ public static class ClaudeHookCommand {
         }
     }
 
-    // ── SessionStart team-memory index injection ────────────────────────
-    //
-    // Best-effort fetch of GET /api/memories/index for the current repo + machine.
-    // Fail-open on a failure / non-2xx / timeout → null, and
-    // MemoryIndexEmitter.BuildFragment(null, …) emits nothing.
-    //
-    // Unresolved repo/machine is NOT an error: the query params are simply omitted, which the
-    // server's scope predicate (`repo_hash IS NULL OR repo_hash = @repo`, likewise machine_tag)
-    // narrows to the caller's GLOBAL, machine-agnostic memories — exactly the repo-independent
-    // subset that should surface everywhere (e.g. a session outside any git repo). It never
-    // returns another repo's repo-scoped memories, so the result stays correctly scoped.
-
-    static async Task<JsonNode?> TryFetchMemoryIndexAsync(HttpClient client, string baseUrl, string? sessionCwd, long processStart) {
-        try {
-            var budget = HookBudget.Remaining(processStart, "session-start");
-            if (budget <= TimeSpan.Zero) return null;
-
-            var repoHash  = await TryResolveRepoHashAsync(sessionCwd);
-            var machineId = await TryResolveMachineIdAsync();
-
-            using var cts  = new CancellationTokenSource(HookBudget.Remaining(processStart, "session-start"));
-            using var resp = await client.GetAsync(BuildMemoryIndexUrl(baseUrl, repoHash, machineId), cts.Token);
-            if (!resp.IsSuccessStatusCode) return null;
-
-            return JsonNode.Parse(await resp.Content.ReadAsStringAsync(cts.Token));
-        } catch {
-            return null; // fail-open — memory injection never breaks the hook
-        }
-    }
-
-    // Bound the join on the parallel fetch by the remaining hook budget so a slow index
-    // fetch can never delay session capture. Timeout or fault → null (nothing injected).
-    static async Task<JsonNode?> AwaitMemoryIndexAsync(Task<JsonNode?> task, long processStart) {
+    static async Task<string?> AwaitMemoryFragmentAsync(Task<string?> task, long processStart) {
         try {
             var budget = HookBudget.Remaining(processStart, "session-start");
             if (budget <= TimeSpan.Zero) return task.IsCompletedSuccessfully ? task.Result : null;
-
             return await task.WaitAsync(budget);
-        } catch {
-            return null;
-        }
+        } catch { return null; }
     }
 
-    internal static string BuildMemoryIndexUrl(string baseUrl, string? repoHash, string? machineId) {
-        var qs = new List<string>();
-        if (repoHash is not null)  qs.Add($"repo={Uri.EscapeDataString(repoHash)}");
-        if (machineId is not null) qs.Add($"machine={Uri.EscapeDataString(machineId)}");
-
-        return qs.Count > 0 ? $"{baseUrl}/api/memories/index?{string.Join('&', qs)}" : $"{baseUrl}/api/memories/index";
-    }
-
-    static async Task<string?> TryResolveRepoHashAsync(string? sessionCwd) {
-        try {
-            var cwd      = string.IsNullOrWhiteSpace(sessionCwd) ? Directory.GetCurrentDirectory() : sessionCwd;
-            // Memory-index scoping needs only owner/repo → skip the PR round-trip.
-            var repoInfo = await RepositoryDetection.DetectRepositoryAsync(cwd, detectPullRequest: false);
-            if (repoInfo?.Owner is null || repoInfo.RepoName is null) return null;
-
-            return RepoHashHelper.ComputeRepoHash(repoInfo.Owner, repoInfo.RepoName);
-        } catch {
-            return null;
-        }
-    }
-
-    static async Task<string?> TryResolveMachineIdAsync() {
-        try { return await MachineIdProvider.GetOrCreateAsync(); } catch { return null; }
-    }
+    internal static string BuildMemoryIndexUrl(string baseUrl, string? repoHash, string? machineId) =>
+        SessionStartMemoryContextProvider.BuildUrl(baseUrl, new SessionStartMemoryScope(repoHash, machineId));
 
     static string? ReadPlanFile(string slug) {
         var planPath = Path.Combine(ClaudePaths.Plans, $"{slug}.md");

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -803,7 +803,7 @@ public static class ClaudeHookCommand {
         TimeSpan budget,
         Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory,
         Func<SessionStartMemoryLeaseStore>? memoryStoreFactory) {
-        if (string.IsNullOrEmpty(nativeSessionId) || budget <= TimeSpan.Zero)
+        if (disabled || string.IsNullOrEmpty(nativeSessionId) || budget <= TimeSpan.Zero)
             return Task.FromResult<string?>(null);
 
         // The memory subsystem is optional. Keep construction itself inside the fail-open

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -34,13 +34,13 @@ public static class ClaudeHookCommand {
     static Task<int> HandleWithDeps(HookSpool spool, long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask)
         => HandleWithDeps(spool, processStart, baseUrl, stdin, updateCheckTask,
             () => HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl),
-            async ct => (await HttpClientExtensions.CreateClientWithAuthStatusAsync(
-                baseUrl, ct, allowAutoRedirect: false)).Client);
+            async (forceRefresh, ct) => (await HttpClientExtensions.CreateClientWithAuthStatusAsync(
+                baseUrl, ct, allowAutoRedirect: false, forceRefresh: forceRefresh)).Client);
 
     internal static async Task<int> HandleWithDeps(
             HookSpool spool, long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask,
             Func<Task<(HttpClient Client, AuthStatus Status)>> clientFactory,
-            Func<CancellationToken, Task<HttpClient>>? memoryClientFactory = null) {
+            Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory = null) {
         string body;
         try { body = await stdin.ReadToEndAsync(); } catch { return 0; }
 
@@ -177,7 +177,7 @@ public static class ClaudeHookCommand {
 
     internal static async Task<int> HandleCore(HttpClient client, AuthStatus authStatus, HookSpool spool,
         long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask = null,
-        Func<CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
+        Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
         Func<SessionStartMemoryLeaseStore>? memoryStoreFactory = null) {
         var body = await stdin.ReadToEndAsync();
 
@@ -514,20 +514,9 @@ public static class ClaudeHookCommand {
                 "compact" => SessionLifecycleReason.Compact,
                 _ => SessionLifecycleReason.New
             };
-            Task<string?> memoryIndexTask = string.IsNullOrEmpty(nativeSessionId)
-                ? Task.FromResult<string?>(null)
-                : new SessionStartMemoryOrchestrator(
-                        memoryStoreFactory?.Invoke() ?? new SessionStartMemoryLeaseStore(),
-                        new SessionStartMemoryContextProvider(
-                            new SessionStartMemoryScopeResolver(),
-                            memoryClientFactory ?? (_ => Task.FromResult(client)),
-                            disposeClients: memoryClientFactory is not null))
-                    .GetFragmentAsync(
-                        new SessionMemoryLifecycle(SessionStartHarness.Claude, nativeSessionId, null,
-                            IsTopLevel: true, ClassificationAuthoritative: true, lifecycleReason,
-                            CallbackMayRepeat: false),
-                        new SessionStartMemoryContextRequest(baseUrl, sessionCwd, memoryDisabled,
-                            HookBudget.Remaining(processStart, "session-start"), CancellationToken.None));
+            var memoryIndexTask = StartMemoryIndexTask(
+                client, baseUrl, nativeSessionId, sessionCwd, memoryDisabled, lifecycleReason,
+                HookBudget.Remaining(processStart, "session-start"), memoryClientFactory, memoryStoreFactory);
 
             // 2. Single bounded POST — keep resp alive to read the response body for the
             //    context-envelope emission and plan-content POST on success.
@@ -801,6 +790,37 @@ public static class ClaudeHookCommand {
 
         if (value is not null && value.Contains('-')) {
             node[fieldName] = value.Replace("-", "");
+        }
+    }
+
+    static Task<string?> StartMemoryIndexTask(
+        HttpClient sharedClient,
+        string baseUrl,
+        string? nativeSessionId,
+        string? cwd,
+        bool disabled,
+        SessionLifecycleReason reason,
+        TimeSpan budget,
+        Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory,
+        Func<SessionStartMemoryLeaseStore>? memoryStoreFactory) {
+        if (string.IsNullOrEmpty(nativeSessionId) || budget <= TimeSpan.Zero)
+            return Task.FromResult<string?>(null);
+
+        // The memory subsystem is optional. Keep construction itself inside the fail-open
+        // boundary: store-root validation and injected factories can throw synchronously.
+        try {
+            var store = memoryStoreFactory?.Invoke() ?? new SessionStartMemoryLeaseStore();
+            var provider = new SessionStartMemoryContextProvider(
+                new SessionStartMemoryScopeResolver(),
+                memoryClientFactory ?? ((_, _) => Task.FromResult(sharedClient)),
+                disposeClients: memoryClientFactory is not null);
+            return new SessionStartMemoryOrchestrator(store, provider).GetFragmentAsync(
+                new SessionMemoryLifecycle(SessionStartHarness.Claude, nativeSessionId, null,
+                    IsTopLevel: true, ClassificationAuthoritative: true, reason,
+                    CallbackMayRepeat: false),
+                new SessionStartMemoryContextRequest(baseUrl, cwd, disabled, budget, CancellationToken.None));
+        } catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) {
+            return Task.FromResult<string?>(null);
         }
     }
 

--- a/src/Capacitor.Cli/MemoryIndexEmitter.cs
+++ b/src/Capacitor.Cli/MemoryIndexEmitter.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json.Nodes;
+using Capacitor.Cli.SessionStartMemory;
 
 namespace Capacitor.Cli;
 
@@ -23,56 +24,58 @@ namespace Capacitor.Cli;
 /// </para>
 /// </summary>
 static class MemoryIndexEmitter {
+    static readonly HashSet<string> Kinds = new(StringComparer.Ordinal) { "preference", "feedback", "project", "reference" };
+
+    public static string? BuildFragment(IEnumerable<SessionStartMemoryEntry> entries) {
+        var org = new List<string>();
+        var team = new List<string>();
+        var user = new List<string>();
+        var inspected = 0;
+        foreach (var entry in entries) {
+            if (++inspected > SessionStartMemoryConstants.MaxEntries) break;
+            if (string.IsNullOrWhiteSpace(entry.MemoryId) || ScalarCount(entry.MemoryId.Trim()) > 256 ||
+                !Kinds.Contains(entry.Kind ?? "")) continue;
+            var slug = Normalize(entry.Slug, 128);
+            var description = Normalize(entry.Description, 512);
+            if (slug.Length == 0 || description.Length == 0) continue;
+            var line = $"- {slug}: {description}";
+            switch (entry.Audience) {
+                case "org": org.Add(line); break;
+                case "team": team.Add(line); break;
+                case "user": user.Add(line); break;
+            }
+        }
+        if (org.Count == 0 && team.Count == 0 && user.Count == 0) return null;
+
+        var prefix = "<!-- kcap-memory-index:v1 -->\n## Team memory\n" +
+            "Durable memories for this repo/context. Call `get_memory <slug>` for the full content of any entry, or `search_memories` to find more.";
+        var sb = new StringBuilder(prefix);
+        if (!AppendBoundedGroup(sb, "Org", org)) return sb.ToString();
+        if (!AppendBoundedGroup(sb, "Team", team)) return sb.ToString();
+        AppendBoundedGroup(sb, "Yours", user);
+        return sb.ToString();
+    }
+
     /// <param name="indexNode">The <c>/api/memories/index</c> response body parsed as a <see cref="JsonNode"/> (expected: a JSON array).</param>
     /// <param name="disabled">True when the user set <c>disable_memory_index</c> on their active profile.</param>
     public static string? BuildFragment(JsonNode? indexNode, bool disabled) {
         if (disabled) return null;
         if (indexNode is not JsonArray entries || entries.Count == 0) return null;
-
-        // Preserve server order (updated_at DESC) within each audience bucket.
-        var org  = new List<string>();
-        var team = new List<string>();
-        var user = new List<string>();
-
+        var typed = new List<SessionStartMemoryEntry>();
         foreach (var node in entries) {
             if (node is not JsonObject o) continue;
-
-            string? slug, description, audience;
             try {
-                slug        = o["slug"]?.GetValue<string>();
-                description = o["description"]?.GetValue<string>();
-                audience    = o["audience"]?.GetValue<string>();
+                typed.Add(new SessionStartMemoryEntry(
+                    o["memory_id"]?.GetValue<string>() ?? "legacy",
+                    o["slug"]?.GetValue<string>(),
+                    o["audience"]?.GetValue<string>(),
+                    o["description"]?.GetValue<string>(),
+                    o["kind"]?.GetValue<string>() ?? "feedback"));
             } catch {
                 continue; // skip a malformed entry rather than dropping the whole block
             }
-
-            if (string.IsNullOrWhiteSpace(slug) || string.IsNullOrWhiteSpace(description)) continue;
-
-            // Collapse any internal whitespace — including newlines — to single spaces so a
-            // description keeps to one bullet. The server validates descriptions as single-line,
-            // but the injected block feeds an LLM's context, so the CLI must not depend on that:
-            // a stray '\n' would otherwise split one memory across lines and distort the grouping.
-            var line = $"- {OneLine(slug)}: {OneLine(description)}";
-            switch (audience) {
-                case "org":  org.Add(line);  break;
-                case "team": team.Add(line); break;
-                case "user": user.Add(line); break;
-                // Unknown/missing audience: skip — we only render the three known buckets,
-                // and grouping on an unrecognized key would be misleading.
-            }
         }
-
-        if (org.Count == 0 && team.Count == 0 && user.Count == 0) return null;
-
-        var sb = new StringBuilder();
-        sb.AppendLine("## Team memory");
-        sb.AppendLine("Durable memories for this repo/context. Call `get_memory <slug>` for the full content of any entry, or `search_memories` to find more.");
-
-        AppendGroup(sb, "Org", org);
-        AppendGroup(sb, "Team", team);
-        AppendGroup(sb, "Yours", user);
-
-        return sb.ToString().TrimEnd();
+        return BuildFragment(typed);
     }
 
     static void AppendGroup(StringBuilder sb, string heading, List<string> lines) {
@@ -86,4 +89,34 @@ static class MemoryIndexEmitter {
     // Collapse all whitespace runs (spaces, tabs, CR/LF) to single spaces and trim, so any
     // value renders as one line. Splitting on null splits on Unicode whitespace.
     static string OneLine(string s) => string.Join(' ', s.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+    static bool AppendBoundedGroup(StringBuilder sb, string heading, List<string> lines) {
+        if (lines.Count == 0) return true;
+        var headerWritten = false;
+        foreach (var line in lines) {
+            var addition = (headerWritten ? "\n" : $"\n\n### {heading}\n") + line;
+            if (Encoding.UTF8.GetByteCount(sb.ToString()) + Encoding.UTF8.GetByteCount(addition) > SessionStartMemoryConstants.MaxFragmentBytes)
+                return false;
+            sb.Append(addition);
+            headerWritten = true;
+        }
+        return true;
+    }
+
+    static string Normalize(string? value, int maxScalars) {
+        if (string.IsNullOrEmpty(value)) return "";
+        var sb = new StringBuilder();
+        var whitespace = false;
+        var count = 0;
+        foreach (var rune in value.EnumerateRunes()) {
+            if (Rune.IsWhiteSpace(rune)) { whitespace = sb.Length > 0; continue; }
+            if (Rune.GetUnicodeCategory(rune) == System.Globalization.UnicodeCategory.Control) continue;
+            if (count++ >= maxScalars) break;
+            if (whitespace) { sb.Append(' '); whitespace = false; }
+            sb.Append(rune.ToString());
+        }
+        return sb.ToString().Trim();
+    }
+
+    static int ScalarCount(string value) => value.EnumerateRunes().Count();
 }

--- a/src/Capacitor.Cli/MemoryIndexEmitter.cs
+++ b/src/Capacitor.Cli/MemoryIndexEmitter.cs
@@ -50,9 +50,10 @@ static class MemoryIndexEmitter {
         var prefix = "<!-- kcap-memory-index:v1 -->\n## Team memory\n" +
             "Durable memories for this repo/context. Call `get_memory <slug>` for the full content of any entry, or `search_memories` to find more.";
         var sb = new StringBuilder(prefix);
-        if (!AppendBoundedGroup(sb, "Org", org)) return sb.ToString();
-        if (!AppendBoundedGroup(sb, "Team", team)) return sb.ToString();
-        AppendBoundedGroup(sb, "Yours", user);
+        var currentBytes = Encoding.UTF8.GetByteCount(prefix);
+        if (!AppendBoundedGroup(sb, "Org", org, ref currentBytes)) return sb.ToString();
+        if (!AppendBoundedGroup(sb, "Team", team, ref currentBytes)) return sb.ToString();
+        AppendBoundedGroup(sb, "Yours", user, ref currentBytes);
         return sb.ToString();
     }
 
@@ -78,26 +79,16 @@ static class MemoryIndexEmitter {
         return BuildFragment(typed);
     }
 
-    static void AppendGroup(StringBuilder sb, string heading, List<string> lines) {
-        if (lines.Count == 0) return;
-
-        sb.AppendLine();
-        sb.AppendLine($"### {heading}");
-        foreach (var l in lines) sb.AppendLine(l);
-    }
-
-    // Collapse all whitespace runs (spaces, tabs, CR/LF) to single spaces and trim, so any
-    // value renders as one line. Splitting on null splits on Unicode whitespace.
-    static string OneLine(string s) => string.Join(' ', s.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
-
-    static bool AppendBoundedGroup(StringBuilder sb, string heading, List<string> lines) {
+    static bool AppendBoundedGroup(StringBuilder sb, string heading, List<string> lines, ref int currentBytes) {
         if (lines.Count == 0) return true;
         var headerWritten = false;
         foreach (var line in lines) {
             var addition = (headerWritten ? "\n" : $"\n\n### {heading}\n") + line;
-            if (Encoding.UTF8.GetByteCount(sb.ToString()) + Encoding.UTF8.GetByteCount(addition) > SessionStartMemoryConstants.MaxFragmentBytes)
+            var additionBytes = Encoding.UTF8.GetByteCount(addition);
+            if (currentBytes + additionBytes > SessionStartMemoryConstants.MaxFragmentBytes)
                 return false;
             sb.Append(addition);
+            currentBytes += additionBytes;
             headerWritten = true;
         }
         return true;

--- a/src/Capacitor.Cli/SessionStartMemory/BoundedJsonFile.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/BoundedJsonFile.cs
@@ -1,0 +1,49 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Capacitor.Cli.SessionStartMemory;
+
+internal static class BoundedJsonFile {
+    static readonly UTF8Encoding StrictUtf8 = new(false, true);
+
+    public static T? Read<T>(string path, int limit, JsonTypeInfo<T> typeInfo) where T : class {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
+        if (stream.Length > limit) throw new InvalidDataException("JSON file exceeds its byte limit.");
+        var buffer = new byte[limit + 1];
+        var total = 0;
+        while (total < buffer.Length) {
+            var read = stream.Read(buffer, total, buffer.Length - total);
+            if (read == 0) break;
+            total += read;
+        }
+        if (total > limit || stream.ReadByte() >= 0) throw new InvalidDataException("JSON file grew beyond its byte limit.");
+        _ = StrictUtf8.GetString(buffer, 0, total);
+        var reader = new Utf8JsonReader(buffer.AsSpan(0, total), new JsonReaderOptions {
+            CommentHandling = JsonCommentHandling.Disallow,
+            AllowTrailingCommas = false
+        });
+        var value = JsonSerializer.Deserialize(ref reader, typeInfo);
+        while (reader.Read()) { }
+        if (reader.BytesConsumed != total) throw new JsonException("Trailing data is not allowed.");
+        return value;
+    }
+
+    public static void AtomicWrite<T>(string root, string destination, T value, int limit, JsonTypeInfo<T> typeInfo) {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(value, typeInfo);
+        if (bytes.Length > limit) throw new InvalidDataException("Serialized JSON exceeds its byte limit.");
+        var stem = Path.GetFileNameWithoutExtension(destination);
+        var temp = Path.Combine(root, $"{stem}.{Guid.NewGuid():N}.tmp");
+        try {
+            using (var stream = new FileStream(temp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
+                if (!OperatingSystem.IsWindows())
+                    try { File.SetUnixFileMode(temp, UnixFileMode.UserRead | UnixFileMode.UserWrite); } catch { }
+                stream.Write(bytes);
+                stream.Flush();
+            }
+            File.Move(temp, destination, overwrite: true);
+        } finally {
+            try { if (File.Exists(temp)) File.Delete(temp); } catch { }
+        }
+    }
+}

--- a/src/Capacitor.Cli/SessionStartMemory/PiSessionPathCanonicalizer.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/PiSessionPathCanonicalizer.cs
@@ -1,0 +1,22 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Capacitor.Cli.SessionStartMemory;
+
+internal static class PiSessionPathCanonicalizer {
+    public static bool TryHash(string? input, out string? hash) {
+        hash = null;
+        if (string.IsNullOrEmpty(input) || input.IndexOf('\0') >= 0 || !Path.IsPathRooted(input)) return false;
+        try {
+            var full = Path.GetFullPath(input);
+            var root = Path.GetPathRoot(full);
+            if (!string.Equals(full, root, StringComparison.Ordinal))
+                full = full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            full = full.Replace(Path.DirectorySeparatorChar, '/').Replace(Path.AltDirectorySeparatorChar, '/');
+            full = full.Normalize(NormalizationForm.FormC);
+            if (OperatingSystem.IsWindows()) full = full.ToUpperInvariant();
+            hash = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(full)));
+            return true;
+        } catch { return false; }
+    }
+}

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContextProvider.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContextProvider.cs
@@ -43,7 +43,7 @@ internal sealed class SessionStartMemoryContextProvider(
                 if (entries.Length == 0) return SessionStartMemoryContextResult.Empty;
                 var fragment = MemoryIndexEmitter.BuildFragment(entries);
                 return fragment is null
-                    ? SessionStartMemoryContextResult.Retry
+                    ? SessionStartMemoryContextResult.Empty
                     : new SessionStartMemoryContextResult(SessionStartMemoryDisposition.Ready, fragment);
                 }
             } finally {

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContextProvider.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContextProvider.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using System.Text.Json;
+
+namespace Capacitor.Cli.SessionStartMemory;
+
+internal sealed class SessionStartMemoryContextProvider(
+    ISessionStartMemoryScopeResolver scopeResolver,
+    Func<CancellationToken, Task<HttpClient>> clientFactory,
+    Action<string>? diagnostic = null,
+    bool disposeClients = false) {
+
+    public async Task<SessionStartMemoryContextResult> GetAsync(SessionStartMemoryContextRequest request) {
+        if (request.Disabled) return SessionStartMemoryContextResult.Empty;
+        if (request.Budget <= TimeSpan.Zero) return SessionStartMemoryContextResult.Retry;
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(request.CancellationToken);
+        cts.CancelAfter(request.Budget);
+        try {
+            var scope = await scopeResolver.ResolveAsync(request.Cwd, cts.Token);
+            HttpClient? firstClient = null;
+            HttpClient? refreshClient = null;
+            try {
+                firstClient = await clientFactory(cts.Token);
+                var response = await SendAsync(firstClient, request.BaseUrl, scope, cts.Token);
+                if (response.StatusCode == HttpStatusCode.Unauthorized) {
+                    response.Dispose();
+                    refreshClient = await clientFactory(cts.Token);
+                    response = await SendAsync(refreshClient, request.BaseUrl, scope, cts.Token);
+                }
+                using (response) {
+                if (response.StatusCode == HttpStatusCode.NoContent) return SessionStartMemoryContextResult.Empty;
+                if (response.StatusCode is HttpStatusCode.BadRequest or HttpStatusCode.NotFound) {
+                    diagnostic?.Invoke($"SessionStart memory endpoint contract mismatch: HTTP {(int)response.StatusCode}.");
+                    return SessionStartMemoryContextResult.Empty;
+                }
+                if (!response.IsSuccessStatusCode)
+                    return new SessionStartMemoryContextResult(SessionStartMemoryDisposition.RetryableFailure,
+                        RetryAfter: ParseRetryAfter(response));
+
+                var bytes = await ReadBoundedAsync(response.Content, cts.Token);
+                var entries = JsonSerializer.Deserialize(bytes,
+                    SessionStartMemoryJsonContext.Default.SessionStartMemoryEntryArray);
+                if (entries is null) return SessionStartMemoryContextResult.Retry;
+                if (entries.Length == 0) return SessionStartMemoryContextResult.Empty;
+                var fragment = MemoryIndexEmitter.BuildFragment(entries);
+                return fragment is null
+                    ? SessionStartMemoryContextResult.Retry
+                    : new SessionStartMemoryContextResult(SessionStartMemoryDisposition.Ready, fragment);
+                }
+            } finally {
+                if (disposeClients) {
+                    firstClient?.Dispose();
+                    if (!ReferenceEquals(firstClient, refreshClient)) refreshClient?.Dispose();
+                }
+            }
+        } catch (Exception ex) when (ex is HttpRequestException or IOException or JsonException or
+                                     OperationCanceledException or UnauthorizedAccessException or InvalidDataException) {
+            diagnostic?.Invoke($"SessionStart memory fetch skipped: {ex.Message}");
+            return SessionStartMemoryContextResult.Retry;
+        }
+    }
+
+    static Task<HttpResponseMessage> SendAsync(HttpClient client, string baseUrl, SessionStartMemoryScope scope,
+        CancellationToken ct) => client.GetAsync(BuildUrl(baseUrl, scope), HttpCompletionOption.ResponseHeadersRead, ct);
+
+    internal static string BuildUrl(string baseUrl, SessionStartMemoryScope scope) {
+        var query = new List<string>();
+        if (scope.RepoHash is not null) query.Add("repo=" + Uri.EscapeDataString(scope.RepoHash));
+        if (scope.MachineTag is not null) query.Add("machine=" + Uri.EscapeDataString(scope.MachineTag));
+        return baseUrl.TrimEnd('/') + "/api/memories/index" + (query.Count == 0 ? "" : "?" + string.Join('&', query));
+    }
+
+    static async Task<byte[]> ReadBoundedAsync(HttpContent content, CancellationToken ct) {
+        await using var stream = await content.ReadAsStreamAsync(ct);
+        var buffer = new byte[SessionStartMemoryConstants.MaxResponseBytes + 1];
+        var total = 0;
+        while (total < buffer.Length) {
+            var read = await stream.ReadAsync(buffer.AsMemory(total, buffer.Length - total), ct);
+            if (read == 0) break;
+            total += read;
+        }
+        if (total > SessionStartMemoryConstants.MaxResponseBytes)
+            throw new InvalidDataException("Memory index response exceeded 256 KiB.");
+        return buffer.AsSpan(0, total).ToArray();
+    }
+
+    static TimeSpan? ParseRetryAfter(HttpResponseMessage response) {
+        if (response.StatusCode != HttpStatusCode.TooManyRequests || response.Headers.RetryAfter is null) return null;
+        if (response.Headers.RetryAfter.Delta is { } delta) return delta;
+        if (response.Headers.RetryAfter.Date is { } date) {
+            var value = date - DateTimeOffset.UtcNow;
+            return value > TimeSpan.Zero ? value : null;
+        }
+        return null;
+    }
+}

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContextProvider.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContextProvider.cs
@@ -5,7 +5,7 @@ namespace Capacitor.Cli.SessionStartMemory;
 
 internal sealed class SessionStartMemoryContextProvider(
     ISessionStartMemoryScopeResolver scopeResolver,
-    Func<CancellationToken, Task<HttpClient>> clientFactory,
+    Func<bool, CancellationToken, Task<HttpClient>> clientFactory,
     Action<string>? diagnostic = null,
     bool disposeClients = false) {
 
@@ -15,15 +15,15 @@ internal sealed class SessionStartMemoryContextProvider(
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(request.CancellationToken);
         cts.CancelAfter(request.Budget);
         try {
-            var scope = await scopeResolver.ResolveAsync(request.Cwd, cts.Token);
+            var scope = await scopeResolver.ResolveAsync(request.Cwd, request.Budget, cts.Token);
             HttpClient? firstClient = null;
             HttpClient? refreshClient = null;
             try {
-                firstClient = await clientFactory(cts.Token);
+                firstClient = await clientFactory(false, cts.Token);
                 var response = await SendAsync(firstClient, request.BaseUrl, scope, cts.Token);
                 if (response.StatusCode == HttpStatusCode.Unauthorized) {
                     response.Dispose();
-                    refreshClient = await clientFactory(cts.Token);
+                    refreshClient = await clientFactory(true, cts.Token);
                     response = await SendAsync(refreshClient, request.BaseUrl, scope, cts.Token);
                 }
                 using (response) {

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContracts.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContracts.cs
@@ -52,7 +52,7 @@ internal sealed record SessionStartMemoryContextResult(
 internal sealed record SessionStartMemoryScope(string? RepoHash, string? MachineTag);
 
 internal interface ISessionStartMemoryScopeResolver {
-    Task<SessionStartMemoryScope> ResolveAsync(string? cwd, CancellationToken ct);
+    Task<SessionStartMemoryScope> ResolveAsync(string? cwd, TimeSpan budget, CancellationToken ct);
 }
 
 internal sealed record SessionStartMemoryLeaseHandle(string Key, long Generation, string Token);

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContracts.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContracts.cs
@@ -1,0 +1,93 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.SessionStartMemory;
+
+internal enum SessionStartHarness {
+    Claude,
+    Codex,
+    Cursor,
+    Copilot,
+    Gemini,
+    Kiro,
+    Pi,
+    OpenCode,
+    Antigravity
+}
+
+internal enum SessionLifecycleReason { New, Resume, Reopen, Fork, Compact, RepeatedTurnCallback, Unknown }
+internal enum SessionMemoryLifecycleDecision { EligibleWithLease, EligibleOneShot, IneligibleNoCommit, RetryLaterNoCommit }
+internal enum SessionStartMemoryDisposition { Ready, CompleteWithoutContext, RetryableFailure }
+
+internal sealed record SessionMemoryLifecycle(
+    SessionStartHarness Harness,
+    string SessionId,
+    string? LifecycleInstanceId,
+    bool IsTopLevel,
+    bool ClassificationAuthoritative,
+    SessionLifecycleReason Reason,
+    bool CallbackMayRepeat);
+
+internal sealed record SessionStartMemoryEntry(
+    [property: JsonPropertyName("memory_id")] string? MemoryId,
+    [property: JsonPropertyName("slug")] string? Slug,
+    [property: JsonPropertyName("audience")] string? Audience,
+    [property: JsonPropertyName("description")] string? Description,
+    [property: JsonPropertyName("kind")] string? Kind);
+
+internal sealed record SessionStartMemoryContextRequest(
+    string BaseUrl,
+    string? Cwd,
+    bool Disabled,
+    TimeSpan Budget,
+    CancellationToken CancellationToken);
+
+internal sealed record SessionStartMemoryContextResult(
+    SessionStartMemoryDisposition Disposition,
+    string? Fragment = null,
+    TimeSpan? RetryAfter = null) {
+    public static readonly SessionStartMemoryContextResult Empty = new(SessionStartMemoryDisposition.CompleteWithoutContext);
+    public static readonly SessionStartMemoryContextResult Retry = new(SessionStartMemoryDisposition.RetryableFailure);
+}
+
+internal sealed record SessionStartMemoryScope(string? RepoHash, string? MachineTag);
+
+internal interface ISessionStartMemoryScopeResolver {
+    Task<SessionStartMemoryScope> ResolveAsync(string? cwd, CancellationToken ct);
+}
+
+internal sealed record SessionStartMemoryLeaseHandle(string Key, long Generation, string Token);
+
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+internal sealed record SessionStartMemoryStoreRecord(
+    [property: JsonPropertyName("schema_version")] int SchemaVersion,
+    [property: JsonPropertyName("policy_version")] int PolicyVersion,
+    [property: JsonPropertyName("fragment_version")] int FragmentVersion,
+    [property: JsonPropertyName("state")] string State,
+    [property: JsonPropertyName("generation")] long Generation,
+    [property: JsonPropertyName("token")] string? Token,
+    [property: JsonPropertyName("attempt")] long Attempt,
+    [property: JsonPropertyName("lease_expires_at")] DateTimeOffset? LeaseExpiresAt,
+    [property: JsonPropertyName("completed_at")] DateTimeOffset? CompletedAt,
+    [property: JsonPropertyName("next_attempt_at")] DateTimeOffset? NextAttemptAt,
+    [property: JsonPropertyName("disposition")] string? Disposition);
+
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+internal sealed record SessionStartMemoryStoreMetadata(
+    [property: JsonPropertyName("schema_version")] int SchemaVersion,
+    [property: JsonPropertyName("last_sweep_at")] DateTimeOffset? LastSweepAt,
+    [property: JsonPropertyName("last_processed_filename")] string? LastProcessedFilename);
+
+internal static class SessionStartMemoryConstants {
+    public const int SchemaVersion = 1;
+    public const int PolicyVersion = 1;
+    public const int FragmentVersion = 1;
+    public const int MaxRecordBytes = 4096;
+    public const int MaxMetadataBytes = 16384;
+    public const int MaxResponseBytes = 256 * 1024;
+    public const int MaxEntries = 200;
+    public const int MaxFragmentBytes = 24 * 1024;
+    public const int NormalRecordCap = 50_000;
+    public const int TotalEntryCap = 55_000;
+    public static readonly TimeSpan LeaseDuration = TimeSpan.FromSeconds(30);
+    public static readonly TimeSpan Retention = TimeSpan.FromDays(30);
+}

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryExtensionState.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryExtensionState.cs
@@ -1,0 +1,31 @@
+using System.Collections.Concurrent;
+
+namespace Capacitor.Cli.SessionStartMemory;
+
+internal sealed class SessionStartMemoryExtensionState {
+    readonly ConcurrentDictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+
+    public async Task ObserveBridgeResultAsync(string localKey, string? fragment) {
+        if (string.IsNullOrEmpty(fragment)) return;
+        var entry = _entries.GetOrAdd(localKey, static _ => new Entry());
+        await entry.Gate.WaitAsync();
+        try { entry.Fragment ??= fragment; }
+        finally { entry.Gate.Release(); }
+    }
+
+    public async Task<string?> TakeForDeliveryAsync(string localKey) {
+        if (!_entries.TryGetValue(localKey, out var entry)) return null;
+        await entry.Gate.WaitAsync();
+        try {
+            if (entry.Delivered || entry.Fragment is null) return null;
+            entry.Delivered = true;
+            return entry.Fragment;
+        } finally { entry.Gate.Release(); }
+    }
+
+    sealed class Entry {
+        public SemaphoreSlim Gate { get; } = new(1, 1);
+        public string? Fragment { get; set; }
+        public bool Delivered { get; set; }
+    }
+}

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryIdentity.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryIdentity.cs
@@ -21,6 +21,8 @@ internal static class SessionStartMemoryIdentity {
         if (string.IsNullOrEmpty(value)) return null;
         if (harness is SessionStartHarness.Cursor or SessionStartHarness.Copilot or SessionStartHarness.Antigravity)
             return Guid.TryParse(value, out var guid) ? guid.ToString("N") : null;
+        if (harness == SessionStartHarness.Claude)
+            return Guid.TryParse(value, out var guid) ? guid.ToString("N") : value;
         if (harness == SessionStartHarness.Pi)
             return PiSessionPathCanonicalizer.TryHash(value, out var hash) ? hash : null;
         return value;

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryIdentity.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryIdentity.cs
@@ -1,0 +1,50 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Capacitor.Cli.SessionStartMemory;
+
+internal static class SessionStartMemoryIdentity {
+    public static string Create(SessionStartHarness harness, string sessionId, string? lifecycleInstanceId) {
+        var normalized = NormalizeSessionId(harness, sessionId)
+            ?? throw new ArgumentException("A stable session identity is required.", nameof(sessionId));
+        using var stream = new MemoryStream();
+        stream.WriteByte(0x01);
+        WritePresent(stream, HarnessToken(harness));
+        WritePresent(stream, normalized);
+        if (lifecycleInstanceId is null) stream.WriteByte(0x00);
+        else WritePresent(stream, lifecycleInstanceId);
+        return Convert.ToHexStringLower(SHA256.HashData(stream.ToArray()));
+    }
+
+    public static string? NormalizeSessionId(SessionStartHarness harness, string? value) {
+        if (string.IsNullOrEmpty(value)) return null;
+        if (harness is SessionStartHarness.Cursor or SessionStartHarness.Copilot or SessionStartHarness.Antigravity)
+            return Guid.TryParse(value, out var guid) ? guid.ToString("N") : null;
+        if (harness == SessionStartHarness.Pi)
+            return PiSessionPathCanonicalizer.TryHash(value, out var hash) ? hash : null;
+        return value;
+    }
+
+    public static string HarnessToken(SessionStartHarness harness) => harness switch {
+        SessionStartHarness.Claude => "claude",
+        SessionStartHarness.Codex => "codex",
+        SessionStartHarness.Cursor => "cursor",
+        SessionStartHarness.Copilot => "copilot",
+        SessionStartHarness.Gemini => "gemini",
+        SessionStartHarness.Kiro => "kiro",
+        SessionStartHarness.Pi => "pi",
+        SessionStartHarness.OpenCode => "opencode",
+        SessionStartHarness.Antigravity => "antigravity",
+        _ => throw new ArgumentOutOfRangeException(nameof(harness))
+    };
+
+    static void WritePresent(Stream stream, string value) {
+        stream.WriteByte(0x01);
+        var bytes = Encoding.UTF8.GetBytes(value);
+        Span<byte> length = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(length, checked((uint)bytes.Length));
+        stream.Write(length);
+        stream.Write(bytes);
+    }
+}

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryJsonContext.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryJsonContext.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.SessionStartMemory;
+
+[JsonSourceGenerationOptions(
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.Unspecified,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(SessionStartMemoryEntry[]))]
+[JsonSerializable(typeof(SessionStartMemoryStoreRecord))]
+[JsonSerializable(typeof(SessionStartMemoryStoreMetadata))]
+[JsonSerializable(typeof(ClaudeMemoryEnvelope))]
+[JsonSerializable(typeof(CodexMemoryEnvelope))]
+[JsonSerializable(typeof(CursorMemoryEnvelope))]
+[JsonSerializable(typeof(CopilotMemoryEnvelope))]
+[JsonSerializable(typeof(GeminiMemoryEnvelope))]
+[JsonSerializable(typeof(AntigravityMemoryEnvelope))]
+internal partial class SessionStartMemoryJsonContext : JsonSerializerContext;
+
+internal sealed record HookMemoryOutput(
+    [property: JsonPropertyName("hookEventName")] string HookEventName,
+    [property: JsonPropertyName("additionalContext")] string AdditionalContext);
+
+internal sealed record HookSpecificMemoryOutput(
+    [property: JsonPropertyName("hookSpecificOutput")] HookMemoryOutput HookSpecificOutput);
+
+internal sealed record ClaudeMemoryEnvelope(
+    [property: JsonPropertyName("hookSpecificOutput")] HookMemoryOutput HookSpecificOutput);
+
+internal sealed record CodexMemoryEnvelope(
+    [property: JsonPropertyName("continue")] bool Continue,
+    [property: JsonPropertyName("hookSpecificOutput")] HookMemoryOutput HookSpecificOutput);
+
+internal sealed record CursorMemoryEnvelope([property: JsonPropertyName("additional_context")] string? AdditionalContext = null);
+internal sealed record CopilotMemoryEnvelope([property: JsonPropertyName("additionalContext")] string? AdditionalContext = null);
+internal sealed record GeminiMemoryEnvelope([property: JsonPropertyName("hookSpecificOutput")] HookMemoryOutput? HookSpecificOutput = null);
+internal sealed record AntigravityMemoryEnvelope([property: JsonPropertyName("injectSteps")] AntigravityMemoryStep[]? InjectSteps = null);
+internal sealed record AntigravityMemoryStep([property: JsonPropertyName("userMessage")] string UserMessage);

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryLeaseStore.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryLeaseStore.cs
@@ -1,0 +1,322 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Capacitor.Cli.SessionStartMemory;
+
+internal sealed partial class SessionStartMemoryLeaseStore {
+    const string MetadataName = "store-meta-v1.json";
+    static readonly TimeSpan NormalSweepInterval = TimeSpan.FromMinutes(15);
+
+    readonly string _root;
+    readonly string _lockPath;
+    readonly string _metadataPath;
+    readonly TimeProvider _time;
+    readonly Action<string>? _diagnostic;
+
+    public SessionStartMemoryLeaseStore(string? root = null, TimeProvider? time = null, Action<string>? diagnostic = null) {
+        _root = SessionStartMemoryStorePaths.ValidateRoot(root ?? SessionStartMemoryStorePaths.DefaultRoot);
+        _lockPath = Path.Combine(_root, "store.lock");
+        _metadataPath = Path.Combine(_root, MetadataName);
+        _time = time ?? TimeProvider.System;
+        _diagnostic = diagnostic;
+    }
+
+    public async Task<SessionStartMemoryLeaseHandle?> TryBeginAsync(
+        string key, TimeSpan budget, CancellationToken ct = default) {
+        if (!KeyRegex().IsMatch(key) || budget <= TimeSpan.Zero) return null;
+        try {
+            using var gate = await AcquireAsync(budget, ct);
+            if (gate is null) return null;
+            EnsureSafeRoot();
+            SweepUnderLock(TimeSpan.FromMilliseconds(25), 5_000, force: false);
+
+            var path = RecordPath(key);
+            var now = _time.GetUtcNow();
+            var current = ReadRecord(path);
+            if (current is not null) {
+                if (!Validate(current)) return null;
+                // Completion remains authoritative until a sweep physically removes the
+                // tombstone. This makes the documented 30-day guarantee a lower bound even
+                // when the opportunistic sweep is delayed by its 15-minute cadence.
+                if (current.State == "completed") return null;
+                if (current.State == "retry_pending" && current.NextAttemptAt is { } next && now < next)
+                    return null;
+                if (current.State == "leased" && current.LeaseExpiresAt is { } expiry && now < expiry)
+                    return null;
+            }
+
+            if (!EnsureWriteCapacity(creatingRecord: current is null)) return null;
+            var generation = checked((current?.Generation ?? 0) + 1);
+            var attempt = current?.State == "retry_pending" ? checked(current.Attempt + 1) : current?.Attempt ?? 0;
+            var token = Convert.ToHexStringLower(RandomNumberGenerator.GetBytes(16));
+            var nextRecord = new SessionStartMemoryStoreRecord(
+                SessionStartMemoryConstants.SchemaVersion,
+                SessionStartMemoryConstants.PolicyVersion,
+                SessionStartMemoryConstants.FragmentVersion,
+                "leased", generation, token, attempt,
+                now + SessionStartMemoryConstants.LeaseDuration, null, null, null);
+            WriteRecord(path, nextRecord);
+            return new SessionStartMemoryLeaseHandle(key, generation, token);
+        } catch (Exception ex) when (IsOperational(ex)) {
+            _diagnostic?.Invoke($"SessionStart memory coordination unavailable: {ex.Message}");
+            return null;
+        }
+    }
+
+    public Task<bool> CompleteAsync(SessionStartMemoryLeaseHandle handle, SessionStartMemoryDisposition disposition,
+        CancellationToken ct = default) => MutateAsync(handle, disposition, retryAfter: null, ct);
+
+    public Task<bool> RetryAsync(SessionStartMemoryLeaseHandle handle, TimeSpan? retryAfter,
+        CancellationToken ct = default) => MutateAsync(handle, SessionStartMemoryDisposition.RetryableFailure, retryAfter, ct);
+
+    async Task<bool> MutateAsync(SessionStartMemoryLeaseHandle handle, SessionStartMemoryDisposition disposition,
+        TimeSpan? retryAfter, CancellationToken ct) {
+        try {
+            using var gate = await AcquireAsync(TimeSpan.FromSeconds(2), ct);
+            if (gate is null) return false;
+            EnsureSafeRoot();
+            var path = RecordPath(handle.Key);
+            var current = ReadRecord(path);
+            if (current is null || !Validate(current) || current.State != "leased" ||
+                current.Generation != handle.Generation ||
+                !CryptographicOperations.FixedTimeEquals(
+                    Encoding.ASCII.GetBytes(current.Token ?? ""),
+                    Encoding.ASCII.GetBytes(handle.Token))) return false;
+            if (!EnsureWriteCapacity(creatingRecord: false)) return false;
+
+            var now = _time.GetUtcNow();
+            SessionStartMemoryStoreRecord next;
+            if (disposition == SessionStartMemoryDisposition.RetryableFailure) {
+                var scheduled = Backoff(current.Attempt);
+                if (retryAfter is { } requested && requested > scheduled) scheduled = requested;
+                if (scheduled > TimeSpan.FromHours(1)) scheduled = TimeSpan.FromHours(1);
+                next = current with {
+                    State = "retry_pending", Token = null, LeaseExpiresAt = null,
+                    NextAttemptAt = now + scheduled, CompletedAt = null,
+                    Disposition = "retryable_failure"
+                };
+            } else {
+                next = current with {
+                    State = "completed", Token = null, LeaseExpiresAt = null,
+                    CompletedAt = now, NextAttemptAt = null,
+                    Disposition = disposition == SessionStartMemoryDisposition.Ready
+                        ? "ready"
+                        : "complete_without_context"
+                };
+            }
+            WriteRecord(path, next);
+            return true;
+        } catch (Exception ex) when (IsOperational(ex)) {
+            _diagnostic?.Invoke($"SessionStart memory coordination unavailable: {ex.Message}");
+            return false;
+        }
+    }
+
+    public async Task SweepAsync(TimeSpan budget, int maxEntries = 5_000, CancellationToken ct = default) {
+        if (budget <= TimeSpan.Zero || maxEntries <= 0) return;
+        try {
+            using var gate = await AcquireAsync(budget, ct);
+            if (gate is null) return;
+            EnsureSafeRoot();
+            SweepUnderLock(budget, maxEntries, force: true);
+        } catch (Exception ex) when (IsOperational(ex)) {
+            _diagnostic?.Invoke($"SessionStart memory sweep skipped: {ex.Message}");
+        }
+    }
+
+    void SweepUnderLock(TimeSpan budget, int maxEntries, bool force) {
+        var now = _time.GetUtcNow();
+        var metadata = ReadMetadata();
+        if (!force && metadata.LastSweepAt is { } last && now >= last && now - last < NormalSweepInterval)
+            return;
+
+        var names = Directory.EnumerateFileSystemEntries(_root)
+            .Select(Path.GetFileName)
+            .Where(static name => name is not null)
+            .Select(static name => name!)
+            .Where(IsSweepCandidate)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        var cursor = ValidateCursor(metadata.LastProcessedFilename) ? metadata.LastProcessedFilename : null;
+        var started = Stopwatch.GetTimestamp();
+        var processed = 0;
+        string? lastProcessed = null;
+        var reachedEnd = true;
+
+        foreach (var name in names) {
+            if (cursor is not null && StringComparer.Ordinal.Compare(name, cursor) <= 0) continue;
+            if (processed >= maxEntries || Stopwatch.GetElapsedTime(started) >= budget) {
+                reachedEnd = false;
+                break;
+            }
+            processed++;
+            lastProcessed = name; // poison entries must never pin cleanup progress
+            var path = Path.Combine(_root, name);
+            try {
+                if (RecordRegex().IsMatch(name)) {
+                    var record = ReadRecord(path);
+                    if (record is not null && Validate(record) && IsSweepExpired(record, now))
+                        File.Delete(path);
+                } else if (TempRegex().IsMatch(name) &&
+                           now - new DateTimeOffset(File.GetLastWriteTimeUtc(path), TimeSpan.Zero) >= TimeSpan.FromDays(1)) {
+                    File.Delete(path);
+                }
+            } catch (Exception ex) when (IsOperational(ex)) {
+                _diagnostic?.Invoke($"SessionStart memory sweep retained {name}: {ex.Message}");
+            }
+        }
+
+        // If the cursor was after every currently valid candidate, wrap now rather than pinning it.
+        if (lastProcessed is null && cursor is not null) reachedEnd = true;
+        var nextCursor = reachedEnd ? null : lastProcessed ?? cursor;
+        WriteMetadata(new SessionStartMemoryStoreMetadata(
+            SessionStartMemoryConstants.SchemaVersion, now, nextCursor));
+    }
+
+    SessionStartMemoryStoreMetadata ReadMetadata() {
+        if (!File.Exists(_metadataPath))
+            return new SessionStartMemoryStoreMetadata(SessionStartMemoryConstants.SchemaVersion, null, null);
+        try {
+            var value = BoundedJsonFile.Read(_metadataPath, SessionStartMemoryConstants.MaxMetadataBytes,
+                SessionStartMemoryJsonContext.Default.SessionStartMemoryStoreMetadata);
+            if (value is null || value.SchemaVersion != SessionStartMemoryConstants.SchemaVersion ||
+                value.LastSweepAt is { } sweepAt && sweepAt.Offset != TimeSpan.Zero ||
+                !ValidateCursor(value.LastProcessedFilename))
+                throw new InvalidDataException("Invalid SessionStart memory sweep metadata.");
+            return value;
+        } catch (Exception ex) when (IsOperational(ex)) {
+            _diagnostic?.Invoke($"SessionStart memory sweep metadata reset: {ex.Message}");
+            return new SessionStartMemoryStoreMetadata(SessionStartMemoryConstants.SchemaVersion, null, null);
+        }
+    }
+
+    void WriteMetadata(SessionStartMemoryStoreMetadata metadata) {
+        if (CountChildren() >= SessionStartMemoryConstants.TotalEntryCap) {
+            _diagnostic?.Invoke("SessionStart memory sweep cursor not persisted: store capacity reached.");
+            return;
+        }
+        try {
+            BoundedJsonFile.AtomicWrite(_root, _metadataPath, metadata, SessionStartMemoryConstants.MaxMetadataBytes,
+                SessionStartMemoryJsonContext.Default.SessionStartMemoryStoreMetadata);
+        } catch (Exception ex) when (IsOperational(ex)) {
+            _diagnostic?.Invoke($"SessionStart memory sweep cursor not persisted: {ex.Message}");
+        }
+    }
+
+    async Task<FileStream?> AcquireAsync(TimeSpan budget, CancellationToken ct) {
+        var started = Stopwatch.GetTimestamp();
+        while (Stopwatch.GetElapsedTime(started) < budget && !ct.IsCancellationRequested) {
+            try {
+                var stream = new FileStream(_lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                SetOwnerOnly(_lockPath);
+                return stream;
+            } catch (IOException) {
+                var remaining = budget - Stopwatch.GetElapsedTime(started);
+                if (remaining <= TimeSpan.Zero) break;
+                await Task.Delay(remaining < TimeSpan.FromMilliseconds(5) ? remaining : TimeSpan.FromMilliseconds(5), ct);
+            }
+        }
+        return null;
+    }
+
+    void EnsureSafeRoot() {
+        var info = new DirectoryInfo(_root);
+        info.Refresh();
+        if (!info.Exists || (info.Attributes & FileAttributes.ReparsePoint) != 0)
+            throw new IOException("SessionStart memory store root is unsafe.");
+    }
+
+    string RecordPath(string key) {
+        if (!KeyRegex().IsMatch(key)) throw new InvalidDataException("Invalid SessionStart memory key.");
+        return Path.Combine(_root, key + ".json");
+    }
+
+    SessionStartMemoryStoreRecord? ReadRecord(string path) {
+        if (!File.Exists(path)) return null;
+        return BoundedJsonFile.Read(path, SessionStartMemoryConstants.MaxRecordBytes,
+            SessionStartMemoryJsonContext.Default.SessionStartMemoryStoreRecord);
+    }
+
+    void WriteRecord(string path, SessionStartMemoryStoreRecord record) {
+        if (!Validate(record)) throw new InvalidDataException("Invalid SessionStart memory record.");
+        BoundedJsonFile.AtomicWrite(_root, path, record, SessionStartMemoryConstants.MaxRecordBytes,
+            SessionStartMemoryJsonContext.Default.SessionStartMemoryStoreRecord);
+    }
+
+    bool EnsureWriteCapacity(bool creatingRecord) {
+        var total = CountChildren();
+        var records = Directory.EnumerateFiles(_root, "*.json")
+            .Count(p => RecordRegex().IsMatch(Path.GetFileName(p)));
+        if (total < SessionStartMemoryConstants.TotalEntryCap &&
+            (!creatingRecord || records < SessionStartMemoryConstants.NormalRecordCap)) return true;
+
+        SweepUnderLock(TimeSpan.FromMilliseconds(250), 10_000, force: true);
+        total = CountChildren();
+        records = Directory.EnumerateFiles(_root, "*.json")
+            .Count(p => RecordRegex().IsMatch(Path.GetFileName(p)));
+        var available = total < SessionStartMemoryConstants.TotalEntryCap &&
+                        (!creatingRecord || records < SessionStartMemoryConstants.NormalRecordCap);
+        if (!available) _diagnostic?.Invoke("SessionStart memory coordination unavailable: store capacity reached.");
+        return available;
+    }
+
+    int CountChildren() => Directory.EnumerateFileSystemEntries(_root)
+        .Count(p => Path.GetFileName(p) is not "store.lock" and not MetadataName);
+
+    static bool Validate(SessionStartMemoryStoreRecord value) {
+        if (value.SchemaVersion != SessionStartMemoryConstants.SchemaVersion ||
+            value.PolicyVersion != SessionStartMemoryConstants.PolicyVersion ||
+            value.FragmentVersion != SessionStartMemoryConstants.FragmentVersion ||
+            value.Generation < 0 || value.Attempt < 0 ||
+            value.State is not ("leased" or "completed" or "retry_pending") ||
+            value.LeaseExpiresAt is { } leaseAt && leaseAt.Offset != TimeSpan.Zero ||
+            value.CompletedAt is { } completedAt && completedAt.Offset != TimeSpan.Zero ||
+            value.NextAttemptAt is { } nextAt && nextAt.Offset != TimeSpan.Zero) return false;
+        return value.State switch {
+            "leased" => value.Token is not null && TokenRegex().IsMatch(value.Token) &&
+                        value.LeaseExpiresAt is not null && value.CompletedAt is null &&
+                        value.NextAttemptAt is null && value.Disposition is null,
+            "completed" => value.Token is null && value.LeaseExpiresAt is null &&
+                           value.CompletedAt is not null && value.NextAttemptAt is null &&
+                           value.Disposition is "ready" or "complete_without_context",
+            "retry_pending" => value.Token is null && value.LeaseExpiresAt is null &&
+                               value.CompletedAt is null && value.NextAttemptAt is not null &&
+                               value.Disposition == "retryable_failure",
+            _ => false
+        };
+    }
+
+    static bool IsSweepExpired(SessionStartMemoryStoreRecord value, DateTimeOffset now) =>
+        value.State == "completed" && value.CompletedAt is { } completed &&
+        now - completed >= SessionStartMemoryConstants.Retention ||
+        value.State == "retry_pending" && value.NextAttemptAt is { } retry &&
+        now - retry >= SessionStartMemoryConstants.Retention;
+
+    static TimeSpan Backoff(long attempt) => attempt switch {
+        <= 0 => TimeSpan.FromSeconds(5),
+        1 => TimeSpan.FromSeconds(30),
+        2 => TimeSpan.FromMinutes(2),
+        _ => TimeSpan.FromMinutes(10)
+    };
+
+    static bool IsSweepCandidate(string name) => RecordRegex().IsMatch(name) || TempRegex().IsMatch(name);
+    static bool ValidateCursor(string? value) => value is null ||
+        value.Length <= 128 && value.All(static c => c <= 0x7f) && IsSweepCandidate(value);
+
+    static void SetOwnerOnly(string path) {
+        if (OperatingSystem.IsWindows()) return;
+        try { File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite); } catch { }
+    }
+
+    static bool IsOperational(Exception ex) => ex is IOException or UnauthorizedAccessException or
+        InvalidDataException or JsonException or OperationCanceledException or OverflowException or
+        ArgumentException or NotSupportedException;
+
+    [GeneratedRegex("^[0-9a-f]{64}$", RegexOptions.CultureInvariant)] private static partial Regex KeyRegex();
+    [GeneratedRegex("^[0-9a-f]{32}$", RegexOptions.CultureInvariant)] private static partial Regex TokenRegex();
+    [GeneratedRegex("^[0-9a-f]{64}\\.json$", RegexOptions.CultureInvariant)] private static partial Regex RecordRegex();
+    [GeneratedRegex("^[0-9a-f]{64}\\.[0-9a-f]{32}\\.tmp$", RegexOptions.CultureInvariant)] private static partial Regex TempRegex();
+}

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryLeaseStore.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryLeaseStore.cs
@@ -27,11 +27,16 @@ internal sealed partial class SessionStartMemoryLeaseStore {
     public async Task<SessionStartMemoryLeaseHandle?> TryBeginAsync(
         string key, TimeSpan budget, CancellationToken ct = default) {
         if (!KeyRegex().IsMatch(key) || budget <= TimeSpan.Zero) return null;
+        var started = Stopwatch.GetTimestamp();
+        TimeSpan Remaining() => RemainingBudget(budget, started);
         try {
-            using var gate = await AcquireAsync(budget, ct);
+            using var gate = await AcquireAsync(Remaining(), ct);
             if (gate is null) return null;
             EnsureSafeRoot();
-            SweepUnderLock(TimeSpan.FromMilliseconds(25), 5_000, force: false);
+            var sweepBudget = Min(Remaining(), TimeSpan.FromMilliseconds(25));
+            if (sweepBudget <= TimeSpan.Zero) return null;
+            SweepUnderLock(sweepBudget, 5_000, force: false);
+            if (Remaining() <= TimeSpan.Zero) return null;
 
             var path = RecordPath(key);
             var now = _time.GetUtcNow();
@@ -48,7 +53,8 @@ internal sealed partial class SessionStartMemoryLeaseStore {
                     return null;
             }
 
-            if (!EnsureWriteCapacity(creatingRecord: current is null)) return null;
+            if (!EnsureWriteCapacity(creatingRecord: current is null, Remaining())) return null;
+            if (Remaining() <= TimeSpan.Zero) return null;
             var generation = checked((current?.Generation ?? 0) + 1);
             var attempt = current?.State == "retry_pending" ? checked(current.Attempt + 1) : current?.Attempt ?? 0;
             var token = Convert.ToHexStringLower(RandomNumberGenerator.GetBytes(16));
@@ -67,15 +73,17 @@ internal sealed partial class SessionStartMemoryLeaseStore {
     }
 
     public Task<bool> CompleteAsync(SessionStartMemoryLeaseHandle handle, SessionStartMemoryDisposition disposition,
-        CancellationToken ct = default) => MutateAsync(handle, disposition, retryAfter: null, ct);
+        TimeSpan budget, CancellationToken ct = default) => MutateAsync(handle, disposition, retryAfter: null, budget, ct);
 
-    public Task<bool> RetryAsync(SessionStartMemoryLeaseHandle handle, TimeSpan? retryAfter,
-        CancellationToken ct = default) => MutateAsync(handle, SessionStartMemoryDisposition.RetryableFailure, retryAfter, ct);
+    public Task<bool> RetryAsync(SessionStartMemoryLeaseHandle handle, TimeSpan? retryAfter, TimeSpan budget,
+        CancellationToken ct = default) => MutateAsync(handle, SessionStartMemoryDisposition.RetryableFailure, retryAfter, budget, ct);
 
     async Task<bool> MutateAsync(SessionStartMemoryLeaseHandle handle, SessionStartMemoryDisposition disposition,
-        TimeSpan? retryAfter, CancellationToken ct) {
+        TimeSpan? retryAfter, TimeSpan budget, CancellationToken ct) {
+        if (budget <= TimeSpan.Zero) return false;
+        var started = Stopwatch.GetTimestamp();
         try {
-            using var gate = await AcquireAsync(TimeSpan.FromSeconds(2), ct);
+            using var gate = await AcquireAsync(RemainingBudget(budget, started), ct);
             if (gate is null) return false;
             EnsureSafeRoot();
             var path = RecordPath(handle.Key);
@@ -85,7 +93,8 @@ internal sealed partial class SessionStartMemoryLeaseStore {
                 !CryptographicOperations.FixedTimeEquals(
                     Encoding.ASCII.GetBytes(current.Token ?? ""),
                     Encoding.ASCII.GetBytes(handle.Token))) return false;
-            if (!EnsureWriteCapacity(creatingRecord: false)) return false;
+            if (!EnsureWriteCapacity(creatingRecord: false, RemainingBudget(budget, started))) return false;
+            if (RemainingBudget(budget, started) <= TimeSpan.Zero) return false;
 
             var now = _time.GetUtcNow();
             SessionStartMemoryStoreRecord next;
@@ -117,40 +126,41 @@ internal sealed partial class SessionStartMemoryLeaseStore {
 
     public async Task SweepAsync(TimeSpan budget, int maxEntries = 5_000, CancellationToken ct = default) {
         if (budget <= TimeSpan.Zero || maxEntries <= 0) return;
+        var started = Stopwatch.GetTimestamp();
         try {
-            using var gate = await AcquireAsync(budget, ct);
+            using var gate = await AcquireAsync(RemainingBudget(budget, started), ct);
             if (gate is null) return;
             EnsureSafeRoot();
-            SweepUnderLock(budget, maxEntries, force: true);
+            SweepUnderLock(RemainingBudget(budget, started), maxEntries, force: true);
         } catch (Exception ex) when (IsOperational(ex)) {
             _diagnostic?.Invoke($"SessionStart memory sweep skipped: {ex.Message}");
         }
     }
 
     void SweepUnderLock(TimeSpan budget, int maxEntries, bool force) {
+        if (budget <= TimeSpan.Zero) return;
+        var started = Stopwatch.GetTimestamp();
         var now = _time.GetUtcNow();
         var metadata = ReadMetadata();
         if (!force && metadata.LastSweepAt is { } last && now >= last && now - last < NormalSweepInterval)
             return;
 
-        var names = Directory.EnumerateFileSystemEntries(_root)
-            .Select(Path.GetFileName)
-            .Where(static name => name is not null)
-            .Select(static name => name!)
-            .Where(IsSweepCandidate)
-            .Order(StringComparer.Ordinal)
-            .ToArray();
         var cursor = ValidateCursor(metadata.LastProcessedFilename) ? metadata.LastProcessedFilename : null;
-        var started = Stopwatch.GetTimestamp();
         var processed = 0;
         string? lastProcessed = null;
         var reachedEnd = true;
+        var seekingCursor = cursor is not null;
 
-        foreach (var name in names) {
-            if (cursor is not null && StringComparer.Ordinal.Compare(name, cursor) <= 0) continue;
+        foreach (var entry in Directory.EnumerateFileSystemEntries(_root)) {
             if (processed >= maxEntries || Stopwatch.GetElapsedTime(started) >= budget) {
                 reachedEnd = false;
                 break;
+            }
+            var name = Path.GetFileName(entry);
+            if (name is null || !IsSweepCandidate(name)) continue;
+            if (seekingCursor) {
+                if (StringComparer.Ordinal.Equals(name, cursor)) seekingCursor = false;
+                continue;
             }
             processed++;
             lastProcessed = name; // poison entries must never pin cleanup progress
@@ -169,11 +179,13 @@ internal sealed partial class SessionStartMemoryLeaseStore {
             }
         }
 
-        // If the cursor was after every currently valid candidate, wrap now rather than pinning it.
-        if (lastProcessed is null && cursor is not null) reachedEnd = true;
+        // A missing cursor is wrapped only after a complete scan. If the budget expired while
+        // seeking it, retain the cursor and continue on the next sweep.
         var nextCursor = reachedEnd ? null : lastProcessed ?? cursor;
-        WriteMetadata(new SessionStartMemoryStoreMetadata(
-            SessionStartMemoryConstants.SchemaVersion, now, nextCursor));
+        var remaining = RemainingBudget(budget, started);
+        if (remaining > TimeSpan.Zero)
+            WriteMetadata(new SessionStartMemoryStoreMetadata(
+                SessionStartMemoryConstants.SchemaVersion, now, nextCursor), remaining);
     }
 
     SessionStartMemoryStoreMetadata ReadMetadata() {
@@ -193,8 +205,9 @@ internal sealed partial class SessionStartMemoryLeaseStore {
         }
     }
 
-    void WriteMetadata(SessionStartMemoryStoreMetadata metadata) {
-        if (CountChildren() >= SessionStartMemoryConstants.TotalEntryCap) {
+    void WriteMetadata(SessionStartMemoryStoreMetadata metadata, TimeSpan budget) {
+        if (!TryCountEntries(budget, stopAtRecordCap: false, out var total, out _) ||
+            total >= SessionStartMemoryConstants.TotalEntryCap) {
             _diagnostic?.Invoke("SessionStart memory sweep cursor not persisted: store capacity reached.");
             return;
         }
@@ -246,25 +259,44 @@ internal sealed partial class SessionStartMemoryLeaseStore {
             SessionStartMemoryJsonContext.Default.SessionStartMemoryStoreRecord);
     }
 
-    bool EnsureWriteCapacity(bool creatingRecord) {
-        var total = CountChildren();
-        var records = Directory.EnumerateFiles(_root, "*.json")
-            .Count(p => RecordRegex().IsMatch(Path.GetFileName(p)));
+    bool EnsureWriteCapacity(bool creatingRecord, TimeSpan budget) {
+        if (budget <= TimeSpan.Zero) return false;
+        var started = Stopwatch.GetTimestamp();
+        if (!TryCountEntries(RemainingBudget(budget, started), creatingRecord, out var total, out var records)) return false;
         if (total < SessionStartMemoryConstants.TotalEntryCap &&
             (!creatingRecord || records < SessionStartMemoryConstants.NormalRecordCap)) return true;
 
-        SweepUnderLock(TimeSpan.FromMilliseconds(250), 10_000, force: true);
-        total = CountChildren();
-        records = Directory.EnumerateFiles(_root, "*.json")
-            .Count(p => RecordRegex().IsMatch(Path.GetFileName(p)));
+        SweepUnderLock(Min(RemainingBudget(budget, started), TimeSpan.FromMilliseconds(250)), 10_000, force: true);
+        if (!TryCountEntries(RemainingBudget(budget, started), creatingRecord, out total, out records)) return false;
         var available = total < SessionStartMemoryConstants.TotalEntryCap &&
                         (!creatingRecord || records < SessionStartMemoryConstants.NormalRecordCap);
         if (!available) _diagnostic?.Invoke("SessionStart memory coordination unavailable: store capacity reached.");
         return available;
     }
 
-    int CountChildren() => Directory.EnumerateFileSystemEntries(_root)
-        .Count(p => Path.GetFileName(p) is not "store.lock" and not MetadataName);
+    bool TryCountEntries(TimeSpan budget, bool stopAtRecordCap, out int total, out int records) {
+        total = 0;
+        records = 0;
+        if (budget <= TimeSpan.Zero) return false;
+        var started = Stopwatch.GetTimestamp();
+        foreach (var path in Directory.EnumerateFileSystemEntries(_root)) {
+            if (Stopwatch.GetElapsedTime(started) >= budget) return false;
+            var name = Path.GetFileName(path);
+            if (name is "store.lock" or MetadataName) continue;
+            total++;
+            if (name is not null && RecordRegex().IsMatch(name)) records++;
+            if (total >= SessionStartMemoryConstants.TotalEntryCap ||
+                stopAtRecordCap && records >= SessionStartMemoryConstants.NormalRecordCap) return true;
+        }
+        return true;
+    }
+
+    static TimeSpan RemainingBudget(TimeSpan budget, long started) {
+        var remaining = budget - Stopwatch.GetElapsedTime(started);
+        return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+    }
+
+    static TimeSpan Min(TimeSpan left, TimeSpan right) => left <= right ? left : right;
 
     static bool Validate(SessionStartMemoryStoreRecord value) {
         if (value.SchemaVersion != SessionStartMemoryConstants.SchemaVersion ||

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryLifecyclePolicy.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryLifecyclePolicy.cs
@@ -6,7 +6,7 @@ internal static class SessionStartMemoryLifecyclePolicy {
             SessionStartMemoryIdentity.NormalizeSessionId(lifecycle.Harness, lifecycle.SessionId) is null ||
             lifecycle.Reason == SessionLifecycleReason.Unknown)
             return SessionMemoryLifecycleDecision.RetryLaterNoCommit;
-        if (!lifecycle.IsTopLevel || lifecycle.Reason is SessionLifecycleReason.Compact or SessionLifecycleReason.RepeatedTurnCallback)
+        if (!lifecycle.IsTopLevel || lifecycle.Reason == SessionLifecycleReason.Compact)
             return SessionMemoryLifecycleDecision.IneligibleNoCommit;
         return lifecycle.CallbackMayRepeat
             ? SessionMemoryLifecycleDecision.EligibleWithLease

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryLifecyclePolicy.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryLifecyclePolicy.cs
@@ -1,0 +1,15 @@
+namespace Capacitor.Cli.SessionStartMemory;
+
+internal static class SessionStartMemoryLifecyclePolicy {
+    public static SessionMemoryLifecycleDecision Decide(SessionMemoryLifecycle lifecycle) {
+        if (!lifecycle.ClassificationAuthoritative ||
+            SessionStartMemoryIdentity.NormalizeSessionId(lifecycle.Harness, lifecycle.SessionId) is null ||
+            lifecycle.Reason == SessionLifecycleReason.Unknown)
+            return SessionMemoryLifecycleDecision.RetryLaterNoCommit;
+        if (!lifecycle.IsTopLevel || lifecycle.Reason is SessionLifecycleReason.Compact or SessionLifecycleReason.RepeatedTurnCallback)
+            return SessionMemoryLifecycleDecision.IneligibleNoCommit;
+        return lifecycle.CallbackMayRepeat
+            ? SessionMemoryLifecycleDecision.EligibleWithLease
+            : SessionMemoryLifecycleDecision.EligibleOneShot;
+    }
+}

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryOrchestrator.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryOrchestrator.cs
@@ -7,21 +7,27 @@ internal sealed class SessionStartMemoryOrchestrator(
 
     public async Task<string?> GetFragmentAsync(SessionMemoryLifecycle lifecycle,
         SessionStartMemoryContextRequest request) {
+        var started = System.Diagnostics.Stopwatch.GetTimestamp();
+        TimeSpan Remaining() {
+            var value = request.Budget - System.Diagnostics.Stopwatch.GetElapsedTime(started);
+            return value > TimeSpan.Zero ? value : TimeSpan.Zero;
+        }
+
         try {
             var decision = SessionStartMemoryLifecyclePolicy.Decide(lifecycle);
             if (decision is SessionMemoryLifecycleDecision.IneligibleNoCommit or SessionMemoryLifecycleDecision.RetryLaterNoCommit)
                 return null;
             var key = SessionStartMemoryIdentity.Create(lifecycle.Harness, lifecycle.SessionId,
                 lifecycle.LifecycleInstanceId);
-            var lease = await store.TryBeginAsync(key, request.Budget, request.CancellationToken);
+            var lease = await store.TryBeginAsync(key, Remaining(), request.CancellationToken);
             if (lease is null) return null;
 
-            var result = await provider.GetAsync(request);
+            var result = await provider.GetAsync(request with { Budget = Remaining() });
             if (result.Disposition == SessionStartMemoryDisposition.RetryableFailure) {
-                await store.RetryAsync(lease, result.RetryAfter, request.CancellationToken);
+                await store.RetryAsync(lease, result.RetryAfter, Remaining(), request.CancellationToken);
                 return null;
             }
-            if (!await store.CompleteAsync(lease, result.Disposition, request.CancellationToken)) return null;
+            if (!await store.CompleteAsync(lease, result.Disposition, Remaining(), request.CancellationToken)) return null;
             return result.Disposition == SessionStartMemoryDisposition.Ready ? result.Fragment : null;
         } catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) {
             diagnostic?.Invoke($"SessionStart memory orchestration skipped: {ex.Message}");

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryOrchestrator.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryOrchestrator.cs
@@ -1,0 +1,31 @@
+namespace Capacitor.Cli.SessionStartMemory;
+
+internal sealed class SessionStartMemoryOrchestrator(
+    SessionStartMemoryLeaseStore store,
+    SessionStartMemoryContextProvider provider,
+    Action<string>? diagnostic = null) {
+
+    public async Task<string?> GetFragmentAsync(SessionMemoryLifecycle lifecycle,
+        SessionStartMemoryContextRequest request) {
+        try {
+            var decision = SessionStartMemoryLifecyclePolicy.Decide(lifecycle);
+            if (decision is SessionMemoryLifecycleDecision.IneligibleNoCommit or SessionMemoryLifecycleDecision.RetryLaterNoCommit)
+                return null;
+            var key = SessionStartMemoryIdentity.Create(lifecycle.Harness, lifecycle.SessionId,
+                lifecycle.LifecycleInstanceId);
+            var lease = await store.TryBeginAsync(key, request.Budget, request.CancellationToken);
+            if (lease is null) return null;
+
+            var result = await provider.GetAsync(request);
+            if (result.Disposition == SessionStartMemoryDisposition.RetryableFailure) {
+                await store.RetryAsync(lease, result.RetryAfter, request.CancellationToken);
+                return null;
+            }
+            if (!await store.CompleteAsync(lease, result.Disposition, request.CancellationToken)) return null;
+            return result.Disposition == SessionStartMemoryDisposition.Ready ? result.Fragment : null;
+        } catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) {
+            diagnostic?.Invoke($"SessionStart memory orchestration skipped: {ex.Message}");
+            return null;
+        }
+    }
+}

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryOrchestrator.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryOrchestrator.cs
@@ -7,6 +7,8 @@ internal sealed class SessionStartMemoryOrchestrator(
 
     public async Task<string?> GetFragmentAsync(SessionMemoryLifecycle lifecycle,
         SessionStartMemoryContextRequest request) {
+        if (request.Disabled) return null;
+
         var started = System.Diagnostics.Stopwatch.GetTimestamp();
         TimeSpan Remaining() {
             var value = request.Budget - System.Diagnostics.Stopwatch.GetElapsedTime(started);

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryOutputAdapters.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryOutputAdapters.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+
+namespace Capacitor.Cli.SessionStartMemory;
+
+internal static class SessionStartMemoryOutputAdapters {
+    public static string Render(SessionStartHarness harness, string? fragment) {
+        if (harness == SessionStartHarness.Claude && fragment is null) return "";
+        if (harness is SessionStartHarness.Kiro or SessionStartHarness.Pi or SessionStartHarness.OpenCode)
+            return fragment is null ? "" : fragment + "\n";
+
+        object envelope = harness switch {
+            SessionStartHarness.Claude => fragment is null
+                ? new ClaudeMemoryEnvelope(null!)
+                : new ClaudeMemoryEnvelope(new HookMemoryOutput("SessionStart", fragment)),
+            SessionStartHarness.Codex => fragment is null
+                ? new CodexMemoryEnvelope(true, null!)
+                : new CodexMemoryEnvelope(true, new HookMemoryOutput("SessionStart", fragment)),
+            SessionStartHarness.Cursor => new CursorMemoryEnvelope(fragment),
+            SessionStartHarness.Copilot => new CopilotMemoryEnvelope(fragment),
+            SessionStartHarness.Gemini => new GeminiMemoryEnvelope(fragment is null ? null : new HookMemoryOutput("SessionStart", fragment)),
+            SessionStartHarness.Antigravity => new AntigravityMemoryEnvelope(fragment is null ? null : [new AntigravityMemoryStep(fragment)]),
+            _ => throw new ArgumentOutOfRangeException(nameof(harness))
+        };
+
+        var json = envelope switch {
+            ClaudeMemoryEnvelope value => fragment is null ? "{}" : JsonSerializer.Serialize(value, SessionStartMemoryJsonContext.Default.ClaudeMemoryEnvelope),
+            CodexMemoryEnvelope value => fragment is null ? "{\"continue\":true}" : JsonSerializer.Serialize(value, SessionStartMemoryJsonContext.Default.CodexMemoryEnvelope),
+            CursorMemoryEnvelope value => JsonSerializer.Serialize(value, SessionStartMemoryJsonContext.Default.CursorMemoryEnvelope),
+            CopilotMemoryEnvelope value => JsonSerializer.Serialize(value, SessionStartMemoryJsonContext.Default.CopilotMemoryEnvelope),
+            GeminiMemoryEnvelope value => JsonSerializer.Serialize(value, SessionStartMemoryJsonContext.Default.GeminiMemoryEnvelope),
+            AntigravityMemoryEnvelope value => JsonSerializer.Serialize(value, SessionStartMemoryJsonContext.Default.AntigravityMemoryEnvelope),
+            _ => throw new InvalidOperationException()
+        };
+        return json + "\n";
+    }
+}

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryScopeResolver.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryScopeResolver.cs
@@ -1,0 +1,19 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.SessionStartMemory;
+
+internal sealed class SessionStartMemoryScopeResolver : ISessionStartMemoryScopeResolver {
+    public async Task<SessionStartMemoryScope> ResolveAsync(string? cwd, CancellationToken ct) {
+        string? repoHash = null;
+        string? machine = null;
+        try {
+            var path = string.IsNullOrWhiteSpace(cwd) ? Directory.GetCurrentDirectory() : cwd;
+            var repo = await RepositoryDetection.DetectRepositoryAsync(path, detectPullRequest: false);
+            if (repo?.Owner is not null && repo.RepoName is not null)
+                repoHash = RepoHashHelper.ComputeRepoHash(repo.Owner, repo.RepoName);
+        } catch { }
+        ct.ThrowIfCancellationRequested();
+        try { machine = await MachineIdProvider.GetOrCreateAsync(); } catch { }
+        return new SessionStartMemoryScope(repoHash, machine);
+    }
+}

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryScopeResolver.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryScopeResolver.cs
@@ -3,17 +3,24 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.SessionStartMemory;
 
 internal sealed class SessionStartMemoryScopeResolver : ISessionStartMemoryScopeResolver {
-    public async Task<SessionStartMemoryScope> ResolveAsync(string? cwd, CancellationToken ct) {
+    public async Task<SessionStartMemoryScope> ResolveAsync(string? cwd, TimeSpan budget, CancellationToken ct) {
+        var started = System.Diagnostics.Stopwatch.GetTimestamp();
+        TimeSpan Remaining() {
+            var value = budget - System.Diagnostics.Stopwatch.GetElapsedTime(started);
+            return value > TimeSpan.Zero ? value : TimeSpan.Zero;
+        }
+
         string? repoHash = null;
         string? machine = null;
         try {
             var path = string.IsNullOrWhiteSpace(cwd) ? Directory.GetCurrentDirectory() : cwd;
-            var repo = await RepositoryDetection.DetectRepositoryAsync(path, detectPullRequest: false);
+            var repo = await RepositoryDetection.DetectRepositoryAsync(path, Remaining(), detectPullRequest: false);
             if (repo?.Owner is not null && repo.RepoName is not null)
                 repoHash = RepoHashHelper.ComputeRepoHash(repo.Owner, repo.RepoName);
         } catch { }
         ct.ThrowIfCancellationRequested();
-        try { machine = await MachineIdProvider.GetOrCreateAsync(); } catch { }
+        if (Remaining() <= TimeSpan.Zero) throw new OperationCanceledException(ct);
+        try { machine = await MachineIdProvider.GetOrCreateAsync(ct); } catch (OperationCanceledException) { throw; } catch { }
         return new SessionStartMemoryScope(repoHash, machine);
     }
 }

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryStorePaths.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryStorePaths.cs
@@ -1,0 +1,21 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.SessionStartMemory;
+
+internal static class SessionStartMemoryStorePaths {
+    public static string DefaultRoot => PathHelpers.ConfigPath(Path.Combine("cache", "session-start-memory-v1"));
+
+    public static string ValidateRoot(string root) {
+        var full = Path.GetFullPath(root);
+        Directory.CreateDirectory(full);
+        if (!OperatingSystem.IsWindows()) {
+            try {
+                File.SetUnixFileMode(full, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            } catch { }
+        }
+        var info = new DirectoryInfo(full);
+        if ((info.Attributes & FileAttributes.ReparsePoint) != 0)
+            throw new IOException("SessionStart memory store root may not be a symlink or reparse point.");
+        return full;
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
@@ -17,6 +17,20 @@ public class ClaudeHookCommandTests {
         await Assert.That(fx.RouteOrder).Contains("session-start");
     }
 
+    [Test]
+    public async Task memory_store_initialization_failure_does_not_suppress_session_start_capture() {
+        using var fx = new Fixture();
+
+        var exit = await ClaudeHookCommand.HandleCore(
+            fx.Client, AuthStatus.Ok, fx.Spool, System.Diagnostics.Stopwatch.GetTimestamp(),
+            "http://localhost", new StringReader(
+                $$"""{"hook_event_name":"SessionStart","session_id":"{{Sid}}","cwd":"/tmp"}"""),
+            memoryStoreFactory: () => throw new UnauthorizedAccessException("read-only store"));
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(fx.RouteOrder).Contains("session-start");
+    }
+
     // the session-start payload gains a best-effort workspace_root (the git repo root
     // for cwd), used server-side by plan-artifact discovery. Fail-open: a cwd with no
     // discoverable .git entry (e.g. "/tmp") must omit the field entirely rather than send null.

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.SessionStartMemory;
 
 namespace Capacitor.Cli.Tests.Unit;
@@ -29,6 +30,29 @@ public class ClaudeHookCommandTests {
 
         await Assert.That(exit).IsEqualTo(0);
         await Assert.That(fx.RouteOrder).Contains("session-start");
+    }
+
+    [Test]
+    public async Task disabled_memory_index_does_not_construct_the_lease_store() {
+        using var fx = new Fixture();
+        var storeConstructed = false;
+        AppConfig.SetResolvedState("http://localhost", "default", new Profile { DisableMemoryIndex = true });
+        try {
+            var exit = await ClaudeHookCommand.HandleCore(
+                fx.Client, AuthStatus.Ok, fx.Spool, System.Diagnostics.Stopwatch.GetTimestamp(),
+                "http://localhost", new StringReader(
+                    $$"""{"hook_event_name":"SessionStart","session_id":"{{Sid}}","cwd":"/tmp"}"""),
+                memoryStoreFactory: () => {
+                    storeConstructed = true;
+                    return new SessionStartMemoryLeaseStore(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+                });
+
+            await Assert.That(exit).IsEqualTo(0);
+            await Assert.That(storeConstructed).IsFalse();
+            await Assert.That(fx.RouteOrder).Contains("session-start");
+        } finally {
+            AppConfig.SetResolvedState("http://localhost", "default", new Profile());
+        }
     }
 
     // the session-start payload gains a best-effort workspace_root (the git repo root

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.SessionStartMemory;
 
 namespace Capacitor.Cli.Tests.Unit;
 
@@ -357,7 +358,8 @@ public class ClaudeHookCommandTests {
 
         public Task<int> HandleAsync(string stdin, long processStart = 0) =>
             ClaudeHookCommand.HandleCore(Client, AuthStatus.Ok, Spool, processStart == 0 ? System.Diagnostics.Stopwatch.GetTimestamp() : processStart,
-                "http://localhost", new StringReader(stdin));
+                "http://localhost", new StringReader(stdin),
+                memoryStoreFactory: () => new SessionStartMemoryLeaseStore(Path.Combine(_tmpHome, "memory")));
 
         public IEnumerable<string> SpoolFiles =>
             Directory.Exists(_spoolPath) ? Directory.EnumerateFiles(_spoolPath) : [];

--- a/test/Capacitor.Cli.Tests.Unit/MemoryIndexEmitterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/MemoryIndexEmitterTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Commands;
+using Capacitor.Cli.SessionStartMemory;
 
 namespace Capacitor.Cli.Tests.Unit;
 
@@ -182,5 +183,22 @@ public class MemoryIndexEmitterTests {
 
         await Assert.That(fragment.TrimStart().StartsWith('{')).IsFalse();
         await Assert.That(fragment).DoesNotContain("hookSpecificOutput");
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task Typed_emitter_keeps_fragment_size_accounting_linear() {
+        var entries = Enumerable.Range(0, SessionStartMemoryConstants.MaxEntries)
+            .Select(i => new SessionStartMemoryEntry(
+                $"id-{i}", $"slug-{i}", "org", "x", "feedback"))
+            .ToArray();
+
+        _ = MemoryIndexEmitter.BuildFragment(entries[..1]);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        var fragment = MemoryIndexEmitter.BuildFragment(entries);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(fragment).IsNotNull();
+        await Assert.That(allocated).IsLessThan(400_000);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
@@ -59,6 +59,15 @@ public class SessionStartMemoryFoundationTests {
     }
 
     [Test]
+    public async Task Authoritative_top_level_repeated_callback_uses_the_lease_store() {
+        var decision = SessionStartMemoryLifecyclePolicy.Decide(new(
+            SessionStartHarness.Kiro, "session", null, true, true,
+            SessionLifecycleReason.RepeatedTurnCallback, CallbackMayRepeat: true));
+
+        await Assert.That(decision).IsEqualTo(SessionMemoryLifecycleDecision.EligibleWithLease);
+    }
+
+    [Test]
     public async Task Typed_emitter_adds_marker_groups_and_never_accepts_bodies() {
         var entries = new[] {
             new SessionStartMemoryEntry("1", "org-rule", "org", "fact", "feedback"),
@@ -125,8 +134,8 @@ public class SessionStartMemoryFoundationTests {
             time.Advance(TimeSpan.FromSeconds(31));
             var replacement = await store.TryBeginAsync(new string('a', 64), TimeSpan.FromSeconds(1));
             await Assert.That(replacement).IsNotNull();
-            await Assert.That(await store.CompleteAsync(first!, SessionStartMemoryDisposition.Ready)).IsFalse();
-            await Assert.That(await store.CompleteAsync(replacement!, SessionStartMemoryDisposition.Ready)).IsTrue();
+            await Assert.That(await store.CompleteAsync(first!, SessionStartMemoryDisposition.Ready, TimeSpan.FromSeconds(1))).IsFalse();
+            await Assert.That(await store.CompleteAsync(replacement!, SessionStartMemoryDisposition.Ready, TimeSpan.FromSeconds(1))).IsTrue();
             await Assert.That(await store.TryBeginAsync(new string('a', 64), TimeSpan.FromSeconds(1))).IsNull();
         } finally { Directory.Delete(root, recursive: true); }
     }
@@ -152,7 +161,7 @@ public class SessionStartMemoryFoundationTests {
             var store = new SessionStartMemoryLeaseStore(root, time);
             var key = new string('e', 64);
             var lease = await store.TryBeginAsync(key, TimeSpan.FromSeconds(1));
-            await store.CompleteAsync(lease!, SessionStartMemoryDisposition.Ready);
+            await store.CompleteAsync(lease!, SessionStartMemoryDisposition.Ready, TimeSpan.FromSeconds(1));
 
             time.Advance(TimeSpan.FromDays(30) - TimeSpan.FromTicks(1));
             await Assert.That(await store.TryBeginAsync(key, TimeSpan.FromSeconds(1))).IsNull();
@@ -170,7 +179,7 @@ public class SessionStartMemoryFoundationTests {
             var store = new SessionStartMemoryLeaseStore(root, time);
             foreach (var key in new[] { new string('a', 64), new string('c', 64) }) {
                 var lease = await store.TryBeginAsync(key, TimeSpan.FromSeconds(1));
-                await store.CompleteAsync(lease!, SessionStartMemoryDisposition.Ready);
+                await store.CompleteAsync(lease!, SessionStartMemoryDisposition.Ready, TimeSpan.FromSeconds(1));
             }
             var poison = Path.Combine(root, new string('b', 64) + ".json");
             await File.WriteAllTextAsync(poison, "not-json");
@@ -192,7 +201,7 @@ public class SessionStartMemoryFoundationTests {
             var store = new SessionStartMemoryLeaseStore(root, time);
             var key = new string('b', 64);
             var lease = await store.TryBeginAsync(key, TimeSpan.FromSeconds(1));
-            await Assert.That(await store.RetryAsync(lease!, null)).IsTrue();
+            await Assert.That(await store.RetryAsync(lease!, null, TimeSpan.FromSeconds(1))).IsTrue();
             await Assert.That(await store.TryBeginAsync(key, TimeSpan.FromSeconds(1))).IsNull();
 
             time.Advance(TimeSpan.FromSeconds(5));
@@ -204,11 +213,11 @@ public class SessionStartMemoryFoundationTests {
     public async Task Provider_maps_empty_malformed_and_ready_responses() {
         var scope = new FixedScopeResolver("repo", "machine");
         var empty = new SessionStartMemoryContextProvider(scope,
-            _ => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.OK, "[]"))));
+            (_, _) => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.OK, "[]"))));
         var malformed = new SessionStartMemoryContextProvider(scope,
-            _ => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.OK, "[{}]"))));
+            (_, _) => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.OK, "[{}]"))));
         var ready = new SessionStartMemoryContextProvider(scope,
-            _ => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.OK,
+            (_, _) => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.OK,
                 "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))));
         var request = new SessionStartMemoryContextRequest("https://example", "/repo", false,
             TimeSpan.FromSeconds(1), CancellationToken.None);
@@ -226,7 +235,7 @@ public class SessionStartMemoryFoundationTests {
     public async Task Provider_omits_only_unresolved_scope_axes() {
         var handler = new CapturingHandler(HttpStatusCode.NoContent, "");
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, "machine tag"),
-            _ => Task.FromResult(new HttpClient(handler)));
+            (_, _) => Task.FromResult(new HttpClient(handler)));
 
         await provider.GetAsync(new SessionStartMemoryContextRequest(
             "https://example.test/", null, false, TimeSpan.FromSeconds(1), CancellationToken.None));
@@ -237,7 +246,9 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task Provider_refreshes_once_after_401_and_refuses_redirect_status() {
         var calls = 0;
-        var refreshing = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null), _ => {
+        var forceRefreshValues = new List<bool>();
+        var refreshing = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null), (forceRefresh, _) => {
+            forceRefreshValues.Add(forceRefresh);
             calls++;
             var status = calls == 1 ? HttpStatusCode.Unauthorized : HttpStatusCode.NoContent;
             return Task.FromResult(new HttpClient(new StaticHandler(status, "")));
@@ -247,10 +258,11 @@ public class SessionStartMemoryFoundationTests {
 
         var healed = await refreshing.GetAsync(request);
         var redirected = await new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
-            _ => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.Redirect, ""))))
+            (_, _) => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.Redirect, ""))))
             .GetAsync(request);
 
         await Assert.That(calls).IsEqualTo(2);
+        await Assert.That(forceRefreshValues).IsEquivalentTo([false, true]);
         await Assert.That(healed.Disposition).IsEqualTo(SessionStartMemoryDisposition.CompleteWithoutContext);
         await Assert.That(redirected.Disposition).IsEqualTo(SessionStartMemoryDisposition.RetryableFailure);
     }
@@ -260,7 +272,7 @@ public class SessionStartMemoryFoundationTests {
         var root = TempDir();
         try {
             var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
-                _ => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.OK,
+                (_, _) => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.OK,
                     "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))));
             var orchestrator = new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root), provider);
             var lifecycle = new SessionMemoryLifecycle(SessionStartHarness.Claude, "session", null,
@@ -289,7 +301,7 @@ public class SessionStartMemoryFoundationTests {
     }
 
     sealed class FixedScopeResolver(string? repo, string? machine) : ISessionStartMemoryScopeResolver {
-        public Task<SessionStartMemoryScope> ResolveAsync(string? cwd, CancellationToken ct) =>
+        public Task<SessionStartMemoryScope> ResolveAsync(string? cwd, TimeSpan budget, CancellationToken ct) =>
             Task.FromResult(new SessionStartMemoryScope(repo, machine));
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
@@ -1,0 +1,312 @@
+using System.Net;
+using System.Text;
+using Capacitor.Cli.SessionStartMemory;
+
+namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
+
+public class SessionStartMemoryFoundationTests {
+    [Test]
+    public async Task Canonical_key_distinguishes_absent_token_from_literal_text() {
+        var absent = SessionStartMemoryIdentity.Create(SessionStartHarness.Claude, "session", null);
+        var literal = SessionStartMemoryIdentity.Create(SessionStartHarness.Claude, "session", "native-session");
+
+        await Assert.That(absent).IsNotEqualTo(literal);
+        await Assert.That(absent).Matches("^[0-9a-f]{64}$");
+    }
+
+    [Test]
+    public async Task Canonical_key_is_length_delimited_and_lifecycle_scoped() {
+        var left = SessionStartMemoryIdentity.Create(SessionStartHarness.Claude, "ab", "c");
+        var right = SessionStartMemoryIdentity.Create(SessionStartHarness.Claude, "a", "bc");
+        var resumed = SessionStartMemoryIdentity.Create(SessionStartHarness.Claude, "ab", "resume-2");
+
+        await Assert.That(left).IsNotEqualTo(right);
+        await Assert.That(left).IsNotEqualTo(resumed);
+    }
+
+    [Test]
+    public async Task Uuid_harnesses_use_lowercase_N_identity() {
+        var id = SessionStartMemoryIdentity.NormalizeSessionId(
+            SessionStartHarness.Cursor, "A0D44A4A-5059-4D1F-9C93-2A1ADCE89C2E");
+
+        await Assert.That(id).IsEqualTo("a0d44a4a50594d1f9c932a1adce89c2e");
+    }
+
+    [Test]
+    public async Task Lifecycle_policy_does_not_poison_unknown_or_subagent_callbacks() {
+        var unknown = SessionStartMemoryLifecyclePolicy.Decide(new(
+            SessionStartHarness.Kiro, "s", null, true, false,
+            SessionLifecycleReason.Unknown, CallbackMayRepeat: true));
+        var subagent = SessionStartMemoryLifecyclePolicy.Decide(new(
+            SessionStartHarness.Kiro, "s", null, false, true,
+            SessionLifecycleReason.New, CallbackMayRepeat: true));
+        var top = SessionStartMemoryLifecyclePolicy.Decide(new(
+            SessionStartHarness.Kiro, "s", null, true, true,
+            SessionLifecycleReason.New, CallbackMayRepeat: true));
+
+        await Assert.That(unknown).IsEqualTo(SessionMemoryLifecycleDecision.RetryLaterNoCommit);
+        await Assert.That(subagent).IsEqualTo(SessionMemoryLifecycleDecision.IneligibleNoCommit);
+        await Assert.That(top).IsEqualTo(SessionMemoryLifecycleDecision.EligibleWithLease);
+    }
+
+    [Test]
+    public async Task Compact_is_ineligible_in_v1() {
+        var decision = SessionStartMemoryLifecyclePolicy.Decide(new(
+            SessionStartHarness.Claude, "s", null, true, true,
+            SessionLifecycleReason.Compact, CallbackMayRepeat: false));
+
+        await Assert.That(decision).IsEqualTo(SessionMemoryLifecycleDecision.IneligibleNoCommit);
+    }
+
+    [Test]
+    public async Task Typed_emitter_adds_marker_groups_and_never_accepts_bodies() {
+        var entries = new[] {
+            new SessionStartMemoryEntry("1", "org-rule", "org", "fact", "feedback"),
+            new SessionStartMemoryEntry("2", "mine", "user", "my fact", "preference")
+        };
+
+        var fragment = MemoryIndexEmitter.BuildFragment(entries);
+
+        await Assert.That(fragment).StartsWith("<!-- kcap-memory-index:v1 -->\n## Team memory");
+        await Assert.That(fragment).Contains("### Org\n- org-rule: fact");
+        await Assert.That(fragment).Contains("### Yours\n- mine: my fact");
+        await Assert.That(Encoding.UTF8.GetByteCount(fragment!)).IsLessThanOrEqualTo(24 * 1024);
+    }
+
+    [Test]
+    public async Task Output_adapters_match_exact_golden_bytes() {
+        const string fragment = "F";
+
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Claude, fragment))
+            .IsEqualTo("{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"F\"}}\n");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Claude, null)).IsEqualTo("");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Codex, fragment))
+            .IsEqualTo("{\"continue\":true,\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"F\"}}\n");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Cursor, null)).IsEqualTo("{}\n");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Cursor, fragment))
+            .IsEqualTo("{\"additional_context\":\"F\"}\n");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Copilot, fragment))
+            .IsEqualTo("{\"additionalContext\":\"F\"}\n");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Copilot, null)).IsEqualTo("{}\n");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Gemini, fragment))
+            .IsEqualTo("{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"F\"}}\n");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Gemini, null)).IsEqualTo("{}\n");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Kiro, fragment)).IsEqualTo("F\n");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Kiro, null)).IsEqualTo("");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Pi, fragment)).IsEqualTo("F\n");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.OpenCode, null)).IsEqualTo("");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Antigravity, fragment))
+            .IsEqualTo("{\"injectSteps\":[{\"userMessage\":\"F\"}]}\n");
+        await Assert.That(SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Antigravity, null)).IsEqualTo("{}\n");
+    }
+
+    [Test]
+    public async Task Extension_state_is_first_nonempty_wins_and_delivers_once() {
+        var state = new SessionStartMemoryExtensionState();
+        await state.ObserveBridgeResultAsync("key", "first");
+        await state.ObserveBridgeResultAsync("key", "second");
+        await state.ObserveBridgeResultAsync("key", null);
+
+        await Assert.That(await state.TakeForDeliveryAsync("key")).IsEqualTo("first");
+        await Assert.That(await state.TakeForDeliveryAsync("key")).IsNull();
+    }
+
+    [Test]
+    public async Task Lease_store_has_one_winner_and_fences_stale_owner() {
+        var root = TempDir();
+        try {
+            var time = new ManualTimeProvider(new DateTimeOffset(2026, 7, 23, 0, 0, 0, TimeSpan.Zero));
+            var store = new SessionStartMemoryLeaseStore(root, time);
+            var first = await store.TryBeginAsync(new string('a', 64), TimeSpan.FromSeconds(1));
+            var blocked = await store.TryBeginAsync(new string('a', 64), TimeSpan.FromSeconds(1));
+            await Assert.That(first).IsNotNull();
+            await Assert.That(blocked).IsNull();
+
+            time.Advance(TimeSpan.FromSeconds(31));
+            var replacement = await store.TryBeginAsync(new string('a', 64), TimeSpan.FromSeconds(1));
+            await Assert.That(replacement).IsNotNull();
+            await Assert.That(await store.CompleteAsync(first!, SessionStartMemoryDisposition.Ready)).IsFalse();
+            await Assert.That(await store.CompleteAsync(replacement!, SessionStartMemoryDisposition.Ready)).IsTrue();
+            await Assert.That(await store.TryBeginAsync(new string('a', 64), TimeSpan.FromSeconds(1))).IsNull();
+        } finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Test]
+    public async Task Concurrent_lease_attempts_have_exactly_one_winner() {
+        var root = TempDir();
+        try {
+            var key = new string('d', 64);
+            var attempts = Enumerable.Range(0, 16)
+                .Select(_ => new SessionStartMemoryLeaseStore(root).TryBeginAsync(key, TimeSpan.FromSeconds(2)));
+            var winners = (await Task.WhenAll(attempts)).Count(static lease => lease is not null);
+
+            await Assert.That(winners).IsEqualTo(1);
+        } finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Test]
+    public async Task Completion_guarantee_expires_at_thirty_day_sweep_boundary() {
+        var root = TempDir();
+        try {
+            var time = new ManualTimeProvider(new DateTimeOffset(2026, 7, 23, 0, 0, 0, TimeSpan.Zero));
+            var store = new SessionStartMemoryLeaseStore(root, time);
+            var key = new string('e', 64);
+            var lease = await store.TryBeginAsync(key, TimeSpan.FromSeconds(1));
+            await store.CompleteAsync(lease!, SessionStartMemoryDisposition.Ready);
+
+            time.Advance(TimeSpan.FromDays(30) - TimeSpan.FromTicks(1));
+            await Assert.That(await store.TryBeginAsync(key, TimeSpan.FromSeconds(1))).IsNull();
+            time.Advance(TimeSpan.FromTicks(1));
+            await store.SweepAsync(TimeSpan.FromSeconds(1));
+            await Assert.That(await store.TryBeginAsync(key, TimeSpan.FromSeconds(1))).IsNotNull();
+        } finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Test]
+    public async Task Sweep_advances_past_poison_record() {
+        var root = TempDir();
+        try {
+            var time = new ManualTimeProvider(new DateTimeOffset(2026, 7, 23, 0, 0, 0, TimeSpan.Zero));
+            var store = new SessionStartMemoryLeaseStore(root, time);
+            foreach (var key in new[] { new string('a', 64), new string('c', 64) }) {
+                var lease = await store.TryBeginAsync(key, TimeSpan.FromSeconds(1));
+                await store.CompleteAsync(lease!, SessionStartMemoryDisposition.Ready);
+            }
+            var poison = Path.Combine(root, new string('b', 64) + ".json");
+            await File.WriteAllTextAsync(poison, "not-json");
+            time.Advance(TimeSpan.FromDays(30));
+
+            await store.SweepAsync(TimeSpan.FromSeconds(1));
+
+            await Assert.That(File.Exists(Path.Combine(root, new string('a', 64) + ".json"))).IsFalse();
+            await Assert.That(File.Exists(poison)).IsTrue();
+            await Assert.That(File.Exists(Path.Combine(root, new string('c', 64) + ".json"))).IsFalse();
+        } finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Test]
+    public async Task Retry_pending_obeys_cooldown_and_then_heals() {
+        var root = TempDir();
+        try {
+            var time = new ManualTimeProvider(new DateTimeOffset(2026, 7, 23, 0, 0, 0, TimeSpan.Zero));
+            var store = new SessionStartMemoryLeaseStore(root, time);
+            var key = new string('b', 64);
+            var lease = await store.TryBeginAsync(key, TimeSpan.FromSeconds(1));
+            await Assert.That(await store.RetryAsync(lease!, null)).IsTrue();
+            await Assert.That(await store.TryBeginAsync(key, TimeSpan.FromSeconds(1))).IsNull();
+
+            time.Advance(TimeSpan.FromSeconds(5));
+            await Assert.That(await store.TryBeginAsync(key, TimeSpan.FromSeconds(1))).IsNotNull();
+        } finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Test]
+    public async Task Provider_maps_empty_malformed_and_ready_responses() {
+        var scope = new FixedScopeResolver("repo", "machine");
+        var empty = new SessionStartMemoryContextProvider(scope,
+            _ => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.OK, "[]"))));
+        var malformed = new SessionStartMemoryContextProvider(scope,
+            _ => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.OK, "[{}]"))));
+        var ready = new SessionStartMemoryContextProvider(scope,
+            _ => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.OK,
+                "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))));
+        var request = new SessionStartMemoryContextRequest("https://example", "/repo", false,
+            TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        await Assert.That((await empty.GetAsync(request)).Disposition)
+            .IsEqualTo(SessionStartMemoryDisposition.CompleteWithoutContext);
+        await Assert.That((await malformed.GetAsync(request)).Disposition)
+            .IsEqualTo(SessionStartMemoryDisposition.RetryableFailure);
+        var result = await ready.GetAsync(request);
+        await Assert.That(result.Disposition).IsEqualTo(SessionStartMemoryDisposition.Ready);
+        await Assert.That(result.Fragment).Contains("- s: d");
+    }
+
+    [Test]
+    public async Task Provider_omits_only_unresolved_scope_axes() {
+        var handler = new CapturingHandler(HttpStatusCode.NoContent, "");
+        var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, "machine tag"),
+            _ => Task.FromResult(new HttpClient(handler)));
+
+        await provider.GetAsync(new SessionStartMemoryContextRequest(
+            "https://example.test/", null, false, TimeSpan.FromSeconds(1), CancellationToken.None));
+
+        await Assert.That(handler.Uri).IsEqualTo("https://example.test/api/memories/index?machine=machine%20tag");
+    }
+
+    [Test]
+    public async Task Provider_refreshes_once_after_401_and_refuses_redirect_status() {
+        var calls = 0;
+        var refreshing = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null), _ => {
+            calls++;
+            var status = calls == 1 ? HttpStatusCode.Unauthorized : HttpStatusCode.NoContent;
+            return Task.FromResult(new HttpClient(new StaticHandler(status, "")));
+        }, disposeClients: true);
+        var request = new SessionStartMemoryContextRequest(
+            "https://example.test", null, false, TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        var healed = await refreshing.GetAsync(request);
+        var redirected = await new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
+            _ => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.Redirect, ""))))
+            .GetAsync(request);
+
+        await Assert.That(calls).IsEqualTo(2);
+        await Assert.That(healed.Disposition).IsEqualTo(SessionStartMemoryDisposition.CompleteWithoutContext);
+        await Assert.That(redirected.Disposition).IsEqualTo(SessionStartMemoryDisposition.RetryableFailure);
+    }
+
+    [Test]
+    public async Task Orchestrator_returns_ready_fragment_only_to_commit_winner() {
+        var root = TempDir();
+        try {
+            var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
+                _ => Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.OK,
+                    "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))));
+            var orchestrator = new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root), provider);
+            var lifecycle = new SessionMemoryLifecycle(SessionStartHarness.Claude, "session", null,
+                true, true, SessionLifecycleReason.New, true);
+            var request = new SessionStartMemoryContextRequest(
+                "https://example.test", null, false, TimeSpan.FromSeconds(1), CancellationToken.None);
+
+            var first = await orchestrator.GetFragmentAsync(lifecycle, request);
+            var repeated = await orchestrator.GetFragmentAsync(lifecycle, request);
+
+            await Assert.That(first).Contains("- s: d");
+            await Assert.That(repeated).IsNull();
+        } finally { Directory.Delete(root, recursive: true); }
+    }
+
+    static string TempDir() {
+        var path = Path.Combine(Path.GetTempPath(), "kcap-memory-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    sealed class ManualTimeProvider(DateTimeOffset now) : TimeProvider {
+        DateTimeOffset _now = now;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan value) => _now += value;
+    }
+
+    sealed class FixedScopeResolver(string? repo, string? machine) : ISessionStartMemoryScopeResolver {
+        public Task<SessionStartMemoryScope> ResolveAsync(string? cwd, CancellationToken ct) =>
+            Task.FromResult(new SessionStartMemoryScope(repo, machine));
+    }
+
+    sealed class StaticHandler(HttpStatusCode status, string body) : HttpMessageHandler {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(status) {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+    }
+
+    sealed class CapturingHandler(HttpStatusCode status, string body) : HttpMessageHandler {
+        public string? Uri { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            Uri = request.RequestUri?.AbsoluteUri;
+            return Task.FromResult(new HttpResponseMessage(status) {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
@@ -33,6 +33,16 @@ public class SessionStartMemoryFoundationTests {
     }
 
     [Test]
+    public async Task Claude_uuid_identity_is_canonical_across_dashed_and_compact_forms() {
+        var dashed = SessionStartMemoryIdentity.Create(
+            SessionStartHarness.Claude, "A0D44A4A-5059-4D1F-9C93-2A1ADCE89C2E", null);
+        var compact = SessionStartMemoryIdentity.Create(
+            SessionStartHarness.Claude, "a0d44a4a50594d1f9c932a1adce89c2e", null);
+
+        await Assert.That(dashed).IsEqualTo(compact);
+    }
+
+    [Test]
     public async Task Lifecycle_policy_does_not_poison_unknown_or_subagent_callbacks() {
         var unknown = SessionStartMemoryLifecyclePolicy.Decide(new(
             SessionStartHarness.Kiro, "s", null, true, false,
@@ -225,7 +235,7 @@ public class SessionStartMemoryFoundationTests {
         await Assert.That((await empty.GetAsync(request)).Disposition)
             .IsEqualTo(SessionStartMemoryDisposition.CompleteWithoutContext);
         await Assert.That((await malformed.GetAsync(request)).Disposition)
-            .IsEqualTo(SessionStartMemoryDisposition.RetryableFailure);
+            .IsEqualTo(SessionStartMemoryDisposition.CompleteWithoutContext);
         var result = await ready.GetAsync(request);
         await Assert.That(result.Disposition).IsEqualTo(SessionStartMemoryDisposition.Ready);
         await Assert.That(result.Fragment).Contains("- s: d");
@@ -285,6 +295,29 @@ public class SessionStartMemoryFoundationTests {
 
             await Assert.That(first).Contains("- s: d");
             await Assert.That(repeated).IsNull();
+        } finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Test]
+    public async Task Disabled_request_does_not_fetch_or_write_a_lease_record() {
+        var root = TempDir();
+        try {
+            var clientCalls = 0;
+            var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null), (_, _) => {
+                clientCalls++;
+                return Task.FromResult(new HttpClient(new StaticHandler(HttpStatusCode.NoContent, "")));
+            });
+            var orchestrator = new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root), provider);
+            var lifecycle = new SessionMemoryLifecycle(SessionStartHarness.Claude, "session", null,
+                true, true, SessionLifecycleReason.New, false);
+
+            var fragment = await orchestrator.GetFragmentAsync(lifecycle,
+                new SessionStartMemoryContextRequest(
+                    "https://example.test", null, true, TimeSpan.FromSeconds(1), CancellationToken.None));
+
+            await Assert.That(fragment).IsNull();
+            await Assert.That(clientCalls).IsEqualTo(0);
+            await Assert.That(Directory.EnumerateFiles(root)).IsEmpty();
         } finally { Directory.Delete(root, recursive: true); }
     }
 


### PR DESCRIPTION
## Summary
- add a typed, source-generated memory-index provider and exact output adapters for all supported harnesses
- add lifecycle identity/policy, fenced cross-process leases, retry cooldowns, bounded persistent state, cleanup cursors, and extension delivery state
- migrate Claude to the shared provider while preserving its existing context composition and fail-open hook behavior
- document foundation vs activation/live-certification status

Companion server contract PR: https://github.com/kurrent-io/kcap-server/pull/1169
Linear: https://linear.app/kurrent/issue/AI-1458/sessionstart-memory-index-shared-provider-lifecycle-marker-and

## Verification
- CLI unit project builds cleanly
- SessionStartMemoryFoundationTests: 17/17
- MemoryIndexEmitterTests: 12/12
- MemoryIndexUrlTests: 4/4
- ClaudeHookCommandTests: 24/24
- full suite: 3,717 passed; 42 unrelated existing Codex TOML temp-path failures; 4 skipped
- local NativeAOT compile reaches ILLink, then the installed SDK fails to launch its arm64 MSBuild task host (MSB4216); PR CI remains the acceptance gate

## Review history
- spec review flow `8ebc699d040b414aa1ada75bd0b467aa` approved round 5
