### PR TITLE
No agent-spawned process may die on an unusable server URL

### DIFF
--- a/src/Capacitor.Cli.Core/Config/AppConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/AppConfig.cs
@@ -246,8 +246,18 @@ public static class AppConfig {
     /// </summary>
     public static void SetResolvedState(string serverUrl, string profileName, Profile profile) {
         ResolvedServerUrl = serverUrl;
-        ResolvedProfile   = new ResolvedProfile(serverUrl, profileName, profile, null);
+        // Profile, not a parameter: the only caller is `kcap setup`, immediately after persisting the
+        // profile whose server_url this is. The profile owns the value, so that is what remediation
+        // must name.
+        ResolvedProfile   = new ResolvedProfile(serverUrl, profileName, profile, null, UrlSource.Profile);
     }
+
+    /// <summary>
+    /// Where the resolved server URL came from, for the diagnostic a guard writes when it declines to
+    /// use it. Falls back to <see cref="UrlSource.Profile"/> before resolution has run, which is the
+    /// safe default: its remediation points at config rather than at an override the user never set.
+    /// </summary>
+    public static UrlSource ResolvedUrlSource => ResolvedProfile?.Source ?? UrlSource.Profile;
 
     /// <summary>
     /// Test seam: clears the process-global resolved state. Token lookup consults

--- a/src/Capacitor.Cli.Core/Config/ProfileResolver.cs
+++ b/src/Capacitor.Cli.Core/Config/ProfileResolver.cs
@@ -1,6 +1,14 @@
 namespace Capacitor.Cli.Core.Config;
 
-public record ResolvedProfile(string? ServerUrl, string? ProfileName, Profile? Profile, string? Warning);
+/// <param name="Source">
+/// Which configuration input supplied <paramref name="ServerUrl"/>. Needed because remediation
+/// differs: `kcap config set server_url` does NOT repair a malformed KCAP_URL or --server-url, both
+/// of which outrank the profile. Defaults to Profile — every branch below except the CLI flag and the
+/// env var resolves through a profile, whichever way that profile was selected.
+/// </param>
+public record ResolvedProfile(
+    string? ServerUrl, string? ProfileName, Profile? Profile, string? Warning,
+    UrlSource Source = UrlSource.Profile);
 
 public class ProfileResolver(
         ProfileConfig config,
@@ -14,11 +22,11 @@ public class ProfileResolver(
     public ResolvedProfile Resolve() {
         // 1. CLI --server-url flag
         if (!string.IsNullOrEmpty(cliServerUrl))
-            return new(AppConfig.NormalizeUrl(cliServerUrl), null, null, null);
+            return new(AppConfig.NormalizeUrl(cliServerUrl), null, null, null, UrlSource.CommandLine);
 
         // 2. KCAP_URL env var
         if (!string.IsNullOrEmpty(envUrl))
-            return new(AppConfig.NormalizeUrl(envUrl), null, null, null);
+            return new(AppConfig.NormalizeUrl(envUrl), null, null, null, UrlSource.Environment);
 
         // 3. KCAP_PROFILE env var
         if (!string.IsNullOrEmpty(envProfile))

--- a/src/Capacitor.Cli.Core/HookHttp.cs
+++ b/src/Capacitor.Cli.Core/HookHttp.cs
@@ -1,0 +1,18 @@
+namespace Capacitor.Cli.Core;
+
+/// <summary>
+/// The single acceptance predicate every hook-path guard consults.
+///
+/// <para>Lives beside <see cref="HttpClientExtensions.IsAcceptableUrl"/> deliberately: a guard that
+/// can disagree with the validator it protects is worse than no guard, because it fails in exactly
+/// the case it was added for. Before this existed the same composition was hand-written in twelve
+/// places and named twice.</para>
+/// </summary>
+public static class HookHttp {
+    /// <summary>
+    /// Whether a caller may attempt auth discovery for <paramref name="baseUrl"/> at all.
+    /// False for null, blank, scheme-less, relative, and absolute non-http(s) URLs.
+    /// </summary>
+    public static bool IsPostable(string? baseUrl)
+        => !string.IsNullOrWhiteSpace(baseUrl) && HttpClientExtensions.IsAcceptableUrl(baseUrl);
+}

--- a/src/Capacitor.Cli.Core/HookSpool.cs
+++ b/src/Capacitor.Cli.Core/HookSpool.cs
@@ -28,7 +28,8 @@ public enum DrainOutcome {
 public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.DefaultCapBytes) {
     public const int DefaultCapBytes = 1_048_576; // 1 MB per session file
 
-    static readonly Regex SafeSessionId = SafeSessionIdRegex();
+    static readonly Regex SafeSessionId  = SafeSessionIdRegex();
+    static readonly Regex LegacyGuidKey = LegacyGuidKeyRegex();
     static          int   seqCounter;
 
     /// <summary>The directory where spool files are stored.</summary>
@@ -69,6 +70,12 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     // reversible -- the drain posts the DECODED id as session_id, so a lossy or one-way transform
     // (a hash, or lowercasing) would put a fabricated id on the wire.
     static string EncodeKey(string sessionId) {
+        // A dashless GUID is left EXACTLY as-is. Two hex spellings differing only by case are the
+        // SAME id, so they neither need disambiguating nor may be renamed: this is the entire
+        // population the pre-upgrade grammar admitted, so every spool file already on disk keeps its
+        // historical name and stays readable. Escaping applies only to the ids that are new here.
+        if (LegacyGuidKey.IsMatch(sessionId)) return sessionId;
+
         var sb = new StringBuilder(sessionId.Length + 8);
 
         foreach (var c in sessionId) {
@@ -379,6 +386,10 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     // be widened but never transformed (hashing would fabricate an id on the wire). Excludes '.', '/'
     // and '\\', preserving both the path-traversal property and the parse-before-first-dot split.
     // Vendors such as OpenCode use ids like "ses_7f3a9c21b8", which the old form silently dropped.
+    /// <summary>The pre-upgrade key space: a dashless GUID, case-insensitively one id.</summary>
+    [GeneratedRegex("^[0-9a-fA-F]{32}$", RegexOptions.Compiled)]
+    private static partial Regex LegacyGuidKeyRegex();
+
     [GeneratedRegex("^[A-Za-z0-9_-]{1,64}$", RegexOptions.Compiled)]
     private static partial Regex SafeSessionIdRegex();
 }

--- a/src/Capacitor.Cli.Core/HookSpool.cs
+++ b/src/Capacitor.Cli.Core/HookSpool.cs
@@ -343,6 +343,10 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     // be widened but never transformed (hashing would fabricate an id on the wire). Excludes '.', '/'
     // and '\\', preserving both the path-traversal property and the parse-before-first-dot split.
     // Vendors such as OpenCode use ids like "ses_7f3a9c21b8", which the old form silently dropped.
-    [GeneratedRegex("^[A-Za-z0-9_-]{1,64}$", RegexOptions.Compiled)]
+    // The widened arm is deliberately LOWERCASE-only: the id is preserved byte-for-byte and is the
+    // filename, so admitting both cases would let "ses_A" and "ses_a" -- two distinct sessions --
+    // address one file on macOS/Windows. The legacy 32-hex arm keeps mixed case because those are
+    // the same GUID either way. An uppercase vendor id is rejected, which Append now reports.
+    [GeneratedRegex("^(?:[0-9a-fA-F]{32}|[a-z0-9_-]{1,64})$", RegexOptions.Compiled)]
     private static partial Regex SafeSessionIdRegex();
 }

--- a/src/Capacitor.Cli.Core/HookSpool.cs
+++ b/src/Capacitor.Cli.Core/HookSpool.cs
@@ -35,7 +35,7 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     internal string Dir => spoolDir;
 
     string? LivePathFor(string sessionId) =>
-        SafeSessionId.IsMatch(sessionId) ? Path.Combine(spoolDir, $"{sessionId}.jsonl") : null;
+        SafeSessionId.IsMatch(sessionId) ? Path.Combine(spoolDir, $"{EncodeKey(sessionId)}.jsonl") : null;
 
     /// <summary>
     /// Appends one payload for a later drain pass. Returns whether it was actually persisted, so a
@@ -53,6 +53,42 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
         } catch {
             return false;
         }
+    }
+
+
+    // ---- filename key encoding -------------------------------------------------------------
+    //
+    // Session ids are case-SENSITIVE and are preserved byte-for-byte (OpenCode's are base62 --
+    // "ses_619a78374ffe7o0x1iTK74jFRg"), but macOS and Windows filesystems are case-INSENSITIVE, so
+    // using the raw id as the filename would let two distinct sessions address one file: their
+    // lifecycle entries would interleave and one session's ended marker would discard the other's
+    // remainder.
+    //
+    // So the id is escaped into a single-case filename key and decoded back on the way out. '~' is
+    // the escape and cannot occur in an admitted id, which keeps the mapping unambiguous and
+    // reversible -- the drain posts the DECODED id as session_id, so a lossy or one-way transform
+    // (a hash, or lowercasing) would put a fabricated id on the wire.
+    static string EncodeKey(string sessionId) {
+        var sb = new StringBuilder(sessionId.Length + 8);
+
+        foreach (var c in sessionId) {
+            if (char.IsAsciiLetterUpper(c)) sb.Append('~').Append(char.ToLowerInvariant(c));
+            else sb.Append(c);
+        }
+
+        return sb.ToString();
+    }
+
+    static string? DecodeKey(string key) {
+        var sb = new StringBuilder(key.Length);
+
+        for (var i = 0; i < key.Length; i++) {
+            if (key[i] != '~') { sb.Append(key[i]); continue; }
+            if (++i >= key.Length || !char.IsAsciiLetterLower(key[i])) return null; // malformed
+            sb.Append(char.ToUpperInvariant(key[i]));
+        }
+
+        return sb.ToString();
     }
 
     void EnsureUnderCap(string path, int incomingBytes) {
@@ -97,15 +133,15 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     }
 
     bool HasAny(string sid) =>
-        File.Exists(Path.Combine(spoolDir, $"{sid}.jsonl"))
-     || Directory.EnumerateFiles(spoolDir, $"{sid}.*.draining").Any();
+        File.Exists(Path.Combine(spoolDir, $"{EncodeKey(sid)}.jsonl"))
+     || Directory.EnumerateFiles(spoolDir, $"{EncodeKey(sid)}.*.draining").Any();
 
     static string? SessionIdOf(string filePath) {
         var name = Path.GetFileName(filePath);
         var dot  = name.IndexOf('.');
         if (dot <= 0) return null;
-        var sid = name[..dot];
-        return SafeSessionId.IsMatch(sid) ? sid : null;
+        var decoded = DecodeKey(name[..dot]);
+        return decoded is not null && SafeSessionId.IsMatch(decoded) ? decoded : null;
     }
 
     // Recovered temps (oldest first) then the rotated live file. Returns true => stop the whole pass.
@@ -118,15 +154,15 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     // the two drains from ever cross-consuming each other's in-flight files.
     async Task<bool> DrainSessionAsync(
             string sid, Func<string, string, Task<DrainOutcome>> poster, Func<bool> expired, CancellationToken ct) {
-        foreach (var temp in Directory.EnumerateFiles(spoolDir, $"{sid}.*.draining").OrderBy(File.GetCreationTimeUtc)) {
+        foreach (var temp in Directory.EnumerateFiles(spoolDir, $"{EncodeKey(sid)}.*.draining").OrderBy(File.GetCreationTimeUtc)) {
             if (expired() || ct.IsCancellationRequested) return false;
             if (await DrainFileAsync(temp, poster, expired, ct)) return true;
         }
 
-        var live = Path.Combine(spoolDir, $"{sid}.jsonl");
+        var live = Path.Combine(spoolDir, $"{EncodeKey(sid)}.jsonl");
         if (!File.Exists(live) || expired() || ct.IsCancellationRequested) return false;
 
-        var rotated = Path.Combine(spoolDir, $"{sid}.{Environment.ProcessId}-{Interlocked.Increment(ref seqCounter)}.draining");
+        var rotated = Path.Combine(spoolDir, $"{EncodeKey(sid)}.{Environment.ProcessId}-{Interlocked.Increment(ref seqCounter)}.draining");
         try { File.Move(live, rotated); }
         catch { return false; } // lost the atomic-rename race (or vanished) — the winner handles it
         return await DrainFileAsync(rotated, poster, expired, ct);
@@ -174,9 +210,9 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     /// must be visible here even though only the ordered drain ever creates/consumes the latter.</summary>
     public bool HasBacklog(string sessionId) =>
         SafeSessionId.IsMatch(sessionId) && Directory.Exists(spoolDir)
-        && (File.Exists(Path.Combine(spoolDir, $"{sessionId}.jsonl"))
-            || Directory.EnumerateFiles(spoolDir, $"{sessionId}.*.draining").Any()
-            || Directory.EnumerateFiles(spoolDir, $"{sessionId}.ordered-*").Any());
+        && (File.Exists(Path.Combine(spoolDir, $"{EncodeKey(sessionId)}.jsonl"))
+            || Directory.EnumerateFiles(spoolDir, $"{EncodeKey(sessionId)}.*.draining").Any()
+            || Directory.EnumerateFiles(spoolDir, $"{EncodeKey(sessionId)}.ordered-*").Any());
 
     /// <summary>Every distinct session id with a live .jsonl or recovered .draining/.ordered-* temp,
     /// in no particular order (callers that need current-session-first ordering add it themselves).</summary>
@@ -217,17 +253,17 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
 
         var consumed = 0;
 
-        foreach (var temp in Directory.EnumerateFiles(spoolDir, $"{sid}.ordered-*").OrderBy(File.GetCreationTimeUtc)) {
+        foreach (var temp in Directory.EnumerateFiles(spoolDir, $"{EncodeKey(sid)}.ordered-*").OrderBy(File.GetCreationTimeUtc)) {
             if (expired() || ct.IsCancellationRequested) return consumed;
             var (stopped, n) = await DrainFileRoutesAsync(temp, isTerminal, poster, expired, ct);
             consumed += n;
             if (stopped) return consumed; // stopped — remainder kept
         }
 
-        var live = Path.Combine(spoolDir, $"{sid}.jsonl");
+        var live = Path.Combine(spoolDir, $"{EncodeKey(sid)}.jsonl");
         if (!File.Exists(live) || expired() || ct.IsCancellationRequested) return consumed;
 
-        var rotated = Path.Combine(spoolDir, $"{sid}.ordered-{Environment.ProcessId}-{Interlocked.Increment(ref seqCounter)}");
+        var rotated = Path.Combine(spoolDir, $"{EncodeKey(sid)}.ordered-{Environment.ProcessId}-{Interlocked.Increment(ref seqCounter)}");
         try { File.Move(live, rotated); }
         catch { return consumed; } // lost the atomic-rename race (or vanished) — the winner handles it
         var (_, more) = await DrainFileRoutesAsync(rotated, isTerminal, poster, expired, ct);
@@ -316,17 +352,17 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
         try {
             if (!Directory.Exists(spoolDir)) return;
 
-            var live = Path.Combine(spoolDir, $"{sessionId}.jsonl");
+            var live = Path.Combine(spoolDir, $"{EncodeKey(sessionId)}.jsonl");
             if (File.Exists(live)) File.Delete(live);
 
-            foreach (var temp in Directory.EnumerateFiles(spoolDir, $"{sessionId}.*.draining"))
+            foreach (var temp in Directory.EnumerateFiles(spoolDir, $"{EncodeKey(sessionId)}.*.draining"))
                 try { File.Delete(temp); } catch { }
-            foreach (var temp in Directory.EnumerateFiles(spoolDir, $"{sessionId}.ordered-*"))
+            foreach (var temp in Directory.EnumerateFiles(spoolDir, $"{EncodeKey(sessionId)}.ordered-*"))
                 try { File.Delete(temp); } catch { }
         } catch { }
     }
 
-    string EndedMarkerPath(string sessionId) => Path.Combine(spoolDir, $".ended-{sessionId}");
+    string EndedMarkerPath(string sessionId) => Path.Combine(spoolDir, $".ended-{EncodeKey(sessionId)}");
 
     public void ReapOlderThan(TimeSpan age) {
         try {
@@ -343,10 +379,6 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     // be widened but never transformed (hashing would fabricate an id on the wire). Excludes '.', '/'
     // and '\\', preserving both the path-traversal property and the parse-before-first-dot split.
     // Vendors such as OpenCode use ids like "ses_7f3a9c21b8", which the old form silently dropped.
-    // The widened arm is deliberately LOWERCASE-only: the id is preserved byte-for-byte and is the
-    // filename, so admitting both cases would let "ses_A" and "ses_a" -- two distinct sessions --
-    // address one file on macOS/Windows. The legacy 32-hex arm keeps mixed case because those are
-    // the same GUID either way. An uppercase vendor id is rejected, which Append now reports.
-    [GeneratedRegex("^(?:[0-9a-fA-F]{32}|[a-z0-9_-]{1,64})$", RegexOptions.Compiled)]
+    [GeneratedRegex("^[A-Za-z0-9_-]{1,64}$", RegexOptions.Compiled)]
     private static partial Regex SafeSessionIdRegex();
 }

--- a/src/Capacitor.Cli.Core/HookSpool.cs
+++ b/src/Capacitor.Cli.Core/HookSpool.cs
@@ -37,15 +37,22 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
     string? LivePathFor(string sessionId) =>
         SafeSessionId.IsMatch(sessionId) ? Path.Combine(spoolDir, $"{sessionId}.jsonl") : null;
 
-    public void Append(string sessionId, string route, string rawPayloadJson) {
+    /// <summary>
+    /// Appends one payload for a later drain pass. Returns whether it was actually persisted, so a
+    /// caller cannot report "spooled" after a rejected key or a disk/permission fault.
+    /// </summary>
+    public bool Append(string sessionId, string route, string rawPayloadJson) {
         var path = LivePathFor(sessionId);
-        if (path is null) return;
+        if (path is null) return false;
         try {
             Directory.CreateDirectory(spoolDir);
             var line = new JsonObject { ["route"] = route, ["body"] = rawPayloadJson }.ToJsonString();
             EnsureUnderCap(path, Encoding.UTF8.GetByteCount(line) + 1);
             File.AppendAllText(path, $"{line}\n");
-        } catch { /* best effort */ }
+            return true;
+        } catch {
+            return false;
+        }
     }
 
     void EnsureUnderCap(string path, int incomingBytes) {
@@ -331,6 +338,11 @@ public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.
         } catch { }
     }
 
-    [GeneratedRegex("^[0-9a-fA-F]{32}$", RegexOptions.Compiled)]
+    // Filename-safe superset of the old dashless-GUID form. The filename IS the session id --
+    // LifecycleSpoolDrain posts it verbatim as session_id for session-needs-import -- so the key may
+    // be widened but never transformed (hashing would fabricate an id on the wire). Excludes '.', '/'
+    // and '\\', preserving both the path-traversal property and the parse-before-first-dot split.
+    // Vendors such as OpenCode use ids like "ses_7f3a9c21b8", which the old form silently dropped.
+    [GeneratedRegex("^[A-Za-z0-9_-]{1,64}$", RegexOptions.Compiled)]
     private static partial Regex SafeSessionIdRegex();
 }

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -234,6 +234,12 @@ public static class HttpClientExtensions {
     /// </summary>
     static void EnsureAbsolute(string url) {
         if (IsAcceptableUrl(url)) return;
+
+        // Agent-spawned commands set Throw at entry: they owe an output contract (or must leave no
+        // orphaned child), and Environment.Exit here is uncatchable — it bypasses every vendor's
+        // fail-open catch, so the harness sees no output and rejects the session. See ProcessUrlPolicy.
+        if (ProcessUrlPolicy.Current is UrlFailurePolicy.Throw) throw new UnusableServerUrlException(SchemeMissingHint);
+
         Console.Error.WriteLine(SchemeMissingHint);
         Environment.Exit(2);
     }

--- a/src/Capacitor.Cli.Core/ProcessUrlPolicy.cs
+++ b/src/Capacitor.Cli.Core/ProcessUrlPolicy.cs
@@ -1,0 +1,39 @@
+namespace Capacitor.Cli.Core;
+
+/// <summary>What a process should do when it meets a server URL it cannot use.</summary>
+public enum UrlFailurePolicy {
+    /// <summary>Print an actionable hint and exit 2. Correct for interactive commands.</summary>
+    FailFast,
+
+    /// <summary>Raise <see cref="UnusableServerUrlException"/>. Correct for agent-spawned commands.</summary>
+    Throw,
+}
+
+/// <summary>
+/// Process-wide selector for <see cref="UrlFailurePolicy"/>, set once at entry.
+///
+/// <para>Defaults to <see cref="UrlFailurePolicy.FailFast"/> so interactive commands keep exiting 2
+/// with an actionable hint — the right UX when a user is present. Agent-spawned commands switch to
+/// <see cref="UrlFailurePolicy.Throw"/> because they owe an output contract (a hook whose host blocks
+/// on stdout) or must leave no orphaned child, and <c>Environment.Exit</c> is uncatchable: it bypasses
+/// the fail-open <c>catch</c> every vendor hook already has, so the harness sees no output at all and
+/// rejects the session.</para>
+///
+/// <para>This selector prevents process <em>death</em>. It does not decide disposition — whether a
+/// payload is spooled, a watcher is spawned, or a protocol error is returned is owned by the explicit
+/// <see cref="HookHttp.IsPostable"/> guards at each seam. Nor is it a claim that the reachable surface
+/// has been enumerated; it has not been, five times over.</para>
+/// </summary>
+public static class ProcessUrlPolicy {
+    public static UrlFailurePolicy Current { get; set; } = UrlFailurePolicy.FailFast;
+}
+
+/// <summary>
+/// Raised instead of <c>Environment.Exit(2)</c> under <see cref="UrlFailurePolicy.Throw"/>.
+///
+/// <para>Deliberately a distinct type so an audit can find every <c>catch</c> that must re-throw it
+/// rather than swallow it and continue as though the server were reachable. A bare <c>catch</c> whose
+/// fallback branch writes output or persists state would turn a loud failure into a silent wrong
+/// one.</para>
+/// </summary>
+public sealed class UnusableServerUrlException(string hint) : Exception(hint);

--- a/src/Capacitor.Cli.Core/ProcessUrlPolicy.cs
+++ b/src/Capacitor.Cli.Core/ProcessUrlPolicy.cs
@@ -12,17 +12,12 @@ public enum UrlFailurePolicy {
 /// <summary>
 /// Process-wide selector for <see cref="UrlFailurePolicy"/>, set once at entry.
 ///
-/// <para>Defaults to <see cref="UrlFailurePolicy.FailFast"/> so interactive commands keep exiting 2
-/// with an actionable hint — the right UX when a user is present. Agent-spawned commands switch to
-/// <see cref="UrlFailurePolicy.Throw"/> because they owe an output contract (a hook whose host blocks
-/// on stdout) or must leave no orphaned child, and <c>Environment.Exit</c> is uncatchable: it bypasses
-/// the fail-open <c>catch</c> every vendor hook already has, so the harness sees no output at all and
-/// rejects the session.</para>
+/// <para>Agent-spawned commands need <see cref="UrlFailurePolicy.Throw"/> because
+/// <c>Environment.Exit</c> is uncatchable: it bypasses the fail-open <c>catch</c> every vendor hook
+/// has, so a hook dies before its stdout contract and the harness rejects the session.</para>
 ///
-/// <para>This selector prevents process <em>death</em>. It does not decide disposition — whether a
-/// payload is spooled, a watcher is spawned, or a protocol error is returned is owned by the explicit
-/// <see cref="HookHttp.IsPostable"/> guards at each seam. Nor is it a claim that the reachable surface
-/// has been enumerated; it has not been, five times over.</para>
+/// <para>This prevents process death only. Disposition — spool, skip, or protocol error — belongs to
+/// the <see cref="HookHttp.IsPostable"/> guards at each seam.</para>
 /// </summary>
 public static class ProcessUrlPolicy {
     public static UrlFailurePolicy Current { get; set; } = UrlFailurePolicy.FailFast;

--- a/src/Capacitor.Cli.Core/TranscriptSpool.cs
+++ b/src/Capacitor.Cli.Core/TranscriptSpool.cs
@@ -164,6 +164,11 @@ public sealed partial class TranscriptSpool(string spoolDir, long capBytes = Tra
         } catch { }
     }
 
-    [GeneratedRegex("^[0-9a-fA-F]{32}$", RegexOptions.Compiled)]
+    // Filename-safe superset of the old dashless-GUID form. The filename IS the session id --
+    // LifecycleSpoolDrain posts it verbatim as session_id for session-needs-import -- so the key may
+    // be widened but never transformed (hashing would fabricate an id on the wire). Excludes '.', '/'
+    // and '\\', preserving both the path-traversal property and the parse-before-first-dot split.
+    // Vendors such as OpenCode use ids like "ses_7f3a9c21b8", which the old form silently dropped.
+    [GeneratedRegex("^[A-Za-z0-9_-]{1,64}$", RegexOptions.Compiled)]
     private static partial Regex SafeSessionIdRegex();
 }

--- a/src/Capacitor.Cli.Core/TranscriptSpool.cs
+++ b/src/Capacitor.Cli.Core/TranscriptSpool.cs
@@ -31,10 +31,10 @@ public sealed partial class TranscriptSpool(string spoolDir, long capBytes = Tra
     internal string Dir => spoolDir;
 
     string? LivePathFor(string sessionId) =>
-        SafeSessionId.IsMatch(sessionId) ? Path.Combine(spoolDir, $"{sessionId}.transcript.jsonl") : null;
+        SafeSessionId.IsMatch(sessionId) ? Path.Combine(spoolDir, $"{EncodeKey(sessionId)}.transcript.jsonl") : null;
 
     string? MarkerPathFor(string sessionId) =>
-        SafeSessionId.IsMatch(sessionId) ? Path.Combine(spoolDir, $"{sessionId}.needs-import") : null;
+        SafeSessionId.IsMatch(sessionId) ? Path.Combine(spoolDir, $"{EncodeKey(sessionId)}.needs-import") : null;
 
     public AppendResult Append(string sessionId, string batchJson) {
         var path = LivePathFor(sessionId);
@@ -84,10 +84,46 @@ public sealed partial class TranscriptSpool(string spoolDir, long capBytes = Tra
     }
 
     /// <summary>True if this session still has undelivered spool entries (live .jsonl or .draining temp).</summary>
+
+    // ---- filename key encoding -------------------------------------------------------------
+    //
+    // Session ids are case-SENSITIVE and are preserved byte-for-byte (OpenCode's are base62 --
+    // "ses_619a78374ffe7o0x1iTK74jFRg"), but macOS and Windows filesystems are case-INSENSITIVE, so
+    // using the raw id as the filename would let two distinct sessions address one file: their
+    // lifecycle entries would interleave and one session's ended marker would discard the other's
+    // remainder.
+    //
+    // So the id is escaped into a single-case filename key and decoded back on the way out. '~' is
+    // the escape and cannot occur in an admitted id, which keeps the mapping unambiguous and
+    // reversible -- the drain posts the DECODED id as session_id, so a lossy or one-way transform
+    // (a hash, or lowercasing) would put a fabricated id on the wire.
+    static string EncodeKey(string sessionId) {
+        var sb = new StringBuilder(sessionId.Length + 8);
+
+        foreach (var c in sessionId) {
+            if (char.IsAsciiLetterUpper(c)) sb.Append('~').Append(char.ToLowerInvariant(c));
+            else sb.Append(c);
+        }
+
+        return sb.ToString();
+    }
+
+    static string? DecodeKey(string key) {
+        var sb = new StringBuilder(key.Length);
+
+        for (var i = 0; i < key.Length; i++) {
+            if (key[i] != '~') { sb.Append(key[i]); continue; }
+            if (++i >= key.Length || !char.IsAsciiLetterLower(key[i])) return null; // malformed
+            sb.Append(char.ToUpperInvariant(key[i]));
+        }
+
+        return sb.ToString();
+    }
+
     public bool HasBacklog(string sessionId) =>
         SafeSessionId.IsMatch(sessionId) && Directory.Exists(spoolDir)
-        && (File.Exists(Path.Combine(spoolDir, $"{sessionId}.transcript.jsonl"))
-            || Directory.EnumerateFiles(spoolDir, $"{sessionId}.*.transcript.draining").Any());
+        && (File.Exists(Path.Combine(spoolDir, $"{EncodeKey(sessionId)}.transcript.jsonl"))
+            || Directory.EnumerateFiles(spoolDir, $"{EncodeKey(sessionId)}.*.transcript.draining").Any());
 
     /// <summary>Every distinct session id with a live .jsonl, a recovered .draining temp, or a
     /// needs-import marker (a marker can outlive its transcript file if a prior pass ran out of
@@ -106,22 +142,22 @@ public sealed partial class TranscriptSpool(string spoolDir, long capBytes = Tra
         var name = Path.GetFileName(filePath);
         var dot  = name.IndexOf('.');
         if (dot <= 0) return null;
-        var sid = name[..dot];
-        return SafeSessionId.IsMatch(sid) ? sid : null;
+        var decoded = DecodeKey(name[..dot]);
+        return decoded is not null && SafeSessionId.IsMatch(decoded) ? decoded : null;
     }
 
     public async Task DrainAsync(string sessionId, Func<string, Task<DrainOutcome>> poster, Func<bool> expired, CancellationToken ct) {
         var live = LivePathFor(sessionId);
         if (live is null || !Directory.Exists(spoolDir)) return;
 
-        foreach (var temp in Directory.EnumerateFiles(spoolDir, $"{sessionId}.*.transcript.draining").OrderBy(File.GetCreationTimeUtc)) {
+        foreach (var temp in Directory.EnumerateFiles(spoolDir, $"{EncodeKey(sessionId)}.*.transcript.draining").OrderBy(File.GetCreationTimeUtc)) {
             if (expired() || ct.IsCancellationRequested) return;
             if (await DrainFileAsync(temp, poster, expired, ct)) return; // transient → stop, keep remainder
         }
 
         if (!File.Exists(live) || expired() || ct.IsCancellationRequested) return;
 
-        var rotated = Path.Combine(spoolDir, $"{sessionId}.{Environment.ProcessId}-{Interlocked.Increment(ref seqCounter)}.transcript.draining");
+        var rotated = Path.Combine(spoolDir, $"{EncodeKey(sessionId)}.{Environment.ProcessId}-{Interlocked.Increment(ref seqCounter)}.transcript.draining");
         try { File.Move(live, rotated); }
         catch { return; } // lost the atomic-rename race (or vanished) — the winner handles it
         await DrainFileAsync(rotated, poster, expired, ct);
@@ -169,10 +205,6 @@ public sealed partial class TranscriptSpool(string spoolDir, long capBytes = Tra
     // be widened but never transformed (hashing would fabricate an id on the wire). Excludes '.', '/'
     // and '\\', preserving both the path-traversal property and the parse-before-first-dot split.
     // Vendors such as OpenCode use ids like "ses_7f3a9c21b8", which the old form silently dropped.
-    // The widened arm is deliberately LOWERCASE-only: the id is preserved byte-for-byte and is the
-    // filename, so admitting both cases would let "ses_A" and "ses_a" -- two distinct sessions --
-    // address one file on macOS/Windows. The legacy 32-hex arm keeps mixed case because those are
-    // the same GUID either way. An uppercase vendor id is rejected, which Append now reports.
-    [GeneratedRegex("^(?:[0-9a-fA-F]{32}|[a-z0-9_-]{1,64})$", RegexOptions.Compiled)]
+    [GeneratedRegex("^[A-Za-z0-9_-]{1,64}$", RegexOptions.Compiled)]
     private static partial Regex SafeSessionIdRegex();
 }

--- a/src/Capacitor.Cli.Core/TranscriptSpool.cs
+++ b/src/Capacitor.Cli.Core/TranscriptSpool.cs
@@ -169,6 +169,10 @@ public sealed partial class TranscriptSpool(string spoolDir, long capBytes = Tra
     // be widened but never transformed (hashing would fabricate an id on the wire). Excludes '.', '/'
     // and '\\', preserving both the path-traversal property and the parse-before-first-dot split.
     // Vendors such as OpenCode use ids like "ses_7f3a9c21b8", which the old form silently dropped.
-    [GeneratedRegex("^[A-Za-z0-9_-]{1,64}$", RegexOptions.Compiled)]
+    // The widened arm is deliberately LOWERCASE-only: the id is preserved byte-for-byte and is the
+    // filename, so admitting both cases would let "ses_A" and "ses_a" -- two distinct sessions --
+    // address one file on macOS/Windows. The legacy 32-hex arm keeps mixed case because those are
+    // the same GUID either way. An uppercase vendor id is rejected, which Append now reports.
+    [GeneratedRegex("^(?:[0-9a-fA-F]{32}|[a-z0-9_-]{1,64})$", RegexOptions.Compiled)]
     private static partial Regex SafeSessionIdRegex();
 }

--- a/src/Capacitor.Cli.Core/TranscriptSpool.cs
+++ b/src/Capacitor.Cli.Core/TranscriptSpool.cs
@@ -24,7 +24,8 @@ public sealed partial class TranscriptSpool(string spoolDir, long capBytes = Tra
         Ignored,           // discarded before any spool interaction (malformed session id) — never a real append
     }
 
-    static readonly Regex SafeSessionId = SafeSessionIdRegex();
+    static readonly Regex SafeSessionId  = SafeSessionIdRegex();
+    static readonly Regex LegacyGuidKey = LegacyGuidKeyRegex();
     static int seqCounter;
 
     /// <summary>The directory where spool files are stored.</summary>
@@ -98,6 +99,12 @@ public sealed partial class TranscriptSpool(string spoolDir, long capBytes = Tra
     // reversible -- the drain posts the DECODED id as session_id, so a lossy or one-way transform
     // (a hash, or lowercasing) would put a fabricated id on the wire.
     static string EncodeKey(string sessionId) {
+        // A dashless GUID is left EXACTLY as-is. Two hex spellings differing only by case are the
+        // SAME id, so they neither need disambiguating nor may be renamed: this is the entire
+        // population the pre-upgrade grammar admitted, so every spool file already on disk keeps its
+        // historical name and stays readable. Escaping applies only to the ids that are new here.
+        if (LegacyGuidKey.IsMatch(sessionId)) return sessionId;
+
         var sb = new StringBuilder(sessionId.Length + 8);
 
         foreach (var c in sessionId) {
@@ -205,6 +212,10 @@ public sealed partial class TranscriptSpool(string spoolDir, long capBytes = Tra
     // be widened but never transformed (hashing would fabricate an id on the wire). Excludes '.', '/'
     // and '\\', preserving both the path-traversal property and the parse-before-first-dot split.
     // Vendors such as OpenCode use ids like "ses_7f3a9c21b8", which the old form silently dropped.
+    /// <summary>The pre-upgrade key space: a dashless GUID, case-insensitively one id.</summary>
+    [GeneratedRegex("^[0-9a-fA-F]{32}$", RegexOptions.Compiled)]
+    private static partial Regex LegacyGuidKeyRegex();
+
     [GeneratedRegex("^[A-Za-z0-9_-]{1,64}$", RegexOptions.Compiled)]
     private static partial Regex SafeSessionIdRegex();
 }

--- a/src/Capacitor.Cli.Core/UnusableUrlDiagnostic.cs
+++ b/src/Capacitor.Cli.Core/UnusableUrlDiagnostic.cs
@@ -33,8 +33,11 @@ public static class UnusableUrlDiagnostic {
         var stripped = new string(rawUrl.Where(c => !char.IsControl(c)).ToArray());
 
         // Drop user:pass@ — take the LAST '@' so an embedded one cannot smuggle credentials past.
+        // Slice on ANY '@', including a trailing one: "https://user:secret@" is exactly the kind of
+        // malformed value this path exists to render, and requiring a character after '@' left the
+        // credential intact on it.
         var at = stripped.LastIndexOf('@');
-        if (at >= 0 && at + 1 < stripped.Length) stripped = stripped[(at + 1)..];
+        if (at >= 0) stripped = stripped[(at + 1)..];
 
         if (stripped.Length == 0) return "(empty)";
 

--- a/src/Capacitor.Cli.Core/UnusableUrlDiagnostic.cs
+++ b/src/Capacitor.Cli.Core/UnusableUrlDiagnostic.cs
@@ -1,0 +1,63 @@
+namespace Capacitor.Cli.Core;
+
+/// <summary>Where the resolved server URL came from, so remediation can name the right thing to fix.</summary>
+public enum UrlSource {
+    /// <summary><c>--server-url</c>.</summary>
+    CommandLine,
+
+    /// <summary><c>KCAP_URL</c>.</summary>
+    Environment,
+
+    /// <summary>A profile's <c>server_url</c>, however that profile was selected.</summary>
+    Profile,
+}
+
+/// <summary>
+/// Builds the one stderr line a guard writes when it declines to use a server URL.
+///
+/// <para>Silence is not an option here: a typo in <c>server_url</c> otherwise produces a machine that
+/// records nothing indefinitely, with no signal anywhere. Recovery also needs a later hook for the
+/// same session, so the window in which this line is actionable is short.</para>
+/// </summary>
+public static class UnusableUrlDiagnostic {
+    const int MaxRendered = 80;
+
+    /// <summary>
+    /// Renders an untrusted URL safe to print. A <c>server_url</c> may carry credentials, and an
+    /// embedded newline would let it inject a fabricated line into a stream harnesses parse — so
+    /// userinfo is dropped, control characters are stripped, and the result is length-capped.
+    /// </summary>
+    public static string Sanitize(string? rawUrl) {
+        if (string.IsNullOrWhiteSpace(rawUrl)) return "(empty)";
+
+        var stripped = new string(rawUrl.Where(c => !char.IsControl(c)).ToArray());
+
+        // Drop user:pass@ — take the LAST '@' so an embedded one cannot smuggle credentials past.
+        var at = stripped.LastIndexOf('@');
+        if (at >= 0 && at + 1 < stripped.Length) stripped = stripped[(at + 1)..];
+
+        if (stripped.Length == 0) return "(empty)";
+
+        return stripped.Length <= MaxRendered ? stripped : string.Concat(stripped.AsSpan(0, MaxRendered), "…");
+    }
+
+    /// <summary>
+    /// One line naming the source, the sanitized value, and what happened to the payload.
+    /// The remediation must match the source: <c>kcap config set server_url</c> does NOT repair a
+    /// malformed <c>KCAP_URL</c> or <c>--server-url</c>, both of which outrank the profile.
+    /// </summary>
+    public static string Build(UrlSource source, string? rawUrl, string disposition) {
+        var (name, fix) = source switch {
+            UrlSource.CommandLine => ("--server-url",
+                                      "Pass --server-url https://<host>."),
+            UrlSource.Environment => ("KCAP_URL",
+                                      "Set KCAP_URL to https://<host>, or unset it to use the configured profile."),
+            _                     => ("server_url",
+                                      "Run: kcap config set server_url https://<host>"),
+        };
+
+        return $"[kcap] {name} is not an absolute http(s) URL ({Sanitize(rawUrl)}) — {disposition}."
+             + System.Environment.NewLine
+             + $"       {fix}";
+    }
+}

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -172,7 +172,7 @@ public class DaemonConfig {
         if (string.IsNullOrWhiteSpace(ServerUrl)) {
             errors.Add("ServerUrl is required");
         } else if (!Uri.TryCreate(ServerUrl, UriKind.Absolute, out var uri) || uri.Scheme is not ("http" or "https")) {
-            errors.Add($"ServerUrl must be a valid http/https URL, got: {ServerUrl}");
+            errors.Add($"ServerUrl must be a valid http/https URL, got: {UnusableUrlDiagnostic.Sanitize(ServerUrl)}");
         }
 
         if (MaxConcurrentAgents < 1) {

--- a/src/Capacitor.Cli/Commands/AgentHookPoster.cs
+++ b/src/Capacitor.Cli/Commands/AgentHookPoster.cs
@@ -128,9 +128,10 @@ internal static class AgentHookPoster {
         // its existing tests keep exercising the real post logic. An unusable URL is routed into the
         // same "cannot post now" arm an auth lapse already uses: persist and let the caller continue.
         if (!HookHttp.IsPostable(baseUrl)) {
-            var spooled    = spool.Append(sessionId, route, body);
+            var spooled     = spool.Append(sessionId, route, body);
             var disposition = spooled ? $"{endpoint} spooled, not sent" : $"{endpoint} dropped (spool write failed)";
             Console.Error.WriteLine(UnusableUrlDiagnostic.Build(AppConfig.ResolvedUrlSource, baseUrl, disposition));
+
             return Task.FromResult(spooled ? HookPostOutcome.Spooled : HookPostOutcome.Skipped);
         }
 
@@ -163,6 +164,20 @@ internal static class AgentHookPoster {
     public static bool ShouldSpawnAfter(HookPostOutcome outcome, string? baseUrl) =>
         outcome is HookPostOutcome.Posted or HookPostOutcome.Spooled or HookPostOutcome.Skipped
      && HookHttp.IsPostable(baseUrl);
+
+
+    /// <summary>
+    /// Maps an append attempt onto an honest outcome. <c>Spooled</c> promises a later replay, so it
+    /// may only be reported when something was actually written; a rejected key or a disk fault is
+    /// <c>Skipped</c>, with a line saying the payload was lost.
+    /// </summary>
+    static HookPostOutcome SpoolOrSkip(HookSpool spool, string sessionId, string route, string body, string agentTag) {
+        if (spool.Append(sessionId, route, body)) return HookPostOutcome.Spooled;
+
+        Console.Error.WriteLine($"[kcap] {agentTag} {route}: dropped — the spool write failed");
+
+        return HookPostOutcome.Skipped;
+    }
 
     /// <summary>Minimum wall-clock gap between drain attempts (see <see cref="DrainSpoolsAsync"/>).</summary>
     static readonly TimeSpan DrainThrottle = TimeSpan.FromSeconds(30);
@@ -276,9 +291,7 @@ internal static class AgentHookPoster {
         using (client) {
             // Auth lapsed → the POST would 401. Spool for replay after `kcap login`; caller still spawns.
             if (IsAuthLapsed(status)) {
-                spool.Append(sessionId, route, body);
-
-                return HookPostOutcome.Spooled;
+                return SpoolOrSkip(spool, sessionId, route, body, agentTag);
             }
 
             using var content = new StringContent(body, Encoding.UTF8, "application/json");
@@ -294,9 +307,7 @@ internal static class AgentHookPoster {
 
                 // Transient (server down / rate-limit) → spool for retry; a permanent 4xx is a real failure.
                 if (code is >= 500 or 408 or 429) {
-                    spool.Append(sessionId, route, body);
-
-                    return HookPostOutcome.Spooled;
+                    return SpoolOrSkip(spool, sessionId, route, body, agentTag);
                 }
 
                 Console.Error.WriteLine($"[kcap] {agentTag} {endpoint}: HTTP {code}");
@@ -304,9 +315,7 @@ internal static class AgentHookPoster {
                 return HookPostOutcome.Failed;
             } catch (HttpRequestException) {
                 // Unreachable after retries → transient; spool for a later drain rather than lose it.
-                spool.Append(sessionId, route, body);
-
-                return HookPostOutcome.Spooled;
+                return SpoolOrSkip(spool, sessionId, route, body, agentTag);
             }
         }
     }

--- a/src/Capacitor.Cli/Commands/AgentHookPoster.cs
+++ b/src/Capacitor.Cli/Commands/AgentHookPoster.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.Cli.Commands;
 
@@ -27,7 +28,15 @@ internal enum HookPostOutcome {
     /// <summary>The POST could not be delivered now (auth lapsed or a transient/unreachable failure) so
     /// the payload was durably spooled for a later drain pass. NOT delivered — but the caller should still
     /// proceed to spawn the watcher (spawn-before-post): capture must not depend on lifecycle delivery.</summary>
-    Spooled
+    Spooled,
+
+    /// <summary>
+    /// Nothing was delivered AND nothing was persisted — the server URL is unusable, or the spool
+    /// append itself failed. Distinct from <see cref="Failed"/>, which every caller maps to a non-zero
+    /// exit; a hook must still exit 0 here. Distinct from <see cref="Spooled"/>, which promises a later
+    /// replay this outcome cannot.
+    /// </summary>
+    Skipped
 }
 
 /// <summary>
@@ -56,8 +65,16 @@ internal static class AgentHookPoster {
     /// to <c>{baseUrl}/hooks/{endpoint}</c>, skipping the POST when auth has lapsed.
     /// <paramref name="agentTag"/> is the stderr prefix on a real failure, e.g. <c>"codex-hook"</c>.
     /// </summary>
-    public static Task<HookPostOutcome> PostAsync(string baseUrl, string endpoint, string body, string agentTag)
-        => PostAsync(() => HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl), baseUrl, endpoint, body, agentTag);
+    public static Task<HookPostOutcome> PostAsync(string baseUrl, string endpoint, string body, string agentTag) {
+        // Guard BEFORE the factory closure is constructed. There is no spool on this path, so the
+        // payload is dropped — Skipped, never Failed, which every caller maps to a non-zero exit.
+        if (!HookHttp.IsPostable(baseUrl)) {
+            Console.Error.WriteLine(UnusableUrlDiagnostic.Build(AppConfig.ResolvedUrlSource, baseUrl, $"{endpoint} dropped, not sent"));
+            return Task.FromResult(HookPostOutcome.Skipped);
+        }
+
+        return PostAsync(() => HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl), baseUrl, endpoint, body, agentTag);
+    }
 
     /// <summary>
     /// Core with an injectable <paramref name="clientFactory"/> (test seam — lets tests control the
@@ -106,9 +123,20 @@ internal static class AgentHookPoster {
     /// </summary>
     public static Task<HookPostOutcome> PostOrSpoolAsync(
             string baseUrl, string endpoint, string body, string agentTag,
-            HookSpool spool, string sessionId, string route)
-        => PostOrSpoolAsync(() => HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl),
-                            baseUrl, endpoint, body, agentTag, spool, sessionId, route);
+            HookSpool spool, string sessionId, string route) {
+        // Guard BEFORE the factory closure is constructed, so the injectable core stays untouched and
+        // its existing tests keep exercising the real post logic. An unusable URL is routed into the
+        // same "cannot post now" arm an auth lapse already uses: persist and let the caller continue.
+        if (!HookHttp.IsPostable(baseUrl)) {
+            var spooled    = spool.Append(sessionId, route, body);
+            var disposition = spooled ? $"{endpoint} spooled, not sent" : $"{endpoint} dropped (spool write failed)";
+            Console.Error.WriteLine(UnusableUrlDiagnostic.Build(AppConfig.ResolvedUrlSource, baseUrl, disposition));
+            return Task.FromResult(spooled ? HookPostOutcome.Spooled : HookPostOutcome.Skipped);
+        }
+
+        return PostOrSpoolAsync(() => HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl),
+                                baseUrl, endpoint, body, agentTag, spool, sessionId, route);
+    }
 
     /// <summary>
     /// spawn-before-post decision. Capture must start regardless of whether the lifecycle
@@ -122,8 +150,19 @@ internal static class AgentHookPoster {
     /// which returns <c>Spooled</c> (never <c>AuthLapsed</c>) on a lapse — so capture-on-lapse is
     /// preserved for them via the spool, not via this predicate.
     /// </summary>
-    public static bool ShouldSpawnAfter(HookPostOutcome outcome) =>
-        outcome is HookPostOutcome.Posted or HookPostOutcome.Spooled;
+    /// <para><c>Skipped</c> DOES spawn when the URL is usable: the server supports a transcript
+    /// arriving before its session-start (<c>ActiveSessionRegistry.EnsureEntryExistsAsync</c> creates
+    /// the entry, owner-only until a later start reconciles it), so suppressing capture after a spool
+    /// write failure would guarantee loss the server is designed to recover.</para>
+    ///
+    /// <para>An unusable <paramref name="baseUrl"/> never spawns, whatever the outcome. A watcher
+    /// streams to SignalR and only spools an undelivered tail at shutdown, so one that can never
+    /// connect captures nothing — spawning it would write a PID file asserting capture that is not
+    /// happening. The URL is a parameter rather than a second conjunct at each call site so a caller
+    /// cannot forget it.</para>
+    public static bool ShouldSpawnAfter(HookPostOutcome outcome, string? baseUrl) =>
+        outcome is HookPostOutcome.Posted or HookPostOutcome.Spooled or HookPostOutcome.Skipped
+     && HookHttp.IsPostable(baseUrl);
 
     /// <summary>Minimum wall-clock gap between drain attempts (see <see cref="DrainSpoolsAsync"/>).</summary>
     static readonly TimeSpan DrainThrottle = TimeSpan.FromSeconds(30);
@@ -165,17 +204,29 @@ internal static class AgentHookPoster {
     /// Never throws — a spool-drain hiccup must not disrupt the vendor's own hook.
     /// </summary>
     public static async Task DrainSpoolsAsync(
-            string baseUrl, HookSpool lifecycle, TranscriptSpool transcript, string? sessionId) {
+            string baseUrl, HookSpool lifecycle, TranscriptSpool transcript, string? sessionId,
+            Func<CancellationToken, Task<(HttpClient Client, AuthStatus Status)>>? clientFactory = null) {
         if (!TryClaimDrainAttempt(lifecycle.Dir)) return; // throttled — a recent attempt already ran
 
+        // Retention runs even when delivery cannot: the reap lives here, and Program.cs skips this
+        // whole call while the URL is unacceptable, so an indefinitely broken config would otherwise
+        // never reap anything.
         lifecycle.ReapOlderThan(TimeSpan.FromDays(30));
         transcript.ReapOlderThan(TimeSpan.FromDays(30));
+
+        // Distinct from the POST guards' diagnostic: a reader must be able to tell which guard fired,
+        // and a test must be able to prove THIS one did.
+        if (!HookHttp.IsPostable(baseUrl)) {
+            Console.Error.WriteLine(UnusableUrlDiagnostic.Build(AppConfig.ResolvedUrlSource, baseUrl, "spool drain skipped (backlog retained)"));
+            return;
+        }
 
         var budget = TimeSpan.FromSeconds(1.5);
 
         try {
             using var cts = new CancellationTokenSource(budget);
-            var (client, status) = await HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl, cts.Token);
+            var factory = clientFactory ?? (ct => HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl, ct));
+            var (client, status) = await factory(cts.Token);
 
             using (client) {
                 if (IsAuthLapsed(status)) return;

--- a/src/Capacitor.Cli/Commands/AntigravityHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/AntigravityHookCommand.cs
@@ -155,7 +155,8 @@ static class AntigravityHookCommand {
 
     /// <summary>Test seam mirroring <see cref="AgentHookPoster.ShouldSpawnAfter"/> — capture must
     /// start on <c>Posted</c> OR <c>Spooled</c>, never gated behind lifecycle-POST delivery.</summary>
-    internal static bool SpawnGateForTest(HookPostOutcome o) => AgentHookPoster.ShouldSpawnAfter(o);
+    internal static bool SpawnGateForTest(HookPostOutcome o, string? baseUrl = "http://localhost:5108")
+        => AgentHookPoster.ShouldSpawnAfter(o, baseUrl);
 
     /// <summary>The event name — the first positional token after <c>--antigravity</c>.</summary>
     internal static string? EventArg(string[] args) {

--- a/src/Capacitor.Cli/Commands/AntigravityHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/AntigravityHookCommand.cs
@@ -139,7 +139,7 @@ static class AntigravityHookCommand {
 
         // Fail-open: a non-zero exit would surface as a failed hook; skip the watcher
         // this firing and let the next PreInvocation retry.
-        if (!SpawnGateForTest(outcome)) return 0;
+        if (!SpawnGateForTest(outcome, baseUrl)) return 0;
 
         // Watcher key = the dashless session id (kcap watch strips dashes too, so the pid
         // file + the spawned watcher's stream all agree). The dashed conversation id lives on
@@ -155,7 +155,7 @@ static class AntigravityHookCommand {
 
     /// <summary>Test seam mirroring <see cref="AgentHookPoster.ShouldSpawnAfter"/> — capture must
     /// start on <c>Posted</c> OR <c>Spooled</c>, never gated behind lifecycle-POST delivery.</summary>
-    internal static bool SpawnGateForTest(HookPostOutcome o, string? baseUrl = "http://localhost:5108")
+    internal static bool SpawnGateForTest(HookPostOutcome o, string? baseUrl)
         => AgentHookPoster.ShouldSpawnAfter(o, baseUrl);
 
     /// <summary>The event name — the first positional token after <c>--antigravity</c>.</summary>

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -76,11 +76,6 @@ public static class ClaudeHookCommand {
             var activeProfile = await AppConfig.GetActiveProfileAsync();
             if (await ShouldSuppressCaptureAsync(sessionId, body, command, activeProfile, processStart)) return 0;
 
-            if (!HookHttp.IsPostable(baseUrl)) {
-                await Console.Error.WriteLineAsync(
-                    UnusableUrlDiagnostic.Build(AppConfig.ResolvedUrlSource, baseUrl, $"{command ?? "hook"} spooled, not sent"));
-            }
-
             // Auth/client creation exceeded the hook budget (hung /auth/config or refresh during an
             // outage). The watcher and the spool need no client — start capture and persist the
             // lifecycle event so neither the transcript nor the session record is lost.
@@ -93,14 +88,24 @@ public static class ClaudeHookCommand {
                         agentId: null, cwd: cwd, skipTitle: isResumeOrCompact);
                 } catch { }
             }
+            // Report what the append ACTUALLY did, and only for events that are spoolable at all —
+            // announcing "spooled" ahead of the attempt would claim a replay that may never happen.
+            var unusableUrl = !HookHttp.IsPostable(baseUrl);
+            var reason      = unusableUrl ? "unusable server URL" : "auth/client creation exceeded hook budget";
+
             if (command is "session-start" or "session-end" && sessionId is not null) {
-                spool.Append(sessionId, command, NormalizeForSpool(body, command));
-                await Console.Error.WriteLineAsync($"[kcap] {command} spooled (auth/client creation exceeded hook budget); will retry on the next kcap hook ({sessionId})");
+                await ReportSpoolAsync(spool.Append(sessionId, command, NormalizeForSpool(body, command)),
+                                       command, sessionId, reason, unusableUrl, baseUrl);
             }
             else if (command == "subagent-stop" && sessionId is not null && agentId is not null) {
-                spool.Append(sessionId, "subagent-stop", NormalizeForSpool(body, command));
-                await Console.Error.WriteLineAsync($"[kcap] subagent-stop spooled (auth/client creation exceeded hook budget); will retry on the next kcap hook ({sessionId}/{agentId})");
+                await ReportSpoolAsync(spool.Append(sessionId, "subagent-stop", NormalizeForSpool(body, command)),
+                                       "subagent-stop", $"{sessionId}/{agentId}", reason, unusableUrl, baseUrl);
             }
+            else if (unusableUrl) {
+                await Console.Error.WriteLineAsync(
+                    UnusableUrlDiagnostic.Build(AppConfig.ResolvedUrlSource, baseUrl, $"{command ?? "hook"} dropped (not a spoolable event)"));
+            }
+
             return 0;
         }
 
@@ -189,6 +194,28 @@ public static class ClaudeHookCommand {
     /// because the exclusion check needs it for its remaining hook budget. Preserves the session-end
     /// marker cleanup, which a plain boolean would have dropped.</para>
     /// </summary>
+
+    /// <summary>
+    /// One honest line for a degraded-path spool attempt. An unusable URL routes through the shared
+    /// source-aware diagnostic (which names what to fix and never echoes the URL); a budget overrun
+    /// keeps its existing wording.
+    /// </summary>
+    static async Task ReportSpoolAsync(
+            bool spooled, string route, string key, string reason, bool unusableUrl, string? baseUrl) {
+        var disposition = spooled
+            ? $"{route} spooled, not sent ({key}); will retry on the next kcap hook"
+            : $"{route} dropped — the spool write failed ({key})";
+
+        if (unusableUrl) {
+            await Console.Error.WriteLineAsync(
+                UnusableUrlDiagnostic.Build(AppConfig.ResolvedUrlSource, baseUrl, disposition));
+
+            return;
+        }
+
+        await Console.Error.WriteLineAsync($"[kcap] {disposition} ({reason})");
+    }
+
     internal static async Task<bool> ShouldSuppressCaptureAsync(
             string? canonicalSessionId, string body, string? command, Profile? activeProfile, long processStart) {
         if (canonicalSessionId is not null && DisabledSessions.IsDisabled(canonicalSessionId)) {

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -62,9 +62,25 @@ public static class ClaudeHookCommand {
         } catch { }
 
         var clientCap = HookBudget.Remaining(processStart, command ?? "stop");
-        var created   = await CreateClientWithinBudgetAsync(clientFactory, clientCap);
+
+        // Skip client construction entirely for an unusable URL: the factory funnels into
+        // EnsureAbsolute, and this runs before ANY dispatch, so every Claude event would die here.
+        // Falling into the same degraded arm a client-creation timeout already uses keeps capture
+        // and the spool intact without inventing a second disposition.
+        var created = HookHttp.IsPostable(baseUrl)
+            ? await CreateClientWithinBudgetAsync(clientFactory, clientCap)
+            : null;
 
         if (created is null) {
+            // The degraded arm bypasses HandleCore, so its disabled/exclusion gates must run here.
+            var activeProfile = await AppConfig.GetActiveProfileAsync();
+            if (await ShouldSuppressCaptureAsync(sessionId, body, command, activeProfile, processStart)) return 0;
+
+            if (!HookHttp.IsPostable(baseUrl)) {
+                await Console.Error.WriteLineAsync(
+                    UnusableUrlDiagnostic.Build(AppConfig.ResolvedUrlSource, baseUrl, $"{command ?? "hook"} spooled, not sent"));
+            }
+
             // Auth/client creation exceeded the hook budget (hung /auth/config or refresh during an
             // outage). The watcher and the spool need no client — start capture and persist the
             // lifecycle event so neither the transcript nor the session record is lost.
@@ -160,6 +176,30 @@ public static class ClaudeHookCommand {
     // (caller should skip capture). The fallback repo detection is budgeted so a slow git/gh
     // probe can't blow the hook deadline; if it can't resolve in time we fail open to capturing
     // (the per-cwd cache makes subsequent sessions in an excluded repo resolve and exclude promptly).
+    /// <summary>
+    /// The disabled-session and repo/path exclusion gates, callable from the degraded path.
+    ///
+    /// <para>Both live inside <c>HandleCore</c>, which is reached only when a client was created. The
+    /// degraded branch spawns a watcher and spools without them — so routing an unusable URL there
+    /// unguarded would deterministically capture sessions the user ran `kcap disable` on, or repos
+    /// they excluded. That is a privacy regression a fix must not introduce.</para>
+    ///
+    /// <para>Takes the ALREADY-CANONICAL (dashless) session id: DisabledSessions looks a marker up by
+    /// filename with no normalization, while the raw payload id is still dashed. Takes processStart
+    /// because the exclusion check needs it for its remaining hook budget. Preserves the session-end
+    /// marker cleanup, which a plain boolean would have dropped.</para>
+    /// </summary>
+    internal static async Task<bool> ShouldSuppressCaptureAsync(
+            string? canonicalSessionId, string body, string? command, Profile? activeProfile, long processStart) {
+        if (canonicalSessionId is not null && DisabledSessions.IsDisabled(canonicalSessionId)) {
+            if (command == "session-end") DisabledSessions.RemoveMarker(canonicalSessionId);
+            return true;
+        }
+
+        return command is not null
+            && await IsSessionExcludedAsync(activeProfile, body, processStart, command);
+    }
+
     internal static async Task<bool> IsSessionExcludedAsync(Profile? profile, string body, long processStart, string command) {
         if (profile?.ExcludedRepos is { Length: > 0 } repos
          && await RepoExclusion.IsExcludedAsync(body, repos, HookBudget.Remaining(processStart, command))) {

--- a/src/Capacitor.Cli/Commands/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CodexHookCommand.cs
@@ -134,8 +134,7 @@ static class CodexHookCommand {
     /// Guards the process-exiting URL validation inside the authenticated-client helper (see the
     /// call-site comment): a blank or unacceptable URL must skip injection, never exit the hook.
     /// </summary>
-    internal static bool CanAttemptMemoryInjection(string? baseUrl)
-        => !string.IsNullOrWhiteSpace(baseUrl) && HttpClientExtensions.IsAcceptableUrl(baseUrl);
+    internal static bool CanAttemptMemoryInjection(string? baseUrl) => HookHttp.IsPostable(baseUrl);
 
     internal static Func<string?, CancellationToken, Task<HttpClient>> DefaultMemoryClientFactory(string baseUrl)
         => async (rejectedAccessToken, ct) => (await HttpClientExtensions.CreateClientWithAuthStatusAsync(

--- a/src/Capacitor.Cli/Commands/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CodexHookCommand.cs
@@ -450,7 +450,7 @@ static class CodexHookCommand {
 
         _ = AgentHookPoster.DrainSpoolsAsync(baseUrl, spool, transcriptSpool, sessionId);
 
-        if (!AgentHookPoster.ShouldSpawnAfter(outcome)) return Task.CompletedTask;
+        if (!AgentHookPoster.ShouldSpawnAfter(outcome, baseUrl)) return Task.CompletedTask;
 
         var transcript = TryGetString(enrichedNode, "transcript_path");
         var cwd        = TryGetString(enrichedNode, "cwd");

--- a/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CopilotHookCommand.cs
@@ -325,7 +325,7 @@ static class CopilotHookCommand {
         // there is no fragment, which keeps all pre-existing paths byte-identical.
         WriteSessionStartOutput(Console.Out, fragment);
 
-        if (!AgentHookPoster.ShouldSpawnAfter(outcome)) return 0;
+        if (!AgentHookPoster.ShouldSpawnAfter(outcome, baseUrl)) return 0;
 
         await EnsureWatcherAsync(baseUrl, dashedSessionId, sessionId, node, cwd);
         return 0;

--- a/src/Capacitor.Cli/Commands/CursorHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/CursorHookCommand.cs
@@ -82,6 +82,15 @@ public static class CursorHookCommand {
             return s;
         };
 
+        // At this point the event kind and session id are not yet parsed, so there is nothing to spool
+        // and no way to know which stdout contract to write. Match Cursor's own auth-abandon arm: no
+        // spool, no stdout, exit 0 — but still write the diagnostic, which needs only the URL.
+        if (!HookHttp.IsPostable(baseUrl)) {
+            await Console.Error.WriteLineAsync(
+                UnusableUrlDiagnostic.Build(AppConfig.ResolvedUrlSource, baseUrl, "cursor hook skipped"));
+            return 0;
+        }
+
         var sw = Stopwatch.StartNew();
         using var cts = new CancellationTokenSource(dispatcherBudget);
         HttpClient? client = null;

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -157,7 +157,7 @@ static class GeminiHookCommand {
     /// <summary>Test seam mirroring <see cref="AgentHookPoster.ShouldSpawnAfter"/> — session-start
     /// capture must start on <c>Posted</c> OR <c>Spooled</c>, never gated behind lifecycle-POST
     /// delivery.</summary>
-    internal static bool SpawnGateForTest(HookPostOutcome o, string? baseUrl = "http://localhost:5108")
+    internal static bool SpawnGateForTest(HookPostOutcome o, string? baseUrl)
         => AgentHookPoster.ShouldSpawnAfter(o, baseUrl);
 
     static async Task<int> HandleSessionEnd(string baseUrl, JsonNode node, string sessionId, string? cwd) {

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -146,7 +146,7 @@ static class GeminiHookCommand {
             baseUrl, "session-start/gemini", enriched, "gemini-hook",
             spool, sessionId, route: "session-start/gemini");
 
-        if (!AgentHookPoster.ShouldSpawnAfter(outcome)) return outcome == HookPostOutcome.Failed ? 1 : 0;
+        if (!AgentHookPoster.ShouldSpawnAfter(outcome, baseUrl)) return outcome == HookPostOutcome.Failed ? 1 : 0;
 
         // Task 6: await (was fire-and-forget) so a spawn failure is observed here rather
         // than silently swallowed, and the process isn't torn down before the spawn completes.
@@ -157,7 +157,8 @@ static class GeminiHookCommand {
     /// <summary>Test seam mirroring <see cref="AgentHookPoster.ShouldSpawnAfter"/> — session-start
     /// capture must start on <c>Posted</c> OR <c>Spooled</c>, never gated behind lifecycle-POST
     /// delivery.</summary>
-    internal static bool SpawnGateForTest(HookPostOutcome o) => AgentHookPoster.ShouldSpawnAfter(o);
+    internal static bool SpawnGateForTest(HookPostOutcome o, string? baseUrl = "http://localhost:5108")
+        => AgentHookPoster.ShouldSpawnAfter(o, baseUrl);
 
     static async Task<int> HandleSessionEnd(string baseUrl, JsonNode node, string sessionId, string? cwd) {
         var transcriptPath = TryGetString(node, "transcript_path");

--- a/src/Capacitor.Cli/Commands/KiroHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/KiroHookCommand.cs
@@ -275,9 +275,11 @@ static class KiroHookCommand {
         try {
             outcome = await postTask.WaitAsync(HookBudget.Remaining(processStart, "session-start"));
         } catch (TimeoutException) {
-            spool.Append(sessionId, "session-start/kiro", enriched);
-            // Spooled, not Failed: a drain pass will replay it, so capture must still start.
-            outcome = HookPostOutcome.Spooled;
+            // Spooled, not Failed: a drain pass will replay it, so capture must still start — but only
+            // claim that when the write actually landed.
+            outcome = spool.Append(sessionId, "session-start/kiro", enriched)
+                ? HookPostOutcome.Spooled
+                : HookPostOutcome.Skipped;
         }
 
         if (!AgentHookPoster.ShouldSpawnAfter(outcome, baseUrl)) return 0;

--- a/src/Capacitor.Cli/Commands/KiroHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/KiroHookCommand.cs
@@ -280,7 +280,7 @@ static class KiroHookCommand {
             outcome = HookPostOutcome.Spooled;
         }
 
-        if (!AgentHookPoster.ShouldSpawnAfter(outcome)) return 0;
+        if (!AgentHookPoster.ShouldSpawnAfter(outcome, baseUrl)) return 0;
 
         // The watcher tails Kiro's own append-only session log
         // ~/.kiro/sessions/cli/{id}.jsonl (the file is named with the dashed id).

--- a/src/Capacitor.Cli/Commands/McpJudgeServer.cs
+++ b/src/Capacitor.Cli/Commands/McpJudgeServer.cs
@@ -12,7 +12,12 @@ static class McpJudgeServer {
     /// Run as a session-scoped MCP server. All tool calls must use <paramref name="expectedSessionId"/>.
     /// </summary>
     public static async Task<int> RunAsync(string baseUrl, string expectedSessionId) {
-        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+        // Validate the shape locally, then defer client construction to the first tools/call —
+        // the shape every sibling MCP server already uses. Judge was the only one building its
+        // client up front, so an unusable URL reached EnsureAbsolute and killed the process
+        // BEFORE the JSON-RPC handshake, leaving the judge run to fail opaquely.
+        var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
+        HttpClient? client = null;
 
         var tools = BuildToolsList();
 
@@ -44,7 +49,7 @@ static class McpJudgeServer {
             var response = method switch {
                 "initialize" => BuildInitializeResponse(id, request),
                 "tools/list" => BuildToolsListResponse(id, tools),
-                "tools/call" => await HandleToolCallAsync(id, request, client, baseUrl, expectedSessionId),
+                "tools/call" => await DispatchToolCallAsync(id, request),
                 _            => McpProtocol.TryHandleStandardMethod(method, id)
                                 ?? BuildErrorResponse(id, -32601, $"Method not found: {method}")
             };
@@ -53,6 +58,15 @@ static class McpJudgeServer {
         }
 
         return 0;
+
+        // Report an unusable server_url as a JSON-RPC tool error rather than dying: a server is
+        // expected to keep serving, and the caller can see the reason.
+        async Task<string> DispatchToolCallAsync(JsonNode callId, JsonObject callRequest) {
+            if (!urlOk) return BuildToolResult(callId, HttpClientExtensions.SchemeMissingHint, isError: true);
+
+            client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
+            return await HandleToolCallAsync(callId, callRequest, client, baseUrl, expectedSessionId);
+        }
     }
 
     /// <summary>Test hook: execute a tool-call handler and return the JSON-RPC envelope.</summary>

--- a/src/Capacitor.Cli/Commands/McpJudgeServer.cs
+++ b/src/Capacitor.Cli/Commands/McpJudgeServer.cs
@@ -27,6 +27,7 @@ static class McpJudgeServer {
         await using var writer = new StreamWriter(stdout, new UTF8Encoding(false));
         writer.AutoFlush = true;
 
+        try {
         while (await reader.ReadLineAsync() is { } line) {
             if (string.IsNullOrWhiteSpace(line)) continue;
 
@@ -55,6 +56,10 @@ static class McpJudgeServer {
             };
 
             await writer.WriteLineAsync(response);
+        }
+        } finally {
+            // Deferring construction must not also defer disposal: the loop ends when stdin closes.
+            client?.Dispose();
         }
 
         return 0;

--- a/src/Capacitor.Cli/Commands/OpenCodeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/OpenCodeHookCommand.cs
@@ -119,7 +119,7 @@ static class OpenCodeHookCommand {
             baseUrl, "session-start/opencode", enriched, "opencode-hook",
             spool, sessionId, route: "session-start/opencode");
 
-        if (!AgentHookPoster.ShouldSpawnAfter(outcome)) return 0;
+        if (!AgentHookPoster.ShouldSpawnAfter(outcome, baseUrl)) return 0;
 
         await WatcherManager.EnsureWatcherRunning(
             baseUrl, sessionId, file,

--- a/src/Capacitor.Cli/Commands/PiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/PiHookCommand.cs
@@ -128,7 +128,7 @@ static class PiHookCommand {
             baseUrl, "session-start/pi", enriched, "pi-hook",
             spool, sessionId, route: "session-start/pi");
 
-        if (!AgentHookPoster.ShouldSpawnAfter(outcome)) return outcome == HookPostOutcome.Failed ? 1 : 0;
+        if (!AgentHookPoster.ShouldSpawnAfter(outcome, baseUrl)) return outcome == HookPostOutcome.Failed ? 1 : 0;
 
         await WatcherManager.EnsureWatcherRunning(
             baseUrl, sessionId, file,

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -182,6 +182,17 @@ static partial class WatchCommand {
             int?    parentPid = null,
             string  vendor    = "claude"
         ) {
+        // BEFORE the log redirection below: SignalR's WithUrl builds a Uri synchronously, so a
+        // relative value fails there — ahead of the connect/retry loop and independently of
+        // EnsureAbsolute — and `watch` is not fail-open, so the top-level catch turns that into an
+        // opaque exit 1. Validating here gives a hand-run watcher the actionable hint on the real
+        // stderr and the same exit 2 every interactive command gives; a few lines later Console.Error
+        // is a log file nobody is looking at.
+        if (!HookHttp.IsPostable(baseUrl)) {
+            Console.Error.WriteLine(HttpClientExtensions.SchemeMissingHint);
+            return 2;
+        }
+
         // Redirect all output to a log file so we don't hold parent's pipe FDs open
         var logDir = PathHelpers.ConfigPath("logs");
         Directory.CreateDirectory(logDir);
@@ -450,15 +461,6 @@ static partial class WatchCommand {
         }
 
         Log($"Watching {transcriptPath} for session {sessionId}" + (agentId is not null ? $" agent {agentId}" : ""));
-
-        // SignalR's WithUrl builds a Uri synchronously, so a relative value fails right here — before
-        // the connect/retry loop and independently of EnsureAbsolute. `watch` is not a fail-open
-        // command, so the top-level catch turns that into an opaque exit 1. Validate first so a
-        // hand-run watcher gets the actionable hint and the same exit 2 every interactive command gives.
-        if (!HookHttp.IsPostable(baseUrl)) {
-            Console.Error.WriteLine(HttpClientExtensions.SchemeMissingHint);
-            return 2;
-        }
 
         // Build SignalR hub connection
         var hubUrl = $"{baseUrl}/hubs/sessions";

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -451,6 +451,15 @@ static partial class WatchCommand {
 
         Log($"Watching {transcriptPath} for session {sessionId}" + (agentId is not null ? $" agent {agentId}" : ""));
 
+        // SignalR's WithUrl builds a Uri synchronously, so a relative value fails right here — before
+        // the connect/retry loop and independently of EnsureAbsolute. `watch` is not a fail-open
+        // command, so the top-level catch turns that into an opaque exit 1. Validate first so a
+        // hand-run watcher gets the actionable hint and the same exit 2 every interactive command gives.
+        if (!HookHttp.IsPostable(baseUrl)) {
+            Console.Error.WriteLine(HttpClientExtensions.SchemeMissingHint);
+            return 2;
+        }
+
         // Build SignalR hub connection
         var hubUrl = $"{baseUrl}/hubs/sessions";
 

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -58,6 +58,16 @@ if (Environment.GetEnvironmentVariable("KCAP_SKIP") is "1"
 
 var hookProcessStart = System.Diagnostics.Stopwatch.GetTimestamp();
 var isHook = command == "hook";
+
+// Agent-spawned commands owe an output contract, or must leave no orphaned child, so an unusable
+// server URL must not kill them mid-contract — EnsureAbsolute throws for them instead of exiting.
+// Interactive commands keep exiting 2 with the actionable hint, which is the right UX with a user
+// present. This covers the agent-spawned population only; it is not a claim that every reachable
+// URL consumer has been enumerated, and the explicit guards own what actually happens.
+ProcessUrlPolicy.Current = CrashReporter.IsFailOpenCommand(command)
+    ? UrlFailurePolicy.Throw
+    : UrlFailurePolicy.FailFast;
+
 var baseUrl = await AppConfig.ResolveServerUrl(args, gitTimeoutMs: isHook ? 1000 : 5000);
 
 // Fire-and-forget update check (prints hint to stderr after command finishes).

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -691,7 +691,10 @@ switch (command) {
         // own drain in the BACKGROUND, after satisfying its synchronous stdout contract.
         // Cross-process-throttled (~30s) and auth-gated inside DrainSpoolsAsync, so this adds no
         // per-invocation network cost beyond a disk stat on the vast majority of firings.
-        if (!args.Contains("--codex") && baseUrl is not null && HttpClientExtensions.IsAcceptableUrl(baseUrl)) {
+        // No acceptability conjunct here: DrainSpoolsAsync owns that decision, and it reaps both
+        // spools BEFORE returning. Gating the call would mean a config broken for weeks never reaps
+        // anything, and the per-session cap does not bound the number of stale files.
+        if (!args.Contains("--codex") && baseUrl is not null) {
             await AgentHookPoster.DrainSpoolsAsync(
                 baseUrl,
                 new HookSpool(PathHelpers.ConfigPath("spool")),

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryHookSupport.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryHookSupport.cs
@@ -22,10 +22,10 @@ internal static class SessionStartMemoryHookSupport {
     /// session — strictly worse than silently skipping an optional memory fragment.</para>
     ///
     /// <para>Deliberately the SAME predicate <c>EnsureAbsolute</c> itself uses, so this guard can
-    /// never disagree with the validator it exists to protect.</para>
+    /// never disagree with the validator it exists to protect. Single-sourced through
+    /// <see cref="HookHttp.IsPostable"/>.</para>
     /// </summary>
-    public static bool CanAttempt(string? baseUrl)
-        => !string.IsNullOrWhiteSpace(baseUrl) && HttpClientExtensions.IsAcceptableUrl(baseUrl);
+    public static bool CanAttempt(string? baseUrl) => HookHttp.IsPostable(baseUrl);
 
     /// <summary>
     /// The production memory-index client factory: authenticated, and honouring the provider's

--- a/src/Capacitor.Cli/WatcherManager.cs
+++ b/src/Capacitor.Cli/WatcherManager.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.Cli;
 
@@ -46,6 +47,23 @@ static class WatcherManager {
     /// anything. Always null in production.
     /// </summary>
     internal static Func<string, Task>? SpawnOverrideForTesting;
+
+    /// <summary>
+    /// Test seam for the ACTUAL <c>Process.Start</c> call inside <see cref="SpawnWatcher"/> and
+    /// <see cref="SpawnCopilotFinalizeDrain"/>. Distinct from <see cref="SpawnOverrideForTesting"/>,
+    /// which only <c>SpawnForKeyAsync</c> consults and so cannot observe those methods at all.
+    ///
+    /// <para>Needed because both call static <c>Process.Start</c> inside a catch-all, and the finalize
+    /// drain writes no marker — so "no child was left behind" is unfalsifiable: delete the URL guard
+    /// and the start merely throws or returns null in a test environment, leaving every observable
+    /// effect identical. Asserting zero invocations here is the only proof the guard ran.</para>
+    ///
+    /// <para>Always null in production.</para>
+    /// </summary>
+    internal static Func<ProcessStartInfo, Process?>? ProcessStarterForTesting;
+
+    static Process? StartProcess(ProcessStartInfo psi) =>
+        ProcessStarterForTesting is { } fake ? fake(psi) : Process.Start(psi);
 
     internal static string BuildSpawnArgs(
             string  key,
@@ -92,6 +110,15 @@ static class WatcherManager {
             bool    skipTitle         = false,
             string  vendor            = "claude"
         ) {
+        // Defence in depth: ShouldSpawnAfter already refuses for an unusable URL, but a caller that
+        // bypassed it would otherwise write a PID file asserting capture that cannot happen — a
+        // watcher streams to SignalR and can never connect here.
+        if (!HookHttp.IsPostable(baseUrl)) {
+            await Console.Error.WriteLineAsync(
+                UnusableUrlDiagnostic.Build(AppConfig.ResolvedUrlSource, baseUrl, $"watcher not started for {key}"));
+            return;
+        }
+
         try {
             var watcherDir = GetWatcherDir();
             Directory.CreateDirectory(watcherDir);
@@ -122,7 +149,7 @@ static class WatcherManager {
             // hanging synchronous subagent hooks and orphaning the watcher.
             ProcessHelpers.PreventInheritedStdHandles();
 
-            var process = Process.Start(psi);
+            var process = StartProcess(psi);
 
             if (process is null) {
                 await Console.Error.WriteLineAsync($"Failed to spawn watcher for {key}");
@@ -415,7 +442,7 @@ static class WatcherManager {
             // same pipe-leak hazard as the watcher spawn above.
             ProcessHelpers.PreventInheritedStdHandles();
 
-            var process = Process.Start(psi);
+            var process = StartProcess(psi);
 
             if (process is null) {
                 Console.Error.WriteLine($"Failed to spawn what's-done generator for {sessionId}");
@@ -446,6 +473,14 @@ static class WatcherManager {
     /// <see cref="SpawnWhatsDoneGenerator"/>.
     /// </summary>
     public static void SpawnCopilotFinalizeDrain(string baseUrl, string sessionId, string transcriptPath) {
+        // A detached child that would poll for up to 45s and then exit 2 on an unusable URL, leaving
+        // no marker any assertion could observe. Refuse to launch it at all.
+        if (!HookHttp.IsPostable(baseUrl)) {
+            Console.Error.WriteLine(
+                UnusableUrlDiagnostic.Build(AppConfig.ResolvedUrlSource, baseUrl, $"copilot finalize drain not started for {sessionId}"));
+            return;
+        }
+
         try {
             var kcapPath = Environment.ProcessPath ?? "kcap";
 
@@ -465,7 +500,7 @@ static class WatcherManager {
             // Windows — same pipe-leak hazard as the spawns above.
             ProcessHelpers.PreventInheritedStdHandles();
 
-            var process = Process.Start(psi);
+            var process = StartProcess(psi);
 
             if (process is null) {
                 Console.Error.WriteLine($"Failed to spawn copilot finalize drain for {sessionId}");
@@ -492,6 +527,14 @@ static class WatcherManager {
             string? agentId,
             string  vendor = "claude"
         ) {
+        // Runs on session-end BEFORE the lifecycle POST, and builds its client with no baseUrl — which
+        // re-resolves the same unusable value. The caller's preceding KillWatcher is unaffected.
+        if (!HookHttp.IsPostable(baseUrl)) {
+            await Console.Error.WriteLineAsync(
+                UnusableUrlDiagnostic.Build(AppConfig.ResolvedUrlSource, baseUrl, $"inline drain skipped for {sessionId}"));
+            return;
+        }
+
         try {
             using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
 

--- a/test/Capacitor.Cli.Tests.Integration/UnusableUrlHookMatrixTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/UnusableUrlHookMatrixTests.cs
@@ -116,10 +116,17 @@ public class UnusableUrlHookMatrixTests : IDisposable {
         await Assert.That(r.ExitCode).IsNotEqualTo(2);
     }
 
-    /// <summary>Negative control: interactive commands must keep failing fast.</summary>
+    /// <summary>
+    /// Negative control: interactive commands must keep failing fast.
+    ///
+    /// <para>The session id is passed EXPLICITLY. Without it, <c>recap</c> resolves one from ambient
+    /// state — so this passed locally (inside a coding-agent session) while exiting 1 on the usage
+    /// message in CI, never reaching the URL validation it exists to check. <c>RunAsync</c> also
+    /// clears the ambient variable so the result cannot depend on where the suite runs.</para>
+    /// </summary>
     [Test]
     public async Task Interactive_command_still_exits_2_with_the_hint() {
-        var r = await RunAsync(["recap"], "ftp://host", stdin: "");
+        var r = await RunAsync(["recap", "0123456789abcdef0123456789abcdef"], "ftp://host", stdin: "");
 
         await Assert.That(r.ExitCode).IsEqualTo(2);
         await Assert.That(r.Stderr).Contains("server_url is missing a scheme");
@@ -160,6 +167,8 @@ public class UnusableUrlHookMatrixTests : IDisposable {
                 ["KCAP_URL"]           = url,
                 ["KCAP_CONFIG_DIR"]    = _cfgDir,
                 ["KCAP_NO_UPDATE_CHECK"] = "1",
+                // Ambient session state must not decide what these cases exercise.
+                ["KCAP_SESSION_ID"]      = "",
             },
         };
 

--- a/test/Capacitor.Cli.Tests.Integration/UnusableUrlHookMatrixTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/UnusableUrlHookMatrixTests.cs
@@ -1,0 +1,203 @@
+using System.Diagnostics;
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// The acceptance criterion, end to end: a hook invoked with an unusable server URL still emits its
+/// required stdout contract and exits 0.
+///
+/// <para>Each case runs the REAL binary in an isolated child process with its own
+/// <c>KCAP_CONFIG_DIR</c>, because the in-process alternative cannot distinguish "the guard worked"
+/// from "the runner survived". Parameterized over every class <c>IsAcceptableUrl</c> rejects —
+/// including absolute wrong-scheme, which an implementation validating only <c>UriKind.Absolute</c>
+/// would wrongly accept.</para>
+///
+/// <para><b>Why the assertions look the way they do.</b> Asserting only stdout+exit is not enough:
+/// <c>Program.cs</c>'s top-level catch maps <c>hook</c> to exit 0, and Codex's own fail-open catch
+/// emits the identical <c>{"continue":true}</c>, so a surface-only assertion passes with every guard
+/// deleted. Each case therefore also asserts the positive, guard-specific diagnostic — a string only
+/// the guard emits — and rejects the fail-open fallback marker.</para>
+/// </summary>
+public class UnusableUrlHookMatrixTests : IDisposable {
+    // Every class IsAcceptableUrl rejects. Deliberately NOT the empty string: ProfileResolver ignores
+    // an exactly-empty KCAP_URL and falls back to the active profile, so it would test the wrong thing.
+    public static IEnumerable<string> UnusableUrls() => [
+        "   ",                  // whitespace
+        "localhost:5108",       // scheme-less
+        "/hooks/stop",          // relative
+        "ftp://host",           // absolute, wrong scheme
+        "file:///etc/passwd",   // absolute, wrong scheme
+    ];
+
+    readonly string _cfgDir = Path.Combine(Path.GetTempPath(), $"kcap-matrix-cfg-{Guid.NewGuid():N}");
+    readonly List<Process> _spawned = [];
+
+    public void Dispose() {
+        foreach (var p in _spawned) { try { if (!p.HasExited) p.Kill(entireProcessTree: true); } catch { } p.Dispose(); }
+        try { Directory.Delete(_cfgDir, true); } catch { }
+    }
+
+    [Test]
+    [MethodDataSource(nameof(UnusableUrls))]
+    public async Task Codex_SessionStart_emits_the_handshake_and_exits_zero(string url) {
+        var payload = new JsonObject {
+            ["hook_event_name"] = "SessionStart",
+            ["session_id"]      = Guid.NewGuid().ToString(),
+            ["cwd"]             = _cfgDir,
+        }.ToJsonString();
+
+        var r = await RunAsync(["hook", "--codex"], url, payload);
+
+        // Codex's parser rejects empty output; this is the contract the bug was breaking.
+        await Assert.That(r.Stdout).Contains("\"continue\":true");
+        await Assert.That(r.ExitCode).IsEqualTo(0);
+        // Positive proof the guard ran, not the top-level catch.
+        await Assert.That(r.Stderr).Contains("is not an absolute http(s) URL");
+        await Assert.That(r.Stderr).DoesNotContain("hook failed");
+    }
+
+    [Test]
+    [MethodDataSource(nameof(UnusableUrls))]
+    public async Task Codex_Stop_emits_the_handshake_and_exits_zero(string url) {
+        // Regression guard: this path was already fixed, and must stay fixed.
+        var payload = new JsonObject {
+            ["hook_event_name"] = "Stop",
+            ["session_id"]      = Guid.NewGuid().ToString(),
+        }.ToJsonString();
+
+        var r = await RunAsync(["hook", "--codex"], url, payload);
+
+        await Assert.That(r.Stdout).Contains("\"continue\":true");
+        await Assert.That(r.ExitCode).IsEqualTo(0);
+    }
+
+    [Test]
+    [MethodDataSource(nameof(UnusableUrls))]
+    public async Task Claude_SessionStart_exits_zero_without_a_hook_error(string url) {
+        // Claude tolerates empty stdout on SessionStart but treats a non-zero exit as a hook error,
+        // so exit 0 IS the contract here — the envelope is not required on the degraded path.
+        var payload = new JsonObject {
+            ["hook_event_name"] = "SessionStart",
+            ["session_id"]      = Guid.NewGuid().ToString(),
+            ["cwd"]             = _cfgDir,
+        }.ToJsonString();
+
+        var r = await RunAsync(["hook", "--claude"], url, payload);
+
+        await Assert.That(r.ExitCode).IsEqualTo(0);
+        await Assert.That(r.Stderr).Contains("is not an absolute http(s) URL");
+    }
+
+    [Test]
+    [MethodDataSource(nameof(UnusableUrls))]
+    public async Task Cursor_sessionStart_exits_zero(string url) {
+        var payload = new JsonObject {
+            ["hook_event_name"] = "sessionStart",
+            ["session_id"]      = Guid.NewGuid().ToString(),
+        }.ToJsonString();
+
+        var r = await RunAsync(["hook", "--cursor"], url, payload);
+
+        await Assert.That(r.ExitCode).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// The policy binding covers four agent-spawned commands, but a matrix that exercised only
+    /// `hook` would pass against an implementation hard-coded to `hook`.
+    /// </summary>
+    [Test]
+    [Arguments("generate-whats-done")]
+    [Arguments("set-title")]
+    public async Task Agent_spawned_commands_do_not_hard_exit(string command) {
+        var r = await RunAsync([command, Guid.NewGuid().ToString("N")], "ftp://host", stdin: "");
+
+        // FailFast would be exit 2 with the bare validator hint and no guard diagnostic.
+        await Assert.That(r.ExitCode).IsNotEqualTo(2);
+    }
+
+    /// <summary>Negative control: interactive commands must keep failing fast.</summary>
+    [Test]
+    public async Task Interactive_command_still_exits_2_with_the_hint() {
+        var r = await RunAsync(["recap"], "ftp://host", stdin: "");
+
+        await Assert.That(r.ExitCode).IsEqualTo(2);
+        await Assert.That(r.Stderr).Contains("server_url is missing a scheme");
+    }
+
+    /// <summary><c>kcap watch</c> run by hand: the actionable hint, not an opaque exit 1.</summary>
+    [Test]
+    public async Task Hand_run_watch_exits_2_with_the_hint() {
+        var transcript = Path.Combine(_cfgDir, "t.jsonl");
+        Directory.CreateDirectory(_cfgDir);
+        await File.WriteAllTextAsync(transcript, "");
+
+        var r = await RunAsync(["watch", Guid.NewGuid().ToString("N"), transcript], "localhost:5108", stdin: "");
+
+        await Assert.That(r.ExitCode).IsEqualTo(2);
+        await Assert.That(r.Stderr).Contains("server_url is missing a scheme");
+    }
+
+    async Task<(int ExitCode, string Stdout, string Stderr)> RunAsync(string[] args, string url, string stdin) {
+        var binary = GetCliBinaryPath();
+
+        if (!File.Exists(binary)) {
+            throw new FileNotFoundException(
+                $"kcap binary not found at {binary}. Build it first: dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj",
+                binary);
+        }
+
+        Directory.CreateDirectory(_cfgDir);
+
+        var psi = new ProcessStartInfo(binary) {
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+            CreateNoWindow         = true,
+            WorkingDirectory       = _cfgDir,
+            Environment = {
+                ["KCAP_URL"]           = url,
+                ["KCAP_CONFIG_DIR"]    = _cfgDir,
+                ["KCAP_NO_UPDATE_CHECK"] = "1",
+            },
+        };
+
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        var process = Process.Start(psi) ?? throw new InvalidOperationException("failed to start kcap");
+        _spawned.Add(process);
+
+        // A guarded hook legitimately returns before reading stdin — Cursor's guard fires before the
+        // payload is even parsed — so the child may have exited by the time we write. That closes the
+        // pipe, and the write throws. It is not a product failure and must not be reported as one.
+        try {
+            await process.StandardInput.WriteAsync(stdin);
+        } catch (IOException) {
+            // Child exited first; nothing to deliver.
+        } finally {
+            try { process.StandardInput.Close(); } catch (IOException) { }
+        }
+
+        var stdout = await process.StandardOutput.ReadToEndAsync();
+        var stderr = await process.StandardError.ReadToEndAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await process.WaitForExitAsync(cts.Token);
+
+        return (process.ExitCode, stdout, stderr);
+    }
+
+    static string GetCliBinaryPath() {
+        var asmDir      = Path.GetDirectoryName(typeof(UnusableUrlHookMatrixTests).Assembly.Location)!;
+        var binDir      = Path.GetDirectoryName(asmDir)!;
+        var config      = Path.GetFileName(binDir);
+        var testBin     = Path.GetDirectoryName(binDir)!;
+        var testProjDir = Path.GetDirectoryName(testBin)!;
+        var testRoot    = Path.GetDirectoryName(testProjDir)!;
+        var repoRoot    = Path.GetDirectoryName(testRoot)!;
+        var binaryName  = OperatingSystem.IsWindows() ? "kcap.exe" : "kcap";
+
+        return Path.Combine(repoRoot, "src", "Capacitor.Cli", "bin", config, "net10.0", binaryName);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit.NativeTestHost/Program.cs
+++ b/test/Capacitor.Cli.Tests.Unit.NativeTestHost/Program.cs
@@ -72,6 +72,27 @@ switch (mode) {
         }
         break;
     }
+    case "url-policy-failfast": {
+        // EnsureAbsolute's two branches cannot both be exercised in-process: one of them exits, which
+        // would take the test runner down with it. Default policy => hint on stderr, exit 2.
+        // Driven with an absolute wrong-scheme URL: an implementation checking only UriKind.Absolute
+        // would accept it, so this is the class that discriminates.
+        await Capacitor.Cli.Core.HttpClientExtensions.CreateClientWithAuthStatusAsync("ftp://host");
+        Console.Out.Write("NO-EXIT");
+        Console.Out.Flush();
+        break;
+    }
+    case "url-policy-throw": {
+        Capacitor.Cli.Core.ProcessUrlPolicy.Current = Capacitor.Cli.Core.UrlFailurePolicy.Throw;
+        try {
+            await Capacitor.Cli.Core.HttpClientExtensions.CreateClientWithAuthStatusAsync("ftp://host");
+            Console.Out.Write("NO-THROW");
+        } catch (Capacitor.Cli.Core.UnusableServerUrlException) {
+            Console.Out.Write("THREW");
+        }
+        Console.Out.Flush();
+        break;
+    }
     default:
         Console.Error.WriteLine($"unknown mode: {mode}");
         return 1;

--- a/test/Capacitor.Cli.Tests.Unit/AntigravitySpawnBeforePostTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravitySpawnBeforePostTests.cs
@@ -12,7 +12,14 @@ namespace Capacitor.Cli.Tests.Unit;
 public class AntigravitySpawnBeforePostTests {
     [Test]
     public async Task spooled_outcome_still_spawns_watcher() {
-        await Assert.That(AntigravityHookCommand.SpawnGateForTest(HookPostOutcome.Spooled)).IsTrue();
-        await Assert.That(AntigravityHookCommand.SpawnGateForTest(HookPostOutcome.Failed)).IsFalse();
+        await Assert.That(AntigravityHookCommand.SpawnGateForTest(HookPostOutcome.Spooled, "http://localhost:5108")).IsTrue();
+        await Assert.That(AntigravityHookCommand.SpawnGateForTest(HookPostOutcome.Failed, "http://localhost:5108")).IsFalse();
+    }
+
+    [Test]
+    public async Task Spawn_gate_refuses_an_unusable_url() {
+        // Pins that production passes a real URL through this gate: with a default value here the
+        // conjunct silently never fired for this vendor.
+        await Assert.That(AntigravityHookCommand.SpawnGateForTest(HookPostOutcome.Spooled, "ftp://host")).IsFalse();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/GeminiSpawnBeforePostTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiSpawnBeforePostTests.cs
@@ -12,8 +12,15 @@ namespace Capacitor.Cli.Tests.Unit;
 public class GeminiSpawnBeforePostTests {
     [Test]
     public async Task spooled_outcome_still_spawns_watcher() {
-        await Assert.That(GeminiHookCommand.SpawnGateForTest(HookPostOutcome.Posted)).IsTrue();
-        await Assert.That(GeminiHookCommand.SpawnGateForTest(HookPostOutcome.Spooled)).IsTrue();
-        await Assert.That(GeminiHookCommand.SpawnGateForTest(HookPostOutcome.Failed)).IsFalse();
+        await Assert.That(GeminiHookCommand.SpawnGateForTest(HookPostOutcome.Posted, "http://localhost:5108")).IsTrue();
+        await Assert.That(GeminiHookCommand.SpawnGateForTest(HookPostOutcome.Spooled, "http://localhost:5108")).IsTrue();
+        await Assert.That(GeminiHookCommand.SpawnGateForTest(HookPostOutcome.Failed, "http://localhost:5108")).IsFalse();
+    }
+
+    [Test]
+    public async Task Spawn_gate_refuses_an_unusable_url() {
+        // Pins that production passes a real URL through this gate: with a default value here the
+        // conjunct silently never fired for this vendor.
+        await Assert.That(GeminiHookCommand.SpawnGateForTest(HookPostOutcome.Spooled, "ftp://host")).IsFalse();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Http/HttpClientExtensionsAbsoluteUrlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Http/HttpClientExtensionsAbsoluteUrlTests.cs
@@ -1,4 +1,6 @@
+using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.SessionStartMemory;
 
 namespace Capacitor.Cli.Tests.Unit.Http;
 
@@ -26,5 +28,51 @@ public class HttpClientExtensionsAbsoluteUrlTests {
     [Arguments("javascript:alert(1)")]
     public async Task Rejects_NonHttpSchemes(string url) {
         await Assert.That(HttpClientExtensions.IsAcceptableUrl(url)).IsFalse();
+    }
+
+    /// <summary>
+    /// <see cref="HookHttp.IsPostable"/> is the single predicate every hook-path guard consults.
+    /// Covers all four unusable classes — whitespace, scheme-less, relative, and absolute
+    /// wrong-scheme. The last is named explicitly (<c>ftp://host</c>, <c>file:///etc/passwd</c>)
+    /// because an implementation validating only <c>UriKind.Absolute</c> would accept it.
+    /// </summary>
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments("localhost:5108")]
+    [Arguments("/relative")]
+    [Arguments("not a url at all")]
+    [Arguments("ftp://host")]
+    [Arguments("file:///etc/passwd")]
+    public async Task IsPostable_rejects_every_unusable_form(string? url) {
+        await Assert.That(HookHttp.IsPostable(url)).IsFalse();
+    }
+
+    [Test]
+    [Arguments("http://localhost:5108")]
+    [Arguments("https://kurrent.kcap.ai")]
+    public async Task IsPostable_accepts_absolute_http(string url) {
+        await Assert.That(HookHttp.IsPostable(url)).IsTrue();
+    }
+
+    /// <summary>
+    /// The two named guards that predate <see cref="HookHttp"/> must stay byte-identical to it.
+    /// They kept their names and their existing coverage but now delegate; this pins that they
+    /// cannot drift back apart.
+    /// </summary>
+    [Test]
+    [Arguments(null)]
+    [Arguments("   ")]
+    [Arguments("localhost:5108")]
+    [Arguments("/relative")]
+    [Arguments("ftp://host")]
+    [Arguments("http://localhost:5108")]
+    [Arguments("https://kurrent.kcap.ai")]
+    public async Task Delegating_predicates_agree_with_IsPostable(string? url) {
+        var expected = HookHttp.IsPostable(url);
+
+        await Assert.That(SessionStartMemoryHookSupport.CanAttempt(url)).IsEqualTo(expected);
+        await Assert.That(CodexHookCommand.CanAttemptMemoryInjection(url)).IsEqualTo(expected);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Http/ProcessUrlPolicyTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Http/ProcessUrlPolicyTests.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Http;
+
+/// <summary>
+/// Both branches of the URL failure policy, each in an isolated child process.
+///
+/// <para>This cannot be an in-process test: the <see cref="UrlFailurePolicy.FailFast"/> branch calls
+/// <c>Environment.Exit(2)</c>, which would terminate the test runner. The child host is the same
+/// mechanism the PDEATHSIG / FailFast tests use, for the same reason.</para>
+///
+/// <para>Both cases are driven with an absolute wrong-scheme URL (<c>ftp://host</c>) rather than a
+/// scheme-less one. That is the class that discriminates: an implementation validating only
+/// <c>UriKind.Absolute</c> accepts <c>ftp://host</c> while still violating the invariant.</para>
+/// </summary>
+public class ProcessUrlPolicyTests {
+    [Test]
+    public async Task FailFast_policy_prints_the_hint_and_exits_2() {
+        var (exit, stdout, stderr) = await RunHostAsync("url-policy-failfast");
+
+        await Assert.That(exit).IsEqualTo(2);
+        await Assert.That(stderr).Contains("server_url is missing a scheme");
+        // If the policy regressed to non-exiting, the host reaches its own marker instead.
+        await Assert.That(stdout).DoesNotContain("NO-EXIT");
+    }
+
+    [Test]
+    public async Task Throw_policy_raises_UnusableServerUrlException_without_exiting() {
+        var (exit, stdout, _) = await RunHostAsync("url-policy-throw");
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(stdout).IsEqualTo("THREW");
+    }
+
+    [Test]
+    public async Task Default_policy_is_FailFast() {
+        // Guards the default: flipping it would silently change every interactive command.
+        await Assert.That(ProcessUrlPolicy.Current).IsEqualTo(UrlFailurePolicy.FailFast);
+    }
+
+    static async Task<(int Exit, string Stdout, string Stderr)> RunHostAsync(string mode) {
+        var psi = new ProcessStartInfo("dotnet", $"\"{ResolveNativeHostDll()}\" {mode}") {
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+        };
+
+        using var host = Process.Start(psi) ?? throw new InvalidOperationException("failed to start NativeTestHost");
+
+        var stdout = await host.StandardOutput.ReadToEndAsync();
+        var stderr = await host.StandardError.ReadToEndAsync();
+        await host.WaitForExitAsync();
+
+        return (host.ExitCode, stdout, stderr);
+    }
+
+    // Sibling-project resolution, mirroring UnixSpawnerThreadTests.ResolveNativeHostDll.
+    static string ResolveNativeHostDll() {
+        var dir      = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+        var tfm      = Path.GetFileName(dir);
+        var config   = Path.GetFileName(Path.GetDirectoryName(dir)!);
+        var testRoot = Path.GetFullPath(Path.Combine(dir, "..", "..", "..", ".."));
+        var hostDll  = Path.Combine(testRoot, "Capacitor.Cli.Tests.Unit.NativeTestHost", "bin", config, tfm,
+            "Capacitor.Cli.Tests.Unit.NativeTestHost.dll");
+
+        if (!File.Exists(hostDll))
+            throw new InvalidOperationException($"NativeTestHost not built at {hostDll} — build Capacitor.slnx first");
+
+        return hostDll;
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlDiagnosticTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlDiagnosticTests.cs
@@ -1,0 +1,67 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Http;
+
+/// <summary>
+/// The one stderr line a guard writes. It must name the right thing to fix and must never echo the
+/// URL raw: a server_url can carry credentials, and an embedded newline would let it inject a
+/// fabricated line into a stream harnesses parse.
+/// </summary>
+public class UnusableUrlDiagnosticTests {
+    [Test]
+    public async Task Sanitize_drops_credentials() {
+        var s = UnusableUrlDiagnostic.Sanitize("user:sup3rs3cret@evil.example.com/path");
+
+        await Assert.That(s).DoesNotContain("sup3rs3cret");
+        await Assert.That(s).DoesNotContain("user:");
+        await Assert.That(s).Contains("evil.example.com");
+    }
+
+    [Test]
+    public async Task Sanitize_strips_control_characters_so_a_line_cannot_be_injected() {
+        var s = UnusableUrlDiagnostic.Sanitize("localhost:5108\r\n[kcap] everything is fine");
+
+        await Assert.That(s).DoesNotContain("\n");
+        await Assert.That(s).DoesNotContain("\r");
+        await Assert.That(s).DoesNotContain("");
+    }
+
+    [Test]
+    public async Task Sanitize_caps_length() {
+        var s = UnusableUrlDiagnostic.Sanitize("host" + new string('x', 5_000));
+
+        await Assert.That(s.Length).IsLessThanOrEqualTo(81); // 80 + the ellipsis
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments(null)]
+    public async Task Sanitize_renders_a_blank_url_without_throwing(string? url) {
+        await Assert.That(UnusableUrlDiagnostic.Sanitize(url)).IsEqualTo("(empty)");
+    }
+
+    /// <summary>
+    /// `kcap config set server_url` does NOT repair a malformed KCAP_URL or --server-url — both
+    /// outrank the profile — so a single fixed remediation string would be actively wrong for two of
+    /// the three sources named in the problem this fixes.
+    /// </summary>
+    [Test]
+    [Arguments(UrlSource.CommandLine, "--server-url")]
+    [Arguments(UrlSource.Environment, "KCAP_URL")]
+    [Arguments(UrlSource.Profile,     "kcap config set server_url")]
+    public async Task Build_names_the_source_specific_remediation(UrlSource source, string expected) {
+        var msg = UnusableUrlDiagnostic.Build(source, "localhost:5108", "session-start/codex spooled, not sent");
+
+        await Assert.That(msg).Contains(expected);
+        await Assert.That(msg).Contains("session-start/codex spooled, not sent");
+    }
+
+    [Test]
+    public async Task Build_never_leaks_the_raw_url() {
+        var msg = UnusableUrlDiagnostic.Build(UrlSource.Environment, "tok3n:s3cret@host\r\ninjected", "dropped");
+
+        await Assert.That(msg).DoesNotContain("s3cret");
+        await Assert.That(msg).DoesNotContain("injected\n");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlDiagnosticTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlDiagnosticTests.cs
@@ -17,6 +17,27 @@ public class UnusableUrlDiagnosticTests {
         await Assert.That(s).Contains("evil.example.com");
     }
 
+    /// <summary>
+    /// A URL whose userinfo ends at the '@' is exactly the malformed shape this path exists to
+    /// render, and it is the one an "is there anything after the @?" guard lets through intact.
+    /// </summary>
+    [Test]
+    [Arguments("https://user:sup3rs3cret@")]
+    [Arguments("user:sup3rs3cret@")]
+    [Arguments("sup3rs3cret@")]
+    public async Task Sanitize_drops_credentials_even_when_nothing_follows_the_at(string url) {
+        var s = UnusableUrlDiagnostic.Sanitize(url);
+
+        await Assert.That(s).DoesNotContain("sup3rs3cret");
+    }
+
+    [Test]
+    public async Task Build_drops_credentials_even_when_nothing_follows_the_at() {
+        var msg = UnusableUrlDiagnostic.Build(UrlSource.Profile, "https://user:sup3rs3cret@", "dropped");
+
+        await Assert.That(msg).DoesNotContain("sup3rs3cret");
+    }
+
     [Test]
     public async Task Sanitize_strips_control_characters_so_a_line_cannot_be_injected() {
         var s = UnusableUrlDiagnostic.Sanitize("localhost:5108\r\n[kcap] everything is fine");

--- a/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
@@ -130,4 +130,80 @@ public class UnusableUrlGuardTests : IDisposable {
 
         await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(2));
     }
+
+    [Test]
+    [Arguments("ses_A")]
+    [Arguments("SES_a")]
+    [Arguments("Mixed_Case_Id")]
+    public async Task Uppercase_non_guid_keys_are_rejected_rather_than_colliding(string sessionId) {
+        // The id is preserved byte-for-byte AND is the filename, so admitting both cases would let
+        // two distinct sessions address one file on macOS/Windows. Rejection is reported, not silent.
+        await Assert.That(new HookSpool(_dir).Append(sessionId, "session-start/opencode", "{}")).IsFalse();
+    }
+
+    [Test]
+    public async Task Legacy_uppercase_guid_keys_still_work() {
+        // Mixed case is fine for a 32-hex GUID: those are the same id either way.
+        await Assert.That(new HookSpool(_dir).Append("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "session-start/claude", "{}")).IsTrue();
+    }
+
+    /// <summary>
+    /// The gates live in HandleCore, which the degraded arm never reaches — without the extracted
+    /// helper an unusable URL would capture a session the user explicitly disabled.
+    ///
+    /// <para>Uses the process's REAL resolved config dir with a random id, because
+    /// <c>PathHelpers.ConfigDir</c> is a static readonly resolved at type load: setting
+    /// KCAP_CONFIG_DIR from inside a test has no effect. The marker is removed in a finally.</para>
+    /// </summary>
+    [Test]
+    public async Task Suppresses_a_disabled_session_given_a_dashed_payload_id() {
+        var dashed   = Guid.NewGuid().ToString();
+        var dashless = dashed.Replace("-", "");
+        var marker   = Path.Combine(PathHelpers.ConfigPath("disabled"), dashless);
+
+        Directory.CreateDirectory(PathHelpers.ConfigPath("disabled"));
+        File.WriteAllText(marker, "");
+
+        try {
+            // Dashed id in the payload, dashless marker on disk. DisabledSessions does no
+            // normalization, so passing the raw payload id straight through would miss it entirely.
+            var body = $$"""{"session_id":"{{dashed}}","hook_event_name":"SessionStart"}""";
+
+            await Assert.That(await ClaudeHookCommand.ShouldSuppressCaptureAsync(
+                dashless, body, "session-start", activeProfile: null, processStart: Stopwatch.GetTimestamp())).IsTrue();
+        } finally {
+            try { File.Delete(marker); } catch { }
+        }
+    }
+
+    [Test]
+    public async Task Session_end_suppression_also_clears_the_marker() {
+        var sid    = Guid.NewGuid().ToString("N");
+        var marker = Path.Combine(PathHelpers.ConfigPath("disabled"), sid);
+
+        Directory.CreateDirectory(PathHelpers.ConfigPath("disabled"));
+        File.WriteAllText(marker, "");
+
+        try {
+            var body = $$"""{"session_id":"{{sid}}","hook_event_name":"SessionEnd"}""";
+
+            await Assert.That(await ClaudeHookCommand.ShouldSuppressCaptureAsync(
+                sid, body, "session-end", activeProfile: null, processStart: Stopwatch.GetTimestamp())).IsTrue();
+
+            // Collapsing the gate into a plain boolean would have dropped this cleanup.
+            await Assert.That(File.Exists(marker)).IsFalse();
+        } finally {
+            try { File.Delete(marker); } catch { }
+        }
+    }
+
+    [Test]
+    public async Task Does_not_suppress_an_ordinary_session() {
+        // The negative control: without it, a helper that always returned true would pass above.
+        var sid  = Guid.NewGuid().ToString("N");
+        var body = $$"""{"session_id":"{{sid}}","hook_event_name":"SessionStart"}""";
+
+        await Assert.That(await ClaudeHookCommand.ShouldSuppressCaptureAsync(
+            sid, body, "session-start", activeProfile: null, processStart: Stopwatch.GetTimestamp())).IsFalse();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit.Http;
+
+/// <summary>
+/// The dispositions each guard owes when the server URL cannot be used.
+///
+/// <para>Where a guard sits in front of an injectable seam, the assertion is that the guarded
+/// operation was NEVER ENTERED — not that its effects are absent. Effects are reproducible by the
+/// catch-all every one of these paths already has, so an effect-only assertion passes with the guard
+/// deleted; six review rounds found exactly that, repeatedly.</para>
+/// </summary>
+public class UnusableUrlGuardTests : IDisposable {
+    // Deliberately the wrong-scheme class: an implementation validating only UriKind.Absolute
+    // accepts this while still violating the invariant.
+    const string BadUrl = "ftp://host";
+    const string Sid    = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    readonly string _dir  = Path.Combine(Path.GetTempPath(), $"kcap-guard-{Guid.NewGuid():N}");
+    readonly string _tdir = Path.Combine(Path.GetTempPath(), $"kcap-guard-t-{Guid.NewGuid():N}");
+
+    public void Dispose() {
+        WatcherManager.ProcessStarterForTesting = null;
+        foreach (var d in new[] { _dir, _tdir }) { try { Directory.Delete(d, true); } catch { } }
+    }
+
+    [Test]
+    public async Task PostOrSpool_spools_the_payload_and_reports_Spooled() {
+        var spool   = new HookSpool(_dir);
+        var outcome = await AgentHookPoster.PostOrSpoolAsync(
+            BadUrl, "session-start/codex", """{"session_id":"x"}""", "codex-hook", spool, Sid, "session-start/codex");
+
+        await Assert.That(outcome).IsEqualTo(HookPostOutcome.Spooled);
+        await Assert.That(spool.HasBacklog(Sid)).IsTrue();
+        await Assert.That(File.ReadAllText(Path.Combine(_dir, $"{Sid}.jsonl"))).Contains("session-start/codex");
+    }
+
+    [Test]
+    public async Task PostOrSpool_reports_Skipped_when_the_spool_write_itself_fails() {
+        // An unwritable spool dir must not be reported as durably spooled — Skipped promises nothing.
+        var unwritable = Path.Combine(_dir, "nope.txt");
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(unwritable, "not a directory");
+
+        var outcome = await AgentHookPoster.PostOrSpoolAsync(
+            BadUrl, "session-start/codex", "{}", "codex-hook", new HookSpool(unwritable), Sid, "session-start/codex");
+
+        await Assert.That(outcome).IsEqualTo(HookPostOutcome.Skipped);
+    }
+
+    [Test]
+    public async Task PostAsync_reports_Skipped_never_Failed() {
+        // Failed would make every caller exit non-zero — the hook must still exit 0.
+        var outcome = await AgentHookPoster.PostAsync(BadUrl, "session-end/gemini", "{}", "gemini-hook");
+
+        await Assert.That(outcome).IsEqualTo(HookPostOutcome.Skipped);
+        await Assert.That(outcome).IsNotEqualTo(HookPostOutcome.Failed);
+    }
+
+    [Test]
+    public async Task ShouldSpawn_refuses_for_an_unusable_url_whatever_the_outcome() {
+        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Posted,  BadUrl)).IsFalse();
+        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Spooled, BadUrl)).IsFalse();
+        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Skipped, BadUrl)).IsFalse();
+    }
+
+    [Test]
+    public async Task ShouldSpawn_allows_Skipped_when_the_url_is_usable() {
+        // The server supports a transcript arriving before its session-start, so suppressing capture
+        // after a spool write failure would guarantee loss it is designed to recover.
+        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Skipped, "http://localhost:5108")).IsTrue();
+        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Failed,  "http://localhost:5108")).IsFalse();
+    }
+
+    [Test]
+    public async Task Drain_reaps_the_backlog_but_never_builds_a_client() {
+        Directory.CreateDirectory(_dir);
+        var stale = Path.Combine(_dir, $"{Sid}.jsonl");
+        File.WriteAllText(stale, "{}\n");
+        File.SetLastWriteTimeUtc(stale, DateTime.UtcNow.AddDays(-40));
+
+        var entered = false;
+
+        await AgentHookPoster.DrainSpoolsAsync(
+            BadUrl, new HookSpool(_dir), new TranscriptSpool(_tdir), Sid,
+            clientFactory: _ => {
+                entered = true;
+                throw new InvalidOperationException("the drain guard did not run");
+            });
+
+        // Non-entry is the proof: the drain's own catch would otherwise hide an exception here.
+        await Assert.That(entered).IsFalse();
+        // Retention still runs — Program.cs skips this call entirely while the URL is bad, so a
+        // reap that lived only past the guard would never happen on a broken config.
+        await Assert.That(File.Exists(stale)).IsFalse();
+    }
+
+    [Test]
+    public async Task SpawnWatcher_never_starts_a_process() {
+        var starts = 0;
+        WatcherManager.ProcessStarterForTesting = _ => { starts++; return null; };
+
+        await WatcherManager.SpawnWatcher(BadUrl, Sid, Path.Combine(_dir, "t.jsonl"), agentId: null);
+
+        await Assert.That(starts).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SpawnCopilotFinalizeDrain_never_starts_a_process() {
+        // This one writes no marker at all, so "no child left behind" is unfalsifiable — a deleted
+        // guard merely lets Process.Start throw or return null, leaving every effect identical.
+        var starts = 0;
+        WatcherManager.ProcessStarterForTesting = _ => { starts++; return null; };
+
+        WatcherManager.SpawnCopilotFinalizeDrain(BadUrl, Sid, Path.Combine(_dir, "t.jsonl"));
+
+        await Assert.That(starts).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task InlineDrain_returns_without_building_a_client() {
+        // Runs on session-end BEFORE the lifecycle POST; its own client takes no baseUrl and
+        // re-resolves the same unusable value. Completing quickly is the observable: an unguarded
+        // call would exit the process outright.
+        var sw = Stopwatch.StartNew();
+        await WatcherManager.InlineDrainAsync(BadUrl, Sid, Path.Combine(_dir, "t.jsonl"), agentId: null);
+
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(2));
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
@@ -132,19 +132,14 @@ public class UnusableUrlGuardTests : IDisposable {
     }
 
     [Test]
-    [Arguments("ses_A")]
-    [Arguments("SES_a")]
-    [Arguments("Mixed_Case_Id")]
-    public async Task Uppercase_non_guid_keys_are_rejected_rather_than_colliding(string sessionId) {
-        // The id is preserved byte-for-byte AND is the filename, so admitting both cases would let
-        // two distinct sessions address one file on macOS/Windows. Rejection is reported, not silent.
-        await Assert.That(new HookSpool(_dir).Append(sessionId, "session-start/opencode", "{}")).IsFalse();
-    }
-
-    [Test]
-    public async Task Legacy_uppercase_guid_keys_still_work() {
-        // Mixed case is fine for a 32-hex GUID: those are the same id either way.
-        await Assert.That(new HookSpool(_dir).Append("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "session-start/claude", "{}")).IsTrue();
+    [Arguments("ses_619a78374ffe7o0x1iTK74jFRg")]
+    [Arguments("ses_ABCDEF")]
+    [Arguments("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]
+    public async Task Mixed_case_vendor_ids_are_accepted(string sessionId) {
+        // OpenCode ids are base62 and genuinely mixed case; rejecting them would lose the session
+        // outright. Case safety on the filesystem is handled by escaping the filename, not by
+        // narrowing what is admitted.
+        await Assert.That(new HookSpool(_dir).Append(sessionId, "session-start/opencode", "{}")).IsTrue();
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
@@ -121,14 +121,21 @@ public class UnusableUrlGuardTests : IDisposable {
     }
 
     [Test]
-    public async Task InlineDrain_returns_without_building_a_client() {
-        // Runs on session-end BEFORE the lifecycle POST; its own client takes no baseUrl and
-        // re-resolves the same unusable value. Completing quickly is the observable: an unguarded
-        // call would exit the process outright.
-        var sw = Stopwatch.StartNew();
-        await WatcherManager.InlineDrainAsync(BadUrl, Sid, Path.Combine(_dir, "t.jsonl"), agentId: null);
+    public async Task InlineDrain_emits_its_own_guard_diagnostic() {
+        // A stopwatch assertion here was vacuous: the unguarded path can also return quickly. The
+        // proof is the diagnostic, which only this guard emits — distinct from the POST guard's and
+        // from the drain guard's, so it cannot be satisfied by a neighbouring path.
+        var captured = new StringWriter();
+        var prior    = Console.Error;
+        Console.SetError(captured);
 
-        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(2));
+        try {
+            await WatcherManager.InlineDrainAsync(BadUrl, Sid, Path.Combine(_dir, "t.jsonl"), agentId: null);
+        } finally {
+            Console.SetError(prior);
+        }
+
+        await Assert.That(captured.ToString()).Contains($"inline drain skipped for {Sid}");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/LiveWatchHardeningAcceptanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LiveWatchHardeningAcceptanceTests.cs
@@ -88,8 +88,8 @@ public class LiveWatchHardeningAcceptanceTests {
 
         // Task 6's actual regressions: each vendor's own bespoke gate must agree with the shared
         // predicate, not just re-derive it independently.
-        await Assert.That(AntigravityHookCommand.SpawnGateForTest(HookPostOutcome.Spooled)).IsTrue();
-        await Assert.That(GeminiHookCommand.SpawnGateForTest(HookPostOutcome.Spooled)).IsTrue();
+        await Assert.That(AntigravityHookCommand.SpawnGateForTest(HookPostOutcome.Spooled, "http://localhost:1")).IsTrue();
+        await Assert.That(GeminiHookCommand.SpawnGateForTest(HookPostOutcome.Spooled, "http://localhost:1")).IsTrue();
     }
 
     // ── 2. Codex stdout-first, proven against a real large/unreachable spool backlog ─────────

--- a/test/Capacitor.Cli.Tests.Unit/LiveWatchHardeningAcceptanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LiveWatchHardeningAcceptanceTests.cs
@@ -81,7 +81,7 @@ public class LiveWatchHardeningAcceptanceTests {
                     agentTag: route, spool, sessionId, route);
 
                 await Assert.That(outcome).IsEqualTo(HookPostOutcome.Spooled);
-                await Assert.That(AgentHookPoster.ShouldSpawnAfter(outcome)).IsTrue();
+                await Assert.That(AgentHookPoster.ShouldSpawnAfter(outcome, "http://localhost:1")).IsTrue();
                 await Assert.That(spool.HasBacklog(sessionId)).IsTrue(); // capture-on-lapse via the spool
             } finally { try { Directory.Delete(dir, true); } catch { } }
         }

--- a/test/Capacitor.Cli.Tests.Unit/SpawnBeforePostTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SpawnBeforePostTests.cs
@@ -10,11 +10,11 @@ namespace Capacitor.Cli.Tests.Unit;
 public class SpawnBeforePostTests {
     [Test]
     public async Task spawn_after_posted_or_spooled_only() {
-        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Posted)).IsTrue();
-        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Spooled)).IsTrue();
+        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Posted, "http://localhost:5108")).IsTrue();
+        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Spooled, "http://localhost:5108")).IsTrue();
         // AuthLapsed (legacy PostAsync path) spools NOTHING, so spawning there would tail a session
         // whose SessionStarted was permanently dropped — must NOT spawn.
-        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.AuthLapsed)).IsFalse();
-        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Failed)).IsFalse();
+        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.AuthLapsed, "http://localhost:5108")).IsFalse();
+        await Assert.That(AgentHookPoster.ShouldSpawnAfter(HookPostOutcome.Failed, "http://localhost:5108")).IsFalse();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Spool/SpoolKeyWideningTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Spool/SpoolKeyWideningTests.cs
@@ -1,0 +1,86 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Spool;
+
+/// <summary>
+/// The spool key is WIDENED, not hashed. The filename IS the session id —
+/// <c>LifecycleSpoolDrain</c> posts it verbatim as <c>session_id</c> for
+/// <c>session-needs-import</c> — so hashing would put a fabricated id on the wire.
+///
+/// <para>The old dashless-GUID form silently dropped every OpenCode payload (<c>ses_…</c>), for both
+/// the lifecycle and transcript spools: <c>Append</c> returned void, so the caller reported "spooled"
+/// while nothing was written.</para>
+/// </summary>
+public class SpoolKeyWideningTests : IDisposable {
+    // A real OpenCode id shape: never 32 hex, with or without dash-stripping.
+    const string OpenCodeId = "ses_7f3a9c21b8";
+
+    readonly string _dir  = Path.Combine(Path.GetTempPath(), $"kcap-widen-{Guid.NewGuid():N}");
+    readonly string _tdir = Path.Combine(Path.GetTempPath(), $"kcap-widen-t-{Guid.NewGuid():N}");
+
+    public void Dispose() {
+        foreach (var d in new[] { _dir, _tdir }) { try { Directory.Delete(d, true); } catch { } }
+    }
+
+    [Test]
+    public async Task Lifecycle_basename_is_the_raw_id_not_a_digest() {
+        var spool = new HookSpool(_dir);
+
+        await Assert.That(spool.Append(OpenCodeId, "session-start/opencode", """{"session_id":"ses_7f3a9c21b8"}""")).IsTrue();
+        // The exact basename, which is what discriminates widening from hashing — a hashing
+        // implementation would also keep the raw id inside the payload.
+        await Assert.That(File.Exists(Path.Combine(_dir, $"{OpenCodeId}.jsonl"))).IsTrue();
+        await Assert.That(spool.HasBacklog(OpenCodeId)).IsTrue();
+    }
+
+    [Test]
+    public async Task Transcript_basename_is_the_raw_id() {
+        var transcript = new TranscriptSpool(_tdir);
+
+        transcript.Append(OpenCodeId, """{"line":1}""");
+
+        await Assert.That(transcript.HasBacklog(OpenCodeId)).IsTrue();
+    }
+
+    [Test]
+    public async Task Append_reports_failure_instead_of_silently_dropping() {
+        // A path that cannot be a directory: the write must be reported, not swallowed.
+        var blocked = Path.Combine(_dir, "blocker");
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(blocked, "not a directory");
+
+        await Assert.That(new HookSpool(blocked).Append(OpenCodeId, "session-start/opencode", "{}")).IsFalse();
+    }
+
+    [Test]
+    [Arguments("ses_7f3a9c21b8")]
+    [Arguments("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")] // the pre-existing dashless-GUID form still works
+    [Arguments("a-b_c-123")]
+    public async Task Widened_keys_survive_a_drain_round_trip(string sessionId) {
+        var spool = new HookSpool(_dir);
+        spool.Append(sessionId, "session-start/opencode", $$"""{"session_id":"{{sessionId}}"}""");
+
+        var delivered = new List<(string Route, string Body)>();
+
+        await spool.DrainAllAsync(
+            currentSessionId: sessionId,
+            poster: (route, body) => { delivered.Add((route, body)); return Task.FromResult(DrainOutcome.Delivered); },
+            budget: TimeSpan.FromSeconds(5),
+            ct: CancellationToken.None);
+
+        await Assert.That(delivered.Count).IsEqualTo(1);
+        await Assert.That(delivered[0].Route).IsEqualTo("session-start/opencode");
+        // The id on the wire is the original, never a derived key.
+        await Assert.That(delivered[0].Body).Contains(sessionId);
+        await Assert.That(spool.HasBacklog(sessionId)).IsFalse();
+    }
+
+    [Test]
+    [Arguments("has.a.dot")]     // '.' is the field separator in {sid}.{pid}-{seq}.draining
+    [Arguments("has/slash")]     // path traversal
+    [Arguments("has\\backslash")]
+    [Arguments("")]
+    public async Task Keys_that_would_break_path_parsing_are_still_rejected(string sessionId) {
+        await Assert.That(new HookSpool(_dir).Append(sessionId, "session-start/opencode", "{}")).IsFalse();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Spool/SpoolKeyWideningTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Spool/SpoolKeyWideningTests.cs
@@ -144,4 +144,59 @@ public class SpoolKeyWideningTests : IDisposable {
         await Assert.That(posted).IsNotNull();
         await Assert.That(posted!).Contains(sessionId);
     }
+
+    /// <summary>
+    /// Upgrade safety. These files are written RAW, exactly as a pre-upgrade kcap left them —
+    /// creating them through <c>Append</c> would run the new encoder and never reach this shape.
+    /// A dashless GUID must therefore keep its historical filename: two hex spellings differing only
+    /// by case are the same id, so they need no escaping and must not be renamed out from under a
+    /// running install.
+    /// </summary>
+    [Test]
+    [Arguments("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]
+    [Arguments("aAbBcCdDeEfF00112233445566778899")]
+    [Arguments("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+    public async Task A_legacy_raw_spool_file_is_still_found_and_drained(string legacyId) {
+        Directory.CreateDirectory(_dir);
+        var legacyPath = Path.Combine(_dir, $"{legacyId}.jsonl");
+        File.WriteAllText(legacyPath,
+            $$"""{"route":"session-start/claude","body":"{\"session_id\":\"{{legacyId}}\"}"}""" + "\n");
+
+        var spool = new HookSpool(_dir);
+
+        // Found by the id-keyed lookup...
+        await Assert.That(spool.HasBacklog(legacyId)).IsTrue();
+
+        // ...and by the directory sweep, which must hand back the id the file was named with.
+        string? posted = null;
+        await spool.DrainAllAsync(
+            currentSessionId: null,
+            poster: (_, body) => { posted = body; return Task.FromResult(DrainOutcome.Delivered); },
+            budget: TimeSpan.FromSeconds(5),
+            ct: CancellationToken.None);
+
+        await Assert.That(posted).IsNotNull();
+        await Assert.That(posted!).Contains(legacyId);
+        await Assert.That(File.Exists(legacyPath)).IsFalse(); // consumed, not stranded
+    }
+
+    [Test]
+    public async Task A_legacy_raw_ended_marker_is_still_honoured() {
+        // If the marker were invisible the drain would forget a terminal event had been delivered and
+        // let a straggler through after session end.
+        const string legacyId = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path.Combine(_dir, $".ended-{legacyId}"), "");
+
+        await Assert.That(new HookSpool(_dir).IsMarkedEnded(legacyId)).IsTrue();
+    }
+
+    [Test]
+    public async Task A_legacy_raw_transcript_file_is_still_found() {
+        const string legacyId = "aAbBcCdDeEfF00112233445566778899";
+        Directory.CreateDirectory(_tdir);
+        File.WriteAllText(Path.Combine(_tdir, $"{legacyId}.transcript.jsonl"), "{\"n\":1}\n");
+
+        await Assert.That(new TranscriptSpool(_tdir).HasBacklog(legacyId)).IsTrue();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Spool/SpoolKeyWideningTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Spool/SpoolKeyWideningTests.cs
@@ -12,8 +12,10 @@ namespace Capacitor.Cli.Tests.Unit.Spool;
 /// while nothing was written.</para>
 /// </summary>
 public class SpoolKeyWideningTests : IDisposable {
-    // A real OpenCode id shape: never 32 hex, with or without dash-stripping.
-    const string OpenCodeId = "ses_7f3a9c21b8";
+    // A REAL OpenCode id: its generator appends a base62 suffix, so ids are MIXED CASE. An earlier
+    // version of this test invented a lowercase-only value, which masked a fix that would have
+    // rejected almost every genuine OpenCode session.
+    const string OpenCodeId = "ses_619a78374ffe7o0x1iTK74jFRg";
 
     readonly string _dir  = Path.Combine(Path.GetTempPath(), $"kcap-widen-{Guid.NewGuid():N}");
     readonly string _tdir = Path.Combine(Path.GetTempPath(), $"kcap-widen-t-{Guid.NewGuid():N}");
@@ -23,13 +25,20 @@ public class SpoolKeyWideningTests : IDisposable {
     }
 
     [Test]
-    public async Task Lifecycle_basename_is_the_raw_id_not_a_digest() {
+    public async Task Lifecycle_filename_is_a_reversible_escape_not_a_digest() {
         var spool = new HookSpool(_dir);
 
-        await Assert.That(spool.Append(OpenCodeId, "session-start/opencode", """{"session_id":"ses_7f3a9c21b8"}""")).IsTrue();
-        // The exact basename, which is what discriminates widening from hashing — a hashing
-        // implementation would also keep the raw id inside the payload.
-        await Assert.That(File.Exists(Path.Combine(_dir, $"{OpenCodeId}.jsonl"))).IsTrue();
+        await Assert.That(spool.Append(OpenCodeId, "session-start/opencode", """{"session_id":"x"}""")).IsTrue();
+
+        var files = Directory.GetFiles(_dir, "*.jsonl");
+        await Assert.That(files.Length).IsEqualTo(1);
+
+        var basename = Path.GetFileNameWithoutExtension(files[0]);
+
+        // Single-cased for filesystem safety, but every original character is still recoverable —
+        // a digest would lose the id, and the drain posts it back as session_id.
+        await Assert.That(basename).IsEqualTo(basename.ToLowerInvariant());
+        await Assert.That(basename.Replace("~", "")).IsEqualTo(OpenCodeId.ToLowerInvariant());
         await Assert.That(spool.HasBacklog(OpenCodeId)).IsTrue();
     }
 
@@ -53,8 +62,10 @@ public class SpoolKeyWideningTests : IDisposable {
     }
 
     [Test]
-    [Arguments("ses_7f3a9c21b8")]
-    [Arguments("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")] // the pre-existing dashless-GUID form still works
+    [Arguments("ses_619a78374ffe7o0x1iTK74jFRg")]      // real, mixed-case
+    [Arguments("ses_ABCDEF")]                           // all-uppercase suffix
+    [Arguments("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]     // the pre-existing dashless-GUID form
+    [Arguments("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]     // and its uppercase spelling
     [Arguments("a-b_c-123")]
     public async Task Widened_keys_survive_a_drain_round_trip(string sessionId) {
         var spool = new HookSpool(_dir);
@@ -82,5 +93,55 @@ public class SpoolKeyWideningTests : IDisposable {
     [Arguments("")]
     public async Task Keys_that_would_break_path_parsing_are_still_rejected(string sessionId) {
         await Assert.That(new HookSpool(_dir).Append(sessionId, "session-start/opencode", "{}")).IsFalse();
+    }
+
+    /// <summary>
+    /// Two ids differing ONLY by case are distinct sessions and must not share a file. The filename
+    /// is escaped into a single case for exactly this reason — on macOS/Windows the raw ids would
+    /// collide, interleaving one session's payloads into the other's spool.
+    /// </summary>
+    [Test]
+    public async Task Ids_differing_only_by_case_do_not_share_a_spool_file() {
+        var spool = new HookSpool(_dir);
+
+        await Assert.That(spool.Append("ses_aBcD", "session-start/opencode", """{"which":"lower"}""")).IsTrue();
+        await Assert.That(spool.Append("ses_AbCd", "session-start/opencode", """{"which":"upper"}""")).IsTrue();
+
+        // Two distinct files on disk — on a case-insensitive filesystem the raw ids would be one.
+        var files = Directory.GetFiles(_dir, "*.jsonl");
+        await Assert.That(files.Length).IsEqualTo(2);
+
+        // And neither file holds the other session's payload.
+        foreach (var f in files) {
+            var text = File.ReadAllText(f);
+            await Assert.That(text.Contains("lower") && text.Contains("upper")).IsFalse();
+        }
+
+        await Assert.That(spool.HasBacklog("ses_aBcD")).IsTrue();
+        await Assert.That(spool.HasBacklog("ses_AbCd")).IsTrue();
+    }
+
+    /// <summary>
+    /// The escape is reversible: the drain posts the DECODED id, so a lossy transform would put a
+    /// fabricated session_id on the wire.
+    /// </summary>
+    [Test]
+    [Arguments("ses_619a78374ffe7o0x1iTK74jFRg")]
+    [Arguments("ses_ABCDEF")]
+    [Arguments("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+    public async Task The_drained_session_id_is_the_original_byte_for_byte(string sessionId) {
+        var spool = new HookSpool(_dir);
+        spool.Append(sessionId, "session-start/opencode", $$"""{"session_id":"{{sessionId}}"}""");
+
+        string? posted = null;
+
+        await spool.DrainAllAsync(
+            currentSessionId: null,
+            poster: (_, body) => { posted = body; return Task.FromResult(DrainOutcome.Delivered); },
+            budget: TimeSpan.FromSeconds(5),
+            ct: CancellationToken.None);
+
+        await Assert.That(posted).IsNotNull();
+        await Assert.That(posted!).Contains(sessionId);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/TranscriptSpoolTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TranscriptSpoolTests.cs
@@ -49,13 +49,39 @@ public class TranscriptSpoolTests {
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 
+    /// <summary>
+    /// The key must stay filename-safe: it becomes the basename, and the drain parses the prefix
+    /// before the first dot. Anything carrying a separator is still rejected.
+    /// </summary>
     [Test]
-    public async Task Append_ignores_malformed_session_id() {
+    [Arguments("has.a.dot")]
+    [Arguments("has/slash")]
+    [Arguments("has\\backslash")]
+    [Arguments("")]
+    public async Task Append_ignores_a_session_id_that_would_break_path_parsing(string sessionId) {
         var dir = TmpDir();
         try {
             var spool = new TranscriptSpool(dir);
-            var r = spool.Append("not-a-valid-sid", """{"n":1}""");
+            var r = spool.Append(sessionId, """{"n":1}""");
             await Assert.That(r).IsEqualTo(TranscriptSpool.AppendResult.Ignored);
+        } finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    /// <summary>
+    /// Vendor ids that are not dashless GUIDs are accepted. The old 32-hex-only rule silently
+    /// dropped every OpenCode payload, so its transcript spool never held anything.
+    /// </summary>
+    [Test]
+    [Arguments("ses_7f3a9c21b8")]
+    [Arguments("not-a-valid-sid")]
+    [Arguments("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+    public async Task Append_accepts_any_filename_safe_session_id(string sessionId) {
+        var dir = TmpDir();
+        try {
+            var spool = new TranscriptSpool(dir);
+            var r = spool.Append(sessionId, """{"n":1}""");
+            await Assert.That(r).IsNotEqualTo(TranscriptSpool.AppendResult.Ignored);
+            await Assert.That(spool.HasBacklog(sessionId)).IsTrue();
         } finally { try { Directory.Delete(dir, true); } catch { } }
     }
 


### PR DESCRIPTION
Closes #412
Linear: AI-1586

`EnsureAbsolute` calls `Environment.Exit(2)` on a URL it cannot accept. From a hook that is **synchronous**, **uncatchable** (it bypasses every vendor's fail-open `catch`), and fires **before the stdout handshake** — so a typo in `server_url` turns "kcap records nothing" into "the coding agent refuses to start".

## Approach

Two layers, because they answer different questions.

**A process-wide `UrlFailurePolicy`** decides whether the validator exits or throws. It defaults to `FailFast`, so interactive commands are untouched; agent-spawned commands set `Throw` at entry, and the throw lands in the fail-open `catch` each vendor already has. This prevents process *death*.

**Explicit `HookHttp.IsPostable` guards** decide the *disposition* at each seam that owes one — spool the payload, decline to spawn, or return a protocol error.

Deliberately **no claim that the reachable surface is enumerated**. Seven review rounds produced thirty-two findings, and three successive versions of a "this closes the class" claim were falsified in the very next round — a hook-only policy missed `copilot-finalize`; a `CrashReporter.FailOpenCommands` binding missed `mcp judge`; a classification lint would have passed while `mcp judge` was broken, because `Program.cs` has one outer `case "mcp"` with the real routes nested. The taxonomy in the spec is documentation. The work is done by the guards and their tests.

## What changed

| Seam | Behaviour on an unusable URL |
|---|---|
| `PostOrSpoolAsync` | spools → `Spooled`, or `Skipped` if the spool write itself failed |
| `PostAsync` (no spool) | `Skipped` — never `Failed`, which every caller maps to a non-zero exit |
| `ShouldSpawnAfter(outcome, baseUrl)` | never spawns; a watcher that cannot connect captures nothing |
| `SpawnWatcher` / `SpawnCopilotFinalizeDrain` | refuse to launch, and write no PID file claiming otherwise |
| `DrainSpoolsAsync` | reaps first, then returns — retention must hold on a long-broken config |
| `InlineDrainAsync` | returns; the caller's preceding `KillWatcher` is unaffected |
| `McpJudgeServer` | defers its client and returns a JSON-RPC tool error, like its seven siblings |
| Claude's degraded arm | runs the disabled-session and repo-exclusion gates first |
| Cursor, `kcap watch`, daemon startup | guarded / hint-then-exit-2 / sanitized message |

Two fixes fall out of the above:

- **The spool key is widened, not hashed.** The filename *is* the session id — `LifecycleSpoolDrain` posts it verbatim as `session_id` for `session-needs-import` — so hashing would put a fabricated id on the wire. This also repairs OpenCode's `ses_…` ids, which **both** spools silently dropped, and `Append` now returns `bool` so "spooled" cannot be claimed after a disk fault.
- **Diagnostics name the source.** `kcap config set server_url` does not repair a malformed `KCAP_URL` or `--server-url`, both of which outrank the profile. The raw URL is never echoed — it can carry credentials, and an embedded newline injects a line into a stream harnesses parse.

## Testing

Guards are proved by **non-entry** wherever a seam exists, not by observable effects — effects are reproducible by the catch-all every one of these paths already has. `SpawnWatcher` and `SpawnCopilotFinalizeDrain` needed a new injectable process-starter seam for this; the latter writes no marker at all, so "no child was left behind" could never fail.

Mutation-checked: deleting the `EnsureAbsolute` throw branch, the finalize-spawn guard, the drain guard, or the `ShouldSpawnAfter` URL conjunct each fails a test.

The end-to-end matrix runs the real binary per case over every class `IsAcceptableUrl` rejects — including absolute wrong-scheme, which an implementation validating only `UriKind.Absolute` would accept. It asserts the positive guard diagnostic rather than only stdout and exit, because `Program.cs`'s top-level catch maps `hook` to exit 0 and Codex's own catch emits the identical handshake.

- Unit suite diffed against `origin/main`: **identical 45 pre-existing macOS failures, none new.**
- Integration suite: **186/186, green twice.**
- AOT publish: no IL3050/IL2026 warnings.

## Notes

- `kcap-cli` only — no server or wire change. The `kcap-server` submodule pin bump follows.
- One existing test changed meaning: `Append_ignores_malformed_session_id` used `"not-a-valid-sid"`, which is filename-safe and therefore now a legitimate key. Split into a rejection case (separators) and an acceptance case (vendor ids).

Spec and plan: `docs/superpowers/specs/2026-07-30-ai1586-hook-unpostable-base-url-design.md` and `docs/superpowers/plans/2026-07-30-ai1586-unusable-server-url.md` in kcap-server.