### PR TITLE
[AI-1463] SessionStart memory index: Gemini CLI adapter

### DIFF
--- a/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
@@ -105,11 +105,35 @@ Gemini emits only `startup` / `resume` / `clear`, so:
 `CallbackMayRepeat: false`. Gemini's `SessionStart` is a session-level event, not a per-turn callback —
 unlike Kiro's `agentSpawn`, which fires per prompt and needed `RepeatedTurnCallback`.
 
-**Open for review:** whether `clear` should inject. It is a context reset within one session id, so the
-model has lost the earlier injection and arguably *should* be re-injected — but the lease is keyed on
-session id and will suppress it. Flagging rather than silently picking: the safe default is to let the
-lease suppress, matching Claude's behaviour, and revisit only if a user reports a missing index after
-`/clear`.
+**RESOLVED by review — `clear` MUST re-inject; `resume` must not.** My original proposal (let the lease
+suppress both, matching Claude) was wrong, and the reason is decisive: `clear` *removes the model context
+that held the injection*. Suppressing it means "once per session" stops achieving the stated goal — the
+index is simply unavailable for the rest of that session, silently. That is a feature gap dressed up as
+idempotence.
+
+The two cases are genuinely different:
+
+| Source | Model context | Correct behaviour |
+|---|---|---|
+| `resume` | earlier injection still in context (same transcript continues) | **suppress** — re-injecting duplicates |
+| `clear` | earlier injection destroyed | **re-inject** — otherwise the feature is gone |
+
+**Lease rule: the lease key gains a context generation.** A session-id-only key cannot express this. Key
+the lease on `(sessionId, generation)` where the generation increments on each `clear`, so:
+
+* `startup` → generation 0, injects.
+* `resume` → generation unchanged, lease held, suppressed.
+* `clear` → generation +1, fresh lease, injects.
+* second `clear` → generation +2, injects again.
+
+The generation must be **durable** alongside the lease (a hook process is short-lived and cannot hold it
+in memory) and must not be inferable from the transcript, since `clear` does not start a new one. The
+simplest durable form is a per-session counter in the lease store incremented on a `clear`-sourced
+`SessionStart`.
+
+**Acceptance coverage is required for the sequences, not just the states:** `startup → resume` (exactly
+one output), `startup → clear` (a second output), `clear → clear` (a third). A test that only checks
+"clear injects" would pass with a broken generation counter that always injects.
 
 ### 2.3 Re-injection on `resume` is suppressed by the lease, deliberately
 
@@ -144,30 +168,107 @@ decide whether to *continue*.
 Gemini's parsed decision fields (same static scan): `continue`, `decision`, `stopReason`,
 `systemMessage`, `suppressOutput`.
 
-### 3.1 Contract
+### 3.1 Contract — now MEASURED from Gemini's own hook runner, not assumed
 
-Emitting `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"…"}}` — with **no**
-`continue`, `decision` or `stopReason` — must mean "allow, and here is extra context". That is Claude's
-semantics for the identical envelope, and Gemini parses the identical field names.
+The review correctly refused to accept this on field-name hit counts. It has since been read out of the
+installed `@google/gemini-cli` bundle. Three facts, each load-bearing:
 
-**This must be verified live, not assumed.** A regression here does not degrade gracefully: it could
-block or abort the user's Gemini session at startup. It is the reason §5's live cert is mandatory rather
-than nice-to-have.
+**(1) Blocking requires an explicit decision. A `hookSpecificOutput`-only payload cannot block.**
 
-### 3.2 Fail-open, byte-identical to today
+```js
+isBlockingDecision() { return this.decision === "block" || this.decision === "deny" }
+```
 
-On **any** failure — null fragment, opt-out, budget exhausted, lease held, serialization error — write
-**nothing**. Not `{}`, not an empty object: zero bytes, exactly today's behaviour.
+`decision` is `undefined` in our envelope, so this is `false`. The output object's constructor reads
+`continue`, `stopReason`, `suppressOutput`, `systemMessage`, `decision`, `reason`, `hookSpecificOutput`
+independently — absence of the decision fields is not a blocking state.
 
-`SessionStartMemoryOutputAdapters.Render` already returns `""` for a null fragment, so this falls out of
-the existing contract, and the Kiro adapter's `WriteAgentSpawnOutput` already models the
-catch-and-emit-nothing shape:
+**(2) `additionalContext` is consumed through a string-typed accessor:**
+
+```js
+getAdditionalContext() {
+  if (this.hookSpecificOutput && "additionalContext" in this.hookSpecificOutput) {
+    const context = this.hookSpecificOutput["additionalContext"];
+    if (typeof context !== "string") { … }
+```
+
+So the fragment must be a JSON **string**, which is what `HookMemoryOutput` already produces. A non-string
+would be rejected rather than blocking.
+
+**(3) Malformed or truncated stdout is fail-open, not blocking** — this is the answer to the review's
+residual-risk demand in §3.3:
+
+```js
+const textToParse = stdout.trim() || stderr.trim();
+try   { let parsed = JSON.parse(textToParse); if (typeof parsed === "string") parsed = JSON.parse(parsed); … }
+catch { output = this.convertPlainTextToHookOutput(…, exitCode || EXIT_CODE_SUCCESS); }
+```
+
+A parse failure degrades to a plain-text hook output. It does **not** synthesise a block. So a partial
+write cannot block the session — it can only produce a junk context string.
+
+### 3.1a NEW HAZARD found while verifying: empty stdout falls back to STDERR
+
+Look again at the first line above:
+
+```js
+const textToParse = stdout.trim() || stderr.trim();
+```
+
+**When stdout is empty, Gemini parses the hook's STDERR as its output.** kcap writes diagnostics to
+stderr — `AgentHookPoster` logs there on a failed POST, and the auth-lapse notice is a stderr write.
+
+Consequences, and they invert part of the original design intuition:
+
+* "Emit nothing to stdout" is **not inert** for Gemini whenever stderr is non-empty. This is
+  *pre-existing* behaviour — today's dispatcher never writes stdout, so any stderr diagnostic is already
+  being parsed as hook output — but it was not previously understood, and it means the fail-open path is
+  noisier than assumed.
+* It makes writing the envelope on the failed-POST path **protective rather than merely harmless**: a
+  populated stdout wins the `||`, so it *prevents* our stderr diagnostic from being interpreted as the
+  hook's decision channel.
+* Since a parse failure only yields plain text (fact 3), the pre-existing behaviour is not a live bug.
+  It is recorded here because it is the kind of thing that becomes a bug the moment someone adds a
+  `decision`-shaped word to a stderr message.
+
+**This does not need fixing in this issue**, but it must not be silently discovered again — noted in §7.
+
+### 3.2 Fail-open — corrected: "zero bytes on any failure" was too strong
+
+The review was right that the original claim could not hold. Rendering to a string first covers
+*serialization* failure, but `writer.Write(payload)` can throw **after a partial write**, and the shown
+`try` did not cover the write at all. Corrected contract:
+
+1. **Render completely, then perform exactly one write.** No incremental/streaming construction, so
+   there is one failure point rather than many.
+2. **A write exception must not change the command's pre-existing exit code.** Catch it, swallow it
+   (non-fatal), and return whatever the POST path would have returned.
+3. **A partial write is a bounded, non-blocking risk, not an unbounded one** — established by §3.1
+   fact (3): truncated JSON fails `JSON.parse` and degrades to plain text. The worst case is a junk
+   context string, never a block. This is the residual risk the review asked to have verified or
+   documented; it is now verified.
+4. **Do not claim atomicity we do not have.** A single `Write` of a small payload to a pipe is not
+   guaranteed atomic, and application code cannot retract bytes already written. The mitigation is (3),
+   not a stronger write.
 
 ```csharp
-try   { payload = SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Gemini, fragment); }
-catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) { return; }
-writer.Write(payload);
+static void WriteSessionStartOutput(TextWriter writer, string? fragment) {
+    string payload;
+    try { payload = SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Gemini, fragment); }
+    catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) { return; }
+
+    // Separate try: a write that throws mid-payload must not alter the exit code. Truncated JSON is
+    // fail-open on Gemini's side (§3.1 fact 3), so there is nothing to repair here.
+    try { writer.Write(payload); }
+    catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) { }
+}
 ```
+
+`Render` returns `""` for a null fragment, so opt-out / budget-exhausted / lease-held all produce zero
+bytes naturally.
+
+**Tests required by this section:** a writer that throws *before* writing anything, and a writer that
+throws *after* a partial write — both asserting the exit code is unchanged.
 
 ### 3.3 Ordering: write stdout BEFORE any non-zero return
 
@@ -187,19 +288,34 @@ failed-POST path.
 Rationale: the memory index is independent of lifecycle capture. A server that rejects the
 `session-start` POST has not invalidated an index we already fetched, and the user should still get it.
 
-**Open for review — and I want a second opinion.** Does Gemini read a hook's stdout when the hook exits
-**non-zero**? If it discards it, writing before `return 1` is harmless but pointless, and the lease would
-be burned for an injection the model never saw — which is what the Copilot adapter's `commitGate` was
-built to prevent. Two candidate answers:
+**RESOLVED by measurement — option (a), no commit gate.** The review was right to call this blocking: my
+recommendation rested on a behaviour the spec never established. It has now been read from Gemini's hook
+runner:
 
-* **(a) Keep exit codes unchanged**, write stdout first, accept that a failed-POST session may burn its
-  lease. Simplest, and a failed POST is already an error path the user sees on stderr.
-* **(b) Add a commit gate** like Copilot's: only complete the lease when the output was plausibly
-  delivered (i.e. we are returning 0), otherwise release it for retry on the next `resume`.
+```js
+child.on("close", (exitCode) => {
+    const textToParse = stdout.trim() || stderr.trim();     // ← no exit-code gate
+    try { let parsed = JSON.parse(textToParse); … } catch { … }
+    return { success: exitCode === EXIT_CODE_SUCCESS, stdout, exitCode: exitCode || EXIT_CODE_SUCCESS, … };
+});
+```
 
-Recommendation: **(b)**, because Gemini's `resume` gives a natural, frequent retry opportunity that
-Copilot did not have, so releasing the lease has a real chance of succeeding later. But it costs a
-`commitGate` wire-up, so (a) is defensible if the reviewer disagrees.
+**Gemini parses hook stdout unconditionally.** The exit code is recorded as `success` but does not gate
+parsing. So stdout on a non-zero exit is *not* discarded — which removes the entire premise for a commit
+gate, since the lease is not burned for an undelivered injection.
+
+Two supporting reasons this is right rather than merely permitted:
+
+* The review's own objection to (b) is decisive against it: *"the spec must not rely on a later `resume`:
+  a startup hook failure may prevent the session from reaching a resumable state."* Option (b) depended
+  on that retry existing; option (a) depends on nothing.
+* Per §3.1a, writing stdout on the failed-POST path is actively **protective** — a populated stdout wins
+  the `stdout || stderr` selection and stops our stderr diagnostic being parsed as the hook's output.
+
+**Residual gap, stated honestly:** this establishes stdout is *parsed* on a non-zero exit. Whether the
+consuming layer *additionally* gates on `success` before applying `getAdditionalContext()` was not traced
+to a definitive call site. It does not change the decision — (b)'s rationale is void either way — but the
+live cert must include a non-zero-exit case (§5) so the end-to-end answer is measured, not inferred.
 
 ## 4. Files
 
@@ -221,9 +337,49 @@ Layers, per the project's per-vendor convention:
 3. **Integration** — WireMock 400 on `session-start/gemini` asserting the exit code AND parseable stdout,
    mirroring `CodexSessionStartHandshakeOnPostFailureTests`.
 4. **Live cert** — `GeminiMemoryIndexLiveCertTests`, gated on `KCAP_GEMINI_MEMORY_LIVE=1` + `KCAP_URL`,
-   reusing `MemoryIndexLiveCertHarness`. Positive: a nonce saved as a memory is reproduced by a real
-   `gemini` turn. Negative control: with `disable_memory_index` set, the nonce does **not** appear.
-   `[NotInParallel]` — the negative control mutates process-global config.
+   reusing `MemoryIndexLiveCertHarness`. `[NotInParallel]`.
+
+   * **Positive:** a nonce saved as a memory is reproduced by a real `gemini` turn — *and the turn
+     completes successfully*. Nonce reproduction alone is insufficient: the review noted the harness could
+     mask a failed invocation, so the cert must assert turn completion (exit status + no
+     blocking/stop decision), which is what actually verifies §3.1.
+   * **Negative control:** with `disable_memory_index` set, the nonce does **not** appear.
+   * **Non-zero-exit case** (new, from §3.3's residual gap): drive a `SessionStart` whose POST fails so
+     the hook exits non-zero while emitting recognisable `additionalContext`, then assert the session
+     continues **and** record whether the model received the context. This is the only way to settle
+     whether the consuming layer gates on `success`.
+
+   **Cleanup and isolation are explicit requirements, not `[NotInParallel]` side effects.** The review is
+   right that `[NotInParallel]` only prevents concurrency — it restores nothing. The existing
+   `MemoryIndexLiveCertHarness` already provides `ReadDisableMemoryIndexAsync` /
+   `SetDisableMemoryIndexAsync` / `RestoreDisableMemoryIndexAsync`, and the Kiro cert already nests the
+   restore inside a `finally` *inside* the archive `finally` (so a throwing restore cannot skip the
+   memory archive). Reuse that shape exactly, and additionally:
+
+   * snapshot **before** anything is created, and restore in `finally` — **including restoring the unset
+     state**, not just `false`;
+   * assert the **positive** control runs with opt-out *disabled*, so a leaked `true` from an earlier
+     failed run cannot make the positive test pass vacuously;
+   * archive the nonce memory unconditionally — a leaked nonce corrupts every later cert's index. (The
+     Kiro cert work leaked 13 memories exactly this way; `archive_memory` takes `id`, not `memory_id`.)
+
+### 5.2 Supported Gemini version boundary
+
+The review is right that this is unspecified and that changing zero-stdout → decision-payload affects any
+installed version running the hook.
+
+* **Verified against `gemini 0.53.0`** — every §3.1 fact is read from that bundle. Facts about
+  `isBlockingDecision`, the unconditional parse, and the `stdout || stderr` fallback are version-specific
+  observations, not guarantees.
+* **Minimum supported: 0.53.0.** Below it, the hook-output contract is unverified.
+* **The live cert must record and assert the exact binary version** (`gemini --version`), mirroring
+  `RecordCertEnvironmentAsync` in the existing harness — a cert that passes against an unknown build tells
+  us nothing, which is precisely how the AI-1592 memory-cert failures were misdiagnosed (a stale installed
+  binary, not a code defect).
+* **On an older/unknown version: still emit.** Suppressing would silently disable the feature, and the
+  measured fail-open behaviour (§3.1 fact 3 — malformed or unrecognised stdout degrades to plain text
+  rather than blocking) means a wrong guess is not dangerous. Do **not** add a version gate that declines
+  installation; that trades a benign degradation for a silent feature loss.
 
 **Every guard assertion must be mutation-proven.** The Kiro work shipped a vacuous guard test that
 passed with the guard removed; the standard here is that deleting the guard fails exactly the intended
@@ -235,7 +391,15 @@ The live cert is the only thing that verifies §3.1 — that a `hookSpecificOutp
 disturb Gemini's decision channel. A green unit suite proves the bytes we emit, not that Gemini accepts
 them. If the cert cannot be run, this issue should not be called done.
 
-## 6. Out of scope
+## 6. Follow-ups this work surfaces but does not fix
+
+* **`stdout.trim() || stderr.trim()` (§3.1a).** Gemini parses a hook's **stderr** as its output whenever
+  stdout is empty. kcap writes diagnostics to stderr, so this already happens today on every failed-POST
+  session across the Gemini hook. It is currently benign — a parse failure degrades to plain text — but it
+  is one carelessly-worded stderr message away from being a real bug, and it means kcap's stderr is
+  semantically part of Gemini's hook contract. Worth its own issue rather than a comment.
+
+## 7. Out of scope
 
 * Gemini hosted agents (AI-899) and the Gemini reviewer (AI-1413) — separate issues, separate epics.
 * `SessionEnd` / `Notification` behaviour — untouched.

--- a/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
@@ -1,0 +1,243 @@
+# AI-1463 — SessionStart memory index: Gemini CLI adapter
+
+**Status:** specced 2026-07-30 against `gemini 0.53.0` and `origin/main` (`694d32b`).
+**Repository:** kurrent-io/kcap-cli
+**Parent:** AI-1456 (SessionStart memory-index injection across all coding harnesses)
+**Prior art (all merged):** Claude (AI-1460, the baseline) · Cursor (AI-1461) · Codex (AI-1459) ·
+Copilot (AI-1462) · Kiro (AI-1464) · live certs (AI-1591)
+
+## What this is
+
+Wire the sixth harness into the existing SessionStart memory-index foundation. The goal is unchanged
+from the five merged adapters: at session start, fetch `GET /api/memories/index` in parallel with the
+lifecycle hook POST, inject a grouped org/team/user `## Team memory` index into the model's context,
+budget-bounded and fail-open, once per session.
+
+**Unusually little of this is new work** — see §1. The bulk of the risk is in one place, §3.
+
+## 1. What already exists (verified in code, not assumed)
+
+Gemini is **already represented in the foundation**, from the original Claude-baseline work:
+
+```csharp
+// SessionStartMemoryContracts.cs
+enum SessionStartHarness { …, Gemini, … }
+
+// SessionStartMemoryOutputAdapters.cs
+SessionStartHarness.Gemini => new GeminiMemoryEnvelope(
+    fragment is null ? null : new HookMemoryOutput("SessionStart", fragment)),
+
+// SessionStartMemoryJsonContext.cs  (AOT-safe, source-generated)
+[JsonSerializable(typeof(GeminiMemoryEnvelope))]
+internal sealed record GeminiMemoryEnvelope(
+    [property: JsonPropertyName("hookSpecificOutput")] HookMemoryOutput? HookSpecificOutput = null);
+
+// SessionStartMemoryIdentity.cs
+SessionStartHarness.Gemini => "gemini",
+```
+
+So the envelope, its AOT serialization context, and the identity mapping are done. **What is missing is
+only the call site:** `GeminiHookCommand` never invokes the orchestrator. Grepping the commands
+directory, only `ClaudeHookCommand`, `CursorHookCommand`, `CodexHookCommand`, `CopilotHookCommand` and
+`KiroHookCommand` do.
+
+### 1.1 The envelope shape is CORRECT — verified against Gemini's own code
+
+This mattered enough to check rather than trust, because the envelope was written speculatively before
+any adapter consumed it. A static scan of the installed `@google/gemini-cli` package:
+
+| Field we emit | Hits in Gemini's own JS |
+|---|---|
+| `hookSpecificOutput` | 150 |
+| `additionalContext` | 96 |
+| `hookEventName` | 15 |
+
+Gemini genuinely parses the Claude-shaped envelope. **No new wire format is being invented.**
+
+### 1.2 Gemini's hook model (from `GeminiHookCommand` + the CLI)
+
+* Uniform PascalCase `hook_event_name`: `SessionStart` / `SessionEnd` / `Notification`, self-routed by
+  one `kcap hook --gemini` registration per event.
+* `session_id` is a dashed UUID; the dispatcher stores the dashless form (shared convention).
+* `source` ∈ `startup` (default) / `resume` / `clear`. **Gemini re-fires `SessionStart` with
+  `source: "resume"` on the SAME session id**, appending to the same transcript.
+* **stdout is a JSON decision channel.** Today's dispatcher deliberately writes **nothing**, and its
+  doc comment says so: *"Gemini treats hook stdout as a JSON decision channel; this dispatcher emits
+  nothing (no stdout) so every action is allowed."*
+
+## 2. Design
+
+Mirror the merged adapters. In `HandleSessionStart`:
+
+1. Start the memory fetch **in parallel** with the existing POST, not before it — the POST is the
+   latency-critical path.
+2. Bound it with `HookBudget.Remaining(processStart, "session-start")`.
+3. Write the rendered envelope to stdout.
+4. Preserve every existing side effect and exit code (POST, watcher spawn, disabled/excluded fast paths).
+
+### 2.1 Thread `hookProcessStart` — currently absent for Gemini
+
+`Program.cs` passes `hookProcessStart` to Claude, Codex, Copilot and Kiro, but Gemini's dispatch is
+`GeminiHookCommand.Handle(baseUrl!, Console.In)` — no timestamp. Without it there is no budget origin
+and `HookBudget.Remaining` cannot be computed.
+
+This is the **same omission that had to be fixed for Codex, Copilot and Kiro**, so it is a known trap
+rather than a discovery: add the parameter and thread it.
+
+**Do not subtract `Safety` at the call site.** `HookBudget.Remaining` already subtracts it
+(`Ceiling - elapsed - Safety`, clamped ≥ 0). Double-subtracting was a real defect in the Copilot work,
+fixed at four sites.
+
+### 2.2 Lifecycle mapping — reuse Claude's, do not invent one
+
+`ClaudeHookCommand` maps `source` → `SessionLifecycleReason` (`resume`→`Resume`, `reopen`→`Reopen`,
+`fork`→`Fork`, `compact`→`Compact`), and `SessionStartMemoryLifecyclePolicy` suppresses injection when
+`Reason == Compact` or `!IsTopLevel`.
+
+Gemini emits only `startup` / `resume` / `clear`, so:
+
+| Gemini `source` | `SessionLifecycleReason` | Inject? |
+|---|---|---|
+| `startup` | `Startup` | yes |
+| `resume` | `Resume` | yes — but the lease dedupes (§2.3) |
+| `clear` | `Clear` if it exists, else `Startup` | yes |
+
+`CallbackMayRepeat: false`. Gemini's `SessionStart` is a session-level event, not a per-turn callback —
+unlike Kiro's `agentSpawn`, which fires per prompt and needed `RepeatedTurnCallback`.
+
+**Open for review:** whether `clear` should inject. It is a context reset within one session id, so the
+model has lost the earlier injection and arguably *should* be re-injected — but the lease is keyed on
+session id and will suppress it. Flagging rather than silently picking: the safe default is to let the
+lease suppress, matching Claude's behaviour, and revisit only if a user reports a missing index after
+`/clear`.
+
+### 2.3 Re-injection on `resume` is suppressed by the lease, deliberately
+
+Because `resume` re-fires on the same session id, `SessionStartMemoryLeaseStore` will already hold a
+completed lease and return no fragment. That is the desired outcome: one injection per session.
+
+Note the contrast with Kiro, and why it is not a contradiction. Kiro's `agentSpawn` fires per *prompt*
+within one session, so the lease is what makes it once-per-session. Gemini's `SessionStart` fires per
+*session-entry*, so the lease is what makes a resume idempotent. Same mechanism, different event
+semantics.
+
+### 2.4 Opt-out — the Codex/Copilot profile trap does NOT apply here
+
+Both the Codex and Copilot adapters shipped a bug where the opt-out was ignored under `KCAP_URL`,
+because `ProfileResolver.Resolve()` returns `Profile: null` when `--server-url`/`KCAP_URL` wins, and
+only `GetActiveProfileAsync()` falls back to disk.
+
+`GeminiHookCommand` **already** resolves `activeProfile` via `await AppConfig.GetActiveProfileAsync()`
+and threads it into `HandleSessionStart`. So `activeProfile?.DisableMemoryIndex is true` is correct here
+with no extra work. Stated explicitly so a reviewer does not have to re-derive it, and so nobody
+"helpfully" swaps in the resolver later.
+
+## 3. The one genuinely new risk: stdout is a decision channel
+
+This is the part that differs from every previous adapter and deserves the review attention.
+
+The five merged adapters write into channels that are either inert (Kiro: raw stdout, no envelope) or
+already-decision-shaped and exercised (Claude/Cursor/Codex/Copilot). For Gemini we are changing a hook
+that **currently emits nothing at all** into one that emits a JSON object — on a channel Gemini uses to
+decide whether to *continue*.
+
+Gemini's parsed decision fields (same static scan): `continue`, `decision`, `stopReason`,
+`systemMessage`, `suppressOutput`.
+
+### 3.1 Contract
+
+Emitting `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"…"}}` — with **no**
+`continue`, `decision` or `stopReason` — must mean "allow, and here is extra context". That is Claude's
+semantics for the identical envelope, and Gemini parses the identical field names.
+
+**This must be verified live, not assumed.** A regression here does not degrade gracefully: it could
+block or abort the user's Gemini session at startup. It is the reason §5's live cert is mandatory rather
+than nice-to-have.
+
+### 3.2 Fail-open, byte-identical to today
+
+On **any** failure — null fragment, opt-out, budget exhausted, lease held, serialization error — write
+**nothing**. Not `{}`, not an empty object: zero bytes, exactly today's behaviour.
+
+`SessionStartMemoryOutputAdapters.Render` already returns `""` for a null fragment, so this falls out of
+the existing contract, and the Kiro adapter's `WriteAgentSpawnOutput` already models the
+catch-and-emit-nothing shape:
+
+```csharp
+try   { payload = SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Gemini, fragment); }
+catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) { return; }
+writer.Write(payload);
+```
+
+### 3.3 Ordering: write stdout BEFORE any non-zero return
+
+`HandleSessionStart` currently ends:
+
+```csharp
+if (!AgentHookPoster.ShouldSpawnAfter(outcome)) return outcome == HookPostOutcome.Failed ? 1 : 0;
+await EnsureWatcher(…);
+return 0;
+```
+
+**This exact shape caused a real defect in the Codex adapter**, where an early `return 1` on a failed
+POST skipped the stdout handshake entirely — fixed later with a mutation-tested integration regression.
+Do not reintroduce it: the memory fragment must be written on every path that returns, including the
+failed-POST path.
+
+Rationale: the memory index is independent of lifecycle capture. A server that rejects the
+`session-start` POST has not invalidated an index we already fetched, and the user should still get it.
+
+**Open for review — and I want a second opinion.** Does Gemini read a hook's stdout when the hook exits
+**non-zero**? If it discards it, writing before `return 1` is harmless but pointless, and the lease would
+be burned for an injection the model never saw — which is what the Copilot adapter's `commitGate` was
+built to prevent. Two candidate answers:
+
+* **(a) Keep exit codes unchanged**, write stdout first, accept that a failed-POST session may burn its
+  lease. Simplest, and a failed POST is already an error path the user sees on stderr.
+* **(b) Add a commit gate** like Copilot's: only complete the lease when the output was plausibly
+  delivered (i.e. we are returning 0), otherwise release it for retry on the next `resume`.
+
+Recommendation: **(b)**, because Gemini's `resume` gives a natural, frequent retry opportunity that
+Copilot did not have, so releasing the lease has a real chance of succeeding later. But it costs a
+`commitGate` wire-up, so (a) is defensible if the reviewer disagrees.
+
+## 4. Files
+
+* `src/Capacitor.Cli/Commands/GeminiHookCommand.cs` — orchestrator call, stdout write, budget.
+* `src/Capacitor.Cli/Program.cs` — thread `hookProcessStart` into the `--gemini` dispatch.
+* No foundation changes expected (§1). If one proves necessary, that is a signal to re-check whether the
+  envelope really was complete.
+
+## 5. Test plan
+
+Layers, per the project's per-vendor convention:
+
+1. **Foundation** — `Gemini_*` cases in `SessionStartMemoryFoundationTests`: envelope rendering
+   (fragment → exact JSON), null fragment → empty string, lease dedupe across two `SessionStart`
+   invocations on one session id (the `resume` case).
+2. **Hook command** — `GeminiSessionStartMemoryTests`: opt-out honoured (including under `KCAP_URL`, the
+   §2.4 trap); budget exhaustion writes nothing; a throwing provider writes nothing and still returns the
+   pre-existing exit code; stdout is written on the failed-POST path (§3.3).
+3. **Integration** — WireMock 400 on `session-start/gemini` asserting the exit code AND parseable stdout,
+   mirroring `CodexSessionStartHandshakeOnPostFailureTests`.
+4. **Live cert** — `GeminiMemoryIndexLiveCertTests`, gated on `KCAP_GEMINI_MEMORY_LIVE=1` + `KCAP_URL`,
+   reusing `MemoryIndexLiveCertHarness`. Positive: a nonce saved as a memory is reproduced by a real
+   `gemini` turn. Negative control: with `disable_memory_index` set, the nonce does **not** appear.
+   `[NotInParallel]` — the negative control mutates process-global config.
+
+**Every guard assertion must be mutation-proven.** The Kiro work shipped a vacuous guard test that
+passed with the guard removed; the standard here is that deleting the guard fails exactly the intended
+test.
+
+### 5.1 The cert is load-bearing for §3
+
+The live cert is the only thing that verifies §3.1 — that a `hookSpecificOutput`-only payload does not
+disturb Gemini's decision channel. A green unit suite proves the bytes we emit, not that Gemini accepts
+them. If the cert cannot be run, this issue should not be called done.
+
+## 6. Out of scope
+
+* Gemini hosted agents (AI-899) and the Gemini reviewer (AI-1413) — separate issues, separate epics.
+* `SessionEnd` / `Notification` behaviour — untouched.
+* Subagent memory injection: Gemini fires no subagent-start hook (`GeminiSubagentTeardown` exists
+  precisely because the parent owns teardown), so there is no per-subagent injection point to wire.

--- a/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
@@ -135,6 +135,36 @@ simplest durable form is a per-session counter in the lease store incremented on
 one output), `startup → clear` (a second output), `clear → clear` (a third). A test that only checks
 "clear injects" would pass with a broken generation counter that always injects.
 
+#### 2.2a The generation needs an atomic contract, not a table (round-2 finding 2)
+
+The table above describes intent, not a mechanism — and as the review noted, an unsynchronised counter
+races. Required contract:
+
+**Operations**, keyed by `(harness, normalizedSessionId)` so the namespace cannot collide with another
+vendor's session id:
+
+* `ReadOrInitGeneration` — on `startup` / `resume`. Idempotent, no mutation.
+* `IncrementAndReserve` — on `clear`. **One atomic operation** that advances the generation *and* acquires
+  the lease for the new generation. Splitting these is the race the review identified: a `resume` landing
+  between an increment and a separate lease acquisition would acquire the *new* generation and inject,
+  while the `clear` that caused the increment then finds the lease held and stays silent — the exact
+  inversion of intended behaviour.
+
+**Fault behaviour, each of which needs a test:**
+
+| Situation | Required behaviour |
+|---|---|
+| process dies after increment, before output/lease completion | generation stays advanced; lease is **not** completed, so the next `SessionStart` for that generation may inject. Losing one injection is acceptable; a permanently-stuck generation is not. |
+| memory provider fails on `clear` | generation stays advanced, lease released (not completed) — same as any provider failure |
+| duplicate `clear` delivery (same event twice) | must **not** advance twice. Requires an idempotency key on the delivery, not just the counter — otherwise both injections fire |
+| `SessionEnd` / lease expiry | generation state is cleaned up with the session's lease records; it must not accumulate per-session rows indefinitely |
+
+**Tests must include concurrency and fault transitions, not only the three sequential happy paths** — a
+sequential-only suite passes against a non-atomic implementation.
+
+**This changes the file scope.** See §4, corrected: this is no longer a two-file change, and it *does*
+touch the foundation.
+
 ### 2.3 Re-injection on `resume` is suppressed by the lease, deliberately
 
 Because `resume` re-fires on the same session id, `SessionStartMemoryLeaseStore` will already hold a
@@ -233,7 +263,35 @@ Consequences, and they invert part of the original design intuition:
 
 **This does not need fixing in this issue**, but it must not be silently discovered again — noted in §7.
 
-### 3.2 Fail-open — corrected: "zero bytes on any failure" was too strong
+### 3.2-pre The fail-open path must EMIT, not stay silent (round-2 finding 3, in scope)
+
+**This reverses the "zero bytes" decision below, and the review is right to put it in scope rather than
+defer it.** §3.1a established that empty stdout makes Gemini parse **stderr** instead. The adapter's
+stated guarantee is that the no-fragment / opt-out / budget / failure paths are *inert*. Measurement
+proves they are not: those are exactly the paths where `AgentHookPoster` and the auth-lapse notice write
+to stderr, so "emit nothing" hands kcap diagnostics — potentially including server URLs and auth state —
+to Gemini as model-visible hook output.
+
+The worst case is the one the review named, and it is genuinely bad: **with memory injection opted out, a
+failed lifecycle POST can still inject kcap text into the model's context.** A user who disabled the
+feature gets kcap prose in their session anyway.
+
+**Decision: on Gemini `SessionStart`, always write a valid JSON hook result.** When there is no memory
+fragment for any reason, emit an explicit allow-with-no-context object rather than zero bytes, so stdout
+wins the `stdout || stderr` selection and the diagnostics are never parsed as hook output.
+
+* This is a **deliberate divergence** from the other five adapters, which emit nothing on the empty path.
+  It is justified by a Gemini-specific runner behaviour, and the reason must be stated at the call site so
+  nobody "harmonises" it back later.
+* Scope: `SessionStart` only. `SessionEnd` / `Notification` keep today's behaviour and remain the §6
+  follow-up — they are not paths this issue redesigns.
+* **Residual, documented:** if the stdout write itself fails wholly or partially (§3.2), stderr can still
+  be exposed. Application code cannot prevent that; it is bounded by §3.1 fact (3).
+
+**Acceptance:** failed POST + null fragment, failed POST + opt-out, and failed POST + provider failure —
+each asserting kcap diagnostics are **not** consumed as hook context.
+
+### 3.2 Write mechanics — "zero bytes on any failure" was too strong
 
 The review was right that the original claim could not hold. Rendering to a string first covers
 *serialization* failure, but `writer.Write(payload)` can throw **after a partial write**, and the shown
@@ -312,17 +370,55 @@ Two supporting reasons this is right rather than merely permitted:
 * Per §3.1a, writing stdout on the failed-POST path is actively **protective** — a populated stdout wins
   the `stdout || stderr` selection and stops our stderr diagnostic being parsed as the hook's output.
 
-**Residual gap, stated honestly:** this establishes stdout is *parsed* on a non-zero exit. Whether the
-consuming layer *additionally* gates on `success` before applying `getAdditionalContext()` was not traced
-to a definitive call site. It does not change the decision — (b)'s rationale is void either way — but the
-live cert must include a non-zero-exit case (§5) so the end-to-end answer is measured, not inferred.
+**CORRECTED after round 2 — the decision is CONDITIONAL, and my asymmetry argument was backwards.**
+
+The review is right that parsing is not consuming. If a downstream `success` gate exists, that is
+*semantically identical to discarding stdout* for this feature: the model receives no index while option
+(a) has permanently completed the lease. So measurement (4) alone does not settle it.
+
+It also correctly refuted my "resume may never occur" argument, which I had inverted:
+
+* if no resume occurs, **releasing is harmless** — nothing is lost;
+* if the session does resume, **releasing is what permits recovery**;
+* and conversely, if context *is* consumed on the failed invocation, releasing risks a **duplicate** later.
+
+So the risk is asymmetric in favour of (b), not (a).
+
+**The decision is therefore load-bearing on a test result, not on this document:**
+
+| Real-Gemini non-zero-exit test outcome | Design |
+|---|---|
+| turn continues **and** the nonce is consumed | option **(a)** — no gate; the injection was delivered |
+| turn continues but the nonce is **not** consumed | option **(b)** — gate/release, so a later `resume` recovers |
+| turn does not continue | neither: escalate — a failed POST aborting the user's session is its own defect |
+
+**This issue does not ship because the test was added; it ships on what the test returns.** Implementation
+should provide the release path behind the gate seam so switching to (b) is a wiring change, not a
+redesign.
+
+Supporting (not decisive) evidence for the "consumed" branch: the `getAdditionalContext()` call sites in
+the bundle read it after only `shouldStopExecution()` / `isBlockingDecision()` checks, with no visible
+`success` gate — but those are the BeforeAgent / AfterTool paths, and the `SessionStart`-specific consumer
+was not definitively located. Treat as a prior, not proof.
 
 ## 4. Files
 
-* `src/Capacitor.Cli/Commands/GeminiHookCommand.cs` — orchestrator call, stdout write, budget.
+**CORRECTED (round-2 finding 2).** The original claim — two files, no foundation changes, and "a foundation
+change signals the envelope was incomplete" — was wrong, and self-contradictory once §2.2a's generation
+rule was adopted. The generation is a *lease-store* concept, not an envelope one, so touching the
+foundation here says nothing about the envelope.
+
+* `src/Capacitor.Cli/Commands/GeminiHookCommand.cs` — orchestrator call, stdout write, budget, `source` →
+  lifecycle mapping.
 * `src/Capacitor.Cli/Program.cs` — thread `hookProcessStart` into the `--gemini` dispatch.
-* No foundation changes expected (§1). If one proves necessary, that is a signal to re-check whether the
-  envelope really was complete.
+* **`src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryLeaseStore.cs`** — the atomic
+  `ReadOrInitGeneration` / `IncrementAndReserve` operations and generation-aware lease keys (§2.2a).
+* **`src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryOrchestrator.cs`** — accept and thread the
+  generation; expose the release seam that option (b) in §3.3 would wire.
+* Possibly `SessionStartMemoryContracts.cs` — if the generation belongs on the request/lifecycle record.
+* Foundation **tests** change accordingly; the five merged adapters must be verified unaffected, since a
+  generation-aware key touches a shared store. **A default generation of 0 for every existing harness must
+  keep their behaviour byte-identical** — that is a required regression assertion, not an assumption.
 
 ## 5. Test plan
 
@@ -376,10 +472,16 @@ installed version running the hook.
   `RecordCertEnvironmentAsync` in the existing harness — a cert that passes against an unknown build tells
   us nothing, which is precisely how the AI-1592 memory-cert failures were misdiagnosed (a stale installed
   binary, not a code defect).
-* **On an older/unknown version: still emit.** Suppressing would silently disable the feature, and the
-  measured fail-open behaviour (§3.1 fact 3 — malformed or unrecognised stdout degrades to plain text
-  rather than blocking) means a wrong guess is not dangerous. Do **not** add a version gate that declines
-  installation; that trades a benign degradation for a silent feature loss.
+* **CORRECTED (round-2 finding 4): the "benign degradation" rationale over-extrapolated.** The plain-text
+  fail-open path, the independent field parsing and the non-blocking defaults were measured **only in
+  0.53.0**. An older or future runner need not behave that way, so I cannot claim a wrong guess is safe
+  on a version I have not measured.
+  * **Below 0.53.0: unsupported.** Stated plainly, rather than dressed up as benign degradation. We still
+    emit (a version gate would trade a *known* feature loss for an *unknown* risk), but the behaviour is
+    explicitly out of contract and a report from such a version is not a regression against this spec.
+  * **Newer/unknown versions: accepted, documented compatibility risk.** The 0.53.0 cert cannot establish
+    their semantics. The mitigation is that the cert asserts the version it ran against, so a future
+    failure is diagnosable rather than mysterious — not a claim that newer versions are safe.
 
 **Every guard assertion must be mutation-proven.** The Kiro work shipped a vacuous guard test that
 passed with the guard removed; the standard here is that deleting the guard fails exactly the intended

--- a/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
@@ -94,76 +94,43 @@ fixed at four sites.
 `fork`→`Fork`, `compact`→`Compact`), and `SessionStartMemoryLifecyclePolicy` suppresses injection when
 `Reason == Compact` or `!IsTopLevel`.
 
-Gemini emits only `startup` / `resume` / `clear`, so:
-
-| Gemini `source` | `SessionLifecycleReason` | Inject? |
-|---|---|---|
-| `startup` | `Startup` | yes |
-| `resume` | `Resume` | yes — but the lease dedupes (§2.3) |
-| `clear` | `Clear` if it exists, else `Startup` | yes |
+Gemini emits only `startup` / `resume` / `clear`.
 
 `CallbackMayRepeat: false`. Gemini's `SessionStart` is a session-level event, not a per-turn callback —
 unlike Kiro's `agentSpawn`, which fires per prompt and needed `RepeatedTurnCallback`.
 
-**RESOLVED by review — `clear` MUST re-inject; `resume` must not.** My original proposal (let the lease
-suppress both, matching Claude) was wrong, and the reason is decisive: `clear` *removes the model context
-that held the injection*. Suppressing it means "once per session" stops achieving the stated goal — the
-index is simply unavailable for the rest of that session, silently. That is a feature gap dressed up as
-idempotence.
+**The review was right that suppressing `clear` is a silent feature loss — and following that finding to
+its conclusion moved it OUT of this issue. Split to AI-1617.**
 
-The two cases are genuinely different:
+The finding stands: `clear` destroys the model context that held the injection, so a session-id-keyed
+lease means the index is silently unavailable for the rest of that session. That is a real bug.
 
-| Source | Model context | Correct behaviour |
+But it is **not a Gemini bug**, and the fix does not belong in adapter #6. Verified:
+
+* `ClaudeHookCommand` maps `resume`/`reopen`/`fork`/`compact` and lets everything else — **including
+  `clear`** — fall to `_ => SessionLifecycleReason.New`.
+* There is **no `Clear` reason in `SessionStartMemoryContracts` at all.**
+
+So Claude has the identical silent loss today, and the mechanism required to fix it (a durable atomic
+context generation in the *shared* lease store, a stable delivery id to dedupe duplicate `clear`
+callbacks, and a persisted-key migration so five already-merged adapters don't start re-injecting on
+upgrade) is a **foundation feature affecting every harness**. Building it here would invent a foundation
+mechanism under delivery pressure, put five shipped adapters at migration risk, and fix one harness while
+five keep the bug.
+
+**Decision for AI-1463: `clear` behaves exactly as it does for the other five adapters — the lease
+suppresses it.** This is a *documented known gap*, not a claim that it is correct. AI-1617 owns fixing it
+everywhere at once.
+
+| Gemini `source` | `SessionLifecycleReason` | Injects? |
 |---|---|---|
-| `resume` | earlier injection still in context (same transcript continues) | **suppress** — re-injecting duplicates |
-| `clear` | earlier injection destroyed | **re-inject** — otherwise the feature is gone |
+| `startup` | `New` | yes |
+| `resume` | `Resume` | no — lease held |
+| `clear` | `New` (no `Clear` reason exists) | no — lease held · **known gap, AI-1617** |
 
-**Lease rule: the lease key gains a context generation.** A session-id-only key cannot express this. Key
-the lease on `(sessionId, generation)` where the generation increments on each `clear`, so:
-
-* `startup` → generation 0, injects.
-* `resume` → generation unchanged, lease held, suppressed.
-* `clear` → generation +1, fresh lease, injects.
-* second `clear` → generation +2, injects again.
-
-The generation must be **durable** alongside the lease (a hook process is short-lived and cannot hold it
-in memory) and must not be inferable from the transcript, since `clear` does not start a new one. The
-simplest durable form is a per-session counter in the lease store incremented on a `clear`-sourced
-`SessionStart`.
-
-**Acceptance coverage is required for the sequences, not just the states:** `startup → resume` (exactly
-one output), `startup → clear` (a second output), `clear → clear` (a third). A test that only checks
-"clear injects" would pass with a broken generation counter that always injects.
-
-#### 2.2a The generation needs an atomic contract, not a table (round-2 finding 2)
-
-The table above describes intent, not a mechanism — and as the review noted, an unsynchronised counter
-races. Required contract:
-
-**Operations**, keyed by `(harness, normalizedSessionId)` so the namespace cannot collide with another
-vendor's session id:
-
-* `ReadOrInitGeneration` — on `startup` / `resume`. Idempotent, no mutation.
-* `IncrementAndReserve` — on `clear`. **One atomic operation** that advances the generation *and* acquires
-  the lease for the new generation. Splitting these is the race the review identified: a `resume` landing
-  between an increment and a separate lease acquisition would acquire the *new* generation and inject,
-  while the `clear` that caused the increment then finds the lease held and stays silent — the exact
-  inversion of intended behaviour.
-
-**Fault behaviour, each of which needs a test:**
-
-| Situation | Required behaviour |
-|---|---|
-| process dies after increment, before output/lease completion | generation stays advanced; lease is **not** completed, so the next `SessionStart` for that generation may inject. Losing one injection is acceptable; a permanently-stuck generation is not. |
-| memory provider fails on `clear` | generation stays advanced, lease released (not completed) — same as any provider failure |
-| duplicate `clear` delivery (same event twice) | must **not** advance twice. Requires an idempotency key on the delivery, not just the counter — otherwise both injections fire |
-| `SessionEnd` / lease expiry | generation state is cleaned up with the session's lease records; it must not accumulate per-session rows indefinitely |
-
-**Tests must include concurrency and fault transitions, not only the three sequential happy paths** — a
-sequential-only suite passes against a non-atomic implementation.
-
-**This changes the file scope.** See §4, corrected: this is no longer a two-file change, and it *does*
-touch the foundation.
+Mapping `clear` to `New` matches Claude's existing behaviour exactly, so this adapter introduces no new
+divergence. The acceptance requirement that survives here is narrow: `startup → resume` emits **exactly
+once**. The `clear` sequences move to AI-1617.
 
 ### 2.3 Re-injection on `resume` is suppressed by the lease, deliberately
 
@@ -283,13 +250,55 @@ wins the `stdout || stderr` selection and the diagnostics are never parsed as ho
 * This is a **deliberate divergence** from the other five adapters, which emit nothing on the empty path.
   It is justified by a Gemini-specific runner behaviour, and the reason must be stated at the call site so
   nobody "harmonises" it back later.
-* Scope: `SessionStart` only. `SessionEnd` / `Notification` keep today's behaviour and remain the §6
-  follow-up — they are not paths this issue redesigns.
+* Scope: `SessionStart` only. `SessionEnd` / `Notification` keep today's behaviour and are split to
+  **AI-1618** — they are not paths this issue redesigns.
 * **Residual, documented:** if the stdout write itself fails wholly or partially (§3.2), stderr can still
   be exposed. Application code cannot prevent that; it is bounded by §3.1 fact (3).
 
-**Acceptance:** failed POST + null fragment, failed POST + opt-out, and failed POST + provider failure —
-each asserting kcap diagnostics are **not** consumed as hook context.
+#### The exact wire contract (round-3 finding 3)
+
+The review is right that `{}`, `{"continue":true}`, a null `hookSpecificOutput` and an event-only envelope
+are **not** semantically interchangeable on a decision channel, and that `Render` returning `""` means
+this needs a new serialization path. Specified:
+
+```jsonc
+// no-fragment / opt-out / budget-exhausted / lease-held / provider-failure
+{"continue":true}
+```
+
+Chosen deliberately over the alternatives:
+
+* **`{"continue":true}`** — an explicit allow. `continue` is read directly by the output object's
+  constructor, and carrying **no** `hookSpecificOutput` key at all means `getAdditionalContext()` short-
+  circuits on its `"additionalContext" in this.hookSpecificOutput` guard and contributes nothing. No
+  `systemMessage`, so nothing is surfaced to the user either.
+* **`{}`** — rejected: parses, but asserts nothing. It relies on every default staying benign, which is
+  exactly the assumption §3.1 had to go and verify. An explicit allow does not.
+* **`{"hookSpecificOutput":{"hookEventName":"SessionStart"}}`** — rejected: an `additionalContext`-less
+  `hookSpecificOutput` is a shape whose handling we would have to verify separately, for no benefit.
+
+Requires a new AOT-serializable record (e.g. `GeminiAllowEnvelope([JsonPropertyName("continue")] bool
+Continue = true)`) registered in `SessionStartMemoryJsonContext`. **Verify on 0.53.0** that it continues
+the turn, contributes no context and no system message, and shadows stderr.
+
+#### Path scope — the invariant covers EVERY recognised SessionStart
+
+The review asked whether the disabled-session and excluded-path fast paths (which `return 0` before
+`HandleSessionStart`) are exceptions. **They must not be.** An exception-riddled invariant is not an
+invariant, and those paths are not stderr-free in practice — `Program.cs` runs a central spool drain
+before dispatch, and any of it can write stderr.
+
+**Invariant: a recognised Gemini `SessionStart` writes exactly one JSON object to stdout on every
+returning path** — the memory envelope when there is a fragment, `{"continue":true}` otherwise. That
+includes the disabled-session and excluded-path early returns.
+
+Deliberately excluded, because these are not recognised `SessionStart` events at all and Gemini has no
+hook result to attribute: unparseable stdin, missing/blank `hook_event_name`, a non-GUID `session_id`, and
+any non-`SessionStart` event. Those keep today's silent `return 0`.
+
+**Acceptance:** failed POST × {null fragment, opt-out, provider failure}, plus disabled-session and
+excluded-path — each asserting exactly one JSON object on stdout and that kcap diagnostics are **not**
+consumed as hook context.
 
 ### 3.2 Write mechanics — "zero bytes on any failure" was too strong
 
@@ -403,22 +412,19 @@ was not definitively located. Treat as a prior, not proof.
 
 ## 4. Files
 
-**CORRECTED (round-2 finding 2).** The original claim — two files, no foundation changes, and "a foundation
-change signals the envelope was incomplete" — was wrong, and self-contradictory once §2.2a's generation
-rule was adopted. The generation is a *lease-store* concept, not an envelope one, so touching the
-foundation here says nothing about the envelope.
+**Scope reverted after the AI-1617 split.** Round 2 correctly pointed out that my original two-file claim
+was self-contradictory *once the generation rule was in scope*. With that rule moved to AI-1617, the small
+scope is honest again — and no lease-key change means **no migration risk to the five merged adapters**,
+which is the main reason the split is worth it.
 
 * `src/Capacitor.Cli/Commands/GeminiHookCommand.cs` — orchestrator call, stdout write, budget, `source` →
-  lifecycle mapping.
+  lifecycle mapping, and the §3.2-pre always-emit invariant across every recognised `SessionStart` path.
 * `src/Capacitor.Cli/Program.cs` — thread `hookProcessStart` into the `--gemini` dispatch.
-* **`src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryLeaseStore.cs`** — the atomic
-  `ReadOrInitGeneration` / `IncrementAndReserve` operations and generation-aware lease keys (§2.2a).
-* **`src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryOrchestrator.cs`** — accept and thread the
-  generation; expose the release seam that option (b) in §3.3 would wire.
-* Possibly `SessionStartMemoryContracts.cs` — if the generation belongs on the request/lifecycle record.
-* Foundation **tests** change accordingly; the five merged adapters must be verified unaffected, since a
-  generation-aware key touches a shared store. **A default generation of 0 for every existing harness must
-  keep their behaviour byte-identical** — that is a required regression assertion, not an assumption.
+* `src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryJsonContext.cs` — register the new
+  `{"continue":true}` allow record (§3.2-pre). This is an *additive* AOT registration, not a change to any
+  existing type, so it cannot alter another harness's output.
+* **No lease-store or orchestrator change.** If one becomes necessary, stop: it means AI-1617 scope has
+  leaked back in.
 
 ## 5. Test plan
 
@@ -426,7 +432,7 @@ Layers, per the project's per-vendor convention:
 
 1. **Foundation** — `Gemini_*` cases in `SessionStartMemoryFoundationTests`: envelope rendering
    (fragment → exact JSON), null fragment → empty string, lease dedupe across two `SessionStart`
-   invocations on one session id (the `resume` case).
+   invocations on one session id (the `resume` case). `clear` sequences move to AI-1617.
 2. **Hook command** — `GeminiSessionStartMemoryTests`: opt-out honoured (including under `KCAP_URL`, the
    §2.4 trap); budget exhaustion writes nothing; a throwing provider writes nothing and still returns the
    pre-existing exit code; stdout is written on the failed-POST path (§3.3).
@@ -493,13 +499,29 @@ The live cert is the only thing that verifies §3.1 — that a `hookSpecificOutp
 disturb Gemini's decision channel. A green unit suite proves the bytes we emit, not that Gemini accepts
 them. If the cert cannot be run, this issue should not be called done.
 
-## 6. Follow-ups this work surfaces but does not fix
+## 6. Split out of this issue — both filed, both Todo
 
-* **`stdout.trim() || stderr.trim()` (§3.1a).** Gemini parses a hook's **stderr** as its output whenever
-  stdout is empty. kcap writes diagnostics to stderr, so this already happens today on every failed-POST
-  session across the Gemini hook. It is currently benign — a parse failure degrades to plain text — but it
-  is one carelessly-worded stderr message away from being a real bug, and it means kcap's stderr is
-  semantically part of Gemini's hook contract. Worth its own issue rather than a comment.
+* **AI-1617 — context-generation lease key, all harnesses.** The `clear` re-injection gap (§2.2). Split
+  because it is foundation-wide (Claude has the identical loss and there is no `Clear` reason in the
+  contracts), and because the required persisted-key change carries a **re-injection migration risk to all
+  five merged adapters** that must not ride along with an adapter PR.
+* **AI-1618 — Gemini stderr shadowing for `SessionEnd` / `Notification`** (§3.1a). The `SessionStart` half
+  is fixed here (§3.2-pre) because it is on the paths this issue redesigns and carries the opt-out leak;
+  the remaining events are theirs.
+
+## 6a. Definition of done (round-3 finding 4)
+
+The conditional §3.3 design is only acceptable if the PR *finalises* it. Required before merge:
+
+1. **Run the live non-zero-exit case and write the result — with the observed `gemini --version` — back
+   into this spec.**
+2. **Delete the branch that was not selected.** The PR must not merge with both (a) and (b) still
+   normative.
+3. **Add the branch-specific lease assertion**, not a generic one:
+   * if **(a)**: the failed-POST invocation *completes* the lease, and a subsequent `resume` emits nothing.
+   * if **(b)**: it *releases* the lease, and a subsequent `resume` retries.
+4. **If the turn aborts, stop and escalate** — that is a defect in its own right, not a probe result to
+   design around, and it must not be recorded as a passing cert.
 
 ## 7. Out of scope
 

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Gemini;
+using Capacitor.Cli.SessionStartMemory;
 
 namespace Capacitor.Cli.Commands;
 
@@ -38,7 +39,91 @@ static class GeminiHookCommand {
     // Gemini's turn loop.
     static readonly TimeSpan NotificationPostBudget = TimeSpan.FromSeconds(2);
 
-    public static async Task<int> Handle(string baseUrl, TextReader stdin) {
+    /// <summary>
+    /// Renders the SessionStart hook result. With a fragment this is the memory envelope; without one it
+    /// is the explicit allow object — NOT zero bytes.
+    ///
+    /// <para>Emitting on the empty path is deliberate and diverges from the other memory adapters. Gemini
+    /// parses <c>stdout.trim() || stderr.trim()</c>, so silent stdout makes it read kcap's STDERR
+    /// diagnostics as the hook's output; a payload wins the <c>||</c> and shadows them. See
+    /// <see cref="GeminiAllowEnvelope"/>. Do not "harmonise" this back to the other adapters' shape.</para>
+    ///
+    /// <para>Two separate try blocks on purpose: rendering completes before any byte is written, and a
+    /// write that throws mid-payload must not alter the command's exit code. A truncated payload is safe
+    /// on Gemini's side — a JSON parse failure degrades to plain text and never synthesises a blocking
+    /// decision, which requires an explicit <c>decision: "block"|"deny"</c>.</para>
+    /// </summary>
+    internal static void WriteSessionStartOutput(TextWriter writer, string? fragment) {
+        string payload;
+
+        try {
+            payload = fragment is null
+                ? System.Text.Json.JsonSerializer.Serialize(
+                    new GeminiAllowEnvelope(), SessionStartMemoryJsonContext.Default.GeminiAllowEnvelope)
+                : SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Gemini, fragment);
+        } catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) {
+            return;
+        }
+
+        // Render returns "" for a null fragment; we never pass null here, but stay defensive rather than
+        // emitting an empty stdout that would silently re-expose stderr.
+        if (string.IsNullOrEmpty(payload)) return;
+
+        try { writer.Write(payload); }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) { }
+    }
+
+    /// <summary>Gemini's <c>source</c> mapped onto the shared lifecycle reason. <c>clear</c> falls to
+    /// <c>New</c> exactly as it does for Claude — there is no <c>Clear</c> reason in the foundation, so
+    /// the session-id lease suppresses re-injection after a context reset. That is a known gap tracked
+    /// separately, not a Gemini-specific choice.</summary>
+    internal static SessionLifecycleReason LifecycleReasonFor(string? source) => source?.ToLowerInvariant() switch {
+        "resume"  => SessionLifecycleReason.Resume,
+        "compact" => SessionLifecycleReason.Compact,
+        _         => SessionLifecycleReason.New
+    };
+
+    static Task<string?> StartMemoryIndexTask(
+            string     baseUrl,
+            string     sessionId,
+            string?    scopeRoot,
+            bool       disabled,
+            SessionLifecycleReason reason,
+            TimeSpan   budget,
+            Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory,
+            Func<SessionStartMemoryLeaseStore>?                 memoryStoreFactory) {
+        if (disabled || string.IsNullOrWhiteSpace(sessionId) || string.IsNullOrWhiteSpace(scopeRoot)
+         || budget <= TimeSpan.Zero
+         || !SessionStartMemoryHookSupport.CanAttempt(baseUrl))
+            return Task.FromResult<string?>(null);
+
+        try {
+            var store = memoryStoreFactory?.Invoke() ?? new SessionStartMemoryLeaseStore();
+            var provider = new SessionStartMemoryContextProvider(
+                new SessionStartMemoryScopeResolver(),
+                memoryClientFactory ?? SessionStartMemoryHookSupport.ClientFactory(baseUrl),
+                disposeClients: memoryClientFactory is null);
+
+            return new SessionStartMemoryOrchestrator(store, provider).GetFragmentAsync(
+                // CallbackMayRepeat: false — Gemini's SessionStart is a session-level event, not a
+                // per-turn callback like Kiro's agentSpawn. A `resume` re-fire on the same session id is
+                // made idempotent by the lease, not by this flag.
+                new SessionMemoryLifecycle(SessionStartHarness.Gemini, sessionId, LifecycleInstanceId: null,
+                    IsTopLevel: true, ClassificationAuthoritative: true, reason, CallbackMayRepeat: false),
+                new SessionStartMemoryContextRequest(baseUrl, scopeRoot, disabled, budget, CancellationToken.None));
+        } catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) {
+            return Task.FromResult<string?>(null);
+        }
+    }
+
+    /// <param name="processStart">Monotonic hook-start stamp anchoring every budget computation;
+    /// defaults to now. Tests pass an older stamp to drive the budget-exhausted branch without sleeping.</param>
+    public static async Task<int> Handle(string baseUrl, TextReader stdin,
+            long processStart = 0,
+            Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
+            Func<SessionStartMemoryLeaseStore>?                 memoryStoreFactory  = null) {
+        var ps = processStart == 0 ? System.Diagnostics.Stopwatch.GetTimestamp() : processStart;
+
         var body = await stdin.ReadToEndAsync();
 
         JsonNode? node;
@@ -63,8 +148,16 @@ static class GeminiHookCommand {
 
         // Mirror the Claude/Codex/Copilot disabled-session fast path: `kcap
         // disable` must stop every POST and watcher restart for the session.
+        // Invariant: a RECOGNISED SessionStart writes exactly one JSON object on every returning path,
+        // including the suppression fast paths below — an exception-riddled invariant is not an
+        // invariant, and these paths are not stderr-free (Program.cs drains the spool before dispatch).
+        // Unrecognised input above (bad JSON, no event name, non-GUID session id) stays silent: Gemini
+        // has no hook result to attribute to it.
+        var isSessionStart = eventName == "SessionStart";
+
         if (DisabledSessions.IsDisabled(sessionId)) {
             if (eventName == "SessionEnd") DisabledSessions.RemoveMarker(sessionId);
+            if (isSessionStart) WriteSessionStartOutput(Console.Out, fragment: null);
             return 0;
         }
 
@@ -77,11 +170,13 @@ static class GeminiHookCommand {
 
         if (activeProfile?.ExcludedPaths is { Length: > 0 } excludedPaths
          && PathExclusion.IsExcluded(cwd, excludedPaths)) {
+            if (isSessionStart) WriteSessionStartOutput(Console.Out, fragment: null);
             return 0;
         }
 
         return eventName switch {
-            "SessionStart" => await HandleSessionStart(baseUrl, node, sessionId, cwd, activeProfile, spool),
+            "SessionStart" => await HandleSessionStart(baseUrl, node, sessionId, cwd, activeProfile, spool,
+                                                       ps, memoryClientFactory, memoryStoreFactory),
             "SessionEnd"   => await HandleSessionEnd(baseUrl, node, sessionId, cwd),
             "Notification" => await HandleNotification(baseUrl, node, sessionId, cwd),
             _              => 0   // unknown / unsubscribed — fail-open like the other dispatchers
@@ -94,7 +189,10 @@ static class GeminiHookCommand {
             string    sessionId,
             string?   cwd,
             Profile?  activeProfile,
-            HookSpool spool
+            HookSpool spool,
+            long      processStart,
+            Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
+            Func<SessionStartMemoryLeaseStore>?                 memoryStoreFactory  = null
         ) {
         var source = TryGetString(node, "source") is { Length: > 0 } s ? s : "startup";
 
@@ -134,8 +232,20 @@ static class GeminiHookCommand {
         if (activeProfile?.ExcludedRepos is { Length: > 0 } excludedRepos
          && await RepoExclusion.IsExcludedAsync(enriched, excludedRepos)) {
             DisabledSessions.Mark(sessionId);
+            WriteSessionStartOutput(Console.Out, fragment: null);
             return 0;
         }
+
+        // Started in PARALLEL with the POST below, not before it — the lifecycle POST is the
+        // latency-critical path. Remaining() already subtracts its own safety margin; do not subtract
+        // again here (double-subtraction was a real defect in the Copilot adapter).
+        var memoryTask = StartMemoryIndexTask(
+            baseUrl, sessionId,
+            scopeRoot: GitRepository.FindRoot(cwd) ?? cwd,
+            disabled: activeProfile?.DisableMemoryIndex is true,
+            reason: LifecycleReasonFor(source),
+            budget: HookBudget.Remaining(processStart, "session-start"),
+            memoryClientFactory, memoryStoreFactory);
 
         // Spawn-before-post: capture must start on Posted OR Spooled (auth lapse /
         // outage) — a doomed/delayed lifecycle POST must never withhold the watcher. On a real
@@ -145,6 +255,14 @@ static class GeminiHookCommand {
         var outcome = await AgentHookPoster.PostOrSpoolAsync(
             baseUrl, "session-start/gemini", enriched, "gemini-hook",
             spool, sessionId, route: "session-start/gemini");
+
+        // Write the hook result BEFORE any return, including the failed-POST return below. The Codex
+        // adapter shipped a defect where an early `return 1` skipped the stdout handshake entirely; do
+        // not reintroduce it. The memory index is independent of lifecycle capture — a server rejecting
+        // the POST has not invalidated an index already fetched — and Gemini parses hook stdout
+        // unconditionally, with the exit code only setting its own `success` flag.
+        WriteSessionStartOutput(Console.Out,
+            await SessionStartMemoryHookSupport.AwaitBounded(memoryTask, processStart, "session-start"));
 
         if (!AgentHookPoster.ShouldSpawnAfter(outcome)) return outcome == HookPostOutcome.Failed ? 1 : 0;
 

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -27,8 +27,15 @@ namespace Capacitor.Cli.Commands;
 ///   SessionEnd   → kill watcher + capped inline drain (mirror of the Copilot /
 ///                  Claude pre-drain cap), then POST /hooks/session-end/gemini.
 ///   Notification → best-effort forward to the Claude-shaped /hooks/notification.
-/// Gemini treats hook stdout as a JSON decision channel; this dispatcher emits
-/// nothing (no stdout) so every action is allowed.
+/// Gemini treats hook stdout as a JSON decision channel, and selects the text to
+/// parse as <c>stdout.trim() || stderr.trim()</c> — so an EMPTY stdout makes it
+/// parse this process's STDERR (where kcap writes failed-POST and auth-lapse
+/// diagnostics) as the hook's result.
+///
+/// Because of that, a recognised SessionStart writes exactly one JSON object on
+/// every returning path: the memory envelope when there is one, else an explicit
+/// <c>{"continue":true}</c>. SessionEnd/Notification still emit nothing, which
+/// leaves them exposed to the same stderr fallback — tracked separately.
 /// </remarks>
 static class GeminiHookCommand {
     // Mirror of CopilotHookCommand.PreHookDrainCap: the drain must
@@ -83,16 +90,6 @@ static class GeminiHookCommand {
         try { writer.Write(payload); }
         catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) { }
     }
-
-    /// <summary>Gemini's <c>source</c> mapped onto the shared lifecycle reason. <c>clear</c> falls to
-    /// <c>New</c> exactly as it does for Claude — there is no <c>Clear</c> reason in the foundation, so
-    /// the session-id lease suppresses re-injection after a context reset. That is a known gap tracked
-    /// separately, not a Gemini-specific choice.</summary>
-    internal static SessionLifecycleReason LifecycleReasonFor(string? source) => source?.ToLowerInvariant() switch {
-        "resume"  => SessionLifecycleReason.Resume,
-        "compact" => SessionLifecycleReason.Compact,
-        _         => SessionLifecycleReason.New
-    };
 
     static Task<string?> StartMemoryIndexTask(
             string     baseUrl,
@@ -260,7 +257,10 @@ static class GeminiHookCommand {
             baseUrl, sessionId,
             scopeRoot: GitRepository.FindRoot(cwd) ?? cwd,
             disabled: activeProfile?.DisableMemoryIndex is true,
-            reason: LifecycleReasonFor(source),
+            // Shared mapper, NOT a local one: it maps an unrecognised source to Unknown, which the
+            // lifecycle policy suppresses. A local mapper defaulting to New would inject on an
+            // unverified reason AND spend the once-per-session lease on it.
+            reason: SessionStartMemoryHookSupport.ReasonFor(source),
             budget: HookBudget.Remaining(processStart, "session-start"),
             memoryClientFactory, memoryStoreFactory);
 

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -46,20 +46,6 @@ static class GeminiHookCommand {
     // Gemini's turn loop.
     static readonly TimeSpan NotificationPostBudget = TimeSpan.FromSeconds(2);
 
-    /// <summary>
-    /// Renders the SessionStart hook result. With a fragment this is the memory envelope; without one it
-    /// is the explicit allow object — NOT zero bytes.
-    ///
-    /// <para>Emitting on the empty path is deliberate and diverges from the other memory adapters. Gemini
-    /// parses <c>stdout.trim() || stderr.trim()</c>, so silent stdout makes it read kcap's STDERR
-    /// diagnostics as the hook's output; a payload wins the <c>||</c> and shadows them. See
-    /// <see cref="GeminiAllowEnvelope"/>. Do not "harmonise" this back to the other adapters' shape.</para>
-    ///
-    /// <para>Two separate try blocks on purpose: rendering completes before any byte is written, and a
-    /// write that throws mid-payload must not alter the command's exit code. A truncated payload is safe
-    /// on Gemini's side — a JSON parse failure degrades to plain text and never synthesises a blocking
-    /// decision, which requires an explicit <c>decision: "block"|"deny"</c>.</para>
-    /// </summary>
     /// <summary>Gemini's explicit allow-with-no-context result. A literal rather than a serializer call
     /// ON PURPOSE: this is the payload every failure path degrades to, so producing it must itself be
     /// incapable of failing. Serializing it would add a throw path to the one value that exists to
@@ -70,6 +56,20 @@ static class GeminiHookCommand {
     /// <c>decision</c>/<c>stopReason</c>, so it cannot block.</para></summary>
     internal const string AllowPayload = """{"continue":true}""";
 
+    /// <summary>
+    /// Renders the SessionStart hook result. With a fragment this is the memory envelope; without one it
+    /// is <see cref="AllowPayload"/> — NOT zero bytes.
+    ///
+    /// <para>Emitting on the empty path is deliberate and diverges from the other memory adapters. Gemini
+    /// parses <c>stdout.trim() || stderr.trim()</c>, so silent stdout makes it read kcap's STDERR
+    /// diagnostics as the hook's output; a payload wins the <c>||</c> and shadows them. Do not
+    /// "harmonise" this back to the other adapters' shape.</para>
+    ///
+    /// <para>Two separate try blocks on purpose: rendering completes before any byte is written, and a
+    /// write that throws mid-payload must not alter the command's exit code. A truncated payload is safe
+    /// on Gemini's side — a JSON parse failure degrades to plain text and never synthesises a blocking
+    /// decision, which requires an explicit <c>decision: "block"|"deny"</c>.</para>
+    /// </summary>
     internal static void WriteSessionStartOutput(TextWriter writer, string? fragment) {
         // Start from the payload that cannot fail, and only upgrade to the memory envelope when
         // rendering genuinely succeeds. Structured this way so that a render throw OR an empty render
@@ -91,12 +91,30 @@ static class GeminiHookCommand {
         catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) { }
     }
 
+    /// <summary>The exact <see cref="SessionMemoryLifecycle"/> this adapter hands the orchestrator.
+    ///
+    /// <para>Extracted so it is testable as a unit: asserting the shared mapper in isolation would stay
+    /// green if this call site reintroduced a local mapper — which is precisely the regression that
+    /// occurred here. Tests feed this into <c>SessionStartMemoryLifecyclePolicy.Decide</c> to assert the
+    /// resulting eligibility, which is the behaviour that actually matters.</para>
+    ///
+    /// <para><c>CallbackMayRepeat: false</c> — Gemini's SessionStart is a session-level event, not a
+    /// per-turn callback like Kiro's agentSpawn. A `resume` re-fire on the same session id is made
+    /// idempotent by the lease, not by this flag.</para></summary>
+    internal static SessionMemoryLifecycle LifecycleFor(string sessionId, string? source) =>
+        new(SessionStartHarness.Gemini, sessionId, LifecycleInstanceId: null,
+            IsTopLevel: true, ClassificationAuthoritative: true,
+            // Shared mapper, NOT a local one: it maps an unrecognised source to Unknown, which the
+            // policy suppresses BEFORE any lease is acquired. A local mapper defaulting to New would
+            // inject on an unverified reason AND spend the once-per-session lease on it.
+            SessionStartMemoryHookSupport.ReasonFor(source), CallbackMayRepeat: false);
+
     static Task<string?> StartMemoryIndexTask(
             string     baseUrl,
             string     sessionId,
             string?    scopeRoot,
             bool       disabled,
-            SessionLifecycleReason reason,
+            string?    source,
             TimeSpan   budget,
             Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory,
             Func<SessionStartMemoryLeaseStore>?                 memoryStoreFactory) {
@@ -113,12 +131,8 @@ static class GeminiHookCommand {
                 disposeClients: memoryClientFactory is null);
 
             return new SessionStartMemoryOrchestrator(store, provider).GetFragmentAsync(
-                // CallbackMayRepeat: false — Gemini's SessionStart is a session-level event, not a
-                // per-turn callback like Kiro's agentSpawn. A `resume` re-fire on the same session id is
-                // made idempotent by the lease, not by this flag.
-                new SessionMemoryLifecycle(SessionStartHarness.Gemini, sessionId, LifecycleInstanceId: null,
-                    IsTopLevel: true, ClassificationAuthoritative: true, reason, CallbackMayRepeat: false),
-                new SessionStartMemoryContextRequest(baseUrl, scopeRoot, disabled, budget, CancellationToken.None));
+                            LifecycleFor(sessionId, source),
+    new SessionStartMemoryContextRequest(baseUrl, scopeRoot, disabled, budget, CancellationToken.None));
         } catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) {
             return Task.FromResult<string?>(null);
         }
@@ -257,10 +271,7 @@ static class GeminiHookCommand {
             baseUrl, sessionId,
             scopeRoot: GitRepository.FindRoot(cwd) ?? cwd,
             disabled: activeProfile?.DisableMemoryIndex is true,
-            // Shared mapper, NOT a local one: it maps an unrecognised source to Unknown, which the
-            // lifecycle policy suppresses. A local mapper defaulting to New would inject on an
-            // unverified reason AND spend the once-per-session lease on it.
-            reason: SessionStartMemoryHookSupport.ReasonFor(source),
+            source: source,
             budget: HookBudget.Remaining(processStart, "session-start"),
             memoryClientFactory, memoryStoreFactory);
 

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -53,22 +53,33 @@ static class GeminiHookCommand {
     /// on Gemini's side — a JSON parse failure degrades to plain text and never synthesises a blocking
     /// decision, which requires an explicit <c>decision: "block"|"deny"</c>.</para>
     /// </summary>
-    internal static void WriteSessionStartOutput(TextWriter writer, string? fragment) {
-        string payload;
+    /// <summary>Gemini's explicit allow-with-no-context result. A literal rather than a serializer call
+    /// ON PURPOSE: this is the payload every failure path degrades to, so producing it must itself be
+    /// incapable of failing. Serializing it would add a throw path to the one value that exists to
+    /// guarantee we never emit zero bytes.
+    ///
+    /// <para>Carries no <c>hookSpecificOutput</c> key, so Gemini's <c>getAdditionalContext()</c>
+    /// short-circuits on its own <c>"additionalContext" in …</c> guard and contributes nothing; and no
+    /// <c>decision</c>/<c>stopReason</c>, so it cannot block.</para></summary>
+    internal const string AllowPayload = """{"continue":true}""";
 
-        try {
-            payload = fragment is null
-                ? System.Text.Json.JsonSerializer.Serialize(
-                    new GeminiAllowEnvelope(), SessionStartMemoryJsonContext.Default.GeminiAllowEnvelope)
-                : SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Gemini, fragment);
-        } catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) {
-            return;
+    internal static void WriteSessionStartOutput(TextWriter writer, string? fragment) {
+        // Start from the payload that cannot fail, and only upgrade to the memory envelope when
+        // rendering genuinely succeeds. Structured this way so that a render throw OR an empty render
+        // degrades to the allow object rather than to silence — silence is what re-exposes stderr.
+        var payload = AllowPayload;
+
+        if (fragment is not null) {
+            try {
+                var rendered = SessionStartMemoryOutputAdapters.Render(SessionStartHarness.Gemini, fragment);
+                if (!string.IsNullOrEmpty(rendered)) payload = rendered;
+            } catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) {
+                // keep AllowPayload
+            }
         }
 
-        // Render returns "" for a null fragment; we never pass null here, but stay defensive rather than
-        // emitting an empty stdout that would silently re-expose stderr.
-        if (string.IsNullOrEmpty(payload)) return;
-
+        // Separate try: a write throwing mid-payload must not alter the command's exit code. A truncated
+        // payload is safe on Gemini's side — a parse failure degrades to plain text, never a block.
         try { writer.Write(payload); }
         catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) { }
     }
@@ -141,8 +152,16 @@ static class GeminiHookCommand {
 
         // Gemini session ids are dashed UUIDs; keep the dashless form for the
         // server (AgentSession-{dashless} convention shared by every vendor).
+        // Recognised from HERE, not after session-id validation. Gemini fired a SessionStart and WILL
+        // read our stdout whatever we make of the rest of the payload, so a bad session id must still
+        // emit — otherwise this path re-exposes the stdout||stderr fallback.
+        var isSessionStart = eventName == "SessionStart";
+
         var dashedSessionId = TryGetString(node, "session_id");
-        if (string.IsNullOrEmpty(dashedSessionId) || !Guid.TryParse(dashedSessionId, out _)) return 0;
+        if (string.IsNullOrEmpty(dashedSessionId) || !Guid.TryParse(dashedSessionId, out _)) {
+            if (isSessionStart) WriteSessionStartOutput(Console.Out, fragment: null);
+            return 0;
+        }
 
         var sessionId = dashedSessionId.Replace("-", "");
 
@@ -151,10 +170,8 @@ static class GeminiHookCommand {
         // Invariant: a RECOGNISED SessionStart writes exactly one JSON object on every returning path,
         // including the suppression fast paths below — an exception-riddled invariant is not an
         // invariant, and these paths are not stderr-free (Program.cs drains the spool before dispatch).
-        // Unrecognised input above (bad JSON, no event name, non-GUID session id) stays silent: Gemini
-        // has no hook result to attribute to it.
-        var isSessionStart = eventName == "SessionStart";
-
+        // Only genuinely unrecognisable input stays silent: unparseable stdin and a missing/blank
+        // hook_event_name, where we cannot know a SessionStart occurred at all.
         if (DisabledSessions.IsDisabled(sessionId)) {
             if (eventName == "SessionEnd") DisabledSessions.RemoveMarker(sessionId);
             if (isSessionStart) WriteSessionStartOutput(Console.Out, fragment: null);

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -701,7 +701,7 @@ switch (command) {
             return await CopilotHookCommand.Handle(baseUrl!, Console.In, args, hookProcessStart);
         }
         if (args.Contains("--gemini")) {
-            return await GeminiHookCommand.Handle(baseUrl!, Console.In);
+            return await GeminiHookCommand.Handle(baseUrl!, Console.In, hookProcessStart);
         }
         if (args.Contains("--kiro")) {
             return await KiroHookCommand.Handle(baseUrl!, Console.In, args, hookProcessStart);

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryJsonContext.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryJsonContext.cs
@@ -15,7 +15,6 @@ namespace Capacitor.Cli.SessionStartMemory;
 [JsonSerializable(typeof(CursorMemoryEnvelope))]
 [JsonSerializable(typeof(CopilotMemoryEnvelope))]
 [JsonSerializable(typeof(GeminiMemoryEnvelope))]
-[JsonSerializable(typeof(GeminiAllowEnvelope))]
 [JsonSerializable(typeof(AntigravityMemoryEnvelope))]
 internal partial class SessionStartMemoryJsonContext : JsonSerializerContext;
 
@@ -37,22 +36,5 @@ internal sealed record CursorMemoryEnvelope([property: JsonPropertyName("additio
 internal sealed record CopilotMemoryEnvelope([property: JsonPropertyName("additionalContext")] string? AdditionalContext = null);
 internal sealed record GeminiMemoryEnvelope([property: JsonPropertyName("hookSpecificOutput")] HookMemoryOutput? HookSpecificOutput = null);
 
-/// <summary>
-/// Gemini's explicit allow-with-no-context hook result: <c>{"continue":true}</c>.
-///
-/// <para><b>Why Gemini emits something on the empty path when the other adapters emit nothing.</b>
-/// Gemini's hook runner selects the text to parse as <c>stdout.trim() || stderr.trim()</c> — so when a
-/// hook writes nothing to stdout it parses the hook's STDERR instead. kcap writes diagnostics there
-/// (failed lifecycle POSTs, the auth-lapse notice), which would then be consumed as hook output. The
-/// worst case is with memory injection opted OUT: a failed POST could still put kcap text into the
-/// model's context. Emitting a payload wins the <c>||</c> and shadows stderr.</para>
-///
-/// <para>Deliberately carries NO <c>hookSpecificOutput</c> key: Gemini's <c>getAdditionalContext()</c>
-/// short-circuits on its own <c>"additionalContext" in hookSpecificOutput</c> guard, so an absent key
-/// contributes nothing. <c>{}</c> was rejected because it asserts nothing and relies on every default
-/// staying benign; an <c>additionalContext</c>-less <c>hookSpecificOutput</c> was rejected as a shape
-/// needing separate verification for no benefit.</para>
-/// </summary>
-internal sealed record GeminiAllowEnvelope([property: JsonPropertyName("continue")] bool Continue = true);
 internal sealed record AntigravityMemoryEnvelope([property: JsonPropertyName("injectSteps")] AntigravityMemoryStep[]? InjectSteps = null);
 internal sealed record AntigravityMemoryStep([property: JsonPropertyName("userMessage")] string UserMessage);

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryJsonContext.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryJsonContext.cs
@@ -15,6 +15,7 @@ namespace Capacitor.Cli.SessionStartMemory;
 [JsonSerializable(typeof(CursorMemoryEnvelope))]
 [JsonSerializable(typeof(CopilotMemoryEnvelope))]
 [JsonSerializable(typeof(GeminiMemoryEnvelope))]
+[JsonSerializable(typeof(GeminiAllowEnvelope))]
 [JsonSerializable(typeof(AntigravityMemoryEnvelope))]
 internal partial class SessionStartMemoryJsonContext : JsonSerializerContext;
 
@@ -35,5 +36,23 @@ internal sealed record CodexMemoryEnvelope(
 internal sealed record CursorMemoryEnvelope([property: JsonPropertyName("additional_context")] string? AdditionalContext = null);
 internal sealed record CopilotMemoryEnvelope([property: JsonPropertyName("additionalContext")] string? AdditionalContext = null);
 internal sealed record GeminiMemoryEnvelope([property: JsonPropertyName("hookSpecificOutput")] HookMemoryOutput? HookSpecificOutput = null);
+
+/// <summary>
+/// Gemini's explicit allow-with-no-context hook result: <c>{"continue":true}</c>.
+///
+/// <para><b>Why Gemini emits something on the empty path when the other adapters emit nothing.</b>
+/// Gemini's hook runner selects the text to parse as <c>stdout.trim() || stderr.trim()</c> — so when a
+/// hook writes nothing to stdout it parses the hook's STDERR instead. kcap writes diagnostics there
+/// (failed lifecycle POSTs, the auth-lapse notice), which would then be consumed as hook output. The
+/// worst case is with memory injection opted OUT: a failed POST could still put kcap text into the
+/// model's context. Emitting a payload wins the <c>||</c> and shadows stderr.</para>
+///
+/// <para>Deliberately carries NO <c>hookSpecificOutput</c> key: Gemini's <c>getAdditionalContext()</c>
+/// short-circuits on its own <c>"additionalContext" in hookSpecificOutput</c> guard, so an absent key
+/// contributes nothing. <c>{}</c> was rejected because it asserts nothing and relies on every default
+/// staying benign; an <c>additionalContext</c>-less <c>hookSpecificOutput</c> was rejected as a shape
+/// needing separate verification for no benefit.</para>
+/// </summary>
+internal sealed record GeminiAllowEnvelope([property: JsonPropertyName("continue")] bool Continue = true);
 internal sealed record AntigravityMemoryEnvelope([property: JsonPropertyName("injectSteps")] AntigravityMemoryStep[]? InjectSteps = null);
 internal sealed record AntigravityMemoryStep([property: JsonPropertyName("userMessage")] string UserMessage);

--- a/test/Capacitor.Cli.Tests.Unit/GeminiSessionStartMemoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiSessionStartMemoryTests.cs
@@ -130,6 +130,53 @@ public class GeminiSessionStartMemoryTests {
         await Assert.That(true).IsTrue();   // reaching here without an exception IS the assertion
     }
 
+    // ── the invariant at the Handle level, not just the writer ────────────────
+
+    /// <summary>
+    /// A `SessionStart` whose `session_id` is missing or not a GUID still emits.
+    ///
+    /// <para>Found by code review. The event is recognisable from `hook_event_name` alone, and Gemini
+    /// reads our stdout regardless of what we make of the rest of the payload — so returning silently
+    /// here re-exposed the `stdout || stderr` fallback. The writer-level tests could not catch it: they
+    /// call <c>WriteSessionStartOutput</c> directly and never exercise <c>Handle</c>'s early returns.</para>
+    /// </summary>
+    [Test, NotInParallel]
+    [Arguments("""{"hook_event_name":"SessionStart"}""")]
+    [Arguments("""{"hook_event_name":"SessionStart","session_id":""}""")]
+    [Arguments("""{"hook_event_name":"SessionStart","session_id":"not-a-guid"}""")]
+    public async Task session_start_with_an_unusable_session_id_still_emits_exactly_one_json_object(string payload) {
+        var captured = await CaptureHandleStdout(payload);
+
+        await Assert.That(captured).IsEqualTo(GeminiHookCommand.AllowPayload);
+        using var doc = System.Text.Json.JsonDocument.Parse(captured);
+        await Assert.That(doc.RootElement.ValueKind).IsEqualTo(System.Text.Json.JsonValueKind.Object);
+    }
+
+    /// <summary>The complement: input we genuinely cannot recognise as a SessionStart stays silent —
+    /// Gemini fired something else (or nothing parseable) and we have no result to attribute.</summary>
+    [Test, NotInParallel]
+    [Arguments("not json at all")]
+    [Arguments("""{"session_id":"3f2504e0-4f89-11d3-9a0c-0305e82c3301"}""")]
+    [Arguments("""{"hook_event_name":"","session_id":"3f2504e0-4f89-11d3-9a0c-0305e82c3301"}""")]
+    public async Task unrecognisable_input_stays_silent(string payload) {
+        await Assert.That(await CaptureHandleStdout(payload)).IsEqualTo("");
+    }
+
+    static async Task<string> CaptureHandleStdout(string payload) {
+        var original = Console.Out;
+        var sw = new StringWriter();
+
+        try {
+            Console.SetOut(sw);
+            // baseUrl is unreachable on purpose: these paths must return before any network work.
+            await GeminiHookCommand.Handle("http://127.0.0.1:1", new StringReader(payload));
+        } finally {
+            Console.SetOut(original);
+        }
+
+        return sw.ToString();
+    }
+
     // ── source → lifecycle mapping ────────────────────────────────────────────
 
     /// <summary><c>clear</c> maps to <c>New</c>, exactly as it does for Claude, so the session-id lease

--- a/test/Capacitor.Cli.Tests.Unit/GeminiSessionStartMemoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiSessionStartMemoryTests.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.SessionStartMemory;
 
 namespace Capacitor.Cli.Tests.Unit;
@@ -68,12 +69,15 @@ public class GeminiSessionStartMemoryTests {
 
     [Test]
     public async Task a_fragment_is_written_as_the_claude_shaped_envelope() {
-        var output = Write("## Team memory\n- prefer the integration suite");
+        const string fragment = "## Team memory\n- prefer the integration suite";
+        using var doc = System.Text.Json.JsonDocument.Parse(Write(fragment));
 
-        await Assert.That(output).Contains("\"hookSpecificOutput\"");
-        await Assert.That(output).Contains("\"hookEventName\":\"SessionStart\"");
-        await Assert.That(output).Contains("\"additionalContext\"");
-        await Assert.That(output).StartsWith("{");
+        // Structural, via the project's JsonElement helpers — substring matching would pass on a
+        // malformed document that merely contained the right characters.
+        var hookSpecific = doc.RootElement.Obj("hookSpecificOutput");
+        await Assert.That(hookSpecific).IsNotNull();
+        await Assert.That(hookSpecific!.Value.Str("hookEventName")).IsEqualTo("SessionStart");
+        await Assert.That(hookSpecific!.Value.Str("additionalContext")).IsEqualTo(fragment);
     }
 
     /// <summary>Inverse of the Kiro contract: Gemini reads JSON, so the fragment MUST be escaped.
@@ -88,10 +92,8 @@ public class GeminiSessionStartMemoryTests {
         await Assert.That(output).DoesNotContain("\n## ");
         // Round-trips back to the original: proof the escaping is correct, not merely present.
         using var doc = System.Text.Json.JsonDocument.Parse(output);
-        var roundTripped = doc.RootElement
-            .GetProperty("hookSpecificOutput").GetProperty("additionalContext").GetString();
 
-        await Assert.That(roundTripped).IsEqualTo(fragment);
+        await Assert.That(doc.RootElement.Obj("hookSpecificOutput")?.Str("additionalContext")).IsEqualTo(fragment);
     }
 
     [Test]
@@ -100,18 +102,28 @@ public class GeminiSessionStartMemoryTests {
     public async Task every_payload_is_exactly_one_parseable_json_object(string? fragment) {
         var output = Write(fragment);
 
+        // Parse() throwing IS the failure; Obj/Str return null on a non-object root, so a non-object
+        // payload fails the follow-up too.
         using var doc = System.Text.Json.JsonDocument.Parse(output);
-        await Assert.That(doc.RootElement.ValueKind).IsEqualTo(System.Text.Json.JsonValueKind.Object);
+        var isObject = doc.RootElement.Obj("hookSpecificOutput") is not null
+                    || doc.RootElement.Str("continue") is not null
+                    || output == GeminiHookCommand.AllowPayload;
+
+        await Assert.That(isObject).IsTrue();
     }
 
     // ── a failing writer must not change the command's exit code ──────────────
 
-    sealed class ThrowingWriter(int failAfterChars) : StringWriter {
-        int _written;
+    /// <summary>Writes <paramref name="charsBeforeThrowing"/> characters of the payload and THEN throws,
+    /// so 0 exercises "fails before any byte" and a positive value exercises a genuine partial write.
+    /// An earlier version only ever threw before writing, leaving the advertised partial-write case
+    /// untested — caught in review.</summary>
+    sealed class ThrowingWriter(int charsBeforeThrowing) : StringWriter {
         public override void Write(string? value) {
-            if (_written >= failAfterChars) throw new IOException("stdout closed");
-            _written += value?.Length ?? 0;
-            base.Write(value);
+            if (value is { Length: > 0 } && charsBeforeThrowing > 0)
+                base.Write(value[..Math.Min(charsBeforeThrowing, value.Length)]);
+
+            throw new IOException("stdout closed");
         }
     }
 
@@ -121,13 +133,15 @@ public class GeminiSessionStartMemoryTests {
     [Test]
     [Arguments(0)]
     [Arguments(5)]
-    public async Task a_throwing_writer_does_not_propagate(int failAfterChars) {
-        var writer = new ThrowingWriter(failAfterChars);
+    public async Task a_throwing_writer_does_not_propagate(int charsBeforeThrowing) {
+        var writer = new ThrowingWriter(charsBeforeThrowing);
 
         GeminiHookCommand.WriteSessionStartOutput(writer, "## Team memory");
         GeminiHookCommand.WriteSessionStartOutput(writer, null);
 
-        await Assert.That(true).IsTrue();   // reaching here without an exception IS the assertion
+        // Reaching here without an exception is the contract. Also prove the writer really did what the
+        // case name claims, so neither case can pass by never throwing at all.
+        await Assert.That(writer.ToString().Length).IsEqualTo(charsBeforeThrowing == 0 ? 0 : charsBeforeThrowing * 2);
     }
 
     // ── the invariant at the Handle level, not just the writer ────────────────
@@ -148,8 +162,8 @@ public class GeminiSessionStartMemoryTests {
         var captured = await CaptureHandleStdout(payload);
 
         await Assert.That(captured).IsEqualTo(GeminiHookCommand.AllowPayload);
-        using var doc = System.Text.Json.JsonDocument.Parse(captured);
-        await Assert.That(doc.RootElement.ValueKind).IsEqualTo(System.Text.Json.JsonValueKind.Object);
+        using var doc = System.Text.Json.JsonDocument.Parse(captured);   // throwing IS the failure
+        await Assert.That(doc.RootElement.Obj("hookSpecificOutput")).IsNull();
     }
 
     /// <summary>The complement: input we genuinely cannot recognise as a SessionStart stays silent —
@@ -179,20 +193,30 @@ public class GeminiSessionStartMemoryTests {
 
     // ── source → lifecycle mapping ────────────────────────────────────────────
 
-    /// <summary><c>clear</c> maps to <c>New</c>, exactly as it does for Claude, so the session-id lease
-    /// suppresses re-injection after a context reset. That is a KNOWN GAP tracked separately (there is no
-    /// <c>Clear</c> reason in the foundation) — pinned here so the gap is deliberate and visible rather
-    /// than an accident someone silently "fixes" for one harness.</summary>
-    // Expected value is passed by NAME, not as the enum: SessionLifecycleReason is internal, so a public
-    // test signature cannot mention it.
+    /// <summary>
+    /// The adapter uses the SHARED <c>SessionStartMemoryHookSupport.ReasonFor</c>, not a local mapper.
+    ///
+    /// <para>An earlier revision hand-rolled one defaulting unrecognised sources to <c>New</c>. That is a
+    /// real bug, not a style point: the lifecycle policy decides eligibility from this reason, so
+    /// defaulting to <c>New</c> would inject on an unverified source AND spend the once-per-session lease
+    /// on it. The shared mapper returns <c>Unknown</c>, which the policy suppresses.</para>
+    ///
+    /// <para><c>clear</c> therefore lands on <c>Unknown</c> and is suppressed by the POLICY rather than by
+    /// the lease. Same observable outcome — no re-injection after a context reset — but suppressed
+    /// explicitly. Re-injection on clear is a known foundation-wide gap tracked separately; pinned here so
+    /// it stays deliberate and visible.</para>
+    /// </summary>
+    // Expected value is passed by NAME: SessionLifecycleReason is internal, so a public test signature
+    // cannot mention it.
     [Test]
     [Arguments("startup", "New")]
     [Arguments("resume",  "Resume")]
-    [Arguments("clear",   "New")]
     [Arguments("compact", "Compact")]
     [Arguments(null,      "New")]
     [Arguments("RESUME",  "Resume")]
-    public async Task source_maps_to_the_shared_lifecycle_reason(string? source, string expected) {
-        await Assert.That(GeminiHookCommand.LifecycleReasonFor(source).ToString()).IsEqualTo(expected);
+    [Arguments("clear",   "Unknown")]
+    [Arguments("wat",     "Unknown")]
+    public async Task source_maps_through_the_shared_lifecycle_mapper(string? source, string expected) {
+        await Assert.That(SessionStartMemoryHookSupport.ReasonFor(source).ToString()).IsEqualTo(expected);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/GeminiSessionStartMemoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiSessionStartMemoryTests.cs
@@ -1,0 +1,151 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.SessionStartMemory;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The Gemini SessionStart memory-injection contract.
+///
+/// <para>Gemini differs from every other adapter in one way that drives most of these tests: its hook
+/// stdout is a JSON <b>decision channel</b>, and its runner selects the text to parse as
+/// <c>stdout.trim() || stderr.trim()</c>. So an empty stdout makes Gemini parse the hook's STDERR —
+/// where kcap writes failed-POST and auth-lapse diagnostics — as the hook's output. That is why the
+/// no-fragment path emits an explicit allow object instead of the zero bytes every other adapter
+/// writes, and why that divergence is pinned here rather than left to be "harmonised" away.</para>
+///
+/// <para>The worst case it prevents: with memory injection opted OUT, a failed lifecycle POST could
+/// otherwise put kcap text into the model's context.</para>
+/// </summary>
+public class GeminiSessionStartMemoryTests {
+    static string Write(string? fragment) {
+        var sw = new StringWriter();
+        GeminiHookCommand.WriteSessionStartOutput(sw, fragment);
+
+        return sw.ToString();
+    }
+
+    // ── the divergence from every other adapter ───────────────────────────────
+
+    /// <summary>The load-bearing one. Zero bytes here would re-expose stderr to Gemini's parser.</summary>
+    [Test]
+    public async Task no_fragment_writes_an_explicit_allow_object_not_zero_bytes() {
+        var output = Write(null);
+
+        await Assert.That(output).IsNotEmpty();
+        await Assert.That(output).IsEqualTo("""{"continue":true}""");
+    }
+
+    /// <summary>The allow object must carry NO <c>hookSpecificOutput</c> key: Gemini's
+    /// <c>getAdditionalContext()</c> short-circuits on its own <c>"additionalContext" in
+    /// hookSpecificOutput</c> guard, so an absent key contributes nothing. A present-but-empty one would
+    /// be a shape we have not verified.</summary>
+    [Test]
+    public async Task the_allow_object_contributes_no_context_and_no_user_visible_message() {
+        var output = Write(null);
+
+        await Assert.That(output).DoesNotContain("hookSpecificOutput");
+        await Assert.That(output).DoesNotContain("additionalContext");
+        await Assert.That(output).DoesNotContain("systemMessage");
+    }
+
+    // ── neither payload may look like a blocking decision ─────────────────────
+
+    /// <summary>Gemini blocks only on an explicit <c>decision: "block"|"deny"</c>
+    /// (<c>isBlockingDecision()</c>), and stops only via <c>continue</c>/<c>stopReason</c>. Neither
+    /// payload may ever carry those, or a memory injection would abort the user's session at startup.</summary>
+    [Test]
+    [Arguments(null)]
+    [Arguments("## Team memory\n- prefer the integration suite")]
+    public async Task no_payload_ever_carries_a_blocking_or_stopping_field(string? fragment) {
+        var output = Write(fragment);
+
+        await Assert.That(output).DoesNotContain("\"decision\"");
+        await Assert.That(output).DoesNotContain("\"stopReason\"");
+        await Assert.That(output).DoesNotContain("\"continue\":false");
+    }
+
+    // ── the fragment envelope ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task a_fragment_is_written_as_the_claude_shaped_envelope() {
+        var output = Write("## Team memory\n- prefer the integration suite");
+
+        await Assert.That(output).Contains("\"hookSpecificOutput\"");
+        await Assert.That(output).Contains("\"hookEventName\":\"SessionStart\"");
+        await Assert.That(output).Contains("\"additionalContext\"");
+        await Assert.That(output).StartsWith("{");
+    }
+
+    /// <summary>Inverse of the Kiro contract: Gemini reads JSON, so the fragment MUST be escaped.
+    /// Emitting raw markdown would produce invalid JSON — which Gemini degrades to plain text rather
+    /// than blocking, but which silently loses the index.</summary>
+    [Test]
+    [Arguments("quote \" backslash \\ tab \t")]
+    [Arguments("- item one\n- item two\n\n### Heading")]
+    public async Task fragment_content_is_json_escaped(string fragment) {
+        var output = Write(fragment);
+
+        await Assert.That(output).DoesNotContain("\n## ");
+        // Round-trips back to the original: proof the escaping is correct, not merely present.
+        using var doc = System.Text.Json.JsonDocument.Parse(output);
+        var roundTripped = doc.RootElement
+            .GetProperty("hookSpecificOutput").GetProperty("additionalContext").GetString();
+
+        await Assert.That(roundTripped).IsEqualTo(fragment);
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("## Team memory")]
+    public async Task every_payload_is_exactly_one_parseable_json_object(string? fragment) {
+        var output = Write(fragment);
+
+        using var doc = System.Text.Json.JsonDocument.Parse(output);
+        await Assert.That(doc.RootElement.ValueKind).IsEqualTo(System.Text.Json.JsonValueKind.Object);
+    }
+
+    // ── a failing writer must not change the command's exit code ──────────────
+
+    sealed class ThrowingWriter(int failAfterChars) : StringWriter {
+        int _written;
+        public override void Write(string? value) {
+            if (_written >= failAfterChars) throw new IOException("stdout closed");
+            _written += value?.Length ?? 0;
+            base.Write(value);
+        }
+    }
+
+    /// <summary>A write that throws — before any byte, or mid-payload — must be swallowed. Rendering
+    /// completes before the single write, so a partial payload is the only exposure, and Gemini degrades
+    /// truncated JSON to plain text rather than synthesising a block.</summary>
+    [Test]
+    [Arguments(0)]
+    [Arguments(5)]
+    public async Task a_throwing_writer_does_not_propagate(int failAfterChars) {
+        var writer = new ThrowingWriter(failAfterChars);
+
+        GeminiHookCommand.WriteSessionStartOutput(writer, "## Team memory");
+        GeminiHookCommand.WriteSessionStartOutput(writer, null);
+
+        await Assert.That(true).IsTrue();   // reaching here without an exception IS the assertion
+    }
+
+    // ── source → lifecycle mapping ────────────────────────────────────────────
+
+    /// <summary><c>clear</c> maps to <c>New</c>, exactly as it does for Claude, so the session-id lease
+    /// suppresses re-injection after a context reset. That is a KNOWN GAP tracked separately (there is no
+    /// <c>Clear</c> reason in the foundation) — pinned here so the gap is deliberate and visible rather
+    /// than an accident someone silently "fixes" for one harness.</summary>
+    // Expected value is passed by NAME, not as the enum: SessionLifecycleReason is internal, so a public
+    // test signature cannot mention it.
+    [Test]
+    [Arguments("startup", "New")]
+    [Arguments("resume",  "Resume")]
+    [Arguments("clear",   "New")]
+    [Arguments("compact", "Compact")]
+    [Arguments(null,      "New")]
+    [Arguments("RESUME",  "Resume")]
+    public async Task source_maps_to_the_shared_lifecycle_reason(string? source, string expected) {
+        await Assert.That(GeminiHookCommand.LifecycleReasonFor(source).ToString()).IsEqualTo(expected);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/GeminiSessionStartMemoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiSessionStartMemoryTests.cs
@@ -219,4 +219,44 @@ public class GeminiSessionStartMemoryTests {
     public async Task source_maps_through_the_shared_lifecycle_mapper(string? source, string expected) {
         await Assert.That(SessionStartMemoryHookSupport.ReasonFor(source).ToString()).IsEqualTo(expected);
     }
+
+    /// <summary>
+    /// The adapter-level guard: asserts the ELIGIBILITY the adapter's own lifecycle produces, not just
+    /// the mapper in isolation.
+    ///
+    /// <para>Found by code review. The mapper test above calls <c>ReasonFor</c> directly, so it would
+    /// stay green if this call site reintroduced a local mapper — the exact regression that occurred
+    /// here. <c>LifecycleFor</c> is what <c>StartMemoryIndexTask</c> actually passes to the orchestrator,
+    /// so running it through the real policy closes that hole.</para>
+    ///
+    /// <para>Why the decision, not an I/O observation: <c>GetFragmentAsync</c> calls <c>Decide</c>
+    /// FIRST — before <c>TryBeginAsync</c> and before the provider fetch — so a
+    /// <c>RetryLaterNoCommit</c> means no lease is acquired and none is spent. Asserting the decision
+    /// proves "suppressed without burning the session's one injection" deterministically, with no
+    /// filesystem or HTTP.</para>
+    /// </summary>
+    [Test]
+    [Arguments("startup", "EligibleOneShot")]      // the positive control: this MUST be eligible, or
+    [Arguments("resume",  "EligibleOneShot")]      // "suppressed" below would prove nothing
+    [Arguments("compact", "IneligibleNoCommit")]
+    [Arguments("clear",   "RetryLaterNoCommit")]   // unknown reason ⇒ suppressed, lease NOT spent
+    [Arguments("wat",     "RetryLaterNoCommit")]
+    public async Task the_adapters_lifecycle_produces_the_expected_policy_decision(string source, string expected) {
+        var lifecycle = GeminiHookCommand.LifecycleFor("3f2504e04f8911d39a0c0305e82c3301", source);
+
+        await Assert.That(SessionStartMemoryLifecyclePolicy.Decide(lifecycle).ToString()).IsEqualTo(expected);
+    }
+
+    /// <summary>The rest of the lifecycle record the adapter builds, pinned so a future edit cannot
+    /// silently turn Gemini into a repeating per-turn callback (Kiro's shape) or a subagent.</summary>
+    [Test]
+    public async Task the_adapters_lifecycle_is_top_level_authoritative_and_non_repeating() {
+        var lifecycle = GeminiHookCommand.LifecycleFor("3f2504e04f8911d39a0c0305e82c3301", "startup");
+
+        await Assert.That(lifecycle.Harness.ToString()).IsEqualTo("Gemini");
+        await Assert.That(lifecycle.IsTopLevel).IsTrue();
+        await Assert.That(lifecycle.ClassificationAuthoritative).IsTrue();
+        await Assert.That(lifecycle.CallbackMayRepeat).IsFalse();
+        await Assert.That(lifecycle.LifecycleInstanceId).IsNull();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/GeminiMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/GeminiMemoryIndexLiveCertTests.cs
@@ -1,0 +1,104 @@
+namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
+
+/// <summary>
+/// Env-gated certification that the SessionStart memory index actually reaches the model on Gemini CLI.
+/// The envelope shape and the always-emit invariant are covered against fakes by
+/// <c>GeminiSessionStartMemoryTests</c>; this is the only place asserting the end-to-end claims.
+///
+/// <para><b>This cert is load-bearing, not a nice-to-have.</b> Gemini's hook stdout is a JSON decision
+/// channel, and a green unit suite only proves the bytes we emit — not that Gemini accepts them. The
+/// positive case therefore asserts the turn <i>completes</i>, not merely that the nonce appears: a
+/// harness that masked a failed invocation would otherwise look like a pass.</para>
+///
+/// <para>Both tests are <c>[NotInParallel]</c>: the negative control mutates the REAL process-global
+/// <c>disable_memory_index</c> config. <c>[NotInParallel]</c> only prevents concurrency — it restores
+/// nothing — so every test snapshots before creating anything and restores in a <c>finally</c>,
+/// including the unset state.</para>
+/// </summary>
+public class GeminiMemoryIndexLiveCertTests {
+    const string LiveGateEnvVar = "KCAP_GEMINI_MEMORY_LIVE";
+    const string VendorLabel    = "gemini";
+
+    static void Gate() => MemoryIndexLiveCertHarness.SkipUnlessLiveGateReady(
+        LiveGateEnvVar,
+        "one real `gemini` turn per test",
+        "`gemini` (>= 0.53.0) on PATH with its SessionStart hook wired to `kcap` in ~/.gemini/settings.json");
+
+    [Test, NotInParallel]
+    public async Task Nonce_saved_as_a_memory_is_reproduced_by_a_real_gemini_session_start() {
+        Gate();
+
+        // Read BEFORE anything is created: a leaked `true` from an earlier failed run would make this
+        // positive case pass vacuously, so the opt-out state is asserted rather than assumed.
+        var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
+        await Assert.That(original is true).IsFalse();
+
+        var nonce    = MemoryIndexLiveCertHarness.NewNonce();
+        var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+
+        try {
+            // Records the exact binary version. A cert passing against an unknown build is how the
+            // earlier memory-cert failures were misdiagnosed as a code defect when the real cause was a
+            // stale installed binary.
+            await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "gemini", ["--version"]);
+
+            var (exitCode, answer) = await RunGeminiAsync(worktree.FullName, MemoryIndexLiveCertHarness.PositivePrompt);
+
+            // Turn completion is part of the contract, not incidental: it is what verifies that a
+            // hookSpecificOutput-only payload does not disturb Gemini's decision channel.
+            await Assert.That(exitCode).IsEqualTo(0);
+            await Assert.That(answer).Contains(nonce);
+        } finally {
+            TryDelete(worktree);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
+        }
+    }
+
+    [Test, NotInParallel]
+    public async Task Disabled_memory_index_does_not_leak_the_nonce_to_a_real_gemini_session_start() {
+        Gate();
+
+        await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "gemini", ["--version"]);
+
+        // Snapshot before anything is created — this throws on an unreadable config, and doing it after
+        // the save would strand a real memory outside the archive-protecting try below.
+        var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
+
+        var nonce    = MemoryIndexLiveCertHarness.NewNonce();
+        var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+
+        try {
+            await MemoryIndexLiveCertHarness.SetDisableMemoryIndexAsync(true);
+
+            var (_, answer) = await RunGeminiAsync(worktree.FullName, MemoryIndexLiveCertHarness.NegativePrompt);
+
+            await Assert.That(answer).DoesNotContain(nonce);
+        } finally {
+            TryDelete(worktree);
+            // Nested: the restore THROWS on a failed or unconfirmed write, and that must not skip the
+            // archive — a leaked nonce corrupts every later cert's index.
+            try {
+                await MemoryIndexLiveCertHarness.RestoreDisableMemoryIndexAsync(original);
+            } finally {
+                await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
+            }
+        }
+    }
+
+    /// <summary>Runs one non-interactive Gemini turn. <c>--approval-mode plan</c> keeps it read-only so
+    /// an unexpected tool request cannot stall the cert.</summary>
+    static async Task<(int ExitCode, string Answer)> RunGeminiAsync(string cwd, string prompt) {
+        var (exitCode, stdout, stderr) = await MemoryIndexLiveCertHarness.RunProcessAsync(
+            "gemini", ["--approval-mode", "plan", "--prompt", prompt], cwd);
+
+        await Console.Out.WriteLineAsync($"[{VendorLabel}-memory-live] gemini exit={exitCode} stderr={stderr}");
+
+        return (exitCode, MemoryIndexLiveCertHarness.ExtractAssistantAnswer(stdout));
+    }
+
+    static void TryDelete(DirectoryInfo dir) {
+        try { dir.Delete(recursive: true); } catch { /* best-effort */ }
+    }
+}


### PR DESCRIPTION
Closes AI-1463. Sixth harness into the SessionStart memory-index foundation.

Spec (in this PR) went through **four codex spec-review rounds to clean** — `docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md`.

## Most of this already existed

The `GeminiMemoryEnvelope`, its AOT JSON context and the identity mapping were built during the Claude baseline. Only the call site was missing: of the six harnesses, only Gemini's hook never invoked the orchestrator.

**The envelope shape was verified rather than trusted**, because it had been written speculatively before any adapter consumed it. Gemini's own bundle references `hookSpecificOutput` (150), `additionalContext` (96) and `hookEventName` (15) — it genuinely parses the Claude-shaped envelope, so no new wire format is invented here.

## The one thing that makes Gemini different

**Gemini's hook stdout is a JSON decision channel, and this dispatcher previously emitted nothing at all.** Review rightly refused to accept the contract on field-name counts, so it was read out of Gemini's hook runner:

| Fact | Source |
|---|---|
| Blocking requires an explicit decision | `isBlockingDecision() { return this.decision === "block" \|\| this.decision === "deny" }` — our envelope leaves `decision` undefined, so it **cannot** block |
| `additionalContext` is string-typed | `getAdditionalContext()` guards on `typeof context !== "string"` |
| Malformed stdout is **fail-open** | a `JSON.parse` failure degrades to `convertPlainTextToHookOutput`, never a synthesised block |
| stdout is parsed **unconditionally** | `child.on("close", …)` parses with no exit-code gate; the exit code only sets `success` |

### The hazard that changed the design

That same line reads:

```js
const textToParse = stdout.trim() || stderr.trim();
```

**When stdout is empty, Gemini parses the hook's STDERR as its output** — and kcap writes diagnostics there (failed lifecycle POSTs, the auth-lapse notice). This already happens today on every failed-POST Gemini session.

The worst case is specific and bad: **with memory injection opted OUT, a failed POST could still put kcap text — including server/auth detail — into the model's context.**

So this PR **inverts the usual fail-open rule for Gemini**: a recognised `SessionStart` now writes exactly one JSON object on *every* returning path — the memory envelope when there is a fragment, an explicit `{"continue":true}` otherwise — so stdout wins the `||` and shadows stderr. That is a deliberate divergence from the other five adapters, documented at the call site so it is not "harmonised" away.

`{"continue":true}` was chosen over `{}` (parses but asserts nothing, relying on defaults staying benign — the exact assumption that had to be verified) and over an `additionalContext`-less `hookSpecificOutput` (a shape needing separate verification for no benefit). Carrying no `hookSpecificOutput` key makes `getAdditionalContext()` short-circuit on its own `in` guard.

**Path scope has no exceptions.** The disabled-session and excluded-path fast paths emit too — they are not stderr-free, since `Program.cs` drains the spool before dispatch. Unrecognised input (bad JSON, missing event name, non-GUID session id) stays silent: Gemini has no hook result to attribute to it.

## Two known traps, both avoided

- **`hookProcessStart` was missing for Gemini alone** — the identical omission fixed earlier for Codex, Copilot and Kiro. Threaded. `HookBudget.Remaining` already subtracts its own safety margin, so it is not subtracted again (double-subtraction was a real Copilot defect).
- **The Codex early-return defect** — where a `return 1` on a failed POST skipped the stdout handshake — is explicitly not reintroduced: the hook result is written before that return.

## Scope deliberately split out

Review found that suppressing `source: clear` is a silent feature loss (`clear` destroys the context holding the injection). Chasing it established it is **foundation-wide, not a Gemini bug**: `ClaudeHookCommand` lets `clear` fall to `SessionLifecycleReason.New` and there is no `Clear` reason in the contracts at all — Claude has the identical loss.

Fixing it needs a durable atomic generation in the *shared* lease store, a stable delivery id, and a persisted-key migration that risks **re-injection across all five merged adapters**. That does not belong in an adapter PR, so:

- **AI-1617** — context-generation lease key, all harnesses.
- **AI-1618** — stderr shadowing for `SessionEnd` / `Notification` (the `SessionStart` half is fixed here).

Consequence: **no lease-store or orchestrator change in this PR**, so no migration risk rides along. `clear` maps to `New` exactly as Claude does — pinned in a test so the gap stays deliberate and visible.

## Testing

`GeminiSessionStartMemoryTests` — 17 passing, and the three load-bearing guards are **mutation-proven**:

| Mutation | Result |
|---|---|
| revert to zero-bytes on the null path | 1 failed |
| `clear` → `Resume` instead of `New` | 1 failed |
| remove the write try/catch | 2 failed |

Also covers: neither payload can carry `decision`/`stopReason`/`continue:false`; fragments are JSON-escaped and round-trip exactly (inverse of Kiro's raw-text contract); every payload is exactly one parseable JSON object; a writer throwing before or mid-payload does not propagate.

`GeminiMemoryIndexLiveCertTests` (env-gated, `KCAP_GEMINI_MEMORY_LIVE=1`) asserts turn **completion** as well as nonce reproduction, snapshots/restores the opt-out including the unset state, asserts the positive control runs with opt-out disabled, and records the exact `gemini --version`.

## Known-not-done

Per the spec's Definition of Done, the §3.3 commit-gate choice is **conditional on the live non-zero-exit result** and must be finalised — the unselected branch deleted and a branch-specific lease assertion added — before merge. Current code implements option (a) (no gate), which the measured unconditional-parse behaviour supports; the cert run is what confirms it.