### PR TITLE
Fix release pipeline: shim smoke race and Alpine musl-gcc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,13 +175,39 @@ jobs:
           # a JIT run instead of the AOT one; acceptable here since this is a load/call smoke,
           # not a perf or AOT-compatibility check (AOT publish itself is already exercised by
           # "Publish daemon AOT binary" above).
-          dotnet run --project test/Capacitor.Cli.Tests.Unit.NativeTestHost -r ${{ matrix.rid }} -- spawn-dummy > smoke-output.txt 2>&1 &
+          #
+          # A musl RID's build output (musl-linked apphost and shim) cannot execute on a glibc
+          # runner at all, so the load-and-call smoke only runs where the host libc matches the
+          # RID: linux-musl-x64 runs it inside its Alpine container; linux-musl-arm64 (glibc
+          # arm64 runner, no container) gets the machine-type check above only.
+          if [[ "${{ matrix.rid }}" == *musl* && ! -f /etc/alpine-release ]]; then
+            echo "Skipping load-and-call smoke: musl build output cannot execute on a glibc host"
+            exit 0
+          fi
+
+          # Build synchronously first: a cold `dotnet run` (restore + build) takes far longer
+          # than any fixed grace period, so the backgrounded run below must only have to start
+          # the already-built host.
+          dotnet build test/Capacitor.Cli.Tests.Unit.NativeTestHost -r ${{ matrix.rid }} -p:MinVerVersionOverride=${{ steps.version.outputs.VERSION }}
+          dotnet run --no-build --project test/Capacitor.Cli.Tests.Unit.NativeTestHost -r ${{ matrix.rid }} -- spawn-dummy > smoke-output.txt 2>&1 &
           HOST_PID=$!
-          sleep 3
+
+          # spawn-dummy blocks forever by design (it's the PDEATHSIG test host), so poll for
+          # the PID= line rather than sleeping a fixed interval, then tear the host down with a
+          # SIGKILL fallback — this step must never hang on a host that ignores SIGTERM.
+          ok=0
+          for _ in $(seq 1 60); do
+            if grep -q '^PID=' smoke-output.txt 2>/dev/null; then ok=1; break; fi
+            if ! kill -0 "$HOST_PID" 2>/dev/null; then break; fi
+            sleep 1
+          done
+          pkill -TERM -P "$HOST_PID" 2>/dev/null || true
           kill "$HOST_PID" 2>/dev/null || true
+          sleep 1
+          kill -9 "$HOST_PID" 2>/dev/null || true
           wait "$HOST_PID" 2>/dev/null || true
           cat smoke-output.txt
-          if ! grep -q '^PID=' smoke-output.txt; then
+          if [[ "$ok" -ne 1 ]]; then
             echo "::error::load-and-call smoke did not see a PID= line from spawn-dummy on ${{ matrix.rid }}"
             exit 1
           fi

--- a/src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj
+++ b/src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj
@@ -55,8 +55,11 @@
     <PropertyGroup Condition="!$(RuntimeIdentifier.StartsWith('win')) And !$([MSBuild]::IsOSPlatform('Windows'))">
         <PtyShimExt Condition="$([MSBuild]::IsOSPlatform('OSX'))">dylib</PtyShimExt>
         <PtyShimExt Condition="!$([MSBuild]::IsOSPlatform('OSX'))">so</PtyShimExt>
-        <!-- musl targets need the musl C library/toolchain, not glibc's cc -->
-        <PtyShimCc Condition="$(RuntimeIdentifier.Contains('musl'))">musl-gcc</PtyShimCc>
+        <!-- musl targets need the musl C library/toolchain, not glibc's cc. On a glibc host
+             that's the musl-gcc cross wrapper (musl-tools); on a musl-native host (Alpine,
+             detected via /etc/alpine-release) plain cc already targets musl and no musl-gcc
+             wrapper exists. -->
+        <PtyShimCc Condition="$(RuntimeIdentifier.Contains('musl')) And !Exists('/etc/alpine-release')">musl-gcc</PtyShimCc>
         <PtyShimCc Condition="'$(PtyShimCc)' == ''">cc</PtyShimCc>
     </PropertyGroup>
 


### PR DESCRIPTION
Closes #355 (auto-imported into Linear from GitHub).

The [v0.11.5 Release run](https://github.com/kurrent-io/kcap-cli/actions/runs/30019803829) failed on all five non-Windows matrix legs. All failures are in steps introduced by #330 that only execute on tag pushes, so this was the first time they ever ran.

## Root causes and fixes

**1. Load-and-call smoke race (linux-x64, linux-arm64, linux-musl-arm64).** The step backgrounded `dotnet run`, slept a fixed 3 seconds, killed it, and grepped for `PID=`. A cold `dotnet run` has to restore and build NativeTestHost first — far longer than 3s — so `smoke-output.txt` was always empty. Now the step builds synchronously first, starts the pre-built host with `dotnet run --no-build`, and polls for the `PID=` line (up to 60s) instead of sleeping.

**2. Smoke hang (osx-arm64).** The macOS runner lost communication after 47 minutes stuck in the same step — SIGTERM of `dotnet run` mid-build followed by a `wait` that never returned. Teardown now escalates to SIGKILL so the step can never hang.

**3. Missing musl-gcc on Alpine (linux-musl-x64).** `dotnet publish` failed with `musl-gcc ... exited with code 127`: the daemon csproj hardcodes `musl-gcc` for musl RIDs, but Alpine ships no `musl-gcc` wrapper — its native `cc` already targets musl (release.yml's own comments document this). The `CompilePtyShim` compiler selection now uses `musl-gcc` only on non-Alpine hosts.

**4. Latent: musl smoke on a glibc host (linux-musl-arm64).** Masked by the 3s race: `dotnet run -r linux-musl-*` produces a musl-linked apphost that cannot execute on the glibc ubuntu-arm runner at all. The load-and-call smoke is now skipped when the RID's libc doesn't match the host; the machine-type check still runs everywhere, and linux-musl-x64 still runs the full smoke natively inside its Alpine container.

## Verification

- Reproduced the Alpine `musl-gcc` failure byte-for-byte in an `alpine:3.20` arm64 container, then confirmed the fixed daemon **AOT publishes end-to-end** there (shim built with `cc`, `libpty_shim.so` present in output).
- Ran the rewritten build → run → poll → teardown smoke script inside the Alpine container (`PID=` in ~2s) and locally on macOS/osx-arm64 (`PID=` seen, no lingering processes after teardown).
- release.yml parses as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)