### PR TITLE
Make the `kcap agent` commands flow-participant aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,7 +961,7 @@ Agent ids are long, so `attach` and `stop` accept **any unique prefix** — an a
 - `kcap agent attach` on one is **read-only** — you see its output, your keystrokes are not delivered, and your terminal size is not applied to it.
 - `kcap agent stop` on one is **refused** unless you pass `--force`, and `stop --all` skips them and says how many it skipped.
 
-Enforcement is in the daemon, so this holds regardless of client version. It does not apply when talking to a daemon older than this feature — that daemon reports no kind, every agent reads as `agent`, and the protections do not engage until it restarts onto the new binary.
+Enforcement lives in the daemon, so a current CLI can't bypass it by skipping the check or lying about `--force`. That guarantee has two version-skew exceptions: an old `kcap` sends the legacy `Stop` request, which has no `--force` concept — the daemon treats that as `--force`, so an old client can silently force-stop a review or review-flow agent. And against an old daemon, `ls`/`attach` degrade silently (no kind reported, every agent reads as `agent`), but `stop` doesn't degrade — it sends a newer request format the old daemon can't decode, so the connection closes and the CLI tells you to restart the daemon instead of stopping anything.
 
 `agent start` auto-starts the daemon if one isn't already running, and needs a configured server for the daemon to record to. `ls`, `attach`, and `stop` only talk to the local socket, so they work without one. A locally-started agent appears in **your own** web UI (owner-only until you share it from the web UI); use `--private` to opt out of registration entirely. Unix only for now.
 

--- a/README.md
+++ b/README.md
@@ -948,7 +948,7 @@ kcap agent start claude -d                    # start without attaching; prints 
 
 ```bash
 kcap agent                 # no subcommand — same as `kcap agent ls`
-kcap agent ls              # list daemon-hosted agents (id, status, repo)
+kcap agent ls              # list daemon-hosted agents (id, status, kind, repo)
 kcap agent attach ab12     # re-attach your terminal (any unique id prefix works)
 kcap agent stop ab12       # graceful /exit, then terminate
 kcap agent stop --all -y   # stop every agent this daemon hosts, no prompt

--- a/README.md
+++ b/README.md
@@ -954,7 +954,14 @@ kcap agent stop ab12       # graceful /exit, then terminate
 kcap agent stop --all -y   # stop every agent this daemon hosts, no prompt
 ```
 
-Agent ids are long, so `attach` and `stop` accept **any unique prefix** — an ambiguous one lists the candidates instead of guessing. `stop --all` includes `--private` agents and prompts for confirmation unless you pass `--yes`/`-y`. `--all` stops **every** agent this daemon hosts, not just the ones you started from this CLI — including agents launched from the web UI and review-flow participants (e.g. reviewers mid-round). Making these commands flow-participant aware is tracked in [#379](https://github.com/kurrent-io/kcap-cli/issues/379). If a stop can't be confirmed (e.g. an agent that never exits, even after SIGKILL), `stop` prints a per-agent "Failed to stop `<id>` — see `kcap daemon logs`." line and exits non-zero; `stop --all` still stops the rest and reports each agent's outcome individually.
+Agent ids are long, so `attach` and `stop` accept **any unique prefix** — an ambiguous one lists the candidates instead of guessing. `stop --all` includes `--private` agents and prompts for confirmation unless you pass `--yes`/`-y`; a stop that cannot be confirmed prints a per-agent failure line and exits non-zero.
+
+**Agents that aren't yours.** `kcap agent ls` shows a `KIND` column: `agent` for ones you started, `review` for PR-review agents, and `review-flow` for review-flow participants (with their role). The daemon protects the latter two, because they are driven by the flow protocol rather than by you:
+
+- `kcap agent attach` on one is **read-only** — you see its output, your keystrokes are not delivered, and your terminal size is not applied to it.
+- `kcap agent stop` on one is **refused** unless you pass `--force`, and `stop --all` skips them and says how many it skipped.
+
+Enforcement is in the daemon, so this holds regardless of client version. It does not apply when talking to a daemon older than this feature — that daemon reports no kind, every agent reads as `agent`, and the protections do not engage until it restarts onto the new binary.
 
 `agent start` auto-starts the daemon if one isn't already running, and needs a configured server for the daemon to record to. `ls`, `attach`, and `stop` only talk to the local socket, so they work without one. A locally-started agent appears in **your own** web UI (owner-only until you share it from the web UI); use `--private` to opt out of registration entirely. Unix only for now.
 

--- a/docs/superpowers/plans/2026-07-29-ai1557-flow-participant-aware-agent-commands.md
+++ b/docs/superpowers/plans/2026-07-29-ai1557-flow-participant-aware-agent-commands.md
@@ -1,0 +1,1030 @@
+# Flow-Participant-Aware `kcap agent` Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `kcap agent ls|attach|stop` recognise review and review-flow agents, show them, attach to them read-only, and refuse to stop them without `--force`.
+
+**Architecture:** The daemon already knows each agent's `LaunchKind` and flow identity; it just never tells the CLI. This carries that across the local socket (three new `AgentList` columns) and enforces protection **daemon-side** for both attach (a new `AttachedReadOnly` frame plus a no-input attach loop) and stop (a new `StopV2` frame carrying a force flag, plus a `skipped` status in `StopAck`).
+
+**Tech Stack:** .NET 10, NativeAOT, TUnit on Microsoft Testing Platform, custom length-prefixed binary IPC over a Unix domain socket.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-ai1557-flow-participant-aware-agent-commands-design.md`
+
+## Global Constraints
+
+- **The protected set is `Kind != LaunchKind.Default`** — `Review` and `ReviewFlow`. Plain web-UI-launched agents (`Default`) are deliberately NOT protected.
+- **Enforcement is daemon-side.** The CLI may mirror a check for a better message, but the daemon must refuse independently — a stale or hand-rolled client cannot bypass protection.
+- **`FrameType` is append-only.** Never renumber or reuse. New values: `StopV2 = 10`, `AttachedReadOnly = 71`.
+- **A read-only viewer never resizes the PTY.** It must not be entered into `AgentInstance.ClientDims`, and its `Resize` frames are ignored.
+- **Do not touch** the `if (agent.IsPrivate) return;` guard in `HandleStopAgent`, or any server-origin stop behaviour.
+- **`AgentRow` parsing accepts 3 or more columns**, defaulting the new ones — a running older daemon must still list correctly.
+- Comment style: self-explanatory code over prose; no Linear issue numbers in comments (GitHub numbers like #379 are fine).
+- **AOT:** verify with `dotnet publish -c Release`, not `dotnet build`. Note `[]` has no natural type, so `var x = cond ? [] : arr;` will not compile — use an explicit type.
+- **Docs land in the same PR**: `README.md` *and* `help-agent.txt`.
+- Run tests as executables: `dotnet run --project test/<proj>/<proj>.csproj`. Filter with `--treenode-filter` (glob syntax), **never** `--filter`.
+- **Known test baseline:** the unit suite has ~42 pre-existing failures in `CodexHookCommandTests` and the uninstall/`config.toml` area, confirmed at the branch's merge base. The gate is **no NEW failures**; the count wobbles 42-43.
+
+---
+
+### Task 1: Carry and show the agent's kind
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs` (`HandleLocalListAsync`)
+- Modify: `src/Capacitor.Cli/Commands/AgentCommand.cs` (`AgentRow`, `FetchAgentsAsync`, `ListAsync`)
+- Test: `test/Capacitor.Cli.Tests.Unit/AgentIdResolutionTests.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs`
+
+**Interfaces:**
+- Produces: `internal readonly record struct AgentRow(string Id, string Status, string Repo, string Kind, string FlowRunId, string FlowRole)`; `internal static AgentRow ParseAgentRow(string line)` on `AgentCommand`; `internal static bool IsProtectedKind(string kind)` on `AgentCommand`; `static string KindText(LaunchKind kind)` on `AgentOrchestrator`.
+- Consumes: existing `AgentInstance.Kind` / `.FlowRunId` / `.FlowRole`, and `LaunchKind { Default, Review, ReviewFlow }` from `Capacitor.Cli.Core.Models`.
+
+- [ ] **Step 1: Write the failing CLI parse tests**
+
+Append to `test/Capacitor.Cli.Tests.Unit/AgentIdResolutionTests.cs`, inside the class:
+
+```csharp
+    [Test]
+    public async Task Row_from_a_current_daemon_carries_kind_and_flow() {
+        var row = AgentCommand.ParseAgentRow("ab12\tRunning\t/repo\treview-flow\tflow-7f3a\treviewer");
+        await Assert.That(row.Id).IsEqualTo("ab12");
+        await Assert.That(row.Status).IsEqualTo("Running");
+        await Assert.That(row.Repo).IsEqualTo("/repo");
+        await Assert.That(row.Kind).IsEqualTo("review-flow");
+        await Assert.That(row.FlowRunId).IsEqualTo("flow-7f3a");
+        await Assert.That(row.FlowRole).IsEqualTo("reviewer");
+    }
+
+    [Test]
+    public async Task Row_from_an_older_daemon_defaults_to_an_unprotected_agent() {
+        // An older daemon sends three columns. Treating the missing kind as `agent` is what
+        // makes the group keep working against it — protection simply does not engage.
+        var row = AgentCommand.ParseAgentRow("ab12\tRunning\t/repo");
+        await Assert.That(row.Kind).IsEqualTo("agent");
+        await Assert.That(row.FlowRunId).IsEqualTo("");
+        await Assert.That(row.FlowRole).IsEqualTo("");
+        await Assert.That(AgentCommand.IsProtectedKind(row.Kind)).IsFalse();
+    }
+
+    [Test]
+    public async Task Review_and_review_flow_are_protected_and_agent_is_not() {
+        await Assert.That(AgentCommand.IsProtectedKind("review")).IsTrue();
+        await Assert.That(AgentCommand.IsProtectedKind("review-flow")).IsTrue();
+        await Assert.That(AgentCommand.IsProtectedKind("agent")).IsFalse();
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/AgentIdResolutionTests/*"`
+Expected: FAIL — compile error, `ParseAgentRow` and `IsProtectedKind` do not exist.
+
+- [ ] **Step 3: Widen `AgentRow` and add the parser**
+
+In `src/Capacitor.Cli/Commands/AgentCommand.cs`, replace the `AgentRow` declaration:
+
+```csharp
+/// One row of the daemon's agent table (`id\tstatus\trepo\tkind\tflowRunId\tflowRole` on the
+/// wire). A daemon older than #379 sends only the first three; the rest default.
+internal readonly record struct AgentRow(
+    string Id, string Status, string Repo, string Kind, string FlowRunId, string FlowRole);
+```
+
+Then add to the `AgentCommand` class, next to `ResolveAgentId`:
+
+```csharp
+    /// Kinds the CLI refuses to mutate by accident: a reviewer mid-round is not the user's to
+    /// type at or stop. Mirrors LaunchKind — anything that is not a plain agent is protected.
+    internal static bool IsProtectedKind(string kind) => kind is "review" or "review-flow";
+
+    /// <summary>Tolerates a short row from an older daemon by defaulting the newer columns.</summary>
+    internal static AgentRow ParseAgentRow(string line) {
+        var p = line.Split('\t');
+
+        return new AgentRow(
+            p[0],
+            p.Length > 1 ? p[1] : "",
+            p.Length > 2 ? p[2] : "",
+            p.Length > 3 && p[3].Length > 0 ? p[3] : "agent",
+            p.Length > 4 ? p[4] : "",
+            p.Length > 5 ? p[5] : "");
+    }
+```
+
+- [ ] **Step 4: Route `FetchAgentsAsync` through the parser**
+
+In `FetchAgentsAsync`, replace the projection:
+
+```csharp
+            return [.. resp.Text.Split('\n')
+                .Where(l => l.Length > 0)
+                .Select(ParseAgentRow)];
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/AgentIdResolutionTests/*"`
+Expected: PASS (10 tests).
+
+- [ ] **Step 6: Write the failing daemon-side list test**
+
+Append to `test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs`, inside the `AgentOrchestratorVendorTests` partial class:
+
+```csharp
+    [Test]
+    public async Task Local_list_reports_each_agent_kind_and_flow_identity() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("plain-1");
+        orch.SeedAgentForTest("rev-1", kind: LaunchKind.Review);
+        orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+        using var client = new DuplexTestStream(new MemoryStream(), new MemoryStream());
+        await orch.HandleLocalListAsync(client, default);
+        client.WrittenStream.Position = 0;
+        var reply = await FrameCodec.ReadAsync(client.WrittenStream, default);
+
+        var rows = reply!.Text.Split('\n').Select(l => l.Split('\t')).ToDictionary(p => p[0], p => p);
+
+        await Assert.That(rows["plain-1"][3]).IsEqualTo("agent");
+        await Assert.That(rows["rev-1"][3]).IsEqualTo("review");
+        await Assert.That(rows["flow-1"][3]).IsEqualTo("review-flow");
+        await Assert.That(rows["flow-1"][4]).IsEqualTo("flow-7f3a");
+        await Assert.That(rows["flow-1"][5]).IsEqualTo("reviewer");
+    }
+```
+
+- [ ] **Step 7: Run it to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/AgentOrchestratorVendorTests/Local_list_reports*"`
+Expected: FAIL — the reply has only three columns, so `rows["plain-1"][3]` throws `IndexOutOfRangeException`.
+
+- [ ] **Step 8: Emit the new columns**
+
+In `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs`, replace `HandleLocalListAsync` and add the mapper:
+
+```csharp
+    /// <summary>Reply to a <c>kcap agent ls</c> request with a tab-separated agent table.</summary>
+    public Task HandleLocalListAsync(Stream stream, CancellationToken ct) {
+        var lines = _agents.Values.Select(a =>
+            $"{a.Id}\t{a.Status}\t{a.RepoPath}\t{KindText(a.Kind)}\t{a.FlowRunId ?? ""}\t{a.FlowRole ?? ""}");
+
+        return FrameCodec.WriteAsync(stream, new LocalFrame(FrameType.AgentList) { Text = string.Join('\n', lines) }, ct);
+    }
+
+    /// Wire spelling of <see cref="LaunchKind"/>. Kept separate from the enum name so the table
+    /// reads as a CLI column rather than a .NET identifier.
+    static string KindText(LaunchKind kind) => kind switch {
+        LaunchKind.Review     => "review",
+        LaunchKind.ReviewFlow => "review-flow",
+        _                     => "agent",
+    };
+```
+
+- [ ] **Step 9: Run it to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/AgentOrchestratorVendorTests/Local_list_reports*"`
+Expected: PASS.
+
+- [ ] **Step 10: Render the KIND column**
+
+In `AgentCommand.ListAsync`, replace the two output lines:
+
+```csharp
+        Console.WriteLine($"{"AGENT",-34} {"STATUS",-10} {"KIND",-12} REPO");
+        foreach (var a in agents) {
+            var role = a.FlowRole.Length > 0 ? $"  [{a.FlowRole}]" : "";
+            Console.WriteLine($"{a.Id,-34} {a.Status,-10} {a.Kind,-12} {a.Repo}{role}");
+        }
+```
+
+- [ ] **Step 11: Verify the build and the full unit suite**
+
+```bash
+dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj
+```
+
+Expected: build succeeds; no new failures beyond the ~42 baseline.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs src/Capacitor.Cli/Commands/AgentCommand.cs test/Capacitor.Cli.Tests.Unit/AgentIdResolutionTests.cs test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+git commit -m "feat(agent): carry and show each agent's launch kind"
+```
+
+---
+
+### Task 2: `StopV2` and `AttachedReadOnly` frames
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/FrameType.cs`
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs`
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/FrameCodecTests.cs`
+
+**Interfaces:**
+- Produces: `FrameType.StopV2 = 10`, `FrameType.AttachedReadOnly = 71`; `LocalFrame.StopV2(bool force, string agentId)`; `FrameCodec.StopV2(LocalFrame f)` returning `(bool force, string agentId)`; `FrameCodec.AttachedReadOnly(string agentId, string reason, byte[] snapshot)` and its decoder `FrameCodec.AttachedReadOnly(LocalFrame f)` returning `(string agentId, string reason, byte[] snapshot)`.
+
+- [ ] **Step 1: Write the failing round-trip tests**
+
+Append to `test/Capacitor.Cli.Tests.Unit/FrameCodecTests.cs`, inside the class:
+
+```csharp
+    [Test]
+    [Arguments(true,  "ab12")]
+    [Arguments(false, "ab12")]
+    [Arguments(false, "")]
+    public async Task StopV2_round_trips_mode_and_id(bool force, string agentId) {
+        var r = await RoundTrip(LocalFrame.StopV2(force, agentId));
+        await Assert.That(r.Type).IsEqualTo(FrameType.StopV2);
+
+        var (gotForce, gotId) = FrameCodec.StopV2(r);
+        await Assert.That(gotForce).IsEqualTo(force);
+        await Assert.That(gotId).IsEqualTo(agentId);
+    }
+
+    [Test]
+    public async Task AttachedReadOnly_round_trips_id_reason_and_snapshot() {
+        var snapshot = new byte[] { 0x1b, 0x5b, 0x41, 0x00, 0xff };
+        var r = await RoundTrip(FrameCodec.AttachedReadOnly("ab12", "review-flow reviewer", snapshot));
+        await Assert.That(r.Type).IsEqualTo(FrameType.AttachedReadOnly);
+
+        var (id, reason, got) = FrameCodec.AttachedReadOnly(r);
+        await Assert.That(id).IsEqualTo("ab12");
+        await Assert.That(reason).IsEqualTo("review-flow reviewer");
+        await Assert.That(got).IsEquivalentTo(snapshot);
+    }
+
+    [Test]
+    public async Task AttachedReadOnly_round_trips_an_empty_snapshot() {
+        var r = await RoundTrip(FrameCodec.AttachedReadOnly("ab12", "review agent", []));
+        var (_, _, got) = FrameCodec.AttachedReadOnly(r);
+        await Assert.That(got).IsEmpty();
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/FrameCodecTests/*"`
+Expected: FAIL — compile error, `LocalFrame.StopV2` and `FrameCodec.AttachedReadOnly` do not exist.
+
+- [ ] **Step 3: Add the frame types**
+
+In `src/Capacitor.Cli.Core/LocalIpc/FrameType.cs`, add `StopV2` after `Stop` and `AttachedReadOnly` after `StopAck`:
+
+```csharp
+    Stop    = 8,   // stop an agent (Text = agent id; empty = every agent this daemon hosts)
+    StopV2  = 10,  // stop with a force flag (see FrameCodec.StopV2); supersedes Stop
+```
+
+```csharp
+    StopAck    = 70, // acknowledgement for Stop (Text = `id\tstatus` per line)
+    AttachedReadOnly = 71, // Attached for a protected agent: id + reason + snapshot, no input accepted
+```
+
+- [ ] **Step 4: Teach the codec both frames**
+
+In `src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs`, add `StopV2` and `AttachedReadOnly` to the pre-encoded arms of `Encode` and `Decode`, alongside `Attached`/`Spawn`:
+
+```csharp
+        FrameType.Attached or FrameType.Spawn
+            or FrameType.StopV2 or FrameType.AttachedReadOnly => f.Bytes, // pre-encoded by the helpers below
+```
+
+```csharp
+        FrameType.Attached or FrameType.Spawn
+            or FrameType.StopV2 or FrameType.AttachedReadOnly => new(t) { Bytes = p },
+```
+
+Then add the structured helpers next to the existing `Attached` pair:
+
+```csharp
+    // --- StopV2 structured payload ---
+    public static LocalFrame StopV2(bool force, string agentId) {
+        using var ms = new MemoryStream();
+        ms.WriteByte((byte)(force ? 1 : 0));
+        WriteLp(ms, agentId);
+        return new(FrameType.StopV2) { Bytes = ms.ToArray(), Text = agentId };
+    }
+    public static (bool force, string agentId) StopV2(LocalFrame f) {
+        var o = 1;
+        return (f.Bytes[0] == 1, ReadLp(f.Bytes, ref o));
+    }
+
+    // --- AttachedReadOnly structured payload ---
+    // Length-prefixed id AND reason before the snapshot: the snapshot is the unbounded tail, so
+    // anything appended after it would be painted onto the user's terminal instead of parsed.
+    public static LocalFrame AttachedReadOnly(string agentId, string reason, byte[] snapshot) {
+        using var ms = new MemoryStream();
+        WriteLp(ms, agentId);
+        WriteLp(ms, reason);
+        ms.Write(snapshot);
+        return new(FrameType.AttachedReadOnly) { Bytes = ms.ToArray(), Text = agentId };
+    }
+    public static (string agentId, string reason, byte[] snapshot) AttachedReadOnly(LocalFrame f) {
+        var o = 0;
+        var id = ReadLp(f.Bytes, ref o);
+        var reason = ReadLp(f.Bytes, ref o);
+        return (id, reason, f.Bytes[o..]);
+    }
+```
+
+- [ ] **Step 5: Add the `LocalFrame` factory**
+
+In `src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs`, after the `StopAck` factory:
+
+```csharp
+    public static LocalFrame StopV2(bool force, string agentId) => FrameCodec.StopV2(force, agentId);
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/FrameCodecTests/*"`
+Expected: PASS, including the five new cases.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/LocalIpc/ test/Capacitor.Cli.Tests.Unit/FrameCodecTests.cs
+git commit -m "feat(ipc): add StopV2 and AttachedReadOnly frames"
+```
+
+---
+
+### Task 3: Daemon-side read-only attach
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs` (`HandleLocalAttachAsync`, `AttachClientLoopAsync`)
+- Test: `test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs`
+
+**Interfaces:**
+- Consumes: `FrameCodec.AttachedReadOnly(string, string, byte[])` (Task 2); `AgentInstance.Kind` / `.FlowRunId` / `.FlowRole`.
+- Produces: `AttachClientLoopAsync(AgentInstance agent, Stream stream, CancellationToken ct, bool readOnly = false)`; `static string ProtectionReason(AgentInstance agent)` on `AgentOrchestrator`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs`, inside the `AgentOrchestratorVendorTests` partial class:
+
+```csharp
+    [Test]
+    public async Task Attaching_to_a_flow_participant_is_read_only() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        var agent = orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+        // Client sends input, then a resize, then detaches. None of the first two may land.
+        var readBuf = new MemoryStream();
+        await FrameCodec.WriteAsync(readBuf, LocalFrame.Stdin("hello"u8.ToArray()), default);
+        await FrameCodec.WriteAsync(readBuf, LocalFrame.Resize(40, 10), default);
+        await FrameCodec.WriteAsync(readBuf, LocalFrame.Detach(), default);
+        readBuf.Position = 0;
+        using var client = new DuplexTestStream(readBuf, new MemoryStream());
+
+        await orch.HandleLocalAttachAsync("flow-1", client, default);
+
+        client.WrittenStream.Position = 0;
+        var first = await FrameCodec.ReadAsync(client.WrittenStream, default);
+
+        await Assert.That(first!.Type).IsEqualTo(FrameType.AttachedReadOnly);
+        var (_, reason, _) = FrameCodec.AttachedReadOnly(first);
+        await Assert.That(reason).Contains("review-flow");
+        await Assert.That(reason).Contains("reviewer");
+
+        // The resize must not have been recorded, so the PTY is never clamped to the viewer.
+        await Assert.That(agent.ClientDims).IsEmpty();
+    }
+
+    [Test]
+    public async Task Attaching_to_a_plain_agent_stays_read_write() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("plain-1");
+
+        var readBuf = new MemoryStream();
+        await FrameCodec.WriteAsync(readBuf, LocalFrame.Detach(), default);
+        readBuf.Position = 0;
+        using var client = new DuplexTestStream(readBuf, new MemoryStream());
+
+        await orch.HandleLocalAttachAsync("plain-1", client, default);
+
+        client.WrittenStream.Position = 0;
+        var first = await FrameCodec.ReadAsync(client.WrittenStream, default);
+        await Assert.That(first!.Type).IsEqualTo(FrameType.Attached);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/AgentOrchestratorVendorTests/Attaching_to*"`
+Expected: FAIL — the flow case gets `FrameType.Attached`, not `AttachedReadOnly`.
+
+- [ ] **Step 3: Add the protection reason and route the attach**
+
+In `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs`, replace `HandleLocalAttachAsync`:
+
+```csharp
+    /// <summary>Attach an existing agent to a local client (used by <c>kcap agent attach</c>).</summary>
+    public Task HandleLocalAttachAsync(string agentId, Stream stream, CancellationToken ct) {
+        if (!_agents.TryGetValue(agentId, out var agent))
+            return FrameCodec.WriteAsync(stream, LocalFrame.Error($"no such agent {agentId}"), ct);
+
+        // A review or flow agent is addressed through the flow protocol, never by typing at it,
+        // so the daemon — not the client — decides this attach carries no input.
+        return AttachClientLoopAsync(agent, stream, ct, readOnly: agent.Kind != LaunchKind.Default);
+    }
+
+    /// Human-readable "why is this read-only", carried on the AttachedReadOnly frame.
+    static string ProtectionReason(AgentInstance agent) {
+        var kind = agent.Kind == LaunchKind.ReviewFlow ? "review-flow" : "review";
+        var role = string.IsNullOrEmpty(agent.FlowRole) ? "" : $", role {agent.FlowRole}";
+        var flow = string.IsNullOrEmpty(agent.FlowRunId) ? "" : $" (flow {agent.FlowRunId}{role})";
+
+        return $"{kind} agent{flow}";
+    }
+```
+
+- [ ] **Step 4: Make the attach loop honour read-only**
+
+In the same file, change `AttachClientLoopAsync`'s signature and three points inside it.
+
+Signature:
+
+```csharp
+    internal async Task AttachClientLoopAsync(
+            AgentInstance agent, Stream stream, CancellationToken ct, bool readOnly = false) {
+```
+
+Replace the `Attached` send with a conditional one (the line currently reading `await Send(FrameCodec.Attached(agent.Id, snapshot));`):
+
+```csharp
+            await Send(readOnly
+                ? FrameCodec.AttachedReadOnly(agent.Id, ProtectionReason(agent), snapshot)
+                : FrameCodec.Attached(agent.Id, snapshot));
+```
+
+Guard the two input arms in the read loop:
+
+```csharp
+                    if (f.Type == FrameType.Stdin) {
+                        if (readOnly) continue; // protected agent: input is never delivered
+
+                        try {
+```
+
+```csharp
+                    } else if (f.Type == FrameType.Resize) {
+                        // A read-only viewer must not enter ClientDims, or the min-clamp would
+                        // let an observer shrink the participant's terminal.
+                        if (!readOnly) ApplyResizeClamp(agent, sink, f.Cols, f.Rows);
+                    }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/AgentOrchestratorVendorTests/Attaching_to*"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Run the whole local-attach family for regressions**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/AgentOrchestratorVendorTests/*"`
+Expected: PASS. The existing spawn-then-attach tests go through `AttachClientLoopAsync` with the new default `readOnly: false` and must be unaffected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+git commit -m "feat(daemon): attach to review and flow agents read-only"
+```
+
+---
+
+### Task 4: CLI read-only attach banner
+
+**Files:**
+- Modify: `src/Capacitor.Cli/Local/LocalAgentClient.cs`
+
+**Interfaces:**
+- Consumes: `FrameType.AttachedReadOnly` and `FrameCodec.AttachedReadOnly(LocalFrame)` (Task 2).
+
+- [ ] **Step 1: Handle the frame in the output pump**
+
+In `src/Capacitor.Cli/Local/LocalAgentClient.cs`, add a `readOnly` flag beside the other loop state (next to `var detached = false;`):
+
+```csharp
+        var       readOnly   = false; // daemon attached us to a protected agent; input is dropped
+```
+
+Then add a case to the `switch (f.Type)` in `outPump`, directly after the `FrameType.Attached` case:
+
+```csharp
+                        case FrameType.AttachedReadOnly:
+                            readOnly = true;
+                            var (_, reason, roSnapshot) = FrameCodec.AttachedReadOnly(f);
+                            if (roSnapshot.Length > 0) TerminalRawMode.WriteStdout(roSnapshot, roSnapshot.Length);
+
+                            var banner = "\r\n— read-only: " + reason + ".\r\n"
+                                       + "  Input is not delivered — address it with the flow tools."
+                                       + " Ctrl-Q d to detach. —\r\n";
+                            var bannerBytes = System.Text.Encoding.UTF8.GetBytes(banner);
+                            TerminalRawMode.WriteStdout(bannerBytes, bannerBytes.Length);
+
+                            // No SizeFrame nudge: the daemon ignores our size for a protected
+                            // agent, so asking for a repaint at our dimensions would mislead.
+                            break;
+```
+
+- [ ] **Step 2: Stop the input and resize pumps from sending**
+
+In the `resizePump` loop, skip sending while read-only — replace its body's send line:
+
+```csharp
+                    if (cur != last) { last = cur; if (!readOnly) await Send(SizeFrame()); }
+```
+
+In the `stdinPump` loop, forward nothing but keep the detach sequence working — replace the forward line:
+
+```csharp
+                    var (forward, detach) = scanner.Process(buf.AsSpan(0, n));
+                    if (forward.Length > 0 && !readOnly) await Send(LocalFrame.Stdin(forward));
+```
+
+- [ ] **Step 3: Verify the build**
+
+```bash
+dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj
+```
+
+Expected: builds with no errors.
+
+- [ ] **Step 4: Verify end to end against a live daemon**
+
+```bash
+dotnet run --project src/Capacitor.Cli/Capacitor.Cli.csproj -- daemon start -d
+dotnet run --project src/Capacitor.Cli/Capacitor.Cli.csproj -- agent start claude --detach
+dotnet run --project src/Capacitor.Cli/Capacitor.Cli.csproj -- agent
+dotnet run --project src/Capacitor.Cli/Capacitor.Cli.csproj -- agent attach <first-4-chars>
+```
+
+Expected: `agent` lists the agent with KIND `agent`; attaching is read-write as before (typing works, `Ctrl-Q d` detaches). A protected agent cannot be produced locally — `agent start` always creates `LaunchKind.Default` — so the read-only banner is covered by the daemon unit tests rather than this smoke check. Say so in your report rather than fabricating a flow.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli/Local/LocalAgentClient.cs
+git commit -m "feat(cli): print the read-only banner and stop sending input"
+```
+
+---
+
+### Task 5: Daemon-side stop protection
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs`
+- Modify: `src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs`
+
+**Interfaces:**
+- Consumes: `FrameCodec.StopV2(LocalFrame)` → `(bool force, string agentId)` (Task 2); `ProtectionReason(AgentInstance)` (Task 3).
+- Produces: `public Task HandleLocalStopV2Async(bool force, string agentId, Stream stream, CancellationToken ct)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs`, inside the `AgentOrchestratorVendorTests` partial class:
+
+```csharp
+    static async Task<LocalFrame?> StopV2AndReadReply(AgentOrchestrator orch, bool force, string agentId) {
+        using var client = new DuplexTestStream(new MemoryStream(), new MemoryStream());
+        await orch.HandleLocalStopV2Async(force, agentId, client, default);
+        client.WrittenStream.Position = 0;
+
+        return await FrameCodec.ReadAsync(client.WrittenStream, default);
+    }
+
+    [Test]
+    public async Task Stopping_a_flow_participant_without_force_is_refused() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+        var reply = await StopV2AndReadReply(orch, force: false, "flow-1");
+
+        await Assert.That(reply!.Type).IsEqualTo(FrameType.Error);
+        await Assert.That(reply.Text).Contains("review-flow");
+        await Assert.That(reply.Text).Contains("--force");
+        await Assert.That(orch.GetAgentForTest("flow-1")!.Status).IsNotEqualTo("Completed");
+    }
+
+    [Test]
+    public async Task Stopping_a_flow_participant_with_force_succeeds() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+        var reply = await StopV2AndReadReply(orch, force: true, "flow-1");
+
+        await Assert.That(reply!.Type).IsEqualTo(FrameType.StopAck);
+        await Assert.That(reply.Text).IsEqualTo("flow-1\tstopped");
+        await Assert.That(orch.GetAgentForTest("flow-1")!.Status).IsEqualTo("Completed");
+    }
+
+    [Test]
+    public async Task Stop_all_without_force_skips_protected_agents_and_says_so() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("plain-1");
+        orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+        var reply = await StopV2AndReadReply(orch, force: false, "");
+
+        var rows = reply!.Text.Split('\n').Select(l => l.Split('\t')).ToDictionary(p => p[0], p => p[1]);
+        await Assert.That(rows["plain-1"]).IsEqualTo("stopped");
+        await Assert.That(rows["flow-1"]).IsEqualTo("skipped");
+        await Assert.That(orch.GetAgentForTest("flow-1")!.Status).IsNotEqualTo("Completed");
+    }
+
+    [Test]
+    public async Task Stop_all_with_force_includes_protected_agents() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("plain-1");
+        orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+        var reply = await StopV2AndReadReply(orch, force: true, "");
+
+        var rows = reply!.Text.Split('\n').Select(l => l.Split('\t')).ToDictionary(p => p[0], p => p[1]);
+        await Assert.That(rows["plain-1"]).IsEqualTo("stopped");
+        await Assert.That(rows["flow-1"]).IsEqualTo("stopped");
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/AgentOrchestratorVendorTests/Stop*"`
+Expected: FAIL — compile error, `HandleLocalStopV2Async` does not exist.
+
+- [ ] **Step 3: Add the V2 handler**
+
+In `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs`, add after `HandleLocalStopAsync`:
+
+```csharp
+    /// <summary>
+    /// `kcap agent stop` with protection. A review or flow agent is refused unless the user
+    /// passed --force; a stop-all reports them as `skipped` rather than silently omitting them.
+    /// </summary>
+    public async Task HandleLocalStopV2Async(bool force, string agentId, Stream stream, CancellationToken ct) {
+        if (agentId.Length == 0) {
+            var all       = _agents.Values.ToList();
+            var eligible  = all.Where(a => force || a.Kind == LaunchKind.Default).ToList();
+            var results   = await Task.WhenAll(eligible.Select(StopAgentCoreAsync));
+            var stopped   = eligible.Zip(results, (a, ok) => $"{a.Id}\t{StatusText(ok)}");
+            var skipped   = all.Except(eligible).Select(a => $"{a.Id}\tskipped");
+
+            await FrameCodec.WriteAsync(stream, LocalFrame.StopAck(string.Join('\n', stopped.Concat(skipped))), ct);
+
+            return;
+        }
+
+        if (_agents.TryGetValue(agentId, out var agent)) {
+            if (!force && agent.Kind != LaunchKind.Default) {
+                await FrameCodec.WriteAsync(stream, LocalFrame.Error(
+                    $"{agentId} is a {ProtectionReason(agent)}. Stopping it mid-round leaves the flow "
+                  + "without a participant. Pass --force to stop it anyway."), ct);
+
+                return;
+            }
+
+            var ok = await StopAgentCoreAsync(agent);
+            await FrameCodec.WriteAsync(stream, LocalFrame.StopAck($"{agentId}\t{StatusText(ok)}"), ct);
+
+            return;
+        }
+
+        // Not live here — it may be a survivor of a previous daemon incarnation, which the PID
+        // record can still reap. Kind is unknown for those, so protection cannot apply.
+        var reaped = await TryStopByPidRecordAsync(agentId);
+
+        await FrameCodec.WriteAsync(
+            stream,
+            reaped ? LocalFrame.StopAck($"{agentId}\t{StatusText(true)}") : LocalFrame.Error($"no such agent {agentId}"),
+            ct);
+    }
+```
+
+- [ ] **Step 4: Route the frame**
+
+In `src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs`, add a case after the `Stop` one and update the fallback message:
+
+```csharp
+                case FrameType.Stop:   await orchestrator.HandleLocalStopAsync(first.Text, stream, ct); break;
+                case FrameType.StopV2: {
+                    var (force, id) = FrameCodec.StopV2(first);
+                    await orchestrator.HandleLocalStopV2Async(force, id, stream, ct);
+
+                    break;
+                }
+                case FrameType.Restart: await HandleRestartAsync(first.Text, stream, ct); break;
+                default: await FrameCodec.WriteAsync(stream, LocalFrame.Error($"expected Spawn/Attach/List/Stop/StopV2/Restart, got {first.Type}"), ct); break;
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/AgentOrchestratorVendorTests/Stop*"`
+Expected: PASS (the four new tests plus the existing `Stop`-path ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+git commit -m "feat(daemon): refuse to stop review and flow agents without force"
+```
+
+---
+
+### Task 6: `kcap agent stop --force`
+
+**Files:**
+- Modify: `src/Capacitor.Cli/Commands/AgentCommand.cs` (`StopAsync`, `SendStopAsync`)
+- Test: `test/Capacitor.Cli.Tests.Unit/AgentCommandRoutingTests.cs`
+
+**Interfaces:**
+- Consumes: `LocalFrame.StopV2(bool, string)` (Task 2); `AgentRow.Kind` and `AgentCommand.IsProtectedKind` (Task 1).
+- Produces: `internal static (string[] Stoppable, string[] Protected) PartitionByProtection(IReadOnlyList<AgentRow> agents)`.
+
+- [ ] **Step 1: Write the failing partition test**
+
+Append to `test/Capacitor.Cli.Tests.Unit/AgentCommandRoutingTests.cs`, inside the class:
+
+```csharp
+    [Test]
+    public async Task Protected_agents_are_partitioned_out_for_the_confirmation_prompt() {
+        AgentRow[] agents = [
+            new("a1", "Running", "/r1", "agent", "", ""),
+            new("f1", "Running", "/r2", "review-flow", "flow-7f3a", "reviewer"),
+            new("v1", "Running", "/r3", "review", "", ""),
+        ];
+
+        var (stoppable, prot) = AgentCommand.PartitionByProtection(agents);
+
+        await Assert.That(stoppable).IsEquivalentTo(new[] { "a1" });
+        await Assert.That(prot).IsEquivalentTo(new[] { "f1", "v1" });
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/AgentCommandRoutingTests/*"`
+Expected: FAIL — compile error, `PartitionByProtection` does not exist.
+
+- [ ] **Step 3: Add the partition helper**
+
+In `src/Capacitor.Cli/Commands/AgentCommand.cs`, next to `IsProtectedKind`:
+
+```csharp
+    /// <summary>Splits an agent list into what `stop --all` will stop and what it will skip.</summary>
+    internal static (string[] Stoppable, string[] Protected) PartitionByProtection(IReadOnlyList<AgentRow> agents) => (
+        [.. agents.Where(a => !IsProtectedKind(a.Kind)).Select(a => a.Id)],
+        [.. agents.Where(a => IsProtectedKind(a.Kind)).Select(a => a.Id)]
+    );
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj --treenode-filter "/*/*/AgentCommandRoutingTests/*"`
+Expected: PASS.
+
+- [ ] **Step 5: Accept `--force` and group the prompt**
+
+In `StopAsync`, add the flag beside the existing `all`/`yes` reads:
+
+```csharp
+        var force = args.Contains("--force");
+```
+
+Replace the usage block so `--force` appears:
+
+```csharp
+        if (!all && !hasId) {
+            await Console.Error.WriteLineAsync("usage: kcap agent stop <agent-id> [--force] [--daemon <name>]");
+            await Console.Error.WriteLineAsync("       kcap agent stop --all [-y] [--force] [--daemon <name>]");
+
+            return 1;
+        }
+```
+
+Replace the `--all` listing block (the `Console.WriteLine($"Found {agents.Count} agents:")` loop) with a grouped one:
+
+```csharp
+            var (stoppable, protectedIds) = PartitionByProtection(agents);
+            var targets = force ? agents.Select(a => a.Id).ToArray() : stoppable;
+
+            if (targets.Length == 0) {
+                Console.WriteLine(protectedIds.Length > 0
+                    ? $"No agents to stop. {protectedIds.Length} review agent(s) skipped — pass --force to include them."
+                    : "No agents.");
+
+                return 0;
+            }
+
+            Console.WriteLine($"Found {targets.Length} agents:");
+            foreach (var a in agents.Where(a => targets.Contains(a.Id))) Console.WriteLine($"  • {a.Id}  {a.Repo}");
+
+            if (!force && protectedIds.Length > 0) {
+                Console.WriteLine($"Skipping {protectedIds.Length} review agent(s) — pass --force to include them:");
+                foreach (var a in agents.Where(a => protectedIds.Contains(a.Id)))
+                    Console.WriteLine($"  • {a.Id}  {a.Kind}  {a.Repo}");
+            }
+
+            if (!yes) {
+                await Console.Out.WriteAsync($"Stop {targets.Length}? [y/N] ");
+                var reply = await Console.In.ReadLineAsync();
+
+                if (!string.Equals(reply?.Trim(), "y", StringComparison.OrdinalIgnoreCase)) {
+                    await Console.Out.WriteLineAsync("Cancelled.");
+
+                    return 0;
+                }
+            }
+
+            target = "";
+```
+
+- [ ] **Step 6: Send `StopV2` and report `skipped`**
+
+Change the `SendStopAsync` call and signature to carry the flag:
+
+```csharp
+        return await SendStopAsync(sock, target, name, force);
+```
+
+```csharp
+    static async Task<int> SendStopAsync(string sock, string agentId, string daemonName, bool force) {
+```
+
+Inside it, replace the write with the V2 frame:
+
+```csharp
+            await FrameCodec.WriteAsync(stream, LocalFrame.StopV2(force, agentId), default);
+```
+
+And replace the `StopAck` arm so `skipped` reads differently from `stopped`/`failed`:
+
+```csharp
+                case FrameType.StopAck:
+                    string[] lines = resp.Text.Length == 0 ? [] : resp.Text.Split('\n');
+                    if (lines.Length == 0) { Console.WriteLine("No agents."); return 0; }
+
+                    var failed  = 0;
+                    var skipped = 0;
+
+                    foreach (var line in lines) {
+                        var parts  = line.Split('\t');
+                        var id     = parts[0];
+                        var status = parts.Length > 1 ? parts[1] : "failed";
+
+                        switch (status) {
+                            case "stopped": Console.WriteLine($"Stopped {id}."); break;
+                            case "skipped": Console.WriteLine($"Skipped {id} — review agent; pass --force to stop it."); skipped++; break;
+                            default:        Console.Error.WriteLine($"Failed to stop {id} — see `kcap daemon logs`."); failed++; break;
+                        }
+                    }
+
+                    if (skipped > 0)
+                        Console.WriteLine($"{skipped} review agent(s) left running — pass --force to stop them.");
+
+                    // Skipping is the documented default, not a failure, so it does not affect
+                    // the exit code.
+                    return failed > 0 ? 1 : 0;
+```
+
+- [ ] **Step 7: Verify the build and the full unit suite**
+
+```bash
+dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj
+```
+
+Expected: build succeeds; no new failures beyond the ~42 baseline.
+
+- [ ] **Step 8: Verify end to end**
+
+```bash
+dotnet run --project src/Capacitor.Cli/Capacitor.Cli.csproj -- daemon start -d
+dotnet run --project src/Capacitor.Cli/Capacitor.Cli.csproj -- agent start claude --detach
+dotnet run --project src/Capacitor.Cli/Capacitor.Cli.csproj -- agent stop --all
+```
+
+Expected: the prompt lists the one agent, stopping prints `Stopped <id>.`, exit 0. Protected agents can't be created locally, so their paths are covered by the Task 5 daemon tests — say so in your report rather than inventing a flow.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Capacitor.Cli/Commands/AgentCommand.cs test/Capacitor.Cli.Tests.Unit/AgentCommandRoutingTests.cs
+git commit -m "feat(cli): add `agent stop --force` and report skipped agents"
+```
+
+---
+
+### Task 7: Documentation and final verification
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/Resources/help-agent.txt`
+- Modify: `README.md`
+- Test: `test/Capacitor.Cli.Tests.Integration/AgentVerbDispatchTests.cs`
+
+- [ ] **Step 1: Update the per-command help**
+
+In `src/Capacitor.Cli.Core/Resources/help-agent.txt`, replace the `Options for stop` block:
+
+```
+Options for stop:
+  --all                   Stop every agent, including --private ones. Review and
+                          review-flow agents are skipped unless --force is given.
+  --force                 Include review and review-flow agents. Stopping a flow
+                          participant mid-round leaves the flow without it.
+  --yes, -y               Skip the confirmation prompt for --all
+```
+
+And add a section after the `Agent ids:` block:
+
+```
+Review and flow agents:
+  Agents the daemon runs as part of a review flow (KIND `review-flow`) or a PR
+  review (`review`) are not yours to drive directly — they are addressed through
+  the flow tools. `attach` gives you a read-only view of one: you see its output,
+  your input is not delivered. `stop` refuses unless you pass --force.
+```
+
+- [ ] **Step 2: Update the README**
+
+In `README.md`, in the `### Local agents (`kcap agent`)` section, replace the paragraph beginning "Agent ids are long" (it currently carries the `--all` warning added when this gap was deferred, pointing at #379):
+
+```markdown
+Agent ids are long, so `attach` and `stop` accept **any unique prefix** — an ambiguous one lists the candidates instead of guessing. `stop --all` includes `--private` agents and prompts for confirmation unless you pass `--yes`/`-y`; a stop that cannot be confirmed prints a per-agent failure line and exits non-zero.
+
+**Agents that aren't yours.** `kcap agent ls` shows a `KIND` column: `agent` for ones you started, `review` for PR-review agents, and `review-flow` for review-flow participants (with their role). The daemon protects the latter two, because they are driven by the flow protocol rather than by you:
+
+- `kcap agent attach` on one is **read-only** — you see its output, your keystrokes are not delivered, and your terminal size is not applied to it.
+- `kcap agent stop` on one is **refused** unless you pass `--force`, and `stop --all` skips them and says how many it skipped.
+
+Enforcement is in the daemon, so this holds regardless of client version. It does not apply when talking to a daemon older than this feature — that daemon reports no kind, every agent reads as `agent`, and the protections do not engage until it restarts onto the new binary.
+```
+
+- [ ] **Step 3: Add an integration case for the refusal**
+
+Append to `test/Capacitor.Cli.Tests.Integration/AgentVerbDispatchTests.cs`, inside the class:
+
+```csharp
+    [Test]
+    public async Task Stop_accepts_the_force_flag_without_treating_it_as_an_id() {
+        // --force must parse as a flag, not as a positional agent id, or the usage line fires.
+        var (_, stderr, _) = await RunCli("agent stop --all --force -y --daemon kcap-dispatch-test-absent");
+
+        await Assert.That(stderr).DoesNotContain("cannot combine an agent id with --all");
+        await Assert.That(stderr).DoesNotContain("usage: kcap agent stop");
+    }
+```
+
+- [ ] **Step 4: Run both suites**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj
+dotnet run --project test/Capacitor.Cli.Tests.Integration/Capacitor.Cli.Tests.Integration.csproj
+```
+
+Expected: unit has no new failures beyond the ~42 baseline; integration fully passes.
+
+- [ ] **Step 5: Verify AOT publishes clean**
+
+```bash
+dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
+dotnet publish src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
+```
+
+Expected: no output from either.
+
+- [ ] **Step 6: Verify the help renders**
+
+```bash
+dotnet run --project src/Capacitor.Cli/Capacitor.Cli.csproj -- agent --help
+```
+
+Expected: the new `Options for stop` and `Review and flow agents` text appears.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/Resources/help-agent.txt README.md test/Capacitor.Cli.Tests.Integration/AgentVerbDispatchTests.cs
+git commit -m "docs: document read-only attach and stop --force for review agents"
+```
+
+---
+
+## PR
+
+Reference both trackers in the description (title stays clean):
+
+- `Closes #379`
+- `AI-1557`
+
+Call out in the body that protection does **not** engage against a daemon older than this change (it reports no kind), and that `--force` still leaves the flow unaware its participant was stopped — attributing that needs server-side work.

--- a/docs/superpowers/plans/2026-07-29-ai1557-flow-participant-aware-agent-commands.md
+++ b/docs/superpowers/plans/2026-07-29-ai1557-flow-participant-aware-agent-commands.md
@@ -827,10 +827,15 @@ Replace the `--all` listing block (the `Console.WriteLine($"Found {agents.Count}
             }
 
             Console.WriteLine($"Found {targets.Length} agents:");
-            foreach (var a in agents.Where(a => targets.Contains(a.Id))) Console.WriteLine($"  • {a.Id}  {a.Repo}");
+            foreach (var a in agents.Where(a => targets.Contains(a.Id) && !protectedIds.Contains(a.Id)))
+                Console.WriteLine($"  • {a.Id}  {a.Repo}");
 
-            if (!force && protectedIds.Length > 0) {
-                Console.WriteLine($"Skipping {protectedIds.Length} review agent(s) — pass --force to include them:");
+            // The spec requires `--all --force` to show the blast radius too: both branches label
+            // protected rows with their Kind before the [y/N] prompt, not just the skip path.
+            if (protectedIds.Length > 0) {
+                Console.WriteLine(force
+                    ? $"Including {protectedIds.Length} review agent(s):"
+                    : $"Skipping {protectedIds.Length} review agent(s) — pass --force to include them:");
                 foreach (var a in agents.Where(a => protectedIds.Contains(a.Id)))
                     Console.WriteLine($"  • {a.Id}  {a.Kind}  {a.Repo}");
             }

--- a/docs/superpowers/specs/2026-07-29-ai1557-flow-participant-aware-agent-commands-design.md
+++ b/docs/superpowers/specs/2026-07-29-ai1557-flow-participant-aware-agent-commands-design.md
@@ -63,6 +63,7 @@ by accident.
 | Value | Direction | Payload |
 |---|---|---|
 | `StopV2 = 10` | client → daemon | `mode⇥agentId` — mode `normal`\|`force`; empty id = all eligible |
+| `AttachedReadOnly = 71` | daemon → client | `lp(agentId) + lp(reason) + snapshot` |
 
 Two payload extensions to existing frames:
 
@@ -70,11 +71,16 @@ Two payload extensions to existing frames:
   `agent`\|`review`\|`review-flow`; the flow fields are empty for non-flow agents.
 - **`StopAck`** rows keep the `id⇥status` shape, with `status` gaining `skipped` alongside the
   existing `stopped`\|`failed`.
-- **`Attached`** gains a trailing read-only flag and reason, appended after the existing payload.
-  This follows the precedent `FrameCodec.Spawn` already set for `isPrivate` ("APPENDED after
-  args: older parsers ignore trailing bytes").
 
-`Stop = 8` stays decodable so nothing regresses mid-upgrade, but the CLI only sends `StopV2`.
+**Why `AttachedReadOnly` is a new frame rather than a flag on `Attached`.** `Attached`'s payload
+is `lp(agentId) + snapshot`, and the decoder returns `f.Bytes[o..]` — the snapshot is *everything
+remaining*. A trailing flag would be swallowed into the replay buffer and painted onto the user's
+terminal. The `isPrivate` trick `FrameCodec.Spawn` uses works only because Spawn's payload is
+fully counted, so it does not transfer. A separate frame also fails closed: an older CLI cannot
+decode type 71, so it errors out instead of silently pumping stdin at a participant.
+
+`Stop = 8` and `Attached = 64` stay decodable so nothing regresses mid-upgrade; the CLI sends
+`StopV2` and the daemon sends `AttachedReadOnly` only for protected agents.
 
 ## Daemon changes
 
@@ -96,8 +102,9 @@ The `IsPrivate` guard on `HandleStopAgent` and the server-origin path are untouc
 - `AgentRow` gains `Kind`, `FlowRunId`, `FlowRole`. The parser accepts **3 or more** columns and
   defaults the new ones, so a running older daemon still lists correctly.
 - `ls` renders a `KIND` column, with the flow role appended for flow agents.
-- `attach` prints the read-only banner when the daemon reports the flag, and skips its own stdin
-  pump — cosmetic, since the daemon already drops it.
+- `attach` prints the read-only banner on `AttachedReadOnly`, and skips its own stdin pump, its
+  resize pump, and the `SizeFrame()` nudge it normally sends on attach. All three are cosmetic —
+  the daemon ignores them for a protected agent — but sending them would be misleading.
 - `stop` accepts `--force`, sends `StopV2`, and reports `skipped` rows distinctly from
   `stopped`. With `--all --force`, the confirmation prompt lists protected agents in their own
   labelled group, so the blast radius is visible before the user answers.

--- a/docs/superpowers/specs/2026-07-29-ai1557-flow-participant-aware-agent-commands-design.md
+++ b/docs/superpowers/specs/2026-07-29-ai1557-flow-participant-aware-agent-commands-design.md
@@ -1,0 +1,140 @@
+# Flow-participant-aware `kcap agent` commands — design
+
+Date: 2026-07-29
+Status: proposed
+Issue: AI-1557 / [#379](https://github.com/kurrent-io/kcap-cli/issues/379)
+
+## Motivation
+
+`kcap agent ls|attach|stop` treats every agent the daemon hosts identically.
+`HandleLocalListAsync` returns all of `_agents` unfiltered and `HandleLocalAttachAsync` attaches
+to any id in it, so an agent the daemon launched as a **review-flow participant** — a reviewer
+mid-round — is indistinguishable from one the user started with `kcap agent start`.
+
+Two concrete failures follow:
+
+1. **Attach injects turns into a flow.** Participants are addressed through the flow protocol
+   (`send_to_participant`), never by typing at them. `kcap agent attach <reviewer-id>` hands the
+   user raw PTY stdin, with no round, no routing, and no record of the interjection.
+2. **Stop kills a participant silently.** `kcap agent stop --all` stops every agent in the map.
+   A reviewer vanishes mid-round and the flow has no idea why.
+
+The second one arrived with `agent stop`, which is why this was deferred rather than solved in
+the same change: the read path was already blind, and the write path made the blindness bite.
+
+The daemon already has everything needed. `AgentInstance` carries `Kind`
+(`LaunchKind.Default`/`Review`/`ReviewFlow`), plus `FlowRunId`/`FlowRole` for flow launches. None
+of it reaches the CLI.
+
+## Goal
+
+The CLI can tell a review or flow agent from the user's own, shows it, and refuses to mutate it
+by accident.
+
+## Decisions
+
+1. **The protected set is `Kind != Default`** — `ReviewFlow` participants and `Review` agents.
+   Plain web-UI-launched agents (`Default`, not locally spawned) stay unprotected: they are the
+   user's own work by another route, and protecting them would make `stop --all` nearly useless.
+
+2. **Attach to a protected agent is read-only**, not refused. Watching a reviewer work is a real
+   debugging need with no other local equivalent, and read-only preserves the flow invariant
+   exactly — output flows out, nothing flows in.
+
+3. **A read-only viewer does not resize the PTY.** It is never added to
+   `AgentInstance.ClientDims`, so it cannot shrink a participant's terminal through the
+   min-clamp. The cost lands on the observer: if their terminal differs from the participant's,
+   their own view wraps or clips. That is the correct side to put it on.
+
+4. **`stop` on a protected agent refuses unless `--force`.** `stop --all` stops only unprotected
+   agents and *states* what it skipped — a silent omission reads as "stopped everything".
+
+5. **Enforcement is daemon-side, not client-side.** The daemon owns the protection for both
+   attach and stop, so a stale or hand-rolled client cannot bypass it, and the two subcommands
+   share one model. This costs a wire change that a client-side filter would not.
+
+6. **Against an older daemon, no protection applies.** Accepted, not mitigated — see Version
+   skew.
+
+## Wire protocol
+
+`FrameType` is append-only. One new value:
+
+| Value | Direction | Payload |
+|---|---|---|
+| `StopV2 = 10` | client → daemon | `mode⇥agentId` — mode `normal`\|`force`; empty id = all eligible |
+
+Two payload extensions to existing frames:
+
+- **`AgentList`** rows become `id⇥status⇥repo⇥kind⇥flowRunId⇥flowRole`. `kind` is
+  `agent`\|`review`\|`review-flow`; the flow fields are empty for non-flow agents.
+- **`StopAck`** rows keep the `id⇥status` shape, with `status` gaining `skipped` alongside the
+  existing `stopped`\|`failed`.
+- **`Attached`** gains a trailing read-only flag and reason, appended after the existing payload.
+  This follows the precedent `FrameCodec.Spawn` already set for `isPrivate` ("APPENDED after
+  args: older parsers ignore trailing bytes").
+
+`Stop = 8` stays decodable so nothing regresses mid-upgrade, but the CLI only sends `StopV2`.
+
+## Daemon changes
+
+- `HandleLocalListAsync` emits the three new columns from `Kind`/`FlowRunId`/`FlowRole`.
+- `HandleLocalAttachAsync` resolves the agent's `Kind`. For a protected agent it runs
+  `AttachClientLoopAsync` in read-only mode: the sink is registered as today, the `Stdin` arm is
+  dropped, the `Resize` arm is dropped, and the client is never entered into `ClientDims`.
+- A new `HandleLocalStopV2Async(mode, agentId, …)` applies decision 4:
+  - explicit id, protected, `normal` → `Error` naming the kind and flow;
+  - explicit id, protected, `force` → stop;
+  - empty id, `normal` → stop unprotected agents; protected ones appear in the ack as `skipped`;
+  - empty id, `force` → stop everything, as `stop --all` does today.
+- `LocalControlServer` routes `FrameType.StopV2`.
+
+The `IsPrivate` guard on `HandleStopAgent` and the server-origin path are untouched.
+
+## Client changes
+
+- `AgentRow` gains `Kind`, `FlowRunId`, `FlowRole`. The parser accepts **3 or more** columns and
+  defaults the new ones, so a running older daemon still lists correctly.
+- `ls` renders a `KIND` column, with the flow role appended for flow agents.
+- `attach` prints the read-only banner when the daemon reports the flag, and skips its own stdin
+  pump — cosmetic, since the daemon already drops it.
+- `stop` accepts `--force`, sends `StopV2`, and reports `skipped` rows distinctly from
+  `stopped`. With `--all --force`, the confirmation prompt lists protected agents in their own
+  labelled group, so the blast radius is visible before the user answers.
+
+## Version skew
+
+An older daemon replies with three-column `AgentList` rows, so every agent reads as `agent` and
+**no protection engages** — `stop --all` behaves exactly as it does today.
+
+This is deliberately not mitigated. A three-column reply from an old daemon is indistinguishable
+from a new daemon reporting three unprotected agents, so there is nothing to detect without
+adding a version probe. The window closes on its own: a daemon self-restarts onto the new binary
+when idle after `kcap update`. `StopV2` is the one place skew is visible, and it already
+surfaces through the existing "this daemon is too old for `agent stop`" message.
+
+## Documentation
+
+- `help-agent.txt` — read-only attach, `stop --force`, and what `stop --all` skips.
+- `README.md` — the `### Local agents (kcap agent)` section. Its current `--all` warning
+  (added when this gap was deferred, pointing at #379) is replaced by the real behaviour.
+
+## Testing
+
+- Daemon: `SeedAgentForTest` already takes `kind`/`flowRunId`/`flowRole`, so protection tests are
+  cheap. Cover — protected attach drops stdin and resize and never enters `ClientDims`;
+  protected stop without force yields `Error`; with force stops; stop-all marks protected rows
+  `skipped` and stops the rest.
+- Client: `AgentRow` parsing for 3-column (old daemon) and 6-column rows; `ls` rendering;
+  `skipped` rows reported distinctly.
+- `AgentVerbDispatchTests` gains a case pinning that a protected agent refuses `stop` without
+  `--force`.
+
+## Out of scope
+
+- **The `--all` confirmation TOCTOU** — the client lists and prompts, then the daemon
+  re-enumerates, so an agent launched during the prompt is stopped unlisted. Tracked separately;
+  this design narrows but does not close it.
+- **Telling the flow that a participant was force-stopped.** The flow still sees a participant
+  vanish; attributing that needs server-side work.
+- **Plain web-UI-launched agents**, per decision 1.

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
@@ -135,6 +135,7 @@ public static class FrameCodec {
         return new(FrameType.StopV2) { Bytes = ms.ToArray(), Text = agentId };
     }
     public static (bool force, string agentId) StopV2(LocalFrame f) {
+        Require(f.Bytes, 0, 1);
         var o = 1;
         return (f.Bytes[0] == 1, ReadLp(f.Bytes, ref o));
     }

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
@@ -50,7 +50,8 @@ public static class FrameCodec {
         FrameType.Error or FrameType.Attach or FrameType.AgentList
             or FrameType.Restart or FrameType.RestartAck
             or FrameType.Stop or FrameType.StopAck => Encoding.UTF8.GetBytes(f.Text),
-        FrameType.Attached or FrameType.Spawn => f.Bytes, // pre-encoded by Attached(...)/Spawn(...)
+        FrameType.Attached or FrameType.Spawn
+            or FrameType.StopV2 or FrameType.AttachedReadOnly => f.Bytes, // pre-encoded by the helpers below
         _ => throw new InvalidDataException($"unencodable frame {f.Type}"),
     };
 
@@ -62,7 +63,8 @@ public static class FrameCodec {
         FrameType.Error or FrameType.Attach or FrameType.AgentList
             or FrameType.Restart or FrameType.RestartAck
             or FrameType.Stop or FrameType.StopAck => new(t) { Text = Encoding.UTF8.GetString(p) },
-        FrameType.Attached or FrameType.Spawn => new(t) { Bytes = p },
+        FrameType.Attached or FrameType.Spawn
+            or FrameType.StopV2 or FrameType.AttachedReadOnly => new(t) { Bytes = p },
         _ => throw new InvalidDataException($"undecodable frame {t}"),
     };
 
@@ -123,6 +125,35 @@ public static class FrameCodec {
     public static (string agentId, byte[] snapshot) Attached(LocalFrame f) {
         var o = 0; var id = ReadLp(f.Bytes, ref o);
         return (id, f.Bytes[o..]);
+    }
+
+    // --- StopV2 structured payload ---
+    public static LocalFrame StopV2(bool force, string agentId) {
+        using var ms = new MemoryStream();
+        ms.WriteByte((byte)(force ? 1 : 0));
+        WriteLp(ms, agentId);
+        return new(FrameType.StopV2) { Bytes = ms.ToArray(), Text = agentId };
+    }
+    public static (bool force, string agentId) StopV2(LocalFrame f) {
+        var o = 1;
+        return (f.Bytes[0] == 1, ReadLp(f.Bytes, ref o));
+    }
+
+    // --- AttachedReadOnly structured payload ---
+    // Length-prefixed id AND reason before the snapshot: the snapshot is the unbounded tail, so
+    // anything appended after it would be painted onto the user's terminal instead of parsed.
+    public static LocalFrame AttachedReadOnly(string agentId, string reason, byte[] snapshot) {
+        using var ms = new MemoryStream();
+        WriteLp(ms, agentId);
+        WriteLp(ms, reason);
+        ms.Write(snapshot);
+        return new(FrameType.AttachedReadOnly) { Bytes = ms.ToArray(), Text = agentId };
+    }
+    public static (string agentId, string reason, byte[] snapshot) AttachedReadOnly(LocalFrame f) {
+        var o = 0;
+        var id = ReadLp(f.Bytes, ref o);
+        var reason = ReadLp(f.Bytes, ref o);
+        return (id, reason, f.Bytes[o..]);
     }
 
     // --- byte helpers ---

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
@@ -18,7 +18,7 @@ public enum FrameType : byte {
     Stdout    = 65,
     Exited    = 66,
     Error     = 67,
-    AgentList = 68, // UTF-8 table payload: one `id\tstatus\tcwd` line per agent
+    AgentList = 68, // UTF-8 table payload: one `id\tstatus\trepo\tkind\tflowRunId\tflowRole` line per agent
     RestartAck = 69, // acknowledgement for Restart (Text = short status)
     StopAck    = 70, // acknowledgement for Stop (Text = one `id\tstatus` line per agent; status is "stopped", "skipped", or "failed")
     AttachedReadOnly = 71, // Attached for a protected agent: id + reason + snapshot, no input accepted

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
@@ -12,6 +12,7 @@ public enum FrameType : byte {
     List    = 6,   // request the daemon's agent list (for `kcap agent ls`)
     Restart = 7,   // request restart-after-update (Text = "when-idle"|"now"|"force")
     Stop    = 8,   // stop an agent (Text = agent id; empty = every agent this daemon hosts)
+    StopV2  = 10,  // stop with a force flag (see FrameCodec.StopV2); supersedes Stop
     // daemon → client
     Attached  = 64,
     Stdout    = 65,
@@ -20,4 +21,5 @@ public enum FrameType : byte {
     AgentList = 68, // UTF-8 table payload: one `id\tstatus\tcwd` line per agent
     RestartAck = 69, // acknowledgement for Restart (Text = short status)
     StopAck    = 70, // acknowledgement for Stop (Text = one `id\tstatus` line per agent; status is "stopped" or "failed")
+    AttachedReadOnly = 71, // Attached for a protected agent: id + reason + snapshot, no input accepted
 }

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
@@ -20,6 +20,6 @@ public enum FrameType : byte {
     Error     = 67,
     AgentList = 68, // UTF-8 table payload: one `id\tstatus\tcwd` line per agent
     RestartAck = 69, // acknowledgement for Restart (Text = short status)
-    StopAck    = 70, // acknowledgement for Stop (Text = one `id\tstatus` line per agent; status is "stopped" or "failed")
+    StopAck    = 70, // acknowledgement for Stop (Text = one `id\tstatus` line per agent; status is "stopped", "skipped", or "failed")
     AttachedReadOnly = 71, // Attached for a protected agent: id + reason + snapshot, no input accepted
 }

--- a/src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs
@@ -22,4 +22,5 @@ public sealed record LocalFrame(FrameType Type) {
     public static LocalFrame RestartAck(string status)  => new(FrameType.RestartAck) { Text = status };
     public static LocalFrame Stop(string agentId)       => new(FrameType.Stop)       { Text = agentId };
     public static LocalFrame StopAck(string payload)    => new(FrameType.StopAck)    { Text = payload };
+    public static LocalFrame StopV2(bool force, string agentId) => FrameCodec.StopV2(force, agentId);
 }

--- a/src/Capacitor.Cli.Core/Resources/help-agent.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-agent.txt
@@ -5,10 +5,12 @@ Usage: kcap agent <subcommand>
 Subcommands:
   start <vendor> [flags] [-- <agent args>]
                           Start an agent the daemon hosts for you
-  ls                      List this daemon's agents (id, status, repo)
+  ls                      List this daemon's agents (id, status, kind, repo)
   attach <agent-id>       Attach your terminal to a running agent
-  stop <agent-id>         Stop an agent (graceful /exit, then terminate)
-  stop --all [-y]         Stop every agent this daemon hosts
+  stop <agent-id> [--force]
+                          Stop an agent (graceful /exit, then terminate)
+  stop --all [-y] [--force]
+                          Stop every agent this daemon hosts
 
 Running `kcap agent` with no subcommand lists agents.
 

--- a/src/Capacitor.Cli.Core/Resources/help-agent.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-agent.txt
@@ -22,13 +22,11 @@ Options for start:
   --                      Everything after this is passed to the vendor CLI verbatim
 
 Options for stop:
-  --all                   Stop every agent, including --private ones
+  --all                   Stop every agent, including --private ones. Review and
+                          review-flow agents are skipped unless --force is given.
+  --force                 Include review and review-flow agents. Stopping a flow
+                          participant mid-round leaves the flow without it.
   --yes, -y               Skip the confirmation prompt for --all
-
-  --all stops every agent this daemon hosts, not just the ones you started
-  from this CLI — including agents launched from the web UI and review-flow
-  participants (e.g. reviewers mid-round). See
-  https://github.com/kurrent-io/kcap-cli/issues/379.
 
 Options for ls, attach, stop:
   --daemon <name>         Target a specific daemon (defaults to your profile's)
@@ -36,6 +34,12 @@ Options for ls, attach, stop:
 Agent ids:
   Any unique prefix works — `kcap agent attach ab12` is enough as long as it
   matches exactly one agent. An ambiguous prefix lists the candidates.
+
+Review and flow agents:
+  Agents the daemon runs as part of a review flow (KIND `review-flow`) or a PR
+  review (`review`) are not yours to drive directly — they are addressed through
+  the flow tools. `attach` gives you a read-only view of one: you see its output,
+  your input is not delivered. `stop` refuses unless you pass --force.
 
 Notes:
   The daemon owns the agent, not your terminal, so you can detach and the agent

--- a/src/Capacitor.Cli.Core/Resources/help-agent.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-agent.txt
@@ -24,8 +24,10 @@ Options for start:
 Options for stop:
   --all                   Stop every agent, including --private ones. Review and
                           review-flow agents are skipped unless --force is given.
-  --force                 Include review and review-flow agents. Stopping a flow
-                          participant mid-round leaves the flow without it.
+  --force                 Stop a single review or review-flow agent that would
+                          otherwise be refused, or include them under --all.
+                          Stopping a flow participant mid-round leaves the flow
+                          without it.
   --yes, -y               Skip the confirmation prompt for --all
 
 Options for ls, attach, stop:
@@ -39,7 +41,8 @@ Review and flow agents:
   Agents the daemon runs as part of a review flow (KIND `review-flow`) or a PR
   review (`review`) are not yours to drive directly — they are addressed through
   the flow tools. `attach` gives you a read-only view of one: you see its output,
-  your input is not delivered. `stop` refuses unless you pass --force.
+  your input is not delivered, and your terminal size is not applied to it.
+  `stop` refuses unless you pass --force.
 
 Notes:
   The daemon owns the agent, not your terminal, so you can detach and the agent

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -28,7 +28,7 @@ Configuration:
 
 Agents:
   agent start <vendor> [-d] [--worktree] [--private] [-- <args>]  Start a daemon-hosted agent
-  agent ls                         List this daemon's agents (id, status, repo)
+  agent ls                         List this daemon's agents (id, status, kind, repo)
   agent attach <id>                Attach your terminal to a running agent (id prefix ok)
   agent stop <id> | --all [-y] [--force]  Stop one agent, or all of them
 

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -30,7 +30,7 @@ Agents:
   agent start <vendor> [-d] [--worktree] [--private] [-- <args>]  Start a daemon-hosted agent
   agent ls                         List this daemon's agents (id, status, repo)
   agent attach <id>                Attach your terminal to a running agent (id prefix ok)
-  agent stop <id> | --all [-y]     Stop one agent, or all of them
+  agent stop <id> | --all [-y] [--force]  Stop one agent, or all of them
 
 Daemon:
   daemon start [-d] [--name N]     Start the daemon (foreground, or -d for background; refuses on duplicate name)

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -22,23 +22,44 @@ internal partial class AgentOrchestrator {
     };
 
     /// <summary>
-    /// Stop one agent (or every agent, when <paramref name="agentId"/> is empty) on behalf of
-    /// `kcap agent stop`. Calls the stop core directly rather than <c>HandleStopAgent</c>: the
-    /// private-agent guard there defends against server-origin commands, and a request arriving
-    /// on the daemon's own 0600 socket is the owner's. Stops run concurrently — each can take up
-    /// to 25s (graceful wait plus terminate), so serial teardown would be unusable.
+    /// Serves the legacy <c>Stop</c> frame from older clients that predate --force. That frame
+    /// has no force concept, so it always behaves as if --force were passed: an older client
+    /// gets exactly its previous (unprotected) behaviour, and gains no new refusals it has no
+    /// way to override.
     /// </summary>
-    public async Task HandleLocalStopAsync(string agentId, Stream stream, CancellationToken ct) {
+    public Task HandleLocalStopAsync(string agentId, Stream stream, CancellationToken ct) =>
+        HandleLocalStopV2Async(force: true, agentId, stream, ct);
+
+    /// <summary>
+    /// `kcap agent stop` with protection. A review or flow agent is refused unless the user
+    /// passed --force; a stop-all reports them as `skipped` rather than silently omitting them.
+    /// Calls the stop core directly rather than <c>HandleStopAgent</c>: the private-agent guard
+    /// there defends against server-origin commands, and a request arriving on the daemon's own
+    /// 0600 socket is the owner's. Stops run concurrently — each can take up to 25s (graceful
+    /// wait plus terminate), so serial teardown would be unusable.
+    /// </summary>
+    public async Task HandleLocalStopV2Async(bool force, string agentId, Stream stream, CancellationToken ct) {
         if (agentId.Length == 0) {
-            var all     = _agents.Values.ToList();
-            var results = await Task.WhenAll(all.Select(StopAgentCoreAsync));
-            var lines   = all.Zip(results, (a, ok) => $"{a.Id}\t{StatusText(ok)}");
-            await FrameCodec.WriteAsync(stream, LocalFrame.StopAck(string.Join('\n', lines)), ct);
+            var all       = _agents.Values.ToList();
+            var eligible  = all.Where(a => force || a.Kind == LaunchKind.Default).ToList();
+            var results   = await Task.WhenAll(eligible.Select(StopAgentCoreAsync));
+            var stopped   = eligible.Zip(results, (a, ok) => $"{a.Id}\t{StatusText(ok)}");
+            var skipped   = all.Except(eligible).Select(a => $"{a.Id}\tskipped");
+
+            await FrameCodec.WriteAsync(stream, LocalFrame.StopAck(string.Join('\n', stopped.Concat(skipped))), ct);
 
             return;
         }
 
         if (_agents.TryGetValue(agentId, out var agent)) {
+            if (!force && agent.Kind != LaunchKind.Default) {
+                await FrameCodec.WriteAsync(stream, LocalFrame.Error(
+                    $"{agentId} is a {ProtectionReason(agent)}. Stopping it mid-round leaves the flow "
+                  + "without a participant. Pass --force to stop it anyway."), ct);
+
+                return;
+            }
+
             var ok = await StopAgentCoreAsync(agent);
             await FrameCodec.WriteAsync(stream, LocalFrame.StopAck($"{agentId}\t{StatusText(ok)}"), ct);
 
@@ -46,7 +67,7 @@ internal partial class AgentOrchestrator {
         }
 
         // Not live here — it may be a survivor of a previous daemon incarnation, which the PID
-        // record can still reap. This is why the client sends full ids verbatim.
+        // record can still reap. Kind is unknown for those, so protection cannot apply.
         var reaped = await TryStopByPidRecordAsync(agentId);
 
         await FrameCodec.WriteAsync(

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -8,10 +8,19 @@ internal partial class AgentOrchestrator {
     /// <summary>Reply to a <c>kcap agent ls</c> request with a tab-separated agent table.</summary>
     public Task HandleLocalListAsync(Stream stream, CancellationToken ct) {
         var lines = _agents.Values.Select(a =>
-            $"{a.Id}\t{a.Status}\t{a.RepoPath}\t{KindText(a.Kind)}\t{a.FlowRunId ?? ""}\t{a.FlowRole ?? ""}");
+            $"{a.Id}\t{a.Status}\t{Cell(a.RepoPath)}\t{KindText(a.Kind)}\t{Cell(a.FlowRunId)}\t{Cell(a.FlowRole)}");
 
         return FrameCodec.WriteAsync(stream, new LocalFrame(FrameType.AgentList) { Text = string.Join('\n', lines) }, ct);
     }
+
+    /// <summary>
+    /// Neutralises the table's own delimiters in a free-form field. A repo path may legally
+    /// contain a tab or newline, which would shift the reader's columns or split the row — and the
+    /// CLI keys `stop --all`'s confirmation off the kind column, so a shifted row understates the
+    /// blast radius the user is agreeing to.
+    /// </summary>
+    static string Cell(string? value) =>
+        value is null ? "" : value.Replace('\t', ' ').Replace('\n', ' ').Replace('\r', ' ');
 
     /// Wire spelling of <see cref="LaunchKind"/>. Kept separate from the enum name so the table
     /// reads as a CLI column rather than a .NET identifier. A future kind that falls through the

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -44,7 +44,12 @@ internal partial class AgentOrchestrator {
             var eligible  = all.Where(a => force || a.Kind == LaunchKind.Default).ToList();
             var results   = await Task.WhenAll(eligible.Select(StopAgentCoreAsync));
             var stopped   = eligible.Zip(results, (a, ok) => $"{a.Id}\t{StatusText(ok)}");
-            var skipped   = all.Except(eligible).Select(a => $"{a.Id}\tskipped");
+
+            // The exact negation of the eligible predicate above — not a set difference.
+            // AgentInstance is a record with mutable fields (Status, LastOutputAt, ...), so
+            // Except would hash teardown-mutable state while the eligible agents are still
+            // draining from the WhenAll above, and could misreport a stopped agent as skipped too.
+            var skipped = all.Where(a => !force && a.Kind != LaunchKind.Default).Select(a => $"{a.Id}\tskipped");
 
             await FrameCodec.WriteAsync(stream, LocalFrame.StopAck(string.Join('\n', stopped.Concat(skipped))), ct);
 
@@ -53,9 +58,14 @@ internal partial class AgentOrchestrator {
 
         if (_agents.TryGetValue(agentId, out var agent)) {
             if (!force && agent.Kind != LaunchKind.Default) {
+                // A flow participant going away mid-round strands the flow; a plain hosted
+                // review has no round to strand, just a result that will never come back.
+                var consequence = agent.Kind == LaunchKind.ReviewFlow
+                    ? "Stopping it mid-round leaves the flow without a participant."
+                    : "Stopping it discards the review before it can report back.";
+
                 await FrameCodec.WriteAsync(stream, LocalFrame.Error(
-                    $"{agentId} is a {ProtectionReason(agent)}. Stopping it mid-round leaves the flow "
-                  + "without a participant. Pass --force to stop it anyway."), ct);
+                    $"{agentId} is a {ProtectionReason(agent)}. {consequence} Pass --force to stop it anyway."), ct);
 
                 return;
             }
@@ -67,7 +77,8 @@ internal partial class AgentOrchestrator {
         }
 
         // Not live here — it may be a survivor of a previous daemon incarnation, which the PID
-        // record can still reap. Kind is unknown for those, so protection cannot apply.
+        // record can still reap. This is why the client sends full ids verbatim. Kind is
+        // unknown for those, so protection cannot apply.
         var reaped = await TryStopByPidRecordAsync(agentId);
 
         await FrameCodec.WriteAsync(

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -148,7 +148,18 @@ internal partial class AgentOrchestrator {
         if (!_agents.TryGetValue(agentId, out var agent))
             return FrameCodec.WriteAsync(stream, LocalFrame.Error($"no such agent {agentId}"), ct);
 
-        return AttachClientLoopAsync(agent, stream, ct);
+        // A review or flow agent is addressed through the flow protocol, never by typing at it,
+        // so the daemon — not the client — decides this attach carries no input.
+        return AttachClientLoopAsync(agent, stream, ct, readOnly: agent.Kind != LaunchKind.Default);
+    }
+
+    /// Human-readable "why is this read-only", carried on the AttachedReadOnly frame.
+    static string ProtectionReason(AgentInstance agent) {
+        var kind = agent.Kind == LaunchKind.ReviewFlow ? "review-flow" : "review";
+        var role = string.IsNullOrEmpty(agent.FlowRole) ? "" : $", role {agent.FlowRole}";
+        var flow = string.IsNullOrEmpty(agent.FlowRunId) ? "" : $" (flow {agent.FlowRunId}{role})";
+
+        return $"{kind} agent{flow}";
     }
 
     /// <summary>
@@ -156,7 +167,8 @@ internal partial class AgentOrchestrator {
     /// client's input (stdin/resize) until it detaches or disconnects. The agent keeps
     /// running either way — the sink is just removed.
     /// </summary>
-    internal async Task AttachClientLoopAsync(AgentInstance agent, Stream stream, CancellationToken ct) {
+    internal async Task AttachClientLoopAsync(
+            AgentInstance agent, Stream stream, CancellationToken ct, bool readOnly = false) {
         // One NetworkStream, two writers (the sink's Stdout frames + Attached/Exited here):
         // serialise all writes through this lock. Reads (the input loop) are independent.
         var writeLock = new SemaphoreSlim(1, 1);
@@ -179,7 +191,9 @@ internal partial class AgentOrchestrator {
 
         try {
             // Bounded replay BEFORE any live chunk so the client paints a coherent screen.
-            await Send(FrameCodec.Attached(agent.Id, snapshot));
+            await Send(readOnly
+                ? FrameCodec.AttachedReadOnly(agent.Id, ProtectionReason(agent), snapshot)
+                : FrameCodec.Attached(agent.Id, snapshot));
             var pump = sink.RunAsync(ct);
 
             // Break this read loop when the agent exits on its own (CleanupAgentAsync trips
@@ -203,6 +217,8 @@ internal partial class AgentOrchestrator {
                     if (f is null || f.Type == FrameType.Detach) break;
 
                     if (f.Type == FrameType.Stdin) {
+                        if (readOnly) continue; // protected agent: input is never delivered
+
                         try {
                             await agent.Runtime.SendRawInputAsync(f.Bytes);
                         } catch (NotSupportedException) {
@@ -215,7 +231,9 @@ internal partial class AgentOrchestrator {
                             break;
                         }
                     } else if (f.Type == FrameType.Resize) {
-                        ApplyResizeClamp(agent, sink, f.Cols, f.Rows);
+                        // A read-only viewer must not enter ClientDims, or the min-clamp would
+                        // let an observer shrink the participant's terminal.
+                        if (!readOnly) ApplyResizeClamp(agent, sink, f.Cols, f.Rows);
                     }
                 }
             } catch (Exception ex) when (ex is EndOfStreamException or IOException or OperationCanceledException) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 
 namespace Capacitor.Cli.Daemon.Services;
@@ -6,10 +7,19 @@ namespace Capacitor.Cli.Daemon.Services;
 internal partial class AgentOrchestrator {
     /// <summary>Reply to a <c>kcap agent ls</c> request with a tab-separated agent table.</summary>
     public Task HandleLocalListAsync(Stream stream, CancellationToken ct) {
-        var lines = _agents.Values.Select(a => $"{a.Id}\t{a.Status}\t{a.RepoPath}");
+        var lines = _agents.Values.Select(a =>
+            $"{a.Id}\t{a.Status}\t{a.RepoPath}\t{KindText(a.Kind)}\t{a.FlowRunId ?? ""}\t{a.FlowRole ?? ""}");
 
         return FrameCodec.WriteAsync(stream, new LocalFrame(FrameType.AgentList) { Text = string.Join('\n', lines) }, ct);
     }
+
+    /// Wire spelling of <see cref="LaunchKind"/>. Kept separate from the enum name so the table
+    /// reads as a CLI column rather than a .NET identifier.
+    static string KindText(LaunchKind kind) => kind switch {
+        LaunchKind.Review     => "review",
+        LaunchKind.ReviewFlow => "review-flow",
+        _                     => "agent",
+    };
 
     /// <summary>
     /// Stop one agent (or every agent, when <paramref name="agentId"/> is empty) on behalf of

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -14,11 +14,16 @@ internal partial class AgentOrchestrator {
     }
 
     /// Wire spelling of <see cref="LaunchKind"/>. Kept separate from the enum name so the table
-    /// reads as a CLI column rather than a .NET identifier.
+    /// reads as a CLI column rather than a .NET identifier. A future kind that falls through the
+    /// switch reports its own enum name rather than masquerading as "agent" — the CLI's
+    /// `IsProtectedKind` then fails safe (protected) on anything it doesn't recognise, instead of
+    /// the daemon advertising an unprotected kind that its own `Kind != Default` checks would
+    /// still protect.
     static string KindText(LaunchKind kind) => kind switch {
+        LaunchKind.Default    => "agent",
         LaunchKind.Review     => "review",
         LaunchKind.ReviewFlow => "review-flow",
-        _                     => "agent",
+        _                     => kind.ToString(),
     };
 
     /// <summary>
@@ -77,8 +82,22 @@ internal partial class AgentOrchestrator {
         }
 
         // Not live here — it may be a survivor of a previous daemon incarnation, which the PID
-        // record can still reap. This is why the client sends full ids verbatim. Kind is
-        // unknown for those, so protection cannot apply.
+        // record can still reap. This is why the client sends full ids verbatim. The record
+        // carries the same Kind/FlowRunId/FlowRole the live agent would have, so protection still
+        // applies — a review-flow survivor from a prior incarnation is refused exactly like a
+        // live one. TryStopByPidRecordAsync itself stays policy-free (it's shared with the
+        // server-origin HandleStopAgent path); the decision is made here, before it ever runs.
+        if (!force && FindPidRecord(agentId) is { Kind: not nameof(LaunchKind.Default) } record) {
+            var consequence = record.Kind == nameof(LaunchKind.ReviewFlow)
+                ? "Stopping it mid-round leaves the flow without a participant."
+                : "Stopping it discards the review before it can report back.";
+
+            await FrameCodec.WriteAsync(stream, LocalFrame.Error(
+                $"{agentId} is a {ProtectionReason(record)}. {consequence} Pass --force to stop it anyway."), ct);
+
+            return;
+        }
+
         var reaped = await TryStopByPidRecordAsync(agentId);
 
         await FrameCodec.WriteAsync(
@@ -185,13 +204,25 @@ internal partial class AgentOrchestrator {
         return AttachClientLoopAsync(agent, stream, ct, readOnly: agent.Kind != LaunchKind.Default);
     }
 
-    /// Human-readable "why is this read-only", carried on the AttachedReadOnly frame.
-    static string ProtectionReason(AgentInstance agent) {
-        var kind = agent.Kind == LaunchKind.ReviewFlow ? "review-flow" : "review";
-        var role = string.IsNullOrEmpty(agent.FlowRole) ? "" : $", role {agent.FlowRole}";
-        var flow = string.IsNullOrEmpty(agent.FlowRunId) ? "" : $" (flow {agent.FlowRunId}{role})";
+    /// Human-readable "why is this read-only/refused", carried on the AttachedReadOnly frame and
+    /// the not-live StopV2 refusal below (which reads the same kind from a persisted PID record
+    /// instead of a live AgentInstance).
+    static string ProtectionReason(AgentInstance agent) => ProtectionReason(agent.Kind.ToString(), agent.FlowRunId, agent.FlowRole);
 
-        return $"{kind} agent{flow}";
+    static string ProtectionReason(AgentPidRecord record) => ProtectionReason(record.Kind, record.FlowRunId, record.FlowRole);
+
+    /// A kind this build doesn't recognise reports its own name rather than being mislabelled as
+    /// "review" — mirrors KindText's fail-safe shape.
+    static string ProtectionReason(string kind, string? flowRunId, string? flowRole) {
+        var label = kind switch {
+            nameof(LaunchKind.ReviewFlow) => "review-flow",
+            nameof(LaunchKind.Review)     => "review",
+            _                             => kind,
+        };
+        var role = string.IsNullOrEmpty(flowRole) ? "" : $", role {flowRole}";
+        var flow = string.IsNullOrEmpty(flowRunId) ? "" : $" (flow {flowRunId}{role})";
+
+        return $"{label} agent{flow}";
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -714,11 +714,6 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     internal void SeedPendingMarkerCandidateForTest(string agentId, string oldEpoch) =>
         _markerCandidates!.Write(new MarkerCandidate(agentId, _daemonId, oldEpoch, 999_999));
 
-    /// <summary>Phase B (D4 §6.4(3) StopAgent fallback): the caller had no in-memory agent for
-    /// this id — consult the PID record and, if a live process still matches its EXACT identity (and,
-    /// on Unix, carries the expected <c>KCAP_AGENT_ID</c> env — ambiguity spares), reap it by identity
-    /// and delete the record on confirmed death. This makes the server's registry-independent S2 stop
-    /// effective even against a NEW daemon incarnation that never knew the agent in memory.</summary>
     /// <summary>Looks up a persisted PID record by agent id, or null if none exists. Read-only and
     /// policy-free — shared by the reap below and by the local-stop protection check in
     /// AgentOrchestrator.LocalIpc.cs, which decides whether to reap at all before this ever runs.</summary>
@@ -730,6 +725,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         return record.AgentId == agentId ? record : null;
     }
 
+    /// <summary>Phase B (D4 §6.4(3) StopAgent fallback): the caller had no in-memory agent for
+    /// this id — consult the PID record and, if a live process still matches its EXACT identity (and,
+    /// on Unix, carries the expected <c>KCAP_AGENT_ID</c> env — ambiguity spares), reap it by identity
+    /// and delete the record on confirmed death. This makes the server's registry-independent S2 stop
+    /// effective even against a NEW daemon incarnation that never knew the agent in memory.</summary>
     async Task<bool> TryStopByPidRecordAsync(string agentId) {
         if (FindPidRecord(agentId) is not { } record) return false;
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -719,11 +719,19 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// on Unix, carries the expected <c>KCAP_AGENT_ID</c> env — ambiguity spares), reap it by identity
     /// and delete the record on confirmed death. This makes the server's registry-independent S2 stop
     /// effective even against a NEW daemon incarnation that never knew the agent in memory.</summary>
-    async Task<bool> TryStopByPidRecordAsync(string agentId) {
-        if (_pidRecords is null) return false;
+    /// <summary>Looks up a persisted PID record by agent id, or null if none exists. Read-only and
+    /// policy-free — shared by the reap below and by the local-stop protection check in
+    /// AgentOrchestrator.LocalIpc.cs, which decides whether to reap at all before this ever runs.</summary>
+    internal AgentPidRecord? FindPidRecord(string agentId) {
+        if (_pidRecords is null) return null;
 
         var record = _pidRecords.ReadAll().FirstOrDefault(r => r.AgentId == agentId);
-        if (record.AgentId != agentId) return false; // no record
+
+        return record.AgentId == agentId ? record : null;
+    }
+
+    async Task<bool> TryStopByPidRecordAsync(string agentId) {
+        if (FindPidRecord(agentId) is not { } record) return false;
 
         var confirmedGone = await ProcessReaper.ReapByRecordAsync(record, _logger, _shutdownCts.Token);
         if (confirmedGone) {
@@ -733,7 +741,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // boot's OrphanReaper record pass re-derives it and Upsert (idempotent on the source-stable
             // (AgentId, OldEpoch) key) collapses onto the committed entry, then completes the delete.
             _resolvedLedger?.Upsert(agentId, record.DaemonEpoch, record.FlowRunId, record.FlowRole);
-            _pidRecords.Delete(agentId); // delete ONLY on confirmed death (spec §6.4(2))
+            _pidRecords?.Delete(agentId); // delete ONLY on confirmed death (spec §6.4(2))
         }
 
         return confirmedGone;

--- a/src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs
@@ -44,8 +44,14 @@ internal sealed partial class LocalControlServer(
                 case FrameType.Attach: await orchestrator.HandleLocalAttachAsync(first.Text, stream, ct); break;
                 case FrameType.List:   await orchestrator.HandleLocalListAsync(stream, ct); break;
                 case FrameType.Stop:   await orchestrator.HandleLocalStopAsync(first.Text, stream, ct); break;
+                case FrameType.StopV2: {
+                    var (force, id) = FrameCodec.StopV2(first);
+                    await orchestrator.HandleLocalStopV2Async(force, id, stream, ct);
+
+                    break;
+                }
                 case FrameType.Restart: await HandleRestartAsync(first.Text, stream, ct); break;
-                default: await FrameCodec.WriteAsync(stream, LocalFrame.Error($"expected Spawn/Attach/List/Stop/Restart, got {first.Type}"), ct); break;
+                default: await FrameCodec.WriteAsync(stream, LocalFrame.Error($"expected Spawn/Attach/List/Stop/StopV2/Restart, got {first.Type}"), ct); break;
             }
         } catch (Exception ex) when (ex is not OperationCanceledException) {
             LogConnectionError(ex);

--- a/src/Capacitor.Cli/Commands/AgentCommand.cs
+++ b/src/Capacitor.Cli/Commands/AgentCommand.cs
@@ -180,10 +180,15 @@ internal static class AgentCommand {
             }
 
             Console.WriteLine($"Found {targets.Length} agents:");
-            foreach (var a in agents.Where(a => targets.Contains(a.Id))) Console.WriteLine($"  • {a.Id}  {a.Repo}");
+            foreach (var a in agents.Where(a => targets.Contains(a.Id) && !protectedIds.Contains(a.Id)))
+                Console.WriteLine($"  • {a.Id}  {a.Repo}");
 
-            if (!force && protectedIds.Length > 0) {
-                Console.WriteLine($"Skipping {protectedIds.Length} review agent(s) — pass --force to include them:");
+            // Both branches label protected rows with their Kind before the [y/N] prompt, so the
+            // blast radius of --force is as visible as the default skip list is.
+            if (protectedIds.Length > 0) {
+                Console.WriteLine(force
+                    ? $"Including {protectedIds.Length} review agent(s):"
+                    : $"Skipping {protectedIds.Length} review agent(s) — pass --force to include them:");
                 foreach (var a in agents.Where(a => protectedIds.Contains(a.Id)))
                     Console.WriteLine($"  • {a.Id}  {a.Kind}  {a.Repo}");
             }
@@ -352,8 +357,11 @@ internal static class AgentCommand {
 
             if (resp.Text.Length == 0) return [];
 
+            // A row needs at least id/status/repo — fewer columns is unparseable, not a short row
+            // to default-fill (a repo path containing a stray tab could otherwise shift the kind
+            // column and mislabel an agent).
             return [.. resp.Text.Split('\n')
-                .Where(l => l.Length > 0)
+                .Where(l => l.Length > 0 && l.Split('\t').Length >= 3)
                 .Select(ParseAgentRow)];
         } catch (Exception ex) when (ex is SocketException or IOException) {
             await Console.Error.WriteLineAsync($"kcap: cannot reach daemon: {ex.Message}");
@@ -446,8 +454,10 @@ internal static class AgentCommand {
     }
 
     /// Kinds the CLI refuses to mutate by accident: a reviewer mid-round is not the user's to
-    /// type at or stop. Mirrors LaunchKind — anything that is not a plain agent is protected.
-    internal static bool IsProtectedKind(string kind) => kind is "review" or "review-flow";
+    /// type at or stop. Mirrors LaunchKind — anything that is not a plain agent is protected,
+    /// including a kind this build doesn't recognise: an unrecognised kind fails safe rather
+    /// than reading as stoppable.
+    internal static bool IsProtectedKind(string kind) => kind is not "agent";
 
     /// <summary>Splits an agent list into what `stop --all` will stop and what it will skip.</summary>
     internal static (string[] Stoppable, string[] Protected) PartitionByProtection(IReadOnlyList<AgentRow> agents) => (

--- a/src/Capacitor.Cli/Commands/AgentCommand.cs
+++ b/src/Capacitor.Cli/Commands/AgentCommand.cs
@@ -357,12 +357,20 @@ internal static class AgentCommand {
 
             if (resp.Text.Length == 0) return [];
 
-            // A row needs at least id/status/repo — fewer columns is unparseable, not a short row
-            // to default-fill (a repo path containing a stray tab could otherwise shift the kind
-            // column and mislabel an agent).
-            return [.. resp.Text.Split('\n')
-                .Where(l => l.Length > 0 && l.Split('\t').Length >= 3)
-                .Select(ParseAgentRow)];
+            // Exactly 3 columns is an older daemon; exactly 6 is a current one. Any other width
+            // means the row was corrupted in transit — most plausibly a delimiter inside a
+            // free-form field — and a shifted kind column would misreport what `stop --all` is
+            // about to do. Refuse the whole table rather than consent to a guess.
+            string[] rows = [.. resp.Text.Split('\n').Where(l => l.Length > 0)];
+
+            if (rows.Any(l => l.Split('\t').Length is not (3 or 6))) {
+                await Console.Error.WriteLineAsync(
+                    "kcap: daemon sent a malformed agent table (unexpected column count); refusing to act on it");
+
+                return null;
+            }
+
+            return [.. rows.Select(ParseAgentRow)];
         } catch (Exception ex) when (ex is SocketException or IOException) {
             await Console.Error.WriteLineAsync($"kcap: cannot reach daemon: {ex.Message}");
 

--- a/src/Capacitor.Cli/Commands/AgentCommand.cs
+++ b/src/Capacitor.Cli/Commands/AgentCommand.cs
@@ -6,8 +6,10 @@ using Capacitor.Cli.Local;
 
 namespace Capacitor.Cli.Commands;
 
-/// One row of the daemon's agent table (`id\tstatus\trepo` on the wire).
-internal readonly record struct AgentRow(string Id, string Status, string Repo);
+/// One row of the daemon's agent table (`id\tstatus\trepo\tkind\tflowRunId\tflowRole` on the
+/// wire). A daemon older than #379 sends only the first three; the rest default.
+internal readonly record struct AgentRow(
+    string Id, string Status, string Repo, string Kind, string FlowRunId, string FlowRole);
 
 /// <summary>
 /// `kcap agent start|ls|stop|attach` — drive daemon-hosted agents from the local
@@ -286,8 +288,11 @@ internal static class AgentCommand {
             return 0;
         }
 
-        Console.WriteLine($"{"AGENT",-34} {"STATUS",-10} REPO");
-        foreach (var a in agents) Console.WriteLine($"{a.Id,-34} {a.Status,-10} {a.Repo}");
+        Console.WriteLine($"{"AGENT",-34} {"STATUS",-10} {"KIND",-12} REPO");
+        foreach (var a in agents) {
+            var role = a.FlowRole.Length > 0 ? $"  [{a.FlowRole}]" : "";
+            Console.WriteLine($"{a.Id,-34} {a.Status,-10} {a.Kind,-12} {a.Repo}{role}");
+        }
 
         return 0;
     }
@@ -327,9 +332,8 @@ internal static class AgentCommand {
             if (resp.Text.Length == 0) return [];
 
             return [.. resp.Text.Split('\n')
-                .Select(l => l.Split('\t'))
-                .Where(p => p.Length == 3)
-                .Select(p => new AgentRow(p[0], p[1], p[2]))];
+                .Where(l => l.Length > 0)
+                .Select(ParseAgentRow)];
         } catch (Exception ex) when (ex is SocketException or IOException) {
             await Console.Error.WriteLineAsync($"kcap: cannot reach daemon: {ex.Message}");
 
@@ -418,6 +422,23 @@ internal static class AgentCommand {
         return string.IsNullOrEmpty(next) || next.StartsWith('-')
             ? (null, "--daemon requires a value")
             : (next, null);
+    }
+
+    /// Kinds the CLI refuses to mutate by accident: a reviewer mid-round is not the user's to
+    /// type at or stop. Mirrors LaunchKind — anything that is not a plain agent is protected.
+    internal static bool IsProtectedKind(string kind) => kind is "review" or "review-flow";
+
+    /// <summary>Tolerates a short row from an older daemon by defaulting the newer columns.</summary>
+    internal static AgentRow ParseAgentRow(string line) {
+        var p = line.Split('\t');
+
+        return new AgentRow(
+            p[0],
+            p.Length > 1 ? p[1] : "",
+            p.Length > 2 ? p[2] : "",
+            p.Length > 3 && p[3].Length > 0 ? p[3] : "agent",
+            p.Length > 4 ? p[4] : "",
+            p.Length > 5 ? p[5] : "");
     }
 
     /// <summary>A full agent id as minted by `Guid.NewGuid().ToString("N")`.</summary>

--- a/src/Capacitor.Cli/Commands/AgentCommand.cs
+++ b/src/Capacitor.Cli/Commands/AgentCommand.cs
@@ -124,6 +124,7 @@ internal static class AgentCommand {
     static async Task<int> StopAsync(string[] args) {
         var all = args.Contains("--all");
         var yes = args.Contains("--yes") || args.Contains("-y");
+        var force = args.Contains("--force");
         var hasId = args.Length > 0 && !args[0].StartsWith('-');
 
         if (all && hasId) {
@@ -133,8 +134,8 @@ internal static class AgentCommand {
         }
 
         if (!all && !hasId) {
-            await Console.Error.WriteLineAsync("usage: kcap agent stop <agent-id> [--daemon <name>]");
-            await Console.Error.WriteLineAsync("       kcap agent stop --all [-y] [--daemon <name>]");
+            await Console.Error.WriteLineAsync("usage: kcap agent stop <agent-id> [--force] [--daemon <name>]");
+            await Console.Error.WriteLineAsync("       kcap agent stop --all [-y] [--force] [--daemon <name>]");
 
             return 1;
         }
@@ -167,11 +168,28 @@ internal static class AgentCommand {
                 return 0;
             }
 
-            Console.WriteLine($"Found {agents.Count} agents:");
-            foreach (var a in agents) Console.WriteLine($"  • {a.Id}  {a.Repo}");
+            var (stoppable, protectedIds) = PartitionByProtection(agents);
+            var targets = force ? agents.Select(a => a.Id).ToArray() : stoppable;
+
+            if (targets.Length == 0) {
+                Console.WriteLine(protectedIds.Length > 0
+                    ? $"No agents to stop. {protectedIds.Length} review agent(s) skipped — pass --force to include them."
+                    : "No agents.");
+
+                return 0;
+            }
+
+            Console.WriteLine($"Found {targets.Length} agents:");
+            foreach (var a in agents.Where(a => targets.Contains(a.Id))) Console.WriteLine($"  • {a.Id}  {a.Repo}");
+
+            if (!force && protectedIds.Length > 0) {
+                Console.WriteLine($"Skipping {protectedIds.Length} review agent(s) — pass --force to include them:");
+                foreach (var a in agents.Where(a => protectedIds.Contains(a.Id)))
+                    Console.WriteLine($"  • {a.Id}  {a.Kind}  {a.Repo}");
+            }
 
             if (!yes) {
-                await Console.Out.WriteAsync($"Stop all {agents.Count}? [y/N] ");
+                await Console.Out.WriteAsync($"Stop {targets.Length}? [y/N] ");
                 var reply = await Console.In.ReadLineAsync();
 
                 if (!string.Equals(reply?.Trim(), "y", StringComparison.OrdinalIgnoreCase)) {
@@ -189,51 +207,54 @@ internal static class AgentCommand {
             target = resolved;
         }
 
-        return await SendStopAsync(sock, target, name);
+        return await SendStopAsync(sock, target, name, force);
     }
 
-    static async Task<int> SendStopAsync(string sock, string agentId, string daemonName) {
+    static async Task<int> SendStopAsync(string sock, string agentId, string daemonName, bool force) {
         try {
             using var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
             await socket.ConnectAsync(new UnixDomainSocketEndPoint(sock));
             await using var stream = new NetworkStream(socket, ownsSocket: false);
 
-            await FrameCodec.WriteAsync(stream, LocalFrame.Stop(agentId), default);
+            await FrameCodec.WriteAsync(stream, LocalFrame.StopV2(force, agentId), default);
             var resp = await FrameCodec.ReadAsync(stream, default);
 
             switch (resp?.Type) {
                 case FrameType.StopAck:
-                    if (resp.Text.Length == 0) {
-                        Console.WriteLine("No agents.");
+                    string[] lines = resp.Text.Length == 0 ? [] : resp.Text.Split('\n');
+                    if (lines.Length == 0) { Console.WriteLine("No agents."); return 0; }
 
-                        return 0;
-                    }
-
-                    var lines     = resp.Text.Split('\n');
-                    var anyFailed = false;
+                    var failed  = 0;
+                    var skipped = 0;
 
                     foreach (var line in lines) {
-                        var parts = line.Split('\t');
-                        var id    = parts[0];
+                        var parts  = line.Split('\t');
+                        var id     = parts[0];
+                        var status = parts.Length > 1 ? parts[1] : "failed";
 
-                        if (parts is [_, "stopped"]) {
-                            Console.WriteLine($"Stopped {id}.");
-                        } else {
-                            Console.WriteLine($"Failed to stop {id} — see `kcap daemon logs`.");
-                            anyFailed = true;
+                        switch (status) {
+                            case "stopped": Console.WriteLine($"Stopped {id}."); break;
+                            case "skipped": Console.WriteLine($"Skipped {id} — review agent; pass --force to stop it."); skipped++; break;
+                            default:        Console.Error.WriteLine($"Failed to stop {id} — see `kcap daemon logs`."); failed++; break;
                         }
                     }
 
-                    return anyFailed ? 1 : 0;
+                    if (skipped > 0)
+                        Console.WriteLine($"{skipped} review agent(s) left running — pass --force to stop them.");
+
+                    // Skipping is the documented default, not a failure, so it does not affect
+                    // the exit code.
+                    return failed > 0 ? 1 : 0;
                 case FrameType.Error:
                     await Console.Error.WriteLineAsync($"kcap: {resp.Text}");
 
                     return 1;
                 case null:
-                    // An older daemon can't decode frame type 8: it faults before its frame
-                    // switch and closes without replying, so we see a clean EOF. `--force` is
-                    // the only restart mode that bypasses the busy check, and this daemon is
-                    // guaranteed busy — the agent we're trying to stop is still running.
+                    // An older daemon can't decode frame type 10 (StopV2): it faults before its
+                    // frame switch and closes without replying, so we see a clean EOF. `--force`
+                    // here is the restart flag, not the stop flag — this daemon is guaranteed
+                    // busy since the stop it never understood never ran, so `restart` needs its
+                    // own override to proceed.
                     await Console.Error.WriteLineAsync(
                         $"kcap: this daemon is too old for `agent stop` — restart it with `kcap daemon restart --force --name {daemonName}`");
 
@@ -427,6 +448,12 @@ internal static class AgentCommand {
     /// Kinds the CLI refuses to mutate by accident: a reviewer mid-round is not the user's to
     /// type at or stop. Mirrors LaunchKind — anything that is not a plain agent is protected.
     internal static bool IsProtectedKind(string kind) => kind is "review" or "review-flow";
+
+    /// <summary>Splits an agent list into what `stop --all` will stop and what it will skip.</summary>
+    internal static (string[] Stoppable, string[] Protected) PartitionByProtection(IReadOnlyList<AgentRow> agents) => (
+        [.. agents.Where(a => !IsProtectedKind(a.Kind)).Select(a => a.Id)],
+        [.. agents.Where(a => IsProtectedKind(a.Kind)).Select(a => a.Id)]
+    );
 
     /// <summary>Tolerates a short row from an older daemon by defaulting the newer columns.</summary>
     internal static AgentRow ParseAgentRow(string line) {

--- a/src/Capacitor.Cli/Local/LocalAgentClient.cs
+++ b/src/Capacitor.Cli/Local/LocalAgentClient.cs
@@ -38,6 +38,7 @@ internal static class LocalAgentClient {
         var       errored    = false; // daemon sent an Error frame (already printed)
         var       detached   = false; // user pressed the detach sequence
         var       inputClosed = false; // local stdin reached EOF
+        var       readOnly   = false; // daemon attached us to a protected agent; input is dropped
 
         async Task Send(LocalFrame f) {
             await writeLock.WaitAsync(ct);
@@ -62,6 +63,20 @@ internal static class LocalAgentClient {
 
                             await Send(SizeFrame()); // nudge a clean repaint at our size
 
+                            break;
+                        case FrameType.AttachedReadOnly:
+                            readOnly = true;
+                            var (_, reason, roSnapshot) = FrameCodec.AttachedReadOnly(f);
+                            if (roSnapshot.Length > 0) TerminalRawMode.WriteStdout(roSnapshot, roSnapshot.Length);
+
+                            var banner = "\r\n— read-only: " + reason + ".\r\n"
+                                       + "  Input is not delivered — address it with the flow tools."
+                                       + " Ctrl-Q d to detach. —\r\n";
+                            var bannerBytes = System.Text.Encoding.UTF8.GetBytes(banner);
+                            TerminalRawMode.WriteStdout(bannerBytes, bannerBytes.Length);
+
+                            // No SizeFrame nudge: the daemon ignores our size for a protected
+                            // agent, so asking for a repaint at our dimensions would mislead.
                             break;
                         case FrameType.Exited:
                             exitCode  = f.ExitCode;
@@ -89,7 +104,7 @@ internal static class LocalAgentClient {
                 while (!ct.IsCancellationRequested && !outPump.IsCompleted) {
                     await Task.Delay(300, ct);
                     var cur = TrySize();
-                    if (cur != last) { last = cur; await Send(SizeFrame()); }
+                    if (cur != last) { last = cur; if (!readOnly) await Send(SizeFrame()); }
                 }
             } catch (Exception ex) when (ex is OperationCanceledException or IOException) {
                 /* shutting down */
@@ -108,7 +123,7 @@ internal static class LocalAgentClient {
                     if (n <= 0) { inputClosed = true; break; }
 
                     var (forward, detach) = scanner.Process(buf.AsSpan(0, n));
-                    if (forward.Length > 0) await Send(LocalFrame.Stdin(forward));
+                    if (forward.Length > 0 && !readOnly) await Send(LocalFrame.Stdin(forward));
                     if (detach) { detached = true; await Send(LocalFrame.Detach()); break; }
                 }
             } catch (Exception ex) when (ex is OperationCanceledException or IOException) {

--- a/test/Capacitor.Cli.Tests.Integration/AgentVerbDispatchTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/AgentVerbDispatchTests.cs
@@ -88,6 +88,15 @@ public class AgentVerbDispatchTests {
         await Assert.That(stderr).Contains("kcap agent start: no server configured");
     }
 
+    [Test]
+    public async Task Stop_accepts_the_force_flag_without_treating_it_as_an_id() {
+        // --force must parse as a flag, not as a positional agent id, or the usage line fires.
+        var (_, stderr, _) = await RunCli("agent stop --all --force -y --daemon kcap-dispatch-test-absent");
+
+        await Assert.That(stderr).DoesNotContain("cannot combine an agent id with --all");
+        await Assert.That(stderr).DoesNotContain("usage: kcap agent stop");
+    }
+
     static async Task<(string Stdout, string Stderr, int ExitCode)> RunCli(
             string argLine, bool clearServerUrl = false) {
         var binary = GetCliBinaryPath();

--- a/test/Capacitor.Cli.Tests.Integration/AgentVerbDispatchTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/AgentVerbDispatchTests.cs
@@ -97,6 +97,19 @@ public class AgentVerbDispatchTests {
         await Assert.That(stderr).DoesNotContain("usage: kcap agent stop");
     }
 
+    [Test]
+    public async Task Stop_force_alone_without_all_or_an_id_still_reports_usage() {
+        // Neither --all nor a positional id is present, so the usage line must fire. If --force
+        // were ever mistreated as the positional agent id, hasId would flip true here and this
+        // would instead try to resolve "--force" as a target — the previous test above can't
+        // catch that regression because its args[0] is "--all", which already forces hasId false
+        // regardless of where --force sits.
+        var (_, stderr, exitCode) = await RunCli("agent stop --force --daemon kcap-dispatch-test-absent");
+
+        await Assert.That(stderr).Contains("usage: kcap agent stop");
+        await Assert.That(exitCode).IsEqualTo(1);
+    }
+
     static async Task<(string Stdout, string Stderr, int ExitCode)> RunCli(
             string argLine, bool clearServerUrl = false) {
         var binary = GetCliBinaryPath();

--- a/test/Capacitor.Cli.Tests.Unit/AgentCommandRoutingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentCommandRoutingTests.cs
@@ -88,4 +88,18 @@ public class AgentCommandRoutingTests {
         await Assert.That(name).IsNull();
         await Assert.That(error).IsNotNull();
     }
+
+    [Test]
+    public async Task Protected_agents_are_partitioned_out_for_the_confirmation_prompt() {
+        AgentRow[] agents = [
+            new("a1", "Running", "/r1", "agent", "", ""),
+            new("f1", "Running", "/r2", "review-flow", "flow-7f3a", "reviewer"),
+            new("v1", "Running", "/r3", "review", "", ""),
+        ];
+
+        var (stoppable, prot) = AgentCommand.PartitionByProtection(agents);
+
+        await Assert.That(stoppable).IsEquivalentTo(new[] { "a1" });
+        await Assert.That(prot).IsEquivalentTo(new[] { "f1", "v1" });
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/AgentIdResolutionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentIdResolutionTests.cs
@@ -4,9 +4,9 @@ namespace Capacitor.Cli.Tests.Unit;
 
 public class AgentIdResolutionTests {
     static readonly AgentRow[] Agents = [
-        new("ab12cd34ef56ab78cd90ef12ab34cd56", "Running", "/repo/one"),
-        new("ab99887766554433221100aabbccddee", "Running", "/repo/two"),
-        new("ff00112233445566778899aabbccddee", "Completed", "/repo/three"),
+        new("ab12cd34ef56ab78cd90ef12ab34cd56", "Running", "/repo/one", "agent", "", ""),
+        new("ab99887766554433221100aabbccddee", "Running", "/repo/two", "agent", "", ""),
+        new("ff00112233445566778899aabbccddee", "Completed", "/repo/three", "agent", "", ""),
     ];
 
     [Test]
@@ -62,5 +62,34 @@ public class AgentIdResolutionTests {
         var (id, err) = AgentCommand.ResolveAgentId([], "0123456789ABCDEF0123456789ABCDEF");
         await Assert.That(id).IsEqualTo("0123456789abcdef0123456789abcdef");
         await Assert.That(err).IsNull();
+    }
+
+    [Test]
+    public async Task Row_from_a_current_daemon_carries_kind_and_flow() {
+        var row = AgentCommand.ParseAgentRow("ab12\tRunning\t/repo\treview-flow\tflow-7f3a\treviewer");
+        await Assert.That(row.Id).IsEqualTo("ab12");
+        await Assert.That(row.Status).IsEqualTo("Running");
+        await Assert.That(row.Repo).IsEqualTo("/repo");
+        await Assert.That(row.Kind).IsEqualTo("review-flow");
+        await Assert.That(row.FlowRunId).IsEqualTo("flow-7f3a");
+        await Assert.That(row.FlowRole).IsEqualTo("reviewer");
+    }
+
+    [Test]
+    public async Task Row_from_an_older_daemon_defaults_to_an_unprotected_agent() {
+        // An older daemon sends three columns. Treating the missing kind as `agent` is what
+        // makes the group keep working against it — protection simply does not engage.
+        var row = AgentCommand.ParseAgentRow("ab12\tRunning\t/repo");
+        await Assert.That(row.Kind).IsEqualTo("agent");
+        await Assert.That(row.FlowRunId).IsEqualTo("");
+        await Assert.That(row.FlowRole).IsEqualTo("");
+        await Assert.That(AgentCommand.IsProtectedKind(row.Kind)).IsFalse();
+    }
+
+    [Test]
+    public async Task Review_and_review_flow_are_protected_and_agent_is_not() {
+        await Assert.That(AgentCommand.IsProtectedKind("review")).IsTrue();
+        await Assert.That(AgentCommand.IsProtectedKind("review-flow")).IsTrue();
+        await Assert.That(AgentCommand.IsProtectedKind("agent")).IsFalse();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -7,6 +7,7 @@ using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Pty;
 using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Tests.Unit.Daemon;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit;
@@ -867,6 +868,49 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(reply.Text).DoesNotContain("flow");
         await Assert.That(reply.Text).Contains("--force");
         await Assert.That(orch.GetAgentForTest("rev-1")!.Status).IsNotEqualTo("Completed");
+    }
+
+    [Test]
+    public async Task Stopping_a_prior_incarnation_flow_survivor_without_force_is_refused_before_reaping() {
+        // Not in _agents — this daemon incarnation never saw it — but its persisted PID record
+        // says it was a review-flow participant. The refusal must fire off the RECORD's Kind
+        // before TryStopByPidRecordAsync (and its live-process reap) ever runs.
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.WritePidRecordForTest(new AgentPidRecord(
+            "ghost-flow", 999_999, "", PidIdentityKind.IdentityUnavailable, "ReviewFlow", "codex",
+            "flow-7f3a", "reviewer", orch.DaemonIdForTest, orch.DaemonEpochForTest, DateTimeOffset.UtcNow));
+
+        var reply = await StopV2AndReadReply(orch, force: false, "ghost-flow");
+
+        await Assert.That(reply!.Type).IsEqualTo(FrameType.Error);
+        await Assert.That(reply.Text).Contains("review-flow");
+        await Assert.That(reply.Text).Contains("--force");
+        // Refused before any reap attempt — the record is untouched.
+        await Assert.That(orch.PidRecordsForTest().Any(r => r.AgentId == "ghost-flow")).IsTrue();
+    }
+
+    [Test]
+    public async Task Stopping_a_prior_incarnation_flow_survivor_with_force_bypasses_the_kind_gate() {
+        // --force must reach TryStopByPidRecordAsync itself (kept policy-free) rather than being
+        // turned back by the new gate above it.
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        using var dummy = DummyProcess.StartSleep(30);
+        var pid      = dummy.Pid;
+        var identity = ProcessIdentity.Capture(pid)!;
+        dummy.Kill(); dummy.WaitForExit(TimeSpan.FromSeconds(5)); // confirmed dead before the reap runs
+
+        orch.WritePidRecordForTest(new AgentPidRecord(
+            "ghost-flow-2", pid, identity, PidIdentityKind.Present, "ReviewFlow", "codex",
+            "flow-7f3a", "reviewer", orch.DaemonIdForTest, orch.DaemonEpochForTest, DateTimeOffset.UtcNow));
+
+        var reply = await StopV2AndReadReply(orch, force: true, "ghost-flow-2");
+
+        await Assert.That(reply!.Type).IsEqualTo(FrameType.StopAck);
+        await Assert.That(reply.Text).IsEqualTo("ghost-flow-2\tstopped");
+        await Assert.That(orch.PidRecordsForTest().Any(r => r.AgentId == "ghost-flow-2")).IsFalse();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -788,6 +788,23 @@ public partial class AgentOrchestratorVendorTests {
     }
 
     [Test]
+    public async Task Stopping_a_non_flow_review_agent_without_force_is_refused_with_an_accurate_message() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("rev-1", kind: LaunchKind.Review);
+
+        var reply = await StopV2AndReadReply(orch, force: false, "rev-1");
+
+        await Assert.That(reply!.Type).IsEqualTo(FrameType.Error);
+        await Assert.That(reply.Text).Contains("review agent");
+        // Unlike a flow participant, a plain hosted review has no round or flow to strand —
+        // the refusal must not claim one.
+        await Assert.That(reply.Text).DoesNotContain("flow");
+        await Assert.That(reply.Text).Contains("--force");
+        await Assert.That(orch.GetAgentForTest("rev-1")!.Status).IsNotEqualTo("Completed");
+    }
+
+    [Test]
     public async Task Stop_all_without_force_skips_protected_agents_and_says_so() {
         var server = new TripwireServerConnection();
         await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -752,6 +752,70 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(reply.Text).IsEqualTo("reaped-1\tstopped");
     }
 
+    static async Task<LocalFrame?> StopV2AndReadReply(AgentOrchestrator orch, bool force, string agentId) {
+        using var client = new DuplexTestStream(new MemoryStream(), new MemoryStream());
+        await orch.HandleLocalStopV2Async(force, agentId, client, default);
+        client.WrittenStream.Position = 0;
+
+        return await FrameCodec.ReadAsync(client.WrittenStream, default);
+    }
+
+    [Test]
+    public async Task Stopping_a_flow_participant_without_force_is_refused() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+        var reply = await StopV2AndReadReply(orch, force: false, "flow-1");
+
+        await Assert.That(reply!.Type).IsEqualTo(FrameType.Error);
+        await Assert.That(reply.Text).Contains("review-flow");
+        await Assert.That(reply.Text).Contains("--force");
+        await Assert.That(orch.GetAgentForTest("flow-1")!.Status).IsNotEqualTo("Completed");
+    }
+
+    [Test]
+    public async Task Stopping_a_flow_participant_with_force_succeeds() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+        var reply = await StopV2AndReadReply(orch, force: true, "flow-1");
+
+        await Assert.That(reply!.Type).IsEqualTo(FrameType.StopAck);
+        await Assert.That(reply.Text).IsEqualTo("flow-1\tstopped");
+        await Assert.That(orch.GetAgentForTest("flow-1")!.Status).IsEqualTo("Completed");
+    }
+
+    [Test]
+    public async Task Stop_all_without_force_skips_protected_agents_and_says_so() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("plain-1");
+        orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+        var reply = await StopV2AndReadReply(orch, force: false, "");
+
+        var rows = reply!.Text.Split('\n').Select(l => l.Split('\t')).ToDictionary(p => p[0], p => p[1]);
+        await Assert.That(rows["plain-1"]).IsEqualTo("stopped");
+        await Assert.That(rows["flow-1"]).IsEqualTo("skipped");
+        await Assert.That(orch.GetAgentForTest("flow-1")!.Status).IsNotEqualTo("Completed");
+    }
+
+    [Test]
+    public async Task Stop_all_with_force_includes_protected_agents() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("plain-1");
+        orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+        var reply = await StopV2AndReadReply(orch, force: true, "");
+
+        var rows = reply!.Text.Split('\n').Select(l => l.Split('\t')).ToDictionary(p => p[0], p => p[1]);
+        await Assert.That(rows["plain-1"]).IsEqualTo("stopped");
+        await Assert.That(rows["flow-1"]).IsEqualTo("stopped");
+    }
+
     /// <summary>A pty double whose process never exits — HasExited stays false even after
     /// TerminateAsync — so a test can drive the "stop could not be confirmed" path without a
     /// real hung process.</summary>

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -1003,4 +1003,30 @@ public partial class AgentOrchestratorVendorTests {
         public void Resize(ushort     _, ushort __) { }
         public void SendInterrupt() { }
     }
+    [Test]
+    public async Task Local_list_neutralises_delimiters_inside_a_free_form_field() {
+        // Repo paths and flow roles are free-form and may legally hold a tab or newline. Emitted
+        // raw they would shift the reader's columns or split the row, and the CLI keys
+        // `stop --all`'s confirmation off the kind column — so a corrupted row would understate
+        // the blast radius the user is agreeing to.
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("tabby-1", kind: LaunchKind.ReviewFlow,
+            flowRunId: "flow\t7f3a", flowRole: "rev\niewer");
+
+        using var client = new DuplexTestStream(new MemoryStream(), new MemoryStream());
+        await orch.HandleLocalListAsync(client, default);
+        client.WrittenStream.Position = 0;
+        var reply = await FrameCodec.ReadAsync(client.WrittenStream, default);
+
+        var rows = reply!.Text.Split('\n');
+        await Assert.That(rows.Length).IsEqualTo(1);
+
+        var cols = rows[0].Split('\t');
+        await Assert.That(cols.Length).IsEqualTo(6);
+        await Assert.That(cols[3]).IsEqualTo("review-flow");
+        await Assert.That(cols[4]).IsEqualTo("flow 7f3a");
+        await Assert.That(cols[5]).IsEqualTo("rev iewer");
+    }
+
 }

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -469,6 +469,7 @@ public partial class AgentOrchestratorVendorTests {
     }
 
     [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
     public async Task Local_socket_list_round_trips_registered_agents_over_a_real_socket() {
         if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
 
@@ -513,6 +514,70 @@ public partial class AgentOrchestratorVendorTests {
             DaemonLockPaths.OverrideDirectoryForTesting(null);
             try { Directory.Delete(sockDir.FullName, true); } catch { /* best-effort */ }
         }
+    }
+
+    /// <summary>
+    /// Pins the one hop nothing else exercises: <see cref="LocalControlServer"/> decoding a raw
+    /// StopV2 frame off a real socket and forwarding its force flag to the orchestrator. The codec
+    /// round-trip (FrameCodecTests) and the handler (StopV2AndReadReply above) are each covered in
+    /// isolation; only a real connection proves the server's frame switch wires them together.
+    /// </summary>
+    static async Task<LocalFrame?> StopV2OverRealSocketAsync(string daemonName, bool force, string agentId) {
+        var sockDir = Directory.CreateTempSubdirectory("kcap-sock-");
+        DaemonLockPaths.OverrideDirectoryForTesting(sockDir.FullName);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        LocalControlServer? listener = null;
+        AgentOrchestrator?  orch     = null;
+
+        try {
+            orch = BuildOrchestrator(new TripwireServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+            orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+            var config = new DaemonConfig { Name = daemonName, ServerUrl = "http://127.0.0.1:1" };
+            listener = new LocalControlServer(config, orch, TestCoordinator(), NullLogger<LocalControlServer>.Instance);
+            await listener.StartAsync(cts.Token);
+
+            var sockPath = LocalSocketPaths.Socket(daemonName);
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (!File.Exists(sockPath) && DateTime.UtcNow < deadline) await Task.Delay(20, cts.Token);
+            await Assert.That(File.Exists(sockPath)).IsTrue();
+
+            using var sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            await sock.ConnectAsync(new UnixDomainSocketEndPoint(sockPath), cts.Token);
+            await using var stream = new NetworkStream(sock, ownsSocket: false);
+
+            await FrameCodec.WriteAsync(stream, LocalFrame.StopV2(force, agentId), cts.Token);
+
+            return await FrameCodec.ReadAsync(stream, cts.Token);
+        } finally {
+            if (orch is not null) await orch.DisposeAsync();
+            if (listener is not null) { await listener.StopAsync(CancellationToken.None); listener.Dispose(); }
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(sockDir.FullName, true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Local_socket_stopv2_without_force_refuses_a_protected_agent_end_to_end() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        var resp = await StopV2OverRealSocketAsync("test-stopv2-refuse", force: false, "flow-1");
+
+        await Assert.That(resp!.Type).IsEqualTo(FrameType.Error);
+        await Assert.That(resp.Text).Contains("--force");
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Local_socket_stopv2_with_force_stops_a_protected_agent_end_to_end() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        var resp = await StopV2OverRealSocketAsync("test-stopv2-force", force: true, "flow-1");
+
+        await Assert.That(resp!.Type).IsEqualTo(FrameType.StopAck);
+        await Assert.That(resp.Text).IsEqualTo("flow-1\tstopped");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -537,6 +537,52 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(rows["flow-1"][5]).IsEqualTo("reviewer");
     }
 
+    [Test]
+    public async Task Attaching_to_a_flow_participant_is_read_only() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        var agent = orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+        // Client sends input, then a resize, then detaches. None of the first two may land.
+        var readBuf = new MemoryStream();
+        await FrameCodec.WriteAsync(readBuf, LocalFrame.Stdin("hello"u8.ToArray()), default);
+        await FrameCodec.WriteAsync(readBuf, LocalFrame.Resize(40, 10), default);
+        await FrameCodec.WriteAsync(readBuf, LocalFrame.Detach(), default);
+        readBuf.Position = 0;
+        using var client = new DuplexTestStream(readBuf, new MemoryStream());
+
+        await orch.HandleLocalAttachAsync("flow-1", client, default);
+
+        client.WrittenStream.Position = 0;
+        var first = await FrameCodec.ReadAsync(client.WrittenStream, default);
+
+        await Assert.That(first!.Type).IsEqualTo(FrameType.AttachedReadOnly);
+        var (_, reason, _) = FrameCodec.AttachedReadOnly(first);
+        await Assert.That(reason).Contains("review-flow");
+        await Assert.That(reason).Contains("reviewer");
+
+        // The resize must not have been recorded, so the PTY is never clamped to the viewer.
+        await Assert.That(agent.ClientDims).IsEmpty();
+    }
+
+    [Test]
+    public async Task Attaching_to_a_plain_agent_stays_read_write() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("plain-1");
+
+        var readBuf = new MemoryStream();
+        await FrameCodec.WriteAsync(readBuf, LocalFrame.Detach(), default);
+        readBuf.Position = 0;
+        using var client = new DuplexTestStream(readBuf, new MemoryStream());
+
+        await orch.HandleLocalAttachAsync("plain-1", client, default);
+
+        client.WrittenStream.Position = 0;
+        var first = await FrameCodec.ReadAsync(client.WrittenStream, default);
+        await Assert.That(first!.Type).IsEqualTo(FrameType.Attached);
+    }
+
     // ── Test doubles for the local-spawn lifecycle ──────────────────────
 
     sealed class EnvCapturingPtyFactory : IPtyProcessFactory {

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -541,7 +541,8 @@ public partial class AgentOrchestratorVendorTests {
     public async Task Attaching_to_a_flow_participant_is_read_only() {
         var server = new TripwireServerConnection();
         await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
-        var agent = orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+        var pty   = new RecordingPtyProcess();
+        var agent = orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer", pty: pty);
 
         // Client sends input, then a resize, then detaches. None of the first two may land.
         var readBuf = new MemoryStream();
@@ -563,15 +564,21 @@ public partial class AgentOrchestratorVendorTests {
 
         // The resize must not have been recorded, so the PTY is never clamped to the viewer.
         await Assert.That(agent.ClientDims).IsEmpty();
+
+        // The stdin frame must never reach the runtime — this is the daemon-side guarantee
+        // itself, not just the client-observable frame type above.
+        await Assert.That(pty.Writes).IsEmpty();
     }
 
     [Test]
     public async Task Attaching_to_a_plain_agent_stays_read_write() {
         var server = new TripwireServerConnection();
         await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
-        orch.SeedAgentForTest("plain-1");
+        var pty = new RecordingPtyProcess();
+        orch.SeedAgentForTest("plain-1", pty: pty);
 
         var readBuf = new MemoryStream();
+        await FrameCodec.WriteAsync(readBuf, LocalFrame.Stdin("hello"u8.ToArray()), default);
         await FrameCodec.WriteAsync(readBuf, LocalFrame.Detach(), default);
         readBuf.Position = 0;
         using var client = new DuplexTestStream(readBuf, new MemoryStream());
@@ -581,6 +588,9 @@ public partial class AgentOrchestratorVendorTests {
         client.WrittenStream.Position = 0;
         var first = await FrameCodec.ReadAsync(client.WrittenStream, default);
         await Assert.That(first!.Type).IsEqualTo(FrameType.Attached);
+
+        // Mirrors the read-only test: an unprotected agent's stdin really does reach the PTY.
+        await Assert.That(pty.Writes).IsEquivalentTo(new[] { "hello" });
     }
 
     // ── Test doubles for the local-spawn lifecycle ──────────────────────

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -515,6 +515,28 @@ public partial class AgentOrchestratorVendorTests {
         }
     }
 
+    [Test]
+    public async Task Local_list_reports_each_agent_kind_and_flow_identity() {
+        var server = new TripwireServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.SeedAgentForTest("plain-1");
+        orch.SeedAgentForTest("rev-1", kind: LaunchKind.Review);
+        orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
+
+        using var client = new DuplexTestStream(new MemoryStream(), new MemoryStream());
+        await orch.HandleLocalListAsync(client, default);
+        client.WrittenStream.Position = 0;
+        var reply = await FrameCodec.ReadAsync(client.WrittenStream, default);
+
+        var rows = reply!.Text.Split('\n').Select(l => l.Split('\t')).ToDictionary(p => p[0], p => p);
+
+        await Assert.That(rows["plain-1"][3]).IsEqualTo("agent");
+        await Assert.That(rows["rev-1"][3]).IsEqualTo("review");
+        await Assert.That(rows["flow-1"][3]).IsEqualTo("review-flow");
+        await Assert.That(rows["flow-1"][4]).IsEqualTo("flow-7f3a");
+        await Assert.That(rows["flow-1"][5]).IsEqualTo("reviewer");
+    }
+
     // ── Test doubles for the local-spawn lifecycle ──────────────────────
 
     sealed class EnvCapturingPtyFactory : IPtyProcessFactory {

--- a/test/Capacitor.Cli.Tests.Unit/FrameCodecTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FrameCodecTests.cs
@@ -130,6 +130,38 @@ public class FrameCodecTests {
         await Assert.That(r.Type).IsEqualTo(FrameType.StopAck);
         await Assert.That(r.Text.Split('\n')).IsEquivalentTo(new[] { "id-one\tstopped", "id-two\tfailed" });
     }
+
+    [Test]
+    [Arguments(true,  "ab12")]
+    [Arguments(false, "ab12")]
+    [Arguments(false, "")]
+    public async Task StopV2_round_trips_mode_and_id(bool force, string agentId) {
+        var r = await RoundTrip(LocalFrame.StopV2(force, agentId));
+        await Assert.That(r.Type).IsEqualTo(FrameType.StopV2);
+
+        var (gotForce, gotId) = FrameCodec.StopV2(r);
+        await Assert.That(gotForce).IsEqualTo(force);
+        await Assert.That(gotId).IsEqualTo(agentId);
+    }
+
+    [Test]
+    public async Task AttachedReadOnly_round_trips_id_reason_and_snapshot() {
+        var snapshot = new byte[] { 0x1b, 0x5b, 0x41, 0x00, 0xff };
+        var r = await RoundTrip(FrameCodec.AttachedReadOnly("ab12", "review-flow reviewer", snapshot));
+        await Assert.That(r.Type).IsEqualTo(FrameType.AttachedReadOnly);
+
+        var (id, reason, got) = FrameCodec.AttachedReadOnly(r);
+        await Assert.That(id).IsEqualTo("ab12");
+        await Assert.That(reason).IsEqualTo("review-flow reviewer");
+        await Assert.That(got).IsEquivalentTo(snapshot);
+    }
+
+    [Test]
+    public async Task AttachedReadOnly_round_trips_an_empty_snapshot() {
+        var r = await RoundTrip(FrameCodec.AttachedReadOnly("ab12", "review agent", []));
+        var (_, _, got) = FrameCodec.AttachedReadOnly(r);
+        await Assert.That(got).IsEmpty();
+    }
 }
 
 /// Stream that returns at most `chunk` bytes per ReadAsync to simulate partial socket reads.


### PR DESCRIPTION
Closes #379
AI-1557

`kcap agent ls|attach|stop` treated every daemon-hosted agent identically, so a review-flow participant — a reviewer mid-round — was indistinguishable from an agent you started. `attach` handed you raw PTY stdin on it, and `stop --all` killed it silently. This teaches the commands the difference.

## What changed

`kcap agent ls` gains a `KIND` column:

```
AGENT                              STATUS     KIND         REPO
3f9acd34ef56ab78cd90ef12ab34cd56   Running    agent        ~/dev/api
ab99887766554433221100aabbccddee   Running    review-flow  ~/dev/api   [reviewer]
ff00112233445566778899aabbccddee   Running    review       ~/dev/web
```

For `review` and `review-flow` agents:

- **`attach` is read-only.** Output streams so you can watch a reviewer work; your keystrokes are not delivered, and your terminal size is not applied to it — a read-only viewer never enters `ClientDims`, so it cannot shrink the participants terminal through the min-clamp.
- **`stop` is refused** unless `--force`, with a message naming the flow.
- **`stop --all` skips them** and reports how many, rather than silently omitting them. `--force` includes them and lists them under their own heading in the confirmation, so the destructive variant shows *more* information than the safe one.

**Enforcement is daemon-side** for both, so a current client cannot bypass it.

## Wire changes

`FrameType` is append-only. `StopV2 = 10` carries a force flag; `AttachedReadOnly = 71` carries id + reason + snapshot. `AgentList` rows grow to `id⇥status⇥repo⇥kind⇥flowRunId⇥flowRole`; `StopAck` gains a `skipped` status.

`AttachedReadOnly` is a separate frame rather than a flag on `Attached` because `Attached`s payload ends with an unbounded snapshot — a trailing flag would be painted onto the users terminal instead of parsed. It also fails closed: an older CLI cannot decode frame 71, so it errors rather than pumping stdin at a participant.

## Version skew — please read

- **Older daemon:** it reports no kind, so `ls`/`attach` degrade silently to unprotected. `stop` does not degrade — it hard-fails, because the CLI sends `StopV2` which that daemon cannot decode, and tells you to restart it.
- **Older CLI:** it sends the legacy `Stop` frame, which has no force concept, so the daemon treats it as `--force`. An old client can therefore silently force-stop a protected agent. Frame 8 postdates v0.11.8, so no released client is affected — but it is a real hole and it is documented in the README rather than glossed.

## Known limitations

- `--force` still leaves the flow unaware its participant was stopped. Attributing that needs server-side work.
- Plain web-UI-launched agents (`LaunchKind.Default`) are deliberately not protected — they are your own work by another route.

## Verification

- Unit 4237 passed / 42 failed on this branch; those 42 are the pre-existing `CodexHookCommandTests`/uninstall-`config.toml` baseline confirmed at the merge base. Zero new.
- Integration 160/160 on the branch.
- **Trial-merged onto current `main` (13 commits ahead) and tested there:** plain `main` fails 45 unit tests, the merged result fails the same 45 with 21 more tests; integration 162/162 solo. So the merge is semantically clean, not merely conflict-free — a check worth doing explicitly after #383 auto-merged cleanly into a guard that shadowed it.
- Both AOT publishes clean of IL3050/IL2026.

## Design and plan

- `docs/superpowers/specs/2026-07-29-ai1557-flow-participant-aware-agent-commands-design.md`
- `docs/superpowers/plans/2026-07-29-ai1557-flow-participant-aware-agent-commands.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)