### PR TITLE
Prove the three unusable-URL guards that landed unproved

### DIFF
--- a/test/Capacitor.Cli.Tests.Integration/UnusableUrlHookMatrixTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/UnusableUrlHookMatrixTests.cs
@@ -30,6 +30,8 @@ public class UnusableUrlHookMatrixTests : IDisposable {
         "file:///etc/passwd",   // absolute, wrong scheme
     ];
 
+    const string Sid = "0123456789abcdef0123456789abcdef";
+
     readonly string _cfgDir = Path.Combine(Path.GetTempPath(), $"kcap-matrix-cfg-{Guid.NewGuid():N}");
     readonly List<Process> _spawned = [];
 
@@ -211,20 +213,20 @@ public class UnusableUrlHookMatrixTests : IDisposable {
     }
 
     /// <summary>
-    /// <c>kcap mcp judge</c> was the only one of the eight MCP servers building its authenticated
-    /// client BEFORE opening stdin/stdout, so an unusable URL killed it ahead of the JSON-RPC
-    /// handshake and the judge run failed opaquely.
-    ///
-    /// <para>A child process is the only honest venue: the failure mode being fixed is the process
-    /// dying, which an in-process test cannot observe. The assertions are that the handshake
-    /// completes, that a tool call comes back as a JSON-RPC tool ERROR rather than a crash, and that
-    /// the server is still answering afterwards — a server must keep serving and report the fault in
-    /// its own protocol.</para>
+    /// Judge alone built its client before opening stdio, so an unusable URL killed it ahead of the
+    /// handshake. Needs a child process: the failure mode is the process dying.
     /// </summary>
     [Test]
     [MethodDataSource(nameof(UnusableUrls))]
     public async Task Mcp_judge_completes_the_handshake_and_returns_a_tool_error(string url) {
         var binary = GetCliBinaryPath();
+
+        if (!File.Exists(binary)) {
+            throw new FileNotFoundException(
+                $"kcap binary not found at {binary}. Build it first: dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj",
+                binary);
+        }
+
         Directory.CreateDirectory(_cfgDir);
 
         var psi = new ProcessStartInfo(binary) {
@@ -235,38 +237,57 @@ public class UnusableUrlHookMatrixTests : IDisposable {
                 ["KCAP_NO_UPDATE_CHECK"] = "1", ["KCAP_SESSION_ID"] = "",
             },
         };
-        foreach (var a in new[] { "mcp", "judge", "--session", "0123456789abcdef0123456789abcdef" }) psi.ArgumentList.Add(a);
+        foreach (var a in new[] { "mcp", "judge", "--session", Sid }) psi.ArgumentList.Add(a);
 
         using var proc = Process.Start(psi) ?? throw new InvalidOperationException("failed to start kcap");
         _spawned.Add(proc);
 
-        await proc.StandardInput.WriteLineAsync("""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}""");
-        var initialize = await ReadLineWithTimeoutAsync(proc);
-        await Assert.That(initialize).IsNotNull();
-        await Assert.That(initialize!).Contains("\"id\":1");
+        var initialize = await SendRequestAsync(proc, Rpc(1, "initialize", new JsonObject()));
+        await Assert.That(initialize).Contains("\"id\":1");
 
-        await proc.StandardInput.WriteLineAsync(
-            """{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_session_recap","arguments":{"session_id":"0123456789abcdef0123456789abcdef"}}}""");
-        var toolCall = await ReadLineWithTimeoutAsync(proc);
+        var toolCall = await SendRequestAsync(proc, Rpc(2, "tools/call", new JsonObject {
+            ["name"]      = "get_session_recap",
+            ["arguments"] = new JsonObject { ["session_id"] = Sid },
+        }));
 
         // The fault is reported IN the protocol, not by dying.
-        await Assert.That(toolCall).IsNotNull();
-        await Assert.That(toolCall!).Contains("server_url is missing a scheme");
+        await Assert.That(toolCall).Contains("server_url is missing a scheme");
 
         // And it is still serving afterwards.
-        await proc.StandardInput.WriteLineAsync("""{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}""");
-        var afterwards = await ReadLineWithTimeoutAsync(proc);
-        await Assert.That(afterwards).IsNotNull();
-        await Assert.That(afterwards!).Contains("\"id\":3");
+        var afterwards = await SendRequestAsync(proc, Rpc(3, "tools/list", new JsonObject()));
+        await Assert.That(afterwards).Contains("\"id\":3");
 
         proc.StandardInput.Close();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
-        await proc.WaitForExitAsync(cts.Token);
+        using var exitCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        await proc.WaitForExitAsync(exitCts.Token);
         await Assert.That(proc.ExitCode).IsNotEqualTo(2);
     }
 
-    static async Task<string?> ReadLineWithTimeoutAsync(Process proc) {
-        var read = proc.StandardOutput.ReadLineAsync();
-        return await Task.WhenAny(read, Task.Delay(TimeSpan.FromSeconds(15))) == read ? await read : null;
+    static string Rpc(int id, string method, JsonObject parameters) =>
+        new JsonObject {
+            ["jsonrpc"] = "2.0",
+            ["id"]      = id,
+            ["method"]  = method,
+            ["params"]  = parameters,
+        }.ToJsonString();
+
+    /// <summary>
+    /// Mirrors <c>McpSessionsServerTests.SendRequest</c>. The cancellation token matters: a
+    /// <c>Task.WhenAny</c> timeout leaves the losing read pending, and it can then consume the next
+    /// response and desynchronise later assertions.
+    /// </summary>
+    static async Task<string> SendRequestAsync(Process proc, string request) {
+        await proc.StandardInput.WriteLineAsync(request);
+        await proc.StandardInput.FlushAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var line = await proc.StandardOutput.ReadLineAsync(cts.Token);
+
+        if (line is null) {
+            var stderr = await proc.StandardError.ReadToEndAsync();
+            throw new InvalidOperationException($"MCP server closed stdout without responding. Stderr: {stderr}");
+        }
+
+        return line;
     }
 }

--- a/test/Capacitor.Cli.Tests.Integration/UnusableUrlHookMatrixTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/UnusableUrlHookMatrixTests.cs
@@ -209,4 +209,64 @@ public class UnusableUrlHookMatrixTests : IDisposable {
 
         return Path.Combine(repoRoot, "src", "Capacitor.Cli", "bin", config, "net10.0", binaryName);
     }
+
+    /// <summary>
+    /// <c>kcap mcp judge</c> was the only one of the eight MCP servers building its authenticated
+    /// client BEFORE opening stdin/stdout, so an unusable URL killed it ahead of the JSON-RPC
+    /// handshake and the judge run failed opaquely.
+    ///
+    /// <para>A child process is the only honest venue: the failure mode being fixed is the process
+    /// dying, which an in-process test cannot observe. The assertions are that the handshake
+    /// completes, that a tool call comes back as a JSON-RPC tool ERROR rather than a crash, and that
+    /// the server is still answering afterwards — a server must keep serving and report the fault in
+    /// its own protocol.</para>
+    /// </summary>
+    [Test]
+    [MethodDataSource(nameof(UnusableUrls))]
+    public async Task Mcp_judge_completes_the_handshake_and_returns_a_tool_error(string url) {
+        var binary = GetCliBinaryPath();
+        Directory.CreateDirectory(_cfgDir);
+
+        var psi = new ProcessStartInfo(binary) {
+            RedirectStandardInput = true, RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = _cfgDir,
+            Environment = {
+                ["KCAP_URL"] = url, ["KCAP_CONFIG_DIR"] = _cfgDir,
+                ["KCAP_NO_UPDATE_CHECK"] = "1", ["KCAP_SESSION_ID"] = "",
+            },
+        };
+        foreach (var a in new[] { "mcp", "judge", "--session", "0123456789abcdef0123456789abcdef" }) psi.ArgumentList.Add(a);
+
+        using var proc = Process.Start(psi) ?? throw new InvalidOperationException("failed to start kcap");
+        _spawned.Add(proc);
+
+        await proc.StandardInput.WriteLineAsync("""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}""");
+        var initialize = await ReadLineWithTimeoutAsync(proc);
+        await Assert.That(initialize).IsNotNull();
+        await Assert.That(initialize!).Contains("\"id\":1");
+
+        await proc.StandardInput.WriteLineAsync(
+            """{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_session_recap","arguments":{"session_id":"0123456789abcdef0123456789abcdef"}}}""");
+        var toolCall = await ReadLineWithTimeoutAsync(proc);
+
+        // The fault is reported IN the protocol, not by dying.
+        await Assert.That(toolCall).IsNotNull();
+        await Assert.That(toolCall!).Contains("server_url is missing a scheme");
+
+        // And it is still serving afterwards.
+        await proc.StandardInput.WriteLineAsync("""{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}""");
+        var afterwards = await ReadLineWithTimeoutAsync(proc);
+        await Assert.That(afterwards).IsNotNull();
+        await Assert.That(afterwards!).Contains("\"id\":3");
+
+        proc.StandardInput.Close();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        await proc.WaitForExitAsync(cts.Token);
+        await Assert.That(proc.ExitCode).IsNotEqualTo(2);
+    }
+
+    static async Task<string?> ReadLineWithTimeoutAsync(Process proc) {
+        var read = proc.StandardOutput.ReadLineAsync();
+        return await Task.WhenAny(read, Task.Delay(TimeSpan.FromSeconds(15))) == read ? await read : null;
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
@@ -208,4 +208,50 @@ public class UnusableUrlGuardTests : IDisposable {
         await Assert.That(await ClaudeHookCommand.ShouldSuppressCaptureAsync(
             sid, body, "session-start", activeProfile: null, processStart: Stopwatch.GetTimestamp())).IsFalse();
     }
+
+    /// <summary>
+    /// Cursor's guard, proved by NON-ENTRY. Asserting exit 0 alone is vacuous: its outer catch-all
+    /// returns 0 too, so that assertion passes with the guard deleted.
+    /// </summary>
+    [Test]
+    public async Task Cursor_never_builds_a_client_for_an_unusable_url() {
+        var entered = false;
+
+        var exit = await CursorHookCommand.HandleInternal(
+            BadUrl,
+            new StringReader("""{"hook_event_name":"sessionStart","session_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"""),
+            budget: TimeSpan.FromSeconds(5),
+            clientFactory: _ => {
+                entered = true;
+                throw new InvalidOperationException("the cursor guard did not run");
+            },
+            spoolFactory: () => new HookSpool(_dir));
+
+        await Assert.That(entered).IsFalse();
+        await Assert.That(exit).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// Claude's guard, same shape. Deleting it lets the exception be swallowed by
+    /// <c>CreateClientWithinBudgetAsync</c>, which then takes the SAME degraded branch — so every
+    /// effect assertion still passes. Only non-entry distinguishes the two.
+    /// </summary>
+    [Test]
+    public async Task Claude_never_builds_a_client_for_an_unusable_url() {
+        var entered = false;
+
+        var exit = await ClaudeHookCommand.HandleWithDeps(
+            new HookSpool(_dir),
+            processStart: Stopwatch.GetTimestamp(),
+            baseUrl: BadUrl,
+            stdin: new StringReader($$"""{"hook_event_name":"SessionStart","session_id":"{{Sid}}"}"""),
+            updateCheckTask: null,
+            clientFactory: () => {
+                entered = true;
+                throw new InvalidOperationException("the claude guard did not run");
+            });
+
+        await Assert.That(entered).IsFalse();
+        await Assert.That(exit).IsEqualTo(0);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
@@ -209,10 +209,7 @@ public class UnusableUrlGuardTests : IDisposable {
             sid, body, "session-start", activeProfile: null, processStart: Stopwatch.GetTimestamp())).IsFalse();
     }
 
-    /// <summary>
-    /// Cursor's guard, proved by NON-ENTRY. Asserting exit 0 alone is vacuous: its outer catch-all
-    /// returns 0 too, so that assertion passes with the guard deleted.
-    /// </summary>
+    /// <summary>Non-entry, not exit 0 — Cursor's outer catch-all also returns 0.</summary>
     [Test]
     public async Task Cursor_never_builds_a_client_for_an_unusable_url() {
         var entered = false;
@@ -232,9 +229,8 @@ public class UnusableUrlGuardTests : IDisposable {
     }
 
     /// <summary>
-    /// Claude's guard, same shape. Deleting it lets the exception be swallowed by
-    /// <c>CreateClientWithinBudgetAsync</c>, which then takes the SAME degraded branch — so every
-    /// effect assertion still passes. Only non-entry distinguishes the two.
+    /// Non-entry: deleting the guard lets <c>CreateClientWithinBudgetAsync</c> swallow the exception
+    /// and take the same degraded branch, so every effect assertion still passes.
     /// </summary>
     [Test]
     public async Task Claude_never_builds_a_client_for_an_unusable_url() {


### PR DESCRIPTION
Follow-up to #413. Linear: AI-1586

Tests only — no production change, 106 lines.

#413 landed with three guards whose tests could not fail if the guard were deleted. The code review named all three in its **first** round; I fixed the other findings and disclosed these instead, then let each subsequent round's new P1 push them down. Stating a gap in a commit message is not closing it.

## Why each was vacuous

| Guard | Why the old assertion proved nothing |
|---|---|
| Cursor | asserted exit 0 — but its outer catch-all returns 0 too |
| Claude client | asserted the degraded-path effects — but deleting the guard lets `CreateClientWithinBudgetAsync` swallow the exception and take the *same* branch, so every effect is identical |
| `McpJudgeServer` | had no test at all |

## What replaces them

Cursor and Claude are proved by **non-entry**, through the injectable client factories they already expose: the factory records invocation and fails the test if called. That is the only assertion form that separates "the guard ran" from "something downstream absorbed it".

`McpJudgeServer` gets a child-process JSON-RPC exchange. A child is the only honest venue, because the failure being fixed is *the process dying before the handshake* — an in-process test cannot observe it. The test completes `initialize`, asserts a `tools/call` returns a protocol-level error rather than crashing, asserts the server still answers a subsequent `tools/list`, and asserts it does not exit 2.

## Mutation-checked

- delete the Cursor guard → 1 failure
- delete the Claude client guard → 1 failure
- restore eager client construction in the judge → 5 failures

Unit suite diffed against `origin/main`: one extra failure, `ImportChainsAsync_dispatches_independent_chains_in_parallel` — a parallel-dispatch timing test unrelated to this change, green 3/3 in isolation. Integration 191/191. AOT publish clean.