### PR TITLE
[AI-1489] Pin the vendor-capable flows schema across every driver projection

### DIFF
--- a/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
+++ b/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
@@ -17,6 +17,11 @@ public static class KcapMcpRegistry {
         ["kcap-analytics"] = new("kcap-analytics", ["mcp", "analytics"], false),
     };
 
+    /// <summary>Every registered id. Exposed so a conformance test can compare this list against the
+    /// canonical registration list in BOTH directions — a registry-only entry is allowlistable but
+    /// never registered with any harness, and checking only the other direction misses it.</summary>
+    public static IEnumerable<string> AllIds => Entries.Values.Select(d => d.Id);
+
     /// <summary>Resolves an allowlist entry to its descriptor. Case-insensitive, trims
     /// surrounding whitespace. A null or blank name — e.g. a wire-deserialized allowlist
     /// element — returns null rather than throwing, so callers can route it through the

--- a/src/Capacitor.Cli.Core/Mcp/HarnessMcpProjections.cs
+++ b/src/Capacitor.Cli.Core/Mcp/HarnessMcpProjections.cs
@@ -1,0 +1,48 @@
+namespace Capacitor.Cli.Core.Mcp;
+
+/// <summary>
+/// How one harness projects the kcap MCP servers into its own config: which subset it receives, which
+/// on-disk shape renders it, and the ownership-marker name it is written under.
+///
+/// <para><b>Why this exists.</b> That tuple used to be written out twice for every harness — once in
+/// <c>PluginCommand</c>'s per-target registration and once in <c>SetupCommand</c>'s installer
+/// delegates — with nothing tying the two together. Either copy could drop a server, pick the wrong
+/// shape, or use a different marker, and the other route would keep working, so a harness could
+/// silently project a different set of tools depending on whether the user ran
+/// <c>kcap plugin install</c> or <c>kcap setup</c>. Conformance tests can only catch that by
+/// exercising both routes; one definition makes it unrepresentable.</para>
+/// </summary>
+public sealed record HarnessMcpProjection(
+    string                        Harness,
+    IReadOnlyList<KcapMcpServer>  Servers,
+    McpConfigShape                Shape
+) {
+    /// <summary>Writes this harness's kcap servers into <paramref name="configPath"/>. The marker name
+    /// is derived from the harness rather than passed in, so the two call sites cannot disagree about
+    /// which entries kcap owns — a mismatch there would strand entries on uninstall.</summary>
+    public JsonMcpConfigWriter.Change Register(string configPath, string? cwd = null) =>
+        JsonMcpConfigWriter.Register(configPath, Servers, Shape, cwd, new McpMarker(Harness));
+
+    public JsonMcpConfigWriter.Change Unregister(string configPath) =>
+        JsonMcpConfigWriter.Unregister(configPath, Shape, new McpMarker(Harness));
+}
+
+/// <summary>The JSON-config harnesses, and the single definition of what each one gets.
+///
+/// <para>Codex is absent on purpose — its registration is TOML with its own ownership ledger
+/// (<c>CodexConfigToml</c>), not this writer. Claude Code is absent because it reads a bundled static
+/// <c>kcap/.mcp.json</c> rather than anything generated. Pi is absent because it registers no MCP
+/// config at all — it emits a bridge that discovers tools at runtime.</para></summary>
+public static class HarnessMcpProjections {
+    // Every non-Claude JSON harness receives the same subset: kcap-workitems is Claude-Code-plugin
+    // only (its session-id default rides the Claude hook env).
+    public static readonly HarnessMcpProjection Cursor      = new("cursor",      KcapMcpServers.ForCursor, McpConfigShape.Standard);
+    public static readonly HarnessMcpProjection Copilot     = new("copilot",     KcapMcpServers.ForCursor, McpConfigShape.Copilot);
+    public static readonly HarnessMcpProjection Gemini      = new("gemini",      KcapMcpServers.ForCursor, McpConfigShape.Gemini);
+    public static readonly HarnessMcpProjection Kiro        = new("kiro",        KcapMcpServers.ForCursor, McpConfigShape.Standard);
+    public static readonly HarnessMcpProjection OpenCode    = new("opencode",    KcapMcpServers.ForCursor, McpConfigShape.OpenCode);
+    public static readonly HarnessMcpProjection Antigravity = new("antigravity", KcapMcpServers.ForCursor, McpConfigShape.Standard);
+
+    public static readonly IReadOnlyList<HarnessMcpProjection> All =
+        [Cursor, Copilot, Gemini, Kiro, OpenCode, Antigravity];
+}

--- a/src/Capacitor.Cli.Core/Mcp/HarnessMcpProjections.cs
+++ b/src/Capacitor.Cli.Core/Mcp/HarnessMcpProjections.cs
@@ -25,6 +25,12 @@ public sealed record HarnessMcpProjection(
 
     public JsonMcpConfigWriter.Change Unregister(string configPath) =>
         JsonMcpConfigWriter.Unregister(configPath, Shape, new McpMarker(Harness));
+
+    /// <summary>Whether kcap currently owns any entry in this harness's config — the "is the MCP
+    /// half already installed?" probe. Here rather than at the call site for the same reason as the
+    /// marker itself: a probe reading a DIFFERENT ownership tuple than the writer would report an
+    /// existing install as absent, and the refresh path would then skip it.</summary>
+    public bool OwnsAnything(string configPath) => new McpMarker(Harness).Owned(configPath).Any();
 }
 
 /// <summary>The JSON-config harnesses, and the single definition of what each one gets.

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -723,8 +723,7 @@ public static class PluginCommand {
     /// not an error code.
     /// </summary>
     static async Task RegisterCursorMcpServersAsync(PluginEnvironment env) {
-        var change = JsonMcpConfigWriter.Register(
-            env.CursorMcpJson, KcapMcpServers.ForCursor, McpConfigShape.Standard, cwd: null, new McpMarker("cursor"));
+        var change = HarnessMcpProjections.Cursor.Register(env.CursorMcpJson);
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:
@@ -1055,8 +1054,7 @@ public static class PluginCommand {
     /// loads them without a manual JSON edit. Never fails the install: a write error is a warning.
     /// </summary>
     static async Task RegisterOpenCodeMcpServersAsync(PluginEnvironment env) {
-        var change = JsonMcpConfigWriter.Register(
-            env.OpenCodeMcpConfigJson, KcapMcpServers.ForCursor, McpConfigShape.OpenCode, cwd: null, new McpMarker("opencode"));
+        var change = HarnessMcpProjections.OpenCode.Register(env.OpenCodeMcpConfigJson);
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:
@@ -1194,8 +1192,7 @@ public static class PluginCommand {
     /// <summary>Registers the kcap MCP servers in Antigravity's own <c>~/.gemini/config/mcp_config.json</c>
     /// (Standard shape). Never fails the install: a write error is a warning.</summary>
     static async Task RegisterAntigravityMcpServersAsync(PluginEnvironment env) {
-        var change = JsonMcpConfigWriter.Register(
-            env.AntigravityMcpConfigJson, KcapMcpServers.ForCursor, McpConfigShape.Standard, cwd: null, new McpMarker("antigravity"));
+        var change = HarnessMcpProjections.Antigravity.Register(env.AntigravityMcpConfigJson);
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:
@@ -1384,8 +1381,7 @@ public static class PluginCommand {
     /// not an error code.
     /// </summary>
     static async Task RegisterCopilotMcpServersAsync(PluginEnvironment env) {
-        var change = JsonMcpConfigWriter.Register(
-            env.CopilotMcpConfigJson, KcapMcpServers.ForCursor, McpConfigShape.Copilot, cwd: null, new McpMarker("copilot"));
+        var change = HarnessMcpProjections.Copilot.Register(env.CopilotMcpConfigJson);
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:
@@ -1628,8 +1624,7 @@ public static class PluginCommand {
     /// fields (kcap leaves autoApprove unset). Never fails the install: a write error is a warning.
     /// </summary>
     static async Task RegisterKiroMcpServersAsync(PluginEnvironment env, string mcpPath) {
-        var change = JsonMcpConfigWriter.Register(
-            mcpPath, KcapMcpServers.ForCursor, McpConfigShape.Standard, cwd: null, new McpMarker("kiro"));
+        var change = HarnessMcpProjections.Kiro.Register(mcpPath);
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:
@@ -1975,8 +1970,7 @@ public static class PluginCommand {
     /// Never fails the install: a write error is a warning, not an error code.
     /// </summary>
     static async Task RegisterGeminiMcpServersAsync(PluginEnvironment env, string settingsPath) {
-        var change = JsonMcpConfigWriter.Register(
-            settingsPath, KcapMcpServers.ForCursor, McpConfigShape.Gemini, cwd: null, new McpMarker("gemini"));
+        var change = HarnessMcpProjections.Gemini.Register(settingsPath);
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -762,7 +762,7 @@ public static class PluginCommand {
         // Cursor is user-scope only (no --project split like Codex), so the kcap MCP
         // entries are always unregistered here, independent of whether hooks.json
         // existed — the two files are unrelated on disk.
-        var mcpChange = JsonMcpConfigWriter.Unregister(env.CursorMcpJson, McpConfigShape.Standard, new McpMarker("cursor"));
+        var mcpChange = HarnessMcpProjections.Cursor.Unregister(env.CursorMcpJson);
         var mcpFailed = mcpChange == JsonMcpConfigWriter.Change.Failed;
 
         if (mcpChange == JsonMcpConfigWriter.Change.Updated) {
@@ -1107,7 +1107,7 @@ public static class PluginCommand {
 
         // MCP servers live in a separate file (~/.config/opencode/opencode.json) — unregister
         // regardless (Unregister owns the ownership-marker cleanup and no-ops when the file is absent).
-        var mcpChange = JsonMcpConfigWriter.Unregister(env.OpenCodeMcpConfigJson, McpConfigShape.OpenCode, new McpMarker("opencode"));
+        var mcpChange = HarnessMcpProjections.OpenCode.Unregister(env.OpenCodeMcpConfigJson);
         var mcpFailed = mcpChange == JsonMcpConfigWriter.Change.Failed;
 
         if (mcpChange == JsonMcpConfigWriter.Change.Updated) {
@@ -1261,7 +1261,7 @@ public static class PluginCommand {
 
         // MCP servers live in a separate mcp_config.json — unregister regardless (Unregister owns the
         // ownership-marker cleanup and no-ops when the file is absent).
-        var mcpChange = JsonMcpConfigWriter.Unregister(env.AntigravityMcpConfigJson, McpConfigShape.Standard, new McpMarker("antigravity"));
+        var mcpChange = HarnessMcpProjections.Antigravity.Unregister(env.AntigravityMcpConfigJson);
         var mcpFailed = mcpChange == JsonMcpConfigWriter.Change.Failed;
 
         if (mcpChange == JsonMcpConfigWriter.Change.Updated) {
@@ -1437,7 +1437,7 @@ public static class PluginCommand {
         // unregister them independently of whether the hooks file existed. Unregister owns
         // the ownership-marker cleanup: it clears the marker on any non-Failed outcome and
         // retains it on Failed so a retry can still identify the kcap-owned entries.
-        var mcpChange = JsonMcpConfigWriter.Unregister(env.CopilotMcpConfigJson, McpConfigShape.Copilot, new McpMarker("copilot"));
+        var mcpChange = HarnessMcpProjections.Copilot.Unregister(env.CopilotMcpConfigJson);
         var mcpFailed = mcpChange == JsonMcpConfigWriter.Change.Failed;
 
         if (mcpChange == JsonMcpConfigWriter.Change.Updated) {
@@ -1524,7 +1524,7 @@ public static class PluginCommand {
         // Kiro's MCP lives in a SEPARATE file (~/.kiro/settings/mcp.json), independent of the agent
         // clone — so a prior `--skip-kiro-hooks` (or a clone that failed because kiro-cli was missing)
         // can leave an MCP-only install with no agent marker.
-        var mcpInstalled = new McpMarker("kiro").Owned(mcpPath).Any();
+        var mcpInstalled = HarnessMcpProjections.Kiro.OwnsAnything(mcpPath);
 
         if (refreshOnly) {
             // Never touch a machine that never opted in (neither hooks nor MCP).
@@ -1645,7 +1645,7 @@ public static class PluginCommand {
 
         // MCP servers live in a separate settings/mcp.json — unregister independently of the agent
         // restore/removal (Unregister owns the ownership-marker cleanup and no-ops when absent).
-        var mcpChange = JsonMcpConfigWriter.Unregister(mcpPath, McpConfigShape.Standard, new McpMarker("kiro"));
+        var mcpChange = HarnessMcpProjections.Kiro.Unregister(mcpPath);
         var mcpFailed = mcpChange == JsonMcpConfigWriter.Change.Failed;
 
         if (mcpChange == JsonMcpConfigWriter.Change.Updated) {
@@ -2034,7 +2034,7 @@ public static class PluginCommand {
         // leave a STALE marker that could later misclassify a user-authored mcpServers.kcap-* entry as
         // kcap-owned. On an absent file it's a no-op (Unchanged) that still clears the marker and
         // never creates a config file.
-        var mcpChange = JsonMcpConfigWriter.Unregister(settingsPath, McpConfigShape.Gemini, new McpMarker("gemini"));
+        var mcpChange = HarnessMcpProjections.Gemini.Unregister(settingsPath);
         mcpFailed = mcpChange == JsonMcpConfigWriter.Change.Failed;
 
         if (mcpChange == JsonMcpConfigWriter.Change.Updated) {

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -344,10 +344,8 @@ public static class SetupCommand {
             RegisterCodexMcp:         () => CodexConfigToml.RegisterKcapMcpServers(),
             // every non-Claude JSON harness registers the ForCursor subset — kcap-workitems
             // is a Claude Code plugin-only tool (its session-id default rides the Claude hook env).
-            RegisterCursorMcp:        () => JsonMcpConfigWriter.Register(
-                CursorPaths.UserMcpJson(), KcapMcpServers.ForCursor, McpConfigShape.Standard, cwd: null, new McpMarker("cursor")),
-            RegisterCopilotMcp:       () => JsonMcpConfigWriter.Register(
-                CopilotPaths.McpConfigJson(), KcapMcpServers.ForCursor, McpConfigShape.Copilot, cwd: null, new McpMarker("copilot")),
+            RegisterCursorMcp:        () => HarnessMcpProjections.Cursor.Register(CursorPaths.UserMcpJson()),
+            RegisterCopilotMcp:       () => HarnessMcpProjections.Copilot.Register(CopilotPaths.McpConfigJson()),
             InstallCopilotInstructions: () => AgentInstructionsWriter.Write(
                 CopilotPaths.InstructionsMd(), KcapAgentInstructions.Body),
             // Skills are already current when the on-disk marker matches this build AND
@@ -355,18 +353,14 @@ public static class SetupCommand {
             // (mirrors PluginCommand's postinstall fast path). A missing/stale marker — or a
             // deleted skill folder — reads as "not current" → prompt + install (self-heals).
             AgentSkillsCurrent:       AgentsSkillsInstaller.IsCurrent,
-            RegisterOpenCodeMcp:      () => JsonMcpConfigWriter.Register(
-                OpenCodePaths.McpConfigJson(), KcapMcpServers.ForCursor, McpConfigShape.OpenCode, cwd: null, new McpMarker("opencode")),
+            RegisterOpenCodeMcp:      () => HarnessMcpProjections.OpenCode.Register(OpenCodePaths.McpConfigJson()),
             InstallOpenCodeInstructions: () => AgentInstructionsWriter.Write(
                 OpenCodePaths.AgentsMd(), KcapAgentInstructions.Body),
-            RegisterKiroMcp:          () => JsonMcpConfigWriter.Register(
-                KiroPaths.SettingsMcpJson(), KcapMcpServers.ForCursor, McpConfigShape.Standard, cwd: null, new McpMarker("kiro")),
-            RegisterGeminiMcp:        () => JsonMcpConfigWriter.Register(
-                GeminiPaths.SettingsJson(), KcapMcpServers.ForCursor, McpConfigShape.Gemini, cwd: null, new McpMarker("gemini")),
+            RegisterKiroMcp:          () => HarnessMcpProjections.Kiro.Register(KiroPaths.SettingsMcpJson()),
+            RegisterGeminiMcp:        () => HarnessMcpProjections.Gemini.Register(GeminiPaths.SettingsJson()),
             InstallGeminiInstructions: () => AgentInstructionsWriter.Write(
                 GeminiPaths.GeminiMd(), KcapAgentInstructions.Body),
-            RegisterAntigravityMcp:   () => JsonMcpConfigWriter.Register(
-                AntigravityPaths.McpConfigJson(), KcapMcpServers.ForCursor, McpConfigShape.Standard, cwd: null, new McpMarker("antigravity")),
+            RegisterAntigravityMcp:   () => HarnessMcpProjections.Antigravity.Register(AntigravityPaths.McpConfigJson()),
             InstallAntigravityInstructions: () => AgentInstructionsWriter.Write(
                 AntigravityPaths.InstructionsMd(), KcapAgentInstructions.Body),
             // Pi has no JSON MCP config — the "MCP" is a second extension file (kcap-mcp.ts).

--- a/src/Capacitor.Cli/Commands/VendorSelection.cs
+++ b/src/Capacitor.Cli/Commands/VendorSelection.cs
@@ -12,7 +12,10 @@ public static class VendorSelection {
         public bool HasError => Error is not null;
     }
 
-    static readonly string[] KnownVendorFlags = ["--claude", "--codex", "--cursor", "--copilot", "--gemini", "--kiro", "--pi", "--opencode", "--antigravity"];
+    // internal, not private: the driver-schema conformance suite pins its hand-written harness table
+    // against this list, so adding a tenth installable target fails there instead of silently leaving
+    // it uncovered. No enumeration of supported harnesses exists in production code otherwise.
+    internal static readonly string[] KnownVendorFlags = ["--claude", "--codex", "--cursor", "--copilot", "--gemini", "--kiro", "--pi", "--opencode", "--antigravity"];
 
     public static Result Parse(string[] args) {
         var vendors = new HashSet<string>(StringComparer.Ordinal);

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
@@ -352,10 +352,22 @@ public class FlowsDriverSchemaConformanceTests {
 
     // The two bundled static files are not written by an installer — Claude Code and Codex's native
     // plugin loader read them straight from the package — so they get their own arm.
+    /// <summary>The bundled static configs, kept as a list rather than inline [Arguments] so the
+    /// coverage assertion below can see them. Qodo flagged that "Codex" and "Codex plugin" both
+    /// reduce to --codex in the tripwire, so deleting the plugin arm left --codex green while one of
+    /// two INDEPENDENT Codex registration mechanisms went untested.</summary>
+    static readonly (string File, string Harness)[] BundledConfigs = [
+        (".mcp.json",       "Claude Code"),
+        (".codex-mcp.json", "Codex plugin"),
+    ];
+
+    public static IEnumerable<Func<(string File, string Harness)>> Bundled() =>
+        BundledConfigs.Select(b => (Func<(string, string)>)(() => b));
+
     [Test]
-    [Arguments(".mcp.json",       "Claude Code")]
-    [Arguments(".codex-mcp.json", "Codex plugin")]
-    public async Task Every_bundled_config_names_the_same_flows_server(string file, string harness) {
+    [MethodDataSource(nameof(Bundled))]
+    public async Task Every_bundled_config_names_the_same_flows_server((string File, string Harness) bundled) {
+        var (file, harness) = bundled;
         var p = Json(harness, "mcpServers")(Path.Combine(RepoKcapDir(), file));
 
         await Assert.That(p.Command).IsEqualTo(KcapMcpServers.Command);
@@ -433,6 +445,18 @@ public class FlowsDriverSchemaConformanceTests {
         } finally {
             dir.Delete(recursive: true);
         }
+    }
+
+    // Deleting a bundled arm can no longer go unnoticed: the covered set is compared against what is
+    // actually shipped in kcap/. A third bundled config, or a deleted arm, fails here.
+    [Test]
+    public async Task Every_bundled_mcp_config_shipped_in_the_package_is_covered() {
+        var shipped = Directory.EnumerateFiles(RepoKcapDir())
+            .Select(Path.GetFileName)
+            .Where(f => f!.EndsWith("mcp.json", StringComparison.Ordinal))
+            .ToArray();
+
+        await Assert.That(BundledConfigs.Select(b => b.File)).IsEquivalentTo(shipped);
     }
 
     // The projection list must cover exactly the JSON harnesses the installer table drives — no more,

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
@@ -1,0 +1,288 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Mcp;
+using Capacitor.Cli.Core.Pi;
+using Tomlyn;
+using Tomlyn.Model;
+
+namespace Capacitor.Cli.Tests.Unit.Mcp;
+
+/// <summary>
+/// Driver-schema conformance: every supported coding harness must reach the SAME vendor-capable
+/// <c>kcap-flows</c> tool schema, so reviewer choice is a property of the request and not of whichever
+/// harness happens to be driving.
+///
+/// <para><b>Why this needs its own suite.</b> The registration path is not one path. Six harnesses
+/// (Cursor, Copilot, Gemini, Kiro, OpenCode, Antigravity) converge on one writer and differ only by a
+/// <see cref="McpConfigShape"/>; Codex writes TOML through a separate engine with its own ownership
+/// ledger; Claude Code loads a hand-maintained static <c>kcap/.mcp.json</c>; and Pi gets a hard-coded
+/// server list inside an embedded TypeScript bridge. Four mechanisms, one contract. The existing
+/// per-harness tests each assert <c>Contains("kcap-flows")</c> in isolation — that a server by that
+/// name was written, not that it resolves to the same executable and therefore the same schema.</para>
+///
+/// <para><b>The failure this prevents</b> is a driver that appears to support named reviewer intent
+/// but cannot express it: a harness whose registration drifts to a different command, or a tool that
+/// quietly gains or loses <c>vendor</c>, leaves a caller believing it named a reviewer when it sent
+/// nothing. A stale-schema driver must never be able to claim it launched the named vendor.</para>
+/// </summary>
+public class FlowsDriverSchemaConformanceTests {
+    // ── the canonical descriptor ──────────────────────────────────────────────────────────────
+
+    static McpTool Tool(string name) =>
+        McpFlowsServer.BuildToolsList().Single(t => t.Name == name);
+
+    /// <summary>The two START tools — the only ones that may route a vendor, because they are the
+    /// only ones that select a reviewer. Everything else addresses a run that already has one.</summary>
+    public static IEnumerable<Func<string>> StartTools() { yield return () => "start_review_flow"; yield return () => "start_flow"; }
+
+    /// <summary>Every tool that operates on an EXISTING run. A vendor here would be either ignored
+    /// (misleading) or a mid-run vendor switch (incoherent) — the applied vendor is pinned at start.</summary>
+    public static IEnumerable<Func<string>> FollowUpTools() {
+        yield return () => "submit_review_round";
+        yield return () => "get_review_flow_status";
+        yield return () => "close_review_flow";
+        yield return () => "send_to_participant";
+        yield return () => "get_flow_status";
+        yield return () => "close_flow";
+    }
+
+    [Test]
+    [MethodDataSource(nameof(StartTools))]
+    public async Task A_start_tool_declares_vendor_as_an_optional_string(string toolName) {
+        var tool = Tool(toolName);
+
+        await Assert.That(tool.InputSchema.Properties.ContainsKey("vendor")).IsTrue()
+            .Because($"{toolName} must be able to name a reviewer vendor");
+        await Assert.That(tool.InputSchema.Properties["vendor"].Type).IsEqualTo("string");
+        // Optional, not required: omitting it is how a caller asks for the server's default, which is
+        // a legitimate and common request. Making it required would break every existing caller.
+        await Assert.That(tool.InputSchema.Required).DoesNotContain("vendor");
+    }
+
+    [Test]
+    [MethodDataSource(nameof(FollowUpTools))]
+    public async Task A_follow_up_tool_does_not_accept_vendor_or_model(string toolName) {
+        var props = Tool(toolName).InputSchema.Properties;
+
+        await Assert.That(props.ContainsKey("vendor")).IsFalse()
+            .Because($"{toolName} addresses an existing run whose vendor was pinned at start");
+        await Assert.That(props.ContainsKey("model")).IsFalse();
+    }
+
+    // The description is the whole mechanism by which a driver LLM learns to pass the parameter.
+    // A correct schema with a description that never mentions naming a reviewer produces a driver
+    // that silently takes the default — which is the exact failure this contract exists to prevent,
+    // and one no structural assertion would catch.
+    [Test]
+    [MethodDataSource(nameof(StartTools))]
+    public async Task The_vendor_description_tells_the_driver_that_named_intent_must_pass_it(string toolName) {
+        var description = Tool(toolName).InputSchema.Properties["vendor"].Description;
+
+        // It must say what omitting it does (either tool's wording -- "Omit to..." or "when omitted")...
+        await Assert.That(description.Contains("omit", StringComparison.OrdinalIgnoreCase)).IsTrue();
+        // ...that the value is a canonical lowercase token, not a display name the driver invents...
+        await Assert.That(description.Contains("lowercase", StringComparison.OrdinalIgnoreCase)).IsTrue();
+        // ...and that there is no silent fallback, so a driver cannot treat it as a hint.
+        await Assert.That(description.Contains("no silent fallback", StringComparison.OrdinalIgnoreCase)
+                       || description.Contains("there is no silent fallback", StringComparison.OrdinalIgnoreCase)).IsTrue();
+    }
+
+    // `model` is meaningless without `vendor` (there is no vendor->model table anywhere), and the
+    // schema cannot express that dependency — so the description has to, or a driver will send a
+    // model alone and get a local rejection it was never warned about.
+    [Test]
+    [MethodDataSource(nameof(StartTools))]
+    public async Task The_model_description_states_its_dependency_on_vendor(string toolName) {
+        var props = Tool(toolName).InputSchema.Properties;
+
+        await Assert.That(props.ContainsKey("model")).IsTrue();
+        await Assert.That(props["model"].Description.Contains("requires 'vendor'", StringComparison.OrdinalIgnoreCase)).IsTrue()
+            .Because("the schema cannot express the dependency, so the description must");
+    }
+
+    // Status output has to be able to name who actually ran. Reviewer self-identification in prose is
+    // explicitly not acceptable evidence, so the vendor must be legible from structured status.
+    [Test]
+    public async Task The_status_tools_can_surface_the_applied_participant_vendor() {
+        const string statusJson = """
+            {"flow_run_id":"f1","definition_id":"spec-review","status":"running",
+             "requested_reviewer_vendor":"claude","applied_reviewer_vendor":"claude",
+             "reviewer_vendor_source":"explicit","applied_reviewer_model":"sonnet"}
+            """;
+
+        var text = McpFlowsServer.FormatStatusResponse(statusJson);
+
+        await Assert.That(text).Contains("claude");
+        await Assert.That(text).Contains("sonnet");
+    }
+
+    // ── every driver projection reaches the same server ───────────────────────────────────────
+
+    /// <summary>One harness's registration, reduced to the only thing that determines which schema it
+    /// gets: the command and arguments its <c>kcap-flows</c> entry resolves to.</summary>
+    public sealed record Projection(string Harness, string Command, string[] Args);
+
+    /// <summary>A scratch dir under the test assembly's own output rather than the system temp root.
+    /// On macOS <c>/var</c> is a symlink, and <c>CodexConfigToml</c>'s path guard rejects any symlinked
+    /// component — so a temp-rooted Codex registration silently returns <c>Failed</c> and writes
+    /// nothing. (The pre-existing <c>CodexConfigTomlTests</c> hit the same wall on macOS.) The
+    /// assembly output directory is a real path on every platform.</summary>
+    static DirectoryInfo Scratch(string prefix) =>
+        Directory.CreateDirectory(Path.Combine(AppContext.BaseDirectory,
+            "conformance-scratch", prefix + Guid.NewGuid().ToString("N")[..8]));
+
+    static string RepoKcapDir() {
+        var d = new DirectoryInfo(AppContext.BaseDirectory);
+        for (; d is not null; d = d.Parent)
+            if (File.Exists(Path.Combine(d.FullName, "kcap", ".mcp.json")))
+                return Path.Combine(d.FullName, "kcap");
+        throw new DirectoryNotFoundException("kcap/ not found above the test base dir");
+    }
+
+    /// <summary>Registers through the REAL writer into a temp file, then reads the entry back. Going
+    /// through the writer rather than asserting on the descriptor is the point: a shape that mangles
+    /// the command (an argv array, a type field, a different block key) is exactly the drift that
+    /// would give one harness a different server.</summary>
+    static Projection ViaJsonWriter(string harness, McpConfigShape shape) {
+        var dir  = Scratch("json-");
+        var path = Path.Combine(dir.FullName, "config.json");
+        try {
+            var change = JsonMcpConfigWriter.Register(path, KcapMcpServers.ForCursor, shape,
+                cwd: "/repo", marker: new McpMarker(harness));
+            if (change == JsonMcpConfigWriter.Change.Failed)
+                throw new InvalidOperationException($"{harness}: writer failed");
+
+            var root  = (JsonObject)JsonNode.Parse(File.ReadAllText(path))!;
+            var entry = (JsonObject)root[shape.BlockKey]!["kcap-flows"]!;
+
+            // OpenCode folds the command and args into one argv array; everyone else splits them.
+            if (shape.CommandAsArgvArray) {
+                var argv = entry["command"]!.AsArray().Select(n => n!.GetValue<string>()).ToArray();
+                return new(harness, argv[0], argv[1..]);
+            }
+
+            return new(harness,
+                entry["command"]!.GetValue<string>(),
+                [.. entry["args"]!.AsArray().Select(n => n!.GetValue<string>())]);
+        } finally {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    static Projection FromStaticJson(string harness, string file) {
+        var root  = (JsonObject)JsonNode.Parse(File.ReadAllText(Path.Combine(RepoKcapDir(), file)))!;
+        var entry = (JsonObject)root["mcpServers"]!["kcap-flows"]!;
+        return new(harness,
+            entry["command"]!.GetValue<string>(),
+            [.. entry["args"]!.AsArray().Select(n => n!.GetValue<string>())]);
+    }
+
+    static Projection FromCodexToml() {
+        var dir  = Scratch("codex-");
+        var path = Path.Combine(dir.FullName, "config.toml");
+        try {
+            var change = CodexConfigToml.RegisterKcapMcpServers(path);
+            if (!File.Exists(path)) throw new InvalidOperationException($"codex register -> {change}, no file at {path}");
+            var toml = File.ReadAllText(path);
+
+            // Parsed shallowly on purpose: the assertion is which executable Codex will launch, and
+            // CodexConfigTomlTests already covers the TOML structure in depth.
+            var model = TomlSerializer.Deserialize<TomlTable>(toml)!;
+            var table = (TomlTable)((TomlTable)model["mcp_servers"]!)["kcap-flows"]!;
+            return new("Codex",
+                (string)table["command"]!,
+                [.. ((TomlArray)table["args"]!).Select(a => (string)a!)]);
+        } finally {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    public static IEnumerable<Func<Projection>> DriverProjections() {
+        // The six harnesses that share the JSON writer, each through its own shape.
+        yield return () => ViaJsonWriter("Cursor",      McpConfigShape.Standard);
+        yield return () => ViaJsonWriter("Kiro",        McpConfigShape.Standard);
+        yield return () => ViaJsonWriter("Antigravity", McpConfigShape.Standard);
+        yield return () => ViaJsonWriter("Gemini",      McpConfigShape.Gemini);
+        yield return () => ViaJsonWriter("Copilot",     McpConfigShape.Copilot);
+        yield return () => ViaJsonWriter("OpenCode",    McpConfigShape.OpenCode);
+        // The three that do not.
+        yield return () => FromCodexToml();
+        yield return () => FromStaticJson("Claude Code",  ".mcp.json");
+        yield return () => FromStaticJson("Codex plugin", ".codex-mcp.json");
+    }
+
+    [Test]
+    [MethodDataSource(nameof(DriverProjections))]
+    public async Task Every_driver_projection_launches_the_same_flows_server(Projection p) {
+        await Assert.That(p.Command).IsEqualTo(KcapMcpServers.Command)
+            .Because($"{p.Harness} must launch the same executable as every other driver");
+        await Assert.That(p.Args).IsEquivalentTo(new[] { "mcp", "flows" })
+            .Because($"{p.Harness} must reach the same subcommand, and therefore the same tool schema");
+    }
+
+    // Pi is the outlier worth its own assertion: it does not write an MCP config at all. It emits a
+    // TypeScript bridge that discovers tools over `tools/list` at runtime and re-exposes them, so its
+    // schema is whatever the server reports — but only for the servers named in a hard-coded literal
+    // inside that blob. If `flows` were dropped from that literal, Pi would silently lose the ability
+    // to start a flow while every other test here still passed.
+    [Test]
+    public async Task The_pi_bridge_still_lists_the_flows_server() {
+        var dir = Scratch("pi-");
+        try {
+            var extension = Path.Combine(dir.FullName, "kcap-mcp.ts");
+            PiMcpExtensionInstaller.Install(extension);
+            var ts = File.ReadAllText(extension);
+
+            await Assert.That(ts).Contains("\"flows\"")
+                .Because("Pi resolves its servers from a literal, so dropping flows is silent");
+        } finally {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    // ── drift tripwires ───────────────────────────────────────────────────────────────────────
+
+    // Two independent copies of the kcap server list exist: KcapMcpServers.All (what gets registered
+    // with harnesses) and KcapMcpRegistry (what a flow definition's mcp: allowlist resolves against,
+    // and the recursion guard's authority). Nothing keeps them in sync. A server added to one and not
+    // the other is either unregistered-but-allowlistable or registered-but-unresolvable, and both
+    // fail far from the edit.
+    [Test]
+    public async Task The_two_server_lists_agree_on_flows_arguments() {
+        var canonical = KcapMcpServers.All.Single(s => s.Name == "kcap-flows");
+        var registry  = KcapMcpRegistry.Resolve("kcap-flows");
+
+        await Assert.That(registry).IsNotNull();
+        await Assert.That(registry!.Args).IsEquivalentTo(canonical.Args);
+        // And the recursion guard still knows flows starts flows — a hosted reviewer must never
+        // receive it.
+        await Assert.That(registry.StartsFlows).IsTrue();
+    }
+
+    [Test]
+    public async Task Every_canonical_server_resolves_in_the_flow_allowlist_registry() {
+        foreach (var s in KcapMcpServers.All)
+            await Assert.That(KcapMcpRegistry.Resolve(s.Name)).IsNotNull()
+                .Because($"{s.Name} is registered with harnesses but unresolvable as an allowlist entry");
+    }
+
+    // The projection table above is hand-written, because no enumeration of supported harnesses
+    // exists in production code — the list is spread across at least four separate string arrays.
+    // Without this, adding a tenth harness would leave the conformance suite quietly passing on nine.
+    // Pinning against the flag arrays makes the omission fail here instead.
+    [Test]
+    public async Task The_projection_table_covers_every_harness_the_cli_claims_to_support() {
+        var covered = DriverProjections().Select(f => f().Harness)
+            .Select(h => h.Split(' ')[0].ToLowerInvariant())
+            .Append("pi")                                    // covered by its own bridge test above
+            .ToHashSet(StringComparer.Ordinal);
+
+        var claimed = VendorSelection.KnownVendorFlags
+            .Select(f => f.TrimStart('-').ToLowerInvariant());
+
+        foreach (var harness in claimed)
+            await Assert.That(covered.Contains(harness)).IsTrue()
+                .Because($"--{harness} is an installable target with no driver-schema conformance coverage");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
@@ -408,6 +408,33 @@ public class FlowsDriverSchemaConformanceTests {
         await Assert.That(flows.ReadOnly).IsFalse();
     }
 
+    // Install/uninstall must read the SAME ownership tuple. Codex review round 3: the projection was
+    // added and consumed by the register paths only — the six remove paths and Kiro's "is the MCP half
+    // already installed?" probe still hard-coded shape and marker names. So changing a projection made
+    // new installs write under one ownership tuple while uninstall looked under the old one (stranding
+    // owned entries) and Kiro's refresh read an existing install as absent. Round-trip per harness.
+    [Test]
+    [MethodDataSource(nameof(Projections))]
+    public async Task A_registered_harness_config_is_fully_unregistered_again(HarnessMcpProjection projection) {
+        var dir  = Scratch($"roundtrip-{projection.Harness}-");
+        var path = Path.Combine(dir.FullName, "config.json");
+        try {
+            projection.Register(path, cwd: "/repo");
+            await Assert.That(projection.OwnsAnything(path)).IsTrue()
+                .Because("the probe must see what the writer just wrote");
+
+            projection.Unregister(path);
+
+            await Assert.That(projection.OwnsAnything(path)).IsFalse();
+            var root = (JsonObject)JsonNode.Parse(File.ReadAllText(path))!;
+            var left = (root[projection.Shape.BlockKey] as JsonObject)?.Count ?? 0;
+            await Assert.That(left).IsEqualTo(0)
+                .Because($"{projection.Harness} stranded kcap entries that uninstall could not see");
+        } finally {
+            dir.Delete(recursive: true);
+        }
+    }
+
     // The projection list must cover exactly the JSON harnesses the installer table drives — no more,
     // no fewer. A harness added to one and not the other is the same divergence in a new place.
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
@@ -122,8 +122,34 @@ public class FlowsDriverSchemaConformanceTests {
 
         var text = McpFlowsServer.FormatStatusResponse(statusJson);
 
-        await Assert.That(text).Contains("claude");
-        await Assert.That(text).Contains("sonnet");
+        // Assert the RENDERED labels, not the bare values. FormatStatusResponse catches formatter
+        // exceptions and returns the original JSON body, so "contains claude" was satisfied by the
+        // fallback — the test passed even if formatting failed completely or the audit rendering were
+        // deleted outright. (Flagged by codex round 2; I had listed it as suspect and left it.)
+        await Assert.That(text).Contains("applied_reviewer_vendor: claude");
+        await Assert.That(text).Contains("applied_reviewer_model: sonnet");
+        await Assert.That(text).Contains("requested_reviewer_vendor: claude");
+        await Assert.That(text).DoesNotContain("\"flow_run_id\"")
+            .Because("raw JSON in the output means the formatter fell back rather than rendering");
+    }
+
+    // The POLLED round path renders the same audit fields from its OWN copy of the code, and it is
+    // the one an agent reads on nearly every flow — status is the path you go to when something looks
+    // wrong. Found while mutation-testing the test above: mutating the audit block in
+    // FormatPolledRoundResult left it green, because the two formatters do not share the rendering.
+    [Test]
+    public async Task The_polled_round_path_also_surfaces_the_applied_participant_vendor() {
+        const string roundJson = """
+            {"flow_run_id":"f1","status":"clean","round_result_kind":"clean",
+             "requested_reviewer_vendor":"cursor","applied_reviewer_vendor":"cursor",
+             "reviewer_vendor_source":"explicit","applied_reviewer_model":"composer"}
+            """;
+
+        var text = McpFlowsServer.FormatPolledRoundResult(
+            System.Text.Json.Nodes.JsonNode.Parse(roundJson)!.AsObject(), "f1");
+
+        await Assert.That(text).Contains("applied_reviewer_vendor: cursor");
+        await Assert.That(text).Contains("applied_reviewer_model: composer");
     }
 
     // ── every driver projection reaches the same server ───────────────────────────────────────
@@ -154,11 +180,27 @@ public class FlowsDriverSchemaConformanceTests {
     public sealed record Arm(
         string                          Name,
         string                          Flag,
-        string?                         ClearEnvVar,
         Action<PluginEnvironment>       OptIn,
         Func<PluginEnvironment, string> ConfigPath,
         Func<string, Projection>        Extract,
         bool                            BareInstall = false);
+
+    /// <summary>Every environment variable any kcap path resolver consults. Kept together so a new
+    /// override cannot be added without this list being the obvious place to add it.</summary>
+    static readonly string[] PathOverrideVariables = [
+        "CODEX_HOME",            // CodexPaths
+        "COPILOT_HOME",          // CopilotPaths
+        "GEMINI_CLI_HOME",       // GeminiPaths — and AntigravityPaths, which reuses GeminiPaths.Root
+        "KIRO_HOME",             // KiroPaths
+        "OPENCODE_CONFIG_DIR",   // OpenCodePaths
+        "XDG_CONFIG_HOME",       // OpenCodePaths fallback
+        "XDG_DATA_HOME",         // OpenCodePaths plugin dir fallback
+    ];
+
+    sealed class EnvScopes(IEnumerable<string> keys) : IDisposable {
+        readonly List<EnvScope> _scopes = [.. keys.Select(k => new EnvScope(k, null))];
+        public void Dispose() { foreach (var s in _scopes) s.Dispose(); }
+    }
 
     sealed class EnvScope : IDisposable {
         readonly string  _key;
@@ -215,7 +257,7 @@ public class FlowsDriverSchemaConformanceTests {
     // MCP, mirroring each harness's own PluginCommand*Tests. That branch also skips the AgentDetector
     // "kcap on PATH" precheck, which a bare install would fail in CI.
     static readonly Arm[] Arms = [
-        new("Cursor", "--cursor", null,
+        new("Cursor", "--cursor",
             env => {
                 Directory.CreateDirectory(Path.GetDirectoryName(env.CursorUserHooksJson)!);
                 File.WriteAllText(env.CursorUserHooksJson,
@@ -223,29 +265,29 @@ public class FlowsDriverSchemaConformanceTests {
             },
             env => env.CursorMcpJson, Json("Cursor", "mcpServers")),
 
-        new("Copilot", "--copilot", "COPILOT_HOME",
+        new("Copilot", "--copilot",
             env => { PluginCommand.InstallCopilotHooks(env.CopilotKcapHooksJson);
                      CopilotHooksInstaller.DeleteMarker(env.CopilotKcapHooksJson); },
             env => env.CopilotMcpConfigJson, Json("Copilot", "mcpServers")),
 
-        new("Gemini", "--gemini", "GEMINI_HOME",
+        new("Gemini", "--gemini",
             env => { PluginCommand.InstallGeminiHooks(env.GeminiSettingsJson);
                      GeminiHooksInstaller.DeleteMarker(env.GeminiSettingsJson); },
             env => env.GeminiSettingsJson, Json("Gemini", "mcpServers")),
 
-        new("Kiro", "--kiro", "KIRO_HOME",
+        new("Kiro", "--kiro",
             env => { Directory.CreateDirectory(Path.GetDirectoryName(env.KiroKcapAgentJson)!);
                      File.WriteAllText(env.KiroKcapAgentJson, """{"name":"kcap","hooks":{}}""");
                      KiroHooksInstaller.WriteMarker(env.KiroKcapAgentJson, "kiro_default"); },
             env => env.KiroMcpJson, Json("Kiro", "mcpServers")),
 
-        new("Antigravity", "--antigravity", "GEMINI_CLI_HOME",
+        new("Antigravity", "--antigravity",
             env => { AntigravityHooksInstaller.Install(env.AntigravityHooksJson);
                      File.WriteAllText(Path.Combine(Path.GetDirectoryName(env.AntigravityHooksJson)!,
                          AntigravityHooksInstaller.MarkerFileName), "0.0.0-stale"); },
             env => env.AntigravityMcpConfigJson, Json("Antigravity", "mcpServers")),
 
-        new("OpenCode", "--opencode", "OPENCODE_CONFIG_DIR",
+        new("OpenCode", "--opencode",
             env => { Directory.CreateDirectory(Path.GetDirectoryName(env.OpenCodeKcapPlugin)!);
                      File.WriteAllText(env.OpenCodeKcapPlugin, "// stale"); },
             env => env.OpenCodeMcpConfigJson, Json("OpenCode", "mcp", argvArray: true)),
@@ -253,7 +295,7 @@ public class FlowsDriverSchemaConformanceTests {
         // Codex installs unconditionally rather than through the `--if-installed` refresh branch, so
         // it takes the bare-install path and needs a planted plugin root. Flagged here rather than
         // hidden, because it is the one arm whose invocation differs.
-        new("Codex", "--codex", null, _ => { }, env => env.CodexConfigTomlPath, FromToml,
+        new("Codex", "--codex", _ => { }, env => env.CodexConfigTomlPath, FromToml,
             BareInstall: true),
     ];
 
@@ -263,14 +305,24 @@ public class FlowsDriverSchemaConformanceTests {
     /// server subset, the shape, or drops flows entirely — which is exactly the drift this suite
     /// claims to catch.</summary>
     static async Task<Projection> InstallAndRead(Arm arm) {
-        using var clear = arm.ClearEnvVar is null ? null : new EnvScope(arm.ClearEnvVar, null);
-        using var home  = new FakeUserHome();
+        // EVERY known path override, cleared for EVERY arm — not a per-arm list. Codex review round
+        // 2 found three wrong: the Gemini arm cleared GEMINI_HOME, a name GeminiPaths does not read
+        // (it honours GEMINI_CLI_HOME); the Codex arm cleared nothing while CodexPaths still gives
+        // ambient CODEX_HOME precedence; and the OpenCode arm cleared OPENCODE_CONFIG_DIR but left
+        // its XDG_CONFIG_HOME fallback live. On any machine with one of those set, the opt-in, the
+        // installer and the extractor all resolve OUTSIDE the fake home — so this test could read and
+        // rewrite a developer's real harness config, and could pass against a pre-existing entry.
+        // A per-arm list is exactly the thing that was wrong, so there is no per-arm list.
+        using var overrides = new EnvScopes(PathOverrideVariables);
+        using var home      = new FakeUserHome();
         var env = TestEnv(home.Path, arm.BareInstall ? PlantFakePlugin() : null);
 
         arm.OptIn(env);
 
         string[] argv = arm.BareInstall
-            ? ["plugin", "install", arm.Flag]
+            // --skip-codex-network-access: a schema conformance test has no business reading or
+            // rewriting the profile's network-access config.
+            ? ["plugin", "install", arm.Flag, "--skip-codex-network-access"]
             : ["plugin", "install", arm.Flag, "--if-installed"];
         var exit = await PluginCommand.HandleAsync(argv, env);
         if (exit != 0) throw new InvalidOperationException($"{arm.Name}: installer exited {exit}");
@@ -328,6 +380,42 @@ public class FlowsDriverSchemaConformanceTests {
         } finally {
             dir.Delete(recursive: true);
         }
+    }
+
+    // ── one definition, both routes ───────────────────────────────────────────────────────────
+    //
+    // Codex review round 2: `kcap setup` registers MCP through its OWN delegates, independently of
+    // `kcap plugin install`. Mutating SetupCommand.RegisterCopilotMcp to drop flows or use a
+    // divergent shape left every installer-driven arm above green — a user could get a different
+    // tool surface depending on which command they ran, and this suite would not notice.
+    //
+    // Fixed structurally rather than by testing both routes: the (subset, shape, marker) tuple now
+    // lives once, in HarnessMcpProjections, and BOTH call sites consume it. There is no longer a
+    // second definition to diverge. These assertions pin that single definition.
+
+    public static IEnumerable<Func<HarnessMcpProjection>> Projections() =>
+        HarnessMcpProjections.All.Select(p => (Func<HarnessMcpProjection>)(() => p));
+
+    [Test]
+    [MethodDataSource(nameof(Projections))]
+    public async Task Every_harness_projection_includes_the_flows_server(HarnessMcpProjection projection) {
+        var flows = projection.Servers.SingleOrDefault(s => s.Name == "kcap-flows");
+
+        await Assert.That(flows).IsNotNull()
+            .Because($"{projection.Harness} would silently lose the ability to start a flow");
+        await Assert.That(flows!.Args).IsEquivalentTo(new[] { "mcp", "flows" }, CollectionOrdering.Matching);
+        // Flows launches a PAID hosted reviewer, so it must never be auto-approved on registration.
+        await Assert.That(flows.ReadOnly).IsFalse();
+    }
+
+    // The projection list must cover exactly the JSON harnesses the installer table drives — no more,
+    // no fewer. A harness added to one and not the other is the same divergence in a new place.
+    [Test]
+    public async Task The_projection_list_matches_the_json_installer_arms() {
+        var projected = HarnessMcpProjections.All.Select(p => p.Harness).ToArray();
+        var installed = Arms.Where(a => !a.BareInstall).Select(a => a.Flag.TrimStart('-')).ToArray();
+
+        await Assert.That(projected).IsEquivalentTo(installed);
     }
 
     // ── drift tripwires ───────────────────────────────────────────────────────────────────────

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
@@ -125,7 +125,7 @@ public class FlowsDriverSchemaConformanceTests {
         // Assert the RENDERED labels, not the bare values. FormatStatusResponse catches formatter
         // exceptions and returns the original JSON body, so "contains claude" was satisfied by the
         // fallback — the test passed even if formatting failed completely or the audit rendering were
-        // deleted outright. (Flagged by codex round 2; I had listed it as suspect and left it.)
+        // deleted outright.
         await Assert.That(text).Contains("applied_reviewer_vendor: claude");
         await Assert.That(text).Contains("applied_reviewer_model: sonnet");
         await Assert.That(text).Contains("requested_reviewer_vendor: claude");
@@ -305,14 +305,12 @@ public class FlowsDriverSchemaConformanceTests {
     /// server subset, the shape, or drops flows entirely — which is exactly the drift this suite
     /// claims to catch.</summary>
     static async Task<Projection> InstallAndRead(Arm arm) {
-        // EVERY known path override, cleared for EVERY arm — not a per-arm list. Codex review round
-        // 2 found three wrong: the Gemini arm cleared GEMINI_HOME, a name GeminiPaths does not read
-        // (it honours GEMINI_CLI_HOME); the Codex arm cleared nothing while CodexPaths still gives
-        // ambient CODEX_HOME precedence; and the OpenCode arm cleared OPENCODE_CONFIG_DIR but left
-        // its XDG_CONFIG_HOME fallback live. On any machine with one of those set, the opt-in, the
-        // installer and the extractor all resolve OUTSIDE the fake home — so this test could read and
-        // rewrite a developer's real harness config, and could pass against a pre-existing entry.
-        // A per-arm list is exactly the thing that was wrong, so there is no per-arm list.
+        // EVERY known path override, cleared for EVERY arm — deliberately not a per-arm list. If any
+        // one is missed, the opt-in, the installer and the extractor all resolve OUTSIDE the fake
+        // home: the test then reads and rewrites the developer's real harness config, and can pass
+        // against a pre-existing entry. The names are easy to get individually wrong (GeminiPaths
+        // reads GEMINI_CLI_HOME, not GEMINI_HOME; OpenCode falls back to XDG_CONFIG_HOME; CodexPaths
+        // gives ambient CODEX_HOME precedence), which is exactly why the list is not per-arm.
         using var overrides = new EnvScopes(PathOverrideVariables);
         using var home      = new FakeUserHome();
         var env = TestEnv(home.Path, arm.BareInstall ? PlantFakePlugin() : null);
@@ -353,9 +351,9 @@ public class FlowsDriverSchemaConformanceTests {
     // The two bundled static files are not written by an installer — Claude Code and Codex's native
     // plugin loader read them straight from the package — so they get their own arm.
     /// <summary>The bundled static configs, kept as a list rather than inline [Arguments] so the
-    /// coverage assertion below can see them. Qodo flagged that "Codex" and "Codex plugin" both
-    /// reduce to --codex in the tripwire, so deleting the plugin arm left --codex green while one of
-    /// two INDEPENDENT Codex registration mechanisms went untested.</summary>
+    /// coverage assertion below can see them. Both reduce to --codex in the tripwire, so an
+    /// inline arm could be deleted while one of two INDEPENDENT Codex registration mechanisms went
+    /// untested.</summary>
     static readonly (string File, string Harness)[] BundledConfigs = [
         (".mcp.json",       "Claude Code"),
         (".codex-mcp.json", "Codex plugin"),
@@ -396,14 +394,12 @@ public class FlowsDriverSchemaConformanceTests {
 
     // ── one definition, both routes ───────────────────────────────────────────────────────────
     //
-    // Codex review round 2: `kcap setup` registers MCP through its OWN delegates, independently of
-    // `kcap plugin install`. Mutating SetupCommand.RegisterCopilotMcp to drop flows or use a
-    // divergent shape left every installer-driven arm above green — a user could get a different
-    // tool surface depending on which command they ran, and this suite would not notice.
+    // `kcap setup` registers MCP through its own delegates, independently of `kcap plugin install`.
+    // Without a shared definition a user could get a different tool surface depending on which
+    // command they ran, and the installer-driven arms above would not notice.
     //
-    // Fixed structurally rather than by testing both routes: the (subset, shape, marker) tuple now
-    // lives once, in HarnessMcpProjections, and BOTH call sites consume it. There is no longer a
-    // second definition to diverge. These assertions pin that single definition.
+    // The (subset, shape, marker) tuple lives once, in HarnessMcpProjections, and BOTH call sites
+    // consume it, so there is no second definition to diverge. These assertions pin that definition.
 
     public static IEnumerable<Func<HarnessMcpProjection>> Projections() =>
         HarnessMcpProjections.All.Select(p => (Func<HarnessMcpProjection>)(() => p));
@@ -420,11 +416,11 @@ public class FlowsDriverSchemaConformanceTests {
         await Assert.That(flows.ReadOnly).IsFalse();
     }
 
-    // Install/uninstall must read the SAME ownership tuple. Codex review round 3: the projection was
-    // added and consumed by the register paths only — the six remove paths and Kiro's "is the MCP half
-    // already installed?" probe still hard-coded shape and marker names. So changing a projection made
-    // new installs write under one ownership tuple while uninstall looked under the old one (stranding
-    // owned entries) and Kiro's refresh read an existing install as absent. Round-trip per harness.
+    // Install/uninstall must read the SAME ownership tuple. If the remove paths or Kiro's "is the MCP
+    // half already installed?" probe hard-code shape and marker instead of going through the
+    // projection, changing a projection makes new installs write under one ownership tuple while
+    // uninstall looks under the old one — stranding entries kcap can no longer see — and the refresh
+    // reads an existing install as absent. Round-trip per harness.
     [Test]
     [MethodDataSource(nameof(Projections))]
     public async Task A_registered_harness_config_is_fully_unregistered_again(HarnessMcpProjection projection) {

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
@@ -2,7 +2,12 @@ using System.Text.Json.Nodes;
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Mcp;
+using Capacitor.Cli.Core.Antigravity;
+using Capacitor.Cli.Core.Copilot;
+using Capacitor.Cli.Core.Gemini;
+using Capacitor.Cli.Core.Kiro;
 using Capacitor.Cli.Core.Pi;
+using TUnit.Assertions.Enums;
 using Tomlyn;
 using Tomlyn.Model;
 
@@ -97,6 +102,10 @@ public class FlowsDriverSchemaConformanceTests {
         var props = Tool(toolName).InputSchema.Properties;
 
         await Assert.That(props.ContainsKey("model")).IsTrue();
+        // Structure as well as prose: a `model` retyped to boolean, or promoted into Required (which
+        // would break every caller relying on the vendor's default model), passed the prose check.
+        await Assert.That(props["model"].Type).IsEqualTo("string");
+        await Assert.That(Tool(toolName).InputSchema.Required).DoesNotContain("model");
         await Assert.That(props["model"].Description.Contains("requires 'vendor'", StringComparison.OrdinalIgnoreCase)).IsTrue()
             .Because("the schema cannot express the dependency, so the description must");
     }
@@ -140,85 +149,165 @@ public class FlowsDriverSchemaConformanceTests {
         throw new DirectoryNotFoundException("kcap/ not found above the test base dir");
     }
 
-    /// <summary>Registers through the REAL writer into a temp file, then reads the entry back. Going
-    /// through the writer rather than asserting on the descriptor is the point: a shape that mangles
-    /// the command (an argv array, a type field, a different block key) is exactly the drift that
-    /// would give one harness a different server.</summary>
-    static Projection ViaJsonWriter(string harness, McpConfigShape shape) {
-        var dir  = Scratch("json-");
-        var path = Path.Combine(dir.FullName, "config.json");
-        try {
-            var change = JsonMcpConfigWriter.Register(path, KcapMcpServers.ForCursor, shape,
-                cwd: "/repo", marker: new McpMarker(harness));
-            if (change == JsonMcpConfigWriter.Change.Failed)
-                throw new InvalidOperationException($"{harness}: writer failed");
+    /// <summary>One harness arm: how to make the installer believe the harness is present, where its
+    /// config lands, and how to read the <c>kcap-flows</c> entry back out.</summary>
+    public sealed record Arm(
+        string                          Name,
+        string                          Flag,
+        string?                         ClearEnvVar,
+        Action<PluginEnvironment>       OptIn,
+        Func<PluginEnvironment, string> ConfigPath,
+        Func<string, Projection>        Extract,
+        bool                            BareInstall = false);
 
-            var root  = (JsonObject)JsonNode.Parse(File.ReadAllText(path))!;
-            var entry = (JsonObject)root[shape.BlockKey]!["kcap-flows"]!;
-
-            // OpenCode folds the command and args into one argv array; everyone else splits them.
-            if (shape.CommandAsArgvArray) {
-                var argv = entry["command"]!.AsArray().Select(n => n!.GetValue<string>()).ToArray();
-                return new(harness, argv[0], argv[1..]);
-            }
-
-            return new(harness,
-                entry["command"]!.GetValue<string>(),
-                [.. entry["args"]!.AsArray().Select(n => n!.GetValue<string>())]);
-        } finally {
-            dir.Delete(recursive: true);
+    sealed class EnvScope : IDisposable {
+        readonly string  _key;
+        readonly string? _prev;
+        public EnvScope(string key, string? value) {
+            _key = key; _prev = Environment.GetEnvironmentVariable(key);
+            Environment.SetEnvironmentVariable(key, value);
         }
+        public void Dispose() => Environment.SetEnvironmentVariable(_key, _prev);
     }
 
-    static Projection FromStaticJson(string harness, string file) {
-        var root  = (JsonObject)JsonNode.Parse(File.ReadAllText(Path.Combine(RepoKcapDir(), file)))!;
-        var entry = (JsonObject)root["mcpServers"]!["kcap-flows"]!;
-        return new(harness,
-            entry["command"]!.GetValue<string>(),
+    static PluginEnvironment TestEnv(string home, string? pluginRoot = null) =>
+        new(HomeDirectory: home, ResolvePluginPath: () => pluginRoot,
+            Stdout: TextWriter.Null, Stderr: TextWriter.Null);
+
+    /// <summary>Codex is the one arm that does not use the `--if-installed` refresh branch (it
+    /// installs unconditionally), so it needs a resolvable plugin root carrying the skills source —
+    /// mirroring PluginCommandCodexTests.PlantFakePlugin.</summary>
+    static string PlantFakePlugin() {
+        var root = Scratch("codex-plugin-").FullName;
+        foreach (var name in AgentsSkillsInstaller.SourceNames) {
+            var dir = Path.Combine(root, "skills", name);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "SKILL.md"), $"---\nname: {name}\n---\n# {name}");
+        }
+        return root;
+    }
+
+    /// <summary>Reads the flows entry from a written JSON config. <paramref name="argvArray"/> covers
+    /// OpenCode, which folds command and args into one array.</summary>
+    static Func<string, Projection> Json(string harness, string blockKey, bool argvArray = false) => path => {
+        var root  = (JsonObject)JsonNode.Parse(File.ReadAllText(path))!;
+        var block = root[blockKey] as JsonObject
+                 ?? throw new InvalidOperationException($"{harness}: no '{blockKey}' block written to {path}");
+        var entry = block["kcap-flows"] as JsonObject
+                 ?? throw new InvalidOperationException($"{harness}: kcap-flows not registered");
+
+        if (argvArray) {
+            var argv = entry["command"]!.AsArray().Select(n => n!.GetValue<string>()).ToArray();
+            return new(harness, argv[0], argv[1..]);
+        }
+        return new(harness, entry["command"]!.GetValue<string>(),
             [.. entry["args"]!.AsArray().Select(n => n!.GetValue<string>())]);
+    };
+
+    static Projection FromToml(string path) {
+        var servers = (TomlTable)TomlSerializer.Deserialize<TomlTable>(File.ReadAllText(path))!["mcp_servers"]!;
+        var entry   = (TomlTable)servers["kcap-flows"]!;
+        return new("Codex", (string)entry["command"]!,
+            [.. ((TomlArray)entry["args"]!).Select(a => (string)a!)]);
     }
 
-    static Projection FromCodexToml() {
-        var dir  = Scratch("codex-");
-        var path = Path.Combine(dir.FullName, "config.toml");
-        try {
-            var change = CodexConfigToml.RegisterKcapMcpServers(path);
-            if (!File.Exists(path)) throw new InvalidOperationException($"codex register -> {change}, no file at {path}");
-            var toml = File.ReadAllText(path);
+    // Each arm seeds "installed but stale" so `--if-installed` takes the refresh branch and registers
+    // MCP, mirroring each harness's own PluginCommand*Tests. That branch also skips the AgentDetector
+    // "kcap on PATH" precheck, which a bare install would fail in CI.
+    static readonly Arm[] Arms = [
+        new("Cursor", "--cursor", null,
+            env => {
+                Directory.CreateDirectory(Path.GetDirectoryName(env.CursorUserHooksJson)!);
+                File.WriteAllText(env.CursorUserHooksJson,
+                    """{"version":1,"hooks":{"sessionStart":[{"command":"kcap hook --cursor"}]}}""");
+            },
+            env => env.CursorMcpJson, Json("Cursor", "mcpServers")),
 
-            // Parsed shallowly on purpose: the assertion is which executable Codex will launch, and
-            // CodexConfigTomlTests already covers the TOML structure in depth.
-            var model = TomlSerializer.Deserialize<TomlTable>(toml)!;
-            var table = (TomlTable)((TomlTable)model["mcp_servers"]!)["kcap-flows"]!;
-            return new("Codex",
-                (string)table["command"]!,
-                [.. ((TomlArray)table["args"]!).Select(a => (string)a!)]);
-        } finally {
-            dir.Delete(recursive: true);
-        }
+        new("Copilot", "--copilot", "COPILOT_HOME",
+            env => { PluginCommand.InstallCopilotHooks(env.CopilotKcapHooksJson);
+                     CopilotHooksInstaller.DeleteMarker(env.CopilotKcapHooksJson); },
+            env => env.CopilotMcpConfigJson, Json("Copilot", "mcpServers")),
+
+        new("Gemini", "--gemini", "GEMINI_HOME",
+            env => { PluginCommand.InstallGeminiHooks(env.GeminiSettingsJson);
+                     GeminiHooksInstaller.DeleteMarker(env.GeminiSettingsJson); },
+            env => env.GeminiSettingsJson, Json("Gemini", "mcpServers")),
+
+        new("Kiro", "--kiro", "KIRO_HOME",
+            env => { Directory.CreateDirectory(Path.GetDirectoryName(env.KiroKcapAgentJson)!);
+                     File.WriteAllText(env.KiroKcapAgentJson, """{"name":"kcap","hooks":{}}""");
+                     KiroHooksInstaller.WriteMarker(env.KiroKcapAgentJson, "kiro_default"); },
+            env => env.KiroMcpJson, Json("Kiro", "mcpServers")),
+
+        new("Antigravity", "--antigravity", "GEMINI_CLI_HOME",
+            env => { AntigravityHooksInstaller.Install(env.AntigravityHooksJson);
+                     File.WriteAllText(Path.Combine(Path.GetDirectoryName(env.AntigravityHooksJson)!,
+                         AntigravityHooksInstaller.MarkerFileName), "0.0.0-stale"); },
+            env => env.AntigravityMcpConfigJson, Json("Antigravity", "mcpServers")),
+
+        new("OpenCode", "--opencode", "OPENCODE_CONFIG_DIR",
+            env => { Directory.CreateDirectory(Path.GetDirectoryName(env.OpenCodeKcapPlugin)!);
+                     File.WriteAllText(env.OpenCodeKcapPlugin, "// stale"); },
+            env => env.OpenCodeMcpConfigJson, Json("OpenCode", "mcp", argvArray: true)),
+
+        // Codex installs unconditionally rather than through the `--if-installed` refresh branch, so
+        // it takes the bare-install path and needs a planted plugin root. Flagged here rather than
+        // hidden, because it is the one arm whose invocation differs.
+        new("Codex", "--codex", null, _ => { }, env => env.CodexConfigTomlPath, FromToml,
+            BareInstall: true),
+    ];
+
+    /// <summary>Runs the REAL installer for one harness against a fake home and reads back what it
+    /// wrote. Going through <c>PluginCommand.HandleAsync</c> rather than reconstructing the writer
+    /// call is the whole point: a reconstruction stays green when the production wiring changes the
+    /// server subset, the shape, or drops flows entirely — which is exactly the drift this suite
+    /// claims to catch.</summary>
+    static async Task<Projection> InstallAndRead(Arm arm) {
+        using var clear = arm.ClearEnvVar is null ? null : new EnvScope(arm.ClearEnvVar, null);
+        using var home  = new FakeUserHome();
+        var env = TestEnv(home.Path, arm.BareInstall ? PlantFakePlugin() : null);
+
+        arm.OptIn(env);
+
+        string[] argv = arm.BareInstall
+            ? ["plugin", "install", arm.Flag]
+            : ["plugin", "install", arm.Flag, "--if-installed"];
+        var exit = await PluginCommand.HandleAsync(argv, env);
+        if (exit != 0) throw new InvalidOperationException($"{arm.Name}: installer exited {exit}");
+
+        var path = arm.ConfigPath(env);
+        if (!File.Exists(path)) throw new InvalidOperationException($"{arm.Name}: no config at {path}");
+
+        return arm.Extract(path);
     }
 
-    public static IEnumerable<Func<Projection>> DriverProjections() {
-        // The six harnesses that share the JSON writer, each through its own shape.
-        yield return () => ViaJsonWriter("Cursor",      McpConfigShape.Standard);
-        yield return () => ViaJsonWriter("Kiro",        McpConfigShape.Standard);
-        yield return () => ViaJsonWriter("Antigravity", McpConfigShape.Standard);
-        yield return () => ViaJsonWriter("Gemini",      McpConfigShape.Gemini);
-        yield return () => ViaJsonWriter("Copilot",     McpConfigShape.Copilot);
-        yield return () => ViaJsonWriter("OpenCode",    McpConfigShape.OpenCode);
-        // The three that do not.
-        yield return () => FromCodexToml();
-        yield return () => FromStaticJson("Claude Code",  ".mcp.json");
-        yield return () => FromStaticJson("Codex plugin", ".codex-mcp.json");
-    }
+    public static IEnumerable<Func<Arm>> InstallerArms() =>
+        Arms.Select(a => (Func<Arm>)(() => a));
 
     [Test]
-    [MethodDataSource(nameof(DriverProjections))]
-    public async Task Every_driver_projection_launches_the_same_flows_server(Projection p) {
+    [NotInParallel("HomeEnvVarMutation")]
+    [MethodDataSource(nameof(InstallerArms))]
+    public async Task Every_installed_driver_launches_the_same_flows_server(Arm arm) {
+        var p = await InstallAndRead(arm);
+
         await Assert.That(p.Command).IsEqualTo(KcapMcpServers.Command)
             .Because($"{p.Harness} must launch the same executable as every other driver");
-        await Assert.That(p.Args).IsEquivalentTo(new[] { "mcp", "flows" })
+        // ORDERED: argv order is semantic. An unordered comparison passes ["flows","mcp"], which
+        // launches nothing.
+        await Assert.That(p.Args).IsEquivalentTo(new[] { "mcp", "flows" }, CollectionOrdering.Matching)
             .Because($"{p.Harness} must reach the same subcommand, and therefore the same tool schema");
+    }
+
+    // The two bundled static files are not written by an installer — Claude Code and Codex's native
+    // plugin loader read them straight from the package — so they get their own arm.
+    [Test]
+    [Arguments(".mcp.json",       "Claude Code")]
+    [Arguments(".codex-mcp.json", "Codex plugin")]
+    public async Task Every_bundled_config_names_the_same_flows_server(string file, string harness) {
+        var p = Json(harness, "mcpServers")(Path.Combine(RepoKcapDir(), file));
+
+        await Assert.That(p.Command).IsEqualTo(KcapMcpServers.Command);
+        await Assert.That(p.Args).IsEquivalentTo(new[] { "mcp", "flows" }, CollectionOrdering.Matching);
     }
 
     // Pi is the outlier worth its own assertion: it does not write an MCP config at all. It emits a
@@ -254,17 +343,32 @@ public class FlowsDriverSchemaConformanceTests {
         var registry  = KcapMcpRegistry.Resolve("kcap-flows");
 
         await Assert.That(registry).IsNotNull();
-        await Assert.That(registry!.Args).IsEquivalentTo(canonical.Args);
+        // ORDERED -- ["flows","mcp"] is not the same command as ["mcp","flows"].
+        await Assert.That(registry!.Args).IsEquivalentTo(canonical.Args, CollectionOrdering.Matching);
         // And the recursion guard still knows flows starts flows — a hosted reviewer must never
         // receive it.
         await Assert.That(registry.StartsFlows).IsTrue();
     }
 
+    // BOTH directions. Canonical-only leaves a server registered with every harness but unresolvable
+    // as an allowlist entry; registry-only leaves one allowlistable but never registered anywhere.
+    // Checking one direction catches half the drift and reads like it catches all of it.
     [Test]
-    public async Task Every_canonical_server_resolves_in_the_flow_allowlist_registry() {
-        foreach (var s in KcapMcpServers.All)
-            await Assert.That(KcapMcpRegistry.Resolve(s.Name)).IsNotNull()
-                .Because($"{s.Name} is registered with harnesses but unresolvable as an allowlist entry");
+    public async Task The_two_server_lists_contain_exactly_the_same_servers() {
+        var canonical = KcapMcpServers.All.Select(s => s.Name).ToArray();
+        var registry  = KcapMcpRegistry.AllIds.ToArray();
+
+        await Assert.That(registry).IsEquivalentTo(canonical);
+    }
+
+    [Test]
+    public async Task Every_server_agrees_on_its_arguments_across_both_lists() {
+        foreach (var s in KcapMcpServers.All) {
+            var d = KcapMcpRegistry.Resolve(s.Name);
+            await Assert.That(d).IsNotNull().Because($"{s.Name} is unresolvable as an allowlist entry");
+            await Assert.That(d!.Args).IsEquivalentTo(s.Args, CollectionOrdering.Matching)
+                .Because($"{s.Name} launches different arguments depending on which list you read");
+        }
     }
 
     // The projection table above is hand-written, because no enumeration of supported harnesses
@@ -273,16 +377,16 @@ public class FlowsDriverSchemaConformanceTests {
     // Pinning against the flag arrays makes the omission fail here instead.
     [Test]
     public async Task The_projection_table_covers_every_harness_the_cli_claims_to_support() {
-        var covered = DriverProjections().Select(f => f().Harness)
-            .Select(h => h.Split(' ')[0].ToLowerInvariant())
-            .Append("pi")                                    // covered by its own bridge test above
+        // Match on the FLAG each arm actually drives, not on a display name split on whitespace —
+        // name-splitting matched by accident and would have kept passing for a harness whose arm was
+        // renamed rather than added.
+        var covered = Arms.Select(a => a.Flag)
+            .Append("--claude")   // bundled kcap/.mcp.json, covered by the static-config test
+            .Append("--pi")       // no MCP config at all, covered by the bridge test
             .ToHashSet(StringComparer.Ordinal);
 
-        var claimed = VendorSelection.KnownVendorFlags
-            .Select(f => f.TrimStart('-').ToLowerInvariant());
-
-        foreach (var harness in claimed)
-            await Assert.That(covered.Contains(harness)).IsTrue()
-                .Because($"--{harness} is an installable target with no driver-schema conformance coverage");
+        foreach (var flag in VendorSelection.KnownVendorFlags)
+            await Assert.That(covered.Contains(flag)).IsTrue()
+                .Because($"{flag} is an installable target with no driver-schema conformance coverage");
     }
 }


### PR DESCRIPTION
[AI-1489] Pin the vendor-capable flows schema across every driver projection

**Leg 1 of AI-1489** — §6 "Schema and registration conformance" plus clarification B's descriptor half. No spend, no reviewers launched. The live crossings and the Copilot routing leg are separate and still blocked on AI-1527.

## The gap

Reviewer choice is meant to be a property of the request, not of whichever harness is driving. Nothing enforced that, because registration was **four mechanisms and two independent definitions**:

| | mechanism |
|---|---|
| Cursor, Copilot, Gemini, Kiro, OpenCode, Antigravity | one JSON writer, differing only by an `McpConfigShape` |
| Codex | TOML, separate engine, own ownership ledger |
| Claude Code | hand-maintained static `kcap/.mcp.json` |
| Pi | hard-coded server list inside an embedded TypeScript bridge |

…and each of the six JSON harnesses had its `(subset, shape, marker)` tuple written out **twice** — once in `PluginCommand`, once in `SetupCommand`'s installer delegates — with nothing tying them together. A user could get a different tool surface depending on whether they ran `kcap plugin install` or `kcap setup`.

The existing per-harness tests each assert `Contains("kcap-flows")` in isolation: that a server *by that name* was written, not that it resolves to the same executable and therefore the same schema.

## What changed

**`HarnessMcpProjections`** (new, `Capacitor.Cli.Core/Mcp/`) holds each harness's `(subset, shape, marker)` once. `PluginCommand`'s six register paths, its six *remove* paths, Kiro's install probe, and all six `SetupCommand` delegates now consume it. `new McpMarker(` no longer appears in `PluginCommand` at all. The divergence is unrepresentable rather than merely detected.

`VendorSelection.KnownVendorFlags` widened `private` → `internal` so the conformance table can pin itself against it.

## What the suite pins

- **`vendor` is an optional string on both START tools**, and on **neither** of the six follow-up tools — the applied vendor is pinned at start, so a vendor on a follow-up is either silently ignored or an incoherent mid-run switch. `model` is pinned structurally too (string, not required).
- **The descriptions carry what the schema cannot** — that omitting `vendor` takes the server default, that the token is canonical lowercase, that there is no silent fallback, and that `model` requires `vendor`. The description is the only mechanism by which a driver LLM learns to pass the parameter.
- **Every driver projection resolves to the same `kcap mcp flows`**, driven through the **real installers** (`PluginCommand.HandleAsync` against a `FakeUserHome`, each arm seeding the same installed-but-stale state its own tests use), with **ordered** argv comparison.
- **Register → probe → unregister round-trips** per harness, so install and uninstall cannot read different ownership tuples and strand entries.
- **Pi's bridge still lists `flows`** — it discovers tools at runtime, so dropping it from that literal is silent.
- **The two server lists agree in both directions.** `KcapMcpServers` (registration) and `KcapMcpRegistry` (allowlist resolution, and the recursion guard's authority) were maintained separately.
- **Both status and polled-round formatters surface the applied vendor/model** — the audit rendering is duplicated across formatters, and the polled path is the one agents read most.

## Tripwires

The harness table is hand-written because **no enumeration of supported harnesses exists in production code** — the list is spread across four string arrays. So it is pinned against `VendorSelection.KnownVendorFlags`, and the bundled static configs are pinned against what is actually shipped in `kcap/`. A tenth harness, or a deleted arm, fails here rather than going quietly uncovered.

## Verification

Every fix mutation-tested. These each fail: dropping `vendor` from `start_flow`; promoting `model` to required; drifting `KcapMcpRegistry`'s args; a registry-only server; removing `flows` from Pi's literal; adding a tenth vendor flag; reversing the canonical argv order; **dropping flows from the shared Copilot projection**; giving Copilot the wrong shape; making `Unregister` use a different marker; deleting a bundled-config arm; and removing the audit rendering from either formatter.

Three earlier versions of these tests passed *vacuously* and were caught by mutation rather than by review — the reconstructed projection table, the dynamic-path ordering test, and the status assertion satisfied by the formatter's raw-JSON fallback.

**Review:** codex clean at `0417cf5` after 4 rounds (2 P1s, 5 P2s). Qodo: 4 findings, 2 already fixed by the codex rounds, 1 fixed here, 1 answered.

**Tests:** 42/42 in this suite. Full `Tests.Unit` failure set byte-identical to the 42-item pre-existing macOS baseline (`CodexConfigTomlTests` and the uninstall paths fail locally because `/var` is a symlink and `CodexConfigToml`'s path guard rejects symlinked components — unrelated to this change; this suite's scratch dirs sit under the assembly output for that reason).
