### PR TITLE
Replace the setup call-to-action with a Next steps box

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,19 @@ server rejects it, or if the token was issued by a different server than the pro
 (re-run `kcap login`). If the server can't be reached it says so and still exits 0, so it stays
 usable offline.
 
-Setup closes by pointing you at the guided tour. Prompt your agent with **"Start kcap guided tour"**
-(or, in Claude Code, `/kcap:guided-tour`) to see what your team has recorded and work through
-per-use-case tutorials for evals, session recall, PR review, and analytics. It ships with the plugin
-and is also installed for Codex and the other `~/.agents/skills/` agents as `kcap-guided-tour`.
+Setup closes with a **Next steps** box. Each item opens with a question, because neither step is for
+everyone:
+
+- **Did you create this Capacitor server?** Complete server setup — inviting teammates, and
+  optionally Slack and your own AI keys — by following
+  [Setup Server](https://capacitor.kurrent.io/docs/getting-started/setup-server/). Always listed:
+  `kcap` can't tell whether you own the server, so you self-select.
+- **New to Capacitor?** Prompt **"Start kcap guided tour"** in your coding agent (or, in Claude Code,
+  `/kcap:guided-tour`) to see what your team has recorded and work through per-use-case tutorials for
+  evals, session recall, PR review, and analytics. It's a prompt rather than a slash command because
+  only Claude Code has slash commands — the skill ships with the plugin and is also installed for
+  Codex and the other `~/.agents/skills/` agents (plus Kiro and Antigravity) as `kcap-guided-tour`.
+  This item only appears when an agent was detected and one of them carries the skill.
 
 For non-interactive environments:
 

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -14,6 +14,7 @@ using Capacitor.Cli.Core.Mcp;
 using Capacitor.Cli.Core.OpenCode;
 using Capacitor.Cli.Core.Pi;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 using Profile = Capacitor.Cli.Core.Config.Profile;
 
 namespace Capacitor.Cli.Commands;
@@ -541,14 +542,61 @@ public static class SetupCommand {
         AnsiConsole.MarkupLine("\n[dim]Optional:[/] start the daemon with [cyan]kcap daemon start -d[/]");
         AnsiConsole.MarkupLine("[dim]Optional:[/] import past sessions with [cyan]kcap import --org[/]");
 
-        if (ShouldOfferGuidedTour(detectedSummary is not null, claudeSettingsPath, stepPaths)) {
-            AnsiConsole.Write(
-                new Panel($"[bold]{Markup.Escape(GuidedTourCallToAction)}[/]")
-                    .BorderColor(Color.Green)
-                    .Padding(1, 0));
-        }
+        WriteNextSteps(ShouldOfferGuidedTour(detectedSummary is not null, claudeSettingsPath, stepPaths));
 
         return 0;
+    }
+
+    /// <summary>
+    /// The closing "Next steps" box. Every item opens with a question the reader can answer about
+    /// themselves, because neither step applies to everyone and the CLI cannot tell which reader it
+    /// has: who owns the server is not knowable from a local setup run. Server setup is therefore
+    /// always listed and a reader who did not create the server self-selects out, while the tour
+    /// needs an agent and the skill on disk.
+    /// </summary>
+    static void WriteNextSteps(bool offerGuidedTour) {
+        var rows = new List<IRenderable>();
+
+        // Each question sits alone on an unindented line and its answer is indented beneath it, so
+        // a reader can skim only the questions and stop at the one that describes them. Padder (not
+        // a "  " prefix) does the indenting because the console wraps these lines — a literal
+        // prefix would only indent the first line of each wrapped answer.
+        foreach (var (question, answer) in NextStepItems(offerGuidedTour)) {
+            if (rows.Count > 0) rows.Add(Text.Empty);
+
+            rows.Add(new Markup($"[bold]{Markup.Escape(question)}[/]"));
+            rows.Add(Text.Empty);
+            rows.Add(new Padder(new Markup(answer), new Padding(2, 0, 0, 0)));
+        }
+
+        AnsiConsole.Write(
+            new Panel(new Rows(rows))
+                .Header("[bold green] Next steps [/]")
+                .BorderColor(Color.Green)
+                .Padding(1, 0));
+    }
+
+    /// <summary>
+    /// The box's items as (question, answer-markup) pairs, split out from the write so the copy can
+    /// be asserted without a console.
+    /// </summary>
+    internal static List<(string Question, string Answer)> NextStepItems(bool offerGuidedTour) {
+        // The URL and the prompt are the two things on this screen a user retypes, so both are cyan.
+        var items = new List<(string, string)> {
+            (ServerSetupQuestion,
+             $"{Markup.Escape(ServerSetupAction)}\n[cyan]{Markup.Escape(ServerSetupDocsUrl)}[/]"),
+        };
+
+        if (offerGuidedTour) {
+            // The quoted prompt carries no markup-special characters, so colouring it inside the
+            // escaped copy is a plain substring swap.
+            items.Add((GuidedTourQuestion,
+                       Markup.Escape(GuidedTourAction)
+                             .Replace(GuidedTourPromptQuoted,
+                                      $"[cyan]{GuidedTourPromptQuoted}[/]", StringComparison.Ordinal)));
+        }
+
+        return items;
     }
 
     /// <summary>
@@ -585,12 +633,43 @@ public static class SetupCommand {
     /// <summary>Source folder name under <c>kcap/skills/</c>; <c>kcap-</c>-prefixed once installed.</summary>
     internal const string GuidedTourSkillName = "guided-tour";
 
+    internal const string GuidedTourQuestion = "New to Capacitor?";
+
     /// <summary>
-    /// A prompt rather than a slash command, because the invocation differs per vendor. Pinned
-    /// against the skill's trigger list by <c>SetupCommandTests</c>.
+    /// A prompt rather than a slash command, because the invocation differs per vendor and this box
+    /// prints for all of them — only Claude Code has <c>/kcap:guided-tour</c>. Pinned against the
+    /// skill's trigger list by <c>SetupCommandTests</c>: vendors match this against the frontmatter
+    /// description, so a phrase that isn't in it won't reliably fire the skill.
     /// </summary>
-    internal const string GuidedTourCallToAction =
-        "Prompt \"Start kcap guided tour\" in your agent for a guided tour of Capacitor";
+    internal const string GuidedTourPrompt = "Start kcap guided tour";
+
+    /// <summary>
+    /// The prompt as it is shown. Quoted as well as coloured: colour is the primary cue but it is
+    /// not always there — <c>NO_COLOR</c>, a redirected stdout, or a plain terminal all drop it, and
+    /// without the quotes the sentence gives no clue where the phrase to type starts and ends.
+    /// </summary>
+    internal const string GuidedTourPromptQuoted = $"\"{GuidedTourPrompt}\"";
+
+    internal const string GuidedTourAction =
+        $"Prompt {GuidedTourPromptQuoted} in your coding agent to see what Capacitor can do for you";
+
+    internal const string GuidedTourCallToAction = $"{GuidedTourQuestion} {GuidedTourAction}";
+
+    /// <summary>
+    /// The owner-only half of server setup — everything that lives in the dashboard rather than in
+    /// this CLI, so it can only be pointed at, not done here.
+    /// <para>"Created this server" rather than "owner or admin" (a role the server hasn't told them
+    /// yet) or "for your team" (the common reader is solo, would answer no, and would skip the keys
+    /// and Slack that are theirs to set up). "Server" and not "workspace": the summary grid printed
+    /// three lines above says <c>Server</c>, and <c>workspace</c> already means the local tree
+    /// everywhere else, including in the review-flow output these same users read.</para>
+    /// </summary>
+    internal const string ServerSetupQuestion = "Did you create this Capacitor server?";
+
+    internal const string ServerSetupAction = "Complete server setup with instructions here:";
+
+    internal const string ServerSetupDocsUrl =
+        "https://capacitor.kurrent.io/docs/getting-started/setup-server/";
 
     /// <summary>
     /// Whether Step 6's import eligibility auth requirement is met: provider <c>None</c> needs no

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -547,20 +547,11 @@ public static class SetupCommand {
         return 0;
     }
 
-    /// <summary>
-    /// The closing "Next steps" box. Every item opens with a question the reader can answer about
-    /// themselves, because neither step applies to everyone and the CLI cannot tell which reader it
-    /// has: who owns the server is not knowable from a local setup run. Server setup is therefore
-    /// always listed and a reader who did not create the server self-selects out, while the tour
-    /// needs an agent and the skill on disk.
-    /// </summary>
+    /// <summary>The closing "Next steps" box: a question per item, its answer indented beneath.</summary>
     static void WriteNextSteps(bool offerGuidedTour) {
         var rows = new List<IRenderable>();
 
-        // Each question sits alone on an unindented line and its answer is indented beneath it, so
-        // a reader can skim only the questions and stop at the one that describes them. Padder (not
-        // a "  " prefix) does the indenting because the console wraps these lines — a literal
-        // prefix would only indent the first line of each wrapped answer.
+        // Padder, not a "  " prefix: these lines wrap, and a prefix indents only the first of them.
         foreach (var (question, answer) in NextStepItems(offerGuidedTour)) {
             if (rows.Count > 0) rows.Add(Text.Empty);
 
@@ -576,20 +567,15 @@ public static class SetupCommand {
                 .Padding(1, 0));
     }
 
-    /// <summary>
-    /// The box's items as (question, answer-markup) pairs, split out from the write so the copy can
-    /// be asserted without a console.
-    /// </summary>
+    /// <summary>The box's (question, answer-markup) pairs, split from the write so copy is testable.</summary>
     internal static List<(string Question, string Answer)> NextStepItems(bool offerGuidedTour) {
-        // The URL and the prompt are the two things on this screen a user retypes, so both are cyan.
         var items = new List<(string, string)> {
             (ServerSetupQuestion,
              $"{Markup.Escape(ServerSetupAction)}\n[cyan]{Markup.Escape(ServerSetupDocsUrl)}[/]"),
         };
 
         if (offerGuidedTour) {
-            // The quoted prompt carries no markup-special characters, so colouring it inside the
-            // escaped copy is a plain substring swap.
+            // Markup-safe: the quoted prompt has no [ or ], so escaping leaves it a plain substring.
             items.Add((GuidedTourQuestion,
                        Markup.Escape(GuidedTourAction)
                              .Replace(GuidedTourPromptQuoted,
@@ -636,18 +622,13 @@ public static class SetupCommand {
     internal const string GuidedTourQuestion = "New to Capacitor?";
 
     /// <summary>
-    /// A prompt rather than a slash command, because the invocation differs per vendor and this box
-    /// prints for all of them — only Claude Code has <c>/kcap:guided-tour</c>. Pinned against the
-    /// skill's trigger list by <c>SetupCommandTests</c>: vendors match this against the frontmatter
-    /// description, so a phrase that isn't in it won't reliably fire the skill.
+    /// A prompt, not <c>/kcap:guided-tour</c>: this box prints for every vendor and only Claude Code
+    /// has slash commands. Must stay a verbatim trigger in the skill's frontmatter description
+    /// (pinned by <c>SetupCommandTests</c>) or it fires nothing.
     /// </summary>
     internal const string GuidedTourPrompt = "Start kcap guided tour";
 
-    /// <summary>
-    /// The prompt as it is shown. Quoted as well as coloured: colour is the primary cue but it is
-    /// not always there — <c>NO_COLOR</c>, a redirected stdout, or a plain terminal all drop it, and
-    /// without the quotes the sentence gives no clue where the phrase to type starts and ends.
-    /// </summary>
+    /// <summary>Quoted as well as coloured — colour is lost to <c>NO_COLOR</c> and redirected stdout.</summary>
     internal const string GuidedTourPromptQuoted = $"\"{GuidedTourPrompt}\"";
 
     internal const string GuidedTourAction =
@@ -656,13 +637,9 @@ public static class SetupCommand {
     internal const string GuidedTourCallToAction = $"{GuidedTourQuestion} {GuidedTourAction}";
 
     /// <summary>
-    /// The owner-only half of server setup — everything that lives in the dashboard rather than in
-    /// this CLI, so it can only be pointed at, not done here.
-    /// <para>"Created this server" rather than "owner or admin" (a role the server hasn't told them
-    /// yet) or "for your team" (the common reader is solo, would answer no, and would skip the keys
-    /// and Slack that are theirs to set up). "Server" and not "workspace": the summary grid printed
-    /// three lines above says <c>Server</c>, and <c>workspace</c> already means the local tree
-    /// everywhere else, including in the review-flow output these same users read.</para>
+    /// Server setup lives in the dashboard, so this can only be pointed at. Always printed: who owns
+    /// the server is not knowable here, so the reader self-selects on the question. Says "server",
+    /// never "workspace" — that word means the local tree everywhere else in this CLI.
     /// </summary>
     internal const string ServerSetupQuestion = "Did you create this Capacitor server?";
 

--- a/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
@@ -263,14 +263,10 @@ public class SetupCommandTests {
 
     [Test]
     public async Task ServerSetupCallToAction_is_the_exact_agreed_wording() {
-        // Opens with a question because the CLI cannot tell whether this reader owns the server —
-        // the reader self-selects, so the wording has to make "not me" an obvious answer. "server",
-        // never "workspace": that word means the local tree everywhere else in this CLI.
+        // Pinned wording: a question the reader self-selects on, then the instruction itself.
         await Assert.That(SetupCommand.ServerSetupQuestion).IsEqualTo(
             "Did you create this Capacitor server?");
 
-        // Opens with the instruction itself, so a reader who answered yes knows what to do without
-        // reading further; the docs page carries the detail.
         await Assert.That(SetupCommand.ServerSetupAction).IsEqualTo(
             "Complete server setup with instructions here:");
 
@@ -280,20 +276,16 @@ public class SetupCommandTests {
 
     [Test]
     public async Task NextSteps_always_lists_server_setup_and_only_adds_the_tour_when_offered() {
-        // Server setup can't be gated on anything local — admin-ness isn't knowable here — so it is
-        // the one item that must survive a run where no agent carried the tour skill.
+        // Server setup is ungated, so it must survive a run where no agent carried the tour skill.
         var withoutTour = SetupCommand.NextStepItems(offerGuidedTour: false);
 
         await Assert.That(withoutTour.Count).IsEqualTo(1);
         await Assert.That(withoutTour[0].Question).IsEqualTo(SetupCommand.ServerSetupQuestion);
-
-        // Cyan: the URL and the prompt are what a reader retypes, so both are set off from the prose.
         await Assert.That(withoutTour[0].Answer)
                     .Contains($"[cyan]{SetupCommand.ServerSetupDocsUrl}[/]");
 
         var withTour = SetupCommand.NextStepItems(offerGuidedTour: true);
 
-        // Server setup stays first: the reader who needs it is blocking their whole team.
         await Assert.That(withTour.Count).IsEqualTo(2);
         await Assert.That(withTour[0].Question).IsEqualTo(SetupCommand.ServerSetupQuestion);
         await Assert.That(withTour[1].Question).IsEqualTo(SetupCommand.GuidedTourQuestion);

--- a/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
@@ -257,7 +257,48 @@ public class SetupCommandTests {
         // prompt it names must appear verbatim in that skill's description (asserted below)
         // or the phrase we tell users to type won't reliably fire it.
         await Assert.That(SetupCommand.GuidedTourCallToAction).IsEqualTo(
-            "Prompt \"Start kcap guided tour\" in your agent for a guided tour of Capacitor");
+            "New to Capacitor? Prompt \"Start kcap guided tour\" in your coding agent to see what "
+          + "Capacitor can do for you");
+    }
+
+    [Test]
+    public async Task ServerSetupCallToAction_is_the_exact_agreed_wording() {
+        // Opens with a question because the CLI cannot tell whether this reader owns the server —
+        // the reader self-selects, so the wording has to make "not me" an obvious answer. "server",
+        // never "workspace": that word means the local tree everywhere else in this CLI.
+        await Assert.That(SetupCommand.ServerSetupQuestion).IsEqualTo(
+            "Did you create this Capacitor server?");
+
+        // Opens with the instruction itself, so a reader who answered yes knows what to do without
+        // reading further; the docs page carries the detail.
+        await Assert.That(SetupCommand.ServerSetupAction).IsEqualTo(
+            "Complete server setup with instructions here:");
+
+        await Assert.That(SetupCommand.ServerSetupDocsUrl).IsEqualTo(
+            "https://capacitor.kurrent.io/docs/getting-started/setup-server/");
+    }
+
+    [Test]
+    public async Task NextSteps_always_lists_server_setup_and_only_adds_the_tour_when_offered() {
+        // Server setup can't be gated on anything local — admin-ness isn't knowable here — so it is
+        // the one item that must survive a run where no agent carried the tour skill.
+        var withoutTour = SetupCommand.NextStepItems(offerGuidedTour: false);
+
+        await Assert.That(withoutTour.Count).IsEqualTo(1);
+        await Assert.That(withoutTour[0].Question).IsEqualTo(SetupCommand.ServerSetupQuestion);
+
+        // Cyan: the URL and the prompt are what a reader retypes, so both are set off from the prose.
+        await Assert.That(withoutTour[0].Answer)
+                    .Contains($"[cyan]{SetupCommand.ServerSetupDocsUrl}[/]");
+
+        var withTour = SetupCommand.NextStepItems(offerGuidedTour: true);
+
+        // Server setup stays first: the reader who needs it is blocking their whole team.
+        await Assert.That(withTour.Count).IsEqualTo(2);
+        await Assert.That(withTour[0].Question).IsEqualTo(SetupCommand.ServerSetupQuestion);
+        await Assert.That(withTour[1].Question).IsEqualTo(SetupCommand.GuidedTourQuestion);
+        await Assert.That(withTour[1].Answer)
+                    .Contains($"[cyan]{SetupCommand.GuidedTourPromptQuoted}[/]");
     }
 
     [Test]
@@ -265,13 +306,13 @@ public class SetupCommandTests {
         // Vendors match a user's message against the frontmatter `description:` only — the body
         // is read after the skill fires. So asserting the phrase is somewhere in the file would
         // pass even if it moved below the fences, where it can no longer trigger anything.
-        var skill = Path.Combine(RepoRoot(), "kcap", "skills", "guided-tour", "SKILL.md");
+        var skill = Path.Combine(RepoRoot(), "kcap", "skills", SetupCommand.GuidedTourSkillName, "SKILL.md");
 
         await Assert.That(File.Exists(skill)).IsTrue();
 
         var description = FrontmatterDescription(await File.ReadAllTextAsync(skill));
 
-        await Assert.That(description).Contains("Start kcap guided tour");
+        await Assert.That(description).Contains(SetupCommand.GuidedTourPrompt);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #428

`kcap setup` closed with one unlabelled green panel naming the guided tour. It never told the person who just created the server that inviting teammates, connecting Slack and adding their own AI keys are still waiting for them in the dashboard — the [Setup Server](https://capacitor.kurrent.io/docs/getting-started/setup-server/) steps the CLI cannot perform.

## Before / after

```
┌──────────────────────────────────────────────────────────────────────────────┐
│ Prompt "Start kcap guided tour" in your agent for a guided tour of Capacitor │
└──────────────────────────────────────────────────────────────────────────────┘
```

```
┌─ Next steps ─────────────────────────────────────────────────────────────────┐
│ Did you create this Capacitor server?                                        │
│                                                                              │
│   Complete server setup with instructions here:                              │
│   https://capacitor.kurrent.io/docs/getting-started/setup-server/            │
│                                                                              │
│ New to Capacitor?                                                            │
│                                                                              │
│   Prompt "Start kcap guided tour" in your coding agent to see what Capacitor │
│   can do for you                                                             │
└──────────────────────────────────────────────────────────────────────────────┘
```

The URL and the quoted prompt render cyan — they are the two things on the screen a reader retypes.

## Why each item is a question

Neither step is for everyone, and the CLI cannot tell which reader it has. **Server ownership is not knowable from a local setup run** — there is no role in the token or config, and `WorkOSDiscovery.RunWithLiveAuthAsync` returns only an exit code, so even the fact that setup just provisioned a tenant never reaches this code. So item 1 always prints and the reader self-selects. Item 2 keeps its existing gating: an agent was detected *and* one of them carries the skill.

Three copy decisions worth naming, because each rules out a phrasing that looks fine:

- **"Did you create this server?" not "Are you the workspace owner or an admin?"** A first-time reader knows what they did five minutes ago; they do not yet know what role the server gave them. The question has to be answerable from what the reader already knows.
- **"…for your team" was wrong on the majority reader.** The common case is a solo dev, who would answer no and skip an item that *is* for them — the AI keys and Slack are theirs to set up. Ownership, not team size, is the axis that splits the audience correctly.
- **"server", never "workspace".** `workspace` is already taken in this codebase for the local tree — `workspace_root` on every hook payload, Codex `--sandbox workspace-write`, Cursor's `<sanitized-workspace>` path — and it is user-facing in review-flow output (`workspace: borrowed` / `workspace: fallback`). The summary grid three lines above this box says `Server`. The docs page is the inconsistent surface here: it is titled "Setup Server" but its body says "workspace owner", which is worth a follow-up on the docs side, not here.

## Guided tour stays a prompt, not `/kcap:guided-tour`

The slash command was tried and reverted. This box prints for all nine vendors, but only Claude Code has slash commands — a Codex- or Cursor-only user, who has the skill installed as `kcap-guided-tour`, would have been told to type something that does nothing. The prompt fires everywhere, and its phrase must appear verbatim in the skill's frontmatter `description:` (asserted) or it fires nowhere.

The phrase is quoted *as well as* coloured: `NO_COLOR`, a redirected stdout or a plain terminal all drop the colour, and without the quotes the sentence gives no clue where the phrase to type starts and ends.

## Implementation

The indent under each question is a Spectre `Padder`, not a `"  "` prefix — a literal prefix only indents the first line, so every wrapped answer would have fallen back to the left margin. Visible at 80 columns, where the tour answer wraps. Rendering is split from the copy (`NextStepItems`) so the wording is asserted without touching the global `AnsiConsole`.

## Tests

41/41 `SetupCommandTests` pass. New: `ServerSetupCallToAction_is_the_exact_agreed_wording`, and `NextSteps_always_lists_server_setup_and_only_adds_the_tour_when_offered` (pins that server setup survives a run where no agent carried the skill, and that both cyan spans are applied). The existing frontmatter-trigger test now matches against the `GuidedTourPrompt` constant rather than a second loose copy of the literal.

README's setup section is updated in the same PR, per the README-sync rule.

**Not verified:** `dotnet publish -c Release` cannot complete on the authoring machine — it fails at the native link step with `'vswhere.exe' is not recognized`, unrelated to this change. ILC trim analysis ran and emitted no IL3050/IL2026; nothing here is reflective (a `List<string>`, `string.Join`, `string.Replace`). CI should be treated as the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)