### PR TITLE
[AI-1439] Await import background tasks; de-flake retry timing tests

### DIFF
--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -467,11 +467,9 @@ static class ImportCommand {
         );
 
     /// <summary>
-    /// True when the import scheduled background title/summary work that the Done phase must
-    /// await (and whose completion the Titles/Summaries rows report). Extracted as a named seam
-    /// so the await-guard decision is unit-testable and can't silently re-invert: the whole class
-    /// of "background tasks never awaited → SemaphoreSlim disposed mid-flight → ObjectDisposedException"
-    /// bug was a single missing negation here.
+    /// True when the import scheduled background title/summary work the Done phase must await
+    /// (and whose results the Titles/Summaries rows report). A named seam so the await-guard
+    /// decision is unit-testable and can't silently re-invert.
     /// </summary>
     internal static bool HadBackgroundWork(ConcurrentBag<Task> backgroundTasks) => !backgroundTasks.IsEmpty;
 

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -467,6 +467,15 @@ static class ImportCommand {
         );
 
     /// <summary>
+    /// True when the import scheduled background title/summary work that the Done phase must
+    /// await (and whose completion the Titles/Summaries rows report). Extracted as a named seam
+    /// so the await-guard decision is unit-testable and can't silently re-invert: the whole class
+    /// of "background tasks never awaited → SemaphoreSlim disposed mid-flight → ObjectDisposedException"
+    /// bug was a single missing negation here.
+    /// </summary>
+    internal static bool HadBackgroundWork(ConcurrentBag<Task> backgroundTasks) => !backgroundTasks.IsEmpty;
+
+    /// <summary>
     /// Compute the per-source Done-grid row for a single vendor.
     /// </summary>
     /// <param name="classifications">All classifications for this vendor (already filtered).</param>
@@ -1559,9 +1568,9 @@ static class ImportCommand {
         }
 
         // --- Background phase (titles / summaries) ---
-        var ranBackground = backgroundTasks.IsEmpty;
+        var hasBackgroundWork = HadBackgroundWork(backgroundTasks);
 
-        if (ranBackground) {
+        if (hasBackgroundWork) {
             display.BeginPhase("Titles & summaries");
 
             if (display.Tty) {
@@ -1638,7 +1647,7 @@ static class ImportCommand {
             TitlesFailed: titlesFailed,
             SummariesGenerated: summariesGenerated,
             SummariesFailed: summariesFailed,
-            RanBackground: ranBackground,
+            RanBackground: hasBackgroundWork,
             RequestedSummaries: summaryTaskCount > 0
         );
 

--- a/test/Capacitor.Cli.Tests.Unit/HttpClientExtensionsRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/HttpClientExtensionsRetryTests.cs
@@ -19,14 +19,13 @@ public class HttpClientExtensionsRetryTests {
             return new HttpResponseMessage(HttpStatusCode.OK); // unreachable — per-attempt CTS fires first.
         }
 
-        // Generous total budget relative to the per-attempt cap: even if a loaded CI runner
-        // stalls the scheduler during the first attempt, plenty of budget remains for a second
-        // one, so the `attempts > 1` assertion stays robust (it is itself condition-based —
-        // it counts real attempts, not elapsed time).
+        // Small per-attempt cap under a modest total: retries accrue fast, so a scheduler stall
+        // can't exhaust the budget before a second attempt — `attempts > 1` stays robust and the
+        // test still finishes in ~1.5s.
         var ex = await Assert.That(async () => await HttpClientExtensions.SendWithRetryAsync(
                     Send,
-                    totalTimeout: TimeSpan.FromMilliseconds(5_000),
-                    perAttemptTimeout: TimeSpan.FromMilliseconds(150),
+                    totalTimeout: TimeSpan.FromMilliseconds(1_500),
+                    perAttemptTimeout: TimeSpan.FromMilliseconds(50),
                     ct: CancellationToken.None
                 )
             )
@@ -59,9 +58,8 @@ public class HttpClientExtensionsRetryTests {
             .Throws<HttpRequestException>();
 
         sw.Stop();
-        // Generous upper bound: strict enforcement is ~300ms. The bound only needs to prove the
-        // total timeout — not the 30s per-attempt cap — governs the wall clock, so 5s stays far
-        // below 30s while giving heavy CI runners ample headroom for scheduling jitter.
+        // Bound only needs to prove the 300ms total — not the 30s per-attempt cap — governs the
+        // wall clock; 5s stays far below 30s with headroom for CI scheduling jitter.
         await Assert.That(sw.ElapsedMilliseconds).IsLessThan(5_000);
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/HttpClientExtensionsRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/HttpClientExtensionsRetryTests.cs
@@ -19,9 +19,13 @@ public class HttpClientExtensionsRetryTests {
             return new HttpResponseMessage(HttpStatusCode.OK); // unreachable — per-attempt CTS fires first.
         }
 
+        // Generous total budget relative to the per-attempt cap: even if a loaded CI runner
+        // stalls the scheduler during the first attempt, plenty of budget remains for a second
+        // one, so the `attempts > 1` assertion stays robust (it is itself condition-based —
+        // it counts real attempts, not elapsed time).
         var ex = await Assert.That(async () => await HttpClientExtensions.SendWithRetryAsync(
                     Send,
-                    totalTimeout: TimeSpan.FromMilliseconds(1_200),
+                    totalTimeout: TimeSpan.FromMilliseconds(5_000),
                     perAttemptTimeout: TimeSpan.FromMilliseconds(150),
                     ct: CancellationToken.None
                 )
@@ -55,9 +59,10 @@ public class HttpClientExtensionsRetryTests {
             .Throws<HttpRequestException>();
 
         sw.Stop();
-        // Generous upper bound: a strict enforcement should be ~300ms; even
-        // under heavy CI load it should be well under 2s.
-        await Assert.That(sw.ElapsedMilliseconds).IsLessThan(2_000);
+        // Generous upper bound: strict enforcement is ~300ms. The bound only needs to prove the
+        // total timeout — not the 30s per-attempt cap — governs the wall clock, so 5s stays far
+        // below 30s while giving heavy CI runners ample headroom for scheduling jitter.
+        await Assert.That(sw.ElapsedMilliseconds).IsLessThan(5_000);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportBackgroundWorkTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportBackgroundWorkTests.cs
@@ -3,13 +3,7 @@ using Capacitor.Cli.Commands;
 
 namespace Capacitor.Cli.Tests.Unit.Import;
 
-/// <summary>
-/// Guards the background-await decision in HandleImport. The variable this helper backs
-/// gates both awaiting Task.WhenAll(backgroundTasks) (so the shared SemaphoreSlim isn't
-/// disposed with tasks still running) and the Done-summary Titles/Summaries rows. A single
-/// missing negation here caused an intermittent ObjectDisposedException in unit runs, so the
-/// decision is pinned directly.
-/// </summary>
+/// <summary>Pins the background-await decision so a re-inversion can't skip Task.WhenAll(backgroundTasks).</summary>
 public class ImportBackgroundWorkTests {
     [Test]
     public async Task HadBackgroundWork_is_false_for_an_empty_bag() {

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportBackgroundWorkTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportBackgroundWorkTests.cs
@@ -1,0 +1,25 @@
+using System.Collections.Concurrent;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit.Import;
+
+/// <summary>
+/// Guards the background-await decision in HandleImport. The variable this helper backs
+/// gates both awaiting Task.WhenAll(backgroundTasks) (so the shared SemaphoreSlim isn't
+/// disposed with tasks still running) and the Done-summary Titles/Summaries rows. A single
+/// missing negation here caused an intermittent ObjectDisposedException in unit runs, so the
+/// decision is pinned directly.
+/// </summary>
+public class ImportBackgroundWorkTests {
+    [Test]
+    public async Task HadBackgroundWork_is_false_for_an_empty_bag() {
+        await Assert.That(ImportCommand.HadBackgroundWork(new ConcurrentBag<Task>())).IsFalse();
+    }
+
+    [Test]
+    public async Task HadBackgroundWork_is_true_when_tasks_were_scheduled() {
+        var bag = new ConcurrentBag<Task> { Task.CompletedTask };
+
+        await Assert.That(ImportCommand.HadBackgroundWork(bag)).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportDisplayGridTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportDisplayGridTests.cs
@@ -71,9 +71,7 @@ public class ImportDisplayGridTests {
         await Assert.That(output).DoesNotContain("By source");
     }
 
-    // Pins the display consequence of the ranBackground fix: when the import ran background
-    // title/summary work, the Titles/Summaries rows must appear; when it didn't, they must not.
-    // The inverted guard used to drop these rows even when work had run.
+    // Titles/Summaries rows must appear iff background work ran (the inverted guard dropped them).
     [Test, NotInParallel]
     public async Task done_grid_renders_titles_and_summaries_rows_when_background_ran() {
         var output = CaptureNonTtyOutput(d => d.WriteDoneGrid(

--- a/test/Capacitor.Cli.Tests.Unit/Import/ImportDisplayGridTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Import/ImportDisplayGridTests.cs
@@ -71,7 +71,36 @@ public class ImportDisplayGridTests {
         await Assert.That(output).DoesNotContain("By source");
     }
 
-    static ImportCommand.FinalCounts MakeFinal(int loaded) => new(
+    // Pins the display consequence of the ranBackground fix: when the import ran background
+    // title/summary work, the Titles/Summaries rows must appear; when it didn't, they must not.
+    // The inverted guard used to drop these rows even when work had run.
+    [Test, NotInParallel]
+    public async Task done_grid_renders_titles_and_summaries_rows_when_background_ran() {
+        var output = CaptureNonTtyOutput(d => d.WriteDoneGrid(
+            MakeFinal(loaded: 3, ranBackground: true, requestedSummaries: true, titlesGenerated: 3, summariesGenerated: 3),
+            bySource: null));
+
+        await Assert.That(output).Contains("Titles");
+        await Assert.That(output).Contains("Summaries");
+    }
+
+    [Test, NotInParallel]
+    public async Task done_grid_omits_titles_and_summaries_rows_when_no_background_work() {
+        var output = CaptureNonTtyOutput(d => d.WriteDoneGrid(
+            MakeFinal(loaded: 3),
+            bySource: null));
+
+        await Assert.That(output).DoesNotContain("Titles");
+        await Assert.That(output).DoesNotContain("Summaries");
+    }
+
+    static ImportCommand.FinalCounts MakeFinal(
+            int  loaded,
+            bool ranBackground      = false,
+            bool requestedSummaries = false,
+            int  titlesGenerated    = 0,
+            int  summariesGenerated = 0
+        ) => new(
         Loaded: loaded,
         Resumed: 0,
         AlreadyLoaded: 0,
@@ -79,13 +108,13 @@ public class ImportDisplayGridTests {
         Excluded: 0,
         ProbeError: 0,
         Errored: 0,
-        TitlesGenerated: 0,
+        TitlesGenerated: titlesGenerated,
         TitlesSkipped: 0,
         TitlesFailed: 0,
-        SummariesGenerated: 0,
+        SummariesGenerated: summariesGenerated,
         SummariesFailed: 0,
-        RanBackground: false,
-        RequestedSummaries: false
+        RanBackground: ranBackground,
+        RequestedSummaries: requestedSummaries
     );
 
     static string CaptureNonTtyOutput(Action<ImportCommand.ImportDisplay> render) {


### PR DESCRIPTION
Fixes two independent sources of kcap-cli unit-test flakiness surfaced while working [#335](https://github.com/kurrent-io/kcap-cli/pull/335). Linear: [AI-1439](https://linear.app/kurrent/issue/AI-1439).

## Part 1 — production bug: `kcap import` never awaited background title/summary work

`ImportCommand.HandleImport` computed the background-phase guard inverted:

```csharp
var ranBackground = backgroundTasks.IsEmpty;   // missing a '!'
```

The one boolean gates (a) the `if (…)` block that `await Task.WhenAll(backgroundTasks)`, and (b) the two Done-summary guards that print the Titles/Summaries rows. Because it was inverted, an import that **has** background work (title generation, or summaries under `--generate-summaries`):

- **skipped** the await block → the method returned while a title task could still be running → the shared `using var concurrencyLimit = new SemaphoreSlim(3)` was disposed → the straggler's `finally { concurrencyLimit.Release(); }` threw **`ObjectDisposedException`** (the intermittent unit failure — rare only because tasks usually finish before the method returns);
- dropped the Titles/Summaries rows from the Done summary.

Introduced in `fa2f013` (2026-04-26); #335's new tests merely exercised `HandleImport` enough to surface it.

**Fix:** `!backgroundTasks.IsEmpty`, renamed to `hasBackgroundWork` and extracted into a named `HadBackgroundWork` seam so the decision is unit-testable and can't silently re-invert — mirroring the existing `ComputePerSourceFinalCounts` "extract-and-test-the-helper-directly" convention in this file. The two `RanBackground: false` early-exit constructions stay correct.

This changes `kcap import`'s observable Done-summary output (the Titles/Summaries rows now appear when there was background work) — intended.

## Part 2 — parallel-load timing flakes

- **`SendWithRetry` timing tests** (the genuine remaining flaky-*failure* vector): widen the wall-clock margins while preserving each invariant.
  - `…_after_budget_exhausted`: `totalTimeout` 1200 ms → 5000 ms, so a scheduler stall during attempt 1 can't consume the whole budget before attempt 2 begins (`attempts > 1` is itself condition-based).
  - `…_enforces_total_timeout_…`: elapsed upper bound 2000 ms → 5000 ms (still ≪ the 30 s per-attempt cap it guards against).
  - These verify timeout enforcement, so they're inherently wall-clock; generous bounds is the correct hardening.
- **Port contention** (`LocalPermissionBridgeTests`, `AgentOrchestratorReviewerTokenTests`, `AgentOrchestratorVendorTests`): already fixed at the **production** level — `LocalPermissionBridge` binds an OS-assigned ephemeral loopback port behind a process-global claim set + 15-attempt transient-bind retry (#340), and the bridge tests carry `[NotInParallel]` grouping. No test change needed.
- **`AcpTranscriptAggregationTests` / `AgentOrchestratorVendorTests` `Task.Delay(200/100)`**: these are "settle, then assert a **negative**" waits — a short wait risks a false *pass* (missed regression), not a flaky *fail* — so they're not the parallel-failure vector and are left as-is.

## Tests

- New `ImportBackgroundWorkTests`: `HadBackgroundWork` empty → false, non-empty → true.
- `ImportDisplayGridTests`: `WriteDoneGrid` renders the Titles/Summaries rows iff `RanBackground`.
- Widened `HttpClientExtensionsRetryTests` margins.

Verified locally: full Import namespace (234), `SetupCommandTests`/`ImportVisibilityTests` (26, drive `HandleImport`), and `HttpClientExtensionsRetryTests` (5) all pass; build clean; `check-linear-ids.sh` passes.

## Out of scope / follow-ups
- Deeper process-global refactor of import background-task lifetime → AI-741.
- AI-1438 is a textual duplicate of AI-1439 — close as dup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)