### PR TITLE
[AI-1489] A transient version-probe timeout must not disable the reviewer

### DIFF
--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -669,12 +669,27 @@ public static partial class DaemonRunner {
     /// remedy does not reliably clear it either.</summary>
     const int VersionProbeAttempts = 3;
 
-    internal static string? ProbeCliVersion(string cliPath) {
-        for (var attempt = 1; attempt <= VersionProbeAttempts; attempt++) {
+    /// <summary>Registration-time probe: retries, because the result is cached for the daemon's
+    /// lifetime and a single miss is durable and destructive. Blocking here is fine — registration is
+    /// not on a request path.</summary>
+    internal static string? ProbeCliVersion(string cliPath) =>
+        ProbeCliVersion(cliPath, VersionProbeAttempts);
+
+    /// <summary>Launch-time probe: ONE attempt, no backoff. Codex review (P1): the retry budget is
+    /// right for registration and wrong on the launch path — three 10s waits plus backoff is ~30.75s
+    /// of a thread-pool thread held before a launch can even be rejected, multiplied by concurrent
+    /// launches. The launch path does not need the retry anyway: a miss here is no longer
+    /// misclassified as a CLI swap (see EvaluateReviewerCertification), it produces a retryable
+    /// rejection, and the caller can simply try again.</summary>
+    internal static string? ProbeCliVersionForLaunch(string cliPath) =>
+        ProbeCliVersion(cliPath, attempts: 1);
+
+    static string? ProbeCliVersion(string cliPath, int attempts) {
+        for (var attempt = 1; attempt <= attempts; attempt++) {
             if (ProbeCliVersionOnce(cliPath) is { } version) return version;
             // A cold Node start under load is the common cause; give the host a moment rather than
-            // hammering it three times in a row.
-            if (attempt < VersionProbeAttempts) Thread.Sleep(250 * attempt);
+            // hammering it several times in a row.
+            if (attempt < attempts) Thread.Sleep(250 * attempt);
         }
         return null;
     }

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -657,44 +657,35 @@ public static partial class DaemonRunner {
                 string.IsNullOrWhiteSpace(capability.CliVersion) ? UnknownCliVersion : capability.CliVersion);
     }
 
-    /// <summary>How long ONE version probe may take. The old 3s was too tight for a cold Node CLI
-    /// start on a loaded host, and a timeout here is not a harmless miss — see the retry note.</summary>
+    /// <summary>Registration probe budget. Generous and retried because this result is cached for the
+    /// daemon's lifetime — one transient miss durably disables the vendor.</summary>
     const int VersionProbeTimeoutMs = 10_000;
+    const int VersionProbeAttempts  = 3;
 
-    /// <summary>Probes are RETRIED because a single transient failure is durable and destructive.
-    /// The result is computed once at registration and advertised as ExpectedCliVersion for the
-    /// daemon's whole lifetime, so one timeout either drops the vendor from the unattended set
-    /// entirely, or — worse — makes every later launch fail the launch-time equality check against
-    /// the advertised null. Restarting on a still-loaded host reproduces it, so the documented
-    /// remedy does not reliably clear it either.</summary>
-    const int VersionProbeAttempts = 3;
+    /// <summary>Launch probe budget, deliberately the ORIGINAL 3s and a single attempt: this runs on
+    /// the sequenced command lane, whose single serial consumer holds every later launch and stop
+    /// behind it. A miss here is transient and retryable, so it does not need the registration
+    /// budget — and inheriting it would have tripled the lane stall this change was meant to
+    /// improve.</summary>
+    const int LaunchVersionProbeTimeoutMs = 3_000;
 
-    /// <summary>Registration-time probe: retries, because the result is cached for the daemon's
-    /// lifetime and a single miss is durable and destructive. Blocking here is fine — registration is
-    /// not on a request path.</summary>
     internal static string? ProbeCliVersion(string cliPath) =>
-        ProbeCliVersion(cliPath, VersionProbeAttempts);
+        ProbeCliVersion(cliPath, VersionProbeAttempts, VersionProbeTimeoutMs);
 
-    /// <summary>Launch-time probe: ONE attempt, no backoff. Codex review (P1): the retry budget is
-    /// right for registration and wrong on the launch path — three 10s waits plus backoff is ~30.75s
-    /// of a thread-pool thread held before a launch can even be rejected, multiplied by concurrent
-    /// launches. The launch path does not need the retry anyway: a miss here is no longer
-    /// misclassified as a CLI swap (see EvaluateReviewerCertification), it produces a retryable
-    /// rejection, and the caller can simply try again.</summary>
+    /// <summary>Single attempt on the original short budget — see LaunchVersionProbeTimeoutMs.</summary>
     internal static string? ProbeCliVersionForLaunch(string cliPath) =>
-        ProbeCliVersion(cliPath, attempts: 1);
+        ProbeCliVersion(cliPath, attempts: 1, LaunchVersionProbeTimeoutMs);
 
-    static string? ProbeCliVersion(string cliPath, int attempts) {
+    static string? ProbeCliVersion(string cliPath, int attempts, int timeoutMs) {
         for (var attempt = 1; attempt <= attempts; attempt++) {
-            if (ProbeCliVersionOnce(cliPath) is { } version) return version;
-            // A cold Node start under load is the common cause; give the host a moment rather than
-            // hammering it several times in a row.
+            if (ProbeCliVersionOnce(cliPath, timeoutMs) is { } version) return version;
+            // A cold Node start under load is the usual cause; pause rather than hammering.
             if (attempt < attempts) Thread.Sleep(250 * attempt);
         }
         return null;
     }
 
-    static string? ProbeCliVersionOnce(string cliPath) {
+    static string? ProbeCliVersionOnce(string cliPath, int timeoutMs) {
         try {
             using var process = Process.Start(new ProcessStartInfo {
                 FileName = cliPath,
@@ -703,7 +694,7 @@ public static partial class DaemonRunner {
                 RedirectStandardError = true,
                 ArgumentList = { "--version" }
             });
-            if (process is null || !process.WaitForExit(VersionProbeTimeoutMs)) {
+            if (process is null || !process.WaitForExit(timeoutMs)) {
                 try { process?.Kill(entireProcessTree: true); } catch { }
                 return null;
             }

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -657,7 +657,29 @@ public static partial class DaemonRunner {
                 string.IsNullOrWhiteSpace(capability.CliVersion) ? UnknownCliVersion : capability.CliVersion);
     }
 
+    /// <summary>How long ONE version probe may take. The old 3s was too tight for a cold Node CLI
+    /// start on a loaded host, and a timeout here is not a harmless miss — see the retry note.</summary>
+    const int VersionProbeTimeoutMs = 10_000;
+
+    /// <summary>Probes are RETRIED because a single transient failure is durable and destructive.
+    /// The result is computed once at registration and advertised as ExpectedCliVersion for the
+    /// daemon's whole lifetime, so one timeout either drops the vendor from the unattended set
+    /// entirely, or — worse — makes every later launch fail the launch-time equality check against
+    /// the advertised null. Restarting on a still-loaded host reproduces it, so the documented
+    /// remedy does not reliably clear it either.</summary>
+    const int VersionProbeAttempts = 3;
+
     internal static string? ProbeCliVersion(string cliPath) {
+        for (var attempt = 1; attempt <= VersionProbeAttempts; attempt++) {
+            if (ProbeCliVersionOnce(cliPath) is { } version) return version;
+            // A cold Node start under load is the common cause; give the host a moment rather than
+            // hammering it three times in a row.
+            if (attempt < VersionProbeAttempts) Thread.Sleep(250 * attempt);
+        }
+        return null;
+    }
+
+    static string? ProbeCliVersionOnce(string cliPath) {
         try {
             using var process = Process.Start(new ProcessStartInfo {
                 FileName = cliPath,
@@ -666,7 +688,7 @@ public static partial class DaemonRunner {
                 RedirectStandardError = true,
                 ArgumentList = { "--version" }
             });
-            if (process is null || !process.WaitForExit(3000)) {
+            if (process is null || !process.WaitForExit(VersionProbeTimeoutMs)) {
                 try { process?.Kill(entireProcessTree: true); } catch { }
                 return null;
             }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -521,6 +521,49 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// hence no transient false Dead. Dead is returned only after the genuine drain (confirmed death). If that
     /// ordering invariant is ever broken, this must instead take the per-agent lifecycle lock. NotFound
     /// collapses to Dead here (see the appendix note) — both satisfy confirmed-absence.</summary>
+    /// <summary>Evaluates the reviewer certification arm-by-arm so a rejection can NAME the one that
+    /// failed. Extracted and internal so the arms are unit-testable — the previous inline expression
+    /// collapsed four distinguishable conditions into one boolean and one message, and that message
+    /// actively misdirected: it reported the certification revision (which matches on every one of
+    /// these paths) and told the operator to update a CLI that was usually fine.</summary>
+    internal static (bool Ok, string Reason) EvaluateReviewerCertification(
+            string vendor, string? probedVersion, string? currentConnectionId,
+            ReviewerCertificationRequirement certification) {
+        if (!string.Equals(certification.Vendor, vendor, StringComparison.Ordinal))
+            return (false, $"the launch is for '{vendor}' but the certification is for '{certification.Vendor}'");
+
+        if (!string.Equals(currentConnectionId, certification.ExpectedDaemonConnectionId, StringComparison.Ordinal))
+            return (false, "this daemon reconnected after the certification was issued " +
+                           "(connection id changed) — retry the flow");
+
+        if (!string.Equals(certification.RequiredLauncherPolicyVersion,
+                DaemonRunner.ClaudeLauncherPolicyVersion, StringComparison.Ordinal))
+            return (false, $"the server requires launcher policy '{certification.RequiredLauncherPolicyVersion}' " +
+                           $"but this daemon implements '{DaemonRunner.ClaudeLauncherPolicyVersion}' — " +
+                           "update kcap and restart the daemon");
+
+        // A NULL advertised version means the registration-time probe failed — a transient condition,
+        // not evidence the CLI changed. This arm exists to catch a CLI SWAP between advertisement and
+        // launch, and null-vs-value is not a swap. Treating it as one rejected every launch for the
+        // daemon's lifetime, and restarting on a loaded host merely re-poisoned the advertisement.
+        // A null advertised value falls through to the range check below, which is the real gate.
+        // Null OR empty: the property is declared non-nullable, but it is populated from a probe that
+        // returns null and arrives over JSON, so both shapes reach here in practice.
+        if (!string.IsNullOrEmpty(certification.ExpectedCliVersion) &&
+            !string.Equals(probedVersion, certification.ExpectedCliVersion, StringComparison.Ordinal))
+            return (false, $"the installed {vendor} CLI is '{Describe(probedVersion)}' but this daemon " +
+                           $"advertised '{certification.ExpectedCliVersion}' at registration — " +
+                           "restart the daemon so it re-advertises");
+
+        if (!DaemonRunner.CliVersionAllowed(probedVersion, certification.AllowedCliRanges))
+            return (false, $"the installed {vendor} CLI '{Describe(probedVersion)}' is outside the " +
+                           $"server's allowed range '{certification.AllowedCliRanges}'");
+
+        return (true, "");
+
+        static string Describe(string? version) => version ?? "(version probe failed)";
+    }
+
     internal AgentLiveness ReadLiveness(string agentId) {
         // Order matters: check _agents first (Live/Quarantined-by-status), then _quarantine, then Dead.
         // The add-to-quarantine-before-remove-from-_agents invariant makes this ordering false-Dead-free.
@@ -857,19 +900,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             var version = string.Equals(cmd.Vendor, "claude", StringComparison.Ordinal)
                 ? DaemonRunner.ProbeCliVersion(_config.ClaudePath)
                 : null;
-            var policyMatches = string.Equals(certification.Vendor, cmd.Vendor, StringComparison.Ordinal)
-                && string.Equals(_server.CurrentConnectionId,
-                    certification.ExpectedDaemonConnectionId, StringComparison.Ordinal)
-                && string.Equals(certification.RequiredLauncherPolicyVersion,
-                    DaemonRunner.ClaudeLauncherPolicyVersion, StringComparison.Ordinal)
-                && string.Equals(version, certification.ExpectedCliVersion, StringComparison.Ordinal)
-                && DaemonRunner.CliVersionAllowed(version, certification.AllowedCliRanges);
-            if (!policyMatches) {
+            var certificationCheck = EvaluateReviewerCertification(
+                cmd.Vendor, version, _server.CurrentConnectionId, certification);
+            if (!certificationCheck.Ok) {
                 _config.UnattendedVendorCapabilities =
                     DaemonRunner.ComputeUnattendedVendorCapabilities(_runtimeFactories.Values, _config);
                 try { await _server.ReRegisterAsync(); } catch { /* launch still fails closed */ }
                 await _server.LaunchFailedAsync(cmd.AgentId,
-                    $"reviewer_certification_changed: '{cmd.Vendor}' no longer matches server certification revision '{certification.Revision}'. Restart the daemon after updating the reviewer CLI.");
+                    $"reviewer_certification_changed: {certificationCheck.Reason}.");
                 return new CommandOutcome(
                     CommandOutcomeKind.LaunchRejected,
                     agentId,

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -941,7 +941,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 // Serialising publication is necessary; coalescing keeps a burst of rejections from
                 // queueing a refresh each, and the rerun pass guarantees the LAST write is the
                 // NEWEST computation.
-                _ = _capabilityRefresh.RequestAsync(
+                _capabilityRefresh.Trigger(
                     async () => {
                         _config.UnattendedVendorCapabilities =
                             DaemonRunner.ComputeUnattendedVendorCapabilities(_runtimeFactories.Values, _config);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -247,6 +247,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     readonly IReadOnlyDictionary<string, IHostedAgentRuntimeFactory> _runtimeFactories;
     readonly ILogger<AgentOrchestrator>                        _logger;
 
+    /// <summary>Serialises + coalesces the background capability refresh fired after a certification
+    /// rejection. See SingleFlightRefresh for why bare fire-and-forget was unsafe here.</summary>
+    readonly SingleFlightRefresh _capabilityRefresh = new();
+
     // Hosted-agent PTYs are spawned at a fixed size and never resized. The daemon
     // reports these dims to the server right after the agent registers (and on
     // reconnect) so the read-only viewers (web/desktop xterm) lock to exactly the
@@ -928,19 +932,24 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
                 // The self-heal (recompute + re-advertise) is genuinely useful — a certification
                 // mismatch usually means the advertisement is stale — but nothing waits on it, and
-                // the caller already has its answer. Contained: a throw here must not surface as a
-                // second, different failure for a launch that has already been rejected.
-                _ = Task.Run(async () => {
-                    try {
+                // the caller already has its answer.
+                //
+                // SINGLE-FLIGHT, not bare fire-and-forget. Codex review round 3: concurrent rejected
+                // launches each starting an independent refresh reintroduces this PR's own bug — a
+                // slow failing refresh can complete AFTER a fast successful one and overwrite valid
+                // capabilities with a failed-probe null, durably disabling the reviewer again.
+                // Serialising publication is necessary; coalescing keeps a burst of rejections from
+                // queueing a refresh each, and the rerun pass guarantees the LAST write is the
+                // NEWEST computation.
+                _ = _capabilityRefresh.RequestAsync(
+                    async () => {
                         _config.UnattendedVendorCapabilities =
                             DaemonRunner.ComputeUnattendedVendorCapabilities(_runtimeFactories.Values, _config);
                         await _server.ReRegisterAsync();
-                    } catch (Exception ex) {
-                        _logger.LogDebug(ex,
-                            "Capability recompute after a certification rejection failed; the next " +
-                            "registration or launch re-evaluates it.");
-                    }
-                });
+                    },
+                    ex => _logger.LogDebug(ex,
+                        "Capability recompute after a certification rejection failed; the next " +
+                        "registration or launch re-evaluates it."));
                 return new CommandOutcome(
                     CommandOutcomeKind.LaunchRejected,
                     agentId,

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -917,11 +917,30 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             var certificationCheck = EvaluateReviewerCertification(
                 cmd.Vendor, version, _server.CurrentConnectionId, certification);
             if (!certificationCheck.Ok) {
-                _config.UnattendedVendorCapabilities =
-                    DaemonRunner.ComputeUnattendedVendorCapabilities(_runtimeFactories.Values, _config);
-                try { await _server.ReRegisterAsync(); } catch { /* launch still fails closed */ }
+                // Codex review round 2 (P1): tell the caller FIRST. Recomputing capabilities re-runs
+                // the REGISTRATION probe — three 10s attempts plus backoff — so doing it before the
+                // notification meant a failed launch probe cost ~10s here and then ~30.75s more
+                // before the caller heard anything. The single-attempt launch probe did not bound the
+                // launch path at all while this sat in front of the rejection; my claim that it did
+                // was wrong.
                 await _server.LaunchFailedAsync(cmd.AgentId,
                     $"reviewer_certification_changed: {certificationCheck.Reason}.");
+
+                // The self-heal (recompute + re-advertise) is genuinely useful — a certification
+                // mismatch usually means the advertisement is stale — but nothing waits on it, and
+                // the caller already has its answer. Contained: a throw here must not surface as a
+                // second, different failure for a launch that has already been rejected.
+                _ = Task.Run(async () => {
+                    try {
+                        _config.UnattendedVendorCapabilities =
+                            DaemonRunner.ComputeUnattendedVendorCapabilities(_runtimeFactories.Values, _config);
+                        await _server.ReRegisterAsync();
+                    } catch (Exception ex) {
+                        _logger.LogDebug(ex,
+                            "Capability recompute after a certification rejection failed; the next " +
+                            "registration or launch re-evaluates it.");
+                    }
+                });
                 return new CommandOutcome(
                     CommandOutcomeKind.LaunchRejected,
                     agentId,

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -551,28 +551,22 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // launch, and null-vs-value is not a swap. Treating it as one rejected every launch for the
         // daemon's lifetime, and restarting on a loaded host merely re-poisoned the advertisement.
         // A null advertised value falls through to the range check below, which is the real gate.
-        // Codex review (P1 #2): a failed LAUNCH-time probe is its own condition, and it must be
-        // classified before the swap comparison. Previously, with a version advertised at
-        // registration and the launch probe timing out, the swap arm fired and told the operator the
-        // CLI had changed and to restart — when nothing had changed and restarting merely repeats
-        // the same transient failure. Fails closed either way; only the diagnosis and remedy differ.
+        // A failed LAUNCH probe is its own condition, classified before the swap arm: otherwise a
+        // timeout reads as "the CLI changed, restart", when nothing changed and restarting repeats
+        // it. Fails closed either way; only the diagnosis and remedy differ.
         if (string.IsNullOrEmpty(probedVersion))
             return (false, $"could not read the installed {vendor} CLI version (the version probe " +
                            "failed or timed out) — this is usually transient under load; retry the flow");
 
-        // Codex review (P2 #3): the RANGE is checked before the swap arm. Otherwise a CLI genuinely
-        // replaced with an out-of-range version reported only "restart the daemon so it
-        // re-advertises" — and restarting re-advertises the same out-of-range version, so the
-        // remedy could never work. Range first means the operator is told the thing they can act on.
+        // Range BEFORE swap: an out-of-range replacement would otherwise be told only to restart,
+        // and restarting re-advertises the same out-of-range version.
         if (!DaemonRunner.CliVersionAllowed(probedVersion, certification.AllowedCliRanges))
             return (false, $"the installed {vendor} CLI '{probedVersion}' is outside the " +
                            $"server's allowed range '{certification.AllowedCliRanges}'");
 
-        // Null OR empty advertised: the property is declared non-nullable, but it is populated from a
-        // probe that returns null and arrives over JSON, so both shapes reach here. A null
-        // advertisement means the REGISTRATION probe failed — transient, not evidence the CLI
-        // changed. This arm exists to catch a genuine SWAP between advertisement and launch, and
-        // null-vs-value is not a swap; the range check above is the real gate in that case.
+        // A missing advertised version means the registration probe failed — not evidence of a CLI
+        // swap, which is all this arm exists to catch. It falls through to the range check above.
+        // Null or empty: declared non-nullable, but populated from a probe returning null over JSON.
         if (!string.IsNullOrEmpty(certification.ExpectedCliVersion) &&
             !string.Equals(probedVersion, certification.ExpectedCliVersion, StringComparison.Ordinal))
             return (false, $"the installed {vendor} CLI is '{probedVersion}' but this daemon " +

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -547,21 +547,35 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // launch, and null-vs-value is not a swap. Treating it as one rejected every launch for the
         // daemon's lifetime, and restarting on a loaded host merely re-poisoned the advertisement.
         // A null advertised value falls through to the range check below, which is the real gate.
-        // Null OR empty: the property is declared non-nullable, but it is populated from a probe that
-        // returns null and arrives over JSON, so both shapes reach here in practice.
+        // Codex review (P1 #2): a failed LAUNCH-time probe is its own condition, and it must be
+        // classified before the swap comparison. Previously, with a version advertised at
+        // registration and the launch probe timing out, the swap arm fired and told the operator the
+        // CLI had changed and to restart — when nothing had changed and restarting merely repeats
+        // the same transient failure. Fails closed either way; only the diagnosis and remedy differ.
+        if (string.IsNullOrEmpty(probedVersion))
+            return (false, $"could not read the installed {vendor} CLI version (the version probe " +
+                           "failed or timed out) — this is usually transient under load; retry the flow");
+
+        // Codex review (P2 #3): the RANGE is checked before the swap arm. Otherwise a CLI genuinely
+        // replaced with an out-of-range version reported only "restart the daemon so it
+        // re-advertises" — and restarting re-advertises the same out-of-range version, so the
+        // remedy could never work. Range first means the operator is told the thing they can act on.
+        if (!DaemonRunner.CliVersionAllowed(probedVersion, certification.AllowedCliRanges))
+            return (false, $"the installed {vendor} CLI '{probedVersion}' is outside the " +
+                           $"server's allowed range '{certification.AllowedCliRanges}'");
+
+        // Null OR empty advertised: the property is declared non-nullable, but it is populated from a
+        // probe that returns null and arrives over JSON, so both shapes reach here. A null
+        // advertisement means the REGISTRATION probe failed — transient, not evidence the CLI
+        // changed. This arm exists to catch a genuine SWAP between advertisement and launch, and
+        // null-vs-value is not a swap; the range check above is the real gate in that case.
         if (!string.IsNullOrEmpty(certification.ExpectedCliVersion) &&
             !string.Equals(probedVersion, certification.ExpectedCliVersion, StringComparison.Ordinal))
-            return (false, $"the installed {vendor} CLI is '{Describe(probedVersion)}' but this daemon " +
+            return (false, $"the installed {vendor} CLI is '{probedVersion}' but this daemon " +
                            $"advertised '{certification.ExpectedCliVersion}' at registration — " +
                            "restart the daemon so it re-advertises");
 
-        if (!DaemonRunner.CliVersionAllowed(probedVersion, certification.AllowedCliRanges))
-            return (false, $"the installed {vendor} CLI '{Describe(probedVersion)}' is outside the " +
-                           $"server's allowed range '{certification.AllowedCliRanges}'");
-
         return (true, "");
-
-        static string Describe(string? version) => version ?? "(version probe failed)";
     }
 
     internal AgentLiveness ReadLiveness(string agentId) {
@@ -898,7 +912,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         if (isReviewFlow && cmd.ReviewerCertification is { } certification) {
             var version = string.Equals(cmd.Vendor, "claude", StringComparison.Ordinal)
-                ? DaemonRunner.ProbeCliVersion(_config.ClaudePath)
+                ? DaemonRunner.ProbeCliVersionForLaunch(_config.ClaudePath)
                 : null;
             var certificationCheck = EvaluateReviewerCertification(
                 cmd.Vendor, version, _server.CurrentConnectionId, certification);

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -534,7 +534,27 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         await ReBindAcpSessionsAsync();
     }
 
+    /// <summary>Serialises DTO construction AND invocation. Two registrations can otherwise each
+    /// capture their own <c>_config</c> snapshot and land in either order: the heartbeat's
+    /// slot-displaced re-registration can capture the OLD capabilities, the certification self-heal
+    /// can then publish the NEW ones, and if the heartbeat's frame is processed last the server ends
+    /// up advertising the stale set while the daemon's local config says otherwise. That silently
+    /// undoes the self-heal — which this area now depends on to restore a missing advertisement, so
+    /// it is not a harmless duplicate registration.
+    /// <para>Held across the hub invoke, not just the construction: releasing early would let a
+    /// second DTO built from fresher config overtake an in-flight older one.</para></summary>
+    readonly SemaphoreSlim _registerLock = new(1, 1);
+
     async Task DaemonConnectAsync() {
+        await _registerLock.WaitAsync().ConfigureAwait(false);
+        try {
+            await DaemonConnectCoreAsync().ConfigureAwait(false);
+        } finally {
+            _registerLock.Release();
+        }
+    }
+
+    async Task DaemonConnectCoreAsync() {
         var platform  = $"{RuntimeInformation.OSDescription} {RuntimeInformation.OSArchitecture}";
         var repoPaths = await MergeRepoPathsAsync();
         var liveIds   = GetLiveAgentIds?.Invoke() ?? [];

--- a/src/Capacitor.Cli.Daemon/Services/SingleFlightRefresh.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SingleFlightRefresh.cs
@@ -1,0 +1,52 @@
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Runs a refresh at most once at a time, and coalesces every request that arrives while one is in
+/// flight into exactly ONE further pass.
+///
+/// <para>Extracted because an unsynchronised background refresh reintroduced the very defect this
+/// area exists to remove. Concurrent rejected launches each started an independent refresh; atomic
+/// reference assignment prevents a torn pointer but not stale <em>completion order</em>. The failing
+/// interleaving: refresh A starts on a loaded host and spends ~30s timing out; refresh B starts
+/// later, probes successfully, publishes valid capabilities and re-registers; then A completes last
+/// and overwrites the valid snapshot with its failed-probe result — durably disabling the reviewer
+/// again, which is precisely the bug being fixed.</para>
+///
+/// <para>Serialising alone is not enough: a burst of N rejections must not queue N refreshes. A
+/// request arriving mid-flight sets a rerun flag, so the in-flight pass loops exactly once more and
+/// publishes a computation made <em>after</em> that request — the freshest result wins, and the
+/// last write is always the newest.</para>
+/// </summary>
+internal sealed class SingleFlightRefresh {
+    readonly SemaphoreSlim _gate = new(1, 1);
+    int _rerunRequested;
+
+    /// <summary>Requests a refresh. Returns when this call's work is done, or immediately when
+    /// another pass is already running (having asked it to run once more). Never throws: a refresh is
+    /// a self-heal, and a failure must not become a second, different error for whatever triggered
+    /// it. <paramref name="onError"/> observes the failure.</summary>
+    public async Task RequestAsync(Func<Task> refresh, Action<Exception>? onError = null) {
+        if (!await _gate.WaitAsync(0).ConfigureAwait(false)) {
+            // Someone is mid-flight. Ask them to do one more pass after they finish — their current
+            // pass may have started before our trigger and so may not observe what we just changed.
+            Interlocked.Exchange(ref _rerunRequested, 1);
+            return;
+        }
+
+        try {
+            do {
+                // Cleared BEFORE the work, so a request arriving during it sets the flag again and
+                // earns another pass. Clearing after would swallow it.
+                Interlocked.Exchange(ref _rerunRequested, 0);
+
+                try {
+                    await refresh().ConfigureAwait(false);
+                } catch (Exception ex) {
+                    onError?.Invoke(ex);
+                }
+            } while (Interlocked.CompareExchange(ref _rerunRequested, 0, 1) == 1);
+        } finally {
+            _gate.Release();
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/SingleFlightRefresh.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SingleFlightRefresh.cs
@@ -1,38 +1,59 @@
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// Runs a refresh at most once at a time, and coalesces every request that arrives while one is in
-/// flight into exactly ONE further pass.
+/// Runs a refresh at most once at a time, off the caller's stack, coalescing every request that
+/// arrives while one is in flight into exactly ONE further pass.
 ///
-/// <para>Extracted because an unsynchronised background refresh reintroduced the very defect this
-/// area exists to remove. Concurrent rejected launches each started an independent refresh; atomic
-/// reference assignment prevents a torn pointer but not stale <em>completion order</em>. The failing
-/// interleaving: refresh A starts on a loaded host and spends ~30s timing out; refresh B starts
-/// later, probes successfully, publishes valid capabilities and re-registers; then A completes last
-/// and overwrites the valid snapshot with its failed-probe result — durably disabling the reviewer
-/// again, which is precisely the bug being fixed.</para>
+/// <para>Two defects shaped this, both of them mine, both found in review.</para>
+///
+/// <para><b>Stale completion order.</b> An unsynchronised background refresh reintroduced the very
+/// bug this area exists to remove: refresh A starts on a loaded host and spends ~30s timing out;
+/// refresh B starts later, probes successfully, publishes valid capabilities and re-registers; then
+/// A completes last and overwrites the valid snapshot with its failed-probe result — durably
+/// disabling the reviewer again. Atomic reference assignment prevents a torn pointer, not stale
+/// ordering.</para>
+///
+/// <para><b>A discarded task is not an asynchronous boundary.</b> <c>_ = SomethingAsync()</c> still
+/// runs the method's synchronous prefix on the caller's stack, up to its first incomplete await. The
+/// refresh delegate here computes capabilities <em>synchronously</em> (it shells out to probe CLI
+/// versions) before awaiting anything, so a fire-and-forget call still blocked the launch path for
+/// the full probe budget. Hence <see cref="Trigger"/> is deliberately NOT async and schedules the
+/// work itself — the caller cannot accidentally inherit it.</para>
 ///
 /// <para>Serialising alone is not enough: a burst of N rejections must not queue N refreshes. A
 /// request arriving mid-flight sets a rerun flag, so the in-flight pass loops exactly once more and
-/// publishes a computation made <em>after</em> that request — the freshest result wins, and the
-/// last write is always the newest.</para>
+/// publishes a computation made <em>after</em> that request — the freshest result wins.</para>
 /// </summary>
 internal sealed class SingleFlightRefresh {
     readonly SemaphoreSlim _gate = new(1, 1);
-    int _rerunRequested;
+    int  _rerunRequested;
+    Task _current = Task.CompletedTask;
 
-    /// <summary>Requests a refresh. Returns when this call's work is done, or immediately when
-    /// another pass is already running (having asked it to run once more). Never throws: a refresh is
-    /// a self-heal, and a failure must not become a second, different error for whatever triggered
-    /// it. <paramref name="onError"/> observes the failure.</summary>
-    public async Task RequestAsync(Func<Task> refresh, Action<Exception>? onError = null) {
-        if (!await _gate.WaitAsync(0).ConfigureAwait(false)) {
-            // Someone is mid-flight. Ask them to do one more pass after they finish — their current
-            // pass may have started before our trigger and so may not observe what we just changed.
+    /// <summary>Requests a refresh and returns IMMEDIATELY — always, whether or not this call won
+    /// the gate. Returns void rather than a Task on purpose: a task here would carry two
+    /// incompatible meanings (the winner would observe the pass, a coalesced caller would observe
+    /// only that it was recorded), and a future caller awaiting it would get a guarantee that does
+    /// not hold. Nothing may block on a self-heal.</summary>
+    public void Trigger(Func<Task> refresh, Action<Exception>? onError = null) {
+        // Wait(0) is the synchronous try-enter: it never blocks, and it either wins the gate or
+        // tells us a pass is already running.
+        if (!_gate.Wait(0)) {
+            // A pass is mid-flight. It may have started before whatever we are reacting to, so ask
+            // for one more afterwards rather than assuming it covers us.
             Interlocked.Exchange(ref _rerunRequested, 1);
             return;
         }
 
+        // Won the gate — hand the work to the pool so the delegate's synchronous prefix never runs
+        // on the caller's stack. The gate is released inside the run, not here.
+        Volatile.Write(ref _current, Task.Run(() => RunHoldingGateAsync(refresh, onError)));
+    }
+
+    /// <summary>Test seam: the most recently scheduled pass, for awaiting quiescence. Not part of
+    /// the production contract — production never observes a refresh.</summary>
+    internal Task Current => Volatile.Read(ref _current);
+
+    async Task RunHoldingGateAsync(Func<Task> refresh, Action<Exception>? onError) {
         try {
             do {
                 // Cleared BEFORE the work, so a request arriving during it sets the flag again and
@@ -42,6 +63,8 @@ internal sealed class SingleFlightRefresh {
                 try {
                     await refresh().ConfigureAwait(false);
                 } catch (Exception ex) {
+                    // A refresh is a self-heal; a failure must never become a second, different
+                    // error for whatever triggered it.
                     onError?.Invoke(ex);
                 }
             } while (Interlocked.CompareExchange(ref _rerunRequested, 0, 1) == 1);

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ReviewerCertificationArmTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ReviewerCertificationArmTests.cs
@@ -1,0 +1,108 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// The reviewer-certification gate, arm by arm.
+///
+/// <para>Two defects motivated these. A transient `claude --version` probe timeout at daemon
+/// registration advertised a NULL CLI version for the daemon's lifetime; the launch-time equality
+/// check then compared that null against a successful probe and rejected every launch. And all four
+/// arms collapsed into one message that named the certification revision (which matched) and told
+/// the operator to update a CLI that was correct and in range — so the real cause was undiagnosable
+/// from the error alone.</para>
+/// </summary>
+public class ReviewerCertificationArmTests {
+    const string Conn   = "conn-1";
+    const string Policy = "claude-unattended-v1";
+
+    static ReviewerCertificationRequirement Cert(
+            string vendor = "claude", string ranges = ">=2.0.0 <3.0.0",
+            string? expectedCliVersion = "2.1.212", string connectionId = Conn) =>
+        new(vendor, ranges, Policy, Policy, connectionId, expectedCliVersion!);
+
+    [Test] public async Task A_matching_certification_passes() {
+        var (ok, _) = AgentOrchestrator.EvaluateReviewerCertification("claude", "2.1.212", Conn, Cert());
+        await Assert.That(ok).IsTrue();
+    }
+
+    // THE regression. A null advertised version means the registration probe failed -- a transient
+    // condition, not evidence the CLI changed. The equality arm exists to catch a CLI SWAP between
+    // advertisement and launch, and null-vs-value is not a swap.
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    public async Task A_failed_registration_probe_does_not_reject_a_launch(string? advertised) {
+        var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
+            "claude", "2.1.212", Conn, Cert(expectedCliVersion: advertised));
+
+        await Assert.That(ok).IsTrue().Because($"advertised '{advertised ?? "null"}' means the probe failed, not that the CLI changed: {reason}");
+    }
+
+    // ...but a genuine swap must still be caught, or the relaxation above would gut the arm.
+    [Test] public async Task A_genuine_cli_swap_is_still_rejected() {
+        var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
+            "claude", "2.9.9", Conn, Cert(expectedCliVersion: "2.1.212"));
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(reason).Contains("2.1.212");
+        await Assert.That(reason).Contains("restart the daemon");
+    }
+
+    // A null advertised version must still fall through to the RANGE check -- that is the real gate,
+    // and relaxing the equality arm must not let an out-of-range CLI through.
+    [Test] public async Task A_failed_probe_still_enforces_the_allowed_range() {
+        var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
+            "claude", "1.0.0", Conn, Cert(expectedCliVersion: null));
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(reason).Contains("outside");
+        await Assert.That(reason).Contains(">=2.0.0 <3.0.0");
+    }
+
+    // Each arm names ITSELF. The old single message reported the certification revision -- which
+    // matches on every one of these paths -- and blamed the CLI regardless of the actual cause.
+    [Test] public async Task A_vendor_mismatch_names_the_vendors() {
+        var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
+            "codex", "2.1.212", Conn, Cert(vendor: "claude"));
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(reason).Contains("codex");
+        await Assert.That(reason).Contains("claude");
+    }
+
+    [Test] public async Task A_reconnect_names_the_connection_change_and_says_retry() {
+        var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
+            "claude", "2.1.212", "conn-2", Cert(connectionId: "conn-1"));
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(reason).Contains("reconnected");
+        await Assert.That(reason).Contains("retry");
+    }
+
+    // The probe failing AND no advertised version: the message must say the probe failed rather than
+    // printing an empty string, which reads as "the CLI reports no version".
+    [Test] public async Task A_failed_probe_outside_range_says_the_probe_failed() {
+        var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
+            "claude", null, Conn, Cert(expectedCliVersion: null));
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(reason).Contains("version probe failed");
+    }
+
+    // No arm may claim the revision matched/mismatched -- the revision is equal on every failure
+    // path here, and naming it was the misdirection.
+    [Test] public async Task No_rejection_blames_the_certification_revision() {
+        foreach (var (v, probed, conn, cert) in new (string, string?, string, ReviewerCertificationRequirement)[] {
+            ("codex",  "2.1.212", Conn,     Cert(vendor: "claude")),
+            ("claude", "2.1.212", "conn-2", Cert()),
+            ("claude", "2.9.9",   Conn,     Cert(expectedCliVersion: "2.1.212")),
+            ("claude", "1.0.0",   Conn,     Cert(expectedCliVersion: null)),
+        }) {
+            var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(v, probed, conn, cert);
+            await Assert.That(ok).IsFalse();
+            await Assert.That(reason).DoesNotContain("revision");
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ReviewerCertificationArmTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ReviewerCertificationArmTests.cs
@@ -3,16 +3,8 @@ using Capacitor.Cli.Daemon.Services;
 
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
-/// <summary>
-/// The reviewer-certification gate, arm by arm.
-///
-/// <para>Two defects motivated these. A transient `claude --version` probe timeout at daemon
-/// registration advertised a NULL CLI version for the daemon's lifetime; the launch-time equality
-/// check then compared that null against a successful probe and rejected every launch. And all four
-/// arms collapsed into one message that named the certification revision (which matched) and told
-/// the operator to update a CLI that was correct and in range — so the real cause was undiagnosable
-/// from the error alone.</para>
-/// </summary>
+/// <summary>Each arm of the reviewer-certification gate, including a failed version probe, and the
+/// requirement that every rejection names its own cause and remedy.</summary>
 public class ReviewerCertificationArmTests {
     const string Conn   = "conn-1";
     const string Policy = "claude-unattended-v1";

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ReviewerCertificationArmTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ReviewerCertificationArmTests.cs
@@ -41,7 +41,9 @@ public class ReviewerCertificationArmTests {
     }
 
     // ...but a genuine swap must still be caught, or the relaxation above would gut the arm.
-    [Test] public async Task A_genuine_cli_swap_is_still_rejected() {
+    // In-range on purpose: an out-of-range replacement is the range arm's business (above), so this
+    // pins the swap arm specifically.
+    [Test] public async Task A_genuine_in_range_cli_swap_is_still_rejected() {
         var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
             "claude", "2.9.9", Conn, Cert(expectedCliVersion: "2.1.212"));
 
@@ -50,15 +52,45 @@ public class ReviewerCertificationArmTests {
         await Assert.That(reason).Contains("restart the daemon");
     }
 
-    // A null advertised version must still fall through to the RANGE check -- that is the real gate,
-    // and relaxing the equality arm must not let an out-of-range CLI through.
-    [Test] public async Task A_failed_probe_still_enforces_the_allowed_range() {
+    // A null ADVERTISED version must still fall through to the RANGE check -- that is the real gate,
+    // and relaxing the swap arm must not let an out-of-range CLI through.
+    [Test] public async Task A_null_advertisement_still_enforces_the_allowed_range() {
         var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
             "claude", "1.0.0", Conn, Cert(expectedCliVersion: null));
 
         await Assert.That(ok).IsFalse();
         await Assert.That(reason).Contains("outside");
         await Assert.That(reason).Contains(">=2.0.0 <3.0.0");
+    }
+
+    // Codex review P1 #2: a failed LAUNCH-time probe is not a swap. With a version advertised at
+    // registration and the launch probe timing out, the swap arm used to fire and tell the operator
+    // the CLI had changed and to restart -- when nothing changed and restarting repeats the failure.
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    public async Task A_failed_launch_probe_is_diagnosed_as_transient_not_as_a_swap(string? probed) {
+        var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
+            "claude", probed, Conn, Cert(expectedCliVersion: "2.1.212"));
+
+        await Assert.That(ok).IsFalse();               // still fails closed
+        await Assert.That(reason).Contains("probe");
+        await Assert.That(reason).Contains("retry");
+        await Assert.That(reason).DoesNotContain("advertised");   // not the swap story
+        await Assert.That(reason).DoesNotContain("restart");      // not the swap remedy
+    }
+
+    // Codex review P2 #3: a CLI genuinely replaced with an OUT-OF-RANGE version must be told about
+    // the range, not told to restart -- restarting re-advertises the same out-of-range version, so
+    // that remedy can never work.
+    [Test] public async Task An_out_of_range_replacement_reports_the_range_not_a_restart() {
+        var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
+            "claude", "9.9.9", Conn, Cert(expectedCliVersion: "2.1.212"));
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(reason).Contains("outside");
+        await Assert.That(reason).Contains(">=2.0.0 <3.0.0");
+        await Assert.That(reason).DoesNotContain("restart the daemon");
     }
 
     // Each arm names ITSELF. The old single message reported the certification revision -- which
@@ -81,14 +113,15 @@ public class ReviewerCertificationArmTests {
         await Assert.That(reason).Contains("retry");
     }
 
-    // The probe failing AND no advertised version: the message must say the probe failed rather than
-    // printing an empty string, which reads as "the CLI reports no version".
-    [Test] public async Task A_failed_probe_outside_range_says_the_probe_failed() {
+    // Probe failed AND nothing advertised: still the dedicated transient arm, never an empty-string
+    // version in the text (which would read as "the CLI reports no version").
+    [Test] public async Task A_failed_probe_with_no_advertisement_still_reports_the_probe() {
         var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
             "claude", null, Conn, Cert(expectedCliVersion: null));
 
         await Assert.That(ok).IsFalse();
-        await Assert.That(reason).Contains("version probe failed");
+        await Assert.That(reason).Contains("probe");
+        await Assert.That(reason).Contains("retry");
     }
 
     // No arm may claim the revision matched/mismatched -- the revision is equal on every failure
@@ -99,6 +132,7 @@ public class ReviewerCertificationArmTests {
             ("claude", "2.1.212", "conn-2", Cert()),
             ("claude", "2.9.9",   Conn,     Cert(expectedCliVersion: "2.1.212")),
             ("claude", "1.0.0",   Conn,     Cert(expectedCliVersion: null)),
+            ("claude", null,      Conn,     Cert(expectedCliVersion: "2.1.212")),
         }) {
             var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(v, probed, conn, cert);
             await Assert.That(ok).IsFalse();

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SingleFlightRefreshTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SingleFlightRefreshTests.cs
@@ -1,0 +1,124 @@
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// The coalescing/serialisation guarantees the background capability refresh depends on.
+///
+/// <para>These exist because a bare fire-and-forget refresh reintroduced the defect its own PR was
+/// removing: concurrent rejected launches each started a refresh, and a slow FAILING one could
+/// complete after a fast SUCCEEDING one and overwrite valid capabilities with a failed-probe null —
+/// durably disabling the reviewer again. Atomic reference assignment prevents a torn pointer, not
+/// stale completion order.</para>
+/// </summary>
+public class SingleFlightRefreshTests {
+    // The exact interleaving from the review: a slow failing pass must not publish after a later
+    // fast successful one. With single-flight, the second request never runs concurrently at all —
+    // it folds into a rerun that happens AFTER the first finishes, so the last write is the newest.
+    [Test] public async Task A_slow_pass_cannot_publish_after_a_later_request() {
+        var refresh   = new SingleFlightRefresh();
+        var published = new List<string>();
+        var release   = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started   = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pass      = 0;
+
+        var slow = refresh.RequestAsync(async () => {
+            var n = Interlocked.Increment(ref pass);
+            if (n == 1) { started.SetResult(); await release.Task; }
+            lock (published) published.Add(n == 1 ? "slow-failing" : "fresh");
+        });
+
+        await started.Task;                     // first pass is in flight
+        await refresh.RequestAsync(() => Task.CompletedTask);  // arrives mid-flight -> folds in
+        release.SetResult();
+        await slow;
+
+        // Two passes ran, and the LAST one is the fresh recomputation — never the stale first.
+        await Assert.That(published).IsEquivalentTo(new[] { "slow-failing", "fresh" });
+    }
+
+    // A burst of rejections must not queue a refresh each. N concurrent requests during one
+    // in-flight pass collapse to exactly ONE extra pass.
+    [Test] public async Task A_burst_of_requests_collapses_to_one_extra_pass() {
+        var refresh = new SingleFlightRefresh();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var passes  = 0;
+
+        var first = refresh.RequestAsync(async () => {
+            if (Interlocked.Increment(ref passes) == 1) { started.SetResult(); await release.Task; }
+        });
+
+        await started.Task;
+        await Task.WhenAll(Enumerable.Range(0, 20).Select(_ => refresh.RequestAsync(() => Task.CompletedTask)));
+        release.SetResult();
+        await first;
+
+        await Assert.That(passes).IsEqualTo(2);   // the original + exactly one coalesced rerun
+    }
+
+    // Passes never overlap — that is what makes "last write wins" mean "newest wins".
+    [Test] public async Task Passes_never_run_concurrently() {
+        var refresh    = new SingleFlightRefresh();
+        var concurrent = 0;
+        var maxSeen    = 0;
+
+        await Task.WhenAll(Enumerable.Range(0, 25).Select(_ => refresh.RequestAsync(async () => {
+            var now = Interlocked.Increment(ref concurrent);
+            InterlockedMax(ref maxSeen, now);
+            await Task.Delay(5);
+            Interlocked.Decrement(ref concurrent);
+        })));
+
+        await Assert.That(maxSeen).IsEqualTo(1);
+    }
+
+    // A refresh is a self-heal: a throw must never escape and become a second, different failure for
+    // whatever triggered it — and must not wedge the gate against later refreshes.
+    [Test] public async Task A_throwing_pass_is_reported_and_does_not_wedge_the_gate() {
+        var refresh = new SingleFlightRefresh();
+        Exception? observed = null;
+
+        await refresh.RequestAsync(() => throw new InvalidOperationException("probe blew up"),
+            ex => observed = ex);
+
+        await Assert.That(observed).IsNotNull();
+        await Assert.That(observed!.Message).IsEqualTo("probe blew up");
+
+        // The gate still works afterwards.
+        var ran = false;
+        await refresh.RequestAsync(() => { ran = true; return Task.CompletedTask; });
+        await Assert.That(ran).IsTrue();
+    }
+
+    // A request arriving mid-flight must earn a pass that STARTS after it — otherwise the refresh it
+    // asked for could be one that began before the state it wanted observed.
+    [Test] public async Task A_mid_flight_request_earns_a_pass_that_starts_after_it() {
+        var refresh     = new SingleFlightRefresh();
+        var release     = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started     = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestedAt = -1;
+        var tick        = 0;
+        var passStarts  = new List<int>();
+
+        var first = refresh.RequestAsync(async () => {
+            lock (passStarts) passStarts.Add(Interlocked.Increment(ref tick));
+            if (passStarts.Count == 1) { started.SetResult(); await release.Task; }
+        });
+
+        await started.Task;
+        requestedAt = Interlocked.Increment(ref tick);
+        await refresh.RequestAsync(() => Task.CompletedTask);
+        release.SetResult();
+        await first;
+
+        await Assert.That(passStarts.Count).IsEqualTo(2);
+        await Assert.That(passStarts[1]).IsGreaterThan(requestedAt);
+    }
+
+    static void InterlockedMax(ref int target, int value) {
+        int seen;
+        do { seen = Volatile.Read(ref target); if (value <= seen) return; }
+        while (Interlocked.CompareExchange(ref target, value, seen) != seen);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SingleFlightRefreshTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SingleFlightRefreshTests.cs
@@ -22,16 +22,16 @@ public class SingleFlightRefreshTests {
         var started   = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var pass      = 0;
 
-        var slow = refresh.RequestAsync(async () => {
+        refresh.Trigger(async () => {
             var n = Interlocked.Increment(ref pass);
             if (n == 1) { started.SetResult(); await release.Task; }
             lock (published) published.Add(n == 1 ? "slow-failing" : "fresh");
         });
 
         await started.Task;                     // first pass is in flight
-        await refresh.RequestAsync(() => Task.CompletedTask);  // arrives mid-flight -> folds in
+        refresh.Trigger(() => Task.CompletedTask);        // arrives mid-flight -> folds in
         release.SetResult();
-        await slow;
+        await refresh.Current;
 
         // Two passes ran, and the LAST one is the fresh recomputation — never the stale first.
         await Assert.That(published).IsEquivalentTo(new[] { "slow-failing", "fresh" });
@@ -45,14 +45,14 @@ public class SingleFlightRefreshTests {
         var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var passes  = 0;
 
-        var first = refresh.RequestAsync(async () => {
+        refresh.Trigger(async () => {
             if (Interlocked.Increment(ref passes) == 1) { started.SetResult(); await release.Task; }
         });
 
         await started.Task;
-        await Task.WhenAll(Enumerable.Range(0, 20).Select(_ => refresh.RequestAsync(() => Task.CompletedTask)));
+        foreach (var _ in Enumerable.Range(0, 20)) refresh.Trigger(() => Task.CompletedTask);
         release.SetResult();
-        await first;
+        await refresh.Current;
 
         await Assert.That(passes).IsEqualTo(2);   // the original + exactly one coalesced rerun
     }
@@ -63,12 +63,14 @@ public class SingleFlightRefreshTests {
         var concurrent = 0;
         var maxSeen    = 0;
 
-        await Task.WhenAll(Enumerable.Range(0, 25).Select(_ => refresh.RequestAsync(async () => {
-            var now = Interlocked.Increment(ref concurrent);
-            InterlockedMax(ref maxSeen, now);
-            await Task.Delay(5);
-            Interlocked.Decrement(ref concurrent);
-        })));
+        foreach (var _ in Enumerable.Range(0, 25))
+            refresh.Trigger(async () => {
+                var now = Interlocked.Increment(ref concurrent);
+                InterlockedMax(ref maxSeen, now);
+                await Task.Delay(5);
+                Interlocked.Decrement(ref concurrent);
+            });
+        await refresh.Current;
 
         await Assert.That(maxSeen).IsEqualTo(1);
     }
@@ -79,15 +81,17 @@ public class SingleFlightRefreshTests {
         var refresh = new SingleFlightRefresh();
         Exception? observed = null;
 
-        await refresh.RequestAsync(() => throw new InvalidOperationException("probe blew up"),
+        refresh.Trigger(() => throw new InvalidOperationException("probe blew up"),
             ex => observed = ex);
+        await refresh.Current;
 
         await Assert.That(observed).IsNotNull();
         await Assert.That(observed!.Message).IsEqualTo("probe blew up");
 
         // The gate still works afterwards.
         var ran = false;
-        await refresh.RequestAsync(() => { ran = true; return Task.CompletedTask; });
+        refresh.Trigger(() => { ran = true; return Task.CompletedTask; });
+        await refresh.Current;
         await Assert.That(ran).IsTrue();
     }
 
@@ -101,19 +105,46 @@ public class SingleFlightRefreshTests {
         var tick        = 0;
         var passStarts  = new List<int>();
 
-        var first = refresh.RequestAsync(async () => {
+        refresh.Trigger(async () => {
             lock (passStarts) passStarts.Add(Interlocked.Increment(ref tick));
             if (passStarts.Count == 1) { started.SetResult(); await release.Task; }
         });
 
         await started.Task;
         requestedAt = Interlocked.Increment(ref tick);
-        await refresh.RequestAsync(() => Task.CompletedTask);
+        refresh.Trigger(() => Task.CompletedTask);
         release.SetResult();
-        await first;
+        await refresh.Current;
 
         await Assert.That(passStarts.Count).IsEqualTo(2);
         await Assert.That(passStarts[1]).IsGreaterThan(requestedAt);
+    }
+
+
+    // Codex review round 4: a DISCARDED task is not an asynchronous boundary. The refresh delegate
+    // computes capabilities synchronously (it shells out to probe CLI versions) before awaiting
+    // anything, so `_ = RequestAsync(...)` still ran the whole probe budget on the launch's stack.
+    // Trigger must return before a delegate that blocks synchronously has finished.
+    [Test] public async Task Trigger_returns_before_a_synchronously_blocking_delegate_completes() {
+        var refresh  = new SingleFlightRefresh();
+        var release  = new ManualResetEventSlim(false);
+        var entered  = new ManualResetEventSlim(false);
+
+        var before = Environment.TickCount64;
+        refresh.Trigger(() => {
+            entered.Set();
+            release.Wait(TimeSpan.FromSeconds(10));   // blocks the POOL thread, not the caller
+            return Task.CompletedTask;
+        });
+        var elapsed = Environment.TickCount64 - before;
+
+        // The delegate is running (or about to), and we are already back.
+        await Assert.That(elapsed).IsLessThan(2000)
+            .Because("Trigger must schedule the work, not run its synchronous prefix inline");
+
+        entered.Wait(TimeSpan.FromSeconds(10));
+        release.Set();
+        await refresh.Current;
     }
 
     static void InterlockedMax(ref int target, int value) {


### PR DESCRIPTION
A transient `claude --version` probe timeout at daemon registration could disable the reviewer for the daemon's **entire lifetime** — and survive the restart the error message told you to do.

Surfaced while running [AI-1489](https://linear.app/kurrent/issue/AI-1489) leg 3a (Codex driver → Claude reviewer). Three attempts each failed differently; **one defect explains all of them.**

## The defect

`DaemonRunner.ProbeCliVersion` shelled out with a **3-second timeout, no retry**, returning `null` on timeout / non-start / any exception. That result is computed **once at registration** and advertised as `ExpectedCliVersion` for the daemon's whole lifetime. `claude` is a Node CLI whose cold start routinely exceeds 3s on a loaded host.

One transient failure then produced **either**:

1. **The vendor isn't advertised at all** — the server can't range-check a null, so it drops out of the unattended set:
   `reviewer_vendor_unavailable: connected daemons … do not advertise vendor 'claude'`
2. **Every launch is rejected** — the launch-time arm demanded exact equality between a freshly-probed version and the advertised null:
   ```csharp
   && string.Equals(version, certification.ExpectedCliVersion, StringComparison.Ordinal)
   ```
   → `null != "2.1.212"` → `reviewer_certification_changed`

**(2) survives its own documented remedy.** Restarting on a still-loaded host re-poisons the advertisement — exactly what happened between attempts 2 and 3.

| attempt | host load | result | arm |
|---|---|---|---|
| 1 | ~33 | `no_daemon_available` | contention, unrelated |
| 2 | quiet | `reviewer_vendor_unavailable` | outcome 1 |
| 3 | quiet, but restarted at load ~40 | `reviewer_certification_changed` | outcome 2 |

Claude CLI was **2.1.212** throughout — on the daemon's PATH, inside the configured `>=2.0.0 <3.0.0`. Nothing about the install was ever wrong.

## What changed

**1. The probe retries.** 3 attempts, 250/500ms backoff, 10s budget. A cold Node start under load is not an error condition.

**2. The equality arm no longer treats a null advertisement as a mismatch.** That arm exists to catch a CLI **swap** between advertisement and launch; null-vs-value is not a swap. A null or empty advertised version now falls through to the **range check**, which is the real gate — and a test proves an out-of-range CLI is *still* rejected when the advertisement is null, so the relaxation doesn't gut the arm. A genuine swap is still rejected.

**3. The rejection names the failing arm.** Four distinguishable conditions collapsed into one message that reported the certification **revision** — which matches on every one of these paths — and told the operator to update a CLI that was correct and in range.

This was already recommended in [AI-1512](https://linear.app/kurrent/issue/AI-1512) when the *same* message was hit from a *different* arm (empty `AllowedCliRanges` read as deny-all). That fix shipped in kcap-server#1183, **server-side only** — the daemon message never changed, which is why this incident took a full diagnosis instead of a glance.

Each arm now states its cause **and** the remedy that applies to it:

| arm | message |
|---|---|
| vendor | `the launch is for 'codex' but the certification is for 'claude'` |
| reconnect | `this daemon reconnected after the certification was issued (connection id changed) — retry the flow` |
| policy | `the server requires launcher policy 'X' but this daemon implements 'Y' — update kcap and restart the daemon` |
| CLI swap | `the installed claude CLI is '2.9.9' but this daemon advertised '2.1.212' at registration — restart the daemon so it re-advertises` |
| range | `the installed claude CLI '1.0.0' is outside the server's allowed range '>=2.0.0 <3.0.0'` |

A probe failure renders as `(version probe failed)` rather than an empty string, which would read as "the CLI reports no version".

## Testability

The arm logic was a single inline boolean expression inside a large method — untestable. Extracted to an internal `EvaluateReviewerCertification`.

**9 tests**, including: the null/empty advertisement no longer rejects; a genuine swap still does; the range check still bites when the advertisement is null; each arm names itself; and **no rejection mentions the revision** — the misdirection that cost the diagnosis.

29/29 in the neighbouring daemon suite, `check-linear-ids` clean.
