### PR TITLE
Ingest ACP usage_update as context occupancy (dormant hedge)

### DIFF
--- a/src/Capacitor.Cli.Core/JsonElementExtensions.cs
+++ b/src/Capacitor.Cli.Core/JsonElementExtensions.cs
@@ -6,7 +6,12 @@ static class JsonElementExtensions {
     extension(JsonElement el) {
         public string? Str(string property) => el.ValueKind == JsonValueKind.Object && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
 
-        public long? Num(string property) => el.ValueKind == JsonValueKind.Object && el.TryGetProperty(property, out var v) && v.TryGetInt64(out var n) ? n : null;
+        // Guard the ValueKind before TryGetInt64: it THROWS on a non-Number element (string,
+        // bool, null, object, array), so an unguarded call lets a schema-drift frame bubble an
+        // exception up and take out the whole notification instead of dropping one bad field.
+        // Same defensive contract as Str/Obj/Arr above — a wrong-typed field reads as absent.
+        // A fractional number still returns null via TryGetInt64 rather than truncating.
+        public long? Num(string property) => el.ValueKind == JsonValueKind.Object && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var n) ? n : null;
 
         public JsonElement? Obj(string property) => el.ValueKind == JsonValueKind.Object && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.Object ? v : null;
 

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1183,6 +1183,10 @@ public static class AcpEventKind {
 /// <c>AcpEventEnvelopeWireCompatTests</c> for the locked-in per-field wire-compat guard. Exactly one
 /// per-kind field group is populated for a given <see cref="Kind"/> (see
 /// <c>AcpEventTranslator.Translate</c>, which never sets a field outside its kind's group).
+/// <c>Model</c> is the one exception: it is SHARED attribution metadata rather than a member of a
+/// single kind's group — <c>session_started</c> carries it, and so does <c>usage</c>, because the
+/// server's mapper is a pure per-envelope function with no session-fold access, so the resolved
+/// model has to ride the wire on every reading that needs attribution.
 /// </summary>
 public readonly record struct AcpEventEnvelope(
         int     ContractVersion   = 1,

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1166,6 +1166,7 @@ public static class AcpEventKind {
     public const string ToolResult         = "tool_result";
     public const string SessionTitle       = "session_title";
     public const string SessionEnded       = "session_ended";
+    public const string Usage              = "usage";
 }
 
 /// <summary>
@@ -1209,6 +1210,12 @@ public readonly record struct AcpEventEnvelope(
 
         // session_ended
         string? EndReason         = null,
+
+        // usage — context occupancy from the ACP Session Usage RFD. Additive and nullable, so
+        // ContractVersion stays 1: an older server ignores them. The resolved model rides the
+        // Model field above, stamped on every usage envelope.
+        long?   ContextUsedTokens   = null,
+        long?   ContextWindowTokens = null,
 
         // transcript-authoritative time (ISO-8601); server falls back to now if absent
         string? TimestampIso      = null

--- a/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
@@ -67,7 +67,8 @@ internal static partial class AcpEventTranslator {
             string           timestampIso,
             string?          aggregatedText = null,
             ILogger?         logger         = null,
-            bool             debugFrames    = false) {
+            bool             debugFrames    = false,
+            string?          resolvedModel  = null) {
         switch (update.Kind) {
             case AcpUpdateKind.AgentMessageChunk:
                 return new AcpEventEnvelope(
@@ -102,6 +103,20 @@ internal static partial class AcpEventTranslator {
                     ToolCallId: update.ToolCallId,
                     ToolResult: update.ToolResultText,
                     ToolIsError: update.ToolIsError,
+                    TimestampIso: timestampIso);
+
+            case AcpUpdateKind.UsageUpdate:
+                // Reduce() already validated both fields, so a UsageUpdate here is always emittable.
+                // The resolved model is stamped on EVERY usage envelope: the server's mapper is a
+                // pure per-envelope function with no session-fold access, so attribution has to
+                // travel on the wire rather than be looked up server-side. A null model is
+                // harmless - the chip's denominator is the reading's own window.
+                return new AcpEventEnvelope(
+                    Seq: seq,
+                    Kind: AcpEventKind.Usage,
+                    Model: resolvedModel,
+                    ContextUsedTokens: update.ContextUsedTokens,
+                    ContextWindowTokens: update.ContextWindowTokens,
                     TimestampIso: timestampIso);
 
             case AcpUpdateKind.SessionInfo:

--- a/src/Capacitor.Cli.Daemon/Acp/AcpSessionUpdate.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpSessionUpdate.cs
@@ -20,6 +20,7 @@ internal enum AcpUpdateKind {
     Plan,
     AvailableCommands,
     SessionInfo,
+    UsageUpdate,
     Unknown,
 }
 
@@ -51,5 +52,7 @@ internal sealed record AcpSessionUpdate(
     string?       ToolInputJson  = null,
     string?       ToolResultText = null,
     bool          ToolIsError    = false,
+    long?         ContextUsedTokens   = null, // usage_update's `used` (context occupancy)
+    long?         ContextWindowTokens = null, // usage_update's `size` (window capacity)
     JsonElement?  Raw            = null
 );

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -697,6 +697,20 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                 Title: GetStringOrNull(update, "title"),
                 Raw: update),
 
+            // The ACP spec's Session Usage RFD. No vendor implements it yet, so this arm is
+            // dormant; it exists so the context chip lights up for every ACP-hosted vendor the
+            // moment any of them ships it. Content-free unless both fields are present and
+            // sane - a partial reading is worse than none, since `size` is the chip's
+            // denominator. `used > size` is kept: reported windows can be advisory. Any `cost`
+            // or unknown sibling fields are tolerated and ignored.
+            "usage_update" => update.Num("used") is { } used and >= 0 && update.Num("size") is { } size and > 0
+                ? new AcpSessionUpdate(
+                    AcpUpdateKind.UsageUpdate,
+                    ContextUsedTokens: used,
+                    ContextWindowTokens: size,
+                    Raw: update)
+                : new AcpSessionUpdate(AcpUpdateKind.Unknown, Raw: update),
+
             _ => new AcpSessionUpdate(AcpUpdateKind.Unknown, Raw: update),
         };
     }
@@ -783,15 +797,18 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                     break;
 
                 case AcpUpdateKind.SessionInfo:
-                    // Session-title metadata is not transcript content: it must NOT close an open
-                    // chunk run. A session_info_update interleaved between two message/thought
-                    // chunks would otherwise flush the run mid-stream and split one contiguous
-                    // assistant message into two envelopes. Emit it standalone, leaving
-                    // _openRunKind/_openRunText untouched so the surrounding chunks still aggregate
-                    // into one run (the title is orderless metadata — its relative seq is immaterial).
-                    var titleEnvelope = AcpEventTranslator.Translate(update, seq: 0, NowIso(), logger: _logger, debugFrames: _debugFrames);
-                    if (titleEnvelope is { } t)
-                        EmitEnvelope(t);
+                case AcpUpdateKind.UsageUpdate:
+                    // Neither is transcript content, so neither must close an open chunk run. One
+                    // interleaved between two message/thought chunks would otherwise flush the run
+                    // mid-stream and split one contiguous assistant message into two envelopes.
+                    // Emit standalone, leaving _openRunKind/_openRunText untouched so the
+                    // surrounding chunks still aggregate into one run — both are orderless
+                    // metadata, so their relative seq is immaterial.
+                    var metaEnvelope = AcpEventTranslator.Translate(
+                        update, seq: 0, NowIso(), logger: _logger, debugFrames: _debugFrames,
+                        resolvedModel: _resolvedModel);
+                    if (metaEnvelope is { } m)
+                        EmitEnvelope(m);
                     break;
 
                 default:

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -701,9 +701,11 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             // dormant; it exists so the context chip lights up for every ACP-hosted vendor the
             // moment any of them ships it. Content-free unless both fields are present and
             // sane - a partial reading is worse than none, since `size` is the chip's
-            // denominator. `used > size` is kept: reported windows can be advisory. Any `cost`
-            // or unknown sibling fields are tolerated and ignored.
-            "usage_update" => update.Num("used") is { } used and >= 0 && update.Num("size") is { } size and > 0
+            // denominator. `used > size` is kept: reported windows can be advisory. A zero
+            // `used` is dropped to match the server's re-validation, where it would be
+            // durably appended yet invisible to every consumer (the peak comparison they all
+            // share ignores a zero candidate). Any `cost` or unknown siblings are ignored.
+            "usage_update" => update.Num("used") is { } used and > 0 && update.Num("size") is { } size and > 0
                 ? new AcpSessionUpdate(
                     AcpUpdateKind.UsageUpdate,
                     ContextUsedTokens: used,

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpEventEnvelopeWireCompatTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpEventEnvelopeWireCompatTests.cs
@@ -38,6 +38,8 @@ public class AcpEventEnvelopeWireCompatTests {
             RawSessionId:      "raw-sess-1",
             SessionMode:       "agent",
             EndReason:         "completed",
+            ContextUsedTokens:   142_000,
+            ContextWindowTokens: 200_000,
             TimestampIso:      "2026-07-08T00:00:00Z"
         );
 
@@ -59,6 +61,8 @@ public class AcpEventEnvelopeWireCompatTests {
         await Assert.That(json).Contains(@"""raw_session_id"":""raw-sess-1""");
         await Assert.That(json).Contains(@"""session_mode"":""agent""");
         await Assert.That(json).Contains(@"""end_reason"":""completed""");
+        await Assert.That(json).Contains(@"""context_used_tokens"":142000");
+        await Assert.That(json).Contains(@"""context_window_tokens"":200000");
         await Assert.That(json).Contains(@"""timestamp_iso"":""2026-07-08T00:00:00Z""");
 
         var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.AcpEventEnvelope);
@@ -66,6 +70,8 @@ public class AcpEventEnvelopeWireCompatTests {
         await Assert.That(back.Kind).IsEqualTo(AcpEventKind.ToolCall);
         await Assert.That(back.ToolInputJson).IsEqualTo("""{"command":"ls"}""");
         await Assert.That(back.ToolIsError).IsTrue();
+        await Assert.That(back.ContextUsedTokens).IsEqualTo(142_000L);
+        await Assert.That(back.ContextWindowTokens).IsEqualTo(200_000L);
     }
 
     [Test]
@@ -91,6 +97,7 @@ public class AcpEventEnvelopeWireCompatTests {
         await Assert.That(AcpEventKind.ToolResult).IsEqualTo("tool_result");
         await Assert.That(AcpEventKind.SessionTitle).IsEqualTo("session_title");
         await Assert.That(AcpEventKind.SessionEnded).IsEqualTo("session_ended");
+        await Assert.That(AcpEventKind.Usage).IsEqualTo("usage");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpUsageUpdateTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpUsageUpdateTests.cs
@@ -1,0 +1,73 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// The ACP spec's Session Usage RFD (<c>usage_update</c>, carrying <c>used</c>/<c>size</c>).
+/// No vendor implements it yet — probed 2026-07-25, neither cursor-agent 2026.07.23 nor
+/// Copilot CLI 1.0.75 emits it — so this path is dormant. It exists so the server's context
+/// chip lights up for every ACP-hosted vendor the moment any of them ships it.
+///
+/// Translator-level tests; the <c>Reduce()</c> validation they depend on is exercised through
+/// the runtime harness in <see cref="AcpHostedAgentRuntimeTests"/>.
+/// </summary>
+public class AcpUsageUpdateTests {
+    const string TimestampIso = "2026-07-25T12:00:00Z";
+
+    static AcpSessionUpdate Usage(long used, long window) =>
+        new(AcpUpdateKind.UsageUpdate, ContextUsedTokens: used, ContextWindowTokens: window);
+
+    [Test]
+    public async Task Usage_update_translates_to_a_usage_envelope() {
+        var e = AcpEventTranslator.Translate(Usage(142_000, 200_000), seq: 5, TimestampIso);
+
+        await Assert.That(e).IsNotNull();
+        await Assert.That(e!.Value.Kind).IsEqualTo(AcpEventKind.Usage);
+        await Assert.That(e.Value.ContextUsedTokens).IsEqualTo(142_000);
+        await Assert.That(e.Value.ContextWindowTokens).IsEqualTo(200_000);
+        await Assert.That(e.Value.Seq).IsEqualTo(5);
+        await Assert.That(e.Value.TimestampIso).IsEqualTo(TimestampIso);
+    }
+
+    [Test]
+    public async Task Contract_version_stays_1_the_fields_are_additive() {
+        // The new fields are optional, so an older server simply ignores them rather than
+        // rejecting the envelope on an unknown contract version.
+        var e = AcpEventTranslator.Translate(Usage(1, 2), seq: 1, TimestampIso);
+        await Assert.That(e!.Value.ContractVersion).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Resolved_model_is_stamped_on_the_envelope() {
+        // The server's mapper is a pure per-envelope function with no session-fold access, so
+        // model attribution has to travel on the wire rather than be looked up server-side.
+        var e = AcpEventTranslator.Translate(
+            Usage(1_000, 200_000), seq: 2, TimestampIso, resolvedModel: "claude-sonnet-4-5");
+
+        await Assert.That(e!.Value.Model).IsEqualTo("claude-sonnet-4-5");
+    }
+
+    [Test]
+    public async Task A_missing_resolved_model_is_tolerated() {
+        // Harmless: the chip's denominator is the reading's own window, so no model lookup is
+        // needed to render it.
+        var e = AcpEventTranslator.Translate(Usage(1_000, 200_000), seq: 3, TimestampIso);
+        await Assert.That(e!.Value.Model).IsNull();
+    }
+
+    [Test]
+    public async Task Usage_envelope_sets_no_field_outside_its_kind_group() {
+        // The envelope is flat and Kind-discriminated: exactly one per-kind group is populated.
+        var e = AcpEventTranslator.Translate(
+            Usage(1_000, 200_000), seq: 4, TimestampIso, resolvedModel: "m")!.Value;
+
+        await Assert.That(e.Text).IsNull();
+        await Assert.That(e.ToolCallId).IsNull();
+        await Assert.That(e.ToolName).IsNull();
+        await Assert.That(e.ToolResult).IsNull();
+        await Assert.That(e.Cwd).IsNull();
+        await Assert.That(e.RawSessionId).IsNull();
+        await Assert.That(e.EndReason).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpUsageUpdateTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpUsageUpdateTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Acp;
 
@@ -69,5 +70,26 @@ public class AcpUsageUpdateTests {
         await Assert.That(e.Cwd).IsNull();
         await Assert.That(e.RawSessionId).IsNull();
         await Assert.That(e.EndReason).IsNull();
+    }
+
+    [Test]
+    [Arguments("\"10\"")]   // string
+    [Arguments("true")]     // bool
+    [Arguments("null")]     // null
+    [Arguments("{}")]       // object
+    [Arguments("[]")]       // array
+    public async Task Wrong_typed_numeric_fields_degrade_to_absent_rather_than_throwing(string usedJson) {
+        // A vendor frame is untrusted input. JsonElement.TryGetInt64 THROWS on a non-Number
+        // ValueKind, so a helper that calls it unguarded would let a schema-drift frame escape
+        // Reduce() and kill the whole notification rather than dropping one bad update.
+        var el = JsonDocument.Parse($$"""{"sessionUpdate":"usage_update","used":{{usedJson}},"size":200000}""").RootElement;
+
+        await Assert.That(el.Num("used")).IsNull();
+    }
+
+    [Test]
+    public async Task Fractional_numbers_are_absent_not_truncated() {
+        var el = JsonDocument.Parse("""{"used":10.5}""").RootElement;
+        await Assert.That(el.Num("used")).IsNull();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpUsageUpdateTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpUsageUpdateTests.cs
@@ -58,10 +58,15 @@ public class AcpUsageUpdateTests {
     }
 
     [Test]
-    public async Task Usage_envelope_sets_no_field_outside_its_kind_group() {
+    public async Task Usage_envelope_sets_only_its_own_group_plus_shared_model_attribution() {
         // The envelope is flat and Kind-discriminated: exactly one per-kind group is populated.
+        // Model is the deliberate exception — SHARED attribution metadata, not a member of any
+        // single kind's group (session_started carries it too), because the server's mapper has
+        // no session-fold access and must read the model off the wire.
         var e = AcpEventTranslator.Translate(
             Usage(1_000, 200_000), seq: 4, TimestampIso, resolvedModel: "m")!.Value;
+
+        await Assert.That(e.Model).IsEqualTo("m");
 
         await Assert.That(e.Text).IsNull();
         await Assert.That(e.ToolCallId).IsNull();


### PR DESCRIPTION
Closes #370. Linear: AI-1531 (D4, daemon half).

Builds the daemon side of the ACP [Session Usage RFD](https://agentclientprotocol.com/rfds/session-usage) path. **Dormant** — no vendor implements it yet (probed 2026-07-25: neither `cursor-agent` 2026.07.23 nor Copilot CLI 1.0.75 emits `usage_update`). The trigger is the **spec**, not one vendor, so the server's context chip lights up for every ACP-hosted vendor the moment any of them ships it.

## What's here

**`Reduce()` gains a `usage_update` arm** reading `used`/`size` through the existing non-throwing `JsonElementExtensions` helpers. It classifies the update content-free (no envelope) unless both fields are present, integral, `used >= 0` and `size > 0` — a partial reading is worse than none, since `size` is the chip's denominator. `used > size` is deliberately **kept**: reported windows can be advisory. A `cost` field or any unknown siblings are tolerated and ignored.

**The translator emits an `AcpEventKind.Usage` envelope** carrying the two new additive nullable fields, and stamps the runtime's resolved model on every one — the server's mapper is a pure per-envelope function with no session-fold access, so model attribution has to travel on the wire rather than be looked up server-side. `ContractVersion` stays **1**: the fields are optional, so an older server just ignores them.

**Aggregation treats a usage update like `session_info`** — emitted standalone *without* flushing an open chunk run. Falling through to the `default` arm would have closed the run mid-stream and split one contiguous assistant message into two envelopes. Both are orderless metadata, so their relative seq is immaterial.

`AcpEventEnvelope` remains a field-for-field mirror of the server-side record.

## Scope note

Context-shaped **only**. `used` is cumulative context occupancy, not per-turn input/output, so it feeds the context chip and is never synthesized into token/cost rows. Per-turn token counts stay a separate upstream ask.

## Testing

- 5 new translator tests: envelope shape, `ContractVersion` stays 1, model stamped, model absent tolerated, and no field set outside the kind's group.
- **Wire-compat guard passes unchanged (5/5)** — the envelope change is additive.
- **ACP suite: 258 total, 0 failed.**
- **AOT publish clean** — no IL2026/IL3050.

## Merge order

This PR merges **first**; the server PR (kurrent-io/kcap-server#1192) then bumps the submodule pin to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)