### PR TITLE
[AI-1517] Generalize reviewer session-id locator to codex + real codex MCP isolation

### DIFF
--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -296,12 +296,15 @@ public static class CodexConfigToml {
     /// <summary>
     /// Reads the top-level <c>[mcp_servers]</c> table keys from <c>~/.codex/config.toml</c>
     /// (or <paramref name="configPath"/>), honouring <c>CODEX_HOME</c> via
-    /// <see cref="CodexPaths.Home"/>. These are the MCP servers a spawned Codex session would
-    /// otherwise inherit — a review-flow reviewer disables each one so only the explicitly
-    /// injected servers load (Codex 0.144.3 has no <c>--strict-mcp-config</c> analog, and a
-    /// bare <c>-c mcp_servers={}</c> is a no-op because <c>-c</c> overrides deep-merge). Returns
-    /// an empty, ordinal-sorted list when the file is missing, unreadable, or has no
-    /// <c>[mcp_servers]</c> table. Read-only; never throws.
+    /// <see cref="CodexPaths.Home"/>. Returns an empty, ordinal-sorted list when the file is
+    /// missing, unreadable, or has no <c>[mcp_servers]</c> table. Read-only; never throws.
+    ///
+    /// NOTE: this reports ONLY config.toml-declared servers. It is NOT the authoritative
+    /// enumeration of what a spawned Codex session inherits — Codex 0.144.3 also composes MCP
+    /// servers from active native plugins, which this misses. The review-flow reviewer isolation
+    /// therefore enumerates via <c>codex mcp list --json</c>
+    /// (<c>Capacitor.Cli.Daemon.Services.CodexMcpInventory</c>), which reports the fully-composed
+    /// effective list (config + plugins).
     /// </summary>
     public static IReadOnlyList<string> ReadMcpServerNames(string? configPath = null) {
         var path = configPath ?? DefaultConfigPath;

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -294,6 +294,36 @@ public static class CodexConfigToml {
     }
 
     /// <summary>
+    /// Reads the top-level <c>[mcp_servers]</c> table keys from <c>~/.codex/config.toml</c>
+    /// (or <paramref name="configPath"/>), honouring <c>CODEX_HOME</c> via
+    /// <see cref="CodexPaths.Home"/>. These are the MCP servers a spawned Codex session would
+    /// otherwise inherit — a review-flow reviewer disables each one so only the explicitly
+    /// injected servers load (Codex 0.144.3 has no <c>--strict-mcp-config</c> analog, and a
+    /// bare <c>-c mcp_servers={}</c> is a no-op because <c>-c</c> overrides deep-merge). Returns
+    /// an empty, ordinal-sorted list when the file is missing, unreadable, or has no
+    /// <c>[mcp_servers]</c> table. Read-only; never throws.
+    /// </summary>
+    public static IReadOnlyList<string> ReadMcpServerNames(string? configPath = null) {
+        var path = configPath ?? DefaultConfigPath;
+
+        if (!File.Exists(path)) return [];
+
+        try {
+            var root = TomlSerializer.Deserialize(File.ReadAllText(path), _tomlTypeInfo.TableInfo);
+
+            if (root is null || !root.TryGetValue("mcp_servers", out var v) || v is not TomlTable servers)
+                return [];
+
+            var names = servers.Keys.ToList();
+            names.Sort(StringComparer.Ordinal);
+
+            return names;
+        } catch {
+            return [];
+        }
+    }
+
+    /// <summary>
     /// Builds the Codex proxy allowlist from a set of Capacitor server URLs (the
     /// active one plus every configured profile). Any host under <c>kcap.ai</c>
     /// collapses to a single <c>**.kcap.ai</c> wildcard — it matches the apex and

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1054,7 +1054,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             try {
                 start = await runtimeFactory.StartAsync(runtimeCtx, _shutdownCts.Token);
-            } catch (CodexHooksNotInstalledException ex) {
+            } catch (Exception ex) when (ex is CodexHooksNotInstalledException or CodexReviewerMcpIsolationException) {
+                // CodexHooksNotInstalledException: hooks preflight failed in Prepare.
+                // CodexReviewerMcpIsolationException: the review-flow reviewer's inherited MCP
+                // servers could not be authoritatively enumerated, so the recursion guard cannot be
+                // proven — fail the launch CLOSED rather than spawn a reviewer that might inherit a
+                // flow-starting server. Both map to the same cleanup path.
                 await _server.LaunchFailedAsync(agentId, ex.Message);
 
                 // No AgentInstance was created, so CleanupAgentAsync won't run — revoke the reviewer

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1048,7 +1048,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             HostedRuntimeStart start;
 
             // Captured BEFORE the spawn so the transcript-based session-id fallback
-            // (DetectClaudeSessionIdAsync) can filter the shared project dir to files
+            // (DetectSessionIdAsync) can filter the shared project/rollout dir to files
             // written by THIS agent's process, not the user's earlier sessions.
             var spawnedAtUtc = DateTime.UtcNow;
 
@@ -1136,17 +1136,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // Start reading output
             _ = ReadAgentOutputAsync(agent);
 
-            // Fallback session-id discovery: the primary link (the spawned Claude's
+            // Fallback session-id discovery: the primary link (the spawned harness's
             // session-start hook POSTing agent_host_id to /hooks/session-start) silently
-            // breaks when the hook can't authenticate (e.g. expired kcap token → 401),
-            // leaving the agent's web chat stuck on "Waiting for session to start..."
-            // forever while the terminal works. The daemon can discover the session id
-            // itself from the transcript file Claude writes and report it over its own
-            // authenticated connection. Claude-vendor only — other vendors have different
-            // transcript layouts. Best-effort background task, cancelled with the agent.
-            if (string.Equals(cmd.Vendor, "claude", StringComparison.OrdinalIgnoreCase)) {
-                _ = DetectClaudeSessionIdAsync(agent, spawnedAtUtc);
-            }
+            // breaks when the hook can't authenticate (e.g. expired kcap token → 401) or
+            // doesn't land in time (an unattended/borrowed reviewer), leaving the agent
+            // without a session id for correlation/display. The daemon can discover the id
+            // itself from the transcript/rollout the harness writes and report it over its
+            // own authenticated connection. Vendor-dispatched — Claude reads its per-worktree
+            // project transcript, Codex reads its ~/.codex/sessions rollout; vendors without a
+            // daemon-side locator no-op (the hook stays their only source). Best-effort
+            // background task, cancelled with the agent — the server converges incarnations on
+            // daemon liveness, so a missing id never blocks a launch.
+            _ = DetectSessionIdAsync(agent, cmd.Vendor, spawnedAtUtc);
 
             // Report the resolved model so the server can display the real model the agent
             // is running (the dispatched `model` may be the "default" no-override sentinel,
@@ -1336,7 +1337,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
                 // Consent/trust dialogs are a PRE-SESSION concern: they render once at startup, before
                 // any session exists. Once the session is live (SessionId resolved from the transcript
-                // by DetectClaudeSessionIdAsync) the dialog phase is over — stop scanning so ordinary
+                // by DetectSessionIdAsync) the dialog phase is over — stop scanning so ordinary
                 // reviewer/tool output that merely quotes a banner phrase (e.g. a reviewer reading the
                 // detector's own source) can't latch a false wedge and kill a healthy reviewer.
                 if (dialogDetector is not null) {
@@ -1425,7 +1426,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // has already exited) — actively terminate it so it can't hold a daemon slot.
         try { await agent.Runtime.TerminateAsync(TimeSpan.FromSeconds(5)); } catch (Exception ex) { LogStopError(ex, agent.Id); }
 
-        // Cancel the read loop's token so the fallback session-id poll (DetectClaudeSessionIdAsync)
+        // Cancel the read loop's token so the fallback session-id poll (DetectSessionIdAsync)
         // stops too; the loop itself exits via the `return` at the call site.
         try { await agent.ReadCts.CancelAsync(); } catch { /* best-effort */ }
     }
@@ -2227,31 +2228,52 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     static readonly TimeSpan SessionIdPollTimeout  = TimeSpan.FromMinutes(3);
 
     /// <summary>
-    /// Background fallback that discovers the spawned Claude's session id from its transcript
-    /// file and reports it to the server, for when the session-start hook (the primary source
-    /// of the agent↔session link) fails — e.g. an expired kcap token means every /hooks POST
-    /// 401s, and the server would otherwise never learn the session id (its recovery path reads
-    /// an AgentRun heartbeat that only the same hook handler writes).
+    /// Vendor-dispatched, best-effort background fallback that discovers a spawned agent's
+    /// session id from the transcript/rollout its harness writes and reports it to the server,
+    /// for when the session-start hook (the primary source of the agent↔session link) fails or
+    /// doesn't land in time — e.g. an expired kcap token 401s every /hooks POST, or an
+    /// unattended/borrowed reviewer completes before the hook correlates. The server no longer
+    /// gates incarnation completion on this id (it converges on daemon liveness), so this only
+    /// resolves the id lazily for correlation/display and never blocks a launch.
     ///
-    /// Polls the Claude project dir for the agent's worktree (symlinked to the SOURCE repo's
-    /// project dir, so it's shared with the user's own sessions — see
-    /// <see cref="SessionTranscriptLocator"/> for how candidates are disambiguated by cwd).
-    /// On a match it sets <see cref="AgentInstance.SessionId"/> and best-effort reports via
-    /// AgentStatusChanged (live registry link) AND an <see cref="AgentRunHeartbeat"/> (so the
-    /// server's restart-recovery FindAgentSessionIdAsync path works too). Once SessionId is
-    /// set, the regular 30 s heartbeat loop and reconnect re-registration keep re-sending it,
-    /// so a transient report failure here self-heals. Stops when the id is known by other
-    /// means, the agent exits (ReadCts), or the daemon shuts down. Never breaks the launch.
+    /// Claude reads its per-worktree Claude project dir (symlinked to the SOURCE repo's, shared
+    /// with the user's own sessions — <see cref="SessionTranscriptLocator"/> disambiguates by
+    /// cwd). Codex reads its <c>~/.codex/sessions</c> rollout tree (shared across all the user's
+    /// Codex sessions — <see cref="CodexSessionRolloutLocator"/> disambiguates by
+    /// <c>payload.cwd</c> + spawn time). A vendor with no daemon-side locator is a no-op: the
+    /// hook stays its only session-id source.
     /// </summary>
-    async Task DetectClaudeSessionIdAsync(AgentInstance agent, DateTime spawnedAtUtc) {
-        try {
-            var projectDir = ClaudePaths.ProjectDir(agent.Worktree.Path);
-            var deadline   = DateTime.UtcNow + SessionIdPollTimeout;
+    async Task DetectSessionIdAsync(AgentInstance agent, string vendor, DateTime spawnedAtUtc) {
+        // The locator scans a shared dir, so a foreign-session file is cached in ruledOut and
+        // never re-opened. A cwd is fixed, so a definitive non-match is permanent; a file with
+        // no cwd yet (still being written) is NOT cached, so the agent's own freshly-created
+        // transcript/rollout is always re-checked.
+        Func<ISet<string>, string?>? locate = vendor.ToLowerInvariant() switch {
+            "claude" => ruledOut => SessionTranscriptLocator.TryLocate(
+                ClaudePaths.ProjectDir(agent.Worktree.Path), agent.Worktree.Path, spawnedAtUtc, ruledOut),
+            "codex" => ruledOut => CodexSessionRolloutLocator.TryLocate(
+                CodexPaths.Sessions, agent.Worktree.Path, spawnedAtUtc, ruledOut),
+            _ => null,
+        };
 
-            // Transcripts confirmed to belong to another session (a foreign cwd) are remembered
-            // here so we don't re-open them every 2 s tick. A session's cwd never changes, so a
-            // definitive non-match is permanent; files still being written (no cwd yet) are NOT
-            // added, so the agent's own freshly-created transcript is always re-checked.
+        if (locate is null) return;
+
+        await PollForSessionIdAsync(agent, locate);
+    }
+
+    /// <summary>
+    /// Shared poll loop for <see cref="DetectSessionIdAsync"/>. Polls <paramref name="locate"/>
+    /// until it resolves a session id, the id is set by other means (hook succeeded), the agent
+    /// exits (ReadCts), the daemon shuts down, or the timeout elapses. On a match it sets
+    /// <see cref="AgentInstance.SessionId"/> and best-effort reports via AgentStatusChanged (live
+    /// registry link) AND an <see cref="AgentRunHeartbeat"/> (so the server's restart-recovery
+    /// FindAgentSessionIdAsync path works too). Once SessionId is set, the 30 s heartbeat loop and
+    /// reconnect re-registration keep re-sending it, so a transient report failure self-heals.
+    /// Never breaks the launch.
+    /// </summary>
+    async Task PollForSessionIdAsync(AgentInstance agent, Func<ISet<string>, string?> locate) {
+        try {
+            var deadline = DateTime.UtcNow + SessionIdPollTimeout;
             var ruledOut = new HashSet<string>();
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
@@ -2259,7 +2281,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             while (DateTime.UtcNow < deadline) {
                 if (agent.SessionId is not null) return; // linked by other means (hook succeeded)
 
-                if (SessionTranscriptLocator.TryLocate(projectDir, agent.Worktree.Path, spawnedAtUtc, ruledOut) is { } sessionId) {
+                if (locate(ruledOut) is { } sessionId) {
                     agent.SessionId ??= sessionId;
 
                     LogSessionIdDetected(agent.Id, sessionId);

--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -19,6 +19,14 @@ internal sealed partial class CodexLauncher(
 
     public bool IsAvailable() => CliResolver.Exists(CliPath);
 
+    /// <summary>
+    /// Enumerates the user-config MCP server names a review-flow reviewer would otherwise
+    /// inherit. Default reads <c>~/.codex/config.toml</c> (CODEX_HOME honoured); injectable so
+    /// <see cref="BuildArgs"/> stays deterministic in unit tests.
+    /// </summary>
+    internal Func<IReadOnlyList<string>> ReadInheritedMcpServerNames { get; init; } =
+        static () => CodexConfigToml.ReadMcpServerNames();
+
     static readonly string[] CriticalHookEvents = ["SessionStart", "Stop", "PermissionRequest"];
 
     public void Prepare(LauncherContext ctx) {
@@ -89,15 +97,22 @@ internal sealed partial class CodexLauncher(
         };
 
         // Review-flow reviewers get exactly ONE MCP server: kcap-flow-result, which can
-        // only submit a result — never start a flow. Clear-then-whitelist, in this order:
-        // the bare `mcp_servers={}` FIRST replaces the entire [mcp_servers] table from
-        // ~/.codex/config.toml; the dotted overrides then insert into the now-empty table.
-        // Dotted overrides alone MERGE into the user's table and would re-expose whatever MCP
-        // servers the user has registered (including a hand-registered kcap-flows with
-        // start_review_flow — the recursion guard would silently vanish).
+        // only submit a result — never start a flow.
+        //
+        // Codex 0.144.3 has NO analog of Claude's `--strict-mcp-config` (an authoritative,
+        // ignores-user-config MCP set), and the previous `-c mcp_servers={}` "clear" is a
+        // NO-OP: a `-c` dotted/table override DEEP-MERGES into the loaded ~/.codex/config.toml,
+        // so an empty table removes nothing (verified with `codex mcp list`). Left as-is, a
+        // reviewer inherits EVERY user MCP server — including a hand-registered kcap-flows with
+        // start_review_flow — and the recursion guard silently vanishes.
+        //
+        // Real isolation instead: disable every server the reviewer would inherit via a
+        // per-server `-c mcp_servers.<name>.enabled=false` (a genuine, honoured Codex config
+        // field — a disabled server is not started), THEN whitelist exactly the injected
+        // kcap-flow-result server (+ any allowlisted, non-flow-starting server). The disable
+        // pass skips the names we whitelist so we never disable a server we mean to enable.
         if (ctx.IsReviewFlow) {
-            args.Add("-c");
-            args.Add("mcp_servers={}");
+            DisableInheritedMcpServers(args, ctx);
             AddFlowResultServer(args, ctx);
             AddAllowlistServers(args, ctx);
         }
@@ -120,6 +135,55 @@ internal sealed partial class CodexLauncher(
         }
 
         return new([.. args], McpConfigPath: null);
+    }
+
+    /// <summary>
+    /// Real MCP isolation for a review-flow reviewer: emits a per-server
+    /// <c>-c mcp_servers.&lt;name&gt;.enabled=false</c> for every server the reviewer would
+    /// otherwise inherit from <c>~/.codex/config.toml</c>, so only the servers we explicitly
+    /// whitelist afterwards actually load. Skips any name we are about to whitelist (so the
+    /// flow-result / allowlist servers stay enabled) and any name that cannot be expressed as a
+    /// Codex <c>-c</c> dotted key — a name containing <c>.</c> would be mis-split by Codex's key
+    /// parser (verified: it errors), so such a name is logged and left (realistic kcap-flows /
+    /// node_repl / computer-use names have no dots).
+    /// </summary>
+    void DisableInheritedMcpServers(List<string> args, LauncherContext ctx) {
+        var whitelisted = WhitelistedServerNames(ctx);
+
+        foreach (var name in ReadInheritedMcpServerNames()) {
+            if (string.IsNullOrEmpty(name)) continue;
+            if (whitelisted.Contains(name)) continue;
+
+            if (name.Contains('.')) {
+                LogInheritedServerUndisableable(name, ctx.AgentId);
+                continue;
+            }
+
+            args.Add("-c");
+            args.Add($"mcp_servers.{name}.enabled=false");
+        }
+    }
+
+    /// <summary>The MCP server names <see cref="AddFlowResultServer"/> +
+    /// <see cref="AddAllowlistServers"/> will enable — the disable pass must never disable one of
+    /// these. Empty when the daemon has no server URL / kcap path (nothing is whitelisted, so the
+    /// disable pass strips everything — the recursion-safe default).</summary>
+    HashSet<string> WhitelistedServerNames(LauncherContext ctx) {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+
+        if (string.IsNullOrWhiteSpace(config.ServerUrl) || string.IsNullOrWhiteSpace(config.CapacitorPath)) return set;
+
+        set.Add("kcap-flow-result");
+
+        foreach (var name in ctx.McpAllowlist ?? []) {
+            var descriptor = KcapMcpRegistry.Resolve(name);
+
+            if (descriptor is null || descriptor.StartsFlows) continue;
+
+            set.Add(descriptor.Id);
+        }
+
+        return set;
     }
 
     /// <summary>Registers the reviewer-side result-submission server. Skipped (zero
@@ -314,4 +378,7 @@ internal sealed partial class CodexLauncher(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "MCP allowlist entry '{Name}' can start flows — stripped (agent {AgentId})")]
     partial void LogAllowlistEntryStripped(string name, string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Inherited MCP server '{Name}' has a dotted name and cannot be disabled via a Codex -c override — it stays available to reviewer agent {AgentId}")]
+    partial void LogInheritedServerUndisableable(string name, string agentId);
 }

--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -20,12 +20,26 @@ internal sealed partial class CodexLauncher(
     public bool IsAvailable() => CliResolver.Exists(CliPath);
 
     /// <summary>
-    /// Enumerates the user-config MCP server names a review-flow reviewer would otherwise
-    /// inherit. Default reads <c>~/.codex/config.toml</c> (CODEX_HOME honoured); injectable so
-    /// <see cref="BuildArgs"/> stays deterministic in unit tests.
+    /// Enumerates the effective MCP server names a review-flow reviewer would otherwise inherit —
+    /// the recursion guard's foundation. Default runs <c>codex mcp list --json</c>
+    /// (<see cref="CodexMcpInventory.ListInheritedServerNames"/>), which reports the fully-composed
+    /// effective list (user <c>$CODEX_HOME/config.toml</c> <c>[mcp_servers]</c> AND active native
+    /// plugins), honouring <c>CODEX_HOME</c> exactly as the spawned reviewer will. Reading
+    /// <c>config.toml</c> alone (the pre-hardening behaviour) missed plugin-registered servers, so a
+    /// flow-capable plugin server would never be disabled. Injectable so <see cref="BuildArgs"/>
+    /// stays deterministic in unit tests. Throwing here is fail-closed — the launch is rejected
+    /// rather than proceeding with an incomplete view of what the reviewer inherits.
     /// </summary>
     internal Func<IReadOnlyList<string>> ReadInheritedMcpServerNames { get; init; } =
-        static () => CodexConfigToml.ReadMcpServerNames();
+        () => CodexMcpInventory.ListInheritedServerNames(config.CodexPath);
+
+    /// <summary>Inert <c>command</c> stamped on every disabled server's override. Codex requires a
+    /// transport to be present to accept an <c>mcp_servers.&lt;name&gt;</c> override — a plugin-provided
+    /// server has no transport at the config layer, so <c>enabled=false</c> alone fails config load
+    /// with "invalid transport" (verified against 0.144.3). Supplying this sentinel satisfies the
+    /// validator; it is never executed because the server is disabled, and Codex does not check that
+    /// the command exists for a disabled server, so the value is cross-platform safe.</summary>
+    internal const string DisabledServerSentinelCommand = "kcap-review-flow-isolation-disabled";
 
     static readonly string[] CriticalHookEvents = ["SessionStart", "Stop", "PermissionRequest"];
 
@@ -99,12 +113,15 @@ internal sealed partial class CodexLauncher(
         // Review-flow reviewers get exactly ONE MCP server: kcap-flow-result (+ any
         // allowlisted, non-flow-starting server) — it can only submit a result, never start a
         // flow. Codex's `-c` overrides deep-merge into ~/.codex/config.toml (no analog of
-        // Claude's `--strict-mcp-config`), so we disable every inherited server via a
-        // per-server `-c mcp_servers.<name>.enabled=false`, then force-enable exactly the
-        // whitelisted names with `enabled=true` — otherwise a reviewer inherits every user MCP
-        // server (including a hand-registered kcap-flows with start_review_flow, vanishing the
-        // recursion guard), or — if the user's own config already disabled a whitelisted name —
-        // starts without its result-submission channel.
+        // Claude's `--strict-mcp-config`), so we (1) DISABLE every inherited server — from
+        // config.toml AND native plugins, enumerated via `codex mcp list --json` — in one
+        // `-c mcp_servers={ … }` table override that handles dotted/plugin names too, then
+        // (2) force-enable exactly the whitelisted names with `enabled=true`. Otherwise a
+        // reviewer inherits every user MCP server (including a hand-registered kcap-flows with
+        // start_review_flow, vanishing the recursion guard), or — if the user's own config
+        // already disabled a whitelisted name — starts without its result-submission channel.
+        // Fail-closed: if the inherited set can't be enumerated, DisableInheritedMcpServers
+        // throws and the launch is rejected rather than proceeding with nothing disabled.
         if (ctx.IsReviewFlow) {
             DisableInheritedMcpServers(args, ctx);
             AddFlowResultServer(args, ctx);
@@ -132,30 +149,53 @@ internal sealed partial class CodexLauncher(
     }
 
     /// <summary>
-    /// Real MCP isolation for a review-flow reviewer: emits a per-server
-    /// <c>-c mcp_servers.&lt;name&gt;.enabled=false</c> for every server the reviewer would
-    /// otherwise inherit from <c>~/.codex/config.toml</c>, so only the servers we explicitly
-    /// whitelist afterwards actually load. Skips any name we are about to whitelist (so the
-    /// flow-result / allowlist servers stay enabled) and any name that cannot be expressed as a
-    /// Codex <c>-c</c> dotted key — a name containing <c>.</c> would be mis-split by Codex's key
-    /// parser (verified: it errors), so such a name is logged and left (realistic kcap-flows /
-    /// node_repl / computer-use names have no dots).
+    /// Real, fail-closed MCP isolation for a review-flow reviewer: disables EVERY server the
+    /// reviewer would otherwise inherit — from the user's <c>$CODEX_HOME/config.toml</c> AND from
+    /// active native plugins (both reported by <see cref="ReadInheritedMcpServerNames"/> via
+    /// <c>codex mcp list --json</c>) — so only the servers we explicitly whitelist afterwards load.
+    ///
+    /// All disables go in ONE <c>-c mcp_servers={ … }</c> TOML-value override rather than per-server
+    /// dotted keys, because:
+    /// <list type="bullet">
+    ///   <item>A dotted/quoted server name (e.g. <c>"corp.flows"</c>) cannot be expressed in Codex's
+    ///     <c>-c</c> dotted-KEY path — it mis-splits and fails config load. A TOML-quoted key inside
+    ///     the VALUE (<c>mcp_servers={"corp.flows"={…}}</c>) targets it exactly, so a dotted flow
+    ///     server is disabled, not skipped (the pre-hardening code logged and LEFT it — the guard
+    ///     bypass this fix closes).</item>
+    ///   <item>A plugin-provided server has no transport at the config layer, so a bare
+    ///     <c>enabled=false</c> fails config load with "invalid transport"; stamping the inert
+    ///     <see cref="DisabledServerSentinelCommand"/> transport satisfies the validator while the
+    ///     server stays off.</item>
+    ///   <item>Multiple separate <c>-c mcp_servers={…}</c> overrides do NOT accumulate (last wins),
+    ///     whereas a single one deep-merges cleanly over the base file and composes with the dotted
+    ///     whitelist ENABLE overrides added afterwards (all verified against Codex 0.144.3).</item>
+    /// </list>
+    ///
+    /// Fail-closed: <see cref="ReadInheritedMcpServerNames"/> throws
+    /// <see cref="CodexReviewerMcpIsolationException"/> when the inherited set cannot be
+    /// authoritatively enumerated; that propagates out of <see cref="BuildArgs"/> and the
+    /// orchestrator rejects the launch — we never proceed having disabled nothing.
     /// </summary>
     void DisableInheritedMcpServers(List<string> args, LauncherContext ctx) {
         var whitelisted = WhitelistedServerNames(ctx);
+
+        var entries = new List<string>();
 
         foreach (var name in ReadInheritedMcpServerNames()) {
             if (string.IsNullOrEmpty(name)) continue;
             if (whitelisted.Contains(name)) continue;
 
-            if (name.Contains('.')) {
-                LogInheritedServerUndisableable(name, ctx.AgentId);
-                continue;
-            }
-
-            args.Add("-c");
-            args.Add($"mcp_servers.{name}.enabled=false");
+            // TomlString both quotes and escapes, so ANY name — dotted, quoted, or containing
+            // control chars — becomes a valid inline-table key that Codex resolves to exactly one
+            // server. The sentinel transport makes plugin-provided (transport-less) servers
+            // disable-able too.
+            entries.Add($"{TomlString(name)}={{enabled=false,command={TomlString(DisabledServerSentinelCommand)},args=[]}}");
         }
+
+        if (entries.Count == 0) return;
+
+        args.Add("-c");
+        args.Add($"mcp_servers={{{string.Join(",", entries)}}}");
     }
 
     /// <summary>The MCP server names <see cref="AddFlowResultServer"/> +
@@ -382,7 +422,4 @@ internal sealed partial class CodexLauncher(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "MCP allowlist entry '{Name}' can start flows — stripped (agent {AgentId})")]
     partial void LogAllowlistEntryStripped(string name, string agentId);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Inherited MCP server '{Name}' has a dotted name and cannot be disabled via a Codex -c override — it stays available to reviewer agent {AgentId}")]
-    partial void LogInheritedServerUndisableable(string name, string agentId);
 }

--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -96,21 +96,15 @@ internal sealed partial class CodexLauncher(
             ctx.IsReviewFlow ? "never" : "on-request"
         };
 
-        // Review-flow reviewers get exactly ONE MCP server: kcap-flow-result, which can
-        // only submit a result — never start a flow.
-        //
-        // Codex 0.144.3 has NO analog of Claude's `--strict-mcp-config` (an authoritative,
-        // ignores-user-config MCP set), and the previous `-c mcp_servers={}` "clear" is a
-        // NO-OP: a `-c` dotted/table override DEEP-MERGES into the loaded ~/.codex/config.toml,
-        // so an empty table removes nothing (verified with `codex mcp list`). Left as-is, a
-        // reviewer inherits EVERY user MCP server — including a hand-registered kcap-flows with
-        // start_review_flow — and the recursion guard silently vanishes.
-        //
-        // Real isolation instead: disable every server the reviewer would inherit via a
-        // per-server `-c mcp_servers.<name>.enabled=false` (a genuine, honoured Codex config
-        // field — a disabled server is not started), THEN whitelist exactly the injected
-        // kcap-flow-result server (+ any allowlisted, non-flow-starting server). The disable
-        // pass skips the names we whitelist so we never disable a server we mean to enable.
+        // Review-flow reviewers get exactly ONE MCP server: kcap-flow-result (+ any
+        // allowlisted, non-flow-starting server) — it can only submit a result, never start a
+        // flow. Codex's `-c` overrides deep-merge into ~/.codex/config.toml (no analog of
+        // Claude's `--strict-mcp-config`), so we disable every inherited server via a
+        // per-server `-c mcp_servers.<name>.enabled=false`, then force-enable exactly the
+        // whitelisted names with `enabled=true` — otherwise a reviewer inherits every user MCP
+        // server (including a hand-registered kcap-flows with start_review_flow, vanishing the
+        // recursion guard), or — if the user's own config already disabled a whitelisted name —
+        // starts without its result-submission channel.
         if (ctx.IsReviewFlow) {
             DisableInheritedMcpServers(args, ctx);
             AddFlowResultServer(args, ctx);
@@ -194,6 +188,12 @@ internal sealed partial class CodexLauncher(
 
         const string name = "kcap-flow-result";
 
+        // Force-enable: the disable pass above skips this name, but the user's OWN
+        // ~/.codex/config.toml may already have it (or never had it) set to enabled=false from
+        // a prior manual registration. `-c` deep-merges over that file, so skipping the disable
+        // is not enough on its own — an explicit enabled=true override wins regardless.
+        args.Add("-c");
+        args.Add($"mcp_servers.{name}.enabled=true");
         args.Add("-c");
         args.Add($"mcp_servers.{name}.command={TomlString(config.CapacitorPath)}");
         args.Add("-c");
@@ -231,6 +231,10 @@ internal sealed partial class CodexLauncher(
             var id       = descriptor.Id;
             var argsList = string.Join(",", descriptor.Args.Select(TomlString));
 
+            // Force-enable for the same reason as AddFlowResultServer: the user's own config
+            // may already carry this name disabled, and `-c` only deep-merges over it.
+            args.Add("-c");
+            args.Add($"mcp_servers.{id}.enabled=true");
             args.Add("-c");
             args.Add($"mcp_servers.{id}.command={TomlString(config.CapacitorPath)}");
             args.Add("-c");

--- a/src/Capacitor.Cli.Daemon/Services/CodexMcpInventory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexMcpInventory.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics;
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Authoritative enumeration of the MCP servers a spawned Codex session would inherit, used by
+/// <see cref="CodexLauncher"/> to disable every non-whitelisted server for an unattended
+/// review-flow reviewer (the recursion guard).
+///
+/// Codex 0.144.3 composes its effective MCP registry from TWO sources: the user-level
+/// <c>$CODEX_HOME/config.toml</c> <c>[mcp_servers]</c> table AND active native plugins (each
+/// plugin manifest can register servers). Reading <c>config.toml</c> alone (the pre-hardening
+/// behaviour) therefore MISSED plugin-provided servers. A project/cwd-level
+/// <c>.codex/config.toml</c> is verified NOT to be an MCP source in 0.144.3 (it carries hooks /
+/// skills / AGENTS.md only), so the two sources above are the complete set.
+///
+/// <c>codex mcp list --json</c> is the one command that reports the fully-composed effective list
+/// (config + plugins), honouring <c>CODEX_HOME</c> exactly as the spawned reviewer will (both
+/// inherit the daemon's environment), so it is the enumeration authority. Failure to run or parse
+/// it is FAIL-CLOSED: the caller must reject the launch rather than proceed with an incomplete
+/// (fail-open) view of what the reviewer would inherit.
+/// </summary>
+internal static class CodexMcpInventory {
+    /// <summary>Max time to wait for <c>codex mcp list --json</c> before treating enumeration as
+    /// failed (fail-closed). Generous: the command only reads config + plugin manifests.</summary>
+    const int TimeoutMs = 15_000;
+
+    /// <summary>
+    /// Runs <c>{codexPath} mcp list --json</c> (inheriting this process's environment, so the same
+    /// <c>CODEX_HOME</c> the reviewer will use is honoured) and returns the effective MCP server
+    /// names (config.toml + plugins). Throws <see cref="CodexReviewerMcpIsolationException"/> if the
+    /// process can't be started, times out, exits non-zero, or emits output that isn't a parseable
+    /// JSON array — never returns a partial/empty list to mask such a failure.
+    /// </summary>
+    public static IReadOnlyList<string> ListInheritedServerNames(string codexPath) {
+        string stdout;
+        string stderr;
+        int    exitCode;
+
+        try {
+            using var process = Process.Start(new ProcessStartInfo {
+                FileName               = codexPath,
+                UseShellExecute        = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError  = true,
+                ArgumentList           = { "mcp", "list", "--json" }
+            }) ?? throw new CodexReviewerMcpIsolationException(
+                $"Could not start '{codexPath} mcp list --json' to enumerate the reviewer's inherited MCP servers.");
+
+            // Read to end BEFORE WaitForExit to avoid a full-pipe deadlock on large output.
+            stdout = process.StandardOutput.ReadToEnd();
+            stderr = process.StandardError.ReadToEnd();
+
+            if (!process.WaitForExit(TimeoutMs)) {
+                try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+
+                throw new CodexReviewerMcpIsolationException(
+                    $"'{codexPath} mcp list --json' timed out while enumerating the reviewer's inherited MCP servers.");
+            }
+
+            exitCode = process.ExitCode;
+        } catch (CodexReviewerMcpIsolationException) {
+            throw;
+        } catch (Exception ex) {
+            throw new CodexReviewerMcpIsolationException(
+                $"Failed to enumerate the reviewer's inherited Codex MCP servers via '{codexPath} mcp list --json': {ex.Message}");
+        }
+
+        if (exitCode != 0) {
+            var detail = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+
+            throw new CodexReviewerMcpIsolationException(
+                $"'{codexPath} mcp list --json' exited {exitCode} while enumerating the reviewer's inherited MCP servers: {detail.Trim()}");
+        }
+
+        return ParseServerNames(stdout);
+    }
+
+    /// <summary>
+    /// Parses the <c>codex mcp list --json</c> payload — a JSON array of <c>{ "name": string, … }</c>
+    /// objects — into the list of server names. Pure and side-effect free (unit-testable without the
+    /// codex binary). Throws <see cref="CodexReviewerMcpIsolationException"/> when the payload isn't a
+    /// JSON array or an element has no string <c>name</c>: an unparseable enumeration must fail closed,
+    /// not silently drop servers. A valid empty array (<c>[]</c>) returns an empty list.
+    /// </summary>
+    public static IReadOnlyList<string> ParseServerNames(string json) {
+        JsonNode? root;
+
+        try {
+            root = JsonNode.Parse(json);
+        } catch (Exception ex) {
+            throw new CodexReviewerMcpIsolationException(
+                $"Could not parse 'codex mcp list --json' output as JSON: {ex.Message}");
+        }
+
+        if (root is not JsonArray array) {
+            throw new CodexReviewerMcpIsolationException(
+                "'codex mcp list --json' output was not a JSON array.");
+        }
+
+        var names = new List<string>(array.Count);
+
+        foreach (var element in array) {
+            if (element?["name"] is not JsonValue nameNode ||
+                !nameNode.TryGetValue<string>(out var name) ||
+                string.IsNullOrEmpty(name)) {
+                throw new CodexReviewerMcpIsolationException(
+                    "'codex mcp list --json' returned an MCP server entry with no usable name.");
+            }
+
+            names.Add(name);
+        }
+
+        return names;
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/CodexReviewerMcpIsolationException.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexReviewerMcpIsolationException.cs
@@ -1,0 +1,13 @@
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Thrown by <see cref="CodexLauncher"/> while building a review-flow reviewer's launch args
+/// when the reviewer's inherited MCP servers cannot be authoritatively enumerated (so we cannot
+/// prove every flow-capable server is disabled). Enumeration is the recursion guard's foundation:
+/// if <c>codex mcp list --json</c> can't be run or parsed, we do NOT fall back to disabling
+/// nothing (which would let a hand-registered flow-starting server through) — we fail the launch
+/// closed. The orchestrator catches this type and emits <see cref="LaunchFailed"/> with the
+/// exception's message + the same worktree/token cleanup as
+/// <see cref="CodexHooksNotInstalledException"/>.
+/// </summary>
+internal sealed class CodexReviewerMcpIsolationException(string message) : Exception(message);

--- a/src/Capacitor.Cli.Daemon/Services/CodexSessionRolloutLocator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexSessionRolloutLocator.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 
@@ -15,11 +16,15 @@ namespace Capacitor.Cli.Daemon.Services;
 /// root, unlike Claude).
 ///
 /// The tree is shared across ALL of the user's Codex sessions, so candidates are filtered by
-/// CREATION time at/after spawn (a rollout still being written by an older, unrelated session
+/// creation time at/after spawn (a rollout still being written by an older, unrelated session
 /// must not pass just because its last-write time is recent) and verified by <c>payload.cwd</c>
 /// equal to the agent's cwd; among matches, the one created closest after spawn wins — not the
-/// numerically earliest creation. The decision logic is pure and unit-tested without a
-/// filesystem; only <see cref="TryLocate"/> touches disk.
+/// numerically earliest creation. That creation time is read from the immutable timestamp
+/// EMBEDDED IN THE FILENAME, not <see cref="File.GetCreationTimeUtc"/>: Linux cannot set file
+/// birth time (<c>SetCreationTime</c> is a no-op) and does not reliably expose it, so the
+/// filesystem creation time is unusable there for distinguishing rollouts — the filename stamp is
+/// Codex's own session-start time, stable and cross-platform. The decision logic is pure and
+/// unit-tested without a filesystem; only <see cref="TryLocate"/> touches disk.
 /// </summary>
 internal static class CodexSessionRolloutLocator {
     /// <summary>How many non-blank rollout lines to inspect for a <c>payload.cwd</c> before
@@ -71,7 +76,11 @@ internal static class CodexSessionRolloutLocator {
                     continue;
                 }
 
-                var creation = File.GetCreationTimeUtc(file);
+                // Read creation time from the filename stamp (immutable, cross-platform), not
+                // File.GetCreationTimeUtc — Linux can neither set nor reliably read file birth
+                // time. Fall back to the filesystem only for a name without a parseable stamp
+                // (never a real Codex rollout); a mislink there is display-only either way.
+                var creation = TryParseCreationFromFileName(file) ?? File.GetCreationTimeUtc(file);
 
                 if (!IsNewEnough(creation, spawnedAtUtc)) continue;
 
@@ -168,6 +177,31 @@ internal static class CodexSessionRolloutLocator {
     /// </summary>
     public static bool IsNewEnough(DateTime creationTimeUtc, DateTime spawnedAtUtc)
         => creationTimeUtc >= spawnedAtUtc - FileTimeSkewTolerance;
+
+    /// <summary>
+    /// Parses Codex's session-start timestamp out of the rollout FILENAME
+    /// (<c>rollout-&lt;yyyy-MM-ddTHH-mm-ss&gt;-&lt;uuid&gt;.jsonl</c>), returned as UTC. Codex writes
+    /// this stamp — and the enclosing <c>YYYY/MM/DD</c> day folder — in LOCAL time, so it is parsed
+    /// as local and converted; the daemon and Codex share a machine and clock, so this round-trips
+    /// against the daemon's UTC spawn time. The stamp is immutable and, unlike
+    /// <see cref="File.GetCreationTimeUtc"/>, cross-platform (Linux cannot set birth time and does
+    /// not reliably expose it). Returns null when the name carries no parseable stamp.
+    /// </summary>
+    internal static DateTime? TryParseCreationFromFileName(string filePath) {
+        var name = Path.GetFileNameWithoutExtension(filePath);
+
+        // rollout-2026-05-07T17-50-21-019e0322-05fc-7570-be65-75719c3ea861
+        // Drop the "rollout" prefix and the trailing 5-chunk UUID; the middle is the local stamp.
+        var parts = name.Split('-');
+        if (parts.Length < 6 || parts[0] != "rollout") return null;
+
+        var stamp = string.Join('-', parts[1..^5]); // 2026-05-07T17-50-21
+
+        return DateTime.TryParseExact(stamp, "yyyy-MM-ddTHH-mm-ss", CultureInfo.InvariantCulture,
+                   DateTimeStyles.AssumeLocal | DateTimeStyles.AdjustToUniversal, out var utc)
+            ? utc
+            : null;
+    }
 
     /// <summary>
     /// Enumerates <c>rollout-*.jsonl</c> files under <c>YYYY/MM/DD</c> day folders, pruning day

--- a/src/Capacitor.Cli.Daemon/Services/CodexSessionRolloutLocator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexSessionRolloutLocator.cs
@@ -1,0 +1,222 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Codex analog of <see cref="SessionTranscriptLocator"/>: discovers the session id of a
+/// freshly spawned hosted Codex reviewer by scanning <c>~/.codex/sessions</c> for the rollout
+/// file Codex writes.
+///
+/// Why this exists: a hosted Codex agent's session id normally reaches the server only via the
+/// <c>kcap hook --codex</c> SessionStart POST (correlated by <c>KCAP_AGENT_ID</c>). When that
+/// link doesn't land in time (unattended/borrowed correlation, or an auth hiccup) the agent has
+/// no session id for correlation/display. Unlike Claude, Codex had no daemon-side fallback. The
+/// server no longer <em>gates</em> incarnation completion on this id (it converges on daemon
+/// liveness), so this is strictly best-effort — it resolves the id lazily when it can and never
+/// blocks the launch.
+///
+/// Codex layout (verified against codex-cli 0.144.3): each session is
+/// <c>~/.codex/sessions/YYYY/MM/DD/rollout-&lt;ISO-ts&gt;-&lt;uuid&gt;.jsonl</c>. The session id is
+/// the trailing filename UUID (== the hook-reported <c>session_id</c> for a top-level CLI
+/// session), parsed + normalized by <see cref="CodexPaths.ExtractSessionIdFromFileName"/>. The
+/// cwd lives in the opening <c>session_meta</c> envelope's <c>payload.cwd</c> — NOT at the JSONL
+/// root the way Claude records it.
+///
+/// Disambiguation: the sessions tree is shared across ALL of the user's Codex sessions, so a
+/// new rollout there is not necessarily the reviewer's. Candidates are filtered by spawn time
+/// and verified by <c>payload.cwd</c> equal to the agent's cwd. When more than one rollout still
+/// matches (a rare borrowed-cwd race with the user's own concurrent session in the same repo),
+/// the earliest one created at/after spawn is chosen — the reviewer's own rollout is created
+/// immediately after the daemon spawns it.
+///
+/// The decision logic (cwd matching, spawn-time filtering) is pure and unit-tested without a
+/// filesystem; only <see cref="TryLocate"/> touches disk.
+/// </summary>
+internal static class CodexSessionRolloutLocator {
+    /// <summary>How many non-blank rollout lines to inspect for a <c>payload.cwd</c> before
+    /// giving up on a candidate. The session_meta envelope is the very first line, so this is
+    /// generous while still bounding the read.</summary>
+    public const int MaxLinesToInspect = 50;
+
+    /// <summary>Slack applied to the spawn-time filter to absorb filesystem timestamp
+    /// granularity and small clock quirks. Safe to be generous: the cwd check is the real
+    /// disambiguator; the time filter only avoids re-reading old sessions.</summary>
+    static readonly TimeSpan FileTimeSkewTolerance = TimeSpan.FromSeconds(5);
+
+    /// <summary>Outcome of inspecting a rollout's early lines for a <c>payload.cwd</c>.</summary>
+    internal enum CwdMatch {
+        /// <summary>A <c>payload.cwd</c> equal to the agent cwd was found — this is the reviewer's rollout.</summary>
+        Yes,
+        /// <summary>A <c>payload.cwd</c> was found but belongs to a different session — a permanent non-match.</summary>
+        No,
+        /// <summary>No parseable <c>payload.cwd</c> in the inspected lines — may still be being written; re-check later.</summary>
+        Unknown,
+    }
+
+    /// <summary>
+    /// Scans <paramref name="sessionsRoot"/> (the <c>~/.codex/sessions</c> tree) for a rollout
+    /// written at/after <paramref name="spawnedAtUtc"/> whose <c>session_meta</c> reports
+    /// <c>payload.cwd</c> equal to <paramref name="cwd"/>. Returns the normalized (dashless,
+    /// lowercase) session id, or null when no candidate matches yet. Best-effort: unreadable or
+    /// malformed candidates are skipped, never thrown.
+    /// </summary>
+    /// <param name="ruledOut">
+    /// Optional set of file paths already confirmed to belong to another session. The caller
+    /// polls every few seconds over a shared tree, so caching definitive non-matches avoids
+    /// re-opening the user's own concurrently-written sessions on every tick. Only
+    /// <em>definitive</em> non-matches are added (a foreign cwd, or a name that isn't a rollout);
+    /// a rollout with no cwd yet is left out so the reviewer's own file is always re-checked.
+    /// </param>
+    public static string? TryLocate(string sessionsRoot, string cwd, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) {
+        if (!Directory.Exists(sessionsRoot)) return null;
+
+        string? earliestId       = null;
+        var     earliestCreation = DateTime.MaxValue;
+
+        foreach (var file in EnumerateRecentRolloutFiles(sessionsRoot, spawnedAtUtc)) {
+            if (ruledOut?.Contains(file) == true) continue;
+
+            try {
+                if (CodexPaths.ExtractSessionIdFromFileName(file) is not { } sessionId) {
+                    ruledOut?.Add(file); // not a rollout — its name won't change
+                    continue;
+                }
+
+                var creation  = File.GetCreationTimeUtc(file);
+                var lastWrite = File.GetLastWriteTimeUtc(file);
+
+                if (!IsNewEnough(creation, lastWrite, spawnedAtUtc)) continue;
+
+                switch (MatchRollout(ReadFirstLines(file), cwd, DefaultPathComparison)) {
+                    case CwdMatch.Yes:
+                        // Pick the earliest-created match: the reviewer's own rollout is created
+                        // immediately after spawn, so a user's later session in the same cwd loses.
+                        if (creation < earliestCreation) {
+                            earliestCreation = creation;
+                            earliestId       = sessionId;
+                        }
+
+                        break;
+                    case CwdMatch.No:
+                        ruledOut?.Add(file); // another session's rollout — cwd is fixed
+                        break;
+                    // CwdMatch.Unknown: no cwd yet — leave uncached, re-check next tick.
+                }
+            } catch {
+                // Candidate vanished mid-scan, is locked, or is otherwise unreadable — skip it;
+                // the caller polls, so a transiently unreadable match is retried next tick.
+            }
+        }
+
+        return earliestId;
+    }
+
+    /// <summary>
+    /// Classifies a candidate rollout by scanning up to <see cref="MaxLinesToInspect"/> non-blank
+    /// lines for a JSON <c>payload.cwd</c> (the <c>session_meta</c> envelope). Returns
+    /// <see cref="CwdMatch.Yes"/> on the first line whose <c>payload.cwd</c> equals
+    /// <paramref name="cwd"/>, <see cref="CwdMatch.No"/> if a <c>payload.cwd</c> was seen but none
+    /// matched, or <see cref="CwdMatch.Unknown"/> if none was seen. Partial/invalid JSON lines are
+    /// tolerated (skipped) and both paths are normalized (separators, trailing separators) before
+    /// comparing.
+    /// </summary>
+    internal static CwdMatch MatchRollout(IEnumerable<string> lines, string cwd, StringComparison comparison) {
+        var target = NormalizePath(cwd);
+
+        var inspected = 0;
+        var sawCwd    = false;
+
+        foreach (var line in lines) {
+            if (inspected >= MaxLinesToInspect) break;
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            inspected++;
+
+            string? cwdValue;
+
+            try {
+                cwdValue = JsonNode.Parse(line)?["payload"]?["cwd"]?.GetValue<string>();
+            } catch {
+                continue; // partial/invalid JSONL line, non-object payload, or non-string cwd
+            }
+
+            if (cwdValue is null) continue;
+
+            sawCwd = true;
+
+            if (string.Equals(NormalizePath(cwdValue), target, comparison)) return CwdMatch.Yes;
+        }
+
+        return sawCwd ? CwdMatch.No : CwdMatch.Unknown;
+    }
+
+    /// <summary>
+    /// True when the file's newest timestamp (creation or last write) is at/after the agent's
+    /// spawn time, minus <see cref="FileTimeSkewTolerance"/>. Filters out the user's own
+    /// pre-existing sessions in the shared tree.
+    /// </summary>
+    public static bool IsNewEnough(DateTime creationTimeUtc, DateTime lastWriteTimeUtc, DateTime spawnedAtUtc) {
+        var newest = creationTimeUtc > lastWriteTimeUtc ? creationTimeUtc : lastWriteTimeUtc;
+
+        return newest >= spawnedAtUtc - FileTimeSkewTolerance;
+    }
+
+    /// <summary>
+    /// Enumerates <c>rollout-*.jsonl</c> files under <c>YYYY/MM/DD</c> day folders, pruning day
+    /// folders older than the spawn's local date minus one day (Codex names folders by local
+    /// date; the one-day slack covers a midnight boundary and timezone skew). Bounds the scan so
+    /// a large history isn't walked on every poll tick.
+    /// </summary>
+    static IEnumerable<string> EnumerateRecentRolloutFiles(string sessionsRoot, DateTime spawnedAtUtc) {
+        var cutoff = spawnedAtUtc.ToLocalTime().Date.AddDays(-1);
+
+        foreach (var year in NumericDirs(sessionsRoot, cutoff.Year)) {
+            foreach (var month in NumericDirs(year.Path, year.Value == cutoff.Year ? cutoff.Month : (int?)null)) {
+                var dayMin = year.Value == cutoff.Year && month.Value == cutoff.Month ? cutoff.Day : (int?)null;
+
+                foreach (var day in NumericDirs(month.Path, dayMin)) {
+                    foreach (var file in Directory.EnumerateFiles(day.Path, "rollout-*.jsonl")) {
+                        yield return file;
+                    }
+                }
+            }
+        }
+    }
+
+    static IEnumerable<(string Path, int Value)> NumericDirs(string parent, int? minInclusive) {
+        if (!Directory.Exists(parent)) yield break;
+
+        foreach (var dir in Directory.EnumerateDirectories(parent)) {
+            if (!int.TryParse(Path.GetFileName(dir), out var value)) continue;
+            if (minInclusive is { } min && value < min) continue;
+
+            yield return (dir, value);
+        }
+    }
+
+    static StringComparison DefaultPathComparison
+        => OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    /// <summary>Unifies separator style and strips trailing separators so
+    /// <c>C:\r\p\</c>, <c>C:/r/p</c> and <c>C:\r\p</c> all compare equal.</summary>
+    static string NormalizePath(string path) => path.Replace('\\', '/').TrimEnd('/');
+
+    /// <summary>
+    /// Reads up to <see cref="MaxLinesToInspect"/> lines with <see cref="FileShare.ReadWrite"/>
+    /// (Codex is appending while we read) into memory, so the pure matcher never holds a file
+    /// handle across JSON parsing.
+    /// </summary>
+    static List<string> ReadFirstLines(string path) {
+        var lines = new List<string>(capacity: 16);
+
+        using var fs     = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(fs);
+
+        while (lines.Count < MaxLinesToInspect && reader.ReadLine() is { } line) {
+            lines.Add(line);
+        }
+
+        return lines;
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/CodexSessionRolloutLocator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexSessionRolloutLocator.cs
@@ -4,33 +4,21 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// Codex analog of <see cref="SessionTranscriptLocator"/>: discovers the session id of a
-/// freshly spawned hosted Codex reviewer by scanning <c>~/.codex/sessions</c> for the rollout
-/// file Codex writes.
+/// Codex analog of <see cref="SessionTranscriptLocator"/>: best-effort discovery of a freshly
+/// spawned hosted Codex reviewer's session id, for correlation/display only — the server
+/// converges on daemon liveness, so a miss or mislink here never blocks the launch.
 ///
-/// Why this exists: a hosted Codex agent's session id normally reaches the server only via the
-/// <c>kcap hook --codex</c> SessionStart POST (correlated by <c>KCAP_AGENT_ID</c>). When that
-/// link doesn't land in time (unattended/borrowed correlation, or an auth hiccup) the agent has
-/// no session id for correlation/display. Unlike Claude, Codex had no daemon-side fallback. The
-/// server no longer <em>gates</em> incarnation completion on this id (it converges on daemon
-/// liveness), so this is strictly best-effort — it resolves the id lazily when it can and never
-/// blocks the launch.
+/// Codex layout: each session is
+/// <c>~/.codex/sessions/YYYY/MM/DD/rollout-&lt;ISO-ts&gt;-&lt;uuid&gt;.jsonl</c>; the session id is
+/// the trailing filename UUID, parsed by <see cref="CodexPaths.ExtractSessionIdFromFileName"/>.
+/// The cwd lives in the opening <c>session_meta</c> envelope's <c>payload.cwd</c> (not the JSONL
+/// root, unlike Claude).
 ///
-/// Codex layout (verified against codex-cli 0.144.3): each session is
-/// <c>~/.codex/sessions/YYYY/MM/DD/rollout-&lt;ISO-ts&gt;-&lt;uuid&gt;.jsonl</c>. The session id is
-/// the trailing filename UUID (== the hook-reported <c>session_id</c> for a top-level CLI
-/// session), parsed + normalized by <see cref="CodexPaths.ExtractSessionIdFromFileName"/>. The
-/// cwd lives in the opening <c>session_meta</c> envelope's <c>payload.cwd</c> — NOT at the JSONL
-/// root the way Claude records it.
-///
-/// Disambiguation: the sessions tree is shared across ALL of the user's Codex sessions, so a
-/// new rollout there is not necessarily the reviewer's. Candidates are filtered by spawn time
-/// and verified by <c>payload.cwd</c> equal to the agent's cwd. When more than one rollout still
-/// matches (a rare borrowed-cwd race with the user's own concurrent session in the same repo),
-/// the earliest one created at/after spawn is chosen — the reviewer's own rollout is created
-/// immediately after the daemon spawns it.
-///
-/// The decision logic (cwd matching, spawn-time filtering) is pure and unit-tested without a
+/// The tree is shared across ALL of the user's Codex sessions, so candidates are filtered by
+/// CREATION time at/after spawn (a rollout still being written by an older, unrelated session
+/// must not pass just because its last-write time is recent) and verified by <c>payload.cwd</c>
+/// equal to the agent's cwd; among matches, the one created closest after spawn wins — not the
+/// numerically earliest creation. The decision logic is pure and unit-tested without a
 /// filesystem; only <see cref="TryLocate"/> touches disk.
 /// </summary>
 internal static class CodexSessionRolloutLocator {
@@ -71,8 +59,8 @@ internal static class CodexSessionRolloutLocator {
     public static string? TryLocate(string sessionsRoot, string cwd, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) {
         if (!Directory.Exists(sessionsRoot)) return null;
 
-        string? earliestId       = null;
-        var     earliestCreation = DateTime.MaxValue;
+        string?   bestId       = null;
+        DateTime? bestCreation = null;
 
         foreach (var file in EnumerateRecentRolloutFiles(sessionsRoot, spawnedAtUtc)) {
             if (ruledOut?.Contains(file) == true) continue;
@@ -83,18 +71,20 @@ internal static class CodexSessionRolloutLocator {
                     continue;
                 }
 
-                var creation  = File.GetCreationTimeUtc(file);
-                var lastWrite = File.GetLastWriteTimeUtc(file);
+                var creation = File.GetCreationTimeUtc(file);
 
-                if (!IsNewEnough(creation, lastWrite, spawnedAtUtc)) continue;
+                if (!IsNewEnough(creation, spawnedAtUtc)) continue;
 
                 switch (MatchRollout(ReadFirstLines(file), cwd, DefaultPathComparison)) {
                     case CwdMatch.Yes:
-                        // Pick the earliest-created match: the reviewer's own rollout is created
-                        // immediately after spawn, so a user's later session in the same cwd loses.
-                        if (creation < earliestCreation) {
-                            earliestCreation = creation;
-                            earliestId       = sessionId;
+                        // Prefer the rollout created closest AFTER spawn — not the numerically
+                        // earliest creation, which could be an older, still-eligible (clock-skew
+                        // tolerance) match. A mislink here is display-only (the server converges
+                        // on daemon liveness), but correlating to the wrong session is still
+                        // worth getting right.
+                        if (bestCreation is null || IsCloserToSpawn(creation, bestCreation.Value, spawnedAtUtc)) {
+                            bestCreation = creation;
+                            bestId       = sessionId;
                         }
 
                         break;
@@ -109,7 +99,24 @@ internal static class CodexSessionRolloutLocator {
             }
         }
 
-        return earliestId;
+        return bestId;
+    }
+
+    /// <summary>True when <paramref name="candidate"/> is a better spawn-time match than
+    /// <paramref name="current"/>: a creation time at/after <paramref name="spawnedAtUtc"/>
+    /// always beats one before it (barring the small clock-skew slack already applied by
+    /// <see cref="IsNewEnough"/>, a rollout cannot causally predate its own spawn); within the
+    /// same side, the creation closest to <paramref name="spawnedAtUtc"/> wins.</summary>
+    static bool IsCloserToSpawn(DateTime candidate, DateTime current, DateTime spawnedAtUtc) {
+        var candidateAfter = candidate >= spawnedAtUtc;
+        var currentAfter   = current   >= spawnedAtUtc;
+
+        if (candidateAfter != currentAfter) return candidateAfter;
+
+        var candidateDistance = candidateAfter ? candidate - spawnedAtUtc : spawnedAtUtc - candidate;
+        var currentDistance   = currentAfter   ? current   - spawnedAtUtc : spawnedAtUtc - current;
+
+        return candidateDistance < currentDistance;
     }
 
     /// <summary>
@@ -152,15 +159,15 @@ internal static class CodexSessionRolloutLocator {
     }
 
     /// <summary>
-    /// True when the file's newest timestamp (creation or last write) is at/after the agent's
-    /// spawn time, minus <see cref="FileTimeSkewTolerance"/>. Filters out the user's own
-    /// pre-existing sessions in the shared tree.
+    /// True when the file's CREATION time is at/after the agent's spawn time, minus
+    /// <see cref="FileTimeSkewTolerance"/>. Deliberately ignores last-write time: an older,
+    /// unrelated session in the same cwd that is still being actively appended to must not pass
+    /// this filter just because it was written to recently — a rollout created before the
+    /// reviewer spawned is not this reviewer's session, regardless of ongoing writes. Filters
+    /// out the user's own pre-existing sessions in the shared tree.
     /// </summary>
-    public static bool IsNewEnough(DateTime creationTimeUtc, DateTime lastWriteTimeUtc, DateTime spawnedAtUtc) {
-        var newest = creationTimeUtc > lastWriteTimeUtc ? creationTimeUtc : lastWriteTimeUtc;
-
-        return newest >= spawnedAtUtc - FileTimeSkewTolerance;
-    }
+    public static bool IsNewEnough(DateTime creationTimeUtc, DateTime spawnedAtUtc)
+        => creationTimeUtc >= spawnedAtUtc - FileTimeSkewTolerance;
 
     /// <summary>
     /// Enumerates <c>rollout-*.jsonl</c> files under <c>YYYY/MM/DD</c> day folders, pruning day

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
@@ -562,4 +562,53 @@ public class CodexConfigTomlTests {
         await Assert.That(File.GetUnixFileMode(path)).IsEqualTo(expected);
         await Assert.That(File.GetUnixFileMode(ledger)).IsEqualTo(expected);
     }
+
+    // ── ReadMcpServerNames: enumerate the [mcp_servers] table a reviewer would inherit ──
+
+    [Test]
+    public async Task ReadMcpServerNames_returns_table_keys_sorted_ordinal() {
+        var path = TempConfig();
+        File.WriteAllText(path, """
+            [mcp_servers.node_repl]
+            command = "node"
+            args = ["repl.js"]
+
+            [mcp_servers.kcap-flows]
+            command = "kcap"
+            args = ["mcp", "flows"]
+
+            [mcp_servers.computer-use]
+            command = "cu"
+            args = []
+            """);
+
+        var names = CodexConfigToml.ReadMcpServerNames(path);
+
+        await Assert.That(names).IsEquivalentTo(new[] { "computer-use", "kcap-flows", "node_repl" });
+    }
+
+    [Test]
+    public async Task ReadMcpServerNames_missing_file_returns_empty() {
+        var path = Path.Combine(Directory.CreateTempSubdirectory("kcap-codextoml-").FullName, "does-not-exist.toml");
+
+        await Assert.That(CodexConfigToml.ReadMcpServerNames(path)).IsEmpty();
+    }
+
+    [Test]
+    public async Task ReadMcpServerNames_no_mcp_servers_table_returns_empty() {
+        var path = TempConfig();
+        File.WriteAllText(path, """
+            model = "gpt-5.3-codex"
+            """);
+
+        await Assert.That(CodexConfigToml.ReadMcpServerNames(path)).IsEmpty();
+    }
+
+    [Test]
+    public async Task ReadMcpServerNames_malformed_toml_returns_empty() {
+        var path = TempConfig();
+        File.WriteAllText(path, "this is = = not valid [toml");
+
+        await Assert.That(CodexConfigToml.ReadMcpServerNames(path)).IsEmpty();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -178,7 +178,10 @@ public class CodexLauncherTests {
         var enabled = args.Where(a => a.StartsWith("mcp_servers.", StringComparison.Ordinal)
                                    && !a.Contains(".enabled=false")).ToArray();
         await Assert.That(enabled.All(a => a.StartsWith("mcp_servers.kcap-flow-result.", StringComparison.Ordinal))).IsTrue();
-        await Assert.That(enabled.Length).IsEqualTo(3);
+        await Assert.That(enabled.Length).IsEqualTo(4);
+
+        // Force-enabled regardless of anything the user's own config may say.
+        await Assert.That(args).Contains("mcp_servers.kcap-flow-result.enabled=true");
 
         var command = enabled.Single(a => a.Contains(".command="));
         await Assert.That(command).Contains("/opt/kcap");
@@ -219,6 +222,30 @@ public class CodexLauncherTests {
         await Assert.That(args).DoesNotContain("mcp_servers.kcap-flow-result.enabled=false");
         await Assert.That(args).Contains("mcp_servers.node_repl.enabled=false");
         await Assert.That(args.Any(a => a.StartsWith("mcp_servers.kcap-flow-result.command=", StringComparison.Ordinal))).IsTrue();
+
+        // Not merely "not disabled" — explicitly forced on. The user's real
+        // ~/.codex/config.toml is what `ReadInheritedMcpServerNames` is standing in for here,
+        // and it may itself already carry `kcap-flow-result` as enabled=false from a prior
+        // manual registration. Since `-c` deep-merges over that file, skipping our own disable
+        // pass isn't enough — only an explicit enabled=true override guarantees the reviewer's
+        // result-submission channel actually starts.
+        await Assert.That(args).Contains("mcp_servers.kcap-flow-result.enabled=true");
+    }
+
+    [Test]
+    public async Task Review_flow_force_enables_whitelisted_allowlist_server_even_if_inherited_as_disabled() {
+        // Same bug as the flow-result server, on the allowlist-server path: the user's config
+        // may already carry an allowlisted kcap server (e.g. kcap-sessions) as enabled=false —
+        // `-c` deep-merges over that, so it must be forced back on, not merely left alone.
+        var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
+        var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
+            ReadInheritedMcpServerNames = static () => ["kcap-sessions"]
+        };
+
+        var args = launcher.BuildArgs(NewFlowCtx(["kcap-sessions"])).Args;
+
+        await Assert.That(args).DoesNotContain("mcp_servers.kcap-sessions.enabled=false");
+        await Assert.That(args).Contains("mcp_servers.kcap-sessions.enabled=true");
     }
 
     [Test]
@@ -561,7 +588,8 @@ public class CodexLauncherTests {
         await Assert.That(dotted.Any(a => a.StartsWith("mcp_servers.kcap-flow-result.", StringComparison.Ordinal))).IsTrue();
 
         var sessionsDotted = dotted.Where(a => a.StartsWith("mcp_servers.kcap-sessions.", StringComparison.Ordinal)).ToArray();
-        await Assert.That(sessionsDotted.Length).IsEqualTo(3);
+        await Assert.That(sessionsDotted.Length).IsEqualTo(4);
+        await Assert.That(args).Contains("mcp_servers.kcap-sessions.enabled=true");
 
         var command = sessionsDotted.Single(a => a.Contains(".command="));
         await Assert.That(command).Contains("/opt/kcap");
@@ -603,6 +631,7 @@ public class CodexLauncherTests {
             "--cd", "/tmp/wt",
             "--sandbox", "workspace-write",
             "--ask-for-approval", "never",
+            "-c", "mcp_servers.kcap-flow-result.enabled=true",
             "-c", "mcp_servers.kcap-flow-result.command=\"/opt/kcap\"",
             "-c", "mcp_servers.kcap-flow-result.args=[\"mcp\",\"flow-result\"]",
             "-c", "mcp_servers.kcap-flow-result.env={KCAP_URL=\"https://t.example\",KCAP_FLOW_AGENT_ID=\"agent-xyz\"}",

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -37,6 +37,17 @@ public class CodexLauncherTests {
         ReviewLaunch: null
     );
 
+    // Real MCP isolation emits ONE `-c mcp_servers={ … }` TOML-value override that disables every
+    // non-whitelisted inherited server (plain, dotted, or plugin-provided) uniformly. These helpers
+    // locate that single override and assert membership without pinning the exact byte layout.
+    static string? DisableTableOverride(string[] args) =>
+        args.FirstOrDefault(a => a.StartsWith("mcp_servers={", StringComparison.Ordinal)
+                              && !a.StartsWith("mcp_servers={}", StringComparison.Ordinal));
+
+    static bool DisablesServer(string[] args, string name) =>
+        DisableTableOverride(args) is { } table
+        && table.Contains($"\"{name}\"={{enabled=false", StringComparison.Ordinal);
+
     [Test]
     public async Task BuildArgs_uses_never_approval_for_hosted_codex() {
         var args = NewLauncher().BuildArgs(NewCtx(isReviewFlow: true)).Args;
@@ -136,8 +147,9 @@ public class CodexLauncherTests {
     [Test]
     public async Task BuildArgs_review_flow_does_not_emit_dead_mcp_servers_clear() {
         // The old `-c mcp_servers={}` "clear" is a no-op in Codex 0.144.3 (`-c` overrides
-        // deep-merge, so an empty table removes nothing). It must be gone — real isolation
-        // is per-server enabled=false disabling instead.
+        // deep-merge, so an empty table removes nothing). It must be gone — real isolation is a
+        // populated `mcp_servers={ "<name>"={enabled=false,…} }` disable table (only emitted when
+        // there is something to disable; empty here since no inherited servers are injected).
         var args   = NewLauncher().BuildArgs(NewCtx(isReviewFlow: true)).Args;
         var joined = string.Join(' ', args);
         await Assert.That(joined).DoesNotContain("mcp_servers={}");
@@ -169,12 +181,13 @@ public class CodexLauncherTests {
 
         await Assert.That(string.Join(' ', args)).DoesNotContain("mcp_servers={}");
 
-        // Every inherited server — including the hand-registered kcap-flows — is disabled.
-        await Assert.That(args).Contains("mcp_servers.kcap-flows.enabled=false");
-        await Assert.That(args).Contains("mcp_servers.node_repl.enabled=false");
-        await Assert.That(args).Contains("mcp_servers.computer-use.enabled=false");
+        // Every inherited server — including the hand-registered kcap-flows — is disabled in the
+        // single table override.
+        await Assert.That(DisablesServer(args, "kcap-flows")).IsTrue();
+        await Assert.That(DisablesServer(args, "node_repl")).IsTrue();
+        await Assert.That(DisablesServer(args, "computer-use")).IsTrue();
 
-        // The ONLY server actually enabled/injected is kcap-flow-result.
+        // The ONLY server actually enabled/injected (via dotted overrides) is kcap-flow-result.
         var enabled = args.Where(a => a.StartsWith("mcp_servers.", StringComparison.Ordinal)
                                    && !a.Contains(".enabled=false")).ToArray();
         await Assert.That(enabled.All(a => a.StartsWith("mcp_servers.kcap-flow-result.", StringComparison.Ordinal))).IsTrue();
@@ -219,8 +232,9 @@ public class CodexLauncherTests {
 
         var args = launcher.BuildArgs(ctx).Args;
 
-        await Assert.That(args).DoesNotContain("mcp_servers.kcap-flow-result.enabled=false");
-        await Assert.That(args).Contains("mcp_servers.node_repl.enabled=false");
+        // kcap-flow-result must NOT appear in the disable table (it is whitelisted).
+        await Assert.That(DisablesServer(args, "kcap-flow-result")).IsFalse();
+        await Assert.That(DisablesServer(args, "node_repl")).IsTrue();
         await Assert.That(args.Any(a => a.StartsWith("mcp_servers.kcap-flow-result.command=", StringComparison.Ordinal))).IsTrue();
 
         // Not merely "not disabled" — explicitly forced on. The user's real
@@ -244,17 +258,19 @@ public class CodexLauncherTests {
 
         var args = launcher.BuildArgs(NewFlowCtx(["kcap-sessions"])).Args;
 
-        await Assert.That(args).DoesNotContain("mcp_servers.kcap-sessions.enabled=false");
+        await Assert.That(DisablesServer(args, "kcap-sessions")).IsFalse();
         await Assert.That(args).Contains("mcp_servers.kcap-sessions.enabled=true");
     }
 
     [Test]
-    public async Task Review_flow_skips_undisableable_dotted_server_name() {
-        // A dotted server name can't be expressed as a Codex `-c` dotted key (Codex mis-splits
-        // it), so it is skipped rather than emitting a broken override that fails config parse.
+    public async Task Review_flow_disables_dotted_server_name() {
+        // HIGH 2: a dotted/quoted server name (e.g. a hand-registered "corp.flows" that can start a
+        // flow) cannot be expressed as a Codex `-c` dotted KEY path — the pre-hardening code logged
+        // and LEFT it enabled, bypassing the recursion guard. The TOML-quoted key inside the single
+        // table-value override targets it exactly, so it IS disabled now.
         var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
         var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
-            ReadInheritedMcpServerNames = static () => ["my.dotted.server", "node_repl"]
+            ReadInheritedMcpServerNames = static () => ["corp.flows", "node_repl"]
         };
         var ctx = new LauncherContext(
             AgentId: "agent-xyz",
@@ -272,8 +288,12 @@ public class CodexLauncherTests {
 
         var args = launcher.BuildArgs(ctx).Args;
 
-        await Assert.That(args.Any(a => a.Contains("my.dotted.server"))).IsFalse();
-        await Assert.That(args).Contains("mcp_servers.node_repl.enabled=false");
+        // The dotted server is disabled (not skipped), and its quoted key is emitted verbatim.
+        await Assert.That(DisablesServer(args, "corp.flows")).IsTrue();
+        await Assert.That(DisableTableOverride(args)!).Contains("\"corp.flows\"={enabled=false");
+        await Assert.That(DisablesServer(args, "node_repl")).IsTrue();
+        // No broken dotted-KEY override (which would fail Codex config load).
+        await Assert.That(args).DoesNotContain("mcp_servers.corp.flows.enabled=false");
     }
 
     [Test]
@@ -301,10 +321,57 @@ public class CodexLauncherTests {
         var args = launcher.BuildArgs(ctx).Args;
 
         await Assert.That(args).DoesNotContain("mcp_servers={}");
-        await Assert.That(args).Contains("mcp_servers.kcap-flows.enabled=false");
-        await Assert.That(args).Contains("mcp_servers.node_repl.enabled=false");
+        await Assert.That(DisablesServer(args, "kcap-flows")).IsTrue();
+        await Assert.That(DisablesServer(args, "node_repl")).IsTrue();
         // Nothing enabled: no flow-result server injected.
         await Assert.That(args.Any(a => a.StartsWith("mcp_servers.kcap-flow-result.", StringComparison.Ordinal))).IsFalse();
+    }
+
+    [Test]
+    public async Task Review_flow_reviewer_inherits_no_user_repo_or_plugin_mcp_server() {
+        // HIGH 1 + HIGH 2 together: `codex mcp list --json` (the injected seam here) reports the
+        // fully-composed effective list — user config.toml servers, a plugin-provided server, and a
+        // dotted-name flow server. EVERY one must be disabled so the reviewer's effective MCP is
+        // ONLY kcap-flow-result — no source (config, plugin, or dotted) leaks a flow-starting tool.
+        var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
+        var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
+            ReadInheritedMcpServerNames = static () => [
+                "kcap-flows",           // user config.toml, plain — the classic recursion vector
+                "corp.flows",           // user config.toml, DOTTED (High 2)
+                "sites-design-picker",  // native plugin-provided (High 1 — missed by config-only)
+                "node_repl"             // plugin/config, benign
+            ]
+        };
+
+        var args = launcher.BuildArgs(NewFlowCtx(null)).Args;
+
+        // Every inherited server, regardless of source or name shape, is disabled.
+        await Assert.That(DisablesServer(args, "kcap-flows")).IsTrue();
+        await Assert.That(DisablesServer(args, "corp.flows")).IsTrue();
+        await Assert.That(DisablesServer(args, "sites-design-picker")).IsTrue();
+        await Assert.That(DisablesServer(args, "node_repl")).IsTrue();
+
+        // The reviewer's ONLY enabled MCP server is kcap-flow-result.
+        var enabled = args.Where(a => a.StartsWith("mcp_servers.", StringComparison.Ordinal)
+                                   && !a.Contains(".enabled=false")).ToArray();
+        await Assert.That(enabled.All(a => a.StartsWith("mcp_servers.kcap-flow-result.", StringComparison.Ordinal))).IsTrue();
+        await Assert.That(args).Contains("mcp_servers.kcap-flow-result.enabled=true");
+    }
+
+    [Test]
+    public async Task Review_flow_fails_closed_when_inherited_servers_cannot_be_enumerated() {
+        // FAIL-CLOSED: if the inherited MCP set can't be authoritatively enumerated (e.g. `codex mcp
+        // list --json` fails), we must NOT proceed having disabled nothing — that would let a
+        // hand-registered flow-starting server through. The enumeration seam throws, and BuildArgs
+        // surfaces it as CodexReviewerMcpIsolationException for the orchestrator to reject the launch.
+        var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
+        var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
+            ReadInheritedMcpServerNames = static () =>
+                throw new CodexReviewerMcpIsolationException("mcp list failed")
+        };
+
+        await Assert.That(() => launcher.BuildArgs(NewFlowCtx(null)))
+            .Throws<CodexReviewerMcpIsolationException>();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -10,8 +10,13 @@ namespace Capacitor.Cli.Tests.Unit.Codex;
 
 [NotInParallel("HomeEnvVarMutation")]
 public class CodexLauncherTests {
+    // Review-flow arg tests must be deterministic w.r.t. the developer's real
+    // ~/.codex/config.toml, so the inherited-server seam defaults to empty. Tests that
+    // exercise the isolation pass inject an explicit inherited list.
     static CodexLauncher NewLauncher() =>
-        new(new DaemonConfig { CodexPath = "codex" }, NullLogger<CodexLauncher>.Instance);
+        new(new DaemonConfig { CodexPath = "codex" }, NullLogger<CodexLauncher>.Instance) {
+            ReadInheritedMcpServerNames = static () => []
+        };
 
     static LauncherContext NewCtx(
         string? prompt       = null,
@@ -129,19 +134,23 @@ public class CodexLauncherTests {
     }
 
     [Test]
-    public async Task BuildArgs_clears_mcp_servers() {
+    public async Task BuildArgs_review_flow_does_not_emit_dead_mcp_servers_clear() {
+        // The old `-c mcp_servers={}` "clear" is a no-op in Codex 0.144.3 (`-c` overrides
+        // deep-merge, so an empty table removes nothing). It must be gone — real isolation
+        // is per-server enabled=false disabling instead.
         var args   = NewLauncher().BuildArgs(NewCtx(isReviewFlow: true)).Args;
         var joined = string.Join(' ', args);
-        await Assert.That(joined).Contains("mcp_servers={}");
-        var cIdx = Array.IndexOf(args, "-c");
-        await Assert.That(cIdx).IsGreaterThan(-1);
-        await Assert.That(args[cIdx + 1]).IsEqualTo("mcp_servers={}");
+        await Assert.That(joined).DoesNotContain("mcp_servers={}");
     }
 
     [Test]
-    public async Task Review_flow_clears_then_whitelists_only_the_flow_result_server() {
+    public async Task Review_flow_disables_inherited_servers_and_whitelists_only_flow_result() {
         var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
-        var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance);
+        var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
+            // The user has a hand-registered kcap-flows (start_review_flow) plus heavy servers —
+            // exactly the recursion-guard threat the dead `mcp_servers={}` clear failed to strip.
+            ReadInheritedMcpServerNames = static () => ["kcap-flows", "node_repl", "computer-use"]
+        };
         var ctx = new LauncherContext(
             AgentId: "agent-xyz",
             SourceRepoPath: "/tmp/repo",
@@ -158,25 +167,25 @@ public class CodexLauncherTests {
 
         var args = launcher.BuildArgs(ctx).Args;
 
-        var clearIdx = Array.IndexOf(args, "mcp_servers={}");
-        await Assert.That(clearIdx).IsGreaterThanOrEqualTo(0);
+        await Assert.That(string.Join(' ', args)).DoesNotContain("mcp_servers={}");
 
-        var dotted = args.Where(a => a.StartsWith("mcp_servers.", StringComparison.Ordinal)).ToArray();
-        await Assert.That(dotted.Length).IsEqualTo(3);
-        await Assert.That(dotted.All(a => a.StartsWith("mcp_servers.kcap-flow-result.", StringComparison.Ordinal))).IsTrue();
+        // Every inherited server — including the hand-registered kcap-flows — is disabled.
+        await Assert.That(args).Contains("mcp_servers.kcap-flows.enabled=false");
+        await Assert.That(args).Contains("mcp_servers.node_repl.enabled=false");
+        await Assert.That(args).Contains("mcp_servers.computer-use.enabled=false");
 
-        // Clear-then-whitelist ORDER: the bare table reset must come BEFORE every dotted override,
-        // otherwise the dotted overrides merge into the user's config.toml table.
-        foreach (var d in dotted) {
-            await Assert.That(Array.IndexOf(args, d)).IsGreaterThan(clearIdx);
-        }
+        // The ONLY server actually enabled/injected is kcap-flow-result.
+        var enabled = args.Where(a => a.StartsWith("mcp_servers.", StringComparison.Ordinal)
+                                   && !a.Contains(".enabled=false")).ToArray();
+        await Assert.That(enabled.All(a => a.StartsWith("mcp_servers.kcap-flow-result.", StringComparison.Ordinal))).IsTrue();
+        await Assert.That(enabled.Length).IsEqualTo(3);
 
-        var command = dotted.Single(a => a.Contains(".command="));
+        var command = enabled.Single(a => a.Contains(".command="));
         await Assert.That(command).Contains("/opt/kcap");
-        var argsOverride = dotted.Single(a => a.Contains(".args="));
+        var argsOverride = enabled.Single(a => a.Contains(".args="));
         await Assert.That(argsOverride).Contains("mcp");
         await Assert.That(argsOverride).Contains("flow-result");
-        var env = dotted.Single(a => a.Contains(".env="));
+        var env = enabled.Single(a => a.Contains(".env="));
         await Assert.That(env).Contains("KCAP_URL");
         await Assert.That(env).Contains("https://t.example");
         await Assert.That(env).Contains("KCAP_FLOW_AGENT_ID");
@@ -184,9 +193,13 @@ public class CodexLauncherTests {
     }
 
     [Test]
-    public async Task Review_flow_without_server_url_injects_no_servers() {
-        var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "" };
-        var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance);
+    public async Task Review_flow_never_disables_a_server_it_is_about_to_whitelist() {
+        // A user server literally named kcap-flow-result must NOT be disabled, or our own
+        // injected submission server would be turned off.
+        var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
+        var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
+            ReadInheritedMcpServerNames = static () => ["kcap-flow-result", "node_repl"]
+        };
         var ctx = new LauncherContext(
             AgentId: "agent-xyz",
             SourceRepoPath: "/tmp/repo",
@@ -203,8 +216,68 @@ public class CodexLauncherTests {
 
         var args = launcher.BuildArgs(ctx).Args;
 
-        await Assert.That(args).Contains("mcp_servers={}");
-        await Assert.That(args.Any(a => a.StartsWith("mcp_servers.", StringComparison.Ordinal))).IsFalse();
+        await Assert.That(args).DoesNotContain("mcp_servers.kcap-flow-result.enabled=false");
+        await Assert.That(args).Contains("mcp_servers.node_repl.enabled=false");
+        await Assert.That(args.Any(a => a.StartsWith("mcp_servers.kcap-flow-result.command=", StringComparison.Ordinal))).IsTrue();
+    }
+
+    [Test]
+    public async Task Review_flow_skips_undisableable_dotted_server_name() {
+        // A dotted server name can't be expressed as a Codex `-c` dotted key (Codex mis-splits
+        // it), so it is skipped rather than emitting a broken override that fails config parse.
+        var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
+        var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
+            ReadInheritedMcpServerNames = static () => ["my.dotted.server", "node_repl"]
+        };
+        var ctx = new LauncherContext(
+            AgentId: "agent-xyz",
+            SourceRepoPath: "/tmp/repo",
+            Worktree: new WorktreeInfo(Path: "/tmp/wt", Branch: "wt-branch", SourceRepo: "/tmp/repo"),
+            Prompt: null,
+            Model: "gpt-5.3-codex",
+            Effort: null,
+            Tools: null,
+            IsReview: false,
+            IsReviewFlow: true,
+            Review: null,
+            ReviewLaunch: null
+        );
+
+        var args = launcher.BuildArgs(ctx).Args;
+
+        await Assert.That(args.Any(a => a.Contains("my.dotted.server"))).IsFalse();
+        await Assert.That(args).Contains("mcp_servers.node_repl.enabled=false");
+    }
+
+    [Test]
+    public async Task Review_flow_without_server_url_disables_inherited_and_injects_no_servers() {
+        // No server URL → nothing is whitelisted (zero-server recursion-safe default), but the
+        // inherited servers are STILL disabled so they don't leak into the reviewer.
+        var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "" };
+        var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
+            ReadInheritedMcpServerNames = static () => ["kcap-flows", "node_repl"]
+        };
+        var ctx = new LauncherContext(
+            AgentId: "agent-xyz",
+            SourceRepoPath: "/tmp/repo",
+            Worktree: new WorktreeInfo(Path: "/tmp/wt", Branch: "wt-branch", SourceRepo: "/tmp/repo"),
+            Prompt: null,
+            Model: "gpt-5.3-codex",
+            Effort: null,
+            Tools: null,
+            IsReview: false,
+            IsReviewFlow: true,
+            Review: null,
+            ReviewLaunch: null
+        );
+
+        var args = launcher.BuildArgs(ctx).Args;
+
+        await Assert.That(args).DoesNotContain("mcp_servers={}");
+        await Assert.That(args).Contains("mcp_servers.kcap-flows.enabled=false");
+        await Assert.That(args).Contains("mcp_servers.node_repl.enabled=false");
+        // Nothing enabled: no flow-result server injected.
+        await Assert.That(args.Any(a => a.StartsWith("mcp_servers.kcap-flow-result.", StringComparison.Ordinal))).IsFalse();
     }
 
     [Test]
@@ -460,7 +533,9 @@ public class CodexLauncherTests {
     // === D-c: definition MCP allowlist materialization ===
 
     static CodexLauncher NewFlowResultLauncher() =>
-        new(new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" }, NullLogger<CodexLauncher>.Instance);
+        new(new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" }, NullLogger<CodexLauncher>.Instance) {
+            ReadInheritedMcpServerNames = static () => []
+        };
 
     static LauncherContext NewFlowCtx(string[]? allowlist) => new LauncherContext(
         AgentId: "agent-xyz",
@@ -480,18 +555,13 @@ public class CodexLauncherTests {
     public async Task ReviewFlow_with_allowlist_merges_servers_into_dotted_overrides() {
         var args = NewFlowResultLauncher().BuildArgs(NewFlowCtx(["kcap-sessions"])).Args;
 
-        var clearIdx = Array.IndexOf(args, "mcp_servers={}");
-        await Assert.That(clearIdx).IsGreaterThanOrEqualTo(0);
+        await Assert.That(string.Join(' ', args)).DoesNotContain("mcp_servers={}");
 
         var dotted = args.Where(a => a.StartsWith("mcp_servers.", StringComparison.Ordinal)).ToArray();
         await Assert.That(dotted.Any(a => a.StartsWith("mcp_servers.kcap-flow-result.", StringComparison.Ordinal))).IsTrue();
 
         var sessionsDotted = dotted.Where(a => a.StartsWith("mcp_servers.kcap-sessions.", StringComparison.Ordinal)).ToArray();
         await Assert.That(sessionsDotted.Length).IsEqualTo(3);
-
-        foreach (var d in sessionsDotted) {
-            await Assert.That(Array.IndexOf(args, d)).IsGreaterThan(clearIdx);
-        }
 
         var command = sessionsDotted.Single(a => a.Contains(".command="));
         await Assert.That(command).Contains("/opt/kcap");
@@ -524,14 +594,15 @@ public class CodexLauncherTests {
     }
 
     [Test]
-    public async Task ReviewFlow_without_allowlist_args_byte_identical_to_today() {
+    public async Task ReviewFlow_no_inherited_servers_emits_only_the_flow_result_whitelist() {
+        // With no inherited servers there is nothing to disable — the dead `mcp_servers={}`
+        // clear is gone and the args are exactly the flow-result whitelist.
         var args = NewFlowResultLauncher().BuildArgs(NewFlowCtx(null)).Args;
 
         string[] expected = [
             "--cd", "/tmp/wt",
             "--sandbox", "workspace-write",
             "--ask-for-approval", "never",
-            "-c", "mcp_servers={}",
             "-c", "mcp_servers.kcap-flow-result.command=\"/opt/kcap\"",
             "-c", "mcp_servers.kcap-flow-result.args=[\"mcp\",\"flow-result\"]",
             "-c", "mcp_servers.kcap-flow-result.env={KCAP_URL=\"https://t.example\",KCAP_FLOW_AGENT_ID=\"agent-xyz\"}",

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexMcpInventoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexMcpInventoryTests.cs
@@ -1,0 +1,56 @@
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Codex;
+
+/// <summary>
+/// Parser-level coverage for the review-flow reviewer's MCP enumeration authority. The full
+/// process-spawn (<c>codex mcp list --json</c>) is exercised manually against the real binary; here
+/// we pin the pure parse of its payload — including that ALL sources (config.toml servers, a native
+/// plugin-provided server, a dotted-name server) are surfaced, which is the High 1 / High 2 gap the
+/// config-only enumeration missed — and that malformed output fails CLOSED (throws) rather than
+/// silently dropping servers.
+/// </summary>
+public class CodexMcpInventoryTests {
+    // A representative `codex mcp list --json` payload: a config.toml server, a plugin-provided
+    // server (no config transport), and a DOTTED-name server — the three shapes the hardened
+    // enumeration must surface so every one gets disabled for the reviewer.
+    const string SampleJson = """
+        [
+          { "name": "kcap-flows", "enabled": true, "disabled_reason": null,
+            "transport": { "type": "stdio", "command": "kcap", "args": ["mcp", "flows"] } },
+          { "name": "corp.flows", "enabled": true, "disabled_reason": null,
+            "transport": { "type": "stdio", "command": "kcap", "args": ["mcp", "flows"] } },
+          { "name": "sites-design-picker", "enabled": true, "disabled_reason": null,
+            "transport": { "type": "stdio", "command": "node", "args": ["./mcp/server.mjs"] } },
+          { "name": "node_repl", "enabled": false, "disabled_reason": null,
+            "transport": { "type": "stdio", "command": "node_repl" } }
+        ]
+        """;
+
+    [Test]
+    public async Task ParseServerNames_surfaces_config_plugin_and_dotted_servers() {
+        var names = CodexMcpInventory.ParseServerNames(SampleJson);
+
+        await Assert.That(names).Contains("kcap-flows");           // config.toml
+        await Assert.That(names).Contains("corp.flows");           // dotted (High 2)
+        await Assert.That(names).Contains("sites-design-picker");  // plugin-provided (High 1)
+        await Assert.That(names).Contains("node_repl");            // even a disabled one is reported
+        await Assert.That(names.Count).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task ParseServerNames_empty_array_returns_empty() {
+        await Assert.That(CodexMcpInventory.ParseServerNames("[]")).IsEmpty();
+    }
+
+    [Test]
+    [Arguments("not json at all")]
+    [Arguments("{ \"name\": \"x\" }")]      // a JSON object, not the expected array
+    [Arguments("[ { \"enabled\": true } ]")] // array element missing a name
+    [Arguments("[ { \"name\": 42 } ]")]      // non-string name
+    [Arguments("[ { \"name\": \"\" } ]")]    // empty name
+    public async Task ParseServerNames_fails_closed_on_malformed_output(string payload) {
+        await Assert.That(() => CodexMcpInventory.ParseServerNames(payload))
+            .Throws<CodexReviewerMcpIsolationException>();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/CodexSessionRolloutLocatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodexSessionRolloutLocatorTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Capacitor.Cli.Daemon.Services;
 
 namespace Capacitor.Cli.Tests.Unit;
@@ -14,10 +15,14 @@ namespace Capacitor.Cli.Tests.Unit;
 public class CodexSessionRolloutLocatorTests {
     const string Cwd = "/Users/dev/repo";
 
+    // cwd is JSON-encoded via JsonSerializer (not naive quote-wrapping): a real Windows path
+    // contains single backslashes, which are invalid unescaped inside a JSON string and were
+    // silently corrupting every TryLocate fixture below on windows-latest CI (JsonNode.Parse
+    // threw, MatchRollout fell back to CwdMatch.Unknown, and TryLocate always returned null).
     static string Meta(string cwd) =>
         "{\"type\":\"session_meta\",\"payload\":{\"id\":\"019f0021-29e3-7461-a781-e2646e16e271\","
-      + "\"session_id\":\"019f0021-29e3-7461-a781-e2646e16e271\",\"cwd\":\"" + cwd
-      + "\",\"originator\":\"codex-tui\"}}";
+      + "\"session_id\":\"019f0021-29e3-7461-a781-e2646e16e271\",\"cwd\":" + JsonSerializer.Serialize(cwd)
+      + ",\"originator\":\"codex-tui\"}}";
 
     // ── cwd match / mismatch (payload.cwd, not root cwd) ─────────────────
 
@@ -74,7 +79,9 @@ public class CodexSessionRolloutLocatorTests {
 
     [Test]
     public async Task WindowsCaseInsensitive_DifferentCase_Matches() {
-        var lines = new[] { Meta(@"C:\\Users\\Dev\\Repo") };
+        // A single-backslash path — Meta() now JSON-encodes it correctly itself; no more
+        // manual pre-doubling to work around the old naive string concatenation.
+        var lines = new[] { Meta(@"C:\Users\Dev\Repo") };
 
         await Assert.That(CodexSessionRolloutLocator.MatchRollout(lines, @"c:\users\dev\repo", StringComparison.OrdinalIgnoreCase))
             .IsEqualTo(CodexSessionRolloutLocator.CwdMatch.Yes);
@@ -127,5 +134,108 @@ public class CodexSessionRolloutLocatorTests {
         var missing = Path.Combine(Path.GetTempPath(), "kcap-codexrollout-missing-" + Guid.NewGuid().ToString("N"));
 
         await Assert.That(CodexSessionRolloutLocator.TryLocate(missing, "/wt", DateTime.UtcNow)).IsNull();
+    }
+
+    // ── IsNewEnough: creation-time-only eligibility ──────────────────────
+
+    [Test]
+    public async Task IsNewEnough_creation_at_spawn_is_true() {
+        var spawn = DateTime.UtcNow;
+        await Assert.That(CodexSessionRolloutLocator.IsNewEnough(spawn, spawn)).IsTrue();
+    }
+
+    [Test]
+    public async Task IsNewEnough_creation_well_before_spawn_is_false_even_if_recently_written() {
+        // The bug: a much-older rollout must fail eligibility on creation time alone — an
+        // ongoing write to it (last-write time) is no longer part of the equation at all.
+        var spawn    = DateTime.UtcNow;
+        var creation = spawn.AddMinutes(-10);
+
+        await Assert.That(CodexSessionRolloutLocator.IsNewEnough(creation, spawn)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsNewEnough_creation_just_within_skew_tolerance_is_true() {
+        var spawn = DateTime.UtcNow;
+        await Assert.That(CodexSessionRolloutLocator.IsNewEnough(spawn.AddSeconds(-4), spawn)).IsTrue();
+    }
+
+    // ── TryLocate: creation-time eligibility + closest-after-spawn selection ─────
+
+    static string WriteRolloutAt(string sessionsRoot, string uuid, string cwd, DateTime creationUtc, DateTime lastWriteUtc) {
+        var file = WriteRollout(sessionsRoot, DateTime.Now, uuid, cwd);
+        File.SetCreationTimeUtc(file, creationUtc);
+        File.SetLastWriteTimeUtc(file, lastWriteUtc);
+        return file;
+    }
+
+    [Test]
+    public async Task TryLocate_ignores_an_older_same_cwd_rollout_still_being_written() {
+        // An older, unrelated rollout in the same (borrowed) cwd that a live process is still
+        // appending to (recent last-write) must NOT be mistaken for the freshly-spawned
+        // reviewer. Only the reviewer's own, genuinely newer rollout should be selected.
+        var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;
+        try {
+            var spawn = DateTime.UtcNow;
+            var wt    = Path.Combine(root, "worktree");
+
+            const string olderUuid = "019f0022-0000-7a02-a630-edbfb043add4";
+            WriteRolloutAt(root, olderUuid, wt, creationUtc: spawn.AddMinutes(-10), lastWriteUtc: spawn.AddSeconds(1));
+
+            const string newerUuid = "019f0022-1111-7a02-a630-edbfb043add5";
+            WriteRolloutAt(root, newerUuid, wt, creationUtc: spawn.AddSeconds(2), lastWriteUtc: spawn.AddSeconds(2));
+
+            var id = CodexSessionRolloutLocator.TryLocate(root, wt, spawn);
+
+            await Assert.That(id).IsEqualTo(newerUuid.Replace("-", ""));
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task TryLocate_returns_null_when_only_a_pre_spawn_rollout_matches() {
+        // Same shape as above minus the reviewer's own rollout: nothing eligible remains, so
+        // TryLocate must not fall back to the stale, still-being-written match.
+        var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;
+        try {
+            var spawn = DateTime.UtcNow;
+            var wt    = Path.Combine(root, "worktree");
+
+            WriteRolloutAt(root, "019f0022-0000-7a02-a630-edbfb043add4", wt,
+                creationUtc: spawn.AddMinutes(-10), lastWriteUtc: spawn.AddSeconds(1));
+
+            var id = CodexSessionRolloutLocator.TryLocate(root, wt, spawn);
+
+            await Assert.That(id).IsNull();
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task TryLocate_prefers_the_rollout_created_closest_after_spawn_over_an_earlier_eligible_one() {
+        // Both rollouts pass the creation-based eligibility window (one via the clock-skew
+        // slack, created just before spawn), so eligibility alone can't disambiguate them.
+        // Picking the numerically EARLIEST creation would wrongly prefer the pre-spawn one —
+        // the reviewer's own rollout is always created at/after its own spawn, so the
+        // at/after candidate must win.
+        var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;
+        try {
+            var spawn = DateTime.UtcNow;
+            var wt    = Path.Combine(root, "worktree");
+
+            const string beforeUuid = "019f0022-2222-7a02-a630-edbfb043add6";
+            WriteRolloutAt(root, beforeUuid, wt, creationUtc: spawn.AddSeconds(-3), lastWriteUtc: spawn.AddSeconds(-3));
+
+            const string afterUuid = "019f0022-3333-7a02-a630-edbfb043add7";
+            WriteRolloutAt(root, afterUuid, wt, creationUtc: spawn.AddSeconds(2), lastWriteUtc: spawn.AddSeconds(2));
+
+            var id = CodexSessionRolloutLocator.TryLocate(root, wt, spawn);
+
+            await Assert.That(id).IsEqualTo(afterUuid.Replace("-", ""));
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/CodexSessionRolloutLocatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodexSessionRolloutLocatorTests.cs
@@ -89,10 +89,16 @@ public class CodexSessionRolloutLocatorTests {
 
     // ── TryLocate over a real ~/.codex/sessions-shaped tree ──────────────
 
-    static string WriteRollout(string sessionsRoot, DateTime day, string uuid, string cwd) {
-        var dir = Path.Combine(sessionsRoot, day.ToString("yyyy"), day.ToString("MM"), day.ToString("dd"));
+    // Encodes the creation instant into the rollout FILENAME — Codex's own scheme
+    // (rollout-<yyyy-MM-ddTHH-mm-ss>-<uuid>.jsonl, local time under a local-dated day folder),
+    // which is exactly what the locator reads. NOT File.SetCreationTimeUtc: that is a no-op on
+    // Linux, so a creation time set that way collapses to "now" on the CI runner and the fixtures
+    // below could not express "older than spawn".
+    static string WriteRollout(string sessionsRoot, string uuid, string cwd, DateTime creationUtc) {
+        var local = creationUtc.ToLocalTime();
+        var dir   = Path.Combine(sessionsRoot, local.ToString("yyyy"), local.ToString("MM"), local.ToString("dd"));
         Directory.CreateDirectory(dir);
-        var file = Path.Combine(dir, $"rollout-{day:yyyy-MM-dd}T00-00-00-{uuid}.jsonl");
+        var file = Path.Combine(dir, $"rollout-{local:yyyy-MM-dd}T{local:HH-mm-ss}-{uuid}.jsonl");
         File.WriteAllText(file, Meta(cwd) + "\n");
         return file;
     }
@@ -104,7 +110,7 @@ public class CodexSessionRolloutLocatorTests {
             var spawn = DateTime.UtcNow;
             var uuid  = "019f0022-1702-7a02-a630-edbfb043add4";
             var wt    = Path.Combine(root, "worktree");
-            WriteRollout(root, DateTime.Now, uuid, wt);
+            WriteRollout(root, uuid, wt, creationUtc: spawn);
 
             var id = CodexSessionRolloutLocator.TryLocate(root, wt, spawn.AddSeconds(-1));
 
@@ -119,7 +125,7 @@ public class CodexSessionRolloutLocatorTests {
         var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;
         try {
             var spawn = DateTime.UtcNow;
-            WriteRollout(root, DateTime.Now, "019f0022-1702-7a02-a630-edbfb043add4", "/some/other/cwd");
+            WriteRollout(root, "019f0022-1702-7a02-a630-edbfb043add4", "/some/other/cwd", creationUtc: spawn);
 
             var id = CodexSessionRolloutLocator.TryLocate(root, Path.Combine(root, "worktree"), spawn.AddSeconds(-1));
 
@@ -161,29 +167,26 @@ public class CodexSessionRolloutLocatorTests {
     }
 
     // ── TryLocate: creation-time eligibility + closest-after-spawn selection ─────
-
-    static string WriteRolloutAt(string sessionsRoot, string uuid, string cwd, DateTime creationUtc, DateTime lastWriteUtc) {
-        var file = WriteRollout(sessionsRoot, DateTime.Now, uuid, cwd);
-        File.SetCreationTimeUtc(file, creationUtc);
-        File.SetLastWriteTimeUtc(file, lastWriteUtc);
-        return file;
-    }
+    // Creation time is expressed via the rollout FILENAME stamp (see WriteRollout) — the locator
+    // reads that, not File.GetCreationTimeUtc, precisely because file birth time is un-settable
+    // and unreliable on Linux. Last-write time is deliberately not a factor: the locator ignores
+    // it, so an "older session still being appended to" is modeled purely by an old filename stamp.
 
     [Test]
     public async Task TryLocate_ignores_an_older_same_cwd_rollout_still_being_written() {
         // An older, unrelated rollout in the same (borrowed) cwd that a live process is still
-        // appending to (recent last-write) must NOT be mistaken for the freshly-spawned
-        // reviewer. Only the reviewer's own, genuinely newer rollout should be selected.
+        // appending to must NOT be mistaken for the freshly-spawned reviewer. Its recent writes
+        // are irrelevant (the locator never reads last-write); only its old creation stamp counts.
         var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;
         try {
             var spawn = DateTime.UtcNow;
             var wt    = Path.Combine(root, "worktree");
 
             const string olderUuid = "019f0022-0000-7a02-a630-edbfb043add4";
-            WriteRolloutAt(root, olderUuid, wt, creationUtc: spawn.AddMinutes(-10), lastWriteUtc: spawn.AddSeconds(1));
+            WriteRollout(root, olderUuid, wt, creationUtc: spawn.AddMinutes(-10));
 
             const string newerUuid = "019f0022-1111-7a02-a630-edbfb043add5";
-            WriteRolloutAt(root, newerUuid, wt, creationUtc: spawn.AddSeconds(2), lastWriteUtc: spawn.AddSeconds(2));
+            WriteRollout(root, newerUuid, wt, creationUtc: spawn.AddSeconds(2));
 
             var id = CodexSessionRolloutLocator.TryLocate(root, wt, spawn);
 
@@ -196,14 +199,13 @@ public class CodexSessionRolloutLocatorTests {
     [Test]
     public async Task TryLocate_returns_null_when_only_a_pre_spawn_rollout_matches() {
         // Same shape as above minus the reviewer's own rollout: nothing eligible remains, so
-        // TryLocate must not fall back to the stale, still-being-written match.
+        // TryLocate must not fall back to the stale pre-spawn match.
         var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;
         try {
             var spawn = DateTime.UtcNow;
             var wt    = Path.Combine(root, "worktree");
 
-            WriteRolloutAt(root, "019f0022-0000-7a02-a630-edbfb043add4", wt,
-                creationUtc: spawn.AddMinutes(-10), lastWriteUtc: spawn.AddSeconds(1));
+            WriteRollout(root, "019f0022-0000-7a02-a630-edbfb043add4", wt, creationUtc: spawn.AddMinutes(-10));
 
             var id = CodexSessionRolloutLocator.TryLocate(root, wt, spawn);
 
@@ -226,10 +228,10 @@ public class CodexSessionRolloutLocatorTests {
             var wt    = Path.Combine(root, "worktree");
 
             const string beforeUuid = "019f0022-2222-7a02-a630-edbfb043add6";
-            WriteRolloutAt(root, beforeUuid, wt, creationUtc: spawn.AddSeconds(-3), lastWriteUtc: spawn.AddSeconds(-3));
+            WriteRollout(root, beforeUuid, wt, creationUtc: spawn.AddSeconds(-3));
 
             const string afterUuid = "019f0022-3333-7a02-a630-edbfb043add7";
-            WriteRolloutAt(root, afterUuid, wt, creationUtc: spawn.AddSeconds(2), lastWriteUtc: spawn.AddSeconds(2));
+            WriteRollout(root, afterUuid, wt, creationUtc: spawn.AddSeconds(2));
 
             var id = CodexSessionRolloutLocator.TryLocate(root, wt, spawn);
 

--- a/test/Capacitor.Cli.Tests.Unit/CodexSessionRolloutLocatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodexSessionRolloutLocatorTests.cs
@@ -1,0 +1,131 @@
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Tests the pure decision logic of <see cref="CodexSessionRolloutLocator"/> — the daemon's
+/// best-effort fallback that links a hosted Codex reviewer to its session id when the
+/// session-start hook doesn't land. Codex writes each session to
+/// <c>~/.codex/sessions/YYYY/MM/DD/rollout-&lt;ts&gt;-&lt;uuid&gt;.jsonl</c>; the session id is the
+/// filename UUID (== the hook-reported <c>session_id</c> for a top-level CLI session), and the
+/// cwd lives in the opening <c>session_meta</c> envelope's <c>payload.cwd</c> (NOT at the JSONL
+/// root the way Claude stores it).
+/// </summary>
+public class CodexSessionRolloutLocatorTests {
+    const string Cwd = "/Users/dev/repo";
+
+    static string Meta(string cwd) =>
+        "{\"type\":\"session_meta\",\"payload\":{\"id\":\"019f0021-29e3-7461-a781-e2646e16e271\","
+      + "\"session_id\":\"019f0021-29e3-7461-a781-e2646e16e271\",\"cwd\":\"" + cwd
+      + "\",\"originator\":\"codex-tui\"}}";
+
+    // ── cwd match / mismatch (payload.cwd, not root cwd) ─────────────────
+
+    [Test]
+    public async Task CwdMatch_ReturnsYes() {
+        await Assert.That(CodexSessionRolloutLocator.MatchRollout([Meta(Cwd)], Cwd, StringComparison.Ordinal))
+            .IsEqualTo(CodexSessionRolloutLocator.CwdMatch.Yes);
+    }
+
+    [Test]
+    public async Task ForeignCwd_ReturnsNo() {
+        // The user's own concurrent session in a different repo — must not be claimed.
+        await Assert.That(CodexSessionRolloutLocator.MatchRollout([Meta("/Users/dev/other")], Cwd, StringComparison.Ordinal))
+            .IsEqualTo(CodexSessionRolloutLocator.CwdMatch.No);
+    }
+
+    [Test]
+    public async Task RootLevelCwd_IsIgnored_ReturnsUnknown() {
+        // Claude puts cwd at the root; Codex does NOT. A root-level cwd must not be treated
+        // as a Codex match, or a Claude transcript would be mis-parsed.
+        var claudeShaped = $$"""{"type":"user","cwd":"{{Cwd}}"}""";
+
+        await Assert.That(CodexSessionRolloutLocator.MatchRollout([claudeShaped], Cwd, StringComparison.Ordinal))
+            .IsEqualTo(CodexSessionRolloutLocator.CwdMatch.Unknown);
+    }
+
+    [Test]
+    public async Task NoCwdYet_ReturnsUnknown() {
+        // A freshly-created rollout whose session_meta line isn't flushed yet.
+        var eventOnly = """{"type":"event_msg","payload":{"type":"task_started"}}""";
+
+        await Assert.That(CodexSessionRolloutLocator.MatchRollout([eventOnly], Cwd, StringComparison.Ordinal))
+            .IsEqualTo(CodexSessionRolloutLocator.CwdMatch.Unknown);
+    }
+
+    [Test]
+    public async Task TrailingSeparator_IsTolerated() {
+        await Assert.That(CodexSessionRolloutLocator.MatchRollout([Meta(Cwd + "/")], Cwd, StringComparison.Ordinal))
+            .IsEqualTo(CodexSessionRolloutLocator.CwdMatch.Yes);
+    }
+
+    [Test]
+    public async Task InvalidJsonLines_AreSkipped() {
+        string[] lines = [
+            "not json",
+            """{"type":"session_meta","payload":{"cwd":123}}""", // cwd not a string
+            """{"truncated":"partial""",
+            Meta(Cwd)
+        ];
+
+        await Assert.That(CodexSessionRolloutLocator.MatchRollout(lines, Cwd, StringComparison.Ordinal))
+            .IsEqualTo(CodexSessionRolloutLocator.CwdMatch.Yes);
+    }
+
+    [Test]
+    public async Task WindowsCaseInsensitive_DifferentCase_Matches() {
+        var lines = new[] { Meta(@"C:\\Users\\Dev\\Repo") };
+
+        await Assert.That(CodexSessionRolloutLocator.MatchRollout(lines, @"c:\users\dev\repo", StringComparison.OrdinalIgnoreCase))
+            .IsEqualTo(CodexSessionRolloutLocator.CwdMatch.Yes);
+    }
+
+    // ── TryLocate over a real ~/.codex/sessions-shaped tree ──────────────
+
+    static string WriteRollout(string sessionsRoot, DateTime day, string uuid, string cwd) {
+        var dir = Path.Combine(sessionsRoot, day.ToString("yyyy"), day.ToString("MM"), day.ToString("dd"));
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, $"rollout-{day:yyyy-MM-dd}T00-00-00-{uuid}.jsonl");
+        File.WriteAllText(file, Meta(cwd) + "\n");
+        return file;
+    }
+
+    [Test]
+    public async Task TryLocate_returns_dashless_session_id_of_the_matching_rollout() {
+        var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;
+        try {
+            var spawn = DateTime.UtcNow;
+            var uuid  = "019f0022-1702-7a02-a630-edbfb043add4";
+            var wt    = Path.Combine(root, "worktree");
+            WriteRollout(root, DateTime.Now, uuid, wt);
+
+            var id = CodexSessionRolloutLocator.TryLocate(root, wt, spawn.AddSeconds(-1));
+
+            await Assert.That(id).IsEqualTo(uuid.Replace("-", ""));
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task TryLocate_ignores_a_foreign_cwd_rollout() {
+        var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;
+        try {
+            var spawn = DateTime.UtcNow;
+            WriteRollout(root, DateTime.Now, "019f0022-1702-7a02-a630-edbfb043add4", "/some/other/cwd");
+
+            var id = CodexSessionRolloutLocator.TryLocate(root, Path.Combine(root, "worktree"), spawn.AddSeconds(-1));
+
+            await Assert.That(id).IsNull();
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task TryLocate_missing_sessions_root_returns_null() {
+        var missing = Path.Combine(Path.GetTempPath(), "kcap-codexrollout-missing-" + Guid.NewGuid().ToString("N"));
+
+        await Assert.That(CodexSessionRolloutLocator.TryLocate(missing, "/wt", DateTime.UtcNow)).IsNull();
+    }
+}


### PR DESCRIPTION
CLI half of the AI-1517 codex-reviewer-regression fix (complements the server liveness-convergence PR). Two changes:

1. **Session-id locator → codex.** The reviewer session-id path was Claude-only (`DetectClaudeSessionIdAsync`). codex 0.144.3 writes `~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` (id = the filename UUID = `session_meta.payload.session_id`); new `CodexSessionRolloutLocator` scans that tree, filters by spawn time, matches `payload.cwd`. Launch-site gate is now vendor-dispatched (`DetectSessionIdAsync`/`PollForSessionIdAsync`); Claude path unchanged. **Best-effort** — the server no longer *requires* the id (it converges on daemon liveness), so this only resolves it for correlation/display.
2. **Real codex MCP isolation.** `-c mcp_servers={}` is a no-op in codex 0.144.3 (`-c` deep-merges) and there's no `--strict-mcp-config` analog, so a review-flow codex reviewer inherited the user's `~/.codex/config.toml` MCP servers — including a hand-registered `kcap-flows` (silently killing the recursion guard). Real isolation = enumerate the inherited `[mcp_servers]` and set per-server `enabled=false` (a genuine, honoured field — verified via `codex mcp list`), then whitelist only `kcap-flow-result`. Verified end-to-end against the codex binary.

Rebased onto main (incl. #362): the `AgentOrchestrator` 3-way merge kept both #362's consent-gate/PTY-capture and this branch's session-id locator. Tests: `CodexSessionRolloutLocator` 10, `ReadMcpServerNames` 4, launcher-isolation 6; `AgentOrchestrator` 87/87; #362 consent/failed-launch suites all green. AOT clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)