### PR TITLE
[AI-1667] Re-pin the hosted-Codex argv vectors after the hook-trust flag

### DIFF
--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexLauncherTests.cs
@@ -817,17 +817,24 @@ public class CodexLauncherTests {
         await Assert.That(args[aIdx + 1]).IsEqualTo(approval);
     }
 
-    /// <summary>The regression that matters most: with no posture block the argv must be EXACTLY what
-    /// this launcher produced before posture selection existed. The expected sequences below are
-    /// literal transcriptions of the pre-change output, so an added, removed, renamed or REORDERED
-    /// argument fails here — comparing two runs of the current implementation would not, since a
-    /// change of that kind moves both sides identically.</summary>
+    /// <summary>The regression that matters most: with no posture block the argv must be EXACTLY the
+    /// sequence pinned below. These are literal transcriptions of the launcher's output, not a second
+    /// run of it, so an added, removed, renamed or REORDERED argument fails here — comparing two runs
+    /// of the current implementation would not, since a change of that kind moves both sides
+    /// identically.
+    ///
+    /// <para>Failing here is the pin doing its job, not a bug in the pin: it means someone changed the
+    /// argv. Re-pin only after confirming the change is intended and correctly ORDERED — the vectors
+    /// are the record of what a hosted Codex process is actually launched with. Re-pinned once for
+    /// <c>--dangerously-bypass-hook-trust</c>, added deliberately so an unattended launch is not parked
+    /// on codex 0.146's "Hooks need review" prompt.</para></summary>
     [Test]
     public async Task BuildArgs_without_a_posture_matches_the_pre_change_argv_exactly() {
         string[] expectedInteractive = [
             "--cd", "/tmp/wt",
             "--sandbox", "workspace-write",
             "--ask-for-approval", "on-request",
+            "--dangerously-bypass-hook-trust",
             "-m", "gpt-5.3-codex",
             "--no-alt-screen"
         ];
@@ -843,6 +850,7 @@ public class CodexLauncherTests {
             "--cd", "/tmp/wt",
             "--sandbox", "workspace-write",
             "--ask-for-approval", "on-request",
+            "--dangerously-bypass-hook-trust",
             "-m", "gpt-5.3-codex",
             "-c", "model_reasoning_effort=\"high\"",
             "--no-alt-screen",


### PR DESCRIPTION
`main` has been failing **Build and test (ubuntu-latest)** since `1190366` (#393) and is still red at `1ac58d5`. Every open PR inherits it on rebase. This is the fix.

```
failed BuildArgs_without_a_posture_matches_the_pre_change_argv_exactly
  Expected to be equivalent to [--cd, /tmp/wt, --sandbox, workspace-write,
    --ask-for-approval, on-request, -m, gpt-5.3-codex, --no-alt-screen]
  but collection has 10 items but expected 9
```

## Root cause

A semantic conflict between two PRs that were each green in isolation:

- **#417** (AI-633) added a **pinned** argv vector, written as a literal transcription precisely so that any added, removed, renamed or **reordered** argument fails.
- **#393** added an unconditional `--dangerously-bypass-hook-trust` to `CodexLauncher.BuildArgs`, so an unattended launch is not parked on codex 0.146's interactive "Hooks need review" prompt.

#393 branched before the pin existed, so its own CI never ran against it.

**Neither change is wrong.** The pin fired exactly as designed and the flag is intentional — what was missing was the re-pin.

## What this does

Both expected vectors gain the flag in its **actual position** (after the approval pair, before `-m`), so the pin keeps asserting ordering rather than mere membership.

It also corrects the test's doc comment, which described the vectors as "literal transcriptions of the pre-change output" — untrue the moment a post-change flag was pinned into them. The comment now states what a failure here means: the argv changed, and re-pinning is correct only after confirming the change is intended and correctly ordered.

Test-only; no production change.

## Verification

`CodexLauncherTests` — 55/58 passing locally. The 3 failures are the pre-existing macOS-local `Prepare_*` config-file cases, which fail identically on unmodified `origin/main`; ubuntu CI reported this one failure and nothing else.

## Prevention

Generic hazard of a pinned-vector test: a PR predating the pin merges green and breaks main. Requiring branches to be up to date before merge is what actually forecloses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)