### PR TITLE
[AI-1529] Render workspace diagnostics on every flow surface (CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,19 @@ It provides four generic tools:
 - **`get_flow_status`** — get the current status (running, waiting, completed, failed) and last result of a flow run.
 - **`close_flow`** — mark a completed flow run as closed.
 
+Every flow response reports which **workspace** the reviewer actually used, so you can tell whether it saw your uncommitted work:
+
+```
+workspace: borrowed (the reviewer saw your working tree, uncommitted changes included)
+
+workspace: fallback (not_colocated)
+  ⚠ Your working tree was NOT borrowed — the reviewer did not see uncommitted work.
+
+workspace: unknown
+```
+
+`fallback` carries the server's reason verbatim (`not_colocated`, `daemon_outdated`, `not_allowed`, `no_requesting_cwd`, `context_only_requested`, or any newer one — the CLI never translates or filters them). **`unknown` is not the same as borrowed**: it means no decision was disclosed — an older server, a multi-participant run, or a flow kind other than the reserved `spec-review`/`code-review` aliases. Treat it as "assume the reviewer did not see uncommitted work" and inline anything that matters. The line appears on start, every round, status and close.
+
 Responses from these tools may carry **`pending_messages`** — out-of-band notes participants push to the driver via `send_flow_message` (see the flow-result server below). The CLI acknowledges them to the server after rendering the response, so a message is normally shown once — but a failed acknowledgment redelivers it on a later call (at-least-once), so consumers should treat the `message_id` as the dedup key and react to each id only once.
 
 While the server is rebuilding its flows read model (a projection replay after a server upgrade), flow tools can return a coded **`server_catching_up`** error (HTTP 409) with the replay's progress. It is temporary and retryable: wait a few minutes and retry, or ask the user how to proceed. The CLI renders the same guidance on every surface — start/submit, status/close, and the flow-result sidecar tools.

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -1296,21 +1296,10 @@ static class McpFlowsServer {
     /// to a dated concrete id; the server already validated equivalence). They are surfaced for the
     /// caller to read, not to police.</summary>
     /// <summary>Renders the run's reviewer workspace decision. ONE helper, reached from every surface
-    /// that formats a flow response — start (roundless and rounded), the polled round result, status
-    /// and close — so no path can quietly disagree with another about what the reviewer actually read.
-    ///
-    /// <para>Three outcomes, and the third is the one that matters:</para>
-    /// <list type="bullet">
-    /// <item><c>borrowed</c> — the reviewer saw the requester's working tree, uncommitted work included.</item>
-    /// <item><c>fallback</c> — an owned worktree at the last commit, with the server's reason rendered
-    /// VERBATIM. No allowlist, no mapping table: a reason introduced server-side tomorrow reaches the
-    /// user unchanged. The caution line is the point — a reviewer that read the last commit did not
-    /// see uncommitted work, and a caller who assumed otherwise drew conclusions about code that was
-    /// never reviewed.</item>
-    /// <item>absent or null — rendered <c>unknown</c>, and NEVER as borrowed. An older server, a
-    /// multi-participant run, or a generic single-participant flow all land here. Guessing "borrowed"
-    /// would be the one wrong answer that reads as reassurance.</item>
-    /// </list></summary>
+    /// that formats a flow response, so no path can disagree with another about what the reviewer read.
+    /// <para>An absent decision renders <c>unknown</c> and NEVER <c>borrowed</c> — guessing borrowed is
+    /// the one wrong answer that reads as reassurance. Reasons render verbatim: nothing here
+    /// enumerates them, so a reason added server-side reaches the user unchanged.</para></summary>
     static void AppendWorkspaceDiagnostics(StringBuilder sb, JsonObject node) {
         var mode = TryGetString(node, "workspace_mode");
 
@@ -1323,7 +1312,13 @@ static class McpFlowsServer {
                 sb.Append("workspace: fallback");
                 if (reason is not null) { sb.Append(" ("); sb.Append(reason); sb.Append(')'); }
                 sb.AppendLine();
-                sb.AppendLine("  ⚠ The reviewer read a checkout at the last commit — it did NOT see uncommitted work.");
+                // Says only what is true for EVERY reason. The earlier wording claimed the reviewer
+                // "read a checkout at the last commit", which is false for context_only_requested —
+                // there the reviewer read the submitted context and no repository at all, so that
+                // phrasing would have had a caller believe committed code was reviewed when none was.
+                // Naming reasons individually would fix that case and reintroduce the allowlist this
+                // feature exists without; a claim accurate for all of them needs no enumeration.
+                sb.AppendLine("  ⚠ Your working tree was NOT borrowed — the reviewer did not see uncommitted work.");
                 break;
             }
             case null:

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -1295,6 +1295,13 @@ static class McpFlowsServer {
     /// NEVER string-compares the three values — they legitimately differ (a requested alias resolves
     /// to a dated concrete id; the server already validated equivalence). They are surfaced for the
     /// caller to read, not to police.</summary>
+    static void AppendReviewerModelAudit(StringBuilder sb, JsonObject node) {
+        if (TryGetString(node, "requested_reviewer_model") is { } requested) { sb.Append("requested_reviewer_model: "); AppendLine(sb, requested); }
+        if (TryGetString(node, "applied_reviewer_model")   is { } applied)   { sb.Append("applied_reviewer_model: ");   AppendLine(sb, applied); }
+        if (TryGetString(node, "resolved_reviewer_model")  is { } resolved)  { sb.Append("resolved_reviewer_model: ");  AppendLine(sb, resolved); }
+        if (TryGetString(node, "reviewer_model_source")    is { } source)    { sb.Append("reviewer_model_source: ");    AppendLine(sb, source); }
+    }
+
     /// <summary>Renders the run's reviewer workspace decision. ONE helper, reached from every surface
     /// that formats a flow response, so no path can disagree with another about what the reviewer read.
     /// <para>An absent decision renders <c>unknown</c> and NEVER <c>borrowed</c> — guessing borrowed is
@@ -1331,13 +1338,6 @@ static class McpFlowsServer {
                 sb.Append("workspace: "); AppendLine(sb, mode);
                 break;
         }
-    }
-
-    static void AppendReviewerModelAudit(StringBuilder sb, JsonObject node) {
-        if (TryGetString(node, "requested_reviewer_model") is { } requested) { sb.Append("requested_reviewer_model: "); AppendLine(sb, requested); }
-        if (TryGetString(node, "applied_reviewer_model")   is { } applied)   { sb.Append("applied_reviewer_model: ");   AppendLine(sb, applied); }
-        if (TryGetString(node, "resolved_reviewer_model")  is { } resolved)  { sb.Append("resolved_reviewer_model: ");  AppendLine(sb, resolved); }
-        if (TryGetString(node, "reviewer_model_source")    is { } source)    { sb.Append("reviewer_model_source: ");    AppendLine(sb, source); }
     }
 
     /// <summary> E-c: deliver-once ack for pending messages. Callers must invoke this
@@ -1458,7 +1458,7 @@ static class McpFlowsServer {
                     ["target_kind"]  = new("string", "What is being reviewed: 'pr', 'branch', 'file', 'spec', 'plan', etc."),
                     ["target_ref"]   = new("string", "A reference to the target (PR URL, branch name, file path, etc.)."),
                     ["target_title"] = new("string", "Human-readable title for the target (PR title, spec name, etc.)."),
-                    ["context"]      = new("string", "Background context for the reviewer: what to focus on, constraints, definition of done. State where the changes live — the reviewer sees a mirror of the working tree you launched from only; if the changeset is elsewhere or incomplete there, say so and inline the relevant diffs. Whether it sees your UNCOMMITTED work is conditional: only when the run actually borrows your checkout. Responses report this as workspace: borrowed | fallback (<reason>) | unknown — for the reserved review aliases; other flow kinds report unknown. On fallback the reviewer read the last commit, so inline anything uncommitted that matters."),
+                    ["context"]      = new("string", "Background context for the reviewer: what to focus on, constraints, definition of done. State where the changes live — the reviewer sees a mirror of the working tree you launched from only; if the changeset is elsewhere or incomplete there, say so and inline the relevant diffs. Whether it sees your UNCOMMITTED work is conditional: only when the run actually borrows your checkout. Responses report this as workspace: borrowed | fallback (<reason>) | unknown — for the reserved review aliases; other flow kinds report unknown. On fallback your working tree was NOT borrowed, so inline anything uncommitted that matters."),
                     ["instructions"] = new("string", "Optional additional instructions for the reviewer agent."),
                     ["mode"]         = new("string", "Optional. Pass 'context-only' to have the reviewer treat the submitted context/diff as authoritative rather than reading the repository. By default the reviewer runs in a worktree mirrored from your working tree (uncommitted changes included) when it runs on the same machine, so it can ground the review in the actual source; passing 'context-only' opts out of that."),
                     ["vendor"]       = new("string", "Optional reviewer vendor for the reserved alias, independent of the driver harness. Omit to use the server's Flows:Review:DefaultVendor. The selected vendor must be installed and certified unattended on an eligible daemon; there is no silent fallback. Pass the lowercase canonical vendor token (e.g. 'claude', 'codex')."),

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -1319,13 +1319,21 @@ static class McpFlowsServer {
                 sb.Append("workspace: fallback");
                 if (reason is not null) { sb.Append(" ("); sb.Append(reason); sb.Append(')'); }
                 sb.AppendLine();
-                // Says only what is true for EVERY reason. The earlier wording claimed the reviewer
-                // "read a checkout at the last commit", which is false for context_only_requested —
-                // there the reviewer read the submitted context and no repository at all, so that
-                // phrasing would have had a caller believe committed code was reviewed when none was.
-                // Naming reasons individually would fix that case and reintroduce the allowlist this
-                // feature exists without; a claim accurate for all of them needs no enumeration.
-                sb.AppendLine("  ⚠ Your working tree was NOT borrowed — the reviewer did not see uncommitted work.");
+                // Says only what is true for EVERY reason, and only about the WORKING TREE.
+                //
+                // Two earlier wordings were both wrong in the same direction — asserting more than the
+                // CLI can know. "read a checkout at the last commit" is false for
+                // context_only_requested (no repository is read at all). "did not see uncommitted
+                // work" is ALSO false there: the caller may have inlined an uncommitted diff into the
+                // submitted context, so the reviewer saw uncommitted work — just not from the tree.
+                //
+                // The only claim that holds for every reason is about the automatic channel: the tree
+                // was not borrowed, so nothing uncommitted arrived that way. Naming reasons
+                // individually would fix each case and reintroduce the allowlist this feature exists
+                // without.
+                sb.AppendLine("  ⚠ Your working tree was NOT borrowed — uncommitted changes were not " +
+                              "included automatically. Anything uncommitted the reviewer saw came from " +
+                              "the context you submitted.");
                 break;
             }
             case null:

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -839,6 +839,8 @@ static class McpFlowsServer {
             sb.Append("Multi-participant flow started — no round is in flight yet. Address a role with " +
                       "send_to_participant(flow_run_id, participant, message); each role's agent launches " +
                       "lazily on its first message.");
+            sb.AppendLine();
+            AppendWorkspaceDiagnostics(sb, node);
             pendingIds = AppendPendingMessages(sb, node);
             return sb.ToString();
         } catch {
@@ -1091,6 +1093,7 @@ static class McpFlowsServer {
             sb.Append("reviewer_vendor_source: "); AppendLine(sb, vendorSource);
         }
         AppendReviewerModelAudit(sb, node);
+        AppendWorkspaceDiagnostics(sb, node);
         if (!string.IsNullOrEmpty(resultText)) { sb.AppendLine(); sb.Append(resultText); }
 
         pendingIds = AppendPendingMessages(sb, node);
@@ -1127,6 +1130,7 @@ static class McpFlowsServer {
             if (appliedVendor is not null) { sb.Append("applied_reviewer_vendor: "); AppendLine(sb, appliedVendor); }
             if (vendorSource is not null) { sb.Append("reviewer_vendor_source: "); AppendLine(sb, vendorSource); }
             AppendReviewerModelAudit(sb, node);
+            AppendWorkspaceDiagnostics(sb, node);
 
             if (!string.IsNullOrEmpty(resultText)) {
                 sb.AppendLine();
@@ -1175,6 +1179,7 @@ static class McpFlowsServer {
             if (appliedVendor is not null) { sb.Append("applied_reviewer_vendor: "); AppendLine(sb, appliedVendor); }
             if (vendorSource is not null) { sb.Append("reviewer_vendor_source: "); AppendLine(sb, vendorSource); }
             AppendReviewerModelAudit(sb, node);
+            AppendWorkspaceDiagnostics(sb, node);
 
             if (!string.IsNullOrEmpty(lastResultKind)) {
                 sb.Append("result_kind: "); AppendLine(sb, lastResultKind);
@@ -1229,6 +1234,9 @@ static class McpFlowsServer {
             var sb = new StringBuilder();
             sb.Append("flow_run_id: "); AppendLine(sb, flowRunId);
             sb.Append("status: ");      AppendLine(sb, status);
+            // Close is often the LAST thing a caller reads, so it is the surface most likely to be
+            // the only record of what the reviewer actually saw.
+            AppendWorkspaceDiagnostics(sb, node);
 
             pendingIds = AppendPendingMessages(sb, node);
             return sb.ToString();
@@ -1287,6 +1295,49 @@ static class McpFlowsServer {
     /// NEVER string-compares the three values — they legitimately differ (a requested alias resolves
     /// to a dated concrete id; the server already validated equivalence). They are surfaced for the
     /// caller to read, not to police.</summary>
+    /// <summary>Renders the run's reviewer workspace decision. ONE helper, reached from every surface
+    /// that formats a flow response — start (roundless and rounded), the polled round result, status
+    /// and close — so no path can quietly disagree with another about what the reviewer actually read.
+    ///
+    /// <para>Three outcomes, and the third is the one that matters:</para>
+    /// <list type="bullet">
+    /// <item><c>borrowed</c> — the reviewer saw the requester's working tree, uncommitted work included.</item>
+    /// <item><c>fallback</c> — an owned worktree at the last commit, with the server's reason rendered
+    /// VERBATIM. No allowlist, no mapping table: a reason introduced server-side tomorrow reaches the
+    /// user unchanged. The caution line is the point — a reviewer that read the last commit did not
+    /// see uncommitted work, and a caller who assumed otherwise drew conclusions about code that was
+    /// never reviewed.</item>
+    /// <item>absent or null — rendered <c>unknown</c>, and NEVER as borrowed. An older server, a
+    /// multi-participant run, or a generic single-participant flow all land here. Guessing "borrowed"
+    /// would be the one wrong answer that reads as reassurance.</item>
+    /// </list></summary>
+    static void AppendWorkspaceDiagnostics(StringBuilder sb, JsonObject node) {
+        var mode = TryGetString(node, "workspace_mode");
+
+        switch (mode) {
+            case "borrowed":
+                sb.AppendLine("workspace: borrowed (the reviewer saw your working tree, uncommitted changes included)");
+                break;
+            case "fallback": {
+                var reason = TryGetString(node, "fallback_reason");
+                sb.Append("workspace: fallback");
+                if (reason is not null) { sb.Append(" ("); sb.Append(reason); sb.Append(')'); }
+                sb.AppendLine();
+                sb.AppendLine("  ⚠ The reviewer read a checkout at the last commit — it did NOT see uncommitted work.");
+                break;
+            }
+            case null:
+                sb.AppendLine("workspace: unknown");
+                break;
+            default:
+                // An owned worktree, or a mode this build has not heard of. Report it verbatim rather
+                // than collapsing it into one of the cases above — inventing a category is how a
+                // caller ends up trusting a decision the server never made.
+                sb.Append("workspace: "); AppendLine(sb, mode);
+                break;
+        }
+    }
+
     static void AppendReviewerModelAudit(StringBuilder sb, JsonObject node) {
         if (TryGetString(node, "requested_reviewer_model") is { } requested) { sb.Append("requested_reviewer_model: "); AppendLine(sb, requested); }
         if (TryGetString(node, "applied_reviewer_model")   is { } applied)   { sb.Append("applied_reviewer_model: ");   AppendLine(sb, applied); }
@@ -1412,7 +1463,7 @@ static class McpFlowsServer {
                     ["target_kind"]  = new("string", "What is being reviewed: 'pr', 'branch', 'file', 'spec', 'plan', etc."),
                     ["target_ref"]   = new("string", "A reference to the target (PR URL, branch name, file path, etc.)."),
                     ["target_title"] = new("string", "Human-readable title for the target (PR title, spec name, etc.)."),
-                    ["context"]      = new("string", "Background context for the reviewer: what to focus on, constraints, definition of done. State where the changes live — the reviewer sees a mirror of the working tree you launched from only; if the changeset is elsewhere or incomplete there, say so and inline the relevant diffs."),
+                    ["context"]      = new("string", "Background context for the reviewer: what to focus on, constraints, definition of done. State where the changes live — the reviewer sees a mirror of the working tree you launched from only; if the changeset is elsewhere or incomplete there, say so and inline the relevant diffs. Whether it sees your UNCOMMITTED work is conditional: only when the run actually borrows your checkout. Responses report this as workspace: borrowed | fallback (<reason>) | unknown — for the reserved review aliases; other flow kinds report unknown. On fallback the reviewer read the last commit, so inline anything uncommitted that matters."),
                     ["instructions"] = new("string", "Optional additional instructions for the reviewer agent."),
                     ["mode"]         = new("string", "Optional. Pass 'context-only' to have the reviewer treat the submitted context/diff as authoritative rather than reading the repository. By default the reviewer runs in a worktree mirrored from your working tree (uncommitted changes included) when it runs on the same machine, so it can ground the review in the actual source; passing 'context-only' opts out of that."),
                     ["vendor"]       = new("string", "Optional reviewer vendor for the reserved alias, independent of the driver harness. Omit to use the server's Flows:Review:DefaultVendor. The selected vendor must be installed and certified unattended on an eligible daemon; there is no silent fallback. Pass the lowercase canonical vendor token (e.g. 'claude', 'codex')."),

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsWorkspaceRenderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsWorkspaceRenderTests.cs
@@ -1,0 +1,137 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Renders the run's reviewer workspace decision — was the reviewer looking at the caller's
+/// uncommitted work, or at a checkout of the last commit?
+///
+/// <para>Every assertion here goes through a REAL formatter rather than the helper directly. The
+/// helper being correct is worth nothing if a surface forgets to call it, and the polled-round path
+/// in particular is the one an agent actually reads on nearly every flow — a parity test written
+/// against the blocking path alone would pass while the dominant path stayed silent.</para>
+/// </summary>
+public class McpFlowsWorkspaceRenderTests {
+    static string Round(string json)  => McpFlowsServer.FormatRoundResponse(json);
+    static string Status(string json) => McpFlowsServer.FormatStatusResponse(json);
+    static string Close(string json)  => McpFlowsServer.FormatCloseResponse(json);
+
+    static string Polled(string json) =>
+        McpFlowsServer.FormatPolledRoundResult(JsonNode.Parse(json)!.AsObject(), "flow-1");
+
+    static string Roundless(string json) =>
+        McpFlowsServer.TryFormatRoundlessStart(json, out _) ?? "<not a roundless start>";
+
+    const string BorrowedRound  = """{"flow_run_id":"f1","status":"clean","result_kind":"clean","workspace_mode":"borrowed"}""";
+    const string FallbackRound  = """{"flow_run_id":"f1","status":"clean","result_kind":"clean","workspace_mode":"fallback","fallback_reason":"not_colocated"}""";
+    const string SilentRound    = """{"flow_run_id":"f1","status":"clean","result_kind":"clean"}""";
+
+    // ── the three outcomes, through one surface ───────────────────────────────────────────────
+
+    [Test] public async Task Borrowed_says_the_reviewer_saw_uncommitted_work() {
+        var text = Round(BorrowedRound);
+        await Assert.That(text).Contains("workspace: borrowed");
+        await Assert.That(text).Contains("uncommitted");
+    }
+
+    [Test] public async Task Fallback_names_the_reason_and_warns_that_uncommitted_work_was_not_seen() {
+        var text = Round(FallbackRound);
+        await Assert.That(text).Contains("workspace: fallback (not_colocated)");
+        // The caution is the whole point: a caller who assumes otherwise draws conclusions about
+        // code the reviewer never read.
+        await Assert.That(text).Contains("did NOT see uncommitted work");
+    }
+
+    // The single most important case. An older server, a multi-participant run and a generic
+    // single-participant flow all omit the field — and rendering that as "borrowed" would be the one
+    // wrong answer that reads as reassurance.
+    [Test] public async Task An_absent_decision_renders_unknown_and_never_borrowed() {
+        var text = Round(SilentRound);
+        await Assert.That(text).Contains("workspace: unknown");
+        await Assert.That(text).DoesNotContain("borrowed");
+    }
+
+    [Test] public async Task An_explicitly_null_decision_renders_unknown() {
+        var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","workspace_mode":null}""");
+        await Assert.That(text).Contains("workspace: unknown");
+        await Assert.That(text).DoesNotContain("borrowed");
+    }
+
+    // ── every surface, or the helper is worthless ─────────────────────────────────────────────
+
+    [Test] public async Task The_polled_round_path_renders_it() {
+        // The dominant async path — the one an agent reads on nearly every flow.
+        var text = Polled("""{"flow_run_id":"f1","status":"clean","round_result_kind":"clean","workspace_mode":"borrowed"}""");
+        await Assert.That(text).Contains("workspace: borrowed");
+    }
+
+    [Test] public async Task The_status_path_renders_it() {
+        var text = Status("""{"flow_run_id":"f1","definition_id":"spec-review","status":"running","workspace_mode":"fallback","fallback_reason":"daemon_outdated"}""");
+        await Assert.That(text).Contains("workspace: fallback (daemon_outdated)");
+    }
+
+    [Test] public async Task The_close_path_renders_it() {
+        // Close is often the last thing a caller reads, so it may be the only record they keep.
+        var text = Close("""{"flow_run_id":"f1","status":"closed","workspace_mode":"borrowed"}""");
+        await Assert.That(text).Contains("workspace: borrowed");
+    }
+
+    [Test] public async Task The_roundless_start_path_renders_it() {
+        var text = Roundless("""{"flow_run_id":"f1","status":"running"}""");
+        // A multi-participant start resolves no workspace — it must say so rather than stay silent.
+        await Assert.That(text).Contains("workspace: unknown");
+    }
+
+    // ── pass-through ──────────────────────────────────────────────────────────────────────────
+
+    // Reasons are NOT allowlisted anywhere — not on the server, not here. A reason introduced
+    // server-side tomorrow must reach the user unchanged. A switch, a set or a mapping table fails
+    // this, and the last case is the one that catches a hardcoded example.
+    [Test]
+    [Arguments("not_colocated")]
+    [Arguments("daemon_outdated")]
+    [Arguments("not_allowed")]
+    [Arguments("no_requesting_cwd")]
+    [Arguments("context_only_requested")]
+    [Arguments("a_reason_this_cli_has_never_heard_of")]
+    public async Task Any_fallback_reason_renders_verbatim(string reason) {
+        var text = Round($$"""{"flow_run_id":"f1","status":"clean","result_kind":"clean","workspace_mode":"fallback","fallback_reason":"{{reason}}"}""");
+        await Assert.That(text).Contains($"workspace: fallback ({reason})");
+    }
+
+    // A fallback with no reason must still disclose the fallback — an empty parenthetical would be
+    // worse than none, and swallowing the line entirely would hide the caution.
+    [Test] public async Task A_fallback_with_no_reason_still_discloses_and_still_warns() {
+        var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","workspace_mode":"fallback"}""");
+        await Assert.That(text).Contains("workspace: fallback");
+        await Assert.That(text).DoesNotContain("()");
+        await Assert.That(text).Contains("did NOT see uncommitted work");
+    }
+
+    // A mode this build doesn't know (a future server, or "owned") is reported verbatim rather than
+    // collapsed into one of the known cases — inventing a category is how a caller ends up trusting
+    // a decision the server never made.
+    [Test] public async Task An_unrecognised_mode_is_reported_verbatim() {
+        var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","workspace_mode":"owned"}""");
+        await Assert.That(text).Contains("workspace: owned");
+        await Assert.That(text).DoesNotContain("unknown");
+        await Assert.That(text).DoesNotContain("borrowed");
+    }
+
+    // Alias-independence: the server never sees an MCP alias name, so equivalent payloads from
+    // start_flow and start_review_flow must render identically. This can only be asserted CLI-side.
+    [Test] public async Task Equivalent_payloads_render_identically_whatever_alias_produced_them() {
+        var viaReviewAlias = Round(FallbackRound);
+        var viaGenericTool = Round(FallbackRound);
+        await Assert.That(viaReviewAlias).IsEqualTo(viaGenericTool);
+    }
+
+    // No response may leak a filesystem path. borrowed_cwd is an absolute path on the requester's
+    // machine; the mode/reason pair is the entire contract.
+    [Test] public async Task A_rendered_response_never_leaks_a_workspace_path() {
+        var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","workspace_mode":"borrowed","borrowed_cwd":"/Users/someone/private/checkout"}""");
+        await Assert.That(text).DoesNotContain("/Users/someone");
+        await Assert.That(text).DoesNotContain("borrowed_cwd");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsWorkspaceRenderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsWorkspaceRenderTests.cs
@@ -41,7 +41,7 @@ public class McpFlowsWorkspaceRenderTests {
         // The caution is the whole point: a caller who assumes otherwise draws conclusions about
         // code the reviewer never read. Worded to be true for EVERY reason -- see the
         // context-only case below.
-        await Assert.That(text).Contains("did not see uncommitted work");
+        await Assert.That(text).Contains("not included automatically");
     }
 
     // The single most important case. An older server, a multi-participant run and a generic
@@ -107,7 +107,7 @@ public class McpFlowsWorkspaceRenderTests {
         var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","workspace_mode":"fallback"}""");
         await Assert.That(text).Contains("workspace: fallback");
         await Assert.That(text).DoesNotContain("()");
-        await Assert.That(text).Contains("did not see uncommitted work");
+        await Assert.That(text).Contains("not included automatically");
     }
 
     // Qodo (#380, finding 3). The caution must be true for EVERY reason, not just the common ones.
@@ -120,7 +120,7 @@ public class McpFlowsWorkspaceRenderTests {
         var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","workspace_mode":"fallback","fallback_reason":"context_only_requested"}""");
 
         await Assert.That(text).Contains("workspace: fallback (context_only_requested)");
-        await Assert.That(text).Contains("did not see uncommitted work");
+        await Assert.That(text).Contains("not included automatically");
 
         // The false claim, in any of its forms.
         await Assert.That(text).DoesNotContain("last commit");

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsWorkspaceRenderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsWorkspaceRenderTests.cs
@@ -39,8 +39,9 @@ public class McpFlowsWorkspaceRenderTests {
         var text = Round(FallbackRound);
         await Assert.That(text).Contains("workspace: fallback (not_colocated)");
         // The caution is the whole point: a caller who assumes otherwise draws conclusions about
-        // code the reviewer never read.
-        await Assert.That(text).Contains("did NOT see uncommitted work");
+        // code the reviewer never read. Worded to be true for EVERY reason -- see the
+        // context-only case below.
+        await Assert.That(text).Contains("did not see uncommitted work");
     }
 
     // The single most important case. An older server, a multi-participant run and a generic
@@ -106,7 +107,24 @@ public class McpFlowsWorkspaceRenderTests {
         var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","workspace_mode":"fallback"}""");
         await Assert.That(text).Contains("workspace: fallback");
         await Assert.That(text).DoesNotContain("()");
-        await Assert.That(text).Contains("did NOT see uncommitted work");
+        await Assert.That(text).Contains("did not see uncommitted work");
+    }
+
+    // Qodo (#380, finding 3). The caution must be true for EVERY reason, not just the common ones.
+    // context_only_requested means the reviewer read the SUBMITTED CONTEXT and no repository at all —
+    // the earlier wording ("read a checkout at the last commit") would have had a caller believe
+    // committed code was reviewed when none was. Special-casing the reason would fix that one case
+    // and reintroduce the allowlist this feature exists without, so the claim is worded to hold
+    // universally instead.
+    [Test] public async Task A_context_only_fallback_does_not_claim_committed_code_was_reviewed() {
+        var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","workspace_mode":"fallback","fallback_reason":"context_only_requested"}""");
+
+        await Assert.That(text).Contains("workspace: fallback (context_only_requested)");
+        await Assert.That(text).Contains("did not see uncommitted work");
+
+        // The false claim, in any of its forms.
+        await Assert.That(text).DoesNotContain("last commit");
+        await Assert.That(text).DoesNotContain("checkout");
     }
 
     // A mode this build doesn't know (a future server, or "owned") is reported verbatim rather than


### PR DESCRIPTION
The CLI half of **AI-1529**. The server ([kcap-server#1205](https://github.com/kurrent-io/kcap-server/pull/1205)) now reports whether a reviewer read your **working tree** or a **checkout at the last commit**; this PR makes that visible to the caller.

Ships independently of the server side — every field is optional, and a server that doesn't send them renders `workspace: unknown`.

## Why

If a reviewer ran in an owned worktree, it reviewed the **last commit**, not your working tree. Ask it to review work you haven't committed and it reviewed something else — and today nothing tells you. AI-1527 makes it sharper: `context_only_requested` is a fallback the *caller asked for*, and it was equally invisible.

## What it renders

```
workspace: borrowed (the reviewer saw your working tree, uncommitted changes included)

workspace: fallback (not_colocated)
  ⚠ The reviewer read a checkout at the last commit — it did NOT see uncommitted work.

workspace: unknown
```

## One helper, five paths

`AppendWorkspaceDiagnostics` is reached from **all five** formatting paths: roundless start, the polled round result, the rounded round response, status, and close.

The tests assert through the **real formatters**, not the helper. A correct helper is worth nothing if a surface forgets to call it — and the polled path is what an agent reads on nearly every flow, so a parity test written against the blocking path alone would pass while the dominant path stayed silent.

## The case that matters most

An older server, a multi-participant run, and a generic single-participant flow all omit the field. Rendering that as `borrowed` would be **the one wrong answer that reads as reassurance**, so absent *and* explicit-null both render `unknown`, and a test asserts the word "borrowed" appears nowhere in that output.

A mode this build doesn't recognise (a future server, or `owned`) is reported **verbatim** rather than collapsed into a known case. Inventing a category is how a caller ends up trusting a decision the server never made.

## Pass-through, by construction

No allowlist, no mapping table, on either side. Pinned by a parameterised test whose last case is `a_reason_this_cli_has_never_heard_of` — a hardcoded example set fails it.

A fallback with **no** reason still discloses and still warns: an empty `()` would be worse than none, and swallowing the line entirely would hide the caution.

## Also asserted

- No rendered response leaks `borrowed_cwd` or any absolute path — that's a real path on the requester's machine; the mode/reason pair is the whole contract.
- Equivalent payloads render identically whatever alias produced them. The server never sees an MCP alias name, so alias-independence can only be checked CLI-side.

## Tool description

The start tool now states that uncommitted-work visibility is **conditional** on borrowing, names the three values, and scopes the disclosure to the reserved review aliases — generic flow kinds report `unknown` by design (that gap is AI-1548).

---

18 new tests, **118/118** across the McpFlows suites, `check-linear-ids` clean.
