### PR TITLE
[AI-1404] Host AWS Kiro CLI as an ACP hosted agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,11 +886,33 @@ KCAP_CURSOR_PATH=/opt/cursor/bin/cursor-agent kcap daemon
 KCAP_CURSOR_MODEL=claude-opus-4-8 kcap daemon
 ```
 
-`KCAP_COPILOT_PATH` overrides the `copilot` binary the daemon spawns for **GitHub Copilot hosted agents** (`copilot --acp --stdio`), mirroring `KCAP_CURSOR_PATH` — the daemon now hosts Claude, Codex, Cursor, and Copilot. `KCAP_KIRO_PATH`, `KCAP_OPENCODE_PATH`, and `KCAP_GEMINI_PATH` remain **reserved** plumbing for the not-yet-hosted Kiro, OpenCode, and Gemini vendors, so setting those three has no observable effect yet.
+`KCAP_COPILOT_PATH` overrides the `copilot` binary the daemon spawns for **GitHub Copilot hosted agents** (`copilot --acp --stdio`), mirroring `KCAP_CURSOR_PATH` — the daemon now hosts Claude, Codex, Cursor, Copilot, and Kiro. `KCAP_OPENCODE_PATH` and `KCAP_GEMINI_PATH` remain **reserved** plumbing for the not-yet-hosted OpenCode and Gemini vendors, so setting those two has no observable effect yet.
 
 ```bash
 KCAP_COPILOT_PATH=/opt/copilot/bin/copilot kcap daemon
 ```
+
+`KCAP_KIRO_PATH` overrides the AWS Kiro CLI binary the daemon spawns for **Kiro hosted agents**
+(`kiro-cli acp`). It defaults to `kiro-cli` — the name a standard install puts on `PATH` — and only
+that one name is probed, so point this at your binary if yours is named differently. As with Cursor,
+if the daemon can't resolve it the `kiro` vendor is simply hidden from the launch dialog rather than
+failing at launch.
+
+```bash
+KCAP_KIRO_PATH=/opt/kiro/bin/kiro-cli kcap daemon
+```
+
+Two limits are worth knowing before you pick Kiro:
+
+- **Interactive hosting only.** Kiro cannot yet be selected as an unattended review-flow reviewer.
+  Kiro inherits the MCP servers from your global `~/.kiro/settings/mcp.json` into every ACP session,
+  which is exactly what you want for a session you are driving yourself, but means an unattended
+  reviewer would be handed the flow-starting `kcap-flows` server. Containment for that is tracked
+  separately.
+- **No model override.** A Kiro hosted agent always runs Kiro's own default model. Kiro's ACP
+  model-selection call is unverified and fails silently, so rather than report a model it might not be
+  running, kcap ignores a requested model for `kiro` and reports none — there is deliberately no
+  `KCAP_KIRO_MODEL`. A *pinned reviewer* model is refused outright rather than silently substituted.
 
 **Hosted Cursor agents run over ACP.** The `cursor` vendor is launched by the daemon as
 `cursor-agent acp` (Cursor's Agent Client Protocol server) in an isolated worktree, driven from the

--- a/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
@@ -88,8 +88,13 @@ The selector parses `session/new`'s `models.availableModels` and then sends
 shape it needs. Its write half (`session/set_config_option` actually taking effect) is **still
 unverified** and must be measured before relying on it.
 
-Two consequences. First, do not add a "`--model` observable in the launch argv" acceptance item: the
-descriptor below never appends `--model`, so it would be unclosable. Second,
+**Decision: Kiro ships with `NoOpModelSelector` and no model override in either issue.** An earlier draft
+kept `ConfigOptionModelSelector` while AI-1410 deferred override — two implementers could then ship
+opposite behaviour, each following part of the spec. Note that `ResolveDefaultModel: null` is NOT
+sufficient on its own: `ResolveRequestedModel` prioritises `RuntimeStartContext.Model`, so a
+dashboard-supplied model would still reach a live selector. The selector itself has to be the no-op.
+
+Also,
 `AcpHostedAgentRuntimeFactory.ReviewerModelResolver` is `null` at this base, so the daemon advertises
 no reviewer-model-resolution capability and the server refuses an ACP review-flow model override
 today. Reviewer model override is therefore an AI-1410 dependency, not a free inheritance.
@@ -139,7 +144,7 @@ public static readonly AcpVendorDescriptor Kiro = new(
     Argv:                ["acp"],
     UnattendedTrustArgv: [],            // AI-1410 owns this; empty keeps unattended off
     SupportsUnattended:  false,         // flipped by AI-1410
-    ModelSelector:       ConfigOptionModelSelector.Instance,
+    ModelSelector:       NoOpModelSelector.Instance,   // see Premise 3 — override deferred
     SupportsMcpServers:  true,          // measured: stdio servers in session/new ARE honoured
     SupportsBorrowedReviewFlow: false   // AI-1410 decides; default off is the safe direction
 );
@@ -187,8 +192,8 @@ Mirrors the Copilot child, minus what has already been measured:
 - [ ] Clean stop; no orphaned child
 - [ ] `SupportedVendors` advertises `kiro` only when the binary resolves
 - [ ] End-to-end capture: the hosted session appears with vendor `kiro`
-- [ ] Model override actually takes effect — measured via `session/set_config_option`, NOT by
-      inspecting argv (see Premise 3)
+- [ ] No model override is attempted — `NoOpModelSelector` is wired, and a dashboard-supplied model is
+      NOT silently honoured (see Premise 3)
 - [ ] Confirm the ACP-reported agent version is logged
 
 Explicitly **not** in this checklist: canonical token counts (absent from ACP; credits remain via

--- a/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
@@ -174,13 +174,20 @@ silent availability change. **Decision — CORRECTED: default to `"kiro-cli"`.**
 argument that does not hold: **measured**, `kiro` is absent from PATH while `kiro-cli` is present, and
 `PluginCommand.KiroBinary` is `"kiro-cli"`. No descriptor consumed `KiroPath` before this issue, so there
 is no compatibility to preserve — and keeping `"kiro"` would have silently never advertised Kiro on a
-standard install until a user discovered `KCAP_KIRO_PATH`. Acceptance needs a **zero-configuration**
-availability test against the supported install, not only env precedence. Do not probe both names. A dual-name probe makes
-advertised availability depend on install layout in a way that is hard to reason about or test, and
-changing the default would be a silent compatibility break for anyone relying on it. Users whose binary
-is `kiro-cli` set `KCAP_KIRO_PATH`, which takes precedence over the default — add acceptance for that
-precedence. `KiroModel` is not added either, since model override is out of scope for AI-1410; it
-arrives with the follow-up that needs it. Availability stays `CliResolver.Exists(KiroPath)`; advertise `kiro` in
+standard install until a user discovered `KCAP_KIRO_PATH`.
+
+Two consequences, and an earlier draft of this section contradicted itself by keeping the old
+argument's tail after reversing the decision:
+
+* **Do not probe both names.** A dual-name probe makes advertised availability depend on install
+  layout in a way that is hard to reason about and hard to test. One default, one override.
+* **Acceptance needs a zero-configuration availability test** against the supported install — Kiro is
+  advertised with no `KCAP_KIRO_PATH` set — *in addition to* an env-precedence test. The precedence
+  test alone is what let the wrong default survive review: it passes identically whichever name the
+  default holds.
+
+`KiroModel` is not added either, since model override is out of scope for AI-1410; it arrives with the
+follow-up that needs it. Availability stays `CliResolver.Exists(KiroPath)`; advertise `kiro` in
 `SupportedVendors` only when it resolves.
 
 ## Verification checklist

--- a/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
@@ -135,7 +135,7 @@ One descriptor plus a factory registration, exactly the Cursor/Copilot shape:
 public static readonly AcpVendorDescriptor Kiro = new(
     Vendor:              "kiro",
     ResolveBinaryPath:   cfg => cfg.KiroPath,
-    ResolveDefaultModel: cfg => cfg.KiroModel,
+    ResolveDefaultModel: _ => null,     // no KiroModel until model override is in scope
     Argv:                ["acp"],
     UnattendedTrustArgv: [],            // AI-1410 owns this; empty keeps unattended off
     SupportsUnattended:  false,         // flipped by AI-1410
@@ -165,9 +165,12 @@ call-level probe against Copilot succeeds. Do not flip it on the strength of Kir
 
 Config surface — **corrected**: `DaemonConfig.KiroPath` **already exists** with default `"kiro"`, not
 `"kiro-cli"`. The spec previously said to add it, which would have produced duplicate plumbing or a
-silent availability change. Decide explicitly between (a) keeping `"kiro"`, (b) probing both
-executable names, or (c) migrating the default — and add acceptance for `KCAP_KIRO_PATH`. Only
-`KiroModel` is genuinely new. Availability stays `CliResolver.Exists(KiroPath)`; advertise `kiro` in
+silent availability change. **Decision: keep the existing `"kiro"` default and do not probe both names.** A dual-name probe makes
+advertised availability depend on install layout in a way that is hard to reason about or test, and
+changing the default would be a silent compatibility break for anyone relying on it. Users whose binary
+is `kiro-cli` set `KCAP_KIRO_PATH`, which takes precedence over the default — add acceptance for that
+precedence. `KiroModel` is not added either, since model override is out of scope for AI-1410; it
+arrives with the follow-up that needs it. Availability stays `CliResolver.Exists(KiroPath)`; advertise `kiro` in
 `SupportedVendors` only when it resolves.
 
 ## Verification checklist
@@ -183,12 +186,15 @@ Mirrors the Copilot child, minus what has already been measured:
       inspecting argv (see Premise 3)
 - [ ] Confirm the ACP-reported agent version is logged
 
-Explicitly **not** in this checklist: token counts (measured absent), auth/tier pre-check (no gate
-exists), `--agent-engine` (deliberately unpinned).
+Explicitly **not** in this checklist: canonical token counts (absent from ACP; credits remain via
+`KiroUsage`), an auth/tier pre-check (no pre-checkable protocol signal exists — the gate itself is
+unproven either way), `--agent-engine` (deliberately unpinned), and model override (deferred by AI-1410
+to its own follow-up, since `set_config_option` is unproven and the selector fails silently).
 
 ## Out of scope
 
 - `SupportsUnattended` stays false; AI-1410 flips it after its own loop verifies.
 - Borrowed review: AI-1410's call, and it needs a containment-token decision, not a default.
-- Kiro's own agent-config MCP servers leaking into a session — an unattended-only hazard.
+- Kiro's **global** `settings/mcp.json` servers leaking into a session — an unattended-only hazard,
+  resolved by AI-1410 with a daemon-owned isolated `KIRO_HOME` (measured to inherit nothing).
 - Kiro's `--effort` flag: no kcap surface exposes effort today; adding one is its own issue.

--- a/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
@@ -165,7 +165,12 @@ call-level probe against Copilot succeeds. Do not flip it on the strength of Kir
 
 Config surface — **corrected**: `DaemonConfig.KiroPath` **already exists** with default `"kiro"`, not
 `"kiro-cli"`. The spec previously said to add it, which would have produced duplicate plumbing or a
-silent availability change. **Decision: keep the existing `"kiro"` default and do not probe both names.** A dual-name probe makes
+silent availability change. **Decision — CORRECTED: default to `"kiro-cli"`.** An earlier draft kept `"kiro"` on a compatibility
+argument that does not hold: **measured**, `kiro` is absent from PATH while `kiro-cli` is present, and
+`PluginCommand.KiroBinary` is `"kiro-cli"`. No descriptor consumed `KiroPath` before this issue, so there
+is no compatibility to preserve — and keeping `"kiro"` would have silently never advertised Kiro on a
+standard install until a user discovered `KCAP_KIRO_PATH`. Acceptance needs a **zero-configuration**
+availability test against the supported install, not only env precedence. Do not probe both names. A dual-name probe makes
 advertised availability depend on install layout in a way that is hard to reason about or test, and
 changing the default would be a silent compatibility break for anyone relying on it. Users whose binary
 is `kiro-cli` set `KCAP_KIRO_PATH`, which takes precedence over the default — add acceptance for that

--- a/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
@@ -47,9 +47,13 @@ A full `initialize` → `session/new` → `session/prompt` loop completed with `
 `KIRO_API_KEY` set in the environment**. So there is no auth handshake and no tier gate at
 initialize/new/prompt on the account this was measured with.
 
-This does **not** prove no account tier can ever be blocked — only that the gate the original design
-feared does not exist at the protocol level. Keep a clear diagnostic for a launch-time auth failure,
-but do not build a tier pre-check: there is nothing to check.
+**Hedge this consistently — an earlier draft of this spec did not.** `authMethods: []` shows there is
+no ACP-mediated auth flow. A prompt succeeding without the variable on ONE machine may simply be using
+cached credentials, so it proves neither "no auth requirement" nor "no tier gate".
+
+The justified conclusion is only this: **there is no reliable protocol or API-key signal to build a
+pre-check on**, so fail on the actual launch/prompt error instead. Anywhere this spec or AI-1410 says
+"no gate exists", read it as "no pre-checkable gate signal exists".
 
 ### Premise 2 — "ACP usage reporting may close Kiro's token gap". IT DOES NOT.
 
@@ -64,14 +68,31 @@ Across a complete prompt turn, **zero** frames carried any of `usage`, `tokens`,
   3  session/update
 ```
 
-So AI-888's "Kiro emits no token counts" stands, and hosting Kiro over ACP does **not** improve its
-cost story. Anything downstream that prices a Kiro session still has nothing to price. Say so rather
-than leaving the hope in the issue.
+So ACP adds no **canonical token counters**, and AI-888's finding stands for tokens.
 
-### Premise 3 — model selection works. CONFIRMED.
+**Do not over-read this into "Kiro cost is unobservable" — that would be wrong.** `KiroUsage.cs`
+already reads billing `metering_usage` credits from Kiro's on-disk session metadata. What is measured
+here is narrower: no canonical token fields appeared in the frames inspected, for this version, on this
+turn. It does not establish absence from `session/load`, other extensions, or the on-disk sidecar.
 
-`--model` is a real flag, so `ConfigOptionModelSelector` (the same selector Cursor and Copilot use)
-applies. AI-1401's model pass-through needs no Kiro-specific work.
+The honest statement is: ACP gives no token counts, credits remain available via the existing sidecar
+path, and any downstream requirement should say which of the two it actually needs.
+
+### Premise 3 — model selection. PARTLY CONFIRMED; my first reading was wrong.
+
+`--model` is a real spawn flag, but that is **not** the mechanism `ConfigOptionModelSelector` uses.
+The selector parses `session/new`'s `models.availableModels` and then sends
+`session/set_config_option` — a spawn flag proves nothing about it.
+
+**Measured:** `session/new` returns BOTH `modes` and `models`, so the selector's read half has the
+shape it needs. Its write half (`session/set_config_option` actually taking effect) is **still
+unverified** and must be measured before relying on it.
+
+Two consequences. First, do not add a "`--model` observable in the launch argv" acceptance item: the
+descriptor below never appends `--model`, so it would be unclosable. Second,
+`AcpHostedAgentRuntimeFactory.ReviewerModelResolver` is `null` at this base, so the daemon advertises
+no reviewer-model-resolution capability and the server refuses an ACP review-flow model override
+today. Reviewer model override is therefore an AI-1410 dependency, not a free inheritance.
 
 ## New facts the original design did not have
 
@@ -80,14 +101,21 @@ for. **Decision: do not pass it.** Pinning a version means owning an upgrade tre
 from what a user gets interactively; the default is what Kiro tests. Revisit only if a measured
 behavioural difference forces it.
 
-**`session/new` returns `modes`.** ACP "modes" are Kiro *agents*: `availableModes` was
-`[kcap, kiro_default, kiro_planner]` with `currentModeId: kcap` — our own installed agent, selected by
-default because `kcap plugin install` wrote `~/.kiro/agents/kcap.json`.
+**`session/new` returns BOTH `modes` and `models`.** ACP "modes" are Kiro *agents*: `availableModes`
+was `[kcap, kiro_default, kiro_planner]` with `currentModeId: kcap` — our own installed agent. A
+`models` object is present alongside it, which is what `ConfigOptionModelSelector` reads (see Premise 3).
+An earlier probe of mine printed a truncated response and I wrongly concluded `models` was absent;
+stated here so the correction is on the record.
 
-**Kiro auto-loads its agent config's MCP servers into an ACP session.** With `mcpServers: []` in
+**Kiro inherits pre-configured MCP servers into an ACP session.** With `mcpServers: []` in
 `session/new`, Kiro still initialized `kcap-flows`, `kcap-review`, `kcap-sessions` and `kcap-memory`.
-Harmless for an interactive hosted agent — it is what the user would get anyway — but it is a hazard
-for the unattended reviewer, so AI-1410 owns it, not this issue.
+
+**Where from matters, and an earlier draft of this spec guessed wrong.** It attributed them to
+`~/.kiro/agents/kcap.json`. They are in fact registered by `PluginCommand.InstallKiro` into GLOBAL
+`~/.kiro/settings/mcp.json` — verified by inspecting that file, which contains exactly those four
+names. Global settings are documented as independent of the agent file, so *switching agents does not
+suppress them*. Harmless for interactive hosting; a hard blocker for the unattended reviewer, and
+AI-1410 now owns finding a mechanism that demonstrably excludes global servers.
 
 **`promptCapabilities.embeddedContext: false`** (Copilot: `true`). Kiro cannot take embedded context
 resources in a prompt; context must be plain text. Interactive hosting does not care. AI-1410 does.
@@ -125,8 +153,21 @@ http/sse only, so interactive `session/new` stdio servers stay disabled."* Kiro 
 stdio despite not advertising it. Copilot's line is an empirical finding about Copilot, not a rule
 about ACP, and must not be generalised.
 
-Config surface: add `KiroPath` (default `kiro-cli`) and `KiroModel` to `DaemonConfig`, mirroring
-`CursorPath`/`CursorModel`. Availability is `CliResolver.Exists(KiroPath)`; advertise `kiro` in
+**And `server_initialized` alone would NOT have been sufficient evidence** — it proves a server
+started, not that its tools are discoverable or callable. A tool can be omitted from `tools/list`,
+refused by trust policy, mis-namespaced, or fail at `tools/call`. So the claim was re-probed properly:
+a purpose-built stdio server exposing one uniquely named tool was injected, Kiro was asked to call it,
+and the server's own log recorded `initialize` → `tools/list` → **`tools/call`**, with the tool's nonce
+reaching the model and the turn ending `end_turn`. That is what justifies `SupportsMcpServers: true`.
+
+By the same standard, Copilot's `SupportsMcpServers: false` should only change if an equivalent
+call-level probe against Copilot succeeds. Do not flip it on the strength of Kiro's result.
+
+Config surface — **corrected**: `DaemonConfig.KiroPath` **already exists** with default `"kiro"`, not
+`"kiro-cli"`. The spec previously said to add it, which would have produced duplicate plumbing or a
+silent availability change. Decide explicitly between (a) keeping `"kiro"`, (b) probing both
+executable names, or (c) migrating the default — and add acceptance for `KCAP_KIRO_PATH`. Only
+`KiroModel` is genuinely new. Availability stays `CliResolver.Exists(KiroPath)`; advertise `kiro` in
 `SupportedVendors` only when it resolves.
 
 ## Verification checklist
@@ -138,7 +179,8 @@ Mirrors the Copilot child, minus what has already been measured:
 - [ ] Clean stop; no orphaned child
 - [ ] `SupportedVendors` advertises `kiro` only when the binary resolves
 - [ ] End-to-end capture: the hosted session appears with vendor `kiro`
-- [ ] Model override reaches the agent (`--model` observable in the launch argv)
+- [ ] Model override actually takes effect — measured via `session/set_config_option`, NOT by
+      inspecting argv (see Premise 3)
 - [ ] Confirm the ACP-reported agent version is logged
 
 Explicitly **not** in this checklist: token counts (measured absent), auth/tier pre-check (no gate

--- a/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
@@ -1,0 +1,152 @@
+# AI-1404 — Kiro CLI as an ACP hosted agent
+
+**Status:** re-specced 2026-07-30 against `kiro-cli 2.12.1` and current `origin/main` (`bc09eac`).
+**Repository:** kurrent-io/kcap-cli
+**Parent:** AI-1399 (multi-vendor ACP hosted agents)
+**Template:** the shipped Copilot child (AI-1403) and the Cursor descriptor — read those, not the
+2026-07-19 sketch on the issue, which predates both.
+
+## Why this was re-specced
+
+The issue's original design was written before AI-1401, AI-1403 and AI-1407 shipped, and it carried
+three unverified premises. Two were wrong. Everything below marked **measured** was observed directly
+against a live `kiro-cli acp` process, not inferred.
+
+## Measured facts
+
+`kiro-cli acp` exists — `Start Agent Client Protocol (ACP) agent`. Its flags:
+
+```
+--agent <AGENT>            agent to use for the first session
+--model <MODEL>            model ID for the first session
+--effort <EFFORT>          low | medium | high | xhigh | max
+-a, --trust-all-tools      auto-approve all tool permission requests
+--trust-tools <NAMES>      trust only this set
+--agent-engine <ENGINE>    v1 | v2 (default) | v3
+```
+
+`initialize` response (**measured**):
+
+```json
+{"protocolVersion":1,
+ "agentCapabilities":{
+   "loadSession":true,
+   "promptCapabilities":{"image":true,"audio":false,"embeddedContext":false},
+   "mcpCapabilities":{"http":true,"sse":false},
+   "sessionCapabilities":{},
+   "auth":{}},
+ "authMethods":[],
+ "agentInfo":{"name":"Kiro CLI Agent","version":"2.15.2"}}
+```
+
+A full `initialize` → `session/new` → `session/prompt` loop completed with `stopReason: end_turn`.
+
+### Premise 1 — "headless requires a paid-tier `KIRO_API_KEY`". NOT REPRODUCED.
+
+`authMethods` is empty, no auth method is advertised, and a real prompt completed with **no
+`KIRO_API_KEY` set in the environment**. So there is no auth handshake and no tier gate at
+initialize/new/prompt on the account this was measured with.
+
+This does **not** prove no account tier can ever be blocked — only that the gate the original design
+feared does not exist at the protocol level. Keep a clear diagnostic for a launch-time auth failure,
+but do not build a tier pre-check: there is nothing to check.
+
+### Premise 2 — "ACP usage reporting may close Kiro's token gap". IT DOES NOT.
+
+Across a complete prompt turn, **zero** frames carried any of `usage`, `tokens`, `inputTokens`,
+`outputTokens`, `tokenUsage` or `totalTokens`. The notification surface was:
+
+```
+  5  _kiro.dev/commands/available
+  4  _kiro.dev/mcp/server_initialized
+  3  _kiro.dev/metadata
+  1  _kiro.dev/subagent/list_update
+  3  session/update
+```
+
+So AI-888's "Kiro emits no token counts" stands, and hosting Kiro over ACP does **not** improve its
+cost story. Anything downstream that prices a Kiro session still has nothing to price. Say so rather
+than leaving the hope in the issue.
+
+### Premise 3 — model selection works. CONFIRMED.
+
+`--model` is a real flag, so `ConfigOptionModelSelector` (the same selector Cursor and Copilot use)
+applies. AI-1401's model pass-through needs no Kiro-specific work.
+
+## New facts the original design did not have
+
+**`--agent-engine v1|v2|v3`, default `v2`.** A spawn-time behavioural switch nobody had accounted
+for. **Decision: do not pass it.** Pinning a version means owning an upgrade treadmill and diverging
+from what a user gets interactively; the default is what Kiro tests. Revisit only if a measured
+behavioural difference forces it.
+
+**`session/new` returns `modes`.** ACP "modes" are Kiro *agents*: `availableModes` was
+`[kcap, kiro_default, kiro_planner]` with `currentModeId: kcap` — our own installed agent, selected by
+default because `kcap plugin install` wrote `~/.kiro/agents/kcap.json`.
+
+**Kiro auto-loads its agent config's MCP servers into an ACP session.** With `mcpServers: []` in
+`session/new`, Kiro still initialized `kcap-flows`, `kcap-review`, `kcap-sessions` and `kcap-memory`.
+Harmless for an interactive hosted agent — it is what the user would get anyway — but it is a hazard
+for the unattended reviewer, so AI-1410 owns it, not this issue.
+
+**`promptCapabilities.embeddedContext: false`** (Copilot: `true`). Kiro cannot take embedded context
+resources in a prompt; context must be plain text. Interactive hosting does not care. AI-1410 does.
+
+**`sessionCapabilities: {}`** — no `list` capability (Copilot advertises `{list:{}}`). Nothing today
+depends on session listing; noted so its absence is not later mistaken for a regression.
+
+**`agentInfo.version` is `2.15.2` while `kiro-cli --version` reports `2.12.1`.** The ACP agent reports
+a different version line from the CLI wrapper. Log the ACP-reported version when diagnosing, and do
+not assume the two match.
+
+## Design
+
+One descriptor plus a factory registration, exactly the Cursor/Copilot shape:
+
+```csharp
+public static readonly AcpVendorDescriptor Kiro = new(
+    Vendor:              "kiro",
+    ResolveBinaryPath:   cfg => cfg.KiroPath,
+    ResolveDefaultModel: cfg => cfg.KiroModel,
+    Argv:                ["acp"],
+    UnattendedTrustArgv: [],            // AI-1410 owns this; empty keeps unattended off
+    SupportsUnattended:  false,         // flipped by AI-1410
+    ModelSelector:       ConfigOptionModelSelector.Instance,
+    SupportsMcpServers:  true,          // measured: stdio servers in session/new ARE honoured
+    SupportsBorrowedReviewFlow: false   // AI-1410 decides; default off is the safe direction
+);
+```
+
+`SupportsMcpServers: true` is the one line that deserves scrutiny, because the Copilot descriptor
+says the opposite for itself on what looks like the same evidence: *"ACP itself advertises MCP over
+http/sse only, so interactive `session/new` stdio servers stay disabled."* Kiro advertises the same
+`{http, sse}` shape — but a **measured** probe passing a stdio server (`command: kcap`,
+`args: [mcp, memory]`) produced `_kiro.dev/mcp/server_initialized` naming that server. Kiro honours
+stdio despite not advertising it. Copilot's line is an empirical finding about Copilot, not a rule
+about ACP, and must not be generalised.
+
+Config surface: add `KiroPath` (default `kiro-cli`) and `KiroModel` to `DaemonConfig`, mirroring
+`CursorPath`/`CursorModel`. Availability is `CliResolver.Exists(KiroPath)`; advertise `kiro` in
+`SupportedVendors` only when it resolves.
+
+## Verification checklist
+
+Mirrors the Copilot child, minus what has already been measured:
+
+- [ ] Dashboard launch → live events; vendor label casing correct
+- [ ] Permission and elicitation round-trips through `AcpInteractionBridge` (Kiro's shapes unverified)
+- [ ] Clean stop; no orphaned child
+- [ ] `SupportedVendors` advertises `kiro` only when the binary resolves
+- [ ] End-to-end capture: the hosted session appears with vendor `kiro`
+- [ ] Model override reaches the agent (`--model` observable in the launch argv)
+- [ ] Confirm the ACP-reported agent version is logged
+
+Explicitly **not** in this checklist: token counts (measured absent), auth/tier pre-check (no gate
+exists), `--agent-engine` (deliberately unpinned).
+
+## Out of scope
+
+- `SupportsUnattended` stays false; AI-1410 flips it after its own loop verifies.
+- Borrowed review: AI-1410's call, and it needs a containment-token decision, not a default.
+- Kiro's own agent-config MCP servers leaking into a session — an unattended-only hazard.
+- Kiro's `--effort` flag: no kcap surface exposes effort today; adding one is its own issue.

--- a/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
@@ -65,24 +65,30 @@ isolated `KIRO_HOME` owned by the daemon for reviewer launches.
 This is a decision, not a candidate list. The prior draft's matrix is collapsed to the one cell that
 mattered.
 
-**What that obliges the design to specify** — an isolated home is a filesystem boundary, so everything
-the reviewer needs must be deliberately placed and everything else deliberately withheld:
+**Validated for the operation this issue actually performs** — not just handshake. In an isolated empty
+home, with the probe MCP server injected via `session/new.mcpServers`:
 
-* **Credentials.** Kiro must still authenticate. Determine what under `KIRO_HOME` carries auth and
-  place exactly that, or confirm auth lives outside `KIRO_HOME` entirely. *Unresolved — must be probed
-  before implementation, and it is the one item that could invalidate this mechanism.*
-* **Deliberately excluded:** `settings/mcp.json` (the whole point), the user's agents, and anything
-  granting write or flow-starting capability.
-* **Placed if required:** only the injected `flow-result` server, which arrives via
-  `session/new.mcpServers` rather than the home, so probably nothing.
-* **Permissions and cleanup:** owner-only; removed when the reviewer is reaped, including on crash.
-* **Concurrency:** one home per reviewer launch, so two concurrent reviews cannot share or race state.
-* **Preflight:** `ComputeUnattendedVendors` must not advertise `kiro` until the daemon can create an
-  isolated home AND authenticate inside it. A failure here refuses the launch with a coded error rather
-  than wedging a round.
+* `session/new` succeeded;
+* `session/prompt` completed `end_turn`;
+* the probe server logged a real **`tools/call`** and its nonce reached the model;
+* **no authentication error of any kind** — nothing on stderr, no auth frame, no failure.
 
-Because this touches daemon process launch rather than the installer, it remains the largest item in
-the issue — but it is now a known quantity rather than an unknown one.
+**Therefore Kiro's credentials do NOT live under `KIRO_HOME`.** That is the finding that collapses most
+of this section's complexity: there is nothing secret to copy into a reviewer home, so the design needs
+no credential source, refresh/expiry handling, atomic secret materialization, symlink validation of
+copied secrets, or secret-bearing cleanup. A reviewer home contains **nothing sensitive**.
+
+What remains to specify is small:
+
+* **Contents:** nothing. Create it empty. `settings/mcp.json` and the user's agents are excluded by
+  simply not being there, which is why the mechanism works.
+* **Permissions:** owner-only anyway, on principle rather than because of secrets.
+* **Concurrency:** one home per reviewer launch, so concurrent reviews cannot race shared state.
+* **Cleanup, including after a daemon crash** — see §4b, which is now a plain temp-directory sweep
+  rather than a secret-handling problem.
+
+Because this touches daemon process launch rather than the installer it is still the largest item here,
+but it is now a small, measured one.
 
 ## Acceptance criterion that must be rewritten
 

--- a/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
@@ -1,11 +1,29 @@
 # AI-1410 — Kiro CLI as an unattended review-flow reviewer
 
-**Status:** re-specced 2026-07-30 against `kiro-cli 2.12.1` and current `origin/main` (`bc09eac`).
+**Status:** re-specced 2026-07-30 against `kiro-cli 2.12.1` / ACP-reported `2.15.2`, and current
+`origin/main` (`bc09eac`). **NOT implementation-ready** — §1.2 is an open containment decision the probe
+created, and §1.5 lists what is still unmeasured. See "Readiness" below.
 **Repository:** kurrent-io/kcap-cli
 **Parent:** AI-1400 (reviewer choice in review flows)
 **Depends on:** AI-1404 (Kiro hosting) · AI-1407 (ACP reviewer foundation) · AI-1402 (vendor selection)
 **Companion spec:** `2026-07-30-ai1404-kiro-acp-hosted-agent-design.md` — all measured protocol facts
 live there and are not repeated.
+
+## Readiness
+
+The MCP result channel is a GO (below). The **containment mechanism is not settled**, and the reason is
+a measurement rather than an omission: §1.2 found that a trusted `fs_read` reads the whole filesystem, so
+`--trust-tools` scoping is not the read boundary the earlier draft assumed. Two things must happen before
+anyone implements this:
+
+1. **Decide §1.2** — OS sandbox (the Copilot `sandbox-exec` route) versus explicitly accepting an
+   owned-worktree-only read surface with the residual risk written down. This is a product/security call,
+   not an implementation detail.
+2. **Probe §1.5** — namespaced `@kcap-flow-result/...` trust on the ACP path. If the reviewer cannot call
+   `flow-result` without approval it cannot deliver a result at all, and it would present as a silent
+   round timeout rather than an error.
+
+Everything else in this spec is decided and measured.
 
 ## The go/no-go, resolved: GO
 
@@ -22,6 +40,10 @@ Re-probed at the call level: a purpose-built stdio server exposing one uniquely 
 in `session/new.mcpServers`, Kiro was asked to call it, and **the server's own log recorded
 `initialize` → `tools/list` → `tools/call`**, with the tool's nonce reaching the model and the turn
 ending `end_turn` under `--trust-all-tools`. That is a real GO.
+
+**But note the flag.** That probe trusted everything, which §1 forbids for a reviewer. It establishes the
+*transport* (Kiro honours stdio servers passed in `session/new`), not that the result tool is callable
+under the scoped trust set we will actually ship — see §1.5, which keeps that open.
 
 So Kiro can carry the injected `flow-result` channel over `session/new`, meaning
 `ReviewFlowMcpTransport: SessionNew` — the Cursor route, not Copilot's `--additional-mcp-config`
@@ -128,35 +150,112 @@ means the answer is not simply "no data".
 
 ## Design
 
-### 1. Trust at spawn
+### 1. Trust at spawn — now MEASURED, and the conclusion changed
 
-`UnattendedTrustArgv` on the Kiro descriptor. Start scoped rather than blanket:
+The previous revision left this section "UNMEASURED and must be probed before implementable". It has now
+been probed against `kiro-cli 2.15.2` in an isolated empty `KIRO_HOME`. **The probe did not confirm the
+design; it falsified part of it.** Read the boundary finding before the tool list.
+
+#### 1.1 The native tool names (measured)
+
+There is a reliable enumeration oracle: an unknown name in `--trust-tools` produces
+`WARNING: --trust-tools arg for custom tool <name> needs to be prepended with @{MCPSERVERNAME}/`,
+while a valid native name produces no warning. Batch-probing candidates gave:
+
+| Valid native tool | Invalid (warned) |
+|---|---|
+| `fs_read`, `fs_write`, `execute_bash`, `use_aws`, `knowledge`, `thinking`, `introspect`, `todo_list`, `gh_issue`, `web_search` | `report_issue`, `code_review`, `fetch`, `mcp` |
+
+Two incidental facts worth pinning, because both can mislead an implementer:
+
+* **A typo is a WARNING, not an error.** `--trust-tools=fs_reed` warns and continues, trusting nothing.
+  So a misspelled trust list degrades silently into "no tools trusted" — a reviewer that mysteriously
+  cannot read. Whatever we ship must be asserted against the real names, not eyeballed.
+* **The trust-flag name and the displayed tool name differ.** The trust flag is `fs_write`, but the
+  transcript says `using tool: write` (and `fs_read` displays as `read`). Do not derive one from the
+  other.
+
+#### 1.2 The boundary finding: `fs_read` is NOT path-scoped
+
+**Measured, and it invalidates the "scoped trust is the read-only boundary" premise.** With
+`--trust-tools=fs_read,thinking` and cwd set to a review worktree, Kiro was asked to read a file in a
+completely unrelated directory outside that worktree. It did:
 
 ```
---trust-tools=<read-only set>        (exact Kiro tool names UNMEASURED — see below)
+Reading file: …/outside.9DinAE/secret.txt, all lines (using tool: read)
+ ✓ Successfully read 25 bytes
+> The file contains exactly one line:
+  SECRET_OUTSIDE_NONCE_9042
 ```
 
-**`shell` must NOT be in this list**, and an earlier draft had it. Trusting `shell` means a write or an
-outside-home command executes WITHOUT emitting a permission frame — so `Fail` never fires and the
-"read-only reviewer" boundary is fiction. That also means the negative acceptance criterion must verify
-that a forbidden **effect** is prevented (ask the reviewer to actually write a file and to read outside
-the worktree, then assert neither happened), not merely that a frame was handled.
+So a trusted `fs_read` is a **whole-filesystem read primitive** under the daemon's uid. On a daemon host
+that reaches `~/.config/kcap/tokens.json`, `~/.aws/credentials`, SSH keys, and every *other* concurrent
+review's worktree — including, per the isolated-home section above, other reviewers' transcript JSONL.
 
-If the remaining read-only tools cannot review a repository, the answer is a real command/filesystem
-sandbox or a command-level read allowlist — not re-adding `shell`. **The exact Kiro tool names and trust
-semantics are UNMEASURED and must be probed before this section is implementable.**
+`--trust-tools` is therefore a **tool-surface** control, not a filesystem boundary. This is the same
+lesson the Copilot borrowed-review work already learned and encoded in
+`AcpBorrowedReviewContainment`: *"widening its tool surface enough to read a snapshot also widens what a
+read tool can be pointed at, so the boundary is an OS sandbox rather than the vendor's own permission
+prompts."* Kiro is in exactly that position.
 
-A reviewer reads and reports; it does not need write. **There is no `--trust-all-tools` fallback.** An
-earlier draft offered one, which contradicted §2 and would have widened the hole it describes: if the
-scoped set proves insufficient, the correct outcome is a failing reviewer to investigate, not a
-blanket-trusted one.
+**Consequence for this issue.** Scoped trust alone does not make a contained reviewer. Options, in
+preference order:
 
-Note Kiro's warning observed during the memory-cert work:
-`--trust-tools arg for custom tool ... needs to be prepended with @{MCPSERVERNAME}/`. So MCP-provided
-tools are namespaced in the trust list, which matters the moment `flow-result` is injected: the
-reviewer must be able to *call* `flow-result` without a prompt, and that likely needs
-`@kcap-flow-result/...` in the trust set. **Verify this explicitly** — a reviewer that cannot call
-`flow-result` without approval cannot deliver a result at all, and would present as a silent timeout.
+1. **OS sandbox** (`sandbox-exec` on macOS, the mechanism Copilot borrowed review already uses) confining
+   reads to the review worktree plus what the CLI needs to start. This is the only option that actually
+   bounds reads.
+2. **Accept the read surface explicitly**, scoped to OWNED worktrees only (borrowed review stays off
+   regardless), with the residual risk written down: a reviewer can read anything the daemon user can.
+   Only defensible on a single-tenant host where the reviewer is already trusted with the repository.
+
+Option 2 must not be chosen silently. If it is chosen, the *reason* it is tolerable is the isolated
+`KIRO_HOME` plus owned-worktree-only scope, not the trust list — and the spec must say so, because a
+later reader will otherwise assume `--trust-tools` was the boundary.
+
+#### 1.3 Writes and shell ARE blocked — but check WHY
+
+`fs_write` omitted from the trust set does block the write, at **effect** level:
+
+```
+Command fs_write is rejected because it matches one or more rules on the denied list:
+  - non-interactive mode (no user to approve)
+```
+
+Note the reason: the denial is attributed to **`--no-interactive` (no user to approve)**, not to the
+trust list. That is good news for wedging — an untrusted tool is *denied*, not left hanging — but it
+means the measured containment came from the non-interactive mode, and an equivalent set omitting
+`fs_write` would deny identically. **`shell`/`execute_bash` must still never be trusted**: the earlier
+draft had it, and trusting it makes writes and out-of-tree commands execute with no frame at all.
+
+**This measurement is on the `chat --no-interactive` path, NOT the ACP path.** The reviewer runs
+`kiro-cli acp`, where there is no `--no-interactive` and a permission request surfaces as an ACP frame
+handled by `AcpInteractionBridge` under the `Fail` policy from §2. Do not carry the "denied list"
+behaviour over to ACP without re-measuring it there — that would repeat the
+`server_initialized`-proves-callability error from AI-1404.
+
+#### 1.4 A negative test needs a positive control
+
+The first attempt at the write test was **vacuous and looked like a pass.** Phrased with
+`PWNED`/`BREACH`/"Do it now", Kiro refused on prompt-injection grounds and never called the tool at all;
+the file's absence proved nothing about trust. Only re-running with a benign, plausible request — and a
+**positive control** with `fs_write` trusted, proving the same request really does write — established
+that the tool was attempted and then blocked.
+
+So the acceptance criteria here must be paired: for every "forbidden effect did not happen" assertion,
+a control showing the effect DOES happen when permitted. Without it, the model's own judgement can
+satisfy the test while the guard is absent.
+
+#### 1.5 What remains unmeasured
+
+`@kcap-flow-result/...` namespaced trust for the injected result tool is **still unverified**. A reviewer
+that cannot call `flow-result` without approval cannot deliver a result at all and would present as a
+silent timeout, so this must be probed on the ACP path before implementation. The AI-1404 probe proved a
+`session/new`-injected stdio server reaches a real `tools/call`, but that was with `--trust-all-tools`,
+which §1 forbids — so it does not transfer.
+
+**There is no `--trust-all-tools` fallback.** An earlier draft offered one, which contradicted §2 and
+would have widened the very hole it describes: if the scoped set proves insufficient, the correct
+outcome is a failing reviewer to investigate, not a blanket-trusted one.
 
 ### 2. Interaction policy — an earlier draft of this spec had a security hole here
 
@@ -312,8 +411,15 @@ specific assertion. Until it is observed, there is nothing to assert against.
 - [ ] The reviewer process is reaped before its home is deleted (§4b)
 - [ ] The user's global `~/.kiro/settings/mcp.json` is byte-identical after a reviewer round (§4b —
       containment never mutates user config)
-- [ ] **Negative:** an untrusted / write-capable / out-of-worktree request is denied or reaps the
-      reviewer (see §2) — not merely absent
+- [ ] **Negative:** an untrusted / write-capable request is denied or reaps the reviewer (see §2) — not
+      merely absent, and **each negative assertion is paired with a positive control** proving the same
+      request succeeds when permitted (§1.4 — the first such test passed vacuously because the model
+      refused on prompt-injection grounds and never called the tool)
+- [ ] **Negative, out-of-worktree read:** currently EXPECTED TO FAIL under scoped trust alone — §1.2
+      measured `fs_read` reading outside the worktree. This checkbox is only closable once §1.2's
+      containment decision is implemented (OS sandbox), or is explicitly restated as accepted risk
+- [ ] A misspelled entry in the trust list cannot ship silently (§1.1 — a typo is a warning, not an
+      error, and degrades to "nothing trusted")
 - [ ] The effective callable tool surface excludes global servers, inspected directly
 - [ ] A missing reviewer configuration refuses the launch with a coded error rather than wedging
 

--- a/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
@@ -10,9 +10,18 @@ live there and are not repeated.
 ## The go/no-go, resolved: GO
 
 The original design listed *"verify `mcpServers` honoring (go/no-go for the flow-result channel)"* as
-an open question. It is now **measured and answered**: a stdio MCP server passed in
-`session/new.mcpServers` (`command: kcap`, `args: [mcp, memory]`) produced
-`_kiro.dev/mcp/server_initialized` naming that server.
+an open question. It is now measured and answered — but the FIRST answer was on insufficient evidence
+and is recorded here as a caution.
+
+An initial probe showed `_kiro.dev/mcp/server_initialized` naming an injected stdio server, and an
+earlier draft of this spec called GO on that. **That was premature**: `server_initialized` proves a
+server process started, not that its tools are discoverable or invocable — a tool can be missing from
+`tools/list`, refused by trust policy, mis-namespaced, or fail at `tools/call`.
+
+Re-probed at the call level: a purpose-built stdio server exposing one uniquely named tool was passed
+in `session/new.mcpServers`, Kiro was asked to call it, and **the server's own log recorded
+`initialize` → `tools/list` → `tools/call`**, with the tool's nonce reaching the model and the turn
+ending `end_turn` under `--trust-all-tools`. That is a real GO.
 
 So Kiro can carry the injected `flow-result` channel over `session/new`, meaning
 `ReviewFlowMcpTransport: SessionNew` — the Cursor route, not Copilot's `--additional-mcp-config`
@@ -24,29 +33,51 @@ Worth stating because it looks contradictory: Kiro advertises `mcpCapabilities: 
 and the Copilot descriptor reads that same shape as *"stdio servers stay disabled."* That is an
 empirical finding about Copilot, not a rule about ACP. Kiro honours stdio without advertising it.
 
-## The blocker the original design did not know about
+## The blocker — and my first proposed mechanism was wrong
 
-**Kiro auto-loads its agent config's MCP servers into every ACP session.** Measured: with
-`mcpServers: []`, Kiro still initialized `kcap-flows`, `kcap-review`, `kcap-sessions` and
-`kcap-memory` from `~/.kiro/agents/kcap.json`.
+**Kiro inherits pre-configured MCP servers into every ACP session.** Measured: with `mcpServers: []`,
+Kiro still initialized `kcap-flows`, `kcap-review`, `kcap-sessions` and `kcap-memory`.
 
-For an unattended reviewer that is not cosmetic — **`kcap-flows` would let a reviewer start nested
-review flows.** The `review-flows` skill already tells a hosted reviewer not to, and the platform
-strips MCP servers from hosted reviewers precisely so it *cannot*. Copilot handles this with
-`--disable-builtin-mcps` in its unattended trust argv. **Kiro has no equivalent flag.**
+For an unattended reviewer this is not cosmetic — **`kcap-flows` would let a reviewer start nested
+review flows.** The `review-flows` skill tells hosted reviewers not to, and the platform strips MCP
+servers from hosted reviewers precisely so it *cannot*. Copilot handles this with
+`--disable-builtin-mcps`; Kiro has no equivalent flag.
 
-Options, in preference order:
+### Why the obvious fix does not work
 
-1. **`--agent <name>` with a purpose-built minimal reviewer agent.** Kiro's MCP servers come from the
-   agent config, and `session/new` confirmed `availableModes` are agents. A `kcap-reviewer` agent
-   carrying no MCP servers is the mechanism Kiro actually gives us. Cost: `kcap plugin install` must
-   write a second agent file, and the reviewer launch must pin it.
-2. **ACP `session/setMode`** to switch to a leaner mode after `session/new` — worse: the servers are
-   already initialized by then.
-3. **Ship without suppression.** Rejected. It hands a reviewer the tool that starts reviewers.
+An earlier draft proposed a purpose-built minimal agent selected via `--agent kcap-reviewer`, reasoning
+that Kiro's MCP servers come from the agent config. **That reasoning was wrong.**
+`PluginCommand.InstallKiro` registers those four servers in GLOBAL `~/.kiro/settings/mcp.json` — and
+inspecting that file confirms it contains exactly `kcap-review`, `kcap-sessions`, `kcap-flows`,
+`kcap-memory`. Both `PluginCommand.cs` and `KiroPaths.cs` document that file as independent of
+`~/.kiro/agents/kcap.json`. So **selecting a different agent may leave `kcap-flows` fully exposed.**
 
-**This decision must be made before implementation**, and option 1 changes the installer, so it is
-the largest single piece of work in this issue — larger than the descriptor change.
+`session/setMode` remains too late (servers are already initialized by `session/new`), but that only
+rules out one alternative; it does not rescue the agent approach.
+
+### Required before implementation: a source-isolation matrix
+
+The mechanism cannot be chosen from what is currently known. Run a matrix against a temporary
+`KIRO_HOME`:
+
+| global `settings/mcp.json` | selected agent declares MCP | expected |
+|---|---|---|
+| present | none | does `kcap-flows` still initialize? |
+| present | minimal agent | does agent selection suppress global? |
+| absent | none | baseline — nothing inherited |
+| absent | minimal agent | agent-only inheritance |
+
+Then pick a mechanism that **demonstrably excludes global servers**. Candidates, none yet validated:
+an isolated reviewer `KIRO_HOME`; a launch-time config boundary; or upstream support for suppression.
+
+Acceptance must inspect the **effective callable tool surface** — what the reviewer can actually
+invoke — not merely which mode was selected. `server_initialized` absence is necessary but not
+sufficient, for the same reason its presence was not sufficient above.
+
+**Estimate correction.** An earlier draft called this "a second agent file + descriptor change" and
+the largest piece of work. It is larger and less certain than that: the mechanism is unknown, an
+isolated `KIRO_HOME` would touch daemon process launch rather than just the installer, and the matrix
+itself is real investigation. This is the item that should gate scheduling.
 
 ## Acceptance criterion that must be rewritten
 
@@ -55,10 +86,15 @@ The issue currently says:
 > `start_review_flow(kind="spec-review", vendor="kiro", model="<priced-model>")` completes a real
 > round unattended end-to-end with the model honored.
 
-**"priced-model" is unsatisfiable.** Kiro's ACP reports no token usage at all (measured — see the
-companion spec), so nothing prices a Kiro reviewer round and the AI-1402 pricing clamp has no input.
-The criterion should assert the model is *honoured*, and state explicitly that cost is not observable
-for Kiro. Leaving "priced" in makes the issue unclosable for a reason unrelated to the work.
+**"priced-model" is very likely unsatisfiable, but state the reason precisely.** ACP surfaced no
+canonical token counters (measured). It does **not** follow that Kiro cost is unobservable:
+`KiroUsage.cs` already reads billing `metering_usage` credits from Kiro's on-disk session metadata.
+
+So the rewrite must say which input the AI-1402 pricing clamp actually needs. If it requires canonical
+token counts against a priced model, Kiro cannot satisfy it and the criterion should assert the model is
+*honoured* while recording that token-based cost is unavailable. If credits suffice, the criterion may
+be satisfiable through the existing sidecar. **Resolve this against the clamp's real requirement before
+rewriting the issue** — do not assert "no cost data" when a credits path exists.
 
 ## Design
 
@@ -81,14 +117,26 @@ reviewer must be able to *call* `flow-result` without a prompt, and that likely 
 `@kcap-flow-result/...` in the trust set. **Verify this explicitly** — a reviewer that cannot call
 `flow-result` without approval cannot deliver a result at all, and would present as a silent timeout.
 
-### 2. Interaction policy
+### 2. Interaction policy — an earlier draft of this spec had a security hole here
 
-`UnattendedInteractionPolicy: AutoApprove` — the Copilot posture, not Cursor's `Fail`.
+The earlier proposal was `AutoApprove` (the Copilot posture) on the grounds that Kiro's known upstream
+prompt leaks (#7398) make a frame expected rather than exceptional, so `Fail` would be flaky.
 
-Cursor earns `Fail` because its own flags are contractually sufficient to suppress interaction frames,
-so a frame means regression. Kiro has *known upstream prompt leaks* (#7398), so a frame is expected
-rather than exceptional, and failing the round on one would make Kiro reviewers flaky by design.
-Revisit once the leaks are fixed upstream.
+**That combination is unsafe and it undoes §1.** `AcpInteractionBridge` documents that `AutoApprove`
+selects an allow option and **does not inspect the tool**. So on exactly the fallback path this design
+expects to exercise, a leaked request for a tool deliberately excluded from `--trust-tools` — a
+write-capable shell command, an out-of-worktree path, anything — is auto-approved. Scoped trust would
+provide no protection whatsoever, and "zero human-routed interactions" would not detect it: the frames
+were handled, just not safely.
+
+**Requirement:** either an allowlist-aware unattended policy that approves only frames matching the
+scoped trust set, or `Fail` on any non-matching frame. Falling back to `--trust-all-tools` makes the
+gap wider, not narrower, and is not an acceptable resolution.
+
+Acceptance needs **negative** criteria, which the earlier draft lacked entirely: an untrusted,
+write-capable, or out-of-bounds request must be denied or must terminate the reviewer, while the known
+safe read and `flow-result` requests still succeed. Without those, this policy is untested by
+construction.
 
 ### 3. Prompt shape
 
@@ -115,9 +163,14 @@ scope here; its own issue once basic reviewing works.
 
 ### 5. Auth
 
-`authMethods: []` and a real prompt completed with no `KIRO_API_KEY` (measured), so there is no auth
-handshake to satisfy and no tier pre-check to build. A launch-time failure must still fail fast with a
-coded diagnostic rather than wedge a round — but that is the generic path, not Kiro-specific.
+`authMethods: []` shows no ACP-mediated auth flow, and a prompt completed with no `KIRO_API_KEY` set —
+but on one machine, which may have had cached credentials. That proves **no pre-checkable signal**, not
+"no auth requirement" and not "no tier gate".
+
+So: build no pre-check, and fail on the real launch/prompt error with a coded diagnostic. And the
+criterion "a tier/auth failure surfaces a coded error" needs a reproducible way to exercise it —
+an isolated unauthenticated `KIRO_HOME` if that reproduces, otherwise a fake ACP peer returning the
+measured auth-failure shape. Without one it cannot be closed.
 
 ## Verification
 
@@ -127,8 +180,13 @@ coded diagnostic rather than wedge a round — but that is the generic path, not
 - [ ] `flow-result` is callable without approval (the §1 namespacing question)
 - [ ] `kcap-flows` is NOT present in the reviewer's session (the §"blocker" suppression works)
 - [ ] Reviewer session captured and reaped; no orphan
-- [ ] Model override honoured — asserted as honoured, not as priced
-- [ ] A tier/auth failure surfaces a coded error instead of a hung round
+- [ ] Model override honoured — via `session/set_config_option`, and only once an ACP
+      `ReviewerModelResolver` exists
+- [ ] A tier/auth failure surfaces a coded error instead of a hung round, exercised by a defined setup
+- [ ] **Negative:** an untrusted / write-capable / out-of-worktree request is denied or reaps the
+      reviewer (see §2) — not merely absent
+- [ ] The effective callable tool surface excludes global servers, inspected directly
+- [ ] A missing reviewer configuration refuses the launch with a coded error rather than wedging
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
@@ -1,0 +1,138 @@
+# AI-1410 — Kiro CLI as an unattended review-flow reviewer
+
+**Status:** re-specced 2026-07-30 against `kiro-cli 2.12.1` and current `origin/main` (`bc09eac`).
+**Repository:** kurrent-io/kcap-cli
+**Parent:** AI-1400 (reviewer choice in review flows)
+**Depends on:** AI-1404 (Kiro hosting) · AI-1407 (ACP reviewer foundation) · AI-1402 (vendor selection)
+**Companion spec:** `2026-07-30-ai1404-kiro-acp-hosted-agent-design.md` — all measured protocol facts
+live there and are not repeated.
+
+## The go/no-go, resolved: GO
+
+The original design listed *"verify `mcpServers` honoring (go/no-go for the flow-result channel)"* as
+an open question. It is now **measured and answered**: a stdio MCP server passed in
+`session/new.mcpServers` (`command: kcap`, `args: [mcp, memory]`) produced
+`_kiro.dev/mcp/server_initialized` naming that server.
+
+So Kiro can carry the injected `flow-result` channel over `session/new`, meaning
+`ReviewFlowMcpTransport: SessionNew` — the Cursor route, not Copilot's `--additional-mcp-config`
+workaround. **Without this the whole issue would have been blocked**, because results arrive *only*
+via the `flow-result` tool (markers are inert since AI-1190) and Kiro has no Copilot-style
+config-preload flag.
+
+Worth stating because it looks contradictory: Kiro advertises `mcpCapabilities: {http:true, sse:false}`
+and the Copilot descriptor reads that same shape as *"stdio servers stay disabled."* That is an
+empirical finding about Copilot, not a rule about ACP. Kiro honours stdio without advertising it.
+
+## The blocker the original design did not know about
+
+**Kiro auto-loads its agent config's MCP servers into every ACP session.** Measured: with
+`mcpServers: []`, Kiro still initialized `kcap-flows`, `kcap-review`, `kcap-sessions` and
+`kcap-memory` from `~/.kiro/agents/kcap.json`.
+
+For an unattended reviewer that is not cosmetic — **`kcap-flows` would let a reviewer start nested
+review flows.** The `review-flows` skill already tells a hosted reviewer not to, and the platform
+strips MCP servers from hosted reviewers precisely so it *cannot*. Copilot handles this with
+`--disable-builtin-mcps` in its unattended trust argv. **Kiro has no equivalent flag.**
+
+Options, in preference order:
+
+1. **`--agent <name>` with a purpose-built minimal reviewer agent.** Kiro's MCP servers come from the
+   agent config, and `session/new` confirmed `availableModes` are agents. A `kcap-reviewer` agent
+   carrying no MCP servers is the mechanism Kiro actually gives us. Cost: `kcap plugin install` must
+   write a second agent file, and the reviewer launch must pin it.
+2. **ACP `session/setMode`** to switch to a leaner mode after `session/new` — worse: the servers are
+   already initialized by then.
+3. **Ship without suppression.** Rejected. It hands a reviewer the tool that starts reviewers.
+
+**This decision must be made before implementation**, and option 1 changes the installer, so it is
+the largest single piece of work in this issue — larger than the descriptor change.
+
+## Acceptance criterion that must be rewritten
+
+The issue currently says:
+
+> `start_review_flow(kind="spec-review", vendor="kiro", model="<priced-model>")` completes a real
+> round unattended end-to-end with the model honored.
+
+**"priced-model" is unsatisfiable.** Kiro's ACP reports no token usage at all (measured — see the
+companion spec), so nothing prices a Kiro reviewer round and the AI-1402 pricing clamp has no input.
+The criterion should assert the model is *honoured*, and state explicitly that cost is not observable
+for Kiro. Leaving "priced" in makes the issue unclosable for a reason unrelated to the work.
+
+## Design
+
+### 1. Trust at spawn
+
+`UnattendedTrustArgv` on the Kiro descriptor. Start scoped rather than blanket:
+
+```
+--trust-tools=fs_read,grep,shell     (exact tool names to be confirmed against `kiro-cli chat --help`)
+```
+
+A reviewer reads and reports; it does not need write. If the scoped set proves insufficient — or if
+upstream's trust-flag prompt leaks (issues #7398, #7483) fire anyway — fall back to
+`--trust-all-tools`, and rely on the interaction policy below rather than on the flag alone.
+
+Note Kiro's warning observed during the memory-cert work:
+`--trust-tools arg for custom tool ... needs to be prepended with @{MCPSERVERNAME}/`. So MCP-provided
+tools are namespaced in the trust list, which matters the moment `flow-result` is injected: the
+reviewer must be able to *call* `flow-result` without a prompt, and that likely needs
+`@kcap-flow-result/...` in the trust set. **Verify this explicitly** — a reviewer that cannot call
+`flow-result` without approval cannot deliver a result at all, and would present as a silent timeout.
+
+### 2. Interaction policy
+
+`UnattendedInteractionPolicy: AutoApprove` — the Copilot posture, not Cursor's `Fail`.
+
+Cursor earns `Fail` because its own flags are contractually sufficient to suppress interaction frames,
+so a frame means regression. Kiro has *known upstream prompt leaks* (#7398), so a frame is expected
+rather than exceptional, and failing the round on one would make Kiro reviewers flaky by design.
+Revisit once the leaks are fixed upstream.
+
+### 3. Prompt shape
+
+`promptCapabilities.embeddedContext: false` (measured). Kiro cannot take embedded context resources,
+so AI-1407's prompt folding must deliver review context as **plain text** for Kiro. Confirm the
+foundation does not assume embedded context for any vendor; if it does, that is a foundation fix, not
+a Kiro one.
+
+### 4. Descriptor changes
+
+Flip on the AI-1404 descriptor:
+
+```csharp
+UnattendedTrustArgv: [/* §1 */],
+SupportsUnattended:  true,
+UnattendedInteractionPolicy: AcpUnattendedInteractionPolicy.AutoApprove,
+ReviewFlowMcpTransport: AcpReviewFlowMcpTransport.SessionNew,   // measured-honoured
+```
+
+Borrowed review stays **off**. It needs a containment-token decision
+(`NativeToolClamp` vs `IndependentSnapshot`) grounded in what Kiro's tool clamp actually permits, and
+the descriptor's own doc comment is explicit that guessing that token wrong is a wiring bug. Out of
+scope here; its own issue once basic reviewing works.
+
+### 5. Auth
+
+`authMethods: []` and a real prompt completed with no `KIRO_API_KEY` (measured), so there is no auth
+handshake to satisfy and no tier pre-check to build. A launch-time failure must still fail fast with a
+coded diagnostic rather than wedge a round — but that is the generic path, not Kiro-specific.
+
+## Verification
+
+- [ ] `start_review_flow(kind="spec-review", vendor="kiro")` completes findings→clean unattended
+- [ ] Same for `code-review`
+- [ ] **Zero** human-routed interactions during the round
+- [ ] `flow-result` is callable without approval (the §1 namespacing question)
+- [ ] `kcap-flows` is NOT present in the reviewer's session (the §"blocker" suppression works)
+- [ ] Reviewer session captured and reaped; no orphan
+- [ ] Model override honoured — asserted as honoured, not as priced
+- [ ] A tier/auth failure surfaces a coded error instead of a hung round
+
+## Out of scope
+
+- Borrowed review for Kiro (containment-token decision).
+- Kiro cost/token reporting — absent upstream; AI-888 stands.
+- `--agent-engine` pinning — deliberately unpinned by AI-1404.
+- Fixing upstream trust-flag prompt leaks.

--- a/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
@@ -73,19 +73,34 @@ home, with the probe MCP server injected via `session/new.mcpServers`:
 * the probe server logged a real **`tools/call`** and its nonce reached the model;
 * **no authentication error of any kind** — nothing on stderr, no auth frame, no failure.
 
-**Therefore Kiro's credentials do NOT live under `KIRO_HOME`.** That is the finding that collapses most
-of this section's complexity: there is nothing secret to copy into a reviewer home, so the design needs
-no credential source, refresh/expiry handling, atomic secret materialization, symlink validation of
-copied secrets, or secret-bearing cleanup. A reviewer home contains **nothing sensitive**.
+**Therefore Kiro's credentials do NOT live under `KIRO_HOME`,** for the auth configuration measured.
+That collapses the *inbound* half of this section: nothing secret has to be copied INTO a reviewer
+home, so the design needs no credential source, no refresh/expiry handling, no atomic secret
+materialization, and no symlink validation of copied secrets.
 
-What remains to specify is small:
+**But an earlier draft then concluded "a reviewer home contains nothing sensitive", and that is
+wrong.** The inbound direction is not the only one. `KiroPaths.ConfigRoot` reads `KIRO_HOME` first, so
+`SessionsDir()` resolves to `{KIRO_HOME}/sessions/cli` — meaning **Kiro writes the reviewer's own
+conversation JSONL into the isolated home**, and that transcript contains the review context it was
+given: the caller's diff, source excerpts, and the reviewer's findings. A reviewer home is therefore
+**write-sensitive even though it is read-empty**, and it is created on a shared multi-tenant daemon
+host.
 
-* **Contents:** nothing. Create it empty. `settings/mcp.json` and the user's agents are excluded by
-  simply not being there, which is why the mechanism works.
-* **Permissions:** owner-only anyway, on principle rather than because of secrets.
-* **Concurrency:** one home per reviewer launch, so concurrent reviews cannot race shared state.
-* **Cleanup, including after a daemon crash** — see §4b, which is now a plain temp-directory sweep
-  rather than a secret-handling problem.
+The practical difference: permissions and cleanup are **security requirements with a stated threat**,
+not tidiness. Concretely —
+
+* **Contents at creation:** nothing. Create it empty. `settings/mcp.json` and the user's agents are
+  excluded by simply not being there, which is why the mechanism works.
+* **Permissions:** `0700`, owner-only, set **at creation** rather than after — a world-readable window
+  between `mkdir` and `chmod` is exactly long enough to leak a transcript on a shared host. Do not
+  place the home inside a world-writable shared temp path that another user could pre-create or
+  substitute; root it under a daemon-owned directory.
+* **Concurrency:** one home per reviewer launch, so concurrent reviews cannot race shared state — and,
+  now that the home is transcript-bearing, so one caller's review context is never readable from
+  another caller's reviewer home.
+* **Cleanup, including after a daemon crash** — see §4b. This is a transcript-disposal requirement, not
+  merely a disk-hygiene one, which is why §4b specifies reaping the process before deleting the tree
+  rather than deleting opportunistically.
 
 Because this touches daemon process launch rather than the installer it is still the largest item here,
 but it is now a small, measured one.
@@ -194,16 +209,89 @@ Borrowed review stays **off**. It needs a containment-token decision
 the descriptor's own doc comment is explicit that guessing that token wrong is a wiring bug. Out of
 scope here; its own issue once basic reviewing works.
 
+### 4a. Model override, and what the daemon may advertise
+
+Model override is **out of scope for this issue** — AI-1404 ships `NoOpModelSelector.Instance` because
+`session/set_config_option` is unproven on Kiro and the selector fails silently when it does not take.
+This section exists because two earlier references pointed at a "§4a" that was never written, so the
+decision had no home and could be re-litigated by whoever implemented it.
+
+The load-bearing part is not the deferral, it is **refusing rather than ignoring**:
+
+* Do **not** wire `AcpHostedAgentRuntimeFactory.ReviewerModelResolver` for Kiro. It is `null` at this
+  base, which is why the server already refuses an ACP review-flow model override. That refusal is the
+  correct behaviour and must be preserved deliberately, not inherited by accident.
+* A Kiro reviewer launched with a caller-supplied model must **fail with a coded error**, never accept
+  the request and run the vendor default. A silently-ignored `model=` is the worst outcome available
+  here: the round completes, the result looks authoritative, and nothing anywhere records that the
+  requested model was not the model that reviewed the code.
+* Correspondingly, `ResolveDefaultModel: _ => null` and `NoOpModelSelector` must both hold. Per AI-1404
+  Premise 3, `ResolveDefaultModel: null` alone is **not** sufficient — `ResolveRequestedModel`
+  prioritises `RuntimeStartContext.Model`, so a dashboard-supplied model still reaches a live selector.
+
+**Availability advertisement is static, and must be gated on resolution, not on the descriptor
+existing.** `SupportsUnattended: true` is what makes `vendor="kiro"` selectable as a reviewer, and a
+daemon that advertises Kiro on a host where `kiro-cli` is absent converts a clean
+`no_daemon_available` into a launch failure mid-round. Advertise the reviewer capability only when
+`CliResolver.Exists(KiroPath)` — the same gate AI-1404 applies to interactive hosting.
+
+### 4b. Reviewer-home lifecycle and crash cleanup
+
+Because the home is transcript-bearing (see the isolated-`KIRO_HOME` decision above), disposal is a
+security requirement. This is the one item that touches daemon process launch, so specify it exactly:
+
+* **Naming:** `kcap-kiro-reviewer-<daemonEpoch>-<launchId>` under a **daemon-owned** root, not directly
+  in the shared system temp dir. `daemonEpoch` is fixed once per daemon process start; `launchId` is
+  per reviewer launch.
+* **Startup sweep, epoch-keyed:** on daemon start, delete every `kcap-kiro-reviewer-*` directory whose
+  epoch is **not** the current epoch. This is what recovers from a crash or `SIGKILL`, and the epoch key
+  is what makes it safe for a second daemon on the same host — a sweep that deleted every matching
+  directory would delete a *live* peer's reviewer home mid-review.
+* **Reap before delete:** terminate the reviewer process and confirm exit before deleting its tree.
+  Deleting under a live Kiro leaves it writing transcript lines into an unlinked or recreated path, and
+  on a crash-recovery pass the owning process may still be alive.
+* **No symlink following** when deleting, and **assert the resolved path is still inside the daemon root**
+  before recursing. Both are the standard recursive-delete hazards; the transcript content is the reason
+  they matter here rather than being theoretical.
+* **Failure handling:** log and continue. A home that cannot be deleted must not fail the review round
+  or block daemon startup — but it must be logged at warning with the path, because a persistent
+  failure is undisposed review context accumulating on disk.
+* **The installer is not involved, and must not be changed.** It is tempting to "fix" the blocker by
+  having `PluginCommand.InstallKiro` stop registering the four servers in global
+  `~/.kiro/settings/mcp.json`, or by removing them at reviewer launch. Both are wrong: those servers
+  are what make kcap work for the user's own interactive Kiro sessions, and mutating a user's global
+  config as a side effect of someone else's review flow is a far worse failure than the one being
+  solved. Containment stays entirely inside the daemon-owned home.
+
 ### 5. Auth
 
 `authMethods: []` shows no ACP-mediated auth flow, and a prompt completed with no `KIRO_API_KEY` set —
 but on one machine, which may have had cached credentials. That proves **no pre-checkable signal**, not
 "no auth requirement" and not "no tier gate".
 
-So: build no pre-check, and fail on the real launch/prompt error with a coded diagnostic. And the
-criterion "a tier/auth failure surfaces a coded error" needs a reproducible way to exercise it —
-an isolated unauthenticated `KIRO_HOME` if that reproduces, otherwise a fake ACP peer returning the
-measured auth-failure shape. Without one it cannot be closed.
+So: build no pre-check, and fail on the real launch/prompt error with a coded diagnostic.
+
+**The acceptance criterion "a tier/auth failure surfaces a coded error" cannot be closed as written, and
+an earlier draft of this section proposed two ways to exercise it that do not exist.** Both are now
+ruled out on evidence:
+
+* *"An isolated unauthenticated `KIRO_HOME` if that reproduces"* — **measured not to reproduce.** The
+  isolated-empty-home probe completed `initialize`, `session/new` and a full `session/prompt` to
+  `end_turn` with no auth error at all. That is the same measurement that proved credentials live
+  outside `KIRO_HOME`; it necessarily also means an empty home does not produce an unauthenticated Kiro.
+* *"Otherwise a fake ACP peer returning the measured auth-failure shape"* — **no auth-failure shape was
+  ever measured.** Not one auth error was observed in any probe. Specifying a fake peer would mean
+  inventing a frame shape and then asserting our handling of our own invention: a test that passes by
+  construction and proves nothing about Kiro.
+
+**Decision: drop the auth-specific criterion from this issue** and replace it with the vendor-agnostic
+property that is actually testable — *a reviewer whose launch or first prompt fails surfaces a coded
+error rather than hanging the round* — exercised with a synthetic non-auth failure (an unresolvable
+binary path, and a peer that exits before responding to `initialize`). That covers the real risk the
+criterion was reaching for, which is a **wedged round**, and it does so without a fabricated fixture.
+
+If a genuine auth/tier failure is ever observed in the field, capture its shape then and add the
+specific assertion. Until it is observed, there is nothing to assert against.
 
 ## Verification
 
@@ -214,7 +302,16 @@ measured auth-failure shape. Without one it cannot be closed.
 - [ ] `kcap-flows` is NOT present in the reviewer's session (the §"blocker" suppression works)
 - [ ] Reviewer session captured and reaped; no orphan
 - [ ] Runs at the vendor default model — override is explicitly out of scope
-- [ ] A tier/auth failure surfaces a coded error instead of a hung round, exercised by a defined setup
+- [ ] A caller-supplied model is **refused with a coded error**, not silently ignored (§4a)
+- [ ] A failed launch / failed first prompt surfaces a coded error instead of a hung round, exercised by
+      a synthetic non-auth failure — unresolvable binary, and a peer that exits before `initialize`
+      (§5; the auth-specific criterion is deliberately dropped as unclosable)
+- [ ] The reviewer home is created `0700` at creation time, under a daemon-owned root (§4b)
+- [ ] A stale reviewer home from a *previous* daemon epoch is swept at startup, and a *current*-epoch
+      home belonging to a live peer is NOT (§4b)
+- [ ] The reviewer process is reaped before its home is deleted (§4b)
+- [ ] The user's global `~/.kiro/settings/mcp.json` is byte-identical after a reviewer round (§4b —
+      containment never mutates user config)
 - [ ] **Negative:** an untrusted / write-capable / out-of-worktree request is denied or reaps the
       reviewer (see §2) — not merely absent
 - [ ] The effective callable tool surface excludes global servers, inspected directly

--- a/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
@@ -112,8 +112,18 @@ means the answer is not simply "no data".
 `UnattendedTrustArgv` on the Kiro descriptor. Start scoped rather than blanket:
 
 ```
---trust-tools=fs_read,grep,shell     (exact tool names to be confirmed against `kiro-cli chat --help`)
+--trust-tools=<read-only set>        (exact Kiro tool names UNMEASURED — see below)
 ```
+
+**`shell` must NOT be in this list**, and an earlier draft had it. Trusting `shell` means a write or an
+outside-home command executes WITHOUT emitting a permission frame — so `Fail` never fires and the
+"read-only reviewer" boundary is fiction. That also means the negative acceptance criterion must verify
+that a forbidden **effect** is prevented (ask the reviewer to actually write a file and to read outside
+the worktree, then assert neither happened), not merely that a frame was handled.
+
+If the remaining read-only tools cannot review a repository, the answer is a real command/filesystem
+sandbox or a command-level read allowlist — not re-adding `shell`. **The exact Kiro tool names and trust
+semantics are UNMEASURED and must be probed before this section is implementable.**
 
 A reviewer reads and reports; it does not need write. **There is no `--trust-all-tools` fallback.** An
 earlier draft offered one, which contradicted §2 and would have widened the hole it describes: if the
@@ -169,7 +179,7 @@ Flip on the AI-1404 descriptor:
 ```csharp
 UnattendedTrustArgv: [/* §1 */],
 SupportsUnattended:  true,
-UnattendedInteractionPolicy: AcpUnattendedInteractionPolicy.AutoApprove,
+UnattendedInteractionPolicy: AcpUnattendedInteractionPolicy.Fail,   // §2 — NOT AutoApprove
 ReviewFlowMcpTransport: AcpReviewFlowMcpTransport.SessionNew,   // measured-honoured
 ```
 

--- a/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1410-kiro-unattended-reviewer-design.md
@@ -55,29 +55,34 @@ inspecting that file confirms it contains exactly `kcap-review`, `kcap-sessions`
 `session/setMode` remains too late (servers are already initialized by `session/new`), but that only
 rules out one alternative; it does not rescue the agent approach.
 
-### Required before implementation: a source-isolation matrix
+### Decision: a daemon-owned reviewer `KIRO_HOME` (measured)
 
-The mechanism cannot be chosen from what is currently known. Run a matrix against a temporary
-`KIRO_HOME`:
+**Measured:** launching `kiro-cli acp` with `KIRO_HOME` pointed at an empty temporary directory
+initializes **zero** MCP servers — `kcap-flows` absent — while `initialize` and `session/new` both
+still succeed. So the containment mechanism is settled, and it is not agent selection: it is an
+isolated `KIRO_HOME` owned by the daemon for reviewer launches.
 
-| global `settings/mcp.json` | selected agent declares MCP | expected |
-|---|---|---|
-| present | none | does `kcap-flows` still initialize? |
-| present | minimal agent | does agent selection suppress global? |
-| absent | none | baseline — nothing inherited |
-| absent | minimal agent | agent-only inheritance |
+This is a decision, not a candidate list. The prior draft's matrix is collapsed to the one cell that
+mattered.
 
-Then pick a mechanism that **demonstrably excludes global servers**. Candidates, none yet validated:
-an isolated reviewer `KIRO_HOME`; a launch-time config boundary; or upstream support for suppression.
+**What that obliges the design to specify** — an isolated home is a filesystem boundary, so everything
+the reviewer needs must be deliberately placed and everything else deliberately withheld:
 
-Acceptance must inspect the **effective callable tool surface** — what the reviewer can actually
-invoke — not merely which mode was selected. `server_initialized` absence is necessary but not
-sufficient, for the same reason its presence was not sufficient above.
+* **Credentials.** Kiro must still authenticate. Determine what under `KIRO_HOME` carries auth and
+  place exactly that, or confirm auth lives outside `KIRO_HOME` entirely. *Unresolved — must be probed
+  before implementation, and it is the one item that could invalidate this mechanism.*
+* **Deliberately excluded:** `settings/mcp.json` (the whole point), the user's agents, and anything
+  granting write or flow-starting capability.
+* **Placed if required:** only the injected `flow-result` server, which arrives via
+  `session/new.mcpServers` rather than the home, so probably nothing.
+* **Permissions and cleanup:** owner-only; removed when the reviewer is reaped, including on crash.
+* **Concurrency:** one home per reviewer launch, so two concurrent reviews cannot share or race state.
+* **Preflight:** `ComputeUnattendedVendors` must not advertise `kiro` until the daemon can create an
+  isolated home AND authenticate inside it. A failure here refuses the launch with a coded error rather
+  than wedging a round.
 
-**Estimate correction.** An earlier draft called this "a second agent file + descriptor change" and
-the largest piece of work. It is larger and less certain than that: the mechanism is unknown, an
-isolated `KIRO_HOME` would touch daemon process launch rather than just the installer, and the matrix
-itself is real investigation. This is the item that should gate scheduling.
+Because this touches daemon process launch rather than the installer, it remains the largest item in
+the issue — but it is now a known quantity rather than an unknown one.
 
 ## Acceptance criterion that must be rewritten
 
@@ -90,11 +95,15 @@ The issue currently says:
 canonical token counters (measured). It does **not** follow that Kiro cost is unobservable:
 `KiroUsage.cs` already reads billing `metering_usage` credits from Kiro's on-disk session metadata.
 
-So the rewrite must say which input the AI-1402 pricing clamp actually needs. If it requires canonical
-token counts against a priced model, Kiro cannot satisfy it and the criterion should assert the model is
-*honoured* while recording that token-based cost is unavailable. If credits suffice, the criterion may
-be satisfiable through the existing sidecar. **Resolve this against the clamp's real requirement before
-rewriting the issue** — do not assert "no cost data" when a credits path exists.
+**Decision: drop the model clause from the acceptance criterion entirely.** Model override is out of
+scope (see §4a), so the criterion becomes:
+
+> `start_review_flow(kind="spec-review", vendor="kiro")` completes a real round unattended end-to-end.
+
+That is closable today. It removes the pricing-clamp question from this issue's critical path rather
+than resolving it by assertion: whether the clamp needs canonical tokens or accepts billing credits is a
+real question, but it belongs to the model-override follow-up, and `KiroUsage.cs`'s existing credits path
+means the answer is not simply "no data".
 
 ## Design
 
@@ -106,9 +115,10 @@ rewriting the issue** — do not assert "no cost data" when a credits path exist
 --trust-tools=fs_read,grep,shell     (exact tool names to be confirmed against `kiro-cli chat --help`)
 ```
 
-A reviewer reads and reports; it does not need write. If the scoped set proves insufficient — or if
-upstream's trust-flag prompt leaks (issues #7398, #7483) fire anyway — fall back to
-`--trust-all-tools`, and rely on the interaction policy below rather than on the flag alone.
+A reviewer reads and reports; it does not need write. **There is no `--trust-all-tools` fallback.** An
+earlier draft offered one, which contradicted §2 and would have widened the hole it describes: if the
+scoped set proves insufficient, the correct outcome is a failing reviewer to investigate, not a
+blanket-trusted one.
 
 Note Kiro's warning observed during the memory-cert work:
 `--trust-tools arg for custom tool ... needs to be prepended with @{MCPSERVERNAME}/`. So MCP-provided
@@ -129,9 +139,16 @@ write-capable shell command, an out-of-worktree path, anything — is auto-appro
 provide no protection whatsoever, and "zero human-routed interactions" would not detect it: the frames
 were handled, just not safely.
 
-**Requirement:** either an allowlist-aware unattended policy that approves only frames matching the
-scoped trust set, or `Fail` on any non-matching frame. Falling back to `--trust-all-tools` makes the
-gap wider, not narrower, and is not an acceptable resolution.
+**Decision: `Fail`** — the Cursor posture. An allowlist-aware policy would need an authoritative tool-ID
+allowlist, Kiro/MCP namespace normalisation, shell-command and path handling, and unknown-frame
+treatment; that is a foundation feature, not a Kiro detail, and inventing it here would leave a matcher
+nobody has specified.
+
+`Fail` accepts the cost the earlier draft was avoiding: if upstream's prompt leaks (#7398) fire, Kiro
+reviewer rounds fail rather than silently auto-approving. **That is the correct direction** — a visibly
+flaky reviewer is a bug report; a tool-blind auto-approver is a security hole that passes its own tests.
+If the leaks prove frequent enough to make Kiro unusable, the answer is an allowlist-aware policy
+specified as its own piece of work, not `AutoApprove`.
 
 Acceptance needs **negative** criteria, which the earlier draft lacked entirely: an untrusted,
 write-capable, or out-of-bounds request must be denied or must terminate the reviewer, while the known
@@ -180,8 +197,7 @@ measured auth-failure shape. Without one it cannot be closed.
 - [ ] `flow-result` is callable without approval (the §1 namespacing question)
 - [ ] `kcap-flows` is NOT present in the reviewer's session (the §"blocker" suppression works)
 - [ ] Reviewer session captured and reaped; no orphan
-- [ ] Model override honoured — via `session/set_config_option`, and only once an ACP
-      `ReviewerModelResolver` exists
+- [ ] Runs at the vendor default model — override is explicitly out of scope
 - [ ] A tier/auth failure surfaces a coded error instead of a hung round, exercised by a defined setup
 - [ ] **Negative:** an untrusted / write-capable / out-of-worktree request is denied or reaps the
       reviewer (see §2) — not merely absent
@@ -191,6 +207,7 @@ measured auth-failure shape. Without one it cannot be closed.
 ## Out of scope
 
 - Borrowed review for Kiro (containment-token decision).
-- Kiro cost/token reporting — absent upstream; AI-888 stands.
+- Model override (see §4a) — its own follow-up.
+- Kiro **canonical token** reporting — absent from ACP; billing credits remain available via `KiroUsage`.
 - `--agent-engine` pinning — deliberately unpinned by AI-1404.
 - Fixing upstream trust-flag prompt leaks.

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -218,4 +218,50 @@ internal static class AcpVendorDescriptors {
         // rather than silently permitting an unverified surface — the safe direction to fail.
         UnattendedInteractionPolicy: AcpUnattendedInteractionPolicy.AutoApprove
     );
+
+    /// <summary>AWS Kiro CLI as an ACP hosted agent (<c>kiro-cli acp</c>). Interactive hosting only:
+    /// unattended review is deliberately withheld until its own issue lands the containment mechanism
+    /// (Kiro inherits the user's GLOBAL <c>~/.kiro/settings/mcp.json</c> servers into every ACP
+    /// session, so an unattended reviewer would be handed <c>kcap-flows</c> and could start nested
+    /// flows). Interactive hosting is unaffected by that inheritance — it is the desired behavior
+    /// there.
+    ///
+    /// <para><b><see cref="SupportsMcpServers"/> is <c>true</c> here while <see cref="Copilot"/> sets
+    /// it <c>false</c>, and the reasoning is NOT contradictory.</b> Both vendors advertise the same
+    /// ACP <c>mcpCapabilities</c> shape (<c>{http, sse}</c> — no stdio), so the advertisement cannot be
+    /// what decides it. Copilot's <c>false</c> is an empirical finding about Copilot. Kiro was probed
+    /// directly: a purpose-built stdio server passed in <c>session/new.mcpServers</c> was driven all
+    /// the way to a real <c>tools/call</c>, with the tool's nonce reaching the model and the turn
+    /// ending <c>end_turn</c>. Kiro honours stdio despite not advertising it.</para>
+    ///
+    /// <para>Note what that probe deliberately established, because a weaker signal was available and
+    /// would have been wrong: <c>_kiro.dev/mcp/server_initialized</c> proves only that a server
+    /// STARTED, not that its tools are discoverable or callable — a tool can be absent from
+    /// <c>tools/list</c>, refused by trust policy, mis-namespaced, or fail at invocation. Flipping
+    /// Copilot's flag needs an equivalent call-level probe against Copilot, not this result.</para>
+    ///
+    /// <para><see cref="NoOpModelSelector"/> is deliberate rather than inherited: Kiro's
+    /// <c>session/new</c> does return a <c>models</c> object, so the read half of
+    /// <see cref="ConfigOptionModelSelector"/> would find the shape it needs — but the write half
+    /// (<c>session/set_config_option</c> actually taking effect) is unverified on Kiro, and that
+    /// selector fails SILENTLY when it does not take. Carrying a live selector would risk a session
+    /// that reports the requested model while running another. <c>ResolveDefaultModel: null</c> alone
+    /// would not be enough, because <c>ResolveRequestedModel</c> prioritises a per-launch
+    /// <c>RuntimeStartContext.Model</c> and would reach a live selector anyway; the selector itself
+    /// has to be the no-op. Model override arrives with the follow-up that verifies the write
+    /// half.</para>
+    ///
+    /// <para><c>--agent-engine v1|v2|v3</c> (default <c>v2</c>) is deliberately NOT passed: pinning it
+    /// diverges the hosted session from what the user gets interactively and buys an upgrade
+    /// treadmill. Revisit only if a measured behavioural difference forces it.</para></summary>
+    public static readonly AcpVendorDescriptor Kiro = new(
+        Vendor:              "kiro",
+        ResolveBinaryPath:   cfg => cfg.KiroPath,
+        ResolveDefaultModel: _ => null,
+        Argv:                ["acp"],
+        UnattendedTrustArgv: [],
+        SupportsUnattended:  false,
+        ModelSelector:       NoOpModelSelector.Instance,
+        SupportsMcpServers:  true
+    );
 }

--- a/src/Capacitor.Cli.Daemon/Acp/IAcpModelSelector.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/IAcpModelSelector.cs
@@ -30,6 +30,23 @@ namespace Capacitor.Cli.Daemon.Acp;
 /// never a bare `catch (Exception)` that would also eat cancellation).
 /// </summary>
 internal interface IAcpModelSelector {
+    /// <summary>
+    /// Whether this selector can actually apply a caller-requested model. <see langword="false"/> means
+    /// a requested model will be silently discarded, so callers must not REPORT one as the model the
+    /// process is running.
+    ///
+    /// <para>This lives on the selector, not as a parallel descriptor flag, because the selector object
+    /// is deliberately the single source of truth for model selection (see
+    /// <c>AcpVendorDescriptor</c>'s note on the removed <c>SupportsModelSelection</c> field — a second
+    /// boolean that also had to agree with the selector was dead state guarded asymmetrically). Asking
+    /// the selector cannot disagree with itself, and it works for a future vendor's own
+    /// implementation or a test double, neither of which is reference-equal to the two singletons
+    /// here.</para>
+    ///
+    /// <para>Consumers must not infer this by type-testing for <see cref="NoOpModelSelector"/>.</para>
+    /// </summary>
+    bool CanSelectModel { get; }
+
     Task<string?> TrySelectAsync(
         AcpConnection     connection,
         string            sessionId,
@@ -50,6 +67,11 @@ internal interface IAcpModelSelector {
 /// </summary>
 internal sealed class ConfigOptionModelSelector : IAcpModelSelector {
     public static readonly ConfigOptionModelSelector Instance = new();
+
+    /// <summary>This selector really does send <c>session/set_config_option</c>, so a requested model
+    /// may be applied. Note it can still fail to MATCH a model and return null — "can select" is a
+    /// capability, not a promise about a specific request.</summary>
+    public bool CanSelectModel => true;
 
     public async Task<string?> TrySelectAsync(
             AcpConnection connection, string sessionId, JsonElement sessionNewResult,
@@ -104,6 +126,11 @@ internal sealed class ConfigOptionModelSelector : IAcpModelSelector {
 /// boolean.</summary>
 internal sealed class NoOpModelSelector : IAcpModelSelector {
     public static readonly NoOpModelSelector Instance = new();
+
+    /// <summary>No hook exists, so a requested model is always discarded. Callers use this to avoid
+    /// REPORTING a model the process is not running — discarding the request quietly is fine, but
+    /// telling the dashboard and analytics that the discarded model is live is not.</summary>
+    public bool CanSelectModel => false;
 
     public Task<string?> TrySelectAsync(
             AcpConnection connection, string sessionId, JsonElement sessionNewResult,

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -119,8 +119,21 @@ public class DaemonConfig {
     /// descriptor consumes this yet). Overridable via KCAP_COPILOT_PATH, mirroring CursorPath.</summary>
     public string CopilotPath { get; set; } = "copilot";
 
-    /// <summary>Reserved — see CopilotPath. Overridable via KCAP_KIRO_PATH.</summary>
-    public string KiroPath { get; set; } = "kiro";
+    /// <summary>
+    /// Path or bare command for AWS Kiro CLI's ACP entry point, spawned as <c>{KiroPath} acp</c> by
+    /// <c>AcpHostedAgentRuntimeFactory</c>. Overridable via <c>KCAP_KIRO_PATH</c>, mirroring
+    /// <see cref="CursorPath"/>.
+    ///
+    /// <para><b>The default is <c>kiro-cli</c>, not <c>kiro</c>.</b> This field predates the
+    /// descriptor that now consumes it and was originally defaulted to <c>"kiro"</c> while unused.
+    /// The shipped binary is <c>kiro-cli</c> — it is what <c>PluginCommand.KiroBinary</c> resolves and
+    /// what a standard install puts on PATH; <c>kiro</c> is not present. Because availability is
+    /// <c>CliResolver.Exists(KiroPath)</c>, leaving the old default would have meant Kiro was never
+    /// advertised as a hosted-agent vendor on a correct install until the operator discovered
+    /// <c>KCAP_KIRO_PATH</c> — a silent no-op rather than a visible failure. Only one name is probed;
+    /// operators with a differently-named binary set the env var.</para>
+    /// </summary>
+    public string KiroPath { get; set; } = "kiro-cli";
 
     /// <summary>Reserved — see CopilotPath. Overridable via KCAP_OPENCODE_PATH.</summary>
     public string OpenCodePath { get; set; } = "opencode";

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -292,6 +292,14 @@ public static partial class DaemonRunner {
                 sp.GetRequiredService<ServerConnection>()
             )
         );
+        builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
+            new AcpHostedAgentRuntimeFactory(
+                AcpVendorDescriptors.Kiro,
+                sp.GetRequiredService<DaemonConfig>(),
+                sp.GetRequiredService<ILoggerFactory>(),
+                sp.GetRequiredService<ServerConnection>()
+            )
+        );
 
         builder.Services.AddSingleton<IReadOnlyDictionary<string, IHostedAgentRuntimeFactory>>(sp =>
             sp.GetServices<IHostedAgentRuntimeFactory>().ToDictionary(f => f.Vendor)

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -269,8 +269,14 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     // Vendor-aware handshake/auth diagnostic labels. `_vendor` is the vendor KEY (e.g. "cursor"),
     // not the binary name — so Cursor keeps its exact prior strings (binary "cursor-agent" +
     // Team-tier hint) via an explicit branch, while any other vendor gets vendor-named generic text.
+    // Kiro needs the same explicit branch as Cursor and for the same reason: its vendor key ("kiro")
+    // is NOT its binary name ("kiro-cli"), so the generic fallback would tell an operator to check a
+    // command that does not exist on a correct install — the least helpful possible text on exactly the
+    // launch-failure path this diagnostic exists to serve.
     string DiagnosticBinary =>
-        _vendor == AcpVendorDescriptors.Cursor.Vendor ? "cursor-agent" : _vendor;
+        _vendor == AcpVendorDescriptors.Cursor.Vendor ? "cursor-agent"
+            : _vendor == AcpVendorDescriptors.Kiro.Vendor ? "kiro-cli"
+            : _vendor;
 
     string DiagnosticAuthHint =>
         _vendor == AcpVendorDescriptors.Cursor.Vendor

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -278,12 +278,20 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             : _vendor == AcpVendorDescriptors.Kiro.Vendor ? "kiro-cli"
             : _vendor;
 
+    // Kiro deliberately gets a hint that names NO command. Cursor and Copilot name a verified login
+    // subcommand; for Kiro no auth requirement, auth method, or login command was ever observed
+    // (`authMethods` came back empty and a prompt completed with no API key set), so inventing a
+    // `kiro-cli login` would be fabricated guidance. The generic fallback is also wrong here for the
+    // same reason DiagnosticBinary needed a branch: it interpolates the vendor KEY and would tell an
+    // operator to authenticate `kiro`, a command absent from a correct install.
     string DiagnosticAuthHint =>
         _vendor == AcpVendorDescriptors.Cursor.Vendor
             ? "run `cursor-agent login` and verify a Team-tier subscription"
             : _vendor == AcpVendorDescriptors.Copilot.Vendor
                 ? "run `copilot login` and verify GitHub Copilot access for your enterprise"
-                : $"authenticate `{_vendor}` and verify your subscription/entitlement";
+                : _vendor == AcpVendorDescriptors.Kiro.Vendor
+                    ? "verify Kiro CLI is signed in and your subscription/entitlement is active"
+                    : $"authenticate `{_vendor}` and verify your subscription/entitlement";
 
     public bool   HasExited           => _process.HasExited;
     public int?   ExitCode            => _process.ExitCode;

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -69,6 +69,11 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// support is untouched.</summary>
     public IReviewerModelResolver? ReviewerModelResolver => null;
 
+    /// <summary>Delegated to the descriptor's selector, which is the single source of truth for model
+    /// selection. Deliberately NOT a type test for <c>NoOpModelSelector</c>: a vendor's own selector
+    /// implementation, or a test double, is equally valid and would defeat one.</summary>
+    public bool SupportsModelSelection => descriptor.ModelSelector.CanSelectModel;
+
     public bool IsAvailable() => CliResolver.Exists(descriptor.ResolveBinaryPath(config));
 
     public async Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -901,6 +901,27 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
         }
 
+        // A runtime that cannot APPLY a model must not REPORT one. effectiveModel above feeds both
+        // RuntimeStartContext.Model (where a no-op selector discards it) and the AgentInstance the
+        // server sees — so without this, such a vendor runs its default while the live model chip and
+        // hosted_agent_started analytics both claim the requested model is live.
+        switch (ModelSelectionLaunchPolicy.Evaluate(
+                    effectiveModel,
+                    runtimeFactory.SupportsModelSelection,
+                    cmd.ExplicitReviewerModel is not null)) {
+            case ModelSelectionDisposition.Reject:
+                await _server.LaunchFailedAsync(cmd.AgentId,
+                    ModelSelectionLaunchPolicy.RejectionReason(cmd.Vendor, effectiveModel!));
+
+                return new CommandOutcome(
+                    CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
+
+            case ModelSelectionDisposition.ClearReportedModel:
+                LogModelSelectionUnsupported(cmd.Vendor, effectiveModel!);
+                effectiveModel = null;
+                break;
+        }
+
         if (isReviewFlow && cmd.Borrowed && !runtimeFactory.SupportsBorrowedReviewFlow) {
             await _server.LaunchFailedAsync(cmd.AgentId,
                 $"Borrowed review flows are not certified for '{cmd.Vendor}'; retry with an owned review worktree.");
@@ -2794,6 +2815,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Launching agent {AgentId} for {Repo} (effort={Effort}, model={Model})")]
     partial void LogLaunching(string agentId, string repo, string effort, string model);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Vendor '{Vendor}' cannot apply a requested model; launching with its default and reporting no model instead of '{RequestedModel}', so the dashboard and analytics are not told a model is live that isn't.")]
+    partial void LogModelSelectionUnsupported(string vendor, string requestedModel);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Agent {AgentId} spawned (PID={Pid}, worktree={Worktree}, vendor={Vendor})")]
     partial void LogAgentSpawned(string agentId, int pid, string worktree, string vendor);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -18,7 +18,11 @@ namespace Capacitor.Cli.Daemon.Services;
 internal record AgentInstance(
         string                  Id,
         string?                 Prompt,
-        string                  Model,
+        // Nullable because "no model is being reported" is a real, intentional state: a runtime that
+        // cannot APPLY a caller-supplied model must not report one (see ModelSelectionLaunchPolicy).
+        // Declaring it non-null while storing null there would let a consumer dereference it with no
+        // warning on exactly the launches where it is absent.
+        string?                 Model,
         string?                 Effort,
         string                  RepoPath,
         string                  Vendor,
@@ -873,7 +877,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // process actually runs — the launch log, the runtime start context, and the registered
         // AgentInstance the server sees via RegisterAgentAsync / AgentRunStarted / every reconnect
         // re-registration — reads the same value. Null block ⇒ legacy path, cmd.Model unchanged.
-        var effectiveModel = cmd.ExplicitReviewerModel?.LaunchModel ?? model;
+        // Explicitly string?, not var: ModelSelectionLaunchPolicy below clears this when the selected
+        // runtime cannot apply a model, and "no model reported" must be representable in the type.
+        string? effectiveModel = cmd.ExplicitReviewerModel?.LaunchModel ?? model;
         var effort        = cmd.Effort;
         var repoPath      = cmd.RepoPath;
         var tools         = cmd.Tools;
@@ -905,21 +911,25 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // RuntimeStartContext.Model (where a no-op selector discards it) and the AgentInstance the
         // server sees — so without this, such a vendor runs its default while the live model chip and
         // hosted_agent_started analytics both claim the requested model is live.
-        switch (ModelSelectionLaunchPolicy.Evaluate(
-                    effectiveModel,
-                    runtimeFactory.SupportsModelSelection,
-                    cmd.ExplicitReviewerModel is not null)) {
-            case ModelSelectionDisposition.Reject:
+        var modelDisposition = ModelSelectionLaunchPolicy.Evaluate(
+            effectiveModel, runtimeFactory.SupportsModelSelection, cmd.ExplicitReviewerModel is not null);
+
+        if (modelDisposition != ModelSelectionDisposition.Honor) {
+            // Non-null by construction: Evaluate returns Honor whenever the requested model is
+            // null/blank, so reaching here means a model really was asked for. Captured before the
+            // clear below so the diagnostics can name it.
+            var unhonorableModel = effectiveModel!;
+
+            if (modelDisposition == ModelSelectionDisposition.Reject) {
                 await _server.LaunchFailedAsync(cmd.AgentId,
-                    ModelSelectionLaunchPolicy.RejectionReason(cmd.Vendor, effectiveModel!));
+                    ModelSelectionLaunchPolicy.RejectionReason(cmd.Vendor, unhonorableModel));
 
                 return new CommandOutcome(
                     CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
+            }
 
-            case ModelSelectionDisposition.ClearReportedModel:
-                LogModelSelectionUnsupported(cmd.Vendor, effectiveModel!);
-                effectiveModel = null;
-                break;
+            LogModelSelectionUnsupported(cmd.Vendor, unhonorableModel);
+            effectiveModel = null;
         }
 
         if (isReviewFlow && cmd.Borrowed && !runtimeFactory.SupportsBorrowedReviewFlow) {
@@ -2814,7 +2824,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // ── LoggerMessage source-generated methods ────────────────────────────
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Launching agent {AgentId} for {Repo} (effort={Effort}, model={Model})")]
-    partial void LogLaunching(string agentId, string repo, string effort, string model);
+    partial void LogLaunching(string agentId, string repo, string effort, string? model);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Vendor '{Vendor}' cannot apply a requested model; launching with its default and reporting no model instead of '{RequestedModel}', so the dashboard and analytics are not told a model is live that isn't.")]
     partial void LogModelSelectionUnsupported(string vendor, string requestedModel);

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs
@@ -94,7 +94,11 @@ internal sealed record LauncherContext(
         string                            SourceRepoPath,
         WorktreeInfo                      Worktree,
         string?                           Prompt,
-        string                            Model,
+        // Nullable for the same reason as RuntimeStartContext.Model, which feeds it: a launch whose
+        // runtime cannot apply a model carries none. Both PTY launchers already handle absence —
+        // ClaudeLauncher via string.IsNullOrEmpty, CodexLauncher via AddModelArg's own null guard — so
+        // this makes the type match what they were already written to expect.
+        string?                           Model,
         string?                           Effort,
         string[]?                         Tools,
         bool                              IsReview,

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -106,7 +106,11 @@ internal sealed record RuntimeStartContext(
         string            SourceRepoPath,
         WorktreeInfo      Worktree,
         string?           Prompt,
-        string            Model,
+        // Nullable: a launch whose runtime cannot APPLY a model carries none, rather than carrying one
+        // the process will not run (see ModelSelectionLaunchPolicy). Every launcher already treats an
+        // absent model as "use the vendor default" — Claude and the ACP factory via
+        // string.IsNullOrEmpty, Codex via AddModelArg — so null is the value they are prepared for.
+        string?           Model,
         string?           Effort,
         string[]?         Tools,
         bool              IsReview,

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -50,6 +50,18 @@ internal interface IHostedAgentRuntimeFactory {
     IReviewerModelResolver? ReviewerModelResolver => null;
 
     /// <summary>
+    /// Whether this runtime can actually APPLY a caller-supplied model. When <see langword="false"/>, a
+    /// requested model is discarded by the runtime, so the orchestrator must not report it as the model
+    /// the process is running — see <see cref="ModelSelectionLaunchPolicy"/>.
+    ///
+    /// <para>Defaults to <see langword="true"/> because every runtime that existed before this seam
+    /// does honour a model: PTY launchers pass one on argv, and both ACP vendors carried a real
+    /// selector. A <see langword="false"/> value is the new case, introduced by a vendor whose
+    /// model-selection hook is unverified.</para>
+    /// </summary>
+    bool SupportsModelSelection => true;
+
+    /// <summary>
     /// Prepares and starts the hosted runtime for this launch. Throws
     /// <see cref="CodexHooksNotInstalledException"/> for the orchestrator to map to a
     /// <c>LaunchFailed</c> with worktree cleanup; any other exception is likewise mapped to

--- a/src/Capacitor.Cli.Daemon/Services/ModelSelectionLaunchPolicy.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ModelSelectionLaunchPolicy.cs
@@ -1,0 +1,68 @@
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// What to do with a caller-supplied model when the selected runtime cannot apply one.
+/// </summary>
+internal enum ModelSelectionDisposition {
+    /// <summary>The runtime can select, or no model was requested: use the requested value as-is.</summary>
+    Honor,
+
+    /// <summary>The runtime cannot select and the request is an ordinary interactive launch: proceed,
+    /// but report no model rather than one the process is not running.</summary>
+    ClearReportedModel,
+
+    /// <summary>The runtime cannot select and the request pins a reviewer model: refuse the launch.</summary>
+    Reject
+}
+
+/// <summary>
+/// Gate for the model a launch REPORTS versus the model it actually runs.
+///
+/// <para><b>The bug this exists to prevent.</b> A runtime whose model selector is a no-op discards a
+/// requested model — correctly and by design. But the orchestrator computes one
+/// <c>effectiveModel</c> and uses it for two different purposes: it becomes
+/// <c>RuntimeStartContext.Model</c> (where the no-op selector drops it) AND the
+/// <c>AgentInstance</c> model published to the server, which drives the live model chip and
+/// <c>hosted_agent_started</c> analytics. Without this gate, launching such a vendor with
+/// <c>model="foo"</c> runs the vendor's default while telling the dashboard and analytics that
+/// <c>foo</c> is live — a silent requested-vs-running mismatch, and precisely the failure mode the
+/// no-op selector was chosen to avoid.
+///
+/// <para><b>Why the two negative cases differ.</b> Clearing the reported model is right for an
+/// interactive launch: the user gets a working agent and honest metadata, and refusing outright would
+/// make the vendor unlaunchable from any caller that always sends a model. It is NOT right for a
+/// pinned reviewer model: a review round's authority depends on which model produced it, so silently
+/// reviewing with a different model — even with truthful metadata — is worse than not reviewing.
+/// There, fail loudly.</para>
+///
+/// <para>Pure so it is unit-testable without the orchestrator, mirroring
+/// <see cref="UnattendedLaunchPolicy"/>.</para>
+/// </summary>
+internal static class ModelSelectionLaunchPolicy {
+    /// <param name="requestedModel">The model this launch would report — the orchestrator's
+    /// <c>effectiveModel</c>, i.e. an explicit reviewer model if present, else the raw command model.</param>
+    /// <param name="supportsModelSelection">The selected runtime's
+    /// <see cref="IHostedAgentRuntimeFactory.SupportsModelSelection"/>.</param>
+    /// <param name="isExplicitReviewerModel">Whether <paramref name="requestedModel"/> came from a
+    /// server-resolved explicit reviewer-model block rather than an ordinary launch.</param>
+    public static ModelSelectionDisposition Evaluate(
+            string? requestedModel, bool supportsModelSelection, bool isExplicitReviewerModel) {
+        // No model requested ⇒ nothing to misreport, whatever the runtime supports. Whitespace counts
+        // as absent, matching what the selectors themselves treat as "no request".
+        if (string.IsNullOrWhiteSpace(requestedModel))
+            return ModelSelectionDisposition.Honor;
+
+        if (supportsModelSelection)
+            return ModelSelectionDisposition.Honor;
+
+        return isExplicitReviewerModel
+            ? ModelSelectionDisposition.Reject
+            : ModelSelectionDisposition.ClearReportedModel;
+    }
+
+    /// <summary>User-facing rejection message for <see cref="ModelSelectionDisposition.Reject"/>.</summary>
+    public static string RejectionReason(string vendor, string requestedModel) =>
+        $"Vendor '{vendor}' cannot apply a requested model, so it cannot honor the pinned reviewer " +
+        $"model '{requestedModel}'; the round would silently run this vendor's default model instead. " +
+        $"Retry without a reviewer-model override, or select a vendor that supports model selection.";
+}

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
@@ -66,6 +66,78 @@ public class AcpVendorDescriptorTests {
     }
 
     [Test]
+    public async Task Kiro_MatchesTodaysHardCodedConstants() {
+        var descriptor = AcpVendorDescriptors.Kiro;
+
+        await Assert.That(descriptor.Vendor).IsEqualTo("kiro");
+        await Assert.That(descriptor.Argv.SequenceEqual(["acp"])).IsTrue();
+
+        // Interactive hosting only. Kiro inherits the user's GLOBAL ~/.kiro/settings/mcp.json servers
+        // into every ACP session, so an unattended reviewer would be handed kcap-flows and could start
+        // nested review flows. Unattended stays off until its own issue lands the containment
+        // mechanism; the empty trust argv is enforced by the constructor when SupportsUnattended is
+        // false, and Disabled is the policy that pairs with it.
+        await Assert.That(descriptor.SupportsUnattended).IsFalse();
+        await Assert.That(descriptor.UnattendedTrustArgv.IsEmpty).IsTrue();
+        await Assert.That(descriptor.UnattendedInteractionPolicy)
+            .IsEqualTo(AcpUnattendedInteractionPolicy.Disabled);
+        await Assert.That(descriptor.SupportsBorrowedReviewFlow).IsFalse();
+        await Assert.That(descriptor.BorrowedReviewContainment)
+            .IsEqualTo(AcpBorrowedReviewContainment.None);
+
+        // TRUE here while Copilot is FALSE, on the same advertised ACP mcpCapabilities shape
+        // ({http, sse} — no stdio). Not a contradiction: Copilot's false is an empirical finding about
+        // Copilot, and Kiro was probed to a real tools/call with a stdio server passed in
+        // session/new.mcpServers — the nonce reached the model. Kiro honours stdio without advertising
+        // it. server_initialized alone would NOT have justified this: it proves a server started, not
+        // that its tools are callable.
+        await Assert.That(descriptor.SupportsMcpServers).IsTrue();
+        await Assert.That(descriptor.ReviewFlowMcpTransport)
+            .IsEqualTo(AcpReviewFlowMcpTransport.SessionNew);
+
+        // NoOp, not ConfigOptionModelSelector. Kiro's session/new DOES return a models object, so the
+        // selector's read half would find its shape — but the write half
+        // (session/set_config_option taking effect) is unverified, and that selector fails SILENTLY.
+        // A live selector would risk a session reporting one model while running another.
+        await Assert.That(descriptor.ModelSelector).IsEqualTo(NoOpModelSelector.Instance);
+    }
+
+    [Test]
+    public async Task Kiro_ResolveBinaryPath_ReadsConfigKiroPath() {
+        var config = new DaemonConfig { KiroPath = "/opt/kiro/kiro-cli" };
+
+        await Assert.That(AcpVendorDescriptors.Kiro.ResolveBinaryPath(config)).IsEqualTo("/opt/kiro/kiro-cli");
+    }
+
+    /// <summary>
+    /// The zero-configuration case, and the one an env-precedence test cannot cover: with nothing set,
+    /// the descriptor must resolve the name a standard install actually puts on PATH.
+    ///
+    /// <para><c>KiroPath</c> predates this descriptor and defaulted to <c>"kiro"</c> while nothing
+    /// consumed it. <c>kiro</c> is not the shipped binary — <c>kiro-cli</c> is, and it is what
+    /// <c>PluginCommand.KiroBinary</c> resolves. Because availability is
+    /// <c>CliResolver.Exists(KiroPath)</c>, the old default meant Kiro was silently never advertised
+    /// on a correct install until an operator discovered <c>KCAP_KIRO_PATH</c>. An override test
+    /// passes identically whichever name the default holds, which is precisely how the wrong default
+    /// survived; this test is the one that fails.</para>
+    /// </summary>
+    [Test]
+    public async Task Kiro_ZeroConfiguration_ResolvesTheShippedBinaryName() {
+        await Assert.That(AcpVendorDescriptors.Kiro.ResolveBinaryPath(new DaemonConfig()))
+            .IsEqualTo("kiro-cli");
+    }
+
+    /// <summary>Model override is out of scope until <c>session/set_config_option</c> is verified on
+    /// Kiro, so no daemon-wide default model is offered either — for ANY config, including one whose
+    /// other vendor model fields are populated.</summary>
+    [Test]
+    public async Task Kiro_ResolveDefaultModel_IsAlwaysNull() {
+        await Assert.That(AcpVendorDescriptors.Kiro.ResolveDefaultModel(new DaemonConfig())).IsNull();
+        await Assert.That(AcpVendorDescriptors.Kiro.ResolveDefaultModel(
+            new DaemonConfig { CursorModel = "claude-opus-4-8" })).IsNull();
+    }
+
+    [Test]
     public async Task Cursor_ResolveBinaryPath_ReadsConfigCursorPath() {
         var config = new DaemonConfig { CursorPath = "/opt/cursor/cursor-agent" };
 

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -998,6 +998,99 @@ public partial class AgentOrchestratorVendorTests {
 
     // ── Backward-compat matrix: which report channel a launch uses ──────────────────────────
 
+    /// <summary>
+    /// A vendor that cannot APPLY a model must not have one REPORTED for it.
+    ///
+    /// <para>Found by code review on the Kiro hosted-agent change. The orchestrator computes one
+    /// <c>effectiveModel</c> and uses it twice: as <c>RuntimeStartContext.Model</c> — where a no-op
+    /// selector silently discards it — and as the <c>AgentInstance</c> model published via
+    /// <c>AgentRegisteredAsync</c>, which drives the live model chip and <c>hosted_agent_started</c>
+    /// analytics. So the vendor ran its default while the dashboard claimed the requested model was
+    /// live: exactly the requested-vs-running mismatch the no-op selector was chosen to avoid.</para>
+    ///
+    /// <para>This is the paired assertion — the launch still SUCCEEDS (refusing would make such a
+    /// vendor unlaunchable from any caller that always sends a model) but reports no model.</para>
+    /// </summary>
+    [Test]
+    public async Task Interactive_launch_for_a_vendor_that_cannot_select_a_model_reports_no_model_and_still_launches() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new SpyPtyProcessFactory();
+            var kiroSpy    = new SpyHostedAgentRuntimeFactory("kiro") {
+                EmitsTerminalOutput    = false,
+                SupportsModelSelection = false
+            };
+
+            await using var orch = BuildOrchestrator(
+                server, ptyFactory, new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [kiroSpy]);
+
+            await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                AgentId: "agent-kiro-model",
+                Prompt: "do the thing",
+                Model: "claude-opus-4-8",   // requested, but this vendor cannot apply it
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "kiro"));
+
+            // Not refused.
+            await Assert.That(server.LaunchFailedCalls).IsEmpty();
+            await Assert.That(kiroSpy.StartCalls).IsEqualTo(1);
+
+            // The model is cleared on BOTH paths — the reported one and the runtime context — so
+            // nothing downstream can resurrect it.
+            await Assert.That(server.AgentRegisteredCalls).Contains(("agent-kiro-model", (string?)null));
+            await Assert.That(kiroSpy.LastContext).IsNotNull();
+            await Assert.That(kiroSpy.LastContext!.Model).IsNull();
+        } finally {
+            cleanup();
+        }
+    }
+
+    /// <summary>The other half of <see cref="ModelSelectionLaunchPolicy"/>: a PINNED reviewer model is
+    /// different in kind from an interactive request. A review round's authority depends on which model
+    /// produced it, so silently reviewing with the vendor default — even with truthful metadata — is
+    /// worse than not reviewing. Reject, before any worktree or process side effects.</summary>
+    [Test]
+    public async Task Explicit_reviewer_model_is_rejected_for_a_vendor_that_cannot_select_a_model() {
+        var server     = new CaptureServerConnection();
+        var ptyFactory = new SpyPtyProcessFactory();
+        var kiroSpy    = new SpyHostedAgentRuntimeFactory("kiro") {
+            SupportsUnattended     = true,
+            SupportsModelSelection = false
+        };
+
+        await using var orch = BuildOrchestrator(
+            server, ptyFactory, new Dictionary<string, IHostedAgentLauncher>(),
+            extraRuntimeFactories: [kiroSpy]);
+
+        await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+            AgentId: "agent-kiro-pinned",
+            Prompt: "review this",
+            Model: "opus",
+            Effort: null,
+            RepoPath: "/tmp/does-not-matter",
+            Tools: null,
+            AttachmentIds: null,
+            Vendor: "kiro",
+            ExplicitReviewerModel: new ExplicitReviewerModelLaunch(
+                LaunchAttemptId: "attempt-kiro", LaunchModel: "claude-opus-4-8",
+                PolicyVersion: "kiro-reviewer-model-v1", EquivalenceKey: "kiro/opus")));
+
+        await Assert.That(server.LaunchFailedCalls).Count().IsEqualTo(1);
+        await Assert.That(server.LaunchFailedCalls[0].AgentId).IsEqualTo("agent-kiro-pinned");
+        // Names the model it refused to fake, so the failure is actionable rather than generic.
+        await Assert.That(server.LaunchFailedCalls[0].Reason).Contains("claude-opus-4-8");
+
+        // Rejected before the runtime was ever started.
+        await Assert.That(kiroSpy.StartCalls).IsEqualTo(0);
+        await Assert.That(server.AgentRegisteredCalls).IsEmpty();
+    }
+
     [Test]
     public async Task NewNew_explicit_model_launch_reports_on_the_v3_channel_and_launches_verbatim_model() {
         var (repoPath, cleanup) = CreateGitRepo();
@@ -1200,6 +1293,11 @@ public partial class AgentOrchestratorVendorTests {
         /// <summary>Task 8: lets a test give this factory a reviewer-model resolver so the
         /// orchestrator's ResolveReviewerModel preflight handler can resolve against it.</summary>
         public IReviewerModelResolver? ReviewerModelResolver { get; init; }
+
+        /// <summary>Defaults to <c>true</c>, matching the interface default and every pre-existing
+        /// runtime. A test sets <c>false</c> to stand in for a vendor whose model-selection hook is a
+        /// no-op (Kiro today), exercising <see cref="ModelSelectionLaunchPolicy"/>.</summary>
+        public bool SupportsModelSelection { get; init; } = true;
 
         /// <summary>Threaded onto the <see cref="FakeHostedAgentRuntime"/> this factory returns —
         /// defaults to <c>false</c> (ACP-shaped) matching this factory's original "cursor" use, but

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonConfigEnvOverrideTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonConfigEnvOverrideTests.cs
@@ -45,7 +45,9 @@ public class DaemonConfigEnvOverrideTests {
         var config = new DaemonConfig();
 
         await Assert.That(config.CopilotPath).IsEqualTo("copilot");
-        await Assert.That(config.KiroPath).IsEqualTo("kiro");
+        // Still a bare command, but "kiro-cli" — the shipped binary name — now that an ACP descriptor
+        // consumes this field and availability is CliResolver.Exists(KiroPath).
+        await Assert.That(config.KiroPath).IsEqualTo("kiro-cli");
         await Assert.That(config.OpenCodePath).IsEqualTo("opencode");
         await Assert.That(config.GeminiPath).IsEqualTo("gemini");
     }
@@ -86,7 +88,7 @@ public class DaemonConfigEnvOverrideTests {
     public async Task KiroPath_EnvVarUnset_KeepsDefault() {
         var config = ApplyEnvOverrides(new DaemonConfig(), copilotPath: null, kiroPath: null, openCodePath: null, geminiPath: null);
 
-        await Assert.That(config.KiroPath).IsEqualTo("kiro");
+        await Assert.That(config.KiroPath).IsEqualTo("kiro-cli");
     }
 
     // ── KCAP_OPENCODE_PATH ────────────────────────────────────────────────────

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -72,6 +72,45 @@ public class AcpHostedAgentRuntimeFactoryTests {
         IsReview: false, IsReviewFlow: false, Review: null,
         Cols: 80, Rows: 24, ServerUrl: null, DaemonBridgeUrl: null, CapacitorPath: "/usr/local/bin/kcap");
 
+    /// <summary>
+    /// The PRODUCTION factory must report its descriptor's model-selection capability. This is the seam
+    /// the orchestrator reads, and nothing else asserted it.
+    ///
+    /// <para>Found by code review, and confirmed by mutation: deleting
+    /// <c>AcpHostedAgentRuntimeFactory.SupportsModelSelection</c> makes it fall back to the interface's
+    /// default <c>true</c> — silently reintroducing the reported-vs-running model mismatch — and **all
+    /// 206 other tests still passed**. The descriptor tests proved
+    /// <c>Kiro.ModelSelector.CanSelectModel == false</c>, and the orchestrator tests proved the behaviour
+    /// when a SPY factory reports false, but nothing connected the two through the real factory.</para>
+    ///
+    /// <para>Cursor and Copilot are asserted alongside Kiro deliberately: a mutation that hard-coded
+    /// <c>false</c> instead of delegating would satisfy a Kiro-only assertion while breaking model
+    /// selection for the two vendors that do support it.</para>
+    ///
+    /// <para><b>Read through <see cref="IHostedAgentRuntimeFactory"/>, not the concrete type</b>, because
+    /// that is how <c>AgentOrchestrator</c> consumes it — and because it makes the guard behavioural
+    /// rather than incidental. Typed concretely, deleting the override produces a COMPILE error (a
+    /// default interface member is not accessible through the implementing type), which happens to break
+    /// the build but never exercises the value the orchestrator would actually observe. Through the
+    /// interface, the deletion instead surfaces as the interface default <c>true</c> and fails this test
+    /// on the exact value that would have caused the reported-vs-running mismatch.</para>
+    /// </summary>
+    [Test]
+    public async Task SupportsModelSelection_DelegatesToTheDescriptorsSelector_ForEachRealVendor() {
+        static IHostedAgentRuntimeFactory Build(AcpVendorDescriptor descriptor) =>
+            new AcpHostedAgentRuntimeFactory(descriptor: descriptor,
+                config: new DaemonConfig(),
+                loggerFactory: NullLoggerFactory.Instance,
+                connection: new CaptureServerConnection(),
+                // Never spawns: this test only reads a capability property, never calls StartAsync.
+                connectionSource: _ => throw new InvalidOperationException(
+                    "SupportsModelSelection must not spawn a process."));
+
+        await Assert.That(Build(AcpVendorDescriptors.Kiro).SupportsModelSelection).IsFalse();
+        await Assert.That(Build(AcpVendorDescriptors.Cursor).SupportsModelSelection).IsTrue();
+        await Assert.That(Build(AcpVendorDescriptors.Copilot).SupportsModelSelection).IsTrue();
+    }
+
     [Test]
     public async Task StartAsync_WiresRequestInteractionDelegate_DispatchesInboundPermissionRequestToTheBridge() {
         var fake       = new FakeAcpAgent();

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -403,6 +403,9 @@ public class AcpHostedAgentRuntimeFactoryTests {
     /// <summary>Parks in model selection until cancelled, so a test can occupy the window between a
     /// completed session/new and StartAsync's return.</summary>
     sealed class BlockingModelSelector(TaskCompletionSource entered) : IAcpModelSelector {
+        // It does attempt selection (that is the point — it parks mid-attempt), so it reports true.
+        public bool CanSelectModel => true;
+
         public async Task<string?> TrySelectAsync(
                 AcpConnection            connection,
                 string                   sessionId,

--- a/test/Capacitor.Cli.Tests.Unit/Services/ModelSelectionLaunchPolicyTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ModelSelectionLaunchPolicyTests.cs
@@ -1,0 +1,98 @@
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// The gate keeping a launch from REPORTING a model it is not running.
+///
+/// <para>Found by code review on the Kiro hosted-agent change: a runtime carrying
+/// <see cref="NoOpModelSelector"/> discards a requested model on the ACP wire, but the orchestrator's
+/// single <c>effectiveModel</c> was still published on the <c>AgentInstance</c> — driving the live
+/// model chip and <c>hosted_agent_started</c> analytics. So Kiro + <c>model="foo"</c> ran Kiro's
+/// default while telling everyone <c>foo</c> was live: the exact silent requested-vs-running mismatch
+/// the no-op selector had been chosen to avoid.</para>
+/// </summary>
+public class ModelSelectionLaunchPolicyTests {
+    const string Requested = "some-model";
+
+    // ── the runtime CAN select: never interfere ────────────────────────────────
+
+    [Test]
+    public async Task SupportsSelection_WithRequestedModel_Honors() {
+        await Assert.That(ModelSelectionLaunchPolicy.Evaluate(
+                Requested, supportsModelSelection: true, isExplicitReviewerModel: false))
+            .IsEqualTo(ModelSelectionDisposition.Honor);
+    }
+
+    [Test]
+    public async Task SupportsSelection_WithExplicitReviewerModel_Honors() {
+        await Assert.That(ModelSelectionLaunchPolicy.Evaluate(
+                Requested, supportsModelSelection: true, isExplicitReviewerModel: true))
+            .IsEqualTo(ModelSelectionDisposition.Honor);
+    }
+
+    // ── no model requested: nothing can be misreported ─────────────────────────
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task NoRequestedModel_Honors_EvenWhenSelectionUnsupported(string? requested) {
+        // Whitespace counts as absent, matching what the selectors themselves treat as "no request" —
+        // otherwise a blank model string would trip a rejection on a launch that asked for nothing.
+        await Assert.That(ModelSelectionLaunchPolicy.Evaluate(
+                requested, supportsModelSelection: false, isExplicitReviewerModel: false))
+            .IsEqualTo(ModelSelectionDisposition.Honor);
+
+        await Assert.That(ModelSelectionLaunchPolicy.Evaluate(
+                requested, supportsModelSelection: false, isExplicitReviewerModel: true))
+            .IsEqualTo(ModelSelectionDisposition.Honor);
+    }
+
+    // ── the runtime CANNOT select: the two negative cases differ ───────────────
+
+    /// <summary>Interactive: proceed with honest metadata. Refusing outright would make the vendor
+    /// unlaunchable from any caller that always sends a model.</summary>
+    [Test]
+    public async Task CannotSelect_InteractiveLaunch_ClearsReportedModel() {
+        await Assert.That(ModelSelectionLaunchPolicy.Evaluate(
+                Requested, supportsModelSelection: false, isExplicitReviewerModel: false))
+            .IsEqualTo(ModelSelectionDisposition.ClearReportedModel);
+    }
+
+    /// <summary>A pinned reviewer model is different in kind: a review round's authority depends on
+    /// which model produced it, so silently reviewing with another model is worse than not reviewing —
+    /// even with truthful metadata.</summary>
+    [Test]
+    public async Task CannotSelect_ExplicitReviewerModel_Rejects() {
+        await Assert.That(ModelSelectionLaunchPolicy.Evaluate(
+                Requested, supportsModelSelection: false, isExplicitReviewerModel: true))
+            .IsEqualTo(ModelSelectionDisposition.Reject);
+    }
+
+    [Test]
+    public async Task RejectionReason_NamesTheVendorAndTheModelItCannotHonor() {
+        var reason = ModelSelectionLaunchPolicy.RejectionReason("kiro", "claude-opus-4-8");
+
+        await Assert.That(reason).Contains("kiro");
+        await Assert.That(reason).Contains("claude-opus-4-8");
+    }
+
+    // ── the selectors are the source of truth for the flag above ──────────────
+
+    [Test]
+    public async Task ConfigOptionSelector_CanSelect_NoOpSelector_Cannot() {
+        await Assert.That(ConfigOptionModelSelector.Instance.CanSelectModel).IsTrue();
+        await Assert.That(NoOpModelSelector.Instance.CanSelectModel).IsFalse();
+    }
+
+    /// <summary>The whole reason this policy exists: Kiro's descriptor is the first to report false.
+    /// Pinned per-vendor so flipping Kiro's selector cannot quietly re-open the mismatch.</summary>
+    [Test]
+    public async Task DescriptorSelectors_ReportSelectionCapabilityPerVendor() {
+        await Assert.That(AcpVendorDescriptors.Kiro.ModelSelector.CanSelectModel).IsFalse();
+        await Assert.That(AcpVendorDescriptors.Cursor.ModelSelector.CanSelectModel).IsTrue();
+        await Assert.That(AcpVendorDescriptors.Copilot.ModelSelector.CanSelectModel).IsTrue();
+    }
+}


### PR DESCRIPTION
Closes AI-1404. Also lands the re-specced designs for AI-1404 and AI-1410 (the unattended Kiro reviewer), which this PR does **not** implement.

**Review status:** codex review flow **clean** (4 rounds across two flows — the first flow's round 3 timed out server-side and its finding was recovered from the reviewer's rollout log, see below). Qodo: 0 bugs, 1 rule violation, resolved.

## What ships

One `AcpVendorDescriptor` plus a factory registration — the Cursor/Copilot shape. **Interactive hosting only.** `SupportsUnattended: false`.

Unattended review is deliberately withheld for AI-1410 because **Kiro inherits the user's GLOBAL `~/.kiro/settings/mcp.json` servers into every ACP session** (measured: with `mcpServers: []`, Kiro still initialized `kcap-flows`, `kcap-review`, `kcap-sessions`, `kcap-memory`). An unattended reviewer would be handed `kcap-flows` and could start nested review flows. That inheritance is *desired* for interactive hosting, so it blocks nothing here.

## The two descriptor judgement calls

**`SupportsMcpServers: true`, where Copilot's descriptor says `false` on what looks like the same evidence.** Both vendors advertise the same ACP `mcpCapabilities` shape (`{http, sse}` — no stdio), so the advertisement cannot be what decides it. Copilot's `false` is an empirical finding about Copilot, not a rule about ACP.

Kiro was probed to a **call-level** result deliberately, because a weaker signal was available and would have been wrong: `_kiro.dev/mcp/server_initialized` proves only that a server *started* — a tool can be absent from `tools/list`, refused by trust policy, mis-namespaced, or fail at invocation. So a purpose-built stdio server exposing one uniquely-named tool was injected via `session/new.mcpServers`, and its own log recorded `initialize` → `tools/list` → **`tools/call`**, with the nonce reaching the model and the turn ending `end_turn`. Copilot's flag should only flip on an equivalent probe against Copilot.

**`NoOpModelSelector`, not `ConfigOptionModelSelector`.** `session/new` *does* return a `models` object, so the selector's read half would find its shape — but the write half (`session/set_config_option`) is unverified on Kiro and that selector **fails silently**. Note `ResolveDefaultModel: null` alone is *not* sufficient: `ResolveRequestedModel` prioritises a per-launch `RuntimeStartContext.Model` and would reach a live selector anyway.

`--agent-engine v1|v2|v3` (default `v2`) is deliberately **not** passed, so a hosted session matches what the user gets interactively.

## The defect review found — reporting a model that isn't running

Choosing `NoOpModelSelector` turned out to be only half the job, and the review caught the other half.

`NoOpModelSelector` does stop a requested model reaching Kiro on the wire. But the orchestrator computes **one** `effectiveModel` and uses it twice: as `RuntimeStartContext.Model` (where the no-op selector discards it) **and** as the `AgentInstance` model published via `AgentRegisteredAsync` — which drives the live model chip and `hosted_agent_started` analytics. So Kiro + `model="foo"` ran Kiro's default while telling the dashboard and analytics that `foo` was live: exactly the silent requested-vs-running mismatch the no-op selector was chosen to avoid.

The fix:

- **`IAcpModelSelector.CanSelectModel`** — the capability lives on the selector, not as a parallel descriptor flag. The descriptor's own docs record that a `SupportsModelSelection` boolean was previously *removed* as dead state that had to agree with the selector and was guarded asymmetrically; asking the selector cannot disagree with itself. It is deliberately **not** a type test for `NoOpModelSelector`, which would mis-answer for a vendor's own selector or a test double.
- **`IHostedAgentRuntimeFactory.SupportsModelSelection`**, default `true` — correct for every runtime predating this seam (PTY passes a model on argv; both ACP vendors carried a real selector), so no existing behaviour moves. The ACP factory delegates to its descriptor's selector.
- **`ModelSelectionLaunchPolicy`** (pure, mirroring `UnattendedLaunchPolicy`) splits the two negative cases, because they differ in kind:
  - *Interactive launch* → clear the reported model, proceed. Refusing outright would make such a vendor unlaunchable from any caller that always sends a model; honest metadata is the actual fix.
  - *Pinned reviewer model* → **reject**, pre-spawn. A review round's authority depends on which model produced it, so silently reviewing with the vendor default is worse than not reviewing, even with truthful metadata.

**Nullability.** Storing the cleared value into `AgentInstance.Model` / `RuntimeStartContext.Model`, both declared non-nullable, meant the records could hold a state their types said was impossible. Making them (plus `LauncherContext.Model` and `LogLaunching`'s parameter) nullable immediately surfaced **two unsafe consumers the compiler had been unable to see** — which is why the finding was worth taking rather than arguing. Both PTY launchers were already written for absence (`ClaudeLauncher` via `string.IsNullOrEmpty`, `CodexLauncher` via `AddModelArg`'s own null guard), so the types now match what the code already expected. `LaunchAgentCommand.Model` stays non-nullable: it is the wire contract for what a caller *asked for*.

## Two latent plumbing bugs fixed

**`DaemonConfig.KiroPath` defaulted to `"kiro"`.** The field predated any consumer. The shipped binary is `kiro-cli` — what `PluginCommand.KiroBinary` resolves, and what a standard install puts on PATH. Because availability is `CliResolver.Exists(KiroPath)`, shipping the old default would have meant **Kiro was never advertised on a correct install** until an operator discovered `KCAP_KIRO_PATH` — a silent no-op, not a visible failure. The existing env-override test could not catch this (it passes identically whichever name the default holds), so a zero-configuration test was added and **mutation-verified**.

**`AcpHostedAgentRuntime` diagnostics** named a command absent from a correct install on the launch-failure path: `DiagnosticBinary` got the explicit branch Cursor already has, and `DiagnosticAuthHint` (which review caught still falling through to the generic arm, telling operators to authenticate `kiro`) now deliberately **names no command** — `authMethods` came back empty and a prompt completed with no API key set, so inventing `kiro-cli login` would be fabricated guidance.

## Test coverage, and the hole review found in it

Round 3's finding was a coverage gap, and mutation confirmed it exactly: **deleting `AcpHostedAgentRuntimeFactory.SupportsModelSelection` reintroduced the original bug via the interface default `true`, and all 206 tests still passed.** The descriptor tests proved Kiro's selector reports `false`, and the orchestrator tests proved the behaviour when a *spy* factory reports `false`, but nothing connected the two through the real factory.

The new test reads the property through `IHostedAgentRuntimeFactory` rather than the concrete type. This matters: typed concretely, deleting the override is a *compile* error (a default interface member is unreachable through the implementing type) — it breaks the build but never exercises the value the orchestrator observes. Through the interface, the deletion surfaces as `true` and fails on the exact value that causes the mismatch. Mutation-verified three ways, each producing exactly one failure: delete override, hard-code `true`, hard-code `false`.

- `AcpVendorDescriptorTests` 13/13 (4 new) · `AcpHostedAgentRuntimeFactoryTests` 68/68 (1 new) · `AgentOrchestratorVendorTests` 116/116 (2 new behavioural) · `ModelSelectionLaunchPolicyTests` 10/10 (new) · `DaemonConfigEnvOverrideTests` 11/11 (2 corrected)
- Full `Tests.Unit`: 4565 total, 45 failed — **all pre-existing macOS clusters** (MCP-registration, config-file, uninstall, PTY-flood); verified none of those files reference `KiroPath`, `AcpVendorDescriptors`, or `IHostedAgentRuntimeFactory`.

## The AI-1410 spec: a probe that falsified the design

Both design docs are in this PR. The AI-1410 spec is now explicitly marked **NOT implementation-ready**, because the probe that was meant to clear its blocker instead broke part of it:

- **`fs_read` is not path-scoped.** With `--trust-tools=fs_read,thinking`, Kiro read a file **entirely outside the working directory** and returned its contents. So a trusted `fs_read` is a whole-filesystem read primitive under the daemon uid. `--trust-tools` is a *tool-surface* control, not a filesystem boundary — the same conclusion `AcpBorrowedReviewContainment` already encodes for Copilot ("widening its tool surface … also widens what a read tool can be pointed at"). Containment now needs an explicit decision: OS sandbox, or owned-worktree-only with the residual risk written down.
- **The reviewer home is transcript-bearing.** `KiroPaths.ConfigRoot` reads `KIRO_HOME` first, so `SessionsDir()` is `{KIRO_HOME}/sessions/cli` — Kiro writes the reviewer's own conversation JSONL, containing the caller's diff and source excerpts, into it. Credentials do not go *in*, but review context comes *out*, so `0700`-at-creation and crash cleanup are security requirements with a stated threat. An earlier draft's "contains nothing sensitive" was wrong.
- **My first negative containment test was vacuous and looked like a pass.** Phrased with `PWNED`/`BREACH`, Kiro refused on prompt-injection grounds and never called the tool; the file's absence proved nothing. Only a positive control (same request with `fs_write` trusted, write succeeds) exposed it. Acceptance criteria now require the pairing.
- Writes *are* blocked at effect level, but the denial reason attributes it to `--no-interactive` ("no user to approve") rather than the trust list — and that was measured on the `chat` path, not the ACP path the reviewer uses. Flagged rather than carried over, to avoid repeating the `server_initialized`-proves-callability error.
- The auth acceptance criterion is **dropped as unclosable**: an isolated empty `KIRO_HOME` was measured *not* to reproduce an unauthenticated Kiro, and no auth-failure shape was ever observed, so a fake peer would assert our handling of our own invention.

Also recorded: the native tool names (`fs_read`, `fs_write`, `execute_bash`, `use_aws`, `knowledge`, `thinking`, `introspect`, `todo_list`, `gh_issue`, `web_search`), and that an unknown `--trust-tools` entry is a **warning, not an error** — so a typo silently degrades to "nothing trusted".

## Known-not-done

**AI-1410 is not started and is not implementation-ready.** Its containment decision is a security call, and namespaced `@kcap-flow-result/...` trust on the ACP path is still unmeasured (the call-level probe above used `--trust-all-tools`, which the spec now forbids, so it does not transfer).

## CI

Ubuntu, both AOT publish checks, and the Linear-ID guard pass. Windows has been red on `main` since an earlier PR on a single pre-existing flake (`Expected to contain "Auto-skipping"`, 1 failure of 4586, macOS/Ubuntu green) — unrelated to this change.