### PR TITLE
[AI-1526] Settlement-aware launch admission (CLI)

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
@@ -90,20 +90,44 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
             return Task.CompletedTask;
         }
 
-        if (!existing.Processed) {
+        if (!existing.Processed)
             _ = _sendAck(new CommandAck(_epoch, item.Seq, item.CommandId, CommandAckState.Accepted));
-        } else {
-            // CurrentState is read LIVE at ack time (immutable execution fact vs current liveness);
-            // the readLiveness delegate reads the daemon lifecycle collections with confirmed-death precedence.
-            var live = _readLiveness(existing.Outcome.AgentId ?? item.AgentId);
-            // Phase B2-b (sequenced-settlement design §5.5): carry the CACHED rejection reason so a
-            // retransmitted duplicate of a rejected launch is still distinguishable as daemon_capacity
-            // (requeue) vs semantic (fail) — the exact lost-rejection case the identity cache answers.
-            var reason = existing.Outcome.RejectReason is { } r ? RejectReasonWireToken(r) : null;
-            _ = _sendAck(new CommandAck(_epoch, item.Seq, item.CommandId, CommandAckState.Processed,
-                existing.Outcome.Kind, live, existing.Outcome.AgentId ?? item.AgentId, existing.Outcome.SessionId, reason));
-        }
+        else
+            _ = _sendAck(BuildProcessedAckLocked(item, existing.Outcome));
+
         return Task.CompletedTask;
+    }
+
+    /// <summary>The terminal <c>Processed</c> ack for a settled command — the ONE builder shared by the
+    /// duplicate-replay path above and the proactive settle ack at the end of <see cref="RunLaneAsync"/>
+    /// (settlement-admission design §3.2 F), so a retransmission can never disagree with the proactive
+    /// send about outcome/agent/session/rejection-reason. <c>CurrentState</c> is read LIVE at ack time
+    /// (immutable execution fact vs current liveness); the readLiveness delegate reads the daemon
+    /// lifecycle collections with confirmed-death precedence. The CACHED rejection reason rides along so
+    /// a rejected launch stays distinguishable as daemon_capacity (requeue) vs semantic (fail) — the
+    /// exact lost-rejection case the identity cache answers. Called under <c>_lock</c>.</summary>
+    CommandAck BuildProcessedAckLocked(SequencedItem item, CommandOutcome outcome) {
+        var live   = _readLiveness(outcome.AgentId ?? item.AgentId);
+        var reason = outcome.RejectReason is { } r ? RejectReasonWireToken(r) : null;
+
+        return new CommandAck(_epoch, item.Seq, item.CommandId, CommandAckState.Processed,
+            outcome.Kind, live, outcome.AgentId ?? item.AgentId, outcome.SessionId, reason);
+    }
+
+    /// <summary>Settlement-admission design (§3.2 F): fire the proactive terminal ack without ever
+    /// letting the send fault the lane. The ack is best-effort telemetry — a disconnected/reconnecting
+    /// server just falls back to the periodic status-report reconcile — so a synchronous throw AND a
+    /// faulted task are both swallowed at Debug. Never awaited: the lane must not block on the wire.</summary>
+    void SendProactiveAck(CommandAck ack) {
+        try {
+            var send = _sendAck(ack);
+            if (send is { IsCompletedSuccessfully: false })
+                _ = send.ContinueWith(
+                    t => _logger.LogDebug(t.Exception, "SequencedCommandProcessor: proactive ack for seq {Seq} failed to send", ack.Seq),
+                    CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "SequencedCommandProcessor: proactive ack for seq {Seq} threw", ack.Seq);
+        }
     }
 
     /// <summary>Phase B2-b (sequenced-settlement design §5.5): the wire token a cached
@@ -168,11 +192,25 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
             if (outcome.Kind == CommandOutcomeKind.LaunchRejected && outcome.RejectReason is { } r)
                 _ = _sendRejected(new CommandRejected(li.Item.Epoch, li.Item.Seq, li.Item.CommandId, r, li.Item.AgentId));
 
+            CommandAck proactiveAck;
             lock (_lock) {
                 if (_cache.TryGetValue(li.Item.Seq, out var e)) { e.Processed = true; e.Outcome = outcome; }
                 AdvanceWatermarkLocked(); // contiguous terminal prefix — serial lane => normally == prior + 1,
                                           // but shared with SynthesizeErrorLocked so a race can never regress it
+                // Settlement-admission design (§3.2 F): built INSIDE the lock, immediately after the entry
+                // is marked Processed and the watermark advanced, so the ack can never advertise a terminal
+                // outcome the cache has not yet recorded (a duplicate arriving between the two would then
+                // answer differently). The send itself happens outside the lock.
+                proactiveAck = BuildProcessedAckLocked(li.Item, outcome);
             }
+
+            // Settlement-admission design (§3.2 F): a FRESH terminal command is acked proactively, not just
+            // a retransmitted duplicate. Without this the server only learns the command settled when its
+            // next periodic status report reconciles (up to one report interval later), and its
+            // one-nonterminal-command-per-daemon invariant rejects any concurrent launch for that whole
+            // window. The server's ack handler is idempotent against replays and unknown/stale acks, so
+            // older servers accept it too and simply retire the slot earlier.
+            SendProactiveAck(proactiveAck);
             li.Done.SetResult();
         }
     }

--- a/src/Capacitor.Cli/Commands/FlowRetryTiming.cs
+++ b/src/Capacitor.Cli/Commands/FlowRetryTiming.cs
@@ -1,0 +1,121 @@
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// The single injectable timing seam shared by the flows MCP server's two retry lanes — the
+/// start/submit POST helper (<c>SendWithSettlementRetryAsync</c>) and the round poll loop
+/// (<c>PollUntilTerminalAsync</c>). Clock reads, backoff/poll delays, per-request timeout sources
+/// and the deadline that cancels an in-flight POST all come from here, so tests drive a virtual
+/// clock with no wall-clock sleeps and no manually pre-cancelled tokens standing in for the real
+/// deadline logic.
+///
+/// <para>Production is backed by <see cref="TimeProvider.System"/>; every member is virtual so a
+/// test clock can override the three primitives (now / delay / timeout source) without the
+/// production types knowing anything about testing. See
+/// docs/superpowers/specs/2026-07-25-ai1526-concurrent-launch-settlement-admission-design.md (3.2 G).</para>
+/// </summary>
+internal class FlowRetryClock {
+    readonly TimeProvider _time;
+
+    public FlowRetryClock(TimeProvider? time = null) => _time = time ?? TimeProvider.System;
+
+    /// <summary>The production clock — real time, real timers.</summary>
+    public static FlowRetryClock System { get; } = new();
+
+    public virtual DateTimeOffset UtcNow => _time.GetUtcNow();
+
+    /// <summary>A non-positive delay completes synchronously (a fully truncated backoff, or a budget
+    /// that expired while the previous attempt was in flight, must not schedule a timer).</summary>
+    public virtual Task DelayAsync(TimeSpan delay, CancellationToken ct = default) =>
+        delay <= TimeSpan.Zero ? Task.CompletedTask : Task.Delay(delay, _time, ct);
+
+    /// <summary>A standalone timeout source — the per-GET bound in the poll lane, and the raw
+    /// deadline half of <see cref="CreateDeadline"/>.</summary>
+    public virtual CancellationTokenSource CreateTimeoutSource(TimeSpan timeout) => new(timeout, _time);
+
+    /// <summary>A deadline linked to the caller's token. The returned scope keeps the two sources
+    /// distinguishable, which is the whole point: the retry helper must return its
+    /// deadline-exhausted result ONLY when its own deadline fired, and rethrow caller cancellation
+    /// untouched.</summary>
+    public FlowDeadlineScope CreateDeadline(TimeSpan remaining, CancellationToken caller) =>
+        new(CreateTimeoutSource(remaining), caller);
+}
+
+/// <summary>A per-attempt deadline token linked to the caller's token, which stays able to say
+/// WHICH of the two fired. Disposing releases both sources.</summary>
+internal sealed class FlowDeadlineScope : IDisposable {
+    readonly CancellationTokenSource _deadline;
+    readonly CancellationTokenSource _linked;
+
+    internal FlowDeadlineScope(CancellationTokenSource deadline, CancellationToken caller) {
+        _deadline = deadline;
+        _linked   = CancellationTokenSource.CreateLinkedTokenSource(caller, deadline.Token);
+    }
+
+    /// <summary>Hand this to the request — it cancels on either the caller's token or the deadline.</summary>
+    public CancellationToken Token => _linked.Token;
+
+    /// <summary>True only when THIS scope's own deadline elapsed, never when the caller cancelled.</summary>
+    public bool DeadlineFired => _deadline.IsCancellationRequested;
+
+    public void Dispose() {
+        _linked.Dispose();
+        _deadline.Dispose();
+    }
+}
+
+/// <summary>
+/// The delay SCHEDULE shared by both flow retry lanes. Pinned formula, so the schedule is
+/// assertable rather than incidental: for retry <c>n</c> (1-based)
+/// <c>raw(n) = min(10s, 500ms · 2^(n−1))</c> — the cap applies BEFORE jitter — then equal jitter
+/// <c>delay(n) = raw(n)/2 + U(0, raw(n)/2)</c>, then truncation to the caller's remaining budget.
+/// First retry is therefore 250–500ms and steady state 5–10s.
+///
+/// <para>Only the schedule is shared: each lane keeps its own budget semantics (the POST lane's
+/// elapsed deadline vs the poll lane's <c>PollCap</c>) and passes its own remaining budget in, so a
+/// policy delay can never overshoot either. The jitter source is injectable so tests assert
+/// deterministic samples from a seeded RNG. See
+/// docs/superpowers/specs/2026-07-25-ai1526-concurrent-launch-settlement-admission-design.md (3.2 G).</para>
+/// </summary>
+internal sealed class SettlementBackoff {
+    internal static readonly TimeSpan BaseDelay = TimeSpan.FromMilliseconds(500);
+    internal static readonly TimeSpan MaxDelay  = TimeSpan.FromSeconds(10);
+
+    // Bounded exponent: retry ordinals are unbounded (the POST lane stops on elapsed time, the poll
+    // lane on PollCap), and 2^n overflows to Infinity long before either budget runs out. Clamping
+    // keeps Raw() total — the min() below would still cap it, but only if the multiply stays finite.
+    const int MaxExponent = 30;
+
+    readonly Func<double> _jitter;
+
+    /// <param name="jitter">Uniform sample in [0,1). Defaults to <see cref="Random.Shared"/>.</param>
+    public SettlementBackoff(Func<double>? jitter = null) => _jitter = jitter ?? Random.Shared.NextDouble;
+
+    public static SettlementBackoff Default { get; } = new();
+
+    /// <summary>Deterministic instance for tests — <see cref="Random"/> is not thread-safe, but a
+    /// backoff is only ever consulted from one lane at a time.</summary>
+    internal static SettlementBackoff Seeded(int seed) {
+        var rng = new Random(seed);
+        return new SettlementBackoff(rng.NextDouble);
+    }
+
+    /// <summary>The un-jittered, already-capped base for retry <paramref name="retry"/> (1-based).</summary>
+    internal static TimeSpan Raw(int retry) {
+        if (retry < 1) retry = 1;
+        var scaled = BaseDelay * Math.Pow(2, Math.Min(retry - 1, MaxExponent));
+        return scaled > MaxDelay ? MaxDelay : scaled;
+    }
+
+    /// <summary>The delay before retry <paramref name="retry"/> (1-based), truncated to
+    /// <paramref name="remainingBudget"/>. A non-positive budget yields zero — the caller is expected
+    /// to have already decided to stop, and must never be pushed past its own bound by this schedule.</summary>
+    public TimeSpan Delay(int retry, TimeSpan remainingBudget) {
+        var raw      = Raw(retry);
+        var half     = raw.Ticks / 2;
+        var jittered = half + (long)(_jitter() * half);
+
+        if (remainingBudget <= TimeSpan.Zero) return TimeSpan.Zero;
+
+        return TimeSpan.FromTicks(Math.Min(jittered, remainingBudget.Ticks));
+    }
+}

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -123,8 +123,10 @@ static class McpFlowsServer {
             string              baseUrl,
             string              cwd,
             string?             repoRoot,
-            RepositoryPayload?  repoInfo
+            RepositoryPayload?  repoInfo,
+            FlowRetryClock?     clock = null
         ) {
+        clock ??= FlowRetryClock.System;
         var paramsNode = request["params"]?.AsObject();
         var toolName   = paramsNode?["name"]?.GetValue<string>();
         var arguments  = paramsNode?["arguments"]?.AsObject();
@@ -163,12 +165,12 @@ static class McpFlowsServer {
                 using var postResponse = toolName switch {
                     "start_review_flow"   => wasModelStart
                         ? await SendWithRefreshRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind"))
-                        : await SendWithSettlementRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind"), Task.Delay),
+                        : await SendWithSettlementRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind"), clock),
                     "start_flow"          => wasModelStart
                         ? await SendWithRefreshRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id"))
-                        : await SendWithSettlementRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id"), Task.Delay),
-                    "submit_review_round" => await SendWithSettlementRetryAsync(client, c => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "context", participant: null, async: true), Task.Delay),
-                    _                     => await SendWithSettlementRetryAsync(client, c => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "message", participant: GetRequiredArg(arguments, "participant"), async: ParseAsyncArg(arguments)), Task.Delay)
+                        : await SendWithSettlementRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id"), clock),
+                    "submit_review_round" => await SendWithSettlementRetryAsync(client, c => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "context", participant: null, async: true), clock),
+                    _                     => await SendWithSettlementRetryAsync(client, c => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "message", participant: GetRequiredArg(arguments, "participant"), async: ParseAsyncArg(arguments)), clock)
                 };
 
                 var postBody = await postResponse.Content.ReadAsStringAsync();
@@ -218,7 +220,7 @@ static class McpFlowsServer {
                 if (!postResponse.IsSuccessStatusCode)
                     return BuildToolResult(id, FormatFlowStartError((int)postResponse.StatusCode, postBody, wasDynamicStart), isError: true);
 
-                var (payload, isError) = await ResolveRoundResultAsync(client, apiRoot, postBody, toolName, wasDynamicStart);
+                var (payload, isError) = await ResolveRoundResultAsync(client, apiRoot, postBody, toolName, wasDynamicStart, clock);
                 return BuildToolResult(id, payload, isError);
             }
 
@@ -249,7 +251,7 @@ static class McpFlowsServer {
                 // above, after the text is fully built — never before, never a superset.
                 var flowRunId = arguments?["flow_run_id"]?.GetValue<string>();
                 if (flowRunId is not null)
-                    await AckRenderedMessagesAsync(client, apiRoot, flowRunId, pendingIds, Task.Delay);
+                    await AckRenderedMessagesAsync(client, apiRoot, flowRunId, pendingIds, clock);
             } else if (toolName is "close_review_flow" or "close_flow") {
                 // E-c: render pending_messages but never ack them — the server delivers
                 // them atomically with the close, so there is nothing left to redeliver.
@@ -348,7 +350,7 @@ static class McpFlowsServer {
     /// attempt. Delay is injectable so unit tests run instantly.
     /// </summary>
     internal static async Task<HttpResponseMessage> SendWithSettlementRetryAsync(
-            HttpClient client, Func<HttpClient, Task<HttpResponseMessage>> send, Func<TimeSpan, Task> delay
+            HttpClient client, Func<HttpClient, Task<HttpResponseMessage>> send, FlowRetryClock clock
         ) {
         for (var attempt = 1;; attempt++) {
             var response = await SendWithRefreshRetryAsync(client, send);
@@ -361,7 +363,7 @@ static class McpFlowsServer {
                 return response;
 
             response.Dispose();
-            await delay(SettlementRetryDelay);
+            await clock.DelayAsync(SettlementRetryDelay);
         }
     }
 
@@ -795,11 +797,11 @@ static class McpFlowsServer {
     /// <paramref name="toolName"/> is the tool that initiated the round (one of
     /// start_review_flow/submit_review_round/start_flow/send_to_participant) — threaded through
     /// so the graceful-cap timeout message can point back at the matching status tool.</summary>
-    static async Task<PollResult> ResolveRoundResultAsync(HttpClient client, string apiRoot, string postBody, string toolName, bool wasDynamicStart) {
+    static async Task<PollResult> ResolveRoundResultAsync(HttpClient client, string apiRoot, string postBody, string toolName, bool wasDynamicStart, FlowRetryClock clock) {
         if (TryFormatRoundlessStart(postBody, out var roundlessPendingIds) is { } roundless) {
             if (roundlessPendingIds.Count > 0 &&
                 JsonNode.Parse(postBody)?.AsObject()?["flow_run_id"]?.GetValue<string>() is { } roundlessRunId)
-                await AckRenderedMessagesAsync(client, apiRoot, roundlessRunId, roundlessPendingIds, Task.Delay);
+                await AckRenderedMessagesAsync(client, apiRoot, roundlessRunId, roundlessPendingIds, clock);
 
             return new(roundless, false);
         }
@@ -815,12 +817,12 @@ static class McpFlowsServer {
 
             // flowRunId may be null here (unparseable body) — nothing to ack against.
             if (flowRunId is not null)
-                await AckRenderedMessagesAsync(client, apiRoot, flowRunId, pendingIds, Task.Delay);
+                await AckRenderedMessagesAsync(client, apiRoot, flowRunId, pendingIds, clock);
 
             return new(formatted, false);
         }
 
-        return await PollUntilTerminalAsync(client, apiRoot, flowRunId, roundNum.Value, toolName, wasDynamicStart);
+        return await PollUntilTerminalAsync(client, apiRoot, flowRunId, roundNum.Value, toolName, wasDynamicStart, clock);
     }
 
     /// <summary>Tool family that started the round determines which status tool the graceful-cap
@@ -830,9 +832,9 @@ static class McpFlowsServer {
     static string StatusToolNameFor(string toolName) =>
         toolName is "start_review_flow" or "submit_review_round" ? "get_review_flow_status" : "get_flow_status";
 
-    static async Task<PollResult> PollUntilTerminalAsync(HttpClient client, string apiRoot, string flowRunId, int roundNumber, string toolName, bool wasDynamicStart) {
+    static async Task<PollResult> PollUntilTerminalAsync(HttpClient client, string apiRoot, string flowRunId, int roundNumber, string toolName, bool wasDynamicStart, FlowRetryClock clock) {
         var url                   = $"{apiRoot}/api/flows/{Uri.EscapeDataString(flowRunId)}";
-        var pollStartedAt         = DateTimeOffset.UtcNow;
+        var pollStartedAt         = clock.UtcNow;
         var deadline              = pollStartedAt + PollCap;
         // Fix #3: anchor the 404 grace window to poll start, not to first-seen-404.
         var notFoundGraceDeadline = pollStartedAt + NotFoundGrace;
@@ -842,8 +844,8 @@ static class McpFlowsServer {
         // the network/5xx transient budget above, which uses the full 3s PollInterval.
         var settlementRetriesUsed = 0;
 
-        while (DateTimeOffset.UtcNow < deadline) {
-            using var getCts = new CancellationTokenSource(PerGetTimeout);
+        while (clock.UtcNow < deadline) {
+            using var getCts = clock.CreateTimeoutSource(PerGetTimeout);
             HttpResponseMessage resp;
             try {
                 resp = await SendWithRefreshRetryAsync(client, c => c.GetAsync(url, getCts.Token));
@@ -853,15 +855,15 @@ static class McpFlowsServer {
                 lastTransientError = ex.Message;
                 if (consecutiveTransient > MaxTransientRetries)
                     return new($"Error: poll failed after {MaxTransientRetries} consecutive network errors: {lastTransientError}", true);
-                await Task.Delay(PollInterval); continue;
+                await clock.DelayAsync(PollInterval); continue;
             }
 
             using (resp) {
                 if (resp.StatusCode == HttpStatusCode.NotFound) {
                     // Fix #3: 404 only gets the grace window anchored to poll start.
-                    if (DateTimeOffset.UtcNow > notFoundGraceDeadline)
+                    if (clock.UtcNow > notFoundGraceDeadline)
                         return new($"Error: flow_run_id {flowRunId} not found.", true);
-                    await Task.Delay(PollInterval); continue;
+                    await clock.DelayAsync(PollInterval); continue;
                 }
 
                 if (resp.StatusCode == HttpStatusCode.Unauthorized)
@@ -881,7 +883,7 @@ static class McpFlowsServer {
                             SettlementRetryableCodes.Contains(code!) &&
                             settlementRetriesUsed < MaxSettlementRetries - 1) {
                         settlementRetriesUsed++;
-                        await Task.Delay(SettlementRetryDelay);
+                        await clock.DelayAsync(SettlementRetryDelay);
                         continue;
                     }
 
@@ -894,7 +896,7 @@ static class McpFlowsServer {
                     lastTransientError = $"HTTP {statusCode}";
                     if (consecutiveTransient > MaxTransientRetries)
                         return new($"Error: poll failed after {MaxTransientRetries} consecutive server errors: {lastTransientError}", true);
-                    await Task.Delay(PollInterval); continue;
+                    await clock.DelayAsync(PollInterval); continue;
                 }
 
                 // Successful response — reset transient counters.
@@ -913,7 +915,7 @@ static class McpFlowsServer {
                 if (runStatus is "closed" or "failed") {
                     if (rn == roundNumber && rs is not null && TerminalRoundStatuses.Contains(rs)) {
                         var formatted = FormatPolledRoundResult(node!, flowRunId, out var pendingIds);
-                        await AckRenderedMessagesAsync(client, apiRoot, flowRunId, pendingIds, Task.Delay);
+                        await AckRenderedMessagesAsync(client, apiRoot, flowRunId, pendingIds, clock);
                         return new(formatted, false);
                     }
                     // Run became terminal before our round produced a result — explicit error.
@@ -923,11 +925,11 @@ static class McpFlowsServer {
                 // Only act on OUR round; an earlier projection may still show a prior round.
                 if (rn == roundNumber && rs is not null && TerminalRoundStatuses.Contains(rs)) {
                     var formatted = FormatPolledRoundResult(node!, flowRunId, out var pendingIds);
-                    await AckRenderedMessagesAsync(client, apiRoot, flowRunId, pendingIds, Task.Delay);
+                    await AckRenderedMessagesAsync(client, apiRoot, flowRunId, pendingIds, clock);
                     return new(formatted, false);
                 }
             }
-            await Task.Delay(PollInterval);
+            await clock.DelayAsync(PollInterval);
         }
 
         // Genuine 8-min cap: round still legitimately running.
@@ -1171,7 +1173,7 @@ static class McpFlowsServer {
     /// AFTER the response text has been fully formatted, passing only the ids that were actually
     /// rendered into that text — never before, never a superset. No-op (no HTTP call at all) when
     /// <paramref name="messageIds"/> is empty, which keeps this byte-compatible with servers that
-    /// predate the ack endpoint. Best-effort: one retry after <paramref name="delay"/>(2s) on any
+    /// predate the ack endpoint. Best-effort: one retry after 2s (on the injected <paramref name="clock"/>) on any
     /// failure (non-2xx or exception), then swallows and logs to stderr — the next status/round/
     /// close call will see the same messages still pending and re-render + re-ack them, so a lost
     /// ack only delays cleanup, it never drops a message.</summary>
@@ -1180,7 +1182,7 @@ static class McpFlowsServer {
             string                apiRoot,
             string                flowRunId,
             IReadOnlyList<string> messageIds,
-            Func<TimeSpan, Task>  delay
+            FlowRetryClock        clock
         ) {
         if (messageIds.Count == 0) return;
 
@@ -1194,7 +1196,7 @@ static class McpFlowsServer {
                 // round endpoints), so an unbounded ack POST could hang the tool response the
                 // driver is waiting on. A timeout surfaces as OperationCanceledException, which
                 // falls into the existing swallow-and-retry-once path below.
-                using var postCts = new CancellationTokenSource(PerAckPostTimeout);
+                using var postCts = clock.CreateTimeoutSource(PerAckPostTimeout);
                 using var response = await SendWithRefreshRetryAsync(
                     client,
                     c => c.PostAsync(url, JsonContent.Create(body, McpJsonContext.Default.AckFlowMessagesDto), postCts.Token)
@@ -1207,7 +1209,7 @@ static class McpFlowsServer {
 
         if (await TryPostAsync()) return;
 
-        await delay(TimeSpan.FromSeconds(2));
+        await clock.DelayAsync(TimeSpan.FromSeconds(2));
 
         if (await TryPostAsync()) return;
 

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -164,16 +164,26 @@ static class McpFlowsServer {
                     && toolName is "start_review_flow" or "start_flow"
                     && !string.IsNullOrWhiteSpace(arguments?["model"]?.GetValue<string>());
 
-                using var postResponse = toolName switch {
+                var sendResult = toolName switch {
                     "start_review_flow"   => wasModelStart
-                        ? await SendWithRefreshRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind"))
-                        : await SendWithSettlementRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind"), clock),
+                        ? new SettlementSendResult.Response(await SendWithRefreshRetryAsync(client, (c, ct) => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind", ct: ct)))
+                        : await SendWithSettlementRetryAsync(client, (c, ct) => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind", ct: ct), clock, backoff),
                     "start_flow"          => wasModelStart
-                        ? await SendWithRefreshRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id"))
-                        : await SendWithSettlementRetryAsync(client, c => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id"), clock),
-                    "submit_review_round" => await SendWithSettlementRetryAsync(client, c => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "context", participant: null, async: true), clock),
-                    _                     => await SendWithSettlementRetryAsync(client, c => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "message", participant: GetRequiredArg(arguments, "participant"), async: ParseAsyncArg(arguments)), clock)
+                        ? new SettlementSendResult.Response(await SendWithRefreshRetryAsync(client, (c, ct) => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id", ct: ct)))
+                        : await SendWithSettlementRetryAsync(client, (c, ct) => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id", ct: ct), clock, backoff),
+                    "submit_review_round" => await SendWithSettlementRetryAsync(client, (c, ct) => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "context", participant: null, async: true, ct: ct), clock, backoff),
+                    _                     => await SendWithSettlementRetryAsync(client, (c, ct) => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "message", participant: GetRequiredArg(arguments, "participant"), async: ParseAsyncArg(arguments), ct: ct), clock, backoff)
                 };
+
+                // Settlement-admission design (§3.2 G): the elapsed deadline is mapped HERE, at the
+                // only place that builds tool results, into a normal MCP tool error carrying the last
+                // coded rejection plus attempt/elapsed diagnostics. It must never escape as an
+                // unhandled stdio fault, and must never turn a retryable busy into something a caller
+                // reads as fatal — the guidance is explicitly "retry".
+                if (sendResult is SettlementSendResult.DeadlineExhausted exhausted)
+                    return BuildToolResult(id, FormatSettlementDeadlineError(exhausted), isError: true);
+
+                using var postResponse = ((SettlementSendResult.Response)sendResult).Value;
 
                 var postBody = await postResponse.Content.ReadAsStringAsync();
 
@@ -227,8 +237,8 @@ static class McpFlowsServer {
             }
 
             using var httpResponse = toolName switch {
-                "get_review_flow_status" or "get_flow_status" => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildFlowUrl(apiRoot, arguments))),
-                "close_review_flow"      or "close_flow"      => await SendWithRefreshRetryAsync(client, c => c.PostAsync(BuildFlowUrl(apiRoot, arguments) + "/close", null)),
+                "get_review_flow_status" or "get_flow_status" => await SendWithRefreshRetryAsync(client, (c, ct) => c.GetAsync(BuildFlowUrl(apiRoot, arguments), ct)),
+                "close_review_flow"      or "close_flow"      => await SendWithRefreshRetryAsync(client, (c, ct) => c.PostAsync(BuildFlowUrl(apiRoot, arguments) + "/close", null, ct)),
                 _                                             => throw new ArgumentException($"Unknown tool: {toolName}")
             };
 
@@ -280,8 +290,10 @@ static class McpFlowsServer {
     /// or refresh-token expired), the original 401 is returned and the caller surfaces the
     /// friendly "Not logged in" message.
     /// </summary>
-    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, Func<HttpClient, Task<HttpResponseMessage>> send) {
-        var response = await send(client);
+    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(
+            HttpClient client, Func<HttpClient, CancellationToken, Task<HttpResponseMessage>> send, CancellationToken ct = default
+        ) {
+        var response = await send(client, ct);
 
         if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
 
@@ -292,16 +304,21 @@ static class McpFlowsServer {
         response.Dispose();
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", refreshed.AccessToken);
 
-        return await send(client);
+        return await send(client, ct);
     }
 
-    // How many times to transparently retry a settlement-layer coded 409 (flow_settlement_busy /
-    // reviewer_launch_incarnation_superseded) before surfacing it via FormatFlowStartError. Both
-    // codes resolve fast against the settlement layer's own reconciliation, so the bound is small
-    // and the backoff short (sub-second) — unlike the network-transient budget in
-    // PollUntilTerminalAsync or the one-shot 401 refresh retry above.
-    const int MaxSettlementRetries = 3;
-    static readonly TimeSpan SettlementRetryDelay = TimeSpan.FromMilliseconds(200);
+    /// <summary>
+    /// How long the start/submit POST lane keeps transparently retrying a settlement-layer coded
+    /// 409, measured as ELAPSED time from the first attempt — including each request's own
+    /// duration, not just the sum of the backoff delays. That distinction is the whole point: a
+    /// settlement-aware server absorbs the wait by HOLDING the request open (up to a per-launch
+    /// admission wait on the order of a minute), so a delay-only budget would let worst-case
+    /// wall-clock blow past the MCP tool timeout the kcap plugin pins for its MCP servers
+    /// (MCP_TOOL_TIMEOUT, 10 minutes) and surface as a harness-level timeout instead of a clean
+    /// tool result. Three minutes fits roughly two full server-side admission waits plus backoff
+    /// while staying far under that ceiling. If the harness pin ever changes, re-derive this.
+    /// </summary>
+    internal static readonly TimeSpan SettlementElapsedDeadline = TimeSpan.FromMinutes(3);
 
     static readonly HashSet<string> SettlementRetryableCodes =
         new(StringComparer.Ordinal) { "flow_settlement_busy", "reviewer_launch_incarnation_superseded" };
@@ -345,28 +362,89 @@ static class McpFlowsServer {
     ///
     /// Only these two codes (via <see cref="TryParseCodedError"/>) trigger a retry; every other
     /// coded 4xx (budget_unverifiable, server_catching_up, client_upgrade_required, etc.) passes
-    /// through untouched. Bounded to <see cref="MaxSettlementRetries"/> attempts with a short,
-    /// sub-second backoff (<see cref="SettlementRetryDelay"/>); on exhaustion the last response
-    /// surfaces as-is via the caller's existing FormatFlowStartError. Wraps (doesn't replace)
-    /// <see cref="SendWithRefreshRetryAsync"/>, so the 401 refresh retry still applies on every
-    /// attempt. Delay is injectable so unit tests run instantly.
+    /// through untouched — as does an UNCODED failure, deliberately: the CLI cannot invent a code,
+    /// so an old server's uncoded 400 still surfaces on the first attempt.
+    ///
+    /// <para>Bounded by <see cref="SettlementElapsedDeadline"/> rather than an attempt count, on the
+    /// <see cref="SettlementBackoff"/> schedule, with the deadline's remaining time propagated as a
+    /// per-request <see cref="CancellationToken"/> so a held POST is abandoned instead of
+    /// overshooting. Each retried POST re-enters a fresh server-side admission wait, which is what
+    /// lets a burst of concurrent launches against one daemon absorb serially.</para>
+    ///
+    /// <para>Returns a discriminated result: <c>Response</c> carries the live response (the caller
+    /// owns it, exactly as before); <c>DeadlineExhausted</c> carries only the last observed coded
+    /// error plus attempt/elapsed diagnostics — this helper disposes every superseded failing
+    /// response, so an exhausted result never carries a live one. The deadline CTS is linked to the
+    /// caller's token; in production that token is <see cref="CancellationToken.None"/> (the stdio
+    /// loop has none), and caller-token cancellation is rethrown untouched — only this helper's OWN
+    /// deadline firing produces <c>DeadlineExhausted</c>.</para>
+    ///
+    /// <para>Wraps (doesn't replace) <see cref="SendWithRefreshRetryAsync"/>, so the 401 refresh
+    /// retry still applies on every attempt. All timing is injectable so unit tests run instantly on
+    /// a virtual clock.</para>
     /// </summary>
-    internal static async Task<HttpResponseMessage> SendWithSettlementRetryAsync(
-            HttpClient client, Func<HttpClient, Task<HttpResponseMessage>> send, FlowRetryClock clock
+    internal static async Task<SettlementSendResult> SendWithSettlementRetryAsync(
+            HttpClient                                                    client,
+            Func<HttpClient, CancellationToken, Task<HttpResponseMessage>> send,
+            FlowRetryClock                                                clock,
+            SettlementBackoff                                             backoff,
+            CancellationToken                                             callerToken = default
         ) {
+        var startedAt = clock.UtcNow;
+        var deadline  = startedAt + SettlementElapsedDeadline;
+
+        string? lastCode    = null;
+        string? lastMessage = null;
+
         for (var attempt = 1;; attempt++) {
-            var response = await SendWithRefreshRetryAsync(client, send);
+            var remaining = deadline - clock.UtcNow;
 
-            if (response.IsSuccessStatusCode || attempt >= MaxSettlementRetries) return response;
+            if (remaining <= TimeSpan.Zero)
+                return new SettlementSendResult.DeadlineExhausted(lastCode, lastMessage, attempt - 1, clock.UtcNow - startedAt);
 
+            using var scope = clock.CreateDeadline(remaining, callerToken);
+
+            HttpResponseMessage response;
+            try {
+                response = await SendWithRefreshRetryAsync(client, send, scope.Token);
+            } catch (OperationCanceledException) when (scope.DeadlineFired && !callerToken.IsCancellationRequested) {
+                // OUR deadline cut an in-flight attempt short — that is an exhausted budget, not a
+                // failure to report. Caller cancellation deliberately falls through and rethrows.
+                return new SettlementSendResult.DeadlineExhausted(lastCode, lastMessage, attempt, clock.UtcNow - startedAt);
+            }
+
+            if (response.IsSuccessStatusCode) return new SettlementSendResult.Response(response);
+
+            // Responses arrive fully buffered (the default completion option), so this read can't
+            // block on the network and needs no token of its own.
             var body = await response.Content.ReadAsStringAsync();
 
-            if (!TryParseCodedError(body, out var code, out _) || !SettlementRetryableCodes.Contains(code!))
-                return response;
+            if (!TryParseCodedError(body, out var code, out var message) || !SettlementRetryableCodes.Contains(code!))
+                return new SettlementSendResult.Response(response);
 
+            lastCode    = code;
+            lastMessage = message;
             response.Dispose();
-            await clock.DelayAsync(SettlementRetryDelay);
+
+            var left = deadline - clock.UtcNow;
+
+            if (left <= TimeSpan.Zero)
+                return new SettlementSendResult.DeadlineExhausted(lastCode, lastMessage, attempt, clock.UtcNow - startedAt);
+
+            await clock.DelayAsync(backoff.Delay(attempt, left), callerToken);
         }
+    }
+
+    /// <summary>The outcome of <see cref="SendWithSettlementRetryAsync"/>: either a response the
+    /// caller owns and disposes, or an exhausted elapsed deadline carrying only diagnostics. Closed
+    /// hierarchy (private base constructor) so every consumer must handle both arms.</summary>
+    internal abstract record SettlementSendResult {
+        SettlementSendResult() { }
+
+        internal sealed record Response(HttpResponseMessage Value) : SettlementSendResult;
+
+        internal sealed record DeadlineExhausted(
+            string? LastCode, string? LastMessage, int Attempts, TimeSpan Elapsed) : SettlementSendResult;
     }
 
     /// <summary>
@@ -547,7 +625,8 @@ static class McpFlowsServer {
             string             cwd,
             string?            repoRoot,
             RepositoryPayload? repoInfo,
-            string             kindArgName
+            string             kindArgName,
+            CancellationToken  ct = default
         ) {
         string? kind;
         string? definitionYaml = null;
@@ -648,7 +727,8 @@ static class McpFlowsServer {
 
         return await client.PostAsync(
             startPath,
-            JsonContent.Create(body, McpJsonContext.Default.StartReviewFlowDto)
+            JsonContent.Create(body, McpJsonContext.Default.StartReviewFlowDto),
+            ct
         );
     }
 
@@ -664,7 +744,8 @@ static class McpFlowsServer {
             JsonObject? arguments,
             string      contextArgName,
             string?     participant,
-            bool        async
+            bool        async,
+            CancellationToken ct = default
         ) {
         var flowRunId    = arguments?["flow_run_id"]?.GetValue<string>();
         var context      = GetRequiredArg(arguments, contextArgName);
@@ -681,7 +762,8 @@ static class McpFlowsServer {
 
         return client.PostAsync(
             $"{apiRoot}/api/flows/{Uri.EscapeDataString(flowRunId)}/rounds",
-            JsonContent.Create(body, McpJsonContext.Default.SubmitReviewRoundDto)
+            JsonContent.Create(body, McpJsonContext.Default.SubmitReviewRoundDto),
+            ct
         );
     }
 
@@ -770,6 +852,35 @@ static class McpFlowsServer {
     internal const string ServerCatchingUpGuidance =
         "The server is catching up after a read-model rebuild — try again in a few minutes, or ask the user what to do.";
 
+    /// <summary>Renders an exhausted settlement elapsed deadline as tool-error text, in the same
+    /// "Error (code): message" shape <see cref="FormatFlowStartError"/> uses for a coded rejection —
+    /// the caller sees the real server code it kept hitting, plus how hard the CLI tried, plus the
+    /// fact that retrying is still the right move. Only the POST lane can produce this; the poll
+    /// lane has its own graceful-cap message and its own budget.</summary>
+    internal static string FormatSettlementDeadlineError(SettlementSendResult.DeadlineExhausted exhausted) {
+        var code    = exhausted.LastCode ?? "flow_settlement_busy";
+        var attempts = exhausted.Attempts == 1 ? "1 attempt" : $"{exhausted.Attempts} attempts";
+        var elapsed  = FormatElapsed(exhausted.Elapsed);
+        var detail   = string.IsNullOrWhiteSpace(exhausted.LastMessage) ? "" : $" Last server message: {exhausted.LastMessage}";
+
+        return $"Error ({code}): gave up after {attempts} over {elapsed} — the daemon is still settling " +
+               $"a prior launch and could not admit this one in time. This is retryable: try again in a " +
+               $"minute, or check for another review flow already running against the same daemon.{detail}";
+    }
+
+    /// <summary>Compact, stable elapsed rendering for the deadline message (e.g. "3m", "2m 30s",
+    /// "45s") — no locale- or tick-dependent formatting in a string an agent may match on.</summary>
+    static string FormatElapsed(TimeSpan elapsed) {
+        if (elapsed < TimeSpan.Zero) elapsed = TimeSpan.Zero;
+
+        var minutes = (int)elapsed.TotalMinutes;
+        var seconds = elapsed.Seconds;
+
+        if (minutes == 0) return $"{Math.Max(seconds, 0)}s";
+
+        return seconds == 0 ? $"{minutes}m" : $"{minutes}m {seconds}s";
+    }
+
     /// <summary>Maps a non-2xx start/submit (or poll) response body to the tool error text.
     /// Status-agnostic contract (dynamic flows): ANY body carrying a string "error" code plus a
     /// "message" is a coded rejection from a dynamic-flows-aware server — surface the server
@@ -851,7 +962,7 @@ static class McpFlowsServer {
             using var getCts = clock.CreateTimeoutSource(PerGetTimeout);
             HttpResponseMessage resp;
             try {
-                resp = await SendWithRefreshRetryAsync(client, c => c.GetAsync(url, getCts.Token));
+                resp = await SendWithRefreshRetryAsync(client, (c, ct) => c.GetAsync(url, ct), getCts.Token);
             } catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException) {
                 // Fix #4: count network/TLS/timeout as transient; stop after budget.
                 consecutiveTransient++;
@@ -1203,7 +1314,8 @@ static class McpFlowsServer {
                 using var postCts = clock.CreateTimeoutSource(PerAckPostTimeout);
                 using var response = await SendWithRefreshRetryAsync(
                     client,
-                    c => c.PostAsync(url, JsonContent.Create(body, McpJsonContext.Default.AckFlowMessagesDto), postCts.Token)
+                    (c, ct) => c.PostAsync(url, JsonContent.Create(body, McpJsonContext.Default.AckFlowMessagesDto), ct),
+                    postCts.Token
                 );
                 return response.IsSuccessStatusCode;
             } catch {

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -124,9 +124,11 @@ static class McpFlowsServer {
             string              cwd,
             string?             repoRoot,
             RepositoryPayload?  repoInfo,
-            FlowRetryClock?     clock = null
+            FlowRetryClock?     clock = null,
+            SettlementBackoff?  backoff = null
         ) {
-        clock ??= FlowRetryClock.System;
+        clock   ??= FlowRetryClock.System;
+        backoff ??= SettlementBackoff.Default;
         var paramsNode = request["params"]?.AsObject();
         var toolName   = paramsNode?["name"]?.GetValue<string>();
         var arguments  = paramsNode?["arguments"]?.AsObject();
@@ -220,7 +222,7 @@ static class McpFlowsServer {
                 if (!postResponse.IsSuccessStatusCode)
                     return BuildToolResult(id, FormatFlowStartError((int)postResponse.StatusCode, postBody, wasDynamicStart), isError: true);
 
-                var (payload, isError) = await ResolveRoundResultAsync(client, apiRoot, postBody, toolName, wasDynamicStart, clock);
+                var (payload, isError) = await ResolveRoundResultAsync(client, apiRoot, postBody, toolName, wasDynamicStart, clock, backoff);
                 return BuildToolResult(id, payload, isError);
             }
 
@@ -797,7 +799,7 @@ static class McpFlowsServer {
     /// <paramref name="toolName"/> is the tool that initiated the round (one of
     /// start_review_flow/submit_review_round/start_flow/send_to_participant) — threaded through
     /// so the graceful-cap timeout message can point back at the matching status tool.</summary>
-    static async Task<PollResult> ResolveRoundResultAsync(HttpClient client, string apiRoot, string postBody, string toolName, bool wasDynamicStart, FlowRetryClock clock) {
+    static async Task<PollResult> ResolveRoundResultAsync(HttpClient client, string apiRoot, string postBody, string toolName, bool wasDynamicStart, FlowRetryClock clock, SettlementBackoff backoff) {
         if (TryFormatRoundlessStart(postBody, out var roundlessPendingIds) is { } roundless) {
             if (roundlessPendingIds.Count > 0 &&
                 JsonNode.Parse(postBody)?.AsObject()?["flow_run_id"]?.GetValue<string>() is { } roundlessRunId)
@@ -822,7 +824,7 @@ static class McpFlowsServer {
             return new(formatted, false);
         }
 
-        return await PollUntilTerminalAsync(client, apiRoot, flowRunId, roundNum.Value, toolName, wasDynamicStart, clock);
+        return await PollUntilTerminalAsync(client, apiRoot, flowRunId, roundNum.Value, toolName, wasDynamicStart, clock, backoff);
     }
 
     /// <summary>Tool family that started the round determines which status tool the graceful-cap
@@ -832,7 +834,7 @@ static class McpFlowsServer {
     static string StatusToolNameFor(string toolName) =>
         toolName is "start_review_flow" or "submit_review_round" ? "get_review_flow_status" : "get_flow_status";
 
-    static async Task<PollResult> PollUntilTerminalAsync(HttpClient client, string apiRoot, string flowRunId, int roundNumber, string toolName, bool wasDynamicStart, FlowRetryClock clock) {
+    static async Task<PollResult> PollUntilTerminalAsync(HttpClient client, string apiRoot, string flowRunId, int roundNumber, string toolName, bool wasDynamicStart, FlowRetryClock clock, SettlementBackoff backoff) {
         var url                   = $"{apiRoot}/api/flows/{Uri.EscapeDataString(flowRunId)}";
         var pollStartedAt         = clock.UtcNow;
         var deadline              = pollStartedAt + PollCap;
@@ -840,8 +842,9 @@ static class McpFlowsServer {
         var notFoundGraceDeadline = pollStartedAt + NotFoundGrace;
         var consecutiveTransient  = 0;
         var lastTransientError    = (string?)null;
-        // Separate, short-backoff budget for the two settlement-layer coded 409s — distinct from
-        // the network/5xx transient budget above, which uses the full 3s PollInterval.
+        // Retry ordinal for the two settlement-layer coded 409s, feeding the shared jittered backoff
+        // schedule — distinct from the network/5xx transient budget above, which uses the full 3s
+        // PollInterval. Reset on any successful GET, so a late busy starts the schedule over.
         var settlementRetriesUsed = 0;
 
         while (clock.UtcNow < deadline) {
@@ -876,14 +879,15 @@ static class McpFlowsServer {
                     var errBody = await resp.Content.ReadAsStringAsync();
 
                     // The same two settlement-layer coded 409s can also surface on the poll GET
-                    // (the server-side backstop mapping an escaped settlement conflict). Bounded,
-                    // short auto-retry before falling through to the immediate-fail path; every
-                    // other coded/uncoded 4xx is untouched.
+                    // (the server-side backstop mapping an escaped settlement conflict). This lane
+                    // shares the POST lane's jittered backoff SCHEDULE but keeps its own budget: the
+                    // retry is bounded by the loop's remaining PollCap, not by an attempt count, and
+                    // the policy delay is truncated so it can never overshoot that cap. Every other
+                    // coded/uncoded 4xx is untouched.
                     if (TryParseCodedError(errBody, out var code, out _) &&
-                            SettlementRetryableCodes.Contains(code!) &&
-                            settlementRetriesUsed < MaxSettlementRetries - 1) {
+                            SettlementRetryableCodes.Contains(code!)) {
                         settlementRetriesUsed++;
-                        await clock.DelayAsync(SettlementRetryDelay);
+                        await clock.DelayAsync(backoff.Delay(settlementRetriesUsed, deadline - clock.UtcNow));
                         continue;
                     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
@@ -70,6 +70,45 @@ public class SequencedCommandProcessorTests {
         await Assert.That(h.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.InternalError); // synth emitted the reject
     }
 
+    // Settlement-admission design (§3.2 F): a FRESH terminal command is now acked proactively at the
+    // end of the lane, so the server retires its one-nonterminal slot within milliseconds of execution
+    // completing instead of waiting for the 60s status-report reconcile. Exactly one ack per settle.
+    [Test] public async Task Fresh_terminal_command_emits_exactly_one_proactive_processed_ack() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted, "a", "sess")));
+
+        var ack = h.Acks.Single();                                               // exactly one, no duplicate involved
+        await Assert.That(ack.Epoch).IsEqualTo("e1");
+        await Assert.That(ack.Seq).IsEqualTo(1L);
+        await Assert.That(ack.CommandId).IsEqualTo("cmd1");
+        await Assert.That(ack.State).IsEqualTo(CommandAckState.Processed);
+        await Assert.That(ack.OutcomeKind).IsEqualTo(CommandOutcomeKind.LaunchExecuted);
+        await Assert.That(ack.CurrentState).IsEqualTo(AgentLiveness.Live);
+        await Assert.That(ack.AgentId).IsEqualTo("a");
+        await Assert.That(ack.SessionId).IsEqualTo("sess");
+        await Assert.That(ack.RejectionReason).IsNull();
+    }
+
+    // The proactive ack is best-effort telemetry to the server: a send failure (server gone /
+    // reconnecting) must never fault the lane, block the watermark, or lose the Done completion.
+    [Test] public async Task Proactive_ack_send_failure_does_not_fault_the_lane() {
+        var acks = 0;
+        await using var p = new SequencedCommandProcessor(
+            "e1", _ => AgentLiveness.Live,
+            _ => { acks++; throw new InvalidOperationException("server gone"); },
+            _ => Task.CompletedTask, NullLogger.Instance);
+
+        await p.SubmitAsync(new SequencedItem(SequencedKind.Launch, "e1", 1, "cmd1", "a1"),
+            () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(1L);   // settled despite the throwing ack
+
+        // The lane is still alive: a second command still executes and advances.
+        await p.SubmitAsync(new SequencedItem(SequencedKind.Launch, "e1", 2, "cmd2", "a2"),
+            () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(2L);
+        await Assert.That(acks).IsEqualTo(2);
+    }
+
     [Test] public async Task Duplicate_of_a_processed_command_is_acked_with_outcome_and_live_state_not_reexecuted() {
         var h = new Harness(); await using var p = h.P();
         var runs = 0;
@@ -77,7 +116,12 @@ public class SequencedCommandProcessorTests {
         await p.SubmitAsync(item, () => { runs++; return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted, "a", "sess")); });
         await p.SubmitAsync(item, () => { runs++; return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)); });
         await Assert.That(runs).IsEqualTo(1);                                    // no re-execution
-        var ack = h.Acks.Single();
+
+        // Two acks now: [0] the proactive settle ack from the lane, [1] the duplicate-replay ack.
+        // Both are Processed and carry the SAME cached outcome — the duplicate path is unchanged.
+        await Assert.That(h.Acks).HasCount().EqualTo(2);
+        await Assert.That(h.Acks[0].State).IsEqualTo(CommandAckState.Processed);  // proactive
+        var ack = h.Acks[1];                                                      // duplicate replay
         await Assert.That(ack.State).IsEqualTo(CommandAckState.Processed);
         await Assert.That(ack.OutcomeKind).IsEqualTo(CommandOutcomeKind.LaunchExecuted);
         await Assert.That(ack.CurrentState).IsEqualTo(AgentLiveness.Live);       // read live at ack time
@@ -110,9 +154,11 @@ public class SequencedCommandProcessorTests {
         await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
         p.AckPrefix(new AckProcessedPrefix("e1", 5));   // over-ahead (> LastProcessedSeq) -> ignored
         p.AckPrefix(new AckProcessedPrefix("WRONG", 1));// stale epoch -> ignored
-        // A duplicate is still answerable (identity not evicted):
+        await Assert.That(h.Acks.Count).IsEqualTo(1);   // only the proactive settle ack so far
+        // A duplicate is still answerable (identity not evicted) — that adds the SECOND ack:
         await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
-        await Assert.That(h.Acks.Count).IsEqualTo(1);
+        await Assert.That(h.Acks.Count).IsEqualTo(2);
+        await Assert.That(h.Acks[1].State).IsEqualTo(CommandAckState.Processed);
     }
 
     [Test] public async Task Non_next_future_seq_is_rejected_wrong_next_without_accepting() {
@@ -141,7 +187,12 @@ public class SequencedCommandProcessorTests {
         await p.SubmitAsync(item, () => Task.FromResult(
             new CommandOutcome(CommandOutcomeKind.LaunchRejected, "a", RejectReason: CommandRejectedReason.DaemonCapacity)));
         await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
-        var ack = h.Acks.Single();
+
+        // [0] is the proactive settle ack, [1] the duplicate replay — BOTH must carry the wire token,
+        // since they are built from the same cached outcome by the one shared builder.
+        await Assert.That(h.Acks).HasCount().EqualTo(2);
+        await Assert.That(h.Acks[0].RejectionReason).IsEqualTo("daemon_capacity");   // proactive
+        var ack = h.Acks[1];                                                          // duplicate replay
         await Assert.That(ack.State).IsEqualTo(CommandAckState.Processed);
         await Assert.That(ack.OutcomeKind).IsEqualTo(CommandOutcomeKind.LaunchRejected);
         await Assert.That(ack.RejectionReason).IsEqualTo("daemon_capacity");
@@ -153,7 +204,9 @@ public class SequencedCommandProcessorTests {
         await p.SubmitAsync(item, () => Task.FromResult(
             new CommandOutcome(CommandOutcomeKind.LaunchRejected, "a", RejectReason: CommandRejectedReason.Semantic)));
         await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
-        await Assert.That(h.Acks.Single().RejectionReason).IsEqualTo("semantic");
+        await Assert.That(h.Acks).HasCount().EqualTo(2);                              // proactive + duplicate replay
+        await Assert.That(h.Acks[0].RejectionReason).IsEqualTo("semantic");
+        await Assert.That(h.Acks[1].RejectionReason).IsEqualTo("semantic");
     }
 
     // A duplicate of a non-rejected (executed) command has no cached reject reason -> null RejectionReason.
@@ -162,6 +215,8 @@ public class SequencedCommandProcessorTests {
         var item = h.Launch(1);
         await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted, "a", "sess")));
         await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
-        await Assert.That(h.Acks.Single().RejectionReason).IsNull();
+        await Assert.That(h.Acks).HasCount().EqualTo(2);                              // proactive + duplicate replay
+        await Assert.That(h.Acks[0].RejectionReason).IsNull();
+        await Assert.That(h.Acks[1].RejectionReason).IsNull();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsServerSettlementRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsServerSettlementRetryTests.cs
@@ -18,6 +18,11 @@ public class McpFlowsServerSettlementRetryTests {
     // the requested schedule is directly assertable (VirtualFlowRetryClock.Delays).
     static VirtualFlowRetryClock Clock() => new();
 
+    /// <summary>Unwraps the settled-response arm; fails loudly (cast) if the helper exhausted its
+    /// deadline, which is never the expectation at these call sites.</summary>
+    static HttpResponseMessage ResponseOf(McpFlowsServer.SettlementSendResult result) =>
+        ((McpFlowsServer.SettlementSendResult.Response)result).Value;
+
     static JsonObject StartArguments() => new() {
         ["kind"]         = "code-review",
         ["target_kind"]  = "pr",
@@ -151,14 +156,16 @@ public class McpFlowsServerSettlementRetryTests {
         using var client = new HttpClient();
 
         var clock = Clock();
-        using var response = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, c => c.PostAsync($"{server.Url}/start", null), clock);
+        using var response = ResponseOf(await McpFlowsServer.SendWithSettlementRetryAsync(
+            client, (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11)));
         var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
         await Assert.That(server.LogEntries.Count()).IsEqualTo(2);
         await Assert.That(delays).HasCount().EqualTo(1);
-        await Assert.That(delays[0]).IsEqualTo(TimeSpan.FromMilliseconds(200));
+        // Equal jitter over the 500ms base: the first retry always lands in [250ms, 500ms].
+        await Assert.That(delays[0]).IsGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(250));
+        await Assert.That(delays[0]).IsLessThanOrEqualTo(TimeSpan.FromMilliseconds(500));
     }
 
     [Test]
@@ -176,34 +183,39 @@ public class McpFlowsServerSettlementRetryTests {
         using var client = new HttpClient();
 
         var clock = Clock();
-        using var response = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, c => c.PostAsync($"{server.Url}/start", null), clock);
+        using var response = ResponseOf(await McpFlowsServer.SendWithSettlementRetryAsync(
+            client, (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11)));
         var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
         await Assert.That(server.LogEntries.Count()).IsEqualTo(2);
     }
 
+    /// <summary>A server that never settles exhausts the ELAPSED deadline, not an attempt count:
+    /// the helper keeps retrying on the shared schedule for the full 3 minutes of virtual time and
+    /// then reports the last coded rejection it saw, with no live response attached.</summary>
     [Test]
-    public async Task Exhaustion_after_max_attempts_returns_final_failing_response() {
+    public async Task Exhaustion_of_the_elapsed_deadline_returns_the_last_coded_error() {
         using var server = WireMockServer.Start();
         server.Given(Request.Create().WithPath("/start").UsingPost())
               .RespondWith(Response.Create().WithStatusCode(409).WithBody(
                   """{"error":"flow_settlement_busy","message":"still racing"}"""));
         using var client = new HttpClient();
 
-        var clock = Clock();
-        using var response = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, c => c.PostAsync($"{server.Url}/start", null), clock);
-        var delays = clock.Delays;
+        var clock  = Clock();
+        var result = await McpFlowsServer.SendWithSettlementRetryAsync(
+            client, (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11));
 
-        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Conflict);
-        // 3 total attempts (bounded), 2 waits in between.
-        await Assert.That(server.LogEntries.Count()).IsEqualTo(3);
-        await Assert.That(delays).HasCount().EqualTo(2);
+        var exhausted = result as McpFlowsServer.SettlementSendResult.DeadlineExhausted;
+        await Assert.That(exhausted).IsNotNull();
+        await Assert.That(exhausted!.LastCode).IsEqualTo("flow_settlement_busy");
+        await Assert.That(exhausted.LastMessage).IsEqualTo("still racing");
+        await Assert.That(exhausted.Elapsed).IsEqualTo(McpFlowsServer.SettlementElapsedDeadline);
+        await Assert.That(exhausted.Attempts).IsEqualTo(server.LogEntries.Count());
 
-        var body = await response.Content.ReadAsStringAsync();
-        await Assert.That(body).Contains("flow_settlement_busy");
+        // Far past the old 3-attempt bound, and it never overshot the deadline.
+        await Assert.That(exhausted.Attempts).IsGreaterThan(10);
+        await Assert.That(clock.Elapsed).IsEqualTo(McpFlowsServer.SettlementElapsedDeadline);
     }
 
     [Test]
@@ -215,8 +227,8 @@ public class McpFlowsServerSettlementRetryTests {
         using var client = new HttpClient();
 
         var clock = Clock();
-        using var response = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, c => c.PostAsync($"{server.Url}/start", null), clock);
+        using var response = ResponseOf(await McpFlowsServer.SendWithSettlementRetryAsync(
+            client, (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11)));
         var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Conflict);
@@ -232,13 +244,151 @@ public class McpFlowsServerSettlementRetryTests {
         using var client = new HttpClient();
 
         var clock = Clock();
-        using var response = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, c => c.PostAsync($"{server.Url}/start", null), clock);
+        using var response = ResponseOf(await McpFlowsServer.SendWithSettlementRetryAsync(
+            client, (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11)));
         var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
         await Assert.That(server.LogEntries.Count()).IsEqualTo(1);
         await Assert.That(delays).IsEmpty();
+    }
+
+    // === Elapsed deadline: token plumbing, request duration, caller cancellation ===
+
+    /// <summary>A fake handler that lets a test observe (and react to) the token the helper actually
+    /// hands to <see cref="HttpClient"/>, and simulate a request that HOLDS server-side.</summary>
+    sealed class TokenObservingHandler(Func<CancellationToken, Task<HttpResponseMessage>> respond) : HttpMessageHandler {
+        public int Requests { get; private set; }
+        public List<CancellationToken> SeenTokens { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {
+            Requests++;
+            SeenTokens.Add(ct);
+            return await respond(ct);
+        }
+    }
+
+    static HttpResponseMessage Busy() => new(HttpStatusCode.Conflict) {
+        Content = new StringContent("""{"error":"flow_settlement_busy","message":"holding"}""")
+    };
+
+    /// <summary>The deadline token must genuinely reach HttpClient — this is impossible to pass if the
+    /// helper creates a CTS but never threads it into the send. The handler holds the "request" past
+    /// the deadline on the virtual clock and then observes its own token already cancelled.</summary>
+    [Test]
+    public async Task Deadline_token_reaches_the_in_flight_post_and_cancels_it() {
+        var clock = Clock();
+
+        var handler = new TokenObservingHandler(ct => {
+            // The attempt holds server-side for longer than the whole elapsed budget.
+            clock.Advance(McpFlowsServer.SettlementElapsedDeadline + TimeSpan.FromSeconds(30));
+            ct.ThrowIfCancellationRequested();          // only possible if the token got through
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://settlement.test") };
+
+        var result = await McpFlowsServer.SendWithSettlementRetryAsync(
+            client, (c, ct) => c.PostAsync("/start", null, ct), clock, SettlementBackoff.Seeded(5));
+
+        var exhausted = result as McpFlowsServer.SettlementSendResult.DeadlineExhausted;
+        await Assert.That(exhausted).IsNotNull();
+        await Assert.That(exhausted!.Attempts).IsEqualTo(1);
+        await Assert.That(handler.Requests).IsEqualTo(1);           // abandoned, not retried past the deadline
+        await Assert.That(handler.SeenTokens[0].CanBeCanceled).IsTrue();
+        await Assert.That(handler.SeenTokens[0].IsCancellationRequested).IsTrue();
+        // No coded body was ever read on this attempt, so there is nothing to report but the shape.
+        await Assert.That(exhausted.LastCode).IsNull();
+    }
+
+    /// <summary>The budget counts REQUEST DURATION, not just the sum of the backoff delays — each
+    /// attempt may itself hold on a server-side admission wait. Simulated 60s-holding busy responses
+    /// therefore exhaust in a handful of attempts, well below the 10-minute MCP tool timeout.</summary>
+    [Test]
+    public async Task Elapsed_deadline_counts_request_duration_not_just_delay_sum() {
+        var clock   = Clock();
+        var handler = new TokenObservingHandler(_ => {
+            clock.Advance(TimeSpan.FromSeconds(60));    // the server held this POST for a full admission wait
+            return Task.FromResult(Busy());
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://settlement.test") };
+
+        var result = await McpFlowsServer.SendWithSettlementRetryAsync(
+            client, (c, ct) => c.PostAsync("/start", null, ct), clock, SettlementBackoff.Seeded(5));
+
+        var exhausted = result as McpFlowsServer.SettlementSendResult.DeadlineExhausted;
+        await Assert.That(exhausted).IsNotNull();
+        await Assert.That(exhausted!.LastCode).IsEqualTo("flow_settlement_busy");
+        // ~3 x 60s of held requests plus backoff — a delay-only budget would have allowed dozens.
+        await Assert.That(handler.Requests).IsLessThanOrEqualTo(4);
+        await Assert.That(clock.Elapsed).IsLessThanOrEqualTo(TimeSpan.FromMinutes(10));   // under MCP_TOOL_TIMEOUT
+        await Assert.That(clock.Elapsed).IsGreaterThanOrEqualTo(McpFlowsServer.SettlementElapsedDeadline);
+    }
+
+    /// <summary>Caller-token cancellation is NOT the helper's deadline: it rethrows untouched rather
+    /// than being laundered into a deadline-exhausted result.</summary>
+    [Test]
+    public async Task Caller_token_cancellation_rethrows_untouched() {
+        var clock = Clock();
+        using var caller = new CancellationTokenSource();
+
+        var handler = new TokenObservingHandler(ct => {
+            caller.Cancel();                            // the CALLER gives up mid-flight
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://settlement.test") };
+
+        await Assert.That(async () => await McpFlowsServer.SendWithSettlementRetryAsync(
+                client, (c, ct) => c.PostAsync("/start", null, ct), clock, SettlementBackoff.Seeded(5), caller.Token))
+            .Throws<OperationCanceledException>();
+    }
+
+    /// <summary>New-CLI burst degradation: enough slow predecessors ahead of this launch to cross the
+    /// deadline yields the documented coded timeout tool result, not a fault and not a success.</summary>
+    [Test]
+    public async Task Burst_deeper_than_the_deadline_degrades_to_the_documented_coded_timeout() {
+        var clock = Clock();
+
+        // Every attempt lands behind a predecessor still settling, each holding ~50s server-side.
+        var handler = new TokenObservingHandler(_ => {
+            clock.Advance(TimeSpan.FromSeconds(50));
+            return Task.FromResult(Busy());
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://settlement.test") };
+
+        var result = await McpFlowsServer.SendWithSettlementRetryAsync(
+            client, (c, ct) => c.PostAsync("/start", null, ct), clock, SettlementBackoff.Seeded(5));
+
+        var exhausted = result as McpFlowsServer.SettlementSendResult.DeadlineExhausted;
+        await Assert.That(exhausted).IsNotNull();
+
+        var text = McpFlowsServer.FormatSettlementDeadlineError(exhausted!);
+        await Assert.That(text).StartsWith("Error (flow_settlement_busy)");
+        await Assert.That(text).Contains("retryable");
+        await Assert.That(text).Contains($"{exhausted!.Attempts} attempts");
+    }
+
+    [Test]
+    [Arguments(0, "0s")]
+    [Arguments(45, "45s")]
+    [Arguments(150, "2m 30s")]
+    [Arguments(180, "3m")]
+    public async Task Deadline_error_renders_elapsed_compactly(int seconds, string expected) {
+        var text = McpFlowsServer.FormatSettlementDeadlineError(
+            new McpFlowsServer.SettlementSendResult.DeadlineExhausted("flow_settlement_busy", "busy", 4, TimeSpan.FromSeconds(seconds)));
+
+        await Assert.That(text).Contains($"over {expected}");
+    }
+
+    [Test]
+    public async Task Deadline_error_singularizes_a_single_attempt_and_omits_an_absent_server_message() {
+        var text = McpFlowsServer.FormatSettlementDeadlineError(
+            new McpFlowsServer.SettlementSendResult.DeadlineExhausted(null, null, 1, TimeSpan.FromMinutes(3)));
+
+        await Assert.That(text).Contains("1 attempt over 3m");
+        await Assert.That(text).DoesNotContain("Last server message");
+        // An attempt that never read a coded body still names the code this lane exists to absorb.
+        await Assert.That(text).StartsWith("Error (flow_settlement_busy)");
     }
 
     // === Wired into the start path via HandleToolCallAsync (full dispatch) ===
@@ -275,25 +425,39 @@ public class McpFlowsServerSettlementRetryTests {
             e => e.RequestMessage.Path == "/api/flows/review/start/v2")).IsEqualTo(2);
     }
 
+    /// <summary>The tool-boundary mapping: an exhausted elapsed deadline becomes a normal MCP tool
+    /// error result carrying the last coded rejection plus attempt count and elapsed time — never an
+    /// unhandled stdio fault, and never phrased as fatal (the busy IS retryable).</summary>
     [Test]
-    public async Task Start_review_flow_exhausts_settlement_retries_and_surfaces_the_coded_message() {
+    public async Task Start_review_flow_maps_an_exhausted_deadline_to_a_coded_tool_error() {
         using var server = WireMockServer.Start();
         server.Given(Request.Create().WithPath("/api/flows/review/start/v2").UsingPost())
               .RespondWith(Response.Create().WithStatusCode(409).WithBody(
                   """{"error":"flow_settlement_busy","message":"A concurrent settlement operation is racing this flow run."}"""));
         using var client = new HttpClient();
 
+        var clock = Clock();
         var response = await McpFlowsServer.HandleToolCallAsync(
             JsonNode.Parse("1")!, ToolCallRequest("start_review_flow", StartArguments()),
-            client, server.Url!, cwd: "/tmp/cwd", repoRoot: null, repoInfo: null);
+            client, server.Url!, cwd: "/tmp/cwd", repoRoot: null, repoInfo: null,
+            clock: clock, backoff: SettlementBackoff.Seeded(3));
 
         var result = JsonNode.Parse(response)!.AsObject();
         await Assert.That(result["result"]!["isError"]!.GetValue<bool>()).IsTrue();
-        var text = result["result"]!["content"]![0]!["text"]!.GetValue<string>();
-        await Assert.That(text).Contains("flow_settlement_busy");
 
-        await Assert.That(server.LogEntries.Count(
-            e => e.RequestMessage.Path == "/api/flows/review/start/v2")).IsEqualTo(3);
+        var text     = result["result"]!["content"]![0]!["text"]!.GetValue<string>();
+        var attempts = server.LogEntries.Count(e => e.RequestMessage.Path == "/api/flows/review/start/v2");
+
+        await Assert.That(text).Contains("flow_settlement_busy");
+        await Assert.That(text).Contains($"{attempts} attempts");
+        await Assert.That(text).Contains("over 3m");
+        await Assert.That(text).Contains("retryable");
+        // The server's own last message rides along, so the caller sees what it kept hitting.
+        await Assert.That(text).Contains("A concurrent settlement operation is racing this flow run.");
+
+        // It genuinely used the elapsed budget rather than a small attempt cap.
+        await Assert.That(attempts).IsGreaterThan(10);
+        await Assert.That(clock.Elapsed).IsEqualTo(McpFlowsServer.SettlementElapsedDeadline);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsServerSettlementRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsServerSettlementRetryTests.cs
@@ -559,6 +559,9 @@ public class McpFlowsServerSettlementRetryTests {
         await Assert.That(clock.Delays).IsEquivalentTo(expected);
         await Assert.That(clock.Delays.Count).IsGreaterThan(3);            // genuinely past the old 3-attempt bound
         await Assert.That(clock.Elapsed).IsLessThanOrEqualTo(pollCap);     // never overshoots PollCap
+        // ...and it is NOT subject to the POST lane's 3-minute elapsed deadline: this lane must be
+        // able to keep polling well past it, all the way to its own cap.
+        await Assert.That(clock.Elapsed).IsGreaterThan(McpFlowsServer.SettlementElapsedDeadline);
 
         // It stopped by exhausting the cap, not by turning the retryable busy into a hard error.
         var result = JsonNode.Parse(response)!.AsObject();

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsServerSettlementRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsServerSettlementRetryTests.cs
@@ -33,6 +33,82 @@ public class McpFlowsServerSettlementRetryTests {
         }
     };
 
+    // === SettlementBackoff: the delay schedule shared by the POST and poll lanes ===
+    //
+    // Pinned formula (settlement-admission design §3.2 G): for retry n (1-based),
+    // raw(n) = min(10s, 500ms · 2^(n−1)) with the cap applied BEFORE jitter, then equal jitter
+    // delay(n) = raw(n)/2 + U(0, raw(n)/2), then truncation to the caller's remaining budget.
+
+    [Test]
+    [Arguments(1, 500)]
+    [Arguments(2, 1_000)]
+    [Arguments(3, 2_000)]
+    [Arguments(4, 4_000)]
+    [Arguments(5, 8_000)]
+    [Arguments(6, 10_000)]   // capped
+    [Arguments(7, 10_000)]
+    [Arguments(40, 10_000)]  // a far-out ordinal must not overflow past the cap
+    public async Task Backoff_raw_is_exponential_and_capped_at_ten_seconds(int retry, int expectedMs) {
+        await Assert.That(SettlementBackoff.Raw(retry)).IsEqualTo(TimeSpan.FromMilliseconds(expectedMs));
+    }
+
+    [Test]
+    public async Task Backoff_applies_the_cap_before_jitter() {
+        // Cap-before-jitter: a saturated ordinal jitters around the 10s CAP (5–10s), never around
+        // the uncapped exponential (which at retry 8 would be 64s → 32–64s if capped afterwards).
+        var low  = new SettlementBackoff(() => 0.0);
+        var high = new SettlementBackoff(() => 0.999);
+
+        await Assert.That(low.Delay(8, TimeSpan.FromHours(1))).IsEqualTo(TimeSpan.FromSeconds(5));
+        await Assert.That(high.Delay(8, TimeSpan.FromHours(1))).IsLessThanOrEqualTo(TimeSpan.FromSeconds(10));
+        await Assert.That(high.Delay(8, TimeSpan.FromHours(1))).IsGreaterThan(TimeSpan.FromSeconds(9));
+    }
+
+    [Test]
+    public async Task Backoff_equal_jitter_puts_the_first_retry_in_250_to_500ms_and_steady_state_in_5_to_10s() {
+        var backoff = SettlementBackoff.Seeded(4242);
+        var budget  = TimeSpan.FromHours(1);   // never the binding constraint here
+
+        for (var i = 0; i < 50; i++) {
+            var first = backoff.Delay(1, budget);
+            await Assert.That(first).IsGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(250));
+            await Assert.That(first).IsLessThanOrEqualTo(TimeSpan.FromMilliseconds(500));
+
+            var steady = backoff.Delay(9, budget);
+            await Assert.That(steady).IsGreaterThanOrEqualTo(TimeSpan.FromSeconds(5));
+            await Assert.That(steady).IsLessThanOrEqualTo(TimeSpan.FromSeconds(10));
+        }
+    }
+
+    [Test]
+    public async Task Backoff_truncates_to_the_remaining_budget() {
+        var backoff = new SettlementBackoff(() => 0.999);   // ~the top of the jitter band
+
+        // Budget shorter than the jittered delay -> exactly the budget, never past it.
+        await Assert.That(backoff.Delay(6, TimeSpan.FromSeconds(2))).IsEqualTo(TimeSpan.FromSeconds(2));
+        // Budget longer -> untruncated.
+        await Assert.That(backoff.Delay(1, TimeSpan.FromHours(1))).IsLessThanOrEqualTo(TimeSpan.FromMilliseconds(500));
+        // Exhausted / negative budget -> zero, never a negative delay.
+        await Assert.That(backoff.Delay(3, TimeSpan.Zero)).IsEqualTo(TimeSpan.Zero);
+        await Assert.That(backoff.Delay(3, TimeSpan.FromSeconds(-5))).IsEqualTo(TimeSpan.Zero);
+    }
+
+    [Test]
+    public async Task Backoff_is_deterministic_for_a_seeded_rng() {
+        // Two independently seeded instances produce the identical sequence — which is what lets the
+        // lane tests below assert the exact schedule the code under test will request.
+        var a = SettlementBackoff.Seeded(99);
+        var b = SettlementBackoff.Seeded(99);
+        var budget = TimeSpan.FromHours(1);
+
+        var fromA = Enumerable.Range(1, 8).Select(n => a.Delay(n, budget)).ToArray();
+        var fromB = Enumerable.Range(1, 8).Select(n => b.Delay(n, budget)).ToArray();
+
+        await Assert.That(fromA).IsEquivalentTo(fromB);
+        // ...and it is a real schedule, not a constant.
+        await Assert.That(fromA.Distinct().Count()).IsGreaterThan(1);
+    }
+
     // === TryParseCodedError: pure decode, shared by FormatFlowStartError and the retry gate ===
 
     [Test]
@@ -277,6 +353,54 @@ public class McpFlowsServerSettlementRetryTests {
 
         await Assert.That(server.LogEntries.Count(
             e => e.RequestMessage.Path == $"/api/flows/{flowRunId}")).IsEqualTo(2);
+    }
+
+    /// <summary>The poll lane shares the POST lane's backoff SCHEDULE but keeps its own budget: it
+    /// retries a settlement-busy GET on the exact same jittered ladder, bounded by the 8-minute
+    /// PollCap rather than by an attempt count, and never overshoots that cap.</summary>
+    [Test]
+    public async Task Poll_lane_settlement_retries_follow_the_shared_schedule_and_stop_at_poll_cap() {
+        const string flowRunId = "flow-poll-schedule";
+        const int    seed      = 7;
+        var          pollCap   = TimeSpan.FromMinutes(8);
+
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/api/flows/review/start/v2").UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json")
+                  .WithBody($$"""{"flow_run_id":"{{flowRunId}}","round_id":"r1","round_number":1,"status":"running","result_kind":null,"result_text":null}"""));
+        // Never settles — the lane must keep retrying until its own cap, not until an attempt count.
+        server.Given(Request.Create().WithPath($"/api/flows/{flowRunId}").UsingGet())
+              .RespondWith(Response.Create().WithStatusCode(409).WithBody(
+                  """{"error":"flow_settlement_busy","message":"still settling"}"""));
+        using var client = new HttpClient();
+
+        var clock = Clock();
+        var response = await McpFlowsServer.HandleToolCallAsync(
+            JsonNode.Parse("1")!, ToolCallRequest("start_review_flow", StartArguments()),
+            client, server.Url!, cwd: "/tmp/cwd", repoRoot: null, repoInfo: null,
+            clock: clock, backoff: SettlementBackoff.Seeded(seed));
+
+        // The independently-seeded oracle: the same ladder, each rung truncated to what is left of
+        // the cap. This is the schedule the lane must have requested, rung for rung.
+        var expected  = new List<TimeSpan>();
+        var oracle    = SettlementBackoff.Seeded(seed);
+        var remaining = pollCap;
+        for (var n = 1; remaining > TimeSpan.Zero; n++) {
+            var next = oracle.Delay(n, remaining);
+            if (next <= TimeSpan.Zero) break;
+            expected.Add(next);
+            remaining -= next;
+        }
+
+        await Assert.That(clock.Delays).IsEquivalentTo(expected);
+        await Assert.That(clock.Delays.Count).IsGreaterThan(3);            // genuinely past the old 3-attempt bound
+        await Assert.That(clock.Elapsed).IsLessThanOrEqualTo(pollCap);     // never overshoots PollCap
+
+        // It stopped by exhausting the cap, not by turning the retryable busy into a hard error.
+        var result = JsonNode.Parse(response)!.AsObject();
+        await Assert.That(result["result"]!["isError"]).IsNull();
+        var text = result["result"]!["content"]![0]!["text"]!.GetValue<string>();
+        await Assert.That(text).Contains("Flow still running");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsServerSettlementRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsServerSettlementRetryTests.cs
@@ -14,7 +14,9 @@ namespace Capacitor.Cli.Tests.Unit;
 /// reached indirectly through HandleToolCallAsync).
 /// </summary>
 public class McpFlowsServerSettlementRetryTests {
-    static Func<TimeSpan, Task> NoDelay(List<TimeSpan> recorded) => ts => { recorded.Add(ts); return Task.CompletedTask; };
+    // Every wait in both retry lanes runs on the injected clock, so these tests are instant and
+    // the requested schedule is directly assertable (VirtualFlowRetryClock.Delays).
+    static VirtualFlowRetryClock Clock() => new();
 
     static JsonObject StartArguments() => new() {
         ["kind"]         = "code-review",
@@ -72,9 +74,10 @@ public class McpFlowsServerSettlementRetryTests {
               .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"flow_run_id":"f-new","status":"running"}"""));
         using var client = new HttpClient();
 
-        var delays = new List<TimeSpan>();
+        var clock = Clock();
         using var response = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, c => c.PostAsync($"{server.Url}/start", null), NoDelay(delays));
+            client, c => c.PostAsync($"{server.Url}/start", null), clock);
+        var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
         await Assert.That(server.LogEntries.Count()).IsEqualTo(2);
@@ -96,9 +99,10 @@ public class McpFlowsServerSettlementRetryTests {
               .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"flow_run_id":"f-new","status":"running"}"""));
         using var client = new HttpClient();
 
-        var delays = new List<TimeSpan>();
+        var clock = Clock();
         using var response = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, c => c.PostAsync($"{server.Url}/start", null), NoDelay(delays));
+            client, c => c.PostAsync($"{server.Url}/start", null), clock);
+        var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
         await Assert.That(server.LogEntries.Count()).IsEqualTo(2);
@@ -112,9 +116,10 @@ public class McpFlowsServerSettlementRetryTests {
                   """{"error":"flow_settlement_busy","message":"still racing"}"""));
         using var client = new HttpClient();
 
-        var delays = new List<TimeSpan>();
+        var clock = Clock();
         using var response = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, c => c.PostAsync($"{server.Url}/start", null), NoDelay(delays));
+            client, c => c.PostAsync($"{server.Url}/start", null), clock);
+        var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Conflict);
         // 3 total attempts (bounded), 2 waits in between.
@@ -133,9 +138,10 @@ public class McpFlowsServerSettlementRetryTests {
                   """{"error":"budget_unverifiable","message":"cannot verify spend"}"""));
         using var client = new HttpClient();
 
-        var delays = new List<TimeSpan>();
+        var clock = Clock();
         using var response = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, c => c.PostAsync($"{server.Url}/start", null), NoDelay(delays));
+            client, c => c.PostAsync($"{server.Url}/start", null), clock);
+        var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Conflict);
         await Assert.That(server.LogEntries.Count()).IsEqualTo(1); // no retry at all
@@ -149,9 +155,10 @@ public class McpFlowsServerSettlementRetryTests {
               .RespondWith(Response.Create().WithStatusCode(400).WithBody("plain text error, not JSON"));
         using var client = new HttpClient();
 
-        var delays = new List<TimeSpan>();
+        var clock = Clock();
         using var response = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, c => c.PostAsync($"{server.Url}/start", null), NoDelay(delays));
+            client, c => c.PostAsync($"{server.Url}/start", null), clock);
+        var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
         await Assert.That(server.LogEntries.Count()).IsEqualTo(1);

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsServerTests.cs
@@ -9,7 +9,9 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Unit;
 
 public class McpFlowsServerTests {
-    static Func<TimeSpan, Task> NoDelay(List<TimeSpan> recorded) => ts => { recorded.Add(ts); return Task.CompletedTask; };
+    // The ack retry's 2s wait now runs on the injected clock, so these tests stay instant while
+    // still asserting the real schedule (VirtualFlowRetryClock.Delays records every requested wait).
+    static VirtualFlowRetryClock Clock() => new();
 
     [Test]
     public async Task start_review_flow_description_discloses_the_paid_hosted_reviewer() {
@@ -251,7 +253,7 @@ public class McpFlowsServerTests {
               .RespondWith(Response.Create().WithStatusCode(200));
         using var client = new HttpClient();
 
-        await McpFlowsServer.AckRenderedMessagesAsync(client, server.Url!, "f1", ["m1", "m2"], NoDelay([]));
+        await McpFlowsServer.AckRenderedMessagesAsync(client, server.Url!, "f1", ["m1", "m2"], Clock());
 
         await Assert.That(server.LogEntries.Count()).IsEqualTo(1);
         var body = server.LogEntries.Single().RequestMessage.Body!;
@@ -268,8 +270,9 @@ public class McpFlowsServerTests {
               .RespondWith(Response.Create().WithStatusCode(500));
         using var client = new HttpClient();
 
-        var delays = new List<TimeSpan>();
-        await McpFlowsServer.AckRenderedMessagesAsync(client, server.Url!, "f1", ["m1"], NoDelay(delays));
+        var clock = Clock();
+        await McpFlowsServer.AckRenderedMessagesAsync(client, server.Url!, "f1", ["m1"], clock);
+        var delays = clock.Delays;
 
         await Assert.That(server.LogEntries.Count()).IsEqualTo(2);
         await Assert.That(delays).HasCount().EqualTo(1);
@@ -290,8 +293,9 @@ public class McpFlowsServerTests {
               .RespondWith(Response.Create().WithStatusCode(200).WithDelay(TimeSpan.FromMilliseconds(300)));
         using var client = new HttpClient { Timeout = TimeSpan.FromMilliseconds(50) };
 
-        var delays = new List<TimeSpan>();
-        await McpFlowsServer.AckRenderedMessagesAsync(client, server.Url!, "f1", ["m1"], NoDelay(delays));
+        var clock = Clock();
+        await McpFlowsServer.AckRenderedMessagesAsync(client, server.Url!, "f1", ["m1"], clock);
+        var delays = clock.Delays;
 
         // No exception propagated, and the retry-after-delay path still ran once — i.e. both the
         // initial attempt and the retry timed out and were swallowed rather than thrown.
@@ -303,7 +307,7 @@ public class McpFlowsServerTests {
         using var server = WireMockServer.Start();
         using var client = new HttpClient();
 
-        await McpFlowsServer.AckRenderedMessagesAsync(client, server.Url!, "f1", [], NoDelay([]));
+        await McpFlowsServer.AckRenderedMessagesAsync(client, server.Url!, "f1", [], Clock());
 
         await Assert.That(server.LogEntries.Count()).IsEqualTo(0);
     }
@@ -335,7 +339,7 @@ public class McpFlowsServerTests {
               .RespondWith(Response.Create().WithStatusCode(200));
         using var client = new HttpClient();
 
-        await McpFlowsServer.AckRenderedMessagesAsync(client, server.Url!, "f1", pendingIds, NoDelay([]));
+        await McpFlowsServer.AckRenderedMessagesAsync(client, server.Url!, "f1", pendingIds, Clock());
 
         await Assert.That(server.LogEntries.Count()).IsEqualTo(1);
         var ackBody = server.LogEntries.Single().RequestMessage.Body!;

--- a/test/Capacitor.Cli.Tests.Unit/VirtualFlowRetryClock.cs
+++ b/test/Capacitor.Cli.Tests.Unit/VirtualFlowRetryClock.cs
@@ -1,0 +1,67 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// A fully virtual <see cref="FlowRetryClock"/>: time only moves when the code under test asks to
+/// wait, or when the test explicitly advances it. Nothing here sleeps, so the settlement/poll retry
+/// tests run instantly while still exercising the REAL deadline logic (timeout sources created
+/// through the clock genuinely cancel once virtual time passes their expiry) rather than a
+/// pre-cancelled token standing in for it.
+/// </summary>
+internal sealed class VirtualFlowRetryClock : FlowRetryClock {
+    readonly object _gate = new();
+    readonly List<(DateTimeOffset At, CancellationTokenSource Source)> _timers = [];
+    DateTimeOffset _now = new(2026, 7, 27, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>Every delay the code under test asked for, in order — the assertable schedule.</summary>
+    public List<TimeSpan> Delays { get; } = [];
+
+    public DateTimeOffset StartedAt { get; }
+
+    public VirtualFlowRetryClock() => StartedAt = _now;
+
+    public TimeSpan Elapsed => _now - StartedAt;
+
+    public override DateTimeOffset UtcNow { get { lock (_gate) return _now; } }
+
+    public override Task DelayAsync(TimeSpan delay, CancellationToken ct = default) {
+        ct.ThrowIfCancellationRequested();
+        lock (_gate) Delays.Add(delay);
+        Advance(delay);
+        return Task.CompletedTask;
+    }
+
+    public override CancellationTokenSource CreateTimeoutSource(TimeSpan timeout) {
+        var source = new CancellationTokenSource();
+
+        if (timeout <= TimeSpan.Zero) {
+            source.Cancel();
+            return source;
+        }
+
+        lock (_gate) _timers.Add((_now + timeout, source));
+        return source;
+    }
+
+    /// <summary>Move virtual time forward, firing any timeout source that comes due. Used by tests
+    /// directly and by fake handlers simulating a request that holds server-side.</summary>
+    public void Advance(TimeSpan by) {
+        if (by <= TimeSpan.Zero) return;
+
+        List<CancellationTokenSource> due = [];
+        lock (_gate) {
+            _now += by;
+            for (var i = _timers.Count - 1; i >= 0; i--) {
+                if (_timers[i].At > _now) continue;
+                due.Add(_timers[i].Source);
+                _timers.RemoveAt(i);
+            }
+        }
+
+        // Cancel outside the lock: a cancellation callback must never re-enter Advance under _gate.
+        foreach (var source in due) {
+            try { source.Cancel(); } catch (ObjectDisposedException) { /* the scope already went away */ }
+        }
+    }
+}


### PR DESCRIPTION
The kcap-cli half of the concurrent-launch settlement-admission work (design §3.2, parts F + G). The companion kcap-server PR ships the settlement-aware admission wait; **either order is safe**, and this PR alone already shrinks the busy window against an already-shipped server.

## The problem

Two review flows started simultaneously against one daemon: the first launches and runs, the second is rejected and the flow **fails durably**. Capacity was never the constraint — the daemon advertises 5 slots and had 1 live agent.

Two CLI-side contributions to that failure:

1. **The window is structural, not a race.** A fresh sequenced launch is never proactively acked — only a retransmitted *duplicate* is. So the server learns the command settled only when the daemon's next periodic status report reconciles, and its one-nonterminal-command-per-daemon invariant rejects any concurrent launch for the predecessor's execution time **plus up to one report interval**.
2. **The retry budget was two orders of magnitude too small.** 3 attempts × 200ms ≈ 400ms total, against a settle window measured in tens of seconds.

## What this changes

### F — proactive terminal ack (`SequencedCommandProcessor`)

At the end of the lane, after marking the entry `Processed` and advancing the watermark, send the same terminal `CommandAck(Processed, outcome, liveState)` the duplicate-replay path already builds — now extracted into one shared builder so the two can never disagree about outcome/agent/session/rejection-reason.

- The ack is **best-effort**: a synchronous throw or a faulted send task is swallowed at Debug and never faults the lane, blocks the watermark, or loses the `Done` completion.
- The 60s report loop remains as backstop; the duplicate-ack path is unchanged.
- The server's ack handler is already idempotent against replays and unknown/stale acks, so **older servers accept it** and simply retire the slot earlier — the shipped-server busy window shrinks from "execution + up to 60s" to "execution only".

### G — a retry budget worthy of the window (`McpFlowsServer`)

**One injectable timing seam** (`FlowRetryClock`, `TimeProvider`-backed) now drives both retry lanes. `PollUntilTerminalAsync` previously hard-coded `DateTimeOffset.UtcNow`, real `Task.Delay` and a real `CancellationTokenSource(PerGetTimeout)`; its clock, delays, per-GET timeout and 404 grace window all come from the provider now, so the tests run on a virtual clock with **no wall-clock sleeps**.

**One shared delay schedule** (`SettlementBackoff`), pinned so it is assertable rather than incidental: for retry `n` (1-based) `raw(n) = min(10s, 500ms · 2^(n−1))` with the **cap applied before jitter**, then equal jitter `raw/2 + U(0, raw/2)`, then truncation to the caller's remaining budget. First retry lands in 250–500ms, steady state in 5–10s. Only the *schedule* is shared — each lane keeps its own budget and passes its own remaining time in, so a policy delay can never overshoot either.

**An elapsed deadline on the POST lane** — 3 minutes from the first attempt, **including each request's own duration**, not just the sum of the delays. That distinction is load-bearing: a settlement-aware server absorbs the wait by *holding the POST open* for its admission wait, so a delay-only budget would let worst-case wall-clock blow past the 10-minute `MCP_TOOL_TIMEOUT` the kcap plugin pins and surface as a harness timeout instead of a clean tool result.

- `SendWithSettlementRetryAsync` returns a discriminated `SettlementSendResult`: `Response` (caller owns it, as before) or `DeadlineExhausted(lastCode, lastMessage, attempts, elapsed)`. The helper disposes every superseded failing response, so an exhausted result never carries a live one.
- Send/refresh delegates are token-aware and threaded into `HttpClient`, so the deadline genuinely cancels an in-flight POST. An acceptance test **observes the token at the handler** — impossible to pass if the token never reaches the send.
- The deadline CTS is linked to the caller's token (`CancellationToken.None` in production — the stdio loop has none). `OperationCanceledException` is caught **only** when the helper's own deadline fired; caller-token cancellation rethrows untouched.
- `HandleToolCallAsync` maps `DeadlineExhausted` into a normal MCP tool error result carrying the code, attempt count and elapsed — never an unhandled stdio fault, and never phrased as fatal, since the busy is genuinely retryable.

The **poll lane** adopts the shared schedule but keeps its own model: its settlement-busy GET retry is bounded by the remaining 8-minute `PollCap` instead of a 3-attempt cap, and it is deliberately **not** subject to the POST deadline (it must keep polling past 3 minutes).

## Deliberately unchanged

- **The retryable code set** (`flow_settlement_busy`, `reviewer_launch_incarnation_superseded`). No new code is load-bearing.
- **Uncoded 4xx is still never retried** — the CLI cannot invent a code, so an old server's uncoded 400 surfaces on the first attempt. `Uncoded_4xx_is_not_retried` / `Different_coded_4xx_is_not_retried` stay green.

§3.3 deferrals (parking a foreground start as a pending retry; the full `DaemonLaunchQueue`) remain unimplemented by design.

## Testing

24 new tests, all on a virtual clock — no wall-clock sleeps anywhere.

- **Backoff:** exponential/capped `Raw` table incl. a far-out ordinal that must not overflow past the cap; cap-before-jitter (a saturated ordinal jitters around 10s, not around the uncapped 64s); the 250–500ms / 5–10s bands over 50 draws; budget truncation incl. zero and negative budgets; seeded determinism.
- **POST lane:** elapsed-deadline exhaustion returns the last coded error with no live response; the deadline token reaches the in-flight POST and cancels it; the budget counts request duration (simulated 60s-holding responses exhaust in ≤4 attempts, well under the 10-min tool timeout); caller-token cancellation rethrows; burst-deeper-than-the-deadline degrades to the documented coded timeout; the tool result is `isError: true` carrying code + attempts + elapsed.
- **Poll lane:** its settlement retries match the shared schedule rung-for-rung against an independently seeded oracle, stop at `PollCap`, never overshoot it, and **continue past the 3-minute POST deadline**.
- **`SequencedCommandProcessor`:** a fresh terminal command emits exactly one proactive `Processed` ack with the right outcome/agent/session; a throwing ack does not fault the lane (a following command still executes and advances). The five existing ack-count pins are migrated to distinguish the proactive ack from the duplicate-replay ack instead of asserting `Single()`.

Full suite: **42 failures, all pre-existing** — identical to the `origin/main` baseline captured before any change (Codex config-toml / MCP-registration / uninstall macOS flake families). Zero new failures; 4006 → 4030 tests.

## Note for the companion server PR

The proactive ack changes daemon→server wire behavior. Because a rejected/faulted execution also emits `CommandRejected` on a fire-and-forget channel, the server must tolerate **either arrival order** of the proactive ack and the rejection for the same command — command terminal exactly once, `OutstandingCommand` cleared, no watermark regression. That assertion lives in the server plan; the two land together.
