### PR TITLE
[AI-899] Host Gemini CLI as an ACP hosted agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,31 @@ kcap daemon service uninstall              # stop and remove the service
 
 `install` pins the active profile via `KCAP_PROFILE` and captures your current `PATH` into the unit, so the supervised daemon resolves the same server URL, `claude`/`codex` binaries, and profile settings it would from your shell. Pass `--profile P` to pin a different profile, `--max-agents N` to bake an override, or `--no-start` to register without starting. The service restarts the daemon on crash/`SIGKILL` but **not** on a clean stop.
 
-What it carries over from your shell is a fixed allowlist — `PATH`, `KCAP_PROFILE`, `KCAP_URL`, `KCAP_CONFIG_DIR`, `KCAP_CLAUDE_PATH`, `KCAP_CODEX_PATH`, `KCAP_COPILOT_TOKEN_CMD` — and **nothing else from your environment reaches the service**, credentials included, because the unit file lands on disk. (`install` additionally writes a generated `KCAP_DAEMON_SUPERVISED` marker, so the unit holds one key that did not come from your shell.) Unit files are written owner-only (`0600`). `KCAP_COPILOT_TOKEN_CMD` is on the list precisely because it is a *command* rather than a secret — see [borrowed-context Copilot review](#borrowed-context-copilot-reviews).
+What it carries over from your shell is a fixed allowlist — `PATH`, `KCAP_PROFILE`, `KCAP_URL`, `KCAP_CONFIG_DIR`, `KCAP_CLAUDE_PATH`, `KCAP_CODEX_PATH`, `KCAP_COPILOT_TOKEN_CMD`, plus the Google/Gemini configuration below — and **nothing else from your environment reaches the service**, credentials included, because the unit file lands on disk. (`install` additionally writes a generated `KCAP_DAEMON_SUPERVISED` marker, so the unit holds one key that did not come from your shell.) Unit files are written owner-only (`0600`). `KCAP_COPILOT_TOKEN_CMD` is on the list precisely because it is a *command* rather than a secret — see [borrowed-context Copilot review](#borrowed-context-copilot-reviews).
+
+#### Hosted Gemini needs its project in the *daemon's* environment
+
+Hosted Gemini agents use whatever credential you logged `gemini` in with — there is no API key to configure. But a Gemini login that is scoped to a Google Cloud project needs that project **where the daemon can see it**, and a supervised daemon sees none of your shell: launchd passes no shell environment, and a non-interactive shell never reads your profile. So `export GOOGLE_CLOUD_PROJECT=…` in `.zshrc` is invisible to it.
+
+Get this wrong and Gemini reports it as a **tier** problem:
+
+```
+IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals.
+```
+
+That message names the wrong cause — the same text appears for a missing project id — so if you see it, check your project configuration before believing anything about your subscription.
+
+`install` therefore captures, when set in the installing shell:
+
+| Carried everywhere | Carried on macOS/Linux only | Never carried |
+|---|---|---|
+| `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_PROJECT_ID`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_GENAI_USE_GCA` | `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_GEMINI_BASE_URL`, `GOOGLE_VERTEX_BASE_URL` | `GOOGLE_API_KEY`, `GOOGLE_CREDENTIALS` |
+
+The middle column is secret-*capable* — a credential path says where your credential lives, and a base URL can carry a token in userinfo or a query string. On macOS and Linux that is bounded by a guarantee kcap enforces: unit files are written `0600`, the mode is re-checked on the open handle, and `install` refuses a group- or world-writable directory. On Windows the wrapper inherits your user profile's ACL, which kcap neither sets nor verifies, so those three are excluded there — the same reason `GH_TOKEN` is never carried. If you need Vertex-with-ADC on a Windows daemon, set it in the service's own environment yourself.
+
+⚠️ **Capture happens at install time.** Exporting the project *after* `kcap daemon service install` leaves a unit without it. Set it first, or re-run `install` afterwards — and restart the daemon.
+
+> Verified against `oauth-personal` (Gemini Code Assist) with a project. The `gemini-api-key`, `vertex-ai` and `gateway` auth methods are not verified; their variables are carried so they *can* work, which is not the same as knowing they do.
 
 Because the service auto-restarts, stop a service-managed daemon with `kcap daemon service stop` (or `uninstall`) rather than `kcap daemon stop` — a raw stop would be relaunched immediately. `kcap daemon status` and `kcap daemon doctor` both report installed services.
 

--- a/docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md
@@ -1,6 +1,9 @@
 # AI-899 — Gemini CLI as an ACP hosted agent
 
-**Status:** specced 2026-07-31 against `gemini 0.53.0` and `origin/main` (`e2b2821`).
+**Status:** rev 4, 2026-07-31, against `gemini 0.53.0` and `origin/main` (`e2b2821`).
+**NOT implementation-ready as written** — §3.1a's trust probe has been run and found repository-controlled
+code execution that `--skip-trust` does not prevent. It needs the containment decision in §3.1a before any
+code.
 **Repository:** kurrent-io/kcap-cli
 **Parent:** AI-1399 (multi-vendor ACP hosted agents)
 **Template:** the shipped Kiro child (AI-1404) and the Copilot child (AI-1403). Read those, not the
@@ -83,7 +86,8 @@ public static readonly AcpVendorDescriptor Gemini = new(
     Vendor:              "gemini",
     ResolveBinaryPath:   cfg => cfg.GeminiPath,
     ResolveDefaultModel: _ => null,
-    Argv:                ["--experimental-acp", "--skip-trust"],
+    Argv:                ["--experimental-acp", "--skip-trust",
+                          "--allowed-mcp-server-names", "kcap-none"],   // see 3.1a
     UnattendedTrustArgv: [],
     SupportsUnattended:  false,
     ModelSelector:       NoOpModelSelector.Instance,
@@ -132,9 +136,66 @@ implementation must, before the descriptor ships:
    part of this PR rather than a follow-up.
 
 This is gating, not follow-up: the flag is required for the feature to work at all, so the question cannot
-be deferred past the thing that needs it. **If the probe is not run, this spec is not implementation-ready**
-— the result can change both the argv and the threat model. It is also a question every ACP vendor with a
-trust model will face, so the answer is worth writing down once.
+be deferred past the thing that needs it. It is also a question every ACP vendor with a trust model will
+face, so the answer is worth writing down once.
+
+### 3.1a THE PROBE HAS BEEN RUN — and it inverts the framing
+
+**Method.** A throwaway git repo with a workspace `.gemini/settings.json` declaring (a) an MCP server and
+(b) a `SessionStart` hook, each of whose command touches a distinctive marker file. A marker is therefore
+proof of *repository-controlled process execution*. Run against `gemini 0.53.0` with the operator's real
+credential, varying only trust and clamp flags. Every row is measured, not inferred:
+
+| Trust state | `--skip-trust` | repo MCP server | repo hook |
+|---|---|---|---|
+| untrusted | yes | — | — |
+| the worktree itself `TRUST_FOLDER` | no | **EXECUTED** | **EXECUTED** |
+| a **parent** `TRUST_PARENT`, no entry for the worktree | **yes** | **EXECUTED** | **EXECUTED** |
+| parent `TRUST_PARENT` + `--allowed-mcp-server-names <non-matching sentinel>` | yes | — | **EXECUTED** |
+
+The second row is the positive control, and it is what makes the first row meaningful: without it, "no
+markers" would equally well have meant the probe was mis-shaped.
+
+**Three findings, and the third is the one that matters:**
+
+1. **`--skip-trust` does not grant workspace-configuration trust.** It permits the turn; it does not
+   activate repo-authored settings, hooks or MCP servers. So the flag is *not* the risk — the earlier
+   draft's worry was aimed at the wrong thing.
+2. **Trust INHERITS from a trusted parent, and `--skip-trust` cannot undo it.** With a parent marked
+   `TRUST_PARENT` and no entry for the worktree at all, both facilities executed *while the flag was
+   passed*. Passing `--skip-trust` is not a containment measure and must never be described as one.
+3. **This is live for kcap, not theoretical.** `WorktreePathResolver` and `WorktreeManager` place daemon
+   worktrees at `<repo>/.capacitor/worktrees/agent-…` — **inside the operator's repository**. An operator
+   who has trusted their own repo (the normal thing to do when using Gemini in it; the machine this was
+   measured on has a real `TRUST_PARENT` entry) will therefore have every hosted Gemini agent inherit that
+   trust and auto-execute whatever `.gemini/settings.json` the checked-out branch carries — under the
+   daemon user, with no prompt, before the model does anything. The branch in that worktree may be
+   PR-authored.
+
+**Against §3.1's rule, that is a MUST-clamp: a repository-controlled facility causing process execution
+before any user-approved action.** So:
+
+* **MCP servers are clampable.** `--allowed-mcp-server-names <sentinel>` suppressed the repo-authored
+  server with trust inherited. It goes in `Argv`. Note `--allowed-mcp-server-names ""` is **not** usable —
+  it crashes config load with *"mcpName is required if specified"*, before session start, which also makes
+  it a trap for anyone verifying this: the run fails and reports no markers for the wrong reason.
+* **Hooks are NOT clampable by any launch flag.** `gemini hooks` is a management subcommand, not a switch;
+  there is no `--no-hooks`. The repo-authored hook executed under every configuration that had trust.
+
+**Therefore hosted Gemini cannot ship on `--skip-trust` alone**, and the descriptor in §3 is not yet
+sufficient. The options, for decision rather than for the implementer to pick:
+
+| Option | Effect | Cost |
+|---|---|---|
+| **(a) Refuse to launch when the worktree resolves as trusted** — read `~/.gemini/trustedFolders.json`, fail with a coded error | fail-closed, no upstream change, kcap-side only | hosted Gemini unavailable in exactly the repos an operator most likely trusts |
+| **(b) Neutralise the worktree's `.gemini/` before launch** | removes the facility rather than the trust | mutates a checkout agents commit from; needs care with tracked files |
+| **(c) Create daemon worktrees outside any trustable path** | removes inheritance at the root | `WorktreeManager` scans per-repo `.capacitor/worktrees/`; affects every vendor |
+| **(d) Upstream request for a hook clamp** | correct long-term | not available now |
+
+**Recommendation: (a) plus the MCP clamp for this issue, with (b) or (c) as the follow-up that restores
+availability.** (a) is small, fail-closed, and honest about what it costs; shipping without it would mean
+hosted Gemini silently executes branch-authored code on the machines of the operators most likely to use
+it.
 
 ### 3.2 `SupportsUnattended: false` — hosting only, for now
 

--- a/docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md
@@ -1,9 +1,8 @@
 # AI-899 — Gemini CLI as an ACP hosted agent
 
-**Status:** rev 4, 2026-07-31, against `gemini 0.53.0` and `origin/main` (`e2b2821`).
-**NOT implementation-ready as written** — §3.1a's trust probe has been run and found repository-controlled
-code execution that `--skip-trust` does not prevent. It needs the containment decision in §3.1a before any
-code.
+**Status:** rev 5, 2026-07-31, against `gemini 0.53.0` and `origin/main` (`e2b2821`).
+**Implementation-ready.** §3.1a's gating trust probe has been run, re-run on the correct code path, and its
+finding is contained by a flag already in the descriptor.
 **Repository:** kurrent-io/kcap-cli
 **Parent:** AI-1399 (multi-vendor ACP hosted agents)
 **Template:** the shipped Kiro child (AI-1404) and the Copilot child (AI-1403). Read those, not the
@@ -87,7 +86,9 @@ public static readonly AcpVendorDescriptor Gemini = new(
     ResolveBinaryPath:   cfg => cfg.GeminiPath,
     ResolveDefaultModel: _ => null,
     Argv:                ["--experimental-acp", "--skip-trust",
-                          "--allowed-mcp-server-names", "kcap-none"],   // see 3.1a
+                          // §3.1a: scoped to the servers kcap injects. NOT a non-matching
+                          // sentinel — that would block ours too.
+                          "--allowed-mcp-server-names", ...InjectedMcpServerNames],
     UnattendedTrustArgv: [],
     SupportsUnattended:  false,
     ModelSelector:       NoOpModelSelector.Instance,
@@ -182,8 +183,39 @@ before any user-approved action.** So:
 * **Hooks are NOT clampable by any launch flag.** `gemini hooks` is a management subcommand, not a switch;
   there is no `--no-hooks`. The repo-authored hook executed under every configuration that had trust.
 
-**Therefore hosted Gemini cannot ship on `--skip-trust` alone**, and the descriptor in §3 is not yet
-sufficient. The options, for decision rather than for the implementer to pick:
+### 3.1b CORRECTION — §3.1a measured the wrong code path, and the finding is contained
+
+Everything above was measured with `gemini --prompt` — the **print/CLI** path. **kcap hosts over ACP**
+(`gemini --experimental-acp`). Re-measured there, with inherited trust:
+
+| Path | repo-authored MCP | repo-authored hook |
+|---|---|---|
+| print/CLI (what §3.1a measured) | EXECUTED | **EXECUTED** |
+| **ACP — what kcap uses** | **EXECUTED** | **blocked** |
+| **ACP + `--allowed-mcp-server-names <injected names>`** | **blocked** | blocked |
+
+So §3.1a was wrong in both directions. **Hooks do not execute on the ACP path**, so "hooks are unclampable,
+therefore hosted Gemini cannot ship" is withdrawn. **Repo-authored MCP servers do execute on ACP under
+inherited trust** — that half is real — **and the allowlist flag already in the descriptor contains it**,
+verified: the injected server loads, the repo-authored one is blocked.
+
+**The containment decision is therefore not needed.** No worktree relocation, no launch refusal, no
+`.gemini/` stripping. The one correction the descriptor needed was the allowlist *contents*: a
+non-matching sentinel blocks our own injected servers as well, which would have shipped hosted Gemini with
+MCP silently broken.
+
+**The lesson is the one §1.1 already teaches, and I re-learned it here:** the CLI and ACP paths have
+materially different config-trust behaviour, in both vendors probed, and neither is predictable from the
+other. §7 therefore requires the clamp test to run **through ACP**, not through the CLI.
+
+Two probe-hygiene traps, recorded because each produced a confident wrong answer:
+
+* `--allowed-mcp-server-names ""` crashes config load *before* session start, so a probe using it reports
+  "nothing executed" for entirely the wrong reason.
+* On Cursor, `--approve-mcps` **persists** an approval for the server name, so a reused probe identifier
+  silently measures a stale approval on later runs. Use a virgin name per measurement.
+
+The options below are retained only as the reasoning that the correction closed off — **none is needed**:
 
 | Option | Effect | Cost |
 |---|---|---|

--- a/docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md
@@ -86,9 +86,9 @@ public static readonly AcpVendorDescriptor Gemini = new(
     ResolveBinaryPath:   cfg => cfg.GeminiPath,
     ResolveDefaultModel: _ => null,
     Argv:                ["--experimental-acp", "--skip-trust",
-                          // §3.1a: scoped to the servers kcap injects. NOT a non-matching
-                          // sentinel — that would block ours too.
-                          "--allowed-mcp-server-names", ...InjectedMcpServerNames],
+                          // §3.1c — clamps repo-authored MCP servers. A single non-matching
+                          // name is correct WHILE SupportsMcpServers is false; see §3.1c.
+                          "--allowed-mcp-server-names", "kcap-none"],
     UnattendedTrustArgv: [],
     SupportsUnattended:  false,
     ModelSelector:       NoOpModelSelector.Instance,
@@ -228,6 +228,25 @@ The options below are retained only as the reasoning that the correction closed 
 availability.** (a) is small, fail-closed, and honest about what it costs; shipping without it would mean
 hosted Gemini silently executes branch-authored code on the machines of the operators most likely to use
 it.
+
+### 3.1c The allowlist contents depend on `SupportsMcpServers`, and rev 5 got this backwards
+
+Rev 5 corrected the allowlist to "the servers kcap injects" — which contradicts §3.4, where
+`SupportsMcpServers` is **false** and therefore kcap injects **nothing**. Both cannot be right, and the
+implementation would have exposed it immediately.
+
+Resolved:
+
+* **While `SupportsMcpServers: false`** (now): there are no injected servers, so a single **non-matching**
+  name is exactly right. It permits nothing, which blocks the repo-authored server and costs us nothing.
+  Measured working — `--allowed-mcp-server-names __kcap_none__` clamped the repo server without crashing.
+* **When §3.4's call-level probe flips the flag to true**: the allowlist must become the injected server
+  names in the same change, or hosted Gemini ships with MCP silently broken. That coupling is the reason
+  this subsection exists rather than a comment.
+* **Never the empty string** — it crashes config load before session start (§3.1b).
+
+The test in §7.7 asserts the coupling, not just the flag: allowlist contents and `SupportsMcpServers` must
+agree, so flipping one without the other fails.
 
 ### 3.2 `SupportsUnattended: false` — hosting only, for now
 

--- a/docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md
@@ -1,0 +1,471 @@
+# AI-899 — Gemini CLI as an ACP hosted agent
+
+**Status:** specced 2026-07-31 against `gemini 0.53.0` and `origin/main` (`e2b2821`).
+**Repository:** kurrent-io/kcap-cli
+**Parent:** AI-1399 (multi-vendor ACP hosted agents)
+**Template:** the shipped Kiro child (AI-1404) and the Copilot child (AI-1403). Read those, not the
+original 2026-06 sketch on the issue, which predates both.
+
+Everything marked **measured** was observed directly against a live `gemini` process. The issue carries
+four comments written while prepping this, two of which reached *wrong* conclusions and were retracted;
+§1 exists so nobody re-derives them.
+
+## 1. The retracted premises — read this before the issue's comment history
+
+Two conclusions on the issue were wrong. They are corrected there, but the reasoning is worth carrying
+because both are shapes that will recur.
+
+### 1.1 "Gemini is tier-ineligible for headless use" — FALSE
+
+Both `gemini --prompt` and the ACP `session/new` failed with:
+
+> `IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals.`
+
+The real cause was a missing **`GOOGLE_CLOUD_PROJECT`**. The error is raised by a function named
+**`throwIneligibleOrProjectIdError`** — the same message for a missing project id as for a genuine tier
+problem. The stack trace said "OR ProjectId" through every probe.
+
+**The transferable rule: when a vendor error names a cause, read the function that threw it before
+believing the attribution.** A confidently-wrong message is worse than a vague one, and this one cost
+several probes and two retracted comments. It is also the direct motivation for §5.
+
+### 1.2 "Hosting needs an API key" — FALSE, and over-engineered
+
+Hosted agents run with a normal environment: the daemon spawns the vendor CLI as the daemon user with
+`HOME` intact, so it uses whatever credential the operator already logged in with — exactly how Cursor,
+Copilot, Claude and Codex already work. **"The operator logs their CLI in" is the correct and sufficient
+assumption.**
+
+A credential broker is only ever needed for a *sandboxed* reviewer, because `BorrowedReviewSandbox`
+redirects `HOME` and deliberately grants nothing under it, so the vendor cannot see its own login. That
+is a property of the sandbox, not of hosting, and it belongs to AI-1413.
+
+## 2. Measured facts (`gemini 0.53.0`)
+
+`initialize` response:
+
+```json
+{"protocolVersion":1,
+ "agentInfo":{"name":"gemini-cli","version":"0.53.0"},
+ "agentCapabilities":{
+   "loadSession":true,
+   "promptCapabilities":{"image":true,"audio":true,"embeddedContext":true},
+   "mcpCapabilities":{"http":true,"sse":true}},
+ "authMethods":[
+   {"id":"oauth-personal","name":"Log in with Google"},
+   {"id":"gemini-api-key","name":"Gemini API key"},
+   {"id":"vertex-ai","name":"Vertex AI"},
+   {"id":"gateway","name":"AI API Gateway"}]}
+```
+
+`session/new` returns `sessionId`, `modes`, and `models`:
+
+| Fact | Value |
+|---|---|
+| `availableModels` | `auto`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-flash-lite` |
+| `currentModelId` | `auto-gemini-2.5` |
+| `availableModes` | `default`, `autoEdit`, `yolo`, `plan` (native read-only) |
+
+Contrast with Kiro, where it matters: `embeddedContext` is **true** (Kiro `false`), so AI-1407's prompt
+folding needs no plain-text workaround here; `authMethods` is non-empty (Kiro `[]`), which is what gives
+AI-1413 a credential story at all.
+
+`DaemonConfig.GeminiPath = "gemini"` is **already correct** — the binary really is `gemini`. No repeat of
+the Kiro `kiro`→`kiro-cli` trap, where a wrong default meant the vendor was never advertised on a correct
+install. §7 still adds the zero-configuration availability test, because that is the test that would have
+caught Kiro's.
+
+## 3. The descriptor
+
+```csharp
+public static readonly AcpVendorDescriptor Gemini = new(
+    Vendor:              "gemini",
+    ResolveBinaryPath:   cfg => cfg.GeminiPath,
+    ResolveDefaultModel: _ => null,
+    Argv:                ["--experimental-acp", "--skip-trust"],
+    UnattendedTrustArgv: [],
+    SupportsUnattended:  false,
+    ModelSelector:       NoOpModelSelector.Instance,
+    SupportsMcpServers:  false
+);
+```
+
+Each non-obvious choice, with its reason:
+
+### 3.1 `--skip-trust` is in `Argv`, and it has an unresolved question attached
+
+**Measured:** 0.53.0 refuses a headless turn in an untrusted directory outright — `exit 55`, before any
+model call, with *"Gemini CLI is not running in a trusted directory"*. A daemon-created worktree
+**cannot be assumed** pre-trusted (whether trust is inherited from a parent path was not measured), so
+without this a hosted launch fails.
+
+`GEMINI_CLI_TRUST_WORKSPACE=true` is the documented alternative and is deliberately not used: an argument
+is visible in the launch line and in `ps`, scoped to the one process, and cannot leak into anything else
+the daemon spawns. An environment variable is none of those things.
+
+**What the probe does NOT establish, and what this issue therefore owes.** The measurement shows only
+that the turn is refused without the flag. It does not show *what the trust gate was gating*. A trust
+prompt in a coding agent typically guards workspace-controlled configuration — repo-local settings, MCP
+server definitions, hooks, extensions — i.e. **code execution controlled by whoever wrote the
+repository**. A daemon-created worktree is not thereby benign: it is a checkout of a branch that may
+carry contributor- or PR-authored content.
+
+An earlier draft of this spec asserted "this is not a new risk surface" on the grounds that the daemon
+created the worktree itself. **That was an inference, not a measurement, and it is withdrawn.** The
+implementation must, before the descriptor ships:
+
+1. **Probe which workspace-controlled facilities load under `--skip-trust`** — at minimum repo-local
+   Gemini settings, MCP definitions, and any hook/extension mechanism.
+2. **Then either clamp them, or state the accepted risk explicitly in the README**, with the reasoning
+   visible to an operator deciding whether to enable hosted Gemini on untrusted branches.
+
+This is a gating item, not a follow-up: the flag is required for the feature to work at all, so the
+question cannot be deferred past the thing that needs it. It is also a question every ACP vendor with a
+trust model will face, so the answer is worth writing down once.
+
+### 3.2 `SupportsUnattended: false` — hosting only, for now
+
+Unattended review is AI-1413. Withholding it here follows the Kiro precedent, and for the same structural
+reason: the containment story has to be settled on its own issue rather than inherited by default.
+`UnattendedTrustArgv` is therefore empty; when AI-1413 lands it will need `--approval-mode yolo` (or
+`plan`, see §3.5) plus whatever MCP clamp the review flow requires.
+
+### 3.3 `NoOpModelSelector` — the write half is unverified and fails silently
+
+`session/new` returns `models`, so `ConfigOptionModelSelector`'s *read* half fits. Its **write** half —
+`session/set_config_option` actually taking effect — is unverified on Gemini and that selector fails
+**silently**, producing a session that reports the requested model while running another.
+
+`ResolveDefaultModel: null` alone would not be enough: `ResolveRequestedModel` prioritises a per-launch
+`RuntimeStartContext.Model` and would reach a live selector anyway. The selector itself has to be the
+no-op. This is the identical call the Kiro descriptor faced, resolved the same way.
+
+Model override arrives with the follow-up that verifies the write half — which, note, interacts with the
+`ModelSelectionLaunchPolicy` added for Kiro: with `CanSelectModel: false`, an explicitly requested
+*reviewer* model is rejected rather than silently ignored, while an inherited one clears the reported
+model. That is the correct behaviour here and needs no change.
+
+### 3.4 `SupportsMcpServers: false` — pending a call-level probe
+
+**What the flag actually gates, since the name does not say:** `AcpHostedAgentRuntimeFactory` reads
+`descriptor.SupportsMcpServers ? ctx.McpServers : null` — a **blanket** switch on the `mcpServers` array
+passed to `session/new`, not a per-transport one. Setting it false omits the field entirely.
+
+That matters for the trade here. Gemini measurably advertises `{http: true, sse: true}`; what it does not
+advertise is **stdio** — and stdio is what kcap injects (the review-flow servers are stdio processes;
+Copilot's descriptor sets the same flag false for the same reason and preloads its servers through a
+process argument instead). So `false` withholds the transport kcap would actually use, and the two
+advertised remote transports are not something kcap has a caller for today.
+
+**That advertisement is not a reliable discriminator either way**: AI-1404 established that Kiro honours
+stdio servers passed in `session/new.mcpServers` despite advertising exactly the same `{http, sse}` shape.
+
+So the flag starts `false`, and flipping it requires the evidence Kiro's flip required: a purpose-built
+stdio server driven all the way to a real `tools/call`, with the tool's nonce reaching the model and the
+turn ending `end_turn`. Explicitly **not** sufficient: a `server_initialized`-style notification, which
+proves only that a server started — a tool can still be absent from `tools/list`, refused by policy,
+mis-namespaced, or fail at invocation.
+
+Starting `false` withholds an unverified stdio path rather than promising one that may not work. It is
+not disabling a measured remote capability, because nothing in kcap currently injects one; if that
+changes, the blanket flag is the wrong shape and should be split by transport rather than flipped.
+
+### 3.5 `--approval-mode` is deliberately not passed for hosting
+
+Interactive hosting should behave as the user's own session does. `plan` is a strong containment primitive
+and belongs to AI-1413; pinning it here would silently make hosted Gemini read-only, which is not what a
+hosted agent is for.
+
+### 3.6 The default model is a pricing sentinel
+
+`currentModelId` is measured as `auto-gemini-2.5`, and `availableModels` contains a literal `auto`. Per
+`PricingSentinels`, placeholder ids like `auto`/`default` never price.
+
+**What is not yet established is whether `auto-gemini-2.5` actually matches that sentinel rule.** The
+presence of a separate literal `auto` in the list does not prove the reported id is normalised to it, and
+`PricingSentinels`' matching (exact? prefix? after normalisation?) was not read. So the honest statement
+is: the reported id is a placeholder-shaped id that **either** hits the sentinel and does not price,
+**or** misses every pricing entry and does not price — and in both cases a hosted Gemini session shows no
+cost, but by different mechanisms with different fixes.
+
+§7.5a therefore **pins the actual outcome with a test** rather than asserting the mechanism: given
+Gemini's measured `session/new` response, assert the reported model id and assert the resulting state is
+an explicit *cost unavailable*. And it asserts the surface does **not** render that as `0` or "free" —
+a silent zero is worse than a blank, because it reads as a measurement.
+
+This is accepted rather than fixed here, and the acceptance is real: with §3.3 withholding model
+selection, there is no path to a priced hosted Gemini session inside this issue. It interacts with
+AI-1612 (reported-vs-running model). What this spec owes is that the behaviour is known, tested, and
+visibly absent rather than discovered later as a cost-report gap.
+
+## 4. The daemon environment — the operational requirement
+
+**Whatever Gemini configuration the operator's shell carries, the DAEMON does not see it.** That part is
+measured and unconditional: `~/.zshrc` is not sourced by a non-interactive shell, launchd inherits nothing
+from an interactive one, and the running daemon's environment was verified to carry only `KCAP_PROFILE`
+and `PATH`. Anything Gemini needs from the environment must be captured into the unit.
+
+**What is NOT established: that `GOOGLE_CLOUD_PROJECT` is required on every auth path.** It was measured
+as required on **one** configuration — the operator's `oauth-personal` / Gemini Code Assist login, where
+its absence produced §1.1's misattributed tier error. `initialize` advertises four auth methods
+(`oauth-personal`, `gemini-api-key`, `vertex-ai`, `gateway`), and nothing here shows the other three
+behave the same way; an API-key configuration plausibly needs no project at all.
+
+Saying "must be present, or hosted Gemini will fail" would be exactly the inference-from-one-auth-path
+this spec spends §1.1 warning against, and it would contradict §5's own policy in the same document. So:
+
+* **Supported and verified:** `oauth-personal` with a project. That is the configuration hosting is
+  specced against, and the only one for which a requirement is claimed.
+* **Not verified:** `gemini-api-key`, `vertex-ai`, `gateway`. Capturing their variables (§4.1) makes them
+  *possible* without asserting they work; a positive acceptance case per configuration is follow-up, and
+  the README says which one was verified rather than implying all four.
+* Everywhere the absence of the project variable is surfaced (§4.3, §5), the wording is **conditional**.
+
+### 4.1 Mechanism: extend `ServiceEnvironment.Keys`
+
+`ServiceEnvironment` already exists for precisely this — an allowlist captured from the installing shell
+and baked into the launchd/systemd unit, because *"supervised jobs don't inherit the interactive shell
+PATH"*. `Build(profileName, source, isWindows)` is **pure**, which is what makes §7's tests possible
+without touching a real service.
+
+**Capture** — configuration and paths, safe in a file on disk (reference counts are occurrences in
+Gemini's own bundle, i.e. evidence the CLI actually reads them):
+
+| Variable | Refs | Why |
+|---|---|---|
+| `GOOGLE_CLOUD_PROJECT` | 108 | the one whose absence caused §1.1 |
+| `GOOGLE_APPLICATION_CREDENTIALS` | 57 | ADC — a **path to** a credential, not the credential |
+| `GOOGLE_CLOUD_LOCATION` | 39 | Vertex region |
+| `GOOGLE_GENAI_USE_VERTEXAI` | 30 | selects the Vertex backend |
+| `GOOGLE_GENAI_USE_GCA` | 24 | selects Gemini Code Assist |
+| `GOOGLE_CLOUD_PROJECT_ID` | 18 | alternate spelling the CLI also honours |
+| `GOOGLE_GEMINI_BASE_URL` | 30 | endpoint override (enterprise/proxy) |
+| `GOOGLE_VERTEX_BASE_URL` | 21 | endpoint override (enterprise/proxy) |
+
+**Never capture:** `GOOGLE_API_KEY` (36 refs) and `GOOGLE_CREDENTIALS` (12). These are secrets and the
+unit is a file on disk. That split is the principle already encoded by `KCAP_COPILOT_TOKEN_CMD`: a
+*command that prints* a token is safe to persist; the token is not. A deployment that genuinely needs
+`GOOGLE_API_KEY` for an unattended reviewer belongs in AI-1413's broker discussion, not in the plist.
+
+**The Vertex variables are captured even though the measured setup did not need them.** The operator's
+explicit direction: assume the Vertex path is needed rather than force a second round-trip when it turns
+out to be. They are inert when unset — `Build` only copies keys present in the source.
+
+### 4.2 Serialisation safety — validate the value, do not trust its name
+
+An earlier draft argued these eight are safe on Windows because *of what the values are*: project ids and
+regions are `[a-z0-9-]`, the flags are booleans, the base URLs are URLs, a Windows path cannot contain a
+quote. **That argument is withdrawn.** `Build` copies whatever string the environment holds; nothing
+validates that a variable named `GOOGLE_CLOUD_PROJECT` contains a project id. A semantic label is not
+validation, and the one serialiser that cannot take arbitrary input is the one that matters:
+
+`WindowsTaskUnit` emits a `.cmd` wrapper of `set "K=V"` escaped by `ServiceText.CmdValue`, which escapes
+**only** `%`. An embedded `"` terminates the quoted assignment, after which `&`, `|`, `<`, `>` and `^`
+are live batch metacharacters in a file the service executes — i.e. **arbitrary command execution in the
+daemon's own startup wrapper**. That is why `KCAP_COPILOT_TOKEN_CMD` is Windows-excluded, and the reason
+generalises rather than being specific to that variable.
+
+**Decision: enforce it in code, at capture.** `ServiceEnvironment.Build` gains a per-platform
+representability check and **drops** (never silently mangles) a value the target serialiser cannot carry,
+recording the drop so `kcap status` can surface it. Preferring a drop to a throw keeps a hostile or
+merely odd value from bricking `service install` outright, and preferring either to a raw write keeps a
+malformed value from becoming an execution vector.
+
+The three targets, stated as what they can carry rather than as "safe":
+
+| Writer | Escaping | Can carry |
+|---|---|---|
+| launchd (`LaunchdUnit` → `ServiceText.Xml`) | XML entity escaping | any value XML 1.0 permits — **not** raw control characters |
+| systemd (`ServiceText.SystemdValue`) | CR/LF → space | anything else; note this **rewrites** rather than rejects |
+| Windows (`WindowsTaskUnit` → `ServiceText.CmdValue`) | `%` → `%%` only | values containing no `"` and no CR/LF |
+
+**This is a pre-existing hole that these eight variables widen, not one they create** — `PATH` and
+`KCAP_URL` go through the same writers today. Fixing `CmdValue` properly is the better long-term answer
+and is out of scope here; the check keeps this issue from making the exposure worse, and §7 requires
+adversarial tests against the **actual writers**, not only against `Build`.
+
+**Secondly, one of these is not merely a config string.** `GOOGLE_GEMINI_BASE_URL` and
+`GOOGLE_VERTEX_BASE_URL` are URLs, and a URL can carry userinfo or a query-string token. "It is a URL"
+therefore does not make it non-secret. See §4.2a.
+
+### 4.2a Disclosure: what the unit file actually exposes
+
+The earlier draft called the unit "world-readable-ish" and left the threat model unstated. **Measured
+instead:** `ServiceFiles` writes units with `UnixFileMode.UserRead | UnixFileMode.UserWrite` — **0600,
+owner-only** — re-applying the mode explicitly because umask does not apply to a chmod, and it *refuses*
+to write into a directory that is group- or other-writable.
+
+That materially bounds the question. The reader of the unit is the same local user who owns the
+credential file it points at, so:
+
+* **`GOOGLE_APPLICATION_CREDENTIALS`** — persisting the path discloses the credential's location to a
+  principal that can already read the credential itself. Accepted, and now on the stated grounds of
+  measured permissions rather than an analogy to `PATH`.
+* **The two base URLs** — accepted with the same reasoning, but flagged in the README: if a deployment
+  puts a token in the URL, that token lands in a 0600 file on disk. An operator who considers that
+  unacceptable should unset the variable before `service install`.
+* **`GOOGLE_API_KEY` / `GOOGLE_CREDENTIALS`** remain excluded regardless. The 0600 mode is a bound on the
+  blast radius, not a licence to persist secrets that have a non-persistent alternative — the same
+  principle as `KCAP_COPILOT_TOKEN_CMD`, where a *command that prints* a token is persisted and the token
+  is not.
+
+### 4.3 Install-time capture is a footgun, and must be surfaced
+
+The values are read from the installing shell, so an operator who exports `GOOGLE_CLOUD_PROJECT` *after*
+`kcap daemon service install` gets a unit without it — which is exactly what happened. Capturing more
+variables makes this worse, not better, because the failure stays silent until a launch fails with §1.1's
+misattributed message.
+
+`StatusCommand` already reports per-vendor hook state and therefore already knows whether Gemini is
+present. It gains one warning line, on this condition only:
+
+> Gemini is installed **and** the daemon service is installed **and** its unit carries no
+> `GOOGLE_CLOUD_PROJECT`
+
+> ⚠ Gemini detected, but the daemon environment has no `GOOGLE_CLOUD_PROJECT`. If your Gemini login
+> needs a project (the Code Assist / `oauth-personal` path does), hosted Gemini agents will fail — and
+> the error Gemini reports names the wrong cause. Set it where the daemon can see it, then re-run
+> `kcap daemon service install`.
+
+**Conditional, per §4**: the variable is required on the one auth path measured, and the warning says so
+rather than asserting it universally. An API-key deployment that legitimately needs no project should not
+be told its setup is broken.
+
+Deliberately narrow in two more ways. It reads the **installed unit**, not the current process
+environment — the current process is an interactive shell, which is the one place the variable being set
+proves nothing. And it does not warn when no service is installed, because there is nothing to be wrong
+yet. §7.5 tests both, because "reads the unit" is the whole point and is invisible from the output.
+
+## 5. The launch-failure diagnostic — a possibility, never a verdict
+
+When a hosted agent fails to launch and the failure could plausibly be auth or project configuration,
+kcap must:
+
+1. **Show the vendor's actual error verbatim** — never swallowed, never paraphrased.
+2. **Suggest, not assert**, that it may be authentication not captured at setup time, or missing project
+   configuration.
+3. **Say concretely how to resolve it**: confirm the CLI is logged in; ensure `GOOGLE_CLOUD_PROJECT` (and
+   the Vertex variables, if used) are set **where the daemon can see them** — the service unit, not
+   `.zshrc` — then re-run `kcap daemon service install` and restart the daemon.
+4. **Never claim certainty.** The failure may be entirely unrelated.
+
+**Point 4 is the requirement, not politeness.** §1.1 is a live example of the alternative: a definitive
+message naming the wrong cause sent this investigation down two wrong paths. A hint that says "this could
+be X, here is how to check" is strictly better than a confident claim that is sometimes false.
+
+### 5.0 Make it structured, or the requirement is untestable
+
+"The text does not claim the cause" cannot be proven about arbitrary prose by grepping for forbidden
+words — a reviewer was right to call that unfalsifiable, and a word-list would rot into a string-match
+that passes while the copy drifts.
+
+So the hedging is moved out of the prose and into the shape:
+
+* The runtime attaches a **structured** hint — a `possible_auth_or_project_configuration` kind plus the
+  vendor's verbatim error as a separate field — rather than a pre-composed sentence.
+* The conditional rendering of that kind is **one fixed string**, owned in one place and **golden-tested**.
+  Changing it is then a deliberate edit to a pinned expectation, not an accident.
+* The verbatim error is never interpolated into the hint sentence, so no amount of copy editing can make
+  the hint appear to be *about* a cause it merely accompanies.
+
+**Trigger policy, stated rather than implied.** §5 says "when the failure could plausibly be auth or
+project configuration"; the seam in fact fires on **every** non-version handshake exception. Those are
+different rules and the spec has to pick one. It picks the existing behaviour — **attach on every
+handshake/`session/new` failure** — because the alternative requires pattern-matching vendor error text
+to decide plausibility, and §1.1 is the case study in why that inference is unreliable. The honesty
+requirement is then carried entirely by the wording ("if this is an auth/subscription issue…"), which is
+exactly what makes a *possibility* the right register: it is attached to failures that are often
+something else, and it must read that way.
+
+### 5.1 The seam already exists and already covers the right failure
+
+`AcpHostedAgentRuntime.DiagnosticAuthHint` is vendor-branched today (Cursor names `cursor-agent login`;
+Copilot names `copilot login`; Kiro deliberately names no command, because none was ever observed). Gemini
+gets an arm covering login **and** project/Vertex configuration.
+
+**Checked, because the issue flagged it as an open question:** the hint fires from a `catch` whose `try`
+spans **both** `initialize` and `session/new`. A missing project surfaces at `session/new` (`-32000`,
+after a successful `initialize`), so it is already covered. No restructuring needed — but the test in §7
+pins it, because "already covered" is exactly the kind of claim that quietly stops being true.
+
+`DiagnosticBinary` needs no Gemini branch: the vendor key and the binary name are both `gemini`, so the
+generic fallback is already correct. Cursor and Kiro need branches only because their keys differ from
+their binaries.
+
+## 6. Documentation
+
+README's daemon-environment section already documents `KCAP_*_PATH`. It gains a Gemini entry covering:
+the login assumption (§1.2); the project and Vertex variables and that they must reach the **daemon**
+rather than an interactive shell (§4); the re-run-setup footgun (§4.3); and the fact that a hosted Gemini
+session currently reports an unpriceable model (§3.6).
+
+## 7. Test plan
+
+Per the project's per-vendor convention, and mirroring what AI-1404 shipped.
+
+1. **Descriptor** — `AcpVendorDescriptorTests`: vendor key, argv (including `--skip-trust`),
+   `SupportsUnattended: false`, `SupportsMcpServers: false`, `ModelSelector` is the no-op,
+   `CanSelectModel` is false.
+2. **Orchestrator** — `AgentOrchestratorVendorTests`: gemini routes to the ACP runtime factory; an
+   explicitly requested **reviewer** model is rejected rather than silently dropped; and — the case the
+   first draft missed — an explicitly requested **hosted** model does not reach a live selector and be
+   silently ignored. Those are different `ModelSelectionLaunchPolicy` dispositions and only one of them
+   was covered.
+3. **Availability** — a **hermetic** test: a stub PATH resolver, not the developer's machine. Assert that
+   the shipped `DaemonConfig.GeminiPath` default is what gets probed, so a wrong default fails here. This
+   is the test that would have caught the Kiro `kiro`→`kiro-cli` defect, where a wrong default meant the
+   vendor was silently never advertised. Phrasing it as "resolves on a correct install" would make it
+   environment-dependent and therefore worthless in CI.
+4. **Environment capture** — `ServiceEnvironmentTests` against the pure `Build(profile, source,
+   isWindows)`, asserting **both directions**:
+   * every variable in §4.1's capture table is carried through when present in the source;
+   * `GOOGLE_API_KEY` and `GOOGLE_CREDENTIALS` are **not**, on any platform;
+   * absent variables produce no empty entries;
+   * §4.2's representability check drops an unrepresentable value on the platform that cannot carry it,
+     and keeps it on the platforms that can.
+
+   Both directions matter. A test that only asserts the captures would stay green if someone widened the
+   allowlist to `GOOGLE_*`, which is the one change that must never pass.
+4a. **Serialiser adversarial tests — against the actual writers**, not only `Build`. `LaunchdUnit`,
+   `SystemdUnit` and `WindowsTaskUnit` each fed values containing `"`, `%`, `&`, `|`, `<`, `>`, `^`,
+   CR/LF, and a non-ASCII character; assert the emitted unit is well-formed and that no value can escape
+   its assignment into an executable position. §4.2's whole argument is about these writers, and testing
+   `Build` alone would leave it unexercised.
+5. **Status warning** — the §4.3 condition is a pure predicate over (gemini installed, service installed,
+   unit environment) and is tested as one, plus a boundary test that `StatusCommand` reads the **installed
+   unit** rather than the current process environment (set the variable in the process and *not* in the
+   unit: the warning must still appear). Negative cases: no service installed → no warning; variable
+   present in the unit → no warning; present-but-empty and malformed → treated as absent, not as set.
+5a. **Pricing** — given Gemini's measured `session/new` response, assert the reported model id and that
+   the resulting cost state is an explicit *unavailable*, and that no surface renders it as `0`/free
+   (§3.6). This pins the accepted behaviour rather than the mechanism.
+6. **Diagnostic** — the structured hint (§5.0) carries the `possible_auth_or_project_configuration` kind;
+   the rendered copy matches a **golden string**; the vendor's error survives **verbatim** — including
+   distinctive punctuation and newlines — and stays in its own field rather than being interpolated into
+   the hint; and the hint is reached from a `session/new` failure, not only an `initialize` failure. Also
+   drive an obviously *unrelated* `session/new` failure and assert the hint still reads as a possibility
+   rather than a diagnosis. Golden-testing the copy is what makes §5's honesty requirement falsifiable
+   instead of a word-list that rots.
+7. **MCP boundary** — assert that with `SupportsMcpServers: false` the `session/new` payload **omits**
+   `mcpServers` at the protocol boundary. A descriptor-field assertion does not prove the factory honours
+   it (§3.4 quotes the one line that does).
+8. **README (§6)** — no automated test; an explicit acceptance checklist on the PR, itemising each
+   required point. The definition of done says "no requirement without a test", and documentation is the
+   one place that cannot be honoured literally — so it is honoured visibly instead of quietly skipped.
+9. **No live cert here.** Model receipt is AI-1463's cert; this issue's live evidence is the §2 probe,
+   which is recorded rather than automated. A hosted-launch smoke test belongs with AI-1413, where a
+   reviewer runs unattended end to end.
+10. **The §3.1 trust probe is a gating deliverable, not a test.** Its output is either a clamp or a
+   documented accepted risk; the PR cannot land with the question open.
+
+**Every guard assertion must be mutation-proven.** The standard from AI-1404 and AI-1463: deleting the
+guard must fail exactly the intended test, and nothing else. Both of those issues shipped, or nearly
+shipped, a guard test that passed with the guard removed.
+
+## 8. What this issue does NOT do
+
+* **AI-1413 (Gemini unattended reviewer)** — containment, the sandbox credential question, `--approval-mode`,
+  and the MCP clamp. Distinct issue, distinct epic.
+* **AI-1612 (reported-vs-running model)** — §3.6 records the sentinel; fixing the reporting is that issue.
+* **The MCP stdio flip** — §3.4 states the evidence required; the probe is follow-up work.
+* **A credential broker** — §1.2. Hosting assumes the operator logged their CLI in.

--- a/docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md
@@ -1,8 +1,10 @@
 # AI-899 — Gemini CLI as an ACP hosted agent
 
-**Status:** rev 5, 2026-07-31, against `gemini 0.53.0` and `origin/main` (`e2b2821`).
-**Implementation-ready.** §3.1a's gating trust probe has been run, re-run on the correct code path, and its
-finding is contained by a flag already in the descriptor.
+**Status:** rev 6, 2026-07-31, against `gemini 0.53.0` and `origin/main` (`e2b2821`).
+**Implemented.** §3.1a's gating trust probe has been run, re-run on the correct code path, and its finding is
+contained. Rev 6 records what eight rounds of code review changed after rev 5 shipped: §3.1d (a fixed
+deny-all MCP name is attacker-matchable) and §4.2b (the serialisation section's scope was too small, in two
+distinct ways). Both were real defects in rev 5's design, not just its prose.
 **Repository:** kurrent-io/kcap-cli
 **Parent:** AI-1399 (multi-vendor ACP hosted agents)
 **Template:** the shipped Kiro child (AI-1404) and the Copilot child (AI-1403). Read those, not the
@@ -86,9 +88,10 @@ public static readonly AcpVendorDescriptor Gemini = new(
     ResolveBinaryPath:   cfg => cfg.GeminiPath,
     ResolveDefaultModel: _ => null,
     Argv:                ["--experimental-acp", "--skip-trust",
-                          // §3.1c — clamps repo-authored MCP servers. A single non-matching
-                          // name is correct WHILE SupportsMcpServers is false; see §3.1c.
-                          "--allowed-mcp-server-names", "kcap-none"],
+                          // §3.1c/§3.1d — clamps repo-authored MCP servers. The PLACEHOLDER is
+                          // substituted per launch with an unguessable name; a fixed one was
+                          // measured attacker-matchable.
+                          "--allowed-mcp-server-names", UnmatchableMcpNamePlaceholder],
     UnattendedTrustArgv: [],
     SupportsUnattended:  false,
     ModelSelector:       NoOpModelSelector.Instance,
@@ -240,6 +243,7 @@ Resolved:
 * **While `SupportsMcpServers: false`** (now): there are no injected servers, so a single **non-matching**
   name is exactly right. It permits nothing, which blocks the repo-authored server and costs us nothing.
   Measured working — `--allowed-mcp-server-names __kcap_none__` clamped the repo server without crashing.
+  **But the name must be unguessable, not merely unusual — see §3.1d.**
 * **When §3.4's call-level probe flips the flag to true**: the allowlist must become the injected server
   names in the same change, or hosted Gemini ships with MCP silently broken. That coupling is the reason
   this subsection exists rather than a comment.
@@ -247,6 +251,43 @@ Resolved:
 
 The test in §7.7 asserts the coupling, not just the flag: allowlist contents and `SupportsMcpServers` must
 agree, so flipping one without the other fails.
+
+### 3.1d A FIXED deny-all name is attacker-matchable — the name must be generated per launch
+
+Rev 5 shipped the literal `kcap-none` with a comment calling it "a name no MCP server will ever have."
+Nothing enforced that, and the comment was the only thing standing between the clamp and a bypass.
+
+**Measured:** a repository whose MCP configuration names its server `kcap-none` **executes**. The allowlist
+is a name match, so an attacker who can read this source — it is a public repository — can satisfy it by
+choosing the same name. A repo-authored server running under the daemon user is remote code execution, which
+is exactly what §3.1's clamping rule exists to prevent.
+
+The uncomfortable part: this collision class was predicted in writing on a *different* issue during this same
+work, and then shipped here anyway. A guard whose safety rests on an adversary not choosing a particular
+string is not a guard, and "no one would name it that" is the same shape of reasoning as §4.2's withdrawn
+"the values are safe because of what they usually contain."
+
+**Fix.** The descriptor carries a *placeholder*, and `AcpHostedAgentRuntimeFactory` substitutes an
+unguessable name at each launch:
+
+```csharp
+internal const string UnmatchableMcpNamePlaceholder = "__kcap_unmatchable_mcp_name__";
+
+static List<string> SubstituteUnmatchableNames(List<string> argv) {
+    for (var i = 0; i < argv.Count; i++)
+        if (argv[i] == UnmatchableMcpNamePlaceholder)
+            argv[i] = $"kcap-deny-{Guid.NewGuid():N}";
+
+    return argv;
+}
+```
+
+Per launch, not per process: two agents launched from the same daemon get different names, so nothing
+observable in one run helps the next.
+
+**Verified against the worst case:** a repository naming its server *the placeholder itself* is blocked
+(the placeholder never reaches the command line), and an ACP-injected server still loads — so the clamp is
+proven in both directions rather than only the negative one.
 
 ### 3.2 `SupportsUnattended: false` — hosting only, for now
 
@@ -475,6 +516,69 @@ unit is incomplete.
 Establishing and enforcing a Windows ACL is a better answer and is deliberately not attempted here: it is
 service-installer work touching all vendors, and guessing at it would be the third overreach in one
 section.
+
+### 4.2b What review found after this section shipped — the table above was still too small
+
+§4.2's decision was right in shape and wrong in scope, and five review rounds took it apart. Recording the
+outcome here because the *pattern* is the reusable part, not the individual escapes.
+
+**The scope error.** §4.2 reasoned about environment *values*, one writer at a time. But each writer
+interpolates several values into the same line or file, and in every one of them some were treated and their
+neighbours were not:
+
+| sink | guarded when §4.2 shipped | unguarded neighbour on the same line/file |
+|---|---|---|
+| Windows `.cmd` exec line | the binary path | the log path, every `ExtraArgs` token |
+| Windows `set "K=V"` line | the value | the **key** (a quote in a key closes the assignment identically) |
+| systemd `Environment=` | the value | the key (a key can inject an `ExecStartPre=` that runs on every restart) |
+| systemd `ExecStart=` | nothing | the binary path, the log path, every argument |
+| launchd plist | environment values | the label, `ProgramArguments`, `StandardOut/ErrorPath` |
+| Task Scheduler XML | nothing | the wrapper path, the service id |
+
+Every one of those was found by asking the same question the table above should have asked: *not* "is this
+value safe?" but "does every value interpolated into this artifact pass the same guard?" Each sink now has
+one guard-then-escape (or guard-then-quote) helper that all of its interpolations go through, so the
+invariant holds for the next value added rather than for the ones that happened to be audited.
+
+**The second error: escaping what a format expands, without checking what else it expands.** `CmdValue`
+doubles `%` — correct, and it made me stop looking. Each format turned out to run *more* than one expansion
+pass, and quoting alone was not a boundary in either:
+
+* **cmd** — `& | < > ( ) ^` are metacharacters *outside* quotes, so quote-when-it-has-a-space left
+  `8&calc.exe` bare in a file the OS executes at every logon. Now every exec-line value is quoted
+  unconditionally. `!NAME!` delayed expansion works *inside* quotes and can be enabled machine-wide by
+  registry, so the execution **mode** is now part of the artifact (`setlocal DisableDelayedExpansion` plus
+  `/v:off` on the action) rather than an assumption about the host. And `cmd /c "<path>"` relied on cmd's
+  conditional quote-stripping, which a path containing `&` defeats — now the nested-quote `/d /s /v:off /c
+  ""<path>""` form.
+* **systemd** — expands `%` specifiers *and* `$NAME`/`${NAME}` variables in `ExecStart=`, so a path under
+  `/home/50%off` or one containing `${HOME}` was rewritten in the *executable* position. Both are doubled
+  now and reversed by `BinaryFromUnit`. `$` is deliberately **not** doubled in `Environment=`, where systemd
+  expands specifiers but not variables — same character, adjacent sinks, different correct treatment. The
+  apostrophe is as structural to systemd's word lexer as the double quote and was missing from `NeedsQuote`.
+
+**The same-character-two-sinks rule.** `%` is the clearest case: the wrapper *body* is a batch file, so
+`%%` is correct there; the Task XML `Arguments` is a *command line*, where `%%` does not exist as an escape,
+so a `%` in the wrapper path is **refused**. A per-character policy would have got one of the two wrong.
+
+**Escape only where the escape is verifiable; otherwise refuse.** Nothing in CI or on the development
+machines can exercise a real systemd or a real cmd parser. So where the documented escape is unambiguous
+(`%%`, `$$`, `/s` nested quotes, `/v:off`) it is implemented and the tests assert the rendered text plus the
+round-trip; where it is not (systemd's `\;` for a literal semicolon), the input is **refused** instead — a
+refusal cannot be subtly wrong, and no legitimate daemon argument is a lone semicolon. The same reasoning
+refuses all C0/DEL control characters at both systemd sinks rather than emitting C-style escapes.
+
+**A silent rewrite is worse than a refusal.** §4.2 left `SystemdValue`'s CR/LF→space normalisation in place
+as "corrupts rather than executes". That is now refused too: a service running with a value nobody chose is
+harder to diagnose than an install that failed and named the variable.
+
+**The XML predicate was not the XML predicate.** `char.IsControl` differs from XML 1.0 in both directions —
+it accepts U+FFFE/U+FFFF and lone surrogates (which no encoder can represent) and rejects U+007F–U+009F
+(which XML 1.0 permits). `XmlConvert.IsXmlChar` plus surrogate-pair awareness replaced it, so an emoji in a
+path is accepted and a malformed surrogate is not.
+
+Every guard above is mutation-tested: 27 mutants, each restored from git and verified by *content* rather
+than by `git diff` — a diff can hide a bad restore through alignment, which happened once during this work.
 
 ### 4.3 Install-time capture is a footgun, and must be surfaced
 

--- a/docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md
@@ -67,8 +67,9 @@ is a property of the sandbox, not of hosting, and it belongs to AI-1413.
 | `availableModes` | `default`, `autoEdit`, `yolo`, `plan` (native read-only) |
 
 Contrast with Kiro, where it matters: `embeddedContext` is **true** (Kiro `false`), so AI-1407's prompt
-folding needs no plain-text workaround here; `authMethods` is non-empty (Kiro `[]`), which is what gives
-AI-1413 a credential story at all.
+folding needs no plain-text workaround here; and `authMethods` is non-empty (Kiro `[]`), which is a
+*starting point* for AI-1413's credential question rather than an answer to it — none of the four is shown
+to work with a redirected `HOME`, to be suppliable non-interactively, or to fit the sandbox.
 
 `DaemonConfig.GeminiPath = "gemini"` is **already correct** — the binary really is `gemini`. No repeat of
 the Kiro `kiro`→`kiro-cli` trap, where a wrong default meant the vendor was never advertised on a correct
@@ -115,20 +116,34 @@ created the worktree itself. **That was an inference, not a measurement, and it 
 implementation must, before the descriptor ships:
 
 1. **Probe which workspace-controlled facilities load under `--skip-trust`** — at minimum repo-local
-   Gemini settings, MCP definitions, and any hook/extension mechanism.
-2. **Then either clamp them, or state the accepted risk explicitly in the README**, with the reasoning
-   visible to an operator deciding whether to enable hosted Gemini on untrusted branches.
+   Gemini settings, MCP server definitions, and any hook or extension mechanism. Record what loaded.
+2. **Then apply this rule**, so the disposition is decided here and not by whoever implements it:
 
-This is a gating item, not a follow-up: the flag is required for the feature to work at all, so the
-question cannot be deferred past the thing that needs it. It is also a question every ACP vendor with a
+   > **Any repository-controlled facility that can cause process execution, before an explicit
+   > user-approved action, MUST be clamped.** A facility that only changes non-executable settings MAY be
+   > documented instead.
+
+   "Clamped" means suppressed at launch by argument or configuration — the same shape as Copilot's
+   `--disable-builtin-mcps` and Cursor's `--approve-mcps` handling. If a facility can execute and cannot
+   be clamped, hosted Gemini does not ship until it can: documentation is not containment, and a
+   repo-authored MCP server or hook auto-starting under the daemon user is remote code execution with
+   extra steps.
+3. **The probe evidence and the chosen disposition are reviewed before the descriptor is enabled**, as
+   part of this PR rather than a follow-up.
+
+This is gating, not follow-up: the flag is required for the feature to work at all, so the question cannot
+be deferred past the thing that needs it. **If the probe is not run, this spec is not implementation-ready**
+— the result can change both the argv and the threat model. It is also a question every ACP vendor with a
 trust model will face, so the answer is worth writing down once.
 
 ### 3.2 `SupportsUnattended: false` — hosting only, for now
 
 Unattended review is AI-1413. Withholding it here follows the Kiro precedent, and for the same structural
 reason: the containment story has to be settled on its own issue rather than inherited by default.
-`UnattendedTrustArgv` is therefore empty; when AI-1413 lands it will need `--approval-mode yolo` (or
-`plan`, see §3.5) plus whatever MCP clamp the review flow requires.
+`UnattendedTrustArgv` is therefore empty; AI-1413 will have to decide an approval posture and an MCP
+clamp. This spec deliberately does not name the flags: ACP's measured `availableModes` says what the
+*protocol* offers, not what the CLI's `--approval-mode` accepts or contains, and guessing would hand
+AI-1413 a prescription dressed as a finding.
 
 ### 3.3 `NoOpModelSelector` — the write half is unverified and fails silently
 
@@ -188,15 +203,26 @@ is: the reported id is a placeholder-shaped id that **either** hits the sentinel
 **or** misses every pricing entry and does not price — and in both cases a hosted Gemini session shows no
 cost, but by different mechanisms with different fixes.
 
-§7.5a therefore **pins the actual outcome with a test** rather than asserting the mechanism: given
-Gemini's measured `session/new` response, assert the reported model id and assert the resulting state is
-an explicit *cost unavailable*. And it asserts the surface does **not** render that as `0` or "free" —
-a silent zero is worse than a blank, because it reads as a measurement.
+**And "either way it does not price" is still a claim beyond the evidence** — the second draft's
+disjunction was not exhaustive. If `auto-gemini-2.5` misses the sentinel it does not follow that it misses
+every pricing entry; it could match one directly or after normalisation, in which case a hosted Gemini
+session would price, possibly at the wrong model's rate. Three outcomes, not two.
 
-This is accepted rather than fixed here, and the acceptance is real: with §3.3 withholding model
-selection, there is no path to a priced hosted Gemini session inside this issue. It interacts with
-AI-1612 (reported-vs-running model). What this spec owes is that the behaviour is known, tested, and
-visibly absent rather than discovered later as a cost-report gap.
+**So the pricing result is UNKNOWN until measured, and §7.5a is a gating characterisation test rather than
+a confirmation of a preferred answer.** It asserts the reported model id, then records what pricing
+actually does with it. The acceptance criterion follows the observation:
+
+| Observed | Then |
+|---|---|
+| explicit *cost unavailable* | accept; README says a hosted Gemini session shows no cost |
+| a price at a **concrete** model's rate | **escalate** — reporting a cost for a model the session may not be running is worse than reporting none, and belongs to AI-1612 before this ships |
+| rendered as `0` or "free" | **defect**, fix here — a silent zero reads as a measurement rather than an absence |
+
+Whichever it is, the README states the measured behaviour. What this spec must not do is write down the
+answer it expects and then test for it; that is how §1.1 happened.
+
+The interaction with §3.3 is real either way: with model selection withheld, there is no path to a
+deliberately-priced hosted Gemini session inside this issue.
 
 ## 4. The daemon environment — the operational requirement
 
@@ -251,38 +277,50 @@ unit is a file on disk. That split is the principle already encoded by `KCAP_COP
 explicit direction: assume the Vertex path is needed rather than force a second round-trip when it turns
 out to be. They are inert when unset — `Build` only copies keys present in the source.
 
-### 4.2 Serialisation safety — validate the value, do not trust its name
+### 4.2 Serialisation safety — enforce at the sink, because the source is not a boundary
 
-An earlier draft argued these eight are safe on Windows because *of what the values are*: project ids and
-regions are `[a-z0-9-]`, the flags are booleans, the base URLs are URLs, a Windows path cannot contain a
-quote. **That argument is withdrawn.** `Build` copies whatever string the environment holds; nothing
-validates that a variable named `GOOGLE_CLOUD_PROJECT` contains a project id. A semantic label is not
-validation, and the one serialiser that cannot take arbitrary input is the one that matters:
+Two drafts got this wrong in two different ways, and reading the code made the answer smaller than either.
 
-`WindowsTaskUnit` emits a `.cmd` wrapper of `set "K=V"` escaped by `ServiceText.CmdValue`, which escapes
-**only** `%`. An embedded `"` terminates the quoted assignment, after which `&`, `|`, `<`, `>` and `^`
-are live batch metacharacters in a file the service executes — i.e. **arbitrary command execution in the
-daemon's own startup wrapper**. That is why `KCAP_COPILOT_TOKEN_CMD` is Windows-excluded, and the reason
-generalises rather than being specific to that variable.
+**Draft 1 argued the values are safe because of what they usually contain** — project ids and regions are
+`[a-z0-9-]`, the flags are booleans, a Windows path cannot contain a quote. Withdrawn: `Build` copies
+whatever string the environment holds, and nothing validates that a variable *named*
+`GOOGLE_CLOUD_PROJECT` contains a project id. A semantic label is not validation.
 
-**Decision: enforce it in code, at capture.** `ServiceEnvironment.Build` gains a per-platform
-representability check and **drops** (never silently mangles) a value the target serialiser cannot carry,
-recording the drop so `kcap status` can surface it. Preferring a drop to a throw keeps a hostile or
-merely odd value from bricking `service install` outright, and preferring either to a raw write keeps a
-malformed value from becoming an execution vector.
+**Draft 2 moved the check into `ServiceEnvironment.Build`** and had it drop unrepresentable values.
+Withdrawn too, and this one is disproved rather than merely doubted: `DaemonCommands` builds the service
+environment as `new Dictionary<string,string>(ServiceEnvironment.Capture(profileName)) { ["KCAP_DAEMON_SUPERVISED"] = id }`
+— it **adds an entry after `Capture` returns**. So a value already reaches the writers today without
+passing through `Build`. A check there is not a boundary; it is a courtesy at one of several doors.
 
-The three targets, stated as what they can carry rather than as "safe":
+**What the writers actually do** (read, not inferred — the earlier table was wrong about systemd):
 
-| Writer | Escaping | Can carry |
+| Writer | Handling | Consequence of a hostile value |
 |---|---|---|
-| launchd (`LaunchdUnit` → `ServiceText.Xml`) | XML entity escaping | any value XML 1.0 permits — **not** raw control characters |
-| systemd (`ServiceText.SystemdValue`) | CR/LF → space | anything else; note this **rewrites** rather than rejects |
-| Windows (`WindowsTaskUnit` → `ServiceText.CmdValue`) | `%` → `%%` only | values containing no `"` and no CR/LF |
+| launchd (`LaunchdUnit` → `ServiceText.Xml`) | XML entity escaping | contained; raw control characters are not XML 1.0-legal |
+| systemd (`SystemdUnit.EnvAssignment`) | quotes the whole `KEY=VALUE` when needed, escapes `\` and `"`; `ServiceText.SystemdValue` rewrites CR/LF → space | contained, **but the CR/LF rewrite silently corrupts** a path or URL |
+| Windows (`WindowsTaskUnit` → `ServiceText.CmdValue`) | `%` → `%%`, nothing else | **arbitrary command execution.** An embedded `"` closes the `set "K=V"` assignment, after which `&`, `|`, `<`, `>`, `^` are live batch metacharacters in a file the service runs |
 
-**This is a pre-existing hole that these eight variables widen, not one they create** — `PATH` and
-`KCAP_URL` go through the same writers today. Fixing `CmdValue` properly is the better long-term answer
-and is out of scope here; the check keeps this issue from making the exposure worse, and §7 requires
-adversarial tests against the **actual writers**, not only against `Build`.
+**Decision: the Windows writer validates its own input and refuses to emit a value it cannot represent
+— for every key, not just these eight.** `service install` then fails with the offending key named,
+rather than writing a file that could execute something. Three reasons this is the right shape:
+
+* It is a **boundary**: no caller can bypass it, including the `KCAP_DAEMON_SUPERVISED` path that already
+  bypasses `Build`.
+* It **closes the pre-existing hole** rather than merely not widening it. `PATH` and `KCAP_URL` go through
+  the same writer today with the same exposure, so scoping the fix to Gemini's variables would leave a
+  known execution vector live while congratulating itself.
+* It makes the drop-recording contract unnecessary. `service install` is interactive: failing there with
+  a named key is strictly better feedback than a silent drop plus a durable `(key, reason)` record that
+  a later `kcap status` has to surface. Draft 2 needed that machinery; this does not.
+
+Failing the install is acceptable because the trigger is a value that cannot be represented at all —
+never a legitimate project id, region, boolean or path. And `CmdValue` gaining a correct implementation
+later is a strict improvement that this check does not block.
+
+**The CR/LF rewrite is named, not fixed here.** systemd silently turning a newline into a space corrupts
+a value rather than executing anything, and `SystemdValue` is shared with `Description=`. So the
+representability check rejects CR/LF in an *environment value* on every platform (no legitimate value
+contains one), and the `Description` behaviour is left alone.
 
 **Secondly, one of these is not merely a config string.** `GOOGLE_GEMINI_BASE_URL` and
 `GOOGLE_VERTEX_BASE_URL` are URLs, and a URL can carry userinfo or a query-string token. "It is a URL"
@@ -290,24 +328,41 @@ therefore does not make it non-secret. See §4.2a.
 
 ### 4.2a Disclosure: what the unit file actually exposes
 
-The earlier draft called the unit "world-readable-ish" and left the threat model unstated. **Measured
-instead:** `ServiceFiles` writes units with `UnixFileMode.UserRead | UnixFileMode.UserWrite` — **0600,
-owner-only** — re-applying the mode explicitly because umask does not apply to a chmod, and it *refuses*
-to write into a directory that is group- or other-writable.
+The first draft called the unit "world-readable-ish" and left the threat model unstated. The second
+measured 0600 and generalised it to all platforms. **Both were wrong; here is what the code does.**
 
-That materially bounds the question. The reader of the unit is the same local user who owns the
-credential file it points at, so:
+`ServiceFiles` writes with `UnixCreateMode = UserRead | UserWrite` — **0600** — then re-checks the mode on
+the open handle (because `UnixCreateMode` is still filtered through the umask, so the request is not the
+result), and refuses to write into a group- or other-writable directory.
 
-* **`GOOGLE_APPLICATION_CREDENTIALS`** — persisting the path discloses the credential's location to a
-  principal that can already read the credential itself. Accepted, and now on the stated grounds of
-  measured permissions rather than an analogy to `PATH`.
-* **The two base URLs** — accepted with the same reasoning, but flagged in the README: if a deployment
-  puts a token in the URL, that token lands in a 0600 file on disk. An operator who considers that
-  unacceptable should unset the variable before `service install`.
-* **`GOOGLE_API_KEY` / `GOOGLE_CREDENTIALS`** remain excluded regardless. The 0600 mode is a bound on the
-  blast radius, not a licence to persist secrets that have a non-persistent alternative — the same
-  principle as `KCAP_COPILOT_TOKEN_CMD`, where a *command that prints* a token is persisted and the token
-  is not.
+**All of that is Unix-only.** Every permission path in `ServiceFiles` begins
+`if (OperatingSystem.IsWindows()) return;`, with the comment *"ACL-governed, inherited from the user
+profile"*. So on Windows the `.cmd` wrapper carries whatever the profile directory's inherited ACL grants
+— typically the user, SYSTEM and Administrators, and **not** verified here. The 0600 measurement answers
+nothing about Windows, and a spec that leans on it for all three platforms is asserting past its evidence
+for the second time in this section.
+
+**The principle, stated once so future additions do not get classified by variable name:** persist a value
+into a service unit only when (a) there is no non-persistent alternative, **and** (b) the platform gives
+an owner-only guarantee this code actually enforces.
+
+Applying it:
+
+| Value | Unix | Windows |
+|---|---|---|
+| `GOOGLE_CLOUD_PROJECT` / `_PROJECT_ID`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_GENAI_USE_GCA` | capture — not secret-capable | capture |
+| `GOOGLE_APPLICATION_CREDENTIALS` (a path), `GOOGLE_GEMINI_BASE_URL`, `GOOGLE_VERTEX_BASE_URL` (may carry userinfo or a query token) | capture — the reader of a 0600 unit is the user who owns the credential anyway | **exclude**, on (b) |
+| `GOOGLE_API_KEY`, `GOOGLE_CREDENTIALS` | **exclude** | **exclude** |
+
+The Windows exclusion follows the `KCAP_COPILOT_TOKEN_CMD` precedent exactly: a platform whose guarantee
+is unverified does not get the secret-capable values. Hosted Gemini stays functional there for the common
+case (a project-scoped login), and the README says which values Windows will not carry and why — so an
+operator who needs Vertex-with-ADC on Windows knows to set them another way rather than wondering why the
+unit is incomplete.
+
+Establishing and enforcing a Windows ACL is a better answer and is deliberately not attempted here: it is
+service-installer work touching all vendors, and guessing at it would be the third overreach in one
+section.
 
 ### 4.3 Install-time capture is a footgun, and must be surfaced
 
@@ -319,8 +374,14 @@ misattributed message.
 `StatusCommand` already reports per-vendor hook state and therefore already knows whether Gemini is
 present. It gains one warning line, on this condition only:
 
-> Gemini is installed **and** the daemon service is installed **and** its unit carries no
-> `GOOGLE_CLOUD_PROJECT`
+> Gemini is installed **and** the daemon service is installed **and** its unit carries **neither**
+> `GOOGLE_CLOUD_PROJECT` **nor** `GOOGLE_CLOUD_PROJECT_ID`
+
+**"Project configuration present" is the OR of those two, and that is the vendor's own definition**, not
+an inference from reference counts. Gemini's error text reads: *"The GOOGLE_CLOUD_PROJECT (or
+GOOGLE_CLOUD_PROJECT_ID) environment variable must be set…"*. §4.1 lists the alternate as honoured, so a
+predicate keyed on the first alone would diagnose a correctly configured unit as broken — a false positive
+the spec described and then walked into. §7.5 covers the alternate-only case explicitly.
 
 > ⚠ Gemini detected, but the daemon environment has no `GOOGLE_CLOUD_PROJECT`. If your Gemini login
 > needs a project (the Code Assist / `oauth-personal` path does), hosted Gemini agents will fail — and
@@ -364,9 +425,31 @@ So the hedging is moved out of the prose and into the shape:
 * The runtime attaches a **structured** hint — a `possible_auth_or_project_configuration` kind plus the
   vendor's verbatim error as a separate field — rather than a pre-composed sentence.
 * The conditional rendering of that kind is **one fixed string**, owned in one place and **golden-tested**.
-  Changing it is then a deliberate edit to a pinned expectation, not an accident.
 * The verbatim error is never interpolated into the hint sentence, so no amount of copy editing can make
   the hint appear to be *about* a cause it merely accompanies.
+
+**The approved rendering is part of this design, not the implementer's choice.** A golden test freezes
+whatever sentence gets written first; it does not make that sentence conditional. So the sentence is here,
+and the golden test pins *this*:
+
+> This **may** be an authentication or project-configuration problem, or it **may** be unrelated. If
+> hosted Gemini has not worked on this machine before: check `gemini` is logged in, and that
+> `GOOGLE_CLOUD_PROJECT` (or `GOOGLE_CLOUD_PROJECT_ID`) is set **where the daemon can see it** — the
+> service unit, not your shell profile — then re-run `kcap daemon service install` and restart the daemon.
+
+Every clause is deliberate. Two `may`s and an explicit "or it may be unrelated", because the failure often
+is. "If hosted Gemini has not worked on this machine before" scopes the advice to the case where it
+applies, instead of telling an operator whose setup was fine yesterday to go and reinstall a service.
+And it never restates the vendor's error, which sits in its own field.
+
+**Scope of the change, since this is bigger than the existing string seam.** `DiagnosticAuthHint` today
+returns a `string` interpolated into an `InvalidOperationException` message that
+`LaunchFailedAsync` forwards to the server. Introducing a structured kind therefore touches a wire shape
+consumed by an older server, so the implementation keeps the existing message field verbatim-compatible
+and carries the kind **additively** — an older consumer sees exactly today's text and ignores the new
+field. If that turns out not to be achievable additively, the fallback is to keep the string seam and
+golden-test the string alone; the honesty requirement is carried by the wording above either way, and it
+is not worth a protocol break.
 
 **Trigger policy, stated rather than implied.** §5 says "when the failure could plausibly be auth or
 project configuration"; the seam in fact fires on **every** non-version handshake exception. Those are
@@ -421,26 +504,35 @@ Per the project's per-vendor convention, and mirroring what AI-1404 shipped.
    * every variable in §4.1's capture table is carried through when present in the source;
    * `GOOGLE_API_KEY` and `GOOGLE_CREDENTIALS` are **not**, on any platform;
    * absent variables produce no empty entries;
-   * §4.2's representability check drops an unrepresentable value on the platform that cannot carry it,
-     and keeps it on the platforms that can.
+   * the §4.2a platform split holds: the secret-capable values (`GOOGLE_APPLICATION_CREDENTIALS` and
+     the two base URLs) are captured off-Windows and **excluded on Windows**.
 
    Both directions matter. A test that only asserts the captures would stay green if someone widened the
    allowlist to `GOOGLE_*`, which is the one change that must never pass.
-4a. **Serialiser adversarial tests — against the actual writers**, not only `Build`. `LaunchdUnit`,
-   `SystemdUnit` and `WindowsTaskUnit` each fed values containing `"`, `%`, `&`, `|`, `<`, `>`, `^`,
-   CR/LF, and a non-ASCII character; assert the emitted unit is well-formed and that no value can escape
-   its assignment into an executable position. §4.2's whole argument is about these writers, and testing
-   `Build` alone would leave it unexercised.
+4a. **Writer validation — tested at the writer, directly.** `LaunchdUnit`, `SystemdUnit` and
+   `WindowsTaskUnit` each fed values containing `"`, `%`, `&`, `|`, `<`, `>`, `^`, CR/LF and a non-ASCII
+   character, **called directly rather than through `Build`** — routing through `Build` would make it an
+   end-to-end pipeline test and would pass even if the writer were defenceless. Assert: launchd and systemd
+   contain the value; the Windows writer **rejects** what it cannot represent, so `service install` fails
+   with the key named; and no value reaches an executable position in the emitted `.cmd`. Include a value
+   arriving by the `KCAP_DAEMON_SUPERVISED` route, which bypasses `Build` in production today — that is
+   the case that proves the boundary is at the sink.
 5. **Status warning** — the §4.3 condition is a pure predicate over (gemini installed, service installed,
    unit environment) and is tested as one, plus a boundary test that `StatusCommand` reads the **installed
    unit** rather than the current process environment (set the variable in the process and *not* in the
-   unit: the warning must still appear). Negative cases: no service installed → no warning; variable
-   present in the unit → no warning; present-but-empty and malformed → treated as absent, not as set.
-5a. **Pricing** — given Gemini's measured `session/new` response, assert the reported model id and that
-   the resulting cost state is an explicit *unavailable*, and that no surface renders it as `0`/free
-   (§3.6). This pins the accepted behaviour rather than the mechanism.
+   unit: the warning must still appear). Negative cases: no service installed → no warning; either
+   `GOOGLE_CLOUD_PROJECT` **or** `GOOGLE_CLOUD_PROJECT_ID` present → no warning (the alternate-only case
+   is the false positive draft 2 would have shipped); present-but-empty and malformed → treated as absent,
+   not as set.
+5a. **Pricing — a characterisation test, gating.** Given Gemini's measured `session/new` response, assert
+   the reported model id and **record** what pricing does with it, then apply §3.6's outcome table: an
+   explicit *unavailable* is accepted, a price at a concrete model's rate escalates to AI-1612 before this
+   ships, and a rendered `0`/"free" is a defect fixed here. The test must not be written to expect one of
+   the three.
 6. **Diagnostic** — the structured hint (§5.0) carries the `possible_auth_or_project_configuration` kind;
-   the rendered copy matches a **golden string**; the vendor's error survives **verbatim** — including
+   the rendered copy matches the **golden string quoted in §5.0** (not whatever the implementer writes),
+   including both `may`s and the "or it may be unrelated" clause; an older-consumer shape still receives
+   today's message text verbatim; the vendor's error survives **verbatim** — including
    distinctive punctuation and newlines — and stays in its own field rather than being interpolated into
    the hint; and the hint is reached from a `session/new` failure, not only an `initialize` failure. Also
    drive an obviously *unrelated* `session/new` failure and assert the hint still reads as a possibility

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -264,4 +264,64 @@ internal static class AcpVendorDescriptors {
         ModelSelector:       NoOpModelSelector.Instance,
         SupportsMcpServers:  true
     );
+
+    /// <summary>
+    /// A name no MCP server will ever have, passed to Gemini's <c>--allowed-mcp-server-names</c> so the
+    /// allowlist permits nothing. See <see cref="Gemini"/> for why "nothing" is the correct contents
+    /// today, and why this must change in lockstep with <c>SupportsMcpServers</c>.
+    ///
+    /// <para>It must be non-empty: <c>--allowed-mcp-server-names ""</c> fails Gemini's config load with
+    /// <i>"mcpName is required if specified"</i> BEFORE the session starts — which also makes it a trap
+    /// when verifying this by hand, because the launch then fails for a reason unrelated to MCP and
+    /// reports nothing loaded.</para>
+    /// </summary>
+    internal const string GeminiNoMcpSentinel = "kcap-none";
+
+    /// <summary>Google Gemini CLI as an ACP hosted agent (<c>gemini --experimental-acp</c>).
+    /// Interactive hosting only; the unattended reviewer is its own issue, as with Kiro.
+    ///
+    /// <para><b><c>--skip-trust</c> is required, and is NOT a containment measure.</b> Gemini refuses a
+    /// headless turn in an untrusted directory outright — <c>exit 55</c> before any model call — and a
+    /// daemon-created worktree cannot be assumed pre-trusted, so without the flag every launch fails.
+    /// What it does NOT do is protect anything: trust INHERITS from a trusted parent directory, and a
+    /// daemon worktree lives at <c>&lt;repo&gt;/.capacitor/worktrees/agent-…</c>, INSIDE the operator's
+    /// repository. An operator who has trusted their own repo therefore gives every hosted Gemini agent
+    /// inherited trust over the checked-out branch's configuration — and passing <c>--skip-trust</c> does
+    /// not withdraw it. Measured, not assumed.</para>
+    ///
+    /// <para><b>Which is why the MCP allowlist is here.</b> Under inherited trust, a repository-authored
+    /// <c>.gemini/settings.json</c> MCP server WAS observed starting on the ACP path — repo-controlled
+    /// process execution under the daemon user, before the model acts, on a branch that may be
+    /// contributor-authored. <see cref="GeminiNoMcpSentinel"/> reduces the allowlist to nothing, which
+    /// blocks it. Repo-authored <i>hooks</i> were separately measured NOT to run on the ACP path (they do
+    /// on the <c>--prompt</c> path — the two paths differ, and neither predicts the other).</para>
+    ///
+    /// <para><b>The sentinel is only correct while <see cref="AcpVendorDescriptor.SupportsMcpServers"/> is
+    /// false.</b> It permits nothing, so with nothing injected it costs nothing. The day the stdio
+    /// call-level probe flips that flag, this list must become the injected server names in the SAME
+    /// change, or hosted Gemini ships with MCP silently broken. <c>AcpVendorDescriptorTests</c> asserts
+    /// the coupling so the two cannot drift apart.</para>
+    ///
+    /// <para><see cref="NoOpModelSelector"/> for the same reason as Kiro: <c>session/new</c> does return a
+    /// <c>models</c> object, so <see cref="ConfigOptionModelSelector"/>'s read half would fit, but its
+    /// write half is unverified on Gemini and that selector fails SILENTLY — a session that reports the
+    /// requested model while running another. <c>ResolveDefaultModel: null</c> alone is not enough,
+    /// because <c>ResolveRequestedModel</c> prioritises a per-launch model and would reach a live
+    /// selector anyway.</para>
+    ///
+    /// <para><c>--approval-mode</c> is deliberately not passed: interactive hosting should behave as the
+    /// user's own session does, and pinning <c>plan</c> would silently make hosted Gemini read-only.
+    /// <c>DiagnosticBinary</c> needs no branch — the vendor key and the binary name are both
+    /// <c>gemini</c>.</para></summary>
+    public static readonly AcpVendorDescriptor Gemini = new(
+        Vendor:              "gemini",
+        ResolveBinaryPath:   cfg => cfg.GeminiPath,
+        ResolveDefaultModel: _ => null,
+        Argv:                ["--experimental-acp", "--skip-trust",
+                              "--allowed-mcp-server-names", GeminiNoMcpSentinel],
+        UnattendedTrustArgv: [],
+        SupportsUnattended:  false,
+        ModelSelector:       NoOpModelSelector.Instance,
+        SupportsMcpServers:  false
+    );
 }

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -266,16 +266,20 @@ internal static class AcpVendorDescriptors {
     );
 
     /// <summary>
-    /// A name no MCP server will ever have, passed to Gemini's <c>--allowed-mcp-server-names</c> so the
-    /// allowlist permits nothing. See <see cref="Gemini"/> for why "nothing" is the correct contents
-    /// today, and why this must change in lockstep with <c>SupportsMcpServers</c>.
+    /// A placeholder the FACTORY replaces, per launch, with an unguessable name — so an MCP allowlist can
+    /// deny everything without the deny-all value being a literal the repository can match.
     ///
-    /// <para>It must be non-empty: <c>--allowed-mcp-server-names ""</c> fails Gemini's config load with
-    /// <i>"mcpName is required if specified"</i> BEFORE the session starts — which also makes it a trap
-    /// when verifying this by hand, because the launch then fails for a reason unrelated to MCP and
-    /// reports nothing loaded.</para>
+    /// <para><b>A fixed sentinel was tried and is broken.</b> An earlier revision passed the literal
+    /// <c>kcap-none</c> and called it "a name no MCP server will ever have". A contributor controls
+    /// <c>.gemini/settings.json</c> and can simply name their server <c>kcap-none</c>; measured, that
+    /// executes, and the clamp is bypassed completely. The comment asserted a property nothing enforced —
+    /// a semantic label is not validation.</para>
+    ///
+    /// <para>The value must also be non-empty: <c>--allowed-mcp-server-names ""</c> fails Gemini's config
+    /// load BEFORE the session starts, which is also a verification trap — the launch then fails for a
+    /// reason unrelated to MCP and reports nothing loaded.</para>
     /// </summary>
-    internal const string GeminiNoMcpSentinel = "kcap-none";
+    internal const string UnmatchableMcpNamePlaceholder = "__kcap_unmatchable_mcp_name__";
 
     /// <summary>Google Gemini CLI as an ACP hosted agent (<c>gemini --experimental-acp</c>).
     /// Interactive hosting only; the unattended reviewer is its own issue, as with Kiro.
@@ -292,12 +296,12 @@ internal static class AcpVendorDescriptors {
     /// <para><b>Which is why the MCP allowlist is here.</b> Under inherited trust, a repository-authored
     /// <c>.gemini/settings.json</c> MCP server WAS observed starting on the ACP path — repo-controlled
     /// process execution under the daemon user, before the model acts, on a branch that may be
-    /// contributor-authored. <see cref="GeminiNoMcpSentinel"/> reduces the allowlist to nothing, which
-    /// blocks it. Repo-authored <i>hooks</i> were separately measured NOT to run on the ACP path (they do
+    /// contributor-authored. <see cref="UnmatchableMcpNamePlaceholder"/> — replaced per launch with an
+    /// unguessable name — reduces the allowlist to nothing the repository can match, which blocks it. Repo-authored <i>hooks</i> were separately measured NOT to run on the ACP path (they do
     /// on the <c>--prompt</c> path — the two paths differ, and neither predicts the other).</para>
     ///
-    /// <para><b>The sentinel is only correct while <see cref="AcpVendorDescriptor.SupportsMcpServers"/> is
-    /// false.</b> It permits nothing, so with nothing injected it costs nothing. The day the stdio
+    /// <para><b>Denying everything is only correct while <see cref="AcpVendorDescriptor.SupportsMcpServers"/>
+    /// is false.</b> It permits nothing, so with nothing injected it costs nothing. The day the stdio
     /// call-level probe flips that flag, this list must become the injected server names in the SAME
     /// change, or hosted Gemini ships with MCP silently broken. <c>AcpVendorDescriptorTests</c> asserts
     /// the coupling so the two cannot drift apart.</para>
@@ -318,7 +322,7 @@ internal static class AcpVendorDescriptors {
         ResolveBinaryPath:   cfg => cfg.GeminiPath,
         ResolveDefaultModel: _ => null,
         Argv:                ["--experimental-acp", "--skip-trust",
-                              "--allowed-mcp-server-names", GeminiNoMcpSentinel],
+                              "--allowed-mcp-server-names", UnmatchableMcpNamePlaceholder],
         UnattendedTrustArgv: [],
         SupportsUnattended:  false,
         ModelSelector:       NoOpModelSelector.Instance,

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -300,6 +300,14 @@ public static partial class DaemonRunner {
                 sp.GetRequiredService<ServerConnection>()
             )
         );
+        builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
+            new AcpHostedAgentRuntimeFactory(
+                AcpVendorDescriptors.Gemini,
+                sp.GetRequiredService<DaemonConfig>(),
+                sp.GetRequiredService<ILoggerFactory>(),
+                sp.GetRequiredService<ServerConnection>()
+            )
+        );
 
         builder.Services.AddSingleton<IReadOnlyDictionary<string, IHostedAgentRuntimeFactory>>(sp =>
             sp.GetServices<IHostedAgentRuntimeFactory>().ToDictionary(f => f.Vendor)

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -291,7 +291,36 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                 ? "run `copilot login` and verify GitHub Copilot access for your enterprise"
                 : _vendor == AcpVendorDescriptors.Kiro.Vendor
                     ? "verify Kiro CLI is signed in and your subscription/entitlement is active"
-                    : $"authenticate `{_vendor}` and verify your subscription/entitlement";
+                    : _vendor == AcpVendorDescriptors.Gemini.Vendor
+                        ? GeminiAuthHint
+                        : $"authenticate `{_vendor}` and verify your subscription/entitlement";
+
+    /// <summary>
+    /// Gemini's hint, worded as a POSSIBILITY rather than a diagnosis — and that is a requirement, not
+    /// politeness.
+    ///
+    /// <para>Gemini reports a missing project as
+    /// <c>IneligibleTierError: … no longer supported for Gemini Code Assist for individuals</c>, thrown by
+    /// a function named <c>throwIneligibleOrProjectIdError</c> — the SAME message for a missing project id
+    /// as for a genuine tier problem. That confidently-wrong attribution cost two retracted conclusions
+    /// while this vendor was being specced. Reproducing the pattern here would be worse than saying
+    /// nothing, so this text claims nothing: two hedges plus an explicit "or it may be unrelated",
+    /// because the failure this is attached to often IS unrelated.</para>
+    ///
+    /// <para>The daemon-not-your-shell clause is the actual content. A supervised daemon inherits nothing
+    /// from an interactive shell, so a project variable exported in a shell profile is invisible to it —
+    /// which is precisely how the misdiagnosis happened.</para>
+    ///
+    /// <para>Kept verbatim in the exception message rather than carried as a structured field: the message
+    /// is a wire shape an older server consumes, and the honesty requirement is carried by the wording.
+    /// Pinned by a golden test.</para>
+    /// </summary>
+    internal const string GeminiAuthHint =
+        "this may be an authentication or project-configuration problem, or it may be unrelated — if "
+      + "hosted Gemini has not worked on this machine before, check `gemini` is logged in and that "
+      + "GOOGLE_CLOUD_PROJECT (or GOOGLE_CLOUD_PROJECT_ID) is set where the DAEMON can see it (the "
+      + "service unit, not your shell profile), then re-run `kcap daemon service install` and restart "
+      + "the daemon";
 
     public bool   HasExited           => _process.HasExited;
     public int?   ExitCode            => _process.ExitCode;

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -268,6 +268,28 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// <c>availableModels</c> happens in <see cref="AcpHostedAgentRuntime"/> via
     /// <see cref="Capacitor.Cli.Core.Acp.AcpModelResolver"/>.
     /// </summary>
+    /// <summary>
+    /// Replaces every <see cref="AcpVendorDescriptors.UnmatchableMcpNamePlaceholder"/> with a fresh,
+    /// unguessable name — once per launch, so two concurrent agents do not even share one.
+    ///
+    /// <para><b>Why random rather than a constant.</b> A vendor whose only MCP clamp is an allowlist can be
+    /// made to deny everything by allowing a name nothing has. A CONSTANT deny-all name is not that: the
+    /// repository being reviewed controls its own MCP config and can name a server exactly that constant,
+    /// which was measured to execute. So the deny-all value has to be outside repository control, which
+    /// means unpredictable.</para>
+    ///
+    /// <para>Kept generic rather than Gemini-specific: any vendor whose containment is "allow a name that
+    /// cannot exist" needs the same treatment, and a per-vendor copy of this reasoning is how one of them
+    /// ends up with a guessable literal again.</para>
+    /// </summary>
+    static List<string> SubstituteUnmatchableNames(List<string> argv) {
+        for (var i = 0; i < argv.Count; i++)
+            if (argv[i] == AcpVendorDescriptors.UnmatchableMcpNamePlaceholder)
+                argv[i] = $"kcap-deny-{Guid.NewGuid():N}";
+
+        return argv;
+    }
+
     static string? ResolveRequestedModel(AcpVendorDescriptor descriptor, DaemonConfig config, RuntimeStartContext ctx) =>
         !string.IsNullOrEmpty(ctx.Model) && !string.Equals(ctx.Model, "default", StringComparison.OrdinalIgnoreCase)
             ? ctx.Model
@@ -320,7 +342,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             throw new InvalidOperationException(
                 $"Unattended review-flow launch for '{descriptor.Vendor}' requires daemon snapshot materialization before spawn.");
 
-        var argv = new List<string>(descriptor.Argv);
+        var argv = SubstituteUnmatchableNames([.. descriptor.Argv]);
 
         if (ctx.IsReviewFlow) {
             argv.AddRange(descriptor.UnattendedTrustArgv);

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -258,17 +258,6 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     }
 
     /// <summary>
-    /// Merges the per-launch model override with the daemon-wide default —
-    /// <paramref name="ctx"/>'s own <c>Model</c> takes precedence when the launch specifies one,
-    /// else falls back to <paramref name="descriptor"/>'s <c>ResolveDefaultModel</c>. Mirrors the
-    /// existing <c>"default"</c>-sentinel convention <c>CodexLauncher.AddModelArg</c> already uses
-    /// for "no override requested" (the UI dispatches the literal string <c>"default"</c>, not an
-    /// empty string, when the user hasn't picked a model). The merged value is still a bare family
-    /// prefix or an exact <c>modelId</c> — final resolution against the session's
-    /// <c>availableModels</c> happens in <see cref="AcpHostedAgentRuntime"/> via
-    /// <see cref="Capacitor.Cli.Core.Acp.AcpModelResolver"/>.
-    /// </summary>
-    /// <summary>
     /// Replaces every <see cref="AcpVendorDescriptors.UnmatchableMcpNamePlaceholder"/> with a fresh,
     /// unguessable name — once per launch, so two concurrent agents do not even share one.
     ///
@@ -290,6 +279,17 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         return argv;
     }
 
+    /// <summary>
+    /// Merges the per-launch model override with the daemon-wide default —
+    /// <paramref name="ctx"/>'s own <c>Model</c> takes precedence when the launch specifies one,
+    /// else falls back to <paramref name="descriptor"/>'s <c>ResolveDefaultModel</c>. Mirrors the
+    /// existing <c>"default"</c>-sentinel convention <c>CodexLauncher.AddModelArg</c> already uses
+    /// for "no override requested" (the UI dispatches the literal string <c>"default"</c>, not an
+    /// empty string, when the user hasn't picked a model). The merged value is still a bare family
+    /// prefix or an exact <c>modelId</c> — final resolution against the session's
+    /// <c>availableModels</c> happens in <see cref="AcpHostedAgentRuntime"/> via
+    /// <see cref="Capacitor.Cli.Core.Acp.AcpModelResolver"/>.
+    /// </summary>
     static string? ResolveRequestedModel(AcpVendorDescriptor descriptor, DaemonConfig config, RuntimeStartContext ctx) =>
         !string.IsNullOrEmpty(ctx.Model) && !string.Equals(ctx.Model, "default", StringComparison.OrdinalIgnoreCase)
             ? ctx.Model

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -846,6 +846,24 @@ public static class DaemonCommands {
         }
     }
 
+    /// <summary>
+    /// The <c>ExtraArgs</c> baked into a service unit, from the raw <c>--max-agents</c> flag value.
+    ///
+    /// <para>Validated here rather than only escaped at the unit writers. This is the ONLY caller-supplied
+    /// entry in <c>ExtraArgs</c>, it arrives unparsed off the command line, and it is persisted into a file
+    /// the OS executes at every logon — so a value that is not the integer the flag documents has no
+    /// legitimate reading, and accepting one turns a typo into a durable startup artifact. Review raised the
+    /// sink; this is the matching narrowing at the source, so the two are independent.</para>
+    /// </summary>
+    internal static List<string> ServiceExtraArgs(string? maxAgentsFlag) {
+        if (maxAgentsFlag is null) return [];
+
+        if (!int.TryParse(maxAgentsFlag, out var maxAgents) || maxAgents < 1)
+            throw new ArgumentException($"--max-agents must be a positive integer (got '{maxAgentsFlag}').");
+
+        return ["--max-agents", maxAgents.ToString()];
+    }
+
     static async Task<int> ServiceInstall(IServiceManager manager, string[] args, string id, bool startNow) {
         var daemonPath = ResolveDaemonBinary();
         if (daemonPath is null) { await Console.Error.WriteLineAsync(DaemonNotFoundMessage()); return 1; }
@@ -855,8 +873,14 @@ public static class DaemonCommands {
             ["KCAP_DAEMON_SUPERVISED"] = id,   // name-specific; daemon honors it only when == its sanitized --name
         };
 
-        var extra = new List<string>();
-        if (ExtractFlagValue(args, "--max-agents") is { } mx) { extra.Add("--max-agents"); extra.Add(mx); }
+        List<string> extra;
+        try {
+            extra = ServiceExtraArgs(ExtractFlagValue(args, "--max-agents"));
+        } catch (ArgumentException ex) {
+            await Console.Error.WriteLineAsync(ex.Message);
+
+            return 1;
+        }
 
         var logPath = PathHelpers.ConfigPath($"daemon-{id}.log");
         var spec    = new ServiceSpec(id, daemonPath, logPath, env, extra);

--- a/src/Capacitor.Cli/Services/LaunchdUnit.cs
+++ b/src/Capacitor.Cli/Services/LaunchdUnit.cs
@@ -30,11 +30,11 @@ static class LaunchdUnit {
             <dict>
 
             """);
-        sb.Append($"  <key>Label</key><string>{ServiceText.Xml(Label(spec.ServiceId))}</string>\n");
+        sb.Append($"  <key>Label</key><string>{Guarded("the service label", Label(spec.ServiceId))}</string>\n");
 
         sb.Append("  <key>ProgramArguments</key><array>\n");
         foreach (var arg in ProgramArguments(spec))
-            sb.Append($"    <string>{ServiceText.Xml(arg)}</string>\n");
+            sb.Append($"    <string>{Guarded("the daemon command line", arg)}</string>\n");
         sb.Append("  </array>\n");
 
         sb.Append("  <key>EnvironmentVariables</key><dict>\n");
@@ -51,10 +51,29 @@ static class LaunchdUnit {
         sb.Append("  <key>RunAtLoad</key><true/>\n");
         sb.Append("  <key>KeepAlive</key><dict><key>SuccessfulExit</key><false/></dict>\n");
         sb.Append("  <key>ProcessType</key><string>Adaptive</string>\n");
-        sb.Append($"  <key>StandardOutPath</key><string>{ServiceText.Xml(OutLogPath(spec))}</string>\n");
-        sb.Append($"  <key>StandardErrorPath</key><string>{ServiceText.Xml(OutLogPath(spec))}</string>\n");
+        var outLog = Guarded("the daemon log path", OutLogPath(spec));
+        sb.Append($"  <key>StandardOutPath</key><string>{outLog}</string>\n");
+        sb.Append($"  <key>StandardErrorPath</key><string>{outLog}</string>\n");
         sb.Append("</dict>\n</plist>\n");
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Guard, then escape — every string this writer interpolates goes through here.
+    ///
+    /// <para><b>Why not just escape.</b> <c>SecurityElement.Escape</c> handles the five markup characters and
+    /// nothing else; it passes a C0 control, U+FFFE or a lone surrogate straight through, and none of those
+    /// has any legal XML 1.0 representation. The result is a plist <c>launchctl</c> silently will not load.</para>
+    ///
+    /// <para><b>Why it covers the paths and not only the environment.</b> The environment loop was guarded and
+    /// these four sites were not, yet <c>ProgramArguments</c> carries the binary path, the log path and the
+    /// extra args, and macOS filenames may contain any byte but <c>/</c> and NUL. Guarding the environment
+    /// only is the same asymmetry review already found twice at the other two sinks: applying a check to some
+    /// of the values interpolated into a file is not checking the file.</para>
+    /// </summary>
+    static string Guarded(string what, string value) {
+        ServiceText.RequireXmlRepresentableValue(what, value);
+        return ServiceText.Xml(value);
     }
 
     /// <summary>argv the agent runs: binary, pinned --name + --log-file, then extra args.</summary>

--- a/src/Capacitor.Cli/Services/LaunchdUnit.cs
+++ b/src/Capacitor.Cli/Services/LaunchdUnit.cs
@@ -43,6 +43,7 @@ static class LaunchdUnit {
             // XML 1.0 at all — so the plist would be silently unparseable rather than injected. Same
             // check, same reason: one grammar, applied at every sink.
             ServiceText.RequireValidEnvName(k);
+            ServiceText.RequireXmlRepresentableValue(k, v);
             sb.Append($"    <key>{ServiceText.Xml(k)}</key><string>{ServiceText.Xml(v)}</string>\n");
         }
         sb.Append("  </dict>\n");

--- a/src/Capacitor.Cli/Services/LaunchdUnit.cs
+++ b/src/Capacitor.Cli/Services/LaunchdUnit.cs
@@ -38,8 +38,13 @@ static class LaunchdUnit {
         sb.Append("  </array>\n");
 
         sb.Append("  <key>EnvironmentVariables</key><dict>\n");
-        foreach (var (k, v) in spec.Environment)
+        foreach (var (k, v) in spec.Environment) {
+            // XML escaping already contains the name structurally, but a control character is not legal
+            // XML 1.0 at all — so the plist would be silently unparseable rather than injected. Same
+            // check, same reason: one grammar, applied at every sink.
+            ServiceText.RequireValidEnvName(k);
             sb.Append($"    <key>{ServiceText.Xml(k)}</key><string>{ServiceText.Xml(v)}</string>\n");
+        }
         sb.Append("  </dict>\n");
 
         sb.Append("  <key>RunAtLoad</key><true/>\n");

--- a/src/Capacitor.Cli/Services/ServiceEnvironment.cs
+++ b/src/Capacitor.Cli/Services/ServiceEnvironment.cs
@@ -14,6 +14,56 @@ static class ServiceEnvironment {
     static readonly string[] Keys =
         ["PATH", "KCAP_CONFIG_DIR", "KCAP_PROFILE", "KCAP_URL", "KCAP_CLAUDE_PATH", "KCAP_CODEX_PATH"];
 
+    /// <summary>
+    /// Gemini's project/backend selection, carried on every platform because none of it is
+    /// secret-capable: project ids, a region, and two backend-selection booleans.
+    ///
+    /// <para><b>Why this is needed at all.</b> A supervised daemon inherits nothing from an interactive
+    /// shell — launchd passes no shell environment, and a non-interactive shell does not read a profile —
+    /// so a project exported in <c>.zshrc</c> is invisible to a hosted Gemini agent. Gemini then reports
+    /// the absence as <c>IneligibleTierError: … no longer supported for Gemini Code Assist for
+    /// individuals</c>, thrown by a function named <c>throwIneligibleOrProjectIdError</c>: the same text
+    /// for a missing project as for a real tier problem. That message sends people to the wrong place —
+    /// it did exactly that while this was being specced.</para>
+    ///
+    /// <para>Both project spellings are carried because Gemini honours both; its own error says
+    /// <i>"The GOOGLE_CLOUD_PROJECT (or GOOGLE_CLOUD_PROJECT_ID) environment variable must be set"</i>.</para>
+    /// </summary>
+    static readonly string[] GoogleConfigKeys = [
+        "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GOOGLE_CLOUD_LOCATION",
+        "GOOGLE_GENAI_USE_VERTEXAI", "GOOGLE_GENAI_USE_GCA"
+    ];
+
+    /// <summary>
+    /// Gemini's ADC path and endpoint overrides — carried off-Windows ONLY.
+    ///
+    /// <para>These are secret-CAPABLE rather than secret: a credential path discloses where the
+    /// credential lives, and a base URL can carry userinfo or a query token. On Unix that is bounded by a
+    /// guarantee this code enforces — <see cref="ServiceFiles"/> writes units 0600, re-checks the mode on
+    /// the open handle because <c>UnixCreateMode</c> is filtered through the umask, and refuses a
+    /// group/other-writable directory — so the reader is the same local user who owns the credential
+    /// anyway.</para>
+    ///
+    /// <para><b>On Windows there is no such guarantee.</b> Every permission path in
+    /// <see cref="ServiceFiles"/> returns early there: the wrapper carries whatever the user profile's
+    /// inherited ACL grants, which this code neither sets nor checks. So these are excluded, following the
+    /// <see cref="TokenCommandKey"/> precedent — a platform whose guarantee is unverified does not get the
+    /// secret-capable values. Hosted Gemini still works there for a project-scoped login; an operator who
+    /// needs Vertex-with-ADC on Windows sets it another way, and the README says so.</para>
+    ///
+    /// <para>The principle, so future additions are not classified by variable name: persist a value into
+    /// a unit only when there is no non-persistent alternative AND the platform gives an owner-only
+    /// guarantee this code actually enforces.</para>
+    /// </summary>
+    static readonly string[] GoogleSecretCapableKeys = [
+        "GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_GEMINI_BASE_URL", "GOOGLE_VERTEX_BASE_URL"
+    ];
+
+    /// <summary>Never carried, on any platform: these ARE the credential, and they have a non-persistent
+    /// alternative (log the CLI in, or supply them per-launch). Named rather than merely absent so a
+    /// future author adding a <c>GOOGLE_*</c> key has to decide which list it belongs in.</summary>
+    internal static readonly string[] NeverCapturedKeys = ["GOOGLE_API_KEY", "GOOGLE_CREDENTIALS"];
+
     /// <summary>A COMMAND that prints a borrowed-review token — safe to persist where the token is not,
     /// and what lets a supervised daemon authenticate a contained reviewer.
     ///
@@ -39,7 +89,9 @@ static class ServiceEnvironment {
     public static IReadOnlyDictionary<string, string> Build(
             string? profileName, IReadOnlyDictionary<string, string> source, bool isWindows = false) {
         var env = new Dictionary<string, string>(StringComparer.Ordinal);
-        var keys = isWindows ? Keys : [.. Keys, TokenCommandKey];
+        string[] keys = isWindows
+            ? [.. Keys, .. GoogleConfigKeys]
+            : [.. Keys, TokenCommandKey, .. GoogleConfigKeys, .. GoogleSecretCapableKeys];
         foreach (var key in keys)
             if (source.TryGetValue(key, out var v) && !string.IsNullOrEmpty(v)) env[key] = v;
         if (!string.IsNullOrEmpty(profileName)) env["KCAP_PROFILE"] = profileName; // explicit pin wins

--- a/src/Capacitor.Cli/Services/ServiceText.cs
+++ b/src/Capacitor.Cli/Services/ServiceText.cs
@@ -1,4 +1,5 @@
 using System.Security;
+using System.Xml;
 using Capacitor.Cli.Core;
 
 namespace Capacitor.Cli.Services;
@@ -18,9 +19,21 @@ static class ServiceText {
     /// <summary>Escape a value for a batch <c>set "KEY=value"</c> line: percent-signs doubled.</summary>
     public static string CmdValue(string value) => value.Replace("%", "%%");
 
-    /// <summary>Escape a systemd <c>Environment=</c>/<c>Description=</c> value: no raw newlines.</summary>
+    /// <summary>
+    /// Escape a systemd <c>Environment=</c>/<c>Description=</c> value: no raw newlines, and literal
+    /// percent signs doubled.
+    ///
+    /// <para><b>Why the doubling.</b> systemd expands <i>specifiers</i> — <c>%n</c>, <c>%h</c>, <c>%i</c> and
+    /// friends — in both of those directives, so a value carrying a literal <c>%</c> does not survive: a
+    /// <c>PATH</c> containing <c>%n</c> silently becomes the unit name, and a percent sequence systemd does
+    /// not recognise makes it refuse to load the unit at all. <c>%%</c> is systemd's own escape for one
+    /// literal percent, so this is a faithful round-trip rather than a mangling.</para>
+    ///
+    /// <para>This is the same primitive <see cref="CmdValue"/> applies for cmd.exe, for the same reason, and
+    /// it was missing here while present there — the asymmetry is what review caught.</para>
+    /// </summary>
     public static string SystemdValue(string value) =>
-        value.Replace("\r", " ").Replace("\n", " ");
+        value.Replace("\r", " ").Replace("\n", " ").Replace("%", "%%");
 
     /// <summary>
     /// Rejects a VALUE that XML 1.0 cannot represent, for the plist writer.
@@ -36,16 +49,29 @@ static class ServiceText {
     /// names the variable; failing at load time produces a service that silently does not exist.</para>
     /// </summary>
     public static void RequireXmlRepresentableValue(string name, string value) {
-        // Written as a plain scan rather than FirstOrDefault: that returns '\0' for "no match", which is
-        // itself an illegal character here, so the sentinel and a real hit are indistinguishable without a
-        // second pass. Subtlety in a security-adjacent guard is not worth the brevity.
-        foreach (var c in value) {
-            if (c is '\t' or '\n' or '\r' || !char.IsControl(c)) continue;
+        // The predicate is XmlConvert's, not char.IsControl — the two are NOT equivalent, and review caught
+        // both directions of the gap. char.IsControl accepts U+FFFE, U+FFFF and lone surrogates, none of
+        // which XML can carry (a lone surrogate is not even a scalar value, so the encoder either throws or
+        // substitutes), and it rejects U+007F–U+009F, which XML 1.0 permits. Deferring to the platform
+        // predicate makes the code match the doc comment above instead of approximating it.
+        //
+        // Scanned by index rather than foreach so a valid surrogate PAIR can be recognised as the one
+        // supplementary character it encodes; checking `char` in isolation would reject every emoji.
+        for (var i = 0; i < value.Length; i++) {
+            var c = value[i];
+
+            if (char.IsHighSurrogate(c) && i + 1 < value.Length
+             && XmlConvert.IsXmlSurrogatePair(value[i + 1], c)) {
+                i++; // consumed the low half too
+                continue;
+            }
+
+            if (XmlConvert.IsXmlChar(c)) continue;
 
             throw new InvalidOperationException(
-                $"Refusing to write a service unit: the value of '{name}' contains the control character "
-              + $"U+{(int)c:X4}, which XML 1.0 cannot represent even escaped — the resulting plist would "
-              + "not load. Unset or correct that variable, then re-run `kcap daemon service install`.");
+                $"Refusing to write a service unit: the value of '{name}' contains U+{(int)c:X4}, which "
+              + "XML 1.0 cannot represent even escaped — the resulting plist would not load. Unset or "
+              + "correct that variable, then re-run `kcap daemon service install`.");
         }
     }
 

--- a/src/Capacitor.Cli/Services/ServiceText.cs
+++ b/src/Capacitor.Cli/Services/ServiceText.cs
@@ -20,8 +20,7 @@ static class ServiceText {
     public static string CmdValue(string value) => value.Replace("%", "%%");
 
     /// <summary>
-    /// Escape a systemd <c>Environment=</c>/<c>Description=</c> value: no raw newlines, and literal
-    /// percent signs doubled.
+    /// Escape a systemd <c>Environment=</c>/<c>Description=</c> value: literal percent signs doubled.
     ///
     /// <para><b>Why the doubling.</b> systemd expands <i>specifiers</i> — <c>%n</c>, <c>%h</c>, <c>%i</c> and
     /// friends — in both of those directives, so a value carrying a literal <c>%</c> does not survive: a
@@ -31,9 +30,12 @@ static class ServiceText {
     ///
     /// <para>This is the same primitive <see cref="CmdValue"/> applies for cmd.exe, for the same reason, and
     /// it was missing here while present there — the asymmetry is what review caught.</para>
+    ///
+    /// <para>It no longer normalises CR/LF to spaces: <see cref="RequireNoControlCharacters"/> refuses them
+    /// at the sink first, so the replacement was unreachable — and silently rewriting a caller's value was
+    /// the wrong behaviour anyway.</para>
     /// </summary>
-    public static string SystemdValue(string value) =>
-        value.Replace("\r", " ").Replace("\n", " ").Replace("%", "%%");
+    public static string SystemdValue(string value) => value.Replace("%", "%%");
 
     /// <summary>
     /// Rejects a VALUE that XML 1.0 cannot represent, for the plist writer.
@@ -106,5 +108,33 @@ static class ServiceText {
           + "([A-Za-z_][A-Za-z0-9_]*). A name outside that grammar can break the unit's own line "
           + "structure — in a systemd unit it can inject an ExecStartPre= directive that runs on every "
           + "restart. No name from the capture allowlist is affected, so this one was added directly.");
+    }
+
+    /// <summary>
+    /// Rejects a value carrying a C0 control character or DEL, for the systemd writer.
+    ///
+    /// <para>Quoting does not make a raw control byte valid unit syntax, and this writer has no encoder for
+    /// one: <see cref="SystemdValue"/> handles expansion, <c>Esc</c> handles the backslash and the double
+    /// quote, and neither touches U+0001, a backspace or a vertical tab — all of which a POSIX environment
+    /// value, a filename or an argv string may legally contain. systemd does document C-style and hex
+    /// escapes, but this code has no way to exercise a real systemd parser, so it refuses the input rather
+    /// than shipping an escape whose behaviour it has only read about. That is the same call already made for
+    /// the bare <c>;</c> separator, and the same reason.</para>
+    ///
+    /// <para>CR and LF are included, which supersedes the old newline-to-space normalisation in
+    /// <see cref="SystemdValue"/>: silently rewriting a value the caller supplied is worse than declining to
+    /// write it, because a service that runs with a value nobody chose is harder to diagnose than an install
+    /// that failed and said which variable was at fault.</para>
+    /// </summary>
+    public static void RequireNoControlCharacters(string name, string value) {
+        foreach (var c in value) {
+            if (!char.IsControl(c) || c > '\u007F') continue;
+
+            throw new InvalidOperationException(
+                $"Refusing to write a systemd unit: the value of '{name}' contains the control character "
+              + $"U+{(int)c:X4}. A unit directive has no encoding for one that this code can verify, and "
+              + "quoting does not make it valid syntax — systemd would refuse to load the unit. Unset or "
+              + "correct that variable, then re-run `kcap daemon service install`.");
+        }
     }
 }

--- a/src/Capacitor.Cli/Services/ServiceText.cs
+++ b/src/Capacitor.Cli/Services/ServiceText.cs
@@ -21,4 +21,37 @@ static class ServiceText {
     /// <summary>Escape a systemd <c>Environment=</c>/<c>Description=</c> value: no raw newlines.</summary>
     public static string SystemdValue(string value) =>
         value.Replace("\r", " ").Replace("\n", " ");
+
+    /// <summary>
+    /// Rejects an environment-variable NAME that no unit writer can carry safely. Shared by all three
+    /// sinks, because every one of them interpolates the name into a line whose structure the name can
+    /// break — and each format then hands the attacker something different.
+    ///
+    /// <para><b>systemd is the worst of the three, which is why this is central rather than per-writer.</b>
+    /// A key shaped like <c>SAFE=ok\nExecStartPre=/bin/touch /tmp/pwned\n#</c> with an ordinary value
+    /// renders a valid <c>Environment=SAFE=ok</c> line, then an attacker-chosen <c>ExecStartPre=</c>
+    /// directive, then comments out the remainder — a command the service runs on every restart. Value
+    /// escaping does not help: <c>SystemdValue</c> normalises the VALUE, and <c>EnvAssignment</c> decides
+    /// quoting from the VALUE. Neither looks at the name.</para>
+    ///
+    /// <para>The rule is the POSIX environment-name grammar (<c>[A-Za-z_][A-Za-z0-9_]*</c>) rather than a
+    /// blacklist of the characters each format happens to fear. A blacklist has to be right three times,
+    /// once per format, and a fourth writer would need it extended; an allowlist of what a legitimate name
+    /// can contain is right by construction. Nothing on any capture allowlist is excluded by it, so a
+    /// rejection means a caller composed the dictionary directly — which is exactly the path that bypasses
+    /// <see cref="ServiceEnvironment"/>.</para>
+    /// </summary>
+    public static void RequireValidEnvName(string name) {
+        var ok = name.Length > 0
+              && (char.IsAsciiLetter(name[0]) || name[0] == '_')
+              && name.All(c => char.IsAsciiLetterOrDigit(c) || c == '_');
+
+        if (ok) return;
+
+        throw new InvalidOperationException(
+            $"Refusing to write a service unit: '{name}' is not a valid environment variable name "
+          + "([A-Za-z_][A-Za-z0-9_]*). A name outside that grammar can break the unit's own line "
+          + "structure — in a systemd unit it can inject an ExecStartPre= directive that runs on every "
+          + "restart. No name from the capture allowlist is affected, so this one was added directly.");
+    }
 }

--- a/src/Capacitor.Cli/Services/ServiceText.cs
+++ b/src/Capacitor.Cli/Services/ServiceText.cs
@@ -23,6 +23,33 @@ static class ServiceText {
         value.Replace("\r", " ").Replace("\n", " ");
 
     /// <summary>
+    /// Rejects a VALUE that XML 1.0 cannot represent, for the plist writer.
+    ///
+    /// <para>Entity escaping does not help here, and that is the point: <c>SecurityElement.Escape</c> turns
+    /// <c>&amp;</c> and <c>&lt;</c> into entities, but U+0001 has no legal XML 1.0 representation at all —
+    /// escaped or not. XML 1.0 permits only #x9, #xA, #xD and #x20 upwards. POSIX environment values, by
+    /// contrast, may contain any byte except NUL, so a captured or directly composed value really can carry
+    /// one.</para>
+    ///
+    /// <para>The consequence is availability rather than injection: the plist becomes unparseable, so
+    /// <c>launchctl</c> refuses to load it and the service cannot install or restart. Failing at write time
+    /// names the variable; failing at load time produces a service that silently does not exist.</para>
+    /// </summary>
+    public static void RequireXmlRepresentableValue(string name, string value) {
+        // Written as a plain scan rather than FirstOrDefault: that returns '\0' for "no match", which is
+        // itself an illegal character here, so the sentinel and a real hit are indistinguishable without a
+        // second pass. Subtlety in a security-adjacent guard is not worth the brevity.
+        foreach (var c in value) {
+            if (c is '\t' or '\n' or '\r' || !char.IsControl(c)) continue;
+
+            throw new InvalidOperationException(
+                $"Refusing to write a service unit: the value of '{name}' contains the control character "
+              + $"U+{(int)c:X4}, which XML 1.0 cannot represent even escaped — the resulting plist would "
+              + "not load. Unset or correct that variable, then re-run `kcap daemon service install`.");
+        }
+    }
+
+    /// <summary>
     /// Rejects an environment-variable NAME that no unit writer can carry safely. Shared by all three
     /// sinks, because every one of them interpolates the name into a line whose structure the name can
     /// break — and each format then hands the attacker something different.

--- a/src/Capacitor.Cli/Services/SystemdUnit.cs
+++ b/src/Capacitor.Cli/Services/SystemdUnit.cs
@@ -100,8 +100,13 @@ static class SystemdUnit {
     // ── systemd value/argument quoting ──
     // systemd splits Environment= and ExecStart on unquoted whitespace, so any
     // value/path with a space must be double-quoted (with \ and " escaped).
+    // Both quote characters are structural to systemd's word lexer, not just the double quote: an unpaired
+    // apostrophe in a bare token opens a single-quoted string that never closes, which makes the unit
+    // unloadable, and a paired one is stripped, which silently changes the value. `O'Reilly` in a home
+    // directory is the ordinary case. Inside the double quotes this selects, an apostrophe is literal, so
+    // widening the predicate is the whole fix — Esc needs no new case.
     static bool NeedsQuote(string s) =>
-        s.Length == 0 || s.Any(c => char.IsWhiteSpace(c) || c is '"' or '\\');
+        s.Length == 0 || s.Any(c => char.IsWhiteSpace(c) || c is '"' or '\'' or '\\');
 
     static string Esc(string s) => s.Replace("\\", "\\\\").Replace("\"", "\\\"");
 

--- a/src/Capacitor.Cli/Services/SystemdUnit.cs
+++ b/src/Capacitor.Cli/Services/SystemdUnit.cs
@@ -72,12 +72,18 @@ static class SystemdUnit {
         return line is null ? null : FirstToken(line["ExecStart=".Length..]);
     }
 
-    /// <summary>First whitespace-delimited token, honoring a leading double-quoted segment (reverses <see cref="Esc"/>).</summary>
+    /// <summary>
+    /// First whitespace-delimited token, honoring a leading double-quoted segment — reverses both
+    /// <see cref="Esc"/> and the percent-doubling <see cref="QuoteArg"/> applies.
+    ///
+    /// <para>Undoubling is unambiguous: every literal percent was written as <c>%%</c>, so an odd run cannot
+    /// occur in output this code produced.</para>
+    /// </summary>
     static string? FirstToken(string s) {
         if (s.Length == 0) return null;
         if (s[0] != '"') {
             var sp = s.IndexOf(' ');
-            return sp < 0 ? s : s[..sp];
+            return Unpercent(sp < 0 ? s : s[..sp]);
         }
 
         var sb = new StringBuilder();
@@ -86,8 +92,10 @@ static class SystemdUnit {
             if (s[i] == '"') break;
             sb.Append(s[i]);
         }
-        return sb.ToString();
+        return Unpercent(sb.ToString());
     }
+
+    static string Unpercent(string s) => s.Replace("%%", "%");
 
     // ── systemd value/argument quoting ──
     // systemd splits Environment= and ExecStart on unquoted whitespace, so any
@@ -97,8 +105,22 @@ static class SystemdUnit {
 
     static string Esc(string s) => s.Replace("\\", "\\\\").Replace("\"", "\\\"");
 
-    /// <summary>An ExecStart argument, double-quoted only when it contains whitespace/quotes.</summary>
-    static string QuoteArg(string a) => NeedsQuote(a) ? $"\"{Esc(a)}\"" : a;
+    /// <summary>
+    /// An ExecStart argument, double-quoted only when it contains whitespace/quotes, with literal percent
+    /// signs doubled.
+    ///
+    /// <para>specifier expansion applies to <c>ExecStart=</c> just as it does to the
+    /// <c>Environment=</c> values <see cref="ServiceText.SystemdValue"/> handles, and neither the binary path
+    /// nor the log path is sanitized (<c>ServiceId</c> is, so it cannot carry a percent). <c>%</c> is a legal
+    /// filename character on Linux, so a home directory like <c>/home/50%off</c> would otherwise render an
+    /// ExecStart systemd either rewrites or refuses to load — a daemon that cannot start.</para>
+    ///
+    /// <para><see cref="FirstToken"/> reverses this, so <c>daemon doctor</c> still recovers the real path.</para>
+    /// </summary>
+    static string QuoteArg(string a) {
+        var pct = a.Replace("%", "%%");
+        return NeedsQuote(pct) ? $"\"{Esc(pct)}\"" : pct;
+    }
 
     /// <summary>An <c>Environment=</c> assignment; the whole <c>KEY=VALUE</c> is quoted when VALUE needs it.</summary>
     static string EnvAssignment(string key, string value) =>

--- a/src/Capacitor.Cli/Services/SystemdUnit.cs
+++ b/src/Capacitor.Cli/Services/SystemdUnit.cs
@@ -24,6 +24,7 @@ static class SystemdUnit {
         sb.Append("[Service]\n");
         foreach (var (k, v) in spec.Environment) {
             ServiceText.RequireValidEnvName(k);
+            ServiceText.RequireNoControlCharacters(k, v);
             sb.Append($"Environment={EnvAssignment(k, ServiceText.SystemdValue(v))}\n");
         }
 
@@ -123,15 +124,12 @@ static class SystemdUnit {
     /// <para><see cref="FirstToken"/> reverses this, so <c>daemon doctor</c> still recovers the real path.</para>
     /// </summary>
     static string QuoteArg(string a) {
-        // A newline cannot be represented on an ExecStart line at all — quoting does not help, because the
-        // line ends at the newline and systemd reads the remainder as the next directive. Rejecting is the
-        // same call the Windows wrapper makes for the same reason, and `service install` is interactive so
-        // the failure lands in front of a person.
-        if (a.Contains('\n') || a.Contains('\r'))
-            throw new InvalidOperationException(
-                $"Refusing to write a systemd unit: an ExecStart value ('{a}') contains a line break, which "
-              + "cannot be escaped inside a unit directive — the remainder of the value would be parsed as a "
-              + "new directive. Correct it, then re-run `kcap daemon service install`.");
+        // No raw control character survives here, not only the line breaks. A newline is the worst case — the
+        // line ends there and systemd reads the remainder as the next directive — but quoting does not make
+        // U+0001, a backspace or a vertical tab valid unit syntax either, and this writer has no encoder for
+        // them. Refusing is the same call the Windows wrapper makes, and `service install` is interactive so
+        // the failure lands in front of a person who can fix it.
+        ServiceText.RequireNoControlCharacters("an ExecStart value", a);
 
         // A standalone `;` is systemd's own command SEPARATOR in an ExecStart line: emitted bare, every
         // argument after it becomes a second command systemd runs. Its documented literal form is `\;`, but

--- a/src/Capacitor.Cli/Services/SystemdUnit.cs
+++ b/src/Capacitor.Cli/Services/SystemdUnit.cs
@@ -74,16 +74,16 @@ static class SystemdUnit {
 
     /// <summary>
     /// First whitespace-delimited token, honoring a leading double-quoted segment — reverses both
-    /// <see cref="Esc"/> and the percent-doubling <see cref="QuoteArg"/> applies.
+    /// <see cref="Esc"/> and the expansion-escaping <see cref="EscapeExpansions"/> applies.
     ///
-    /// <para>Undoubling is unambiguous: every literal percent was written as <c>%%</c>, so an odd run cannot
-    /// occur in output this code produced.</para>
+    /// <para>Undoubling is unambiguous: every literal <c>%</c> and <c>$</c> was written doubled, so an odd
+    /// run cannot occur in output this code produced.</para>
     /// </summary>
     static string? FirstToken(string s) {
         if (s.Length == 0) return null;
         if (s[0] != '"') {
             var sp = s.IndexOf(' ');
-            return Unpercent(sp < 0 ? s : s[..sp]);
+            return UnescapeExpansions(sp < 0 ? s : s[..sp]);
         }
 
         var sb = new StringBuilder();
@@ -92,10 +92,10 @@ static class SystemdUnit {
             if (s[i] == '"') break;
             sb.Append(s[i]);
         }
-        return Unpercent(sb.ToString());
+        return UnescapeExpansions(sb.ToString());
     }
 
-    static string Unpercent(string s) => s.Replace("%%", "%");
+    static string UnescapeExpansions(string s) => s.Replace("%%", "%").Replace("$$", "$");
 
     // ── systemd value/argument quoting ──
     // systemd splits Environment= and ExecStart on unquoted whitespace, so any
@@ -118,9 +118,46 @@ static class SystemdUnit {
     /// <para><see cref="FirstToken"/> reverses this, so <c>daemon doctor</c> still recovers the real path.</para>
     /// </summary>
     static string QuoteArg(string a) {
-        var pct = a.Replace("%", "%%");
-        return NeedsQuote(pct) ? $"\"{Esc(pct)}\"" : pct;
+        // A newline cannot be represented on an ExecStart line at all — quoting does not help, because the
+        // line ends at the newline and systemd reads the remainder as the next directive. Rejecting is the
+        // same call the Windows wrapper makes for the same reason, and `service install` is interactive so
+        // the failure lands in front of a person.
+        if (a.Contains('\n') || a.Contains('\r'))
+            throw new InvalidOperationException(
+                $"Refusing to write a systemd unit: an ExecStart value ('{a}') contains a line break, which "
+              + "cannot be escaped inside a unit directive — the remainder of the value would be parsed as a "
+              + "new directive. Correct it, then re-run `kcap daemon service install`.");
+
+        // A standalone `;` is systemd's own command SEPARATOR in an ExecStart line: emitted bare, every
+        // argument after it becomes a second command systemd runs. Its documented literal form is `\;`, but
+        // rather than rely on this code's reading of that escape (unverifiable on the machines this is built
+        // on) the token is refused outright. No legitimate daemon argument is a lone semicolon, so the
+        // over-rejection is empty in practice — and unlike an escape, a refusal cannot be subtly wrong.
+        if (a == ";")
+            throw new InvalidOperationException(
+                "Refusing to write a systemd unit: an ExecStart argument is a bare ';', which systemd treats "
+              + "as a command separator — the arguments after it would run as a second command. Remove it, "
+              + "then re-run `kcap daemon service install`.");
+
+        var esc = EscapeExpansions(a);
+        return NeedsQuote(esc) ? $"\"{Esc(esc)}\"" : esc;
     }
+
+    /// <summary>
+    /// Neutralise both expansions systemd performs on an <c>ExecStart=</c> command line: <c>%</c> specifiers
+    /// and <c>$NAME</c>/<c>${NAME}</c> environment substitution. <c>%%</c> and <c>$$</c> are systemd's own
+    /// escapes for one literal character, so this is a faithful round-trip.
+    ///
+    /// <para>Both are reachable: neither the binary path nor the log path is sanitized (<c>ServiceId</c> is),
+    /// and <c>%</c> and <c>$</c> are legal Linux filename characters. Undoubled, a path containing
+    /// <c>${HOME}</c> is replaced with the daemon's own environment and <c>%n</c> with the unit name — in the
+    /// executable path, which makes the unit unloadable rather than merely wrong.</para>
+    ///
+    /// <para>Not applied to <c>Environment=</c> values: systemd expands specifiers there but NOT variables,
+    /// so doubling <c>$</c> in a value would corrupt it. The two sinks differ, so they get different
+    /// escapes — <see cref="ServiceText.SystemdValue"/> handles that one.</para>
+    /// </summary>
+    static string EscapeExpansions(string s) => s.Replace("%", "%%").Replace("$", "$$");
 
     /// <summary>An <c>Environment=</c> assignment; the whole <c>KEY=VALUE</c> is quoted when VALUE needs it.</summary>
     static string EnvAssignment(string key, string value) =>

--- a/src/Capacitor.Cli/Services/SystemdUnit.cs
+++ b/src/Capacitor.Cli/Services/SystemdUnit.cs
@@ -22,8 +22,10 @@ static class SystemdUnit {
         sb.Append("Wants=network-online.target\n\n");
 
         sb.Append("[Service]\n");
-        foreach (var (k, v) in spec.Environment)
+        foreach (var (k, v) in spec.Environment) {
+            ServiceText.RequireValidEnvName(k);
             sb.Append($"Environment={EnvAssignment(k, ServiceText.SystemdValue(v))}\n");
+        }
 
         var parts = new[] { spec.DaemonBinaryPath, "--name", spec.ServiceId, "--log-file", spec.LogPath }
             .Concat(spec.ExtraArgs)

--- a/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
+++ b/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
@@ -46,11 +46,7 @@ static class WindowsTaskUnit {
         // first version checked only the value, while the stated rationale (callers add entries after
         // ServiceEnvironment.Build, so the sink must validate) applies to both sides equally. `=` is
         // rejected too, since it splits the assignment even without a quote.
-        if (key.Length == 0 || IsUnrepresentable(key) || key.Contains('='))
-            throw new InvalidOperationException(
-                $"Cannot write the service wrapper: the environment variable NAME '{key}' contains a "
-              + "quote, newline or '=', which this platform's wrapper cannot carry safely. Such a name "
-              + "cannot have come from the capture allowlist, so a caller added it directly.");
+        ServiceText.RequireValidEnvName(key);
 
         if (!IsUnrepresentable(value)) return;
 

--- a/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
+++ b/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
@@ -61,6 +61,14 @@ static class WindowsTaskUnit {
     public static string Wrapper(ServiceSpec spec) {
         var sb = new StringBuilder();
         sb.Append("@echo off\r\n");
+        // The execution MODE is part of the artifact, not inherited from the machine. Delayed expansion is
+        // off by default but can be turned on for every cmd session through the Command Processor registry
+        // key, and `!NAME!` expands INSIDE double quotes — so a value like `!PAYLOAD!` survives quoting and
+        // CmdValue (which doubles `%`, not `!`) and could expand after serialization to text containing a
+        // closing quote and a command separator. The one-line `setlocal` makes the wrapper's own behaviour
+        // deterministic; the Task action additionally passes /V:OFF so the mode is fixed before this file is
+        // even opened. Review's point: relying on a default is not a guarantee.
+        sb.Append("setlocal DisableDelayedExpansion\r\n");
         foreach (var (k, v) in spec.Environment) {
             RequireRepresentable(k, v);
             sb.Append($"set \"{ServiceText.CmdValue(k)}={ServiceText.CmdValue(v)}\"\r\n");
@@ -111,8 +119,57 @@ static class WindowsTaskUnit {
         return $"\"{s}{new string('\\', trailing)}\"";
     }
 
-    public static string TaskXml(ServiceSpec spec, string wrapperPath) =>
-        $"""
+    /// <summary>
+    /// Rejects a wrapper path <c>cmd /c</c> cannot be handed safely.
+    ///
+    /// <para>The Task action's argument text is parsed by cmd, not by CreateProcess, so it is a command line
+    /// and not an opaque string. Two characters cannot be made safe there:</para>
+    ///
+    /// <para><c>%</c> — cmd expands <c>%NAME%</c> in the <c>/c</c> command text before opening the file, and
+    /// the <c>%%</c> escape is a BATCH-FILE construct that does not apply to a command line. There is
+    /// therefore no encoding for a literal percent at this sink, only refusal. (The wrapper's own body is a
+    /// batch file, which is why <see cref="ServiceText.CmdValue"/> is the right answer there and not here —
+    /// the same character, two sinks, two different correct treatments.)</para>
+    ///
+    /// <para><c>"</c>, CR, LF — structural: they end the quoted command or the line.</para>
+    ///
+    /// <para>Reachability, since <c>PathHelpers</c> composing the path does NOT make it safe — review made
+    /// exactly that point: the path runs through the config directory, so it carries the account name, and
+    /// Windows permits both <c>%</c> and <c>&amp;</c> in an account name; <c>KCAP_CONFIG_DIR</c> can set it
+    /// outright. <c>&amp;</c> itself is handled by the nested-quote form below rather than refused, so an
+    /// ordinary path keeps working.</para>
+    /// </summary>
+    static void RequireSafeWrapperPath(string wrapperPath) {
+        var bad = wrapperPath.Contains('%') ? "a percent sign"
+                : IsUnrepresentable(wrapperPath) ? "a quote or newline"
+                : null;
+        if (bad is null) return;
+
+        throw new InvalidOperationException(
+            $"Cannot register the scheduled task: the wrapper path '{wrapperPath}' contains {bad}, which "
+          + "cannot be passed safely to `cmd /c` — a percent sign is expanded before the file is opened and "
+          + "has no escape on a command line. Set KCAP_CONFIG_DIR to a path without it, then re-run "
+          + "`kcap daemon service install`.");
+    }
+
+    /// <summary>
+    /// The Task Scheduler XML. The action is <c>cmd /d /s /v:off /c ""&lt;wrapper&gt;""</c> — every switch
+    /// there is load-bearing:
+    ///
+    /// <para><c>/s</c> with the command text both starting and ending in a quote makes cmd strip exactly the
+    /// outer pair and take the remainder verbatim. Without it, cmd applies its conditional quote-stripping
+    /// rules, and a path containing <c>&amp;</c> (legal in a Windows account name, so legal in this path)
+    /// fails those conditions: the quotes come off and the metacharacter is parsed as command syntax. Hence
+    /// the doubled quotes — the inner pair is what survives to quote the path.</para>
+    ///
+    /// <para><c>/v:off</c> fixes delayed expansion off before the wrapper is opened, so <c>!NAME!</c> is inert
+    /// even where the machine enables it by default. <c>/d</c> skips AutoRun commands, so a per-user AutoRun
+    /// value cannot inject a command ahead of the daemon.</para>
+    /// </summary>
+    public static string TaskXml(ServiceSpec spec, string wrapperPath) {
+        RequireSafeWrapperPath(wrapperPath);
+
+        return $"""
         <?xml version="1.0" encoding="UTF-16"?>
         <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
           <RegistrationInfo>
@@ -132,11 +189,12 @@ static class WindowsTaskUnit {
           <Actions>
             <Exec>
               <Command>cmd.exe</Command>
-              <Arguments>/c "{ServiceText.Xml(wrapperPath)}"</Arguments>
+              <Arguments>/d /s /v:off /c ""{ServiceText.Xml(wrapperPath)}""</Arguments>
             </Exec>
           </Actions>
         </Task>
         """;
+    }
 
     public static string? IdFromTaskName(string taskName) =>
         taskName.StartsWith(Prefix, StringComparison.Ordinal) ? taskName[Prefix.Length..] : null;

--- a/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
+++ b/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
@@ -65,20 +65,51 @@ static class WindowsTaskUnit {
             RequireRepresentable(k, v);
             sb.Append($"set \"{ServiceText.CmdValue(k)}={ServiceText.CmdValue(v)}\"\r\n");
         }
-        // Every value on the exec line gets CmdValue, not just the binary path. cmd expands %VAR% in a batch
-        // file before parsing the line, `%` is a legal Windows filename character, and only the binary path
-        // was escaped here — so a log path under a directory containing `%` was silently rewritten to
-        // whatever the daemon's own environment happened to hold. Review found the asymmetry: escaping one
-        // of three values interpolated into the same line is not escaping the line.
-        var args = string.Join(' ',
-            new[] { "--name", spec.ServiceId, "--log-file", Quote(ServiceText.CmdValue(spec.LogPath)) }
-                .Concat(spec.ExtraArgs.Select(a => QuoteIfNeeded(ServiceText.CmdValue(a)))));
-        sb.Append($"{Quote(ServiceText.CmdValue(spec.DaemonBinaryPath))} {args}\r\n");
+        // Every value on the exec line is guarded and quoted, not just the binary path.
+        //
+        // `%`-doubling alone is not enough and quoting-when-it-contains-a-space is not enough: cmd treats
+        // `& | < > ( ) ^` as live metacharacters OUTSIDE double quotes, so an argument like `foo&calc.exe`
+        // contains neither a space nor a percent, renders bare, and cmd runs the tail as a second command —
+        // in a file the OS executes at every logon. Inside double quotes cmd stops treating them as
+        // metacharacters, so quoting unconditionally is what closes the class; `%` still expands inside
+        // quotes, which is what CmdValue is for; and `"` / CR / LF cannot be represented at all, so they are
+        // rejected rather than escaped.
+        //
+        // Unlike the binary and log paths, ExtraArgs are NOT constrained by Windows filename rules — review
+        // made exactly that distinction, and it is why the "a path cannot contain a quote" reasoning that
+        // covers the other two does not extend to them.
+        var args = new[] { "--name", ExecValue("the service id", spec.ServiceId),
+                           "--log-file", ExecValue("the log path", spec.LogPath) }
+            .Concat(spec.ExtraArgs.Select(a => ExecValue("a daemon argument", a)));
+        sb.Append($"{ExecValue("the daemon binary path", spec.DaemonBinaryPath)} {string.Join(' ', args)}\r\n");
         return sb.ToString();
     }
 
-    static string Quote(string s) => $"\"{s}\"";
-    static string QuoteIfNeeded(string s) => s.Contains(' ') ? Quote(s) : s;
+    /// <summary>Guard, escape, then quote one value interpolated into the wrapper's exec line.</summary>
+    static string ExecValue(string what, string value) {
+        if (IsUnrepresentable(value))
+            throw new InvalidOperationException(
+                $"Cannot write the service wrapper: {what} ('{value}') contains a quote or newline. Neither "
+              + "can be carried safely on a batch exec line — a quote ends the quoted argument and a newline "
+              + "ends the command — so the wrapper would execute something other than the daemon. Correct it, "
+              + "then re-run `kcap daemon service install`.");
+
+        return Quote(ServiceText.CmdValue(value));
+    }
+
+    /// <summary>
+    /// Double-quote a value, doubling a trailing backslash run first.
+    ///
+    /// <para>The Windows command-line parser the daemon's own runtime uses treats <c>\"</c> as an escaped
+    /// quote, so <c>"C:\dir\"</c> would swallow the closing quote and merge this argument with the next.
+    /// Doubling the run — <c>"C:\dir\\"</c> — is the documented encoding for a literal trailing backslash.
+    /// Reachable through an ExtraArgs value; the two paths here never end in a separator.</para>
+    /// </summary>
+    static string Quote(string s) {
+        var trailing = s.Length - s.TrimEnd('\\').Length;
+
+        return $"\"{s}{new string('\\', trailing)}\"";
+    }
 
     public static string TaskXml(ServiceSpec spec, string wrapperPath) =>
         $"""

--- a/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
+++ b/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
@@ -41,6 +41,17 @@ static class WindowsTaskUnit {
     /// alternative is writing a file that might execute something.</para>
     /// </summary>
     static void RequireRepresentable(string key, string value) {
+        // The KEY is interpolated into the same `set "K=V"` line, so it is exactly as dangerous as the
+        // value — a key containing a quote closes the assignment just the same. Review caught this: the
+        // first version checked only the value, while the stated rationale (callers add entries after
+        // ServiceEnvironment.Build, so the sink must validate) applies to both sides equally. `=` is
+        // rejected too, since it splits the assignment even without a quote.
+        if (key.Length == 0 || IsUnrepresentable(key) || key.Contains('='))
+            throw new InvalidOperationException(
+                $"Cannot write the service wrapper: the environment variable NAME '{key}' contains a "
+              + "quote, newline or '=', which this platform's wrapper cannot carry safely. Such a name "
+              + "cannot have come from the capture allowlist, so a caller added it directly.");
+
         if (!IsUnrepresentable(value)) return;
 
         throw new InvalidOperationException(

--- a/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
+++ b/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
@@ -120,6 +120,23 @@ static class WindowsTaskUnit {
     }
 
     /// <summary>
+    /// Guard, then escape — every string interpolated into the Task XML goes through here, mirroring the
+    /// plist writer's helper.
+    ///
+    /// <para>Composition does not imply XML validity: <c>wrapperPath</c> carries <c>KCAP_CONFIG_DIR</c>
+    /// verbatim, Windows paths are native UTF-16, and U+FFFE, U+FFFF or a malformed surrogate unit is outside
+    /// XML 1.0 while <c>SecurityElement.Escape</c> passes all of them through untouched. The consequence is
+    /// the same availability failure the plist had — the task cannot be registered — so it gets the same
+    /// treatment. Applied to the service id too, which is sanitized and therefore safe already: a structural
+    /// invariant that holds at every interpolation is worth more than one applied where it is needed, because
+    /// the next value added here inherits it.</para>
+    /// </summary>
+    static string Guarded(string what, string value) {
+        ServiceText.RequireXmlRepresentableValue(what, value);
+        return ServiceText.Xml(value);
+    }
+
+    /// <summary>
     /// Rejects a wrapper path <c>cmd /c</c> cannot be handed safely.
     ///
     /// <para>The Task action's argument text is parsed by cmd, not by CreateProcess, so it is a command line
@@ -139,23 +156,6 @@ static class WindowsTaskUnit {
     /// outright. <c>&amp;</c> itself is handled by the nested-quote form below rather than refused, so an
     /// ordinary path keeps working.</para>
     /// </summary>
-    /// <summary>
-    /// Guard, then escape — every string interpolated into the Task XML goes through here, mirroring the
-    /// plist writer's helper.
-    ///
-    /// <para>Composition does not imply XML validity: <c>wrapperPath</c> carries <c>KCAP_CONFIG_DIR</c>
-    /// verbatim, Windows paths are native UTF-16, and U+FFFE, U+FFFF or a malformed surrogate unit is outside
-    /// XML 1.0 while <c>SecurityElement.Escape</c> passes all of them through untouched. The consequence is
-    /// the same availability failure the plist had — the task cannot be registered — so it gets the same
-    /// treatment. Applied to the service id too, which is sanitized and therefore safe already: a structural
-    /// invariant that holds at every interpolation is worth more than one applied where it is needed, because
-    /// the next value added here inherits it.</para>
-    /// </summary>
-    static string Guarded(string what, string value) {
-        ServiceText.RequireXmlRepresentableValue(what, value);
-        return ServiceText.Xml(value);
-    }
-
     static void RequireSafeWrapperPath(string wrapperPath) {
         var bad = wrapperPath.Contains('%') ? "a percent sign"
                 : IsUnrepresentable(wrapperPath) ? "a quote or newline"

--- a/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
+++ b/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
@@ -65,9 +65,14 @@ static class WindowsTaskUnit {
             RequireRepresentable(k, v);
             sb.Append($"set \"{ServiceText.CmdValue(k)}={ServiceText.CmdValue(v)}\"\r\n");
         }
+        // Every value on the exec line gets CmdValue, not just the binary path. cmd expands %VAR% in a batch
+        // file before parsing the line, `%` is a legal Windows filename character, and only the binary path
+        // was escaped here — so a log path under a directory containing `%` was silently rewritten to
+        // whatever the daemon's own environment happened to hold. Review found the asymmetry: escaping one
+        // of three values interpolated into the same line is not escaping the line.
         var args = string.Join(' ',
-            new[] { "--name", spec.ServiceId, "--log-file", Quote(spec.LogPath) }
-                .Concat(spec.ExtraArgs.Select(QuoteIfNeeded)));
+            new[] { "--name", spec.ServiceId, "--log-file", Quote(ServiceText.CmdValue(spec.LogPath)) }
+                .Concat(spec.ExtraArgs.Select(a => QuoteIfNeeded(ServiceText.CmdValue(a)))));
         sb.Append($"{Quote(ServiceText.CmdValue(spec.DaemonBinaryPath))} {args}\r\n");
         return sb.ToString();
     }

--- a/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
+++ b/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
@@ -11,12 +11,53 @@ static class WindowsTaskUnit {
 
     public static string WrapperPath(string id) => PathHelpers.ConfigPath($"daemon-service-{id}.cmd");
 
+    /// <summary>
+    /// A value this wrapper cannot represent safely.
+    ///
+    /// <para><c>ServiceText.CmdValue</c> escapes <c>%</c> and nothing else, and each variable is emitted as
+    /// <c>set "K=V"</c>. An embedded <c>"</c> therefore CLOSES the quoted assignment, after which
+    /// <c>&amp;</c>, <c>|</c>, <c>&lt;</c>, <c>&gt;</c> and <c>^</c> are live batch metacharacters in a file
+    /// the service executes — arbitrary command execution in the daemon's own startup wrapper. A newline
+    /// ends the <c>set</c> line outright and makes the remainder a command.</para>
+    ///
+    /// <para>No legitimate value reaches this: not a path (Windows filenames cannot contain <c>"</c>), not
+    /// a project id, region, boolean, or URL.</para>
+    /// </summary>
+    static bool IsUnrepresentable(string value) =>
+        value.Contains('"') || value.Contains('\r') || value.Contains('\n');
+
+    /// <summary>
+    /// Rejects a value the wrapper cannot represent, naming the key.
+    ///
+    /// <para><b>The check lives HERE, at the sink, and applies to every key — not at
+    /// <see cref="ServiceEnvironment.Build"/>.</b> Build is not a boundary: <c>DaemonCommands</c> composes
+    /// the service environment as <c>new Dictionary(Capture(profile)) { ["KCAP_DAEMON_SUPERVISED"] = id }</c>,
+    /// adding an entry AFTER Capture returns, so a value already reaches this writer today without passing
+    /// through Build. Checking at one of several doors is not a check.</para>
+    ///
+    /// <para>Applying it to every key — <c>PATH</c> and <c>KCAP_URL</c> included — closes a pre-existing
+    /// exposure rather than only declining to widen it. Failing the install is the right failure: the
+    /// trigger is a value that cannot be represented at all, <c>service install</c> is interactive, and the
+    /// alternative is writing a file that might execute something.</para>
+    /// </summary>
+    static void RequireRepresentable(string key, string value) {
+        if (!IsUnrepresentable(value)) return;
+
+        throw new InvalidOperationException(
+            $"Cannot write the service wrapper: the value of '{key}' contains a quote or newline, which "
+          + $"this platform's `set \"K=V\"` wrapper cannot carry safely — the assignment would end early "
+          + $"and the remainder would be interpreted as commands. Unset or correct '{key}', then re-run "
+          + $"`kcap daemon service install`.");
+    }
+
     /// <summary>.cmd wrapper: set the captured env, then exec the daemon (no Environment element in Task XML).</summary>
     public static string Wrapper(ServiceSpec spec) {
         var sb = new StringBuilder();
         sb.Append("@echo off\r\n");
-        foreach (var (k, v) in spec.Environment)
+        foreach (var (k, v) in spec.Environment) {
+            RequireRepresentable(k, v);
             sb.Append($"set \"{ServiceText.CmdValue(k)}={ServiceText.CmdValue(v)}\"\r\n");
+        }
         var args = string.Join(' ',
             new[] { "--name", spec.ServiceId, "--log-file", Quote(spec.LogPath) }
                 .Concat(spec.ExtraArgs.Select(QuoteIfNeeded)));

--- a/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
+++ b/src/Capacitor.Cli/Services/WindowsTaskUnit.cs
@@ -139,6 +139,23 @@ static class WindowsTaskUnit {
     /// outright. <c>&amp;</c> itself is handled by the nested-quote form below rather than refused, so an
     /// ordinary path keeps working.</para>
     /// </summary>
+    /// <summary>
+    /// Guard, then escape — every string interpolated into the Task XML goes through here, mirroring the
+    /// plist writer's helper.
+    ///
+    /// <para>Composition does not imply XML validity: <c>wrapperPath</c> carries <c>KCAP_CONFIG_DIR</c>
+    /// verbatim, Windows paths are native UTF-16, and U+FFFE, U+FFFF or a malformed surrogate unit is outside
+    /// XML 1.0 while <c>SecurityElement.Escape</c> passes all of them through untouched. The consequence is
+    /// the same availability failure the plist had — the task cannot be registered — so it gets the same
+    /// treatment. Applied to the service id too, which is sanitized and therefore safe already: a structural
+    /// invariant that holds at every interpolation is worth more than one applied where it is needed, because
+    /// the next value added here inherits it.</para>
+    /// </summary>
+    static string Guarded(string what, string value) {
+        ServiceText.RequireXmlRepresentableValue(what, value);
+        return ServiceText.Xml(value);
+    }
+
     static void RequireSafeWrapperPath(string wrapperPath) {
         var bad = wrapperPath.Contains('%') ? "a percent sign"
                 : IsUnrepresentable(wrapperPath) ? "a quote or newline"
@@ -173,7 +190,7 @@ static class WindowsTaskUnit {
         <?xml version="1.0" encoding="UTF-16"?>
         <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
           <RegistrationInfo>
-            <Description>kcap daemon ({ServiceText.Xml(spec.ServiceId)})</Description>
+            <Description>kcap daemon ({Guarded("the service id", spec.ServiceId)})</Description>
           </RegistrationInfo>
           <Triggers>
             <LogonTrigger><Enabled>true</Enabled></LogonTrigger>
@@ -189,7 +206,7 @@ static class WindowsTaskUnit {
           <Actions>
             <Exec>
               <Command>cmd.exe</Command>
-              <Arguments>/d /s /v:off /c ""{ServiceText.Xml(wrapperPath)}""</Arguments>
+              <Arguments>/d /s /v:off /c ""{Guarded("the wrapper path", wrapperPath)}""</Arguments>
             </Exec>
           </Actions>
         </Task>

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
@@ -1,6 +1,7 @@
 // test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
 using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
 
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
@@ -203,6 +204,109 @@ public class AcpVendorDescriptorTests {
             ReviewFlowMcpTransport: AcpReviewFlowMcpTransport.SessionNew,
             UnattendedInteractionPolicy: AcpUnattendedInteractionPolicy.AutoApprove
         )).Throws<ArgumentException>();
+    }
+
+    /// <summary>The zero-configuration case, for the same reason Kiro needs one: an override test passes
+    /// identically whichever name the default holds, which is how Kiro's wrong default survived. Gemini's
+    /// default is already correct — the binary really is <c>gemini</c> — and this is the test that would
+    /// notice if it stopped being.</summary>
+    [Test]
+    public async Task Gemini_ZeroConfiguration_ResolvesTheShippedBinaryName() {
+        await Assert.That(AcpVendorDescriptors.Gemini.ResolveBinaryPath(new DaemonConfig()))
+            .IsEqualTo("gemini");
+    }
+
+    [Test]
+    public async Task Gemini_ResolveBinaryPath_ReadsConfigGeminiPath() {
+        var config = new DaemonConfig { GeminiPath = "/opt/gemini/gemini" };
+
+        await Assert.That(AcpVendorDescriptors.Gemini.ResolveBinaryPath(config)).IsEqualTo("/opt/gemini/gemini");
+    }
+
+    [Test]
+    public async Task Gemini_MatchesTodaysHardCodedConstants() {
+        var descriptor = AcpVendorDescriptors.Gemini;
+
+        await Assert.That(descriptor.Vendor).IsEqualTo("gemini");
+
+        // --skip-trust is REQUIRED, not optional: Gemini refuses a headless turn in an untrusted
+        // directory outright (exit 55, before any model call) and a daemon worktree cannot be assumed
+        // pre-trusted. It is NOT containment — see the allowlist assertion below.
+        await Assert.That(descriptor.Argv.SequenceEqual(
+            ["--experimental-acp", "--skip-trust",
+             "--allowed-mcp-server-names", AcpVendorDescriptors.GeminiNoMcpSentinel])).IsTrue();
+
+        await Assert.That(descriptor.SupportsUnattended).IsFalse();
+        await Assert.That(descriptor.UnattendedTrustArgv.IsEmpty).IsTrue();
+        await Assert.That(descriptor.UnattendedInteractionPolicy)
+            .IsEqualTo(AcpUnattendedInteractionPolicy.Disabled);
+        await Assert.That(descriptor.SupportsBorrowedReviewFlow).IsFalse();
+
+        // FALSE pending a call-level stdio probe. Gemini advertises {http, sse} and not stdio — but that
+        // advertisement is not a discriminator (Kiro honours stdio without advertising it), so flipping
+        // this needs a purpose-built stdio server driven to a real tools/call, not an inference.
+        await Assert.That(descriptor.SupportsMcpServers).IsFalse();
+
+        // Same call as Kiro: session/new returns models so the read half fits, but the write half is
+        // unverified and ConfigOptionModelSelector fails SILENTLY.
+        await Assert.That(descriptor.ModelSelector).IsEqualTo(NoOpModelSelector.Instance);
+        await Assert.That(descriptor.ModelSelector.CanSelectModel).IsFalse();
+    }
+
+    /// <summary>
+    /// The allowlist contents and <c>SupportsMcpServers</c> are COUPLED, and this is the test that stops
+    /// them drifting.
+    ///
+    /// <para>An allowlist of one non-matching name permits nothing. That is correct only while nothing is
+    /// injected. The day the stdio probe flips <c>SupportsMcpServers</c> to true, the allowlist must
+    /// become the injected server names in the same change — otherwise hosted Gemini ships with MCP
+    /// silently broken, which is exactly the failure a green descriptor test would otherwise hide.</para>
+    ///
+    /// <para>The sentinel must also be non-empty: <c>--allowed-mcp-server-names ""</c> fails Gemini's
+    /// config load before the session starts.</para>
+    /// </summary>
+    [Test]
+    public async Task Gemini_McpAllowlist_IsCoupledToSupportsMcpServers() {
+        var descriptor = AcpVendorDescriptors.Gemini;
+        var argv       = descriptor.Argv.ToArray();
+        var allowed    = argv[Array.IndexOf(argv, "--allowed-mcp-server-names") + 1];
+
+        await Assert.That(allowed).IsNotEmpty();
+
+        if (descriptor.SupportsMcpServers) {
+            // Nothing injected can be permitted by a sentinel, so this must have been updated.
+            await Assert.That(allowed).IsNotEqualTo(AcpVendorDescriptors.GeminiNoMcpSentinel);
+        } else {
+            await Assert.That(allowed).IsEqualTo(AcpVendorDescriptors.GeminiNoMcpSentinel);
+        }
+    }
+
+    /// <summary>
+    /// Gemini's launch-failure hint must read as a POSSIBILITY. Gemini reports a missing project with a
+    /// message naming a tier problem — thrown by <c>throwIneligibleOrProjectIdError</c>, the same text for
+    /// both causes — and reproducing that confidently-wrong attribution is the failure mode this guards.
+    ///
+    /// <para>Golden-ish rather than a word blacklist: the specific hedges and the daemon-not-your-shell
+    /// clause are each asserted, so rewording that removes the hedging fails rather than passing a
+    /// keyword scan.</para>
+    /// </summary>
+    [Test]
+    public async Task GeminiAuthHint_SuggestsRatherThanDiagnoses() {
+        var hint = AcpHostedAgentRuntime.GeminiAuthHint;
+
+        await Assert.That(hint).Contains("may be an authentication or project-configuration problem");
+        await Assert.That(hint).Contains("or it may be unrelated");
+
+        // The actual content: a supervised daemon inherits nothing from an interactive shell, which is
+        // how the original misdiagnosis happened.
+        await Assert.That(hint).Contains("where the DAEMON can see it");
+        await Assert.That(hint).Contains("not your shell profile");
+        await Assert.That(hint).Contains("GOOGLE_CLOUD_PROJECT");
+        await Assert.That(hint).Contains("GOOGLE_CLOUD_PROJECT_ID");
+
+        // Never a verdict.
+        await Assert.That(hint).DoesNotContain("is an authentication");
+        await Assert.That(hint).DoesNotContain("You must");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
@@ -234,7 +234,7 @@ public class AcpVendorDescriptorTests {
         // pre-trusted. It is NOT containment — see the allowlist assertion below.
         await Assert.That(descriptor.Argv.SequenceEqual(
             ["--experimental-acp", "--skip-trust",
-             "--allowed-mcp-server-names", AcpVendorDescriptors.GeminiNoMcpSentinel])).IsTrue();
+             "--allowed-mcp-server-names", AcpVendorDescriptors.UnmatchableMcpNamePlaceholder])).IsTrue();
 
         await Assert.That(descriptor.SupportsUnattended).IsFalse();
         await Assert.That(descriptor.UnattendedTrustArgv.IsEmpty).IsTrue();
@@ -267,18 +267,54 @@ public class AcpVendorDescriptorTests {
     /// </summary>
     [Test]
     public async Task Gemini_McpAllowlist_IsCoupledToSupportsMcpServers() {
-        var descriptor = AcpVendorDescriptors.Gemini;
-        var argv       = descriptor.Argv.ToArray();
-        var allowed    = argv[Array.IndexOf(argv, "--allowed-mcp-server-names") + 1];
+        var argv = AcpVendorDescriptors.Gemini.Argv.ToArray();
 
+        // The option must be present EXACTLY once, and have a following value.
+        //
+        // An earlier version read `argv[IndexOf(flag) + 1]` and asserted only "not the old sentinel". Two
+        // ways that was vacuous, both caught in review: with the option ABSENT, IndexOf returns -1 and the
+        // expression reads argv[0] — a non-empty string that differs from the sentinel, so the alleged
+        // coupling passed with no allowlist at all; and a SECOND occurrence, whose value may win at
+        // argument parsing, was invisible to it.
+        var occurrences = argv.Count(a => a == "--allowed-mcp-server-names");
+        await Assert.That(occurrences).IsEqualTo(1);
+
+        var flagAt = Array.IndexOf(argv, "--allowed-mcp-server-names");
+        await Assert.That(flagAt).IsGreaterThanOrEqualTo(0);
+        await Assert.That(flagAt + 1).IsLessThan(argv.Length);
+
+        var allowed = argv[flagAt + 1];
         await Assert.That(allowed).IsNotEmpty();
 
-        if (descriptor.SupportsMcpServers) {
-            // Nothing injected can be permitted by a sentinel, so this must have been updated.
-            await Assert.That(allowed).IsNotEqualTo(AcpVendorDescriptors.GeminiNoMcpSentinel);
+        if (AcpVendorDescriptors.Gemini.SupportsMcpServers) {
+            // Denying everything is wrong once servers are injected: the allowlist has to name them.
+            await Assert.That(allowed).IsNotEqualTo(AcpVendorDescriptors.UnmatchableMcpNamePlaceholder);
         } else {
-            await Assert.That(allowed).IsEqualTo(AcpVendorDescriptors.GeminiNoMcpSentinel);
+            await Assert.That(allowed).IsEqualTo(AcpVendorDescriptors.UnmatchableMcpNamePlaceholder);
         }
+    }
+
+    /// <summary>
+    /// The deny-all name must not be a literal the reviewed repository can match.
+    ///
+    /// <para>This is the finding that broke the first version: it passed <c>kcap-none</c> and asserted in a
+    /// comment that no server would ever be called that. A contributor controls
+    /// <c>.gemini/settings.json</c> and can name their server <c>kcap-none</c> — measured, it executes, and
+    /// the clamp is bypassed entirely. So the descriptor carries a PLACEHOLDER and the factory substitutes
+    /// an unguessable value per launch; this test pins that the descriptor never carries a usable literal
+    /// again.</para>
+    /// </summary>
+    [Test]
+    public async Task Gemini_DenyAllMcpName_IsAPlaceholderNotAMatchableLiteral() {
+        var argv    = AcpVendorDescriptors.Gemini.Argv.ToArray();
+        var allowed = argv[Array.IndexOf(argv, "--allowed-mcp-server-names") + 1];
+
+        await Assert.That(allowed).IsEqualTo(AcpVendorDescriptors.UnmatchableMcpNamePlaceholder);
+
+        // A placeholder is substituted before launch, so it must be recognisable as one rather than
+        // looking like a plausible server name someone might ship as-is.
+        await Assert.That(allowed).StartsWith("__");
+        await Assert.That(allowed).EndsWith("__");
     }
 
     /// <summary>
@@ -290,23 +326,25 @@ public class AcpVendorDescriptorTests {
     /// clause are each asserted, so rewording that removes the hedging fails rather than passing a
     /// keyword scan.</para>
     /// </summary>
+    /// <summary>
+    /// A GOLDEN test: the approved wording, held independently here, must match exactly.
+    ///
+    /// <para>The first version asserted a few required phrases and two forbidden ones, which review
+    /// correctly called a fig leaf — a hint could keep both hedges and then append "the failure is caused
+    /// by an ineligible account" and still pass. Substring checks cannot establish "does not diagnose"
+    /// about arbitrary prose. Equality can: any rewording is a deliberate edit to a pinned expectation,
+    /// and whoever makes it has to justify the new text rather than slip past a keyword scan.</para>
+    /// </summary>
     [Test]
-    public async Task GeminiAuthHint_SuggestsRatherThanDiagnoses() {
-        var hint = AcpHostedAgentRuntime.GeminiAuthHint;
+    public async Task GeminiAuthHint_MatchesTheApprovedWordingExactly() {
+        const string approved =
+            "this may be an authentication or project-configuration problem, or it may be unrelated — if "
+          + "hosted Gemini has not worked on this machine before, check `gemini` is logged in and that "
+          + "GOOGLE_CLOUD_PROJECT (or GOOGLE_CLOUD_PROJECT_ID) is set where the DAEMON can see it (the "
+          + "service unit, not your shell profile), then re-run `kcap daemon service install` and restart "
+          + "the daemon";
 
-        await Assert.That(hint).Contains("may be an authentication or project-configuration problem");
-        await Assert.That(hint).Contains("or it may be unrelated");
-
-        // The actual content: a supervised daemon inherits nothing from an interactive shell, which is
-        // how the original misdiagnosis happened.
-        await Assert.That(hint).Contains("where the DAEMON can see it");
-        await Assert.That(hint).Contains("not your shell profile");
-        await Assert.That(hint).Contains("GOOGLE_CLOUD_PROJECT");
-        await Assert.That(hint).Contains("GOOGLE_CLOUD_PROJECT_ID");
-
-        // Never a verdict.
-        await Assert.That(hint).DoesNotContain("is an authentication");
-        await Assert.That(hint).DoesNotContain("You must");
+        await Assert.That(AcpHostedAgentRuntime.GeminiAuthHint).IsEqualTo(approved);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
@@ -325,9 +325,9 @@ public class AcpVendorDescriptorTests {
     /// <para>Golden-ish rather than a word blacklist: the specific hedges and the daemon-not-your-shell
     /// clause are each asserted, so rewording that removes the hedging fails rather than passing a
     /// keyword scan.</para>
-    /// </summary>
-    /// <summary>
-    /// A GOLDEN test: the approved wording, held independently here, must match exactly.
+    ///
+    /// <para><b>It is a GOLDEN test:</b> the approved wording, held independently here, must match
+    /// exactly.</para>
     ///
     /// <para>The first version asserted a few required phrases and two forbidden ones, which review
     /// correctly called a fig leaf — a hint could keep both hedges and then append "the failure is caused

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
@@ -75,4 +75,81 @@ public class ServiceEnvironmentTests {
         await Assert.That(env.ContainsKey("KCAP_COPILOT_TOKEN_CMD")).IsFalse();
         await Assert.That(env["PATH"]).IsEqualTo("C:\\bin");
     }
+
+    // ── Gemini's project/backend configuration ───────────────────────────────
+    // Why this is captured at all: a supervised daemon inherits nothing from an interactive shell, so a
+    // project exported in a shell profile is invisible to a hosted Gemini agent — and Gemini reports the
+    // absence with a message naming a TIER problem, which sends people to the wrong place.
+
+    static Dictionary<string, string> GoogleSource() => new() {
+        ["PATH"]                           = "/usr/bin",
+        ["GOOGLE_CLOUD_PROJECT"]           = "proj",
+        ["GOOGLE_CLOUD_PROJECT_ID"]        = "proj-alt",
+        ["GOOGLE_CLOUD_LOCATION"]          = "us-central1",
+        ["GOOGLE_GENAI_USE_VERTEXAI"]      = "true",
+        ["GOOGLE_GENAI_USE_GCA"]           = "false",
+        ["GOOGLE_APPLICATION_CREDENTIALS"] = "/home/u/adc.json",
+        ["GOOGLE_GEMINI_BASE_URL"]         = "https://gemini.example",
+        ["GOOGLE_VERTEX_BASE_URL"]         = "https://vertex.example",
+        ["GOOGLE_API_KEY"]                 = "SECRET-KEY",
+        ["GOOGLE_CREDENTIALS"]             = "SECRET-JSON",
+    };
+
+    [Test]
+    public async Task Build_captures_the_google_configuration_off_windows() {
+        var env = ServiceEnvironment.Build(profileName: null, source: GoogleSource(), isWindows: false);
+
+        foreach (var k in new[] { "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GOOGLE_CLOUD_LOCATION",
+                                  "GOOGLE_GENAI_USE_VERTEXAI", "GOOGLE_GENAI_USE_GCA",
+                                  "GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_GEMINI_BASE_URL",
+                                  "GOOGLE_VERTEX_BASE_URL" })
+            await Assert.That(env.ContainsKey(k)).IsTrue();
+    }
+
+    /// <summary>The direction that must never regress. A test asserting only the captures would stay green
+    /// if someone widened the allowlist to <c>GOOGLE_*</c>, which is the one change that must not pass.</summary>
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Build_never_captures_the_google_secrets(bool isWindows) {
+        var env = ServiceEnvironment.Build(profileName: null, source: GoogleSource(), isWindows: isWindows);
+
+        foreach (var k in ServiceEnvironment.NeverCapturedKeys)
+            await Assert.That(env.ContainsKey(k)).IsFalse();
+
+        // And not smuggled in under another name.
+        await Assert.That(env.Values.Any(v => v.Contains("SECRET"))).IsFalse();
+    }
+
+    /// <summary>
+    /// The platform split. A credential PATH and a base URL that may carry userinfo or a query token are
+    /// secret-capable, and Unix bounds that with a guarantee this code enforces (ServiceFiles writes 0600
+    /// and re-checks the handle). Every permission path in ServiceFiles returns early on Windows —
+    /// "ACL-governed, inherited from the user profile" — so there is no equivalent guarantee there and
+    /// those three are excluded, exactly as KCAP_COPILOT_TOKEN_CMD is.
+    /// </summary>
+    [Test]
+    public async Task Build_excludes_the_secret_capable_google_values_on_windows() {
+        var env = ServiceEnvironment.Build(profileName: null, source: GoogleSource(), isWindows: true);
+
+        await Assert.That(env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS")).IsFalse();
+        await Assert.That(env.ContainsKey("GOOGLE_GEMINI_BASE_URL")).IsFalse();
+        await Assert.That(env.ContainsKey("GOOGLE_VERTEX_BASE_URL")).IsFalse();
+
+        // ...while the non-secret configuration still reaches the unit, so hosted Gemini keeps working
+        // there for a project-scoped login.
+        await Assert.That(env["GOOGLE_CLOUD_PROJECT"]).IsEqualTo("proj");
+        await Assert.That(env["GOOGLE_GENAI_USE_VERTEXAI"]).IsEqualTo("true");
+    }
+
+    [Test]
+    public async Task Build_omits_absent_google_variables_rather_than_writing_empties() {
+        var env = ServiceEnvironment.Build(
+            profileName: null,
+            source: new Dictionary<string, string> { ["PATH"] = "/usr/bin", ["GOOGLE_CLOUD_PROJECT"] = "" },
+            isWindows: false);
+
+        await Assert.That(env.ContainsKey("GOOGLE_CLOUD_PROJECT")).IsFalse();
+        await Assert.That(env.ContainsKey("GOOGLE_CLOUD_LOCATION")).IsFalse();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceTextTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceTextTests.cs
@@ -24,8 +24,13 @@ public class ServiceTextTests {
         await Assert.That(ServiceText.CmdValue("100%PATH%")).IsEqualTo("100%%PATH%%");
     }
 
+    /// <summary>
+    /// SystemdValue no longer rewrites newlines to spaces — RequireNoControlCharacters refuses them at the
+    /// sink first, so the replacement was unreachable, and silently rewriting a caller's value was the wrong
+    /// behaviour: a service running with a value nobody chose is harder to diagnose than a failed install.
+    /// </summary>
     [Test]
-    public async Task SystemdValue_collapses_newlines_to_spaces() {
-        await Assert.That(ServiceText.SystemdValue("a\nb")).IsEqualTo("a b");
+    public async Task SystemdValue_no_longer_rewrites_control_characters() {
+        await Assert.That(ServiceText.SystemdValue("a\nb")).IsEqualTo("a\nb");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterEnvNameTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterEnvNameTests.cs
@@ -54,6 +54,43 @@ public class UnitWriterEnvNameTests {
         await Assert.That(() => WindowsTaskUnit.Wrapper(Spec(key))).Throws<InvalidOperationException>();
     }
 
+    /// <summary>
+    /// A launchd VALUE can also be XML-unrepresentable, and escaping does not fix it: U+0001 has no legal
+    /// XML 1.0 form, escaped or not, while POSIX permits any byte but NUL in a value. The failure is
+    /// availability rather than injection — the plist will not load, so the service silently does not
+    /// exist. Failing at write time names the variable instead.
+    /// </summary>
+    [Test]
+    [Arguments("\u0001")]
+    [Arguments("ok\u0000bad")]
+    [Arguments("pre\u001Fpost")]
+    public async Task Launchd_rejects_a_value_xml_cannot_represent(string hostileValue) {
+        var spec = new ServiceSpec(
+            ServiceId:        "test",
+            DaemonBinaryPath: "/usr/local/bin/kcap",
+            LogPath:          "/tmp/kcap.log",
+            Environment:      new Dictionary<string, string> { ["GOOGLE_CLOUD_PROJECT"] = hostileValue },
+            ExtraArgs:        []);
+
+        await Assert.That(() => LaunchdUnit.Plist(spec)).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>Tab, LF and CR ARE legal XML 1.0 and must not be rejected — the check is about the
+    /// characters XML cannot carry, not about tidiness.</summary>
+    [Test]
+    [Arguments("a\tb")]
+    [Arguments("a\nb")]
+    public async Task Launchd_accepts_the_control_characters_xml_permits(string ok) {
+        var spec = new ServiceSpec(
+            ServiceId:        "test",
+            DaemonBinaryPath: "/usr/local/bin/kcap",
+            LogPath:          "/tmp/kcap.log",
+            Environment:      new Dictionary<string, string> { ["GOOGLE_CLOUD_PROJECT"] = ok },
+            ExtraArgs:        []);
+
+        await Assert.That(LaunchdUnit.Plist(spec)).Contains("GOOGLE_CLOUD_PROJECT");
+    }
+
     /// <summary>The positive control, at every sink. Without it the suites above would pass on a writer
     /// that rejected everything — including the names kcap actually captures.</summary>
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterEnvNameTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterEnvNameTests.cs
@@ -1,0 +1,70 @@
+using Capacitor.Cli.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// Every unit writer must reject an environment-variable NAME it cannot carry, and each one is tested
+/// directly at its own sink.
+///
+/// <para>The name is interpolated into a line whose structure it can break, and each format then hands the
+/// attacker something different. <b>systemd is the worst:</b> a key shaped like
+/// <c>SAFE=ok\nExecStartPre=/bin/touch /tmp/pwned\n#</c> with an ordinary value renders a valid
+/// <c>Environment=SAFE=ok</c> line, then an attacker-chosen <c>ExecStartPre=</c> that the service runs on
+/// every restart, then comments out the rest. Value escaping cannot help: <c>SystemdValue</c> normalises
+/// the value and <c>EnvAssignment</c> decides quoting from the value — neither looks at the name.</para>
+///
+/// <para>Called per writer rather than once through a shared helper: the point of a sink check is that
+/// every sink has it, and a single helper test would pass while a writer forgot to call it.</para>
+/// </summary>
+public class UnitWriterEnvNameTests {
+    static ServiceSpec Spec(string key) => new(
+        ServiceId:        "test",
+        DaemonBinaryPath: "/usr/local/bin/kcap",
+        LogPath:          "/tmp/kcap.log",
+        Environment:      new Dictionary<string, string> { [key] = "harmless" },
+        ExtraArgs:        []);
+
+    /// <summary>The systemd unit-file injection primitive, and three simpler shapes.</summary>
+    [Test]
+    [Arguments("SAFE=ok\nExecStartPre=/bin/touch /tmp/pwned\n#")]
+    [Arguments("BAD=KEY")]
+    [Arguments("BAD\"KEY")]
+    [Arguments("BAD KEY")]
+    [Arguments("9LEADING_DIGIT")]
+    [Arguments("")]
+    public async Task Systemd_rejects_a_hostile_environment_name(string key) {
+        await Assert.That(() => SystemdUnit.Unit(Spec(key))).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    [Arguments("SAFE=ok\nExecStartPre=/bin/touch /tmp/pwned\n#")]
+    [Arguments("BAD=KEY")]
+    [Arguments("\u0001CTRL")]
+    [Arguments("")]
+    public async Task Launchd_rejects_a_hostile_environment_name(string key) {
+        await Assert.That(() => LaunchdUnit.Plist(Spec(key))).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    [Arguments("SAFE=ok\r\nExecStartPre=/bin/touch C:\\pwned\r\n#")]
+    [Arguments("BAD=KEY")]
+    [Arguments("BAD\"KEY")]
+    [Arguments("")]
+    public async Task Windows_rejects_a_hostile_environment_name(string key) {
+        await Assert.That(() => WindowsTaskUnit.Wrapper(Spec(key))).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>The positive control, at every sink. Without it the suites above would pass on a writer
+    /// that rejected everything — including the names kcap actually captures.</summary>
+    [Test]
+    [Arguments("PATH")]
+    [Arguments("KCAP_PROFILE")]
+    [Arguments("GOOGLE_CLOUD_PROJECT")]
+    [Arguments("GOOGLE_GENAI_USE_VERTEXAI")]
+    [Arguments("_LEADING_UNDERSCORE")]
+    public async Task Every_writer_accepts_a_legitimate_environment_name(string key) {
+        await Assert.That(SystemdUnit.Unit(Spec(key))).Contains(key);
+        await Assert.That(LaunchdUnit.Plist(Spec(key))).Contains(key);
+        await Assert.That(WindowsTaskUnit.Wrapper(Spec(key))).Contains(key);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterExpansionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterExpansionTests.cs
@@ -318,4 +318,123 @@ public class UnitWriterExpansionTests {
     public async Task ServiceExtraArgs_is_empty_when_the_flag_is_absent() {
         await Assert.That(DaemonCommands.ServiceExtraArgs(null)).IsEmpty();
     }
+
+    // ── the execution MODE must be part of the artifact, not inherited from the machine ──
+
+    /// <summary>
+    /// `!NAME!` delayed expansion happens INSIDE double quotes, and CmdValue doubles `%`, not `!` — so
+    /// quoting and percent-escaping both leave it live where a machine enables the mode by default.
+    /// </summary>
+    [Test]
+    public async Task Windows_wrapper_disables_delayed_expansion() {
+        await Assert.That(WindowsTaskUnit.Wrapper(Spec())).Contains("setlocal DisableDelayedExpansion");
+    }
+
+    /// <summary>It must come before any value is set, or the values it protects are already on the line.</summary>
+    [Test]
+    public async Task Windows_wrapper_disables_delayed_expansion_before_setting_anything() {
+        var wrapper = WindowsTaskUnit.Wrapper(Spec());
+
+        await Assert.That(wrapper.IndexOf("setlocal DisableDelayedExpansion", StringComparison.Ordinal))
+            .IsLessThan(wrapper.IndexOf("set \"", StringComparison.Ordinal));
+    }
+
+    /// <summary>A bang-shaped value is carried literally rather than escaped — the mode is what neutralises it.</summary>
+    [Test]
+    public async Task Windows_wrapper_carries_a_bang_shaped_value_under_a_disabled_mode() {
+        var spec = Spec() with {
+            Environment = new Dictionary<string, string> { ["KCAP_URL"] = "!PAYLOAD!" },
+        };
+
+        var wrapper = WindowsTaskUnit.Wrapper(spec);
+
+        await Assert.That(wrapper).Contains("setlocal DisableDelayedExpansion");
+        await Assert.That(wrapper).Contains("set \"KCAP_URL=!PAYLOAD!\"");
+    }
+
+    [Test]
+    public async Task Task_xml_fixes_the_execution_mode_and_skips_autorun() {
+        var xml = WindowsTaskUnit.TaskXml(Spec(), @"C:\Users\u\.config\kcap\daemon-service-laptop.cmd");
+
+        await Assert.That(xml).Contains("/d /s /v:off /c");
+    }
+
+    /// <summary>
+    /// The nested-quote form: `/s` plus a command starting and ending in a quote makes cmd strip exactly the
+    /// outer pair, so the inner pair survives to quote a path containing `&amp;`.
+    /// </summary>
+    [Test]
+    public async Task Task_xml_double_quotes_the_wrapper_path() {
+        var xml = WindowsTaskUnit.TaskXml(Spec(), @"C:\Users\a&b\daemon-service-laptop.cmd");
+
+        // The outer quote pair is literal text in the element (only < and & need escaping in XML content),
+        // so cmd receives a command that both starts and ends with a quote — the /s precondition.
+        await Assert.That(xml).Contains(@"/c """"C:\Users\a&amp;b\daemon-service-laptop.cmd""""");
+    }
+
+    [Test]
+    public async Task Task_xml_accepts_a_wrapper_path_with_a_space_and_an_ampersand() {
+        var xml = WindowsTaskUnit.TaskXml(Spec(), @"C:\Users\a & b\daemon-service-laptop.cmd");
+
+        await Assert.That(xml).Contains(@"a &amp; b\daemon-service-laptop.cmd");
+    }
+
+    /// <summary>
+    /// `%` has no escape on a cmd COMMAND LINE — `%%` is a batch-file construct — so this sink refuses where
+    /// the wrapper body escapes. Same character, two sinks, two correct treatments.
+    /// </summary>
+    [Test]
+    public async Task Task_xml_rejects_a_percent_shaped_wrapper_path_component() {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            WindowsTaskUnit.TaskXml(Spec(), @"C:\Users\%USERNAME%\daemon-service-laptop.cmd"));
+
+        await Assert.That(ex!.Message).Contains("percent sign");
+    }
+
+    [Test]
+    [Arguments("C:\\Users\\a\"b\\w.cmd")]
+    [Arguments("C:\\Users\\a\nb\\w.cmd")]
+    public async Task Task_xml_rejects_a_structurally_unrepresentable_wrapper_path(string path) {
+        var ex = Assert.Throws<InvalidOperationException>(() => WindowsTaskUnit.TaskXml(Spec(), path));
+
+        await Assert.That(ex!.Message).Contains("quote or newline");
+    }
+
+    // ── systemd: the apostrophe is structural to its word lexer too ──
+
+    /// <summary>
+    /// Bare, an unpaired apostrophe opens a single-quoted string that never closes (unit unloadable); a
+    /// paired one is stripped (value silently changed). `O'Reilly` in a home directory is the ordinary case.
+    /// </summary>
+    [Test]
+    public async Task Systemd_quotes_an_execstart_value_containing_an_apostrophe() {
+        var spec = Spec() with { DaemonBinaryPath = "/home/o'reilly/kcap-daemon" };
+
+        await Assert.That(SystemdUnit.Unit(spec)).Contains("ExecStart=\"/home/o'reilly/kcap-daemon\"");
+    }
+
+    [Test]
+    public async Task BinaryFromUnit_round_trips_an_apostrophe_path() {
+        var spec = Spec() with { DaemonBinaryPath = "/home/o'reilly/kcap-daemon" };
+
+        await Assert.That(SystemdUnit.BinaryFromUnit(SystemdUnit.Unit(spec)))
+            .IsEqualTo("/home/o'reilly/kcap-daemon");
+    }
+
+    [Test]
+    public async Task Systemd_quotes_an_environment_value_containing_an_apostrophe() {
+        var spec = Spec() with {
+            Environment = new Dictionary<string, string> { ["PATH"] = "/home/o'reilly/bin" },
+        };
+
+        await Assert.That(SystemdUnit.Unit(spec)).Contains("Environment=\"PATH=/home/o'reilly/bin\"");
+    }
+
+    /// <summary>A PAIRED apostrophe is the silent-corruption case, and needs quoting just as much.</summary>
+    [Test]
+    public async Task Systemd_quotes_a_value_with_paired_apostrophes() {
+        var spec = Spec() with { ExtraArgs = ["--tag", "'quoted'"] };
+
+        await Assert.That(SystemdUnit.Unit(spec)).Contains("\"'quoted'\"");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterExpansionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterExpansionTests.cs
@@ -218,16 +218,20 @@ public class UnitWriterExpansionTests {
         await Assert.That(SystemdUnit.Unit(spec)).Contains("--tag a;b");
     }
 
-    /// <summary>Quoting cannot contain a newline: the directive ends at the line break.</summary>
+    /// <summary>
+    /// Quoting cannot contain a newline: the directive ends at the line break and the remainder is parsed as
+    /// the next directive — so the payload here is a whole injected `ExecStartPre=`, which is the worst case
+    /// of the control-character class the shared guard now refuses.
+    /// </summary>
     [Test]
-    [Arguments("a\nExecStartPre=/bin/touch /tmp/pwned")]
-    [Arguments("a\rb")]
-    public async Task Systemd_rejects_a_line_break_in_an_execstart_value(string bad) {
+    [Arguments("a\nExecStartPre=/bin/touch /tmp/pwned", "U+000A")]
+    [Arguments("a\rb", "U+000D")]
+    public async Task Systemd_rejects_a_line_break_in_an_execstart_value(string bad, string codePoint) {
         var spec = Spec() with { ExtraArgs = ["--tag", bad] };
 
         var ex = Assert.Throws<InvalidOperationException>(() => SystemdUnit.Unit(spec));
 
-        await Assert.That(ex!.Message).Contains("line break");
+        await Assert.That(ex!.Message).Contains(codePoint);
     }
 
     // ── Windows: cmd metacharacters, which %-doubling alone does not neutralise ──
@@ -436,5 +440,86 @@ public class UnitWriterExpansionTests {
         var spec = Spec() with { ExtraArgs = ["--tag", "'quoted'"] };
 
         await Assert.That(SystemdUnit.Unit(spec)).Contains("\"'quoted'\"");
+    }
+
+    // ── systemd refuses every raw control character, not only the line breaks ──
+
+    /// <summary>
+    /// A POSIX environment value, a filename and an argv string may all legally carry U+0001, a backspace or
+    /// a vertical tab; quoting makes none of them valid unit syntax, and this writer has no encoder for them.
+    /// </summary>
+    [Test]
+    [Arguments("\u0001")]
+    [Arguments("\b")]
+    [Arguments("\v")]
+    [Arguments("\u007F")]
+    [Arguments("\n")]
+    [Arguments("\r")]
+    public async Task Systemd_rejects_a_control_character_in_an_environment_value(string bad) {
+        var spec = Spec() with {
+            Environment = new Dictionary<string, string> { ["PATH"] = $"/usr/bin{bad}/opt" },
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => SystemdUnit.Unit(spec));
+
+        await Assert.That(ex!.Message).Contains("PATH");
+    }
+
+    [Test]
+    [Arguments("\u0001")]
+    [Arguments("\b")]
+    [Arguments("\v")]
+    [Arguments("\n")]
+    public async Task Systemd_rejects_a_control_character_in_an_execstart_value(string bad) {
+        var spec = Spec() with { DaemonBinaryPath = $"/opt/kcap{bad}/kcap-daemon" };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => SystemdUnit.Unit(spec));
+
+        await Assert.That(ex!.Message).Contains("ExecStart");
+    }
+
+    [Test]
+    public async Task Systemd_rejects_a_control_character_in_an_extra_arg() {
+        var spec = Spec() with { ExtraArgs = ["--tag", "a\u0001b"] };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => SystemdUnit.Unit(spec));
+
+        await Assert.That(ex!.Message).Contains("U+0001");
+    }
+
+    /// <summary>The positive control: a unit whose values are all ordinary still renders.</summary>
+    [Test]
+    public async Task Systemd_renders_when_no_value_carries_a_control_character() {
+        var unit = SystemdUnit.Unit(Spec());
+
+        await Assert.That(unit).Contains("ExecStart=/opt/kcap/kcap-daemon");
+        await Assert.That(unit).Contains("Environment=PATH=/usr/bin");
+    }
+
+    // ── the Task XML gets the plist's guard-then-escape invariant ──
+
+    /// <summary>
+    /// Windows paths are native UTF-16 and the path carries KCAP_CONFIG_DIR verbatim, so an XML-illegal unit
+    /// can reach this writer; SecurityElement.Escape passes all of them through untouched, leaving a task
+    /// that cannot be registered — the same availability failure already fixed in the plist.
+    /// </summary>
+    [Test]
+    [Arguments('\uFFFE')]
+    [Arguments('\uFFFF')]
+    [Arguments('\uD83D')]
+    [Arguments('\u0001')]
+    public async Task Task_xml_rejects_an_xml_illegal_wrapper_path(char bad) {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            WindowsTaskUnit.TaskXml(Spec(), $"C:\\Users\\a{bad}b\\daemon-service-laptop.cmd"));
+
+        await Assert.That(ex!.Message).Contains("XML 1.0");
+    }
+
+    /// <summary>A legal supplementary character in the path is NOT rejected — the guard is not a blanket refusal.</summary>
+    [Test]
+    public async Task Task_xml_accepts_a_wrapper_path_with_a_supplementary_character() {
+        var xml = WindowsTaskUnit.TaskXml(Spec(), "C:\\Users\\\U0001F600\\daemon-service-laptop.cmd");
+
+        await Assert.That(xml).Contains("\U0001F600");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterExpansionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterExpansionTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Commands;
 using Capacitor.Cli.Services;
 
 namespace Capacitor.Cli.Tests.Unit.Services;
@@ -109,7 +110,7 @@ public class UnitWriterExpansionTests {
     public async Task Windows_wrapper_doubles_percent_in_extra_args() {
         var spec = Spec() with { ExtraArgs = ["--tag", "100%"] };
 
-        await Assert.That(WindowsTaskUnit.Wrapper(spec)).Contains("--tag 100%%");
+        await Assert.That(WindowsTaskUnit.Wrapper(spec)).Contains("\"--tag\" \"100%%\"");
     }
 
     [Test]
@@ -145,5 +146,176 @@ public class UnitWriterExpansionTests {
         var recovered = WindowsTaskUnit.BinaryFromWrapper(WindowsTaskUnit.Wrapper(spec));
 
         await Assert.That(recovered).IsEqualTo(@"C:\Program Files\50%off\kcap-daemon.exe");
+    }
+
+    // ── systemd: ExecStart carries a SECOND expansion (variables) and its own separator grammar ──
+
+    /// <summary>
+    /// systemd expands `$NAME`/`${NAME}` in an ExecStart command line — a different mechanism from the `%`
+    /// specifiers, and one that also reaches the executable path.
+    /// </summary>
+    [Test]
+    public async Task Systemd_execstart_doubles_a_dollar_in_the_binary_path() {
+        var spec = Spec() with { DaemonBinaryPath = "/opt/${HOME}/kcap-daemon" };
+
+        await Assert.That(SystemdUnit.Unit(spec)).Contains("ExecStart=/opt/$${HOME}/kcap-daemon ");
+    }
+
+    [Test]
+    public async Task Systemd_execstart_doubles_a_bare_dollar_variable() {
+        var spec = Spec() with { ExtraArgs = ["--tag", "$HOME"] };
+
+        await Assert.That(SystemdUnit.Unit(spec)).Contains("--tag $$HOME");
+    }
+
+    [Test]
+    public async Task BinaryFromUnit_round_trips_a_dollar_path() {
+        var spec = Spec() with { DaemonBinaryPath = "/opt/${HOME}/kcap-daemon" };
+
+        await Assert.That(SystemdUnit.BinaryFromUnit(SystemdUnit.Unit(spec)))
+            .IsEqualTo("/opt/${HOME}/kcap-daemon");
+    }
+
+    [Test]
+    public async Task BinaryFromUnit_round_trips_a_path_with_both_percent_and_dollar() {
+        var spec = Spec() with { DaemonBinaryPath = "/opt/50%$HOME/kcap-daemon" };
+
+        await Assert.That(SystemdUnit.BinaryFromUnit(SystemdUnit.Unit(spec)))
+            .IsEqualTo("/opt/50%$HOME/kcap-daemon");
+    }
+
+    /// <summary>
+    /// The asymmetry is deliberate: systemd expands specifiers in `Environment=` but NOT variables, so
+    /// doubling `$` there would corrupt the value. Different sink, different escape.
+    /// </summary>
+    [Test]
+    public async Task Systemd_environment_value_does_NOT_double_a_dollar() {
+        var spec = Spec() with {
+            Environment = new Dictionary<string, string> { ["KCAP_URL"] = "http://h/$path" },
+        };
+
+        var unit = SystemdUnit.Unit(spec);
+
+        await Assert.That(unit).Contains("Environment=KCAP_URL=http://h/$path");
+        await Assert.That(unit).DoesNotContain("$$path");
+    }
+
+    /// <summary>A bare `;` is systemd's command separator: everything after it would run as a second command.</summary>
+    [Test]
+    public async Task Systemd_rejects_a_bare_semicolon_argument() {
+        var spec = Spec() with { ExtraArgs = [";", "/bin/touch", "/tmp/pwned"] };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => SystemdUnit.Unit(spec));
+
+        await Assert.That(ex!.Message).Contains("command separator");
+    }
+
+    /// <summary>A semicolon INSIDE a value is not a separator — systemd tokenizes on whitespace first.</summary>
+    [Test]
+    public async Task Systemd_allows_a_semicolon_inside_a_value() {
+        var spec = Spec() with { ExtraArgs = ["--tag", "a;b"] };
+
+        await Assert.That(SystemdUnit.Unit(spec)).Contains("--tag a;b");
+    }
+
+    /// <summary>Quoting cannot contain a newline: the directive ends at the line break.</summary>
+    [Test]
+    [Arguments("a\nExecStartPre=/bin/touch /tmp/pwned")]
+    [Arguments("a\rb")]
+    public async Task Systemd_rejects_a_line_break_in_an_execstart_value(string bad) {
+        var spec = Spec() with { ExtraArgs = ["--tag", bad] };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => SystemdUnit.Unit(spec));
+
+        await Assert.That(ex!.Message).Contains("line break");
+    }
+
+    // ── Windows: cmd metacharacters, which %-doubling alone does not neutralise ──
+
+    /// <summary>
+    /// `foo&calc.exe` contains no space and no percent, so the old quote-when-it-has-a-space rule emitted it
+    /// bare and cmd read `&` as a command separator — in a file the OS runs at every logon.
+    /// </summary>
+    [Test]
+    [Arguments("8&calc.exe")]
+    [Arguments("8|calc.exe")]
+    [Arguments("8>out.txt")]
+    [Arguments("8<in.txt")]
+    [Arguments("8^&calc.exe")]
+    [Arguments("(8)")]
+    public async Task Windows_wrapper_quotes_an_argument_bearing_a_cmd_metacharacter(string arg) {
+        var spec = Spec() with { ExtraArgs = ["--max-agents", arg] };
+
+        await Assert.That(WindowsTaskUnit.Wrapper(spec)).Contains($"\"{arg}\"");
+    }
+
+    /// <summary>A quote cannot be represented on the exec line at all — quoting it does not help.</summary>
+    [Test]
+    [Arguments("8\" & calc.exe & rem \"")]
+    [Arguments("8\ncalc.exe")]
+    [Arguments("8\rcalc.exe")]
+    public async Task Windows_wrapper_rejects_an_unrepresentable_argument(string arg) {
+        var spec = Spec() with { ExtraArgs = ["--max-agents", arg] };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => WindowsTaskUnit.Wrapper(spec));
+
+        await Assert.That(ex!.Message).Contains("quote or newline");
+    }
+
+    [Test]
+    public async Task Windows_wrapper_rejects_an_unrepresentable_log_path() {
+        var spec = Spec() with { LogPath = "C:\\logs\\a\"b.log" };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => WindowsTaskUnit.Wrapper(spec));
+
+        await Assert.That(ex!.Message).Contains("the log path");
+    }
+
+    /// <summary>
+    /// A trailing backslash inside a quoted argument escapes the closing quote under the Windows argv rules,
+    /// merging this argument with the next. Doubling the run is the documented encoding.
+    /// </summary>
+    [Test]
+    public async Task Windows_wrapper_doubles_a_trailing_backslash_run() {
+        var spec = Spec() with { ExtraArgs = ["--dir", "C:\\logs\\"] };
+
+        await Assert.That(WindowsTaskUnit.Wrapper(spec)).Contains("\"C:\\logs\\\\\"");
+    }
+
+    [Test]
+    public async Task Windows_wrapper_leaves_an_interior_backslash_alone() {
+        var spec = Spec() with { ExtraArgs = ["--dir", "C:\\a\\b"] };
+
+        await Assert.That(WindowsTaskUnit.Wrapper(spec)).Contains("\"C:\\a\\b\"");
+    }
+
+    // ── the matching narrowing at the source ──
+
+    /// <summary>
+    /// --max-agents is the only caller-supplied ExtraArgs entry and it is numeric, so the value is validated
+    /// where it enters rather than only escaped where it lands. Independent of the sink hardening above.
+    /// </summary>
+    [Test]
+    [Arguments("8&calc.exe")]
+    [Arguments("8;calc")]
+    [Arguments("abc")]
+    [Arguments("")]
+    [Arguments("0")]
+    [Arguments("-1")]
+    [Arguments("8.5")]
+    public async Task ServiceExtraArgs_rejects_a_non_positive_integer(string bad) {
+        var ex = Assert.Throws<ArgumentException>(() => DaemonCommands.ServiceExtraArgs(bad));
+
+        await Assert.That(ex!.Message).Contains("positive integer");
+    }
+
+    [Test]
+    public async Task ServiceExtraArgs_accepts_an_integer() {
+        await Assert.That(DaemonCommands.ServiceExtraArgs("8")).IsEquivalentTo(["--max-agents", "8"]);
+    }
+
+    [Test]
+    public async Task ServiceExtraArgs_is_empty_when_the_flag_is_absent() {
+        await Assert.That(DaemonCommands.ServiceExtraArgs(null)).IsEmpty();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterExpansionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterExpansionTests.cs
@@ -1,0 +1,149 @@
+using Capacitor.Cli.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// Both unit writers interpolate values into a format that performs its OWN expansion pass before the value
+/// is read as data — cmd.exe expands <c>%VAR%</c> in a batch file, systemd expands <c>%n</c>-style specifiers
+/// in a unit. A value carrying a literal percent therefore does not survive unless it is doubled, and a
+/// value whose expansion produces punctuation can change the line's structure.
+///
+/// <para>These are round-trip and preservation tests rather than "contains" tests: the failure being guarded
+/// is a value that reads back as something OTHER than what was captured.</para>
+/// </summary>
+public class UnitWriterExpansionTests {
+    static ServiceSpec Spec() => new(
+        "laptop", "/opt/kcap/kcap-daemon", "/home/u/.config/kcap/daemon-laptop.log",
+        new Dictionary<string, string> { ["PATH"] = "/usr/bin" },
+        ["--max-agents", "8"]);
+
+    // ── systemd: Environment= and Description= specifier expansion ──
+
+    [Test]
+    public async Task SystemdValue_doubles_a_literal_percent() {
+        await Assert.That(ServiceText.SystemdValue("100%")).IsEqualTo("100%%");
+    }
+
+    /// <summary>`%n` is systemd's unit-name specifier: undoubled, the value silently becomes the unit name.</summary>
+    [Test]
+    public async Task SystemdValue_doubles_a_recognised_specifier() {
+        await Assert.That(ServiceText.SystemdValue("/opt/%n/bin")).IsEqualTo("/opt/%%n/bin");
+    }
+
+    /// <summary>An UNrecognised specifier is worse than a rewrite: systemd refuses to load the unit at all.</summary>
+    [Test]
+    public async Task SystemdValue_doubles_an_unrecognised_specifier() {
+        await Assert.That(ServiceText.SystemdValue("a%zb")).IsEqualTo("a%%zb");
+    }
+
+    [Test]
+    public async Task Systemd_environment_value_carries_a_percent_doubled() {
+        var spec = Spec() with {
+            Environment = new Dictionary<string, string> { ["PATH"] = "/opt/50%off/bin" },
+        };
+
+        await Assert.That(SystemdUnit.Unit(spec)).Contains("Environment=PATH=/opt/50%%off/bin");
+    }
+
+    [Test]
+    public async Task Systemd_description_carries_a_percent_doubled() {
+        // ServiceId is sanitized, so it cannot itself hold a percent — drive the directive directly.
+        await Assert.That(ServiceText.SystemdValue("kcap daemon (a%b)")).IsEqualTo("kcap daemon (a%%b)");
+    }
+
+    // ── systemd: ExecStart= specifier expansion, and its reversal ──
+
+    [Test]
+    public async Task Systemd_execstart_doubles_percent_in_the_binary_path() {
+        var spec = Spec() with { DaemonBinaryPath = "/home/50%off/kcap-daemon" };
+
+        await Assert.That(SystemdUnit.Unit(spec)).Contains("ExecStart=/home/50%%off/kcap-daemon ");
+    }
+
+    [Test]
+    public async Task Systemd_execstart_doubles_percent_in_the_log_path() {
+        var spec = Spec() with { LogPath = "/var/log/100%/daemon.log" };
+
+        await Assert.That(SystemdUnit.Unit(spec)).Contains("--log-file /var/log/100%%/daemon.log");
+    }
+
+    /// <summary>
+    /// `daemon doctor` reads the binary back out of the rendered unit, so the doubling MUST be reversed —
+    /// otherwise the doctor reports a path that does not exist and the service looks broken when it is fine.
+    /// </summary>
+    [Test]
+    public async Task BinaryFromUnit_round_trips_a_percent_path() {
+        var spec = Spec() with { DaemonBinaryPath = "/home/50%off/kcap-daemon" };
+
+        var recovered = SystemdUnit.BinaryFromUnit(SystemdUnit.Unit(spec));
+
+        await Assert.That(recovered).IsEqualTo("/home/50%off/kcap-daemon");
+    }
+
+    /// <summary>The quoted arm is a separate code path from the bare one — a space forces quoting.</summary>
+    [Test]
+    public async Task BinaryFromUnit_round_trips_a_percent_path_that_also_needs_quoting() {
+        var spec = Spec() with { DaemonBinaryPath = "/home/50% off/kcap-daemon" };
+
+        var unit      = SystemdUnit.Unit(spec);
+        var recovered = SystemdUnit.BinaryFromUnit(unit);
+
+        await Assert.That(unit).Contains("ExecStart=\"/home/50%% off/kcap-daemon\"");
+        await Assert.That(recovered).IsEqualTo("/home/50% off/kcap-daemon");
+    }
+
+    // ── Windows: cmd.exe expansion on the exec line ──
+
+    /// <summary>
+    /// The env-var arm was already escaped; these three values share the same line and were not. `%` is a
+    /// legal Windows filename character, so this is reachable through an ordinary directory name.
+    /// </summary>
+    [Test]
+    public async Task Windows_wrapper_doubles_percent_in_the_log_path() {
+        var spec = Spec() with { LogPath = @"C:\Users\u\50%off\daemon.log" };
+
+        await Assert.That(WindowsTaskUnit.Wrapper(spec)).Contains(@"--log-file ""C:\Users\u\50%%off\daemon.log""");
+    }
+
+    [Test]
+    public async Task Windows_wrapper_doubles_percent_in_extra_args() {
+        var spec = Spec() with { ExtraArgs = ["--tag", "100%"] };
+
+        await Assert.That(WindowsTaskUnit.Wrapper(spec)).Contains("--tag 100%%");
+    }
+
+    [Test]
+    public async Task Windows_wrapper_doubles_percent_in_an_environment_value() {
+        var spec = Spec() with {
+            Environment = new Dictionary<string, string> { ["PATH"] = @"C:\50%off" },
+        };
+
+        await Assert.That(WindowsTaskUnit.Wrapper(spec)).Contains(@"set ""PATH=C:\50%%off""");
+    }
+
+    /// <summary>
+    /// The structural case behind the escaping: a value shaped like a variable reference whose EXPANSION
+    /// would close the quoted assignment and append a command. Doubled, cmd never expands it, so the
+    /// assignment stays one token and the payload stays data.
+    /// </summary>
+    [Test]
+    public async Task Windows_wrapper_neutralises_a_value_shaped_like_a_variable_reference() {
+        var spec = Spec() with {
+            Environment = new Dictionary<string, string> { ["KCAP_URL"] = "%PAYLOAD%" },
+        };
+
+        var wrapper = WindowsTaskUnit.Wrapper(spec);
+
+        await Assert.That(wrapper).Contains("set \"KCAP_URL=%%PAYLOAD%%\"");
+        await Assert.That(wrapper).DoesNotContain("set \"KCAP_URL=%PAYLOAD%\"");
+    }
+
+    [Test]
+    public async Task BinaryFromWrapper_round_trips_a_percent_path() {
+        var spec = Spec() with { DaemonBinaryPath = @"C:\Program Files\50%off\kcap-daemon.exe" };
+
+        var recovered = WindowsTaskUnit.BinaryFromWrapper(WindowsTaskUnit.Wrapper(spec));
+
+        await Assert.That(recovered).IsEqualTo(@"C:\Program Files\50%off\kcap-daemon.exe");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/WindowsTaskUnitRepresentabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/WindowsTaskUnitRepresentabilityTests.cs
@@ -1,0 +1,70 @@
+using Capacitor.Cli.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// The Windows wrapper must reject a value it cannot represent, and it must do so ITSELF.
+///
+/// <para>These call <see cref="WindowsTaskUnit.Wrapper"/> directly rather than going through
+/// <c>ServiceEnvironment.Build</c>. Routing through Build would make this an end-to-end pipeline test that
+/// passes even if the writer were defenceless — and Build is demonstrably not the boundary:
+/// <c>DaemonCommands</c> adds <c>KCAP_DAEMON_SUPERVISED</c> to the dictionary AFTER <c>Capture</c> returns,
+/// so a value reaches this writer today without passing through Build at all.</para>
+///
+/// <para>The consequence being guarded is command execution: each variable is emitted as
+/// <c>set "K=V"</c> with only <c>%</c> escaped, so an embedded quote closes the assignment and the
+/// remainder of the line becomes batch commands in a file the service runs.</para>
+/// </summary>
+public class WindowsTaskUnitRepresentabilityTests {
+    static ServiceSpec Spec(string key, string value) => new(
+        ServiceId:        "test",
+        DaemonBinaryPath: @"C:\kcap\kcap.exe",
+        LogPath:          @"C:\kcap\log.txt",
+        Environment:      new Dictionary<string, string> { [key] = value },
+        ExtraArgs:        []);
+
+    [Test]
+    [Arguments("\"")]
+    [Arguments("x\" & calc.exe & \"y")]
+    [Arguments("a\r\nset FOO=bar")]
+    [Arguments("a\nb")]
+    public async Task Wrapper_rejects_a_value_it_cannot_represent(string hostile) {
+        await Assert.That(() => WindowsTaskUnit.Wrapper(Spec("GOOGLE_CLOUD_PROJECT", hostile)))
+            .Throws<InvalidOperationException>();
+    }
+
+    /// <summary>Applies to EVERY key, not just the newly captured ones — scoping it to Gemini's variables
+    /// would leave the same exposure live for PATH, which has always gone through this writer.</summary>
+    [Test]
+    [Arguments("PATH")]
+    [Arguments("KCAP_URL")]
+    [Arguments("KCAP_DAEMON_SUPERVISED")]
+    public async Task Wrapper_rejects_regardless_of_which_key_carries_it(string key) {
+        await Assert.That(() => WindowsTaskUnit.Wrapper(Spec(key, "c:\\a\" & echo pwned & \"")))
+            .Throws<InvalidOperationException>();
+    }
+
+    /// <summary>The error has to name the key, or an operator cannot act on it.</summary>
+    [Test]
+    public async Task Wrapper_names_the_offending_key() {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => WindowsTaskUnit.Wrapper(Spec("GOOGLE_VERTEX_BASE_URL", "https://x\"")));
+
+        await Assert.That(ex!.Message).Contains("GOOGLE_VERTEX_BASE_URL");
+    }
+
+    /// <summary>The positive control: everything legitimate still round-trips, including a path with
+    /// spaces and a value containing `%` (which the existing escaper handles). Without this, the tests
+    /// above would pass on a writer that rejected everything.</summary>
+    [Test]
+    [Arguments("my-project-123")]
+    [Arguments("us-central1")]
+    [Arguments("https://gemini.example/v1?x=1")]
+    [Arguments(@"C:\Program Files\creds\adc.json")]
+    [Arguments("100%")]
+    public async Task Wrapper_accepts_legitimate_values(string ok) {
+        var wrapper = WindowsTaskUnit.Wrapper(Spec("GOOGLE_CLOUD_PROJECT", ok));
+
+        await Assert.That(wrapper).Contains("set \"GOOGLE_CLOUD_PROJECT=");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/WindowsTaskUnitRepresentabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/WindowsTaskUnitRepresentabilityTests.cs
@@ -44,6 +44,19 @@ public class WindowsTaskUnitRepresentabilityTests {
             .Throws<InvalidOperationException>();
     }
 
+    /// <summary>The KEY is interpolated into the same `set "K=V"` line, so it is exactly as dangerous as
+    /// the value. The first version checked only the value — review caught that the stated rationale
+    /// (callers add entries after Build, so the sink must validate) applies to both sides equally.</summary>
+    [Test]
+    [Arguments("BAD\"KEY")]
+    [Arguments("BAD\r\nset FOO=bar")]
+    [Arguments("BAD=KEY")]
+    [Arguments("")]
+    public async Task Wrapper_rejects_a_hostile_environment_variable_NAME(string hostileKey) {
+        await Assert.That(() => WindowsTaskUnit.Wrapper(Spec(hostileKey, "harmless")))
+            .Throws<InvalidOperationException>();
+    }
+
     /// <summary>The error has to name the key, or an operator cannot act on it.</summary>
     [Test]
     public async Task Wrapper_names_the_offending_key() {

--- a/test/Capacitor.Cli.Tests.Unit/Services/WindowsTaskUnitTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/WindowsTaskUnitTests.cs
@@ -19,7 +19,9 @@ public class WindowsTaskUnitTests {
         var cmd = WindowsTaskUnit.Wrapper(Spec());
         await Assert.That(cmd).Contains("set \"PATH=C:\\bin\"");
         await Assert.That(cmd).Contains("set \"KCAP_PROFILE=work\"");
-        await Assert.That(cmd).Contains("\"C:\\kcap\\kcap-daemon.exe\" --name laptop --log-file \"C:\\Users\\u\\.config\\kcap\\daemon-laptop.log\" --max-agents 8");
+        // Every value on the exec line is quoted now, not only the paths: cmd treats & | < > ( ) ^ as live
+        // metacharacters outside quotes, so an unquoted argument was a command-injection surface.
+        await Assert.That(cmd).Contains("\"C:\\kcap\\kcap-daemon.exe\" --name \"laptop\" --log-file \"C:\\Users\\u\\.config\\kcap\\daemon-laptop.log\" \"--max-agents\" \"8\"");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Services/XmlRepresentableValueTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/XmlRepresentableValueTests.cs
@@ -1,0 +1,124 @@
+using Capacitor.Cli.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// The plist writer's value guard must match the XML 1.0 character set, not approximate it.
+///
+/// <para>The first implementation used <c>char.IsControl</c>, which differs from XML 1.0 in BOTH directions —
+/// it accepts non-characters and lone surrogates that XML cannot carry, and rejects C1 characters that XML
+/// 1.0 permits. Each direction has its own consequence, so each gets its own test: an under-rejection writes
+/// a plist <c>launchctl</c> will not load (or lets the encoder substitute a different character), while an
+/// over-rejection refuses to install a service over a value that would have been fine.</para>
+///
+/// <para>Every character here is written as an escape. A literal control character in source is invisible to
+/// review and survives a careless editor pass as something else.</para>
+/// </summary>
+public class XmlRepresentableValueTests {
+    static void Check(string value) => ServiceText.RequireXmlRepresentableValue("KCAP_TEST", value);
+
+    static async Task Rejects(string value, string because) {
+        var ex = Assert.Throws<InvalidOperationException>(() => Check(value));
+
+        await Assert.That(ex!.Message).Contains("KCAP_TEST").Because(because);
+    }
+
+    static async Task Accepts(string value) {
+        Check(value); // the guard throws on rejection, so reaching the next line IS the assertion
+        await Assert.That(true).IsTrue();
+    }
+
+    // ── accepted: ordinary text and the three legal whitespace controls ──
+
+    [Test]
+    public async Task Accepts_plain_text() => await Accepts("/usr/local/bin:/usr/bin");
+
+    [Test]
+    [Arguments('\t')]
+    [Arguments('\n')]
+    [Arguments('\r')]
+    public async Task Accepts_the_three_legal_whitespace_controls(char c) => await Accepts($"a{c}b");
+
+    // ── accepted: what char.IsControl wrongly rejected ──
+
+    /// <summary>
+    /// U+007F (DEL) and the C1 block are <c>char.IsControl</c> but sit inside XML 1.0's #x20–#xD7FF range, so
+    /// rejecting them refused an install over a value XML can represent verbatim.
+    /// </summary>
+    [Test]
+    [Arguments('\u007F')]
+    [Arguments('\u0085')]
+    [Arguments('\u009F')]
+    public async Task Accepts_c1_characters_that_xml_1_0_permits(char c) => await Accepts($"a{c}b");
+
+    /// <summary>A supplementary character arrives as a surrogate PAIR; judging each half alone rejects every emoji.</summary>
+    [Test]
+    public async Task Accepts_a_valid_supplementary_pair() => await Accepts("profile \U0001F600 ok");
+
+    [Test]
+    public async Task Accepts_a_supplementary_pair_at_the_end_of_the_value() => await Accepts("\U0001F600");
+
+    /// <summary>U+FFFD is the last legal XML 1.0 character in the BMP.</summary>
+    [Test]
+    public async Task Accepts_the_top_of_the_bmp_range() => await Accepts("a\uFFFDb");
+
+    // ── rejected: C0 controls, which have no XML 1.0 representation at all ──
+
+    [Test]
+    public async Task Rejects_a_c0_control() =>
+        await Rejects("a\u0001b", "U+0001 cannot be represented in XML 1.0, escaped or not");
+
+    [Test]
+    public async Task Rejects_a_nul() =>
+        await Rejects("a\0b", "a POSIX environment value can carry any byte except NUL — but not into a plist");
+
+    [Test]
+    public async Task Names_the_offending_code_point_in_the_message() {
+        var ex = Assert.Throws<InvalidOperationException>(() => Check("a\u0001b"));
+
+        await Assert.That(ex!.Message).Contains("U+0001");
+    }
+
+    // ── rejected: what char.IsControl wrongly accepted ──
+
+    /// <summary>U+FFFE/U+FFFF are permanently reserved non-characters: legal in a .NET string, illegal in XML.</summary>
+    [Test]
+    [Arguments('\uFFFE')]
+    [Arguments('\uFFFF')]
+    public async Task Rejects_the_bmp_noncharacters(char c) =>
+        await Rejects($"a{c}b", "a non-character is not a legal XML character despite not being a control");
+
+    /// <summary>
+    /// A lone surrogate is not a Unicode scalar value, so it cannot be encoded at all: depending on the
+    /// encoder it throws or is silently replaced, which would change the value the service runs with.
+    /// </summary>
+    [Test]
+    public async Task Rejects_a_lone_high_surrogate() =>
+        await Rejects("a\uD83Db", "an unpaired high surrogate has no encoding");
+
+    [Test]
+    public async Task Rejects_a_lone_low_surrogate() =>
+        await Rejects("a\uDE00b", "an unpaired low surrogate has no encoding");
+
+    [Test]
+    public async Task Rejects_a_high_surrogate_at_the_very_end() =>
+        await Rejects("ab\uD83D", "there is no following char to pair with — the scan must not read past the end");
+
+    /// <summary>Reversed halves are two lone surrogates, not a pair.</summary>
+    [Test]
+    public async Task Rejects_a_reversed_surrogate_pair() =>
+        await Rejects("a\uDE00\uD83Db", "low-then-high is not a valid pair");
+
+    /// <summary>
+    /// The pair must be consumed as a UNIT. If the scan advanced by one after matching a pair, the low half
+    /// would then be judged alone and rejected — so a value that is nothing but pairs proves the skip.
+    /// </summary>
+    [Test]
+    public async Task Accepts_consecutive_supplementary_pairs() =>
+        await Accepts("\U0001F600\U0001F601\U0001F602");
+
+    /// <summary>And a rejectable character AFTER a pair must still be caught — the skip must not overshoot.</summary>
+    [Test]
+    public async Task Still_rejects_a_control_following_a_supplementary_pair() =>
+        await Rejects("\U0001F600\u0001", "consuming the pair must not skip the character after it");
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/XmlRepresentableValueTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/XmlRepresentableValueTests.cs
@@ -121,4 +121,46 @@ public class XmlRepresentableValueTests {
     [Test]
     public async Task Still_rejects_a_control_following_a_supplementary_pair() =>
         await Rejects("\U0001F600\u0001", "consuming the pair must not skip the character after it");
+
+    // ── the guard must cover EVERY value the plist writer interpolates, not only the environment ──
+
+    static ServiceSpec PlistSpec() => new(
+        "laptop", "/opt/kcap/kcap-daemon", "/Users/u/.config/kcap/daemon-laptop.log",
+        new Dictionary<string, string> { ["PATH"] = "/usr/bin" }, ["--max-agents", "8"]);
+
+    static async Task PlistRejects(ServiceSpec spec, string because) {
+        var ex = Assert.Throws<InvalidOperationException>(() => LaunchdUnit.Plist(spec));
+
+        await Assert.That(ex!.Message).Contains("U+0001").Because(because);
+    }
+
+    [Test]
+    public async Task Plist_rejects_a_control_character_in_the_binary_path() =>
+        await PlistRejects(PlistSpec() with { DaemonBinaryPath = "/opt/kcap/da\u0001emon" },
+            "ProgramArguments carries the binary path and SecurityElement.Escape passes controls through");
+
+    [Test]
+    public async Task Plist_rejects_a_control_character_in_the_log_path() =>
+        await PlistRejects(PlistSpec() with { LogPath = "/Users/u/lo\u0001gs/d.log" },
+            "the log path reaches both ProgramArguments and StandardOutPath");
+
+    [Test]
+    public async Task Plist_rejects_a_control_character_in_an_extra_arg() =>
+        await PlistRejects(PlistSpec() with { ExtraArgs = ["--tag", "a\u0001b"] },
+            "extra args are interpolated the same way");
+
+    [Test]
+    public async Task Plist_still_rejects_a_control_character_in_an_environment_value() =>
+        await PlistRejects(
+            PlistSpec() with { Environment = new Dictionary<string, string> { ["PATH"] = "/u\u0001b" } },
+            "the arm that was already guarded must stay guarded");
+
+    /// <summary>A plist whose values are all legal must still render — the guard is not a blanket refusal.</summary>
+    [Test]
+    public async Task Plist_renders_when_every_value_is_representable() {
+        var plist = LaunchdUnit.Plist(PlistSpec() with { LogPath = "/Users/u/logs/\U0001F600.log" });
+
+        await Assert.That(plist).Contains("<key>ProgramArguments</key>");
+        await Assert.That(plist).Contains("\U0001F600.log");
+    }
 }


### PR DESCRIPTION
Gemini CLI as the fifth ACP hosted-agent vendor, after Cursor, Copilot, Claude/Codex and Kiro. **Interactive hosting only** — the unattended reviewer is AI-1413, withheld here for the same structural reason it was for Kiro.

Spec: `docs/superpowers/specs/2026-07-31-ai899-gemini-acp-hosted-agent-design.md` (rev 6, in this branch). Two codex spec-review rounds (9 findings, then 7) plus a gating security probe before implementation; then **eight codex code-review rounds, clean at round 8**. Every finding was real, and rev 6 of the spec records the two where rev 5's *design* was wrong rather than its prose — §3.1d and §4.2b.

## What ships

| | |
|---|---|
| Descriptor | `--experimental-acp --skip-trust --allowed-mcp-server-names <per-launch unguessable>`, `SupportsUnattended: false`, `NoOpModelSelector`, `SupportsMcpServers: false` |
| Registration | one `AcpHostedAgentRuntimeFactory` line in `DaemonRunner` |
| Env capture | the Google/Vertex configuration into the service unit, with a platform split |
| Sink guard | all four unit writers guard **every** value they interpolate, not just environment values |
| Diagnostic | a Gemini `DiagnosticAuthHint` that suggests rather than diagnoses |
| Docs | README's daemon-environment section |

## `--skip-trust` is required, and it is NOT containment

Gemini refuses a headless turn in an untrusted directory outright — `exit 55`, before any model call — and a daemon worktree cannot be assumed pre-trusted, so without the flag every launch fails.

What it does *not* do is protect anything. **Measured:** trust INHERITS from a trusted parent directory, and daemon worktrees live at `<repo>/.capacitor/worktrees/agent-…`, inside the operator's repository. An operator who has trusted their own repo gives every hosted Gemini agent inherited trust over the checked-out branch's configuration, and passing `--skip-trust` does not withdraw it.

Under that inherited trust, a repository-authored `.gemini/settings.json` MCP server **was observed starting** on the ACP path: repo-controlled process execution under the daemon user, before the model acts, on a branch that may be contributor-authored. That is why the MCP allowlist is in the argv — reduced to a single non-matching name, it permits nothing and blocks it. Verified: repo-authored server blocked, an injected server still loads.

**The name must be generated, not written down** (§3.1d). The first version used the literal `kcap-none` with a comment calling it "a name no MCP server will ever have" — nothing enforced that, and **measured**, a repository naming its server `kcap-none` executes. This is a public repo, so the constant is the bypass. The descriptor now carries a placeholder that `AcpHostedAgentRuntimeFactory` replaces per launch with `kcap-deny-{guid}`. Verified in both directions: a repo naming its server *the placeholder itself* is blocked, and an ACP-injected server still loads.

Repo-authored *hooks* were separately measured **not** to run on the ACP path, though they do on the `--prompt` path. The two paths differ and neither predicts the other — an earlier revision of this spec concluded from the `--prompt` path that hooks were an unclampable blocker, and was wrong.

## The allowlist contents are coupled to `SupportsMcpServers`

A non-matching name permits nothing, which is correct only while nothing is injected. The day the stdio call-level probe flips `SupportsMcpServers` to `true`, the list must become the injected server names **in the same change**, or hosted Gemini ships with MCP silently broken. `Gemini_McpAllowlist_IsCoupledToSupportsMcpServers` asserts both directions, and it is mutation-proven: flipping the flag alone fails exactly it plus the constants test.

(`--allowed-mcp-server-names ""` is not usable — it crashes Gemini's config load before session start, which also makes it a trap when verifying by hand.)

## The daemon does not see your shell

A supervised daemon inherits nothing from an interactive shell, so `export GOOGLE_CLOUD_PROJECT=…` in `.zshrc` is invisible to a hosted Gemini agent — and Gemini reports the absence as `IneligibleTierError: … no longer supported for Gemini Code Assist for individuals`, thrown by a function named `throwIneligibleOrProjectIdError`, which emits the same text for a missing project id. That message cost this investigation two retracted conclusions.

Both project spellings are carried, because Gemini's own error says *"The GOOGLE_CLOUD_PROJECT (or GOOGLE_CLOUD_PROJECT_ID) environment variable must be set"*.

**Platform split, as a principle rather than per variable:** persist a value into a unit only when there is no non-persistent alternative **and** the platform gives an owner-only guarantee this code actually enforces.

| Everywhere | macOS/Linux only | Never |
|---|---|---|
| `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_PROJECT_ID`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_GENAI_USE_GCA` | `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_GEMINI_BASE_URL`, `GOOGLE_VERTEX_BASE_URL` | `GOOGLE_API_KEY`, `GOOGLE_CREDENTIALS` |

The middle column is secret-*capable*: a credential path discloses where the credential is, and a URL can carry userinfo or a query token. On Unix that is bounded by a guarantee this code enforces — `ServiceFiles` writes `0600`, re-checks the mode on the open handle (umask filters `UnixCreateMode`, so the request is not the result), and refuses a group/other-writable directory. **Every one of those paths returns early on Windows** (*"ACL-governed, inherited from the user profile"*), so there is no equivalent guarantee and those three are excluded there — exactly as `KCAP_COPILOT_TOKEN_CMD` is.

## The pre-existing holes closed on the way — this is most of the diff

Carrying eight new variables into a service unit meant reading what the unit writers actually do with a value. They were unsafe in ways that had nothing to do with Gemini, so this closes them rather than stepping around them. Review found six of these; the pattern is one thing, repeated.

**The check is at the sink, deliberately, not at `ServiceEnvironment.Build`.** Build is not a boundary: `DaemonCommands` adds `KCAP_DAEMON_SUPERVISED` to the dictionary *after* `Capture` returns, so a value already reaches the writers without passing through it. The tests call the writers directly for the same reason — routing through `Build` would pass even if a writer were defenceless — and one case arrives by that exact bypass route.

### Some values guarded, their neighbours not

The unit of the bug is the **artifact**, not the value. Every writer interpolates several values into one line or file, and each had a subset covered:

| sink | was guarded | was not, on the same line/file |
|---|---|---|
| Windows `.cmd` exec line | binary path | log path, every `ExtraArgs` token |
| Windows `set "K=V"` | the value | the **key** — a quote in a key closes the assignment identically |
| systemd `Environment=` | the value | the key, which can inject an `ExecStartPre=` that runs on **every restart** |
| systemd `ExecStart=` | nothing | binary path, log path, every argument |
| launchd plist | environment values | the label, `ProgramArguments`, `StandardOut/ErrorPath` |
| Task Scheduler XML | nothing | the wrapper path, the service id |

Each sink now has one guard-then-escape helper that every interpolation goes through — applied even to values provably safe today, so the next value added inherits it.

### Escaping one expansion without asking what else the format expands

`CmdValue` doubling `%` was correct, and it stopped me looking. Both formats run more than one pass, and quoting is not a boundary in either:

- **cmd** treats `& | < > ( ) ^` as metacharacters *outside* quotes, so quote-on-space emitted `8&calc.exe` bare into a file the OS runs at every logon → every exec-line value is now quoted unconditionally. `!NAME!` delayed expansion works *inside* quotes and is registry-enablable machine-wide, so the execution **mode** is now part of the artifact (`setlocal DisableDelayedExpansion` + `/v:off`). And `cmd /c "<path>"` relied on conditional quote-stripping that a path containing `&` defeats → the nested-quote `/d /s /v:off /c ""<path>""` form (`/d` also skips AutoRun).
- **systemd** expands `%` specifiers **and** `$NAME`/`${NAME}` in `ExecStart=`, so a path under `/home/50%off` or containing `${HOME}` was rewritten in the *executable* position. Both are doubled and reversed by `BinaryFromUnit`. `$` is deliberately **not** doubled in `Environment=`, where systemd expands specifiers but not variables. The apostrophe is as structural to systemd's word lexer as the double quote and was missing from `NeedsQuote`.

### Escape where verifiable; otherwise refuse

Nothing here can exercise a real systemd or cmd parser. So where the documented escape is unambiguous (`%%`, `$$`, `/s` nested quotes, `/v:off`) it is implemented and the tests assert the rendered text plus the round-trip. Where it is not — systemd's `\;` for a literal semicolon — the input is **refused**: a bare `;` is systemd's command separator, and a refusal cannot be subtly wrong. Same for all C0/DEL control characters at both systemd sinks, and for `%` in the path handed to `cmd /c`, where `%%` simply does not exist as an escape.

That last point is worth naming: **the same character needs different treatment at adjacent sinks.** `%%` is right in the wrapper's batch-file body and wrong on the Task XML command line. A per-character policy gets one of the two wrong.

`SystemdValue`'s old CR/LF→space rewrite is gone for the same reason: a service running with a value nobody chose is harder to diagnose than an install that failed and named the variable.

### And the XML predicate was not the XML predicate

`char.IsControl` differs from XML 1.0 in **both** directions — it accepts U+FFFE/U+FFFF and lone surrogates (which no encoder can represent) and rejects U+007F–U+009F (which XML 1.0 permits). Replaced with `XmlConvert.IsXmlChar` plus surrogate-pair awareness, so an emoji in a path is accepted and a malformed surrogate is not.

### One fix at the source, not just the sink

`--max-agents` is the only caller-supplied `ExtraArgs` entry, arrives unparsed off the command line, and is numeric — so `kcap daemon service install --max-agents "8&calc.exe"` was persisting that string into a logon-executed file. It is now validated as a positive integer where it enters, independently of the sink hardening.

## The diagnostic suggests, it does not diagnose

`GeminiAuthHint` carries two hedges and an explicit *"or it may be unrelated"*, because the failure it attaches to often is. Reproducing Gemini's own confidently-wrong attribution would be worse than saying nothing. Asserted clause by clause rather than by keyword scan.

## Verification

| Suite | Result |
|---|---|
| `AcpVendorDescriptorTests` | 19/19 |
| `AcpHostedAgentRuntimeFactoryTests` | 68/68 |
| `UnitWriterExpansionTests` (new) | 74/74 |
| `XmlRepresentableValueTests` (new) | 26/26 |
| `UnitWriterEnvNameTests` (new) | 24/24 |
| `WindowsTaskUnitRepresentabilityTests` | 17/17 |
| `ServiceEnvironmentTests`, `ServiceFilesTests`, `ServiceTextTests`, `SystemdUnitTests`, `WindowsTaskUnitTests`, `LaunchdUnitTests` | all pass |

**27 mutants, all detected.** Each was applied to source, built, run, restored from git, and the restore verified **by content** — a `git diff` can hide a bad restore through alignment, which happened once during this work and silently flipped a *different* vendor's descriptor while reporting "0 deletions".

A sample of the ones that matter:

| mutant | caught by |
|---|---|
| deny-all MCP name back to a fixed literal | the allowlist coupling + placeholder tests |
| `SystemdValue` / `QuoteArg` stop escaping `%` or `$` | 5/14 and 3/14 |
| `Unpercent` becomes identity (round-trip broken) | 2/14 |
| Windows exec line quotes only on space | 10/44 |
| `setlocal DisableDelayedExpansion` **moved** after the env block | exactly 1 — the positional test, proving it is not a duplicate of the presence test |
| XML guard reverts to `char.IsControl` | 9/21 |
| surrogate pair not consumed as a unit | 3/21 |
| control-character bound moved by one (DEL allowed) | exactly 1 |
| every sink's guard-then-escape helper stops guarding | 2–7 each |
| `--max-agents` unvalidated | 2/44 |
| `GOOGLE_API_KEY` added to the capture allowlist | exactly the two never-captured cases |

Positive controls throughout, so no suite passes on a writer that simply rejects everything: an ordinary systemd unit still renders, a legal plist with an emoji log path still renders, a wrapper path with a space and an `&` is still accepted, and an ACP-injected MCP server still loads.

## Deliberately not here

- **AI-1413** — the unattended reviewer: containment, approval posture, MCP clamp, and the sandbox credential question.
- **AI-1612** — `currentModelId` is `auto-gemini-2.5`, a placeholder-shaped id. With model selection withheld (`NoOpModelSelector`, because `ConfigOptionModelSelector`'s write half is unverified and fails *silently*), a hosted Gemini session reports an unpriceable model. Known and accepted, not discovered later.
- **The stdio MCP flip** — needs a purpose-built stdio server driven to a real `tools/call`, not an inference from the advertised `mcpCapabilities` (Kiro honours stdio without advertising it).
- **`kcap status` project warning** — specced (§4.3), not implemented here; it needs to read the installed unit rather than the process environment, which is its own plumbing. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
