### PR TITLE
Stop the daemon reconnect loop spinning against a healthy connection

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -416,6 +416,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// <summary>Raw <see cref="HubConnection.StartAsync"/> — a seam for the same reason.</summary>
     internal virtual Task StartHubAsync(CancellationToken ct) => _hub.StartAsync(ct);
 
+    /// <summary>Raw <see cref="HubConnection.StopAsync"/> — a seam so
+    /// <see cref="ForceReconnectAsync"/>'s wedged-transport cap is unit-testable.</summary>
+    internal virtual Task StopHubAsync(CancellationToken ct) => _hub.StopAsync(ct);
+
+    /// <summary>How long <see cref="ForceReconnectAsync"/> waits for the hub stop before
+    /// abandoning it. Settable so tests don't wait the real 5 s.</summary>
+    internal TimeSpan ForceStopCap { get; set; } = TimeSpan.FromSeconds(5);
+
     internal async Task ConnectWithRetryAsync(CancellationToken ct) {
         await _connectLock.WaitAsync(ct);
 
@@ -669,20 +677,28 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// transport and a new server-side conn id, then re-registers via
     /// <see cref="RegisterDaemonAsync"/>. Used when the heartbeat ping times out
     /// or throws — the WebSocket is hung and only a fresh connection
-    /// recovers it. StopAsync is capped at 5 s so a wedged transport
-    /// can't stall the heartbeat loop indefinitely (Qodo).
+    /// recovers it. The stop is capped at <see cref="ForceStopCap"/> so a wedged
+    /// transport can't stall the heartbeat loop indefinitely (Qodo). The cap is
+    /// enforced from OUTSIDE via <c>WaitAsync</c>: <c>HubConnection.StopAsync</c>'s
+    /// cancellation token is dead in the pinned client (its connection-lock wait and
+    /// transport stop run on <c>token: default</c>), so passing the token in would
+    /// never actually bound the await. Abandoning the wait is safe — StopAsync
+    /// signals its internal stop token synchronously before its first await, so the
+    /// teardown is already underway; when it eventually completes, Closed fires and
+    /// <see cref="OnClosed"/> reconnects, and until then each heartbeat tick stays
+    /// bounded and keeps retrying.
     /// </summary>
     public async Task ForceReconnectAsync() {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(_ct);
-        cts.CancelAfter(TimeSpan.FromSeconds(5));
+        cts.CancelAfter(ForceStopCap);
 
         try {
-            await _hub.StopAsync(cts.Token);
+            await StopHubAsync(CancellationToken.None).WaitAsync(cts.Token);
         } catch (OperationCanceledException) when (!_ct.IsCancellationRequested) {
-            // StopAsync didn't return in 5 s — transport is wedged. OnClosed
+            // StopAsync didn't return within the cap — transport is wedged. OnClosed
             // may still fire eventually, but we don't want to block the
             // heartbeat loop on it. The next tick will retry.
-            _logger.LogWarning("ForceReconnectAsync: StopAsync exceeded 5 s — abandoning wait");
+            _logger.LogWarning("ForceReconnectAsync: StopAsync exceeded {CapSeconds:F0} s — abandoning wait", ForceStopCap.TotalSeconds);
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -79,7 +79,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public Func<string, Task<BorrowProbeResult>>? ProbeBorrowSourceHandler { get; set; }
 
     /// <summary>
-    /// Callback invoked at <see cref="RegisterDaemon"/> time to snapshot the
+    /// Callback invoked at <see cref="RegisterDaemonAsync"/> time to snapshot the
     /// agent IDs currently hosted by this daemon. The server uses this to
     /// reconcile its registry against the daemon's view. Set by
     /// <see cref="AgentOrchestrator"/> at startup; when null, an empty array
@@ -387,38 +387,88 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         await ConnectWithRetryAsync(ct);
     }
 
-    async Task ConnectWithRetryAsync(CancellationToken ct) {
-        var delays  = new[] { 1, 2, 5, 10, 30 };
-        var attempt = 0;
+    /// <summary>
+    /// Serializes <see cref="ConnectWithRetryAsync"/> so the initial connect and every
+    /// <see cref="OnClosed"/>-triggered reconnect share ONE retry loop. Without this, each
+    /// close event spawned another concurrent loop against the same <see cref="HubConnection"/>;
+    /// the loser called <c>StartAsync</c> on a hub the winner had already started and got
+    /// "cannot be started if it is not in the Disconnected state" — forever, at Warning,
+    /// every 30s, against a perfectly healthy connection (issue #374).
+    /// </summary>
+    readonly SemaphoreSlim _connectLock = new(1, 1);
 
-        while (!ct.IsCancellationRequested) {
-            try {
-                LogConnecting(_config.ServerUrl);
-                await _hub.StartAsync(ct);
-                await RegisterDaemon();
-                _connectedTimestamp = Stopwatch.GetTimestamp();
-                LogConnected(_config.Name);
+    /// <summary>
+    /// Backoff schedule for <see cref="ConnectWithRetryAsync"/> (stays at the last entry once
+    /// exhausted). Settable so tests can drive the retry path without real multi-second waits.
+    /// </summary>
+    internal TimeSpan[] ConnectRetryDelays { get; set; } = [
+        TimeSpan.FromSeconds(1),
+        TimeSpan.FromSeconds(2),
+        TimeSpan.FromSeconds(5),
+        TimeSpan.FromSeconds(10),
+        TimeSpan.FromSeconds(30)
+    ];
 
-                return;
-            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
-                throw;
-            } catch (Exception ex) when (IsNameInUse(ex)) {
-                // server explicitly rejected this daemon because
-                // another live daemon owns the (owner, name) slot. Don't
-                // retry — retrying would just thrash the incumbent.
-                // RegisterDaemon already fired OnNameInUse before re-throwing
-                // here; we just need to propagate so DaemonRunner exits
-                // with code 3 instead of looping forever.
-                throw;
-            } catch (Exception ex) {
-                var delay = delays[Math.Min(attempt, delays.Length - 1)];
-                LogConnectionAttemptFailed(ex, attempt + 1, delay);
-                await Task.Delay(TimeSpan.FromSeconds(delay), ct);
-                attempt++;
+    /// <summary>Raw hub state — a seam so the retry loop's state checks are unit-testable
+    /// without a live SignalR transport.</summary>
+    internal virtual HubConnectionState HubState => _hub.State;
+
+    /// <summary>Raw <see cref="HubConnection.StartAsync"/> — a seam for the same reason.</summary>
+    internal virtual Task StartHubAsync(CancellationToken ct) => _hub.StartAsync(ct);
+
+    internal async Task ConnectWithRetryAsync(CancellationToken ct) {
+        await _connectLock.WaitAsync(ct);
+
+        try {
+            var attempt = 0;
+
+            while (!ct.IsCancellationRequested) {
+                try {
+                    // Another path may have healed the connection while this call was queued on
+                    // the lock or sleeping in backoff — SignalR's automatic reconnect
+                    // (OnReconnected → RegisterDaemonAsync) or the heartbeat's ReRegisterAsync.
+                    // A live, registered connection needs nothing from this loop.
+                    if (IsReady) return;
+
+                    // Only start a hub that is actually Disconnected. Connected means the
+                    // transport is fine and registration is the missing half (e.g. the previous
+                    // iteration's RegisterDaemonAsync threw after StartAsync succeeded).
+                    // Connecting/Reconnecting means automatic reconnect owns the transport;
+                    // RegisterDaemonAsync below fails ("connection is not active"), we back off,
+                    // and re-check — auto-reconnect terminally either restores the connection or
+                    // exhausts to Disconnected (firing Closed), so this converges.
+                    if (HubState == HubConnectionState.Disconnected) {
+                        LogConnecting(_config.ServerUrl);
+                        await StartHubAsync(ct);
+                    }
+
+                    await RegisterDaemonAsync();
+                    _connectedTimestamp = Stopwatch.GetTimestamp();
+                    LogConnected(_config.Name);
+
+                    return;
+                } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                    throw;
+                } catch (Exception ex) when (IsNameInUse(ex)) {
+                    // server explicitly rejected this daemon because
+                    // another live daemon owns the (owner, name) slot. Don't
+                    // retry — retrying would just thrash the incumbent.
+                    // RegisterDaemonAsync already fired OnNameInUse before re-throwing
+                    // here; we just need to propagate so DaemonRunner exits
+                    // with code 3 instead of looping forever.
+                    throw;
+                } catch (Exception ex) {
+                    var delay = ConnectRetryDelays[Math.Min(attempt, ConnectRetryDelays.Length - 1)];
+                    LogConnectionAttemptFailed(ex, attempt + 1, delay.TotalSeconds);
+                    await Task.Delay(delay, ct);
+                    attempt++;
+                }
             }
-        }
 
-        ct.ThrowIfCancellationRequested();
+            ct.ThrowIfCancellationRequested();
+        } finally {
+            _connectLock.Release();
+        }
     }
 
     async Task OnClosed(Exception? ex) {
@@ -457,7 +507,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// readiness on the heartbeat slot-displacement path (DaemonHeartbeatLoop.cs → ReRegisterAsync),
     /// where the transport stays up and no Reconnecting/Closed event fires.
     /// </summary>
-    Task RegisterDaemon() =>
+    internal virtual Task RegisterDaemonAsync() =>
         _gate.RunRegistrationAsync(
             daemonConnect: DaemonConnectAsync,
             reRegisterAgents: ReRegisterAgentsAndAcpBindingsAsync
@@ -467,7 +517,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// Composes the existing per-agent re-registration hook with the ACP reconnect re-bind — AFTER
     /// agent re-registration, so per-session agent ownership is restored before an ACP binding tries
     /// to reference its agent. Both steps
-    /// run inside <see cref="RegisterDaemon"/>'s <see cref="RegistrationGate.RunRegistrationAsync"/>
+    /// run inside <see cref="RegisterDaemonAsync"/>'s <see cref="RegistrationGate.RunRegistrationAsync"/>
     /// bracket, i.e. strictly BEFORE <see cref="IsReady"/> can report true — <c>internal</c> (not
     /// <c>private</c>) so it can be driven directly in tests without a live hub connection.
     /// </summary>
@@ -539,7 +589,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// <summary>
     /// Set by <see cref="AgentOrchestrator"/>: re-registers this daemon's live agents with the
     /// server (AgentRegistered + AgentStatusChanged) so per-session ownership is restored after a
-    /// (re-)connect. Invoked inside <see cref="RegisterDaemon"/> BEFORE readiness is restored, so
+    /// (re-)connect. Invoked inside <see cref="RegisterDaemonAsync"/> BEFORE readiness is restored, so
     /// a permission invoke gated on <see cref="IsReady"/> can't beat session-ownership recovery.
     /// Null until wired (early startup / tests) — treated as a no-op.
     /// </summary>
@@ -566,7 +616,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// Auto-reconnect started: the transport is no longer Connected and the
     /// server-side registration for this connection is stale. Clear readiness so
     /// nothing invokes a daemon-scoped hub method until <see cref="OnReconnected"/>
-    /// re-runs <see cref="RegisterDaemon"/>.
+    /// re-runs <see cref="RegisterDaemonAsync"/>.
     /// </summary>
     Task OnReconnecting(Exception? error) {
         _gate.MarkUnregistered();
@@ -577,7 +627,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// <summary>
     /// True when the hub is Connected AND this connection has completed a full
     /// (re-)registration — <c>DaemonConnect</c> AND per-agent re-registration (see
-    /// <see cref="RegisterDaemon"/>). The permission-request retry loop waits on this rather than
+    /// <see cref="RegisterDaemonAsync"/>). The permission-request retry loop waits on this rather than
     /// raw <see cref="HubConnectionState.Connected"/> so a retry can't race re-registration.
     /// <c>virtual</c> so unit tests can control readiness directly without a live SignalR transport
     /// (see the ACP hub-method tests).
@@ -590,7 +640,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
 
     async Task OnReconnected(string? connectionId) {
         LogReconnected();
-        await RegisterDaemon();
+        await RegisterDaemonAsync();
         _connectedTimestamp = Stopwatch.GetTimestamp();
     }
 
@@ -611,13 +661,13 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// the heartbeat loop when the server reports it doesn't recognise this
     /// connection as a daemon (slot displaced or never registered).
     /// </summary>
-    public Task ReRegisterAsync() => RegisterDaemon();
+    public Task ReRegisterAsync() => RegisterDaemonAsync();
 
     /// <summary>
     /// Stops the underlying hub. <see cref="OnClosed"/> fires and calls
     /// <see cref="ConnectWithRetryAsync"/>, which establishes a fresh
     /// transport and a new server-side conn id, then re-registers via
-    /// <see cref="RegisterDaemon"/>. Used when the heartbeat ping times out
+    /// <see cref="RegisterDaemonAsync"/>. Used when the heartbeat ping times out
     /// or throws — the WebSocket is hung and only a fresh connection
     /// recovers it. StopAsync is capped at 5 s so a wedged transport
     /// can't stall the heartbeat loop indefinitely (Qodo).
@@ -863,7 +913,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// FALSE. Gating this call on <see cref="IsReady"/> (the way the public wrapper does) would
     /// therefore deadlock: <see cref="IsReady"/> can only become true once this very method returns.
     /// The transport itself is already <see cref="HubConnectionState.Connected"/> by the time
-    /// <see cref="RegisterDaemon"/> runs (that is what triggered it), so invoking the raw hub method
+    /// <see cref="RegisterDaemonAsync"/> runs (that is what triggered it), so invoking the raw hub method
     /// here is safe — exactly the same reasoning that lets <see cref="AgentRegisteredAsync"/>/
     /// <see cref="AgentStatusChangedAsync"/> be called ungated from
     /// <c>AgentOrchestrator.ReRegisterAgentsAsync</c>. Best-effort per binding: one binding's re-bind
@@ -1147,7 +1197,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     partial void LogConnected(string name);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Connection attempt {Attempt} failed, retrying in {Delay}s")]
-    partial void LogConnectionAttemptFailed(Exception ex, int attempt, int delay);
+    partial void LogConnectionAttemptFailed(Exception ex, int attempt, double delay);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "SignalR connection closed after {UptimeSeconds:F1}s uptime, will reconnect")]
     partial void LogConnectionClosed(Exception? ex, double uptimeSeconds);

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ConnectWithRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ConnectWithRetryTests.cs
@@ -37,6 +37,14 @@ public class ConnectWithRetryTests {
         /// first loop mid-connect while a concurrent ConnectWithRetryAsync call is issued.</summary>
         public TaskCompletionSource? StartHold { get; set; }
 
+        /// <summary>When set, StopHubAsync returns this instead of completing — lets a test wedge
+        /// the transport stop that ForceReconnectAsync must abandon at its cap.</summary>
+        public TaskCompletionSource? StopHold { get; set; }
+
+        /// <summary>Fired synchronously on every RegisterDaemonAsync call — lets a test observe
+        /// failed attempts deterministically instead of sleeping.</summary>
+        public Action? OnRegisterAttempt { get; set; }
+
         internal override HubConnectionState HubState => State;
         internal override bool               IsReady  => Ready;
 
@@ -51,8 +59,17 @@ public class ConnectWithRetryTests {
             State = HubConnectionState.Connected;
         }
 
+        internal override Task StopHubAsync(CancellationToken ct) =>
+            StopHold?.Task ?? Task.CompletedTask;
+
         internal override Task RegisterDaemonAsync() {
             RegisterCalls++;
+            OnRegisterAttempt?.Invoke();
+
+            // Mirror the real hub-invoke contract: DaemonConnect can only succeed on a
+            // Connected transport ("cannot be called if the connection is not active").
+            if (State != HubConnectionState.Connected)
+                return Task.FromException(new InvalidOperationException("The 'InvokeCoreAsync' method cannot be called if the connection is not active"));
 
             if (FailRegisterRemaining > 0) {
                 FailRegisterRemaining--;
@@ -125,17 +142,38 @@ public class ConnectWithRetryTests {
             ConnectRetryDelays = FastDelays
         };
 
+        // Registration fails while the fake is Reconnecting (see RegisterDaemonAsync), so the
+        // loop must back off and retry. Observe two failed attempts deterministically before
+        // emulating SignalR's automatic reconnect healing the transport.
+        var twoAttemptsFailed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        conn.OnRegisterAttempt = () => {
+            if (conn.RegisterCalls >= 2) twoAttemptsFailed.TrySetResult();
+        };
+
         var loop = conn.ConnectWithRetryAsync(CancellationToken.None);
 
-        // Give the loop a few iterations against the Reconnecting hub, then emulate SignalR's
-        // automatic reconnect healing the transport and OnReconnected re-registering.
-        await Task.Delay(TimeSpan.FromMilliseconds(100));
+        await twoAttemptsFailed.Task.WaitAsync(HangGuard);
+        await Assert.That(loop.IsCompleted).IsFalse();
+
         conn.State = HubConnectionState.Connected;
-        conn.Ready = true;
 
         await loop.WaitAsync(HangGuard);
 
         await Assert.That(conn.StartCalls).IsEqualTo(0);
+        await Assert.That(conn.Ready).IsTrue();
+    }
+
+    [Test]
+    public async Task ForceReconnect_abandons_a_wedged_stop_at_the_cap() {
+        var conn = new RetryTestConnection {
+            ForceStopCap = TimeSpan.FromMilliseconds(50)
+        };
+        // Never completed: emulates the pinned client's StopAsync hanging on its internal
+        // connection-lock wait, which ignores the caller's cancellation token entirely.
+        conn.StopHold = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Must return at the cap instead of hanging the heartbeat tick forever.
+        await conn.ForceReconnectAsync().WaitAsync(HangGuard);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ConnectWithRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ConnectWithRetryTests.cs
@@ -1,0 +1,175 @@
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// Regression tests for issue #374: the daemon reconnect loop spun forever calling
+/// <c>HubConnection.StartAsync</c> against a hub that was not <c>Disconnected</c> — a healthy,
+/// registered connection kept logging "cannot be started if it is not in the Disconnected state"
+/// at Warning every 30s, and every <c>Closed</c> event minted another concurrent loop. Mirrors the
+/// <c>AcpServerConnectionTests</c> approach: no live SignalR transport;
+/// <see cref="RetryTestConnection"/> overrides the internal seams (<c>HubState</c>,
+/// <c>StartHubAsync</c>, <c>RegisterDaemonAsync</c>, <c>IsReady</c>) and emulates the real
+/// <c>HubConnection.StartAsync</c> contract of throwing when not Disconnected.
+/// </summary>
+public class ConnectWithRetryTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    sealed class RetryTestConnection() : ServerConnection(
+        new DaemonConfig { Name = "test", ServerUrl = "http://127.0.0.1:1" },
+        NullLoggerFactory.Instance,
+        NullLogger<ServerConnection>.Instance
+    ) {
+        public HubConnectionState State { get; set; } = HubConnectionState.Disconnected;
+        public bool Ready { get; set; }
+
+        public int StartCalls    { get; private set; }
+        public int RegisterCalls { get; private set; }
+
+        /// <summary>How many RegisterDaemonAsync calls should throw before they start
+        /// succeeding — drives the "register failed after a successful start" path.</summary>
+        public int FailRegisterRemaining { get; set; }
+
+        /// <summary>When set, StartHubAsync awaits this before returning — lets a test hold the
+        /// first loop mid-connect while a concurrent ConnectWithRetryAsync call is issued.</summary>
+        public TaskCompletionSource? StartHold { get; set; }
+
+        internal override HubConnectionState HubState => State;
+        internal override bool               IsReady  => Ready;
+
+        internal override async Task StartHubAsync(CancellationToken ct) {
+            StartCalls++;
+
+            if (State != HubConnectionState.Disconnected)
+                throw new InvalidOperationException("The HubConnection cannot be started if it is not in the Disconnected state.");
+
+            if (StartHold is { } hold) await hold.Task.WaitAsync(ct);
+
+            State = HubConnectionState.Connected;
+        }
+
+        internal override Task RegisterDaemonAsync() {
+            RegisterCalls++;
+
+            if (FailRegisterRemaining > 0) {
+                FailRegisterRemaining--;
+
+                return Task.FromException(new InvalidOperationException("simulated DaemonConnect failure"));
+            }
+
+            Ready = true;
+
+            return Task.CompletedTask;
+        }
+    }
+
+    static TimeSpan[] FastDelays => [TimeSpan.FromMilliseconds(10)];
+
+    [Test]
+    public async Task Live_registered_connection_is_left_alone() {
+        var conn = new RetryTestConnection {
+            State             = HubConnectionState.Connected,
+            Ready             = true,
+            ConnectRetryDelays = FastDelays
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+
+        await conn.ConnectWithRetryAsync(cts.Token).WaitAsync(HangGuard);
+
+        await Assert.That(conn.StartCalls).IsEqualTo(0);
+        await Assert.That(conn.RegisterCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Connected_but_unregistered_hub_is_registered_without_a_start_attempt() {
+        var conn = new RetryTestConnection {
+            State             = HubConnectionState.Connected,
+            Ready             = false,
+            ConnectRetryDelays = FastDelays
+        };
+
+        await conn.ConnectWithRetryAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(conn.StartCalls).IsEqualTo(0);
+        await Assert.That(conn.RegisterCalls).IsEqualTo(1);
+        await Assert.That(conn.Ready).IsTrue();
+    }
+
+    [Test]
+    public async Task Register_failure_after_a_successful_start_retries_without_restarting_the_hub() {
+        var conn = new RetryTestConnection {
+            State               = HubConnectionState.Disconnected,
+            FailRegisterRemaining = 1,
+            ConnectRetryDelays   = FastDelays
+        };
+
+        await conn.ConnectWithRetryAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // One physical start; the failed registration is retried on the already-started hub
+        // instead of a doomed second StartAsync (which the fake, like the real HubConnection,
+        // rejects when not Disconnected).
+        await Assert.That(conn.StartCalls).IsEqualTo(1);
+        await Assert.That(conn.RegisterCalls).IsEqualTo(2);
+        await Assert.That(conn.Ready).IsTrue();
+    }
+
+    [Test]
+    public async Task Reconnecting_hub_is_never_started_and_the_loop_exits_once_it_heals() {
+        var conn = new RetryTestConnection {
+            State             = HubConnectionState.Reconnecting,
+            Ready             = false,
+            ConnectRetryDelays = FastDelays
+        };
+
+        var loop = conn.ConnectWithRetryAsync(CancellationToken.None);
+
+        // Give the loop a few iterations against the Reconnecting hub, then emulate SignalR's
+        // automatic reconnect healing the transport and OnReconnected re-registering.
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+        conn.State = HubConnectionState.Connected;
+        conn.Ready = true;
+
+        await loop.WaitAsync(HangGuard);
+
+        await Assert.That(conn.StartCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Concurrent_calls_share_one_loop_and_one_start() {
+        var conn = new RetryTestConnection { ConnectRetryDelays = FastDelays };
+        var hold = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        conn.StartHold = hold;
+
+        var first  = conn.ConnectWithRetryAsync(CancellationToken.None);
+        var second = conn.ConnectWithRetryAsync(CancellationToken.None);
+
+        // Let the second call reach the lock while the first is held mid-StartAsync — before the
+        // fix it would have raced ahead and called StartAsync on the same hub concurrently.
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+        await Assert.That(conn.StartCalls).IsEqualTo(1);
+
+        hold.SetResult();
+        await Task.WhenAll(first, second).WaitAsync(HangGuard);
+
+        await Assert.That(conn.StartCalls).IsEqualTo(1);
+        await Assert.That(conn.RegisterCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Cancellation_during_backoff_propagates() {
+        var conn = new RetryTestConnection {
+            State               = HubConnectionState.Connected,
+            FailRegisterRemaining = int.MaxValue,
+            ConnectRetryDelays   = [TimeSpan.FromSeconds(30)]
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        await Assert.That(async () => await conn.ConnectWithRetryAsync(cts.Token).WaitAsync(HangGuard))
+            .Throws<OperationCanceledException>();
+    }
+}


### PR DESCRIPTION
Closes #374 — Linear AI-1545.

## Root cause

`ServerConnection.ConnectWithRetryAsync` had two compounding defects:

1. **A retry iteration always called `StartAsync`.** The try block was `StartAsync` → `RegisterDaemon`, so when registration threw *after* a successful start (the incident log shows exactly this: `DaemonConnectAsync` → `The 'InvokeCoreAsync' method cannot be called if the connection is not active`, i.e. the transport dropped into `Reconnecting` between the two steps), the next iteration called `StartAsync` on a non-`Disconnected` hub. That throws `The HubConnection cannot be started if it is not in the Disconnected state`, lands in the generic catch, backs off, and repeats. Once automatic reconnect healed the transport and `OnReconnected` re-registered, the daemon was fully healthy — but the loop could never succeed (it never reached the register step again) and never exit: an unkillable Warning every 30s against a live connection. 12,348 occurrences in one daemon log, streaks of 900+ (~7.8h).
2. **The loop was not serialized.** It runs from the initial `ConnectAsync` and from every `Closed` event, so each disconnect episode could mint another concurrent zombie loop. The log shows three interleaved loops racing one hub — "Connection attempt 1277", "attempt 3", and "attempt 2" logging within the same second.

## Fix

`ConnectWithRetryAsync` is now:

- **serialized** behind a `SemaphoreSlim(1,1)` — the initial connect and every `Closed`-triggered reconnect share one loop; a queued caller that acquires the lock after someone else already healed the connection returns immediately;
- **state-aware** — each iteration first exits if `IsReady` (auto-reconnect + `OnReconnected`, or the heartbeat's `ReRegisterAsync`, already restored a registered connection), then calls `StartAsync` **only when the hub is actually `Disconnected`**, then always (re-)attempts `RegisterDaemonAsync`. A register-step failure now retries registration on the live hub instead of a doomed restart. While the hub is `Connecting`/`Reconnecting`, the register attempt fails transiently and the loop backs off — automatic reconnect terminally either restores the connection (loop observes `IsReady` and exits) or exhausts to `Disconnected` (loop starts the hub), so it converges.

No behavioural change to name-in-use propagation, cancellation, backoff schedule, or the `OnReconnected`/heartbeat re-registration paths.

## Tests

New `ConnectWithRetryTests` (mirrors the `AcpServerConnectionTests` fake-subclass approach; new internal seams `HubState`/`StartHubAsync`/`RegisterDaemonAsync`, and `ConnectRetryDelays` made settable so the retry path runs in milliseconds). The fake mirrors the real `HubConnection.StartAsync` contract of throwing when not `Disconnected`:

- live registered connection → **no** start/register attempt (acceptance: "connection is live → no reconnect attempt");
- connected-but-unregistered hub → registered without a start attempt;
- register failure after a successful start → retried registration, **one** physical start (acceptance: "connection failed → the retry path can actually succeed");
- `Reconnecting` hub → never started; loop exits once the transport heals;
- concurrent calls → one loop, one start;
- cancellation during backoff propagates.

**Mutation-verified:** with the loop temporarily reverted to the pre-fix logic (unconditional `StartAsync`, no lock), 5 of the 6 tests fail; all 6 pass against the fix.

## Verification

- Full `Tests.Unit` suite: 3962 passed / 42 failed — the 42 are exactly the pre-existing macOS `/tmp`-symlink / parallel-load flake families (CodexConfigToml, Uninstall, CodexLauncher, CodexConfigWriter, PluginCodexInstall), none daemon-related.
- `dotnet publish -c Release`: no IL3050/IL2026 AOT warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round (codex, clean on round 2)

The codex review flow surfaced a P1 in the adjacent recovery path, fixed in the second commit: **`HubConnection.StopAsync`'s cancellation token is a dead parameter** in the pinned 10.0.8 client (`StopAsyncCore` waits the connection lock and stops the transport on `token: default` — verified against the `release/10.0` source), so `ForceReconnectAsync`'s 5s cap never actually fired and a wedged transport would have hung the single heartbeat tick forever, permanently killing liveness probing. The cap is now enforced from outside via `.WaitAsync(cts.Token)` through a new `StopHubAsync` seam with a settable `ForceStopCap`, plus a regression test that wedges the stop and asserts the call returns at the cap (mutation-verified: passing the token inward instead fails the test). The reviewer's P2 also hardened the reconnecting-state test: the fake now fails registration unless the hub is Connected (mirroring the real invoke contract) and the test observes failed attempts deterministically instead of sleeping.
