### PR TITLE
[AI-1294] Isolate MCP markers from the real ~/.kcap in unit tests

### DIFF
--- a/src/Capacitor.Cli.Core/Mcp/McpMarker.cs
+++ b/src/Capacitor.Cli.Core/Mcp/McpMarker.cs
@@ -26,10 +26,10 @@ public sealed class McpMarker(string harness, Func<string, string>? markerPathFo
 
     // Test seam: redirect the CENTRAL marker root (normally the user profile's `.kcap`) so unit tests
     // never read/write the real shared `~/.kcap/mcp-markers` — a single process-global dir that races
-    // across parallel suites and pollutes the developer's home (AI-1294). Pinned once for the whole
-    // test assembly by `McpMarkerGlobalSetup` (mirrors `DaemonLockPaths.OverrideDirectoryForTesting` /
-    // `DaemonPathsGlobalSetup`), so there is no per-test null window that would fall back to the real dir.
-    static string? _centralRootOverride;
+    // across parallel suites and pollutes the developer's home. Pinned once for the whole test
+    // assembly by `McpMarkerGlobalSetup` (mirrors `DaemonLockPaths.OverrideDirectoryForTesting` /
+    // `DaemonPathsGlobalSetup`). Volatile so the assembly-hook write publishes to every test thread.
+    static volatile string? _centralRootOverride;
     internal static void OverrideCentralRootForTesting(string? kcapRoot) => _centralRootOverride = kcapRoot;
 
     public bool Owns(string configPath, string name, JsonNode entry) {

--- a/src/Capacitor.Cli.Core/Mcp/McpMarker.cs
+++ b/src/Capacitor.Cli.Core/Mcp/McpMarker.cs
@@ -24,6 +24,14 @@ public interface IMcpMarker {
 public sealed class McpMarker(string harness, Func<string, string>? markerPathFor = null) : IMcpMarker {
     const int Version = 1;
 
+    // Test seam: redirect the CENTRAL marker root (normally the user profile's `.kcap`) so unit tests
+    // never read/write the real shared `~/.kcap/mcp-markers` — a single process-global dir that races
+    // across parallel suites and pollutes the developer's home (AI-1294). Pinned once for the whole
+    // test assembly by `McpMarkerGlobalSetup` (mirrors `DaemonLockPaths.OverrideDirectoryForTesting` /
+    // `DaemonPathsGlobalSetup`), so there is no per-test null window that would fall back to the real dir.
+    static string? _centralRootOverride;
+    internal static void OverrideCentralRootForTesting(string? kcapRoot) => _centralRootOverride = kcapRoot;
+
     public bool Owns(string configPath, string name, JsonNode entry) {
         if (!Owned(configPath).Contains(name)) return false;
         if (entry is not JsonObject obj) return false; // malformed/non-object entry → not ours; never throw
@@ -78,7 +86,8 @@ public sealed class McpMarker(string harness, Func<string, string>? markerPathFo
         if (isUserScope) return Path.Combine(dir, $".kcap-mcp-version-{Path.GetFileName(configPath)}");
 
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(Path.GetFullPath(configPath))))[..16].ToLowerInvariant();
-        return Path.Combine(home, ".kcap", "mcp-markers", $"{harness}-{hash}.json");
+        var centralRoot = _centralRootOverride ?? Path.Combine(home, ".kcap");
+        return Path.Combine(centralRoot, "mcp-markers", $"{harness}-{hash}.json");
     }
 
     static bool IsInsideRepo(string dir) {

--- a/test/Capacitor.Cli.Tests.Unit/FakeUserHome.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FakeUserHome.cs
@@ -1,29 +1,23 @@
-using System.Text.Json.Nodes;
-
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// A disposable fake user home for one test, shared across the per-harness plugin
-/// test suites (Cursor, Copilot, Gemini, …) so each doesn't re-derive MCP-marker
-/// isolation.
+/// A disposable fake user home for one test, shared across the per-harness plugin test suites
+/// (Cursor, Copilot, Gemini, …) so each doesn't re-derive path isolation.
 ///
-/// Rooted UNDER the real user profile (<see cref="Environment.SpecialFolder.UserProfile"/>),
-/// because <c>McpMarker</c> classifies a config as user-scope — writing its
-/// ownership marker as a sidecar next to the config rather than centrally under
-/// <c>~/.kcap/mcp-markers</c> — only for configs under the profile. Rooting here
-/// keeps the common case a contained sidecar on every OS (GetFolderPath(UserProfile)
-/// ignores $HOME on Windows, and a redirected TEMP can sit outside the profile).
+/// Rooted UNDER the real user profile (<see cref="Environment.SpecialFolder.UserProfile"/>), because
+/// <c>McpMarker</c> classifies a config as user-scope — writing its ownership marker as a sidecar next
+/// to the config — only for configs under the profile. Rooting here keeps the common case a contained
+/// sidecar on every OS (GetFolderPath(UserProfile) ignores $HOME on Windows, and a redirected TEMP can
+/// sit outside the profile). The sidecar lives under <see cref="Path"/> and is removed with the
+/// directory on dispose.
 ///
-/// On <see cref="Dispose"/> it deletes the home AND sweeps <c>~/.kcap/mcp-markers</c>
-/// for any central marker whose recorded config points under this home — covering
-/// the edge where the real profile is itself a git repo (McpMarker.IsInsideRepo then
-/// treats the config as non-user-scope, so the marker lands centrally). So no
-/// ownership-marker state can persist past the test on any OS or repo layout, for
-/// either a test's direct McpMarker calls or the production <c>plugin --&lt;harness&gt;</c>
-/// paths it exercises.
+/// The central-marker case (the edge where the real profile is itself a git repo, so McpMarker treats
+/// the config as non-user-scope and would write under <c>~/.kcap/mcp-markers</c>) no longer needs
+/// per-test handling here: <see cref="McpMarkerGlobalSetup"/> pins McpMarker's central root to a
+/// throwaway temp dir for the whole assembly, so NO test touches the real shared dir (AI-1294).
 ///
-/// Suites using this must be <c>[NotInParallel("HomeEnvVarMutation")]</c> so the
-/// profile McpMarker reads stays stable underneath the test.
+/// Suites using this must be <c>[NotInParallel("HomeEnvVarMutation")]</c> so the profile McpMarker
+/// reads stays stable underneath the test.
 /// </summary>
 sealed class FakeUserHome : IDisposable {
     public string Path { get; } = System.IO.Path.Combine(
@@ -33,28 +27,6 @@ sealed class FakeUserHome : IDisposable {
     public FakeUserHome() => Directory.CreateDirectory(Path);
 
     public void Dispose() {
-        SweepOwnedCentralMarkers();
         try { Directory.Delete(Path, recursive: true); } catch { /* best effort */ }
-    }
-
-    // Central markers live at ~/.kcap/mcp-markers/<harness>-<hash>.json with a
-    // "config" field recording the absolute config path they own. Remove any whose
-    // config is under this home (the repo-profile edge); sidecar markers under Path
-    // are already removed with the directory.
-    void SweepOwnedCentralMarkers() {
-        var markersDir = System.IO.Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".kcap", "mcp-markers");
-        if (!Directory.Exists(markersDir)) return;
-
-        var homePrefix = System.IO.Path.GetFullPath(Path) + System.IO.Path.DirectorySeparatorChar;
-        foreach (var file in Directory.EnumerateFiles(markersDir, "*.json")) {
-            try {
-                if (JsonNode.Parse(File.ReadAllText(file)) is not JsonObject marker) continue;
-                var config = (string?)marker["config"];
-                if (config is null) continue;
-                if (System.IO.Path.GetFullPath(config).StartsWith(homePrefix, StringComparison.Ordinal))
-                    File.Delete(file);
-            } catch { /* ignore unreadable/foreign markers */ }
-        }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/FakeUserHome.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FakeUserHome.cs
@@ -14,7 +14,7 @@ namespace Capacitor.Cli.Tests.Unit;
 /// The central-marker case (the edge where the real profile is itself a git repo, so McpMarker treats
 /// the config as non-user-scope and would write under <c>~/.kcap/mcp-markers</c>) no longer needs
 /// per-test handling here: <see cref="McpMarkerGlobalSetup"/> pins McpMarker's central root to a
-/// throwaway temp dir for the whole assembly, so NO test touches the real shared dir (AI-1294).
+/// throwaway temp dir for the whole assembly, so NO test touches the real shared dir.
 ///
 /// Suites using this must be <c>[NotInParallel("HomeEnvVarMutation")]</c> so the profile McpMarker
 /// reads stays stable underneath the test.

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpMarkerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpMarkerTests.cs
@@ -97,7 +97,7 @@ public class McpMarkerTests {
     // Exercises the REAL central-path resolution (no per-config markerPathFor override). The central
     // root is the assembly-pinned throwaway temp dir (McpMarkerGlobalSetup), never the real
     // ~/.kcap/mcp-markers, so this touches no shared real state — no cleanup or serialization needed
-    // (a/b resolve to distinct config-hash files, AI-1294).
+    // (a/b resolve to distinct config-hash files).
     [Test]
     public async Task Two_configs_in_same_dir_have_independent_ownership() {
         var dir = Directory.CreateTempSubdirectory("kcap-marker-indep-").FullName;

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpMarkerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpMarkerTests.cs
@@ -94,18 +94,18 @@ public class McpMarkerTests {
         await Assert.That(m.Owned(equiv)).Contains("kcap-review"); // equivalent path form still recognized
     }
 
+    // Exercises the REAL central-path resolution (no per-config markerPathFor override). The central
+    // root is the assembly-pinned throwaway temp dir (McpMarkerGlobalSetup), never the real
+    // ~/.kcap/mcp-markers, so this touches no shared real state — no cleanup or serialization needed
+    // (a/b resolve to distinct config-hash files, AI-1294).
     [Test]
     public async Task Two_configs_in_same_dir_have_independent_ownership() {
         var dir = Directory.CreateTempSubdirectory("kcap-marker-indep-").FullName;
-        var m = new McpMarker("test"); // real MarkerPath resolution (no override)
+        var m = new McpMarker("test"); // real MarkerPath resolution → central root under the pinned temp
         var a = Path.Combine(dir, "a.json");
         var b = Path.Combine(dir, "b.json");
-        try {
-            m.Record(a, ["kcap-review"]);
-            await Assert.That(m.Owned(a)).Contains("kcap-review"); // a owns it
-            await Assert.That(m.Owned(b)).IsEmpty();               // b is independent of a
-        } finally {
-            m.Clear(a); // remove the central-state marker this test created under ~/.kcap
-        }
+        m.Record(a, ["kcap-review"]);
+        await Assert.That(m.Owned(a)).Contains("kcap-review"); // a owns it
+        await Assert.That(m.Owned(b)).IsEmpty();               // b is independent of a
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/McpMarkerGlobalSetup.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpMarkerGlobalSetup.cs
@@ -1,0 +1,38 @@
+using Capacitor.Cli.Core.Mcp;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Assembly-level safety net for MCP ownership markers (mirrors <see cref="DaemonPathsGlobalSetup"/>).
+///
+/// <para><see cref="McpMarker"/>'s central store is pinned under the real user profile
+/// (<c>~/.kcap/mcp-markers</c>) via <c>GetFolderPath(UserProfile)</c>, which ignores a redirected
+/// <c>$HOME</c>/<c>KCAP_CONFIG_DIR</c>. So any test that constructs a real <c>McpMarker</c> (the plugin
+/// suites, <c>UninstallCommandTests</c>, <c>McpMarkerTests</c>) reads/writes/deletes the developer's
+/// real central dir. Under parallel execution those cross-suite touches raced (AI-1294) — and they
+/// pollute the real home regardless.</para>
+///
+/// <para>Pinning the central root to a throwaway temp dir for the whole process makes the real
+/// directory unreachable regardless of test order or parallelism, with no per-test override to
+/// maintain (and no <c>null</c> window that would fall back to the real dir). Marker files are keyed
+/// by config-path hash, so parallel tests write distinct files here and never collide; nothing
+/// enumerates the dir, so concurrent writes are safe.</para>
+/// </summary>
+public class McpMarkerGlobalSetup {
+    internal static readonly string SharedMarkerRoot = Path.Combine(
+        Path.GetTempPath(),
+        "kcap-mcp-markers-tests-" + Guid.NewGuid().ToString("N")[..8]
+    );
+
+    [Before(Assembly)]
+    public static void PinCentralMarkerRoot() {
+        Directory.CreateDirectory(SharedMarkerRoot);
+        McpMarker.OverrideCentralRootForTesting(SharedMarkerRoot);
+    }
+
+    [After(Assembly)]
+    public static void CleanupCentralMarkerRoot() {
+        McpMarker.OverrideCentralRootForTesting(null);
+        try { Directory.Delete(SharedMarkerRoot, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/McpMarkerGlobalSetup.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpMarkerGlobalSetup.cs
@@ -3,20 +3,11 @@ using Capacitor.Cli.Core.Mcp;
 namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
-/// Assembly-level safety net for MCP ownership markers (mirrors <see cref="DaemonPathsGlobalSetup"/>).
-///
-/// <para><see cref="McpMarker"/>'s central store is pinned under the real user profile
-/// (<c>~/.kcap/mcp-markers</c>) via <c>GetFolderPath(UserProfile)</c>, which ignores a redirected
-/// <c>$HOME</c>/<c>KCAP_CONFIG_DIR</c>. So any test that constructs a real <c>McpMarker</c> (the plugin
-/// suites, <c>UninstallCommandTests</c>, <c>McpMarkerTests</c>) reads/writes/deletes the developer's
-/// real central dir. Under parallel execution those cross-suite touches raced (AI-1294) — and they
-/// pollute the real home regardless.</para>
-///
-/// <para>Pinning the central root to a throwaway temp dir for the whole process makes the real
-/// directory unreachable regardless of test order or parallelism, with no per-test override to
-/// maintain (and no <c>null</c> window that would fall back to the real dir). Marker files are keyed
-/// by config-path hash, so parallel tests write distinct files here and never collide; nothing
-/// enumerates the dir, so concurrent writes are safe.</para>
+/// Pins <see cref="McpMarker"/>'s central marker root to a throwaway temp dir for the whole test
+/// assembly (mirrors <see cref="DaemonPathsGlobalSetup"/>). Without it a real <c>McpMarker</c>
+/// resolves the central store under the real user profile (<c>~/.kcap/mcp-markers</c>), which
+/// parallel suites raced on and which pollutes the developer's home. Set once before any test runs —
+/// no per-test override, and no window where a test falls back to the real dir.
 /// </summary>
 public class McpMarkerGlobalSetup {
     internal static readonly string SharedMarkerRoot = Path.Combine(
@@ -30,9 +21,11 @@ public class McpMarkerGlobalSetup {
         McpMarker.OverrideCentralRootForTesting(SharedMarkerRoot);
     }
 
+    // Delete the temp root but leave the override pinned: a late/background McpMarker call after
+    // teardown then just recreates a file under the (removed) temp root, never the real ~/.kcap —
+    // nulling the override here would reopen that real-home fallback window.
     [After(Assembly)]
     public static void CleanupCentralMarkerRoot() {
-        McpMarker.OverrideCentralRootForTesting(null);
         try { Directory.Delete(SharedMarkerRoot, recursive: true); } catch { /* best effort */ }
     }
 }


### PR DESCRIPTION
## Problem

The `Capacitor.Cli.Tests.Unit` suite shows **1–3 flaky failures per full parallel run**, always in the MCP-marker / env plugin suites (`PluginCommand{Cursor,Copilot,Gemini}Tests`, `McpMarkerTests`) — every failing test passes in isolation. Intermittent red CI for the whole team.

## Root cause

`McpMarker`'s **central** store is the real, process-global `~/.kcap/mcp-markers`, resolved via `GetFolderPath(UserProfile)` — which ignores a redirected `$HOME`/`KCAP_CONFIG_DIR`. So any test that constructs a real `McpMarker` (the plugin suites, `UninstallCommandTests`, and `McpMarkerTests.Two_configs_in_same_dir_have_independent_ownership`, which had **no `[NotInParallel]` key**) reads/writes/deletes there, and `FakeUserHome.Dispose` **enumerated** that dir to sweep leaked markers. A concurrent create/delete during that enumeration — e.g. the unkeyed `Two_configs` test racing a plugin suite's `FakeUserHome` sweep — is the race. It also pollutes the developer's real `~/.kcap`.

## Fix

Mirrors the existing `DaemonPathsGlobalSetup` pattern:

- Add `McpMarker.OverrideCentralRootForTesting(string?)` — a test seam for the central `.kcap` root (analogous to `DaemonLockPaths.OverrideDirectoryForTesting`).
- **`McpMarkerGlobalSetup`** (`[Before(Assembly)]`) pins that root to a throwaway temp dir for the **whole test assembly**, cleaned in `[After(Assembly)]`. Because it's set once for the process (never a per-test `null` window), **no test touches the real `~/.kcap/mcp-markers`** — the cross-suite race is structurally impossible and the real home is no longer polluted. Marker files are keyed by config-path hash, so parallel tests write distinct files and nothing enumerates the dir.
- Remove `FakeUserHome`'s now-unnecessary central-marker sweep (the enumerate-shared-dir race) and per-test override; the one real-resolution marker test no longer needs cleanup or its own key.

## Verification

- **Deterministic:** after a full parallel run of the unit suite, the real `~/.kcap/mcp-markers` is **byte-for-byte untouched (incl. directory mtime)** — proving no test touches the shared dir, so the race surface is gone.
- **No regression:** full-suite failure count is unchanged vs `main` (the remaining failures are pre-existing local dev-home environment collisions — unrelated home-writing tests — which are green in CI's clean home).
- The de-flake is a parallel-load property, confirmed by the mechanism (nothing touches the shared dir) + CI.

Closes AI-1294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)