### PR TITLE
[AI-1514] Release guard: stamp+verify tag SHA in npm metadata; refuse a moved/re-cut tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,16 +29,13 @@ jobs:
           wait-interval: 15
           checks-discovery-timeout: 300
 
-  # Process guard: a release tag must be minted exactly once. npm can never
-  # re-publish an existing version, so the only way this workflow re-runs for
-  # a tag name whose version is already on npm is if the tag was deleted and
-  # recreated (or force-moved) — possibly onto a different commit than what
-  # was originally released. That's the failure mode that let a published
-  # npm artifact silently diverge from what its git tag claimed: the tag
-  # moved after publish, and nothing caught it. Runs standalone (no `needs`)
-  # so it fails within seconds, before the "Wait for CI" polling and the
-  # six-runner build matrix spend any time or money on a release that's
-  # going to be refused anyway.
+  # Guards against a moved/re-cut release tag: npm never lets a version
+  # republish, so this workflow only re-runs for an already-published version
+  # if the tag was deleted+recreated (or force-moved) onto a different commit
+  # — the failure mode that lets a published npm artifact silently diverge
+  # from its git tag. Runs standalone (no `needs`) so it fails in seconds,
+  # before CI polling and the six-runner build matrix spend time/money on a
+  # release that's refused anyway.
   verify-release-immutable:
     name: Refuse a moved or re-cut release tag
     runs-on: ubuntu-latest
@@ -65,21 +62,14 @@ jobs:
 
           echo "Checking npm registry for an existing $PKG@$VERSION ..."
 
-          # Queries one `npm view` field for "$PKG@$VERSION", retrying a
-          # couple of times on transient failures. Prints exactly one of:
-          #   FOUND:<value>  npm view exited 0; <value> may be empty if the
-          #                  field itself just isn't set on that published
-          #                  record (this is how versions published before
-          #                  a field existed look — safe to query).
-          #   NOTFOUND       npm gave a definitive "no such package/version"
-          #                  signal (E404) — a real answer, just negative.
-          # and returns 0 for either. On a genuine failure (network,
-          # registry outage, auth error, or anything else that can't be
-          # positively classified) after retries are exhausted, it prints
-          # nothing useful and returns 1 — the caller MUST treat that as
-          # ambiguous and refuse to release, NEVER as "not found". This is
-          # the crux of the guard: an ignored/misread npm error must not be
-          # able to masquerade as "brand-new version, proceed".
+          # Queries one `npm view` field for "$PKG@$VERSION", retrying on
+          # transient failures. Prints "FOUND:<value>" (value may be empty
+          # for a field that predates this guard) or "NOTFOUND" (npm's
+          # definitive E404) and returns 0 for either. On a genuine failure
+          # (network/registry/auth) after retries, it returns 1 — the caller
+          # MUST treat that as ambiguous and refuse to release, NEVER as
+          # "not found", so an ignored/misread npm error can't masquerade as
+          # "brand-new version, proceed".
           npm_view_field() {
             local field="$1" attempts=3 delay=3 i out err rc errfile
             for ((i = 1; i <= attempts; i++)); do
@@ -118,23 +108,18 @@ jobs:
           query_status="ok"
           published_sha=""
 
-          # kcapReleaseCommit is the explicit stamp this same guard's sibling
-          # step writes into published package.json (see "Update package
-          # versions and publish platform packages" / "Publish wrapper
-          # package" below) — the single source of truth for which commit a
-          # given npm version was built from, matching MinVer's own
-          # AssemblyInformationalVersion build-metadata suffix baked into the
-          # binary (both ultimately derive from the same checked-out HEAD /
-          # github.sha for this tag).
+          # kcapReleaseCommit is the explicit stamp the sibling publish step
+          # writes into package.json — source of truth for which commit an
+          # npm version was built from (matches MinVer's build-metadata
+          # suffix baked into the binary; both derive from the same tag's
+          # checked-out HEAD).
           if result=$(npm_view_field kcapReleaseCommit); then
             if [ "$result" != "NOTFOUND" ]; then
               published_sha="${result#FOUND:}"
 
-              # Fallback for versions published before this guard existed:
-              # npm records `gitHead` automatically on every publish run from
-              # inside a git checkout (true for every job in this workflow),
-              # so it already carries the same information for older
-              # releases.
+              # Fallback for pre-guard versions: npm auto-records `gitHead`
+              # on every publish from a git checkout, so it already carries
+              # the same info for older releases.
               if [ -z "$published_sha" ]; then
                 if result=$(npm_view_field gitHead); then
                   if [ "$result" != "NOTFOUND" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,92 @@ jobs:
           wait-interval: 15
           checks-discovery-timeout: 300
 
+  # Process guard: a release tag must be minted exactly once. npm can never
+  # re-publish an existing version, so the only way this workflow re-runs for
+  # a tag name whose version is already on npm is if the tag was deleted and
+  # recreated (or force-moved) — possibly onto a different commit than what
+  # was originally released. That's the failure mode that let a published
+  # npm artifact silently diverge from what its git tag claimed: the tag
+  # moved after publish, and nothing caught it. Runs standalone (no `needs`)
+  # so it fails within seconds, before the "Wait for CI" polling and the
+  # six-runner build matrix spend any time or money on a release that's
+  # going to be refused anyway.
+  verify-release-immutable:
+    name: Refuse a moved or re-cut release tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Extract version from tag
+        id: version
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse to re-publish or re-point an already-released version
+        shell: bash
+        run: |
+          set -euo pipefail
+          PKG="@kurrent/kcap"
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          THIS_SHA="${{ github.sha }}"
+
+          echo "Checking npm registry for an existing $PKG@$VERSION ..."
+
+          # kcapReleaseCommit is the explicit stamp this same guard's sibling
+          # step writes into published package.json (see "Update package
+          # versions and publish platform packages" / "Publish wrapper
+          # package" below) — the single source of truth for which commit a
+          # given npm version was built from, matching MinVer's own
+          # AssemblyInformationalVersion build-metadata suffix baked into the
+          # binary (both ultimately derive from the same checked-out HEAD /
+          # github.sha for this tag). `npm view` on a field that doesn't
+          # exist on the package exits 0 with empty output (verified), so
+          # this is safe to query even for versions published before the
+          # field existed.
+          set +e
+          published_sha=$(npm view "$PKG@$VERSION" kcapReleaseCommit --registry https://registry.npmjs.org 2>/dev/null)
+          set -e
+
+          # Fallback for versions published before this guard existed:
+          # npm records `gitHead` automatically on every publish run from
+          # inside a git checkout (true for every job in this workflow), so
+          # it already carries the same information for older releases.
+          if [ -z "$published_sha" ]; then
+            set +e
+            published_sha=$(npm view "$PKG@$VERSION" gitHead --registry https://registry.npmjs.org 2>/dev/null)
+            set -e
+          fi
+
+          # Pure pass/fail decision lives in a standalone, unit-tested script
+          # (scripts/verify-release-not-recut.sh + .test.sh) — this step only
+          # does the registry lookup and CI-specific error formatting.
+          set +e
+          verdict=$(bash scripts/verify-release-not-recut.sh "$THIS_SHA" "$published_sha")
+          rc=$?
+          set -e
+
+          if [ "$rc" -eq 0 ]; then
+            echo "No existing $PKG@$VERSION on npm — first-time publish for this version, proceeding."
+            exit 0
+          fi
+
+          echo "::error::$PKG@$VERSION is already published on npm (built from commit $published_sha)."
+          if [ "$verdict" = "republish" ]; then
+            echo "::error::This workflow run is for the SAME commit. npm forbids republishing an existing version even unchanged — if this is a retry of a partially-failed release, cut a NEW version instead of re-running this tag."
+          else
+            echo "::error::This workflow run is building from a DIFFERENT commit ($THIS_SHA)."
+            echo "::error::That means tag ${GITHUB_REF_NAME} has been moved or re-cut after ${PKG}@${VERSION}'s npm artifact was already published from commit $published_sha — the exact failure mode that let a published binary silently diverge from what its tag claimed. Refusing to publish."
+            echo "::error::Cut a NEW version for this commit instead of re-pointing an already-released tag."
+          fi
+          exit 1
+
   build:
-    needs: ci
+    needs: [ci, verify-release-immutable]
     strategy:
       fail-fast: false
       matrix:
@@ -394,6 +478,15 @@ jobs:
 
             cd "$dir"
             npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+            # Stamp the exact commit this tag points to into the published
+            # package metadata, so the artifact self-describes the commit it
+            # was built from — checked by "Refuse a moved or re-cut release
+            # tag" above on every future release of this package. Same
+            # source of truth (github.sha) as the +<sha> build metadata
+            # MinVer bakes into the binary's AssemblyInformationalVersion.
+            npm pkg set kcapReleaseCommit="${{ github.sha }}" kcapReleaseTag="${{ github.ref_name }}"
+
             npm publish --access public --tag "${{ steps.disttag.outputs.TAG }}"
             cd -
           done
@@ -425,6 +518,7 @@ jobs:
             }
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
+          npm pkg set kcapReleaseCommit="${{ github.sha }}" kcapReleaseTag="${{ github.ref_name }}"
           npm publish --access public --tag "${{ steps.disttag.outputs.TAG }}"
 
   github-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,59 @@ jobs:
 
           echo "Checking npm registry for an existing $PKG@$VERSION ..."
 
+          # Queries one `npm view` field for "$PKG@$VERSION", retrying a
+          # couple of times on transient failures. Prints exactly one of:
+          #   FOUND:<value>  npm view exited 0; <value> may be empty if the
+          #                  field itself just isn't set on that published
+          #                  record (this is how versions published before
+          #                  a field existed look — safe to query).
+          #   NOTFOUND       npm gave a definitive "no such package/version"
+          #                  signal (E404) — a real answer, just negative.
+          # and returns 0 for either. On a genuine failure (network,
+          # registry outage, auth error, or anything else that can't be
+          # positively classified) after retries are exhausted, it prints
+          # nothing useful and returns 1 — the caller MUST treat that as
+          # ambiguous and refuse to release, NEVER as "not found". This is
+          # the crux of the guard: an ignored/misread npm error must not be
+          # able to masquerade as "brand-new version, proceed".
+          npm_view_field() {
+            local field="$1" attempts=3 delay=3 i out err rc errfile
+            for ((i = 1; i <= attempts; i++)); do
+              errfile="$(mktemp)"
+              if out=$(npm view "$PKG@$VERSION" "$field" --registry https://registry.npmjs.org 2>"$errfile"); then
+                rc=0
+              else
+                rc=$?
+              fi
+              err="$(cat "$errfile")"
+              rm -f "$errfile"
+
+              if [ "$rc" -eq 0 ]; then
+                echo "FOUND:${out}"
+                return 0
+              fi
+
+              # npm's own "this doesn't exist" signal, across the exit-code
+              # conventions different npm versions use for it (some report
+              # E404 in stderr text even for a plain field-not-found).
+              if printf '%s' "$err" | grep -qiE '(^|[^0-9])E404([^0-9]|$)|404 Not Found'; then
+                echo "NOTFOUND"
+                return 0
+              fi
+
+              echo "npm view '$field' attempt $i/$attempts failed (exit $rc): ${err:-<no output>}" >&2
+              if [ "$i" -lt "$attempts" ]; then
+                sleep "$delay"
+              fi
+            done
+
+            echo "::error::npm view '$field' for $PKG@$VERSION failed after $attempts attempts: ${err:-<no output>}"
+            return 1
+          }
+
+          query_status="ok"
+          published_sha=""
+
           # kcapReleaseCommit is the explicit stamp this same guard's sibling
           # step writes into published package.json (see "Update package
           # versions and publish platform packages" / "Publish wrapper
@@ -72,35 +125,47 @@ jobs:
           # given npm version was built from, matching MinVer's own
           # AssemblyInformationalVersion build-metadata suffix baked into the
           # binary (both ultimately derive from the same checked-out HEAD /
-          # github.sha for this tag). `npm view` on a field that doesn't
-          # exist on the package exits 0 with empty output (verified), so
-          # this is safe to query even for versions published before the
-          # field existed.
-          set +e
-          published_sha=$(npm view "$PKG@$VERSION" kcapReleaseCommit --registry https://registry.npmjs.org 2>/dev/null)
-          set -e
+          # github.sha for this tag).
+          if result=$(npm_view_field kcapReleaseCommit); then
+            if [ "$result" != "NOTFOUND" ]; then
+              published_sha="${result#FOUND:}"
 
-          # Fallback for versions published before this guard existed:
-          # npm records `gitHead` automatically on every publish run from
-          # inside a git checkout (true for every job in this workflow), so
-          # it already carries the same information for older releases.
-          if [ -z "$published_sha" ]; then
-            set +e
-            published_sha=$(npm view "$PKG@$VERSION" gitHead --registry https://registry.npmjs.org 2>/dev/null)
-            set -e
+              # Fallback for versions published before this guard existed:
+              # npm records `gitHead` automatically on every publish run from
+              # inside a git checkout (true for every job in this workflow),
+              # so it already carries the same information for older
+              # releases.
+              if [ -z "$published_sha" ]; then
+                if result=$(npm_view_field gitHead); then
+                  if [ "$result" != "NOTFOUND" ]; then
+                    published_sha="${result#FOUND:}"
+                  fi
+                else
+                  query_status="error"
+                fi
+              fi
+            fi
+          else
+            query_status="error"
           fi
 
           # Pure pass/fail decision lives in a standalone, unit-tested script
           # (scripts/verify-release-not-recut.sh + .test.sh) — this step only
-          # does the registry lookup and CI-specific error formatting.
+          # does the registry lookup, retries, and CI-specific error
+          # formatting.
           set +e
-          verdict=$(bash scripts/verify-release-not-recut.sh "$THIS_SHA" "$published_sha")
+          verdict=$(bash scripts/verify-release-not-recut.sh "$THIS_SHA" "$published_sha" "$query_status")
           rc=$?
           set -e
 
           if [ "$rc" -eq 0 ]; then
             echo "No existing $PKG@$VERSION on npm — first-time publish for this version, proceeding."
             exit 0
+          fi
+
+          if [ "$verdict" = "error" ]; then
+            echo "::error::Could not verify release immutability against npm for $PKG@$VERSION: the registry lookup did not complete successfully after retries. Refusing to publish rather than risk silently letting a moved/re-cut tag through."
+            exit 1
           fi
 
           echo "::error::$PKG@$VERSION is already published on npm (built from commit $published_sha)."

--- a/scripts/verify-release-not-recut.sh
+++ b/scripts/verify-release-not-recut.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Decides whether a release build should proceed, given the commit this
+# build is for and the commit npm already has on record for the exact
+# version being released (empty string if the version has never been
+# published). Pure decision logic only — network/registry lookups and any
+# CI-specific error formatting live in the caller (release.yml).
+#
+# Exit 0 + "ok"        -> version never published, proceed.
+# Exit 1 + "republish" -> already published from the SAME commit: npm
+#                         forbids republishing a version even unchanged.
+# Exit 1 + "moved"     -> already published from a DIFFERENT commit: the
+#                         release tag was moved/re-cut after that version's
+#                         npm artifact was published (the AI-1514 failure
+#                         mode) — refuse.
+set -euo pipefail
+this_sha="${1:?usage: verify-release-not-recut.sh <this-sha> <published-sha-or-empty>}"
+published_sha="${2:-}"
+
+if [ -z "$published_sha" ]; then
+  echo "ok"
+  exit 0
+fi
+
+if [ "$published_sha" = "$this_sha" ]; then
+  echo "republish"
+  exit 1
+fi
+
+echo "moved"
+exit 1

--- a/scripts/verify-release-not-recut.sh
+++ b/scripts/verify-release-not-recut.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Decides whether a release build should proceed, given the commit this
-# build is for and the commit npm already has on record for the exact
+# build is for, the commit npm already has on record for the exact
 # version being released (empty string if the version has never been
-# published). Pure decision logic only — network/registry lookups and any
+# published), and whether that npm lookup itself was trustworthy. Pure
+# decision logic only — network/registry lookups, retries, and any
 # CI-specific error formatting live in the caller (release.yml).
 #
 # Exit 0 + "ok"        -> version never published, proceed.
@@ -12,9 +13,22 @@
 #                         release tag was moved/re-cut after that version's
 #                         npm artifact was published (the AI-1514 failure
 #                         mode) — refuse.
+# Exit 1 + "error"     -> the npm lookup did not complete successfully
+#                         (network/registry/auth error, or anything the
+#                         caller couldn't positively classify as a real
+#                         "not found") — this guard's whole purpose is to
+#                         refuse a moved/re-cut tag, so an inconclusive
+#                         lookup must NEVER be treated as "brand new
+#                         version". Fail closed instead.
 set -euo pipefail
-this_sha="${1:?usage: verify-release-not-recut.sh <this-sha> <published-sha-or-empty>}"
+this_sha="${1:?usage: verify-release-not-recut.sh <this-sha> <published-sha-or-empty> [query-status: ok|error]}"
 published_sha="${2:-}"
+query_status="${3:-ok}"
+
+if [ "$query_status" != "ok" ]; then
+  echo "error"
+  exit 1
+fi
 
 if [ -z "$published_sha" ]; then
   echo "ok"

--- a/scripts/verify-release-not-recut.test.sh
+++ b/scripts/verify-release-not-recut.test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+sh="$here/verify-release-not-recut.sh"
+
+fail=0
+assert() {
+  local this="$1" published="$2" want_out="$3" want_rc="$4"
+  local got rc
+  set +e
+  got="$(bash "$sh" "$this" "$published")"
+  rc=$?
+  set -e
+  if [ "$got" != "$want_out" ] || [ "$rc" != "$want_rc" ]; then
+    echo "FAIL: this='$this' published='$published' -> out='$got' rc=$rc (want out='$want_out' rc=$want_rc)"
+    fail=1
+  fi
+}
+
+# Never published before -> proceed.
+assert "abc1234" ""        "ok"        0
+# Already published from the exact same commit (e.g. a harmless re-run) -> refuse.
+assert "abc1234" "abc1234" "republish" 1
+# Already published from a DIFFERENT commit -> the moved/re-cut-tag case (AI-1514). Refuse.
+assert "abc1234" "def5678" "moved"     1
+# Real-world reproduction: v0.11.5 published from e0b3d233..., tag later moved to 99b820e0.
+assert "99b820e0000000000000000000000000000000" "e0b3d23397fc795117b1a2fccb64e172859ba5a1" "moved" 1
+
+[ "$fail" -eq 0 ] && echo "ok" || exit 1

--- a/scripts/verify-release-not-recut.test.sh
+++ b/scripts/verify-release-not-recut.test.sh
@@ -5,14 +5,14 @@ sh="$here/verify-release-not-recut.sh"
 
 fail=0
 assert() {
-  local this="$1" published="$2" want_out="$3" want_rc="$4"
+  local this="$1" published="$2" want_out="$3" want_rc="$4" query_status="${5:-ok}"
   local got rc
   set +e
-  got="$(bash "$sh" "$this" "$published")"
+  got="$(bash "$sh" "$this" "$published" "$query_status")"
   rc=$?
   set -e
   if [ "$got" != "$want_out" ] || [ "$rc" != "$want_rc" ]; then
-    echo "FAIL: this='$this' published='$published' -> out='$got' rc=$rc (want out='$want_out' rc=$want_rc)"
+    echo "FAIL: this='$this' published='$published' query_status='$query_status' -> out='$got' rc=$rc (want out='$want_out' rc=$want_rc)"
     fail=1
   fi
 }
@@ -25,5 +25,12 @@ assert "abc1234" "abc1234" "republish" 1
 assert "abc1234" "def5678" "moved"     1
 # Real-world reproduction: v0.11.5 published from e0b3d233..., tag later moved to 99b820e0.
 assert "99b820e0000000000000000000000000000000" "e0b3d23397fc795117b1a2fccb64e172859ba5a1" "moved" 1
+# The npm lookup itself errored (network/registry/auth failure, or anything
+# the caller couldn't positively classify as a real "not found") -> the
+# guard's whole purpose is refusing a moved/re-cut tag, so it must fail
+# CLOSED rather than treat the ambiguity as "brand new version". The
+# published-sha argument is irrelevant/ignored here — even an empty one
+# (what a naively-swallowed npm error looks like) must still refuse.
+assert "abc1234" ""        "error"     1 "error"
 
 [ "$fail" -eq 0 ] && echo "ok" || exit 1


### PR DESCRIPTION
The process-guard half of AI-1514 (v0.11.6 itself is already cut + deployed). Prevents a recurrence of the moved-tag / stale-npm-artifact incident (published 0.11.5 was commit `e0b3d233`, but the `v0.11.5` tag was later moved to `99b820e0`, so the installable artifact silently diverged from the tag).

- **Stamp:** `npm pkg set kcapReleaseCommit=<github.sha> kcapReleaseTag=<github.ref_name>` before every publish (platform packages + wrapper); MinVer already bakes the same SHA into `AssemblyInformationalVersion`.
- **Verify:** a standalone fail-fast `verify-release-immutable` job (no `needs` → fails in seconds) refuses to publish if the version already exists on npm, distinguishing same-commit (npm forbids any republish) from different-commit (the moved-tag case); `build`/`publish-npm`/`github-release` all gate on it.
- Decision logic extracted to `scripts/verify-release-not-recut.sh` (+`.test.sh`, 4/4). Ran the guard live against the real npm registry — confirmed 0.11.5 carries `gitHead=e0b3d233`, reproduced the incident (simulated re-cut → correctly refused). actionlint + shellcheck clean.

Follow-up: no `concurrency:` group yet (narrow TOCTOU on two simultaneous release runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)