### PR TITLE
[AI-1513] Handle Claude bypass-permissions consent: pre-accept + fail-fast + PTY capture

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -197,6 +197,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     AgentPidRecordStore? _pidRecords;
     AgentKillQuarantine? _quarantine;
     OrphanReaper?        _orphanReaper;
+
+    // Retained tail-of-PTY capture for a FAILED launch — written under the same per-daemon record
+    // root as the PID records ({state}/{name}/agents/failed/), so a failed reviewer's terminal output
+    // (e.g. the consent dialog it wedged on) survives the worktree teardown for post-mortem.
+    FailedLaunchLog?     _failedLaunchLog;
     string               _daemonId    = "";
     string               _daemonEpoch = "";
 
@@ -338,6 +343,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         var recordRoot = Path.Combine(
             config.StateDir ?? DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(config.Name));
         _pidRecords  = new AgentPidRecordStore(recordRoot, logger);
+        _failedLaunchLog = new FailedLaunchLog(recordRoot);
         _quarantine  = new AgentKillQuarantine(logger);
         _daemonId    = ComputeDaemonId(config.Name);
         _daemonEpoch = config.DaemonEpoch ?? Guid.NewGuid().ToString("N");
@@ -1310,6 +1316,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // until the whole daemon exits.
         using var sendCts = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
 
+        // An UNATTENDED reviewer (bypassPermissions, no human present) can wedge forever on a
+        // one-time consent/trust dialog — the original silent failure. Watch its PTY stream for the
+        // known banners and fail the launch fast with an actionable reason instead of dying at the
+        // server's session-id timeout. Only for unattended review-flow agents: an interactive agent's
+        // human viewer can dismiss the prompt themselves, so we must not fail-fast for them.
+        var dialogDetector = agent is { Kind: LaunchKind.ReviewFlow, Runtime.EmitsTerminalOutput: true }
+            ? new ConsentDialogDetector()
+            : null;
+
         try {
             await foreach (var data in agent.Runtime.ReadOutputAsync(agent.ReadCts.Token)) {
                 agent.LastOutputAt      = DateTime.UtcNow;
@@ -1318,6 +1333,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 if (agent.Status == "Starting") {
                     agent.Status = "Running";
                     if (!agent.IsPrivate) _ = _server.AgentStatusChangedAsync(agent.Id, "Running", agent.SessionId);
+                }
+
+                if (dialogDetector?.Observe(data) is { } wedgeReason) {
+                    await FailWedgedLaunchAsync(agent, wedgeReason);
+                    return; // stop reading — the finally runs finalize + cleanup (kills the wedged PTY)
                 }
 
                 // Append to the replay buffer AND fan out to local sinks atomically under
@@ -1365,6 +1385,45 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         }
     }
 
+    /// <summary>
+    /// Fails a launch that the PTY dialog detector caught wedged on a consent/trust dialog: reports
+    /// an actionable <c>LaunchFailed</c> (so the server surfaces it instead of timing out silently),
+    /// persists the terminal tail for post-mortem, terminates the wedged (still-alive) process, and
+    /// cancels the read loop so its finally runs the normal finalize + cleanup. Sets Status="Failed"
+    /// FIRST so FinalizeAgentRunAsync skips its own startup-failure classification (no double report).
+    /// </summary>
+    async Task FailWedgedLaunchAsync(AgentInstance agent, string reason) {
+        LogConsentDialogWedge(agent.Id, reason);
+
+        // Capture the banner before termination/cleanup discards the buffer.
+        PersistFailedLaunchLog(agent, reason);
+
+        agent.Status           = "Failed";
+        agent.PendingEndReason = "consent_dialog_wedge";
+
+        if (!agent.IsPrivate) {
+            _ = _server.LaunchFailedAsync(agent.Id, reason);
+            _ = _server.AgentStatusChangedAsync(agent.Id, "Failed", agent.SessionId);
+            _ = _server.AppendAgentRunEventAsync(agent.Id, new AgentRunStopped("failed", null));
+        }
+
+        // The wedged process is still ALIVE on the dialog (unlike an ordinary startup failure, which
+        // has already exited) — actively terminate it so it can't hold a daemon slot.
+        try { await agent.Runtime.TerminateAsync(TimeSpan.FromSeconds(5)); } catch (Exception ex) { LogStopError(ex, agent.Id); }
+
+        // Cancel the read loop's token so the fallback session-id poll (DetectClaudeSessionIdAsync)
+        // stops too; the loop itself exits via the `return` at the call site.
+        try { await agent.ReadCts.CancelAsync(); } catch { /* best-effort */ }
+    }
+
+    /// <summary>Best-effort: persist the tail of an agent's PTY output to the retained failed-launch
+    /// log. Never throws (FailedLaunchLog swallows I/O errors) — a diagnostic write must not disturb
+    /// teardown.</summary>
+    void PersistFailedLaunchLog(AgentInstance agent, string reason) {
+        var path = _failedLaunchLog?.Persist(agent.Id, agent.OutputBuffer.Snapshot(), reason);
+        if (path is not null) LogFailedLaunchCaptured(agent.Id, path);
+    }
+
     async Task FinalizeAgentRunAsync(AgentInstance agent) {
         try {
             // PTY output can end before waitpid reports the child as exited.
@@ -1410,6 +1469,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     status = "Failed";
 
                     LogStartupFailed(agent.Id, exitCode, reason);
+
+                    // Persist the PTY tail before cleanup drops the in-memory buffer and removes the
+                    // worktree, so a startup failure is diagnosable post-mortem (see FailedLaunchLog).
+                    PersistFailedLaunchLog(agent, reason);
 
                     if (!agent.IsPrivate) _ = _server.LaunchFailedAsync(agent.Id, reason);
                 }
@@ -2468,6 +2531,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     [LoggerMessage(Level = LogLevel.Warning, Message = "Agent {AgentId} failed during startup (exit code {ExitCode}): {Reason}")]
     partial void LogStartupFailed(string agentId, int? exitCode, string reason);
 
+    [LoggerMessage(Level = LogLevel.Error, Message = "Agent {AgentId} wedged on an unattended consent/trust dialog — failing the launch fast: {Reason}")]
+    partial void LogConsentDialogWedge(string agentId, string reason);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Captured failed-launch terminal tail for agent {AgentId} at {Path}")]
+    partial void LogFailedLaunchCaptured(string agentId, string path);
+
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to download attachment {Id}: {Status}")]
     partial void LogAttachmentNotFound(string id, System.Net.HttpStatusCode status);
 
@@ -2554,6 +2623,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// without going through SignalR. Keeps the private handler private to everyone else.
     /// </summary>
     internal Task HandleLaunchAgentForTest(LaunchAgentCommand cmd) => HandleLaunchAgent(cmd);
+
+    /// <summary>Test-only: drive the per-agent PTY read loop directly (mirrors the fire-and-forget
+    /// <c>_ = ReadAgentOutputAsync(agent)</c> in HandleLaunchAgent) so a seeded agent's consent-dialog
+    /// fail-fast + tail-capture can be exercised without the full ReviewFlow launch gauntlet.</summary>
+    internal Task ReadAgentOutputForTest(AgentInstance agent) => ReadAgentOutputAsync(agent);
+
+    /// <summary>Test-only: the retained failed-launch log root, for asserting a capture landed.</summary>
+    internal FailedLaunchLog? FailedLaunchLogForTest => _failedLaunchLog;
 
     /// <summary>Test-only: register a pre-built agent so cleanup/lifecycle can be driven directly.</summary>
     internal void RegisterAgentForTest(AgentInstance agent) => _agents[agent.Id] = agent;

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -198,9 +198,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     AgentKillQuarantine? _quarantine;
     OrphanReaper?        _orphanReaper;
 
-    // Retained tail-of-PTY capture for a FAILED launch — written under the same per-daemon record
-    // root as the PID records ({state}/{name}/agents/failed/), so a failed reviewer's terminal output
-    // (e.g. the consent dialog it wedged on) survives the worktree teardown for post-mortem.
+    // Tail-of-PTY capture for a FAILED launch, under the same per-daemon record root as the PID
+    // records ({state}/{name}/agents/failed/) — survives worktree teardown for post-mortem.
     FailedLaunchLog?     _failedLaunchLog;
     string               _daemonId    = "";
     string               _daemonEpoch = "";

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1335,9 +1335,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     if (!agent.IsPrivate) _ = _server.AgentStatusChangedAsync(agent.Id, "Running", agent.SessionId);
                 }
 
-                if (dialogDetector?.Observe(data) is { } wedgeReason) {
-                    await FailWedgedLaunchAsync(agent, wedgeReason);
-                    return; // stop reading — the finally runs finalize + cleanup (kills the wedged PTY)
+                // Consent/trust dialogs are a PRE-SESSION concern: they render once at startup, before
+                // any session exists. Once the session is live (SessionId resolved from the transcript
+                // by DetectClaudeSessionIdAsync) the dialog phase is over — stop scanning so ordinary
+                // reviewer/tool output that merely quotes a banner phrase (e.g. a reviewer reading the
+                // detector's own source) can't latch a false wedge and kill a healthy reviewer.
+                if (dialogDetector is not null) {
+                    if (agent.SessionId is not null) {
+                        dialogDetector = null; // session live — release the detector + its window
+                    } else if (dialogDetector.Observe(data) is { } wedgeReason) {
+                        await FailWedgedLaunchAsync(agent, data, wedgeReason);
+                        return; // stop reading — the finally runs finalize + cleanup (kills the wedged PTY)
+                    }
                 }
 
                 // Append to the replay buffer AND fan out to local sinks atomically under
@@ -1392,8 +1401,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// cancels the read loop so its finally runs the normal finalize + cleanup. Sets Status="Failed"
     /// FIRST so FinalizeAgentRunAsync skips its own startup-failure classification (no double report).
     /// </summary>
-    async Task FailWedgedLaunchAsync(AgentInstance agent, string reason) {
+    async Task FailWedgedLaunchAsync(AgentInstance agent, byte[] triggeringChunk, string reason) {
         LogConsentDialogWedge(agent.Id, reason);
+
+        // The detector inspects a chunk BEFORE the read loop appends it to OutputBuffer, so append the
+        // triggering chunk now — otherwise a banner delivered in the first chunk (the common case) is
+        // absent from the persisted tail, defeating the very capture this log exists to preserve.
+        // TerminalOutputBuffer.Append is self-synchronized; the read loop has stopped feeding it.
+        agent.OutputBuffer.Append(triggeringChunk);
 
         // Capture the banner before termination/cleanup discards the buffer.
         PersistFailedLaunchLog(agent, reason);

--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -513,6 +513,11 @@ internal sealed partial class ClaudeLauncher(
     /// rename (POSIX <c>rename(2)</c> / Win32 <c>MoveFileEx</c> with replace).
     /// A crash or concurrent reader never sees a truncated file — either the
     /// previous contents or the new contents, never a partial write.
+    ///
+    /// On Unix the target's existing permissions are PRESERVED across the temp+rename: rename(2)
+    /// swaps in the temp's inode, so a temp created under the umask (0644) would silently RELAX a
+    /// 0600 <c>settings.json</c> (which may hold secrets under <c>env</c>). The temp is stamped with
+    /// the target's current mode before creation, or 0600 for a brand-new file. No-op on Windows.
     /// </summary>
     internal static void WriteJsonAtomic(string path, JsonNode root) {
         // The temp file is written alongside the target, so the destination dir must
@@ -521,17 +526,50 @@ internal sealed partial class ClaudeLauncher(
         // relocated config — create it so the trust write doesn't throw.
         if (Path.GetDirectoryName(path) is { Length: > 0 } dir) Directory.CreateDirectory(dir);
 
+        var createMode = ResolveCreateMode(path);
+
         var tmp = path + ".tmp-" + Environment.ProcessId + "-" + Guid.NewGuid().ToString("N");
-        File.WriteAllText(tmp, root.ToJsonString(IndentedJsonOpts));
+
+        var options = new FileStreamOptions { Mode = FileMode.Create, Access = FileAccess.Write };
+        if (createMode is { } m) options.UnixCreateMode = m;
 
         try {
+            using (var fs = new FileStream(tmp, options))
+            using (var writer = new StreamWriter(fs)) {
+                writer.Write(root.ToJsonString(IndentedJsonOpts));
+            }
+
             File.Move(tmp, path, overwrite: true);
+
+            // Re-assert the mode on the published path (belt-and-braces against what the rename
+            // carries across, and against `overwrite: true` replacing a differently-moded target).
+            if (createMode is { } published && !OperatingSystem.IsWindows()) {
+                try { File.SetUnixFileMode(path, published); } catch { /* best-effort */ }
+            }
         } catch {
             try { File.Delete(tmp); } catch {
                 /* best-effort */
             }
 
             throw;
+        }
+    }
+
+    /// <summary>
+    /// The Unix create-mode for a <see cref="WriteJsonAtomic"/> temp: the target's CURRENT mode when
+    /// it already exists (preserve it — never relax a locked-down settings file), else owner-only
+    /// 0600 for a brand-new file. <c>null</c> on Windows (no Unix mode to apply).
+    /// </summary>
+    static UnixFileMode? ResolveCreateMode(string targetPath) {
+        if (OperatingSystem.IsWindows()) return null;
+
+        try {
+            return File.Exists(targetPath)
+                ? File.GetUnixFileMode(targetPath)
+                : UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        } catch {
+            // If the mode can't be read, fail safe to owner-only rather than the umask default.
+            return UnixFileMode.UserRead | UnixFileMode.UserWrite;
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -62,13 +62,12 @@ internal sealed partial class ClaudeLauncher(
         }
 
         // Unattended review-flow reviewers launch with `--permission-mode bypassPermissions`
-        // (see BuildArgs). On a host where the interactive Claude CLI has never accepted bypass
-        // mode, Claude blocks on a full-screen one-time consent dialog — no session ever starts and
-        // the launch dies silently at the server's session-id timeout. Pre-accept it here in the
-        // user settings (the store Claude 2.1.x actually reads/writes for this) so the reviewer
-        // starts cleanly. Only for the bypass path — interactive agents never pass bypassPermissions
-        // and a human can dismiss any prompt anyway. Best-effort: a settings glitch never blocks
-        // launch (the PTY dialog detector is the fail-fast backstop if this didn't take).
+        // (see BuildArgs). On a host that hasn't accepted bypass mode, Claude blocks on a
+        // one-time consent dialog and the launch dies silently at the server's timeout.
+        // Pre-accept it here in user settings so the reviewer starts cleanly — only for the
+        // bypass path, since interactive agents never pass it and a human can dismiss any
+        // prompt. Best-effort: the PTY dialog detector is the fail-fast backstop if this didn't
+        // take.
         if (ctx.IsReviewFlow) {
             try {
                 AcceptBypassPermissionsMode();

--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -61,6 +61,22 @@ internal sealed partial class ClaudeLauncher(
             LogTrustWorktreeFailed(ex, ctx.AgentId);
         }
 
+        // Unattended review-flow reviewers launch with `--permission-mode bypassPermissions`
+        // (see BuildArgs). On a host where the interactive Claude CLI has never accepted bypass
+        // mode, Claude blocks on a full-screen one-time consent dialog — no session ever starts and
+        // the launch dies silently at the server's session-id timeout. Pre-accept it here in the
+        // user settings (the store Claude 2.1.x actually reads/writes for this) so the reviewer
+        // starts cleanly. Only for the bypass path — interactive agents never pass bypassPermissions
+        // and a human can dismiss any prompt anyway. Best-effort: a settings glitch never blocks
+        // launch (the PTY dialog detector is the fail-fast backstop if this didn't take).
+        if (ctx.IsReviewFlow) {
+            try {
+                AcceptBypassPermissionsMode();
+            } catch (Exception ex) {
+                LogBypassAcceptFailed(ex, ctx.AgentId);
+            }
+        }
+
         try {
             if (ctx.Tools is { Length: > 0 }) {
                 MergeToolPermissions(ctx.Worktree.Path, ctx.Tools);
@@ -421,6 +437,63 @@ internal sealed partial class ClaudeLauncher(
     }
 
     /// <summary>
+    /// The user-settings boolean Claude 2.1.x reads to skip its Bypass-Permissions consent dialog.
+    /// Verified against the shipped 2.1.x binary: it reads this key from userSettings (and localSettings/
+    /// flagSettings/policySettings) and writes it to userSettings when the user accepts the dialog
+    /// interactively. The legacy <c>bypassPermissionsModeAccepted</c> flag in <c>~/.claude.json</c> was
+    /// migrated to this key and is no longer honored directly, so we write THIS one.
+    /// </summary>
+    internal const string BypassPermissionsAcceptedKey = "skipDangerousModePermissionPrompt";
+
+    /// <summary>
+    /// Records acceptance of Claude's Bypass-Permissions consent dialog in the user settings file
+    /// Claude reads (<c>$CLAUDE_CONFIG_DIR/settings.json</c> when set, else <c>~/.claude/settings.json</c>) —
+    /// the same effect as accepting the dialog once interactively, so an unattended reviewer never
+    /// wedges on it. The spawned Claude inherits <c>CLAUDE_CONFIG_DIR</c> from the daemon, so it reads
+    /// the same file this resolves.
+    /// </summary>
+    static void AcceptBypassPermissionsMode() => AcceptBypassPermissionsMode(ClaudePaths.UserSettings);
+
+    /// <summary>
+    /// Sets <see cref="BypassPermissionsAcceptedKey"/> = true in the settings file at
+    /// <paramref name="settingsPath"/>, merging into any existing settings and preserving every other
+    /// key. Idempotent. Deliberately does NOT overwrite a settings file it cannot parse — the file is
+    /// user-owned and may carry keys/comments the daemon must not destroy. Serialized under the same
+    /// lock as the other shared-config writes.
+    /// </summary>
+    internal static void AcceptBypassPermissionsMode(string settingsPath) {
+        lock (TrustWriteLock) {
+            JsonObject settings;
+
+            if (File.Exists(settingsPath)) {
+                JsonNode? parsed;
+                try {
+                    parsed = JsonNode.Parse(File.ReadAllText(settingsPath));
+                } catch {
+                    // Unparseable, user-owned settings — never clobber it.
+                    return;
+                }
+
+                if (parsed is not JsonObject obj) return; // a non-object root is not ours to rewrite
+                settings = obj;
+            } else {
+                settings = [];
+            }
+
+            var already = settings[BypassPermissionsAcceptedKey] is JsonValue v
+             && v.TryGetValue<bool>(out var b)
+             && b;
+
+            if (already) return;
+
+            // Bool literal assignment stays AOT-safe (matches the hasTrustDialogAccepted write above);
+            // JsonValue.Create<string> is the shape that trips IL3050, not this.
+            settings[BypassPermissionsAcceptedKey] = true;
+            WriteJsonAtomic(settingsPath, settings);
+        }
+    }
+
+    /// <summary>
     /// Loads a JSON object from disk, tolerating missing files and non-object roots
     /// by returning a fresh <see cref="JsonObject"/>. Ensures pre-trust logic never
     /// throws on an unexpected config shape and reintroduces the launch hang.
@@ -529,6 +602,9 @@ internal sealed partial class ClaudeLauncher(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to pre-trust worktree for agent {AgentId} (continuing)")]
     partial void LogTrustWorktreeFailed(Exception ex, string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to pre-accept bypass-permissions mode for agent {AgentId} (continuing; the reviewer may wedge on the consent dialog)")]
+    partial void LogBypassAcceptFailed(Exception ex, string agentId);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to merge tool permissions for agent {AgentId} (continuing)")]
     partial void LogToolPermissionsFailed(Exception ex, string agentId);

--- a/src/Capacitor.Cli.Daemon/Services/ConsentDialogDetector.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ConsentDialogDetector.cs
@@ -1,0 +1,98 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Watches a spawned CLI's PTY output stream for a one-time, full-screen consent/trust dialog that
+/// a hosted, UNATTENDED launch (a review-flow reviewer) can never dismiss — so the process would
+/// otherwise sit on the prompt forever, no session would ever start, and the launch would die
+/// silently at the server's 30 s "waiting for session id" timeout with nothing surfaced.
+///
+/// The motivating case is Claude Code's Bypass-Permissions consent dialog ("WARNING: Claude Code
+/// running in Bypass Permissions mode … 2. Yes, I accept"), which blocks on any host where the
+/// interactive CLI has never accepted bypass mode. The launcher now pre-accepts it in the user
+/// settings, but this detector is the belt-and-braces fail-fast for when that write didn't take
+/// (organization policy override, a relocated config dir, a read-only settings file, etc.).
+///
+/// The detector maintains a bounded, ANSI-stripped rolling window of recent output so a banner
+/// delivered across several PTY reads (or torn mid-word at a chunk boundary) still matches. A
+/// signature trips only when ALL of its markers are present in the window, which keeps ordinary
+/// session output — even output that mentions "bypass permissions mode" in prose — from tripping
+/// it. Once tripped it latches: the launch is already doomed, so every later frame reports the
+/// same reason.
+///
+/// Text-only + source-generated regex — no reflection — so it is safe in the NativeAOT daemon.
+/// </summary>
+internal sealed partial class ConsentDialogDetector {
+    /// <summary>A known blocking dialog: it trips when every marker is present in the window.</summary>
+    /// <param name="Markers">Ordinal-ignore-case substrings that must ALL be present to trip.</param>
+    /// <param name="Message">The actionable, human-readable failure reported to the server.</param>
+    readonly record struct Signature(string[] Markers, string Message);
+
+    static readonly Signature[] Signatures = [
+        new(
+            ["bypass permissions mode", "yes, i accept"],
+            "Claude is blocked on the Bypass-Permissions consent dialog and cannot be accepted "
+          + "unattended. Accept it once by launching Claude interactively on this host and choosing "
+          + "\"Yes, I accept\" (or by setting \"skipDangerousModePermissionPrompt\": true in the Claude "
+          + "user settings), then retry the launch."),
+        new(
+            ["do you trust the files in this"],
+            "Claude is blocked on the workspace-trust dialog and cannot be accepted unattended. Trust "
+          + "the folder once by launching Claude interactively in it, then retry the launch."),
+    ];
+
+    // The banner box is well under this; the whole dialog (headline + wrapped explanation + options)
+    // fits, so both markers of a multi-line signature co-exist in the window at once. Cheap in memory.
+    const int WindowChars = 16384;
+
+    readonly StringBuilder _window = new();
+    string?                _tripped;
+
+    /// <summary>True once a blocking dialog has been detected (latched).</summary>
+    public bool Tripped => _tripped is not null;
+
+    /// <summary>
+    /// Feeds one raw PTY chunk. Returns the actionable failure message once a blocking dialog is
+    /// detected (and on every call thereafter — it latches), else <c>null</c>. Never throws:
+    /// decoding is lenient and matching is pure string work.
+    /// </summary>
+    public string? Observe(ReadOnlySpan<byte> chunk) {
+        if (_tripped is not null) return _tripped;
+        if (chunk.IsEmpty) return null;
+
+        // Markers are ASCII, so a multi-byte char torn at a chunk boundary (box-drawing glyphs) only
+        // corrupts non-marker glyphs — never the ASCII markers themselves.
+        var text = Encoding.UTF8.GetString(chunk);
+        Append(StripAnsi(text));
+
+        var window = _window.ToString();
+
+        foreach (var sig in Signatures) {
+            var all = true;
+            foreach (var marker in sig.Markers) {
+                if (!window.Contains(marker, StringComparison.OrdinalIgnoreCase)) { all = false; break; }
+            }
+
+            if (all) return _tripped = sig.Message;
+        }
+
+        return null;
+    }
+
+    void Append(string text) {
+        _window.Append(text);
+
+        if (_window.Length > WindowChars) {
+            _window.Remove(0, _window.Length - WindowChars);
+        }
+    }
+
+    static string StripAnsi(string s) => AnsiRegex().Replace(s, "");
+
+    // CSI (colour/cursor/erase), OSC (…BEL), charset-select, and private-mode sequences — the same
+    // families AgentOrchestrator strips for its terminal-text extraction.
+    [GeneratedRegex(@"\x1B\[[0-9;?]*[A-Za-z]|\x1B\].*?\x07|\x1B[()][AB012]|\x1B[=>]")]
+    private static partial Regex AnsiRegex();
+}

--- a/src/Capacitor.Cli.Daemon/Services/ConsentDialogDetector.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ConsentDialogDetector.cs
@@ -17,10 +17,15 @@ namespace Capacitor.Cli.Daemon.Services;
 ///
 /// The detector maintains a bounded, ANSI-stripped rolling window of recent output so a banner
 /// delivered across several PTY reads (or torn mid-word at a chunk boundary) still matches. A
-/// signature trips only when ALL of its markers are present in the window, which keeps ordinary
-/// session output — even output that mentions "bypass permissions mode" in prose — from tripping
-/// it. Once tripped it latches: the launch is already doomed, so every later frame reports the
-/// same reason.
+/// signature trips only when ALL of its markers are present in the window. Crucially, a signature's
+/// markers require STRUCTURAL evidence of the rendered dialog — the headline phrase PLUS the
+/// numbered selection menu ("1. No, exit" / "2. Yes, I accept") — not just the loose phrases. Prose
+/// or source that merely mentions "bypass permissions mode" and "yes, i accept" (this very file
+/// does) does not reproduce the numbered menu layout, so it cannot trip. This is defence-in-depth:
+/// the orchestrator additionally scans ONLY during the pre-session dialog phase (the consent dialog
+/// renders once at startup, before any session begins) and stops the moment the session is live, so
+/// ordinary reviewer/tool output that quotes a banner never reaches the detector at all. Once
+/// tripped it latches: the launch is already doomed, so every later frame reports the same reason.
 ///
 /// Text-only + source-generated regex — no reflection — so it is safe in the NativeAOT daemon.
 /// </summary>
@@ -31,14 +36,20 @@ internal sealed partial class ConsentDialogDetector {
     readonly record struct Signature(string[] Markers, string Message);
 
     static readonly Signature[] Signatures = [
+        // Bypass-Permissions consent dialog. Requires the headline PLUS BOTH numbered menu options
+        // ("1. No, exit" / "2. Yes, I accept") — the rendered selection layout, which prose/source
+        // that merely quotes the phrases does not reproduce. This structural set is what keeps a
+        // reviewer reading this file (or any doc that names the feature) from tripping a false wedge.
         new(
-            ["bypass permissions mode", "yes, i accept"],
+            ["bypass permissions mode", "1. no, exit", "2. yes, i accept"],
             "Claude is blocked on the Bypass-Permissions consent dialog and cannot be accepted "
           + "unattended. Accept it once by launching Claude interactively on this host and choosing "
           + "\"Yes, I accept\" (or by setting \"skipDangerousModePermissionPrompt\": true in the Claude "
           + "user settings), then retry the launch."),
+        // Workspace-trust dialog. The headline question is already highly specific; pairing it with a
+        // numbered menu option keeps it structural (a numbered selection, not loose prose).
         new(
-            ["do you trust the files in this"],
+            ["do you trust the files in this", "1. yes, proceed"],
             "Claude is blocked on the workspace-trust dialog and cannot be accepted unattended. Trust "
           + "the folder once by launching Claude interactively in it, then retry the launch."),
     ];

--- a/src/Capacitor.Cli.Daemon/Services/ConsentDialogDetector.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ConsentDialogDetector.cs
@@ -4,30 +4,21 @@ using System.Text.RegularExpressions;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// Watches a spawned CLI's PTY output stream for a one-time, full-screen consent/trust dialog that
-/// a hosted, UNATTENDED launch (a review-flow reviewer) can never dismiss — so the process would
-/// otherwise sit on the prompt forever, no session would ever start, and the launch would die
-/// silently at the server's 30 s "waiting for session id" timeout with nothing surfaced.
+/// Watches a spawned CLI's PTY output for Claude Code's one-time Bypass-Permissions consent
+/// dialog, which a hosted, UNATTENDED launch (a review-flow reviewer) can never dismiss — it
+/// would otherwise block forever and die silently at the server's 30s "waiting for session id"
+/// timeout. The launcher pre-accepts bypass mode in user settings; this detector is the
+/// belt-and-braces fail-fast for when that write didn't take (org policy override, a relocated
+/// config dir, a read-only settings file, etc.).
 ///
-/// The motivating case is Claude Code's Bypass-Permissions consent dialog ("WARNING: Claude Code
-/// running in Bypass Permissions mode … 2. Yes, I accept"), which blocks on any host where the
-/// interactive CLI has never accepted bypass mode. The launcher now pre-accepts it in the user
-/// settings, but this detector is the belt-and-braces fail-fast for when that write didn't take
-/// (organization policy override, a relocated config dir, a read-only settings file, etc.).
+/// Maintains a bounded, ANSI-stripped rolling window so a banner split across PTY reads still
+/// matches. A signature trips only when ALL its markers — including the STRUCTURAL numbered
+/// menu layout ("1. No, exit" / "2. Yes, I accept"), not just the loose phrases — are present, so
+/// prose that merely mentions "bypass permissions mode" (like this file) can't false-trip.
+/// Defence-in-depth: the orchestrator also scans only during the pre-session phase, so ordinary
+/// session output never reaches the detector. Once tripped it latches.
 ///
-/// The detector maintains a bounded, ANSI-stripped rolling window of recent output so a banner
-/// delivered across several PTY reads (or torn mid-word at a chunk boundary) still matches. A
-/// signature trips only when ALL of its markers are present in the window. Crucially, a signature's
-/// markers require STRUCTURAL evidence of the rendered dialog — the headline phrase PLUS the
-/// numbered selection menu ("1. No, exit" / "2. Yes, I accept") — not just the loose phrases. Prose
-/// or source that merely mentions "bypass permissions mode" and "yes, i accept" (this very file
-/// does) does not reproduce the numbered menu layout, so it cannot trip. This is defence-in-depth:
-/// the orchestrator additionally scans ONLY during the pre-session dialog phase (the consent dialog
-/// renders once at startup, before any session begins) and stops the moment the session is live, so
-/// ordinary reviewer/tool output that quotes a banner never reaches the detector at all. Once
-/// tripped it latches: the launch is already doomed, so every later frame reports the same reason.
-///
-/// Text-only + source-generated regex — no reflection — so it is safe in the NativeAOT daemon.
+/// Text-only + source-generated regex — no reflection — safe in the NativeAOT daemon.
 /// </summary>
 internal sealed partial class ConsentDialogDetector {
     /// <summary>A known blocking dialog: it trips when every marker is present in the window.</summary>

--- a/src/Capacitor.Cli.Daemon/Services/FailedLaunchLog.cs
+++ b/src/Capacitor.Cli.Daemon/Services/FailedLaunchLog.cs
@@ -1,0 +1,66 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Persists the tail of a hosted agent's PTY output when its launch FAILS, under
+/// <c>{state-dir}/agents/failed/{sha256(agentId)}.log</c> — a directory that survives the failed
+/// launch's worktree teardown.
+///
+/// Motivation: a failed launch disposed the runtime, removed the throwaway worktree, and dropped
+/// the in-memory terminal ring, so the terminal output that explained the failure (e.g. the
+/// Bypass-Permissions consent dialog the reviewer wedged on) was invisible post-mortem — the
+/// original incident was an hours-long blind debug. Keeping the last N KB on disk turns the next
+/// one into a <c>cat</c>.
+///
+/// Best-effort by design: any I/O failure is swallowed and returns <c>null</c> — persisting a
+/// diagnostic must never itself fail a teardown. The filename is a SHA-256 of the (untrusted,
+/// wire-delivered) agent id, NOT the id itself, so no <c>..</c>/separator can escape the directory
+/// (same discipline as <see cref="AgentPidRecordStore"/>). Plain file I/O — NativeAOT-safe.
+/// </summary>
+internal sealed class FailedLaunchLog(string stateDir, int maxBytes = 64 * 1024) {
+    readonly string _dir = Path.Combine(stateDir, "agents", "failed");
+
+    /// <summary>The retained failed-launch directory ({state}/agents/failed). Exposed for tests to
+    /// assert a capture landed.</summary>
+    public string Dir => _dir;
+
+    /// <summary>
+    /// Writes (overwriting any prior entry for this agent) a header line plus the last
+    /// <c>maxBytes</c> of <paramref name="terminalOutput"/>. Returns the file path, or <c>null</c>
+    /// if persisting failed.
+    /// </summary>
+    public string? Persist(string agentId, byte[] terminalOutput, string reason) {
+        try {
+            Directory.CreateDirectory(_dir);
+
+            var path = Path.Combine(_dir, SafeName(agentId) + ".log");
+            var tail = terminalOutput.Length > maxBytes
+                ? terminalOutput[^maxBytes..]
+                : terminalOutput;
+
+            var header = Encoding.UTF8.GetBytes(
+                $"# kcap failed-launch capture\n" +
+                $"# time:   {DateTimeOffset.UtcNow:O}\n" +
+                $"# agent:  {agentId}\n" +
+                $"# reason: {reason}\n" +
+                $"# --- last {tail.Length} bytes of PTY output follow ---\n");
+
+            // Temp + rename so a concurrent reader never sees a half-written capture.
+            var tmp = path + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
+            using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None)) {
+                fs.Write(header);
+                fs.Write(tail);
+            }
+
+            File.Move(tmp, path, overwrite: true);
+            return path;
+        } catch {
+            return null; // best-effort — never fail a teardown over a diagnostic write
+        }
+    }
+
+    static string SafeName(string agentId) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(agentId ?? ""))).ToLowerInvariant();
+}

--- a/src/Capacitor.Cli.Daemon/Services/FailedLaunchLog.cs
+++ b/src/Capacitor.Cli.Daemon/Services/FailedLaunchLog.cs
@@ -14,6 +14,12 @@ namespace Capacitor.Cli.Daemon.Services;
 /// original incident was an hours-long blind debug. Keeping the last N KB on disk turns the next
 /// one into a <c>cat</c>.
 ///
+/// The retained tail can hold the reviewer's prompt, tool output, and any secrets the PTY echoed,
+/// so on Unix the directory is created owner-only (0700) and the file owner-only (0600) — other
+/// local users must not be able to traverse in or read it. The mode is stamped at creation (via
+/// <c>UnixCreateMode</c>) so there is never a world-readable window, and re-asserted after the
+/// atomic rename. All mode work no-ops on Windows.
+///
 /// Best-effort by design: any I/O failure is swallowed and returns <c>null</c> — persisting a
 /// diagnostic must never itself fail a teardown. The filename is a SHA-256 of the (untrusted,
 /// wire-delivered) agent id, NOT the id itself, so no <c>..</c>/separator can escape the directory
@@ -35,6 +41,11 @@ internal sealed class FailedLaunchLog(string stateDir, int maxBytes = 64 * 1024)
         try {
             Directory.CreateDirectory(_dir);
 
+            // Owner-only directory: 0700 stops other local users traversing in to the 0600 files.
+            if (!OperatingSystem.IsWindows()) {
+                try { File.SetUnixFileMode(_dir, DirMode); } catch { /* best-effort */ }
+            }
+
             var path = Path.Combine(_dir, SafeName(agentId) + ".log");
             var tail = terminalOutput.Length > maxBytes
                 ? terminalOutput[^maxBytes..]
@@ -47,19 +58,36 @@ internal sealed class FailedLaunchLog(string stateDir, int maxBytes = 64 * 1024)
                 $"# reason: {reason}\n" +
                 $"# --- last {tail.Length} bytes of PTY output follow ---\n");
 
-            // Temp + rename so a concurrent reader never sees a half-written capture.
+            // Temp + rename so a concurrent reader never sees a half-written capture. The temp is
+            // created 0600 from its first byte (UnixCreateMode) — a chmod after writing would leave a
+            // window where the secret-bearing tail is world-readable — and the atomic rename carries
+            // 0600 onto the final file.
             var tmp = path + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
-            using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None)) {
+
+            var options = new FileStreamOptions { Mode = FileMode.Create, Access = FileAccess.Write, Share = FileShare.None };
+            if (!OperatingSystem.IsWindows()) options.UnixCreateMode = FileMode0600;
+
+            using (var fs = new FileStream(tmp, options)) {
                 fs.Write(header);
                 fs.Write(tail);
             }
 
             File.Move(tmp, path, overwrite: true);
+
+            // Re-assert 0600 on the published path: `overwrite: true` may have replaced a pre-existing
+            // final file, and this closes any platform gap in what the rename carries across.
+            if (!OperatingSystem.IsWindows()) {
+                try { File.SetUnixFileMode(path, FileMode0600); } catch { /* best-effort */ }
+            }
+
             return path;
         } catch {
             return null; // best-effort — never fail a teardown over a diagnostic write
         }
     }
+
+    const UnixFileMode FileMode0600 = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+    const UnixFileMode DirMode      = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
 
     static string SafeName(string agentId) =>
         Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(agentId ?? ""))).ToLowerInvariant();

--- a/src/Capacitor.Cli.Daemon/Services/FailedLaunchLog.cs
+++ b/src/Capacitor.Cli.Daemon/Services/FailedLaunchLog.cs
@@ -5,25 +5,19 @@ namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
 /// Persists the tail of a hosted agent's PTY output when its launch FAILS, under
-/// <c>{state-dir}/agents/failed/{sha256(agentId)}.log</c> — a directory that survives the failed
-/// launch's worktree teardown.
+/// <c>{state-dir}/agents/failed/{sha256(agentId)}.log</c> — survives the failed launch's
+/// worktree teardown, so the output that explained the failure (e.g. the consent dialog it
+/// wedged on) is still available post-mortem instead of an hours-long blind debug.
 ///
-/// Motivation: a failed launch disposed the runtime, removed the throwaway worktree, and dropped
-/// the in-memory terminal ring, so the terminal output that explained the failure (e.g. the
-/// Bypass-Permissions consent dialog the reviewer wedged on) was invisible post-mortem — the
-/// original incident was an hours-long blind debug. Keeping the last N KB on disk turns the next
-/// one into a <c>cat</c>.
+/// The retained tail can hold the reviewer's prompt, tool output, and any secrets the PTY
+/// echoed, so on Unix the directory is owner-only (0700) and the file owner-only (0600) —
+/// stamped at creation via <c>UnixCreateMode</c> and re-asserted after the atomic rename, so
+/// there's never a world-readable window. No-ops on Windows.
 ///
-/// The retained tail can hold the reviewer's prompt, tool output, and any secrets the PTY echoed,
-/// so on Unix the directory is created owner-only (0700) and the file owner-only (0600) — other
-/// local users must not be able to traverse in or read it. The mode is stamped at creation (via
-/// <c>UnixCreateMode</c>) so there is never a world-readable window, and re-asserted after the
-/// atomic rename. All mode work no-ops on Windows.
-///
-/// Best-effort by design: any I/O failure is swallowed and returns <c>null</c> — persisting a
-/// diagnostic must never itself fail a teardown. The filename is a SHA-256 of the (untrusted,
-/// wire-delivered) agent id, NOT the id itself, so no <c>..</c>/separator can escape the directory
-/// (same discipline as <see cref="AgentPidRecordStore"/>). Plain file I/O — NativeAOT-safe.
+/// Best-effort: any I/O failure is swallowed and returns <c>null</c> — a diagnostic must never
+/// fail a teardown. The filename is a SHA-256 of the (untrusted) agent id, not the id itself, so
+/// no <c>..</c>/separator can escape the directory (same discipline as
+/// <see cref="AgentPidRecordStore"/>). Plain file I/O — NativeAOT-safe.
 /// </summary>
 internal sealed class FailedLaunchLog(string stateDir, int maxBytes = 64 * 1024) {
     readonly string _dir = Path.Combine(stateDir, "agents", "failed");

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorConsentDialogTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorConsentDialogTests.cs
@@ -1,0 +1,108 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Pty;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// End-to-end wiring of the consent-dialog fail-fast into the orchestrator's PTY read loop: an
+/// unattended review-flow reviewer that renders the Bypass-Permissions consent dialog must
+/// (1) fail the launch fast with the actionable coded reason (instead of dying silently at the
+/// server's session-id timeout), (2) terminate the wedged-but-alive process, and (3) leave a
+/// retained tail-of-PTY capture on disk. Also proves an interactive (Default) agent is NOT
+/// failed-fast on the same output — its human viewer can dismiss the prompt.
+///
+/// Partial of <see cref="AgentOrchestratorVendorTests"/> to reuse its BuildOrchestrator /
+/// CaptureServerConnection / SpyPtyProcessFactory harness.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    // The real Claude 2.1.x banner, condensed to the two matched markers.
+    const string BypassDialogOutput =
+        "\x1b[2J\x1b[H WARNING: Claude Code running in Bypass Permissions mode \n" +
+        " In Bypass Permissions mode, Claude Code will not ask for your approval.\n" +
+        " 1. No, exit\n 2. Yes, I accept\n";
+
+    [Test]
+    public async Task ReviewFlow_reviewer_wedged_on_bypass_dialog_fails_fast_and_captures_the_tail() {
+        var server = new CaptureServerConnection();
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var pty   = new BypassBannerPtyProcess(BypassDialogOutput);
+        var agent = orch.SeedAgentForTest("rev-wedge", LaunchKind.ReviewFlow, status: "Starting", pty: pty);
+
+        await orch.ReadAgentOutputForTest(agent).WaitAsync(TimeSpan.FromSeconds(10));
+
+        // (1) Actionable fail-fast, not a silent session-id timeout.
+        var failed = server.LaunchFailedCalls.SingleOrDefault(c => c.AgentId == "rev-wedge");
+        await Assert.That(failed.Reason).IsNotNull();
+        await Assert.That(failed.Reason).Contains("Bypass-Permissions");
+        await Assert.That(server.StatusChangedCalls).Contains(("rev-wedge", "Failed"));
+
+        // (2) The wedged (still-alive) process was terminated.
+        await Assert.That(pty.Terminated).IsTrue();
+
+        // (3) The PTY tail is on disk for post-mortem, containing the dialog text.
+        var failedDir = orch.FailedLaunchLogForTest!.Dir;
+        var logs = Directory.Exists(failedDir) ? Directory.GetFiles(failedDir, "*.log") : [];
+        await Assert.That(logs.Length).IsEqualTo(1);
+        var captured = await File.ReadAllTextAsync(logs[0]);
+        await Assert.That(captured).Contains("Yes, I accept");
+    }
+
+    [Test]
+    public async Task Interactive_agent_is_not_failed_fast_on_the_same_dialog_output() {
+        var server = new CaptureServerConnection();
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        // Default (interactive) kind: a human viewer can accept the dialog, so no fail-fast.
+        // The PTY exits on its own after the banner so the read loop terminates for the test.
+        var pty   = new BypassBannerPtyProcess(BypassDialogOutput, exitAfterBanner: true);
+        var agent = orch.SeedAgentForTest("interactive", LaunchKind.Default, status: "Starting", pty: pty);
+
+        await orch.ReadAgentOutputForTest(agent).WaitAsync(TimeSpan.FromSeconds(10));
+
+        // No consent-dialog fail-fast fired (the process was never force-terminated by the detector).
+        await Assert.That(pty.Terminated).IsFalse();
+        await Assert.That(server.LaunchFailedCalls.Any(c => c.Reason.Contains("Bypass-Permissions"))).IsFalse();
+    }
+
+    /// <summary>Emits a scripted banner chunk then either blocks alive (a real wedge — the detector
+    /// must terminate it) or exits (interactive control case). Records whether TerminateAsync ran.</summary>
+    sealed class BypassBannerPtyProcess(string banner, bool exitAfterBanner = false) : IPtyProcess {
+        volatile bool _exited;
+        public int  Pid       => 5150;
+        public bool HasExited => _exited || exitAfterBanner;
+        public int? ExitCode  => HasExited ? 0 : null;
+        public bool Terminated { get; private set; }
+
+        public ValueTask DisposeAsync() { _exited = true; return default; }
+        public Task WaitForExitAsync(TimeSpan? _) => Task.CompletedTask;
+
+        public Task TerminateAsync(TimeSpan? _) {
+            Terminated = true;
+            _exited    = true;
+            return Task.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<byte[]> ReadOutputAsync([EnumeratorCancellation] CancellationToken ct = default) {
+            yield return Encoding.UTF8.GetBytes(banner);
+
+            if (!exitAfterBanner) {
+                try { await Task.Delay(Timeout.InfiniteTimeSpan, ct); } catch (OperationCanceledException) { /* stopped */ }
+            }
+
+            yield break;
+        }
+
+        public Task WriteAsync(string _) => Task.CompletedTask;
+        public Task WriteAsync(byte[] _) => Task.CompletedTask;
+        public void Resize(ushort     _, ushort __) { }
+        public void SendInterrupt() { }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorConsentDialogTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorConsentDialogTests.cs
@@ -45,12 +45,42 @@ public partial class AgentOrchestratorVendorTests {
         // (2) The wedged (still-alive) process was terminated.
         await Assert.That(pty.Terminated).IsTrue();
 
-        // (3) The PTY tail is on disk for post-mortem, containing the dialog text.
+        // (3) The PTY tail is on disk for post-mortem, containing the TRIGGERING banner chunk — not
+        // just the coded reason header. The detector inspects a chunk before the read loop appends it
+        // to OutputBuffer, so a banner delivered in the first chunk (this shape) must still be captured.
+        // Assert on banner-only text ("will not ask for your approval") that the reason string does
+        // NOT contain, so this can't pass merely because the reason header quotes "Yes, I accept".
         var failedDir = orch.FailedLaunchLogForTest!.Dir;
         var logs = Directory.Exists(failedDir) ? Directory.GetFiles(failedDir, "*.log") : [];
         await Assert.That(logs.Length).IsEqualTo(1);
         var captured = await File.ReadAllTextAsync(logs[0]);
-        await Assert.That(captured).Contains("Yes, I accept");
+        await Assert.That(captured).Contains("will not ask for your approval");
+    }
+
+    [Test]
+    public async Task ReviewFlow_reviewer_with_a_live_session_is_not_failed_fast_on_banner_like_output() {
+        var server = new CaptureServerConnection();
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        // The consent/trust dialog is a PRE-SESSION event: it renders once at startup, before any
+        // session exists. Once the session is live (SessionId resolved from the transcript) the dialog
+        // phase is over, so the detector must stop scanning — otherwise ordinary reviewer/tool output
+        // that merely quotes a banner phrase would latch a false wedge and kill a healthy reviewer.
+        var pty   = new BypassBannerPtyProcess(BypassDialogOutput, exitAfterBanner: true);
+        var agent = orch.SeedAgentForTest("rev-live", LaunchKind.ReviewFlow, status: "Starting", pty: pty);
+        agent.SessionId = "live-session-abc";
+
+        await orch.ReadAgentOutputForTest(agent).WaitAsync(TimeSpan.FromSeconds(10));
+
+        // No consent-dialog fail-fast fired: the wedged-detector never terminated the process, and no
+        // Bypass-Permissions coded reason was reported (a startup-failure classification of the raw
+        // banner text is a different, non-hyphenated reason and is not asserted here).
+        await Assert.That(pty.Terminated).IsFalse();
+        await Assert.That(
+            server.LaunchFailedCalls.Any(c => c.AgentId == "rev-live" && c.Reason.Contains("Bypass-Permissions")))
+            .IsFalse();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherBypassAcceptanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherBypassAcceptanceTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Tests <see cref="ClaudeLauncher.AcceptBypassPermissionsMode(string)"/> — the pre-accept that
+/// stops an unattended review-flow reviewer wedging on Claude's Bypass-Permissions consent dialog.
+///
+/// The consent flag Claude 2.1.x actually reads is <c>skipDangerousModePermissionPrompt</c> in the
+/// user settings (verified against the shipped 2.1.x binary: it reads that key from userSettings and
+/// writes it there when the user accepts the dialog interactively). Writing the legacy
+/// <c>bypassPermissionsModeAccepted</c> into <c>~/.claude.json</c> was NOT honored, hence this.
+/// </summary>
+public class ClaudeLauncherBypassAcceptanceTests {
+    // Kept in step with ClaudeLauncher's constant; asserting the literal here is deliberate — a
+    // silent rename of the key would re-introduce the wedge, and this test would catch it.
+    const string Key = "skipDangerousModePermissionPrompt";
+
+    static string TempSettings() {
+        var dir = Path.Combine(Path.GetTempPath(), "kcap-claude-settings-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return Path.Combine(dir, "settings.json");
+    }
+
+    static void Cleanup(string settingsPath) {
+        try { Directory.Delete(Path.GetDirectoryName(settingsPath)!, true); } catch { /* best-effort */ }
+    }
+
+    [Test]
+    public async Task Writes_the_acceptance_flag_when_settings_file_is_absent() {
+        var path = TempSettings();
+        try {
+            ClaudeLauncher.AcceptBypassPermissionsMode(path);
+
+            await Assert.That(File.Exists(path)).IsTrue();
+            var root = JsonNode.Parse(await File.ReadAllTextAsync(path))!.AsObject();
+            await Assert.That(root[Key]!.GetValue<bool>()).IsTrue();
+        } finally { Cleanup(path); }
+    }
+
+    [Test]
+    public async Task Preserves_existing_user_settings_when_adding_the_flag() {
+        var path = TempSettings();
+        try {
+            await File.WriteAllTextAsync(path,
+                """{"skipWorkflowUsageWarning":true,"env":{"MCP_TOOL_TIMEOUT":"600000"}}""");
+
+            ClaudeLauncher.AcceptBypassPermissionsMode(path);
+
+            var root = JsonNode.Parse(await File.ReadAllTextAsync(path))!.AsObject();
+            await Assert.That(root[Key]!.GetValue<bool>()).IsTrue();
+            // Sibling keys must survive untouched.
+            await Assert.That(root["skipWorkflowUsageWarning"]!.GetValue<bool>()).IsTrue();
+            await Assert.That(root["env"]!["MCP_TOOL_TIMEOUT"]!.GetValue<string>()).IsEqualTo("600000");
+        } finally { Cleanup(path); }
+    }
+
+    [Test]
+    public async Task Is_idempotent_when_flag_already_true() {
+        var path = TempSettings();
+        try {
+            await File.WriteAllTextAsync(path, """{"skipDangerousModePermissionPrompt":true,"keep":"me"}""");
+
+            ClaudeLauncher.AcceptBypassPermissionsMode(path);
+
+            var root = JsonNode.Parse(await File.ReadAllTextAsync(path))!.AsObject();
+            await Assert.That(root[Key]!.GetValue<bool>()).IsTrue();
+            await Assert.That(root["keep"]!.GetValue<string>()).IsEqualTo("me");
+        } finally { Cleanup(path); }
+    }
+
+    [Test]
+    public async Task Does_not_clobber_an_unparseable_settings_file() {
+        var path = TempSettings();
+        try {
+            const string garbage = "this is not { valid json";
+            await File.WriteAllTextAsync(path, garbage);
+
+            // Must NOT destroy a settings file it can't parse (user-owned, may contain comments the
+            // daemon shouldn't touch). Leaves it exactly as-is rather than overwriting.
+            ClaudeLauncher.AcceptBypassPermissionsMode(path);
+
+            await Assert.That(await File.ReadAllTextAsync(path)).IsEqualTo(garbage);
+        } finally { Cleanup(path); }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherWriteJsonAtomicTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherWriteJsonAtomicTests.cs
@@ -22,4 +22,41 @@ public class ClaudeLauncherWriteJsonAtomicTests {
             root.Delete(recursive: true);
         }
     }
+
+    // settings.json may hold secrets under `env`, so an atomic temp+rename must NOT relax its mode:
+    // a fresh temp created under the umask (0644) would silently widen a 0600 target after the rename.
+    [Test]
+    public async Task WriteJsonAtomic_preserves_an_existing_owner_only_mode() {
+        if (OperatingSystem.IsWindows()) return;
+
+        var root = Directory.CreateTempSubdirectory("kcap-wja-perms-");
+        try {
+            var path = Path.Combine(root.FullName, "settings.json");
+            await File.WriteAllTextAsync(path, "{}");
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+            ClaudeLauncher.WriteJsonAtomic(path, new JsonObject { ["k"] = "v" });
+
+            await Assert.That(File.GetUnixFileMode(path)).IsEqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        } finally {
+            root.Delete(recursive: true);
+        }
+    }
+
+    // A brand-new settings file is created owner-only (0600) rather than inheriting the umask.
+    [Test]
+    public async Task WriteJsonAtomic_creates_a_new_file_owner_only() {
+        if (OperatingSystem.IsWindows()) return;
+
+        var root = Directory.CreateTempSubdirectory("kcap-wja-new-");
+        try {
+            var path = Path.Combine(root.FullName, "settings.json");
+
+            ClaudeLauncher.WriteJsonAtomic(path, new JsonObject { ["k"] = "v" });
+
+            await Assert.That(File.GetUnixFileMode(path)).IsEqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        } finally {
+            root.Delete(recursive: true);
+        }
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ConsentDialogDetectorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ConsentDialogDetectorTests.cs
@@ -103,6 +103,24 @@ public class ConsentDialogDetectorTests {
     }
 
     [Test]
+    public async Task Prose_quoting_the_banner_phrases_without_the_menu_layout_does_not_trip() {
+        var detector = new ConsentDialogDetector();
+
+        // A reviewer reading source/docs about the feature (e.g. this detector's own file, which
+        // literally contains both phrases): the headline "bypass permissions mode" AND the accept
+        // wording "Yes, I accept" both appear, but NOT the dialog's numbered "1. No, exit" /
+        // "2. Yes, I accept" selection menu. Only the real full-screen dialog renders that numbered
+        // layout, so the co-occurrence of loose phrases in prose must NOT trip a false wedge.
+        var reason = detector.Observe(Utf8(
+            "This watchdog trips when Claude renders its bypass permissions mode dialog, where an "
+          + "unattended reviewer would otherwise have to choose \"Yes, I accept\" with no human "
+          + "present to answer it.\n"));
+
+        await Assert.That(reason).IsNull();
+        await Assert.That(detector.Tripped).IsFalse();
+    }
+
+    [Test]
     public async Task Marker_split_mid_word_across_two_chunks_still_trips() {
         var detector = new ConsentDialogDetector();
 

--- a/test/Capacitor.Cli.Tests.Unit/ConsentDialogDetectorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ConsentDialogDetectorTests.cs
@@ -1,0 +1,116 @@
+using System.Text;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Tests <see cref="ConsentDialogDetector"/> — the PTY-stream watchdog that trips a fail-fast
+/// when a spawned interactive CLI renders a one-time consent/trust dialog no unattended launch
+/// can dismiss. Covers the real bypass-permissions banner (the wedge that motivated this),
+/// chunk-split delivery, ANSI-interspersed frames, the workspace-trust dialog, and — critically —
+/// that ordinary session output never trips it (no false positives).
+/// </summary>
+public class ConsentDialogDetectorTests {
+    static byte[] Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
+    // The real Claude 2.1.x full-screen banner (text extracted from the shipped CLI binary).
+    const string BypassBanner =
+        "WARNING: Claude Code running in Bypass Permissions mode\n\n" +
+        "In Bypass Permissions mode, Claude Code will not ask for your approval before running " +
+        "potentially dangerous commands.\n\n" +
+        "By proceeding, you accept all responsibility for actions taken while running in Bypass " +
+        "Permissions mode.\n\n" +
+        "1. No, exit\n" +
+        "2. Yes, I accept\n";
+
+    [Test]
+    public async Task Bypass_permissions_banner_in_one_chunk_trips_with_the_coded_message() {
+        var detector = new ConsentDialogDetector();
+
+        var reason = detector.Observe(Utf8(BypassBanner));
+
+        await Assert.That(reason).IsNotNull();
+        await Assert.That(reason!).Contains("Bypass-Permissions");
+    }
+
+    [Test]
+    public async Task Bypass_banner_split_across_chunks_still_trips_once_both_markers_arrive() {
+        var detector = new ConsentDialogDetector();
+
+        // Headline arrives first — not enough on its own (the accept option hasn't rendered yet).
+        var partial = detector.Observe(Utf8("WARNING: Claude Code running in Bypass Permissions mode\n"));
+        await Assert.That(partial).IsNull();
+
+        // The accept option lands in a later frame — now it trips.
+        var reason = detector.Observe(Utf8("\n1. No, exit\n2. Yes, I accept\n"));
+        await Assert.That(reason).IsNotNull();
+    }
+
+    [Test]
+    public async Task Ansi_interspersed_banner_trips() {
+        var detector = new ConsentDialogDetector();
+
+        // A realistic Ink frame: box-drawing borders + SGR colour codes + cursor moves around the text.
+        var framed =
+            "\x1b[2J\x1b[H\x1b[1m\x1b[33m╭──────────────────────────────╮\x1b[0m\n" +
+            "\x1b[1m WARNING: Claude Code running in Bypass Permissions mode \x1b[0m\n" +
+            "\x1b[2m 1. No, exit \x1b[0m\n" +
+            "\x1b[36m 2. Yes, I accept \x1b[0m\n" +
+            "\x1b[33m╰──────────────────────────────╯\x1b[0m\n";
+
+        var reason = detector.Observe(Utf8(framed));
+
+        await Assert.That(reason).IsNotNull();
+    }
+
+    [Test]
+    public async Task Workspace_trust_dialog_trips_with_a_trust_specific_message() {
+        var detector = new ConsentDialogDetector();
+
+        var reason = detector.Observe(Utf8("Do you trust the files in this folder?\n1. Yes, proceed\n2. No, exit\n"));
+
+        await Assert.That(reason).IsNotNull();
+        await Assert.That(reason!).Contains("trust");
+    }
+
+    [Test]
+    public async Task Detector_latches_and_returns_the_same_message_on_later_chunks() {
+        var detector = new ConsentDialogDetector();
+
+        var first = detector.Observe(Utf8(BypassBanner));
+        await Assert.That(first).IsNotNull();
+
+        // Subsequent output must keep reporting the same tripped reason (the launch is already doomed).
+        var again = detector.Observe(Utf8("some later redraw frame"));
+        await Assert.That(again).IsEqualTo(first);
+        await Assert.That(detector.Tripped).IsTrue();
+    }
+
+    [Test]
+    public async Task Ordinary_session_output_never_trips() {
+        var detector = new ConsentDialogDetector();
+
+        // Real reviewer chatter that name-drops the feature but is NOT the consent dialog.
+        string?[] results = [
+            detector.Observe(Utf8("Reading files and running the review...\n")),
+            detector.Observe(Utf8("The change enables bypass permissions mode for the daemon.\n")),
+            detector.Observe(Utf8("I accept that this is a reasonable approach. Yes.\n")),
+            detector.Observe(Utf8("Do you trust the tests? They pass locally.\n")),
+        ];
+
+        foreach (var r in results) await Assert.That(r).IsNull();
+        await Assert.That(detector.Tripped).IsFalse();
+    }
+
+    [Test]
+    public async Task Marker_split_mid_word_across_two_chunks_still_trips() {
+        var detector = new ConsentDialogDetector();
+
+        // The headline is delivered byte-torn ("Bypass Permis" | "sions mode"), exactly like a PTY
+        // read that ends mid-word. The rolling window stitches the frames back together.
+        await Assert.That(detector.Observe(Utf8("WARNING: Claude Code running in Bypass Permis"))).IsNull();
+        var reason = detector.Observe(Utf8("sions mode\n1. No, exit\n2. Yes, I accept\n"));
+
+        await Assert.That(reason).IsNotNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/FailedLaunchLogTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FailedLaunchLogTests.cs
@@ -1,0 +1,96 @@
+using System.Text;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Tests <see cref="FailedLaunchLog"/> — the post-mortem retained tail of a failed hosted-agent
+/// launch. A failed launch tears down the worktree and drops the in-memory PTY buffer, so the
+/// terminal output (e.g. the consent dialog the reviewer wedged on) was invisible afterwards. This
+/// persists the last N KB under <c>{state}/agents/failed/</c> so the next incident is a 2-minute
+/// <c>cat</c> instead of an hours-long blind debug.
+/// </summary>
+public class FailedLaunchLogTests {
+    static string TempDir() {
+        var d = Path.Combine(Path.GetTempPath(), "kcap-faillog-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(d);
+        return d;
+    }
+
+    [Test]
+    public async Task Persist_writes_a_retained_file_containing_the_output_and_reason() {
+        var dir = TempDir();
+        try {
+            var log = new FailedLaunchLog(dir);
+
+            var path = log.Persist("agent-1", Encoding.UTF8.GetBytes("WARNING: Bypass Permissions mode\n2. Yes, I accept\n"), "wedged on the consent dialog");
+
+            await Assert.That(path).IsNotNull();
+            await Assert.That(File.Exists(path!)).IsTrue();
+
+            // Lives under the retained failed/ directory, NOT the worktree that gets deleted.
+            await Assert.That(path!.Replace('\\', '/')).Contains("/agents/failed/");
+
+            var content = await File.ReadAllTextAsync(path!);
+            await Assert.That(content).Contains("2. Yes, I accept");           // the PTY tail
+            await Assert.That(content).Contains("wedged on the consent dialog"); // the reason header
+            await Assert.That(content).Contains("agent-1");                     // the agent id header
+        } finally {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Test]
+    public async Task Persist_keeps_only_the_last_N_bytes_of_a_large_stream() {
+        var dir = TempDir();
+        try {
+            // 8 KB cap; feed 20 KB where only the tail carries the smoking gun.
+            var log = new FailedLaunchLog(dir, maxBytes: 8 * 1024);
+
+            var head = new string('A', 20 * 1024);
+            var payload = head + "TAIL-MARKER-2. Yes, I accept";
+            var path = log.Persist("big", Encoding.UTF8.GetBytes(payload), "startup failure");
+
+            var content = await File.ReadAllTextAsync(path!);
+            await Assert.That(content).Contains("TAIL-MARKER-2. Yes, I accept"); // tail retained
+            // The body was truncated: nowhere near the full 20 KB of 'A's survives.
+            await Assert.That(content.Length < 12 * 1024).IsTrue();
+        } finally {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Test]
+    public async Task Persist_is_resilient_to_empty_output() {
+        var dir = TempDir();
+        try {
+            var log = new FailedLaunchLog(dir);
+
+            var path = log.Persist("empty", [], "process exited before any output");
+
+            await Assert.That(path).IsNotNull();
+            var content = await File.ReadAllTextAsync(path!);
+            await Assert.That(content).Contains("process exited before any output");
+        } finally {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Test]
+    public async Task Persist_uses_a_path_safe_filename_for_a_hostile_agent_id() {
+        var dir = TempDir();
+        try {
+            var log = new FailedLaunchLog(dir);
+
+            // An agent id that crosses the SignalR wire unconstrained must never escape the dir.
+            var path = log.Persist("../../etc/passwd", Encoding.UTF8.GetBytes("x"), "reason");
+
+            await Assert.That(path).IsNotNull();
+            var full = Path.GetFullPath(path!);
+            var failedRoot = Path.GetFullPath(Path.Combine(dir, "agents", "failed"));
+            await Assert.That(full.StartsWith(failedRoot, StringComparison.Ordinal)).IsTrue();
+        } finally {
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/FailedLaunchLogTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FailedLaunchLogTests.cs
@@ -77,6 +77,30 @@ public class FailedLaunchLogTests {
     }
 
     [Test]
+    public async Task Persist_creates_an_owner_only_file_in_an_owner_only_directory() {
+        // The retained tail can hold the reviewer's prompt, tool output, and any secrets the PTY
+        // echoed, so it must not be world/group readable. Unix-only: file modes are a no-op on Windows.
+        if (OperatingSystem.IsWindows()) return;
+
+        var dir = TempDir();
+        try {
+            var log = new FailedLaunchLog(dir);
+
+            var path = log.Persist("agent-perms", Encoding.UTF8.GetBytes("secret PTY tail"), "wedged");
+
+            await Assert.That(path).IsNotNull();
+
+            const UnixFileMode ownerOnlyFile = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+            const UnixFileMode ownerOnlyDir  = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+
+            await Assert.That(File.GetUnixFileMode(path!)).IsEqualTo(ownerOnlyFile);
+            await Assert.That(File.GetUnixFileMode(log.Dir)).IsEqualTo(ownerOnlyDir);
+        } finally {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Test]
     public async Task Persist_uses_a_path_safe_filename_for_a_hostile_agent_id() {
         var dir = TempDir();
         try {


### PR DESCRIPTION
Hosted Claude reviewers wedge silently on Claude's one-time Bypass-Permissions consent dialog (no session ever starts; the server times out at 30s with an unrelated-looking error). Three fixes:

1. **Pre-accept** — writes `skipDangerousModePermissionPrompt: true` into the settings file claude 2.1.x actually reads (`$CLAUDE_CONFIG_DIR/settings.json` else `~/.claude/settings.json`), the same effect as accepting the dialog once interactively (verified against the 2.1.206 binary; the legacy `~/.claude.json` key is migrated + no longer honored, which is why poking it failed). Idempotent, preserves other keys, never clobbers an unparseable file. **The host-global scope was explicitly reviewed and authorized by the maintainer** — hosted reviewers already run `--permission-mode bypassPermissions` by design; this removes the one-time interactive wedge, it does not grant new powers.
2. **Fail fast** — `ConsentDialogDetector` scans the reviewer's PTY (ANSI-stripped, latching) and, on the consent/trust banner, reports a coded `LaunchFailed` + terminates the wedged process instead of the silent 30s timeout (review-flow launches only).
3. **PTY capture** — persists the last 64KB of a FAILED launch's PTY to `{state}/{name}/agents/failed/` (survives worktree teardown) for post-mortem.

17 new tests; AOT publish clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)