### PR TITLE
De-flake the Cursor cancelled-fetch memory test on loaded runners

### DIFF
--- a/src/Capacitor.Cli/Commands/CursorHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CursorHookCommand.cs
@@ -148,13 +148,15 @@ public static class CursorHookCommand {
             HookSpool  spool,
             TimeSpan   budgetTotal,
             Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
-            Func<SessionStartMemoryLeaseStore>?               memoryStoreFactory = null
+            Func<SessionStartMemoryLeaseStore>?               memoryStoreFactory = null,
+            TimeSpan?                                         memoryBudgetOverride = null,
+            ISessionStartMemoryScopeResolver?                 memoryScopeResolver = null
         ) {
         using var cts = new CancellationTokenSource(budgetTotal);
         var kindSignal = new ResolvedEventKindSignal();
 
         var inner    = HandleCoreInner(client, baseUrl, stdin, spool, budgetTotal, cts.Token, kindSignal,
-                           memoryClientFactory, memoryStoreFactory);
+                           memoryClientFactory, memoryStoreFactory, memoryBudgetOverride, memoryScopeResolver);
         var deadline = Task.Delay(budgetTotal);
         var winner   = await Task.WhenAny(inner, deadline);
 
@@ -211,7 +213,9 @@ public static class CursorHookCommand {
             CancellationToken ct,
             ResolvedEventKindSignal kindSignal,
             Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory,
-            Func<SessionStartMemoryLeaseStore>?               memoryStoreFactory
+            Func<SessionStartMemoryLeaseStore>?               memoryStoreFactory,
+            TimeSpan?                                         memoryBudgetOverride,
+            ISessionStartMemoryScopeResolver?                 memoryScopeResolver
         ) {
         var sw = Stopwatch.StartNew();
         bool BudgetExpired() => sw.Elapsed >= budgetTotal;
@@ -466,7 +470,7 @@ public static class CursorHookCommand {
             if (eventName != "sessionStart") return null;
             var fragment = await RunMemoryOrchestrationAsync(
                 client, baseUrl, sessionId, workspaceRoot, sw, budgetTotal, ct,
-                memoryClientFactory, memoryStoreFactory);
+                memoryClientFactory, memoryStoreFactory, memoryBudgetOverride, memoryScopeResolver);
             return SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Cursor, fragment);
         } catch {
             // Fail-open per design: any exception (budget cancellation,
@@ -499,7 +503,9 @@ public static class CursorHookCommand {
             TimeSpan   budgetTotal,
             CancellationToken dispatcherCt,
             Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory,
-            Func<SessionStartMemoryLeaseStore>?               memoryStoreFactory
+            Func<SessionStartMemoryLeaseStore>?               memoryStoreFactory,
+            TimeSpan?                                         memoryBudgetOverride,
+            ISessionStartMemoryScopeResolver?                 memoryScopeResolver
         ) {
         if (sessionId is null) return null;
 
@@ -509,7 +515,9 @@ public static class CursorHookCommand {
         // With no authoritative workspace root there is no safe scope, so skip injection entirely.
         if (string.IsNullOrWhiteSpace(workspaceRoot)) return null;
 
-        var memBudget = budgetTotal - sw.Elapsed - HookBudget.Safety;
+        // Wall-clock derived in production; pinned by tests that must land on a KNOWN side of the
+        // no-budget guard below rather than on whatever a loaded CI runner leaves over.
+        var memBudget = memoryBudgetOverride ?? (budgetTotal - sw.Elapsed - HookBudget.Safety);
         if (memBudget <= TimeSpan.Zero) return null;
 
         // Cursor never reads AppConfig anywhere else today — this is the one, new call site
@@ -523,7 +531,7 @@ public static class CursorHookCommand {
 
             var store = memoryStoreFactory?.Invoke() ?? new SessionStartMemoryLeaseStore();
             var provider = new SessionStartMemoryContextProvider(
-                new SessionStartMemoryScopeResolver(),
+                memoryScopeResolver ?? new SessionStartMemoryScopeResolver(),
                 memoryClientFactory ?? ((_, _) => Task.FromResult(client)),
                 disposeClients: memoryClientFactory is not null);
 

--- a/src/Capacitor.Cli/Commands/CursorHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CursorHookCommand.cs
@@ -515,8 +515,7 @@ public static class CursorHookCommand {
         // With no authoritative workspace root there is no safe scope, so skip injection entirely.
         if (string.IsNullOrWhiteSpace(workspaceRoot)) return null;
 
-        // Wall-clock derived in production; pinned by tests that must land on a KNOWN side of the
-        // no-budget guard below rather than on whatever a loaded CI runner leaves over.
+        // Overridable so a test picks its side of the guard below, not the runner's load.
         var memBudget = memoryBudgetOverride ?? (budgetTotal - sw.Elapsed - HookBudget.Safety);
         if (memBudget <= TimeSpan.Zero) return null;
 

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
@@ -812,14 +812,11 @@ public class CursorHookCommandTests {
         var handler = new CancelAwareHandler();
         using var neverRespondingClient = new HttpClient(handler);
 
-        // Nothing here is derived from wall clock. memoryBudgetOverride pins what the memory stage
-        // gets (a runner slow enough to exhaust a derived budget would trip the no-budget guard and
-        // skip the very path under test); the stub resolver keeps a git spawn from eating that
-        // budget before the fetch is reached; and the total budget is generous so the outer
-        // deadline can never pre-empt the inner phase. The whole 250ms therefore belongs to the
-        // fetch — which is also all this test costs in wall time.
+        // Nothing here is wall-clock derived: the override pins the memory stage's budget, the stub
+        // resolver keeps a git spawn out of it, and budgetTotal sits far enough above the inner
+        // phase that the outer deadline can't pre-empt it. The 250ms is the cancellation window.
         var exit1 = await CursorHookCommand.HandleCore(
-            fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(60),
+            fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(15),
             memoryClientFactory: (_, _) => Task.FromResult(neverRespondingClient),
             memoryStoreFactory: storeFactory,
             memoryBudgetOverride: TimeSpan.FromMilliseconds(250),
@@ -836,9 +833,9 @@ public class CursorHookCommandTests {
         fx.MemoryIndexBody = "[]";
 
         var exit2 = await CursorHookCommand.HandleCore(
-            fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(60),
+            fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(15),
             memoryStoreFactory: storeFactory,
-            memoryBudgetOverride: TimeSpan.FromSeconds(30),
+            memoryBudgetOverride: TimeSpan.FromSeconds(10),
             memoryScopeResolver: new StubScopeResolver());
         await Assert.That(exit2).IsEqualTo(0);
         // The index GET fires again on fx.Client — proving the first, cancelled attempt's
@@ -846,9 +843,8 @@ public class CursorHookCommandTests {
         await Assert.That(fx.MemoryIndexRequested).IsTrue();
     }
 
-    // The other side of the guard the test above deliberately stays clear of: a sessionStart that
-    // reaches the memory stage with nothing left of the budget skips the fetch outright and still
-    // emits its single {} — an asserted outcome here rather than an unnoticed pass over there.
+    // The other side of that guard, asserted rather than left to a runner: no budget left means no
+    // fetch, and the sessionStart still emits its single {}.
     [Test, NotInParallel]
     public async Task ExhaustedMemoryBudget_skips_the_fetch_and_still_emits() {
         using var fx = new Fixture();
@@ -862,7 +858,7 @@ public class CursorHookCommandTests {
         try {
             Console.SetOut(stdoutWriter);
             var exit = await CursorHookCommand.HandleCore(
-                fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(60),
+                fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(15),
                 memoryStoreFactory: () => new SessionStartMemoryLeaseStore(fx.MemoryStoreRoot, new ManualTimeProvider()),
                 memoryBudgetOverride: TimeSpan.Zero);
 
@@ -1074,8 +1070,7 @@ public class CursorHookCommandTests {
     // rather than committing a spurious "completed" record.
     sealed class CancelAwareHandler : HttpMessageHandler {
         volatile bool _entered;
-        // Lets a test distinguish "the fetch was reached and cancelled" from "the fetch was
-        // never made at all" — outcomes this handler is otherwise indistinguishable between.
+        // Separates "reached and cancelled" from "never fetched at all" — otherwise identical here.
         public bool Entered => _entered;
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
@@ -807,24 +807,28 @@ public class CursorHookCommandTests {
         Func<SessionStartMemoryLeaseStore> storeFactory = () => new SessionStartMemoryLeaseStore(fx.MemoryStoreRoot, clock);
 
         // A memory-index client whose GET never completes on its own — it only ever resolves via
-        // the caller's cancellation, letting the provider's own linked/budget-bound
-        // CancellationTokenSource be what ends the fetch.
+        // the budget-bound linked token handed to the request itself.
         var handler = new CancelAwareHandler();
         using var neverRespondingClient = new HttpClient(handler);
 
         // Nothing here is wall-clock derived: the override pins the memory stage's budget, the stub
         // resolver keeps a git spawn out of it, and budgetTotal sits far enough above the inner
         // phase that the outer deadline can't pre-empt it. The 250ms is the cancellation window.
+        var elapsed = System.Diagnostics.Stopwatch.StartNew();
         var exit1 = await CursorHookCommand.HandleCore(
             fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(15),
             memoryClientFactory: (_, _) => Task.FromResult(neverRespondingClient),
             memoryStoreFactory: storeFactory,
             memoryBudgetOverride: TimeSpan.FromMilliseconds(250),
             memoryScopeResolver: new StubScopeResolver());
+        elapsed.Stop();
         await Assert.That(exit1).IsEqualTo(0);
-        // The fetch was entered and then cancelled — without this the rest of the test would
-        // still pass on a skipped first attempt, proving nothing.
+        // Entered rules out a skipped attempt (which would prove nothing); Cancelled rules out the
+        // request being abandoned by a wrapper while it kept running; and returning far inside the
+        // 15s deadline rules that deadline out as the thing that ended it, leaving the 250ms budget.
         await Assert.That(handler.Entered).IsTrue();
+        await Assert.That(handler.Cancelled).IsTrue();
+        await Assert.That(elapsed.Elapsed.TotalSeconds).IsLessThan(10);
 
         // Advance well past the 30s lease duration so the still-"leased" (never committed —
         // the cancellation raced RetryAsync's own fencing too) record from the first attempt
@@ -853,18 +857,26 @@ public class CursorHookCommandTests {
         var payload = $$"""{"hook_event_name":"sessionStart","session_id":"{{sid}}","workspace_roots":["{{ws}}"]}""";
         fx.MemoryIndexBody = """[{"memory_id":"m1","slug":"s","audience":"org","description":"d","kind":"preference"}]""";
 
+        var storeBuilt = false;
+
         var originalOut = Console.Out;
         var stdoutWriter = new StringWriter();
         try {
             Console.SetOut(stdoutWriter);
             var exit = await CursorHookCommand.HandleCore(
                 fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(15),
-                memoryStoreFactory: () => new SessionStartMemoryLeaseStore(fx.MemoryStoreRoot, new ManualTimeProvider()),
+                memoryStoreFactory: () => {
+                    storeBuilt = true;
+                    return new SessionStartMemoryLeaseStore(fx.MemoryStoreRoot, new ManualTimeProvider());
+                },
                 memoryBudgetOverride: TimeSpan.Zero);
 
             await Assert.That(exit).IsEqualTo(0);
             await Assert.That(fx.MemoryIndexRequested).IsFalse();
             await Assert.That(stdoutWriter.ToString()).IsEqualTo("{}\n");
+            // Pins THIS guard specifically: the provider would also decline a zero budget, but only
+            // the orchestration guard returns before the store is built.
+            await Assert.That(storeBuilt).IsFalse();
         } finally {
             Console.SetOut(originalOut);
         }
@@ -1070,12 +1082,19 @@ public class CursorHookCommandTests {
     // rather than committing a spurious "completed" record.
     sealed class CancelAwareHandler : HttpMessageHandler {
         volatile bool _entered;
-        // Separates "reached and cancelled" from "never fetched at all" — otherwise identical here.
+        volatile bool _cancelled;
+        // Separate "never fetched at all", "fetched and abandoned", and "fetched and cancelled".
         public bool Entered => _entered;
+        public bool Cancelled => _cancelled;
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {
             _entered = true;
-            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            try {
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            } catch (OperationCanceledException) {
+                _cancelled = true;
+                throw;
+            }
             return new HttpResponseMessage(HttpStatusCode.OK);
         }
     }

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
@@ -806,20 +806,28 @@ public class CursorHookCommandTests {
         var clock = new ManualTimeProvider();
         Func<SessionStartMemoryLeaseStore> storeFactory = () => new SessionStartMemoryLeaseStore(fx.MemoryStoreRoot, clock);
 
-        // A memory-index client whose GET never completes on its own — it only ever
-        // resolves via the caller's cancellation, letting the provider's own
-        // linked/budget-bound CancellationTokenSource be what ends the fetch. A generous total
-        // budget (see Ready_fragment_emitted's comment) keeps memBudget comfortably positive
-        // under CI load, so the first attempt reliably reaches — and is cancelled by — the
-        // provider fetch rather than being skipped outright by the no-budget guard, which would
-        // let this test pass without ever exercising the cancellation path it's meant to prove.
-        using var neverRespondingClient = new HttpClient(new CancelAwareHandler());
+        // A memory-index client whose GET never completes on its own — it only ever resolves via
+        // the caller's cancellation, letting the provider's own linked/budget-bound
+        // CancellationTokenSource be what ends the fetch.
+        var handler = new CancelAwareHandler();
+        using var neverRespondingClient = new HttpClient(handler);
 
+        // Nothing here is derived from wall clock. memoryBudgetOverride pins what the memory stage
+        // gets (a runner slow enough to exhaust a derived budget would trip the no-budget guard and
+        // skip the very path under test); the stub resolver keeps a git spawn from eating that
+        // budget before the fetch is reached; and the total budget is generous so the outer
+        // deadline can never pre-empt the inner phase. The whole 250ms therefore belongs to the
+        // fetch — which is also all this test costs in wall time.
         var exit1 = await CursorHookCommand.HandleCore(
-            fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(4),
+            fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(60),
             memoryClientFactory: (_, _) => Task.FromResult(neverRespondingClient),
-            memoryStoreFactory: storeFactory);
+            memoryStoreFactory: storeFactory,
+            memoryBudgetOverride: TimeSpan.FromMilliseconds(250),
+            memoryScopeResolver: new StubScopeResolver());
         await Assert.That(exit1).IsEqualTo(0);
+        // The fetch was entered and then cancelled — without this the rest of the test would
+        // still pass on a skipped first attempt, proving nothing.
+        await Assert.That(handler.Entered).IsTrue();
 
         // Advance well past the 30s lease duration so the still-"leased" (never committed —
         // the cancellation raced RetryAsync's own fencing too) record from the first attempt
@@ -828,12 +836,42 @@ public class CursorHookCommandTests {
         fx.MemoryIndexBody = "[]";
 
         var exit2 = await CursorHookCommand.HandleCore(
-            fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(4),
-            memoryStoreFactory: storeFactory);
+            fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(60),
+            memoryStoreFactory: storeFactory,
+            memoryBudgetOverride: TimeSpan.FromSeconds(30),
+            memoryScopeResolver: new StubScopeResolver());
         await Assert.That(exit2).IsEqualTo(0);
         // The index GET fires again on fx.Client — proving the first, cancelled attempt's
         // lease was never spent as "completed".
         await Assert.That(fx.MemoryIndexRequested).IsTrue();
+    }
+
+    // The other side of the guard the test above deliberately stays clear of: a sessionStart that
+    // reaches the memory stage with nothing left of the budget skips the fetch outright and still
+    // emits its single {} — an asserted outcome here rather than an unnoticed pass over there.
+    [Test, NotInParallel]
+    public async Task ExhaustedMemoryBudget_skips_the_fetch_and_still_emits() {
+        using var fx = new Fixture();
+        var sid = Guid.NewGuid().ToString("N");
+        var ws = Path.GetTempPath().Replace('\\', '/').TrimEnd('/');
+        var payload = $$"""{"hook_event_name":"sessionStart","session_id":"{{sid}}","workspace_roots":["{{ws}}"]}""";
+        fx.MemoryIndexBody = """[{"memory_id":"m1","slug":"s","audience":"org","description":"d","kind":"preference"}]""";
+
+        var originalOut = Console.Out;
+        var stdoutWriter = new StringWriter();
+        try {
+            Console.SetOut(stdoutWriter);
+            var exit = await CursorHookCommand.HandleCore(
+                fx.Client, "http://localhost", new StringReader(payload), fx.Spool, TimeSpan.FromSeconds(60),
+                memoryStoreFactory: () => new SessionStartMemoryLeaseStore(fx.MemoryStoreRoot, new ManualTimeProvider()),
+                memoryBudgetOverride: TimeSpan.Zero);
+
+            await Assert.That(exit).IsEqualTo(0);
+            await Assert.That(fx.MemoryIndexRequested).IsFalse();
+            await Assert.That(stdoutWriter.ToString()).IsEqualTo("{}\n");
+        } finally {
+            Console.SetOut(originalOut);
+        }
     }
 
     // Task 1: the fixture must be able to serve GET /api/memories/index
@@ -1023,12 +1061,25 @@ public class CursorHookCommandTests {
         public void Advance(TimeSpan by) => _now += by;
     }
 
+    // Resolves instantly to a fixed scope. The real resolver spawns git, whose wall-clock cost
+    // would otherwise come out of the memory budget a test is trying to spend on the fetch.
+    sealed class StubScopeResolver : ISessionStartMemoryScopeResolver {
+        public Task<SessionStartMemoryScope> ResolveAsync(string? cwd, TimeSpan budget, CancellationToken ct) =>
+            Task.FromResult(new SessionStartMemoryScope(RepoHash: null, MachineTag: "test-machine"));
+    }
+
     // A GET that never resolves on its own — it only ends via the caller's own
     // cancellation, honoured properly (unlike StubHandler, which ignores its ct). Used to
     // prove a memory fetch cancelled at the budget deadline leaves the lease uncommitted
     // rather than committing a spurious "completed" record.
     sealed class CancelAwareHandler : HttpMessageHandler {
+        volatile bool _entered;
+        // Lets a test distinguish "the fetch was reached and cancelled" from "the fetch was
+        // never made at all" — outcomes this handler is otherwise indistinguishable between.
+        public bool Entered => _entered;
+
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {
+            _entered = true;
             await Task.Delay(Timeout.InfiniteTimeSpan, ct);
             return new HttpResponseMessage(HttpStatusCode.OK);
         }


### PR DESCRIPTION
`CursorHookCommandTests.CancelledFetch_leaves_lease_uncommitted` failed on `windows-latest` in an unrelated PR (#371) and passed on a plain rerun of the same commit, with ubuntu green both times.

Closes #372 — Linear AI-1539.

## Root cause

The memory stage gets `budgetTotal - sw.Elapsed - HookBudget.Safety`, measured off a real `Stopwatch`. Under runner load `sw.Elapsed` crosses `budgetTotal - 1.5s`, the no-budget guard returns before the fetch, and the test lands on whichever side the runner happened to pick:

- **starving the second attempt** → `MemoryIndexRequested` stays false and the assertion fails (the observed flake);
- **starving the first attempt** → the fetch is skipped and the test passes *without exercising the cancellation path it exists to prove* — the direction the old comment anticipated but could not prevent.

Reproduced locally by shrinking `budgetTotal` below `Safety` (arithmetically identical to a slow runner), which yields the byte-identical CI failure:

```
AssertionException: Expected to be true but found False
  at Assert.That(fx.MemoryIndexRequested).IsTrue()
```

There is a second, deeper coupling. The provider spends that same budget on `scopeResolver.ResolveAsync` **before** the fetch, and the real resolver spawns `git`. Pinning the budget alone still left the fetch racing a process spawn — verified, not assumed: a pinned 250 ms budget with the real resolver still never reached the fetch on an unloaded laptop.

## Fix

`HandleCore` takes two optional seams alongside its existing `memoryClientFactory` / `memoryStoreFactory` ones:

- `memoryBudgetOverride` — pins what the memory stage gets instead of deriving it from elapsed wall clock;
- `memoryScopeResolver` — keeps a `git` spawn out of that budget.

Both default to exactly what they replaced, so **production behaviour is unchanged** (`memoryBudgetOverride ?? (budgetTotal - sw.Elapsed - HookBudget.Safety)`, `memoryScopeResolver ?? new SessionStartMemoryScopeResolver()`). `HandleInternal`, the production caller, passes neither.

The test now spends its whole pinned 250 ms on the fetch itself. A new sibling test, `ExhaustedMemoryBudget_skips_the_fetch_and_still_emits`, covers the no-budget branch — both sides of the guard are asserted outcomes rather than one being a silent flake.

## Making the new assertions actually bite

Review (codex) flagged that both new assertions could pass vacuously. Fixed in 4a94584:

- **The exhausted-budget test didn't pin the guard it names.** `SessionStartMemoryContextProvider` *independently* declines a non-positive budget, so deleting the orchestration guard left the observables identical. It now asserts the store factory was never invoked — the store is built only after that guard. Verified by mutation: with the guard deleted the test fails on exactly that assertion.
- **`handler.Entered` only proved `SendAsync` started**, and would have stayed true had the outer deadline been what ended things. The handler now also records that the request itself observed cancellation, and the test bounds its own runtime well inside that deadline.

Attribution between the orchestration CTS and the provider's linked CTS is deliberately *not* asserted: both are armed from the same `memBudget` on one linked chain, so it isn't an observable property. The comment was reworded to claim only what holds rather than adding a seam to distinguish two halves of one budget.

## Verification

- The probe that reproduced the failure (`budgetTotal` below `Safety`) now **passes** against the fixed test.
- `CursorHookCommandTests` 38/38 green.
- Full unit suite compared against an `origin/main` baseline worktree: ~45 pre-existing macOS failures in the MCP-registration / codex-config / uninstall / daemon families on **both** sides. The three timing-heavy daemon tests that differ between the two runs each pass in isolation on this branch and are untouched by this diff.
- `dotnet publish -c Release`: no IL3050/IL2026 warnings.
- Wall time: the test's former ~2.5 s hang drops to 250 ms, now below host-startup noise.

Qodo's two findings (comment verbosity against the repo's minimal-comment rule; worst-case test runtime, which is why `budgetTotal` is 15 s rather than the 60 s first pushed) are addressed in d96ec42.
