### PR TITLE
[AI-1591] Live model-receipt certification for the Codex, Copilot and Kiro memory adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ AI-1456 child issue.
 | Cursor IDE (Agent Window) | yes | yes (same adapter — `sessionStart`'s `additional_context`) | **upstream-degraded**: the hook emits the correct JSON, but whether the IDE's Agent Window actually surfaces it to the model is not guaranteed — a known Cursor IDE limitation, not a `kcap` defect | hook output correct; model receipt not guaranteed |
 | GitHub Copilot CLI | yes | yes (`sessionStart`'s top-level `additionalContext`; silent when there is nothing to inject) | **certified** — gated live cert, `copilot 1.0.75` | available |
 | Gemini CLI | yes | no | pending | available |
-| Kiro CLI | yes | yes (`agentSpawn` raw stdout — no envelope; Kiro appends hook stdout to agent context verbatim) | **certified** — gated live cert, `kiro-cli 2.12.1`, including a resumed second turn proving no re-injection | available — injects **once per session** despite `agentSpawn` firing every prompt |
+| Kiro CLI | yes | yes (`agentSpawn` raw stdout — no envelope; Kiro appends hook stdout to agent context verbatim) | **certified** — gated live cert, `kiro-cli 2.12.1`. The once-per-session dedupe is unit-covered only: a resumed `kiro-cli` invocation carries a different hook session id, so it cannot certify it | available — injects **once per session** despite `agentSpawn` firing every prompt |
 | Pi | yes | no | pending | extension bridge required |
 | OpenCode | yes | no | pending | extension bridge required |
 | Antigravity | yes | no | pending | `PreInvocation` adapter required |

--- a/README.md
+++ b/README.md
@@ -209,12 +209,12 @@ AI-1456 child issue.
 | Harness | Shared foundation | Hook/extension wired | Live receipt | Upstream status |
 |---------|-------------------|----------------------|--------------|-----------------|
 | Claude Code | yes | yes | existing baseline | available |
-| Codex CLI | yes | yes (`SessionStart`'s `hookSpecificOutput.additionalContext`, combined with the `continue` handshake) | pending | available |
+| Codex CLI | yes | yes (`SessionStart`'s `hookSpecificOutput.additionalContext`, combined with the `continue` handshake) | **certified** — gated live cert, `codex-cli 0.144.3`, needs kcap ≥ the release carrying this adapter | available |
 | Cursor CLI (`cursor-agent`) | yes | yes | manual, recorded live-cert gate (needs `cursor-agent` + a reachable server + a memory in scope; not run in CI) | available — **supported** |
 | Cursor IDE (Agent Window) | yes | yes (same adapter — `sessionStart`'s `additional_context`) | **upstream-degraded**: the hook emits the correct JSON, but whether the IDE's Agent Window actually surfaces it to the model is not guaranteed — a known Cursor IDE limitation, not a `kcap` defect | hook output correct; model receipt not guaranteed |
-| GitHub Copilot CLI | yes | yes (`sessionStart`'s top-level `additionalContext`; silent when there is nothing to inject) | pending | available |
+| GitHub Copilot CLI | yes | yes (`sessionStart`'s top-level `additionalContext`; silent when there is nothing to inject) | **certified** — gated live cert, `copilot 1.0.75` | available |
 | Gemini CLI | yes | no | pending | available |
-| Kiro CLI | yes | yes (`agentSpawn` raw stdout — no envelope; Kiro appends hook stdout to agent context verbatim) | pending | available — injects **once per session** despite `agentSpawn` firing every prompt |
+| Kiro CLI | yes | yes (`agentSpawn` raw stdout — no envelope; Kiro appends hook stdout to agent context verbatim) | **certified** — gated live cert, `kiro-cli 2.12.1`, including a resumed second turn proving no re-injection | available — injects **once per session** despite `agentSpawn` firing every prompt |
 | Pi | yes | no | pending | extension bridge required |
 | OpenCode | yes | no | pending | extension bridge required |
 | Antigravity | yes | no | pending | `PreInvocation` adapter required |

--- a/src/Capacitor.Cli/Commands/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CodexHookCommand.cs
@@ -413,8 +413,6 @@ static class CodexHookCommand {
             baseUrl, "session-start/codex", enriched, "codex-hook", spool,
             sessionId: sessionId ?? "", route: "session-start/codex");
 
-        if (outcome == HookPostOutcome.Failed) return 1;
-
         // Codex blocks on this hook's stdout — satisfy the handshake contract FIRST, and only
         // then run the best-effort watcher-ensure and the global spool drain. Routed through
         // RunSessionStartHandshakeForTest so the ordering is provable in isolation (see
@@ -423,13 +421,21 @@ static class CodexHookCommand {
         // Resolve the optional memory fragment BEFORE entering the handshake, so the ordering seam
         // still receives a synchronous write: the fragment is already a value by the time
         // writeStdout runs, and the post-stdout work remains strictly after it.
+        //
+        // The handshake now runs on EVERY outcome, including a permanent POST rejection. It used to be
+        // skipped by an early `return 1` above, which left Codex — a host that BLOCKS on this hook's
+        // stdout — with zero bytes: no `continue`, no context, just a wait for its hook timeout. The
+        // recording outcome must not decide whether the host can proceed.
         var fragment = await AwaitMemoryFragmentAsync(memoryTask, processStart);
 
         await RunSessionStartHandshakeForTest(
             writeStdout: () => WriteSessionStartOutput(Console.Out, fragment),
             postStdoutWork: () => RunPostStdoutWork(baseUrl, spool, enrichedNode, sessionId, outcome));
 
-        return 0;
+        // Non-zero on a permanent rejection is preserved — it is the signal the session was not
+        // recorded — but it is now reported AFTER the handshake rather than instead of it. The watcher
+        // still does not spawn: RunPostStdoutWork gates that on ShouldSpawnAfter(outcome).
+        return outcome == HookPostOutcome.Failed ? 1 : 0;
     }
 
     // Everything here runs AFTER Codex's stdout handshake and is best-effort: spawning the

--- a/test/Capacitor.Cli.Tests.Integration/CodexSessionStartHandshakeOnPostFailureTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CodexSessionStartHandshakeOnPostFailureTests.cs
@@ -40,7 +40,7 @@ public class CodexSessionStartHandshakeOnPostFailureTests : IDisposable {
         }
     }
 
-    [Test, NotInParallel("AppConfig_FileState")]
+    [Test, NotInParallel]
     public async Task A_rejected_lifecycle_post_still_satisfies_the_blocking_stdout_handshake() {
         var config = new ProfileConfig {
             ActiveProfile = "work",

--- a/test/Capacitor.Cli.Tests.Integration/CodexSessionStartHandshakeOnPostFailureTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CodexSessionStartHandshakeOnPostFailureTests.cs
@@ -1,0 +1,93 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// Codex BLOCKS on its SessionStart hook's stdout and its parser rejects empty output. So a
+/// permanent lifecycle-POST rejection must still produce the handshake — the recording outcome cannot
+/// be allowed to decide whether the host can proceed.
+///
+/// <para>It used to. An early <c>return 1</c> on <see cref="HookPostOutcome.Failed"/> sat BEFORE the
+/// handshake, so a server 4xx left Codex with zero bytes: no <c>continue</c>, no context, just a wait
+/// for its hook timeout. Verified by hand at the time — a rejected payload produced literally no
+/// stdout. The non-zero exit is still reported (the session genuinely was not recorded), just after
+/// the handshake rather than instead of it.</para>
+///
+/// <para>This is the sibling of the AI-1586-family hazard where a hook exits before satisfying a
+/// stdout-blocking host.</para>
+/// </summary>
+public class CodexSessionStartHandshakeOnPostFailureTests : IDisposable {
+    readonly WireMockServer _server         = WireMockServer.Start();
+    readonly string         _configPath     = PathHelpers.ConfigPath("config.json");
+    readonly string?        _previousConfig;
+
+    public CodexSessionStartHandshakeOnPostFailureTests() {
+        _previousConfig = File.Exists(_configPath) ? File.ReadAllText(_configPath) : null;
+    }
+
+    public void Dispose() {
+        _server.Stop();
+
+        if (_previousConfig is null) {
+            if (File.Exists(_configPath)) File.Delete(_configPath);
+        } else {
+            File.WriteAllText(_configPath, _previousConfig);
+        }
+    }
+
+    [Test, NotInParallel("AppConfig_FileState")]
+    public async Task A_rejected_lifecycle_post_still_satisfies_the_blocking_stdout_handshake() {
+        var config = new ProfileConfig {
+            ActiveProfile = "work",
+            Profiles      = new() { ["work"] = new Profile { ServerUrl = _server.Url } }
+        };
+        await AppConfig.SaveProfileConfig(config);
+
+        // A permanent rejection: PostOrSpoolAsync returns Failed for a genuine non-2xx (transport and
+        // auth failures spool instead), which is exactly the case that used to skip the handshake.
+        _server.Given(Request.Create().WithPath("/hooks/session-start/codex").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(400));
+
+        // No transcript_path → short-circuits before the watcher spawn.
+        const string payload =
+            """
+            {
+              "hook_event_name": "SessionStart",
+              "session_id":      "handshake-on-failure",
+              "cwd":             "/tmp",
+              "model":           "gpt-5"
+            }
+            """;
+
+        var originalOut  = Console.Out;
+        var stdoutWriter = new StringWriter();
+        Console.SetOut(stdoutWriter);
+
+        try {
+            var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
+
+            // The rejection is still reported — this is not "pretend it worked".
+            await Assert.That(exit).IsEqualTo(1);
+
+            // ...but Codex still got a parseable handshake rather than nothing at all.
+            var stdout = stdoutWriter.ToString();
+            await Assert.That(stdout).IsNotEmpty();
+
+            var doc = System.Text.Json.JsonDocument.Parse(stdout);
+            await Assert.That(doc.RootElement.GetProperty("continue").GetBoolean()).IsTrue();
+
+            // And the POST really was attempted and really was rejected, so the assertions above are
+            // about the Failed path and not some earlier short-circuit.
+            var requests = _server.FindLogEntries(
+                Request.Create().WithPath("/hooks/session-start/codex").UsingPost());
+            await Assert.That(requests.Count).IsEqualTo(1);
+        } finally {
+            Console.SetOut(originalOut);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Integration/CodexSessionStartHandshakeOnPostFailureTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CodexSessionStartHandshakeOnPostFailureTests.cs
@@ -18,8 +18,8 @@ namespace Capacitor.Cli.Tests.Integration;
 /// stdout. The non-zero exit is still reported (the session genuinely was not recorded), just after
 /// the handshake rather than instead of it.</para>
 ///
-/// <para>This is the sibling of the AI-1586-family hazard where a hook exits before satisfying a
-/// stdout-blocking host.</para>
+/// <para>Same family as the other known hazard where a hook exits before satisfying a stdout-blocking
+/// host — the unguarded auth discovery in the lifecycle poster, tracked separately.</para>
 /// </summary>
 public class CodexSessionStartHandshakeOnPostFailureTests : IDisposable {
     readonly WireMockServer _server         = WireMockServer.Start();

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CodexMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CodexMemoryIndexLiveCertTests.cs
@@ -43,13 +43,16 @@ public class CodexMemoryIndexLiveCertTests {
     [Test, NotInParallel]
     public async Task Disabled_memory_index_does_not_leak_the_nonce_to_a_real_codex_session_start() {
         Gate();
-        var nonce   = MemoryIndexLiveCertHarness.NewNonce();
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         // Recorded here too: a stale PATH kcap makes a negative control pass vacuously.
         await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "codex", ["--version"]);
 
+        // Read BEFORE anything is created. This throws on an unreadable config, and doing it after the
+        // save would strand a real memory outside the archive-protecting try below.
         var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
+
+        var nonce    = MemoryIndexLiveCertHarness.NewNonce();
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         try {
             await MemoryIndexLiveCertHarness.SetDisableMemoryIndexAsync(true);

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CodexMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CodexMemoryIndexLiveCertTests.cs
@@ -1,0 +1,96 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
+
+/// <summary>
+/// Env-gated certification that the SessionStart memory index actually reaches the model on Codex
+/// CLI. The envelope, budget, lease and fail-open behaviour are covered against fakes by
+/// <c>CodexSessionStartMemoryTests</c>; this is the only place asserting the end-to-end claim.
+///
+/// <para>Both tests are <c>[NotInParallel]</c>: the negative control mutates the REAL process-global
+/// <c>disable_memory_index</c> profile config via a `kcap config set` subprocess, so an interleaved
+/// positive run could observe the disabled flag and fail for the wrong reason.</para>
+/// </summary>
+public class CodexMemoryIndexLiveCertTests {
+    const string LiveGateEnvVar = "KCAP_CODEX_MEMORY_LIVE";
+    const string VendorLabel    = "codex";
+
+    static void Gate() => MemoryIndexLiveCertHarness.SkipUnlessLiveGateReady(
+        LiveGateEnvVar,
+        "a real `codex exec` turn",
+        "`codex` on PATH with its SessionStart hook wired to `kcap` in ~/.codex/hooks.json");
+
+    [Test, NotInParallel]
+    public async Task Nonce_saved_as_a_memory_is_reproduced_by_a_real_codex_session_start() {
+        Gate();
+
+        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
+        var nonce   = MemoryIndexLiveCertHarness.NewNonce();
+
+        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+
+        try {
+            await MemoryIndexLiveCertHarness.RecordVersionAsync(VendorLabel, "codex", ["--version"]);
+
+            var answer = await RunCodexAsync(MemoryIndexLiveCertHarness.PositivePrompt);
+
+            await Assert.That(answer).Contains(nonce);
+        } finally {
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+        }
+    }
+
+    /// <summary>
+    /// Negative control. Without it the positive test is not evidence: an identically-worded ask with
+    /// injection DISABLED must not surface the nonce, which is what rules out the nonce arriving by
+    /// some other channel or the assertion being trivially satisfiable.
+    /// </summary>
+    [Test, NotInParallel]
+    public async Task Disabled_memory_index_does_not_leak_the_nonce_to_a_real_codex_session_start() {
+        Gate();
+
+        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
+        var nonce   = MemoryIndexLiveCertHarness.NewNonce();
+
+        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+
+        var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
+
+        try {
+            await MemoryIndexLiveCertHarness.SetDisableMemoryIndexAsync(true);
+
+            var answer = await RunCodexAsync(MemoryIndexLiveCertHarness.NegativePrompt);
+
+            await Assert.That(answer).DoesNotContain(nonce);
+        } finally {
+            await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+        }
+    }
+
+    /// <summary>
+    /// Runs one non-interactive Codex turn in a throwaway directory.
+    ///
+    /// <para>The prompt goes over STDIN with <c>-</c> rather than as an argument: `codex exec` reads
+    /// from stdin when the prompt is `-` or absent, and passing a long prompt as an argument has been
+    /// observed to hang. <c>--skip-git-repo-check</c> is required because the cert worktree is a bare
+    /// temp directory, not a repo.</para>
+    /// </summary>
+    static async Task<string> RunCodexAsync(string prompt) {
+        var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
+
+        try {
+            var (exitCode, stdout, stderr) = await MemoryIndexLiveCertHarness.RunProcessAsync(
+                "codex", ["exec", "--skip-git-repo-check", "-"], worktree.FullName, stdin: prompt);
+
+            await Console.Out.WriteLineAsync($"[{VendorLabel}-memory-live] codex exit={exitCode} stderr={stderr}");
+            await Assert.That(exitCode).IsEqualTo(0);
+
+            return MemoryIndexLiveCertHarness.ExtractAssistantAnswer(stdout);
+        } finally {
+            try { worktree.Delete(recursive: true); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CodexMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CodexMemoryIndexLiveCertTests.cs
@@ -25,7 +25,7 @@ public class CodexMemoryIndexLiveCertTests {
         var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         try {
-            await MemoryIndexLiveCertHarness.RecordVersionAsync(VendorLabel, "codex", ["--version"]);
+            await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "codex", ["--version"]);
 
             var answer = await RunCodexAsync(MemoryIndexLiveCertHarness.PositivePrompt);
 
@@ -45,6 +45,9 @@ public class CodexMemoryIndexLiveCertTests {
         Gate();
         var nonce   = MemoryIndexLiveCertHarness.NewNonce();
         var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+
+        // Recorded here too: a stale PATH kcap makes a negative control pass vacuously.
+        await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "codex", ["--version"]);
 
         var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CodexMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CodexMemoryIndexLiveCertTests.cs
@@ -58,8 +58,13 @@ public class CodexMemoryIndexLiveCertTests {
 
             await Assert.That(answer).DoesNotContain(nonce);
         } finally {
-            await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
-            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
+            // Nested: the restore THROWS on a failed or unconfirmed write, and that must not
+            // be allowed to skip the archive — a leaked nonce corrupts every later cert's index.
+            try {
+                await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
+            } finally {
+                await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
+            }
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CodexMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CodexMemoryIndexLiveCertTests.cs
@@ -1,5 +1,3 @@
-using Capacitor.Cli.Core;
-
 namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
 
 /// <summary>
@@ -23,12 +21,8 @@ public class CodexMemoryIndexLiveCertTests {
     [Test, NotInParallel]
     public async Task Nonce_saved_as_a_memory_is_reproduced_by_a_real_codex_session_start() {
         Gate();
-
-        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
         var nonce   = MemoryIndexLiveCertHarness.NewNonce();
-
-        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         try {
             await MemoryIndexLiveCertHarness.RecordVersionAsync(VendorLabel, "codex", ["--version"]);
@@ -37,7 +31,7 @@ public class CodexMemoryIndexLiveCertTests {
 
             await Assert.That(answer).Contains(nonce);
         } finally {
-            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
         }
     }
 
@@ -49,12 +43,8 @@ public class CodexMemoryIndexLiveCertTests {
     [Test, NotInParallel]
     public async Task Disabled_memory_index_does_not_leak_the_nonce_to_a_real_codex_session_start() {
         Gate();
-
-        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
         var nonce   = MemoryIndexLiveCertHarness.NewNonce();
-
-        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
 
@@ -66,7 +56,7 @@ public class CodexMemoryIndexLiveCertTests {
             await Assert.That(answer).DoesNotContain(nonce);
         } finally {
             await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
-            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CopilotMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CopilotMemoryIndexLiveCertTests.cs
@@ -1,0 +1,93 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
+
+/// <summary>
+/// Env-gated certification that the SessionStart memory index actually reaches the model on GitHub
+/// Copilot CLI. The envelope, budget, lease and silence-on-no-fragment behaviour are covered against
+/// fakes by <c>CopilotSessionStartMemoryTests</c>; this is the only place asserting the end-to-end
+/// claim.
+///
+/// <para>Copilot's adapter is the one that writes NOTHING when there is no fragment, so the negative
+/// control here doubles as proof that silence really is silence on the wire and not an empty envelope
+/// the model might still narrate.</para>
+///
+/// <para>Both tests are <c>[NotInParallel]</c>: the negative control mutates the REAL process-global
+/// <c>disable_memory_index</c> profile config.</para>
+/// </summary>
+public class CopilotMemoryIndexLiveCertTests {
+    const string LiveGateEnvVar = "KCAP_COPILOT_MEMORY_LIVE";
+    const string VendorLabel    = "copilot";
+
+    static void Gate() => MemoryIndexLiveCertHarness.SkipUnlessLiveGateReady(
+        LiveGateEnvVar,
+        "a real `copilot -p` turn",
+        "`copilot` on PATH with its SessionStart hook wired to `kcap` in ~/.copilot/hooks/");
+
+    [Test, NotInParallel]
+    public async Task Nonce_saved_as_a_memory_is_reproduced_by_a_real_copilot_session_start() {
+        Gate();
+
+        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
+        var nonce   = MemoryIndexLiveCertHarness.NewNonce();
+
+        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+
+        try {
+            await MemoryIndexLiveCertHarness.RecordVersionAsync(VendorLabel, "copilot", ["--version"]);
+
+            var answer = await RunCopilotAsync(MemoryIndexLiveCertHarness.PositivePrompt);
+
+            await Assert.That(answer).Contains(nonce);
+        } finally {
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+        }
+    }
+
+    [Test, NotInParallel]
+    public async Task Disabled_memory_index_does_not_leak_the_nonce_to_a_real_copilot_session_start() {
+        Gate();
+
+        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
+        var nonce   = MemoryIndexLiveCertHarness.NewNonce();
+
+        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+
+        var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
+
+        try {
+            await MemoryIndexLiveCertHarness.SetDisableMemoryIndexAsync(true);
+
+            var answer = await RunCopilotAsync(MemoryIndexLiveCertHarness.NegativePrompt);
+
+            await Assert.That(answer).DoesNotContain(nonce);
+        } finally {
+            await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+        }
+    }
+
+    /// <summary>
+    /// Runs one non-interactive Copilot turn in a throwaway directory. <c>-p</c> is Copilot's
+    /// documented non-interactive scripting mode. No tool grants are passed: the prompt is
+    /// answerable from injected context alone, so granting tools would widen what a cert run can do
+    /// on this machine for no benefit.
+    /// </summary>
+    static async Task<string> RunCopilotAsync(string prompt) {
+        var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
+
+        try {
+            var (exitCode, stdout, stderr) = await MemoryIndexLiveCertHarness.RunProcessAsync(
+                "copilot", ["-p", prompt], worktree.FullName);
+
+            await Console.Out.WriteLineAsync($"[{VendorLabel}-memory-live] copilot exit={exitCode} stderr={stderr}");
+            await Assert.That(exitCode).IsEqualTo(0);
+
+            return MemoryIndexLiveCertHarness.ExtractAssistantAnswer(stdout);
+        } finally {
+            try { worktree.Delete(recursive: true); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CopilotMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CopilotMemoryIndexLiveCertTests.cs
@@ -57,8 +57,13 @@ public class CopilotMemoryIndexLiveCertTests {
 
             await Assert.That(answer).DoesNotContain(nonce);
         } finally {
-            await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
-            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
+            // Nested: the restore THROWS on a failed or unconfirmed write, and that must not
+            // be allowed to skip the archive — a leaked nonce corrupts every later cert's index.
+            try {
+                await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
+            } finally {
+                await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
+            }
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CopilotMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CopilotMemoryIndexLiveCertTests.cs
@@ -29,7 +29,7 @@ public class CopilotMemoryIndexLiveCertTests {
         var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         try {
-            await MemoryIndexLiveCertHarness.RecordVersionAsync(VendorLabel, "copilot", ["--version"]);
+            await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "copilot", ["--version"]);
 
             var answer = await RunCopilotAsync(MemoryIndexLiveCertHarness.PositivePrompt);
 
@@ -44,6 +44,9 @@ public class CopilotMemoryIndexLiveCertTests {
         Gate();
         var nonce   = MemoryIndexLiveCertHarness.NewNonce();
         var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+
+        // Recorded here too: a stale PATH kcap makes a negative control pass vacuously.
+        await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "copilot", ["--version"]);
 
         var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CopilotMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CopilotMemoryIndexLiveCertTests.cs
@@ -1,5 +1,3 @@
-using Capacitor.Cli.Core;
-
 namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
 
 /// <summary>
@@ -27,12 +25,8 @@ public class CopilotMemoryIndexLiveCertTests {
     [Test, NotInParallel]
     public async Task Nonce_saved_as_a_memory_is_reproduced_by_a_real_copilot_session_start() {
         Gate();
-
-        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
         var nonce   = MemoryIndexLiveCertHarness.NewNonce();
-
-        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         try {
             await MemoryIndexLiveCertHarness.RecordVersionAsync(VendorLabel, "copilot", ["--version"]);
@@ -41,19 +35,15 @@ public class CopilotMemoryIndexLiveCertTests {
 
             await Assert.That(answer).Contains(nonce);
         } finally {
-            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
         }
     }
 
     [Test, NotInParallel]
     public async Task Disabled_memory_index_does_not_leak_the_nonce_to_a_real_copilot_session_start() {
         Gate();
-
-        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
         var nonce   = MemoryIndexLiveCertHarness.NewNonce();
-
-        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
 
@@ -65,7 +55,7 @@ public class CopilotMemoryIndexLiveCertTests {
             await Assert.That(answer).DoesNotContain(nonce);
         } finally {
             await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
-            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CopilotMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/CopilotMemoryIndexLiveCertTests.cs
@@ -42,13 +42,16 @@ public class CopilotMemoryIndexLiveCertTests {
     [Test, NotInParallel]
     public async Task Disabled_memory_index_does_not_leak_the_nonce_to_a_real_copilot_session_start() {
         Gate();
-        var nonce   = MemoryIndexLiveCertHarness.NewNonce();
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         // Recorded here too: a stale PATH kcap makes a negative control pass vacuously.
         await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "copilot", ["--version"]);
 
+        // Read BEFORE anything is created. This throws on an unreadable config, and doing it after the
+        // save would strand a real memory outside the archive-protecting try below.
         var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
+
+        var nonce    = MemoryIndexLiveCertHarness.NewNonce();
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         try {
             await MemoryIndexLiveCertHarness.SetDisableMemoryIndexAsync(true);

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/KiroMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/KiroMemoryIndexLiveCertTests.cs
@@ -1,5 +1,3 @@
-using Capacitor.Cli.Core;
-
 namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
 
 /// <summary>
@@ -30,12 +28,8 @@ public class KiroMemoryIndexLiveCertTests {
     [Test, NotInParallel]
     public async Task Nonce_saved_as_a_memory_is_reproduced_by_a_real_kiro_agent_spawn() {
         Gate();
-
-        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
         var nonce   = MemoryIndexLiveCertHarness.NewNonce();
-
-        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
 
@@ -47,7 +41,7 @@ public class KiroMemoryIndexLiveCertTests {
             await Assert.That(answer).Contains(nonce);
         } finally {
             TryDelete(worktree);
-            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
         }
     }
 
@@ -62,12 +56,8 @@ public class KiroMemoryIndexLiveCertTests {
     [Test, NotInParallel]
     public async Task A_resumed_kiro_session_does_not_get_the_index_injected_a_second_time() {
         Gate();
-
-        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
         var nonce   = MemoryIndexLiveCertHarness.NewNonce();
-
-        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
 
@@ -87,19 +77,15 @@ public class KiroMemoryIndexLiveCertTests {
             await Assert.That(second).DoesNotContain(nonce);
         } finally {
             TryDelete(worktree);
-            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
         }
     }
 
     [Test, NotInParallel]
     public async Task Disabled_memory_index_does_not_leak_the_nonce_to_a_real_kiro_agent_spawn() {
         Gate();
-
-        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
         var nonce   = MemoryIndexLiveCertHarness.NewNonce();
-
-        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
@@ -113,7 +99,7 @@ public class KiroMemoryIndexLiveCertTests {
         } finally {
             TryDelete(worktree);
             await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
-            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/KiroMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/KiroMemoryIndexLiveCertTests.cs
@@ -46,9 +46,21 @@ public class KiroMemoryIndexLiveCertTests {
     }
 
     /// <summary>
-    /// THE Kiro-specific claim: agentSpawn fires again on the second prompt, and the index must NOT
-    /// be injected again. Turn one must see the nonce; turn two, resumed in the same directory (hence
-    /// the same Kiro session id, hence the same lease key), must not.
+    /// THE Kiro-specific claim: agentSpawn fires again on the second prompt, and the index must NOT be
+    /// injected again. Turn two is resumed in the same directory, so it is the same Kiro session id and
+    /// therefore the same lease key.
+    ///
+    /// <para><b>Why a SECOND nonce, saved only after turn one.</b> The obvious shape — ask turn two
+    /// whether a "new" block was injected and assert the first nonce is absent — cannot work. Turn
+    /// one's own answer put that nonce into the conversation history, so turn two can see it whether or
+    /// not the index was re-injected, and "was this block NEW?" is a semantic judgment the model may
+    /// get right or wrong for its own reasons. It could false-pass on a broken lease and false-fail on
+    /// a working one.</para>
+    ///
+    /// <para>Saving a second memory AFTER turn one makes the property observable instead. Nonce two was
+    /// never in the history, so it can only reach the model via a FRESH index fetch. Absent means no
+    /// second fetch happened — the lease held. Present means it did. No model meta-reasoning
+    /// involved.</para>
     ///
     /// <para>A failure here means the lease is not holding in production even though the unit tests
     /// pass — the exact gap between "our bytes dedupe" and "the model stops seeing it".</para>
@@ -56,10 +68,9 @@ public class KiroMemoryIndexLiveCertTests {
     [Test, NotInParallel]
     public async Task A_resumed_kiro_session_does_not_get_the_index_injected_a_second_time() {
         Gate();
-        var nonce   = MemoryIndexLiveCertHarness.NewNonce();
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+        var firstNonce    = MemoryIndexLiveCertHarness.NewNonce();
+        var firstMemoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, firstNonce);
 
-        // Recorded here too: a stale PATH kcap makes a negative control pass vacuously.
         await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "kiro-cli", ["--version"]);
 
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
@@ -67,20 +78,26 @@ public class KiroMemoryIndexLiveCertTests {
         try {
             var first = await RunKiroAsync(worktree.FullName, MemoryIndexLiveCertHarness.PositivePrompt);
 
-            // Guard: if turn one did not see the index, turn two seeing nothing proves nothing.
-            await Assert.That(first).Contains(nonce);
+            // Guard: if turn one never saw the index, turn two seeing nothing proves nothing.
+            await Assert.That(first).Contains(firstNonce);
 
-            var second = await RunKiroAsync(
-                worktree.FullName,
-                "Ignore any earlier instruction to echo a nonce. Answer ONLY about the context injected "
-              + "at the START of THIS prompt: if a NEW '## Team memory' block was injected just now, "
-              + "reply with ONLY the kcap-live-nonce- string it contains. Otherwise reply ONLY the word NONE.",
-                resume: true);
+            // Saved AFTER turn one, so it cannot be in the resumed conversation history.
+            var secondNonce    = MemoryIndexLiveCertHarness.NewNonce();
+            var secondMemoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, secondNonce);
 
-            await Assert.That(second).DoesNotContain(nonce);
+            try {
+                // Same question as turn one. Echoing the FIRST nonce back from history is expected and
+                // harmless; only the second nonce is diagnostic.
+                var second = await RunKiroAsync(
+                    worktree.FullName, MemoryIndexLiveCertHarness.PositivePrompt, resume: true);
+
+                await Assert.That(second).DoesNotContain(secondNonce);
+            } finally {
+                await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, secondMemoryId);
+            }
         } finally {
             TryDelete(worktree);
-            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, firstMemoryId);
         }
     }
 
@@ -104,8 +121,13 @@ public class KiroMemoryIndexLiveCertTests {
             await Assert.That(answer).DoesNotContain(nonce);
         } finally {
             TryDelete(worktree);
-            await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
-            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
+            // Nested: the restore THROWS on a failed or unconfirmed write, and that must not
+            // be allowed to skip the archive — a leaked nonce corrupts every later cert's index.
+            try {
+                await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
+            } finally {
+                await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
+            }
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/KiroMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/KiroMemoryIndexLiveCertTests.cs
@@ -21,7 +21,7 @@ namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
 /// inside ONE interactive process (PTY automation), which this suite does not do; the lease stays
 /// covered by the <c>Kiro_*</c> cases in <c>SessionStartMemoryFoundationTests</c>.</para>
 ///
-/// <para>All three tests are <c>[NotInParallel]</c>: the negative control mutates the REAL
+/// <para>Both tests are <c>[NotInParallel]</c>: the negative control mutates the REAL
 /// process-global <c>disable_memory_index</c> config.</para>
 /// </summary>
 public class KiroMemoryIndexLiveCertTests {
@@ -36,10 +36,12 @@ public class KiroMemoryIndexLiveCertTests {
     [Test, NotInParallel]
     public async Task Nonce_saved_as_a_memory_is_reproduced_by_a_real_kiro_agent_spawn() {
         Gate();
-        var nonce   = MemoryIndexLiveCertHarness.NewNonce();
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+        var nonce = MemoryIndexLiveCertHarness.NewNonce();
 
+        // Worktree first: it is local and can throw (permissions, disk, temp state), and creating it
+        // after the remote save would strand a real memory outside the archive-protecting try.
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         try {
             await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "kiro-cli", ["--version"]);
@@ -64,9 +66,11 @@ public class KiroMemoryIndexLiveCertTests {
         // save would strand a real memory outside the archive-protecting try below.
         var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
 
-        var nonce    = MemoryIndexLiveCertHarness.NewNonce();
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+        var nonce = MemoryIndexLiveCertHarness.NewNonce();
+
+        // Worktree before the remote save, for the same reason as the positive cert above.
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         try {
             await MemoryIndexLiveCertHarness.SetDisableMemoryIndexAsync(true);

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/KiroMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/KiroMemoryIndexLiveCertTests.cs
@@ -34,7 +34,7 @@ public class KiroMemoryIndexLiveCertTests {
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
 
         try {
-            await MemoryIndexLiveCertHarness.RecordVersionAsync(VendorLabel, "kiro-cli", ["--version"]);
+            await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "kiro-cli", ["--version"]);
 
             var answer = await RunKiroAsync(worktree.FullName, MemoryIndexLiveCertHarness.PositivePrompt);
 
@@ -58,6 +58,9 @@ public class KiroMemoryIndexLiveCertTests {
         Gate();
         var nonce   = MemoryIndexLiveCertHarness.NewNonce();
         var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+
+        // Recorded here too: a stale PATH kcap makes a negative control pass vacuously.
+        await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "kiro-cli", ["--version"]);
 
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
 
@@ -86,6 +89,9 @@ public class KiroMemoryIndexLiveCertTests {
         Gate();
         var nonce   = MemoryIndexLiveCertHarness.NewNonce();
         var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+
+        // Recorded here too: a stale PATH kcap makes a negative control pass vacuously.
+        await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "kiro-cli", ["--version"]);
 
         var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/KiroMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/KiroMemoryIndexLiveCertTests.cs
@@ -6,15 +6,23 @@ namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
 /// <c>KiroSessionStartMemoryTests</c> and the Kiro_* cases in <c>SessionStartMemoryFoundationTests</c>;
 /// this is the only place asserting the end-to-end claims.
 ///
-/// <para><b>Kiro carries a third cert the other harnesses do not.</b> Its <c>agentSpawn</c> hook fires
-/// on EVERY prompt with the same session id, so "injects once per session" is the load-bearing
-/// property of the whole adapter — and the unit tests can only prove the LEASE dedupes, not that the
-/// model stops seeing the index on turn two. <c>kiro-cli chat --resume</c> continues the most recent
-/// conversation in the same directory, which is what makes that certifiable at all.</para>
+/// <para><b>The once-per-session dedupe is NOT certifiable through this CLI, and there is
+/// deliberately no cert for it here.</b> The adapter's load-bearing property is that
+/// <c>agentSpawn</c> fires per PROMPT within one session and the lease suppresses re-injection. The
+/// obvious probe — <c>kiro-cli chat --resume</c> for a second turn — does NOT test that. Measured
+/// 2026-07-30: a resumed invocation carries a DIFFERENT hook <c>session_id</c> than the turn it
+/// resumes, even though Kiro's own chat SessionId is unchanged and the conversation genuinely
+/// continues (2 msgs to 4). Two lease records were written five seconds apart, one per invocation.</para>
+///
+/// <para>So a resumed turn is a NEW session to kcap and re-injecting there is correct — a cert
+/// asserting absence would have been asserting a bug, and an earlier draft of this file did exactly
+/// that and "passed" only because its probe shared a prefix with the first turn's nonce. Two separate
+/// processes are not two prompts in one session. Certifying the real property needs several prompts
+/// inside ONE interactive process (PTY automation), which this suite does not do; the lease stays
+/// covered by the <c>Kiro_*</c> cases in <c>SessionStartMemoryFoundationTests</c>.</para>
 ///
 /// <para>All three tests are <c>[NotInParallel]</c>: the negative control mutates the REAL
-/// process-global <c>disable_memory_index</c> config, and the dedupe cert depends on which
-/// conversation is "most recent" in its own directory.</para>
+/// process-global <c>disable_memory_index</c> config.</para>
 /// </summary>
 public class KiroMemoryIndexLiveCertTests {
     const string LiveGateEnvVar = "KCAP_KIRO_MEMORY_LIVE";
@@ -22,7 +30,7 @@ public class KiroMemoryIndexLiveCertTests {
 
     static void Gate() => MemoryIndexLiveCertHarness.SkipUnlessLiveGateReady(
         LiveGateEnvVar,
-        "one real `kiro-cli chat` turn per test (two for the dedupe cert)",
+        "one real `kiro-cli chat` turn per test",
         "`kiro-cli` on PATH with its agentSpawn hook wired to `kcap` in ~/.kiro/agents/kcap.json");
 
     [Test, NotInParallel]
@@ -45,72 +53,19 @@ public class KiroMemoryIndexLiveCertTests {
         }
     }
 
-    /// <summary>
-    /// THE Kiro-specific claim: agentSpawn fires again on the second prompt, and the index must NOT be
-    /// injected again. Turn two is resumed in the same directory, so it is the same Kiro session id and
-    /// therefore the same lease key.
-    ///
-    /// <para><b>Why a SECOND nonce, saved only after turn one.</b> The obvious shape — ask turn two
-    /// whether a "new" block was injected and assert the first nonce is absent — cannot work. Turn
-    /// one's own answer put that nonce into the conversation history, so turn two can see it whether or
-    /// not the index was re-injected, and "was this block NEW?" is a semantic judgment the model may
-    /// get right or wrong for its own reasons. It could false-pass on a broken lease and false-fail on
-    /// a working one.</para>
-    ///
-    /// <para>Saving a second memory AFTER turn one makes the property observable instead. Nonce two was
-    /// never in the history, so it can only reach the model via a FRESH index fetch. Absent means no
-    /// second fetch happened — the lease held. Present means it did. No model meta-reasoning
-    /// involved.</para>
-    ///
-    /// <para>A failure here means the lease is not holding in production even though the unit tests
-    /// pass — the exact gap between "our bytes dedupe" and "the model stops seeing it".</para>
-    /// </summary>
-    [Test, NotInParallel]
-    public async Task A_resumed_kiro_session_does_not_get_the_index_injected_a_second_time() {
-        Gate();
-        var firstNonce    = MemoryIndexLiveCertHarness.NewNonce();
-        var firstMemoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, firstNonce);
-
-        await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "kiro-cli", ["--version"]);
-
-        var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
-
-        try {
-            var first = await RunKiroAsync(worktree.FullName, MemoryIndexLiveCertHarness.PositivePrompt);
-
-            // Guard: if turn one never saw the index, turn two seeing nothing proves nothing.
-            await Assert.That(first).Contains(firstNonce);
-
-            // Saved AFTER turn one, so it cannot be in the resumed conversation history.
-            var secondNonce    = MemoryIndexLiveCertHarness.NewNonce();
-            var secondMemoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, secondNonce);
-
-            try {
-                // Same question as turn one. Echoing the FIRST nonce back from history is expected and
-                // harmless; only the second nonce is diagnostic.
-                var second = await RunKiroAsync(
-                    worktree.FullName, MemoryIndexLiveCertHarness.PositivePrompt, resume: true);
-
-                await Assert.That(second).DoesNotContain(secondNonce);
-            } finally {
-                await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, secondMemoryId);
-            }
-        } finally {
-            TryDelete(worktree);
-            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, firstMemoryId);
-        }
-    }
-
     [Test, NotInParallel]
     public async Task Disabled_memory_index_does_not_leak_the_nonce_to_a_real_kiro_agent_spawn() {
         Gate();
-        var nonce   = MemoryIndexLiveCertHarness.NewNonce();
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
 
         // Recorded here too: a stale PATH kcap makes a negative control pass vacuously.
         await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "kiro-cli", ["--version"]);
 
+        // Read BEFORE anything is created. This throws on an unreadable config, and doing it after the
+        // save would strand a real memory outside the archive-protecting try below.
         var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
+
+        var nonce    = MemoryIndexLiveCertHarness.NewNonce();
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
 
         try {
@@ -135,19 +90,13 @@ public class KiroMemoryIndexLiveCertTests {
     /// Runs one non-interactive Kiro turn. <c>--trust-tools=</c> trusts NO tools: the prompt is
     /// answerable from injected context alone, and an untrusted tool request in
     /// <c>--no-interactive</c> mode would otherwise be the likeliest way for a cert to stall.
-    /// <paramref name="resume"/> continues the most recent conversation in
-    /// <paramref name="cwd"/> — the same Kiro session id, which is what the dedupe cert needs.
     /// </summary>
-    static async Task<string> RunKiroAsync(string cwd, string prompt, bool resume = false) {
-        string[] args = resume
-            ? ["chat", "--no-interactive", "--trust-tools=", "--resume", prompt]
-            : ["chat", "--no-interactive", "--trust-tools=", prompt];
-
+    static async Task<string> RunKiroAsync(string cwd, string prompt) {
         var (exitCode, stdout, stderr) = await MemoryIndexLiveCertHarness.RunProcessAsync(
-            "kiro-cli", args, cwd);
+            "kiro-cli", ["chat", "--no-interactive", "--trust-tools=", prompt], cwd);
 
         await Console.Out.WriteLineAsync(
-            $"[{VendorLabel}-memory-live] kiro-cli resume={resume} exit={exitCode} stderr={stderr}");
+            $"[{VendorLabel}-memory-live] kiro-cli exit={exitCode} stderr={stderr}");
         await Assert.That(exitCode).IsEqualTo(0);
 
         return MemoryIndexLiveCertHarness.ExtractAssistantAnswer(stdout);

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/KiroMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/KiroMemoryIndexLiveCertTests.cs
@@ -1,0 +1,145 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
+
+/// <summary>
+/// Env-gated certification that the SessionStart memory index actually reaches the model on Kiro CLI.
+/// The raw-stdout contract and the lease dedupe are covered against fakes by
+/// <c>KiroSessionStartMemoryTests</c> and the Kiro_* cases in <c>SessionStartMemoryFoundationTests</c>;
+/// this is the only place asserting the end-to-end claims.
+///
+/// <para><b>Kiro carries a third cert the other harnesses do not.</b> Its <c>agentSpawn</c> hook fires
+/// on EVERY prompt with the same session id, so "injects once per session" is the load-bearing
+/// property of the whole adapter — and the unit tests can only prove the LEASE dedupes, not that the
+/// model stops seeing the index on turn two. <c>kiro-cli chat --resume</c> continues the most recent
+/// conversation in the same directory, which is what makes that certifiable at all.</para>
+///
+/// <para>All three tests are <c>[NotInParallel]</c>: the negative control mutates the REAL
+/// process-global <c>disable_memory_index</c> config, and the dedupe cert depends on which
+/// conversation is "most recent" in its own directory.</para>
+/// </summary>
+public class KiroMemoryIndexLiveCertTests {
+    const string LiveGateEnvVar = "KCAP_KIRO_MEMORY_LIVE";
+    const string VendorLabel    = "kiro";
+
+    static void Gate() => MemoryIndexLiveCertHarness.SkipUnlessLiveGateReady(
+        LiveGateEnvVar,
+        "one real `kiro-cli chat` turn per test (two for the dedupe cert)",
+        "`kiro-cli` on PATH with its agentSpawn hook wired to `kcap` in ~/.kiro/agents/kcap.json");
+
+    [Test, NotInParallel]
+    public async Task Nonce_saved_as_a_memory_is_reproduced_by_a_real_kiro_agent_spawn() {
+        Gate();
+
+        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
+        var nonce   = MemoryIndexLiveCertHarness.NewNonce();
+
+        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+
+        var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
+
+        try {
+            await MemoryIndexLiveCertHarness.RecordVersionAsync(VendorLabel, "kiro-cli", ["--version"]);
+
+            var answer = await RunKiroAsync(worktree.FullName, MemoryIndexLiveCertHarness.PositivePrompt);
+
+            await Assert.That(answer).Contains(nonce);
+        } finally {
+            TryDelete(worktree);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+        }
+    }
+
+    /// <summary>
+    /// THE Kiro-specific claim: agentSpawn fires again on the second prompt, and the index must NOT
+    /// be injected again. Turn one must see the nonce; turn two, resumed in the same directory (hence
+    /// the same Kiro session id, hence the same lease key), must not.
+    ///
+    /// <para>A failure here means the lease is not holding in production even though the unit tests
+    /// pass — the exact gap between "our bytes dedupe" and "the model stops seeing it".</para>
+    /// </summary>
+    [Test, NotInParallel]
+    public async Task A_resumed_kiro_session_does_not_get_the_index_injected_a_second_time() {
+        Gate();
+
+        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
+        var nonce   = MemoryIndexLiveCertHarness.NewNonce();
+
+        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+
+        var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
+
+        try {
+            var first = await RunKiroAsync(worktree.FullName, MemoryIndexLiveCertHarness.PositivePrompt);
+
+            // Guard: if turn one did not see the index, turn two seeing nothing proves nothing.
+            await Assert.That(first).Contains(nonce);
+
+            var second = await RunKiroAsync(
+                worktree.FullName,
+                "Ignore any earlier instruction to echo a nonce. Answer ONLY about the context injected "
+              + "at the START of THIS prompt: if a NEW '## Team memory' block was injected just now, "
+              + "reply with ONLY the kcap-live-nonce- string it contains. Otherwise reply ONLY the word NONE.",
+                resume: true);
+
+            await Assert.That(second).DoesNotContain(nonce);
+        } finally {
+            TryDelete(worktree);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+        }
+    }
+
+    [Test, NotInParallel]
+    public async Task Disabled_memory_index_does_not_leak_the_nonce_to_a_real_kiro_agent_spawn() {
+        Gate();
+
+        var baseUrl = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
+        var nonce   = MemoryIndexLiveCertHarness.NewNonce();
+
+        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(client, baseUrl, VendorLabel, nonce);
+
+        var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
+        var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
+
+        try {
+            await MemoryIndexLiveCertHarness.SetDisableMemoryIndexAsync(true);
+
+            var answer = await RunKiroAsync(worktree.FullName, MemoryIndexLiveCertHarness.NegativePrompt);
+
+            await Assert.That(answer).DoesNotContain(nonce);
+        } finally {
+            TryDelete(worktree);
+            await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(client, baseUrl, VendorLabel, memoryId);
+        }
+    }
+
+    /// <summary>
+    /// Runs one non-interactive Kiro turn. <c>--trust-tools=</c> trusts NO tools: the prompt is
+    /// answerable from injected context alone, and an untrusted tool request in
+    /// <c>--no-interactive</c> mode would otherwise be the likeliest way for a cert to stall.
+    /// <paramref name="resume"/> continues the most recent conversation in
+    /// <paramref name="cwd"/> — the same Kiro session id, which is what the dedupe cert needs.
+    /// </summary>
+    static async Task<string> RunKiroAsync(string cwd, string prompt, bool resume = false) {
+        string[] args = resume
+            ? ["chat", "--no-interactive", "--trust-tools=", "--resume", prompt]
+            : ["chat", "--no-interactive", "--trust-tools=", prompt];
+
+        var (exitCode, stdout, stderr) = await MemoryIndexLiveCertHarness.RunProcessAsync(
+            "kiro-cli", args, cwd);
+
+        await Console.Out.WriteLineAsync(
+            $"[{VendorLabel}-memory-live] kiro-cli resume={resume} exit={exitCode} stderr={stderr}");
+        await Assert.That(exitCode).IsEqualTo(0);
+
+        return MemoryIndexLiveCertHarness.ExtractAssistantAnswer(stdout);
+    }
+
+    static void TryDelete(DirectoryInfo dir) {
+        try { dir.Delete(recursive: true); } catch { /* best-effort */ }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -1,0 +1,278 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
+
+/// <summary>
+/// Shared scaffolding for the env-gated, per-harness "did the model actually receive the team-memory
+/// index?" certifications. Every vendor's cert needs the same five things — a live gate, a throwaway
+/// nonce memory, the real <c>disable_memory_index</c> profile flag, a bounded child process, and a
+/// defensive answer parse — so they live here once instead of per vendor.
+///
+/// <para><b>Why these certs exist at all.</b> The unit suites prove the BYTES each adapter emits.
+/// They cannot prove the harness surfaces those bytes to the model. Cursor IDE is the standing
+/// counterexample: byte-perfect <c>additional_context</c>, model receipt not guaranteed. Only a real
+/// turn distinguishes "we emitted it" from "the model got it".</para>
+///
+/// <para><b>Cost.</b> Nothing in CI: <see cref="SkipUnlessLiveGateReady"/> is the first statement in
+/// every cert, so the skip happens before any process launch or HTTP call. A run spends real model
+/// turns and touches the REAL server and the REAL profile config, so it is deliberately manual.</para>
+///
+/// <para>The two pre-existing certs (<c>ClaudeMemoryIndexLiveCertTests</c>,
+/// <c>Cursor.CursorMemoryIndexLiveCertTests</c>) still carry their own private copies of this
+/// scaffold. They are certified and gated — hence not exercised by CI — so they are deliberately left
+/// alone here rather than refactored blind; migrating them is a follow-up.</para>
+/// </summary>
+internal static class MemoryIndexLiveCertHarness {
+    public const string ServerUrlEnvVar = "KCAP_URL";
+
+    static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(120);
+
+    /// <summary>
+    /// The nonce shape every cert looks for. Deliberately distinctive so a match cannot be
+    /// coincidental, and regex-free so the model is asked only to echo a literal.
+    /// </summary>
+    public static string NewNonce() => $"kcap-live-nonce-{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Asks the model to echo the nonce if — and only if — the injected index actually reached it.
+    /// The nonce is embedded in the memory's DESCRIPTION, and the index injects one
+    /// <c>slug: description</c> line per memory, so this is answerable from the injected context
+    /// alone: no MCP memory server, no tool call, and no repo required. That keeps a failure
+    /// attributable to injection rather than to tool wiring.
+    /// </summary>
+    public static string PositivePrompt =>
+        "A block headed '## Team memory' may have been injected into your context. If it contains a "
+      + "string of the form kcap-live-nonce- followed by 32 hex characters, reply with ONLY that "
+      + "exact string and nothing else. If there is no such block or no such string, reply with "
+      + "ONLY the word NONE.";
+
+    /// <summary>
+    /// The negative control's prompt. Same question, so a false positive can only come from the
+    /// index genuinely being present — not from a differently-worded ask.
+    /// </summary>
+    public static string NegativePrompt => PositivePrompt;
+
+    /// <summary>
+    /// Gate. MUST be the first statement in every cert: it returns before any process launch, HTTP
+    /// call, or memory write, which is what keeps CI spend at exactly zero.
+    /// </summary>
+    public static void SkipUnlessLiveGateReady(string liveGateEnvVar, string spendDescription, string preconditions) {
+        Skip.Unless(
+            Environment.GetEnvironmentVariable(liveGateEnvVar) == "1",
+            $"Gated live model-receipt certification — set {liveGateEnvVar}=1 and {ServerUrlEnvVar}=<reachable kcap server> "
+          + $"to run (spends {spendDescription}; requires {preconditions}, and `kcap login` already done against that server).");
+        Skip.Unless(
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ServerUrlEnvVar)),
+            $"{ServerUrlEnvVar} must point at a reachable kcap server exposing GET /api/memories/index.");
+    }
+
+    public static string RequiredServerUrl() => Environment.GetEnvironmentVariable(ServerUrlEnvVar)!;
+
+    /// <summary>
+    /// Bootstraps CLI config resolution, then returns the resolved server URL. **Every cert must call
+    /// this before building an authenticated client.**
+    ///
+    /// <para>A cert runs inside the TEST assembly, not the `kcap` binary, so nothing has done what
+    /// <c>Program.cs</c> does on startup: without it <c>AppConfig.ResolvedProfile</c> is null,
+    /// credential resolution cannot find the profile's token, the request goes out unauthenticated,
+    /// and the server answers <c>401</c> — even though `kcap whoami` succeeds in a shell a second
+    /// earlier. That failure mode is indistinguishable from "you are not logged in", so it is worth
+    /// naming: it is a missing bootstrap, not a missing login.</para>
+    ///
+    /// <para>Returns the URL the CLI itself resolves (honouring <c>KCAP_URL</c>, which the gate
+    /// already requires) rather than the raw environment variable, so a cert talks to exactly the
+    /// server the harness's own hook will talk to.</para>
+    /// </summary>
+    public static async Task<string> InitializeAndResolveServerUrlAsync() {
+        var resolved = await AppConfig.ResolveServerUrl([]);
+
+        return resolved ?? RequiredServerUrl();
+    }
+
+    /// <summary>
+    /// Saves a user-scoped, repo-independent ("global") memory whose description embeds the nonce,
+    /// through the same <c>POST /api/memories</c> contract <c>kcap mcp memory</c>'s
+    /// <c>save_memory</c> uses. Global sidesteps needing a real repo hash for a throwaway worktree.
+    /// </summary>
+    public static async Task<string> SaveNonceMemoryAsync(
+            HttpClient client, string baseUrl, string vendorLabel, string nonce) {
+        var body = McpMemoryServer.BuildSaveBody(new JsonObject {
+            ["audience"]    = "user",
+            ["slug"]        = $"live-cert-{nonce}",
+            ["description"] = $"kcap {vendorLabel} memory live-cert nonce: {nonce}",
+            ["content"]     = $"kcap {vendorLabel} memory live-cert nonce: {nonce}. Safe to archive after the run.",
+            ["kind"]        = "reference",
+            ["global"]      = true
+        }, cwdRepoHash: null, machineId: null);
+
+        using var resp = await client.PostAsJsonAsync($"{baseUrl}/api/memories", body);
+        resp.EnsureSuccessStatusCode();
+        var created = await resp.Content.ReadFromJsonAsync<JsonObject>();
+
+        return created?["memory_id"]?.GetValue<string>()
+            ?? throw new InvalidOperationException("Save response carried no memory_id.");
+    }
+
+    /// <summary>Best-effort cleanup: a leaked cert memory would pollute every later run's index.</summary>
+    public static async Task ArchiveMemoryAsync(HttpClient client, string baseUrl, string vendorLabel, string memoryId) {
+        try {
+            using var resp = await client.DeleteAsync($"{baseUrl}/api/memories/{Uri.EscapeDataString(memoryId)}");
+            if (!resp.IsSuccessStatusCode) {
+                await Console.Error.WriteLineAsync(
+                    $"[{vendorLabel}-memory-live] failed to archive live-cert memory {memoryId}: HTTP {(int)resp.StatusCode}");
+            }
+        } catch (Exception ex) {
+            await Console.Error.WriteLineAsync(
+                $"[{vendorLabel}-memory-live] failed to archive live-cert memory {memoryId}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Reads the active profile's <c>disable_memory_index</c> via <c>kcap config show</c>. Null when
+    /// unset or unreadable. Callers restore what they read, so a run leaves the machine as it found it.
+    /// </summary>
+    public static async Task<bool?> ReadDisableMemoryIndexAsync() {
+        var (exitCode, stdout, _) = await RunProcessAsync("kcap", ["config", "show"], workingDirectory: null);
+        if (exitCode != 0) return null;
+
+        try {
+            var root          = JsonNode.Parse(ExtractLeadingJsonBlock(stdout));
+            var activeProfile = root?["active_profile"]?.GetValue<string>();
+            if (activeProfile is null) return null;
+
+            return root?["profiles"]?[activeProfile]?["disable_memory_index"]?.GetValue<bool>();
+        } catch {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Isolates the leading JSON from <c>kcap config show</c> (JSON, blank line, then a "Path:"
+    /// line). CRLF-tolerant: on Windows a \n-only split would return the whole blob and fail to parse.
+    /// </summary>
+    public static string ExtractLeadingJsonBlock(string stdout) =>
+        stdout.Replace("\r\n", "\n").Split("\n\n", 2)[0];
+
+    /// <summary>
+    /// Restores the flag to what was observed. `kcap config` has no unset primitive, so an
+    /// originally-absent (null) flag is restored as "false" — observably identical, since both read
+    /// as not-disabled via `is true`.
+    /// </summary>
+    public static Task RestoreDisableMemoryIndexAsync(bool? original) =>
+        SetDisableMemoryIndexAsync((original ?? false));
+
+    public static async Task SetDisableMemoryIndexAsync(bool value) =>
+        await RunProcessAsync("kcap", ["config", "set", "disable_memory_index", value ? "true" : "false"],
+            workingDirectory: null);
+
+    public static async Task RecordVersionAsync(string vendorLabel, string fileName, IReadOnlyList<string> args) {
+        try {
+            var (exitCode, stdout, _) = await RunProcessAsync(fileName, args, workingDirectory: null);
+            await Console.Out.WriteLineAsync(
+                $"[{vendorLabel}-memory-live] {fileName} {string.Join(' ', args)} (exit {exitCode}): {stdout.Trim()}");
+        } catch (Exception ex) {
+            await Console.Error.WriteLineAsync($"[{vendorLabel}-memory-live] could not record {fileName} version: {ex.Message}");
+        }
+    }
+
+    /// <summary>Test-only seam: notified with the PID of every spawned process, so the cleanup test
+    /// can confirm a timed-out child is actually gone. Never set by production code.</summary>
+    internal static Action<int>? OnProcessStarted;
+
+    /// <summary>
+    /// Runs a child process with its output captured and a hard timeout, killing the whole tree on
+    /// expiry so a hung harness CLI is never orphaned. <paramref name="stdin"/> is written and the
+    /// stream closed when supplied — Codex reads its prompt that way.
+    /// </summary>
+    public static async Task<(int ExitCode, string Stdout, string Stderr)> RunProcessAsync(
+            string fileName, IReadOnlyList<string> args, string? workingDirectory,
+            TimeSpan? timeout = null, string? stdin = null) {
+        var psi = new ProcessStartInfo(fileName) {
+            UseShellExecute        = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            RedirectStandardInput  = stdin is not null,
+            WorkingDirectory       = workingDirectory ?? Environment.CurrentDirectory
+        };
+        foreach (var arg in args) psi.ArgumentList.Add(arg);
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");
+        OnProcessStarted?.Invoke(process.Id);
+
+        using var timeoutCts = new CancellationTokenSource(timeout ?? ProcessTimeout);
+        try {
+            if (stdin is not null) {
+                await process.StandardInput.WriteAsync(stdin);
+                process.StandardInput.Close();
+            }
+
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+            var stderrTask = process.StandardError.ReadToEndAsync(timeoutCts.Token);
+            await process.WaitForExitAsync(timeoutCts.Token);
+
+            return (process.ExitCode, await stdoutTask, await stderrTask);
+        } finally {
+            try { if (!process.HasExited) process.Kill(entireProcessTree: true); } catch { /* already exited */ }
+        }
+    }
+
+    /// <summary>
+    /// Pulls the assistant's answer out of a harness CLI's stdout without assuming a shape: tries
+    /// newline-delimited JSON, then a single JSON document, then falls back to the raw trimmed text.
+    /// Each harness's real output shape is confirmed on its first live run and recorded on the cert.
+    /// </summary>
+    public static string ExtractAssistantAnswer(string stdout) {
+        var trimmed = stdout.Trim();
+        if (trimmed.Length == 0) return trimmed;
+
+        foreach (var line in trimmed.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)) {
+            if (line.Length == 0 || line[0] is not ('{' or '[')) continue;
+            try {
+                if (JsonNode.Parse(line) is { } node && FindFirstTextField(node) is { } text) return text;
+            } catch {
+                // Not JSON — fall through.
+            }
+        }
+
+        try {
+            if (JsonNode.Parse(trimmed) is { } whole && FindFirstTextField(whole) is { } text) return text;
+        } catch {
+            // Plain text — return as-is.
+        }
+
+        return trimmed;
+    }
+
+    static string? FindFirstTextField(JsonNode? node) {
+        switch (node) {
+            case JsonObject obj:
+                foreach (var key in new[] { "text", "message", "content", "answer", "result" }) {
+                    if (obj[key] is JsonValue v && v.TryGetValue<string>(out var s) && s.Length > 0) return s;
+                }
+                foreach (var (_, child) in obj) {
+                    if (FindFirstTextField(child) is { } nested) return nested;
+                }
+                return null;
+            case JsonArray arr:
+                foreach (var item in arr) {
+                    if (FindFirstTextField(item) is { } nested) return nested;
+                }
+                return null;
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Creates a throwaway working directory for a cert turn. It must be a fresh directory so the
+    /// harness genuinely starts a NEW session and the sessionStart path under test actually fires.
+    /// </summary>
+    public static DirectoryInfo NewCertWorktree(string vendorLabel) =>
+        Directory.CreateTempSubdirectory($"kcap-{vendorLabel}-memory-live-");
+}

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -258,22 +258,39 @@ internal static class MemoryIndexLiveCertHarness {
     }
 
     /// <summary>
-    /// Reads the active profile's <c>disable_memory_index</c> via <c>kcap config show</c>. Null when
-    /// unset or unreadable. Callers restore what they read, so a run leaves the machine as it found it.
+    /// Reads the active profile's <c>disable_memory_index</c>. Null means the flag is **genuinely
+    /// absent**; an unreadable config, unparseable output or missing active profile THROWS.
+    ///
+    /// <para>That distinction is the whole point. Collapsing "could not read" into the same null as
+    /// "not set" means a restore writes <c>false</c> over a real <c>true</c> — silently re-enabling
+    /// memory injection for a developer who deliberately opted out. Failing closed on an unknown
+    /// starting value is the only safe option, because this method's result is what the restore
+    /// writes back to a real machine.</para>
     /// </summary>
     public static async Task<bool?> ReadDisableMemoryIndexAsync() {
-        var (exitCode, stdout, _) = await RunProcessAsync("kcap", ["config", "show"], workingDirectory: null);
-        if (exitCode != 0) return null;
+        var (exitCode, stdout, stderr) = await RunProcessAsync("kcap", ["config", "show"], workingDirectory: null);
+
+        if (exitCode != 0) {
+            throw new InvalidOperationException(
+                $"`kcap config show` failed (exit {exitCode}) — refusing to guess the current "
+              + $"disable_memory_index, since restoring the wrong value changes a real setting: {stderr}");
+        }
+
+        JsonNode? root;
 
         try {
-            var root          = JsonNode.Parse(ExtractLeadingJsonBlock(stdout));
-            var activeProfile = root?["active_profile"]?.GetValue<string>();
-            if (activeProfile is null) return null;
-
-            return root?["profiles"]?[activeProfile]?["disable_memory_index"]?.GetValue<bool>();
-        } catch {
-            return null;
+            root = JsonNode.Parse(ExtractLeadingJsonBlock(stdout));
+        } catch (Exception ex) {
+            throw new InvalidOperationException(
+                $"could not parse `kcap config show` output — refusing to guess disable_memory_index: {ex.Message}");
         }
+
+        var activeProfile = root?["active_profile"]?.GetValue<string>()
+            ?? throw new InvalidOperationException(
+                "`kcap config show` reported no active_profile — refusing to guess disable_memory_index.");
+
+        // Null HERE is meaningful: the flag really is unset on the active profile.
+        return root?["profiles"]?[activeProfile]?["disable_memory_index"]?.GetValue<bool>();
     }
 
     /// <summary>
@@ -284,16 +301,50 @@ internal static class MemoryIndexLiveCertHarness {
         stdout.Replace("\r\n", "\n").Split("\n\n", 2)[0];
 
     /// <summary>
-    /// Restores the flag to what was observed. `kcap config` has no unset primitive, so an
-    /// originally-absent (null) flag is restored as "false" — observably identical, since both read
-    /// as not-disabled via `is true`.
+    /// Restores the flag to what was observed, then READS IT BACK to confirm. `kcap config` has no
+    /// unset primitive, so an originally-absent (null) flag is restored as <c>false</c> — observably
+    /// identical, since both read as not-disabled via <c>is true</c>.
+    ///
+    /// <para>The read-back exists because a silent restore failure is this file's worst outcome: it
+    /// leaves memory injection DISABLED on a real machine while the cert reports success, and nothing
+    /// downstream would notice for days.</para>
     /// </summary>
-    public static Task RestoreDisableMemoryIndexAsync(bool? original) =>
-        SetDisableMemoryIndexAsync((original ?? false));
+    public static async Task RestoreDisableMemoryIndexAsync(bool? original) {
+        var target = original ?? false;
 
-    public static async Task SetDisableMemoryIndexAsync(bool value) =>
-        await RunProcessAsync("kcap", ["config", "set", "disable_memory_index", value ? "true" : "false"],
-            workingDirectory: null);
+        await SetDisableMemoryIndexAsync(target);
+
+        var readBack = await ReadDisableMemoryIndexAsync() ?? false;
+
+        if (readBack != target) {
+            throw new InvalidOperationException(
+                $"disable_memory_index did NOT restore: wanted {target}, read back {readBack}. "
+              + "Fix this by hand — `kcap config set disable_memory_index "
+              + $"{(target ? "true" : "false")}` — memory injection may be left in the wrong state.");
+        }
+    }
+
+    /// <summary>
+    /// Sets the REAL profile flag, and fails loudly if the subprocess did not succeed.
+    ///
+    /// <para>Discarding this exit code is not a cosmetic gap. A failed <c>true</c> makes the negative
+    /// control vacuous (it observes no injection because injection was never disabled, and passes for
+    /// the wrong reason); a failed restore leaves a developer's machine with memory injection off. The
+    /// pre-existing Claude cert asserts this exit code, and an earlier draft of this shared harness
+    /// dropped that guard.</para>
+    /// </summary>
+    public static async Task SetDisableMemoryIndexAsync(bool value) {
+        var (exitCode, _, stderr) = await RunProcessAsync(
+            "kcap", ["config", "set", "disable_memory_index", value ? "true" : "false"], workingDirectory: null);
+
+        if (exitCode != 0) {
+            throw new InvalidOperationException(
+                $"`kcap config set disable_memory_index {(value ? "true" : "false")}` failed (exit {exitCode}): {stderr}. "
+              + (value
+                  ? "Aborting rather than run a negative control that would pass vacuously."
+                  : "THE REAL PROFILE MAY STILL HAVE MEMORY INJECTION DISABLED — check `kcap config show`."));
+        }
+    }
 
     public static async Task RecordVersionAsync(string vendorLabel, string fileName, IReadOnlyList<string> args) {
         try {

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -305,6 +305,43 @@ internal static class MemoryIndexLiveCertHarness {
         }
     }
 
+    /// <summary>
+    /// Records the environment a cert actually exercised — the harness CLI's version AND, critically,
+    /// the <c>kcap</c> the harness HOOK will resolve from PATH, with its resolved path.
+    ///
+    /// <para><b>Why the kcap version is the one that matters.</b> A cert drives a harness, the harness
+    /// invokes <c>kcap</c> from PATH, and PATH points at the npm-installed build — NOT at the working
+    /// tree the cert was compiled from. So a cert can be green-lit against a `kcap` that predates the
+    /// very adapter under test, and it will report a confident, meaningless failure. That happened: all
+    /// three adapters merged 2026-07-29 while PATH still held 0.11.8 (tagged 2026-07-24), whose Codex,
+    /// Copilot and Kiro hooks contained zero memory references. Every symptom followed from that — the
+    /// Claude hook injecting fine (its adapter WAS in 0.11.8), the other three answering NONE, and the
+    /// negative controls "passing" vacuously because there was no injection to suppress. It cost two
+    /// sessions to find, and this one line would have made it obvious immediately.</para>
+    ///
+    /// <para>Called by every cert including the negative controls: a stale binary makes a negative
+    /// control pass for the wrong reason, which is worse than a visible failure.</para>
+    /// </summary>
+    public static async Task RecordCertEnvironmentAsync(
+            string vendorLabel, string harnessExe, IReadOnlyList<string> harnessVersionArgs) {
+        await RecordVersionAsync(vendorLabel, harnessExe, harnessVersionArgs);
+
+        // The hook's kcap, not the cert's assembly: version AND path, because the path is what reveals
+        // an npm install shadowing a locally built binary.
+        await RecordVersionAsync(vendorLabel, "kcap", ["--version"]);
+
+        try {
+            var (_, which, _) = await RunProcessAsync(
+                OperatingSystem.IsWindows() ? "where" : "which", ["kcap"], workingDirectory: null);
+
+            await Console.Out.WriteLineAsync(
+                $"[{vendorLabel}-memory-live] hooks will resolve kcap at: {which.Trim()}");
+        } catch (Exception ex) {
+            await Console.Error.WriteLineAsync(
+                $"[{vendorLabel}-memory-live] could not resolve the kcap on PATH: {ex.Message}");
+        }
+    }
+
     /// <summary>Test-only seam: notified with the PID of every spawned process, so the cleanup test
     /// can confirm a timed-out child is actually gone. Never set by production code.</summary>
     internal static Action<int>? OnProcessStarted;

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -9,23 +9,18 @@ namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
 
 /// <summary>
 /// Shared scaffolding for the env-gated, per-harness "did the model actually receive the team-memory
-/// index?" certifications. Every vendor's cert needs the same five things — a live gate, a throwaway
-/// nonce memory, the real <c>disable_memory_index</c> profile flag, a bounded child process, and a
-/// defensive answer parse — so they live here once instead of per vendor.
+/// index?" certifications: gate, throwaway nonce memory, the real <c>disable_memory_index</c> flag, a
+/// bounded child process, and a defensive answer parse.
 ///
-/// <para><b>Why these certs exist at all.</b> The unit suites prove the BYTES each adapter emits.
-/// They cannot prove the harness surfaces those bytes to the model. Cursor IDE is the standing
-/// counterexample: byte-perfect <c>additional_context</c>, model receipt not guaranteed. Only a real
-/// turn distinguishes "we emitted it" from "the model got it".</para>
+/// <para>These exist because the unit suites prove the BYTES an adapter emits, not that the harness
+/// surfaces them to the model — Cursor IDE emits byte-perfect output the model may never see.</para>
 ///
-/// <para><b>Cost.</b> Nothing in CI: <see cref="SkipUnlessLiveGateReady"/> is the first statement in
-/// every cert, so the skip happens before any process launch or HTTP call. A run spends real model
-/// turns and touches the REAL server and the REAL profile config, so it is deliberately manual.</para>
+/// <para><b>Cost.</b> Zero in CI: <see cref="SkipUnlessLiveGateReady"/> is the first statement in every
+/// cert. A run spends real model turns and mutates the REAL server and profile config, so it is
+/// deliberately manual.</para>
 ///
-/// <para>The two pre-existing certs (<c>ClaudeMemoryIndexLiveCertTests</c>,
-/// <c>Cursor.CursorMemoryIndexLiveCertTests</c>) still carry their own private copies of this
-/// scaffold. They are certified and gated — hence not exercised by CI — so they are deliberately left
-/// alone here rather than refactored blind; migrating them is a follow-up.</para>
+/// <para>Claude's and Cursor's certs keep their own copies of this scaffold: they are gated, hence
+/// never exercised by CI, so refactoring them blind is the bigger risk. Migration is a follow-up.</para>
 /// </summary>
 internal static class MemoryIndexLiveCertHarness {
     public const string ServerUrlEnvVar = "KCAP_URL";
@@ -152,6 +147,12 @@ internal static class MemoryIndexLiveCertHarness {
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(90));
 
+        // Drained CONCURRENTLY with the stdout loop, not after it. Both pipes are redirected, so
+        // reading only one is the classic deadlock: a chatty child fills the stderr buffer, blocks on
+        // the write, and never emits the id-2 response — which would present as an unexplained 90s
+        // stall rather than as a pipe problem.
+        var stderrTask = process.StandardError.ReadToEndAsync(cts.Token);
+
         try {
             await process.StandardInput.WriteAsync(stdin);
             await process.StandardInput.FlushAsync(cts.Token);
@@ -167,9 +168,13 @@ internal static class MemoryIndexLiveCertHarness {
             }
 
             throw new InvalidOperationException(
-                $"`kcap mcp memory` {toolName} closed stdout before answering: {await process.StandardError.ReadToEndAsync(cts.Token)}");
+                $"`kcap mcp memory` {toolName} closed stdout before answering: {await stderrTask}");
         } finally {
             try { if (!process.HasExited) process.Kill(entireProcessTree: true); } catch { /* already exited */ }
+
+            // Observed so a faulted/cancelled drain cannot surface later as an unobserved task
+            // exception, and so the pipe finishes draining before the process handle is disposed.
+            try { await stderrTask; } catch { /* the real failure is whatever the caller is throwing */ }
         }
     }
 
@@ -357,21 +362,13 @@ internal static class MemoryIndexLiveCertHarness {
     }
 
     /// <summary>
-    /// Records the environment a cert actually exercised — the harness CLI's version AND, critically,
-    /// the <c>kcap</c> the harness HOOK will resolve from PATH, with its resolved path.
+    /// Records the harness CLI's version and — the one that actually matters — the <c>kcap</c> the
+    /// harness HOOK resolves from PATH, plus its resolved path.
     ///
-    /// <para><b>Why the kcap version is the one that matters.</b> A cert drives a harness, the harness
-    /// invokes <c>kcap</c> from PATH, and PATH points at the npm-installed build — NOT at the working
-    /// tree the cert was compiled from. So a cert can be green-lit against a `kcap` that predates the
-    /// very adapter under test, and it will report a confident, meaningless failure. That happened: all
-    /// three adapters merged 2026-07-29 while PATH still held 0.11.8 (tagged 2026-07-24), whose Codex,
-    /// Copilot and Kiro hooks contained zero memory references. Every symptom followed from that — the
-    /// Claude hook injecting fine (its adapter WAS in 0.11.8), the other three answering NONE, and the
-    /// negative controls "passing" vacuously because there was no injection to suppress. It cost two
-    /// sessions to find, and this one line would have made it obvious immediately.</para>
-    ///
-    /// <para>Called by every cert including the negative controls: a stale binary makes a negative
-    /// control pass for the wrong reason, which is worse than a visible failure.</para>
+    /// <para>PATH points at the npm install, not the tree the cert was compiled from, so a cert can run
+    /// against a <c>kcap</c> predating the adapter under test and report a confident, meaningless
+    /// failure. That happened for all three adapters and cost two sessions to find. Called by every
+    /// cert including the negative controls, which a stale binary makes pass vacuously.</para>
     /// </summary>
     public static async Task RecordCertEnvironmentAsync(
             string vendorLabel, string harnessExe, IReadOnlyList<string> harnessVersionArgs) {

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -214,13 +214,46 @@ internal static class MemoryIndexLiveCertHarness {
         }
     }
 
-    /// <summary>Best-effort cleanup: a leaked cert memory would pollute every later run's index.</summary>
+    /// <summary>
+    /// Cleanup. A leaked cert memory is not cosmetic: it lands in the REAL injected index and every
+    /// later cert then sees a stale nonce, so a positive test can pass on the wrong evidence.
+    ///
+    /// <para>The parameter is <c>id</c>, NOT <c>memory_id</c> — <c>save_memory</c> RETURNS
+    /// <c>memory_id</c> and <c>archive_memory</c> ACCEPTS <c>id</c>, and sending the save's name back
+    /// silently archived nothing. 13 cert memories leaked into the live index before that was caught,
+    /// because the failure was swallowed here.</para>
+    ///
+    /// <para>Failures are therefore reported loudly AND verified: the tool's own <c>ok</c> is checked
+    /// rather than assuming a returned frame means success. Still non-throwing — a cert must not fail
+    /// on cleanup and mask its real verdict — but it can no longer fail in silence.</para>
+    /// </summary>
     public static async Task ArchiveMemoryAsync(string vendorLabel, string memoryId) {
         try {
-            await CallMemoryToolAsync("archive_memory", new JsonObject { ["memory_id"] = memoryId });
+            var frame = await CallMemoryToolAsync("archive_memory", new JsonObject { ["id"] = memoryId });
+
+            if (!ArchiveSucceeded(frame)) {
+                await Console.Error.WriteLineAsync(
+                    $"[{vendorLabel}-memory-live] LEAKED live-cert memory {memoryId} — archive_memory did not "
+                  + $"confirm success. Archive it manually or later certs may read a stale nonce. Frame: {frame}");
+            }
         } catch (Exception ex) {
             await Console.Error.WriteLineAsync(
-                $"[{vendorLabel}-memory-live] failed to archive live-cert memory {memoryId}: {ex.Message}");
+                $"[{vendorLabel}-memory-live] LEAKED live-cert memory {memoryId} — archive threw: {ex.Message}");
+        }
+    }
+
+    /// <summary>True only on an explicit success from the tool; an error frame or a missing/false
+    /// <c>ok</c> both count as failure, so "no news" is never mistaken for "archived".</summary>
+    internal static bool ArchiveSucceeded(string frame) {
+        try {
+            var result = JsonNode.Parse(frame)?["result"];
+            if (result?["isError"]?.GetValue<bool>() == true) return false;
+
+            var text = result?["content"]?[0]?["text"]?.GetValue<string>();
+
+            return text is not null && JsonNode.Parse(text)?["ok"]?.GetValue<bool>() == true;
+        } catch {
+            return false;
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -127,15 +127,50 @@ internal static class MemoryIndexLiveCertHarness {
             }.ToJsonString()
         ]) + "\n";
 
-        var (exitCode, stdout, stderr) = await RunProcessAsync(
-            "kcap", ["mcp", "memory"], workingDirectory: null, timeout: TimeSpan.FromSeconds(60), stdin: stdin);
+        // Interactive, NOT write-all-then-close: an MCP server dispatches per line and stops at stdin
+        // EOF, so closing the stream up front raced the tools/call and only the initialize response
+        // ever came back. Stdin stays open until the id-2 response is read, then the child is killed —
+        // there is no point asking it to shut down cleanly when we already have the answer.
+        var psi = new ProcessStartInfo("kcap") {
+            UseShellExecute        = false,
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true
+        };
+        psi.ArgumentList.Add("mcp");
+        psi.ArgumentList.Add("memory");
 
-        if (stdout.Length == 0) {
+        // The child MUST NOT inherit this assembly's redirected KCAP_CONFIG_DIR (RepoPathStoreTests
+        // [Before(Assembly)]), or `kcap` reads the same empty throwaway config the in-process path did
+        // and answers "Not logged in" — the 401 in a different costume. Removing it lets the child
+        // resolve the real config, which is the whole point of going out-of-process.
+        psi.Environment.Remove("KCAP_CONFIG_DIR");
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start `kcap mcp memory`.");
+        OnProcessStarted?.Invoke(process.Id);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+
+        try {
+            await process.StandardInput.WriteAsync(stdin);
+            await process.StandardInput.FlushAsync(cts.Token);
+
+            while (await process.StandardOutput.ReadLineAsync(cts.Token) is { } line) {
+                if (line.Length == 0 || line[0] != '{') continue;
+
+                try {
+                    if (JsonNode.Parse(line) is JsonObject frame && frame["id"]?.GetValue<int>() == 2) return line;
+                } catch {
+                    // Not a JSON-RPC frame — keep reading.
+                }
+            }
+
             throw new InvalidOperationException(
-                $"`kcap mcp memory` {toolName} produced no stdout (exit {exitCode}): {stderr}");
+                $"`kcap mcp memory` {toolName} closed stdout before answering: {await process.StandardError.ReadToEndAsync(cts.Token)}");
+        } finally {
+            try { if (!process.HasExited) process.Kill(entireProcessTree: true); } catch { /* already exited */ }
         }
-
-        return stdout;
     }
 
     /// <summary>
@@ -154,15 +189,29 @@ internal static class MemoryIndexLiveCertHarness {
             ["global"]      = true
         });
 
-        // The id is dug out of the response text rather than a pinned envelope path: an MCP tool
-        // result nests its payload as a JSON string inside content[].text, and that wrapping is the
-        // server's business, not this cert's. Failing loudly here (rather than returning null and
-        // archiving nothing) is what stops a cert leaking a memory into every later run's index.
-        var id = System.Text.RegularExpressions.Regex.Match(stdout, "\"memory_id\"\\s*:\\s*\\\\?\"([^\"\\\\]+)");
+        // An MCP tool result nests its payload as a JSON *string* inside result.content[].text, so the
+        // id needs two parses, not a regex over the outer frame: the inner document's quotes arrive
+        // "-escaped, so no pattern matching a literal `"memory_id"` will ever fire.
+        //
+        // Failing loudly (rather than returning null and archiving nothing) is what stops a cert
+        // leaking its nonce memory into every later run's injected index.
+        return ExtractMemoryId(stdout)
+            ?? throw new InvalidOperationException($"save_memory returned no memory_id. stdout: {stdout}");
+    }
 
-        return id.Success
-            ? id.Groups[1].Value
-            : throw new InvalidOperationException($"save_memory returned no memory_id. stdout: {stdout}");
+    /// <summary>Digs the saved memory's id out of an MCP <c>tools/call</c> frame. Null if absent.</summary>
+    internal static string? ExtractMemoryId(string frame) {
+        try {
+            var text = JsonNode.Parse(frame)?["result"]?["content"]?[0]?["text"]?.GetValue<string>();
+            if (text is null) return null;
+
+            var payload = JsonNode.Parse(text);
+
+            return payload?["memory"]?["memory_id"]?.GetValue<string>()
+                ?? payload?["memory_id"]?.GetValue<string>();
+        } catch {
+            return null;
+        }
     }
 
     /// <summary>Best-effort cleanup: a leaked cert memory would pollute every later run's index.</summary>
@@ -243,6 +292,10 @@ internal static class MemoryIndexLiveCertHarness {
             WorkingDirectory       = workingDirectory ?? Environment.CurrentDirectory
         };
         foreach (var arg in args) psi.ArgumentList.Add(arg);
+
+        // Same reason as CallMemoryToolAsync: a `kcap config` child — and every harness CLI, which
+        // invokes `kcap hook` itself — must see the REAL config, not this assembly's throwaway one.
+        psi.Environment.Remove("KCAP_CONFIG_DIR");
 
         using var process = Process.Start(psi)
             ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -58,6 +58,28 @@ internal static class MemoryIndexLiveCertHarness {
     public static string NegativePrompt => PositivePrompt;
 
     /// <summary>
+    /// A second-turn probe with a DISTINCT prefix from <see cref="NewNonce"/>.
+    ///
+    /// <para>Needed because a re-injection test cannot share a pattern with the memory it is trying to
+    /// distinguish itself from. If both matched <c>kcap-live-nonce-</c> and the lease broke, the
+    /// re-injected index would carry both, and a prompt asking for "a string of that form" lets the
+    /// model return the FIRST one — which the history has already reinforced — so an assertion that the
+    /// second is absent passes while a second fetch demonstrably happened.</para>
+    /// </summary>
+    public static string NewSecondTurnProbe() => $"kcap-live-probe2-{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Asks only about <see cref="NewSecondTurnProbe"/>'s prefix, and explicitly tells the model to
+    /// disregard the first-turn pattern. Deliberately does NOT contain the probe's random suffix: the
+    /// model must read it from injected context, not echo it back out of the question.
+    /// </summary>
+    public static string SecondTurnProbePrompt =>
+        "A block headed '## Team memory' may have been injected into your context at the start of THIS "
+      + "prompt. If it contains a string of the form kcap-live-probe2- followed by 32 hex characters, "
+      + "reply with ONLY that exact string and nothing else. Otherwise reply with ONLY the word NONE. "
+      + "Disregard any kcap-live-nonce- string entirely; it is not what this question asks about.";
+
+    /// <summary>
     /// Gate. MUST be the first statement in every cert: it returns before any process launch, HTTP
     /// call, or memory write, which is what keeps CI spend at exactly zero.
     /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -95,37 +95,80 @@ internal static class MemoryIndexLiveCertHarness {
     }
 
     /// <summary>
-    /// Saves a user-scoped, repo-independent ("global") memory whose description embeds the nonce,
-    /// through the same <c>POST /api/memories</c> contract <c>kcap mcp memory</c>'s
-    /// <c>save_memory</c> uses. Global sidesteps needing a real repo hash for a throwaway worktree.
+    /// Drives one <c>kcap mcp memory</c> tool call as a SUBPROCESS and returns its raw stdout.
+    ///
+    /// <para><b>Why a subprocess and not an in-process HttpClient.</b> This assembly redirects
+    /// <c>KCAP_CONFIG_DIR</c> to a throwaway directory for its whole lifetime
+    /// (<c>RepoPathStoreTests</c>'s <c>[Before(Assembly)]</c> hook), so in-process credential
+    /// resolution reads an EMPTY config: every authenticated call 401s with "Not authenticated" even
+    /// though `kcap whoami` succeeds in a shell a second earlier. A real `kcap` child reads the real
+    /// config, so routing the memory lifecycle through the CLI is the only way a cert in this assembly
+    /// can authenticate at all. It is also closer to what we are certifying — the same binary the
+    /// harness hook invokes.</para>
+    ///
+    /// <para>Speaks just enough MCP: initialize, initialized, then one <c>tools/call</c>, all written
+    /// up front. The server processes them in order and exits on stdin EOF, which is exactly the
+    /// write-then-close shape <see cref="RunProcessAsync"/> already provides.</para>
     /// </summary>
-    public static async Task<string> SaveNonceMemoryAsync(
-            HttpClient client, string baseUrl, string vendorLabel, string nonce) {
-        var body = McpMemoryServer.BuildSaveBody(new JsonObject {
+    static async Task<string> CallMemoryToolAsync(string toolName, JsonObject arguments) {
+        var stdin = string.Join('\n', [
+            new JsonObject {
+                ["jsonrpc"] = "2.0", ["id"] = 1, ["method"] = "initialize",
+                ["params"] = new JsonObject {
+                    ["protocolVersion"] = "2024-11-05",
+                    ["capabilities"]    = new JsonObject(),
+                    ["clientInfo"]      = new JsonObject { ["name"] = "kcap-live-cert", ["version"] = "1" }
+                }
+            }.ToJsonString(),
+            new JsonObject { ["jsonrpc"] = "2.0", ["method"] = "notifications/initialized" }.ToJsonString(),
+            new JsonObject {
+                ["jsonrpc"] = "2.0", ["id"] = 2, ["method"] = "tools/call",
+                ["params"] = new JsonObject { ["name"] = toolName, ["arguments"] = arguments }
+            }.ToJsonString()
+        ]) + "\n";
+
+        var (exitCode, stdout, stderr) = await RunProcessAsync(
+            "kcap", ["mcp", "memory"], workingDirectory: null, timeout: TimeSpan.FromSeconds(60), stdin: stdin);
+
+        if (stdout.Length == 0) {
+            throw new InvalidOperationException(
+                $"`kcap mcp memory` {toolName} produced no stdout (exit {exitCode}): {stderr}");
+        }
+
+        return stdout;
+    }
+
+    /// <summary>
+    /// Saves a user-scoped, repo-independent ("global") memory whose description embeds the nonce.
+    /// Global sidesteps needing a real repo hash for a throwaway worktree, and the description is
+    /// where the nonce must live: the injected index carries <c>slug: description</c> lines, so this
+    /// is what makes the cert answerable from injected context alone.
+    /// </summary>
+    public static async Task<string> SaveNonceMemoryAsync(string vendorLabel, string nonce) {
+        var stdout = await CallMemoryToolAsync("save_memory", new JsonObject {
             ["audience"]    = "user",
             ["slug"]        = $"live-cert-{nonce}",
             ["description"] = $"kcap {vendorLabel} memory live-cert nonce: {nonce}",
             ["content"]     = $"kcap {vendorLabel} memory live-cert nonce: {nonce}. Safe to archive after the run.",
             ["kind"]        = "reference",
             ["global"]      = true
-        }, cwdRepoHash: null, machineId: null);
+        });
 
-        using var resp = await client.PostAsJsonAsync($"{baseUrl}/api/memories", body);
-        resp.EnsureSuccessStatusCode();
-        var created = await resp.Content.ReadFromJsonAsync<JsonObject>();
+        // The id is dug out of the response text rather than a pinned envelope path: an MCP tool
+        // result nests its payload as a JSON string inside content[].text, and that wrapping is the
+        // server's business, not this cert's. Failing loudly here (rather than returning null and
+        // archiving nothing) is what stops a cert leaking a memory into every later run's index.
+        var id = System.Text.RegularExpressions.Regex.Match(stdout, "\"memory_id\"\\s*:\\s*\\\\?\"([^\"\\\\]+)");
 
-        return created?["memory_id"]?.GetValue<string>()
-            ?? throw new InvalidOperationException("Save response carried no memory_id.");
+        return id.Success
+            ? id.Groups[1].Value
+            : throw new InvalidOperationException($"save_memory returned no memory_id. stdout: {stdout}");
     }
 
     /// <summary>Best-effort cleanup: a leaked cert memory would pollute every later run's index.</summary>
-    public static async Task ArchiveMemoryAsync(HttpClient client, string baseUrl, string vendorLabel, string memoryId) {
+    public static async Task ArchiveMemoryAsync(string vendorLabel, string memoryId) {
         try {
-            using var resp = await client.DeleteAsync($"{baseUrl}/api/memories/{Uri.EscapeDataString(memoryId)}");
-            if (!resp.IsSuccessStatusCode) {
-                await Console.Error.WriteLineAsync(
-                    $"[{vendorLabel}-memory-live] failed to archive live-cert memory {memoryId}: HTTP {(int)resp.StatusCode}");
-            }
+            await CallMemoryToolAsync("archive_memory", new JsonObject { ["memory_id"] = memoryId });
         } catch (Exception ex) {
             await Console.Error.WriteLineAsync(
                 $"[{vendorLabel}-memory-live] failed to archive live-cert memory {memoryId}: {ex.Message}");

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -58,28 +58,6 @@ internal static class MemoryIndexLiveCertHarness {
     public static string NegativePrompt => PositivePrompt;
 
     /// <summary>
-    /// A second-turn probe with a DISTINCT prefix from <see cref="NewNonce"/>.
-    ///
-    /// <para>Needed because a re-injection test cannot share a pattern with the memory it is trying to
-    /// distinguish itself from. If both matched <c>kcap-live-nonce-</c> and the lease broke, the
-    /// re-injected index would carry both, and a prompt asking for "a string of that form" lets the
-    /// model return the FIRST one — which the history has already reinforced — so an assertion that the
-    /// second is absent passes while a second fetch demonstrably happened.</para>
-    /// </summary>
-    public static string NewSecondTurnProbe() => $"kcap-live-probe2-{Guid.NewGuid():N}";
-
-    /// <summary>
-    /// Asks only about <see cref="NewSecondTurnProbe"/>'s prefix, and explicitly tells the model to
-    /// disregard the first-turn pattern. Deliberately does NOT contain the probe's random suffix: the
-    /// model must read it from injected context, not echo it back out of the question.
-    /// </summary>
-    public static string SecondTurnProbePrompt =>
-        "A block headed '## Team memory' may have been injected into your context at the start of THIS "
-      + "prompt. If it contains a string of the form kcap-live-probe2- followed by 32 hex characters, "
-      + "reply with ONLY that exact string and nothing else. Otherwise reply with ONLY the word NONE. "
-      + "Disregard any kcap-live-nonce- string entirely; it is not what this question asks about.";
-
-    /// <summary>
     /// Gate. MUST be the first statement in every cert: it returns before any process launch, HTTP
     /// call, or memory write, which is what keeps CI spend at exactly zero.
     /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
@@ -116,6 +116,57 @@ public class MemoryIndexLiveCertHarnessTests {
         await Assert.That(MemoryIndexLiveCertHarness.ArchiveSucceeded(frame)).IsFalse();
     }
 
+    // Restoring the REAL profile flag is this file's highest-consequence action: a wrong value leaves a
+    // developer's machine with memory injection in the wrong state, silently, for days. So the read
+    // must never guess — an unreadable config has to be distinguishable from a genuinely unset flag,
+    // because the two imply opposite restores.
+    [Test]
+    public async Task A_missing_active_profile_is_a_read_failure_not_an_absent_flag() {
+        var source = await File.ReadAllTextAsync(HarnessSourcePath());
+
+        var start = source.IndexOf("public static async Task<bool?> ReadDisableMemoryIndexAsync()", StringComparison.Ordinal);
+        await Assert.That(start).IsGreaterThan(-1);
+
+        var body = source.Substring(start, Math.Min(1600, source.Length - start));
+
+        // Every failure branch throws; only the genuinely-unset case may return null.
+        await Assert.That(body).Contains("throw new InvalidOperationException");
+        await Assert.That(body).DoesNotContain("return null;");
+    }
+
+    // A discarded exit code here makes a negative control pass vacuously (injection was never actually
+    // disabled) or leaves the real profile disabled after the run. The pre-existing Claude cert asserts
+    // it; an earlier draft of this shared harness dropped that guard.
+    [Test]
+    public async Task Setting_the_real_flag_fails_loudly_rather_than_discarding_the_exit_code() {
+        var source = await File.ReadAllTextAsync(HarnessSourcePath());
+
+        var start = source.IndexOf("public static async Task SetDisableMemoryIndexAsync(bool value)", StringComparison.Ordinal);
+        await Assert.That(start).IsGreaterThan(-1);
+
+        var body = source.Substring(start, Math.Min(900, source.Length - start));
+
+        await Assert.That(body).Contains("exitCode != 0");
+        await Assert.That(body).Contains("throw new InvalidOperationException");
+    }
+
+    // A restore that silently no-ops is indistinguishable from success without a read-back.
+    [Test]
+    public async Task Restoring_the_real_flag_reads_it_back_to_confirm() {
+        var source = await File.ReadAllTextAsync(HarnessSourcePath());
+
+        var start = source.IndexOf("public static async Task RestoreDisableMemoryIndexAsync(bool? original)", StringComparison.Ordinal);
+        await Assert.That(start).IsGreaterThan(-1);
+
+        var body = source.Substring(start, Math.Min(900, source.Length - start));
+
+        await Assert.That(body).Contains("ReadDisableMemoryIndexAsync");
+        await Assert.That(body).Contains("readBack != target");
+    }
+
+    static string HarnessSourcePath() => Path.Combine(
+        RepoRoot(), "test", "Capacitor.Cli.Tests.Unit", "SessionStartMemory", "MemoryIndexLiveCertHarness.cs");
+
     /// <summary>Walks up from this file's compile-time path to the repo root.</summary>
     static string RepoRoot([System.Runtime.CompilerServices.CallerFilePath] string here = "") {
         var dir = Path.GetDirectoryName(here);

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
@@ -95,6 +95,56 @@ public class MemoryIndexLiveCertHarnessTests {
         }
     }
 
+    // 13 cert memories leaked into the live index because archive_memory was sent `memory_id` (what
+    // save_memory RETURNS) instead of `id` (what archive_memory ACCEPTS), and the failure was
+    // swallowed. A leaked nonce is not cosmetic — it enters the REAL injected index, so a later
+    // positive cert can pass on a stale nonce rather than the one it just saved.
+    [Test]
+    public async Task An_explicit_ok_is_the_only_thing_counted_as_archived() {
+        await Assert.That(MemoryIndexLiveCertHarness.ArchiveSucceeded(
+            """{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":true}"}]}}"""))
+            .IsTrue();
+    }
+
+    [Test]
+    [Arguments("""{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Not logged in."}],"isError":true}}""")]
+    [Arguments("""{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":false}"}]}}""")]
+    [Arguments("""{"jsonrpc":"2.0","id":2,"result":{"content":[]}}""")]
+    [Arguments("""{"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"unknown argument memory_id"}}""")]
+    [Arguments("not json at all")]
+    public async Task Anything_short_of_an_explicit_ok_is_treated_as_a_leak(string frame) {
+        await Assert.That(MemoryIndexLiveCertHarness.ArchiveSucceeded(frame)).IsFalse();
+    }
+
+    /// <summary>Walks up from this file's compile-time path to the repo root.</summary>
+    static string RepoRoot([System.Runtime.CompilerServices.CallerFilePath] string here = "") {
+        var dir = Path.GetDirectoryName(here);
+
+        while (dir is not null && !File.Exists(Path.Combine(dir, "Capacitor.slnx")))
+            dir = Path.GetDirectoryName(dir);
+
+        return dir ?? throw new InvalidOperationException($"repo root not found from {here}");
+    }
+
+    // The other half of the leak, which no assertion on a response frame can catch: the ARGUMENT NAME.
+    // save_memory returns `memory_id`; archive_memory accepts `id`. Sending the former archived nothing
+    // and returned a frame that looked fine. Pinned at the source, since reaching it for real needs a
+    // live authenticated server.
+    [Test]
+    public async Task Archive_is_called_with_id_not_the_memory_id_that_save_returns() {
+        var source = await File.ReadAllTextAsync(Path.Combine(
+            RepoRoot(), "test", "Capacitor.Cli.Tests.Unit", "SessionStartMemory",
+            "MemoryIndexLiveCertHarness.cs"));
+
+        var start = source.IndexOf("CallMemoryToolAsync(\"archive_memory\"", StringComparison.Ordinal);
+        await Assert.That(start).IsGreaterThan(-1);
+
+        var callSite = source.Substring(start, Math.Min(160, source.Length - start));
+
+        await Assert.That(callSite).Contains("[\"id\"]");
+        await Assert.That(callSite).DoesNotContain("memory_id");
+    }
+
     [Test]
     public async Task A_timed_out_process_is_killed_rather_than_left_running() {
         var (fileName, args) = OperatingSystem.IsWindows()

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
@@ -1,0 +1,148 @@
+namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
+
+/// <summary>
+/// Ungated, CI-safe coverage for the parts of the shared live-cert scaffold that do NOT need a live
+/// harness process. The certs themselves are gated and therefore never exercised by CI, so without
+/// these the scaffold would be entirely untested — a parser or cleanup bug would surface only during
+/// a manual certification run, i.e. after spending a real model turn.
+/// </summary>
+public class MemoryIndexLiveCertHarnessTests {
+    [Test]
+    public async Task Plain_text_output_is_returned_as_is() {
+        await Assert.That(MemoryIndexLiveCertHarness.ExtractAssistantAnswer("  kcap-live-nonce-abc123  \n"))
+            .IsEqualTo("kcap-live-nonce-abc123");
+    }
+
+    [Test]
+    public async Task Single_json_object_with_a_result_field_extracts_the_text() {
+        await Assert.That(MemoryIndexLiveCertHarness.ExtractAssistantAnswer(
+            """{"type":"result","result":"kcap-live-nonce-abc123"}"""))
+            .IsEqualTo("kcap-live-nonce-abc123");
+    }
+
+    [Test]
+    public async Task Newline_delimited_json_stream_extracts_the_first_matching_text_field() {
+        var stdout = """
+                     {"type":"system","subtype":"init"}
+                     {"type":"assistant","message":{"content":[{"type":"text","text":"kcap-live-nonce-abc123"}]}}
+                     """;
+
+        await Assert.That(MemoryIndexLiveCertHarness.ExtractAssistantAnswer(stdout))
+            .IsEqualTo("kcap-live-nonce-abc123");
+    }
+
+    [Test]
+    public async Task Empty_output_returns_empty() {
+        await Assert.That(MemoryIndexLiveCertHarness.ExtractAssistantAnswer("   \n  ")).IsEqualTo("");
+    }
+
+    // A cert asserts Contains(nonce) / DoesNotContain(nonce) on this parser's output, so a parser that
+    // silently dropped the answer would make the NEGATIVE control pass vacuously. Pin that plain
+    // markdown prose (Kiro's `--format plain` shape) survives intact.
+    [Test]
+    public async Task Markdown_prose_containing_the_nonce_is_preserved() {
+        var stdout = "> I found this in the team memory block:\n\nkcap-live-nonce-deadbeef\n";
+
+        await Assert.That(MemoryIndexLiveCertHarness.ExtractAssistantAnswer(stdout))
+            .Contains("kcap-live-nonce-deadbeef");
+    }
+
+    [Test]
+    public async Task Leading_json_block_extraction_splits_on_an_lf_blank_line() {
+        var stdout = "{\"active_profile\":\"default\"}\n\nPath: ~/.config/kcap/config.json\n";
+
+        await Assert.That(MemoryIndexLiveCertHarness.ExtractLeadingJsonBlock(stdout))
+            .IsEqualTo("{\"active_profile\":\"default\"}");
+    }
+
+    [Test]
+    public async Task Leading_json_block_extraction_tolerates_a_crlf_blank_line() {
+        var stdout = "{\"active_profile\":\"default\"}\r\n\r\nPath: C:\\Users\\me\\config.json\r\n";
+
+        await Assert.That(MemoryIndexLiveCertHarness.ExtractLeadingJsonBlock(stdout))
+            .IsEqualTo("{\"active_profile\":\"default\"}");
+    }
+
+    [Test]
+    public async Task Each_nonce_is_unique_and_matches_the_shape_the_prompts_ask_for() {
+        var a = MemoryIndexLiveCertHarness.NewNonce();
+        var b = MemoryIndexLiveCertHarness.NewNonce();
+
+        await Assert.That(a).IsNotEqualTo(b);
+        await Assert.That(a).Matches("^kcap-live-nonce-[0-9a-f]{32}$");
+        await Assert.That(MemoryIndexLiveCertHarness.PositivePrompt).Contains("kcap-live-nonce-");
+    }
+
+    // The negative control MUST ask the identical question, or a false positive could come from the
+    // wording rather than from the index being absent.
+    [Test]
+    public async Task The_negative_control_asks_the_identical_question() {
+        await Assert.That(MemoryIndexLiveCertHarness.NegativePrompt)
+            .IsEqualTo(MemoryIndexLiveCertHarness.PositivePrompt);
+    }
+
+    [Test]
+    public async Task A_cert_worktree_is_a_fresh_empty_directory() {
+        var first  = MemoryIndexLiveCertHarness.NewCertWorktree("probe");
+        var second = MemoryIndexLiveCertHarness.NewCertWorktree("probe");
+
+        try {
+            await Assert.That(first.FullName).IsNotEqualTo(second.FullName);
+            await Assert.That(first.EnumerateFileSystemInfos()).IsEmpty();
+        } finally {
+            try { first.Delete(recursive: true); } catch { /* best-effort */ }
+            try { second.Delete(recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Test]
+    public async Task A_timed_out_process_is_killed_rather_than_left_running() {
+        var (fileName, args) = OperatingSystem.IsWindows()
+            ? ("cmd.exe", (IReadOnlyList<string>) ["/c", "ping", "-n", "120", "127.0.0.1"])
+            : ("sleep", (IReadOnlyList<string>) ["120"]);
+
+        int? pid = null;
+        MemoryIndexLiveCertHarness.OnProcessStarted = p => pid = p;
+
+        try {
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                MemoryIndexLiveCertHarness.RunProcessAsync(
+                    fileName, args, workingDirectory: null, timeout: TimeSpan.FromMilliseconds(200)));
+        } finally {
+            MemoryIndexLiveCertHarness.OnProcessStarted = null;
+        }
+
+        await Assert.That(pid).IsNotNull();
+
+        var deadline   = DateTime.UtcNow.AddSeconds(5);
+        var stillAlive = true;
+
+        while (DateTime.UtcNow < deadline) {
+            try {
+                using var proc = System.Diagnostics.Process.GetProcessById(pid!.Value);
+                if (proc.HasExited) { stillAlive = false; break; }
+            } catch (ArgumentException) {
+                stillAlive = false;
+                break;
+            }
+            await Task.Delay(50);
+        }
+
+        await Assert.That(stillAlive).IsFalse();
+    }
+
+    // stdin is how Codex receives its prompt; if the harness failed to write-and-close it, `codex exec -`
+    // would block forever and the cert would time out after spending nothing but wall-clock.
+    [Test]
+    public async Task Supplied_stdin_is_written_and_closed_so_a_reader_sees_eof() {
+        var (fileName, args) = OperatingSystem.IsWindows()
+            ? ("cmd.exe", (IReadOnlyList<string>) ["/c", "more"])
+            : ("cat", (IReadOnlyList<string>) []);
+
+        var (exitCode, stdout, _) = await MemoryIndexLiveCertHarness.RunProcessAsync(
+            fileName, args, workingDirectory: null, timeout: TimeSpan.FromSeconds(20), stdin: "kcap-stdin-probe");
+
+        await Assert.That(exitCode).IsEqualTo(0);
+        await Assert.That(stdout).Contains("kcap-stdin-probe");
+    }
+}


### PR DESCRIPTION
Adds gated live-receipt certification for the three SessionStart memory adapters that shipped with unit tests only, certifies what is certifiable, and fixes a Codex handshake hazard found while diagnosing.

Linear: AI-1591 (see also AI-1592, resolved)

## Why these certs exist

Unit tests prove the **bytes we emit**. They cannot prove the harness **surfaces those bytes to the model**. Cursor IDE is the standing counterexample: byte-perfect `additional_context`, model receipt not guaranteed. Only a real turn distinguishes "we emitted it" from "the model got it".

They earned their cost immediately — on first run they surfaced that Codex, Copilot and Kiro were all delivering nothing. That turned out to be a **stale installed binary**, not a code defect (AI-1592): PATH held kcap 0.11.8, tagged five days before the three adapters merged, and its Codex/Copilot/Kiro hooks contained zero memory references.

## CI cost: zero, verified

`SkipUnlessLiveGateReady` is the first statement in every cert — a runtime `Skip.Unless` before any process launch, HTTP call or memory write — requiring **both** `KCAP_<VENDOR>_MEMORY_LIVE=1` and a non-empty `KCAP_URL`. With the gate unset all **6** certs report `skipped`. Cost lands only on a deliberate manual run.

## What is certified

Against a local build of this branch, PATH-prepended, the installed CLI untouched:

| Cert | Result |
|---|---|
| Codex positive | **PASS** — codex-cli 0.144.3 |
| Copilot positive | **PASS** — copilot 1.0.75 |
| Kiro positive | **PASS** — kiro-cli 2.12.1 |

**Negative controls not re-run live.** They toggle the shared profile's `disable_memory_index` while other sessions run on this machine. Unit-covered; they run with the official certs post-release.

## What is explicitly NOT certified, and why

Kiro's **once-per-session dedupe** — the property the whole Kiro adapter rests on — is **unit-covered only**.

An earlier revision of this PR claimed to certify it via `kiro-cli chat --resume`. Review showed that cert could false-pass, and fixing it revealed the premise was wrong. Measured directly on 2026-07-30:

- Kiro's chat SessionId is **unchanged** across `--resume`, and the conversation genuinely continues (`2 msgs` → `4 msgs`);
- but the lease store gained **two distinct records five seconds apart**, one per invocation.

So the **hook's `session_id` differs per invocation**. A resumed turn is a new session to kcap, and re-injecting into it is *correct* — the cert was asserting a bug. Two processes are not two prompts in one session. Observing the real property needs several prompts inside ONE interactive process (PTY automation), which this suite does not do. The cert was removed rather than left passing for the wrong reason, with the measurement recorded in the class doc so nobody rebuilds it the same way.

## One scaffold, not five copies

Claude and Cursor each carry a private ~300-line copy of this scaffold. Rather than add a fourth and fifth, `MemoryIndexLiveCertHarness` holds it once and each vendor cert is just the gate, the CLI invocation and the assertions. The two pre-existing certs are left alone deliberately — they are gated, hence not exercised by CI, so refactoring them blind is a worse risk than the duplication. Migrating them is a follow-up.

## Four infrastructure blockers hit building this

1. **In-process auth is impossible in this assembly.** `RepoPathStoreTests`'s `[Before(Assembly)]` points `KCAP_CONFIG_DIR` at a throwaway dir for the whole lifetime, so credential resolution reads an empty config and 401s — while `kcap whoami` succeeds in a shell. The memory lifecycle therefore runs through a `kcap mcp memory` **subprocess**, which is also closer to what is being certified.
2. **Children inherit that redirect.** Both spawn sites drop `KCAP_CONFIG_DIR` — which matters for the harness CLIs too, since each invokes `kcap hook` itself.
3. **MCP needs interactive stdio.** A server dispatches per line and stops at stdin EOF, so writing all frames then closing raced the `tools/call`.
4. **`archive_memory` takes `id`, not the `memory_id` that `save_memory` returns.** Sending the save's name back archived nothing and a catch-all hid it — **13 nonce memories leaked into the real index**. Not cosmetic: a leaked nonce enters the *injected* index, so a later positive cert can pass on a stale one. Now uses `id`, verifies the tool's own `ok`, and reports leaks loudly by id. All 13 archived; zero remain.

## The cert's own blind spot, now closed

The certs recorded the **harness** version but never the **kcap** version the hooks resolve from PATH — and PATH points at the npm install, not the tree the cert was compiled from. That is exactly what made AI-1592 a two-session hunt. `RecordCertEnvironmentAsync` now logs the harness version, `kcap --version`, and the resolved `which kcap` path, from **every** cert including the negative controls.

## Fail-closed handling of the real config flag

The negative controls mutate a real machine setting, so the harness now: throws on an unreadable config rather than conflating it with an unset flag (restoring `false` over a real `true` would silently re-enable injection for someone who opted out); asserts the `kcap config set` exit code (a failed enable makes the control vacuous, a failed restore leaves injection off); reads the value back to confirm the restore; and archives inside a nested `finally` so a restore throw cannot skip cleanup. Reads happen before anything is created, and the temp worktree before the remote save, so no failure path strands a memory.

## Bonus fix: Codex handshake on a rejected POST

Codex blocks on this hook's stdout and its parser rejects empty output, but an early `return 1` on `Failed` sat **before** the handshake. A server 4xx left Codex with zero bytes — no `continue`, no context, just a wait for its hook timeout. Verified by hand. The handshake now runs on every outcome; the non-zero exit is reported after it. The watcher still doesn't spawn (`RunPostStdoutWork` gates on `ShouldSpawnAfter`). Narrow by construction: `PostOrSpoolAsync` returns `Failed` only for a genuine non-2xx.

## Tests

**22 ungated CI-safe tests** covering the scaffold — without them it would be wholly untested, since the certs never run in CI. Parser shapes, nonce shape, identical negative prompt, fresh worktree, timeout kills the child, stdin written *and* closed, explicit-`ok`-only archive acceptance across five failure shapes, and three guards for the fail-closed config properties.

**Two mutation-tested guards**, because a guard that never fails proves nothing:
- archive argument name — reverting to `memory_id` fails it
- Codex handshake-on-failure — restoring the early return fails it on empty stdout

Worth recording: the first mutation run reported a **false pass** off a stale build while concurrent builds were in flight. `dotnet build-server shutdown` plus an explicit build before `--no-build` is what made it truthful.

## Docs

README matrix rows flipped to certified with the observed harness versions and, for Codex, the kcap version floor. Kiro's row states the dedupe is unit-covered only, with the reason. No row flipped on unit evidence.

## Known follow-ups, not in this PR

- **A kcap release is the remaining blocker for users**: npm latest is still 0.11.8, so the adapters are inert for anyone installing today.
- Migrating the Claude and Cursor certs onto the shared scaffold, and re-certifying them — their in-process pattern means they have almost certainly never run.
- Certifying Kiro's per-prompt dedupe would need PTY automation of an interactive session.