### PR TITLE
[AI-910][AI-1516] Fix two kcap-cli parallel-load flakes

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
@@ -151,15 +151,18 @@ internal static class ProcessReaper {
     /// signal sent, so a transient Ambiguous keeps polling (never spares here); returns false at window
     /// expiry so the caller retains the record for the next sweep.</summary>
     static async Task<bool> PollForConfirmedDeathAsync(int pid, string expectedIdentity, TimeSpan window, CancellationToken ct) {
-        for (var waited = TimeSpan.Zero; waited < window; waited += TimeSpan.FromMilliseconds(250)) {
+        // Classify, then delay-and-reclassify until the window elapses — the final classify happens
+        // AFTER the last delay (when waited >= window), so a death reflected during that last interval
+        // is still confirmed rather than dropped.
+        for (var waited = TimeSpan.Zero; ; waited += TimeSpan.FromMilliseconds(250)) {
             switch (Classify(pid, expectedIdentity)) {
                 case LeaderState.Dead:     return true;
                 case LeaderState.Recycled: return true;
             }
+
+            if (waited >= window) return false;
             await Task.Delay(250, ct);
         }
-
-        return false;
     }
 
     /// <summary>SIGTERM/SIGKILL the target's process group (Unix; falls back to the bare pid when it

--- a/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
@@ -114,17 +114,12 @@ internal static class ProcessReaper {
 
             SignalGroup(pid, hard: false); // SIGTERM the group (leader is proven ours → group is our lineage)
 
-            // Grace poll. The leader was proven ours immediately above, so a TRANSIENT Ambiguous here is
-            // the death transition — kill(pid,0) still answers for an instant after the process has begun
-            // exiting while /proc/{pid}/stat has already gone, so the start-token read is momentarily
-            // unreadable — NOT a reason to spare. Keep polling for the definitive Dead/Recycled; only
-            // those confirm within the window (see PollForConfirmedDeathAsync).
+            // Poll for a definitive verdict; a transient Ambiguous (a proven-ours leader momentarily
+            // unreadable mid-death-transition) keeps polling instead of sparing — see PollForConfirmedDeathAsync.
             if (await PollForConfirmedDeathAsync(pid, expectedIdentity, GraceBeforeKill, ct)) return true;
 
-            // Grace elapsed without a definitive gone verdict. Re-gate before the hard kill: never SIGKILL
-            // a pid recycled to a foreign process, or one we can no longer prove is ours — ambiguity spares
-            // BEFORE we escalate, so the safety invariant ("only a proven-ours leader is ever signalled")
-            // is unchanged.
+            // Re-gate before the hard kill: never SIGKILL a recycled/unprovable pid — ambiguity still
+            // spares before we escalate, so the safety invariant is unchanged.
             switch (Classify(pid, expectedIdentity)) {
                 case LeaderState.Dead:      return true;
                 case LeaderState.Recycled:  return true;
@@ -133,14 +128,15 @@ internal static class ProcessReaper {
 
             SignalGroup(pid, hard: true); // SIGKILL the group while the leader is still proven ours
 
-            // SIGKILL WILL terminate it; the OS just needs a moment to reflect the death (reap the zombie /
-            // update /proc), which under heavy parallel load can exceed a single tick. Poll the same way
-            // rather than checking once, so a slow-to-reflect kill isn't misreported as still-alive.
-            if (await PollForConfirmedDeathAsync(pid, expectedIdentity, ConfirmAfterKill, ct)) return true;
+            // Poll for the guaranteed kill to be reflected (zombie reaped / pid gone), which under load can
+            // exceed one tick. On Windows the hard signal is a no-op — the soft signal above already
+            // tree-killed and the grace poll gave it the full window — so don't add a second long wait there.
+            var postKillWindow = OperatingSystem.IsWindows() ? TimeSpan.FromMilliseconds(250) : ConfirmAfterKill;
+            if (await PollForConfirmedDeathAsync(pid, expectedIdentity, postKillWindow, ct)) return true;
 
             logger.LogWarning(
                 "ProcessReaper: pid {Pid} (agent {AgentId}) not confirmed gone within {Grace}s+{Kill}s — retained for next sweep",
-                pid, agentId, GraceBeforeKill.TotalSeconds, ConfirmAfterKill.TotalSeconds);
+                pid, agentId, GraceBeforeKill.TotalSeconds, postKillWindow.TotalSeconds);
             return false;
         } catch (OperationCanceledException) {
             return false;
@@ -150,12 +146,10 @@ internal static class ProcessReaper {
         }
     }
 
-    /// <summary>Poll <see cref="Classify"/> every 250ms up to <paramref name="window"/> for a DEFINITIVE
-    /// gone verdict (Dead, or a proven pid-recycle — our process is gone either way). Called ONLY after
-    /// ownership was proven and the kill signal already sent, so a transient Ambiguous (a proven-ours
-    /// leader momentarily unreadable mid-death-transition, or a slow-to-reflect kill under load) is NOT a
-    /// spare — it just keeps polling. Returns false if the window elapses without a definitive verdict, so
-    /// the caller retains the record for the next sweep (never a false confirmed-gone).</summary>
+    /// <summary>Poll <see cref="Classify"/> every 250ms up to <paramref name="window"/> for a definitive
+    /// gone verdict (Dead or a proven pid-recycle). Called only after ownership is proven and the kill
+    /// signal sent, so a transient Ambiguous keeps polling (never spares here); returns false at window
+    /// expiry so the caller retains the record for the next sweep.</summary>
     static async Task<bool> PollForConfirmedDeathAsync(int pid, string expectedIdentity, TimeSpan window, CancellationToken ct) {
         for (var waited = TimeSpan.Zero; waited < window; waited += TimeSpan.FromMilliseconds(250)) {
             switch (Classify(pid, expectedIdentity)) {

--- a/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
@@ -29,7 +29,8 @@ namespace Capacitor.Cli.Daemon.Services;
 /// which kills descendants with the leader at the OS level.</para>
 /// </summary>
 internal static class ProcessReaper {
-    static readonly TimeSpan GraceBeforeKill = TimeSpan.FromSeconds(5);
+    static readonly TimeSpan GraceBeforeKill  = TimeSpan.FromSeconds(5);
+    static readonly TimeSpan ConfirmAfterKill = TimeSpan.FromSeconds(5);
 
     enum LeaderState { Dead, Ours, Recycled, Ambiguous }
 
@@ -113,17 +114,17 @@ internal static class ProcessReaper {
 
             SignalGroup(pid, hard: false); // SIGTERM the group (leader is proven ours → group is our lineage)
 
-            for (var waited = TimeSpan.Zero; waited < GraceBeforeKill; waited += TimeSpan.FromMilliseconds(250)) {
-                switch (Classify(pid, expectedIdentity)) {
-                    case LeaderState.Dead:      return true; // leader (and the group it anchored) gone
-                    case LeaderState.Recycled:  return true;
-                    case LeaderState.Ambiguous: return false;
-                }
-                await Task.Delay(250, ct);
-            }
+            // Grace poll. The leader was proven ours immediately above, so a TRANSIENT Ambiguous here is
+            // the death transition — kill(pid,0) still answers for an instant after the process has begun
+            // exiting while /proc/{pid}/stat has already gone, so the start-token read is momentarily
+            // unreadable — NOT a reason to spare. Keep polling for the definitive Dead/Recycled; only
+            // those confirm within the window (see PollForConfirmedDeathAsync).
+            if (await PollForConfirmedDeathAsync(pid, expectedIdentity, GraceBeforeKill, ct)) return true;
 
-            // Grace elapsed. Re-classify immediately before the hard kill — the pid may have been recycled
-            // during the last wait, and SIGKILL to a recycled group would hit unrelated processes.
+            // Grace elapsed without a definitive gone verdict. Re-gate before the hard kill: never SIGKILL
+            // a pid recycled to a foreign process, or one we can no longer prove is ours — ambiguity spares
+            // BEFORE we escalate, so the safety invariant ("only a proven-ours leader is ever signalled")
+            // is unchanged.
             switch (Classify(pid, expectedIdentity)) {
                 case LeaderState.Dead:      return true;
                 case LeaderState.Recycled:  return true;
@@ -131,22 +132,40 @@ internal static class ProcessReaper {
             }
 
             SignalGroup(pid, hard: true); // SIGKILL the group while the leader is still proven ours
-            await Task.Delay(250, ct);
 
-            switch (Classify(pid, expectedIdentity)) {
-                case LeaderState.Dead:      return true;
-                case LeaderState.Recycled:  return true;
-                case LeaderState.Ambiguous: return false; // became uncomparable → unconfirmed, retain
-                default:
-                    logger.LogWarning("ProcessReaper: pid {Pid} (agent {AgentId}) still alive after SIGKILL — retained for next sweep", pid, agentId);
-                    return false;
-            }
+            // SIGKILL WILL terminate it; the OS just needs a moment to reflect the death (reap the zombie /
+            // update /proc), which under heavy parallel load can exceed a single tick. Poll the same way
+            // rather than checking once, so a slow-to-reflect kill isn't misreported as still-alive.
+            if (await PollForConfirmedDeathAsync(pid, expectedIdentity, ConfirmAfterKill, ct)) return true;
+
+            logger.LogWarning(
+                "ProcessReaper: pid {Pid} (agent {AgentId}) not confirmed gone within {Grace}s+{Kill}s — retained for next sweep",
+                pid, agentId, GraceBeforeKill.TotalSeconds, ConfirmAfterKill.TotalSeconds);
+            return false;
         } catch (OperationCanceledException) {
             return false;
         } catch (Exception ex) {
             logger.LogWarning(ex, "ProcessReaper: kill of pid {Pid} (agent {AgentId}) failed", pid, agentId);
             return false;
         }
+    }
+
+    /// <summary>Poll <see cref="Classify"/> every 250ms up to <paramref name="window"/> for a DEFINITIVE
+    /// gone verdict (Dead, or a proven pid-recycle — our process is gone either way). Called ONLY after
+    /// ownership was proven and the kill signal already sent, so a transient Ambiguous (a proven-ours
+    /// leader momentarily unreadable mid-death-transition, or a slow-to-reflect kill under load) is NOT a
+    /// spare — it just keeps polling. Returns false if the window elapses without a definitive verdict, so
+    /// the caller retains the record for the next sweep (never a false confirmed-gone).</summary>
+    static async Task<bool> PollForConfirmedDeathAsync(int pid, string expectedIdentity, TimeSpan window, CancellationToken ct) {
+        for (var waited = TimeSpan.Zero; waited < window; waited += TimeSpan.FromMilliseconds(250)) {
+            switch (Classify(pid, expectedIdentity)) {
+                case LeaderState.Dead:     return true;
+                case LeaderState.Recycled: return true;
+            }
+            await Task.Delay(250, ct);
+        }
+
+        return false;
     }
 
     /// <summary>SIGTERM/SIGKILL the target's process group (Unix; falls back to the bare pid when it

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -24,23 +24,27 @@ public static class ClaudeHookCommand {
     // send the POST; the server's StopAndDrain + the "kcap import" hint recover the rest.
     static readonly TimeSpan PreHookDrainCap = TimeSpan.FromSeconds(8);
 
-    public static Task<int> Handle(string baseUrl, TextReader stdin, Task? updateCheckTask = null, long processStart = 0) {
+    public static Task<int> Handle(string baseUrl, TextReader stdin, Task? updateCheckTask = null, long processStart = 0,
+            TextWriter? stdout = null) {
         var spool = new HookSpool(PathHelpers.ConfigPath("spool"));
         spool.ReapOlderThan(TimeSpan.FromDays(30));
         var ps = processStart == 0 ? Stopwatch.GetTimestamp() : processStart;
-        return HandleWithDeps(spool, ps, baseUrl, stdin, updateCheckTask);
+        return HandleWithDeps(spool, ps, baseUrl, stdin, updateCheckTask, stdout);
     }
 
-    static Task<int> HandleWithDeps(HookSpool spool, long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask)
+    static Task<int> HandleWithDeps(HookSpool spool, long processStart, string baseUrl, TextReader stdin,
+            Task? updateCheckTask, TextWriter? stdout = null)
         => HandleWithDeps(spool, processStart, baseUrl, stdin, updateCheckTask,
             () => HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl),
             async (forceRefresh, ct) => (await HttpClientExtensions.CreateClientWithAuthStatusAsync(
-                baseUrl, ct, allowAutoRedirect: false, forceRefresh: forceRefresh)).Client);
+                baseUrl, ct, allowAutoRedirect: false, forceRefresh: forceRefresh)).Client,
+            stdout);
 
     internal static async Task<int> HandleWithDeps(
             HookSpool spool, long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask,
             Func<Task<(HttpClient Client, AuthStatus Status)>> clientFactory,
-            Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory = null) {
+            Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
+            TextWriter? stdout = null) {
         string body;
         try { body = await stdin.ReadToEndAsync(); } catch { return 0; }
 
@@ -87,7 +91,7 @@ public static class ClaudeHookCommand {
         var (client, authStatus) = created.Value;
         try {
             return await HandleCore(client, authStatus, spool, processStart, baseUrl, new StringReader(body),
-                updateCheckTask, memoryClientFactory);
+                updateCheckTask, memoryClientFactory, stdout: stdout);
         } catch (Exception ex) {
             await Console.Error.WriteLineAsync($"[kcap] claude hook failed (fail-open): {ex.Message}");
             return 0;
@@ -178,7 +182,13 @@ public static class ClaudeHookCommand {
     internal static async Task<int> HandleCore(HttpClient client, AuthStatus authStatus, HookSpool spool,
         long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask = null,
         Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
-        Func<SessionStartMemoryLeaseStore>? memoryStoreFactory = null) {
+        Func<SessionStartMemoryLeaseStore>? memoryStoreFactory = null,
+        TextWriter? stdout = null) {
+        // Hook stdout (the SessionStart hookSpecificOutput envelope / systemMessage nudge) goes to the
+        // injected writer when provided, else the process Console. Injecting a writer lets tests capture
+        // it WITHOUT redirecting the process-global Console.Out — so a concurrently-running test writing
+        // to Console can't leak into the capture (the flake this fixes).
+        var writer = stdout ?? Console.Out;
         var body = await stdin.ReadToEndAsync();
 
         var eventName = ExtractEventName(body);
@@ -304,7 +314,7 @@ public static class ClaudeHookCommand {
                         ? "[kcap] Authentication expired — session recording is paused. Run 'kcap login' to resume."
                         : "[kcap] Not authenticated — session recording is off. Run 'kcap login' to start recording."
                 };
-                Console.WriteLine(notice.ToJsonString());
+                writer.WriteLine(notice.ToJsonString());
             }
             return 0;
         }
@@ -575,7 +585,7 @@ public static class ClaudeHookCommand {
                     var envelope = SessionStartAdditionalContext.BuildEnvelope(lessonsFragment, nudgeFragment, memoryFragment);
 
                     if (envelope is not null) {
-                        Console.WriteLine(envelope);
+                        writer.WriteLine(envelope);
                     }
                 } catch {
                     // Best effort — never break session capture for hook output emission.

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -252,7 +252,7 @@ public static class ClaudeHookCommand {
             var permProfile = await AppConfig.GetActiveProfileAsync();
             var selfHeal    = !await IsSessionExcludedAsync(permProfile, body, processStart, command);
 
-            return await PermissionRequestCommand.Handle(baseUrl, body, selfHeal);
+            return await PermissionRequestCommand.Handle(baseUrl, body, selfHeal, stdout);
         }
 
         // On session-start, clear the last-emitted repo cache so this session always gets a

--- a/src/Capacitor.Cli/Commands/PermissionRequestCommand.cs
+++ b/src/Capacitor.Cli/Commands/PermissionRequestCommand.cs
@@ -13,7 +13,7 @@ static class PermissionRequestCommand {
     // selfHealWatcher is false when the caller determined the session is excluded
     // (excluded_repos/excluded_paths): we still handle the permission decision, but must NOT
     // spawn a transcript-uploading watcher for a project the user opted out of recording.
-    public static async Task<int> Handle(string baseUrl, string? body, bool selfHealWatcher = true) {
+    public static async Task<int> Handle(string baseUrl, string? body, bool selfHealWatcher = true, TextWriter? stdout = null) {
         body ??= await Console.In.ReadToEndAsync();
 
         JsonNode? node;
@@ -49,14 +49,14 @@ static class PermissionRequestCommand {
         var isRenderedAgent = Environment.GetEnvironmentVariable("KCAP_RENDERED_AGENT") is "1";
 
         if (isRenderedAgent) {
-            return await HandleRenderedAgent(baseUrl, node, sessionId);
+            return await HandleRenderedAgent(baseUrl, node, sessionId, stdout);
         }
 
         // Non-rendered agent: record the permission event and return immediately
         return await HandleRecordOnly(baseUrl, node, sessionId);
     }
 
-    static async Task<int> HandleRenderedAgent(string baseUrl, JsonNode node, string sessionId) {
+    static async Task<int> HandleRenderedAgent(string baseUrl, JsonNode node, string sessionId, TextWriter? stdout = null) {
         var toolName    = node["tool_name"]?.GetValue<string>() ?? "Unknown";
         var toolInput   = node["tool_input"];
         var suggestions = node["permission_suggestions"];
@@ -78,10 +78,10 @@ static class PermissionRequestCommand {
         // auth, so an accidentally / maliciously set non-loopback value would leak the
         // hook payload (tool name, raw tool input) to an arbitrary endpoint.
         if (TryGetLoopbackDaemonUrl(out var daemonUrl)) {
-            return await PostAsync(daemonUrl + "/claude/permission-request", payload, authenticated: false);
+            return await PostAsync(daemonUrl + "/claude/permission-request", payload, authenticated: false, stdout);
         }
 
-        return await PostAsync(baseUrl + "/hooks/permission-request", payload, authenticated: true);
+        return await PostAsync(baseUrl + "/hooks/permission-request", payload, authenticated: true, stdout);
     }
 
     /// <summary>
@@ -131,7 +131,7 @@ static class PermissionRequestCommand {
         return false;
     }
 
-    static async Task<int> PostAsync(string url, JsonObject payload, bool authenticated) {
+    static async Task<int> PostAsync(string url, JsonObject payload, bool authenticated, TextWriter? stdout = null) {
         using var client = authenticated
             ? await HttpClientExtensions.CreateAuthenticatedClientAsync()
             : new HttpClient();
@@ -153,7 +153,7 @@ static class PermissionRequestCommand {
             }
 
             var responseBody = await response.Content.ReadAsStringAsync();
-            Console.Write(responseBody);
+            (stdout ?? Console.Out).Write(responseBody);
 
             return 0;
         } catch (TaskCanceledException) {

--- a/test/Capacitor.Cli.Tests.Integration/ClaudeHookStdoutTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/ClaudeHookStdoutTests.cs
@@ -12,19 +12,12 @@ namespace Capacitor.Cli.Tests.Integration;
 /// envelope shape — including the single-envelope invariant when both
 /// <c>top_clusters</c> and <c>version</c> are present.
 ///
-/// Stdout is captured by passing an explicit <see cref="TextWriter"/> to
-/// <c>Handle</c> (its <c>stdout</c> parameter) instead of redirecting the
-/// process-global <c>Console.Out</c>. The capture is private to each test, so a
-/// concurrently-running test whose SUT writes to <c>Console.Out</c> (e.g.
-/// <c>CodexHookCommand</c> emitting <c>{"continue":true}</c>) can't leak into it
-/// — the contamination flake this removes (a keyed <c>[NotInParallel]</c>
-/// couldn't, since a differently-keyed test still ran concurrently).
-///
-/// The tests stay <c>[NotInParallel]</c>: they still exercise process-global
-/// state (the <c>KCAP_CONFIG_DIR</c> config + the in-process auth-provider
-/// discovery cache) and real hook HTTP timing that isn't parallel-safe. The
-/// injected writer is the durable fix for the capture-contamination class —
-/// it holds even if the serialization is ever relaxed.
+/// Stdout is captured via an explicit <see cref="TextWriter"/> passed to
+/// <c>Handle</c> (its <c>stdout</c> parameter), not by redirecting the global
+/// <c>Console.Out</c> — so another concurrently-running test's <c>Console.Out</c>
+/// write can't leak into the capture. The tests stay <c>[NotInParallel]</c>
+/// because they still touch process-global config/auth-cache and real hook HTTP
+/// timing; the injected writer is the durable fix for the contamination class.
 ///
 /// Test payloads deliberately OMIT <c>transcript_path</c> so the session-start
 /// path short-circuits before <c>WatcherManager.EnsureWatcherRunning</c>;

--- a/test/Capacitor.Cli.Tests.Integration/ClaudeHookStdoutTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/ClaudeHookStdoutTests.cs
@@ -8,30 +8,33 @@ namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
 /// Exercises <see cref="ClaudeHookCommand.Handle"/> end-to-end against a
-/// WireMock server and captures stdout to validate the SessionStart
-/// <c>hookSpecificOutput</c> envelope shape — including the
-/// single-envelope invariant when both <c>top_clusters</c> and
-/// <c>version</c> are present.
+/// WireMock server and validates the SessionStart <c>hookSpecificOutput</c>
+/// envelope shape — including the single-envelope invariant when both
+/// <c>top_clusters</c> and <c>version</c> are present.
 ///
-/// Test payloads deliberately OMIT <c>transcript_path</c> so the
-/// session-start path short-circuits before
-/// <c>WatcherManager.EnsureWatcherRunning</c>; spawning the watcher's
-/// child process corrupts TUnit's <c>Console</c> capture (see
-/// <c>test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs:47-53</c>).
+/// Stdout is captured by passing an explicit <see cref="TextWriter"/> to
+/// <c>Handle</c> (its <c>stdout</c> parameter) instead of redirecting the
+/// process-global <c>Console.Out</c>. The capture is private to each test, so a
+/// concurrently-running test whose SUT writes to <c>Console.Out</c> (e.g.
+/// <c>CodexHookCommand</c> emitting <c>{"continue":true}</c>) can't leak into it
+/// — the contamination flake this removes (a keyed <c>[NotInParallel]</c>
+/// couldn't, since a differently-keyed test still ran concurrently).
 ///
-/// Config isolation is provided by <see cref="IntegrationGlobalSetup"/>,
-/// which points <c>KCAP_CONFIG_DIR</c> at a fresh temp directory before
-/// any test code touches <c>PathHelpers</c>. Without it, a developer-side
-/// <c>excluded_paths</c> entry covering the test <c>cwd</c> would silently
-/// short-circuit <c>ClaudeHookCommand</c> and make these tests pass for
-/// the wrong reason.
+/// The tests stay <c>[NotInParallel]</c>: they still exercise process-global
+/// state (the <c>KCAP_CONFIG_DIR</c> config + the in-process auth-provider
+/// discovery cache) and real hook HTTP timing that isn't parallel-safe. The
+/// injected writer is the durable fix for the capture-contamination class —
+/// it holds even if the serialization is ever relaxed.
 ///
-/// Each test is <c>[NotInParallel]</c> with NO group key — i.e. globally
-/// sequential — because it redirects the process-global <c>Console.Out</c>.
-/// A group key is insufficient: another file's test whose SUT writes to
-/// <c>Console.Out</c> (e.g. <c>CodexHookCommand</c> emitting
-/// <c>{"continue":true}</c>) can run under a DIFFERENT key and leak into the
-/// capture. Do not re-add a group key here.
+/// Test payloads deliberately OMIT <c>transcript_path</c> so the session-start
+/// path short-circuits before <c>WatcherManager.EnsureWatcherRunning</c>;
+/// spawning the watcher's child process would still corrupt capture.
+///
+/// Config isolation is provided by <see cref="IntegrationGlobalSetup"/>, which
+/// points <c>KCAP_CONFIG_DIR</c> at a fresh temp directory before any test code
+/// touches <c>PathHelpers</c>. Without it, a developer-side <c>excluded_paths</c>
+/// entry covering the test <c>cwd</c> would silently short-circuit
+/// <c>ClaudeHookCommand</c> and make these tests pass for the wrong reason.
 /// </summary>
 public class ClaudeHookStdoutTests : IDisposable {
     readonly WireMockServer _server = WireMockServer.Start();
@@ -49,16 +52,13 @@ public class ClaudeHookStdoutTests : IDisposable {
         }
         """;
 
-    static async Task<string> CaptureStdoutAsync(Func<Task> action) {
-        var original = Console.Out;
-        var sw       = new StringWriter();
-        Console.SetOut(sw);
-        try {
-            await action();
-        } finally {
-            Console.SetOut(original);
-        }
-        return sw.ToString();
+    // Capture hook stdout via the injected writer — no Console.SetOut, so nothing another
+    // concurrently-running test writes to Console can contaminate it.
+    async Task<string> RunSessionStartAsync() {
+        var stdout = new StringWriter();
+        await ClaudeHookCommand.Handle(
+            _server.Url!, new StringReader(SessionStartPayloadWithoutTranscriptPath()), stdout: stdout);
+        return stdout.ToString();
     }
 
     [Test, NotInParallel]
@@ -71,9 +71,7 @@ public class ClaudeHookStdoutTests : IDisposable {
                     .WithBody("""{ "version": "999.0.0" }""")
             );
 
-        var stdout = await CaptureStdoutAsync(() =>
-            ClaudeHookCommand.Handle(_server.Url!, new StringReader(SessionStartPayloadWithoutTranscriptPath()))
-        );
+        var stdout = await RunSessionStartAsync();
 
         var trimmed = stdout.Trim();
         await Assert.That(trimmed).IsNotEmpty();
@@ -106,9 +104,7 @@ public class ClaudeHookStdoutTests : IDisposable {
                     )
             );
 
-        var stdout = await CaptureStdoutAsync(() =>
-            ClaudeHookCommand.Handle(_server.Url!, new StringReader(SessionStartPayloadWithoutTranscriptPath()))
-        );
+        var stdout = await RunSessionStartAsync();
 
         var trimmed = stdout.Trim();
 
@@ -132,9 +128,7 @@ public class ClaudeHookStdoutTests : IDisposable {
         _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
 
-        var stdout = await CaptureStdoutAsync(() =>
-            ClaudeHookCommand.Handle(_server.Url!, new StringReader(SessionStartPayloadWithoutTranscriptPath()))
-        );
+        var stdout = await RunSessionStartAsync();
 
         await Assert.That(stdout.Trim()).IsEqualTo("");
     }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/StopAgentPidFallbackTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/StopAgentPidFallbackTests.cs
@@ -26,20 +26,25 @@ public partial class AgentOrchestratorVendorTests {
 
         await orch.HandleStopAgent("ghost");
 
-        // The record-pass reap kills once ownership is provable: Linux confirms via the KCAP_AGENT_ID
-        // env, Windows has no Unix env guard so an exact (pid, start-identity) match is sufficient. Only
-        // macOS 26 spares — its env is redacted, so the (Unix) env guard can't confirm and ambiguity
-        // never kills.
         if (!OperatingSystem.IsMacOS()) {
-            // Linux / Windows → reaped by identity, record deleted on confirmed death.
+            // Linux / Windows → ownership is provable (Linux confirms via the KCAP_AGENT_ID env,
+            // Windows via an exact (pid, start-identity) match), so the record-pass reap kills by
+            // identity and deletes the record on CONFIRMED death.
             dummy.WaitForExit(TimeSpan.FromSeconds(10));
             await Assert.That(dummy.HasExited).IsTrue();
             await Assert.That(orch.PidRecordsForTest().Any(r => r.AgentId == "ghost")).IsFalse();
         } else {
-            // macOS: env unreadable → SPARED; process still alive, record retained for a later sweep.
-            await Assert.That(dummy.HasExited).IsFalse();
-            await Assert.That(orch.PidRecordsForTest().Any(r => r.AgentId == "ghost")).IsTrue();
-            dummy.Kill();
+            // macOS → whether the reap can PROVE ownership depends on the OS version's start-identity
+            // readability: older macOS redacts another process's identity (Ambiguous → spared, record
+            // retained), macOS 26+ can read it (Ours → reaped by identity, deleted on confirmed death,
+            // converging with Linux/Windows). Accept either outcome, but assert the real invariant —
+            // the record is deleted IFF the process was confirmed gone. (This is what the fix restores:
+            // the reaper must not report a still-alive-then-killed process as unconfirmed and strand its
+            // record — deleted-vs-retained must track the process's actual fate.)
+            dummy.WaitForExit(TimeSpan.FromSeconds(10));
+            var retained = orch.PidRecordsForTest().Any(r => r.AgentId == "ghost");
+            await Assert.That(retained).IsEqualTo(!dummy.HasExited);
+            if (!dummy.HasExited) dummy.Kill();
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/StopAgentPidFallbackTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/StopAgentPidFallbackTests.cs
@@ -34,13 +34,9 @@ public partial class AgentOrchestratorVendorTests {
             await Assert.That(dummy.HasExited).IsTrue();
             await Assert.That(orch.PidRecordsForTest().Any(r => r.AgentId == "ghost")).IsFalse();
         } else {
-            // macOS → whether the reap can PROVE ownership depends on the OS version's start-identity
-            // readability: older macOS redacts another process's identity (Ambiguous → spared, record
-            // retained), macOS 26+ can read it (Ours → reaped by identity, deleted on confirmed death,
-            // converging with Linux/Windows). Accept either outcome, but assert the real invariant —
-            // the record is deleted IFF the process was confirmed gone. (This is what the fix restores:
-            // the reaper must not report a still-alive-then-killed process as unconfirmed and strand its
-            // record — deleted-vs-retained must track the process's actual fate.)
+            // macOS → the outcome depends on this OS version's start-identity readability (older macOS
+            // redacts it → spared/retained; macOS 26+ reads it → reaped/deleted), so accept either but
+            // assert the real invariant: the record is deleted IFF the process was confirmed gone.
             dummy.WaitForExit(TimeSpan.FromSeconds(10));
             var retained = orch.PidRecordsForTest().Any(r => r.AgentId == "ghost");
             await Assert.That(retained).IsEqualTo(!dummy.HasExited);

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/StopAgentPidFallbackTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/StopAgentPidFallbackTests.cs
@@ -6,9 +6,11 @@ namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
 /// Phase B (D4 §6.4(3)): <c>HandleStopAgent</c> for an id not in the registry falls back to the
-/// PID record and reaps a matching live process by exact identity. OS-aware: Linux confirms the
-/// <c>KCAP_AGENT_ID</c> env and reaps; macOS 26 can't read the env, so it SPARES (ambiguity never
-/// kills). Partial of <see cref="AgentOrchestratorVendorTests"/> to call the private HandleStopAgent.
+/// PID record and reaps a matching live process by exact identity. OS-aware: Linux/Windows can prove
+/// ownership (Linux via the <c>KCAP_AGENT_ID</c> env) and reap; on macOS the outcome depends on the OS
+/// version's start-identity readability (redacted → spared, readable → reaped), so the test asserts the
+/// record is deleted iff the process was confirmed gone. Partial of
+/// <see cref="AgentOrchestratorVendorTests"/> to call the private HandleStopAgent.
 /// </summary>
 public partial class AgentOrchestratorVendorTests {
     [Test]


### PR DESCRIPTION
Fixes two kcap-cli test flakes. Linear: [AI-910](https://linear.app/kurrent/issue/AI-910), [AI-1516](https://linear.app/kurrent/issue/AI-1516).

## AI-910 — `ClaudeHookStdoutTests` stdout-capture contamination

The three tests captured hook stdout by redirecting the **process-global `Console.Out`** to a `StringWriter`. A concurrently-running test whose SUT writes to `Console.Out` (e.g. `CodexHookCommand` emitting `{"continue":true}`) leaked a second JSON object into the capture → `JsonReaderException: '{' is invalid after a single JSON value`.

**Fix (issue's preferred option 1):** thread an optional `TextWriter? stdout` through `ClaudeHookCommand.Handle → HandleWithDeps → HandleCore` (default `Console.Out`). The SessionStart `hookSpecificOutput` envelope and the auth-lapsed `systemMessage` nudge now write to that writer. Each test passes its own `StringWriter` — no `Console.SetOut`, so nothing another test writes to `Console` can contaminate it. This is the durable fix for the class (a keyed `[NotInParallel]` couldn't prevent it; the writer does, regardless of scheduling).

`[NotInParallel]` is **kept**: the injection ends the contamination flake, but these tests still exercise process-global state (`KCAP_CONFIG_DIR` config + the in-process auth-provider cache) and real hook HTTP timing. (Verified that fully parallelizing them exposes an *unrelated* empty-envelope flake under load — out of scope.)

## AI-1516 — `HandleStopAgent` reap-by-pid-record confirmation race

Surfaced on PR #360's first ubuntu run: `HandleStopAgent_unknown_id_reaps_by_pid_record_where_env_is_readable` intermittently failed with the PID record still present after the process had exited.

**Root cause:** `ProcessReaper.KillConfirmAsync`'s `Classify` reads `IsAlive` (`kill(0)`) then the start token (`/proc/{pid}/stat`). A SIGTERM'd, proven-ours process in its death transition reads `alive=true` but its token momentarily unreadable → `Ambiguous`. The grace loop returned false on that transient `Ambiguous`, so the reaper reported *unconfirmed* even though the process was (about to be) dead → the record was stranded (`ReapByRecordAsync` deletes only on confirmed-gone). The single fixed 250ms post-SIGKILL check had the same fragility under OS-reflection lag.

**Fix:** both confirmation waits (grace + post-SIGKILL) poll via a shared `PollForConfirmedDeathAsync` for a *definitive* `Dead`/`Recycled`, treating a transient `Ambiguous` as **keep polling** (we've already proven ownership and signalled). The pre-signal and pre-SIGKILL **gates** still spare on `Ambiguous` — the safety invariant is unchanged: only a proven-ours leader is ever signalled, and a persistently-ambiguous target is still retained for the next sweep.

**Test correction (see the Linear comment).** The test's macOS branch asserted "always spares (`HasExited == false`)", but tracing showed that's a **race**, not a real spare: on macOS 26.5.2 `Classify = Ours` (identity is readable) so the reaper *does* SIGTERM the dummy — the old code only "passed" by returning on the first transient `Ambiguous` **before the SIGTERM landed**, leaving the process dead-but-record-retained (the exact bug). The macOS branch now asserts the real invariant — **record deleted IFF the process was confirmed gone** — making it a true regression guard (fails on the pre-fix dead-but-retained state, passes on the fix) and robust across macOS versions.

## Verification (local, macOS 26.5.2)
- `ClaudeHookStdoutTests` 3/3; full `Capacitor.Cli.Tests.Integration` **144/144**; `ClaudeHookCommandTests` 35/35; `SpoolOutageRecoveryTests` 2/2.
- Reaper test 4/4; `AgentOrchestratorVendorTests` **84/84**; `OrphanReaperTests` 9/9.
- Build clean; `check-linear-ids.sh` passes.
- The Linux reap+confirm path (the CI flake) is validated by the ubuntu CI leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)