### PR TITLE
Bind stored tokens to their minting server; make whoami tell the truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,7 +1079,7 @@ Use `--keep-config` to preserve profiles, tokens, and ignore lists when you plan
 
 ```bash
 kcap status         # server health check
-kcap whoami         # show current authenticated user
+kcap whoami         # show current identity + ask the server if it accepts your token
 kcap login          # authenticate via OAuth (browser flow by default)
 kcap login --device # force device-code flow (use in SSH / headless envs)
 kcap update         # upgrade the CLI and refresh agent plugins (npm-global installs)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ When setup finishes, `kcap` sends a best-effort POST to the server's `/api/users
 
 > **Restart your coding agent for live recording to begin.** Hooks only load at session start, so a session that was already running when you ran setup keeps running without them and won't stream live. Start a new session (or `claude --continue`) to pick the hooks up — setup prints this reminder when it installs any hooks. A manual `kcap import` of the in-progress session only yields a frozen snapshot.
 
-Verify with `kcap whoami` and `kcap status`.
+Verify with `kcap whoami` and `kcap status`. `kcap whoami` prints your identity and the profile it
+resolved, then asks the server whether it actually accepts your token — it exits non-zero if the
+server rejects it, or if the token was issued by a different server than the profile now targets
+(re-run `kcap login`). If the server can't be reached it says so and still exits 0, so it stays
+usable offline.
 
 Setup closes by pointing you at the guided tour. Prompt your agent with **"Start kcap guided tour"**
 (or, in Claude Code, `/kcap:guided-tour`) to see what your team has recorded and work through

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -19,7 +19,13 @@ public static class AuthProvider {
 public enum GitHubFlow { Browser, Device }
 
 public static class OAuthLoginFlow {
-    public static async Task<int> LoginWithDiscoveryAsync(string serverUrl, bool forceDevice) {
+    /// <param name="profile">
+    /// Target profile for the saved token. Null means "whichever profile this process resolved" —
+    /// correct for `kcap login`. `kcap setup` passes its chosen profile explicitly, because it
+    /// deliberately configures the on-disk active profile even when the current directory resolves
+    /// to a different one, and its token must land in the same place its config does.
+    /// </param>
+    public static async Task<int> LoginWithDiscoveryAsync(string serverUrl, bool forceDevice, string? profile = null) {
         // ReSharper disable once ShortLivedHttpClient
         using var http = new HttpClient();
 
@@ -43,8 +49,8 @@ public static class OAuthLoginFlow {
 
         return config.Provider switch {
             AuthProvider.None      => HandleNoneLogin(),
-            AuthProvider.GitHubApp => await HandleGitHubLogin(serverUrl, config, forceDevice),
-            AuthProvider.WorkOS    => await HandleWorkOSLogin(config),
+            AuthProvider.GitHubApp => await HandleGitHubLogin(serverUrl, config, forceDevice, profile),
+            AuthProvider.WorkOS    => await HandleWorkOSLogin(serverUrl, config, profile),
             _                      => HandleUnknownProvider(config.Provider)
         };
     }
@@ -317,7 +323,8 @@ public static class OAuthLoginFlow {
                 AccessToken    = exchange.AccessToken,
                 ExpiresAt      = DateTimeOffset.UtcNow.AddSeconds(exchange.ExpiresIn),
                 GitHubUsername = exchange.Username,
-                Provider       = provider
+                Provider       = provider,
+                ServerUrl      = ServerIdentity.Canonicalize(serverUrl)
             }
         );
 
@@ -370,7 +377,8 @@ public static class OAuthLoginFlow {
                 AccessToken    = exchange.AccessToken,
                 ExpiresAt      = DateTimeOffset.UtcNow.AddSeconds(exchange.ExpiresIn),
                 GitHubUsername = exchange.Username,
-                Provider       = provider
+                Provider       = provider,
+                ServerUrl      = ServerIdentity.Canonicalize(serverUrl)
             }
         );
 
@@ -425,12 +433,14 @@ public static class OAuthLoginFlow {
         }
     }
 
-    static async Task<int> HandleGitHubLogin(string serverUrl, AuthDiscoveryResponse config, bool forceDevice) {
+    static async Task<int> HandleGitHubLogin(string serverUrl, AuthDiscoveryResponse config, bool forceDevice, string? profile = null) {
         var accessToken = await AcquireGitHubTokenAsync(config.GithubClientId!, config.GithubCodeExchangeUrl, forceDevice);
 
         if (accessToken is null) return 1;
 
-        return await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider);
+        return profile is null
+            ? await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider)
+            : await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider, profile);
     }
 
     internal static async Task<string?> AcquireGitHubTokenAsync(string clientId, string? codeExchangeUrl, bool forceDevice) {
@@ -454,8 +464,8 @@ public static class OAuthLoginFlow {
         return await RunDeviceFlowAsync(clientId);
     }
 
-    static Task<int> HandleWorkOSLogin(AuthDiscoveryResponse config) =>
-        LoginWorkOSAsync(config.ClientId!, config.OrganizationId);
+    static Task<int> HandleWorkOSLogin(string serverUrl, AuthDiscoveryResponse config, string? profile = null) =>
+        LoginWorkOSAsync(serverUrl, config.ClientId!, config.OrganizationId, profile);
 
     const string WorkOSApiBase = "https://api.workos.com";
 
@@ -532,7 +542,7 @@ public static class OAuthLoginFlow {
                       + (string.IsNullOrEmpty(description) ? "" : $" — {description}")
     };
 
-    static async Task<int> LoginWorkOSAsync(string clientId, string? organizationId) {
+    static async Task<int> LoginWorkOSAsync(string serverUrl, string clientId, string? organizationId, string? profile = null) {
         // AuthenticateWorkOSAsync already reported the specific failure reason to stderr.
         var json = await AuthenticateWorkOSAsync(clientId, organizationId, new LoopbackBrowser());
         if (json is null) return 1;
@@ -547,16 +557,20 @@ public static class OAuthLoginFlow {
 
         var username = WorkOSDisplayName(json.User);
 
-        await TokenStore.SaveAsync(
-            new() {
-                AccessToken    = json.AccessToken,
-                RefreshToken   = json.RefreshToken,
-                ExpiresAt      = TokenStore.JwtExpiry(json.AccessToken),
-                GitHubUsername = username,
-                Provider       = AuthProvider.WorkOS,
-                ClientId       = clientId
-            }
-        );
+        var saved = new StoredTokens {
+            AccessToken    = json.AccessToken,
+            RefreshToken   = json.RefreshToken,
+            ExpiresAt      = TokenStore.JwtExpiry(json.AccessToken),
+            GitHubUsername = username,
+            Provider       = AuthProvider.WorkOS,
+            ClientId       = clientId,
+            // The kcap server we authenticated FOR — not api.workos.com, which issued the
+            // token but says nothing about which Capacitor server will accept it.
+            ServerUrl      = ServerIdentity.Canonicalize(serverUrl)
+        };
+
+        if (profile is null) await TokenStore.SaveAsync(saved);
+        else await TokenStore.SaveAsync(profile, saved);
 
         await Console.Out.WriteLineAsync($"Logged in as {username}");
 

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -318,13 +318,19 @@ public static class OAuthLoginFlow {
 
         var exchange = (await exchangeResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.TokenExchangeResponse))!;
 
+        if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
+            Console.Error.WriteLine($"Error: {identityError}");
+
+            return 1;
+        }
+
         await TokenStore.SaveAsync(
             new() {
                 AccessToken    = exchange.AccessToken,
                 ExpiresAt      = DateTimeOffset.UtcNow.AddSeconds(exchange.ExpiresIn),
                 GitHubUsername = exchange.Username,
                 Provider       = provider,
-                ServerUrl      = ServerIdentity.Canonicalize(serverUrl)
+                ServerUrl      = canonical
             }
         );
 
@@ -371,6 +377,12 @@ public static class OAuthLoginFlow {
 
         var exchange = (await exchangeResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.TokenExchangeResponse))!;
 
+        if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
+            Console.Error.WriteLine($"Error: {identityError}");
+
+            return 1;
+        }
+
         await TokenStore.SaveAsync(
             profile,
             new StoredTokens {
@@ -378,7 +390,7 @@ public static class OAuthLoginFlow {
                 ExpiresAt      = DateTimeOffset.UtcNow.AddSeconds(exchange.ExpiresIn),
                 GitHubUsername = exchange.Username,
                 Provider       = provider,
-                ServerUrl      = ServerIdentity.Canonicalize(serverUrl)
+                ServerUrl      = canonical
             }
         );
 
@@ -557,6 +569,12 @@ public static class OAuthLoginFlow {
 
         var username = WorkOSDisplayName(json.User);
 
+        if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
+            Console.Error.WriteLine($"Error: {identityError}");
+
+            return 1;
+        }
+
         var saved = new StoredTokens {
             AccessToken    = json.AccessToken,
             RefreshToken   = json.RefreshToken,
@@ -566,7 +584,7 @@ public static class OAuthLoginFlow {
             ClientId       = clientId,
             // The kcap server we authenticated FOR — not api.workos.com, which issued the
             // token but says nothing about which Capacitor server will accept it.
-            ServerUrl      = ServerIdentity.Canonicalize(serverUrl)
+            ServerUrl      = canonical
         };
 
         if (profile is null) await TokenStore.SaveAsync(saved);

--- a/src/Capacitor.Cli.Core/Auth/ServerIdentity.cs
+++ b/src/Capacitor.Cli.Core/Auth/ServerIdentity.cs
@@ -31,6 +31,29 @@ public static class ServerIdentity {
     }
 
     /// <summary>
+    /// Canonical form for stamping onto a freshly minted token, or an error message naming the
+    /// problem. A null <c>ServerUrl</c> means "pre-upgrade token, binding unenforced", so a NEW
+    /// token must never be saved with one: silently storing null here would downgrade a token we
+    /// could have bound into one that any server is allowed to receive.
+    /// </summary>
+    public static bool TryCanonicalizeForStamping(string? url, out string canonical, out string error) {
+        var result = Canonicalize(url);
+
+        if (result is null) {
+            canonical = "";
+            error     = $"Server URL '{url}' is not usable as a server identity — it must be an "
+                      + "absolute http(s) URL with no user info, query string, or fragment.";
+
+            return false;
+        }
+
+        canonical = result;
+        error     = "";
+
+        return true;
+    }
+
+    /// <summary>
     /// True when both sides name the same server. A non-canonicalizable side never matches:
     /// we fail closed to "no binding assertion can be made" rather than to a false match.
     /// </summary>

--- a/src/Capacitor.Cli.Core/Auth/ServerIdentity.cs
+++ b/src/Capacitor.Cli.Core/Auth/ServerIdentity.cs
@@ -1,0 +1,43 @@
+namespace Capacitor.Cli.Core.Auth;
+
+/// <summary>
+/// Canonical identity for a Capacitor server URL — the comparison used to decide whether a
+/// stored token may be presented to a given server.
+///
+/// Whole-string comparison is not safe here: <c>https://x</c> and <c>https://x:443</c> are the
+/// same server, host casing is irrelevant, but a path IS significant (path-routed deployments)
+/// and is case-sensitive per HTTP. A configured server URL is a request base, so userinfo,
+/// query and fragment are rejected outright rather than silently dropped — dropping them would
+/// make <c>https://host/base?tenant=a</c> and <c>?tenant=b</c> compare equal.
+/// </summary>
+public static class ServerIdentity {
+    /// <summary>
+    /// Canonical form of <paramref name="url"/>, or <c>null</c> when it is not an admissible
+    /// server base (unparseable, relative, non-http(s), or carrying userinfo/query/fragment).
+    /// </summary>
+    public static string? Canonicalize(string? url) {
+        if (string.IsNullOrWhiteSpace(url)) return null;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return null;
+        if (uri.Scheme is not ("http" or "https")) return null;
+        if (!string.IsNullOrEmpty(uri.UserInfo)) return null;
+        if (!string.IsNullOrEmpty(uri.Query)) return null;
+        if (!string.IsNullOrEmpty(uri.Fragment)) return null;
+
+        // Uri lowercases scheme and host (and IDN-normalizes the host) for us; Port is the
+        // effective port, so an implicit and an explicit default port converge here.
+        var path = uri.AbsolutePath.TrimEnd('/');
+
+        return $"{uri.Scheme}://{uri.Host}:{uri.Port}{path}";
+    }
+
+    /// <summary>
+    /// True when both sides name the same server. A non-canonicalizable side never matches:
+    /// we fail closed to "no binding assertion can be made" rather than to a false match.
+    /// </summary>
+    public static bool SameServer(string? left, string? right) {
+        var a = Canonicalize(left);
+        var b = Canonicalize(right);
+
+        return a is not null && b is not null && string.Equals(a, b, StringComparison.Ordinal);
+    }
+}

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -315,7 +315,10 @@ public static class TokenStore {
             return new(null, AuthStatus.WrongServer, snapshot.ServerUrl, profile);
         }
 
-        var valid = await GetValidTokensAsync();
+        // Pinned to the profile resolved above: re-resolving here would let a concurrent
+        // `kcap use` switch profiles mid-call and return another profile's token while
+        // TokenResolution.ProfileName still names the first one.
+        var valid = await GetValidTokensForProfileAsync(profile, ct);
 
         if (valid is null) {
             return new(null, AuthStatus.Expired, snapshot.ServerUrl, profile);
@@ -336,8 +339,47 @@ public static class TokenStore {
     static bool BoundToTarget(StoredTokens tokens, string targetBaseUrl) =>
         tokens.ServerUrl is null || ServerIdentity.SameServer(tokens.ServerUrl, targetBaseUrl);
 
-    public static async Task<StoredTokens?> GetValidTokensAsync() {
-        var tokens = await LoadAsync();
+    /// <summary>
+    /// Recovers a usable token after the server rejected <paramref name="rejectedAccessToken"/>.
+    ///
+    /// Rotation is attempted first. If it fails, the fallback is a RAW read — deliberately not the
+    /// refresh-aware accessor, which would see the same expired token and refresh a second time,
+    /// re-spending a WorkOS refresh token that is single-use.
+    ///
+    /// The raw result is returned even when it equals the rejected token. Resending it is usually
+    /// futile, but it is the recovery that shipped (a server that rejected transiently — a rolling
+    /// restart, a node with stale key material — accepts the very next attempt), and the callers
+    /// retry at most once either way.
+    /// </summary>
+    public static async Task<StoredTokens?> RecoverForServerAsync(
+            string targetBaseUrl, string rejectedAccessToken, CancellationToken ct = default) {
+        var rotated = await ForceRefreshAsync(rejectedAccessToken, targetBaseUrl, ct);
+
+        if (rotated is not null) return rotated;
+
+        var profile = await ResolveActiveProfileAsync(ct);
+        var stored  = await LoadWithLegacyFallbackAsync(profile, ct);
+
+        if (stored is null) return null;
+
+        return BoundToTarget(stored, targetBaseUrl) ? stored : null;
+    }
+
+    /// <summary>
+    /// Raw, refresh-free read for an explicitly named profile (honouring the owner-scoped legacy
+    /// fallback). For diagnostics that must observe exactly what is on disk without mutating it.
+    /// </summary>
+    public static Task<StoredTokens?> LoadForProfileAsync(string profile, CancellationToken ct = default) =>
+        LoadWithLegacyFallbackAsync(profile, ct);
+
+    public static async Task<StoredTokens?> GetValidTokensAsync() =>
+        await GetValidTokensForProfileAsync(await ResolveActiveProfileAsync());
+
+    // Load-and-refresh for ONE profile, resolved by the caller. Everything that refreshes goes
+    // through here so a single call never resolves the profile twice and can't straddle a
+    // concurrent profile switch.
+    static async Task<StoredTokens?> GetValidTokensForProfileAsync(string profile, CancellationToken ct = default) {
+        var tokens = await LoadWithLegacyFallbackAsync(profile, ct);
 
         if (tokens is null) {
             return null;
@@ -346,8 +388,6 @@ public static class TokenStore {
         if (!tokens.IsExpired) {
             return tokens;
         }
-
-        var profile = await ResolveActiveProfileAsync();
 
         // Both providers rotate/re-issue on refresh, so serialize across processes
         // (hooks, watcher, daemon, MCP share one token store) with a profile-scoped

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -279,6 +279,13 @@ public static class TokenStore {
     // An explicit --server-url / KCAP_URL override resolves no profile name at all (the resolver
     // returns null there), which correctly falls through to the on-disk active profile — the
     // server-binding check is what protects that path.
+    /// <summary>
+    /// The profile whose token file this process reads — exposed for diagnostics that need to
+    /// report it without triggering a load or refresh.
+    /// </summary>
+    public static Task<string> ResolveProfileNameAsync(CancellationToken ct = default) =>
+        ResolveActiveProfileAsync(ct);
+
     static async Task<string> ResolveActiveProfileAsync(CancellationToken ct = default) {
         if (AppConfig.ResolvedProfile?.ProfileName is { Length: > 0 } resolved) return resolved;
 
@@ -304,16 +311,30 @@ public static class TokenStore {
             return new(null, AuthStatus.NotAuthenticated, null, profile);
         }
 
-        if (snapshot.ServerUrl is not null && !ServerIdentity.SameServer(snapshot.ServerUrl, targetBaseUrl)) {
+        if (!BoundToTarget(snapshot, targetBaseUrl)) {
             return new(null, AuthStatus.WrongServer, snapshot.ServerUrl, profile);
         }
 
         var valid = await GetValidTokensAsync();
 
-        return valid is not null
+        if (valid is null) {
+            return new(null, AuthStatus.Expired, snapshot.ServerUrl, profile);
+        }
+
+        // Re-check: the load/refresh above re-reads storage, so a concurrent login or profile
+        // repoint could have replaced the token we vetted with one for a different server.
+        // Checking only the first snapshot would let that replacement through.
+        return BoundToTarget(valid, targetBaseUrl)
             ? new(valid, AuthStatus.Ok, valid.ServerUrl, profile)
-            : new(null, AuthStatus.Expired, snapshot.ServerUrl, profile);
+            : new(null, AuthStatus.WrongServer, valid.ServerUrl, profile);
     }
+
+    /// <summary>
+    /// Whether <paramref name="tokens"/> may be presented to <paramref name="targetBaseUrl"/>.
+    /// An unbound (pre-upgrade) token is permitted — there is nothing to contradict.
+    /// </summary>
+    static bool BoundToTarget(StoredTokens tokens, string targetBaseUrl) =>
+        tokens.ServerUrl is null || ServerIdentity.SameServer(tokens.ServerUrl, targetBaseUrl);
 
     public static async Task<StoredTokens?> GetValidTokensAsync() {
         var tokens = await LoadAsync();
@@ -355,8 +376,14 @@ public static class TokenStore {
     /// rotate a credential that was never rejected — and for WorkOS, whose refresh token is
     /// single-use, that is a real cost, not just extra traffic.
     /// </summary>
+    /// <param name="expectedServerUrl">
+    /// The server the caller is about to retry against. The lock may hand back a token a PEER
+    /// process persisted rather than one we rotated, and that peer could have logged into a
+    /// different server — so the adopted token is binding-checked before it is returned. Callers
+    /// that have no target (there are none today) may pass null to skip the check.
+    /// </param>
     public static async Task<StoredTokens?> ForceRefreshAsync(
-            string rejectedAccessToken, CancellationToken ct = default) {
+            string rejectedAccessToken, string? expectedServerUrl = null, CancellationToken ct = default) {
         var profile = await ResolveActiveProfileAsync(ct);
         var tokens = await LoadWithLegacyFallbackAsync(profile, ct);
         if (tokens is null) return null;
@@ -369,12 +396,16 @@ public static class TokenStore {
         };
         if (tokens.Provider is not (AuthProvider.WorkOS or AuthProvider.GitHubApp)) return null;
 
-        return await RefreshWithCrossProcessLockAsync(
+        var refreshed = await RefreshWithCrossProcessLockAsync(
             profile,
             tokens,
             refresh,
             needsRefresh: t => string.Equals(t.AccessToken, rejectedAccessToken, StringComparison.Ordinal),
             cancellationToken: ct);
+
+        if (refreshed is null || expectedServerUrl is null) return refreshed;
+
+        return BoundToTarget(refreshed, expectedServerUrl) ? refreshed : null;
     }
 
     // The decision the daemon's proactive-refresh tick makes each time it wakes. Kept a

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -24,8 +24,29 @@ public record StoredTokens {
     [JsonPropertyName("client_id")]
     public string? ClientId { get; init; }
 
+    /// <summary>
+    /// Canonical URL of the server that minted this token (see <see cref="ServerIdentity"/>).
+    /// Null on files written before this field existed — those stay unenforced and are stamped
+    /// the next time a login or an unambiguous refresh rewrites them.
+    /// </summary>
+    [JsonPropertyName("server_url")]
+    public string? ServerUrl { get; init; }
+
     public bool IsExpired => DateTimeOffset.UtcNow >= ExpiresAt - TimeSpan.FromSeconds(30);
 }
+
+/// <summary>
+/// Outcome of resolving a token for a specific target server. <see cref="Tokens"/> is non-null
+/// only when <see cref="Status"/> is <see cref="AuthStatus.Ok"/> — a token bound to a different
+/// server is never handed out. <see cref="IssuedServerUrl"/> carries the (non-secret) diagnostic
+/// from the SAME snapshot the decision was made on, so a caller never has to re-read storage to
+/// build its message and can't race a concurrent profile/token change into a mismatched one.
+/// </summary>
+public sealed record TokenResolution(
+    StoredTokens? Tokens,
+    AuthStatus    Status,
+    string?       IssuedServerUrl,
+    string        ProfileName);
 
 // Outcome of a proactive-refresh tick (<see cref="TokenStore.RefreshIfExpiringAsync"/>).
 // NotDue = no-op (no tokens, the None provider, or the token still comfortably valid);
@@ -198,17 +219,34 @@ public static class TokenStore {
     // file is "not authenticated" — do NOT resurrect stale credentials from a legacy file whose
     // best-effort deletion previously failed. Shared by LoadAsync() and RefreshIfExpiringAsync so
     // both get the legacy fallback without re-resolving the active profile.
-    static async Task<StoredTokens?> LoadWithLegacyFallbackAsync(string profile) {
+    //
+    // The legacy file is a single global credential belonging to whichever profile was active
+    // before the per-profile store existed — its migration owner. Now that lookup follows the
+    // RESOLVED profile, an unscoped fallback would hand that credential to any repo-resolved
+    // profile that simply has no token yet (and it carries no ServerUrl, so the binding check
+    // can't catch it either). Restrict it to the migration owner.
+    static async Task<StoredTokens?> LoadWithLegacyFallbackAsync(string profile, CancellationToken ct = default) {
         var (state, tokens) = await ReadTokenFileAsync(ProfileTokenPath(profile));
 
         if (state == TokenFileState.Loaded) return tokens;
 
-        if (state == TokenFileState.Missing) {
+        if (state == TokenFileState.Missing && await IsLegacyOwnerAsync(profile, ct)) {
             var (_, legacy) = await ReadTokenFileAsync(LegacyTokenPath);
             return legacy;
         }
 
-        return null; // Unusable (corrupt) active profile
+        return null; // Unusable (corrupt), or a profile that doesn't own the legacy credential
+    }
+
+    // The legacy credential's owner is the on-disk active profile, with an absent/empty value
+    // normalizing to "default". Note this is deliberately NOT "profile == active || profile ==
+    // default": with active profile Y configured, a resolution that lands on "default" must not
+    // pick up Y's legacy credential.
+    static async Task<bool> IsLegacyOwnerAsync(string profile, CancellationToken ct) {
+        var cfg    = await AppConfig.LoadProfileConfig(ct);
+        var active = string.IsNullOrEmpty(cfg.ActiveProfile) ? "default" : cfg.ActiveProfile;
+
+        return string.Equals(profile, active, StringComparison.Ordinal);
     }
 
     public static async Task SaveAsync(StoredTokens tokens) {
@@ -235,9 +273,46 @@ public static class TokenStore {
         return Task.CompletedTask;
     }
 
+    // Which profile's token file this process should use. Prefer the profile the rest of the
+    // process already resolved (KCAP_PROFILE, repo .kcap.json, git-remote match, `kcap use`
+    // binding) so a repo bound to profile X doesn't silently send the active profile's token.
+    // An explicit --server-url / KCAP_URL override resolves no profile name at all (the resolver
+    // returns null there), which correctly falls through to the on-disk active profile — the
+    // server-binding check is what protects that path.
     static async Task<string> ResolveActiveProfileAsync(CancellationToken ct = default) {
+        if (AppConfig.ResolvedProfile?.ProfileName is { Length: > 0 } resolved) return resolved;
+
         var cfg = await AppConfig.LoadProfileConfig(ct);
         return string.IsNullOrEmpty(cfg.ActiveProfile) ? "default" : cfg.ActiveProfile;
+    }
+
+    /// <summary>
+    /// Resolves a token for a specific target server. This is the ONLY way a bearer token should
+    /// reach an outgoing request: a token bound to a different server is withheld here, before any
+    /// network call, instead of being sent and rejected with an opaque 401 the CLI cannot explain.
+    ///
+    /// The binding check deliberately runs on the raw snapshot BEFORE any refresh — refreshing a
+    /// token we are about to refuse to use would spend a rotating credential (and a round-trip to
+    /// its own server) for nothing.
+    /// </summary>
+    public static async Task<TokenResolution> GetValidTokensForServerAsync(
+            string targetBaseUrl, CancellationToken ct = default) {
+        var profile  = await ResolveActiveProfileAsync(ct);
+        var snapshot = await LoadWithLegacyFallbackAsync(profile, ct);
+
+        if (snapshot is null) {
+            return new(null, AuthStatus.NotAuthenticated, null, profile);
+        }
+
+        if (snapshot.ServerUrl is not null && !ServerIdentity.SameServer(snapshot.ServerUrl, targetBaseUrl)) {
+            return new(null, AuthStatus.WrongServer, snapshot.ServerUrl, profile);
+        }
+
+        var valid = await GetValidTokensAsync();
+
+        return valid is not null
+            ? new(valid, AuthStatus.Ok, valid.ServerUrl, profile)
+            : new(null, AuthStatus.Expired, snapshot.ServerUrl, profile);
     }
 
     public static async Task<StoredTokens?> GetValidTokensAsync() {
@@ -273,10 +348,17 @@ public static class TokenStore {
     /// Forces one provider refresh even when the locally cached access token has not expired.
     /// Used only after a server 401 proves that the otherwise-valid token is no longer accepted.
     /// The existing profile-scoped lock still serializes rotating credentials across processes.
+    ///
+    /// <paramref name="rejectedAccessToken"/> is the token the failing request actually sent.
+    /// Refreshing is conditional on the persisted token still BEING that one: if a peer process
+    /// rotated in between, its fresh token is adopted as-is. Refreshing unconditionally would
+    /// rotate a credential that was never rejected — and for WorkOS, whose refresh token is
+    /// single-use, that is a real cost, not just extra traffic.
     /// </summary>
-    public static async Task<StoredTokens?> ForceRefreshAsync(CancellationToken ct = default) {
+    public static async Task<StoredTokens?> ForceRefreshAsync(
+            string rejectedAccessToken, CancellationToken ct = default) {
         var profile = await ResolveActiveProfileAsync(ct);
-        var tokens = await LoadWithLegacyFallbackAsync(profile);
+        var tokens = await LoadWithLegacyFallbackAsync(profile, ct);
         if (tokens is null) return null;
 
         Func<StoredTokens, Task<StoredTokens?>> refresh = tokens.Provider switch {
@@ -288,7 +370,11 @@ public static class TokenStore {
         if (tokens.Provider is not (AuthProvider.WorkOS or AuthProvider.GitHubApp)) return null;
 
         return await RefreshWithCrossProcessLockAsync(
-            profile, tokens, refresh, needsRefresh: static _ => true, cancellationToken: ct);
+            profile,
+            tokens,
+            refresh,
+            needsRefresh: t => string.Equals(t.AccessToken, rejectedAccessToken, StringComparison.Ordinal),
+            cancellationToken: ct);
     }
 
     // The decision the daemon's proactive-refresh tick makes each time it wakes. Kept a
@@ -495,8 +581,16 @@ public static class TokenStore {
         RefreshGitHubAsync(tokens, CancellationToken.None);
 
     static async Task<StoredTokens?> RefreshGitHubAsync(StoredTokens tokens, CancellationToken ct) {
-        var baseUrl = AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KCAP_URL") ?? "http://localhost:5108";
-        var url     = $"{baseUrl}/auth/refresh";
+        // A bound token refreshes against the server that minted it: /auth/refresh validates the
+        // existing token's signature, so posting it anywhere else can only fail — and would leak
+        // it to a server that never issued it.
+        var configured = AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KCAP_URL");
+        var baseUrl    = tokens.ServerUrl ?? configured ?? "http://localhost:5108";
+        var url        = $"{baseUrl}/auth/refresh";
+
+        // Stamp an unbound (pre-upgrade) token only when the endpoint came from real configuration.
+        // The localhost default is a fallback, not evidence of where the token was minted.
+        var stamped = tokens.ServerUrl ?? (configured is not null ? ServerIdentity.Canonicalize(configured) : null);
 
         // PostWithRetryAsync runs EnsureAbsolute, which Environment.Exit(2)s on a scheme-less URL.
         // Refresh is reached from daemon/background callers via GetValidTokensAsync and must fail
@@ -534,7 +628,8 @@ public static class TokenStore {
             // written to the wrong profile if the active profile changes mid-refresh.
             return tokens with {
                 AccessToken = json.AccessToken,
-                ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(json.ExpiresIn)
+                ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(json.ExpiresIn),
+                ServerUrl = stamped
             };
         } catch {
             return null;

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -353,12 +353,14 @@ public static class TokenStore {
     /// </summary>
     public static async Task<StoredTokens?> RecoverForServerAsync(
             string targetBaseUrl, string rejectedAccessToken, CancellationToken ct = default) {
-        var rotated = await ForceRefreshAsync(rejectedAccessToken, targetBaseUrl, ct);
+        // Resolved ONCE for the whole operation: the rotation and the fallback read must describe
+        // the same profile even if `kcap use` runs during a slow rotation.
+        var profile = await ResolveActiveProfileAsync(ct);
+        var rotated = await ForceRefreshForProfileAsync(profile, rejectedAccessToken, targetBaseUrl, ct);
 
         if (rotated is not null) return rotated;
 
-        var profile = await ResolveActiveProfileAsync(ct);
-        var stored  = await LoadWithLegacyFallbackAsync(profile, ct);
+        var stored = await LoadWithLegacyFallbackAsync(profile, ct);
 
         if (stored is null) return null;
 
@@ -423,8 +425,15 @@ public static class TokenStore {
     /// that have no target (there are none today) may pass null to skip the check.
     /// </param>
     public static async Task<StoredTokens?> ForceRefreshAsync(
-            string rejectedAccessToken, string? expectedServerUrl = null, CancellationToken ct = default) {
-        var profile = await ResolveActiveProfileAsync(ct);
+            string rejectedAccessToken, string? expectedServerUrl = null, CancellationToken ct = default) =>
+        await ForceRefreshForProfileAsync(
+            await ResolveActiveProfileAsync(ct), rejectedAccessToken, expectedServerUrl, ct);
+
+    // Forced rotation for ONE profile, resolved by the caller — so a recovery that rotates and
+    // then falls back to a raw read cannot straddle a concurrent `kcap use` and return a
+    // different profile's token than the one it just tried to rotate.
+    static async Task<StoredTokens?> ForceRefreshForProfileAsync(
+            string profile, string rejectedAccessToken, string? expectedServerUrl, CancellationToken ct) {
         var tokens = await LoadWithLegacyFallbackAsync(profile, ct);
         if (tokens is null) return null;
 

--- a/src/Capacitor.Cli.Core/Auth/UnauthorizedRetryHandler.cs
+++ b/src/Capacitor.Cli.Core/Auth/UnauthorizedRetryHandler.cs
@@ -37,7 +37,7 @@ internal sealed class UnauthorizedRetryHandler(StoredTokens initial, string targ
         // `applied` — not a re-read of _current — is what this request actually sent. A peer
         // request may have refreshed in the meantime, and attributing the rejection to its fresh
         // token would rotate a credential that was never rejected.
-        var refreshed = await TokenStore.ForceRefreshAsync(applied.AccessToken, targetBaseUrl, cancellationToken);
+        var refreshed = await TokenStore.RecoverForServerAsync(targetBaseUrl, applied.AccessToken, cancellationToken);
 
         if (refreshed is null) return response; // Nothing better to try — surface the original 401.
 

--- a/src/Capacitor.Cli.Core/Auth/UnauthorizedRetryHandler.cs
+++ b/src/Capacitor.Cli.Core/Auth/UnauthorizedRetryHandler.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Capacitor.Cli.Core.Auth;
+
+/// <summary>
+/// Recovers from a single 401 by force-refreshing the token and resending once.
+///
+/// This exists because a token can be locally unexpired yet already rejected by the server
+/// (clock skew, a server-side invalidation, an early re-issue). Without it, every interactive
+/// command turns that into a hard failure telling the user to re-run `kcap login` when a refresh
+/// would have sufficed.
+///
+/// Only ONE component may own 401-retry on a given client, or a single rejection multiplies into
+/// several refreshes; this handler is installed exclusively by
+/// <c>HttpClientExtensions.CreateAuthenticatedClientAsync</c>, and call sites that used to run
+/// their own retry loop on top of that client have had theirs removed.
+/// </summary>
+internal sealed class UnauthorizedRetryHandler(StoredTokens initial) : DelegatingHandler {
+    // Swapped as a whole reference, never mutated in place, so concurrent requests either see the
+    // old token or the new one. Volatile because requests on a long-lived client run on many
+    // threads and a refresh on one must become visible to the rest.
+    StoredTokens _current = initial;
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) {
+        // Apply the handler's own token rather than trusting the client's default header: after a
+        // refresh, that default still carries the token the server already rejected.
+        var applied = Volatile.Read(ref _current);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", applied.AccessToken);
+
+        var response = await base.SendAsync(request, cancellationToken);
+
+        if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
+        if (!CanResend(request)) return response;
+
+        // `applied` — not a re-read of _current — is what this request actually sent. A peer
+        // request may have refreshed in the meantime, and attributing the rejection to its fresh
+        // token would rotate a credential that was never rejected.
+        var refreshed = await TokenStore.ForceRefreshAsync(applied.AccessToken, cancellationToken);
+
+        if (refreshed is null) return response; // Nothing better to try — surface the original 401.
+
+        Volatile.Write(ref _current, refreshed);
+        response.Dispose();
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", refreshed.AccessToken);
+
+        // base.SendAsync, not a recursive call into this method: exactly one extra attempt, so a
+        // second 401 reaches the caller instead of looping.
+        return await base.SendAsync(request, cancellationToken);
+    }
+
+    // Buffered content re-serializes from its byte array on every send; a stream-backed body is
+    // consumed by the first attempt and cannot be replayed. StringContent and FormUrlEncodedContent
+    // both derive from ByteArrayContent, so this covers every body the CLI sends.
+    static bool CanResend(HttpRequestMessage request) => request.Content is null or ByteArrayContent;
+}

--- a/src/Capacitor.Cli.Core/Auth/UnauthorizedRetryHandler.cs
+++ b/src/Capacitor.Cli.Core/Auth/UnauthorizedRetryHandler.cs
@@ -16,7 +16,7 @@ namespace Capacitor.Cli.Core.Auth;
 /// <c>HttpClientExtensions.CreateAuthenticatedClientAsync</c>, and call sites that used to run
 /// their own retry loop on top of that client have had theirs removed.
 /// </summary>
-internal sealed class UnauthorizedRetryHandler(StoredTokens initial) : DelegatingHandler {
+internal sealed class UnauthorizedRetryHandler(StoredTokens initial, string targetBaseUrl) : DelegatingHandler {
     // Swapped as a whole reference, never mutated in place, so concurrent requests either see the
     // old token or the new one. Volatile because requests on a long-lived client run on many
     // threads and a refresh on one must become visible to the rest.
@@ -37,7 +37,7 @@ internal sealed class UnauthorizedRetryHandler(StoredTokens initial) : Delegatin
         // `applied` — not a re-read of _current — is what this request actually sent. A peer
         // request may have refreshed in the meantime, and attributing the rejection to its fresh
         // token would rotate a credential that was never rejected.
-        var refreshed = await TokenStore.ForceRefreshAsync(applied.AccessToken, cancellationToken);
+        var refreshed = await TokenStore.ForceRefreshAsync(applied.AccessToken, targetBaseUrl, cancellationToken);
 
         if (refreshed is null) return response; // Nothing better to try — surface the original 401.
 
@@ -51,8 +51,10 @@ internal sealed class UnauthorizedRetryHandler(StoredTokens initial) : Delegatin
         return await base.SendAsync(request, cancellationToken);
     }
 
-    // Buffered content re-serializes from its byte array on every send; a stream-backed body is
-    // consumed by the first attempt and cannot be replayed. StringContent and FormUrlEncodedContent
-    // both derive from ByteArrayContent, so this covers every body the CLI sends.
-    static bool CanResend(HttpRequestMessage request) => request.Content is null or ByteArrayContent;
+    // Content that re-serializes on every send can be replayed; a stream-backed body is consumed
+    // by the first attempt and cannot. ByteArrayContent (and its StringContent /
+    // FormUrlEncodedContent subclasses) re-reads its buffer, and JsonContent re-serializes its
+    // value — omitting JsonContent would silently leave the JSON-posting call sites unprotected.
+    static bool CanResend(HttpRequestMessage request) =>
+        request.Content is null or ByteArrayContent or System.Net.Http.Json.JsonContent;
 }

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -149,7 +149,10 @@ public static class WorkOSDiscovery {
                 ExpiresAt      = TokenStore.JwtExpiry(switched.AccessToken),
                 GitHubUsername = username,
                 Provider       = AuthProvider.WorkOS,
-                ClientId       = clientId
+                ClientId       = clientId,
+                // The tenant's own origin: this token is org-scoped to the tenant we just switched
+                // into, and only that tenant's server will accept it.
+                ServerUrl      = ServerIdentity.Canonicalize(picked.Origin)
             });
 
         await Console.Out.WriteLineAsync($"Logged in as {username} → {picked.Label}");

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -135,6 +135,12 @@ public static class WorkOSDiscovery {
             return 1;
         }
 
+        if (!ServerIdentity.TryCanonicalizeForStamping(picked.Origin, out var canonical, out var identityError)) {
+            await Console.Error.WriteLineAsync($"Error: {identityError}");
+
+            return 1;
+        }
+
         var username = OAuthLoginFlow.WorkOSDisplayName(auth.User);
 
         var cfg = await AppConfig.LoadProfileConfig();
@@ -152,7 +158,7 @@ public static class WorkOSDiscovery {
                 ClientId       = clientId,
                 // The tenant's own origin: this token is org-scoped to the tenant we just switched
                 // into, and only that tenant's server will accept it.
-                ServerUrl      = ServerIdentity.Canonicalize(picked.Origin)
+                ServerUrl      = canonical
             });
 
         await Console.Out.WriteLineAsync($"Logged in as {username} → {picked.Label}");

--- a/src/Capacitor.Cli.Core/Config/AppConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/AppConfig.cs
@@ -249,6 +249,16 @@ public static class AppConfig {
         ResolvedProfile   = new ResolvedProfile(serverUrl, profileName, profile, null);
     }
 
+    /// <summary>
+    /// Test seam: clears the process-global resolved state. Token lookup consults
+    /// <see cref="ResolvedProfile"/>, so a value left behind by an earlier test would silently
+    /// redirect a later test's token reads to another profile.
+    /// </summary>
+    internal static void ResetResolvedStateForTesting() {
+        ResolvedServerUrl = null;
+        ResolvedProfile   = null;
+    }
+
     public static async Task<ProfileConfig> LoadProfileConfig(CancellationToken ct = default) {
         if (!File.Exists(ConfigPath))
             return new() { Profiles = new() { ["default"] = new() } };

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -78,13 +78,13 @@ public static class HttpClientExtensions {
         // A forced refresh is only meaningful for a token we already hold and that the server
         // just rejected; the binding check below still gates whether it may be used at all.
         if (rejectedAccessToken is not null) {
-            await TokenStore.ForceRefreshAsync(rejectedAccessToken, ct);
+            await TokenStore.ForceRefreshAsync(rejectedAccessToken, baseUrl, ct);
         }
 
         var resolution = await TokenStore.GetValidTokensForServerAsync(baseUrl, ct);
 
         if (resolution is { Status: AuthStatus.Ok, Tokens: not null }) {
-            var client = NewClient(autoRetryUnauthorized ? new UnauthorizedRetryHandler(resolution.Tokens) : null);
+            var client = NewClient(autoRetryUnauthorized ? new UnauthorizedRetryHandler(resolution.Tokens, baseUrl) : null);
             client.DefaultRequestHeaders.Authorization = new("Bearer", resolution.Tokens.AccessToken);
 
             return (client, AuthStatus.Ok, resolution);

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -75,10 +75,19 @@ public static class HttpClientExtensions {
             return (NewClient(), AuthStatus.NoAuthRequired, null); // No auth needed
         }
 
-        // A forced refresh is only meaningful for a token we already hold and that the server
-        // just rejected; the binding check below still gates whether it may be used at all.
+        // Recovery from a server rejection is self-contained: it already attempted a rotation and
+        // applied the binding check. Falling through to the resolving accessor afterwards would let
+        // an expired token be refreshed a SECOND time — re-spending a single-use WorkOS refresh
+        // token — so this path returns directly.
         if (rejectedAccessToken is not null) {
-            await TokenStore.ForceRefreshAsync(rejectedAccessToken, baseUrl, ct);
+            var recovered = await TokenStore.RecoverForServerAsync(baseUrl, rejectedAccessToken, ct);
+
+            if (recovered is null) return (NewClient(), AuthStatus.Expired, null);
+
+            var recoveredClient = NewClient(autoRetryUnauthorized ? new UnauthorizedRetryHandler(recovered, baseUrl) : null);
+            recoveredClient.DefaultRequestHeaders.Authorization = new("Bearer", recovered.AccessToken);
+
+            return (recoveredClient, AuthStatus.Ok, null);
         }
 
         var resolution = await TokenStore.GetValidTokensForServerAsync(baseUrl, ct);

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -24,6 +24,13 @@ public enum AuthStatus {
 
     /// <summary>No token is stored at all — login required.</summary>
     NotAuthenticated,
+
+    /// <summary>
+    /// A token is stored, but it was minted by a different server than the one being targeted.
+    /// No refresh can heal this (the server validates the token's own signature) — only a login
+    /// against the target server, or switching to the profile that owns it.
+    /// </summary>
+    WrongServer,
 }
 
 public static class HttpClientExtensions {
@@ -36,29 +43,54 @@ public static class HttpClientExtensions {
     /// </summary>
     public static async Task<(HttpClient Client, AuthStatus Status)> CreateClientWithAuthStatusAsync(
         string? baseUrl = null, CancellationToken ct = default, bool allowAutoRedirect = true,
-        bool forceRefresh = false) {
-        var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = allowAutoRedirect });
+        string? rejectedAccessToken = null) {
+        var (client, status, _) = await CreateClientCoreAsync(baseUrl, ct, allowAutoRedirect,
+            rejectedAccessToken, autoRetryUnauthorized: false);
 
+        return (client, status);
+    }
+
+    /// <summary>
+    /// Shared client construction. Returns the resolution alongside the client so callers that
+    /// report a mismatch quote the issuing server from the same snapshot the decision used.
+    /// </summary>
+    static async Task<(HttpClient Client, AuthStatus Status, TokenResolution? Resolution)> CreateClientCoreAsync(
+        string? baseUrl, CancellationToken ct, bool allowAutoRedirect,
+        string? rejectedAccessToken, bool autoRetryUnauthorized) {
         baseUrl ??= AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KCAP_URL") ?? "http://localhost:5108";
+
+        HttpClient NewClient(DelegatingHandler? retry = null) {
+            var primary = new HttpClientHandler { AllowAutoRedirect = allowAutoRedirect };
+
+            if (retry is null) return new(primary);
+
+            retry.InnerHandler = primary;
+
+            return new(retry);
+        }
+
         var provider = await DiscoverProviderAsync(baseUrl, ct);
 
         if (provider == "None") {
-            return (client, AuthStatus.NoAuthRequired); // No auth needed
+            return (NewClient(), AuthStatus.NoAuthRequired, null); // No auth needed
         }
 
-        var tokens = forceRefresh
-            ? await TokenStore.ForceRefreshAsync(ct)
-            : await TokenStore.GetValidTokensAsync();
-
-        if (tokens is not null) {
-            client.DefaultRequestHeaders.Authorization = new("Bearer", tokens.AccessToken);
-
-            return (client, AuthStatus.Ok);
+        // A forced refresh is only meaningful for a token we already hold and that the server
+        // just rejected; the binding check below still gates whether it may be used at all.
+        if (rejectedAccessToken is not null) {
+            await TokenStore.ForceRefreshAsync(rejectedAccessToken, ct);
         }
 
-        var stored = await TokenStore.LoadAsync();
+        var resolution = await TokenStore.GetValidTokensForServerAsync(baseUrl, ct);
 
-        return (client, stored is not null ? AuthStatus.Expired : AuthStatus.NotAuthenticated);
+        if (resolution is { Status: AuthStatus.Ok, Tokens: not null }) {
+            var client = NewClient(autoRetryUnauthorized ? new UnauthorizedRetryHandler(resolution.Tokens) : null);
+            client.DefaultRequestHeaders.Authorization = new("Bearer", resolution.Tokens.AccessToken);
+
+            return (client, AuthStatus.Ok, resolution);
+        }
+
+        return (NewClient(), resolution.Status, resolution);
     }
 
     /// <summary>
@@ -67,8 +99,15 @@ public static class HttpClientExtensions {
     /// server uses "None" provider, skips auth entirely. Interactive CLI commands use this; hook
     /// callers should prefer <see cref="CreateClientWithAuthStatusAsync"/> so they control messaging.
     /// </summary>
-    public static async Task<HttpClient> CreateAuthenticatedClientAsync(string? baseUrl = null, CancellationToken ct = default) {
-        var (client, status) = await CreateClientWithAuthStatusAsync(baseUrl, ct);
+    /// <param name="autoRetryUnauthorized">
+    /// Installs <see cref="UnauthorizedRetryHandler"/> so a 401 is transparently retried once after
+    /// a refresh. Pass <c>false</c> from callers that run their own 401-retry loop over the returned
+    /// client — the MCP servers do — so a single rejection isn't retried (and refreshed) twice.
+    /// </param>
+    public static async Task<HttpClient> CreateAuthenticatedClientAsync(string? baseUrl = null, CancellationToken ct = default,
+            bool autoRetryUnauthorized = true) {
+        var (client, status, resolution) = await CreateClientCoreAsync(baseUrl, ct, allowAutoRedirect: true,
+            rejectedAccessToken: null, autoRetryUnauthorized);
 
         switch (status) {
             case AuthStatus.Expired:
@@ -77,6 +116,13 @@ public static class HttpClientExtensions {
                 break;
             case AuthStatus.NotAuthenticated:
                 await Console.Error.WriteLineAsync("Not authenticated. Run 'kcap login' to authenticate.");
+
+                break;
+            case AuthStatus.WrongServer:
+                var target = baseUrl ?? AppConfig.ResolvedServerUrl ?? "the configured server";
+                await Console.Error.WriteLineAsync(
+                    $"Stored token was issued by {resolution?.IssuedServerUrl} but this command targets {target}. " +
+                    $"Run 'kcap login' (or switch profiles with 'kcap use') to authenticate against {target}.");
 
                 break;
         }

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -7,7 +7,7 @@ Getting Started:
   status                           Show server, auth, and daemon status
   login                            Authenticate via OAuth (browser)
   logout                           Remove stored credentials
-  whoami                           Show current authenticated user
+  whoami                           Show current user; verify the server accepts your token
 
 Profiles:
   profile add <name> --server-url <url>  Add a server profile

--- a/src/Capacitor.Cli.Core/Resources/help-whoami.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-whoami.txt
@@ -1,3 +1,12 @@
-kcap whoami — Show current authenticated user
+kcap whoami — Show current authenticated user and verify the server accepts your token
 
 Usage: kcap whoami
+
+Prints the stored identity (username, provider, profile, expiry) and then asks the
+server whether it actually accepts that token.
+
+Exit codes:
+  0  the server accepts the token, or acceptance could not be checked (server
+     unreachable, endpoint unavailable, or a server-side error)
+  1  no token stored, the server rejected the token, or the token was issued by a
+     different server than the one this profile targets — run `kcap login`

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1893,10 +1893,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             try {
                 using var httpClient = _httpClientFactory.CreateClient("Attachments");
 
-                var tokens = await TokenStore.GetValidTokensAsync();
+                var resolution = await TokenStore.GetValidTokensForServerAsync(_config.ServerUrl);
 
-                if (tokens is not null) {
-                    httpClient.DefaultRequestHeaders.Authorization = new("Bearer", tokens.AccessToken);
+                if (resolution.Tokens is not null) {
+                    httpClient.DefaultRequestHeaders.Authorization = new("Bearer", resolution.Tokens.AccessToken);
                 }
 
                 var response = await httpClient.GetAsync($"/api/attachments/{id}");

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -176,9 +176,9 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                 $"{config.ServerUrl.TrimEnd('/')}/hubs/sessions",
                 options => {
                     options.AccessTokenProvider = async () => {
-                        var tokens = await TokenStore.GetValidTokensAsync();
+                        var resolution = await TokenStore.GetValidTokensForServerAsync(config.ServerUrl);
 
-                        return tokens?.AccessToken;
+                        return resolution.Tokens?.AccessToken;
                     };
                 }
             )
@@ -1145,10 +1145,10 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                 while (!ct.IsCancellationRequested) {
                     try {
                         _httpClient ??= new();
-                        var tokens = await TokenStore.GetValidTokensAsync();
+                        var resolution = await TokenStore.GetValidTokensForServerAsync(_config.ServerUrl, ct);
 
-                        if (tokens?.AccessToken is not null) {
-                            _httpClient.DefaultRequestHeaders.Authorization = new("Bearer", tokens.AccessToken);
+                        if (resolution.Tokens?.AccessToken is not null) {
+                            _httpClient.DefaultRequestHeaders.Authorization = new("Bearer", resolution.Tokens.AccessToken);
                         }
 
                         var response = await _httpClient.PostAsync(url, new StringContent(payload, Encoding.UTF8, "application/json"), ct);

--- a/src/Capacitor.Cli.Daemon/Services/SpoolDrainLoop.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SpoolDrainLoop.cs
@@ -68,7 +68,7 @@ internal sealed class SpoolDrainLoop {
             var (client, status) = await _clientFactory();
 
             using (client) {
-                if (status is AuthStatus.Expired or AuthStatus.NotAuthenticated) {
+                if (status is AuthStatus.Expired or AuthStatus.NotAuthenticated or AuthStatus.WrongServer) {
                     _logger.LogDebug("Spool-drain tick: auth lapsed — skipping this pass");
 
                     return;

--- a/src/Capacitor.Cli/Commands/AgentHookPoster.cs
+++ b/src/Capacitor.Cli/Commands/AgentHookPoster.cs
@@ -45,7 +45,11 @@ internal enum HookPostOutcome {
 /// </summary>
 internal static class AgentHookPoster {
     /// <summary>Auth has genuinely lapsed → any POST would 401. <c>Ok</c> and <c>NoAuthRequired</c> are usable.</summary>
-    public static bool IsAuthLapsed(AuthStatus status) => status is AuthStatus.Expired or AuthStatus.NotAuthenticated;
+    // Anything that isn't a usable client is a lapse. WrongServer especially: the client carries no
+    // bearer, so posting anyway earns a 401 that the spool would classify as permanent and DROP —
+    // discarding lifecycle/transcript data over a fixable profile mismatch.
+    public static bool IsAuthLapsed(AuthStatus status) =>
+        status is AuthStatus.Expired or AuthStatus.NotAuthenticated or AuthStatus.WrongServer;
 
     /// <summary>
     /// Builds an auth-aware client for <paramref name="baseUrl"/> and POSTs <paramref name="body"/>

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -307,7 +307,7 @@ public static class ClaudeHookCommand {
         // Auth lapsed: do not POST (server would 401) and do not drain (a 401 would Drop the
         // spool backlog). Exit cleanly (0) so Claude shows no per-turn error banner; nudge once on
         // session-start via a systemMessage (shown to the user, not injected into the model context).
-        if (authStatus is AuthStatus.Expired or AuthStatus.NotAuthenticated) {
+        if (authStatus is AuthStatus.Expired or AuthStatus.NotAuthenticated or AuthStatus.WrongServer) {
             if (command == "session-start") {
                 var notice = new JsonObject {
                     ["systemMessage"] = authStatus == AuthStatus.Expired

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -36,14 +36,14 @@ public static class ClaudeHookCommand {
             Task? updateCheckTask, TextWriter? stdout = null)
         => HandleWithDeps(spool, processStart, baseUrl, stdin, updateCheckTask,
             () => HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl),
-            async (forceRefresh, ct) => (await HttpClientExtensions.CreateClientWithAuthStatusAsync(
-                baseUrl, ct, allowAutoRedirect: false, forceRefresh: forceRefresh)).Client,
+            async (rejectedAccessToken, ct) => (await HttpClientExtensions.CreateClientWithAuthStatusAsync(
+                baseUrl, ct, allowAutoRedirect: false, rejectedAccessToken: rejectedAccessToken)).Client,
             stdout);
 
     internal static async Task<int> HandleWithDeps(
             HookSpool spool, long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask,
             Func<Task<(HttpClient Client, AuthStatus Status)>> clientFactory,
-            Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
+            Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
             TextWriter? stdout = null) {
         string body;
         try { body = await stdin.ReadToEndAsync(); } catch { return 0; }
@@ -181,7 +181,7 @@ public static class ClaudeHookCommand {
 
     internal static async Task<int> HandleCore(HttpClient client, AuthStatus authStatus, HookSpool spool,
         long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask = null,
-        Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
+        Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
         Func<SessionStartMemoryLeaseStore>? memoryStoreFactory = null,
         TextWriter? stdout = null) {
         // Hook stdout (the SessionStart hookSpecificOutput envelope / systemMessage nudge) goes to the
@@ -811,7 +811,7 @@ public static class ClaudeHookCommand {
         bool disabled,
         SessionLifecycleReason reason,
         TimeSpan budget,
-        Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory,
+        Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory,
         Func<SessionStartMemoryLeaseStore>? memoryStoreFactory) {
         if (disabled || string.IsNullOrEmpty(nativeSessionId) || budget <= TimeSpan.Zero)
             return Task.FromResult<string?>(null);

--- a/src/Capacitor.Cli/Commands/CursorHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CursorHookCommand.cs
@@ -147,7 +147,7 @@ public static class CursorHookCommand {
             TextReader stdin,
             HookSpool  spool,
             TimeSpan   budgetTotal,
-            Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
+            Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
             Func<SessionStartMemoryLeaseStore>?               memoryStoreFactory = null,
             TimeSpan?                                         memoryBudgetOverride = null,
             ISessionStartMemoryScopeResolver?                 memoryScopeResolver = null
@@ -212,7 +212,7 @@ public static class CursorHookCommand {
             TimeSpan   budgetTotal,
             CancellationToken ct,
             ResolvedEventKindSignal kindSignal,
-            Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory,
+            Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory,
             Func<SessionStartMemoryLeaseStore>?               memoryStoreFactory,
             TimeSpan?                                         memoryBudgetOverride,
             ISessionStartMemoryScopeResolver?                 memoryScopeResolver
@@ -502,7 +502,7 @@ public static class CursorHookCommand {
             Stopwatch  sw,
             TimeSpan   budgetTotal,
             CancellationToken dispatcherCt,
-            Func<bool, CancellationToken, Task<HttpClient>>? memoryClientFactory,
+            Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory,
             Func<SessionStartMemoryLeaseStore>?               memoryStoreFactory,
             TimeSpan?                                         memoryBudgetOverride,
             ISessionStartMemoryScopeResolver?                 memoryScopeResolver

--- a/src/Capacitor.Cli/Commands/McpAnalyticsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpAnalyticsServer.cs
@@ -149,8 +149,8 @@ static class McpAnalyticsServer {
 
         try {
             using var httpResponse = toolName switch {
-                "get_analytics_schema" => await SendWithRefreshRetryAsync(client, c => c.GetAsync($"{baseUrl}/api/analytics/schema")),
-                "query_analytics"      => await SendWithRefreshRetryAsync(client, c => c.PostAsync($"{baseUrl}/api/analytics/query", ToJsonContent(BuildQueryBody(arguments, cwdRepoHash)))),
+                "get_analytics_schema" => await SendWithRefreshRetryAsync(client, baseUrl, c => c.GetAsync($"{baseUrl}/api/analytics/schema")),
+                "query_analytics"      => await SendWithRefreshRetryAsync(client, baseUrl, c => c.PostAsync($"{baseUrl}/api/analytics/query", ToJsonContent(BuildQueryBody(arguments, cwdRepoHash)))),
                 _                      => throw new ArgumentException($"Unknown tool: {toolName}")
             };
 
@@ -237,7 +237,7 @@ static class McpAnalyticsServer {
         }
     }
 
-    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, Func<HttpClient, Task<HttpResponseMessage>> send) {
+    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, string baseUrl, Func<HttpClient, Task<HttpResponseMessage>> send) {
         var response = await send(client);
 
         if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
@@ -253,8 +253,9 @@ static class McpAnalyticsServer {
         // A failed rotation must not be worse than no rotation: fall back to whatever is stored so
         // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
-            ? await TokenStore.GetValidTokensAsync()
-            : await TokenStore.ForceRefreshAsync(rejected) ?? await TokenStore.GetValidTokensAsync();
+            ? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens
+            : await TokenStore.ForceRefreshAsync(rejected, baseUrl)
+              ?? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens;
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpAnalyticsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpAnalyticsServer.cs
@@ -254,8 +254,7 @@ static class McpAnalyticsServer {
         // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
             ? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens
-            : await TokenStore.ForceRefreshAsync(rejected, baseUrl)
-              ?? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens;
+            : await TokenStore.RecoverForServerAsync(baseUrl, rejected);
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpAnalyticsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpAnalyticsServer.cs
@@ -250,9 +250,11 @@ static class McpAnalyticsServer {
         // nothing to refresh, so just pick up whatever is stored now.
         var rejected = client.DefaultRequestHeaders.Authorization?.Parameter;
 
+        // A failed rotation must not be worse than no rotation: fall back to whatever is stored so
+        // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
             ? await TokenStore.GetValidTokensAsync()
-            : await TokenStore.ForceRefreshAsync(rejected);
+            : await TokenStore.ForceRefreshAsync(rejected) ?? await TokenStore.GetValidTokensAsync();
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpAnalyticsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpAnalyticsServer.cs
@@ -45,7 +45,7 @@ static class McpAnalyticsServer {
                 return BuildToolResult(callId, HttpClientExtensions.SchemeMissingHint, isError: true);
 
             try {
-                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, autoRetryUnauthorized: false);
                 return await HandleToolCallAsync(callId, callRequest, client, baseUrl, cwdRepoHash);
             } catch (Exception ex) {
                 await Console.Error.WriteLineAsync($"kcap mcp analytics: unexpected error handling tools/call: {ex}");
@@ -242,7 +242,17 @@ static class McpAnalyticsServer {
 
         if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
 
-        var refreshed = await TokenStore.GetValidTokensAsync();
+        // Force a refresh against the token this client actually sent: the 401 proves the server
+        // rejected it even though it may still look unexpired locally, which a plain load would
+        // not heal. Passing the rejected token also means a peer process that already refreshed is
+        // adopted rather than rotated a second time. With no token attached at all — this MCP
+        // process outlives a `kcap login` that finished after the client was built — there is
+        // nothing to refresh, so just pick up whatever is stored now.
+        var rejected = client.DefaultRequestHeaders.Authorization?.Parameter;
+
+        var refreshed = rejected is null
+            ? await TokenStore.GetValidTokensAsync()
+            : await TokenStore.ForceRefreshAsync(rejected);
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
@@ -177,6 +177,7 @@ static class McpFlowResultServer {
         for (var attempt = 1; attempt <= MaxAttempts; attempt++) {
             using var response = await SendWithRefreshRetryAsync(
                 client,
+                apiRoot,
                 c => c.PostAsync(url, JsonContent.Create(body, McpJsonContext.Default.SubmitReviewerResultDto))
             );
             var responseBody = await response.Content.ReadAsStringAsync();
@@ -250,6 +251,7 @@ static class McpFlowResultServer {
         for (var attempt = 1; attempt <= MaxAttempts; attempt++) {
             using var response = await SendWithRefreshRetryAsync(
                 client,
+                apiRoot,
                 c => c.PostAsync(url, JsonContent.Create(body, McpJsonContext.Default.SendFlowMessageDto))
             );
 
@@ -301,7 +303,7 @@ static class McpFlowResultServer {
     /// <see cref="TokenStore.GetValidTokensAsync"/> for a fresh token, update the client's
     /// <c>Authorization</c> header, and retry the same request once.
     /// </summary>
-    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, Func<HttpClient, Task<HttpResponseMessage>> send) {
+    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, string baseUrl, Func<HttpClient, Task<HttpResponseMessage>> send) {
         var response = await send(client);
 
         if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
@@ -317,8 +319,9 @@ static class McpFlowResultServer {
         // A failed rotation must not be worse than no rotation: fall back to whatever is stored so
         // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
-            ? await TokenStore.GetValidTokensAsync()
-            : await TokenStore.ForceRefreshAsync(rejected) ?? await TokenStore.GetValidTokensAsync();
+            ? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens
+            : await TokenStore.ForceRefreshAsync(rejected, baseUrl)
+              ?? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens;
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
@@ -88,7 +88,7 @@ static class McpFlowResultServer {
                 if (toolName is not ("submit_review_result" or "send_flow_message"))
                     return BuildToolResult(callId, $"Error: Unknown tool: {toolName}", isError: true);
 
-                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, autoRetryUnauthorized: false);
 
                 var (text, isError) = toolName switch {
                     "submit_review_result" => await SubmitCoreAsync(client, apiRoot, agentId, arguments, delay: Task.Delay),
@@ -306,7 +306,17 @@ static class McpFlowResultServer {
 
         if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
 
-        var refreshed = await TokenStore.GetValidTokensAsync();
+        // Force a refresh against the token this client actually sent: the 401 proves the server
+        // rejected it even though it may still look unexpired locally, which a plain load would
+        // not heal. Passing the rejected token also means a peer process that already refreshed is
+        // adopted rather than rotated a second time. With no token attached at all — this MCP
+        // process outlives a `kcap login` that finished after the client was built — there is
+        // nothing to refresh, so just pick up whatever is stored now.
+        var rejected = client.DefaultRequestHeaders.Authorization?.Parameter;
+
+        var refreshed = rejected is null
+            ? await TokenStore.GetValidTokensAsync()
+            : await TokenStore.ForceRefreshAsync(rejected);
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
@@ -320,8 +320,7 @@ static class McpFlowResultServer {
         // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
             ? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens
-            : await TokenStore.ForceRefreshAsync(rejected, baseUrl)
-              ?? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens;
+            : await TokenStore.RecoverForServerAsync(baseUrl, rejected);
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
@@ -314,9 +314,11 @@ static class McpFlowResultServer {
         // nothing to refresh, so just pick up whatever is stored now.
         var rejected = client.DefaultRequestHeaders.Authorization?.Parameter;
 
+        // A failed rotation must not be worse than no rotation: fall back to whatever is stored so
+        // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
             ? await TokenStore.GetValidTokensAsync()
-            : await TokenStore.ForceRefreshAsync(rejected);
+            : await TokenStore.ForceRefreshAsync(rejected) ?? await TokenStore.GetValidTokensAsync();
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -305,9 +305,11 @@ static class McpFlowsServer {
         // nothing to refresh, so just pick up whatever is stored now.
         var rejected = client.DefaultRequestHeaders.Authorization?.Parameter;
 
+        // A failed rotation must not be worse than no rotation: fall back to whatever is stored so
+        // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
             ? await TokenStore.GetValidTokensAsync()
-            : await TokenStore.ForceRefreshAsync(rejected, ct);
+            : await TokenStore.ForceRefreshAsync(rejected, ct) ?? await TokenStore.GetValidTokensAsync();
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -310,8 +310,7 @@ static class McpFlowsServer {
         // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
             ? (await TokenStore.GetValidTokensForServerAsync(baseUrl, ct)).Tokens
-            : await TokenStore.ForceRefreshAsync(rejected, baseUrl, ct)
-              ?? (await TokenStore.GetValidTokensForServerAsync(baseUrl, ct)).Tokens;
+            : await TokenStore.RecoverForServerAsync(baseUrl, rejected, ct);
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -48,7 +48,7 @@ static class McpFlowsServer {
 
             try {
                 if (client is null) {
-                    client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+                    client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, autoRetryUnauthorized: false);
                     // the review-flow endpoints long-poll (start_review_flow /
                     // submit_review_round block server-side up to ~10 min while the reviewer runs).
                     // The default 100s timeout would abort the POST, which the server sees as a
@@ -297,7 +297,17 @@ static class McpFlowsServer {
 
         if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
 
-        var refreshed = await TokenStore.GetValidTokensAsync();
+        // Force a refresh against the token this client actually sent: the 401 proves the server
+        // rejected it even though it may still look unexpired locally, which a plain load would
+        // not heal. Passing the rejected token also means a peer process that already refreshed is
+        // adopted rather than rotated a second time. With no token attached at all — this MCP
+        // process outlives a `kcap login` that finished after the client was built — there is
+        // nothing to refresh, so just pick up whatever is stored now.
+        var rejected = client.DefaultRequestHeaders.Authorization?.Parameter;
+
+        var refreshed = rejected is null
+            ? await TokenStore.GetValidTokensAsync()
+            : await TokenStore.ForceRefreshAsync(rejected, ct);
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -166,13 +166,13 @@ static class McpFlowsServer {
 
                 var sendResult = toolName switch {
                     "start_review_flow"   => wasModelStart
-                        ? new SettlementSendResult.Response(await SendWithRefreshRetryAsync(client, (c, ct) => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind", ct: ct)))
-                        : await SendWithSettlementRetryAsync(client, (c, ct) => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind", ct: ct), clock, backoff),
+                        ? new SettlementSendResult.Response(await SendWithRefreshRetryAsync(client, apiRoot, (c, ct) => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind", ct: ct)))
+                        : await SendWithSettlementRetryAsync(client, apiRoot, (c, ct) => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "kind", ct: ct), clock, backoff),
                     "start_flow"          => wasModelStart
-                        ? new SettlementSendResult.Response(await SendWithRefreshRetryAsync(client, (c, ct) => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id", ct: ct)))
-                        : await SendWithSettlementRetryAsync(client, (c, ct) => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id", ct: ct), clock, backoff),
-                    "submit_review_round" => await SendWithSettlementRetryAsync(client, (c, ct) => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "context", participant: null, async: true, ct: ct), clock, backoff),
-                    _                     => await SendWithSettlementRetryAsync(client, (c, ct) => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "message", participant: GetRequiredArg(arguments, "participant"), async: ParseAsyncArg(arguments), ct: ct), clock, backoff)
+                        ? new SettlementSendResult.Response(await SendWithRefreshRetryAsync(client, apiRoot, (c, ct) => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id", ct: ct)))
+                        : await SendWithSettlementRetryAsync(client, apiRoot, (c, ct) => StartFlowAsync(c, apiRoot, arguments, cwd, repoRoot, repoInfo, kindArgName: "definition_id", ct: ct), clock, backoff),
+                    "submit_review_round" => await SendWithSettlementRetryAsync(client, apiRoot, (c, ct) => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "context", participant: null, async: true, ct: ct), clock, backoff),
+                    _                     => await SendWithSettlementRetryAsync(client, apiRoot, (c, ct) => SubmitRoundAsync(c, apiRoot, arguments, contextArgName: "message", participant: GetRequiredArg(arguments, "participant"), async: ParseAsyncArg(arguments), ct: ct), clock, backoff)
                 };
 
                 // Settlement-admission design (§3.2 G): the elapsed deadline is mapped HERE, at the
@@ -237,8 +237,8 @@ static class McpFlowsServer {
             }
 
             using var httpResponse = toolName switch {
-                "get_review_flow_status" or "get_flow_status" => await SendWithRefreshRetryAsync(client, (c, ct) => c.GetAsync(BuildFlowUrl(apiRoot, arguments), ct)),
-                "close_review_flow"      or "close_flow"      => await SendWithRefreshRetryAsync(client, (c, ct) => c.PostAsync(BuildFlowUrl(apiRoot, arguments) + "/close", null, ct)),
+                "get_review_flow_status" or "get_flow_status" => await SendWithRefreshRetryAsync(client, apiRoot, (c, ct) => c.GetAsync(BuildFlowUrl(apiRoot, arguments), ct)),
+                "close_review_flow"      or "close_flow"      => await SendWithRefreshRetryAsync(client, apiRoot, (c, ct) => c.PostAsync(BuildFlowUrl(apiRoot, arguments) + "/close", null, ct)),
                 _                                             => throw new ArgumentException($"Unknown tool: {toolName}")
             };
 
@@ -291,7 +291,8 @@ static class McpFlowsServer {
     /// friendly "Not logged in" message.
     /// </summary>
     static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(
-            HttpClient client, Func<HttpClient, CancellationToken, Task<HttpResponseMessage>> send, CancellationToken ct = default
+            HttpClient client, string baseUrl, Func<HttpClient, CancellationToken, Task<HttpResponseMessage>> send,
+            CancellationToken ct = default
         ) {
         var response = await send(client, ct);
 
@@ -308,8 +309,9 @@ static class McpFlowsServer {
         // A failed rotation must not be worse than no rotation: fall back to whatever is stored so
         // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
-            ? await TokenStore.GetValidTokensAsync()
-            : await TokenStore.ForceRefreshAsync(rejected, ct) ?? await TokenStore.GetValidTokensAsync();
+            ? (await TokenStore.GetValidTokensForServerAsync(baseUrl, ct)).Tokens
+            : await TokenStore.ForceRefreshAsync(rejected, baseUrl, ct)
+              ?? (await TokenStore.GetValidTokensForServerAsync(baseUrl, ct)).Tokens;
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 
@@ -397,6 +399,7 @@ static class McpFlowsServer {
     /// </summary>
     internal static async Task<SettlementSendResult> SendWithSettlementRetryAsync(
             HttpClient                                                    client,
+            string                                                        apiRoot,
             Func<HttpClient, CancellationToken, Task<HttpResponseMessage>> send,
             FlowRetryClock                                                clock,
             SettlementBackoff                                             backoff,
@@ -418,7 +421,7 @@ static class McpFlowsServer {
 
             HttpResponseMessage response;
             try {
-                response = await SendWithRefreshRetryAsync(client, send, scope.Token);
+                response = await SendWithRefreshRetryAsync(client, apiRoot, send, scope.Token);
             } catch (OperationCanceledException) when (scope.DeadlineFired && !callerToken.IsCancellationRequested) {
                 // OUR deadline cut an in-flight attempt short — that is an exhausted budget, not a
                 // failure to report. Caller cancellation deliberately falls through and rethrows.
@@ -984,7 +987,7 @@ static class McpFlowsServer {
             using var getCts = clock.CreateTimeoutSource(PerGetTimeout);
             HttpResponseMessage resp;
             try {
-                resp = await SendWithRefreshRetryAsync(client, (c, ct) => c.GetAsync(url, ct), getCts.Token);
+                resp = await SendWithRefreshRetryAsync(client, apiRoot, (c, ct) => c.GetAsync(url, ct), getCts.Token);
             } catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException) {
                 // Fix #4: count network/TLS/timeout as transient; stop after budget.
                 consecutiveTransient++;
@@ -1336,6 +1339,7 @@ static class McpFlowsServer {
                 using var postCts = clock.CreateTimeoutSource(PerAckPostTimeout);
                 using var response = await SendWithRefreshRetryAsync(
                     client,
+                    apiRoot,
                     (c, ct) => c.PostAsync(url, JsonContent.Create(body, McpJsonContext.Default.AckFlowMessagesDto), ct),
                     postCts.Token
                 );

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -203,8 +203,7 @@ static class McpMemoryServer {
         // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
             ? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens
-            : await TokenStore.ForceRefreshAsync(rejected, baseUrl)
-              ?? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens;
+            : await TokenStore.RecoverForServerAsync(baseUrl, rejected);
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -199,9 +199,11 @@ static class McpMemoryServer {
         // nothing to refresh, so just pick up whatever is stored now.
         var rejected = client.DefaultRequestHeaders.Authorization?.Parameter;
 
+        // A failed rotation must not be worse than no rotation: fall back to whatever is stored so
+        // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
             ? await TokenStore.GetValidTokensAsync()
-            : await TokenStore.ForceRefreshAsync(rejected);
+            : await TokenStore.ForceRefreshAsync(rejected) ?? await TokenStore.GetValidTokensAsync();
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -149,12 +149,12 @@ static class McpMemoryServer {
 
         try {
             using var httpResponse = toolName switch {
-                "search_memories" => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildSearchUrl(baseUrl, arguments, cwdRepoHash, machineId))),
-                "get_memory"      => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildGetUrl(baseUrl, arguments, cwdRepoHash, machineId))),
-                "save_memory"     => await SendWithRefreshRetryAsync(client, c => c.PostAsync($"{baseUrl}/api/memories", ToJsonContent(BuildSaveBody(arguments, cwdRepoHash, machineId)))),
-                "update_memory"   => await SendWithRefreshRetryAsync(client, c => c.PutAsync($"{baseUrl}/api/memories/{Uri.EscapeDataString(Id(arguments))}", ToJsonContent(BuildUpdateBody(arguments)))),
-                "rescope_memory"  => await SendWithRefreshRetryAsync(client, c => c.PostAsync($"{baseUrl}/api/memories/{Uri.EscapeDataString(Id(arguments))}/rescope", ToJsonContent(BuildRescopeBody(arguments)))),
-                "archive_memory"  => await SendWithRefreshRetryAsync(client, c => c.DeleteAsync($"{baseUrl}/api/memories/{Uri.EscapeDataString(Id(arguments))}")),
+                "search_memories" => await SendWithRefreshRetryAsync(client, baseUrl, c => c.GetAsync(BuildSearchUrl(baseUrl, arguments, cwdRepoHash, machineId))),
+                "get_memory"      => await SendWithRefreshRetryAsync(client, baseUrl, c => c.GetAsync(BuildGetUrl(baseUrl, arguments, cwdRepoHash, machineId))),
+                "save_memory"     => await SendWithRefreshRetryAsync(client, baseUrl, c => c.PostAsync($"{baseUrl}/api/memories", ToJsonContent(BuildSaveBody(arguments, cwdRepoHash, machineId)))),
+                "update_memory"   => await SendWithRefreshRetryAsync(client, baseUrl, c => c.PutAsync($"{baseUrl}/api/memories/{Uri.EscapeDataString(Id(arguments))}", ToJsonContent(BuildUpdateBody(arguments)))),
+                "rescope_memory"  => await SendWithRefreshRetryAsync(client, baseUrl, c => c.PostAsync($"{baseUrl}/api/memories/{Uri.EscapeDataString(Id(arguments))}/rescope", ToJsonContent(BuildRescopeBody(arguments)))),
+                "archive_memory"  => await SendWithRefreshRetryAsync(client, baseUrl, c => c.DeleteAsync($"{baseUrl}/api/memories/{Uri.EscapeDataString(Id(arguments))}")),
                 _                 => throw new ArgumentException($"Unknown tool: {toolName}")
             };
 
@@ -186,7 +186,7 @@ static class McpMemoryServer {
     /// or refresh-token expired), the original 401 is returned and the caller surfaces the
     /// friendly "Not logged in" message.
     /// </summary>
-    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, Func<HttpClient, Task<HttpResponseMessage>> send) {
+    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, string baseUrl, Func<HttpClient, Task<HttpResponseMessage>> send) {
         var response = await send(client);
 
         if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
@@ -202,8 +202,9 @@ static class McpMemoryServer {
         // A failed rotation must not be worse than no rotation: fall back to whatever is stored so
         // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
-            ? await TokenStore.GetValidTokensAsync()
-            : await TokenStore.ForceRefreshAsync(rejected) ?? await TokenStore.GetValidTokensAsync();
+            ? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens
+            : await TokenStore.ForceRefreshAsync(rejected, baseUrl)
+              ?? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens;
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -40,7 +40,7 @@ static class McpMemoryServer {
                 return BuildToolResult(callId, HttpClientExtensions.SchemeMissingHint, isError: true);
 
             try {
-                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, autoRetryUnauthorized: false);
                 return await HandleToolCallAsync(callId, callRequest, client, baseUrl, cwdRepoHash, machineId);
             } catch (Exception ex) {
                 // Unexpected: log the detail to stderr (not to the client, which could leak local
@@ -191,7 +191,17 @@ static class McpMemoryServer {
 
         if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
 
-        var refreshed = await TokenStore.GetValidTokensAsync();
+        // Force a refresh against the token this client actually sent: the 401 proves the server
+        // rejected it even though it may still look unexpired locally, which a plain load would
+        // not heal. Passing the rejected token also means a peer process that already refreshed is
+        // adopted rather than rotated a second time. With no token attached at all — this MCP
+        // process outlives a `kcap login` that finished after the client was built — there is
+        // nothing to refresh, so just pick up whatever is stored now.
+        var rejected = client.DefaultRequestHeaders.Authorization?.Parameter;
+
+        var refreshed = rejected is null
+            ? await TokenStore.GetValidTokensAsync()
+            : await TokenStore.ForceRefreshAsync(rejected);
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -143,11 +143,11 @@ static class McpSessionsServer {
 
         try {
             using var httpResponse = toolName switch {
-                "search_sessions"        => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildSearchUrl(baseUrl, arguments, cwdRepoHash))),
-                "get_session_summary"    => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildSummaryUrl(baseUrl, arguments))),
-                "get_session_transcript" => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildTranscriptUrl(baseUrl, arguments))),
-                "get_turn"               => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildTurnDetailUrl(baseUrl, arguments))),
-                "list_turns"             => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildTurnsUrl(baseUrl, arguments))),
+                "search_sessions"        => await SendWithRefreshRetryAsync(client, baseUrl, c => c.GetAsync(BuildSearchUrl(baseUrl, arguments, cwdRepoHash))),
+                "get_session_summary"    => await SendWithRefreshRetryAsync(client, baseUrl, c => c.GetAsync(BuildSummaryUrl(baseUrl, arguments))),
+                "get_session_transcript" => await SendWithRefreshRetryAsync(client, baseUrl, c => c.GetAsync(BuildTranscriptUrl(baseUrl, arguments))),
+                "get_turn"               => await SendWithRefreshRetryAsync(client, baseUrl, c => c.GetAsync(BuildTurnDetailUrl(baseUrl, arguments))),
+                "list_turns"             => await SendWithRefreshRetryAsync(client, baseUrl, c => c.GetAsync(BuildTurnsUrl(baseUrl, arguments))),
                 _                        => throw new ArgumentException($"Unknown tool: {toolName}")
             };
 
@@ -182,7 +182,7 @@ static class McpSessionsServer {
     /// or refresh-token expired), the original 401 is returned and the caller surfaces the
     /// friendly "Not logged in" message.
     /// </summary>
-    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, Func<HttpClient, Task<HttpResponseMessage>> send) {
+    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, string baseUrl, Func<HttpClient, Task<HttpResponseMessage>> send) {
         var response = await send(client);
 
         if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
@@ -198,8 +198,9 @@ static class McpSessionsServer {
         // A failed rotation must not be worse than no rotation: fall back to whatever is stored so
         // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
-            ? await TokenStore.GetValidTokensAsync()
-            : await TokenStore.ForceRefreshAsync(rejected) ?? await TokenStore.GetValidTokensAsync();
+            ? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens
+            : await TokenStore.ForceRefreshAsync(rejected, baseUrl)
+              ?? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens;
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -195,9 +195,11 @@ static class McpSessionsServer {
         // nothing to refresh, so just pick up whatever is stored now.
         var rejected = client.DefaultRequestHeaders.Authorization?.Parameter;
 
+        // A failed rotation must not be worse than no rotation: fall back to whatever is stored so
+        // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
             ? await TokenStore.GetValidTokensAsync()
-            : await TokenStore.ForceRefreshAsync(rejected);
+            : await TokenStore.ForceRefreshAsync(rejected) ?? await TokenStore.GetValidTokensAsync();
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -199,8 +199,7 @@ static class McpSessionsServer {
         // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
             ? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens
-            : await TokenStore.ForceRefreshAsync(rejected, baseUrl)
-              ?? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens;
+            : await TokenStore.RecoverForServerAsync(baseUrl, rejected);
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -39,7 +39,7 @@ static class McpSessionsServer {
                 return BuildToolResult(callId, HttpClientExtensions.SchemeMissingHint, isError: true);
 
             try {
-                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, autoRetryUnauthorized: false);
                 return await HandleToolCallAsync(callId, callRequest, client, baseUrl, cwdRepoHash);
             } catch (Exception ex) {
                 // Unexpected: log the detail to stderr (not to the client, which could leak local
@@ -187,7 +187,17 @@ static class McpSessionsServer {
 
         if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
 
-        var refreshed = await TokenStore.GetValidTokensAsync();
+        // Force a refresh against the token this client actually sent: the 401 proves the server
+        // rejected it even though it may still look unexpired locally, which a plain load would
+        // not heal. Passing the rejected token also means a peer process that already refreshed is
+        // adopted rather than rotated a second time. With no token attached at all — this MCP
+        // process outlives a `kcap login` that finished after the client was built — there is
+        // nothing to refresh, so just pick up whatever is stored now.
+        var rejected = client.DefaultRequestHeaders.Authorization?.Parameter;
+
+        var refreshed = rejected is null
+            ? await TokenStore.GetValidTokensAsync()
+            : await TokenStore.ForceRefreshAsync(rejected);
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -173,9 +173,11 @@ static class McpWorkItemsServer {
         // nothing to refresh, so just pick up whatever is stored now.
         var rejected = client.DefaultRequestHeaders.Authorization?.Parameter;
 
+        // A failed rotation must not be worse than no rotation: fall back to whatever is stored so
+        // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
             ? await TokenStore.GetValidTokensAsync()
-            : await TokenStore.ForceRefreshAsync(rejected);
+            : await TokenStore.ForceRefreshAsync(rejected) ?? await TokenStore.GetValidTokensAsync();
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -177,8 +177,7 @@ static class McpWorkItemsServer {
         // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
             ? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens
-            : await TokenStore.ForceRefreshAsync(rejected, baseUrl)
-              ?? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens;
+            : await TokenStore.RecoverForServerAsync(baseUrl, rejected);
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -43,7 +43,7 @@ static class McpWorkItemsServer {
                 return BuildToolResult(callId, HttpClientExtensions.SchemeMissingHint, isError: true);
 
             try {
-                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, autoRetryUnauthorized: false);
                 return await HandleToolCallAsync(callId, callRequest, client, baseUrl);
             } catch (Exception ex) {
                 // Unexpected: log the detail to stderr (not to the client, which could leak local
@@ -165,7 +165,17 @@ static class McpWorkItemsServer {
 
         if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
 
-        var refreshed = await TokenStore.GetValidTokensAsync();
+        // Force a refresh against the token this client actually sent: the 401 proves the server
+        // rejected it even though it may still look unexpired locally, which a plain load would
+        // not heal. Passing the rejected token also means a peer process that already refreshed is
+        // adopted rather than rotated a second time. With no token attached at all — this MCP
+        // process outlives a `kcap login` that finished after the client was built — there is
+        // nothing to refresh, so just pick up whatever is stored now.
+        var rejected = client.DefaultRequestHeaders.Authorization?.Parameter;
+
+        var refreshed = rejected is null
+            ? await TokenStore.GetValidTokensAsync()
+            : await TokenStore.ForceRefreshAsync(rejected);
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -127,8 +127,8 @@ static class McpWorkItemsServer {
 
         try {
             using var httpResponse = toolName switch {
-                "declare_work_item"      => await SendWithRefreshRetryAsync(client, c => c.PostAsync($"{baseUrl}/api/work-items/declare", ToJsonContent(BuildDeclareBody(arguments)))),
-                "get_session_work_items" => await SendWithRefreshRetryAsync(client, c => c.GetAsync(BuildSessionUrl(baseUrl, arguments))),
+                "declare_work_item"      => await SendWithRefreshRetryAsync(client, baseUrl, c => c.PostAsync($"{baseUrl}/api/work-items/declare", ToJsonContent(BuildDeclareBody(arguments)))),
+                "get_session_work_items" => await SendWithRefreshRetryAsync(client, baseUrl, c => c.GetAsync(BuildSessionUrl(baseUrl, arguments))),
                 _                        => throw new ArgumentException($"Unknown tool: {toolName}")
             };
 
@@ -160,7 +160,7 @@ static class McpWorkItemsServer {
     /// or refresh-token expired), the original 401 is returned and the caller surfaces the
     /// friendly "Not logged in" message.
     /// </summary>
-    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, Func<HttpClient, Task<HttpResponseMessage>> send) {
+    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, string baseUrl, Func<HttpClient, Task<HttpResponseMessage>> send) {
         var response = await send(client);
 
         if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
@@ -176,8 +176,9 @@ static class McpWorkItemsServer {
         // A failed rotation must not be worse than no rotation: fall back to whatever is stored so
         // the pre-existing "re-read and resend once" recovery still happens.
         var refreshed = rejected is null
-            ? await TokenStore.GetValidTokensAsync()
-            : await TokenStore.ForceRefreshAsync(rejected) ?? await TokenStore.GetValidTokensAsync();
+            ? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens
+            : await TokenStore.ForceRefreshAsync(rejected, baseUrl)
+              ?? (await TokenStore.GetValidTokensForServerAsync(baseUrl)).Tokens;
 
         if (refreshed is null) return response; // genuinely not logged in; keep the original 401
 

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -471,7 +471,7 @@ public static class SetupCommand {
         // tell the server this user has finished CLI setup, so the dashboard
         // can flip the new-tenant welcome modal from "Waiting for CLI to register"
         // to "Registered". Best-effort — never block setup completion on this.
-        await PingCliSetupAsync(serverUrl, activeName);
+        await PingCliSetupAsync(serverUrl, activeName, provider);
 
         await Console.Out.WriteLineAsync();
 
@@ -838,7 +838,7 @@ public static class SetupCommand {
     //     wall-clock bound is enforced independently of what HttpClient does
     //     internally. If the delay wins, HttpClient disposal on method-exit
     //     cancels the in-flight POST.
-    static async Task PingCliSetupAsync(string serverUrl, string profile) {
+    static async Task PingCliSetupAsync(string serverUrl, string profile, string provider) {
         // The ping is intentionally silent (see method-doc), which also hides why the
         // dashboard welcome modal never flips when it fails — e.g. a token the server
         // rejects or maps to a different identity. Set KCAP_DEBUG to surface the
@@ -846,6 +846,15 @@ public static class SetupCommand {
         var  debug = Environment.GetEnvironmentVariable("KCAP_DEBUG") is { Length: > 0 };
         void Debug(string message) {
             if (debug) Console.Error.WriteLine($"[kcap] cli-setup ping: {message}");
+        }
+
+        // A None-provider server neither needs nor should receive a bearer. Setup performs no login
+        // on that path, so any token still in the profile belongs to whatever server it pointed at
+        // before — sending it here would disclose it to an unrelated host.
+        if (provider == AuthProvider.None) {
+            Debug("skipped — server requires no authentication");
+
+            return;
         }
 
         try {

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -79,7 +79,7 @@ public static class SetupCommand {
         var existingProfile = await AppConfig.LoadProfileConfig();
         var activeProfile   = string.IsNullOrWhiteSpace(existingProfile.ActiveProfile) ? "default" : existingProfile.ActiveProfile;
         var existing        = existingProfile.Profiles.GetValueOrDefault(activeProfile);
-        var existingTokens  = await TokenStore.LoadAsync();
+        var existingTokens  = await TokenStore.LoadAsync(activeProfile);
 
         if (existing?.ServerUrl is not null && existingTokens is not null && !noPrompt) {
             var rerun = AnsiConsole.Prompt(
@@ -147,16 +147,16 @@ public static class SetupCommand {
         } else if (provider == AuthProvider.None) {
             await Console.Out.WriteLineAsync("  Auth provider is None — no login required.");
         } else if (preAuthToken is not null) {
-            var exchangeResult = await OAuthLoginFlow.ExchangeAndSaveAsync(serverUrl, preAuthToken, provider);
+            var exchangeResult = await OAuthLoginFlow.ExchangeAndSaveAsync(serverUrl, preAuthToken, provider, activeProfile);
             if (exchangeResult != 0) {
                 await Console.Error.WriteLineAsync("  Token exchange failed.");
                 return 1;
             }
             // Keep formatting consistent with the non-discovery branch
-            var tokens = await TokenStore.LoadAsync();
+            var tokens = await TokenStore.LoadAsync(activeProfile);
             AnsiConsole.MarkupLine($"  [green]✓[/] Logged in as [cyan]{Markup.Escape(tokens?.GitHubUsername ?? "?")}[/]");
         } else {
-            var loginResult = await OAuthLoginFlow.LoginWithDiscoveryAsync(serverUrl, forceDevice);
+            var loginResult = await OAuthLoginFlow.LoginWithDiscoveryAsync(serverUrl, forceDevice, activeProfile);
 
             if (loginResult != 0) {
                 await Console.Error.WriteLineAsync("  Login failed.");
@@ -164,7 +164,7 @@ public static class SetupCommand {
                 return 1;
             }
 
-            var tokens = await TokenStore.LoadAsync();
+            var tokens = await TokenStore.LoadAsync(activeProfile);
             await Console.Out.WriteLineAsync($"  ✓ Logged in as {tokens?.GitHubUsername}");
         }
 
@@ -436,7 +436,7 @@ public static class SetupCommand {
 
         // Save config
         var profileConfig  = await AppConfig.LoadProfileConfig();
-        var activeName     = profileConfig.ActiveProfile;
+        var activeName     = string.IsNullOrWhiteSpace(profileConfig.ActiveProfile) ? "default" : profileConfig.ActiveProfile;
         var defaultProfile = profileConfig.Profiles.GetValueOrDefault(activeName) ?? new Profile();
 
         defaultProfile = defaultProfile with {
@@ -458,12 +458,12 @@ public static class SetupCommand {
         // CLI/env/repo precedence and possibly landing on something else.
         AppConfig.SetResolvedState(serverUrl, activeName, defaultProfile);
 
-        var finalTokens = await TokenStore.LoadAsync();
+        var finalTokens = await TokenStore.LoadAsync(activeName);
 
         // tell the server this user has finished CLI setup, so the dashboard
         // can flip the new-tenant welcome modal from "Waiting for CLI to register"
         // to "Registered". Best-effort — never block setup completion on this.
-        await PingCliSetupAsync(serverUrl);
+        await PingCliSetupAsync(serverUrl, activeName);
 
         await Console.Out.WriteLineAsync();
 
@@ -486,8 +486,10 @@ public static class SetupCommand {
         // degrades to an ineligible (best-effort) skip rather than throwing out of setup — the
         // import path's own errors are caught inside RunImportStepAsync, and this eligibility
         // probe (awaited outside that boundary) must be equally non-fatal.
+        // Server-scoped: the import step is only actually authorized if the token both refreshes
+        // and belongs to the server we just configured.
         var authSatisfied = await IsAuthSatisfiedAsync(
-            provider, static async () => await TokenStore.GetValidTokensAsync() is not null);
+            provider, async () => (await TokenStore.GetValidTokensForServerAsync(serverUrl)).Tokens is not null);
 
         await RunImportStepAsync(
             currentRepo, authSatisfied, skipImport, noPrompt,
@@ -828,7 +830,7 @@ public static class SetupCommand {
     //     wall-clock bound is enforced independently of what HttpClient does
     //     internally. If the delay wins, HttpClient disposal on method-exit
     //     cancels the in-flight POST.
-    static async Task PingCliSetupAsync(string serverUrl) {
+    static async Task PingCliSetupAsync(string serverUrl, string profile) {
         // The ping is intentionally silent (see method-doc), which also hides why the
         // dashboard welcome modal never flips when it fails — e.g. a token the server
         // rejects or maps to a different identity. Set KCAP_DEBUG to surface the
@@ -839,7 +841,7 @@ public static class SetupCommand {
         }
 
         try {
-            var tokens = await TokenStore.LoadAsync();
+            var tokens = await TokenStore.LoadAsync(profile);
             if (tokens is null || tokens.IsExpired) {
                 Debug(tokens is null ? "skipped — no stored token" : "skipped — token expired");
 

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -132,6 +132,14 @@ public static class SetupCommand {
             var discovered = await RunDiscoveryAsync(args, forceDevice);
             if (discovered is null) return 1;
             (serverUrl, preAuthToken, provider, loginComplete) = discovered.Value;
+
+            // Discovery activates the tenant you picked, so the profile captured before it ran is
+            // now stale. Step 2 must save the token under the profile setup will actually
+            // configure, or the token lands on the old profile and the new one has none.
+            var afterDiscovery = await AppConfig.LoadProfileConfig();
+            activeProfile = string.IsNullOrWhiteSpace(afterDiscovery.ActiveProfile)
+                ? "default"
+                : afterDiscovery.ActiveProfile;
         }
 
         await Console.Out.WriteLineAsync();
@@ -844,6 +852,15 @@ public static class SetupCommand {
             var tokens = await TokenStore.LoadAsync(profile);
             if (tokens is null || tokens.IsExpired) {
                 Debug(tokens is null ? "skipped — no stored token" : "skipped — token expired");
+
+                return;
+            }
+
+            // Re-running setup to point an authenticated profile at a different server would
+            // otherwise send the previous server's bearer to the new one. Checked inline rather
+            // than through the resolving accessor to keep this path refresh-free and time-bound.
+            if (tokens.ServerUrl is not null && !ServerIdentity.SameServer(tokens.ServerUrl, serverUrl)) {
+                Debug($"skipped — stored token belongs to {tokens.ServerUrl}");
 
                 return;
             }

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -459,9 +459,9 @@ static partial class WatchCommand {
                 hubUrl,
                 options => {
                     options.AccessTokenProvider = async () => {
-                        var t = await TokenStore.GetValidTokensAsync();
+                        var resolution = await TokenStore.GetValidTokensForServerAsync(baseUrl);
 
-                        return t?.AccessToken;
+                        return resolution.Tokens?.AccessToken;
                     };
                 }
             )

--- a/src/Capacitor.Cli/Commands/WhoamiCommand.cs
+++ b/src/Capacitor.Cli/Commands/WhoamiCommand.cs
@@ -6,12 +6,9 @@ using Capacitor.Cli.Core.Config;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Reports who you are AND whether the server agrees.
-///
-/// Printing local token metadata alone is misleading: "expires tomorrow" says only that a clock
-/// hasn't passed, not that any server accepts the token. That gap once turned a real 401 into a
-/// multi-day misdiagnosis, because whoami cheerfully reported a valid token for a server that was
-/// rejecting every request. So this asks the server directly.
+/// Reports the stored identity and whether the server actually accepts it. Local metadata alone
+/// is not an answer: "expires tomorrow" only says a clock hasn't passed, so a token the server
+/// rejects still looks valid. Hence the probe.
 /// </summary>
 public static class WhoamiCommand {
     /// <summary>Cheap authenticated GET used purely to ask "do you accept this token?".</summary>

--- a/src/Capacitor.Cli/Commands/WhoamiCommand.cs
+++ b/src/Capacitor.Cli/Commands/WhoamiCommand.cs
@@ -52,7 +52,7 @@ public static class WhoamiCommand {
         // WorkOS credential (single-use refresh token) as a side effect of merely running whoami,
         // and would let the expiry printed here describe a different token than the one probed.
         var profile  = await TokenStore.ResolveProfileNameAsync();
-        var snapshot = await TokenStore.LoadAsync();
+        var snapshot = await TokenStore.LoadForProfileAsync(profile);
 
         if (snapshot is null) {
             Console.Error.WriteLine("Not authenticated. Run `kcap login`.");

--- a/src/Capacitor.Cli/Commands/WhoamiCommand.cs
+++ b/src/Capacitor.Cli/Commands/WhoamiCommand.cs
@@ -47,11 +47,12 @@ public static class WhoamiCommand {
             return 0;
         }
 
-        // ONE snapshot for everything below. The probe deliberately does not refresh, so the
-        // expiry printed here is always the expiry of the token that was probed — otherwise a
-        // refresh between the two could print one token's details and test another's.
-        var resolution = await TokenStore.GetValidTokensForServerAsync(baseUrl);
-        var snapshot   = resolution.Tokens ?? await TokenStore.LoadAsync();
+        // ONE raw snapshot for everything below — deliberately NOT the refresh-aware accessor.
+        // Diagnosing your auth must not mutate it: routing this through a refresh could rotate a
+        // WorkOS credential (single-use refresh token) as a side effect of merely running whoami,
+        // and would let the expiry printed here describe a different token than the one probed.
+        var profile  = await TokenStore.ResolveProfileNameAsync();
+        var snapshot = await TokenStore.LoadAsync();
 
         if (snapshot is null) {
             Console.Error.WriteLine("Not authenticated. Run `kcap login`.");
@@ -61,16 +62,16 @@ public static class WhoamiCommand {
 
         await Console.Out.WriteLineAsync($"Username: {snapshot.GitHubUsername}");
         await Console.Out.WriteLineAsync($"Provider: {snapshot.Provider}");
-        await Console.Out.WriteLineAsync($"Profile:  {resolution.ProfileName}");
+        await Console.Out.WriteLineAsync($"Profile:  {profile}");
         await Console.Out.WriteLineAsync($"Expires:  {snapshot.ExpiresAt:u}");
         await Console.Out.WriteLineAsync($"Server:   {baseUrl}");
         await Console.Out.WriteLineAsync($"Expired:  {(snapshot.IsExpired ? "yes" : "no")}");
 
         // A token minted elsewhere can never be accepted here, and no refresh can change that —
         // say so instead of spending a request to be told 401.
-        if (resolution.Status == AuthStatus.WrongServer) {
+        if (snapshot.ServerUrl is not null && !ServerIdentity.SameServer(snapshot.ServerUrl, baseUrl)) {
             await Console.Out.WriteLineAsync(
-                $"Server:   token was issued by {resolution.IssuedServerUrl} — run 'kcap login'");
+                $"Server:   token was issued by {snapshot.ServerUrl} — run 'kcap login'");
 
             return 1;
         }

--- a/src/Capacitor.Cli/Commands/WhoamiCommand.cs
+++ b/src/Capacitor.Cli/Commands/WhoamiCommand.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// Reports who you are AND whether the server agrees.
+///
+/// Printing local token metadata alone is misleading: "expires tomorrow" says only that a clock
+/// hasn't passed, not that any server accepts the token. That gap once turned a real 401 into a
+/// multi-day misdiagnosis, because whoami cheerfully reported a valid token for a server that was
+/// rejecting every request. So this asks the server directly.
+/// </summary>
+public static class WhoamiCommand {
+    /// <summary>Cheap authenticated GET used purely to ask "do you accept this token?".</summary>
+    internal const string ProbePath = "/api/me/notification-prefs";
+
+    static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>The server's verdict on the token, and the exit code it implies.</summary>
+    internal readonly record struct ProbeVerdict(string Line, int ExitCode);
+
+    /// <summary>
+    /// Maps a probe response to what we tell the user. ONLY 401/403 are verdicts about the token:
+    /// everything else means we failed to ask, and reporting that as "rejected" would send people
+    /// to re-run `kcap login` for an outage or an older server that lacks the endpoint.
+    /// </summary>
+    internal static ProbeVerdict Interpret(HttpStatusCode? status) => status switch {
+        null                                    => new("could not verify (server unreachable)", 0),
+        HttpStatusCode.Unauthorized             => new("REJECTS this token (run 'kcap login')", 1),
+        HttpStatusCode.Forbidden                => new("REJECTS this token (run 'kcap login')", 1),
+        HttpStatusCode.NotFound                 => new("could not verify (endpoint not available on this server)", 0),
+        >= HttpStatusCode.OK and < (HttpStatusCode)300              => new("accepts this token", 0),
+        >= (HttpStatusCode)300 and < (HttpStatusCode)400            => new("could not verify (unexpected redirect)", 0),
+        { } other                               => new($"could not verify (server error {(int)other})", 0)
+    };
+
+    public static async Task<int> HandleAsync(string baseUrl) {
+        var provider = await HttpClientExtensions.DiscoverProviderAsync(baseUrl);
+
+        if (provider == "None") {
+            await Console.Out.WriteLineAsync("Provider: None (no authentication)");
+            await Console.Out.WriteLineAsync($"Server:   {baseUrl}");
+
+            return 0;
+        }
+
+        // ONE snapshot for everything below. The probe deliberately does not refresh, so the
+        // expiry printed here is always the expiry of the token that was probed — otherwise a
+        // refresh between the two could print one token's details and test another's.
+        var resolution = await TokenStore.GetValidTokensForServerAsync(baseUrl);
+        var snapshot   = resolution.Tokens ?? await TokenStore.LoadAsync();
+
+        if (snapshot is null) {
+            Console.Error.WriteLine("Not authenticated. Run `kcap login`.");
+
+            return 1;
+        }
+
+        await Console.Out.WriteLineAsync($"Username: {snapshot.GitHubUsername}");
+        await Console.Out.WriteLineAsync($"Provider: {snapshot.Provider}");
+        await Console.Out.WriteLineAsync($"Profile:  {resolution.ProfileName}");
+        await Console.Out.WriteLineAsync($"Expires:  {snapshot.ExpiresAt:u}");
+        await Console.Out.WriteLineAsync($"Server:   {baseUrl}");
+        await Console.Out.WriteLineAsync($"Expired:  {(snapshot.IsExpired ? "yes" : "no")}");
+
+        // A token minted elsewhere can never be accepted here, and no refresh can change that —
+        // say so instead of spending a request to be told 401.
+        if (resolution.Status == AuthStatus.WrongServer) {
+            await Console.Out.WriteLineAsync(
+                $"Server:   token was issued by {resolution.IssuedServerUrl} — run 'kcap login'");
+
+            return 1;
+        }
+
+        var verdict = Interpret(await ProbeAsync(baseUrl, snapshot.AccessToken));
+        await Console.Out.WriteLineAsync($"Server:   {verdict.Line}");
+
+        return verdict.ExitCode;
+    }
+
+    // Null means "we never got an answer" (transport failure or timeout), which is deliberately
+    // distinct from any status code the server did return.
+    static async Task<HttpStatusCode?> ProbeAsync(string baseUrl, string accessToken) {
+        try {
+            // No redirect following: a login redirect would otherwise masquerade as some other
+            // status. No retry handler either — this client must send exactly the token we printed.
+            using var http = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+            http.DefaultRequestHeaders.Authorization = new("Bearer", accessToken);
+
+            using var response = await http.GetOnceAsync(
+                $"{AppConfig.NormalizeUrl(baseUrl)}{ProbePath}", ProbeTimeout);
+
+            return response.StatusCode;
+        } catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException or IOException) {
+            return null;
+        }
+    }
+}

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -246,32 +246,8 @@ switch (command) {
 
         return 0;
     }
-    case "whoami": {
-        var provider = await HttpClientExtensions.DiscoverProviderAsync(baseUrl!);
-
-        if (provider == "None") {
-            await Console.Out.WriteLineAsync("Provider: None (no authentication)");
-            await Console.Out.WriteLineAsync($"Server:   {baseUrl!}");
-
-            return 0;
-        }
-
-        var tokens = await TokenStore.LoadAsync();
-
-        if (tokens is null) {
-            Console.Error.WriteLine("Not authenticated. Run `kcap login`.");
-
-            return 1;
-        }
-
-        await Console.Out.WriteLineAsync($"Username: {tokens.GitHubUsername}");
-        await Console.Out.WriteLineAsync($"Provider: {tokens.Provider}");
-        await Console.Out.WriteLineAsync($"Expires:  {tokens.ExpiresAt:u}");
-        await Console.Out.WriteLineAsync($"Server:   {baseUrl!}");
-        await Console.Out.WriteLineAsync($"Expired:  {(tokens.IsExpired ? "yes" : "no")}");
-
-        return 0;
-    }
+    case "whoami":
+        return await WhoamiCommand.HandleAsync(baseUrl!);
     case "daemon":
         return await DaemonCommands.HandleAsync(args);
     case "run-agent":

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContextProvider.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContextProvider.cs
@@ -5,7 +5,7 @@ namespace Capacitor.Cli.SessionStartMemory;
 
 internal sealed class SessionStartMemoryContextProvider(
     ISessionStartMemoryScopeResolver scopeResolver,
-    Func<bool, CancellationToken, Task<HttpClient>> clientFactory,
+    Func<string?, CancellationToken, Task<HttpClient>> clientFactory,
     Action<string>? diagnostic = null,
     bool disposeClients = false) {
 
@@ -19,11 +19,16 @@ internal sealed class SessionStartMemoryContextProvider(
             HttpClient? firstClient = null;
             HttpClient? refreshClient = null;
             try {
-                firstClient = await clientFactory(false, cts.Token);
+                firstClient = await clientFactory(null, cts.Token);
                 var response = await SendAsync(firstClient, request.BaseUrl, scope, cts.Token);
                 if (response.StatusCode == HttpStatusCode.Unauthorized) {
                     response.Dispose();
-                    refreshClient = await clientFactory(true, cts.Token);
+                    // Retry against the token this client actually sent, so a peer process that
+                    // refreshed in the meantime is adopted rather than rotated a second time. A
+                    // null here (no token was attached) simply means there is nothing to force —
+                    // the retry still picks up whatever is stored now.
+                    var rejected = firstClient.DefaultRequestHeaders.Authorization?.Parameter;
+                    refreshClient = await clientFactory(rejected, cts.Token);
                     response = await SendAsync(refreshClient, request.BaseUrl, scope, cts.Token);
                 }
                 using (response) {

--- a/test/Capacitor.Cli.Tests.Unit/CrossProcessRefreshTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CrossProcessRefreshTests.cs
@@ -29,6 +29,9 @@ public class CrossProcessRefreshTests {
         if (Directory.Exists(TokensDir)) Directory.Delete(TokensDir, recursive: true);
         var cfg = Capacitor.Cli.Core.Config.AppConfig.GetConfigPath();
         if (File.Exists(cfg)) File.Delete(cfg);
+        // Token lookup now consults AppConfig.ResolvedProfile, so a value left behind by another
+        // test would redirect these reads to a different profile.
+        Capacitor.Cli.Core.Config.AppConfig.ResetResolvedStateForTesting();
     }
 
     static StoredTokens Token(string accessToken, DateTimeOffset expiresAt) => new() {

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsServerSettlementRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsServerSettlementRetryTests.cs
@@ -157,7 +157,7 @@ public class McpFlowsServerSettlementRetryTests {
 
         var clock = Clock();
         using var response = ResponseOf(await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11)));
+            client, "https://flows.example.test", (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11)));
         var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
@@ -184,7 +184,7 @@ public class McpFlowsServerSettlementRetryTests {
 
         var clock = Clock();
         using var response = ResponseOf(await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11)));
+            client, "https://flows.example.test", (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11)));
         var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
@@ -204,7 +204,7 @@ public class McpFlowsServerSettlementRetryTests {
 
         var clock  = Clock();
         var result = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11));
+            client, "https://flows.example.test", (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11));
 
         var exhausted = result as McpFlowsServer.SettlementSendResult.DeadlineExhausted;
         await Assert.That(exhausted).IsNotNull();
@@ -228,7 +228,7 @@ public class McpFlowsServerSettlementRetryTests {
 
         var clock = Clock();
         using var response = ResponseOf(await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11)));
+            client, "https://flows.example.test", (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11)));
         var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Conflict);
@@ -245,7 +245,7 @@ public class McpFlowsServerSettlementRetryTests {
 
         var clock = Clock();
         using var response = ResponseOf(await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11)));
+            client, "https://flows.example.test", (c, ct) => c.PostAsync($"{server.Url}/start", null, ct), clock, SettlementBackoff.Seeded(11)));
         var delays = clock.Delays;
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
@@ -288,7 +288,7 @@ public class McpFlowsServerSettlementRetryTests {
         using var client = new HttpClient(handler) { BaseAddress = new Uri("http://settlement.test") };
 
         var result = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, (c, ct) => c.PostAsync("/start", null, ct), clock, SettlementBackoff.Seeded(5));
+            client, "https://flows.example.test", (c, ct) => c.PostAsync("/start", null, ct), clock, SettlementBackoff.Seeded(5));
 
         var exhausted = result as McpFlowsServer.SettlementSendResult.DeadlineExhausted;
         await Assert.That(exhausted).IsNotNull();
@@ -313,7 +313,7 @@ public class McpFlowsServerSettlementRetryTests {
         using var client = new HttpClient(handler) { BaseAddress = new Uri("http://settlement.test") };
 
         var result = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, (c, ct) => c.PostAsync("/start", null, ct), clock, SettlementBackoff.Seeded(5));
+            client, "https://flows.example.test", (c, ct) => c.PostAsync("/start", null, ct), clock, SettlementBackoff.Seeded(5));
 
         var exhausted = result as McpFlowsServer.SettlementSendResult.DeadlineExhausted;
         await Assert.That(exhausted).IsNotNull();
@@ -339,7 +339,7 @@ public class McpFlowsServerSettlementRetryTests {
         using var client = new HttpClient(handler) { BaseAddress = new Uri("http://settlement.test") };
 
         await Assert.That(async () => await McpFlowsServer.SendWithSettlementRetryAsync(
-                client, (c, ct) => c.PostAsync("/start", null, ct), clock, SettlementBackoff.Seeded(5), caller.Token))
+                client, "https://flows.example.test", (c, ct) => c.PostAsync("/start", null, ct), clock, SettlementBackoff.Seeded(5), caller.Token))
             .Throws<OperationCanceledException>();
     }
 
@@ -357,7 +357,7 @@ public class McpFlowsServerSettlementRetryTests {
         using var client = new HttpClient(handler) { BaseAddress = new Uri("http://settlement.test") };
 
         var result = await McpFlowsServer.SendWithSettlementRetryAsync(
-            client, (c, ct) => c.PostAsync("/start", null, ct), clock, SettlementBackoff.Seeded(5));
+            client, "https://flows.example.test", (c, ct) => c.PostAsync("/start", null, ct), clock, SettlementBackoff.Seeded(5));
 
         var exhausted = result as McpFlowsServer.SettlementSendResult.DeadlineExhausted;
         await Assert.That(exhausted).IsNotNull();

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsServerTests.cs
@@ -663,9 +663,11 @@ public class McpFlowsServerTests {
 
     static async Task SeedDefaultTokenAsync() {
         // The active profile must resolve to "default" so GetValidTokensAsync() loads what we seed —
-        // clear any config.json a sibling token-store test may have left in the shared config dir.
+        // clear any config.json a sibling token-store test may have left in the shared config dir,
+        // and the process-global resolved profile, which token lookup now prefers over config.
         var cfg = Capacitor.Cli.Core.Config.AppConfig.GetConfigPath();
         if (File.Exists(cfg)) File.Delete(cfg);
+        Capacitor.Cli.Core.Config.AppConfig.ResetResolvedStateForTesting();
 
         await TokenStore.SaveAsync("default", new StoredTokens {
             AccessToken    = FreshBearer,

--- a/test/Capacitor.Cli.Tests.Unit/ServerIdentityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ServerIdentityTests.cs
@@ -50,6 +50,35 @@ public class ServerIdentityTests {
     }
 
     [Test]
+    // The canonical form always carries the EFFECTIVE port, which is what makes an implicit and an
+    // explicit default port compare equal.
+    [Arguments("https://kcap.example.com/", "https://kcap.example.com:443")]
+    [Arguments("https://KCAP.Example.COM:443", "https://kcap.example.com:443")]
+    [Arguments("http://localhost:5108", "http://localhost:5108")]
+    public async Task Stamping_yields_the_canonical_form(string input, string expected) {
+        var ok = ServerIdentity.TryCanonicalizeForStamping(input, out var canonical, out var error);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(canonical).IsEqualTo(expected);
+        await Assert.That(error).IsEmpty();
+    }
+
+    [Test]
+    [Arguments("https://kcap.example.com?tenant=a")]
+    [Arguments("https://user:pw@kcap.example.com")]
+    [Arguments("ftp://kcap.example.com")]
+    [Arguments("kcap.example.com")]
+    public async Task Stamping_refuses_a_url_it_cannot_bind(string url) {
+        // A null ServerUrl means "pre-upgrade token, unenforced". Minting a NEW token with one
+        // would silently downgrade it to a credential any server is allowed to receive, so login
+        // must fail loudly instead.
+        var ok = ServerIdentity.TryCanonicalizeForStamping(url, out _, out var error);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(error).Contains(url);
+    }
+
+    [Test]
     public async Task Unparseable_side_never_matches_a_valid_side() {
         // Fail closed: "we can't tell" must not read as "same server".
         await Assert.That(ServerIdentity.SameServer("not a url", "https://kcap.example.com")).IsFalse();

--- a/test/Capacitor.Cli.Tests.Unit/ServerIdentityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ServerIdentityTests.cs
@@ -1,0 +1,58 @@
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Server identity decides whether a stored token may be sent to a given server, so both
+/// directions matter: too strict and a legitimate token is refused, too loose and a token
+/// crosses to a server that never issued it.
+/// </summary>
+public class ServerIdentityTests {
+    [Test]
+    [Arguments("https://kcap.example.com", "https://kcap.example.com:443")]
+    [Arguments("http://kcap.example.com", "http://kcap.example.com:80")]
+    [Arguments("https://KCAP.Example.COM", "https://kcap.example.com")]
+    [Arguments("HTTPS://kcap.example.com", "https://kcap.example.com")]
+    [Arguments("https://kcap.example.com/", "https://kcap.example.com")]
+    [Arguments("https://kcap.example.com/base/", "https://kcap.example.com/base")]
+    public async Task Equivalent_urls_name_the_same_server(string left, string right)
+        => await Assert.That(ServerIdentity.SameServer(left, right)).IsTrue();
+
+    [Test]
+    [Arguments("https://kcap.example.com", "https://other.example.com")]
+    [Arguments("https://kcap.example.com", "http://kcap.example.com")]
+    [Arguments("https://kcap.example.com:8443", "https://kcap.example.com")]
+    // Paths are case-sensitive in HTTP, so two path-routed tenants must stay distinct.
+    [Arguments("https://kcap.example.com/Tenant", "https://kcap.example.com/tenant")]
+    [Arguments("https://kcap.example.com/a", "https://kcap.example.com/b")]
+    public async Task Different_servers_do_not_match(string left, string right)
+        => await Assert.That(ServerIdentity.SameServer(left, right)).IsFalse();
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments("kcap.example.com")]            // relative — no scheme
+    [Arguments("ftp://kcap.example.com")]      // not http(s)
+    [Arguments("https://user:pw@kcap.example.com")] // userinfo
+    [Arguments("https://kcap.example.com?tenant=a")] // query
+    [Arguments("https://kcap.example.com#frag")]     // fragment
+    public async Task Inadmissible_inputs_canonicalize_to_null(string? url)
+        => await Assert.That(ServerIdentity.Canonicalize(url)).IsNull();
+
+    [Test]
+    public async Task Query_bearing_urls_never_match_even_each_other() {
+        // Dropping the query instead of rejecting it would make these compare equal.
+        await Assert.That(ServerIdentity.SameServer(
+            "https://kcap.example.com/base?tenant=a", "https://kcap.example.com/base?tenant=b")).IsFalse();
+        await Assert.That(ServerIdentity.SameServer(
+            "https://kcap.example.com/base?tenant=a", "https://kcap.example.com/base?tenant=a")).IsFalse();
+    }
+
+    [Test]
+    public async Task Unparseable_side_never_matches_a_valid_side() {
+        // Fail closed: "we can't tell" must not read as "same server".
+        await Assert.That(ServerIdentity.SameServer("not a url", "https://kcap.example.com")).IsFalse();
+        await Assert.That(ServerIdentity.SameServer(null, null)).IsFalse();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
@@ -256,12 +256,16 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task Provider_refreshes_once_after_401_and_refuses_redirect_status() {
         var calls = 0;
-        var forceRefreshValues = new List<bool>();
-        var refreshing = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null), (forceRefresh, _) => {
-            forceRefreshValues.Add(forceRefresh);
+        var rejectedTokens = new List<string?>();
+        var refreshing = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null), (rejectedAccessToken, _) => {
+            rejectedTokens.Add(rejectedAccessToken);
             calls++;
             var status = calls == 1 ? HttpStatusCode.Unauthorized : HttpStatusCode.NoContent;
-            return Task.FromResult(new HttpClient(new StaticHandler(status, "")));
+            var client = new HttpClient(new StaticHandler(status, ""));
+            // The real factory attaches a bearer; the retry identifies which token was rejected
+            // by reading it back off the client that sent it.
+            client.DefaultRequestHeaders.Authorization = new("Bearer", calls == 1 ? "rejected-token" : "fresh-token");
+            return Task.FromResult(client);
         }, disposeClients: true);
         var request = new SessionStartMemoryContextRequest(
             "https://example.test", null, false, TimeSpan.FromSeconds(1), CancellationToken.None);
@@ -272,7 +276,7 @@ public class SessionStartMemoryFoundationTests {
             .GetAsync(request);
 
         await Assert.That(calls).IsEqualTo(2);
-        await Assert.That(forceRefreshValues).IsEquivalentTo([false, true]);
+        await Assert.That(rejectedTokens).IsEquivalentTo([null, "rejected-token"]);
         await Assert.That(healed.Disposition).IsEqualTo(SessionStartMemoryDisposition.CompleteWithoutContext);
         await Assert.That(redirected.Disposition).IsEqualTo(SessionStartMemoryDisposition.RetryableFailure);
     }

--- a/test/Capacitor.Cli.Tests.Unit/TokenServerBindingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TokenServerBindingTests.cs
@@ -214,6 +214,47 @@ public class TokenServerBindingTests {
         await Assert.That(await TokenStore.ForceRefreshAsync("anything")).IsNull();
     }
 
+    [Test]
+    public async Task Force_refresh_refuses_to_adopt_a_peer_token_for_a_different_server() {
+        // The peer that replaced our rejected token may have logged into a DIFFERENT server. The
+        // dedup rule alone would hand that token back, and the caller would send it to the server
+        // that just rejected us.
+        await TokenStore.SaveAsync("default",
+            Tokens(serverUrl: OtherServer, username: "peer") with { AccessToken = "peer-token" });
+
+        var adopted = await TokenStore.ForceRefreshAsync("stale-rejected-token", Server);
+
+        await Assert.That(adopted).IsNull();
+    }
+
+    [Test]
+    public async Task Force_refresh_adopts_a_peer_token_bound_to_the_same_server() {
+        await TokenStore.SaveAsync("default",
+            Tokens(serverUrl: Server, username: "peer") with { AccessToken = "peer-token" });
+
+        var adopted = await TokenStore.ForceRefreshAsync("stale-rejected-token", Server);
+
+        await Assert.That(adopted?.AccessToken).IsEqualTo("peer-token");
+    }
+
+    [Test]
+    public async Task Accessor_rejects_a_token_swapped_to_another_server_after_the_first_read() {
+        // Models a concurrent login/repoint landing between the accessor's snapshot read and its
+        // load-and-refresh read: checking only the first snapshot would let the replacement through.
+        await TokenStore.SaveAsync("default", Tokens(serverUrl: null, username: "unbound"));
+
+        var resolution = await TokenStore.GetValidTokensForServerAsync(Server);
+        await Assert.That(resolution.Status).IsEqualTo(AuthStatus.Ok);
+
+        // Now the stored token is bound elsewhere — the next resolution must refuse it.
+        await TokenStore.SaveAsync("default", Tokens(serverUrl: OtherServer, username: "swapped"));
+
+        var after = await TokenStore.GetValidTokensForServerAsync(Server);
+
+        await Assert.That(after.Status).IsEqualTo(AuthStatus.WrongServer);
+        await Assert.That(after.Tokens).IsNull();
+    }
+
     // ── Round-trip ───────────────────────────────────────────────────────────
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/TokenServerBindingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TokenServerBindingTests.cs
@@ -255,6 +255,53 @@ public class TokenServerBindingTests {
         await Assert.That(after.Tokens).IsNull();
     }
 
+    // ── Recovery after a rejection ───────────────────────────────────────────
+
+    [Test]
+    public async Task Recovery_adopts_a_differing_stored_token_without_a_second_rotation() {
+        // A peer refresh (or a fresh login) landed while we were being rejected. The rotation
+        // attempt finds the stored token no longer matches the rejected one and returns it as-is.
+        await TokenStore.SaveAsync("default",
+            Tokens(serverUrl: Server, username: "peer") with { AccessToken = "peer-token" });
+
+        var recovered = await TokenStore.RecoverForServerAsync(Server, "rejected-token");
+
+        await Assert.That(recovered?.AccessToken).IsEqualTo("peer-token");
+    }
+
+    [Test]
+    public async Task Recovery_falls_back_to_the_stored_token_without_a_second_rotation() {
+        // Rotation was attempted and failed (unroutable refresh endpoint). The fallback is a RAW
+        // read: the same token comes back for one more attempt, and — the point of the finding —
+        // no second provider refresh is issued, so a single-use refresh token isn't re-spent.
+        await TokenStore.SaveAsync("default",
+            Tokens(serverUrl: OtherServer) with { AccessToken = "rejected-token" });
+
+        var recovered = await TokenStore.RecoverForServerAsync(OtherServer, "rejected-token");
+
+        await Assert.That(recovered?.AccessToken).IsEqualTo("rejected-token");
+    }
+
+    [Test]
+    public async Task Recovery_of_an_expired_token_does_not_refresh_twice() {
+        // The failure mode behind the finding: falling back to the refresh-aware accessor would
+        // see this expired token and rotate a SECOND time. A raw fallback returns it untouched.
+        await TokenStore.SaveAsync("default",
+            Tokens(serverUrl: OtherServer, expiresIn: TimeSpan.FromMinutes(-5)) with { AccessToken = "rejected-token" });
+
+        var recovered = await TokenStore.RecoverForServerAsync(OtherServer, "rejected-token");
+
+        await Assert.That(recovered?.AccessToken).IsEqualTo("rejected-token");
+    }
+
+    [Test]
+    public async Task Recovery_refuses_a_stored_token_bound_to_another_server() {
+        await TokenStore.SaveAsync("default",
+            Tokens(serverUrl: OtherServer) with { AccessToken = "elsewhere-token" });
+
+        await Assert.That(await TokenStore.RecoverForServerAsync(Server, "rejected-token")).IsNull();
+    }
+
     // ── Round-trip ───────────────────────────────────────────────────────────
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/TokenServerBindingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TokenServerBindingTests.cs
@@ -1,0 +1,250 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The rules that keep a token from reaching a server that never issued it, and that keep token
+/// lookup pointed at the profile the rest of the process resolved.
+///
+/// Shares the process-wide KCAP_CONFIG_DIR (see <see cref="TokenStoreProfileTests"/>) and mutates
+/// AppConfig's process-global resolved state, so the whole class is serialized.
+/// </summary>
+[NotInParallel(nameof(TokenStoreProfileTests))]
+public class TokenServerBindingTests {
+    const string Server = "https://kcap.example.com";
+
+    // Deliberately unroutable (discard port): any refresh these tests did NOT intend gets refused
+    // immediately, so a regression that reintroduces a rotation fails in milliseconds instead of
+    // hanging on DNS or a retry budget.
+    const string OtherServer = "http://127.0.0.1:9";
+
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+    static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
+
+    // Only the profiles these tests own. Wiping the whole token directory would be hostile to
+    // sibling classes that seed their own tokens in the shared KCAP_CONFIG_DIR.
+    static readonly string[] OwnedProfiles = ["default", "acme", "widgets", "bound", "unbound"];
+
+    [Before(Test)]
+    public void Cleanup() {
+        if (File.Exists(LegacyPath)) File.Delete(LegacyPath);
+
+        foreach (var profile in OwnedProfiles) {
+            var path = Path.Combine(TokensDir, $"{profile}.json");
+            if (File.Exists(path)) File.Delete(path);
+        }
+
+        var cfg = AppConfig.GetConfigPath();
+        if (File.Exists(cfg)) File.Delete(cfg);
+
+        AppConfig.ResetResolvedStateForTesting();
+    }
+
+    [After(Test)]
+    public void ResetResolvedState() => AppConfig.ResetResolvedStateForTesting();
+
+    // ── Binding ──────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Token_bound_to_the_target_server_is_handed_out() {
+        await TokenStore.SaveAsync("default", Tokens(serverUrl: Server));
+
+        var resolution = await TokenStore.GetValidTokensForServerAsync(Server);
+
+        await Assert.That(resolution.Status).IsEqualTo(AuthStatus.Ok);
+        await Assert.That(resolution.Tokens).IsNotNull();
+    }
+
+    [Test]
+    public async Task Token_bound_to_another_server_is_withheld_with_a_diagnosable_status() {
+        await TokenStore.SaveAsync("default", Tokens(serverUrl: OtherServer));
+
+        var resolution = await TokenStore.GetValidTokensForServerAsync(Server);
+
+        await Assert.That(resolution.Status).IsEqualTo(AuthStatus.WrongServer);
+        // The whole point: the token must not be reachable by the caller...
+        await Assert.That(resolution.Tokens).IsNull();
+        // ...but the caller still needs to be able to say WHICH server it belongs to.
+        await Assert.That(resolution.IssuedServerUrl).IsEqualTo(OtherServer);
+    }
+
+    [Test]
+    public async Task Pre_upgrade_token_without_a_binding_is_not_enforced() {
+        // Files written before server_url existed must keep working; they get stamped later.
+        await TokenStore.SaveAsync("default", Tokens(serverUrl: null));
+
+        var resolution = await TokenStore.GetValidTokensForServerAsync(Server);
+
+        await Assert.That(resolution.Status).IsEqualTo(AuthStatus.Ok);
+        await Assert.That(resolution.Tokens).IsNotNull();
+    }
+
+    [Test]
+    public async Task Binding_is_checked_before_any_refresh_is_attempted() {
+        // An EXPIRED token bound elsewhere must not trigger a refresh: we already know we won't
+        // use it, and refreshing would spend a rotating credential (and a round trip) for nothing.
+        // The refresh endpoint here is unroutable, so a refresh attempt would stall or throw
+        // rather than returning promptly with WrongServer.
+        await TokenStore.SaveAsync("default", Tokens(serverUrl: OtherServer, expiresIn: TimeSpan.FromMinutes(-5)));
+
+        var resolution = await TokenStore.GetValidTokensForServerAsync(Server);
+
+        await Assert.That(resolution.Status).IsEqualTo(AuthStatus.WrongServer);
+        await Assert.That(resolution.Tokens).IsNull();
+    }
+
+    [Test]
+    public async Task No_token_at_all_reports_not_authenticated() {
+        var resolution = await TokenStore.GetValidTokensForServerAsync(Server);
+
+        await Assert.That(resolution.Status).IsEqualTo(AuthStatus.NotAuthenticated);
+        await Assert.That(resolution.Tokens).IsNull();
+    }
+
+    // ── Resolved-profile lookup ──────────────────────────────────────────────
+
+    [Test]
+    public async Task Lookup_follows_the_resolved_profile_not_the_active_one() {
+        await WriteConfigAsync(active: "acme", extraProfile: "widgets");
+        await TokenStore.SaveAsync("acme",    Tokens(serverUrl: Server, username: "acme-user"));
+        await TokenStore.SaveAsync("widgets", Tokens(serverUrl: Server, username: "widgets-user"));
+
+        AppConfig.SetResolvedState(Server, "widgets", new Profile { ServerUrl = Server });
+
+        var resolution = await TokenStore.GetValidTokensForServerAsync(Server);
+
+        await Assert.That(resolution.ProfileName).IsEqualTo("widgets");
+        await Assert.That(resolution.Tokens!.GitHubUsername).IsEqualTo("widgets-user");
+    }
+
+    [Test]
+    public async Task Lookup_falls_back_to_the_active_profile_when_nothing_was_resolved() {
+        // An explicit --server-url / KCAP_URL override resolves no profile name at all.
+        await WriteConfigAsync(active: "acme");
+        await TokenStore.SaveAsync("acme", Tokens(serverUrl: Server, username: "acme-user"));
+
+        var resolution = await TokenStore.GetValidTokensForServerAsync(Server);
+
+        await Assert.That(resolution.ProfileName).IsEqualTo("acme");
+        await Assert.That(resolution.Tokens!.GitHubUsername).IsEqualTo("acme-user");
+    }
+
+    // ── Legacy tokens.json ownership ─────────────────────────────────────────
+
+    [Test]
+    public async Task Legacy_credential_is_available_to_its_migration_owner() {
+        await WriteConfigAsync(active: "acme");
+        await WriteLegacyAsync(Tokens(serverUrl: null, username: "legacy-user"));
+
+        var loaded = await TokenStore.LoadAsync();
+
+        await Assert.That(loaded).IsNotNull();
+        await Assert.That(loaded!.GitHubUsername).IsEqualTo("legacy-user");
+    }
+
+    [Test]
+    public async Task Legacy_credential_is_withheld_from_a_different_resolved_profile() {
+        // Otherwise a repo bound to a token-less profile silently borrows the active profile's
+        // pre-upgrade credential — and it carries no binding, so nothing downstream can catch it.
+        await WriteConfigAsync(active: "acme", extraProfile: "widgets");
+        await WriteLegacyAsync(Tokens(serverUrl: null, username: "legacy-user"));
+
+        AppConfig.SetResolvedState(Server, "widgets", new Profile { ServerUrl = Server });
+
+        await Assert.That(await TokenStore.LoadAsync()).IsNull();
+    }
+
+    [Test]
+    public async Task Legacy_credential_is_withheld_from_default_when_another_profile_is_active() {
+        // "default" gets no special exemption: with acme active, the legacy credential is acme's.
+        await WriteConfigAsync(active: "acme", extraProfile: "default");
+        await WriteLegacyAsync(Tokens(serverUrl: null, username: "legacy-user"));
+
+        AppConfig.SetResolvedState(Server, "default", new Profile { ServerUrl = Server });
+
+        await Assert.That(await TokenStore.LoadAsync()).IsNull();
+    }
+
+    [Test]
+    public async Task Legacy_credential_is_available_to_default_when_no_active_profile_is_set() {
+        // An absent/empty active profile normalizes to "default", which then owns the credential.
+        await WriteLegacyAsync(Tokens(serverUrl: null, username: "legacy-user"));
+
+        var loaded = await TokenStore.LoadAsync();
+
+        await Assert.That(loaded).IsNotNull();
+        await Assert.That(loaded!.GitHubUsername).IsEqualTo("legacy-user");
+    }
+
+    // ── Force-refresh dedup ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task Force_refresh_adopts_a_peers_token_instead_of_rotating_again() {
+        // The stored token is NOT the one that was rejected — a peer already refreshed. Rotating
+        // again would spend a fresh credential that nothing rejected (and for WorkOS, whose
+        // refresh token is single-use, that can invalidate the peer's session).
+        await TokenStore.SaveAsync("default",
+            Tokens(serverUrl: OtherServer, username: "peer") with { AccessToken = "peer-token" });
+
+        var result = await TokenStore.ForceRefreshAsync("stale-rejected-token");
+
+        // Returned without contacting any refresh endpoint — there is none reachable in this test,
+        // so an attempted rotation would have yielded null instead.
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.AccessToken).IsEqualTo("peer-token");
+    }
+
+    [Test]
+    public async Task Force_refresh_attempts_a_rotation_when_the_stored_token_is_the_rejected_one() {
+        // Nobody else refreshed, so this really is the rejected credential: a rotation must be
+        // attempted. It fails here (no reachable refresh endpoint), which is how we can tell the
+        // attempt was made at all.
+        await TokenStore.SaveAsync("default",
+            Tokens(serverUrl: OtherServer) with { AccessToken = "rejected-token" });
+
+        var result = await TokenStore.ForceRefreshAsync("rejected-token");
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task Force_refresh_with_no_stored_token_is_a_no_op() {
+        await Assert.That(await TokenStore.ForceRefreshAsync("anything")).IsNull();
+    }
+
+    // ── Round-trip ───────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Saved_binding_survives_a_round_trip_and_is_absent_when_not_set() {
+        await TokenStore.SaveAsync("bound",   Tokens(serverUrl: Server));
+        await TokenStore.SaveAsync("unbound", Tokens(serverUrl: null));
+
+        await Assert.That((await TokenStore.LoadAsync("bound"))!.ServerUrl).IsEqualTo(Server);
+        await Assert.That((await TokenStore.LoadAsync("unbound"))!.ServerUrl).IsNull();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    static StoredTokens Tokens(string? serverUrl, string username = "alice", TimeSpan? expiresIn = null) => new() {
+        AccessToken    = "access-token",
+        ExpiresAt      = DateTimeOffset.UtcNow.Add(expiresIn ?? TimeSpan.FromHours(1)),
+        GitHubUsername = username,
+        Provider       = AuthProvider.GitHubApp,
+        ServerUrl      = serverUrl
+    };
+
+    static async Task WriteConfigAsync(string active, string? extraProfile = null) {
+        var profiles = new Dictionary<string, Profile> { [active] = new() { ServerUrl = Server } };
+        if (extraProfile is not null) profiles[extraProfile] = new() { ServerUrl = Server };
+
+        await AppConfig.SaveProfileConfig(new ProfileConfig { ActiveProfile = active, Profiles = profiles });
+    }
+
+    static async Task WriteLegacyAsync(StoredTokens tokens) {
+        Directory.CreateDirectory(Path.GetDirectoryName(LegacyPath)!);
+        await File.WriteAllTextAsync(LegacyPath,
+            System.Text.Json.JsonSerializer.Serialize(tokens, CapacitorJsonContext.Default.StoredTokens));
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/TokenStoreProfileTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TokenStoreProfileTests.cs
@@ -31,6 +31,9 @@ public class TokenStoreProfileTests {
         // assertions order-dependent.
         var cfg = Capacitor.Cli.Core.Config.AppConfig.GetConfigPath();
         if (File.Exists(cfg)) File.Delete(cfg);
+        // Token lookup now consults AppConfig.ResolvedProfile, so a value left behind by another
+        // test would redirect these reads to a different profile.
+        Capacitor.Cli.Core.Config.AppConfig.ResetResolvedStateForTesting();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/UnauthorizedRetryHandlerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UnauthorizedRetryHandlerTests.cs
@@ -134,6 +134,37 @@ public class UnauthorizedRetryHandlerTests {
     }
 
     [Test]
+    public async Task A_json_body_is_replayed_on_the_retry() {
+        // JsonContent re-serializes its value on every send, so it IS replayable. Excluding it
+        // would silently leave every JSON-posting call site without 401 recovery.
+        await TokenStore.SaveAsync("default", Token("peer-refreshed"));
+
+        var transport = new RecordingHandler(HttpStatusCode.Unauthorized, HttpStatusCode.OK);
+        using var client = Client(transport, Token("original"));
+
+        var response = await client.PostAsync("https://kcap.example.com/api/thing",
+            System.Net.Http.Json.JsonContent.Create(new { hello = "world" }));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(transport.SentTokens).IsEquivalentTo(["original", "peer-refreshed"]);
+    }
+
+    [Test]
+    public async Task A_peer_token_for_a_different_server_is_never_adopted() {
+        // The handler is pinned to one server; a peer login elsewhere must not be picked up and
+        // sent to it.
+        await TokenStore.SaveAsync("default", Token("peer-elsewhere") with { ServerUrl = "http://127.0.0.1:9" });
+
+        var transport = new RecordingHandler(HttpStatusCode.Unauthorized, HttpStatusCode.OK);
+        using var client = Client(transport, Token("original"));
+
+        var response = await client.GetAsync("https://kcap.example.com/api/thing");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+        await Assert.That(transport.SentTokens).IsEquivalentTo(["original"]);
+    }
+
+    [Test]
     public async Task A_non_replayable_body_is_not_retried() {
         // Resending a consumed stream would send an empty or corrupt body; surfacing the 401 is
         // the honest outcome.
@@ -170,7 +201,7 @@ public class UnauthorizedRetryHandlerTests {
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     static HttpClient Client(RecordingHandler transport, StoredTokens initial) {
-        var retry = new UnauthorizedRetryHandler(initial) { InnerHandler = transport };
+        var retry = new UnauthorizedRetryHandler(initial, "https://kcap.example.com") { InnerHandler = transport };
 
         return new(retry);
     }

--- a/test/Capacitor.Cli.Tests.Unit/UnauthorizedRetryHandlerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UnauthorizedRetryHandlerTests.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The 401-retry handler's contract. These exercise the real handler over a fake transport and a
+/// real on-disk token store, because the failure modes that matter — attributing a 401 to the
+/// wrong token, resending with a stale header, leaking the first response — all live in the
+/// interaction, not in any single method.
+///
+/// Uses the shared KCAP_CONFIG_DIR and AppConfig's global resolved state, so it is serialized.
+/// </summary>
+[NotInParallel(nameof(TokenStoreProfileTests))]
+public class UnauthorizedRetryHandlerTests {
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+    static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
+
+    // Only the profiles these tests own. Wiping the whole token directory would be hostile to
+    // sibling classes that seed their own tokens in the shared KCAP_CONFIG_DIR.
+    static readonly string[] OwnedProfiles = ["default", "acme", "widgets", "bound", "unbound"];
+
+    [Before(Test)]
+    public void Cleanup() {
+        if (File.Exists(LegacyPath)) File.Delete(LegacyPath);
+
+        foreach (var profile in OwnedProfiles) {
+            var path = Path.Combine(TokensDir, $"{profile}.json");
+            if (File.Exists(path)) File.Delete(path);
+        }
+
+        var cfg = AppConfig.GetConfigPath();
+        if (File.Exists(cfg)) File.Delete(cfg);
+
+        AppConfig.ResetResolvedStateForTesting();
+    }
+
+    [After(Test)]
+    public void ResetResolvedState() => AppConfig.ResetResolvedStateForTesting();
+
+    [Test]
+    public async Task Non_401_responses_pass_through_untouched() {
+        var transport = new RecordingHandler(HttpStatusCode.OK);
+        using var client = Client(transport, Token("original"));
+
+        var response = await client.GetAsync("https://kcap.example.com/api/thing");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(transport.SentTokens).IsEquivalentTo(["original"]);
+    }
+
+    [Test]
+    public async Task Every_request_carries_the_handlers_own_token_not_the_client_default() {
+        // The client default header still holds whatever was attached at construction; after a
+        // refresh only the handler knows the current token.
+        var transport = new RecordingHandler(HttpStatusCode.OK);
+        using var client = Client(transport, Token("handler-token"));
+        client.DefaultRequestHeaders.Authorization = new("Bearer", "stale-default");
+
+        await client.GetAsync("https://kcap.example.com/api/thing");
+
+        await Assert.That(transport.SentTokens).IsEquivalentTo(["handler-token"]);
+    }
+
+    [Test]
+    public async Task A_401_that_cannot_be_refreshed_surfaces_as_a_single_attempt() {
+        // No stored token, so the refresh has nothing to work with: the caller must see the 401
+        // rather than a silent extra round trip.
+        var transport = new RecordingHandler(HttpStatusCode.Unauthorized);
+        using var client = Client(transport, Token("original"));
+
+        var response = await client.GetAsync("https://kcap.example.com/api/thing");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+        await Assert.That(transport.SentTokens.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task A_peer_refresh_is_adopted_and_the_request_is_retried_with_it() {
+        // The store already holds a NEWER token than the one this request sent — exactly what a
+        // peer process leaves behind. The retry must adopt it (and the dedup rule means no
+        // rotation is attempted, so no refresh endpoint is contacted).
+        await TokenStore.SaveAsync("default", Token("peer-refreshed"));
+
+        var transport = new RecordingHandler(HttpStatusCode.Unauthorized, HttpStatusCode.OK);
+        using var client = Client(transport, Token("original"));
+
+        var response = await client.GetAsync("https://kcap.example.com/api/thing");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(transport.SentTokens).IsEquivalentTo(["original", "peer-refreshed"]);
+    }
+
+    [Test]
+    public async Task Exactly_one_extra_attempt_is_made_when_the_retry_also_fails() {
+        await TokenStore.SaveAsync("default", Token("peer-refreshed"));
+
+        var transport = new RecordingHandler(HttpStatusCode.Unauthorized, HttpStatusCode.Unauthorized);
+        using var client = Client(transport, Token("original"));
+
+        var response = await client.GetAsync("https://kcap.example.com/api/thing");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+        await Assert.That(transport.SentTokens.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task The_first_401_response_is_disposed_before_the_retry() {
+        // Every recovered 401 would otherwise leak its response content/connection.
+        await TokenStore.SaveAsync("default", Token("peer-refreshed"));
+
+        var transport = new RecordingHandler(HttpStatusCode.Unauthorized, HttpStatusCode.OK);
+        using var client = Client(transport, Token("original"));
+
+        await client.GetAsync("https://kcap.example.com/api/thing");
+
+        await Assert.That(transport.FirstResponseContentDisposed).IsTrue();
+    }
+
+    [Test]
+    public async Task A_buffered_body_is_replayed_on_the_retry() {
+        await TokenStore.SaveAsync("default", Token("peer-refreshed"));
+
+        var transport = new RecordingHandler(HttpStatusCode.Unauthorized, HttpStatusCode.OK);
+        using var client = Client(transport, Token("original"));
+
+        var response = await client.PostAsync("https://kcap.example.com/api/thing",
+            new StringContent("""{"hello":"world"}"""));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(transport.SentBodies).IsEquivalentTo(["""{"hello":"world"}""", """{"hello":"world"}"""]);
+    }
+
+    [Test]
+    public async Task A_non_replayable_body_is_not_retried() {
+        // Resending a consumed stream would send an empty or corrupt body; surfacing the 401 is
+        // the honest outcome.
+        await TokenStore.SaveAsync("default", Token("peer-refreshed"));
+
+        var transport = new RecordingHandler(HttpStatusCode.Unauthorized, HttpStatusCode.OK);
+        using var client = Client(transport, Token("original"));
+
+        var response = await client.PostAsync("https://kcap.example.com/api/thing",
+            new StreamContent(new MemoryStream("body"u8.ToArray())));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+        await Assert.That(transport.SentTokens.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Concurrent_requests_share_one_refreshed_token_without_sending_a_bogus_one() {
+        // Sanity check on the shared mutable token under parallel use. The precise
+        // rejected-token attribution this depends on is asserted directly against the dedup rule
+        // in TokenServerBindingTests — here we only establish that concurrency doesn't produce a
+        // token that was never in play, or a torn read.
+        await TokenStore.SaveAsync("default", Token("peer-refreshed"));
+
+        var transport = new RecordingHandler(HttpStatusCode.Unauthorized, HttpStatusCode.OK);
+        using var client = Client(transport, Token("original"));
+
+        var responses = await Task.WhenAll(
+            Enumerable.Range(0, 4).Select(_ => client.GetAsync("https://kcap.example.com/api/thing")));
+
+        await Assert.That(transport.SentTokens.All(t => t is "original" or "peer-refreshed")).IsTrue();
+        await Assert.That(responses.Count(r => r.StatusCode == HttpStatusCode.OK)).IsGreaterThan(0);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    static HttpClient Client(RecordingHandler transport, StoredTokens initial) {
+        var retry = new UnauthorizedRetryHandler(initial) { InnerHandler = transport };
+
+        return new(retry);
+    }
+
+    static StoredTokens Token(string accessToken) => new() {
+        AccessToken    = accessToken,
+        ExpiresAt      = DateTimeOffset.UtcNow.AddHours(1),
+        GitHubUsername = "alice",
+        Provider       = AuthProvider.GitHubApp,
+        ServerUrl      = "https://kcap.example.com"
+    };
+
+    sealed class RecordingHandler(params HttpStatusCode[] statuses) : HttpMessageHandler {
+        readonly Lock _gate = new();
+        int           _call;
+
+        public List<string> SentTokens { get; } = [];
+        public List<string> SentBodies { get; } = [];
+        public bool         FirstResponseContentDisposed { get; private set; }
+
+        TrackedContent? _firstContent;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken) {
+            var body = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            int index;
+            lock (_gate) {
+                index = _call++;
+                SentTokens.Add(request.Headers.Authorization?.Parameter ?? "<none>");
+                if (body is not null) SentBodies.Add(body);
+            }
+
+            var status  = statuses[Math.Min(index, statuses.Length - 1)];
+            var content = new TrackedContent(() => FirstResponseContentDisposed = true);
+
+            if (index == 0) _firstContent = content;
+
+            return new(status) { Content = index == 0 ? content : new StringContent("") };
+        }
+
+        sealed class TrackedContent(Action onDispose) : StringContent("") {
+            protected override void Dispose(bool disposing) {
+                if (disposing) onDispose();
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/WhoamiProbeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WhoamiProbeTests.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// whoami's whole value is that it distinguishes "the server rejected your token" from "I could
+/// not ask". Collapsing those would send people to re-run `kcap login` for an outage — the same
+/// class of misdirection that made whoami untrustworthy in the first place.
+/// </summary>
+public class WhoamiProbeTests {
+    [Test]
+    [Arguments(HttpStatusCode.Unauthorized)]
+    [Arguments(HttpStatusCode.Forbidden)]
+    public async Task Auth_failures_are_the_only_token_verdict(HttpStatusCode status) {
+        var verdict = WhoamiCommand.Interpret(status);
+
+        await Assert.That(verdict.ExitCode).IsEqualTo(1);
+        await Assert.That(verdict.Line).Contains("REJECTS");
+    }
+
+    [Test]
+    [Arguments(HttpStatusCode.OK)]
+    [Arguments(HttpStatusCode.NoContent)]
+    public async Task Success_reports_acceptance(HttpStatusCode status) {
+        var verdict = WhoamiCommand.Interpret(status);
+
+        await Assert.That(verdict.ExitCode).IsEqualTo(0);
+        await Assert.That(verdict.Line).Contains("accepts");
+    }
+
+    [Test]
+    // 404: an older server without the probe endpoint — says nothing about the token.
+    [Arguments(HttpStatusCode.NotFound)]
+    // 3xx: a login redirect must not be read as a rejection.
+    [Arguments(HttpStatusCode.Redirect)]
+    // Server-side trouble is not the user's credential being wrong.
+    [Arguments(HttpStatusCode.RequestTimeout)]
+    [Arguments(HttpStatusCode.TooManyRequests)]
+    [Arguments(HttpStatusCode.InternalServerError)]
+    [Arguments(HttpStatusCode.BadGateway)]
+    public async Task Non_auth_responses_are_reported_as_unverified_not_rejected(HttpStatusCode status) {
+        var verdict = WhoamiCommand.Interpret(status);
+
+        await Assert.That(verdict.ExitCode).IsEqualTo(0);
+        await Assert.That(verdict.Line).Contains("could not verify");
+        await Assert.That(verdict.Line).DoesNotContain("REJECTS");
+    }
+
+    [Test]
+    public async Task Unreachable_server_keeps_whoami_usable_offline() {
+        var verdict = WhoamiCommand.Interpret(null);
+
+        await Assert.That(verdict.ExitCode).IsEqualTo(0);
+        await Assert.That(verdict.Line).Contains("unreachable");
+    }
+
+    [Test]
+    public async Task Server_error_line_names_the_status_so_it_is_actionable() {
+        await Assert.That(WhoamiCommand.Interpret(HttpStatusCode.InternalServerError).Line).Contains("500");
+    }
+}


### PR DESCRIPTION
Closes #386
Linear: AI-1504

Spec (codex-reviewed clean over 4 rounds): `docs/superpowers/specs/2026-07-28-ai1504-token-server-binding-design.md` in kcap-server.

## Why

A stored token carried no record of which server issued it. A multi-profile config — or a single profile whose `server_url` was re-pointed after login — would send one server's token to another. The server rejects it with a bare 401, and `/auth/refresh` can't heal it (it validates the token's own signature), so the CLI reported "not authenticated" for a token that was perfectly valid somewhere else.

`kcap whoami` made that much harder to diagnose than it should have been: it only printed local file metadata, so it called such a token valid while every request was being rejected. That gap is what turned the original incident into a multi-day misdiagnosis.

## What changed

**D0 — canonical server identity.** One `ServerIdentity` helper: scheme + host + effective port + case-sensitive path. Userinfo, query and fragment are *rejected* rather than dropped, so `…/base?tenant=a` and `?tenant=b` can't compare equal. A non-canonicalizable side never matches (fail closed).

**D1 — tokens bound to their minting server.** `StoredTokens` gains a nullable `server_url`, stamped at login and carried through refresh. Stamping authority is explicit per site — generic `SaveAsync` never infers it from ambient state, and the localhost fallback is never mistaken for evidence. GitHub refresh now targets `tokens.ServerUrl` first, so a bound token can't be posted to a server that never issued it.

Enforcement lives in one accessor, `GetValidTokensForServerAsync`, which is now the only way a bearer reaches a request. It checks the binding on the raw snapshot **before** any refresh (a token we've already decided not to use shouldn't spend a rotating credential), and returns the issuing URL alongside the verdict so callers name both servers without re-reading storage. Every attachment site moved onto it: the HTTP client factory, daemon SignalR + event POSTs, the watcher, attachment downloads, and the setup ping.

Pre-upgrade tokens have no binding and stay unenforced until a login or unambiguous refresh stamps them; old CLIs ignore the new field.

**D2 — lookup follows the resolved profile.** `TokenStore` now prefers the profile the process resolved (`KCAP_PROFILE`, `.kcap.json`, git-remote, `kcap use`) over the on-disk active profile. Two carve-outs:
- `kcap setup` deliberately configures the *active* profile, so it now does every token operation against that profile explicitly (no parameterless token calls remain in it).
- The legacy `tokens.json` fallback is scoped to its migration owner. An unscoped fallback would hand that unbound credential to any repo-resolved profile lacking a token — and being unbound, D1 couldn't catch it. There is deliberately no `"default"` exemption.

**D3 — whoami verifies.** Prints the resolving profile, then asks the server. Only 401/403 are a verdict; unreachable, missing endpoint (older server), redirect and 5xx all report "could not verify" at exit 0, so nobody is sent to re-run `kcap login` over an outage.

**D4 — one-shot 401 recovery, single owner.** A `DelegatingHandler` refreshes once and resends. The refresh is conditional on the persisted token still being the rejected one, so a peer that already refreshed is adopted rather than rotated again — which for WorkOS (single-use refresh token) would invalidate the peer's session. The handler applies its own token per request (a stale client default would resend exactly what was just rejected), disposes the first 401, and resends exactly once, non-reentrantly.

## Deviation from the spec, and why

The spec asserted MCP servers use the handler-free factory and could keep their retry loops untouched. They don't — all eight call `CreateAuthenticatedClientAsync`, so installing the handler there would have stacked two retry owners (the exact hazard the spec was trying to avoid). Resolved per the spec's own PR-audit rule — one retry owner per path — by having the MCP servers opt out of the handler (`autoRetryUnauthorized: false`) and keep their existing loops, now upgraded to the deduped force-refresh. The two MCP servers with no loop of their own keep the handler.

## Testing

New: `ServerIdentityTests` (21), `TokenServerBindingTests` (15), `UnauthorizedRetryHandlerTests` (9), `WhoamiProbeTests` (12).

Key assertions were **mutation-tested** — skipping the retry header update, dropping the first-response dispose, and reverting the refresh dedup each fail a test. Tests that could hang on an unintended refresh point at an unroutable address so a regression fails in milliseconds.

Full unit suite vs. an `origin/main` baseline worktree on the same machine: **42 failures on this branch vs 72 on baseline, with zero failures unique to this branch** (the remainder are pre-existing macOS environment flakes).

Two adjustments were needed because token lookup now consults process-global resolved state — correct in production (resolved once at startup) but leaky in a shared test process: the token-store test classes reset it, and `McpFlowsServerTests.SeedDefaultTokenAsync` clears it alongside the `config.json` it already cleared for the same reason. That was found by bisecting a real cross-test failure, not assumed.

AOT publish: 0 IL2026/IL3050 warnings. README + `help-whoami`/`help-usage` updated for the new whoami output and exit codes.