### PR TITLE
[AI-1630] Poll the spool for content, with a shared read, in the drain-budget test

### DIFF
--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
@@ -365,15 +365,36 @@ public class CursorHookCommandTests {
 
         await Assert.That(exit).IsEqualTo(0);
 
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
-        while (!fx.SpoolFiles.Any() && DateTime.UtcNow < deadline) {
+        // Poll for the CONTENT, not the file's existence. The spool file goes through three states here:
+        // seeded-with-sessionStart (above) → deleted once the drain delivers that line (HookSpool removes
+        // a fully-consumed file) → re-created by the fresh sessionEnd's append on the abandoned
+        // background continuation. An existence check cannot tell state 1 from state 3, so it can be
+        // satisfied by the SEEDED file and read stale content that never contains sessionEnd.
+        //
+        // The read is also shared and IOException-tolerant: the append (File.AppendAllText) and the
+        // drain's rewrite both hold the file open for Write while they run, and a File.ReadAllText* open
+        // denies Write — a sharing violation on Windows, where it is mandatory, and invisible on Unix.
+        var deadline     = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        var spoolContent = (string?)null;
+
+        while (DateTime.UtcNow < deadline) {
+            if (fx.SpoolFiles.SingleOrDefault() is { } path) {
+                try {
+                    await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    using var       reader = new StreamReader(stream);
+                    spoolContent = await reader.ReadToEndAsync();
+                } catch (IOException) {
+                    // Mid-write; look again next tick.
+                }
+
+                if (spoolContent?.Contains("sessionEnd", StringComparison.Ordinal) == true) break;
+            }
+
             await Task.Delay(20);
         }
 
-        var spoolPath = fx.SpoolFiles.SingleOrDefault();
-        await Assert.That(spoolPath).IsNotNull();
-        var spoolContent = await File.ReadAllTextAsync(spoolPath!);
-        await Assert.That(spoolContent).Contains("sessionEnd");
+        await Assert.That(spoolContent).IsNotNull();
+        await Assert.That(spoolContent!).Contains("sessionEnd");
     }
 
     // Task 2: single-writer, deadline-safe stdout emission for Cursor's

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
@@ -378,34 +378,39 @@ public class CursorHookCommandTests {
         // SingleOrDefault is deliberate: the only *.jsonl in the spool dir is HookSpool's per-session live
         // file, and this test uses one session id, so a second match would be a real bug worth throwing on.
         // (Its temps are `.draining`/`.ordered-*` and the ended marker is `.ended-<key>` — none match.)
-        var deadline      = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        const int budgetSeconds = 10;
+
+        var deadline      = DateTime.UtcNow + TimeSpan.FromSeconds(budgetSeconds);
         var spoolContent  = (string?)null;
+        var observedEnd   = false;
         var lastIoFailure = (IOException?)null;
 
-        while (DateTime.UtcNow < deadline) {
+        while (!observedEnd && DateTime.UtcNow < deadline) {
             if (fx.SpoolFiles.SingleOrDefault() is { } path) {
                 try {
                     await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                     using var       reader = new StreamReader(stream);
                     spoolContent  = await reader.ReadToEndAsync();
-                    lastIoFailure = null;
+                    lastIoFailure = null; // a clean read means any earlier failure was the transient race
+                    observedEnd   = spoolContent.Contains("sessionEnd", StringComparison.Ordinal);
                 } catch (IOException ex) {
                     // The enumerate→open race, NOT a sharing conflict — FileShare.ReadWrite already permits
                     // the writers. Between states 2 and 3 the file is deleted and re-created, so a path
-                    // EnumerateFiles just returned can be gone by the time we open it. Keep the failure so a
-                    // persistent fault is reported as itself rather than as "content never appeared".
+                    // EnumerateFiles just returned can be gone by the time we open it.
                     lastIoFailure = ex;
                 }
-
-                if (spoolContent?.Contains("sessionEnd", StringComparison.Ordinal) == true) break;
             }
 
-            await Task.Delay(20);
+            if (!observedEnd) await Task.Delay(20);
         }
 
-        if (spoolContent is null && lastIoFailure is not null) {
+        // Gated on whether the TARGET was observed, not on content being null: a clean read of the stale
+        // seeded line leaves content non-null, so a null check would skip this and let a persistent
+        // filesystem fault masquerade as "the append never happened".
+        if (!observedEnd && lastIoFailure is not null) {
             throw new IOException(
-                $"spool file never became readable within {deadline:O}: {lastIoFailure.Message}", lastIoFailure);
+                $"spool never yielded sessionEnd within {budgetSeconds}s; last IO failure: {lastIoFailure.Message}",
+                lastIoFailure);
         }
 
         await Assert.That(spoolContent).IsNotNull();

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
@@ -371,26 +371,41 @@ public class CursorHookCommandTests {
         // background continuation. An existence check cannot tell state 1 from state 3, so it can be
         // satisfied by the SEEDED file and read stale content that never contains sessionEnd.
         //
-        // The read is also shared and IOException-tolerant: the append (File.AppendAllText) and the
-        // drain's rewrite both hold the file open for Write while they run, and a File.ReadAllText* open
-        // denies Write — a sharing violation on Windows, where it is mandatory, and invisible on Unix.
-        var deadline     = DateTime.UtcNow + TimeSpan.FromSeconds(10);
-        var spoolContent = (string?)null;
+        // The read shares read+write because the old File.ReadAllTextAsync (FileShare.Read) DENIED Write,
+        // so it collided with the append/rewrite holding the file open — mandatory on Windows, invisible
+        // on Unix, and the failure CI recorded.
+        //
+        // SingleOrDefault is deliberate: the only *.jsonl in the spool dir is HookSpool's per-session live
+        // file, and this test uses one session id, so a second match would be a real bug worth throwing on.
+        // (Its temps are `.draining`/`.ordered-*` and the ended marker is `.ended-<key>` — none match.)
+        var deadline      = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        var spoolContent  = (string?)null;
+        var lastIoFailure = (IOException?)null;
 
         while (DateTime.UtcNow < deadline) {
             if (fx.SpoolFiles.SingleOrDefault() is { } path) {
                 try {
                     await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                     using var       reader = new StreamReader(stream);
-                    spoolContent = await reader.ReadToEndAsync();
-                } catch (IOException) {
-                    // Mid-write; look again next tick.
+                    spoolContent  = await reader.ReadToEndAsync();
+                    lastIoFailure = null;
+                } catch (IOException ex) {
+                    // The enumerate→open race, NOT a sharing conflict — FileShare.ReadWrite already permits
+                    // the writers. Between states 2 and 3 the file is deleted and re-created, so a path
+                    // EnumerateFiles just returned can be gone by the time we open it. Keep the failure so a
+                    // persistent fault is reported as itself rather than as "content never appeared".
+                    lastIoFailure = ex;
                 }
 
                 if (spoolContent?.Contains("sessionEnd", StringComparison.Ordinal) == true) break;
             }
 
             await Task.Delay(20);
+        }
+
+        if (spoolContent is null && lastIoFailure is not null) {
+            throw new IOException(
+                $"spool file never became readable within {deadline:O}: {lastIoFailure.Message}", lastIoFailure);
         }
 
         await Assert.That(spoolContent).IsNotNull();

--- a/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Cursor/CursorHookCommandTests.cs
@@ -365,19 +365,11 @@ public class CursorHookCommandTests {
 
         await Assert.That(exit).IsEqualTo(0);
 
-        // Poll for the CONTENT, not the file's existence. The spool file goes through three states here:
-        // seeded-with-sessionStart (above) → deleted once the drain delivers that line (HookSpool removes
-        // a fully-consumed file) → re-created by the fresh sessionEnd's append on the abandoned
-        // background continuation. An existence check cannot tell state 1 from state 3, so it can be
-        // satisfied by the SEEDED file and read stale content that never contains sessionEnd.
-        //
-        // The read shares read+write because the old File.ReadAllTextAsync (FileShare.Read) DENIED Write,
-        // so it collided with the append/rewrite holding the file open — mandatory on Windows, invisible
-        // on Unix, and the failure CI recorded.
-        //
-        // SingleOrDefault is deliberate: the only *.jsonl in the spool dir is HookSpool's per-session live
-        // file, and this test uses one session id, so a second match would be a real bug worth throwing on.
-        // (Its temps are `.draining`/`.ordered-*` and the ended marker is `.ended-<key>` — none match.)
+        // Poll for CONTENT, not existence: the spool file is seeded → deleted once drained → re-created by
+        // the fresh sessionEnd, and an existence check cannot tell the seeded file from the re-created one.
+        // The handle must block nothing the drain does — HookSpool both appends to and File.Move/Delete's
+        // this exact path, and every restriction is mandatory on Windows but invisible on Unix.
+        // SingleOrDefault: a second *.jsonl for one session id would be a real bug worth throwing on.
         const int budgetSeconds = 10;
 
         var deadline      = DateTime.UtcNow + TimeSpan.FromSeconds(budgetSeconds);
@@ -388,15 +380,16 @@ public class CursorHookCommandTests {
         while (!observedEnd && DateTime.UtcNow < deadline) {
             if (fx.SpoolFiles.SingleOrDefault() is { } path) {
                 try {
-                    await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                    using var       reader = new StreamReader(stream);
+                    await using var stream = new FileStream(
+                        path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                    using var reader = new StreamReader(stream);
                     spoolContent  = await reader.ReadToEndAsync();
                     lastIoFailure = null; // a clean read means any earlier failure was the transient race
                     observedEnd   = spoolContent.Contains("sessionEnd", StringComparison.Ordinal);
                 } catch (IOException ex) {
-                    // The enumerate→open race, NOT a sharing conflict — FileShare.ReadWrite already permits
-                    // the writers. Between states 2 and 3 the file is deleted and re-created, so a path
-                    // EnumerateFiles just returned can be gone by the time we open it.
+                    // The enumerate→open race, not a sharing conflict: the share flags above permit
+                    // everything the drain does, but a path EnumerateFiles just returned can be deleted
+                    // before we open it.
                     lastIoFailure = ex;
                 }
             }


### PR DESCRIPTION
Fixes one of the two Windows flakes in `CursorHookCommandTests`. Linear: [AI-1630](https://linear.app/kurrent/issue/AI-1630).

## What was wrong

`fresh_canonical_event_is_spooled_when_drain_consumes_budget` waited for the spool **file to exist**, then read it with `File.ReadAllTextAsync`. Both halves are defective, and together they explain the observed failure.

The spool file passes through three states in this test:

1. **seeded** with a `sessionStart` line — the test does this itself, before `HandleCore`;
2. **deleted** once the drain delivers that line — `HookSpool` removes a fully-consumed file (`HookSpool.cs:206`/`321`);
3. **re-created** by the fresh `sessionEnd` append, which lands on the *abandoned background continuation* after `HandleCore`'s 30 ms deadline returns.

An existence check can't tell state 1 from state 3. So `while (!fx.SpoolFiles.Any() …)` can be satisfied by the **seeded** file and then read stale content that never contains `sessionEnd` — an assertion failure unrelated to the behaviour under test.

Separately: the append (`File.AppendAllText`) and the drain's rewrite both hold the file open for Write while they run, sharing only Read. `File.ReadAllText*` opens `FileShare.Read`, which **denies Write** — so a read landing mid-append is a sharing violation on Windows (mandatory there, invisible on Unix). That is the failure CI actually recorded:

```
The process cannot access the file
'…\kcap-cursor-hook-test-049764e9\spool\8c3276c2c8f743ce98898c2becf5240a.jsonl'
because it is being used by another process.
```

## The fix

Poll for the **content** — the thing the assertion is actually about — reading with `FileShare.ReadWrite`, tolerating a transient `IOException`, and treating an absent file as "not yet" rather than a failure (which also covers state 2).

## Scope — deliberately partial

This fixes **one** of the two tests named in the issue. The other, `home_dir_and_agent_host_id_are_injected`, **does not touch the spool at all** — it asserts on the POSTed payload — so its Windows sharing failure is *not* explained by this change. I've left it open on the issue rather than assume this covers it; if it recurs it needs its own log and investigation. Claiming otherwise would just hide the next occurrence.

## Note on a correction

My first version of this comment claimed the poll "waits for nothing" because the file always exists. That was wrong — `HookSpool` deletes a fully-drained file, so state 2 is real and the poll *is* meaningful in that window. The accurate defect is that existence can't distinguish the seeded file from the re-created one. Corrected before opening this, because the comment is what the next person will trust.

## Verification

`CursorHookCommandTests` 40/40 across repeated runs (timing-sensitive, so run more than once), build clean, `check-linear-ids.sh` ✓. The Windows leg is where the sharing half is actually exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)