### PR TITLE
[AI-1463] Finalise the Gemini SessionStart memory certification

### DIFF
--- a/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
@@ -434,27 +434,38 @@ real index and then failed its POST.
 a live alternative. Parsing was not assumed to be consuming: the model reproducing the nonce is what
 distinguishes them, and it is the assertion the cert makes.
 
-**Every link is measured on the same invocation; nothing is inferred from a stand-in or from a
-turn-global count.** Two review rounds were needed to get here, and both objections were right:
+**Every link is measured on the same invocation; nothing is inferred from a stand-in, a turn-global
+count, or a shared identifier.** Three review rounds were needed to get here and each objection was
+right. They are worth recording, because each rejected version looks sufficient:
 
-* A first draft proved the non-zero exit from a SEPARATE direct `kcap hook --gemini` run. That is a
-  substitution — every assertion could hold while Gemini's own hook returned 0 through some session- or
-  source-dependent branch. Fixed by prepending a recording shim named `kcap` to the PATH Gemini inherits,
-  capturing each hook invocation's stdin, stdout and exit code.
-* The second draft then asserted "some forced 400 happened during the turn", which is turn-global: with
-  two hook invocations, one could carry the nonce and exit non-zero for an unrelated reason while the
-  *other* hit the forced failure, and the cert would still be green. Fixed by correlating on session id —
-  the invocation whose `additionalContext` carried the nonce must be the invocation whose POST the forced
-  mapping rejected.
+1. Proving the non-zero exit from a SEPARATE direct `kcap hook --gemini` run is a **substitution** —
+   every assertion could hold while Gemini's own hook returned 0 through some session- or
+   source-dependent branch. Fixed by a recording shim named `kcap`, prepended to the PATH Gemini
+   inherits, that captures each hook invocation's exit code, stdout and stderr.
+2. "Some forced 400 happened during the turn" is **turn-global** — with two hook invocations, one could
+   carry the nonce while a *different* one took the 400.
+3. Correlating those two on **session id** narrows it but does not close it: a session id is reused
+   across invocations (`startup` and `resume` share one), so the same counterexample survives with equal
+   ids.
+
+The closing evidence is per-invocation: the invocation whose `additionalContext` carried the nonce must
+itself have written the failed-POST diagnostic (`… session-start/gemini: HTTP 400`) to *its own* stderr.
 
 So the assertion chain is: the recorded invocation that delivered the nonce **is** the one that exited
-non-zero, **and** is the one whose session-start POST the forced mapping (identified by its response-body
-marker, so an upstream 400 relayed by the catch-all proxy cannot stand in) rejected, **and** the turn
-completed, **and** the model reproduced the nonce.
+non-zero, **and** is the one whose own stderr reports the rejected session-start POST, **and** that 400
+came from this test's forced mapping rather than from upstream (matched on the response-body marker),
+**and** the turn completed, **and** the model reproduced the nonce.
 
 The recorded exit code is nullable by design: an unreadable or half-written record fails the assertion
 rather than satisfying it. An earlier version used an `int.MinValue` sentinel, which is non-zero and
 therefore passed the exact property under test — the shape of a false-pass, caught in review.
+
+**Cleanup is now a gate, not a log line.** A leaked nonce memory makes a later positive case pass on the
+previous run's evidence, so any cert that cannot *confirm* its nonce memory was removed — an
+unconfirmed archive, a throwing archive, or a save whose id could not be recovered — marks the run, and
+`SkipUnlessLiveGateReady` then refuses to start any further live case in that process. Recovery-by-slug
+is polled rather than asked once, and distinguishes "confirmed absent" from "could not tell", because
+only the first means the index is clean.
 
 Covering tests: `GeminiMemoryIndexLiveCertTests.Failed_session_start_post_still_delivers_the_index_to_a_real_gemini_session`
 (live, gated) and `GeminiSessionStartHandshakeOnPostFailureTests` (integration, always run) — the latter

--- a/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
@@ -460,12 +460,23 @@ The recorded exit code is nullable by design: an unreadable or half-written reco
 rather than satisfying it. An earlier version used an `int.MinValue` sentinel, which is non-zero and
 therefore passed the exact property under test — the shape of a false-pass, caught in review.
 
-**Cleanup is now a gate, not a log line.** A leaked nonce memory makes a later positive case pass on the
-previous run's evidence, so any cert that cannot *confirm* its nonce memory was removed — an
-unconfirmed archive, a throwing archive, or a save whose id could not be recovered — marks the run, and
-`SkipUnlessLiveGateReady` then refuses to start any further live case in that process. Recovery-by-slug
-is polled rather than asked once, and distinguishes "confirmed absent" from "could not tell", because
-only the first means the index is clean.
+**Cleanup is a gate, not a log line, and it fails closed.** A leaked nonce memory makes a later positive
+case pass on the previous run's evidence — the one failure a cert must never produce — so any cert that
+cannot *confirm* its nonce memory was removed marks the run. Two gates read that mark, because one is
+not enough: `SkipUnlessLiveGateReady` refuses to start any further live case (prospective), and an
+`[After(Assembly)]` teardown fails the run (retrospective — otherwise a cleanup failure in the *last*
+case is observed by nobody and the run reports green).
+
+Three things follow from taking "confirm" literally:
+
+* `ArchiveMemoryAsync` returns whether the archive was **confirmed**, so no caller can claim a clean
+  index off a swallowed failure.
+* Recovery-by-slug archives **every** exact match, not the first. Server-side slug uniqueness is not
+  something this harness can verify, and the property required is "no memory carrying this run's nonce
+  remains" — which one archive does not give.
+* An empty search result is **not** treated as absence. The read model behind search is not documented
+  as strongly consistent and no maximum lag is published, so a created memory can be invisible now and
+  present a moment later. Anything short of "found and archived, confirmed" is dirty.
 
 Covering tests: `GeminiMemoryIndexLiveCertTests.Failed_session_start_post_still_delivers_the_index_to_a_real_gemini_session`
 (live, gated) and `GeminiSessionStartHandshakeOnPostFailureTests` (integration, always run) — the latter

--- a/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
@@ -410,6 +410,43 @@ the bundle read it after only `shouldStopExecution()` / `isBlockingDecision()` c
 `success` gate — but those are the BeforeAgent / AfterTool paths, and the `SessionStart`-specific consumer
 was not definitively located. Treat as a prior, not proof.
 
+### 3.3a SETTLED BY LIVE MEASUREMENT — 2026-07-31 — row 1: option (a), no commit gate
+
+Run against **`gemini 0.53.0`**, `kcap 0.11.10-alpha.0.10+998ec34` (the tree merged as `e2b2821`),
+macOS 26.5.2 / osx-arm64.
+
+The failure is real rather than simulated: a WireMock instance proxied the whole API to the configured
+server and failed **only** `POST /hooks/session-start/gemini`. The index fetch on the same base URL was
+proxied through untouched — the one arrangement that produces the shape under test, a hook that fetched a
+real index and then failed its POST.
+
+| Link | Observed |
+|---|---|
+| lifecycle POST | `400` at the proxy; hook stderr `[kcap] gemini-hook session-start/gemini: HTTP 400` |
+| index fetch | `GET /api/memories/index?machine=… → 200`, same base URL, same invocation |
+| hook exit code | **1** |
+| hook stdout | 558 bytes — `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"…## Team memory…"}}` |
+| gemini turn | exit **0** — the turn completed |
+| model receipt | the nonce was reproduced in the answer |
+
+**Row 1 fires: the turn continues AND the context is consumed.** Option **(a)** is the design, and option
+(b) is withdrawn — it is retained above only as the reasoning that made the measurement necessary, not as
+a live alternative. Parsing was not assumed to be consuming: the model reproducing the nonce is what
+distinguishes them, and it is the assertion the cert makes.
+
+Two links the live turn cannot prove on its own, so both are asserted separately:
+
+* Gemini's exit code says nothing about its hook's exit code. The cert therefore drives the same binary
+  against the same proxy directly and asserts a non-zero exit **with** parseable `additionalContext`; and
+* it asserts the proxy actually failed a session-start POST during the turn — otherwise a green run is
+  equally consistent with the POST having quietly succeeded.
+
+Covering tests: `GeminiMemoryIndexLiveCertTests.Failed_session_start_post_still_delivers_the_index_to_a_real_gemini_session`
+(live, gated) and `GeminiSessionStartHandshakeOnPostFailureTests` (integration, always run) — the latter
+also carries the branch-specific lease assertion §6a.3 requires for (a): the failed-POST invocation
+COMPLETES the lease, and a subsequent `resume` emits the bare allow object and no context. That assertion
+is mutation-proven — resuming a different session id instead re-emits the index and fails the test.
+
 ## 4. Files
 
 **Scope reverted after the AI-1617 split.** Round 2 correctly pointed out that my original two-file claim
@@ -493,6 +530,36 @@ installed version running the hook.
 passed with the guard removed; the standard here is that deleting the guard fails exactly the intended
 test.
 
+### 5.3 Two harness defects the first live run exposed — both fixed here
+
+Neither is a product defect; both made the cert lie, which is worse than a cert that fails.
+
+1. **The trusted-folder gate silently voided the run.** Every cert runs in a freshly created throwaway
+   worktree, which is by definition untrusted, and 0.53.0 refuses a headless turn there outright —
+   `exit 55`, before any model call. The positive case failed honestly on it. The negative control
+   **passed vacuously**: it asserted only that the nonce was absent, and a turn that never ran trivially
+   contains no nonce. Fixed by passing `--skip-trust` and by asserting turn completion in the negative
+   control too. Note the shape of the failure — the guard test that cannot fail is the one that looks
+   green.
+
+2. **The recorded `kcap` version described the wrong binary.** `Process.Start` resolves a
+   separator-free filename against the WORKING DIRECTORY before PATH, and the test assembly's working
+   directory is its own output folder, which contains a `kcap` copied there by the project reference. So
+   `RecordCertEnvironmentAsync` — the method that exists to stop exactly the AI-1592 stale-binary
+   misdiagnosis — recorded the test build (`+e2b2821`) while its own sibling `which kcap` line reported
+   the PATH build (`+998ec34`) that the hook would actually run. The two lines disagreed in the same
+   output and nothing noticed. Fixed by resolving bare command names against PATH explicitly, in
+   `RunProcessAsync` **and** in `CallMemoryToolAsync`, which builds its own `ProcessStartInfo` and would
+   otherwise have saved the nonce memory with a different binary from the one serving the hook. The
+   resolution order is a pure function (PATH and platform passed, not probed) with hermetic,
+   mutation-proven coverage in `MemoryIndexLiveCertHarnessTests`.
+
+**Also worth pinning for the next adapter:** `session_id` is validated with `Guid.TryParse`, and a
+failure takes the same emit-and-return-0 path as a suppressed session. A decorated id (`cert-{guid}`)
+therefore produces a plausible exit 0 with the allow object and **no HTTP traffic at all** — a probe
+written that way measures nothing and looks like a product finding. Both new tests use bare GUIDs and say
+why.
+
 ### 5.1 The cert is load-bearing for §3
 
 The live cert is the only thing that verifies §3.1 — that a `hookSpecificOutput`-only payload does not
@@ -522,6 +589,17 @@ The conditional §3.3 design is only acceptable if the PR *finalises* it. Requir
    * if **(b)**: it *releases* the lease, and a subsequent `resume` retries.
 4. **If the turn aborts, stop and escalate** — that is a defect in its own right, not a probe result to
    design around, and it must not be recorded as a passing cert.
+
+### 6a-status — closed 2026-07-31, after the merge of #414
+
+The adapter PR merged (`e2b2821`) with all four still open; they are closed by the follow-up that adds
+§3.3a and §5.3 above. Recording that honestly matters more than the tidier story: the merge gate the spec
+set for itself did not hold, and the measurement it was gating on could have changed the design.
+
+1. **Done** — §3.3a: row 1, against `gemini 0.53.0`.
+2. **Done** — (b) is withdrawn in §3.3a; only (a) is normative.
+3. **Done** — in `GeminiSessionStartHandshakeOnPostFailureTests`, mutation-proven.
+4. **Not triggered** — the turn completed (exit 0) in every live run, including the failed-POST one.
 
 ## 7. Out of scope
 

--- a/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
@@ -422,10 +422,10 @@ real index and then failed its POST.
 
 | Link | Observed |
 |---|---|
-| lifecycle POST | `400` at the proxy; hook stderr `[kcap] gemini-hook session-start/gemini: HTTP 400` |
+| lifecycle POST | `400` from the forced mapping (matched on its body marker, not merely "a 400 at that path"); hook stderr `[kcap] gemini-hook session-start/gemini: HTTP 400` |
 | index fetch | `GET /api/memories/index?machine=… → 200`, same base URL, same invocation |
-| hook exit code | **1** |
-| hook stdout | 558 bytes — `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"…## Team memory…"}}` |
+| hook exit code | **non-zero**, read from the hook **Gemini itself ran** |
+| hook stdout | `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"…## Team memory…"}}`, carrying the nonce |
 | gemini turn | exit **0** — the turn completed |
 | model receipt | the nonce was reproduced in the answer |
 
@@ -434,12 +434,14 @@ real index and then failed its POST.
 a live alternative. Parsing was not assumed to be consuming: the model reproducing the nonce is what
 distinguishes them, and it is the assertion the cert makes.
 
-Two links the live turn cannot prove on its own, so both are asserted separately:
-
-* Gemini's exit code says nothing about its hook's exit code. The cert therefore drives the same binary
-  against the same proxy directly and asserts a non-zero exit **with** parseable `additionalContext`; and
-* it asserts the proxy actually failed a session-start POST during the turn — otherwise a green run is
-  equally consistent with the POST having quietly succeeded.
+**The exit code is measured on the invocation that delivered the context, not inferred from a stand-in.**
+A first draft proved the non-zero exit from a SEPARATE direct `kcap hook --gemini` run against the same
+proxy; review was right that this is a substitution — every assertion could hold while Gemini's own hook
+returned 0 through some session- or source-dependent branch, and the conclusion would still be false.
+The cert now prepends a recording shim named `kcap` to the PATH Gemini inherits, captures each hook
+invocation's exit code and stdout, and asserts that the invocation whose `additionalContext` carried the
+nonce is the one that exited non-zero. Same process, both facts. It also asserts the FORCED mapping fired,
+by response-body marker, so an upstream 400 relayed by the catch-all proxy cannot be mistaken for it.
 
 Covering tests: `GeminiMemoryIndexLiveCertTests.Failed_session_start_post_still_delivers_the_index_to_a_real_gemini_session`
 (live, gated) and `GeminiSessionStartHandshakeOnPostFailureTests` (integration, always run) — the latter
@@ -530,9 +532,10 @@ installed version running the hook.
 passed with the guard removed; the standard here is that deleting the guard fails exactly the intended
 test.
 
-### 5.3 Two harness defects the first live run exposed — both fixed here
+### 5.3 Three harness defects running the cert exposed — all fixed here
 
-Neither is a product defect; both made the cert lie, which is worse than a cert that fails.
+None is a product defect; the first two made the cert lie, which is worse than a cert that fails, and the
+third made it hang.
 
 1. **The trusted-folder gate silently voided the run.** Every cert runs in a freshly created throwaway
    worktree, which is by definition untrusted, and 0.53.0 refuses a headless turn there outright —
@@ -553,6 +556,15 @@ Neither is a product defect; both made the cert lie, which is worse than a cert 
    otherwise have saved the nonce memory with a different binary from the one serving the hook. The
    resolution order is a pure function (PATH and platform passed, not probed) with hermetic,
    mutation-proven coverage in `MemoryIndexLiveCertHarnessTests`.
+
+3. **A PATH shim must not wrap the MCP servers.** The recording shim added for §3.3a is a `kcap` on
+   PATH — and the same PATH entry is used by the four long-lived `kcap mcp <server>` stdio servers
+   Gemini launches from `~/.gemini/settings.json`. Buffering a stdio JSON-RPC server's stdout traps its
+   handshake response until it exits, which it never does. Measured: every run hung at exactly the 120s
+   harness timeout, with four wrapped `kcap mcp …` processes alive and **zero** HTTP traffic. The shim
+   now `exec`s anything that is not `kcap hook`, making it completely transparent for everything else.
+   Buffering remains safe for the hook itself, and only because Gemini's runner parses on `close` rather
+   than reading incrementally.
 
 **Also worth pinning for the next adapter:** `session_id` is validated with `Guid.TryParse`, and a
 failure takes the same emit-and-return-0 path as a suppressed session. A decorated id (`cert-{guid}`)

--- a/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
@@ -434,14 +434,27 @@ real index and then failed its POST.
 a live alternative. Parsing was not assumed to be consuming: the model reproducing the nonce is what
 distinguishes them, and it is the assertion the cert makes.
 
-**The exit code is measured on the invocation that delivered the context, not inferred from a stand-in.**
-A first draft proved the non-zero exit from a SEPARATE direct `kcap hook --gemini` run against the same
-proxy; review was right that this is a substitution — every assertion could hold while Gemini's own hook
-returned 0 through some session- or source-dependent branch, and the conclusion would still be false.
-The cert now prepends a recording shim named `kcap` to the PATH Gemini inherits, captures each hook
-invocation's exit code and stdout, and asserts that the invocation whose `additionalContext` carried the
-nonce is the one that exited non-zero. Same process, both facts. It also asserts the FORCED mapping fired,
-by response-body marker, so an upstream 400 relayed by the catch-all proxy cannot be mistaken for it.
+**Every link is measured on the same invocation; nothing is inferred from a stand-in or from a
+turn-global count.** Two review rounds were needed to get here, and both objections were right:
+
+* A first draft proved the non-zero exit from a SEPARATE direct `kcap hook --gemini` run. That is a
+  substitution — every assertion could hold while Gemini's own hook returned 0 through some session- or
+  source-dependent branch. Fixed by prepending a recording shim named `kcap` to the PATH Gemini inherits,
+  capturing each hook invocation's stdin, stdout and exit code.
+* The second draft then asserted "some forced 400 happened during the turn", which is turn-global: with
+  two hook invocations, one could carry the nonce and exit non-zero for an unrelated reason while the
+  *other* hit the forced failure, and the cert would still be green. Fixed by correlating on session id —
+  the invocation whose `additionalContext` carried the nonce must be the invocation whose POST the forced
+  mapping rejected.
+
+So the assertion chain is: the recorded invocation that delivered the nonce **is** the one that exited
+non-zero, **and** is the one whose session-start POST the forced mapping (identified by its response-body
+marker, so an upstream 400 relayed by the catch-all proxy cannot stand in) rejected, **and** the turn
+completed, **and** the model reproduced the nonce.
+
+The recorded exit code is nullable by design: an unreadable or half-written record fails the assertion
+rather than satisfying it. An earlier version used an `int.MinValue` sentinel, which is non-zero and
+therefore passed the exact property under test — the shape of a false-pass, caught in review.
 
 Covering tests: `GeminiMemoryIndexLiveCertTests.Failed_session_start_post_still_delivers_the_index_to_a_real_gemini_session`
 (live, gated) and `GeminiSessionStartHandshakeOnPostFailureTests` (integration, always run) — the latter

--- a/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1463-gemini-memory-adapter-design.md
@@ -467,16 +467,22 @@ not enough: `SkipUnlessLiveGateReady` refuses to start any further live case (pr
 `[After(Assembly)]` teardown fails the run (retrospective — otherwise a cleanup failure in the *last*
 case is observed by nobody and the run reports green).
 
-Three things follow from taking "confirm" literally:
+Taking "confirm" literally is what shaped the rest:
 
 * `ArchiveMemoryAsync` returns whether the archive was **confirmed**, so no caller can claim a clean
   index off a swallowed failure.
-* Recovery-by-slug archives **every** exact match, not the first. Server-side slug uniqueness is not
-  something this harness can verify, and the property required is "no memory carrying this run's nonce
-  remains" — which one archive does not give.
-* An empty search result is **not** treated as absence. The read model behind search is not documented
-  as strongly consistent and no maximum lag is published, so a created memory can be invisible now and
-  present a moment later. Anything short of "found and archived, confirmed" is dirty.
+* An ambiguous save — no id in the response, **or a throw from the call itself**, which does not mean
+  the server declined the create — runs a best-effort sweep for the slug and marks the run dirty
+  **unconditionally**, even when every observed match was archived. Archiving what a search returned
+  proves only that the matches visible during a finite polling window are gone. Slugs are unique per
+  pool but service-enforced rather than constrained by the database, so a duplicate is not excluded by
+  construction, and with no published projection lag a second memory can surface after the last poll.
+  "Everything I could see is archived" is weaker than "nothing carrying this nonce remains", and only
+  the second would justify calling the index clean.
+* An empty search result is therefore **not** absence either — it is just an observation.
+
+The sweep mitigates; the mark tells the truth. The alternative, claiming clean on a finite observation,
+is exactly how a later run's positive case ends up passing on this run's nonce.
 
 Covering tests: `GeminiMemoryIndexLiveCertTests.Failed_session_start_post_still_delivers_the_index_to_a_real_gemini_session`
 (live, gated) and `GeminiSessionStartHandshakeOnPostFailureTests` (integration, always run) — the latter

--- a/test/Capacitor.Cli.Tests.Integration/GeminiSessionStartHandshakeOnPostFailureTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/GeminiSessionStartHandshakeOnPostFailureTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.SessionStartMemory;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// A rejected lifecycle POST must still deliver the memory index to Gemini — and must spend the lease
+/// exactly once while doing so.
+///
+/// <para>Gemini's runner selects the text to parse as <c>stdout.trim() || stderr.trim()</c>, so zero
+/// bytes on this path would hand it kcap's failed-POST stderr diagnostic as the hook result. That is the
+/// hazard the Codex adapter actually shipped once (an early <c>return 1</c> before the handshake), and
+/// the reason the write is ordered before every return.</para>
+///
+/// <para>This is the integration half of the design's non-zero-exit question. The live half — that a
+/// real <c>gemini</c> turn CONSUMES context from a hook that exited non-zero — is
+/// <c>GeminiMemoryIndexLiveCertTests</c>; only the two together justify "no commit gate", because this
+/// test can prove the bytes were written but not that Gemini used them.</para>
+/// </summary>
+public class GeminiSessionStartHandshakeOnPostFailureTests : IDisposable {
+    readonly WireMockServer _server     = WireMockServer.Start();
+    readonly string         _configPath = PathHelpers.ConfigPath("config.json");
+    readonly string?        _previousConfig;
+    readonly string         _memoryRoot =
+        Path.Combine(Path.GetTempPath(), $"kcap-gemini-failed-post-{Guid.NewGuid():N}");
+
+    public GeminiSessionStartHandshakeOnPostFailureTests() {
+        _previousConfig = File.Exists(_configPath) ? File.ReadAllText(_configPath) : null;
+    }
+
+    public void Dispose() {
+        _server.Stop();
+
+        try { Directory.Delete(_memoryRoot, recursive: true); } catch { /* best-effort */ }
+
+        if (_previousConfig is null) {
+            if (File.Exists(_configPath)) File.Delete(_configPath);
+        } else {
+            File.WriteAllText(_configPath, _previousConfig);
+        }
+    }
+
+    [Test, NotInParallel]
+    public async Task A_rejected_lifecycle_post_still_delivers_the_memory_index_and_spends_the_lease_once() {
+        var config = new ProfileConfig {
+            ActiveProfile = "work",
+            Profiles      = new() { ["work"] = new Profile { ServerUrl = _server.Url } }
+        };
+        await AppConfig.SaveProfileConfig(config);
+
+        // A permanent rejection: PostOrSpoolAsync returns Failed only for a genuine non-2xx (transport
+        // and auth failures spool instead), which is the one outcome that keeps the non-zero exit.
+        _server.Given(Request.Create().WithPath("/hooks/session-start/gemini").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(400));
+
+        // The index is served on the SAME base URL as the rejected POST — that combination is the whole
+        // point. An index fetched successfully must not be discarded because the lifecycle POST failed.
+        _server.Given(Request.Create().WithPath("/api/memories/index").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(
+                """
+                [{"memory_id":"m1","slug":"cert-slug","audience":"user",
+                  "description":"failed-post index delivery","kind":"reference"}]
+                """));
+
+        // A BARE GUID, deliberately: the dispatcher validates `session_id` with `Guid.TryParse`, and a
+        // decorated id takes the same emit-and-return-0 path as a suppressed session — producing a
+        // plausible-looking allow object with no POST attempted at all.
+        var sessionId = Guid.NewGuid().ToString();
+
+        var (startupExit, startupStdout) = await RunAsync(sessionId, source: "startup");
+
+        // The rejection is still reported — this is not "pretend it worked".
+        await Assert.That(startupExit).IsEqualTo(1);
+
+        // ...but the index still reached Gemini, as a parseable decision payload.
+        await Assert.That(AdditionalContextOf(startupStdout)).Contains("cert-slug");
+
+        // And the POST really was attempted and really was rejected, so the assertions above describe
+        // the Failed path rather than some earlier short-circuit.
+        var posts = _server.FindLogEntries(
+            Request.Create().WithPath("/hooks/session-start/gemini").UsingPost());
+        await Assert.That(posts.Count).IsEqualTo(1);
+
+        // The design's branch-specific lease assertion. The chosen branch is "no commit gate": the
+        // failed-POST invocation COMPLETES the lease because the injection was delivered. A `resume` on
+        // the same session must therefore emit the allow object and no context — if this ever produced
+        // the index a second time, the lease was released and the branch has silently flipped.
+        var (resumeExit, resumeStdout) = await RunAsync(sessionId, source: "resume");
+
+        await Assert.That(resumeExit).IsEqualTo(1);
+        await Assert.That(resumeStdout).IsEqualTo("""{"continue":true}""");
+    }
+
+    async Task<(int ExitCode, string Stdout)> RunAsync(string sessionId, string source) {
+        // No transcript_path → short-circuits before the watcher spawn.
+        var payload =
+            $$"""
+              {
+                "hook_event_name": "SessionStart",
+                "session_id":      "{{sessionId}}",
+                "cwd":             "/tmp",
+                "source":          "{{source}}"
+              }
+              """;
+
+        var originalOut  = Console.Out;
+        var stdoutWriter = new StringWriter();
+        Console.SetOut(stdoutWriter);
+
+        try {
+            // An unauthenticated client is deliberate: the stub needs no bearer, and the default factory
+            // would drag real credential resolution into a test about the failed-POST path.
+            var exit = await GeminiHookCommand.Handle(
+                _server.Url!, new StringReader(payload),
+                memoryClientFactory: (_, _) => Task.FromResult(new HttpClient()),
+                memoryStoreFactory:  () => new SessionStartMemoryLeaseStore(_memoryRoot));
+
+            return (exit, stdoutWriter.ToString());
+        } finally {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    static string AdditionalContextOf(string stdout) {
+        using var doc = JsonDocument.Parse(stdout.Trim());
+
+        return doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("additionalContext").GetString()!;
+    }
+}

--- a/test/Capacitor.Cli.Tests.Integration/GeminiSessionStartHandshakeOnPostFailureTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/GeminiSessionStartHandshakeOnPostFailureTests.cs
@@ -24,25 +24,32 @@ namespace Capacitor.Cli.Tests.Integration;
 /// test can prove the bytes were written but not that Gemini used them.</para>
 /// </summary>
 public class GeminiSessionStartHandshakeOnPostFailureTests : IDisposable {
+    // Declaration order is load-bearing. Field initializers run top-down, so the config snapshot is
+    // taken BEFORE the server is started: if reading the config throws, the constructor never completes,
+    // `Dispose` is never called, and anything started above it would leak.
+    readonly string  _configPath     = PathHelpers.ConfigPath("config.json");
+    readonly string? _previousConfig = File.Exists(PathHelpers.ConfigPath("config.json"))
+        ? File.ReadAllText(PathHelpers.ConfigPath("config.json"))
+        : null;
+
     readonly WireMockServer _server     = WireMockServer.Start();
-    readonly string         _configPath = PathHelpers.ConfigPath("config.json");
-    readonly string?        _previousConfig;
     readonly string         _memoryRoot =
         Path.Combine(Path.GetTempPath(), $"kcap-gemini-failed-post-{Guid.NewGuid():N}");
 
-    public GeminiSessionStartHandshakeOnPostFailureTests() {
-        _previousConfig = File.Exists(_configPath) ? File.ReadAllText(_configPath) : null;
-    }
-
+    /// <summary>Restores the developer's REAL config first and unconditionally. It is the only cleanup
+    /// here that touches machine state outside this test, so no other step — notably a throwing
+    /// <c>_server.Stop()</c> — may be able to skip it and leave the active profile pointed at a dead
+    /// WireMock URL.</summary>
     public void Dispose() {
-        _server.Stop();
-
-        try { Directory.Delete(_memoryRoot, recursive: true); } catch { /* best-effort */ }
-
-        if (_previousConfig is null) {
-            if (File.Exists(_configPath)) File.Delete(_configPath);
-        } else {
-            File.WriteAllText(_configPath, _previousConfig);
+        try {
+            if (_previousConfig is null) {
+                if (File.Exists(_configPath)) File.Delete(_configPath);
+            } else {
+                File.WriteAllText(_configPath, _previousConfig);
+            }
+        } finally {
+            try { _server.Stop(); }                                  catch { /* best-effort */ }
+            try { Directory.Delete(_memoryRoot, recursive: true); }  catch { /* best-effort */ }
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/GeminiMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/GeminiMemoryIndexLiveCertTests.cs
@@ -24,6 +24,9 @@ public class GeminiMemoryIndexLiveCertTests {
     const string LiveGateEnvVar = "KCAP_GEMINI_MEMORY_LIVE";
     const string VendorLabel    = "gemini";
 
+    const string SessionStartPath     = "/hooks/session-start/gemini";
+    const string ForcedFailureMarker  = "kcap_cert_forced_session_start_failure";
+
     static void Gate() => MemoryIndexLiveCertHarness.SkipUnlessLiveGateReady(
         LiveGateEnvVar,
         "one real `gemini` turn per test",
@@ -40,7 +43,7 @@ public class GeminiMemoryIndexLiveCertTests {
 
         var nonce    = MemoryIndexLiveCertHarness.NewNonce();
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+        var memoryId = await SaveNonceOrCleanUpAsync(nonce, worktree);
 
         try {
             // Records the exact binary version. A cert passing against an unknown build is how the
@@ -72,7 +75,7 @@ public class GeminiMemoryIndexLiveCertTests {
 
         var nonce    = MemoryIndexLiveCertHarness.NewNonce();
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+        var memoryId = await SaveNonceOrCleanUpAsync(nonce, worktree);
 
         try {
             await MemoryIndexLiveCertHarness.SetDisableMemoryIndexAsync(true);
@@ -113,12 +116,13 @@ public class GeminiMemoryIndexLiveCertTests {
     /// the very same base URL is proxied through untouched, which is the only arrangement that produces
     /// the shape under test — a hook that fetched a real index and then failed its POST.</para>
     ///
-    /// <para><b>Two links, asserted separately, because the live turn alone cannot prove either.</b>
-    /// Gemini's exit code says nothing about its hook's exit code, so (1) the proxy is asserted to have
-    /// actually failed a session-start POST during the run, and (2) the same binary is driven directly
-    /// against the same proxy to prove that a failed POST does exit non-zero AND still writes parseable
-    /// <c>additionalContext</c>. Without (2) a green run here would be equally consistent with the POST
-    /// having quietly succeeded.</para>
+    /// <para><b>The claim is about ONE invocation, so it is measured on that one invocation.</b> An
+    /// earlier draft proved the non-zero exit from a SEPARATE direct <c>kcap hook --gemini</c> run and
+    /// inferred the rest; review was right that this is a substitution, not a proof — every assertion
+    /// could hold while Gemini's own hook returned 0 through some session- or source-dependent branch.
+    /// Instead a recording shim named <c>kcap</c> is prepended to the PATH Gemini inherits, so the exit
+    /// code and stdout of the hook GEMINI ran are captured directly, and the test asserts that the very
+    /// invocation whose <c>additionalContext</c> carried the nonce is the one that exited non-zero.</para>
     /// </summary>
     [Test, NotInParallel]
     public async Task Failed_session_start_post_still_delivers_the_index_to_a_real_gemini_session() {
@@ -129,45 +133,50 @@ public class GeminiMemoryIndexLiveCertTests {
 
         var upstream = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
 
-        // The proxy is stood up BEFORE the nonce memory is saved, deliberately: everything that can throw
-        // during setup must throw while there is still nothing to clean up. A leaked nonce memory
-        // corrupts every later cert's injected index, so the window between the save and the archiving
-        // `finally` is kept as narrow as it can be.
+        // Proxy and shim are stood up BEFORE the nonce memory is saved, deliberately: everything that
+        // can throw during setup should throw while there is still nothing to clean up. A leaked nonce
+        // memory corrupts every later cert's injected index.
         using var proxy = WireMockServer.Start();
+        using var hooks = new HookRecorder();
 
         // Ordering matters: the specific mapping is registered first and at a higher priority, so the
         // catch-all proxy cannot swallow the one route this test exists to fail.
-        proxy.Given(Request.Create().WithPath("/hooks/session-start/gemini").UsingPost())
+        proxy.Given(Request.Create().WithPath(SessionStartPath).UsingPost())
              .AtPriority(1)
-             .RespondWith(Response.Create().WithStatusCode(400)
-                                           .WithBody("""{"error":"ai1463_cert_forced_session_start_failure"}"""));
+             .RespondWith(Response.Create().WithStatusCode(400).WithBody($$"""{"error":"{{ForcedFailureMarker}}"}"""));
         proxy.Given(Request.Create().WithPath("/*").UsingAnyMethod())
              .AtPriority(100)
              .RespondWith(Response.Create().WithProxy(upstream));
 
-        var viaProxy = new Dictionary<string, string> { ["KCAP_URL"] = proxy.Url! };
+        var viaProxy = new Dictionary<string, string> {
+            ["KCAP_URL"] = proxy.Url!,
+            ["PATH"]     = hooks.PrependedTo(Environment.GetEnvironmentVariable("PATH"))
+        };
 
         var nonce    = MemoryIndexLiveCertHarness.NewNonce();
         var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
-        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+        var memoryId = await SaveNonceOrCleanUpAsync(nonce, worktree);
 
         try {
             await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "gemini", ["--version"]);
 
-            // (2) The hook link, proven directly: same binary, same proxy, a real failed POST.
-            var (hookExit, hookStdout) = await RunSessionStartHookAsync(worktree.FullName, viaProxy);
-
-            await Assert.That(hookExit).IsNotEqualTo(0);
-            await Assert.That(AdditionalContextOf(hookStdout)).IsNotNull();
-
-            var failedPostsBefore = FailedSessionStartPosts(proxy);
-
             var (exitCode, answer) = await RunGeminiAsync(
                 worktree.FullName, MemoryIndexLiveCertHarness.PositivePrompt, viaProxy);
 
-            // (1) The turn's own hook really did hit the failing route — otherwise this degenerates
-            // into the plain positive case with extra machinery.
-            await Assert.That(FailedSessionStartPosts(proxy)).IsGreaterThan(failedPostsBefore);
+            // The turn's own hook really did hit the FORCED failure — matched on the response body
+            // marker, not merely on "a 400 at that path", so an upstream 400 arriving through the
+            // catch-all proxy could not be mistaken for this mapping firing.
+            await Assert.That(ForcedSessionStartFailures(proxy)).IsGreaterThan(0);
+
+            // The invocation that delivered the index, identified by the nonce in the context Gemini
+            // itself was handed. There is no substitution here: this IS the hook Gemini ran.
+            var delivering = hooks.Invocations
+                .Select(i => (i.ExitCode, Context: AdditionalContextOf(i.Stdout)))
+                .Where(i => i.Context?.Contains(nonce) == true)
+                .ToList();
+
+            await Assert.That(delivering).IsNotEmpty();
+            await Assert.That(delivering.All(i => i.ExitCode != 0)).IsTrue();
 
             await Assert.That(exitCode).IsEqualTo(0);
             await Assert.That(answer).Contains(nonce);
@@ -177,31 +186,15 @@ public class GeminiMemoryIndexLiveCertTests {
         }
     }
 
-    /// <summary>Drives `kcap hook --gemini` with a minimal SessionStart payload, returning its exit code
-    /// and stdout. The session id is a fresh GUID so the run cannot collide with a real session — and,
-    /// because the POST is failed by the proxy, nothing is created on the server either.
-    ///
-    /// <para>It must be a BARE, parseable GUID. The dispatcher validates <c>session_id</c> with
-    /// <c>Guid.TryParse</c> and a failure takes the same emit-and-return-0 path as a suppressed session,
-    /// so a decorated id (<c>cert-{guid}</c>) silently produces a passing-looking exit 0 with the allow
-    /// object and NO HTTP traffic at all — which is exactly what this test would otherwise be measuring
-    /// instead of the failed POST.</para></summary>
-    static async Task<(int ExitCode, string Stdout)> RunSessionStartHookAsync(
-            string cwd, IReadOnlyDictionary<string, string> environment) {
-        var payload = new JsonObject {
-            ["hook_event_name"] = "SessionStart",
-            ["session_id"]      = Guid.NewGuid().ToString(),
-            ["cwd"]             = cwd,
-            ["source"]          = "startup"
-        }.ToJsonString();
-
-        var (exitCode, stdout, stderr) = await MemoryIndexLiveCertHarness.RunProcessAsync(
-            "kcap", ["hook", "--gemini"], cwd, stdin: payload, environment: environment);
-
-        await Console.Out.WriteLineAsync(
-            $"[{VendorLabel}-memory-live] hook exit={exitCode} stdout={stdout} stderr={stderr}");
-
-        return (exitCode, stdout);
+    /// <summary>Saves the nonce memory, deleting the worktree if the save throws — the memory is the
+    /// expensive thing to leak, but a save failure must not also strand a temp directory.</summary>
+    static async Task<string> SaveNonceOrCleanUpAsync(string nonce, DirectoryInfo worktree) {
+        try {
+            return await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+        } catch {
+            TryDelete(worktree);
+            throw;
+        }
     }
 
     /// <summary>The injected text, or null when the payload carries none — this is what Gemini's runner
@@ -214,9 +207,89 @@ public class GeminiMemoryIndexLiveCertTests {
         }
     }
 
-    static int FailedSessionStartPosts(WireMockServer proxy) =>
+    /// <summary>Counts only responses this test's own mapping produced, identified by its body marker.
+    /// Counting "400 at that path" instead would also count an upstream 400 relayed by the catch-all
+    /// proxy, and the point of the assertion is that the FORCED failure fired.</summary>
+    static int ForcedSessionStartFailures(WireMockServer proxy) =>
         proxy.LogEntries.Count(e =>
-            e.RequestMessage.Path == "/hooks/session-start/gemini" && e.ResponseMessage.StatusCode is 400);
+            e.RequestMessage.Path == SessionStartPath
+         && e.ResponseMessage.StatusCode is 400
+         && e.ResponseMessage.BodyData?.BodyAsString?.Contains(ForcedFailureMarker) == true);
+
+    /// <summary>
+    /// A throwaway PATH entry holding a shim named <c>kcap</c> that runs the real one and records each
+    /// invocation's exit code and stdout.
+    ///
+    /// <para><b>Only <c>kcap hook</c> is recorded; everything else is <c>exec</c>'d straight through.</b>
+    /// That is not tidiness — recording buffers the child's stdout to a file and replays it on exit,
+    /// and the same PATH entry is used by the four long-lived <c>kcap mcp</c> stdio servers Gemini
+    /// launches from <c>~/.gemini/settings.json</c>. Buffering a stdio JSON-RPC server traps its
+    /// handshake response until it exits, which it never does, so the turn stalls until the harness
+    /// timeout. Measured: a recorder without this guard hung every run at exactly 120s, with four
+    /// wrapped <c>kcap mcp …</c> processes alive and zero HTTP traffic.</para>
+    ///
+    /// <para>Buffering IS safe for the hook, and only because Gemini's runner collects stdout and parses
+    /// on <c>close</c> rather than reading incrementally. Do not lift this shim to a harness that
+    /// streams.</para>
+    ///
+    /// <para>The real binary is resolved from the UNMODIFIED PATH at construction time, so the shim
+    /// cannot re-enter itself.</para>
+    /// </summary>
+    sealed class HookRecorder : IDisposable {
+        readonly string _root;
+        readonly string _log;
+
+        public HookRecorder() {
+            _root = Directory.CreateTempSubdirectory($"kcap-{VendorLabel}-hook-recorder-").FullName;
+            _log  = Directory.CreateDirectory(Path.Combine(_root, "log")).FullName;
+
+            BinDir = Directory.CreateDirectory(Path.Combine(_root, "bin")).FullName;
+
+            var real  = MemoryIndexLiveCertHarness.ResolveOnPath("kcap");
+            var shim  = Path.Combine(BinDir, "kcap");
+
+            File.WriteAllText(shim,
+                $"""
+                 #!/bin/sh
+                 # Anything that is not a hook — notably the long-lived `kcap mcp <server>` stdio
+                 # servers — must be completely transparent, so hand the process over rather than
+                 # wrapping its streams.
+                 if [ "$1" != "hook" ]; then exec "{real}" "$@"; fi
+
+                 out="{_log}/$$.out"
+                 err="{_log}/$$.err"
+                 "{real}" "$@" > "$out" 2> "$err"
+                 status=$?
+                 cat "$out"
+                 cat "$err" >&2
+                 printf '%s' "$status" > "{_log}/$$.exit"
+                 exit "$status"
+                 """);
+            File.SetUnixFileMode(shim,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        public string BinDir { get; }
+
+        public string PrependedTo(string? path) =>
+            string.IsNullOrEmpty(path) ? BinDir : $"{BinDir}{Path.PathSeparator}{path}";
+
+        /// <summary>One entry per completed shim invocation. An invocation still in flight has no
+        /// <c>.exit</c> file yet and is skipped, so a partially written pair is never reported.</summary>
+        public IReadOnlyList<(int ExitCode, string Stdout)> Invocations =>
+            [.. Directory.EnumerateFiles(_log, "*.exit")
+                .Select(exitFile => (
+                    ExitCode: int.TryParse(File.ReadAllText(exitFile).Trim(), out var code) ? code : int.MinValue,
+                    Stdout:   ReadOrEmpty(Path.ChangeExtension(exitFile, ".out"))))];
+
+        static string ReadOrEmpty(string path) {
+            try { return File.ReadAllText(path); } catch { return ""; }
+        }
+
+        public void Dispose() {
+            try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+        }
+    }
 
     /// <summary>Runs one non-interactive Gemini turn. <c>--approval-mode plan</c> keeps it read-only so
     /// an unexpected tool request cannot stall the cert.

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/GeminiMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/GeminiMemoryIndexLiveCertTests.cs
@@ -163,20 +163,30 @@ public class GeminiMemoryIndexLiveCertTests {
             var (exitCode, answer) = await RunGeminiAsync(
                 worktree.FullName, MemoryIndexLiveCertHarness.PositivePrompt, viaProxy);
 
-            // The turn's own hook really did hit the FORCED failure — matched on the response body
-            // marker, not merely on "a 400 at that path", so an upstream 400 arriving through the
-            // catch-all proxy could not be mistaken for this mapping firing.
-            await Assert.That(ForcedSessionStartFailures(proxy)).IsGreaterThan(0);
-
-            // The invocation that delivered the index, identified by the nonce in the context Gemini
-            // itself was handed. There is no substitution here: this IS the hook Gemini ran.
+            // The invocations that delivered the index, identified by the nonce in the context Gemini
+            // itself was handed. There is no substitution here: these ARE hooks Gemini ran.
             var delivering = hooks.Invocations
-                .Select(i => (i.ExitCode, Context: AdditionalContextOf(i.Stdout)))
-                .Where(i => i.Context?.Contains(nonce) == true)
+                .Where(i => AdditionalContextOf(i.Stdout)?.Contains(nonce) == true)
                 .ToList();
 
             await Assert.That(delivering).IsNotEmpty();
-            await Assert.That(delivering.All(i => i.ExitCode != 0)).IsTrue();
+
+            // Non-zero exit, per delivering invocation. `ExitCode` is nullable ON PURPOSE: an
+            // unreadable or half-written exit record must FAIL this, not satisfy it. An earlier
+            // version mapped a parse failure to int.MinValue, which is != 0 and therefore passed the
+            // very property under test — a sentinel that satisfies the assertion is a false-pass path.
+            await Assert.That(delivering.All(i => i.ExitCode is { } code && code != 0)).IsTrue();
+
+            // ...and each of those invocations is the one whose POST the FORCED mapping rejected.
+            // A turn-global "some 400 happened" assertion is not enough: with two hook invocations,
+            // one could carry the nonce and exit non-zero for an unrelated reason while the OTHER hit
+            // the forced failure, and every assertion would still pass without the claim being true.
+            // Correlating on session id closes that — and the marker match means an upstream 400
+            // relayed by the catch-all proxy cannot stand in for this mapping firing.
+            var rejected = ForcedFailureSessionIds(proxy);
+
+            await Assert.That(rejected).IsNotEmpty();
+            await Assert.That(delivering.All(i => SessionIdOf(i.Stdin) is { } id && rejected.Contains(id))).IsTrue();
 
             await Assert.That(exitCode).IsEqualTo(0);
             await Assert.That(answer).Contains(nonce);
@@ -207,14 +217,28 @@ public class GeminiMemoryIndexLiveCertTests {
         }
     }
 
-    /// <summary>Counts only responses this test's own mapping produced, identified by its body marker.
-    /// Counting "400 at that path" instead would also count an upstream 400 relayed by the catch-all
-    /// proxy, and the point of the assertion is that the FORCED failure fired.</summary>
-    static int ForcedSessionStartFailures(WireMockServer proxy) =>
-        proxy.LogEntries.Count(e =>
-            e.RequestMessage.Path == SessionStartPath
-         && e.ResponseMessage.StatusCode is 400
-         && e.ResponseMessage.BodyData?.BodyAsString?.Contains(ForcedFailureMarker) == true);
+    /// <summary>The session ids whose session-start POST this test's own mapping rejected, identified by
+    /// its response-body marker. Matching on the marker rather than on "400 at that path" is what stops
+    /// an upstream 400, relayed by the catch-all proxy, standing in for the forced failure.</summary>
+    static HashSet<string> ForcedFailureSessionIds(WireMockServer proxy) =>
+        [.. proxy.LogEntries
+            .Where(e => e.RequestMessage.Path == SessionStartPath
+                     && e.ResponseMessage.StatusCode is 400
+                     && e.ResponseMessage.BodyData?.BodyAsString?.Contains(ForcedFailureMarker) == true)
+            .Select(e => SessionIdOf(e.RequestMessage.Body))
+            .OfType<string>()];
+
+    /// <summary>The session id in a hook payload or a posted lifecycle body, dash-stripped so the two
+    /// compare: the hook receives Gemini's dashed UUID and forwards the dashless form to the server.</summary>
+    static string? SessionIdOf(string? json) {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+
+        try {
+            return JsonNode.Parse(json)?["session_id"]?.GetValue<string>()?.Replace("-", "");
+        } catch {
+            return null;
+        }
+    }
 
     /// <summary>
     /// A throwaway PATH entry holding a shim named <c>kcap</c> that runs the real one and records each
@@ -256,9 +280,14 @@ public class GeminiMemoryIndexLiveCertTests {
                  # wrapping its streams.
                  if [ "$1" != "hook" ]; then exec "{real}" "$@"; fi
 
+                 in="{_log}/$$.in"
                  out="{_log}/$$.out"
                  err="{_log}/$$.err"
-                 "{real}" "$@" > "$out" 2> "$err"
+                 # stdin is drained to a file and replayed, so the payload can be correlated with the
+                 # POST the proxy saw. A hook's stdin is written once and closed, so buffering it is
+                 # not a streaming hazard the way stdout would be for a long-lived process.
+                 cat > "$in"
+                 "{real}" "$@" < "$in" > "$out" 2> "$err"
                  status=$?
                  cat "$out"
                  cat "$err" >&2
@@ -274,12 +303,20 @@ public class GeminiMemoryIndexLiveCertTests {
         public string PrependedTo(string? path) =>
             string.IsNullOrEmpty(path) ? BinDir : $"{BinDir}{Path.PathSeparator}{path}";
 
-        /// <summary>One entry per completed shim invocation. An invocation still in flight has no
-        /// <c>.exit</c> file yet and is skipped, so a partially written pair is never reported.</summary>
-        public IReadOnlyList<(int ExitCode, string Stdout)> Invocations =>
+        /// <summary>
+        /// One entry per completed shim invocation. An invocation still in flight has no <c>.exit</c>
+        /// file yet and is skipped, so a partially written set is never reported.
+        ///
+        /// <para><c>ExitCode</c> is nullable rather than defaulted: an unreadable or half-written record
+        /// must fail an assertion, never satisfy one. A sentinel here (the first version used
+        /// <c>int.MinValue</c>) is <c>!= 0</c> and would have passed the exact property the cert
+        /// exists to check.</para>
+        /// </summary>
+        public IReadOnlyList<(int? ExitCode, string Stdin, string Stdout)> Invocations =>
             [.. Directory.EnumerateFiles(_log, "*.exit")
                 .Select(exitFile => (
-                    ExitCode: int.TryParse(File.ReadAllText(exitFile).Trim(), out var code) ? code : int.MinValue,
+                    ExitCode: int.TryParse(File.ReadAllText(exitFile).Trim(), out var code) ? code : (int?)null,
+                    Stdin:    ReadOrEmpty(Path.ChangeExtension(exitFile, ".in")),
                     Stdout:   ReadOrEmpty(Path.ChangeExtension(exitFile, ".out"))))];
 
         static string ReadOrEmpty(string path) {

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/GeminiMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/GeminiMemoryIndexLiveCertTests.cs
@@ -1,3 +1,8 @@
+using System.Text.Json.Nodes;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
 namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
 
 /// <summary>
@@ -72,8 +77,14 @@ public class GeminiMemoryIndexLiveCertTests {
         try {
             await MemoryIndexLiveCertHarness.SetDisableMemoryIndexAsync(true);
 
-            var (_, answer) = await RunGeminiAsync(worktree.FullName, MemoryIndexLiveCertHarness.NegativePrompt);
+            var (exitCode, answer) = await RunGeminiAsync(worktree.FullName, MemoryIndexLiveCertHarness.NegativePrompt);
 
+            // Turn completion is asserted FIRST, and it is what stops this control being vacuous: a
+            // turn that never ran trivially contains no nonce. Observed for real — before
+            // `--skip-trust` was passed, gemini exited 55 on the trust gate and this test passed
+            // while proving nothing at all. The claim is "the opt-out suppressed the injection",
+            // which is only meaningful if the model was actually asked.
+            await Assert.That(exitCode).IsEqualTo(0);
             await Assert.That(answer).DoesNotContain(nonce);
         } finally {
             TryDelete(worktree);
@@ -87,11 +98,139 @@ public class GeminiMemoryIndexLiveCertTests {
         }
     }
 
-    /// <summary>Runs one non-interactive Gemini turn. <c>--approval-mode plan</c> keeps it read-only so
-    /// an unexpected tool request cannot stall the cert.</summary>
-    static async Task<(int ExitCode, string Answer)> RunGeminiAsync(string cwd, string prompt) {
+    /// <summary>
+    /// The third case §3.3 owes: a SessionStart whose lifecycle POST genuinely fails, so the hook exits
+    /// non-zero while still emitting <c>additionalContext</c> — does the model still receive it?
+    ///
+    /// <para>§3.3 chose "no commit gate" on a reading of Gemini's hook runner (<c>stdout.trim() ||
+    /// stderr.trim()</c>, parsed with no exit-code gate). That is a source reading, not a behavioural
+    /// one, and the spec's definition of done requires settling it live. This test is that settlement:
+    /// if Gemini ever did discard a failing hook's stdout, the lease would be spent on an injection the
+    /// model never saw, and the decision would have to flip to a commit gate.</para>
+    ///
+    /// <para>The failure is REAL, not simulated: a WireMock instance proxies the whole API to the
+    /// configured server and fails exactly <c>POST /hooks/session-start/gemini</c>. The index fetch on
+    /// the very same base URL is proxied through untouched, which is the only arrangement that produces
+    /// the shape under test — a hook that fetched a real index and then failed its POST.</para>
+    ///
+    /// <para><b>Two links, asserted separately, because the live turn alone cannot prove either.</b>
+    /// Gemini's exit code says nothing about its hook's exit code, so (1) the proxy is asserted to have
+    /// actually failed a session-start POST during the run, and (2) the same binary is driven directly
+    /// against the same proxy to prove that a failed POST does exit non-zero AND still writes parseable
+    /// <c>additionalContext</c>. Without (2) a green run here would be equally consistent with the POST
+    /// having quietly succeeded.</para>
+    /// </summary>
+    [Test, NotInParallel]
+    public async Task Failed_session_start_post_still_delivers_the_index_to_a_real_gemini_session() {
+        Gate();
+
+        var original = await MemoryIndexLiveCertHarness.ReadDisableMemoryIndexAsync();
+        await Assert.That(original is true).IsFalse();
+
+        var upstream = await MemoryIndexLiveCertHarness.InitializeAndResolveServerUrlAsync();
+
+        // The proxy is stood up BEFORE the nonce memory is saved, deliberately: everything that can throw
+        // during setup must throw while there is still nothing to clean up. A leaked nonce memory
+        // corrupts every later cert's injected index, so the window between the save and the archiving
+        // `finally` is kept as narrow as it can be.
+        using var proxy = WireMockServer.Start();
+
+        // Ordering matters: the specific mapping is registered first and at a higher priority, so the
+        // catch-all proxy cannot swallow the one route this test exists to fail.
+        proxy.Given(Request.Create().WithPath("/hooks/session-start/gemini").UsingPost())
+             .AtPriority(1)
+             .RespondWith(Response.Create().WithStatusCode(400)
+                                           .WithBody("""{"error":"ai1463_cert_forced_session_start_failure"}"""));
+        proxy.Given(Request.Create().WithPath("/*").UsingAnyMethod())
+             .AtPriority(100)
+             .RespondWith(Response.Create().WithProxy(upstream));
+
+        var viaProxy = new Dictionary<string, string> { ["KCAP_URL"] = proxy.Url! };
+
+        var nonce    = MemoryIndexLiveCertHarness.NewNonce();
+        var worktree = MemoryIndexLiveCertHarness.NewCertWorktree(VendorLabel);
+        var memoryId = await MemoryIndexLiveCertHarness.SaveNonceMemoryAsync(VendorLabel, nonce);
+
+        try {
+            await MemoryIndexLiveCertHarness.RecordCertEnvironmentAsync(VendorLabel, "gemini", ["--version"]);
+
+            // (2) The hook link, proven directly: same binary, same proxy, a real failed POST.
+            var (hookExit, hookStdout) = await RunSessionStartHookAsync(worktree.FullName, viaProxy);
+
+            await Assert.That(hookExit).IsNotEqualTo(0);
+            await Assert.That(AdditionalContextOf(hookStdout)).IsNotNull();
+
+            var failedPostsBefore = FailedSessionStartPosts(proxy);
+
+            var (exitCode, answer) = await RunGeminiAsync(
+                worktree.FullName, MemoryIndexLiveCertHarness.PositivePrompt, viaProxy);
+
+            // (1) The turn's own hook really did hit the failing route — otherwise this degenerates
+            // into the plain positive case with extra machinery.
+            await Assert.That(FailedSessionStartPosts(proxy)).IsGreaterThan(failedPostsBefore);
+
+            await Assert.That(exitCode).IsEqualTo(0);
+            await Assert.That(answer).Contains(nonce);
+        } finally {
+            TryDelete(worktree);
+            await MemoryIndexLiveCertHarness.ArchiveMemoryAsync(VendorLabel, memoryId);
+        }
+    }
+
+    /// <summary>Drives `kcap hook --gemini` with a minimal SessionStart payload, returning its exit code
+    /// and stdout. The session id is a fresh GUID so the run cannot collide with a real session — and,
+    /// because the POST is failed by the proxy, nothing is created on the server either.
+    ///
+    /// <para>It must be a BARE, parseable GUID. The dispatcher validates <c>session_id</c> with
+    /// <c>Guid.TryParse</c> and a failure takes the same emit-and-return-0 path as a suppressed session,
+    /// so a decorated id (<c>cert-{guid}</c>) silently produces a passing-looking exit 0 with the allow
+    /// object and NO HTTP traffic at all — which is exactly what this test would otherwise be measuring
+    /// instead of the failed POST.</para></summary>
+    static async Task<(int ExitCode, string Stdout)> RunSessionStartHookAsync(
+            string cwd, IReadOnlyDictionary<string, string> environment) {
+        var payload = new JsonObject {
+            ["hook_event_name"] = "SessionStart",
+            ["session_id"]      = Guid.NewGuid().ToString(),
+            ["cwd"]             = cwd,
+            ["source"]          = "startup"
+        }.ToJsonString();
+
         var (exitCode, stdout, stderr) = await MemoryIndexLiveCertHarness.RunProcessAsync(
-            "gemini", ["--approval-mode", "plan", "--prompt", prompt], cwd);
+            "kcap", ["hook", "--gemini"], cwd, stdin: payload, environment: environment);
+
+        await Console.Out.WriteLineAsync(
+            $"[{VendorLabel}-memory-live] hook exit={exitCode} stdout={stdout} stderr={stderr}");
+
+        return (exitCode, stdout);
+    }
+
+    /// <summary>The injected text, or null when the payload carries none — this is what Gemini's runner
+    /// parses, so parsing it the same way is the assertion that the bytes were usable.</summary>
+    static string? AdditionalContextOf(string stdout) {
+        try {
+            return JsonNode.Parse(stdout.Trim())?["hookSpecificOutput"]?["additionalContext"]?.GetValue<string>();
+        } catch {
+            return null;
+        }
+    }
+
+    static int FailedSessionStartPosts(WireMockServer proxy) =>
+        proxy.LogEntries.Count(e =>
+            e.RequestMessage.Path == "/hooks/session-start/gemini" && e.ResponseMessage.StatusCode is 400);
+
+    /// <summary>Runs one non-interactive Gemini turn. <c>--approval-mode plan</c> keeps it read-only so
+    /// an unexpected tool request cannot stall the cert.
+    ///
+    /// <para><c>--skip-trust</c> is REQUIRED, not hygiene. Every cert runs in a freshly created
+    /// throwaway worktree, which is by definition not in the user's trusted-folders list, and 0.53.0
+    /// refuses a headless turn outright in an untrusted directory — <c>exit 55</c>, before any model
+    /// call. Without it the positive case fails on the trust gate and, worse, the negative control
+    /// passes vacuously (see its exit-code assertion).</para></summary>
+    static async Task<(int ExitCode, string Answer)> RunGeminiAsync(
+            string cwd, string prompt, IReadOnlyDictionary<string, string>? environment = null) {
+        var (exitCode, stdout, stderr) = await MemoryIndexLiveCertHarness.RunProcessAsync(
+            "gemini", ["--skip-trust", "--approval-mode", "plan", "--prompt", prompt], cwd,
+            environment: environment);
 
         await Console.Out.WriteLineAsync($"[{VendorLabel}-memory-live] gemini exit={exitCode} stderr={stderr}");
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/GeminiMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/GeminiMemoryIndexLiveCertTests.cs
@@ -27,6 +27,12 @@ public class GeminiMemoryIndexLiveCertTests {
     const string SessionStartPath     = "/hooks/session-start/gemini";
     const string ForcedFailureMarker  = "kcap_cert_forced_session_start_failure";
 
+    /// <summary>What the poster's failed-POST branch writes to stderr — <c>[kcap] {agentTag}
+    /// {endpoint}: HTTP {code}</c>. Matched on the route-and-status tail rather than the whole line, so
+    /// the cert does not break on an agent-tag rename, but still cannot be satisfied by a failure on
+    /// some other route.</summary>
+    const string FailedPostDiagnostic = "session-start/gemini: HTTP 400";
+
     static void Gate() => MemoryIndexLiveCertHarness.SkipUnlessLiveGateReady(
         LiveGateEnvVar,
         "one real `gemini` turn per test",
@@ -116,13 +122,21 @@ public class GeminiMemoryIndexLiveCertTests {
     /// the very same base URL is proxied through untouched, which is the only arrangement that produces
     /// the shape under test — a hook that fetched a real index and then failed its POST.</para>
     ///
-    /// <para><b>The claim is about ONE invocation, so it is measured on that one invocation.</b> An
-    /// earlier draft proved the non-zero exit from a SEPARATE direct <c>kcap hook --gemini</c> run and
-    /// inferred the rest; review was right that this is a substitution, not a proof — every assertion
-    /// could hold while Gemini's own hook returned 0 through some session- or source-dependent branch.
-    /// Instead a recording shim named <c>kcap</c> is prepended to the PATH Gemini inherits, so the exit
-    /// code and stdout of the hook GEMINI ran are captured directly, and the test asserts that the very
-    /// invocation whose <c>additionalContext</c> carried the nonce is the one that exited non-zero.</para>
+    /// <para><b>The claim is about ONE invocation, so every link is measured on that one invocation.</b>
+    /// A recording shim named <c>kcap</c> is prepended to the PATH Gemini inherits, capturing each hook
+    /// invocation's exit code, stdout and stderr. The test picks the invocation whose
+    /// <c>additionalContext</c> carried the nonce — the hook Gemini actually consumed — and asserts, of
+    /// that same invocation, that it exited non-zero and that its own stderr carries the failed-POST
+    /// diagnostic for the session-start route.</para>
+    ///
+    /// <para>Three weaker versions were tried and each was holed in review; they are worth naming
+    /// because each looks sufficient. (1) Proving the non-zero exit from a SEPARATE direct
+    /// <c>kcap hook --gemini</c> run is a substitution: Gemini's own hook could have returned 0 through
+    /// a session- or source-dependent branch. (2) "Some forced 400 happened during the turn" is
+    /// turn-global: one invocation could carry the nonce while a DIFFERENT one took the 400. (3)
+    /// Correlating those two on session id narrows it but does not close it, because a session id is
+    /// reused across invocations — <c>startup</c> and <c>resume</c> share one. Only per-invocation
+    /// evidence closes it.</para>
     /// </summary>
     [Test, NotInParallel]
     public async Task Failed_session_start_post_still_delivers_the_index_to_a_real_gemini_session() {
@@ -177,16 +191,21 @@ public class GeminiMemoryIndexLiveCertTests {
             // very property under test — a sentinel that satisfies the assertion is a false-pass path.
             await Assert.That(delivering.All(i => i.ExitCode is { } code && code != 0)).IsTrue();
 
-            // ...and each of those invocations is the one whose POST the FORCED mapping rejected.
-            // A turn-global "some 400 happened" assertion is not enough: with two hook invocations,
-            // one could carry the nonce and exit non-zero for an unrelated reason while the OTHER hit
-            // the forced failure, and every assertion would still pass without the claim being true.
-            // Correlating on session id closes that — and the marker match means an upstream 400
-            // relayed by the catch-all proxy cannot stand in for this mapping firing.
-            var rejected = ForcedFailureSessionIds(proxy);
+            // ...and each of those invocations rejected its OWN POST. This is per-invocation evidence,
+            // read from that invocation's own stderr — `[kcap] {agentTag} {endpoint}: HTTP {code}` is
+            // written by the failed-POST branch of the poster itself.
+            //
+            // Two weaker versions were tried and both were holed in review. "Some forced 400 happened
+            // during the turn" is turn-global: one invocation could carry the nonce while a DIFFERENT
+            // one took the 400. Correlating on session id narrows that but does not close it, because a
+            // session id is reused across invocations — `startup` and `resume` share one, which is
+            // exactly the shape the integration test exercises.
+            await Assert.That(delivering.All(i => i.Stderr.Contains(FailedPostDiagnostic))).IsTrue();
 
-            await Assert.That(rejected).IsNotEmpty();
-            await Assert.That(delivering.All(i => SessionIdOf(i.Stdin) is { } id && rejected.Contains(id))).IsTrue();
+            // The proxy assertion is now doing one job only, and it is a job the stderr cannot do:
+            // proving the 400 came from THIS test's mapping rather than from upstream via the
+            // catch-all proxy. Both halves are needed — neither implies the other.
+            await Assert.That(ForcedSessionStartFailures(proxy)).IsGreaterThan(0);
 
             await Assert.That(exitCode).IsEqualTo(0);
             await Assert.That(answer).Contains(nonce);
@@ -217,28 +236,14 @@ public class GeminiMemoryIndexLiveCertTests {
         }
     }
 
-    /// <summary>The session ids whose session-start POST this test's own mapping rejected, identified by
-    /// its response-body marker. Matching on the marker rather than on "400 at that path" is what stops
-    /// an upstream 400, relayed by the catch-all proxy, standing in for the forced failure.</summary>
-    static HashSet<string> ForcedFailureSessionIds(WireMockServer proxy) =>
-        [.. proxy.LogEntries
-            .Where(e => e.RequestMessage.Path == SessionStartPath
-                     && e.ResponseMessage.StatusCode is 400
-                     && e.ResponseMessage.BodyData?.BodyAsString?.Contains(ForcedFailureMarker) == true)
-            .Select(e => SessionIdOf(e.RequestMessage.Body))
-            .OfType<string>()];
-
-    /// <summary>The session id in a hook payload or a posted lifecycle body, dash-stripped so the two
-    /// compare: the hook receives Gemini's dashed UUID and forwards the dashless form to the server.</summary>
-    static string? SessionIdOf(string? json) {
-        if (string.IsNullOrWhiteSpace(json)) return null;
-
-        try {
-            return JsonNode.Parse(json)?["session_id"]?.GetValue<string>()?.Replace("-", "");
-        } catch {
-            return null;
-        }
-    }
+    /// <summary>Counts only responses this test's own mapping produced, identified by its body marker.
+    /// Counting "400 at that path" instead would also count an upstream 400 relayed by the catch-all
+    /// proxy, and the point of this assertion is that the FORCED failure is what fired.</summary>
+    static int ForcedSessionStartFailures(WireMockServer proxy) =>
+        proxy.LogEntries.Count(e =>
+            e.RequestMessage.Path == SessionStartPath
+         && e.ResponseMessage.StatusCode is 400
+         && e.ResponseMessage.BodyData?.BodyAsString?.Contains(ForcedFailureMarker) == true);
 
     /// <summary>
     /// A throwaway PATH entry holding a shim named <c>kcap</c> that runs the real one and records each
@@ -280,14 +285,9 @@ public class GeminiMemoryIndexLiveCertTests {
                  # wrapping its streams.
                  if [ "$1" != "hook" ]; then exec "{real}" "$@"; fi
 
-                 in="{_log}/$$.in"
                  out="{_log}/$$.out"
                  err="{_log}/$$.err"
-                 # stdin is drained to a file and replayed, so the payload can be correlated with the
-                 # POST the proxy saw. A hook's stdin is written once and closed, so buffering it is
-                 # not a streaming hazard the way stdout would be for a long-lived process.
-                 cat > "$in"
-                 "{real}" "$@" < "$in" > "$out" 2> "$err"
+                 "{real}" "$@" > "$out" 2> "$err"
                  status=$?
                  cat "$out"
                  cat "$err" >&2
@@ -312,12 +312,12 @@ public class GeminiMemoryIndexLiveCertTests {
         /// <c>int.MinValue</c>) is <c>!= 0</c> and would have passed the exact property the cert
         /// exists to check.</para>
         /// </summary>
-        public IReadOnlyList<(int? ExitCode, string Stdin, string Stdout)> Invocations =>
+        public IReadOnlyList<(int? ExitCode, string Stdout, string Stderr)> Invocations =>
             [.. Directory.EnumerateFiles(_log, "*.exit")
                 .Select(exitFile => (
                     ExitCode: int.TryParse(File.ReadAllText(exitFile).Trim(), out var code) ? code : (int?)null,
-                    Stdin:    ReadOrEmpty(Path.ChangeExtension(exitFile, ".in")),
-                    Stdout:   ReadOrEmpty(Path.ChangeExtension(exitFile, ".out"))))];
+                    Stdout:   ReadOrEmpty(Path.ChangeExtension(exitFile, ".out")),
+                    Stderr:   ReadOrEmpty(Path.ChangeExtension(exitFile, ".err"))))];
 
         static string ReadOrEmpty(string path) {
             try { return File.ReadAllText(path); } catch { return ""; }

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/LiveCertIndexCleanlinessGuard.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/LiveCertIndexCleanlinessGuard.cs
@@ -1,0 +1,25 @@
+namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
+
+/// <summary>
+/// Fails the RUN if any live cert left a nonce memory it could not confirm was removed.
+///
+/// <para><b>Why this exists as well as the gate in <c>SkipUnlessLiveGateReady</c>.</b> That gate is
+/// prospective: it stops the NEXT case from starting against a possibly-dirty index. But if the
+/// cleanup failure happens in the last case — or the only one — nothing ever looks at the flag, and a
+/// run that leaked a nonce reports green. A leaked nonce makes a LATER run's positive case pass on
+/// this run's evidence, so it has to be a failure now, not a warning nobody reads.</para>
+///
+/// <para>Costs nothing when no live cert ran: the flag can only be set by the gated cert path, so in
+/// CI this hook observes null and returns.</para>
+/// </summary>
+public class LiveCertIndexCleanlinessGuard {
+    [After(Assembly)]
+    public static void FailIfALiveCertLeftTheIndexDirty() {
+        if (MemoryIndexLiveCertHarness.IndexCleanlinessUnconfirmed is not { } reason) return;
+
+        throw new InvalidOperationException(
+            "A live memory cert could not confirm its nonce memory was removed, so the real injected "
+          + "index may now carry a stale nonce — which would make a later run's positive case pass on "
+          + $"this run's evidence. Find and archive it before certifying anything again. Reason: {reason}");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -203,9 +203,13 @@ internal static class MemoryIndexLiveCertHarness {
         // "-escaped, so no pattern matching a literal `"memory_id"` will ever fire.
         //
         // Failing loudly (rather than returning null and archiving nothing) is what stops a cert
-        // leaking its nonce memory into every later run's injected index.
+        // leaking its nonce memory into every later run's injected index. The slug is named in the
+        // message because this is the one failure the caller CANNOT clean up: archiving needs the id,
+        // and if the memory was created before the response went unparseable, a human has to remove it.
         return ExtractMemoryId(stdout)
-            ?? throw new InvalidOperationException($"save_memory returned no memory_id. stdout: {stdout}");
+            ?? throw new InvalidOperationException(
+                $"save_memory returned no memory_id for slug live-cert-{nonce} — if the memory WAS "
+              + $"created, archive it by hand or it will pollute every later cert's index. stdout: {stdout}");
     }
 
     /// <summary>Digs the saved memory's id out of an MCP <c>tools/call</c> frame. Null if absent.</summary>
@@ -412,7 +416,7 @@ internal static class MemoryIndexLiveCertHarness {
     /// certs are gated and are not run on Windows, and a half-right implementation would be worse than
     /// the documented status quo.</para>
     /// </summary>
-    static string ResolveOnPath(string fileName) =>
+    internal static string ResolveOnPath(string fileName) =>
         ResolveOnPath(fileName, Environment.GetEnvironmentVariable("PATH"), OperatingSystem.IsWindows());
 
     /// <summary>Pure overload: PATH and platform are passed rather than probed, so the resolution order
@@ -425,11 +429,37 @@ internal static class MemoryIndexLiveCertHarness {
             if (dir.Length == 0) continue;
 
             var candidate = Path.Combine(dir, fileName);
-            if (File.Exists(candidate)) return candidate;
+            if (IsExecutableFile(candidate)) return candidate;
         }
 
         // Unresolved: hand the bare name back so Process.Start produces its own, clearer error.
         return fileName;
+    }
+
+    /// <summary>
+    /// Existence is NOT the test a shell applies. <c>which</c> and <c>execvp</c> skip a PATH entry whose
+    /// match is not executable and keep looking, so resolving on <c>File.Exists</c> alone would stop at a
+    /// non-executable same-named file and either fail the launch or — worse for this harness —
+    /// disagree with the <c>which kcap</c> line recorded beside it, which is the exact disagreement the
+    /// resolver exists to remove.
+    ///
+    /// <para>Any of the three execute bits counts, rather than the one that applies to this process's
+    /// uid/gid: .NET exposes no <c>access(X_OK)</c>, and over-accepting here can only ever fall back to
+    /// the platform's own error, whereas under-accepting would silently skip the right binary.</para>
+    /// </summary>
+    static bool IsExecutableFile(string path) {
+        if (!File.Exists(path)) return false;
+
+        try {
+            const UnixFileMode anyExecute =
+                UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
+
+            return (File.GetUnixFileMode(path) & anyExecute) != 0;
+        } catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException) {
+            // Unreadable mode: treat as a miss and keep walking PATH rather than returning a path we
+            // cannot vouch for.
+            return false;
+        }
     }
 
     /// <summary>Test-only seam: notified with the PID of every spawned process, so the cleanup test

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -222,32 +222,38 @@ internal static class MemoryIndexLiveCertHarness {
         // where it makes a later positive case pass on stale evidence. Naming the slug in the exception
         // makes that diagnosable but leaves the pollution in place, so recover the id by its (unique,
         // nonce-derived) slug and archive it here.
-        var (recovered, lookupFailed) = await FindMemoryIdBySlugAsync(slug);
+        var matches = await FindMemoryIdsBySlugAsync(slug);
 
-        if (recovered is not null) {
-            await ArchiveMemoryAsync(vendorLabel, recovered);
+        // EVERY exact match, not the first: server-side slug uniqueness is not something this harness
+        // can verify, and a retried create would leave a second memory carrying the same nonce. The
+        // property required is "no memory with this run's nonce remains", which one archive cannot give.
+        var archivedEverything = matches.Count > 0;
 
+        foreach (var id in matches) archivedEverything &= await ArchiveMemoryAsync(vendorLabel, id);
+
+        if (archivedEverything) {
             throw new InvalidOperationException(
-                $"save_memory returned no memory_id for slug {slug}; the memory HAD been created "
-              + $"({recovered}) and has been archived, so the index is clean. stdout: {stdout}");
+                $"save_memory returned no memory_id for slug {slug}; {matches.Count} memor"
+              + $"{(matches.Count == 1 ? "y" : "ies")} with that slug HAD been created and "
+              + $"{(matches.Count == 1 ? "has" : "have")} been archived, confirmed, so the index is "
+              + $"clean. stdout: {stdout}");
         }
 
-        // "The search failed" and "the search confirmed nothing is there" are different facts and must
-        // not collapse into one message: only the second means the index is definitely clean.
-        if (lookupFailed) {
-            MarkIndexPossiblyDirty(
-                $"a save for slug {slug} returned no id and the recovery lookup itself failed, so it is "
-              + "unknown whether a nonce memory exists");
-
-            throw new InvalidOperationException(
-                $"save_memory returned no memory_id for slug {slug}, AND the recovery lookup failed — it "
-              + $"is unknown whether a memory was created. Check for that slug and archive it if present. "
-              + $"stdout: {stdout}");
-        }
+        // Everything else is dirty, INCLUDING "the search came back empty". An empty result is not
+        // proof of absence: the read model behind search is not documented as strongly consistent and
+        // no maximum lag is published, so a memory that was created can be invisible now and present
+        // a moment later. Claiming "clean" on that basis is precisely the overstatement this cert
+        // exists to avoid — and the cost of being wrong is a later positive case passing on a stale
+        // nonce. Fail closed.
+        MarkIndexPossiblyDirty(
+            $"a save for slug {slug} returned no id, and cleanup could not be confirmed "
+          + $"({matches.Count} exact match(es) found, all archived: {archivedEverything})");
 
         throw new InvalidOperationException(
-            $"save_memory returned no memory_id for slug {slug}, and repeated lookups confirmed no memory "
-          + $"with that slug exists — nothing was created, so the index is clean. stdout: {stdout}");
+            $"save_memory returned no memory_id for slug {slug}, and cleanup could NOT be confirmed — "
+          + $"{matches.Count} exact match(es) found. A created-but-not-yet-visible memory cannot be "
+          + $"ruled out, so treat the live index as dirty: search for that slug and archive anything "
+          + $"that appears. stdout: {stdout}");
     }
 
     /// <summary>The slug a cert's nonce memory is saved under. Unique per run by construction, which is
@@ -255,18 +261,21 @@ internal static class MemoryIndexLiveCertHarness {
     internal static string SlugFor(string nonce) => $"live-cert-{nonce}";
 
     /// <summary>
-    /// Looks a memory up by EXACT slug, for the one path that has no id: a save whose response could not
-    /// be parsed.
+    /// Every memory id with this EXACT slug, for the one path that has no id: a save whose response
+    /// could not be parsed.
     ///
-    /// <para>Polled rather than asked once. A memory that WAS created may not be searchable the instant
-    /// after — the read model behind search is not documented as strongly consistent — and a single
-    /// lookup would then report "nothing there" about a memory that appears a second later and pollutes
-    /// every subsequent cert. A transient search failure has the same shape. So: bounded retries, and a
-    /// return that distinguishes <b>confirmed absent</b> from <b>could not tell</b>, because only the
-    /// first means the index is clean.</para>
+    /// <para>Polled rather than asked once, because a memory that WAS created may not be searchable the
+    /// instant after and a transient failure looks the same as absence. Accumulated across attempts
+    /// rather than returned on the first hit, so a duplicate that only becomes visible on a later poll
+    /// is still collected.</para>
+    ///
+    /// <para>It deliberately does NOT report "confirmed absent". No maximum projection lag is
+    /// published, so an empty result cannot establish absence at all, and offering that answer would
+    /// only tempt the caller into the claim. The caller treats anything short of "found and archived"
+    /// as dirty.</para>
     /// </summary>
-    static async Task<(string? MemoryId, bool LookupFailed)> FindMemoryIdBySlugAsync(string slug) {
-        var anyLookupSucceeded = false;
+    static async Task<IReadOnlyList<string>> FindMemoryIdsBySlugAsync(string slug) {
+        var found = new HashSet<string>(StringComparer.Ordinal);
 
         for (var attempt = 0; attempt < 3; attempt++) {
             if (attempt > 0) await Task.Delay(TimeSpan.FromSeconds(2));
@@ -275,20 +284,18 @@ internal static class MemoryIndexLiveCertHarness {
                 var frame = await CallMemoryToolAsync("search_memories", new JsonObject { ["query"] = slug });
                 var text  = JsonNode.Parse(frame)?["result"]?["content"]?[0]?["text"]?.GetValue<string>();
 
-                if (text is null || JsonNode.Parse(text) is not JsonArray hits) continue;   // unusable: not an answer
-
-                anyLookupSucceeded = true;
+                if (text is null || JsonNode.Parse(text) is not JsonArray hits) continue;
 
                 foreach (var hit in hits)
                     if (hit?["slug"]?.GetValue<string>() == slug && hit["memory_id"]?.GetValue<string>() is { } id)
-                        return (id, false);
+                        found.Add(id);
             } catch {
-                // Transient or terminal — indistinguishable from here, so keep trying and let the
-                // caller treat "never got a usable answer" as unknown rather than as absent.
+                // Transient or terminal — indistinguishable from here. Keep polling; the caller fails
+                // closed on anything it could not positively clean up.
             }
         }
 
-        return (null, !anyLookupSucceeded);
+        return [.. found];
     }
 
     /// <summary>
@@ -301,6 +308,11 @@ internal static class MemoryIndexLiveCertHarness {
     static string? _indexCleanlinessUnconfirmed;
 
     internal static void MarkIndexPossiblyDirty(string reason) => _indexCleanlinessUnconfirmed ??= reason;
+
+    /// <summary>The reason the index may be dirty, or null. Read by the assembly teardown, which is what
+    /// makes a cleanup failure in the LAST case fail the run rather than merely warn — the prospective
+    /// gate in <see cref="SkipUnlessLiveGateReady"/> can only stop a case that comes after it.</summary>
+    internal static string? IndexCleanlinessUnconfirmed => _indexCleanlinessUnconfirmed;
 
     /// <summary>Digs the saved memory's id out of an MCP <c>tools/call</c> frame. Null if absent.</summary>
     internal static string? ExtractMemoryId(string frame) {
@@ -333,20 +345,28 @@ internal static class MemoryIndexLiveCertHarness {
     /// line the operator may not read is not a sufficient response to the failure mode this exists to
     /// prevent.</para>
     /// </summary>
-    public static async Task ArchiveMemoryAsync(string vendorLabel, string memoryId) {
+    /// <returns><see langword="true"/> only when the archive was CONFIRMED. Callers that go on to claim
+    /// the index is clean must check it; the ones that call this from a <c>finally</c> may ignore it,
+    /// because the run-level mark plus the assembly teardown already turn a swallowed failure into a
+    /// failed run.</returns>
+    public static async Task<bool> ArchiveMemoryAsync(string vendorLabel, string memoryId) {
         try {
             var frame = await CallMemoryToolAsync("archive_memory", new JsonObject { ["id"] = memoryId });
 
-            if (!ArchiveSucceeded(frame)) {
-                MarkIndexPossiblyDirty($"archive_memory did not confirm success for {memoryId}");
-                await Console.Error.WriteLineAsync(
-                    $"[{vendorLabel}-memory-live] LEAKED live-cert memory {memoryId} — archive_memory did not "
-                  + $"confirm success. Archive it manually or later certs may read a stale nonce. Frame: {frame}");
-            }
+            if (ArchiveSucceeded(frame)) return true;
+
+            MarkIndexPossiblyDirty($"archive_memory did not confirm success for {memoryId}");
+            await Console.Error.WriteLineAsync(
+                $"[{vendorLabel}-memory-live] LEAKED live-cert memory {memoryId} — archive_memory did not "
+              + $"confirm success. Archive it manually or later certs may read a stale nonce. Frame: {frame}");
+
+            return false;
         } catch (Exception ex) {
             MarkIndexPossiblyDirty($"archive_memory threw for {memoryId}: {ex.Message}");
             await Console.Error.WriteLineAsync(
                 $"[{vendorLabel}-memory-live] LEAKED live-cert memory {memoryId} — archive threw: {ex.Message}");
+
+            return false;
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -65,6 +65,17 @@ internal static class MemoryIndexLiveCertHarness {
         Skip.Unless(
             !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ServerUrlEnvVar)),
             $"{ServerUrlEnvVar} must point at a reachable kcap server exposing GET /api/memories/index.");
+
+        // AFTER the skips, so CI (where nothing ran and nothing can be dirty) still skips rather than
+        // throws. A cert that runs against a possibly-polluted index can pass on another run's nonce,
+        // so refusing to start is the only safe response — and it must be an error, not a skip, because
+        // a skip reads as "not run today" rather than "your live index may need cleaning".
+        if (_indexCleanlinessUnconfirmed is { } reason) {
+            throw new InvalidOperationException(
+                "Refusing to start a live cert: an earlier case in this run could not confirm its nonce "
+              + $"memory was removed, so the injected index may carry a stale nonce and a positive case "
+              + $"could pass on it. Clean up, then re-run. Reason: {reason}");
+        }
     }
 
     public static string RequiredServerUrl() => Environment.GetEnvironmentVariable(ServerUrlEnvVar)!;
@@ -211,7 +222,7 @@ internal static class MemoryIndexLiveCertHarness {
         // where it makes a later positive case pass on stale evidence. Naming the slug in the exception
         // makes that diagnosable but leaves the pollution in place, so recover the id by its (unique,
         // nonce-derived) slug and archive it here.
-        var recovered = await TryFindMemoryIdBySlugAsync(slug);
+        var (recovered, lookupFailed) = await FindMemoryIdBySlugAsync(slug);
 
         if (recovered is not null) {
             await ArchiveMemoryAsync(vendorLabel, recovered);
@@ -221,35 +232,75 @@ internal static class MemoryIndexLiveCertHarness {
               + $"({recovered}) and has been archived, so the index is clean. stdout: {stdout}");
         }
 
+        // "The search failed" and "the search confirmed nothing is there" are different facts and must
+        // not collapse into one message: only the second means the index is definitely clean.
+        if (lookupFailed) {
+            MarkIndexPossiblyDirty(
+                $"a save for slug {slug} returned no id and the recovery lookup itself failed, so it is "
+              + "unknown whether a nonce memory exists");
+
+            throw new InvalidOperationException(
+                $"save_memory returned no memory_id for slug {slug}, AND the recovery lookup failed — it "
+              + $"is unknown whether a memory was created. Check for that slug and archive it if present. "
+              + $"stdout: {stdout}");
+        }
+
         throw new InvalidOperationException(
-            $"save_memory returned no memory_id for slug {slug}, and no memory with that slug could be "
-          + $"found — most likely nothing was created. If one appears later, archive it by hand or it "
-          + $"will pollute every later cert's index. stdout: {stdout}");
+            $"save_memory returned no memory_id for slug {slug}, and repeated lookups confirmed no memory "
+          + $"with that slug exists — nothing was created, so the index is clean. stdout: {stdout}");
     }
 
     /// <summary>The slug a cert's nonce memory is saved under. Unique per run by construction, which is
     /// what makes recovery-by-slug unambiguous.</summary>
     internal static string SlugFor(string nonce) => $"live-cert-{nonce}";
 
-    /// <summary>Looks a memory up by EXACT slug, for the one path that has no id: a save whose response
-    /// could not be parsed. Returns null when nothing matches — including when the search itself
-    /// fails, because a failed lookup and an absent memory call for the same (loud) handling.</summary>
-    static async Task<string?> TryFindMemoryIdBySlugAsync(string slug) {
-        try {
-            var frame = await CallMemoryToolAsync("search_memories", new JsonObject { ["query"] = slug });
-            var text  = JsonNode.Parse(frame)?["result"]?["content"]?[0]?["text"]?.GetValue<string>();
+    /// <summary>
+    /// Looks a memory up by EXACT slug, for the one path that has no id: a save whose response could not
+    /// be parsed.
+    ///
+    /// <para>Polled rather than asked once. A memory that WAS created may not be searchable the instant
+    /// after — the read model behind search is not documented as strongly consistent — and a single
+    /// lookup would then report "nothing there" about a memory that appears a second later and pollutes
+    /// every subsequent cert. A transient search failure has the same shape. So: bounded retries, and a
+    /// return that distinguishes <b>confirmed absent</b> from <b>could not tell</b>, because only the
+    /// first means the index is clean.</para>
+    /// </summary>
+    static async Task<(string? MemoryId, bool LookupFailed)> FindMemoryIdBySlugAsync(string slug) {
+        var anyLookupSucceeded = false;
 
-            if (text is null || JsonNode.Parse(text) is not JsonArray hits) return null;
+        for (var attempt = 0; attempt < 3; attempt++) {
+            if (attempt > 0) await Task.Delay(TimeSpan.FromSeconds(2));
 
-            foreach (var hit in hits)
-                if (hit?["slug"]?.GetValue<string>() == slug)
-                    return hit["memory_id"]?.GetValue<string>();
+            try {
+                var frame = await CallMemoryToolAsync("search_memories", new JsonObject { ["query"] = slug });
+                var text  = JsonNode.Parse(frame)?["result"]?["content"]?[0]?["text"]?.GetValue<string>();
 
-            return null;
-        } catch {
-            return null;
+                if (text is null || JsonNode.Parse(text) is not JsonArray hits) continue;   // unusable: not an answer
+
+                anyLookupSucceeded = true;
+
+                foreach (var hit in hits)
+                    if (hit?["slug"]?.GetValue<string>() == slug && hit["memory_id"]?.GetValue<string>() is { } id)
+                        return (id, false);
+            } catch {
+                // Transient or terminal — indistinguishable from here, so keep trying and let the
+                // caller treat "never got a usable answer" as unknown rather than as absent.
+            }
         }
+
+        return (null, !anyLookupSucceeded);
     }
+
+    /// <summary>
+    /// Records that this run may have left a nonce memory in the REAL injected index.
+    ///
+    /// <para>This is not a log line, it is a stop: a stale nonce makes a later positive case pass on
+    /// evidence from an earlier run, which is the one failure a cert must never produce. Once set,
+    /// <see cref="SkipUnlessLiveGateReady"/> refuses to start any further live case in this process.</para>
+    /// </summary>
+    static string? _indexCleanlinessUnconfirmed;
+
+    internal static void MarkIndexPossiblyDirty(string reason) => _indexCleanlinessUnconfirmed ??= reason;
 
     /// <summary>Digs the saved memory's id out of an MCP <c>tools/call</c> frame. Null if absent.</summary>
     internal static string? ExtractMemoryId(string frame) {
@@ -277,18 +328,23 @@ internal static class MemoryIndexLiveCertHarness {
     ///
     /// <para>Failures are therefore reported loudly AND verified: the tool's own <c>ok</c> is checked
     /// rather than assuming a returned frame means success. Still non-throwing — a cert must not fail
-    /// on cleanup and mask its real verdict — but it can no longer fail in silence.</para>
+    /// on cleanup and mask its real verdict — but it can no longer fail in silence, and it now also
+    /// marks the run so that no LATER case starts against an index that may hold this nonce. A stderr
+    /// line the operator may not read is not a sufficient response to the failure mode this exists to
+    /// prevent.</para>
     /// </summary>
     public static async Task ArchiveMemoryAsync(string vendorLabel, string memoryId) {
         try {
             var frame = await CallMemoryToolAsync("archive_memory", new JsonObject { ["id"] = memoryId });
 
             if (!ArchiveSucceeded(frame)) {
+                MarkIndexPossiblyDirty($"archive_memory did not confirm success for {memoryId}");
                 await Console.Error.WriteLineAsync(
                     $"[{vendorLabel}-memory-live] LEAKED live-cert memory {memoryId} — archive_memory did not "
                   + $"confirm success. Archive it manually or later certs may read a stale nonce. Frame: {frame}");
             }
         } catch (Exception ex) {
+            MarkIndexPossiblyDirty($"archive_memory threw for {memoryId}: {ex.Message}");
             await Console.Error.WriteLineAsync(
                 $"[{vendorLabel}-memory-live] LEAKED live-cert memory {memoryId} — archive threw: {ex.Message}");
         }

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -126,7 +126,11 @@ internal static class MemoryIndexLiveCertHarness {
         // EOF, so closing the stream up front raced the tools/call and only the initialize response
         // ever came back. Stdin stays open until the id-2 response is read, then the child is killed —
         // there is no point asking it to shut down cleanly when we already have the answer.
-        var psi = new ProcessStartInfo("kcap") {
+        // Resolved against PATH for the same reason RunProcessAsync does it — this call site builds its
+        // own ProcessStartInfo and would otherwise pick up the `kcap` sitting in this assembly's output
+        // directory. The nonce memory would then be saved by one binary and the index served to a hook
+        // running another.
+        var psi = new ProcessStartInfo(ResolveOnPath("kcap")) {
             UseShellExecute        = false,
             RedirectStandardInput  = true,
             RedirectStandardOutput = true,
@@ -390,6 +394,44 @@ internal static class MemoryIndexLiveCertHarness {
         }
     }
 
+    /// <summary>
+    /// Resolves a bare command name against PATH, explicitly, before handing it to
+    /// <see cref="ProcessStartInfo"/>.
+    ///
+    /// <para><b>This is not belt-and-braces — without it the harness runs the wrong binary.</b>
+    /// <c>Process.Start</c> tries a separator-free filename against the WORKING DIRECTORY before it
+    /// consults PATH, and this assembly's working directory is its own output folder, which contains a
+    /// <c>kcap</c> copied there by the <c>Capacitor.Cli</c> project reference. So every
+    /// <c>RunProcessAsync("kcap", …)</c> silently ran the test build while
+    /// <see cref="RecordCertEnvironmentAsync"/>'s sibling <c>which kcap</c> reported the PATH one — the
+    /// two lines disagreed, and the version line that exists precisely to pin the binary under test was
+    /// describing a different binary from the one the hook would run. Observed: a cert recorded
+    /// <c>+e2b2821</c> (the test build) while the hook ran <c>+998ec34</c> (the PATH build).</para>
+    ///
+    /// <para>Windows is left alone deliberately: correct resolution there needs PATHEXT handling, these
+    /// certs are gated and are not run on Windows, and a half-right implementation would be worse than
+    /// the documented status quo.</para>
+    /// </summary>
+    static string ResolveOnPath(string fileName) =>
+        ResolveOnPath(fileName, Environment.GetEnvironmentVariable("PATH"), OperatingSystem.IsWindows());
+
+    /// <summary>Pure overload: PATH and platform are passed rather than probed, so the resolution order
+    /// is testable without mutating this process's environment.</summary>
+    internal static string ResolveOnPath(string fileName, string? pathValue, bool isWindows) {
+        if (isWindows || Path.IsPathRooted(fileName) || fileName.Contains(Path.DirectorySeparatorChar))
+            return fileName;
+
+        foreach (var dir in (pathValue ?? "").Split(Path.PathSeparator)) {
+            if (dir.Length == 0) continue;
+
+            var candidate = Path.Combine(dir, fileName);
+            if (File.Exists(candidate)) return candidate;
+        }
+
+        // Unresolved: hand the bare name back so Process.Start produces its own, clearer error.
+        return fileName;
+    }
+
     /// <summary>Test-only seam: notified with the PID of every spawned process, so the cleanup test
     /// can confirm a timed-out child is actually gone. Never set by production code.</summary>
     internal static Action<int>? OnProcessStarted;
@@ -399,10 +441,16 @@ internal static class MemoryIndexLiveCertHarness {
     /// expiry so a hung harness CLI is never orphaned. <paramref name="stdin"/> is written and the
     /// stream closed when supplied — Codex reads its prompt that way.
     /// </summary>
+    /// <param name="environment">Extra variables layered over the inherited environment, applied AFTER
+    /// the <c>KCAP_CONFIG_DIR</c> scrub. The one caller is the non-zero-exit cert, which redirects a
+    /// harness CLI's <c>KCAP_URL</c> at a proxy that fails exactly the lifecycle POST — the variable has
+    /// to reach a grandchild (agent → its hook), which is why it is set on the environment rather than
+    /// passed as an argument.</param>
     public static async Task<(int ExitCode, string Stdout, string Stderr)> RunProcessAsync(
             string fileName, IReadOnlyList<string> args, string? workingDirectory,
-            TimeSpan? timeout = null, string? stdin = null) {
-        var psi = new ProcessStartInfo(fileName) {
+            TimeSpan? timeout = null, string? stdin = null,
+            IReadOnlyDictionary<string, string>? environment = null) {
+        var psi = new ProcessStartInfo(ResolveOnPath(fileName)) {
             UseShellExecute        = false,
             RedirectStandardOutput = true,
             RedirectStandardError  = true,
@@ -414,6 +462,10 @@ internal static class MemoryIndexLiveCertHarness {
         // Same reason as CallMemoryToolAsync: a `kcap config` child — and every harness CLI, which
         // invokes `kcap hook` itself — must see the REAL config, not this assembly's throwaway one.
         psi.Environment.Remove("KCAP_CONFIG_DIR");
+
+        // AFTER the scrub, so an explicit override is never silently dropped by it.
+        if (environment is not null)
+            foreach (var (key, value) in environment) psi.Environment[key] = value;
 
         using var process = Process.Start(psi)
             ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -202,58 +202,67 @@ internal static class MemoryIndexLiveCertHarness {
     /// </summary>
     public static async Task<string> SaveNonceMemoryAsync(string vendorLabel, string nonce) {
         var slug = SlugFor(nonce);
+        string stdout;
 
-        var stdout = await CallMemoryToolAsync("save_memory", new JsonObject {
-            ["audience"]    = "user",
-            ["slug"]        = slug,
-            ["description"] = $"kcap {vendorLabel} memory live-cert nonce: {nonce}",
-            ["content"]     = $"kcap {vendorLabel} memory live-cert nonce: {nonce}. Safe to archive after the run.",
-            ["kind"]        = "reference",
-            ["global"]      = true
-        });
+        // The CALL is wrapped, not just its result. A throw here — a timed-out child, an unreadable
+        // frame, a lost response — does not mean the server declined to create the memory, and an
+        // unwrapped throw would leave the run unmarked and the sweep unrun.
+        try {
+            stdout = await CallMemoryToolAsync("save_memory", new JsonObject {
+                ["audience"]    = "user",
+                ["slug"]        = slug,
+                ["description"] = $"kcap {vendorLabel} memory live-cert nonce: {nonce}",
+                ["content"]     = $"kcap {vendorLabel} memory live-cert nonce: {nonce}. Safe to archive after the run.",
+                ["kind"]        = "reference",
+                ["global"]      = true
+            });
+        } catch (Exception ex) {
+            var swept = await SweepAmbiguousSaveAsync(
+                vendorLabel, slug, $"the save_memory call threw before returning a frame: {ex.Message}");
+
+            throw new InvalidOperationException(
+                $"save_memory threw for slug {slug}; the server may still have created the memory. "
+              + $"{swept}", ex);
+        }
 
         // An MCP tool result nests its payload as a JSON *string* inside result.content[].text, so the
         // id needs two parses, not a regex over the outer frame: the inner document's quotes arrive
         // "-escaped, so no pattern matching a literal `"memory_id"` will ever fire.
         if (ExtractMemoryId(stdout) is { } memoryId) return memoryId;
 
-        // The save may have SUCCEEDED and only its response gone unusable, in which case a real memory
-        // now exists with no id to archive it by — and a leaked nonce lands in the real injected index,
-        // where it makes a later positive case pass on stale evidence. Naming the slug in the exception
-        // makes that diagnosable but leaves the pollution in place, so recover the id by its (unique,
-        // nonce-derived) slug and archive it here.
-        var matches = await FindMemoryIdsBySlugAsync(slug);
-
-        // EVERY exact match, not the first: server-side slug uniqueness is not something this harness
-        // can verify, and a retried create would leave a second memory carrying the same nonce. The
-        // property required is "no memory with this run's nonce remains", which one archive cannot give.
-        var archivedEverything = matches.Count > 0;
-
-        foreach (var id in matches) archivedEverything &= await ArchiveMemoryAsync(vendorLabel, id);
-
-        if (archivedEverything) {
-            throw new InvalidOperationException(
-                $"save_memory returned no memory_id for slug {slug}; {matches.Count} memor"
-              + $"{(matches.Count == 1 ? "y" : "ies")} with that slug HAD been created and "
-              + $"{(matches.Count == 1 ? "has" : "have")} been archived, confirmed, so the index is "
-              + $"clean. stdout: {stdout}");
-        }
-
-        // Everything else is dirty, INCLUDING "the search came back empty". An empty result is not
-        // proof of absence: the read model behind search is not documented as strongly consistent and
-        // no maximum lag is published, so a memory that was created can be invisible now and present
-        // a moment later. Claiming "clean" on that basis is precisely the overstatement this cert
-        // exists to avoid — and the cost of being wrong is a later positive case passing on a stale
-        // nonce. Fail closed.
-        MarkIndexPossiblyDirty(
-            $"a save for slug {slug} returned no id, and cleanup could not be confirmed "
-          + $"({matches.Count} exact match(es) found, all archived: {archivedEverything})");
-
         throw new InvalidOperationException(
-            $"save_memory returned no memory_id for slug {slug}, and cleanup could NOT be confirmed — "
-          + $"{matches.Count} exact match(es) found. A created-but-not-yet-visible memory cannot be "
-          + $"ruled out, so treat the live index as dirty: search for that slug and archive anything "
-          + $"that appears. stdout: {stdout}");
+            $"save_memory returned no memory_id for slug {slug}. "
+          + $"{await SweepAmbiguousSaveAsync(vendorLabel, slug, "save_memory returned no memory_id")} "
+          + $"stdout: {stdout}");
+    }
+
+    /// <summary>
+    /// Best-effort cleanup after a save whose outcome is UNKNOWN, plus an unconditional dirty mark.
+    ///
+    /// <para><b>The mark is unconditional on purpose, even when every observed match was archived.</b>
+    /// Archiving what a search returned proves only that the matches visible during a finite polling
+    /// window are gone. Slugs are documented as unique per pool and enforced by the service rather than
+    /// by a database constraint, so a duplicate is not excluded by construction; and with no published
+    /// maximum projection lag, a second memory that becomes visible after the last poll cannot be ruled
+    /// out either. "Everything I could see is archived" is a weaker statement than "nothing carrying
+    /// this nonce remains", and only the second would justify calling the index clean.</para>
+    ///
+    /// <para>So the sweep mitigates and the mark tells the truth: this run stops here, and the operator
+    /// is told exactly what to look for. The alternative — claiming clean on a finite observation — is
+    /// how a later run's positive case ends up passing on this run's nonce.</para>
+    /// </summary>
+    static async Task<string> SweepAmbiguousSaveAsync(string vendorLabel, string slug, string cause) {
+        var matches  = await FindMemoryIdsBySlugAsync(slug);
+        var archived = 0;
+
+        foreach (var id in matches)
+            if (await ArchiveMemoryAsync(vendorLabel, id)) archived++;
+
+        MarkIndexPossiblyDirty($"{cause}; archived {archived}/{matches.Count} observed match(es) for slug {slug}");
+
+        return $"Archived {archived} of {matches.Count} observed match(es). The run is marked dirty "
+             + $"regardless, because a duplicate or not-yet-visible memory with this slug cannot be "
+             + $"ruled out — search for `{slug}` and archive anything that appears.";
     }
 
     /// <summary>The slug a cert's nonce memory is saved under. Unique per run by construction, which is

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -539,12 +539,19 @@ internal static class MemoryIndexLiveCertHarness {
     /// <para>Windows is left alone deliberately: correct resolution there needs PATHEXT handling, these
     /// certs are gated and are not run on Windows, and a half-right implementation would be worse than
     /// the documented status quo.</para>
+    ///
+    /// <para><b>An unresolved bare name throws rather than being passed through.</b> Passing it through
+    /// would hand the problem back to <c>Process.Start</c> — which consults the working directory first
+    /// and would therefore run the shadowing copy, silently, on exactly the path where resolution had
+    /// already failed.</para>
     /// </summary>
     internal static string ResolveOnPath(string fileName) =>
         ResolveOnPath(fileName, Environment.GetEnvironmentVariable("PATH"), OperatingSystem.IsWindows());
 
     /// <summary>Pure overload: PATH and platform are passed rather than probed, so the resolution order
     /// is testable without mutating this process's environment.</summary>
+    /// <exception cref="FileNotFoundException">A bare command name that is not on PATH. Throwing is the
+    /// point — see the remarks on the single-argument overload.</exception>
     internal static string ResolveOnPath(string fileName, string? pathValue, bool isWindows) {
         if (isWindows || Path.IsPathRooted(fileName) || fileName.Contains(Path.DirectorySeparatorChar))
             return fileName;
@@ -556,8 +563,19 @@ internal static class MemoryIndexLiveCertHarness {
             if (IsExecutableFile(candidate)) return candidate;
         }
 
-        // Unresolved: hand the bare name back so Process.Start produces its own, clearer error.
-        return fileName;
+        // Unresolved: THROW rather than hand the bare name back.
+        //
+        // An earlier version returned the name with the comment "so Process.Start produces its own,
+        // clearer error" — which is wrong for the one command that matters. `Process.Start` consults the
+        // WORKING DIRECTORY before PATH, and this assembly's working directory is its own output folder,
+        // which holds a `kcap` copied there by the project reference. So the fallback does not produce
+        // an error at all: it silently runs the test build, which is the exact wrong-binary failure this
+        // resolver exists to prevent, reintroduced on the unresolved path.
+        throw new FileNotFoundException(
+            $"'{fileName}' is not on PATH. Refusing to fall back to the bare name: Process.Start would "
+          + $"resolve it against the working directory, and this assembly's output folder contains a "
+          + $"`kcap` — so the fallback would silently run the wrong binary rather than fail. "
+          + $"PATH searched: {pathValue}");
     }
 
     [DllImport("libc", EntryPoint = "access", SetLastError = true)]

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net.Http.Json;
+using System.Runtime.InteropServices;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core;
@@ -189,9 +190,11 @@ internal static class MemoryIndexLiveCertHarness {
     /// is what makes the cert answerable from injected context alone.
     /// </summary>
     public static async Task<string> SaveNonceMemoryAsync(string vendorLabel, string nonce) {
+        var slug = SlugFor(nonce);
+
         var stdout = await CallMemoryToolAsync("save_memory", new JsonObject {
             ["audience"]    = "user",
-            ["slug"]        = $"live-cert-{nonce}",
+            ["slug"]        = slug,
             ["description"] = $"kcap {vendorLabel} memory live-cert nonce: {nonce}",
             ["content"]     = $"kcap {vendorLabel} memory live-cert nonce: {nonce}. Safe to archive after the run.",
             ["kind"]        = "reference",
@@ -201,15 +204,51 @@ internal static class MemoryIndexLiveCertHarness {
         // An MCP tool result nests its payload as a JSON *string* inside result.content[].text, so the
         // id needs two parses, not a regex over the outer frame: the inner document's quotes arrive
         // "-escaped, so no pattern matching a literal `"memory_id"` will ever fire.
-        //
-        // Failing loudly (rather than returning null and archiving nothing) is what stops a cert
-        // leaking its nonce memory into every later run's injected index. The slug is named in the
-        // message because this is the one failure the caller CANNOT clean up: archiving needs the id,
-        // and if the memory was created before the response went unparseable, a human has to remove it.
-        return ExtractMemoryId(stdout)
-            ?? throw new InvalidOperationException(
-                $"save_memory returned no memory_id for slug live-cert-{nonce} — if the memory WAS "
-              + $"created, archive it by hand or it will pollute every later cert's index. stdout: {stdout}");
+        if (ExtractMemoryId(stdout) is { } memoryId) return memoryId;
+
+        // The save may have SUCCEEDED and only its response gone unusable, in which case a real memory
+        // now exists with no id to archive it by — and a leaked nonce lands in the real injected index,
+        // where it makes a later positive case pass on stale evidence. Naming the slug in the exception
+        // makes that diagnosable but leaves the pollution in place, so recover the id by its (unique,
+        // nonce-derived) slug and archive it here.
+        var recovered = await TryFindMemoryIdBySlugAsync(slug);
+
+        if (recovered is not null) {
+            await ArchiveMemoryAsync(vendorLabel, recovered);
+
+            throw new InvalidOperationException(
+                $"save_memory returned no memory_id for slug {slug}; the memory HAD been created "
+              + $"({recovered}) and has been archived, so the index is clean. stdout: {stdout}");
+        }
+
+        throw new InvalidOperationException(
+            $"save_memory returned no memory_id for slug {slug}, and no memory with that slug could be "
+          + $"found — most likely nothing was created. If one appears later, archive it by hand or it "
+          + $"will pollute every later cert's index. stdout: {stdout}");
+    }
+
+    /// <summary>The slug a cert's nonce memory is saved under. Unique per run by construction, which is
+    /// what makes recovery-by-slug unambiguous.</summary>
+    internal static string SlugFor(string nonce) => $"live-cert-{nonce}";
+
+    /// <summary>Looks a memory up by EXACT slug, for the one path that has no id: a save whose response
+    /// could not be parsed. Returns null when nothing matches — including when the search itself
+    /// fails, because a failed lookup and an absent memory call for the same (loud) handling.</summary>
+    static async Task<string?> TryFindMemoryIdBySlugAsync(string slug) {
+        try {
+            var frame = await CallMemoryToolAsync("search_memories", new JsonObject { ["query"] = slug });
+            var text  = JsonNode.Parse(frame)?["result"]?["content"]?[0]?["text"]?.GetValue<string>();
+
+            if (text is null || JsonNode.Parse(text) is not JsonArray hits) return null;
+
+            foreach (var hit in hits)
+                if (hit?["slug"]?.GetValue<string>() == slug)
+                    return hit["memory_id"]?.GetValue<string>();
+
+            return null;
+        } catch {
+            return null;
+        }
     }
 
     /// <summary>Digs the saved memory's id out of an MCP <c>tools/call</c> frame. Null if absent.</summary>
@@ -436,6 +475,11 @@ internal static class MemoryIndexLiveCertHarness {
         return fileName;
     }
 
+    [DllImport("libc", EntryPoint = "access", SetLastError = true)]
+    static extern int LibcAccess(string pathname, int mode);
+
+    const int X_OK = 1;
+
     /// <summary>
     /// Existence is NOT the test a shell applies. <c>which</c> and <c>execvp</c> skip a PATH entry whose
     /// match is not executable and keep looking, so resolving on <c>File.Exists</c> alone would stop at a
@@ -443,22 +487,34 @@ internal static class MemoryIndexLiveCertHarness {
     /// disagree with the <c>which kcap</c> line recorded beside it, which is the exact disagreement the
     /// resolver exists to remove.
     ///
-    /// <para>Any of the three execute bits counts, rather than the one that applies to this process's
-    /// uid/gid: .NET exposes no <c>access(X_OK)</c>, and over-accepting here can only ever fall back to
-    /// the platform's own error, whereas under-accepting would silently skip the right binary.</para>
+    /// <para><b>The question is EFFECTIVE executability, so ask the kernel.</b> An earlier version tested
+    /// "any of the three execute bits is set", justified by "over-accepting can only fall back to the
+    /// platform's own error" — which is wrong, and review caught it: this resolver returns an ABSOLUTE
+    /// path, so there is no fallback to a later PATH entry. A file that is owner-executable but owned by
+    /// someone else, or sits on a <c>noexec</c> mount, would be selected here and would simply fail to
+    /// launch, while a shell would have kept walking. <c>access(path, X_OK)</c> answers for the current
+    /// identity, which is the same question <c>execvp</c> asks.</para>
+    ///
+    /// <para><c>File.Exists</c> stays as the first gate, and not merely as an optimisation:
+    /// <c>access(X_OK)</c> succeeds on a DIRECTORY, so dropping it would let a directory named
+    /// <c>kcap</c> shadow the binary.</para>
     /// </summary>
     static bool IsExecutableFile(string path) {
         if (!File.Exists(path)) return false;
 
         try {
-            const UnixFileMode anyExecute =
-                UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
+            return LibcAccess(path, X_OK) == 0;
+        } catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException or MarshalDirectiveException) {
+            // No libc to ask (a platform these gated certs are not run on). Fall back to the mode bits:
+            // weaker, but strictly better than resolving on existence alone.
+            try {
+                const UnixFileMode anyExecute =
+                    UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
 
-            return (File.GetUnixFileMode(path) & anyExecute) != 0;
-        } catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException) {
-            // Unreadable mode: treat as a miss and keep walking PATH rather than returning a path we
-            // cannot vouch for.
-            return false;
+                return (File.GetUnixFileMode(path) & anyExecute) != 0;
+            } catch (Exception inner) when (inner is IOException or UnauthorizedAccessException or PlatformNotSupportedException) {
+                return false;
+            }
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
@@ -7,6 +7,94 @@ namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
 /// a manual certification run, i.e. after spending a real model turn.
 /// </summary>
 public class MemoryIndexLiveCertHarnessTests {
+    // ── command resolution ────────────────────────────────────────────────────
+    // The bug these cover: `Process.Start` tries a separator-free filename against the WORKING
+    // DIRECTORY before PATH, and this assembly's working directory is its own output folder — which
+    // contains a `kcap` copied there by the Capacitor.Cli project reference. Every harness
+    // `RunProcessAsync("kcap", …)` therefore ran the test build, while the cert's own `which kcap` line
+    // reported the PATH build the hook would actually run. The version a cert records is the whole
+    // point of recording it, so the two silently describing different binaries is the failure mode
+    // that recording exists to prevent.
+
+    [Test]
+    public async Task A_bare_command_resolves_to_the_first_PATH_entry_that_has_it() {
+        using var probe = new PathProbe();
+
+        var resolved = MemoryIndexLiveCertHarness.ResolveOnPath(
+            probe.CommandName, $"{probe.EmptyDir}{Path.PathSeparator}{probe.BinDir}", isWindows: false);
+
+        await Assert.That(resolved).IsEqualTo(probe.ExecutablePath);
+    }
+
+    /// <summary>An earlier PATH entry wins — resolution order is first-match, as the shell's is.</summary>
+    [Test]
+    public async Task Earlier_PATH_entries_win_over_later_ones() {
+        using var first  = new PathProbe();
+        using var second = new PathProbe(first.CommandName);
+
+        var resolved = MemoryIndexLiveCertHarness.ResolveOnPath(
+            first.CommandName, $"{first.BinDir}{Path.PathSeparator}{second.BinDir}", isWindows: false);
+
+        await Assert.That(resolved).IsEqualTo(first.ExecutablePath);
+    }
+
+    /// <summary>A name that is already a path is the caller's explicit choice; never rewritten.</summary>
+    [Test]
+    [Arguments("/usr/bin/env")]
+    [Arguments("./local-thing")]
+    public async Task An_explicit_path_is_passed_through_untouched(string fileName) {
+        using var probe = new PathProbe();
+
+        await Assert.That(MemoryIndexLiveCertHarness.ResolveOnPath(fileName, probe.BinDir, isWindows: false))
+            .IsEqualTo(fileName);
+    }
+
+    /// <summary>Unresolvable: hand the bare name back so Process.Start raises its own clearer error,
+    /// rather than inventing a path that does not exist.</summary>
+    [Test]
+    public async Task An_unresolvable_command_is_returned_unchanged() {
+        using var probe = new PathProbe();
+
+        await Assert.That(MemoryIndexLiveCertHarness.ResolveOnPath("kcap-no-such-command", probe.BinDir, isWindows: false))
+            .IsEqualTo("kcap-no-such-command");
+    }
+
+    /// <summary>Windows is deliberately left on the platform's own resolution: doing it correctly needs
+    /// PATHEXT handling, and a half-right implementation would be worse than the documented status quo.
+    /// These certs are gated and are not run there.</summary>
+    [Test]
+    public async Task Windows_resolution_is_deliberately_left_to_the_platform() {
+        using var probe = new PathProbe();
+
+        await Assert.That(MemoryIndexLiveCertHarness.ResolveOnPath(probe.CommandName, probe.BinDir, isWindows: true))
+            .IsEqualTo(probe.CommandName);
+    }
+
+    /// <summary>A throwaway PATH entry holding one uniquely named executable, plus an empty sibling
+    /// directory to prove a miss is skipped rather than treated as a match.</summary>
+    sealed class PathProbe : IDisposable {
+        readonly string _root;
+
+        public PathProbe(string? commandName = null) {
+            _root       = Directory.CreateTempSubdirectory("kcap-path-probe-").FullName;
+            BinDir      = Directory.CreateDirectory(Path.Combine(_root, "bin")).FullName;
+            EmptyDir    = Directory.CreateDirectory(Path.Combine(_root, "empty")).FullName;
+            CommandName = commandName ?? $"kcap-probe-{Guid.NewGuid():N}";
+
+            ExecutablePath = Path.Combine(BinDir, CommandName);
+            File.WriteAllText(ExecutablePath, "#!/bin/sh\nexit 0\n");
+        }
+
+        public string BinDir         { get; }
+        public string EmptyDir       { get; }
+        public string CommandName    { get; }
+        public string ExecutablePath { get; }
+
+        public void Dispose() {
+            try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
     [Test]
     public async Task Plain_text_output_is_returned_as_is() {
         await Assert.That(MemoryIndexLiveCertHarness.ExtractAssistantAnswer("  kcap-live-nonce-abc123  \n"))

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
@@ -55,14 +55,14 @@ public class MemoryIndexLiveCertHarnessTests {
         await Assert.That(resolved).IsEqualTo(executable.ExecutablePath);
     }
 
-    /// <summary>...and when the only match is non-executable there is nothing to resolve to, so the bare
-    /// name comes back and the platform raises its own error.</summary>
+    /// <summary>...and when the only match is non-executable there is nothing to resolve to, so this
+    /// throws for the same reason an absent command does.</summary>
     [Test]
     public async Task A_non_executable_only_match_does_not_resolve() {
         using var probe = new PathProbe(executable: false);
 
-        await Assert.That(MemoryIndexLiveCertHarness.ResolveOnPath(probe.CommandName, probe.BinDir, isWindows: false))
-            .IsEqualTo(probe.CommandName);
+        await Assert.That(() => MemoryIndexLiveCertHarness.ResolveOnPath(probe.CommandName, probe.BinDir, isWindows: false))
+            .Throws<FileNotFoundException>();
     }
 
     /// <summary>A name that is already a path is the caller's explicit choice; never rewritten.</summary>
@@ -76,14 +76,16 @@ public class MemoryIndexLiveCertHarnessTests {
             .IsEqualTo(fileName);
     }
 
-    /// <summary>Unresolvable: hand the bare name back so Process.Start raises its own clearer error,
-    /// rather than inventing a path that does not exist.</summary>
+    /// <summary>An unresolvable bare name must THROW, not pass through. Passing it through hands the
+    /// problem to <c>Process.Start</c>, which consults the working directory first — so on the one
+    /// command that matters it would silently run the `kcap` in this assembly's output folder rather
+    /// than fail, reintroducing the wrong-binary bug on the path where resolution already failed.</summary>
     [Test]
-    public async Task An_unresolvable_command_is_returned_unchanged() {
+    public async Task An_unresolvable_command_throws_rather_than_falling_back_to_the_working_directory() {
         using var probe = new PathProbe();
 
-        await Assert.That(MemoryIndexLiveCertHarness.ResolveOnPath("kcap-no-such-command", probe.BinDir, isWindows: false))
-            .IsEqualTo("kcap-no-such-command");
+        await Assert.That(() => MemoryIndexLiveCertHarness.ResolveOnPath("kcap-no-such-command", probe.BinDir, isWindows: false))
+            .Throws<FileNotFoundException>();
     }
 
     /// <summary>Windows is deliberately left on the platform's own resolution: doing it correctly needs

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
@@ -8,6 +8,11 @@ namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
 /// </summary>
 public class MemoryIndexLiveCertHarnessTests {
     // ── command resolution ────────────────────────────────────────────────────
+    //
+    // The Unix-semantics cases are skipped on Windows rather than adapted: the branch under test is the
+    // one guarded by `isWindows: false`, it asks the kernel `access(X_OK)`, and its probes need real
+    // execute bits — none of which Windows can provide. Adapting them there would test a different
+    // resolver. Only the isWindows: true passthrough runs everywhere, and it touches no file mode.
     // The bug these cover: `Process.Start` tries a separator-free filename against the WORKING
     // DIRECTORY before PATH, and this assembly's working directory is its own output folder — which
     // contains a `kcap` copied there by the Capacitor.Cli project reference. Every harness
@@ -18,6 +23,8 @@ public class MemoryIndexLiveCertHarnessTests {
 
     [Test]
     public async Task A_bare_command_resolves_to_the_first_PATH_entry_that_has_it() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Unix PATH semantics: needs real execute bits and access(X_OK).");
+
         using var probe = new PathProbe();
 
         var resolved = MemoryIndexLiveCertHarness.ResolveOnPath(
@@ -29,6 +36,8 @@ public class MemoryIndexLiveCertHarnessTests {
     /// <summary>An earlier PATH entry wins — resolution order is first-match, as the shell's is.</summary>
     [Test]
     public async Task Earlier_PATH_entries_win_over_later_ones() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Unix PATH semantics: needs real execute bits and access(X_OK).");
+
         using var first  = new PathProbe();
         using var second = new PathProbe(first.CommandName);
 
@@ -44,6 +53,8 @@ public class MemoryIndexLiveCertHarnessTests {
     /// with the <c>which kcap</c> line recorded beside it.</summary>
     [Test]
     public async Task A_non_executable_match_is_skipped_for_a_later_executable_one() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Unix PATH semantics: needs real execute bits and access(X_OK).");
+
         using var notExecutable = new PathProbe(executable: false);
         using var executable    = new PathProbe(notExecutable.CommandName);
 
@@ -59,6 +70,8 @@ public class MemoryIndexLiveCertHarnessTests {
     /// throws for the same reason an absent command does.</summary>
     [Test]
     public async Task A_non_executable_only_match_does_not_resolve() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Unix PATH semantics: needs real execute bits and access(X_OK).");
+
         using var probe = new PathProbe(executable: false);
 
         await Assert.That(() => MemoryIndexLiveCertHarness.ResolveOnPath(probe.CommandName, probe.BinDir, isWindows: false))
@@ -70,6 +83,8 @@ public class MemoryIndexLiveCertHarnessTests {
     [Arguments("/usr/bin/env")]
     [Arguments("./local-thing")]
     public async Task An_explicit_path_is_passed_through_untouched(string fileName) {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Unix PATH semantics: needs real execute bits and access(X_OK).");
+
         using var probe = new PathProbe();
 
         await Assert.That(MemoryIndexLiveCertHarness.ResolveOnPath(fileName, probe.BinDir, isWindows: false))
@@ -82,6 +97,8 @@ public class MemoryIndexLiveCertHarnessTests {
     /// than fail, reintroducing the wrong-binary bug on the path where resolution already failed.</summary>
     [Test]
     public async Task An_unresolvable_command_throws_rather_than_falling_back_to_the_working_directory() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Unix PATH semantics: needs real execute bits and access(X_OK).");
+
         using var probe = new PathProbe();
 
         await Assert.That(() => MemoryIndexLiveCertHarness.ResolveOnPath("kcap-no-such-command", probe.BinDir, isWindows: false))
@@ -114,9 +131,14 @@ public class MemoryIndexLiveCertHarnessTests {
 
             ExecutablePath = Path.Combine(BinDir, CommandName);
             File.WriteAllText(ExecutablePath, "#!/bin/sh\nexit 0\n");
-            File.SetUnixFileMode(ExecutablePath, executable
-                ? UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
-                : UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+            // `File.SetUnixFileMode` THROWS on Windows, and the probe is constructed by the one test
+            // that does run there (the isWindows: true passthrough), which never looks at the mode.
+            if (!OperatingSystem.IsWindows()) {
+                File.SetUnixFileMode(ExecutablePath, executable
+                    ? UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    : UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
         }
 
         public string BinDir         { get; }

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarnessTests.cs
@@ -38,6 +38,33 @@ public class MemoryIndexLiveCertHarnessTests {
         await Assert.That(resolved).IsEqualTo(first.ExecutablePath);
     }
 
+    /// <summary>Existence is not the test a shell applies: a non-executable match is skipped and the
+    /// walk continues, exactly as <c>which</c> and <c>execvp</c> do. Resolving on existence alone would
+    /// stop here and hand back a file that cannot be launched — or, worse for this harness, disagree
+    /// with the <c>which kcap</c> line recorded beside it.</summary>
+    [Test]
+    public async Task A_non_executable_match_is_skipped_for_a_later_executable_one() {
+        using var notExecutable = new PathProbe(executable: false);
+        using var executable    = new PathProbe(notExecutable.CommandName);
+
+        var resolved = MemoryIndexLiveCertHarness.ResolveOnPath(
+            notExecutable.CommandName,
+            $"{notExecutable.BinDir}{Path.PathSeparator}{executable.BinDir}",
+            isWindows: false);
+
+        await Assert.That(resolved).IsEqualTo(executable.ExecutablePath);
+    }
+
+    /// <summary>...and when the only match is non-executable there is nothing to resolve to, so the bare
+    /// name comes back and the platform raises its own error.</summary>
+    [Test]
+    public async Task A_non_executable_only_match_does_not_resolve() {
+        using var probe = new PathProbe(executable: false);
+
+        await Assert.That(MemoryIndexLiveCertHarness.ResolveOnPath(probe.CommandName, probe.BinDir, isWindows: false))
+            .IsEqualTo(probe.CommandName);
+    }
+
     /// <summary>A name that is already a path is the caller's explicit choice; never rewritten.</summary>
     [Test]
     [Arguments("/usr/bin/env")]
@@ -70,12 +97,14 @@ public class MemoryIndexLiveCertHarnessTests {
             .IsEqualTo(probe.CommandName);
     }
 
-    /// <summary>A throwaway PATH entry holding one uniquely named executable, plus an empty sibling
-    /// directory to prove a miss is skipped rather than treated as a match.</summary>
+    /// <summary>A throwaway PATH entry holding one uniquely named file, plus an empty sibling directory
+    /// to prove a miss is skipped rather than treated as a match. <paramref name="executable"/> controls
+    /// the execute bit, because "exists" and "is executable" are different questions and the resolver
+    /// must answer the second one.</summary>
     sealed class PathProbe : IDisposable {
         readonly string _root;
 
-        public PathProbe(string? commandName = null) {
+        public PathProbe(string? commandName = null, bool executable = true) {
             _root       = Directory.CreateTempSubdirectory("kcap-path-probe-").FullName;
             BinDir      = Directory.CreateDirectory(Path.Combine(_root, "bin")).FullName;
             EmptyDir    = Directory.CreateDirectory(Path.Combine(_root, "empty")).FullName;
@@ -83,6 +112,9 @@ public class MemoryIndexLiveCertHarnessTests {
 
             ExecutablePath = Path.Combine(BinDir, CommandName);
             File.WriteAllText(ExecutablePath, "#!/bin/sh\nexit 0\n");
+            File.SetUnixFileMode(ExecutablePath, executable
+                ? UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                : UnixFileMode.UserRead | UnixFileMode.UserWrite);
         }
 
         public string BinDir         { get; }


### PR DESCRIPTION
Follow-up to #414, which merged with all four of its definition-of-done items still open. This runs the measurement they were gating on, writes the result back into the spec, and fixes the harness defects that running it exposed.

**Test and docs only — no production code changes.**

## §3.3 is settled — live, row 1, option (a)

Against **`gemini 0.53.0`**, `kcap 0.11.10-alpha.0.10+998ec34` (the tree merged as `e2b2821`), macOS 26.5.2 / osx-arm64.

The failure is real rather than simulated: a WireMock instance proxies the whole API to the configured server and fails **only** `POST /hooks/session-start/gemini`. The index fetch on the same base URL is proxied untouched — the one arrangement that produces the shape under test.

| Link | Observed |
|---|---|
| lifecycle POST | `400` from the forced mapping, matched on its response-body marker |
| index fetch | `GET /api/memories/index?machine=… → 200`, same base URL, same invocation |
| hook exit code | **non-zero**, read from the hook Gemini itself ran |
| hook stdout | `hookSpecificOutput.additionalContext` carrying the nonce |
| gemini turn | exit **0** — completed |
| model receipt | the nonce reproduced in the answer |

The turn continues **and** the context is consumed, so option **(a)** — no commit gate — is the design and option (b) is withdrawn.

### Getting the measurement honest took four attempts

Each rejected version looked sufficient, and each was holed in review. Worth recording, because the same shapes will recur in the next adapter's cert:

1. **Substitution.** Proving the non-zero exit from a *separate* direct `kcap hook --gemini` run — Gemini's own hook could have returned 0 through a session- or source-dependent branch.
2. **Turn-global.** "Some forced 400 happened during the turn" — with two invocations, one could carry the nonce while a *different* one took the 400.
3. **Shared identifier.** Correlating those two on session id — but a session id is reused across invocations (`startup` and `resume` share one).
4. **Per-invocation evidence** (this one): a recording shim named `kcap` on the PATH Gemini inherits captures each invocation's exit code, stdout and stderr. The invocation whose `additionalContext` carried the nonce must *itself* have exited non-zero and written the failed-POST diagnostic to *its own* stderr.

## Harness defects the run exposed — all fixed

None is a product defect. The first three made the cert **lie**, which is worse than a cert that fails.

1. **The trusted-folder gate silently voided the run.** Certs run in a fresh throwaway worktree, which 0.53.0 refuses as untrusted (`exit 55`, before any model call). The positive case failed honestly; the negative control **passed vacuously** — a turn that never ran trivially contains no nonce. Fixed with `--skip-trust`; the negative control now asserts turn completion too.
2. **The recorded `kcap` version described the wrong binary.** `Process.Start` resolves a separator-free filename against the working directory before PATH, and this assembly's output folder holds a `kcap` copied there by the project reference. `RecordCertEnvironmentAsync` — which exists to stop a stale-binary misdiagnosis — recorded the test build while its own sibling `which kcap` line reported the PATH build. Resolution is now explicit, asks `access(X_OK)` rather than `File.Exists`, and **throws** rather than falling back to a bare name the working directory would satisfy.
3. **An `int.MinValue` sentinel satisfied the property under test.** An unreadable exit record is `!= 0`. Now nullable: a parse failure fails the assertion.
4. **A PATH shim must not wrap the MCP servers.** The recording shim is a `kcap` on PATH, and so are the four long-lived `kcap mcp` stdio servers Gemini launches. Buffering a stdio JSON-RPC server's stdout traps its handshake until it exits, which it never does — every run hung at exactly 120s with four wrapped processes alive and zero HTTP traffic. The shim now `exec`s anything that is not `kcap hook`.
5. **Cleanup was a log line, not a gate.** A leaked nonce memory makes a *later* run's positive case pass on this run's evidence. Now: `ArchiveMemoryAsync` reports whether the archive was confirmed; an ambiguous save (no id **or** a throw from the call) sweeps for the slug and marks the run dirty unconditionally; a prospective gate refuses to start further cases and an `[After(Assembly)]` teardown fails the run — because a cleanup failure in the *last* case is otherwise observed by nobody.

## New coverage

- `GeminiMemoryIndexLiveCertTests` — the non-zero-exit case (gated), plus turn-completion in the negative control.
- `GeminiSessionStartHandshakeOnPostFailureTests` — the integration half the test plan called for, carrying the branch-specific lease assertion (a) requires: the failed-POST invocation *completes* the lease, and a later `resume` emits no context.
- `MemoryIndexLiveCertHarnessTests` — seven hermetic cases pinning PATH resolution.
- `LiveCertIndexCleanlinessGuard` — the assembly teardown.

## Verification

| Suite | Result |
|---|---|
| `GeminiMemoryIndexLiveCertTests` (live, gated) | 3/3 |
| `MemoryIndexLiveCertHarnessTests` | 30/30 |
| `GeminiSessionStartMemoryTests` | 30/30 |
| `SessionStartMemoryFoundationTests` | 28/28 |
| `GeminiSessionStartHandshakeOnPostFailureTests` | 1/1 |

**Mutation-proven, not asserted:** reverting the execute-bit check to `File.Exists` fails exactly the two resolution tests; resuming a different session id fails the lease assertion; dropping the dash normalisation failed the (since-replaced) id correlation; pointing the stderr diagnostic at a route that does not fail here fails exactly that assertion.

**Review:** six rounds with a hosted codex reviewer, clean at round 6; Qodo's `PATH fallback runs cwd` fixed in `cbeaf65` — it caught the working-directory fallback that the review flow did not reach.

Also pinned, because it cost a wrong conclusion mid-run: `session_id` is validated with `Guid.TryParse`, and a failure takes the same emit-and-return-0 path as a suppressed session — a decorated id produces a plausible exit 0 with the allow object and **no HTTP traffic at all**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)