### PR TITLE
[AI-1519] Fix codex reviewer launch for url-based MCP servers in config.toml

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -20,9 +20,9 @@ internal sealed partial class CodexLauncher(
     public bool IsAvailable() => CliResolver.Exists(CliPath);
 
     /// <summary>
-    /// Enumerates the effective MCP server names a review-flow reviewer would otherwise inherit —
+    /// Enumerates the effective MCP servers a review-flow reviewer would otherwise inherit —
     /// the recursion guard's foundation. Default runs <c>codex mcp list --json</c>
-    /// (<see cref="CodexMcpInventory.ListInheritedServerNames"/>), which reports the fully-composed
+    /// (<see cref="CodexMcpInventory.ListInheritedServers"/>), which reports the fully-composed
     /// effective list (user <c>$CODEX_HOME/config.toml</c> <c>[mcp_servers]</c> AND active native
     /// plugins), honouring <c>CODEX_HOME</c> exactly as the spawned reviewer will. Reading
     /// <c>config.toml</c> alone (the pre-hardening behaviour) missed plugin-registered servers, so a
@@ -30,15 +30,19 @@ internal sealed partial class CodexLauncher(
     /// stays deterministic in unit tests. Throwing here is fail-closed — the launch is rejected
     /// rather than proceeding with an incomplete view of what the reviewer inherits.
     /// </summary>
-    internal Func<IReadOnlyList<string>> ReadInheritedMcpServerNames { get; init; } =
-        () => CodexMcpInventory.ListInheritedServerNames(config.CodexPath);
+    internal Func<IReadOnlyList<InheritedMcpServer>> ReadInheritedMcpServers { get; init; } =
+        () => CodexMcpInventory.ListInheritedServers(config.CodexPath);
 
-    /// <summary>Inert <c>command</c> stamped on every disabled server's override. Codex requires a
-    /// transport to be present to accept an <c>mcp_servers.&lt;name&gt;</c> override — a plugin-provided
-    /// server has no transport at the config layer, so <c>enabled=false</c> alone fails config load
-    /// with "invalid transport" (verified against 0.144.3). Supplying this sentinel satisfies the
-    /// validator; it is never executed because the server is disabled, and Codex does not check that
-    /// the command exists for a disabled server, so the value is cross-platform safe.</summary>
+    /// <summary>Inert <c>command</c> stamped on a disabled TRANSPORT-LESS server's override. Codex
+    /// requires a transport to be present to accept an <c>mcp_servers.&lt;name&gt;</c> override — a
+    /// plugin-provided server has no transport at the config layer, so <c>enabled=false</c> alone
+    /// fails config load with "invalid transport" (verified against 0.144.3). Supplying this sentinel
+    /// satisfies the validator; it is never executed because the server is disabled, and Codex does
+    /// not check that the command exists for a disabled server, so the value is cross-platform safe.
+    /// NEVER stamped on a url-based server: <c>-c</c> deep-merges over <c>config.toml</c>, so a
+    /// config-defined url server would end up with BOTH <c>url</c> and <c>command</c> and fail config
+    /// load with "url is not supported for stdio" (AI-1519, verified against 0.144.6) — those
+    /// re-state their own <c>url</c> instead.</summary>
     internal const string DisabledServerSentinelCommand = "kcap-review-flow-isolation-disabled";
 
     static readonly string[] CriticalHookEvents = ["SessionStart", "Stop", "PermissionRequest"];
@@ -165,13 +169,18 @@ internal sealed partial class CodexLauncher(
     ///   <item>A plugin-provided server has no transport at the config layer, so a bare
     ///     <c>enabled=false</c> fails config load with "invalid transport"; stamping the inert
     ///     <see cref="DisabledServerSentinelCommand"/> transport satisfies the validator while the
-    ///     server stays off.</item>
+    ///     server stays off. A URL-BASED server must NOT get that sentinel: the deep-merge would
+    ///     leave it with both <c>url</c> and <c>command</c>, which fails config load with "url is
+    ///     not supported for stdio" (AI-1519) — its override re-states the enumerated <c>url</c> as
+    ///     the transport instead, which is valid whether the server came from config.toml (merges
+    ///     onto the identical url) or a plugin (the config-layer entry then carries its own
+    ///     transport).</item>
     ///   <item>Multiple separate <c>-c mcp_servers={…}</c> overrides do NOT accumulate (last wins),
     ///     whereas a single one deep-merges cleanly over the base file and composes with the dotted
     ///     whitelist ENABLE overrides added afterwards (all verified against Codex 0.144.3).</item>
     /// </list>
     ///
-    /// Fail-closed: <see cref="ReadInheritedMcpServerNames"/> throws
+    /// Fail-closed: <see cref="ReadInheritedMcpServers"/> throws
     /// <see cref="CodexReviewerMcpIsolationException"/> when the inherited set cannot be
     /// authoritatively enumerated; that propagates out of <see cref="BuildArgs"/> and the
     /// orchestrator rejects the launch — we never proceed having disabled nothing.
@@ -181,15 +190,18 @@ internal sealed partial class CodexLauncher(
 
         var entries = new List<string>();
 
-        foreach (var name in ReadInheritedMcpServerNames()) {
-            if (string.IsNullOrEmpty(name)) continue;
-            if (whitelisted.Contains(name)) continue;
+        foreach (var server in ReadInheritedMcpServers()) {
+            if (string.IsNullOrEmpty(server.Name)) continue;
+            if (whitelisted.Contains(server.Name)) continue;
 
             // TomlString both quotes and escapes, so ANY name — dotted, quoted, or containing
             // control chars — becomes a valid inline-table key that Codex resolves to exactly one
-            // server. The sentinel transport makes plugin-provided (transport-less) servers
-            // disable-able too.
-            entries.Add($"{TomlString(name)}={{enabled=false,command={TomlString(DisabledServerSentinelCommand)},args=[]}}");
+            // server. A url server keeps its own transport (deep-merging the sentinel command onto
+            // it would fail config load — AI-1519); the sentinel transport makes plugin-provided
+            // (transport-less) servers disable-able too.
+            entries.Add(server.Url is { Length: > 0 } url
+                ? $"{TomlString(server.Name)}={{enabled=false,url={TomlString(url)}}}"
+                : $"{TomlString(server.Name)}={{enabled=false,command={TomlString(DisabledServerSentinelCommand)},args=[]}}");
         }
 
         if (entries.Count == 0) return;

--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -41,7 +41,7 @@ internal sealed partial class CodexLauncher(
     /// not check that the command exists for a disabled server, so the value is cross-platform safe.
     /// NEVER stamped on a url-based server: <c>-c</c> deep-merges over <c>config.toml</c>, so a
     /// config-defined url server would end up with BOTH <c>url</c> and <c>command</c> and fail config
-    /// load with "url is not supported for stdio" (AI-1519, verified against 0.144.6) — those
+    /// load with "url is not supported for stdio" (verified against 0.144.6) — those
     /// re-state their own <c>url</c> instead.</summary>
     internal const string DisabledServerSentinelCommand = "kcap-review-flow-isolation-disabled";
 
@@ -171,7 +171,7 @@ internal sealed partial class CodexLauncher(
     ///     <see cref="DisabledServerSentinelCommand"/> transport satisfies the validator while the
     ///     server stays off. A URL-BASED server must NOT get that sentinel: the deep-merge would
     ///     leave it with both <c>url</c> and <c>command</c>, which fails config load with "url is
-    ///     not supported for stdio" (AI-1519) — its override re-states the enumerated <c>url</c> as
+    ///     not supported for stdio" — its override re-states the enumerated <c>url</c> as
     ///     the transport instead, which is valid whether the server came from config.toml (merges
     ///     onto the identical url) or a plugin (the config-layer entry then carries its own
     ///     transport).</item>
@@ -197,7 +197,7 @@ internal sealed partial class CodexLauncher(
             // TomlString both quotes and escapes, so ANY name — dotted, quoted, or containing
             // control chars — becomes a valid inline-table key that Codex resolves to exactly one
             // server. A url server keeps its own transport (deep-merging the sentinel command onto
-            // it would fail config load — AI-1519); the sentinel transport makes plugin-provided
+            // it would fail config load); the sentinel transport makes plugin-provided
             // (transport-less) servers disable-able too.
             entries.Add(server.Url is { Length: > 0 } url
                 ? $"{TomlString(server.Name)}={{enabled=false,url={TomlString(url)}}}"

--- a/src/Capacitor.Cli.Daemon/Services/CodexMcpInventory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexMcpInventory.cs
@@ -28,12 +28,13 @@ internal static class CodexMcpInventory {
 
     /// <summary>
     /// Runs <c>{codexPath} mcp list --json</c> (inheriting this process's environment, so the same
-    /// <c>CODEX_HOME</c> the reviewer will use is honoured) and returns the effective MCP server
-    /// names (config.toml + plugins). Throws <see cref="CodexReviewerMcpIsolationException"/> if the
-    /// process can't be started, times out, exits non-zero, or emits output that isn't a parseable
-    /// JSON array — never returns a partial/empty list to mask such a failure.
+    /// <c>CODEX_HOME</c> the reviewer will use is honoured) and returns the effective MCP servers
+    /// (config.toml + plugins), each with its transport url when it has one. Throws
+    /// <see cref="CodexReviewerMcpIsolationException"/> if the process can't be started, times out,
+    /// exits non-zero, or emits output that isn't a parseable JSON array — never returns a
+    /// partial/empty list to mask such a failure.
     /// </summary>
-    public static IReadOnlyList<string> ListInheritedServerNames(string codexPath) {
+    public static IReadOnlyList<InheritedMcpServer> ListInheritedServers(string codexPath) {
         string stdout;
         string stderr;
         int    exitCode;
@@ -74,17 +75,20 @@ internal static class CodexMcpInventory {
                 $"'{codexPath} mcp list --json' exited {exitCode} while enumerating the reviewer's inherited MCP servers: {detail.Trim()}");
         }
 
-        return ParseServerNames(stdout);
+        return ParseServers(stdout);
     }
 
     /// <summary>
-    /// Parses the <c>codex mcp list --json</c> payload — a JSON array of <c>{ "name": string, … }</c>
-    /// objects — into the list of server names. Pure and side-effect free (unit-testable without the
-    /// codex binary). Throws <see cref="CodexReviewerMcpIsolationException"/> when the payload isn't a
-    /// JSON array or an element has no string <c>name</c>: an unparseable enumeration must fail closed,
-    /// not silently drop servers. A valid empty array (<c>[]</c>) returns an empty list.
+    /// Parses the <c>codex mcp list --json</c> payload — a JSON array of
+    /// <c>{ "name": string, "transport": { "url": string?, … }?, … }</c> objects — into the list of
+    /// servers. Pure and side-effect free (unit-testable without the codex binary). Throws
+    /// <see cref="CodexReviewerMcpIsolationException"/> when the payload isn't a JSON array or an
+    /// element has no string <c>name</c>: an unparseable enumeration must fail closed, not silently
+    /// drop servers. The transport url is best-effort (null when absent or non-string) — either
+    /// value still yields a DISABLING override downstream, so it can shape but never bypass the
+    /// isolation. A valid empty array (<c>[]</c>) returns an empty list.
     /// </summary>
-    public static IReadOnlyList<string> ParseServerNames(string json) {
+    public static IReadOnlyList<InheritedMcpServer> ParseServers(string json) {
         JsonNode? root;
 
         try {
@@ -99,7 +103,7 @@ internal static class CodexMcpInventory {
                 "'codex mcp list --json' output was not a JSON array.");
         }
 
-        var names = new List<string>(array.Count);
+        var servers = new List<InheritedMcpServer>(array.Count);
 
         foreach (var element in array) {
             if (element?["name"] is not JsonValue nameNode ||
@@ -109,9 +113,20 @@ internal static class CodexMcpInventory {
                     "'codex mcp list --json' returned an MCP server entry with no usable name.");
             }
 
-            names.Add(name);
+            var url = element["transport"]?["url"] is JsonValue urlNode &&
+                      urlNode.TryGetValue<string>(out var value) &&
+                      !string.IsNullOrEmpty(value)
+                ? value
+                : null;
+
+            servers.Add(new(name, url));
         }
 
-        return names;
+        return servers;
     }
 }
+
+/// <summary>One effective MCP server a spawned Codex session would inherit. <see cref="Url"/> is the
+/// transport url for a url-based (streamable_http) server, null for stdio/transport-less ones — it
+/// selects the shape of the disabling override in <see cref="CodexLauncher"/> (AI-1519).</summary>
+internal readonly record struct InheritedMcpServer(string Name, string? Url = null);

--- a/src/Capacitor.Cli.Daemon/Services/CodexMcpInventory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexMcpInventory.cs
@@ -144,5 +144,5 @@ internal static class CodexMcpInventory {
 
 /// <summary>One effective MCP server a spawned Codex session would inherit. <see cref="Url"/> is the
 /// transport url for a url-based (streamable_http) server, null for stdio/transport-less ones — it
-/// selects the shape of the disabling override in <see cref="CodexLauncher"/> (AI-1519).</summary>
+/// selects the shape of the disabling override in <see cref="CodexLauncher"/>.</summary>
 internal readonly record struct InheritedMcpServer(string Name, string? Url = null);

--- a/src/Capacitor.Cli.Daemon/Services/CodexMcpInventory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexMcpInventory.cs
@@ -75,7 +75,17 @@ internal static class CodexMcpInventory {
                 $"'{codexPath} mcp list --json' exited {exitCode} while enumerating the reviewer's inherited MCP servers: {detail.Trim()}");
         }
 
-        return ParseServers(stdout);
+        try {
+            return ParseServers(stdout);
+        } catch (CodexReviewerMcpIsolationException) {
+            throw;
+        } catch (Exception ex) {
+            // Parse-time surprises must reach the orchestrator AS the isolation exception — its
+            // launch-rejection catch filters on that type, and anything else would bypass the
+            // fail-closed LaunchFailed cleanup path.
+            throw new CodexReviewerMcpIsolationException(
+                $"Could not interpret 'codex mcp list --json' output: {ex.Message}");
+        }
     }
 
     /// <summary>
@@ -106,14 +116,20 @@ internal static class CodexMcpInventory {
         var servers = new List<InheritedMcpServer>(array.Count);
 
         foreach (var element in array) {
-            if (element?["name"] is not JsonValue nameNode ||
+            // Shape-check BEFORE any string indexer: JsonNode's indexer THROWS on a non-object
+            // node, and an unwrapped exception type would escape the
+            // CodexReviewerMcpIsolationException contract the orchestrator's fail-closed
+            // launch-rejection path catches.
+            if (element is not JsonObject entry ||
+                entry["name"] is not JsonValue nameNode ||
                 !nameNode.TryGetValue<string>(out var name) ||
                 string.IsNullOrEmpty(name)) {
                 throw new CodexReviewerMcpIsolationException(
                     "'codex mcp list --json' returned an MCP server entry with no usable name.");
             }
 
-            var url = element["transport"]?["url"] is JsonValue urlNode &&
+            var url = entry["transport"] is JsonObject transport &&
+                      transport["url"] is JsonValue urlNode &&
                       urlNode.TryGetValue<string>(out var value) &&
                       !string.IsNullOrEmpty(value)
                 ? value

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -360,7 +360,7 @@ public class CodexLauncherTests {
 
     [Test]
     public async Task Review_flow_disables_url_based_servers_via_their_own_url_not_the_sentinel_command() {
-        // AI-1519: `-c` overrides deep-merge over ~/.codex/config.toml, so stamping the sentinel
+        // `-c` overrides deep-merge over ~/.codex/config.toml, so stamping the sentinel
         // command onto a config-defined url (streamable_http) server left the merged entry with
         // BOTH url and command — codex then fails config load with "url is not supported for
         // stdio" (verified against 0.144.6), bricking every reviewer launch for a user with e.g.

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -15,7 +15,7 @@ public class CodexLauncherTests {
     // exercise the isolation pass inject an explicit inherited list.
     static CodexLauncher NewLauncher() =>
         new(new DaemonConfig { CodexPath = "codex" }, NullLogger<CodexLauncher>.Instance) {
-            ReadInheritedMcpServerNames = static () => []
+            ReadInheritedMcpServers = static () => []
         };
 
     static LauncherContext NewCtx(
@@ -161,7 +161,7 @@ public class CodexLauncherTests {
         var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
             // The user has a hand-registered kcap-flows (start_review_flow) plus heavy servers —
             // exactly the recursion-guard threat the dead `mcp_servers={}` clear failed to strip.
-            ReadInheritedMcpServerNames = static () => ["kcap-flows", "node_repl", "computer-use"]
+            ReadInheritedMcpServers = static () => [new("kcap-flows"), new("node_repl"), new("computer-use")]
         };
         var ctx = new LauncherContext(
             AgentId: "agent-xyz",
@@ -214,7 +214,7 @@ public class CodexLauncherTests {
         // injected submission server would be turned off.
         var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
         var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
-            ReadInheritedMcpServerNames = static () => ["kcap-flow-result", "node_repl"]
+            ReadInheritedMcpServers = static () => [new("kcap-flow-result"), new("node_repl")]
         };
         var ctx = new LauncherContext(
             AgentId: "agent-xyz",
@@ -238,7 +238,7 @@ public class CodexLauncherTests {
         await Assert.That(args.Any(a => a.StartsWith("mcp_servers.kcap-flow-result.command=", StringComparison.Ordinal))).IsTrue();
 
         // Not merely "not disabled" — explicitly forced on. The user's real
-        // ~/.codex/config.toml is what `ReadInheritedMcpServerNames` is standing in for here,
+        // ~/.codex/config.toml is what `ReadInheritedMcpServers` is standing in for here,
         // and it may itself already carry `kcap-flow-result` as enabled=false from a prior
         // manual registration. Since `-c` deep-merges over that file, skipping our own disable
         // pass isn't enough — only an explicit enabled=true override guarantees the reviewer's
@@ -253,7 +253,7 @@ public class CodexLauncherTests {
         // `-c` deep-merges over that, so it must be forced back on, not merely left alone.
         var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
         var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
-            ReadInheritedMcpServerNames = static () => ["kcap-sessions"]
+            ReadInheritedMcpServers = static () => [new("kcap-sessions")]
         };
 
         var args = launcher.BuildArgs(NewFlowCtx(["kcap-sessions"])).Args;
@@ -270,7 +270,7 @@ public class CodexLauncherTests {
         // table-value override targets it exactly, so it IS disabled now.
         var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
         var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
-            ReadInheritedMcpServerNames = static () => ["corp.flows", "node_repl"]
+            ReadInheritedMcpServers = static () => [new("corp.flows"), new("node_repl")]
         };
         var ctx = new LauncherContext(
             AgentId: "agent-xyz",
@@ -302,7 +302,7 @@ public class CodexLauncherTests {
         // inherited servers are STILL disabled so they don't leak into the reviewer.
         var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "" };
         var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
-            ReadInheritedMcpServerNames = static () => ["kcap-flows", "node_repl"]
+            ReadInheritedMcpServers = static () => [new("kcap-flows"), new("node_repl")]
         };
         var ctx = new LauncherContext(
             AgentId: "agent-xyz",
@@ -335,11 +335,11 @@ public class CodexLauncherTests {
         // ONLY kcap-flow-result — no source (config, plugin, or dotted) leaks a flow-starting tool.
         var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
         var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
-            ReadInheritedMcpServerNames = static () => [
-                "kcap-flows",           // user config.toml, plain — the classic recursion vector
-                "corp.flows",           // user config.toml, DOTTED (High 2)
-                "sites-design-picker",  // native plugin-provided (High 1 — missed by config-only)
-                "node_repl"             // plugin/config, benign
+            ReadInheritedMcpServers = static () => [
+                new("kcap-flows"),           // user config.toml, plain — the classic recursion vector
+                new("corp.flows"),           // user config.toml, DOTTED (High 2)
+                new("sites-design-picker"),  // native plugin-provided (High 1 — missed by config-only)
+                new("node_repl")             // plugin/config, benign
             ]
         };
 
@@ -359,6 +359,34 @@ public class CodexLauncherTests {
     }
 
     [Test]
+    public async Task Review_flow_disables_url_based_servers_via_their_own_url_not_the_sentinel_command() {
+        // AI-1519: `-c` overrides deep-merge over ~/.codex/config.toml, so stamping the sentinel
+        // command onto a config-defined url (streamable_http) server left the merged entry with
+        // BOTH url and command — codex then fails config load with "url is not supported for
+        // stdio" (verified against 0.144.6), bricking every reviewer launch for a user with e.g.
+        // [mcp_servers.linear] url = "…". The disable override for a url server must re-state its
+        // own url as the transport; stdio/transport-less servers keep the sentinel shape.
+        var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
+        var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
+            ReadInheritedMcpServers = static () => [
+                new("linear", "https://mcp.linear.app/mcp"),  // config-defined streamable_http
+                new("node_repl")                              // stdio — keeps the sentinel shape
+            ]
+        };
+
+        var args  = launcher.BuildArgs(NewFlowCtx(null)).Args;
+        var table = DisableTableOverride(args);
+
+        await Assert.That(table).IsNotNull();
+        await Assert.That(table!).Contains("\"linear\"={enabled=false,url=\"https://mcp.linear.app/mcp\"}");
+        await Assert.That(table).DoesNotContain("\"linear\"={enabled=false,command=");
+        await Assert.That(table).Contains(
+            $"\"node_repl\"={{enabled=false,command=\"{CodexLauncher.DisabledServerSentinelCommand}\"");
+        await Assert.That(DisablesServer(args, "linear")).IsTrue();
+        await Assert.That(DisablesServer(args, "node_repl")).IsTrue();
+    }
+
+    [Test]
     public async Task Review_flow_fails_closed_when_inherited_servers_cannot_be_enumerated() {
         // FAIL-CLOSED: if the inherited MCP set can't be authoritatively enumerated (e.g. `codex mcp
         // list --json` fails), we must NOT proceed having disabled nothing — that would let a
@@ -366,7 +394,7 @@ public class CodexLauncherTests {
         // surfaces it as CodexReviewerMcpIsolationException for the orchestrator to reject the launch.
         var config = new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" };
         var launcher = new CodexLauncher(config, NullLogger<CodexLauncher>.Instance) {
-            ReadInheritedMcpServerNames = static () =>
+            ReadInheritedMcpServers = static () =>
                 throw new CodexReviewerMcpIsolationException("mcp list failed")
         };
 
@@ -628,7 +656,7 @@ public class CodexLauncherTests {
 
     static CodexLauncher NewFlowResultLauncher() =>
         new(new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" }, NullLogger<CodexLauncher>.Instance) {
-            ReadInheritedMcpServerNames = static () => []
+            ReadInheritedMcpServers = static () => []
         };
 
     static LauncherContext NewFlowCtx(string[]? allowlist) => new LauncherContext(

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexMcpInventoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexMcpInventoryTests.cs
@@ -14,7 +14,8 @@ public class CodexMcpInventoryTests {
     // A representative `codex mcp list --json` payload: a config.toml server, a plugin-provided
     // server (no config transport), a DOTTED-name server, and a url-based (streamable_http) server
     // — the four shapes the hardened enumeration must surface so every one gets disabled for the
-    // reviewer (the url shape needs its transport carried through — AI-1519).
+    // reviewer (the url shape needs its transport carried through so the disable override can
+    // re-state it instead of stamping the colliding sentinel command).
     const string SampleJson = """
         [
           { "name": "kcap-flows", "enabled": true, "disabled_reason": null,

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexMcpInventoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexMcpInventoryTests.cs
@@ -12,8 +12,9 @@ namespace Capacitor.Cli.Tests.Unit.Codex;
 /// </summary>
 public class CodexMcpInventoryTests {
     // A representative `codex mcp list --json` payload: a config.toml server, a plugin-provided
-    // server (no config transport), and a DOTTED-name server — the three shapes the hardened
-    // enumeration must surface so every one gets disabled for the reviewer.
+    // server (no config transport), a DOTTED-name server, and a url-based (streamable_http) server
+    // — the four shapes the hardened enumeration must surface so every one gets disabled for the
+    // reviewer (the url shape needs its transport carried through — AI-1519).
     const string SampleJson = """
         [
           { "name": "kcap-flows", "enabled": true, "disabled_reason": null,
@@ -23,24 +24,47 @@ public class CodexMcpInventoryTests {
           { "name": "sites-design-picker", "enabled": true, "disabled_reason": null,
             "transport": { "type": "stdio", "command": "node", "args": ["./mcp/server.mjs"] } },
           { "name": "node_repl", "enabled": false, "disabled_reason": null,
-            "transport": { "type": "stdio", "command": "node_repl" } }
+            "transport": { "type": "stdio", "command": "node_repl" } },
+          { "name": "linear", "enabled": true, "disabled_reason": null,
+            "transport": { "type": "streamable_http", "url": "https://mcp.linear.app/mcp",
+                           "bearer_token_env_var": null } }
         ]
         """;
 
     [Test]
-    public async Task ParseServerNames_surfaces_config_plugin_and_dotted_servers() {
-        var names = CodexMcpInventory.ParseServerNames(SampleJson);
+    public async Task ParseServers_surfaces_config_plugin_dotted_and_url_servers() {
+        var servers = CodexMcpInventory.ParseServers(SampleJson);
+        var byName  = servers.ToDictionary(s => s.Name);
 
-        await Assert.That(names).Contains("kcap-flows");           // config.toml
-        await Assert.That(names).Contains("corp.flows");           // dotted (High 2)
-        await Assert.That(names).Contains("sites-design-picker");  // plugin-provided (High 1)
-        await Assert.That(names).Contains("node_repl");            // even a disabled one is reported
-        await Assert.That(names.Count).IsEqualTo(4);
+        await Assert.That(byName.Keys).Contains("kcap-flows");           // config.toml
+        await Assert.That(byName.Keys).Contains("corp.flows");           // dotted (High 2)
+        await Assert.That(byName.Keys).Contains("sites-design-picker");  // plugin-provided (High 1)
+        await Assert.That(byName.Keys).Contains("node_repl");            // even a disabled one is reported
+        await Assert.That(servers.Count).IsEqualTo(5);
+
+        // The url transport is carried through for the streamable_http server, and only for it.
+        await Assert.That(byName["linear"].Url).IsEqualTo("https://mcp.linear.app/mcp");
+        await Assert.That(byName["kcap-flows"].Url).IsNull();
+        await Assert.That(byName["node_repl"].Url).IsNull();
     }
 
     [Test]
-    public async Task ParseServerNames_empty_array_returns_empty() {
-        await Assert.That(CodexMcpInventory.ParseServerNames("[]")).IsEmpty();
+    [Arguments("""[ { "name": "x" } ]""")]                                       // no transport at all
+    [Arguments("""[ { "name": "x", "transport": null } ]""")]                    // null transport
+    [Arguments("""[ { "name": "x", "transport": { "url": 42 } } ]""")]           // non-string url
+    [Arguments("""[ { "name": "x", "transport": { "url": "" } } ]""")]           // empty url
+    public async Task ParseServers_treats_missing_or_unusable_url_as_null(string payload) {
+        // Best-effort url: either shape still yields a DISABLING override downstream, so an odd
+        // transport must not fail the enumeration — it just selects the sentinel-command shape.
+        var servers = CodexMcpInventory.ParseServers(payload);
+
+        await Assert.That(servers.Count).IsEqualTo(1);
+        await Assert.That(servers[0].Url).IsNull();
+    }
+
+    [Test]
+    public async Task ParseServers_empty_array_returns_empty() {
+        await Assert.That(CodexMcpInventory.ParseServers("[]")).IsEmpty();
     }
 
     [Test]
@@ -49,8 +73,8 @@ public class CodexMcpInventoryTests {
     [Arguments("[ { \"enabled\": true } ]")] // array element missing a name
     [Arguments("[ { \"name\": 42 } ]")]      // non-string name
     [Arguments("[ { \"name\": \"\" } ]")]    // empty name
-    public async Task ParseServerNames_fails_closed_on_malformed_output(string payload) {
-        await Assert.That(() => CodexMcpInventory.ParseServerNames(payload))
+    public async Task ParseServers_fails_closed_on_malformed_output(string payload) {
+        await Assert.That(() => CodexMcpInventory.ParseServers(payload))
             .Throws<CodexReviewerMcpIsolationException>();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexMcpInventoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexMcpInventoryTests.cs
@@ -53,6 +53,9 @@ public class CodexMcpInventoryTests {
     [Arguments("""[ { "name": "x", "transport": null } ]""")]                    // null transport
     [Arguments("""[ { "name": "x", "transport": { "url": 42 } } ]""")]           // non-string url
     [Arguments("""[ { "name": "x", "transport": { "url": "" } } ]""")]           // empty url
+    [Arguments("""[ { "name": "x", "transport": 42 } ]""")]                      // non-object transport
+    [Arguments("""[ { "name": "x", "transport": "weird" } ]""")]                 // string transport
+    [Arguments("""[ { "name": "x", "transport": [ "list" ] } ]""")]              // array transport
     public async Task ParseServers_treats_missing_or_unusable_url_as_null(string payload) {
         // Best-effort url: either shape still yields a DISABLING override downstream, so an odd
         // transport must not fail the enumeration — it just selects the sentinel-command shape.
@@ -73,7 +76,12 @@ public class CodexMcpInventoryTests {
     [Arguments("[ { \"enabled\": true } ]")] // array element missing a name
     [Arguments("[ { \"name\": 42 } ]")]      // non-string name
     [Arguments("[ { \"name\": \"\" } ]")]    // empty name
+    [Arguments("[ 42 ]")]                    // non-object element
+    [Arguments("[ \"just-a-string\" ]")]     // string element
+    [Arguments("[ null ]")]                  // null element
     public async Task ParseServers_fails_closed_on_malformed_output(string payload) {
+        // Must be the ISOLATION exception, never a raw JsonNode indexer throw — the orchestrator's
+        // fail-closed launch-rejection path filters on the exception type.
         await Assert.That(() => CodexMcpInventory.ParseServers(payload))
             .Throws<CodexReviewerMcpIsolationException>();
     }


### PR DESCRIPTION
## Problem

Since 0.11.8 (#365, AI-1517's codex MCP isolation), **every codex review-flow reviewer launch fails** for any user whose `~/.codex/config.toml` defines an MCP server with a `url` (streamable_http) transport — e.g. the `[mcp_servers.linear]` / `[mcp_servers.sentry]` blocks the Codex desktop app writes and keeps rewriting:

```
participant_launch_failed: Error loading config.toml: url is not supported for stdio in `mcp_servers.linear`
```

## Root cause

`CodexLauncher.DisableInheritedMcpServers` stamps the sentinel `command="kcap-review-flow-isolation-disabled"` onto **every** disabled server's override. Codex `-c` overrides deep-merge over `config.toml`, so a config-defined url server ends up with BOTH `url` and `command` in the merged entry — codex classifies it as stdio and rejects the config at load. Reproduced byte-for-byte on codex 0.144.6:

```
$ codex -c 'mcp_servers={"linear"={enabled=false,command="kcap-review-flow-isolation-disabled",args=[]}}' mcp list
Error: failed to load configuration
Caused by: url is not supported for stdio in `mcp_servers.linear`
```

The sentinel exists for plugin-provided servers (no transport at the config layer → bare `enabled=false` fails validation), but it must never collide with a config-defined url transport.

## Fix

`codex mcp list --json` (already the enumeration authority in `CodexMcpInventory`) reports each server's `transport` — the parser previously kept only `name`. It now carries the transport `url`, and the disable override branches:

- url-based server → `{enabled=false,url="<same url>"}` (verified to pass config load and disable the server; also valid for a plugin-provided url server, since the config-layer entry then carries its own transport)
- stdio / transport-less → sentinel `{enabled=false,command=…,args=[]}` (unchanged)

The url is best-effort (null on odd transports — either shape still DISABLES, so it can shape but never bypass isolation); enumeration stays fail-closed.

## Testing

- New regression test `Review_flow_disables_url_based_servers_via_their_own_url_not_the_sentinel_command` (RED on main).
- `CodexMcpInventoryTests` extended with a streamable_http payload entry + url-extraction assertions and best-effort-null cases; fail-closed cases unchanged.
- `CodexMcpInventoryTests` 11/11, `CodexLauncherTests` 40 passing (the 3 `Prepare_*` failures are pre-existing on this machine — identical counts control-run on pristine main).
- Live verification: with the equivalent override shape, codex 0.144.6 loads the config and lists every server disabled.

Closes AI-1519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)