### PR TITLE
Make hosted Codex agents work on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,9 @@ After discovery, the import surfaces a one-shot report of any transcript working
 
 ### Daemon
 
-The daemon connects to the Capacitor server and runs Claude Code, Codex, or Cursor agents in isolated git worktrees, controlled from the dashboard. The daemon supports hosted Claude, Codex, and Cursor (`cursor` vendor) agents on macOS and Linux — choose the vendor from the dashboard's launch dialog. At startup the daemon probes `daemon.claude_path`, `daemon.codex_path`, and the Cursor CLI (`cursor-agent`, overridable via `KCAP_CURSOR_PATH` — see [Daemon config settings](#daemon-config-settings)) and advertises only the vendors it can actually spawn, so the launch dialog hides whichever agent isn't installed on the selected daemon.
+The daemon connects to the Capacitor server and runs Claude Code, Codex, or Cursor agents in isolated git worktrees, controlled from the dashboard. Hosted Claude and Codex agents run on macOS, Linux, **and Windows**; hosted Cursor (`cursor` vendor) is macOS and Linux only — choose the vendor from the dashboard's launch dialog. At startup the daemon probes `daemon.claude_path`, `daemon.codex_path`, and the Cursor CLI (`cursor-agent`, overridable via `KCAP_CURSOR_PATH` — see [Daemon config settings](#daemon-config-settings)) and advertises only the vendors it can actually spawn, so the launch dialog hides whichever agent isn't installed on the selected daemon.
+
+> **Windows and hosted Codex:** needs Windows 10 1809 (build 17763) or newer — Windows 11 recommended — because that's the floor for Codex's own Windows sandbox. Older builds don't advertise the `codex` vendor at all. The sandbox *implementation* (`elevated`, which needs one-time admin-approved `winget` setup, vs `unelevated`) is whatever your `~/.codex/config.toml` `[windows] sandbox` says; the daemon inherits it rather than overriding it. Codex is found on `PATH` whether installed via `winget` (`codex.exe`) or npm (`codex.cmd`).
 
 ```bash
 kcap daemon start                   # start in foreground (defaults --name to your OS username)

--- a/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
+++ b/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
@@ -184,7 +184,7 @@ static class ClaudeCliRunner {
             CancellationToken ct
         ) {
         // Resolve rather than pass "claude" verbatim: CreateProcess appends only .exe, so the
-        // npm-installed claude.cmd shim on Windows would never be found (AI-72).
+        // npm-installed claude.cmd shim on Windows would never be found.
         var exePath = CliExecutable.Resolve("claude");
 
         if (exePath is null) {

--- a/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
+++ b/src/Capacitor.Cli.Core/ClaudeCliRunner.cs
@@ -183,8 +183,18 @@ static class ClaudeCliRunner {
             string?           systemPrompt,
             CancellationToken ct
         ) {
+        // Resolve rather than pass "claude" verbatim: CreateProcess appends only .exe, so the
+        // npm-installed claude.cmd shim on Windows would never be found (AI-72).
+        var exePath = CliExecutable.Resolve("claude");
+
+        if (exePath is null) {
+            log("claude not found on PATH");
+
+            return null;
+        }
+
         var psi = new ProcessStartInfo {
-            FileName               = "claude",
+            FileName               = exePath,
             WorkingDirectory       = workingDir,
             RedirectStandardOutput = true,
             RedirectStandardError  = true,

--- a/src/Capacitor.Cli.Core/CliExecutable.cs
+++ b/src/Capacitor.Cli.Core/CliExecutable.cs
@@ -2,22 +2,14 @@ namespace Capacitor.Cli.Core;
 
 /// <summary>
 /// Resolves a CLI command (<c>"codex"</c>, <c>"claude"</c>, or a configured path) to a
-/// concrete executable the way a shell would: direct check for a rooted path, otherwise a
-/// <c>PATH</c> walk, plus <c>PATHEXT</c> candidates on Windows. On Unix a candidate must
-/// carry at least one execute bit.
+/// concrete executable like a shell would: a rooted path directly, otherwise a <c>PATH</c>
+/// walk with <c>PATHEXT</c> candidates on Windows (execute-bit check on Unix).
 ///
-/// <para>Resolution is required — not a nicety — for
-/// <see cref="System.Diagnostics.ProcessStartInfo.FileName"/> with
-/// <c>UseShellExecute = false</c>: that path goes through <c>CreateProcess</c>, which
-/// appends only <c>.exe</c>. npm installs the agent CLIs on Windows as a <c>.cmd</c> shim
-/// with no <c>.exe</c> alongside, so a bare <c>"codex"</c>/<c>"claude"</c> fails outright
-/// with "The system cannot find the file specified" — which is how headless title and
-/// what's-done generation silently degraded on Windows.</para>
-///
-/// <para>Handing the resolved full path to <c>FileName</c> is sufficient: .NET 8+ applies
-/// cmd-specific argument escaping when the target is a <c>.cmd</c>/<c>.bat</c>, so a
-/// <c>cmd.exe /c</c> wrapper is NOT needed here — and adding one would reintroduce the
-/// argument-injection hazard that escaping fix closed.</para>
+/// <para>Required because <c>ProcessStartInfo.FileName</c> with <c>UseShellExecute = false</c>
+/// goes through <c>CreateProcess</c>, which appends only <c>.exe</c> — so a bare
+/// <c>"codex"</c>/<c>"claude"</c> never finds npm's extensionless <c>.cmd</c> shims. Handing
+/// the resolved path to <c>FileName</c> is enough; .NET escapes <c>.cmd</c>/<c>.bat</c> args
+/// itself, so no <c>cmd.exe /c</c> wrapper (which would reopen an argument-injection hole).</para>
 /// </summary>
 public static class CliExecutable {
     /// <summary>

--- a/src/Capacitor.Cli.Core/CliExecutable.cs
+++ b/src/Capacitor.Cli.Core/CliExecutable.cs
@@ -76,28 +76,18 @@ public static class CliExecutable {
         if (!OperatingSystem.IsWindows())
             return IsExecutable(basePath) ? Full(basePath) : null;
 
-        if (HasExecutableExtension(basePath) && File.Exists(basePath)) return Full(basePath);
-
+        // Windows launches a bare name via PATHEXT — codex.cmd, never the extensionless
+        // "#!/bin/sh" twin npm drops beside it (CreateProcess can't run a shell script). Probe
+        // the PATHEXT candidates FIRST so a .cmd/.exe beats the twin, then fall back to the base
+        // path itself — for an already-extensioned path, or a genuinely extensionless executable
+        // that has no PATHEXT sibling.
         foreach (var ext in WindowsExtensions()) {
             var candidate = basePath + ext;
 
             if (File.Exists(candidate)) return Full(candidate);
         }
 
-        return null;
-    }
-
-    /// <summary>Whether <paramref name="path"/>'s extension is one <c>PATHEXT</c> lists — the
-    /// only files Windows launches by name. A bare extensionless twin never qualifies.</summary>
-    static bool HasExecutableExtension(string path) {
-        var ext = Path.GetExtension(path);
-
-        if (ext.Length == 0) return false;
-
-        foreach (var known in WindowsExtensions())
-            if (string.Equals(known, ext, StringComparison.OrdinalIgnoreCase)) return true;
-
-        return false;
+        return File.Exists(basePath) ? Full(basePath) : null;
     }
 
     /// <summary>Absolute form, or the path unchanged if it can't be expanded (a hit we could

--- a/src/Capacitor.Cli.Core/CliExecutable.cs
+++ b/src/Capacitor.Cli.Core/CliExecutable.cs
@@ -64,23 +64,40 @@ public static class CliExecutable {
     public static bool Exists(string? command) => Resolve(command) is not null;
 
     /// <summary>
-    /// <paramref name="basePath"/> itself when executable, else (Windows only) the first
-    /// <c>PATHEXT</c> extension appended to it that is. Hits come back fully qualified —
-    /// callers hand the result straight to <c>ProcessStartInfo.FileName</c>, and
-    /// <c>CursorBorrowedReviewValidation</c> walks it as a path.
+    /// <paramref name="basePath"/> resolved to something Windows/Unix will actually launch.
+    /// On Unix that is the path itself when it carries an execute bit. On Windows a bare
+    /// extensionless file is NOT runnable via <c>CreateProcess</c> — npm installs a Git-Bash
+    /// <c>#!/bin/sh</c> shim (no extension) right beside <c>codex.cmd</c>, and handing that
+    /// script to <c>CreateProcess</c> fails with error 193 — so the base path wins only when
+    /// it already carries a <c>PATHEXT</c> extension; otherwise the first <c>PATHEXT</c>
+    /// candidate appended to it does. Hits come back fully qualified.
     /// </summary>
     static string? FirstCandidate(string basePath) {
-        if (IsExecutable(basePath)) return Full(basePath);
+        if (!OperatingSystem.IsWindows())
+            return IsExecutable(basePath) ? Full(basePath) : null;
 
-        if (!OperatingSystem.IsWindows()) return null;
+        if (HasExecutableExtension(basePath) && File.Exists(basePath)) return Full(basePath);
 
         foreach (var ext in WindowsExtensions()) {
             var candidate = basePath + ext;
 
-            if (IsExecutable(candidate)) return Full(candidate);
+            if (File.Exists(candidate)) return Full(candidate);
         }
 
         return null;
+    }
+
+    /// <summary>Whether <paramref name="path"/>'s extension is one <c>PATHEXT</c> lists — the
+    /// only files Windows launches by name. A bare extensionless twin never qualifies.</summary>
+    static bool HasExecutableExtension(string path) {
+        var ext = Path.GetExtension(path);
+
+        if (ext.Length == 0) return false;
+
+        foreach (var known in WindowsExtensions())
+            if (string.Equals(known, ext, StringComparison.OrdinalIgnoreCase)) return true;
+
+        return false;
     }
 
     /// <summary>Absolute form, or the path unchanged if it can't be expanded (a hit we could

--- a/src/Capacitor.Cli.Core/CliExecutable.cs
+++ b/src/Capacitor.Cli.Core/CliExecutable.cs
@@ -1,0 +1,125 @@
+namespace Capacitor.Cli.Core;
+
+/// <summary>
+/// Resolves a CLI command (<c>"codex"</c>, <c>"claude"</c>, or a configured path) to a
+/// concrete executable the way a shell would: direct check for a rooted path, otherwise a
+/// <c>PATH</c> walk, plus <c>PATHEXT</c> candidates on Windows. On Unix a candidate must
+/// carry at least one execute bit.
+///
+/// <para>Resolution is required — not a nicety — for
+/// <see cref="System.Diagnostics.ProcessStartInfo.FileName"/> with
+/// <c>UseShellExecute = false</c>: that path goes through <c>CreateProcess</c>, which
+/// appends only <c>.exe</c>. npm installs the agent CLIs on Windows as a <c>.cmd</c> shim
+/// with no <c>.exe</c> alongside, so a bare <c>"codex"</c>/<c>"claude"</c> fails outright
+/// with "The system cannot find the file specified" — which is how headless title and
+/// what's-done generation silently degraded on Windows.</para>
+///
+/// <para>Handing the resolved full path to <c>FileName</c> is sufficient: .NET 8+ applies
+/// cmd-specific argument escaping when the target is a <c>.cmd</c>/<c>.bat</c>, so a
+/// <c>cmd.exe /c</c> wrapper is NOT needed here — and adding one would reintroduce the
+/// argument-injection hazard that escaping fix closed.</para>
+/// </summary>
+public static class CliExecutable {
+    /// <summary>
+    /// Returns the full path to the executable <paramref name="command"/> names, or null
+    /// when nothing matches. A rooted <paramref name="command"/> is checked directly (and,
+    /// on Windows, retried with <c>PATHEXT</c> extensions so an extensionless configured
+    /// path like <c>C:\tools\codex</c> still resolves to <c>codex.cmd</c>).
+    /// </summary>
+    public static string? Resolve(string? command) {
+        if (string.IsNullOrWhiteSpace(command)) return null;
+
+        // Anything with a directory component is a path, not a PATH lookup — mirrors how a
+        // shell treats "./codex" and "C:\tools\codex.cmd" alike.
+        if (Path.IsPathRooted(command) || command.Contains('/') || command.Contains('\\'))
+            return FirstCandidate(command);
+
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+
+        if (string.IsNullOrEmpty(pathEnv)) return null;
+
+        // Splitting on the platform separator is sufficient: POSIX disallows quoted PATH
+        // entries and Windows tolerates raw paths in PATH.
+        foreach (var dir in pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)) {
+            // A malformed PATH entry (invalid characters on Windows) must not abort the walk.
+            string candidate;
+
+            try {
+                candidate = Path.Combine(dir, command);
+            } catch (ArgumentException) {
+                continue;
+            }
+
+            if (FirstCandidate(candidate) is { } hit) return hit;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="command"/> resolves to something executable. Equivalent to
+    /// <c>Resolve(command) is not null</c>; kept as a named predicate for the daemon's
+    /// startup vendor probe.
+    /// </summary>
+    public static bool Exists(string? command) => Resolve(command) is not null;
+
+    /// <summary>
+    /// <paramref name="basePath"/> itself when executable, else (Windows only) the first
+    /// <c>PATHEXT</c> extension appended to it that is. Hits come back fully qualified —
+    /// callers hand the result straight to <c>ProcessStartInfo.FileName</c>, and
+    /// <c>CursorBorrowedReviewValidation</c> walks it as a path.
+    /// </summary>
+    static string? FirstCandidate(string basePath) {
+        if (IsExecutable(basePath)) return Full(basePath);
+
+        if (!OperatingSystem.IsWindows()) return null;
+
+        foreach (var ext in WindowsExtensions()) {
+            var candidate = basePath + ext;
+
+            if (IsExecutable(candidate)) return Full(candidate);
+        }
+
+        return null;
+    }
+
+    /// <summary>Absolute form, or the path unchanged if it can't be expanded (a hit we could
+    /// stat is more useful to the caller than a null).</summary>
+    static string? Full(string path) {
+        try {
+            return Path.GetFullPath(path);
+        } catch {
+            return path;
+        }
+    }
+
+    static string[] WindowsExtensions() {
+        var pathExt = Environment.GetEnvironmentVariable("PATHEXT");
+        var raw     = string.IsNullOrEmpty(pathExt) ? ".EXE;.CMD;.BAT;.COM" : pathExt;
+
+        return raw.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    /// <summary>
+    /// File exists AND (on Unix) has at least one execute bit set. True <c>access(X_OK)</c>
+    /// would need a P/Invoke against the effective UID/GID; the rare false positive
+    /// (execute bits set but unrelated owner) degrades to the same outcome as a
+    /// runtime-broken binary — a launch failure we already surface.
+    /// </summary>
+    static bool IsExecutable(string path) {
+        if (!File.Exists(path)) return false;
+        if (OperatingSystem.IsWindows()) return true; // PATHEXT already filtered the candidates
+
+        const UnixFileMode anyExecute =
+            UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
+
+        try {
+            return (File.GetUnixFileMode(path) & anyExecute) != 0;
+        } catch {
+            // TOCTOU race (file removed between the two calls), permission denied, or other
+            // I/O failure — treat as not executable so we never advertise a vendor we can't
+            // actually spawn.
+            return false;
+        }
+    }
+}

--- a/src/Capacitor.Cli.Core/CodexCliRunner.cs
+++ b/src/Capacitor.Cli.Core/CodexCliRunner.cs
@@ -66,8 +66,18 @@ static class CodexCliRunner {
             string            reasoning,
             CancellationToken ct
         ) {
+        // Resolve rather than pass "codex" verbatim: CreateProcess appends only .exe, so the
+        // npm-installed codex.cmd shim on Windows would never be found (AI-72).
+        var exePath = CliExecutable.Resolve("codex");
+
+        if (exePath is null) {
+            log("codex not found on PATH");
+
+            return null;
+        }
+
         var psi = new ProcessStartInfo {
-            FileName               = "codex",
+            FileName               = exePath,
             WorkingDirectory       = workingDir,
             RedirectStandardOutput = true,
             RedirectStandardError  = true,

--- a/src/Capacitor.Cli.Core/CodexCliRunner.cs
+++ b/src/Capacitor.Cli.Core/CodexCliRunner.cs
@@ -67,7 +67,7 @@ static class CodexCliRunner {
             CancellationToken ct
         ) {
         // Resolve rather than pass "codex" verbatim: CreateProcess appends only .exe, so the
-        // npm-installed codex.cmd shim on Windows would never be found (AI-72).
+        // npm-installed codex.cmd shim on Windows would never be found.
         var exePath = CliExecutable.Resolve("codex");
 
         if (exePath is null) {

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -66,7 +66,8 @@ public static class CodexConfigToml {
             : Update(configPath ?? DefaultConfigPath, root => MutateNetworkAccess(root, allowDomains), out _);
 
     /// <summary>
-    /// Writes the per-worktree pre-trust entry:
+    /// Writes the per-worktree pre-trust entry, keyed in Codex's own normalised form (see
+    /// <see cref="CodexPaths.NormalizeProjectKey"/>):
     /// <code>
     /// [projects."/abs/worktree/path"]
     /// trust_level = "trusted"
@@ -438,7 +439,10 @@ public static class CodexConfigToml {
 
     static bool MutateTrust(TomlTable root, string worktreePath) {
         var projects = GetOrAddTable(root, "projects");
-        var entry    = GetOrAddTable(projects, worktreePath);
+        // TOML keys are case-sensitive, so the key has to be in the exact form Codex looks up
+        // — see CodexPaths.NormalizeProjectKey. Writing worktreePath verbatim leaves Codex on
+        // the trust prompt on Windows.
+        var entry = GetOrAddTable(projects, CodexPaths.NormalizeProjectKey(worktreePath));
 
         if (entry.TryGetValue("trust_level", out var existing) &&
             existing is string s && string.Equals(s, "trusted", StringComparison.Ordinal))

--- a/src/Capacitor.Cli.Core/CodexPaths.cs
+++ b/src/Capacitor.Cli.Core/CodexPaths.cs
@@ -15,6 +15,25 @@ public static class CodexPaths {
     public static string UserHooksJson => Path.Combine(Home(), "hooks.json");
 
     /// <summary>
+    /// Matches Codex's <c>[projects."&lt;path&gt;"]</c> key normalisation: absolute, and on
+    /// Windows lowercased with backslashes preserved. Codex writes
+    /// <c>[projects."c:\\users\\me\\src\\repo"]</c> for <c>C:\Users\me\src\repo</c> — drive
+    /// letter included — so a raw mixed-case path is a different, case-sensitive TOML key and
+    /// our pre-trust write would be invisible to Codex, leaving it parked on the directory
+    /// trust prompt (the Codex analogue of the Claude trust hang in
+    /// <c>ClaudeLauncher.NormalizeClaudeProjectKey</c>).
+    ///
+    /// <para>Lowercasing is Windows-only and deliberately so: Unix filesystems are
+    /// case-sensitive, Codex does not fold case there, and the macOS/Linux hosted path
+    /// already works.</para>
+    /// </summary>
+    public static string NormalizeProjectKey(string path) {
+        var full = Path.GetFullPath(path);
+
+        return OperatingSystem.IsWindows() ? full.ToLowerInvariant() : full;
+    }
+
+    /// <summary>
     /// Walk <c>~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl</c>, optionally pruning
     /// directories below <paramref name="since"/>. Returns one entry per rollout
     /// with the session id parsed from the filename suffix

--- a/src/Capacitor.Cli.Core/CodexPaths.cs
+++ b/src/Capacitor.Cli.Core/CodexPaths.cs
@@ -15,17 +15,11 @@ public static class CodexPaths {
     public static string UserHooksJson => Path.Combine(Home(), "hooks.json");
 
     /// <summary>
-    /// Matches Codex's <c>[projects."&lt;path&gt;"]</c> key normalisation: absolute, and on
-    /// Windows lowercased with backslashes preserved. Codex writes
-    /// <c>[projects."c:\\users\\me\\src\\repo"]</c> for <c>C:\Users\me\src\repo</c> — drive
-    /// letter included — so a raw mixed-case path is a different, case-sensitive TOML key and
-    /// our pre-trust write would be invisible to Codex, leaving it parked on the directory
-    /// trust prompt (the Codex analogue of the Claude trust hang in
-    /// <c>ClaudeLauncher.NormalizeClaudeProjectKey</c>).
-    ///
-    /// <para>Lowercasing is Windows-only and deliberately so: Unix filesystems are
-    /// case-sensitive, Codex does not fold case there, and the macOS/Linux hosted path
-    /// already works.</para>
+    /// Matches Codex's own <c>[projects."&lt;path&gt;"]</c> key form: absolute, and on Windows
+    /// lowercased (backslashes kept). TOML keys are case-sensitive, so a raw mixed-case path is
+    /// a different key — the pre-trust write is then invisible to Codex and it parks on the
+    /// directory-trust prompt. Windows-only: Unix filesystems are case-sensitive and Codex does
+    /// not fold case there.
     /// </summary>
     public static string NormalizeProjectKey(string path) {
         var full = Path.GetFullPath(path);

--- a/src/Capacitor.Cli.Daemon/Pty/Windows/ConPtyProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Windows/ConPtyProcess.cs
@@ -40,7 +40,10 @@ public sealed class ConPtyProcess : IPtyProcess {
         _jobHandle    = jobHandle;
     }
 
-    static (string command, bool isCmd) ResolveCommand(string command) {
+    // Internal for unit tests: the extensionless-twin preference bug (returning npm's
+    // Git-Bash "#!/bin/sh" shim instead of codex.cmd, which CreateProcessW rejects with 193)
+    // is Windows-reality-specific and only reproducible by exercising this resolver directly.
+    internal static (string command, bool isCmd) ResolveCommand(string command) {
         if (Path.HasExtension(command) && File.Exists(command)) {
             return (command, command.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase));
         }
@@ -60,18 +63,22 @@ public sealed class ConPtyProcess : IPtyProcess {
         var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? "";
 
         foreach (var dir in pathEnv.Split(';', StringSplitOptions.RemoveEmptyEntries)) {
-            var exact = Path.Combine(dir, command);
-
-            if (File.Exists(exact)) {
-                return (exact, false);
-            }
-
+            // Windows launches a bare name through PATHEXT — codex.cmd, never the
+            // extensionless "#!/bin/sh" twin npm drops beside it (CreateProcessW fails 193
+            // on that script). Probe the executable extensions BEFORE the bare file so a
+            // .cmd/.exe always wins when both live in the same directory.
             foreach (var ext in new[] { ".exe", ".cmd" }) {
                 var candidate = Path.Combine(dir, command + ext);
 
                 if (File.Exists(candidate)) {
                     return (candidate, ext == ".cmd");
                 }
+            }
+
+            var exact = Path.Combine(dir, command);
+
+            if (File.Exists(exact)) {
+                return (exact, false);
             }
         }
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1141,12 +1141,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             try {
                 start = await runtimeFactory.StartAsync(runtimeCtx, _shutdownCts.Token);
-            } catch (Exception ex) when (ex is CodexHooksNotInstalledException or CodexReviewerMcpIsolationException) {
+            } catch (Exception ex) when (ex is CodexHooksNotInstalledException or CodexReviewerMcpIsolationException
+                                            or CodexUnsupportedWindowsException) {
                 // CodexHooksNotInstalledException: hooks preflight failed in Prepare.
                 // CodexReviewerMcpIsolationException: the review-flow reviewer's inherited MCP
                 // servers could not be authoritatively enumerated, so the recursion guard cannot be
                 // proven — fail the launch CLOSED rather than spawn a reviewer that might inherit a
-                // flow-starting server. Both map to the same cleanup path.
+                // flow-starting server.
+                // CodexUnsupportedWindowsException: Windows build older than 10.0.17763, where
+                // Codex's Windows sandbox does not exist — carries the version + doc link.
+                // All map to the same cleanup path.
                 await _server.LaunchFailedAsync(agentId, ex.Message);
 
                 // No AgentInstance was created, so CleanupAgentAsync won't run — revoke the reviewer

--- a/src/Capacitor.Cli.Daemon/Services/CliResolver.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CliResolver.cs
@@ -1,70 +1,29 @@
+using Capacitor.Cli.Core;
+
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// Best-effort lookup that mirrors how a shell finds an executable: if the
-/// configured path is absolute, check the file directly; otherwise walk
-/// <c>PATH</c> (plus <c>PATHEXT</c> on Windows). On Unix, requires at least
-/// one execute bit (mirrors <c>AgentDetector.IsExecutable</c> in the CLI
-/// project — keep the two in sync). Used by
-/// <see cref="IHostedAgentLauncher.IsAvailable"/> at daemon startup
-/// to decide which vendor launchers to advertise over <c>DaemonConnect</c>.
+/// Best-effort lookup that mirrors how a shell finds an executable. Now a thin alias over
+/// <see cref="CliExecutable"/>, which owns the single copy of the PATH/PATHEXT walk shared
+/// with the headless runners — this file used to carry its own near-identical copy behind a
+/// "keep the two in sync" comment that the Windows <c>.cmd</c> gap slipped through anyway.
+/// Used by <see cref="IHostedAgentLauncher.IsAvailable"/> at daemon startup to decide which
+/// vendor launchers to advertise over <c>DaemonConnect</c>.
 ///
-/// <para>This intentionally does NOT execute the binary — startup must stay
-/// cheap. False positives (binary present, exec bit set, but unusable for
-/// some other reason) surface later as the existing <c>LaunchFailed</c>
-/// path.</para>
+/// <para>This intentionally does NOT execute the binary — startup must stay cheap. False
+/// positives (binary present, exec bit set, but unusable for some other reason) surface
+/// later as the existing <c>LaunchFailed</c> path.</para>
 /// </summary>
 internal static class CliResolver {
     /// <summary>
-    /// Returns <c>true</c> when <paramref name="cliPath"/> resolves to an
-    /// existing, executable file — either directly (absolute path) or via
-    /// <c>PATH</c> lookup (bare command).
+    /// Returns <c>true</c> when <paramref name="cliPath"/> resolves to an existing,
+    /// executable file — either directly (rooted path) or via <c>PATH</c> lookup (bare
+    /// command).
     /// </summary>
-    public static bool Exists(string cliPath) {
-        return ResolveExecutable(cliPath) is not null;
-    }
-
-    public static string? ResolveExecutable(string cliPath) {
-        if (string.IsNullOrWhiteSpace(cliPath)) return null;
-
-        if (Path.IsPathFullyQualified(cliPath))
-            return IsExecutable(cliPath) ? Path.GetFullPath(cliPath) : null;
-
-        // Bare command — walk PATH. Splitting on the platform separator is
-        // sufficient; we don't need to handle quoted PATH entries because
-        // POSIX disallows them and Windows tolerates raw paths in PATH.
-        var pathEnv = Environment.GetEnvironmentVariable("PATH");
-
-        if (string.IsNullOrEmpty(pathEnv)) return null;
-
-        var extensions = OperatingSystem.IsWindows()
-            ? (Environment.GetEnvironmentVariable("PATHEXT") ?? ".EXE;.CMD;.BAT;.COM").Split(';', StringSplitOptions.RemoveEmptyEntries)
-            : [""];
-
-        return pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-            .SelectMany(dir => extensions.Select(ext => Path.Combine(dir, cliPath + ext)))
-            .FirstOrDefault(IsExecutable);
-    }
+    public static bool Exists(string cliPath) => CliExecutable.Exists(cliPath);
 
     /// <summary>
-    /// File exists AND (on Unix) has at least one execute bit set. Kept in
-    /// sync with <c>AgentDetector.IsExecutable</c>; if the heuristic moves
-    /// (e.g. to <c>access(X_OK)</c> via P/Invoke), bump both copies.
+    /// The fully-qualified executable <paramref name="cliPath"/> resolves to, or null.
     /// </summary>
-    static bool IsExecutable(string path) {
-        if (!File.Exists(path)) return false;
-        if (OperatingSystem.IsWindows()) return true; // PATHEXT already filtered the candidates
-
-        const UnixFileMode anyExecute =
-            UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
-
-        try {
-            return (File.GetUnixFileMode(path) & anyExecute) != 0;
-        } catch {
-            // TOCTOU race (file removed between File.Exists and GetUnixFileMode),
-            // permission denied, or other I/O failure — treat as not executable
-            // so the daemon doesn't advertise a vendor it can't actually spawn.
-            return false;
-        }
-    }
+    public static string? ResolveExecutable(string cliPath) => CliExecutable.Resolve(cliPath);
 }

--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -26,7 +26,24 @@ internal sealed partial class CodexLauncher(
     /// slug-level equivalence key). Stateless singleton.</summary>
     public IReviewerModelResolver? ReviewerModelResolver => CodexReviewerModelResolver.Instance;
 
-    public bool IsAvailable() => CliResolver.Exists(CliPath);
+    // Codex supports its Windows sandbox on Windows 10 1809 (build 17763) and newer only;
+    // Windows 11 is the recommended baseline. Older builds lack the APIs its restricted-token
+    // and ACL boundaries rely on, so the CLI is unusable there even when installed.
+    // https://developers.openai.com/codex/windows
+    const int MinWindowsBuild = 17763;
+
+    internal const string UnsupportedWindowsMessage =
+        "Hosted Codex agents need Windows 10 1809 (build 17763) or newer — Windows 11 recommended. " +
+        "Codex's Windows sandbox is unavailable on this host. "                                      +
+        "See https://developers.openai.com/codex/windows";
+
+    /// <summary>Non-Windows is always supported — the macOS/Linux path predates this gate.</summary>
+    internal static bool WindowsVersionSupported =>
+        !OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, MinWindowsBuild);
+
+    // Version gate BEFORE the PATH probe, so an unsupported host never advertises the vendor at
+    // all — the launch dialog hides Codex rather than offering a launch that cannot work.
+    public bool IsAvailable() => WindowsVersionSupported && CliResolver.Exists(CliPath);
 
     /// <summary>
     /// Enumerates the effective MCP servers a review-flow reviewer would otherwise inherit —
@@ -57,6 +74,11 @@ internal sealed partial class CodexLauncher(
     static readonly string[] CriticalHookEvents = ["SessionStart", "Stop", "PermissionRequest"];
 
     public void Prepare(LauncherContext ctx) {
+        // Step 0: refuse an unsupported Windows build before touching the worktree. IsAvailable
+        // normally keeps us off this path entirely; this catches an in-flight or stale-vendor-list
+        // launch and turns it into an actionable LaunchFailed instead of a spawn error.
+        if (!WindowsVersionSupported) throw new CodexUnsupportedWindowsException(UnsupportedWindowsMessage);
+
         // A borrowed cwd is the user's own repo: skip the repo-mutating steps (overlay,
         // ~/.codex trust write). Only the read-only hooks preflight runs for it.
         var owned = ctx.Work == WorkLocation.OwnedWorktree;

--- a/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexLauncher.cs
@@ -145,6 +145,13 @@ internal sealed partial class CodexLauncher(
             ctx.IsReviewFlow ? "never" : "on-request"
         };
 
+        // codex 0.146+ parks the interactive session on a "Hooks need review" prompt for any hook
+        // it hasn't persisted trust for. A hosted launch has no one to answer it, so it hangs at
+        // "Waiting for session to start". kcap installs and owns these hooks (it vets the source),
+        // so bypass the per-invocation trust gate — same posture as the sandbox/approval flags
+        // above. Global flag, so it also covers unattended review-flow reviewers.
+        args.Add("--dangerously-bypass-hook-trust");
+
         // Review-flow reviewers get exactly ONE MCP server: kcap-flow-result (+ any
         // allowlisted, non-flow-starting server) — it can only submit a result, never start a
         // flow. Codex's `-c` overrides deep-merge into ~/.codex/config.toml (no analog of

--- a/src/Capacitor.Cli.Daemon/Services/CodexUnsupportedWindowsException.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexUnsupportedWindowsException.cs
@@ -1,0 +1,15 @@
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Thrown by <see cref="CodexLauncher"/>'s Prepare preflight when the host is a Windows build
+/// older than 10.0.17763 (Windows 10 1809), below which Codex does not support its Windows
+/// sandbox. The orchestrator catches this type and emits <c>LaunchFailed</c> with the
+/// exception's message, so the user gets the version requirement and the doc link rather than
+/// an opaque spawn failure.
+///
+/// <para>Normally unreachable from the dashboard: <see cref="CodexLauncher.IsAvailable"/>
+/// applies the same gate, so an unsupported host never advertises the <c>codex</c> vendor in
+/// the first place. This covers the race where a launch command was already in flight (or the
+/// dashboard held a stale vendor list).</para>
+/// </summary>
+internal sealed class CodexUnsupportedWindowsException(string message) : Exception(message);

--- a/test/Capacitor.Cli.Tests.Unit/CliExecutableTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CliExecutableTests.cs
@@ -54,6 +54,52 @@ public class CliExecutableTests {
         }
     }
 
+    /// <summary>The CreateProcessW-193 regression: npm installs an extensionless Git-Bash
+    /// <c>#!/bin/sh</c> shim RIGHT NEXT TO <c>codex.cmd</c>. A bare extensionless file is not
+    /// launchable via <c>CreateProcess</c> (error 193 — not a valid Win32 application), so with
+    /// both present the resolver must return the <c>.cmd</c>, never the shim.</summary>
+    [Test, NotInParallel]
+    public async Task Resolve_prefers_cmd_over_extensionless_twin_on_windows() {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var dir  = Directory.CreateTempSubdirectory("kcap-cliexe-twin-").FullName;
+        var name = $"kcap-twinprobe-{Guid.NewGuid():N}";
+        var shim = Path.Combine(dir, name);          // extensionless "#!/bin/sh" shim
+        var cmd  = Path.Combine(dir, name + ".cmd");
+        await File.WriteAllTextAsync(shim, "#!/bin/sh\nexit 0\n");
+        await File.WriteAllTextAsync(cmd, "@echo off\r\n");
+
+        var savedPath = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", $"{dir}{Path.PathSeparator}{savedPath}");
+
+        try {
+            await Assert.That(CliExecutable.Resolve(name)).IsEqualTo(cmd, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            Environment.SetEnvironmentVariable("PATH", savedPath);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>Same twin, reached through a rooted extensionless configured path
+    /// (<c>daemon.codex_path = C:\tools\codex</c>): must still land on <c>codex.cmd</c>, not the
+    /// extensionless shim beside it.</summary>
+    [Test]
+    public async Task Resolve_prefers_cmd_over_extensionless_twin_for_rooted_path_on_windows() {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var dir  = Directory.CreateTempSubdirectory("kcap-cliexe-twinrooted-").FullName;
+        var stem = Path.Combine(dir, "codex");
+        await File.WriteAllTextAsync(stem, "#!/bin/sh\n");        // extensionless shim
+        await File.WriteAllTextAsync(stem + ".cmd", "@echo off\r\n");
+
+        try {
+            await Assert.That(CliExecutable.Resolve(stem))
+                .IsEqualTo(stem + ".cmd", StringComparison.OrdinalIgnoreCase);
+        } finally {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     /// <summary>A configured <c>daemon.codex_path</c> may omit the extension; on Windows that
     /// must still land on the <c>.cmd</c> next to it rather than reporting "not installed".</summary>
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/CliExecutableTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CliExecutableTests.cs
@@ -1,0 +1,140 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Covers the shared PATH/PATHEXT resolver behind the headless runners
+/// (<c>ClaudeCliRunner</c> / <c>CodexCliRunner</c>) and the daemon's vendor probe.
+///
+/// <para>The Windows <c>.cmd</c> cases are the regression this type exists for:
+/// <c>ProcessStartInfo.FileName</c> with <c>UseShellExecute = false</c> goes through
+/// <c>CreateProcess</c>, which appends only <c>.exe</c>. npm installs the agent CLIs as a
+/// <c>.cmd</c> shim with no <c>.exe</c>, so passing a bare <c>"codex"</c>/<c>"claude"</c>
+/// failed with "The system cannot find the file specified" — silently degrading session
+/// titles and what's-done summaries on Windows for every npm-installed harness.</para>
+/// </summary>
+public class CliExecutableTests {
+    [Test]
+    public async Task Resolve_returns_null_for_empty_input() {
+        await Assert.That(CliExecutable.Resolve(null)).IsNull();
+        await Assert.That(CliExecutable.Resolve("")).IsNull();
+        await Assert.That(CliExecutable.Resolve("   ")).IsNull();
+    }
+
+    [Test]
+    public async Task Resolve_returns_null_when_bare_command_not_on_path() {
+        await Assert.That(CliExecutable.Resolve($"kcap-absent-{Guid.NewGuid():N}")).IsNull();
+    }
+
+    /// <summary>The whole point: a bare command backed only by a <c>.cmd</c> shim must resolve
+    /// to that shim's full path, because <c>CreateProcess</c> will not find it otherwise.</summary>
+    [Test, NotInParallel]
+    public async Task Resolve_finds_cmd_shim_for_bare_command_on_windows() {
+        if (!OperatingSystem.IsWindows()) return; // .cmd shims are a Windows-only npm artifact
+
+        var dir  = Directory.CreateTempSubdirectory("kcap-cliexe-cmd-").FullName;
+        var name = $"kcap-shimprobe-{Guid.NewGuid():N}";
+        var shim = Path.Combine(dir, name + ".cmd");
+        await File.WriteAllTextAsync(shim, "@echo off\r\necho hi\r\n");
+
+        var savedPath = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", $"{dir}{Path.PathSeparator}{savedPath}");
+
+        try {
+            var resolved = CliExecutable.Resolve(name);
+
+            // Case-insensitive: the extension comes from PATHEXT, which is conventionally
+            // uppercase (".CMD"), so the resolved path won't match the on-disk casing. Harmless
+            // — Windows paths are case-insensitive and CreateProcess accepts either.
+            await Assert.That(resolved).IsEqualTo(shim, StringComparison.OrdinalIgnoreCase);
+            await Assert.That(CliExecutable.Exists(name)).IsTrue();
+        } finally {
+            Environment.SetEnvironmentVariable("PATH", savedPath);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>A configured <c>daemon.codex_path</c> may omit the extension; on Windows that
+    /// must still land on the <c>.cmd</c> next to it rather than reporting "not installed".</summary>
+    [Test]
+    public async Task Resolve_appends_extension_to_rooted_path_on_windows() {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var dir  = Directory.CreateTempSubdirectory("kcap-cliexe-rooted-").FullName;
+        var stem = Path.Combine(dir, "codex");
+        await File.WriteAllTextAsync(stem + ".cmd", "@echo off\r\n");
+
+        try {
+            await Assert.That(CliExecutable.Resolve(stem))
+                .IsEqualTo(stem + ".cmd", StringComparison.OrdinalIgnoreCase);
+        } finally {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Resolve_returns_fully_qualified_path_for_relative_input() {
+        var dir  = Directory.CreateTempSubdirectory("kcap-cliexe-rel-").FullName;
+        var name = OperatingSystem.IsWindows() ? "probe.cmd" : "probe";
+        var full = Path.Combine(dir, name);
+        await File.WriteAllTextAsync(full, "#!/bin/sh\nexit 0\n");
+        MakeExecutable(full);
+
+        // A path with a directory component but no root — must resolve against the cwd, not PATH.
+        var relative = Path.GetRelativePath(Directory.GetCurrentDirectory(), full);
+
+        try {
+            var resolved = CliExecutable.Resolve(relative);
+
+            await Assert.That(resolved).IsNotNull();
+            await Assert.That(Path.IsPathFullyQualified(resolved!)).IsTrue();
+            await Assert.That(resolved).IsEqualTo(full);
+        } finally {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Resolve_returns_null_for_non_executable_file_on_unix() {
+        if (OperatingSystem.IsWindows()) return; // Windows has no exec bit
+
+        var path = Path.Combine(Directory.CreateTempSubdirectory("kcap-cliexe-noexec-").FullName, "probe");
+        await File.WriteAllTextAsync(path, "#!/bin/sh\n");
+        File.SetUnixFileMode(path, UnixFileMode.UserRead);
+
+        await Assert.That(CliExecutable.Resolve(path)).IsNull();
+    }
+
+    /// <summary>An unusable PATH entry must not abort the walk before later entries are tried —
+    /// a missing directory and a stray-quote entry both have to be skipped, not fatal.</summary>
+    [Test, NotInParallel]
+    public async Task Resolve_continues_past_unusable_path_entries() {
+        var dir  = Directory.CreateTempSubdirectory("kcap-cliexe-badpath-").FullName;
+        var name = $"kcap-lateprobe-{Guid.NewGuid():N}";
+        var file = Path.Combine(dir, OperatingSystem.IsWindows() ? name + ".cmd" : name);
+        await File.WriteAllTextAsync(file, "");
+        MakeExecutable(file);
+
+        var savedPath = Environment.GetEnvironmentVariable("PATH");
+        var junk      = $"{Path.Combine(dir, "nope")}{Path.PathSeparator}\"quoted{Path.PathSeparator}";
+        // Junk entries FIRST so the good directory is only reached if the walk continued.
+        Environment.SetEnvironmentVariable("PATH", junk + dir);
+
+        try {
+            await Assert.That(CliExecutable.Resolve(name)).IsEqualTo(file, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            Environment.SetEnvironmentVariable("PATH", savedPath);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    static void MakeExecutable(string path) {
+        if (OperatingSystem.IsWindows()) return;
+        File.SetUnixFileMode(
+            path,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+          | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+          | UnixFileMode.OtherRead | UnixFileMode.OtherExecute
+        );
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigWriterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigWriterTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Tomlyn;
@@ -28,6 +29,14 @@ public class CodexConfigWriterTests {
     static TomlTable ReadToml(string path) =>
         TomlSerializer.Deserialize<TomlTable>(File.ReadAllText(path))!;
 
+    /// <summary>The <c>[projects]</c> key Codex itself would use — absolute, and lowercased on
+    /// Windows. Asserting on the raw input path would only hold on Unix.</summary>
+    static string Key(string worktreePath) => CodexPaths.NormalizeProjectKey(worktreePath);
+
+    /// <summary>A seeded <c>[projects.'…']</c> header under the normalised key. TOML literal
+    /// strings (single quotes) pass Windows backslashes through unescaped.</summary>
+    static string SeededHeader(string worktreePath) => $"[projects.'{Key(worktreePath)}']";
+
     [Test]
     public async Task Writes_initial_projects_table_when_config_toml_missing() {
         var (tmp, original) = ScopedHome();
@@ -41,7 +50,7 @@ public class CodexConfigWriterTests {
 
             var root     = ReadToml(configPath);
             var projects = (TomlTable)root["projects"];
-            var entry    = (TomlTable)projects["/tmp/some-worktree"];
+            var entry    = (TomlTable)projects[Key("/tmp/some-worktree")];
             await Assert.That((string)entry["trust_level"]).IsEqualTo("trusted");
         } finally { RestoreHome(original, tmp); }
     }
@@ -89,7 +98,7 @@ public class CodexConfigWriterTests {
 
             var projects = (TomlTable)root["projects"];
             await Assert.That((string)((TomlTable)projects["/existing/path"])["trust_level"]).IsEqualTo("trusted");
-            await Assert.That((string)((TomlTable)projects["/tmp/new-wt"])["trust_level"]).IsEqualTo("trusted");
+            await Assert.That((string)((TomlTable)projects[Key("/tmp/new-wt")])["trust_level"]).IsEqualTo("trusted");
         } finally { RestoreHome(original, tmp); }
     }
 
@@ -102,16 +111,16 @@ public class CodexConfigWriterTests {
 
             File.WriteAllText(
                 Path.Combine(codexDir, "config.toml"),
-                """
-                [projects."/tmp/wt"]
-                trust_level = "ask"
-                """
+                $"""
+                 {SeededHeader("/tmp/wt")}
+                 trust_level = "ask"
+                 """
             );
 
             CodexConfigWriter.TrustWorktree("/tmp/wt", NullLogger.Instance);
 
             var root  = ReadToml(Path.Combine(codexDir, "config.toml"));
-            var entry = (TomlTable)((TomlTable)root["projects"])["/tmp/wt"];
+            var entry = (TomlTable)((TomlTable)root["projects"])[Key("/tmp/wt")];
             await Assert.That((string)entry["trust_level"]).IsEqualTo("trusted");
         } finally { RestoreHome(original, tmp); }
     }
@@ -126,10 +135,10 @@ public class CodexConfigWriterTests {
 
             File.WriteAllText(
                 configPath,
-                """
-                [projects."/tmp/wt"]
-                trust_level = "trusted"
-                """
+                $"""
+                 {SeededHeader("/tmp/wt")}
+                 trust_level = "trusted"
+                 """
             );
             var originalMtime = File.GetLastWriteTimeUtc(configPath);
 
@@ -169,7 +178,7 @@ public class CodexConfigWriterTests {
             var projects   = (TomlTable)root["projects"];
 
             for (var i = 0; i < 20; i++) {
-                var entry = (TomlTable)projects[$"/tmp/wt-{i}"];
+                var entry = (TomlTable)projects[Key($"/tmp/wt-{i}")];
                 await Assert.That((string)entry["trust_level"]).IsEqualTo("trusted");
             }
         } finally { RestoreHome(original, tmp); }

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -108,6 +108,15 @@ public class CodexLauncherTests {
     }
 
     [Test]
+    public async Task BuildArgs_bypasses_hook_trust_for_hosted_and_review_flow() {
+        // codex 0.146+ parks the interactive session on a "Hooks need review" prompt for hooks
+        // it hasn't persisted trust for; an unattended hosted launch has no one to answer it and
+        // hangs forever. kcap owns these hooks, so every hosted launch must bypass the gate.
+        await Assert.That(NewLauncher().BuildArgs(NewCtx()).Args).Contains("--dangerously-bypass-hook-trust");
+        await Assert.That(NewLauncher().BuildArgs(NewCtx(isReviewFlow: true)).Args).Contains("--dangerously-bypass-hook-trust");
+    }
+
+    [Test]
     public async Task BuildArgs_includes_cd_with_worktree_path() {
         var args = NewLauncher().BuildArgs(NewCtx()).Args;
         var cdIdx = Array.IndexOf(args, "--cd");
@@ -728,6 +737,7 @@ public class CodexLauncherTests {
             "--cd", "/tmp/wt",
             "--sandbox", "workspace-write",
             "--ask-for-approval", "never",
+            "--dangerously-bypass-hook-trust",
             "-c", "mcp_servers.kcap-flow-result.enabled=true",
             "-c", "mcp_servers.kcap-flow-result.command=\"/opt/kcap\"",
             "-c", "mcp_servers.kcap-flow-result.args=[\"mcp\",\"flow-result\"]",

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -536,10 +536,12 @@ public class CodexLauncherTests {
             NewLauncher().Prepare(ctx);
 
             var configToml = File.ReadAllText(Path.Combine(home, ".codex", "config.toml"));
-            // The TOML writer emits the path as a basic (double-quoted) key, so
-            // backslashes are escaped per spec (\ → \\). Match the escaped form
-            // so the assertion holds on Windows too (no-op on POSIX paths).
-            var escapedWorktree = worktree.Replace("\\", "\\\\");
+            // The key is written in Codex's own normalised form (absolute, lowercased on
+            // Windows — see CodexPaths.NormalizeProjectKey), not the raw worktree path. The TOML
+            // writer then emits it as a basic (double-quoted) key, so backslashes are escaped
+            // per spec (\ → \\); match the escaped form so this holds on Windows too (both are
+            // no-ops on POSIX paths).
+            var escapedWorktree = CodexPaths.NormalizeProjectKey(worktree).Replace("\\", "\\\\");
             await Assert.That(configToml).Contains($"\"{escapedWorktree}\"");
             await Assert.That(configToml).Contains("trust_level = \"trusted\"");
         } finally {

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexProjectKeyTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexProjectKeyTests.cs
@@ -1,0 +1,81 @@
+using Capacitor.Cli.Core;
+using Tomlyn;
+using Tomlyn.Model;
+
+namespace Capacitor.Cli.Tests.Unit.Codex;
+
+/// <summary>
+/// Covers the <c>[projects."…"]</c> pre-trust key form. Codex normalises the path before it
+/// looks the entry up — on Windows to lowercase, drive letter included — and TOML keys are
+/// case-sensitive, so a raw mixed-case worktree path is a *different* key. The write then has
+/// no effect and Codex parks on its directory-trust prompt: the hosted agent never starts a
+/// session and the dashboard sits on "Waiting for session to start…" with an empty terminal.
+/// Same failure PR #265 fixed for Claude's <c>~/.claude.json</c> trust key.
+/// </summary>
+public class CodexProjectKeyTests {
+    [Test]
+    public async Task NormalizeProjectKey_lowercases_on_windows_and_keeps_backslashes() {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var key = CodexPaths.NormalizeProjectKey(@"C:\Users\Me\Src\Repo\.capacitor\worktrees\Agent-01");
+
+        await Assert.That(key).IsEqualTo(@"c:\users\me\src\repo\.capacitor\worktrees\agent-01");
+    }
+
+    /// <summary>Unix filesystems are case-sensitive and Codex does not fold case there —
+    /// lowercasing would break the macOS/Linux path that already works.</summary>
+    [Test]
+    public async Task NormalizeProjectKey_preserves_case_on_unix() {
+        if (OperatingSystem.IsWindows()) return;
+
+        const string path = "/Users/Me/Src/Repo/.capacitor/worktrees/Agent-01";
+
+        await Assert.That(CodexPaths.NormalizeProjectKey(path)).IsEqualTo(path);
+    }
+
+    [Test]
+    public async Task NormalizeProjectKey_is_absolute_and_collapsed() {
+        var key = CodexPaths.NormalizeProjectKey(
+            Path.Combine(Directory.GetCurrentDirectory(), "sub", "..", "leaf"));
+
+        await Assert.That(Path.IsPathFullyQualified(key)).IsTrue();
+        await Assert.That(key).DoesNotContain("..");
+    }
+
+    /// <summary>End-to-end through the writer: two casings of one worktree must land on a single
+    /// entry, not two. Before normalisation this produced two — one of them inert.</summary>
+    [Test]
+    public async Task TrustWorktree_writes_one_entry_regardless_of_input_casing() {
+        var configPath = Path.Combine(
+            Directory.CreateTempSubdirectory("kcap-codexkey-").FullName, "config.toml");
+
+        var upper = OperatingSystem.IsWindows()
+            ? @"C:\Src\Repo\Worktrees\Agent-01"
+            : "/Src/Repo/Worktrees/Agent-01";
+
+        CodexConfigToml.TrustWorktree(upper, configPath);
+        CodexConfigToml.TrustWorktree(upper.ToLowerInvariant(), configPath);
+
+        var projects = (TomlTable)TomlSerializer.Deserialize<TomlTable>(
+            await File.ReadAllTextAsync(configPath))!["projects"];
+
+        // Windows folds both inputs onto one key; Unix is case-sensitive so they stay distinct.
+        await Assert.That(projects.Count).IsEqualTo(OperatingSystem.IsWindows() ? 1 : 2);
+        await Assert.That(projects.ContainsKey(CodexPaths.NormalizeProjectKey(upper))).IsTrue();
+    }
+
+    /// <summary>A second call for the same worktree is a no-op, so a relaunch doesn't rewrite
+    /// the user's config.</summary>
+    [Test]
+    public async Task TrustWorktree_is_idempotent_under_the_normalized_key() {
+        var configPath = Path.Combine(
+            Directory.CreateTempSubdirectory("kcap-codexkey-idem-").FullName, "config.toml");
+
+        var path = OperatingSystem.IsWindows() ? @"C:\Src\Wt" : "/Src/Wt";
+
+        await Assert.That(CodexConfigToml.TrustWorktree(path, configPath))
+            .IsEqualTo(CodexConfigToml.Change.Updated);
+        await Assert.That(CodexConfigToml.TrustWorktree(path, configPath))
+            .IsEqualTo(CodexConfigToml.Change.Unchanged);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexWindowsVersionGateTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexWindowsVersionGateTests.cs
@@ -1,0 +1,54 @@
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Codex;
+
+/// <summary>
+/// Covers the Windows-version floor for hosted Codex. Codex only supports its Windows sandbox
+/// on Windows 10 1809 (build 17763) and newer, so older hosts must not advertise the vendor —
+/// and a launch that slips through anyway (in-flight command, stale dashboard vendor list) has
+/// to fail with the version requirement rather than an opaque spawn error.
+///
+/// <para>The rejection branch itself can't be exercised here: the gate reads the real OS
+/// version and there's no seam to fake it (deliberately — the check is one expression, and an
+/// injectable version provider would be more machinery than the thing it guards). What these
+/// tests do pin down is the far likelier failure: the gate mis-rejecting a *supported* host,
+/// which would silently hide Codex from every launch dialog on Windows.</para>
+/// </summary>
+public class CodexWindowsVersionGateTests {
+    static CodexLauncher NewLauncher(string cliPath) =>
+        new(new DaemonConfig { CodexPath = cliPath }, NullLogger<CodexLauncher>.Instance);
+
+    /// <summary>CI runs Windows Server 2022 / Windows 11 and Linux — all supported. A false here
+    /// means the gate is wrong, not that the host is genuinely too old.</summary>
+    [Test]
+    public async Task Current_host_is_reported_supported() {
+        await Assert.That(CodexLauncher.WindowsVersionSupported).IsTrue();
+    }
+
+    /// <summary>The gate must not swallow the PATH probe: on a supported host, availability is
+    /// still decided by whether the configured CLI resolves.</summary>
+    [Test]
+    public async Task IsAvailable_is_false_for_unresolvable_cli_on_supported_host() {
+        await Assert.That(NewLauncher($"kcap-codex-absent-{Guid.NewGuid():N}").IsAvailable()).IsFalse();
+    }
+
+    [Test]
+    public async Task Rejection_message_carries_the_build_number_and_doc_link() {
+        await Assert.That(CodexLauncher.UnsupportedWindowsMessage).Contains("17763");
+        await Assert.That(CodexLauncher.UnsupportedWindowsMessage)
+            .Contains("https://developers.openai.com/codex/windows");
+    }
+
+    /// <summary>The orchestrator only converts an allowlisted set of preflight exceptions into a
+    /// user-visible <c>LaunchFailed</c>; anything else becomes a generic failure. Pin the type so
+    /// the message can't quietly stop reaching the dashboard.</summary>
+    [Test]
+    public async Task Unsupported_windows_exception_carries_its_message() {
+        var ex = new CodexUnsupportedWindowsException(CodexLauncher.UnsupportedWindowsMessage);
+
+        await Assert.That(ex.Message).IsEqualTo(CodexLauncher.UnsupportedWindowsMessage);
+        await Assert.That(ex).IsAssignableTo<Exception>();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Pty/ConPtyResolveCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Pty/ConPtyResolveCommandTests.cs
@@ -1,0 +1,62 @@
+using Capacitor.Cli.Daemon.Pty.Windows;
+
+namespace Capacitor.Cli.Tests.Unit.Pty;
+
+/// <summary>
+/// Regression for the hosted-launch <c>CreateProcessW failed: 193</c> failure. The ConPty
+/// command resolver must prefer <c>codex.cmd</c> over npm's extensionless Git-Bash
+/// <c>#!/bin/sh</c> twin, and flag it as a <c>.cmd</c> so <c>Spawn</c> wraps it in
+/// <c>cmd.exe /c</c>. A bare extensionless script handed straight to <c>CreateProcessW</c>
+/// fails with 193 (not a valid Win32 application) — which parked hosted Codex launches on
+/// Windows at "Waiting for session to start…".
+/// </summary>
+public class ConPtyResolveCommandTests {
+    [Test, NotInParallel]
+    public async Task ResolveCommand_prefers_cmd_over_extensionless_twin_on_path() {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var dir  = Directory.CreateTempSubdirectory("kcap-conpty-twin-").FullName;
+        var name = $"kcap-conptyprobe-{Guid.NewGuid():N}";
+        await File.WriteAllTextAsync(Path.Combine(dir, name), "#!/bin/sh\nexit 0\n"); // shim twin
+        var cmd = Path.Combine(dir, name + ".cmd");
+        await File.WriteAllTextAsync(cmd, "@echo off\r\n");
+
+        var savedPath = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", $"{dir}{Path.PathSeparator}{savedPath}");
+
+        try {
+            var (resolved, isCmd) = ConPtyProcess.ResolveCommand(name);
+
+            await Assert.That(resolved).IsEqualTo(cmd, StringComparison.OrdinalIgnoreCase);
+            await Assert.That(isCmd).IsTrue(); // drives the cmd.exe /c wrapper in Spawn
+        } finally {
+            Environment.SetEnvironmentVariable("PATH", savedPath);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>A plain <c>.exe</c> still resolves and is NOT flagged as a <c>.cmd</c>, so it
+    /// runs directly without a needless <c>cmd.exe</c> wrapper.</summary>
+    [Test, NotInParallel]
+    public async Task ResolveCommand_finds_exe_and_marks_not_cmd() {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var dir  = Directory.CreateTempSubdirectory("kcap-conpty-exe-").FullName;
+        var name = $"kcap-conptyexe-{Guid.NewGuid():N}";
+        var exe  = Path.Combine(dir, name + ".exe");
+        await File.WriteAllTextAsync(exe, "");
+
+        var savedPath = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", $"{dir}{Path.PathSeparator}{savedPath}");
+
+        try {
+            var (resolved, isCmd) = ConPtyProcess.ResolveCommand(name);
+
+            await Assert.That(resolved).IsEqualTo(exe, StringComparison.OrdinalIgnoreCase);
+            await Assert.That(isCmd).IsFalse();
+        } finally {
+            Environment.SetEnvironmentVariable("PATH", savedPath);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Closes AI-72 (`[Codex] Hosted Codex agents on Windows`).

No GitHub issue — none was filed for this, and the repo's practice is that the Linear ID is the invariant reference while `Closes #N` appears only where a GitHub issue already exists.

## Why

The macOS/Linux hosted-Codex path shipped in AI-68, and the daemon has always registered the Codex launcher unconditionally — so a Windows daemon already advertises `vendor: codex` and routes launches to it. What was missing were three Windows-specific gaps behind that, and the docs still said hosted agents were macOS/Linux only.

Re-auditing AI-72 also found its own premises had gone stale (Codex is now 0.128.0, the issue was written against ~0.115) — see the [status re-evaluation on the issue](https://linear.app/kurrent/issue/AI-72/codex-hosted-codex-agents-on-windows). Two scope items in the description were dead ends and are intentionally not implemented; details at the bottom.

## What this changes

**1. Trust key had the wrong case on Windows.** Codex normalises its `[projects."<path>"]` key before looking it up — lowercase, drive letter included. Observed on a real Win11 box, where Codex wrote `[projects."c:\users\<user>\documents\..."]` for a mixed-case path. TOML keys are case-sensitive, so writing the raw worktree path was a *different* key: the pre-trust write had no effect and Codex fell back to its directory-trust prompt. Same failure mode #265 fixed for Claude's `~/.claude.json` key — agent shows **Active**, terminal stays empty, chat stuck on "Waiting for session to start…".

`CodexPaths.NormalizeProjectKey` now writes the key in Codex's own form. Lowercasing is Windows-only and deliberately so: Unix filesystems are case-sensitive, Codex doesn't fold case there, and the macOS/Linux path already works.

**2. Headless runners couldn't spawn at all on Windows.** `ProcessStartInfo.FileName` with `UseShellExecute = false` goes through `CreateProcess`, which appends only `.exe`. npm installs the agent CLIs as a `.cmd` shim with no `.exe` alongside, so a bare `"codex"` failed with *"The system cannot find the file specified"*. Reproduced directly:

```
1 bare 'codex'        FAIL Win32Exception: ... The system cannot find the file specified.
2 full .cmd path      OK   exit=0 out='codex-cli 0.128.0'
```

**This hit `ClaudeCliRunner` identically** (`claude.cmd` is equally `.exe`-less), so session titles and what's-done summaries were silently degraded for *every* npm-installed harness on Windows, not just Codex — tracked separately as **AI-1582**, since the Claude-side impact shouldn't be buried in a Codex issue. That issue also records that this resolver commit can be lifted into its own PR if review prefers #393 to stay narrowly about hosted Codex.

New `CliExecutable` owns a single PATH/PATHEXT walk for both runners and the daemon's vendor probe — which carried a near-duplicate copy behind a "keep the two in sync" comment that this gap slipped through anyway.

Line 2 above is also why there's no `cmd.exe /c` wrapper: handing the resolved full path to `FileName` is sufficient, because .NET 8+ applies cmd-specific argument escaping for `.cmd`/`.bat` targets. Adding a wrapper would reintroduce the argument-injection hazard that escaping fix closed.

**3. No Windows version floor.** Codex only supports its Windows sandbox on Windows 10 1809 (build 17763) and newer. The gate runs *before* the PATH probe in `IsAvailable()`, so an older host never advertises the vendor and the launch dialog simply hides Codex; `Prepare` also fails fast with the version requirement and doc link, for a launch already in flight or a stale dashboard vendor list.

**4. Docs.** README claimed hosted agents run "on macOS and Linux". Corrected, with a Windows/Codex note covering the version floor, sandbox-implementation inheritance, and winget-vs-npm discovery. README was the only surface making a platform claim — no help text needed changing.

## Testing

- 16 new tests across `CliExecutableTests`, `CodexProjectKeyTests`, `CodexWindowsVersionGateTests`.
- 4 existing assertions in `CodexConfigWriterTests`/`CodexLauncherTests` updated: they hardcoded raw `/tmp/wt` keys and **would have failed on the Windows CI leg** after the normalisation change.
- Full unit suite on Win11: **4261 passed, 12 failed** — all pre-existing and unrelated (10 symlink tests needing `SeCreateSymbolicLinkPrivilege` locally, 2 load-dependent file-tailing flakes, each confirmed passing in isolation). None in touched files.
- AOT publish clean for CLI and daemon, zero IL3050/IL2026.

## AI-72 acceptance criteria: what this PR does and does not do

| # | Criterion | This PR |
|---|---|---|
| 1 | Win11 spike (binary path, `config.toml` schema, sandbox selection) | **Done** — findings in the [issue re-evaluation](https://linear.app/kurrent/issue/AI-72/codex-hosted-codex-agents-on-windows), applied below |
| 2 | `DaemonConfig` resolves a sensible default `CodexPath` on Windows | **Done** — already worked (`"codex"` + PATHEXT); this PR makes the resolution shared and adds extension probing so an extensionless configured path also resolves |
| 3 | `HostedAgentLaunch` accepts `vendor: codex` on Windows daemons | **Already worked** — launcher registration was never OS-gated. Behaviour unchanged; now covered by a test that the new version gate doesn't break it |
| 4 | Launch in a fresh worktree with pre-trust applied | **Fixed** — pre-trust was silently ineffective on Windows (change 1) |
| 5 | Daemon config opts into `elevated` sandbox | **Not done — moved to AI-633.** See "Deliberately not in scope" below |
| 6 | `CodexCliRunner` produces a working title on Windows | **Fixed** — it could not spawn at all before (change 2) |
| 7 | Terminal relay through Windows PTY; private desktop doesn't break stdio | **Not claimed.** No code change appears needed — `ConPtyProcess` already resolves and wraps `.cmd` — but this is unverified and needs the smoke test |
| 8 | Permission requests round-trip through `LocalPermissionBridge` | **Not claimed.** Platform-neutral loopback HTTP with no OS branches, so no change needed, but likewise unverified |
| 9 | Windows < 1809 rejection with a clear error + doc link | **Done** (change 3) |
| 10 | End-to-end smoke: multi-turn Win11 session with a tool call + permission prompt | **Not done** — needs a dashboard-driven launch; not possible from CI or headlessly |

**6 of 10 closed** (1, 2, 3, 4, 6, 9) · **1 deferred by design** (5 → AI-633) · **3 open pending a manual Win11 smoke test** (7, 8, 10 — two of which probably already work and need only confirmation).

Because 7, 8 and 10 are unverified, this PR should be read as "the Windows blockers are fixed and the code paths are in place", not "hosted Codex on Windows is certified working end to end". AI-72 should stay open until the smoke test runs.

## Deliberately not in scope

**Sandbox-implementation selection.** The issue describes `elevated`/`unelevated` as something the daemon passes to the spawned process. It isn't a `--sandbox` value — it's a separate `[windows] sandbox` key in `config.toml` selecting the sandbox *implementation*, orthogonal to the `read-only`/`workspace-write` policy the launcher already passes. Since hosted launches don't pass `--ignore-user-config`, the user's setting is already inherited. A daemon-level override belongs with the vendor-wide sandbox/approval work in **AI-633** rather than here.

**winget path hardcoding.** The issue wants `%LOCALAPPDATA%\Microsoft\WinGet\Packages\…\codex.exe` with an npm fallback. `CliExecutable` handles both generically via PATHEXT, so this is unnecessary.

## Reviewer note

One claim here rests on inference rather than measurement. Codex demonstrably *writes* lowercase keys; I could not confirm it also *reads* case-sensitively (the TUI probe needs a real console for PTY sizing). Lowercase is correct under both possible reader semantics — normalise-then-compare, or case-insensitive scan — whereas mixed-case only works under one, so the change is safe either way. But whether the old code was *actively* hanging on Windows or merely fragile is unconfirmed.

Consequently the acceptance criteria needing a dashboard-driven launch remain open and are **not** claimed by this PR: terminal relay through the private desktop, permission round-trip via `LocalPermissionBridge`, and the end-to-end Win11 smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




---

## Update — Win11 E2E smoke verified + two follow-on fixes

A manual Windows 11 smoke test against **current-stable codex 0.146.0** ran a hosted Codex agent end to end: it launched, streamed the terminal, executed a tool call (`git status` + `ping`), and completed a multi-turn turn. That closes the criteria previously left as "pending manual smoke" — **7 (terminal relay), 8 (permission round-trip), 10 (E2E)**. Getting there surfaced two additional Windows-only defects, both fixed in this PR:

**5. Hosted launch died at spawn with `CreateProcessW failed: 193`.** `ConPtyProcess.ResolveCommand` and the shared `CliExecutable.Resolve` both preferred a bare, extensionless file over the `.cmd` when both exist — and npm installs a Git-Bash `#!/bin/sh` shim (no extension) right beside `codex.cmd`. Raw `CreateProcessW` can run neither a `.cmd` nor a shell script, so a hosted launch failed 193; headless title/what's-done generation hit the same shim. Both resolvers now probe `PATHEXT` (`.exe`/`.cmd`) before accepting any extensionless file, mirroring how Windows launches a bare name (Unix executable shims unchanged). Regression tests cover the extensionless-twin for both resolvers.

**6. Hosted session hung at codex 0.146's "Hooks need review" gate.** codex 0.146 added an interactive startup prompt for any hook without persisted trust; an unattended hosted launch has no one to answer it, so it parked forever on "Waiting for session to start". `CodexLauncher.BuildArgs` now passes codex's own `--dangerously-bypass-hook-trust` on every hosted launch — kcap installs and owns these hooks, which is exactly the flag's intent. The gate lives in codex's `tui` crate, so the headless `CodexCliRunner` (`codex exec`) was never affected; the global flag also covers unattended review-flow reviewers.

### codex version note
The **0.128.0** the issue targeted is a transitional build that rejects kcap's `[features.network_proxy]` config (features briefly went boolean-only) — but **current-stable 0.146.0** accepts it again via `FeatureToml<NetworkProxyConfigToml>` (bool *or* table), so **no config-writer change is needed to support current stable codex**. A minimum-codex-version guard for hosted agents is a reasonable follow-up.

### Known follow-up (not in this PR)
The daemon's CLI **version probe** (`DaemonRunner.ProbeCliVersion`) still bare-spawns `"codex"` without the shared resolver, so it logs `codex CLI version unknown` on Windows and would reject Codex as a review-flow reviewer there. Tracked separately.
