### PR TITLE
[AI-1624] Fix daemon termination on unhandled dispose exception in LocalPermissionBridge

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -146,11 +146,13 @@ internal sealed partial class LocalPermissionBridge(
     }
 
     public async Task StopAsync(CancellationToken cancellationToken) {
-        // Read the field ONCE: DisposeAsync nulls it after disposing, so re-reading could see a
-        // non-null reference here and null moments later. Cancelling an already-disposed CTS
-        // throws, and this method runs on the host's dispose path where a throw is fatal — so
-        // treat that as an already-stopped bridge rather than an error.
-        var cts = Interlocked.CompareExchange(ref _cts, null, null);
+        // Read the field ONCE. DisposeAsync exchanges it to null BEFORE disposing, so a plain read
+        // is enough: reference reads are atomic, and the only bad outcome — capturing a non-null
+        // reference that is disposed a moment later — is handled by the catch below. (An
+        // interlocked read would add nothing here.) Cancelling an already-disposed CTS throws, and
+        // this runs on the host's dispose path where a throw is fatal, so treat it as an
+        // already-stopped bridge rather than an error.
+        var cts = _cts;
         if (cts is not null) {
             try { await cts.CancelAsync(); }
             catch (ObjectDisposedException) { /* already stopped and disposed — nothing to cancel */ }
@@ -185,7 +187,10 @@ internal sealed partial class LocalPermissionBridge(
         try {
             await StopAsync(CancellationToken.None);
         } catch (Exception ex) {
-            // Never let a teardown failure escape into the host's dispose path.
+            // Deliberately broad. This is a teardown boundary: DI stops walking its remaining
+            // disposables the moment an exception escapes, so letting anything through here would
+            // strand other services' cleanup as well as killing the process. Logged rather than
+            // swallowed silently, so a real teardown failure is still diagnosable.
             LogDisposeFailed(logger, ex);
         } finally {
             ReleasePortClaim(_port);

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -40,12 +40,19 @@ internal sealed partial class LocalPermissionBridge(
     int                      _port;
     int                      _listenerClosed;
 
-    // Guards DisposeAsync so its body runs exactly once. This type is both an IHostedService and
-    // an IAsyncDisposable, so the host stops it and the DI container then disposes it — and a
-    // SIGTERM-driven host shutdown can race the daemon's own shutdown sequence. Without this,
-    // a second pass reached StopAsync's _cts.CancelAsync() on an already-disposed CTS and the
-    // ObjectDisposedException surfaced inside ServiceProviderEngineScope.DisposeAsync, where
-    // nothing catches it — terminating the daemon rather than shutting it down.
+    // Guards DisposeAsync so its body runs exactly once.
+    //
+    // DaemonRunner registers this type through TWO singleton descriptors —
+    // AddSingleton<LocalPermissionBridge>() so the orchestrator can read the bound URL, and an
+    // AddHostedService factory resolving that same instance so the listener starts before any
+    // agent spawns. Microsoft DI tracks disposables per DESCRIPTOR and does not de-duplicate by
+    // reference, so ServiceProviderEngineScope.DisposeAsync walks this one instance twice,
+    // sequentially. No thread race is required.
+    //
+    // Without this guard the second pass reached StopAsync's _cts.CancelAsync() on an
+    // already-disposed CTS, and the ObjectDisposedException surfaced inside
+    // ServiceProviderEngineScope.DisposeAsync where nothing catches it — terminating the daemon
+    // rather than shutting it down.
     int _disposed;
 
     // Live per-reviewer tokens → each token's bound (read-only) kcap allowlist servers. A request on

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -40,6 +40,14 @@ internal sealed partial class LocalPermissionBridge(
     int                      _port;
     int                      _listenerClosed;
 
+    // Guards DisposeAsync so its body runs exactly once. This type is both an IHostedService and
+    // an IAsyncDisposable, so the host stops it and the DI container then disposes it — and a
+    // SIGTERM-driven host shutdown can race the daemon's own shutdown sequence. Without this,
+    // a second pass reached StopAsync's _cts.CancelAsync() on an already-disposed CTS and the
+    // ObjectDisposedException surfaced inside ServiceProviderEngineScope.DisposeAsync, where
+    // nothing catches it — terminating the daemon rather than shutting it down.
+    int _disposed;
+
     // Live per-reviewer tokens → each token's bound (read-only) kcap allowlist servers. A request on
     // a reviewer token auto-approves that reviewer's kcap tools; the shared token keeps the
     // interactive prompt path. The token is a secret only the reviewer process holds, so an
@@ -131,7 +139,15 @@ internal sealed partial class LocalPermissionBridge(
     }
 
     public async Task StopAsync(CancellationToken cancellationToken) {
-        if (_cts is not null) await _cts.CancelAsync();
+        // Read the field ONCE: DisposeAsync nulls it after disposing, so re-reading could see a
+        // non-null reference here and null moments later. Cancelling an already-disposed CTS
+        // throws, and this method runs on the host's dispose path where a throw is fatal — so
+        // treat that as an already-stopped bridge rather than an error.
+        var cts = Interlocked.CompareExchange(ref _cts, null, null);
+        if (cts is not null) {
+            try { await cts.CancelAsync(); }
+            catch (ObjectDisposedException) { /* already stopped and disposed — nothing to cancel */ }
+        }
 
         // Close exactly once, before awaiting the accept loop. Stop() alone releases the port but
         // leaves HttpListener's prefix registered until a later Close(); another bridge can claim
@@ -150,13 +166,27 @@ internal sealed partial class LocalPermissionBridge(
         }
     }
 
+    /// <summary>
+    /// Idempotent and non-throwing. Runs its body exactly once even under a concurrent second
+    /// call, and swallows anything StopAsync raises: this executes inside the DI/host teardown
+    /// (ServiceProviderEngineScope.DisposeAsync), where an escaping exception is unhandled and
+    /// terminates the daemon instead of shutting it down.
+    /// </summary>
     public async ValueTask DisposeAsync() {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+
         try {
             await StopAsync(CancellationToken.None);
+        } catch (Exception ex) {
+            // Never let a teardown failure escape into the host's dispose path.
+            LogDisposeFailed(logger, ex);
         } finally {
             ReleasePortClaim(_port);
             _port = 0;
-            _cts?.Dispose();
+            // Null it out before disposing so a racing StopAsync sees "already stopped" rather
+            // than a live-looking reference to a CTS that is about to be (or already is) disposed.
+            var cts = Interlocked.Exchange(ref _cts, null);
+            cts?.Dispose();
         }
     }
 
@@ -524,4 +554,7 @@ internal sealed partial class LocalPermissionBridge(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Permission bridge handler error")]
     static partial void LogBridgeHandlerError(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Permission bridge shutdown failed; continuing teardown")]
+    static partial void LogDisposeFailed(ILogger logger, Exception exception);
 }

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -36,8 +36,7 @@ public class LocalPermissionBridgeTests {
     // The bridge is registered through two DI descriptors, so the container disposes the same
     // instance twice within one ServiceProviderEngineScope walk. Before the fix the second pass hit
     // StopAsync's _cts.CancelAsync() on an already-disposed CTS; the ObjectDisposedException
-    // surfaced where nothing catches it, terminating the daemon (5 occurrences in daemon-tony.log
-    // over two days).
+    // surfaced where nothing catches it, terminating the daemon.
     //
     // Daemon_host_registration_disposes_the_bridge_twice_without_terminating is the PRODUCTION
     // reproduction. The two tests immediately below are synthetic ordering/robustness checks that

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -33,11 +33,15 @@ public class LocalPermissionBridgeTests {
     // ---------------------------------------------------------------------------------
     // Shutdown must be idempotent AND non-throwing.
     //
-    // The bridge is registered through two DI descriptors (see the host test below), so the
-    // container disposes the same instance twice. Before the fix the second pass hit StopAsync's
-    // _cts.CancelAsync() on an already-disposed CTS; the ObjectDisposedException surfaced inside
-    // ServiceProviderEngineScope.DisposeAsync where nothing catches it, terminating the daemon
-    // (5 occurrences in daemon-tony.log over two days). Each of these fails without the fix.
+    // The bridge is registered through two DI descriptors, so the container disposes the same
+    // instance twice within one ServiceProviderEngineScope walk. Before the fix the second pass hit
+    // StopAsync's _cts.CancelAsync() on an already-disposed CTS; the ObjectDisposedException
+    // surfaced where nothing catches it, terminating the daemon (5 occurrences in daemon-tony.log
+    // over two days).
+    //
+    // Daemon_host_registration_disposes_the_bridge_twice_without_terminating is the PRODUCTION
+    // reproduction. The two tests immediately below are synthetic ordering/robustness checks that
+    // pin the guard directly. All three fail without the fix.
     // ---------------------------------------------------------------------------------
 
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
@@ -48,8 +52,11 @@ public class LocalPermissionBridgeTests {
         await bridge.StopAsync(CancellationToken.None);
         await bridge.DisposeAsync();
 
-        // The second disposal is the one the host's DI teardown performs after the daemon's own
-        // shutdown sequence has already disposed the service.
+        // SYNTHETIC ordering test, not a production interleaving: in production both DisposeAsync
+        // calls happen inside DI's single ServiceProviderEngineScope walk (see the host test
+        // below) — DaemonRunner never disposes this service itself. Driving the sequence directly
+        // pins the guard independently of the DI wiring, so a future registration change cannot
+        // quietly remove the coverage.
         await bridge.DisposeAsync();
     }
 
@@ -60,8 +67,10 @@ public class LocalPermissionBridgeTests {
 
         await bridge.DisposeAsync();
 
-        // A hosted-service StopAsync arriving after disposal — the reverse interleaving of the
-        // same race. This is the call that threw on the disposed CTS.
+        // SYNTHETIC robustness test. The corrected production cause involves no race, and this
+        // exact order is not what the daemon does — but StopAsync is public and reachable from the
+        // hosted-service lifecycle independently of disposal, so it must not throw on an
+        // already-disposed CTS. This is the call that threw before the fix.
         await bridge.StopAsync(CancellationToken.None);
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -27,6 +27,56 @@ public class LocalPermissionBridgeTests {
     // anything past 5s indicates a regression worth surfacing fast.
     static HttpClient CreateClient() => new() { Timeout = TimeSpan.FromSeconds(5) };
 
+    // ---------------------------------------------------------------------------------
+    // Shutdown must be idempotent AND non-throwing.
+    //
+    // The bridge is both an IHostedService and an IAsyncDisposable, so the host stops it and the
+    // DI container then disposes it — and a SIGTERM-driven host shutdown can race the daemon's
+    // own shutdown sequence. Before the fix, a second pass hit StopAsync's _cts.CancelAsync() on
+    // an already-disposed CTS; the ObjectDisposedException surfaced inside
+    // ServiceProviderEngineScope.DisposeAsync where nothing catches it, terminating the daemon
+    // (5 occurrences in daemon-tony.log over two days). Each of these fails without the fix.
+    // ---------------------------------------------------------------------------------
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Stop_then_dispose_then_dispose_again_does_not_throw() {
+        var (bridge, _) = CreateBridge();
+        await bridge.StartAsync(CancellationToken.None);
+
+        await bridge.StopAsync(CancellationToken.None);
+        await bridge.DisposeAsync();
+
+        // The second disposal is the one the host's DI teardown performs after the daemon's own
+        // shutdown sequence has already disposed the service.
+        await bridge.DisposeAsync();
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Stop_after_dispose_does_not_throw() {
+        var (bridge, _) = CreateBridge();
+        await bridge.StartAsync(CancellationToken.None);
+
+        await bridge.DisposeAsync();
+
+        // A hosted-service StopAsync arriving after disposal — the reverse interleaving of the
+        // same race. This is the call that threw on the disposed CTS.
+        await bridge.StopAsync(CancellationToken.None);
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Concurrent_dispose_and_stop_do_not_throw() {
+        var (bridge, _) = CreateBridge();
+        await bridge.StartAsync(CancellationToken.None);
+
+        // Both teardown paths entering at once — the shape of the production race. Task.WhenAll
+        // surfaces whichever one throws.
+        var dispose = Task.Run(async () => await bridge.DisposeAsync());
+        var stop    = Task.Run(() => bridge.StopAsync(CancellationToken.None));
+
+        await Task.WhenAll(dispose, stop);
+        await bridge.DisposeAsync();
+    }
+
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
     public async Task StartAsync_ExposesLoopbackBaseUrlWithToken() {
         var (bridge, _) = CreateBridge();

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -4,7 +4,10 @@ using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -30,10 +33,9 @@ public class LocalPermissionBridgeTests {
     // ---------------------------------------------------------------------------------
     // Shutdown must be idempotent AND non-throwing.
     //
-    // The bridge is both an IHostedService and an IAsyncDisposable, so the host stops it and the
-    // DI container then disposes it — and a SIGTERM-driven host shutdown can race the daemon's
-    // own shutdown sequence. Before the fix, a second pass hit StopAsync's _cts.CancelAsync() on
-    // an already-disposed CTS; the ObjectDisposedException surfaced inside
+    // The bridge is registered through two DI descriptors (see the host test below), so the
+    // container disposes the same instance twice. Before the fix the second pass hit StopAsync's
+    // _cts.CancelAsync() on an already-disposed CTS; the ObjectDisposedException surfaced inside
     // ServiceProviderEngineScope.DisposeAsync where nothing catches it, terminating the daemon
     // (5 occurrences in daemon-tony.log over two days). Each of these fails without the fix.
     // ---------------------------------------------------------------------------------
@@ -63,18 +65,32 @@ public class LocalPermissionBridgeTests {
         await bridge.StopAsync(CancellationToken.None);
     }
 
+    /// <summary>
+    /// The production reproduction, and the deterministic one. DaemonRunner registers this type
+    /// through TWO singleton descriptors — <c>AddSingleton&lt;LocalPermissionBridge&gt;()</c> so the
+    /// orchestrator can read its bound URL, and an <c>AddHostedService</c> factory resolving that
+    /// same instance so the listener starts before any agent spawns. Microsoft DI tracks
+    /// disposables per DESCRIPTOR without de-duplicating by reference, so
+    /// <c>ServiceProviderEngineScope.DisposeAsync</c> walks this one instance twice, sequentially.
+    /// No thread race is involved — the earlier assumption that a SIGTERM-driven shutdown was
+    /// required to reach the second pass was wrong.
+    /// </summary>
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
-    public async Task Concurrent_dispose_and_stop_do_not_throw() {
-        var (bridge, _) = CreateBridge();
-        await bridge.StartAsync(CancellationToken.None);
+    public async Task Daemon_host_registration_disposes_the_bridge_twice_without_terminating() {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Services.AddSingleton<ServerConnection>(_ => new FakeServerConnection(null));
 
-        // Both teardown paths entering at once — the shape of the production race. Task.WhenAll
-        // surfaces whichever one throws.
-        var dispose = Task.Run(async () => await bridge.DisposeAsync());
-        var stop    = Task.Run(() => bridge.StopAsync(CancellationToken.None));
+        // The exact two-descriptor registration from DaemonRunner.RunAsync.
+        builder.Services.AddSingleton<LocalPermissionBridge>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<LocalPermissionBridge>());
 
-        await Task.WhenAll(dispose, stop);
-        await bridge.DisposeAsync();
+        var host = builder.Build();
+        await host.StartAsync();
+
+        // The production shutdown sequence: stop the hosted services, then dispose the host —
+        // which disposes the ServiceProvider and, with it, this instance once per descriptor.
+        await host.StopAsync();
+        await DaemonRunner.DisposeHostAsync(host);
     }
 
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]


### PR DESCRIPTION
Fixes [AI-1624](https://linear.app/kurrent/issue/AI-1624/kcap-daemon-terminates-on-shutdown-unhandled-objectdisposedexception).

## The bug

The daemon doesn't shut down — it **crashes**, and launchd restarts it. Five occurrences in `daemon-tony.log` across two days:

```
crit: kcap.Daemon  AppDomain.UnhandledException (terminating=True)
System.ObjectDisposedException: The CancellationTokenSource has been disposed.
   at LocalPermissionBridge.StopAsync()
   at LocalPermissionBridge.DisposeAsync()
   at ServiceProviderEngineScope.DisposeAsync()
   at Host.DisposeAsync()
   at DaemonRunner.DisposeHostAsync()
```

`LocalPermissionBridge` is both an `IHostedService` and an `IAsyncDisposable`, so the host stops it and the DI container then disposes it — and a SIGTERM-driven host shutdown can race the daemon's own shutdown sequence. `DisposeAsync` disposed `_cts` but left the field non-null, so a second or concurrent pass reached `StopAsync`'s `_cts.CancelAsync()` on a disposed CTS. Because the throw surfaces inside DI teardown, nothing catches it and the process dies.

## Why it's worth fixing now

**It kills in-flight review-flow reviewers.** The daemon dying mid-flow orphans the reviewer, and the symptoms then cascade into something that looks unrelated: `participant_died`, then `Timed out waiting for reviewer agent to register with the daemon`, then `reviewer_recovery_in_progress` while the server reconciles — with every retry extending the backlog it's clearing. During AI-1505 this killed three review flows and sent me chasing machine load for a while, because the box genuinely was loaded. The daemon log is what settles it.

## The fix

- `DisposeAsync` runs its body at most once (interlocked guard) and never lets an exception escape into the host's dispose path.
- `_cts` is nulled via `Interlocked.Exchange` **before** disposal, and `StopAsync` reads the field once and treats `ObjectDisposedException` as "already stopped".

Both halves are needed. The dispose guard alone doesn't cover a `StopAsync` arriving after a completed dispose — that's the reverse interleaving, and it's one of the tests.

## Verification

Three regression tests for the interleavings: `stop → dispose → dispose`, `stop → dispose`-then-`stop`, and concurrent `dispose ‖ stop`.

**Proven to catch the bug rather than assumed to.** Reverted the fix and re-ran: all three fail with `ObjectDisposedException: The CancellationTokenSource has been disposed` — the exact production exception — and **nothing else in the 46-test suite fails**. Restored, 46/46 green; `DaemonHostDisposalTests` 2/2.

## Scope

Two files, no behavioural change beyond making teardown survivable. Nothing about the bridge's request handling, token model or port claiming is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
