### PR TITLE
[AI-1674] Disable branch-resolvable clean/smudge filters during worktree creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1153,6 +1153,9 @@ kcap agent start claude -d                    # start without attaching; prints 
     pointer text inside agent worktrees, and a custom filter driver does not run there.** Disabled drivers
     are logged at startup of each worktree so the effect is visible rather than mysterious.
 
+- **Detach** without stopping the agent with the prefix key **`Ctrl-Q` then `d`**. The agent keeps running in the daemon.
+- **Permissions:** for a registered agent, permission prompts appear in the web UI (the same dialog as hosted agents); with `--private`, prompts are answered natively in your terminal.
+
 ```bash
 kcap agent                 # no subcommand — same as `kcap agent ls`
 kcap agent ls              # list daemon-hosted agents (id, status, kind, repo)

--- a/README.md
+++ b/README.md
@@ -1149,8 +1149,11 @@ kcap agent start claude -d                    # start without attaching; prints 
     `.gitattributes` is branch content and selects which filter driver applies, so a driver whose command is
     relative — `filter.x.smudge=./tools/f` — has the branch supply the executable. No command is inspected
     and no driver is exempt: four narrower designs were each defeated at their exemption, so there is
-    deliberately nothing left to parse, resolve or impersonate. **No custom filter driver runs inside an agent
-    worktree.** What that means for file contents depends on how the worktree is built:
+    deliberately nothing left to parse, resolve or impersonate. **No custom filter driver runs during the git
+    commands kcap uses to create and populate a worktree** — that is the window in which branch content is
+    first materialised, before an agent is running. The overrides are per-command, not persistent: git
+    operations the agent itself runs inside the worktree afterwards use the repository's own configuration.
+    What the disabling means for file contents depends on how the worktree is built:
     - *Owned worktrees* check out through git, so LFS-tracked files appear as pointer text.
     - *Standalone snapshots* copy the source directory's bytes and re-commit them with the clean filter
       disabled, so whatever the source already held — smudged content included — is what you get.

--- a/README.md
+++ b/README.md
@@ -1132,8 +1132,8 @@ kcap agent start claude -d                    # start without attaching; prints 
 - **Work location:** by default the agent runs **in place in your current directory** (it edits your real files). Pass `--worktree` to run in a throwaway git worktree instead.
 
 - **What a worktree deliberately does NOT inherit:** an agent worktree is a checkout of whatever branch is
-  being worked on, so anything committed there is content the agent's own author may not control. Two things
-  are therefore neutralised when kcap creates one:
+  being worked on, so anything committed there is content the agent's own author may not control. These are
+  therefore neutralised when kcap creates one:
 
   - **Workspace MCP config is removed** — `.mcp.json`, `.cursor/mcp.json`, `.gemini/settings.json`,
     `.kiro/settings/mcp.json`, `.vscode/mcp.json`, `.github/copilot/mcp.json`, `.copilot/mcp.json`,

--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,11 @@ kcap agent start claude -d                    # start without attaching; prints 
     `core.hooksPath` such as `.githooks`, the hook scripts are themselves branch content and git would run
     `post-checkout` during `worktree add`. This applies only to kcap's own creation commands; hooks in the
     agent's own later commits are unaffected.
+  - **Branch-resolvable clean/smudge filters are disabled for those same commands.** `.gitattributes` is
+    branch content and selects which filter driver applies, so a driver whose command is *relative* —
+    `filter.x.smudge=./tools/f` — has the branch supply the executable. Only relative commands are
+    disabled: a PATH-resolved or absolute one such as `git-lfs filter-process` is left alone, so LFS
+    repositories check out normally.
 - **Detach** without stopping the agent with the prefix key **`Ctrl-Q` then `d`**. The agent keeps running in the daemon.
 - **Permissions:** for a registered agent, permission prompts appear in the web UI (the same dialog as hosted agents); with `--private`, prompts are answered natively in your terminal.
 

--- a/README.md
+++ b/README.md
@@ -1145,11 +1145,14 @@ kcap agent start claude -d                    # start without attaching; prints 
     `core.hooksPath` such as `.githooks`, the hook scripts are themselves branch content and git would run
     `post-checkout` during `worktree add`. This applies only to kcap's own creation commands; hooks in the
     agent's own later commits are unaffected.
-  - **Branch-resolvable clean/smudge filters are disabled for those same commands.** `.gitattributes` is
-    branch content and selects which filter driver applies, so a driver whose command is *relative* —
-    `filter.x.smudge=./tools/f` — has the branch supply the executable. Only relative commands are
-    disabled: a PATH-resolved or absolute one such as `git-lfs filter-process` is left alone, so LFS
-    repositories check out normally.
+  - **Clean/smudge filters are disabled for those same commands, except `lfs`.** `.gitattributes` is branch
+    content and selects which filter driver applies, so a driver whose command is relative —
+    `filter.x.smudge=./tools/f` — has the branch supply the executable. Containment is an allowlist of
+    driver *names* rather than an analysis of commands: a command is a shell program, and no amount of
+    parsing reliably decides what one will execute. `lfs` is allowlisted because git-lfs is ubiquitous and
+    disabling it fails silently, yielding pointer files instead of content. **A custom filter driver
+    therefore does not run inside an agent worktree** — if you rely on one and have verified it, that is a
+    deliberate gap to raise rather than a bug.
 - **Detach** without stopping the agent with the prefix key **`Ctrl-Q` then `d`**. The agent keeps running in the daemon.
 - **Permissions:** for a registered agent, permission prompts appear in the web UI (the same dialog as hosted agents); with `--private`, prompts are answered natively in your terminal.
 

--- a/README.md
+++ b/README.md
@@ -1147,12 +1147,14 @@ kcap agent start claude -d                    # start without attaching; prints 
     agent's own later commits are unaffected.
   - **Clean/smudge filters are disabled for those same commands, except `lfs`.** `.gitattributes` is branch
     content and selects which filter driver applies, so a driver whose command is relative —
-    `filter.x.smudge=./tools/f` — has the branch supply the executable. Containment is an allowlist of
-    driver *names* rather than an analysis of commands: a command is a shell program, and no amount of
-    parsing reliably decides what one will execute. `lfs` is allowlisted because git-lfs is ubiquitous and
-    disabling it fails silently, yielding pointer files instead of content. **A custom filter driver
-    therefore does not run inside an agent worktree** — if you rely on one and have verified it, that is a
-    deliberate gap to raise rather than a bug.
+    `filter.x.smudge=./tools/f` — has the branch supply the executable. No filter command is inspected to
+    decide this: a command is a shell program, and no parsing reliably decides what one will execute.
+    Instead every driver but `lfs` is disabled outright, and `lfs` is **rebound to kcap's own command**
+    using an absolute `git-lfs` path resolved by the daemon — so LFS keeps working without anything from
+    your config being executed. If `git-lfs` cannot be found, `lfs` is disabled too and LFS files check out
+    as pointers. **A custom filter driver does not run inside an agent worktree**, and a wrapper you have
+    put in front of git-lfs is bypassed there; if you rely on either, raise it rather than treating it as a
+    bug.
 - **Detach** without stopping the agent with the prefix key **`Ctrl-Q` then `d`**. The agent keeps running in the daemon.
 - **Permissions:** for a registered agent, permission prompts appear in the web UI (the same dialog as hosted agents); with `--private`, prompts are answered natively in your terminal.
 

--- a/README.md
+++ b/README.md
@@ -1145,18 +1145,13 @@ kcap agent start claude -d                    # start without attaching; prints 
     `core.hooksPath` such as `.githooks`, the hook scripts are themselves branch content and git would run
     `post-checkout` during `worktree add`. This applies only to kcap's own creation commands; hooks in the
     agent's own later commits are unaffected.
-  - **Clean/smudge filters are disabled for those same commands, except `lfs`.** `.gitattributes` is branch
-    content and selects which filter driver applies, so a driver whose command is relative —
-    `filter.x.smudge=./tools/f` — has the branch supply the executable. No filter command is inspected to
-    decide this: a command is a shell program, and no parsing reliably decides what one will execute.
-    Instead every driver but `lfs` is disabled outright, and `lfs` is **rebound to kcap's own command**
-    using an absolute `git-lfs` path resolved by the daemon — so LFS keeps working without anything from
-    your config being executed. If `git-lfs` cannot be found, `lfs` is disabled too and LFS files check out
-    as pointers. **A custom filter driver does not run inside an agent worktree**, and a wrapper you have
-    put in front of git-lfs is bypassed there; if you rely on either, raise it rather than treating it as a
-    bug.
-- **Detach** without stopping the agent with the prefix key **`Ctrl-Q` then `d`**. The agent keeps running in the daemon.
-- **Permissions:** for a registered agent, permission prompts appear in the web UI (the same dialog as hosted agents); with `--private`, prompts are answered natively in your terminal.
+  - **Clean/smudge filters are disabled for those same commands — all of them, including `lfs`.**
+    `.gitattributes` is branch content and selects which filter driver applies, so a driver whose command is
+    relative — `filter.x.smudge=./tools/f` — has the branch supply the executable. No command is inspected
+    and no driver is exempt: four narrower designs were each defeated at their exemption, so there is
+    deliberately nothing left to parse, resolve or impersonate. **LFS-tracked files therefore check out as
+    pointer text inside agent worktrees, and a custom filter driver does not run there.** Disabled drivers
+    are logged at startup of each worktree so the effect is visible rather than mysterious.
 
 ```bash
 kcap agent                 # no subcommand — same as `kcap agent ls`

--- a/README.md
+++ b/README.md
@@ -1149,9 +1149,11 @@ kcap agent start claude -d                    # start without attaching; prints 
     `.gitattributes` is branch content and selects which filter driver applies, so a driver whose command is
     relative — `filter.x.smudge=./tools/f` — has the branch supply the executable. No command is inspected
     and no driver is exempt: four narrower designs were each defeated at their exemption, so there is
-    deliberately nothing left to parse, resolve or impersonate. **LFS-tracked files therefore check out as
-    pointer text inside agent worktrees, and a custom filter driver does not run there.** Disabled drivers
-    are logged at startup of each worktree so the effect is visible rather than mysterious.
+    deliberately nothing left to parse, resolve or impersonate. **A custom filter driver does not run inside an
+    agent worktree, and LFS-tracked files check out as pointer text there.** Borrowed review snapshots are
+    the exception: they are rebuilt from the source working tree, so they carry the real content the source
+    already had — and refuse to build if the source itself holds unsmudged pointers. Disabled drivers are
+    logged per worktree so the effect is visible rather than mysterious.
 
 - **Detach** without stopping the agent with the prefix key **`Ctrl-Q` then `d`**. The agent keeps running in the daemon.
 - **Permissions:** for a registered agent, permission prompts appear in the web UI (the same dialog as hosted agents); with `--private`, prompts are answered natively in your terminal.

--- a/README.md
+++ b/README.md
@@ -1149,11 +1149,15 @@ kcap agent start claude -d                    # start without attaching; prints 
     `.gitattributes` is branch content and selects which filter driver applies, so a driver whose command is
     relative — `filter.x.smudge=./tools/f` — has the branch supply the executable. No command is inspected
     and no driver is exempt: four narrower designs were each defeated at their exemption, so there is
-    deliberately nothing left to parse, resolve or impersonate. **A custom filter driver does not run inside an
-    agent worktree, and LFS-tracked files check out as pointer text there.** Borrowed review snapshots are
-    the exception: they are rebuilt from the source working tree, so they carry the real content the source
-    already had — and refuse to build if the source itself holds unsmudged pointers. Disabled drivers are
-    logged per worktree so the effect is visible rather than mysterious.
+    deliberately nothing left to parse, resolve or impersonate. **No custom filter driver runs inside an agent
+    worktree.** What that means for file contents depends on how the worktree is built:
+    - *Owned worktrees* check out through git, so LFS-tracked files appear as pointer text.
+    - *Standalone snapshots* copy the source directory's bytes and re-commit them with the clean filter
+      disabled, so whatever the source already held — smudged content included — is what you get.
+    - *Borrowed review snapshots* are rebuilt from the source working tree and carry its real content; they
+      refuse to build if the source itself holds unsmudged LFS pointers.
+
+    Disabled drivers are logged per worktree so the effect is visible rather than mysterious.
 
 - **Detach** without stopping the agent with the prefix key **`Ctrl-Q` then `d`**. The agent keeps running in the daemon.
 - **Permissions:** for a registered agent, permission prompts appear in the web UI (the same dialog as hosted agents); with `--private`, prompts are answered natively in your terminal.

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
@@ -1,0 +1,84 @@
+namespace Capacitor.Cli.Daemon.Services;
+
+public partial class WorktreeManager {
+    /// <summary>
+    /// Git config that disables any clean/smudge/process filter whose command would be supplied by the
+    /// branch, for the commands that materialise branch content.
+    ///
+    /// <para><b>The vector.</b> <c>.gitattributes</c> is branch content and SELECTS which filter driver
+    /// applies to a path. The driver's command comes from the operator's config — but if that command is
+    /// relative, it resolves against the worktree, so the branch supplies the executable. Measured:
+    /// <c>filter.x.smudge=./tools/f</c> plus a branch-committed <c>tools/f</c> runs during
+    /// <c>worktree add</c>, before anything has neutralised the tree. <c>core.hooksPath</c> does not affect
+    /// filters at all.</para>
+    ///
+    /// <para><b>Why not disable every filter.</b> That breaks <c>git-lfs</c>, whose <c>filter.lfs.smudge</c>
+    /// is entirely legitimate and whose absence yields pointer files instead of content — silently. The
+    /// distinguishing property is whether the command resolves to branch content, so only relative commands
+    /// are neutralised and PATH- or absolutely-resolved ones are left alone.</para>
+    ///
+    /// <para><b>Enumeration is sound here.</b> A filter can only run if it is DEFINED in config, and the
+    /// branch can only select from what is defined — so disabling the definitions that are branch-resolvable
+    /// covers every driver the branch could reach.</para>
+    ///
+    /// <para><b><c>required</c> must be cleared too.</b> Measured: with <c>filter.x.required=true</c>, an
+    /// empty smudge command is FATAL and <c>worktree add</c> fails outright. Suppressing the command alone
+    /// would turn this guard into a launch failure for any repo using a required filter.</para>
+    /// </summary>
+    internal static async Task<string[]> BranchResolvableFilterOverridesAsync(string repoPath) {
+        // Best effort: `config --get-regexp` exits non-zero when nothing matches, which is the common case
+        // (no filters defined at all). A failure here must not fail the launch — it simply means no
+        // overrides, and the guard is additive.
+        var listed = await RunGitCaptureResult(repoPath, GitTimeout, sourceReadOnly: true,
+            "config", "--get-regexp", "^filter\\..*\\.(clean|smudge|process)$");
+        if (listed.ExitCode != 0 || string.IsNullOrWhiteSpace(listed.Stdout)) return [];
+
+        var drivers = new SortedSet<string>(StringComparer.Ordinal);
+
+        foreach (var line in listed.Stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries)) {
+            var split = line.IndexOf(' ');
+            if (split <= 0) continue;
+
+            var name    = line[..split];                       // filter.<driver>.<op>
+            var command = line[(split + 1)..].Trim();
+            var parts   = name.Split('.');
+            if (parts.Length < 3 || !ResolvesToBranchContent(command)) continue;
+
+            drivers.Add(string.Join('.', parts[1..^1]));       // a driver name may itself contain dots
+        }
+
+        return [.. drivers.SelectMany(static driver => new[] {
+            "-c", $"filter.{driver}.clean=",
+            "-c", $"filter.{driver}.smudge=",
+            "-c", $"filter.{driver}.process=",
+            "-c", $"filter.{driver}.required=false"
+        })];
+    }
+
+    /// <summary>
+    /// Whether a filter command could execute something the branch supplies.
+    ///
+    /// <para>Every whitespace-separated token is examined, not just the executable: <c>sh -c 'cat
+    /// ./tools/x'</c> has an absolute-or-PATH executable and a branch-controlled payload. Any token that
+    /// looks like a relative path condemns the whole command, which is the fail-closed direction — the cost
+    /// of a false positive is one legitimate filter disabled inside agent worktrees, against branch-supplied
+    /// code executing as the daemon user.</para>
+    /// </summary>
+    internal static bool ResolvesToBranchContent(string command) {
+        foreach (var raw in command.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)) {
+            var token = raw.Trim('"', '\'');
+            if (token.Length == 0) continue;
+
+            if (token.StartsWith("./", StringComparison.Ordinal) ||
+                token.StartsWith("../", StringComparison.Ordinal) ||
+                token.StartsWith(".\\", StringComparison.Ordinal) ||
+                token.StartsWith("..\\", StringComparison.Ordinal)) return true;
+
+            // A separator without an absolute root is relative — `tools/f`. A bare name (`git-lfs`) is
+            // PATH-resolved and cannot be supplied by the branch, so it is left alone.
+            if ((token.Contains('/') || token.Contains('\\')) && !Path.IsPathRooted(token)) return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
@@ -11,27 +11,8 @@ public sealed class BranchFilterInventoryException(string repoPath, string detai
 
 public partial class WorktreeManager {
     /// <summary>
-    /// Filter drivers permitted to run while branch content is materialised. Everything else defined in the
-    /// operator's config is disabled for those commands.
-    ///
-    /// <para><c>lfs</c> is here because git-lfs is ubiquitous and disabling it does not fail loudly — it
-    /// silently yields pointer files instead of content. Membership is necessary but NOT sufficient: the
-    /// binding is authenticated too, see <see cref="IsAuthenticAllowedDriverAsync"/>.</para>
-    /// </summary>
-    internal static readonly string[] AllowedFilterDrivers = ["lfs"];
-
-    /// <summary>The executable an allowlisted driver is rebound to.</summary>
-    const string AllowedFilterBinary = "git-lfs";
-
-    /// <summary>The absolute path substituted into an allowlisted driver's command, or null when the binary
-    /// cannot be resolved — in which case the driver is disabled rather than left on the operator's own
-    /// command. Exposed so tests can skip when the host has no git-lfs.</summary>
-    internal static string? ResolvedAllowedFilterBinary =>
-        CliResolver.ResolveExecutable(AllowedFilterBinary) is { } p && Path.IsPathRooted(p) ? p : null;
-
-    /// <summary>
-    /// Config overrides disabling every filter driver except an authenticated
-    /// <see cref="AllowedFilterDrivers"/>, for the git commands that materialise or ingest branch content.
+    /// Config overrides disabling EVERY defined clean/smudge/process filter, for the git commands that
+    /// materialise or ingest branch content.
     ///
     /// <para><b>The vector.</b> <c>.gitattributes</c> is branch content and SELECTS which driver applies to
     /// a path. The command comes from the operator's config, but a relative one resolves against the
@@ -39,20 +20,26 @@ public partial class WorktreeManager {
     /// branch-committed <c>tools/f</c> runs during <c>worktree add</c>. <c>core.hooksPath</c> does not
     /// affect filters.</para>
     ///
-    /// <para><b>Why not classify the command.</b> The first version did, and review defeated it four ways:
-    /// <c>sh tools</c> and <c>python filter.py</c> execute a branch-supplied file with no path separator;
-    /// <c>/bin/true;./tools/f</c> is one rooted token whose shell runs the relative half; and <c>%f</c> is
-    /// substituted by git AFTER any inspection. A command string is a shell program, and deciding what a
-    /// shell program will execute is not something a tokeniser can do.</para>
+    /// <para><b>Why there is no exemption, not even for git-lfs.</b> Four successive designs tried to keep
+    /// LFS working and each was defeated in review, always in the same place — the exemption:</para>
+    /// <list type="number">
+    /// <item>Classify the command, disable relative ones. <c>sh tools</c> and <c>python filter.py</c> run a
+    /// branch file with no separator; <c>/bin/true;./tools/f</c> is one rooted token whose shell runs the
+    /// relative half; <c>%f</c> is substituted after any inspection.</item>
+    /// <item>Allowlist the NAME <c>lfs</c>. A name is a convention — <c>filter.lfs.smudge=./tools/f</c> is
+    /// legal config, and a branch selecting <c>filter=lfs</c> rides the allowlist to its own file.</item>
+    /// <item>Authenticate the binding by the command's first token. Git runs the whole value through a
+    /// shell, so <c>git-lfs smudge -- %f; ./tools/f</c> passes and then executes branch content.</item>
+    /// <item>Rebind to a <c>git-lfs</c> we resolve ourselves. The daemon's PATH is ambient — it inherits the
+    /// launching shell's, which may carry a relative or repo-local entry — and the resolved path was
+    /// interpolated unquoted into what is, again, a shell program.</item>
+    /// </list>
     ///
-    /// <para><b>Enumerated by NAME ONLY</b> (<c>--name-only -z</c>), so config VALUES never enter this
-    /// parse: a value of <c>cat\n./tools/f</c> would read to a line-splitting inventory as a safe record
-    /// plus an ignored line while git executes the whole thing.</para>
-    ///
-    /// <para><b>Enumerated in the SAME context the guarded command runs in</b>, with the same config
-    /// visibility — not <c>sourceReadOnly</c>, which sets <c>GIT_CONFIG_NOSYSTEM</c> and would hide a
-    /// system-scoped driver that is live during materialisation, and against the same directory, so a
-    /// conditional <c>includeIf.gitdir</c> resolves identically for both.</para>
+    /// <para>Four mechanisms, four holes, all guarding one exception. Disabling every driver has no such
+    /// surface: nothing is parsed, nothing is resolved, nothing is authenticated, and there is no name to
+    /// impersonate. The cost is real and is documented rather than hidden — LFS-tracked files check out as
+    /// pointer text inside agent worktrees, and a custom filter does not run there. Removals are logged so
+    /// an operator sees it happen instead of wondering why a file looks wrong.</para>
     /// </summary>
     /// <exception cref="BranchFilterInventoryException">Enumeration failed, or a driver name cannot be
     /// safely expressed as an override.</exception>
@@ -67,8 +54,7 @@ public partial class WorktreeManager {
             throw new BranchFilterInventoryException(gitContextPath,
                 $"`git config --get-regexp` exited {listed.ExitCode}: {listed.Stderr.Trim()}");
 
-        var disable = new SortedSet<string>(StringComparer.Ordinal);
-        var allowed = new SortedSet<string>(StringComparer.Ordinal);
+        var drivers = new SortedSet<string>(StringComparer.Ordinal);
 
         foreach (var key in listed.Stdout.Split('\0', StringSplitOptions.RemoveEmptyEntries)) {
             var parts = key.Trim().Split('.');
@@ -79,23 +65,17 @@ public partial class WorktreeManager {
             // `-c key=value` splits at the FIRST '='. A driver legally named `evil=x` would be written as
             // key `filter.evil`, leaving `filter.evil=x.smudge` live while the override LOOKED applied.
             // Git permits arbitrary subsection characters, so refuse rather than mis-encode: a guard that
-            // silently does nothing is worse than a launch that fails.
+            // silently does nothing is worse than a launch that fails. The env transport that would carry
+            // such a name safely is tracked separately.
             if (driver.Contains('=') || driver.Contains('\n') || driver.Contains('\0'))
                 throw new BranchFilterInventoryException(gitContextPath,
                     $"Filter driver '{driver}' has a name that cannot be safely expressed as a command-line "
                   + "override, so it cannot be contained.");
 
-            if (AllowedFilterDrivers.Contains(driver, StringComparer.Ordinal)) allowed.Add(driver);
-            else disable.Add(driver);
+            drivers.Add(driver);
         }
 
-        // An allowlisted driver whose canonical form cannot be built (no resolvable git-lfs) falls through
-        // to the disable set — never left live on the operator's own command.
-        foreach (var driver in allowed)
-            if (CanonicalAllowedDriverOverrides(driver).Length == 0) disable.Add(driver);
-
-        return [.. allowed.SelectMany(CanonicalAllowedDriverOverrides),
-                .. disable.SelectMany(static driver => new[] {
+        return [.. drivers.SelectMany(static driver => new[] {
             "-c", $"filter.{driver}.clean=",
             "-c", $"filter.{driver}.smudge=",
             "-c", $"filter.{driver}.process=",
@@ -103,38 +83,5 @@ public partial class WorktreeManager {
             // Clearing the command alone would turn this guard into a denial of service.
             "-c", $"filter.{driver}.required=false"
         })];
-    }
-
-    /// <summary>
-    /// The overrides that keep an allowlisted driver working — by REPLACING its command with our own,
-    /// built from a <c>git-lfs</c> we resolved ourselves, rather than by vetting the operator's string.
-    ///
-    /// <para>Authenticating the operator's command was the previous attempt and review showed it unsound:
-    /// git runs the whole value through a shell, so <c>git-lfs smudge -- %f; ./tools/f</c> passes any
-    /// first-token check and then executes branch content; a branch-owned <c>/repo/tools/git-lfs</c> passes
-    /// by basename; and a bare <c>git-lfs</c> can be shadowed if the inherited PATH has a relative
-    /// component. Every one of those is a way for a string to look like the binary without being it.</para>
-    ///
-    /// <para>So nothing the operator wrote is executed. The command is ours, the path is absolute and
-    /// resolved by us, and the operator's value is simply overwritten for the guarded commands. If
-    /// <c>git-lfs</c> cannot be resolved there is nothing trustworthy to substitute, so the driver is
-    /// disabled like any other — pointer files rather than an unvetted execution.</para>
-    ///
-    /// <para>Cost, deliberately accepted: an operator who wraps git-lfs behind their own script loses that
-    /// wrapper inside agent worktrees. Their wrapper is exactly the branch-reachable indirection this
-    /// exists to remove.</para>
-    /// </summary>
-    static string[] CanonicalAllowedDriverOverrides(string driver) {
-        if (!AllowedFilterDrivers.Contains(driver, StringComparer.Ordinal)) return [];
-
-        var resolved = CliResolver.ResolveExecutable(AllowedFilterBinary);
-        if (resolved is null || !Path.IsPathRooted(resolved)) return [];
-
-        return [
-            "-c", $"filter.{driver}.clean={resolved} clean -- %f",
-            "-c", $"filter.{driver}.smudge={resolved} smudge -- %f",
-            "-c", $"filter.{driver}.process={resolved} filter-process",
-            "-c", $"filter.{driver}.required=true"
-        ];
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
@@ -1,84 +1,84 @@
 namespace Capacitor.Cli.Daemon.Services;
 
+/// <summary>Thrown when the filter drivers active for a repository cannot be enumerated, so it is not known
+/// which of them a branch could reach. Fail-closed: the alternative is materialising branch content with
+/// every filter live.</summary>
+public sealed class BranchFilterInventoryException(string repoPath, string detail)
+    : Exception($"Refusing to build a worktree for '{repoPath}': the active git filter drivers could not be "
+              + $"enumerated, so branch-selected filters cannot be contained. {detail}") {
+    public string RepoPath { get; } = repoPath;
+}
+
 public partial class WorktreeManager {
     /// <summary>
-    /// Git config that disables any clean/smudge/process filter whose command would be supplied by the
-    /// branch, for the commands that materialise branch content.
+    /// Filter drivers permitted to run while branch content is materialised. Everything else defined in the
+    /// operator's config is disabled for those commands.
     ///
-    /// <para><b>The vector.</b> <c>.gitattributes</c> is branch content and SELECTS which filter driver
-    /// applies to a path. The driver's command comes from the operator's config — but if that command is
-    /// relative, it resolves against the worktree, so the branch supplies the executable. Measured:
-    /// <c>filter.x.smudge=./tools/f</c> plus a branch-committed <c>tools/f</c> runs during
-    /// <c>worktree add</c>, before anything has neutralised the tree. <c>core.hooksPath</c> does not affect
-    /// filters at all.</para>
-    ///
-    /// <para><b>Why not disable every filter.</b> That breaks <c>git-lfs</c>, whose <c>filter.lfs.smudge</c>
-    /// is entirely legitimate and whose absence yields pointer files instead of content — silently. The
-    /// distinguishing property is whether the command resolves to branch content, so only relative commands
-    /// are neutralised and PATH- or absolutely-resolved ones are left alone.</para>
-    ///
-    /// <para><b>Enumeration is sound here.</b> A filter can only run if it is DEFINED in config, and the
-    /// branch can only select from what is defined — so disabling the definitions that are branch-resolvable
-    /// covers every driver the branch could reach.</para>
-    ///
-    /// <para><b><c>required</c> must be cleared too.</b> Measured: with <c>filter.x.required=true</c>, an
-    /// empty smudge command is FATAL and <c>worktree add</c> fails outright. Suppressing the command alone
-    /// would turn this guard into a launch failure for any repo using a required filter.</para>
+    /// <para><c>lfs</c> is here because git-lfs is ubiquitous and its command is a fixed, PATH-resolved
+    /// binary the branch cannot influence — and because disabling it does not fail loudly, it silently
+    /// yields pointer files instead of content.</para>
     /// </summary>
-    internal static async Task<string[]> BranchResolvableFilterOverridesAsync(string repoPath) {
-        // Best effort: `config --get-regexp` exits non-zero when nothing matches, which is the common case
-        // (no filters defined at all). A failure here must not fail the launch — it simply means no
-        // overrides, and the guard is additive.
-        var listed = await RunGitCaptureResult(repoPath, GitTimeout, sourceReadOnly: true,
-            "config", "--get-regexp", "^filter\\..*\\.(clean|smudge|process)$");
-        if (listed.ExitCode != 0 || string.IsNullOrWhiteSpace(listed.Stdout)) return [];
+    internal static readonly string[] AllowedFilterDrivers = ["lfs"];
+
+    /// <summary>
+    /// Config overrides disabling every filter driver except <see cref="AllowedFilterDrivers"/>, for the
+    /// git commands that materialise or ingest branch content.
+    ///
+    /// <para><b>The vector.</b> <c>.gitattributes</c> is branch content and SELECTS which driver applies to
+    /// a path. The command comes from the operator's config, but a relative one resolves against the
+    /// worktree, so the branch supplies the executable. Measured: <c>filter.x.smudge=./tools/f</c> with a
+    /// branch-committed <c>tools/f</c> runs during <c>worktree add</c>. <c>core.hooksPath</c> does not
+    /// affect filters.</para>
+    ///
+    /// <para><b>Why an allowlist of NAMES and not an analysis of commands.</b> The first version classified
+    /// the command string — relative paths were disabled, PATH-resolved ones kept. Review took it apart:
+    /// <c>sh tools</c> and <c>python filter.py</c> execute a branch-supplied file with no path separator at
+    /// all; <c>/bin/true;./tools/f</c> is one rooted token whose shell runs the relative half; and <c>%f</c>
+    /// is substituted by git AFTER any inspection we could do. A command string is a shell program, and
+    /// deciding what a shell program will execute is not something a tokeniser can do. The name is not a
+    /// program — a branch can only select from drivers the operator already defined, and whether one of
+    /// those is trusted is the operator's answer to give, not ours to infer.</para>
+    ///
+    /// <para><b>Enumerated by NAME ONLY.</b> <c>--name-only -z</c> means values never enter the parse, which
+    /// removes the newline-in-a-config-value bypass a line-split inventory has: a value of
+    /// <c>cat\n./tools/f</c> reads as a safe record plus an ignored line while git executes the whole
+    /// thing.</para>
+    ///
+    /// <para><b>Enumerated in the SAME context the command will run in</b>, with the same config visibility
+    /// — not <c>sourceReadOnly</c>, which sets <c>GIT_CONFIG_NOSYSTEM</c> and would hide a system-scoped
+    /// driver that is then live during materialisation, and against the directory the command uses, so a
+    /// conditional <c>includeIf.gitdir</c> resolves the same way for both.</para>
+    /// </summary>
+    /// <exception cref="BranchFilterInventoryException">Enumeration failed for a reason other than "no
+    /// drivers defined".</exception>
+    internal static async Task<string[]> BranchFilterOverridesAsync(string gitContextPath) {
+        var listed = await RunGitCaptureResult(gitContextPath, GitTimeout, sourceReadOnly: false,
+            "config", "--name-only", "-z", "--get-regexp", "^filter\\..*\\.(clean|smudge|process)$");
+
+        // Exit 1 is git's "no key matched" — the common case of a repo with no filters at all. Anything
+        // else means we do not KNOW what is defined, and proceeding with an empty override set would run
+        // the materialisation with every driver live.
+        if (listed.ExitCode is not (0 or 1))
+            throw new BranchFilterInventoryException(gitContextPath,
+                $"`git config --get-regexp` exited {listed.ExitCode}: {listed.Stderr.Trim()}");
 
         var drivers = new SortedSet<string>(StringComparer.Ordinal);
 
-        foreach (var line in listed.Stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries)) {
-            var split = line.IndexOf(' ');
-            if (split <= 0) continue;
+        foreach (var key in listed.Stdout.Split('\0', StringSplitOptions.RemoveEmptyEntries)) {
+            var parts = key.Trim().Split('.');
+            if (parts.Length < 3) continue;
 
-            var name    = line[..split];                       // filter.<driver>.<op>
-            var command = line[(split + 1)..].Trim();
-            var parts   = name.Split('.');
-            if (parts.Length < 3 || !ResolvesToBranchContent(command)) continue;
-
-            drivers.Add(string.Join('.', parts[1..^1]));       // a driver name may itself contain dots
+            var driver = string.Join('.', parts[1..^1]);       // a driver name may itself contain dots
+            if (!AllowedFilterDrivers.Contains(driver, StringComparer.Ordinal)) drivers.Add(driver);
         }
 
         return [.. drivers.SelectMany(static driver => new[] {
             "-c", $"filter.{driver}.clean=",
             "-c", $"filter.{driver}.smudge=",
             "-c", $"filter.{driver}.process=",
+            // Measured: with `required=true`, an empty command is FATAL and the checkout fails outright.
+            // Clearing the command alone would turn this guard into a denial of service.
             "-c", $"filter.{driver}.required=false"
         })];
-    }
-
-    /// <summary>
-    /// Whether a filter command could execute something the branch supplies.
-    ///
-    /// <para>Every whitespace-separated token is examined, not just the executable: <c>sh -c 'cat
-    /// ./tools/x'</c> has an absolute-or-PATH executable and a branch-controlled payload. Any token that
-    /// looks like a relative path condemns the whole command, which is the fail-closed direction — the cost
-    /// of a false positive is one legitimate filter disabled inside agent worktrees, against branch-supplied
-    /// code executing as the daemon user.</para>
-    /// </summary>
-    internal static bool ResolvesToBranchContent(string command) {
-        foreach (var raw in command.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)) {
-            var token = raw.Trim('"', '\'');
-            if (token.Length == 0) continue;
-
-            if (token.StartsWith("./", StringComparison.Ordinal) ||
-                token.StartsWith("../", StringComparison.Ordinal) ||
-                token.StartsWith(".\\", StringComparison.Ordinal) ||
-                token.StartsWith("..\\", StringComparison.Ordinal)) return true;
-
-            // A separator without an absolute root is relative — `tools/f`. A bare name (`git-lfs`) is
-            // PATH-resolved and cannot be supplied by the branch, so it is left alone.
-            if ((token.Contains('/') || token.Contains('\\')) && !Path.IsPathRooted(token)) return true;
-        }
-
-        return false;
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
@@ -37,9 +37,13 @@ public partial class WorktreeManager {
     ///
     /// <para>Four mechanisms, four holes, all guarding one exception. Disabling every driver has no such
     /// surface: nothing is parsed, nothing is resolved, nothing is authenticated, and there is no name to
-    /// impersonate. The cost is real and is documented rather than hidden — LFS-tracked files check out as
-    /// pointer text inside agent worktrees, and a custom filter does not run there. Removals are logged so
-    /// an operator sees it happen instead of wondering why a file looks wrong.</para>
+    /// impersonate. The cost is real and is documented rather than hidden. Be precise about the boundary:
+    /// these overrides are PER-COMMAND, covering the git commands kcap uses to create and populate a
+    /// worktree — the window in which branch content is first materialised, before an agent is running.
+    /// Git the agent runs there afterwards uses the repository's own configuration. What that means for
+    /// file contents also differs by path: an owned worktree checks out through git and so holds LFS
+    /// pointer text, while standalone and borrowed snapshots carry the source's own bytes (see the README).
+    /// Removals are logged so an operator sees it happen instead of wondering why a file looks wrong.</para>
     /// </summary>
     /// <exception cref="BranchFilterInventoryException">Enumeration failed, or a driver name cannot be
     /// safely expressed as an override.</exception>

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
@@ -20,8 +20,14 @@ public partial class WorktreeManager {
     /// </summary>
     internal static readonly string[] AllowedFilterDrivers = ["lfs"];
 
-    /// <summary>The executable an allowlisted driver must actually invoke.</summary>
+    /// <summary>The executable an allowlisted driver is rebound to.</summary>
     const string AllowedFilterBinary = "git-lfs";
+
+    /// <summary>The absolute path substituted into an allowlisted driver's command, or null when the binary
+    /// cannot be resolved — in which case the driver is disabled rather than left on the operator's own
+    /// command. Exposed so tests can skip when the host has no git-lfs.</summary>
+    internal static string? ResolvedAllowedFilterBinary =>
+        CliResolver.ResolveExecutable(AllowedFilterBinary) is { } p && Path.IsPathRooted(p) ? p : null;
 
     /// <summary>
     /// Config overrides disabling every filter driver except an authenticated
@@ -62,6 +68,7 @@ public partial class WorktreeManager {
                 $"`git config --get-regexp` exited {listed.ExitCode}: {listed.Stderr.Trim()}");
 
         var disable = new SortedSet<string>(StringComparer.Ordinal);
+        var allowed = new SortedSet<string>(StringComparer.Ordinal);
 
         foreach (var key in listed.Stdout.Split('\0', StringSplitOptions.RemoveEmptyEntries)) {
             var parts = key.Trim().Split('.');
@@ -78,10 +85,17 @@ public partial class WorktreeManager {
                     $"Filter driver '{driver}' has a name that cannot be safely expressed as a command-line "
                   + "override, so it cannot be contained.");
 
-            if (!await IsAuthenticAllowedDriverAsync(gitContextPath, driver)) disable.Add(driver);
+            if (AllowedFilterDrivers.Contains(driver, StringComparer.Ordinal)) allowed.Add(driver);
+            else disable.Add(driver);
         }
 
-        return [.. disable.SelectMany(static driver => new[] {
+        // An allowlisted driver whose canonical form cannot be built (no resolvable git-lfs) falls through
+        // to the disable set — never left live on the operator's own command.
+        foreach (var driver in allowed)
+            if (CanonicalAllowedDriverOverrides(driver).Length == 0) disable.Add(driver);
+
+        return [.. allowed.SelectMany(CanonicalAllowedDriverOverrides),
+                .. disable.SelectMany(static driver => new[] {
             "-c", $"filter.{driver}.clean=",
             "-c", $"filter.{driver}.smudge=",
             "-c", $"filter.{driver}.process=",
@@ -92,37 +106,35 @@ public partial class WorktreeManager {
     }
 
     /// <summary>
-    /// Whether <paramref name="driver"/> is allowlisted AND actually bound to the expected binary.
+    /// The overrides that keep an allowlisted driver working — by REPLACING its command with our own,
+    /// built from a <c>git-lfs</c> we resolved ourselves, rather than by vetting the operator's string.
     ///
-    /// <para>Trusting the NAME alone is the same mistake as trusting a command string, reached from the
-    /// other side: <c>filter.lfs.smudge=./tools/f</c> is a legal config, and a branch selecting
-    /// <c>filter=lfs</c> would ride the allowlist straight to its own file. This is NOT the general command
-    /// classification that was removed — it is the far narrower question "does this invoke the one binary
-    /// we decided to trust", decided on the first token's filename. Anything unreadable or unexpected fails
-    /// closed and the driver is disabled like any other.</para>
+    /// <para>Authenticating the operator's command was the previous attempt and review showed it unsound:
+    /// git runs the whole value through a shell, so <c>git-lfs smudge -- %f; ./tools/f</c> passes any
+    /// first-token check and then executes branch content; a branch-owned <c>/repo/tools/git-lfs</c> passes
+    /// by basename; and a bare <c>git-lfs</c> can be shadowed if the inherited PATH has a relative
+    /// component. Every one of those is a way for a string to look like the binary without being it.</para>
+    ///
+    /// <para>So nothing the operator wrote is executed. The command is ours, the path is absolute and
+    /// resolved by us, and the operator's value is simply overwritten for the guarded commands. If
+    /// <c>git-lfs</c> cannot be resolved there is nothing trustworthy to substitute, so the driver is
+    /// disabled like any other — pointer files rather than an unvetted execution.</para>
+    ///
+    /// <para>Cost, deliberately accepted: an operator who wraps git-lfs behind their own script loses that
+    /// wrapper inside agent worktrees. Their wrapper is exactly the branch-reachable indirection this
+    /// exists to remove.</para>
     /// </summary>
-    static async Task<bool> IsAuthenticAllowedDriverAsync(string gitContextPath, string driver) {
-        if (!AllowedFilterDrivers.Contains(driver, StringComparer.Ordinal)) return false;
+    static string[] CanonicalAllowedDriverOverrides(string driver) {
+        if (!AllowedFilterDrivers.Contains(driver, StringComparer.Ordinal)) return [];
 
-        foreach (var op in new[] { "clean", "smudge", "process" }) {
-            var value = await RunGitCaptureResult(gitContextPath, GitTimeout, sourceReadOnly: false,
-                "config", "--get", $"filter.{driver}.{op}");
+        var resolved = CliResolver.ResolveExecutable(AllowedFilterBinary);
+        if (resolved is null || !Path.IsPathRooted(resolved)) return [];
 
-            if (value.ExitCode == 1) continue;                 // not defined for this operation
-            if (value.ExitCode != 0) return false;             // unreadable — do not extend trust
-
-            var first = value.Stdout.Trim()
-                .Split([' ', '\t', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries)
-                .FirstOrDefault();
-
-            if (first is null) return false;
-
-            var name = Path.GetFileName(first.Trim('"', '\''));
-            if (!name.Equals(AllowedFilterBinary, StringComparison.OrdinalIgnoreCase) &&
-                !name.Equals(AllowedFilterBinary + ".exe", StringComparison.OrdinalIgnoreCase))
-                return false;
-        }
-
-        return true;
+        return [
+            "-c", $"filter.{driver}.clean={resolved} clean -- %f",
+            "-c", $"filter.{driver}.smudge={resolved} smudge -- %f",
+            "-c", $"filter.{driver}.process={resolved} filter-process",
+            "-c", $"filter.{driver}.required=true"
+        ];
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
@@ -1,11 +1,11 @@
 namespace Capacitor.Cli.Daemon.Services;
 
-/// <summary>Thrown when the filter drivers active for a repository cannot be enumerated, so it is not known
-/// which of them a branch could reach. Fail-closed: the alternative is materialising branch content with
-/// every filter live.</summary>
+/// <summary>Thrown when the filter drivers active for a repository cannot be enumerated or cannot be safely
+/// overridden, so it is not known which of them a branch could reach. Fail-closed: the alternative is
+/// materialising branch content with every filter live.</summary>
 public sealed class BranchFilterInventoryException(string repoPath, string detail)
-    : Exception($"Refusing to build a worktree for '{repoPath}': the active git filter drivers could not be "
-              + $"enumerated, so branch-selected filters cannot be contained. {detail}") {
+    : Exception($"Refusing to build a worktree for '{repoPath}': git filter drivers could not be contained. "
+              + detail) {
     public string RepoPath { get; } = repoPath;
 }
 
@@ -14,15 +14,18 @@ public partial class WorktreeManager {
     /// Filter drivers permitted to run while branch content is materialised. Everything else defined in the
     /// operator's config is disabled for those commands.
     ///
-    /// <para><c>lfs</c> is here because git-lfs is ubiquitous and its command is a fixed, PATH-resolved
-    /// binary the branch cannot influence — and because disabling it does not fail loudly, it silently
-    /// yields pointer files instead of content.</para>
+    /// <para><c>lfs</c> is here because git-lfs is ubiquitous and disabling it does not fail loudly — it
+    /// silently yields pointer files instead of content. Membership is necessary but NOT sufficient: the
+    /// binding is authenticated too, see <see cref="IsAuthenticAllowedDriverAsync"/>.</para>
     /// </summary>
     internal static readonly string[] AllowedFilterDrivers = ["lfs"];
 
+    /// <summary>The executable an allowlisted driver must actually invoke.</summary>
+    const string AllowedFilterBinary = "git-lfs";
+
     /// <summary>
-    /// Config overrides disabling every filter driver except <see cref="AllowedFilterDrivers"/>, for the
-    /// git commands that materialise or ingest branch content.
+    /// Config overrides disabling every filter driver except an authenticated
+    /// <see cref="AllowedFilterDrivers"/>, for the git commands that materialise or ingest branch content.
     ///
     /// <para><b>The vector.</b> <c>.gitattributes</c> is branch content and SELECTS which driver applies to
     /// a path. The command comes from the operator's config, but a relative one resolves against the
@@ -30,49 +33,55 @@ public partial class WorktreeManager {
     /// branch-committed <c>tools/f</c> runs during <c>worktree add</c>. <c>core.hooksPath</c> does not
     /// affect filters.</para>
     ///
-    /// <para><b>Why an allowlist of NAMES and not an analysis of commands.</b> The first version classified
-    /// the command string — relative paths were disabled, PATH-resolved ones kept. Review took it apart:
-    /// <c>sh tools</c> and <c>python filter.py</c> execute a branch-supplied file with no path separator at
-    /// all; <c>/bin/true;./tools/f</c> is one rooted token whose shell runs the relative half; and <c>%f</c>
-    /// is substituted by git AFTER any inspection we could do. A command string is a shell program, and
-    /// deciding what a shell program will execute is not something a tokeniser can do. The name is not a
-    /// program — a branch can only select from drivers the operator already defined, and whether one of
-    /// those is trusted is the operator's answer to give, not ours to infer.</para>
+    /// <para><b>Why not classify the command.</b> The first version did, and review defeated it four ways:
+    /// <c>sh tools</c> and <c>python filter.py</c> execute a branch-supplied file with no path separator;
+    /// <c>/bin/true;./tools/f</c> is one rooted token whose shell runs the relative half; and <c>%f</c> is
+    /// substituted by git AFTER any inspection. A command string is a shell program, and deciding what a
+    /// shell program will execute is not something a tokeniser can do.</para>
     ///
-    /// <para><b>Enumerated by NAME ONLY.</b> <c>--name-only -z</c> means values never enter the parse, which
-    /// removes the newline-in-a-config-value bypass a line-split inventory has: a value of
-    /// <c>cat\n./tools/f</c> reads as a safe record plus an ignored line while git executes the whole
-    /// thing.</para>
+    /// <para><b>Enumerated by NAME ONLY</b> (<c>--name-only -z</c>), so config VALUES never enter this
+    /// parse: a value of <c>cat\n./tools/f</c> would read to a line-splitting inventory as a safe record
+    /// plus an ignored line while git executes the whole thing.</para>
     ///
-    /// <para><b>Enumerated in the SAME context the command will run in</b>, with the same config visibility
-    /// — not <c>sourceReadOnly</c>, which sets <c>GIT_CONFIG_NOSYSTEM</c> and would hide a system-scoped
-    /// driver that is then live during materialisation, and against the directory the command uses, so a
-    /// conditional <c>includeIf.gitdir</c> resolves the same way for both.</para>
+    /// <para><b>Enumerated in the SAME context the guarded command runs in</b>, with the same config
+    /// visibility — not <c>sourceReadOnly</c>, which sets <c>GIT_CONFIG_NOSYSTEM</c> and would hide a
+    /// system-scoped driver that is live during materialisation, and against the same directory, so a
+    /// conditional <c>includeIf.gitdir</c> resolves identically for both.</para>
     /// </summary>
-    /// <exception cref="BranchFilterInventoryException">Enumeration failed for a reason other than "no
-    /// drivers defined".</exception>
+    /// <exception cref="BranchFilterInventoryException">Enumeration failed, or a driver name cannot be
+    /// safely expressed as an override.</exception>
     internal static async Task<string[]> BranchFilterOverridesAsync(string gitContextPath) {
         var listed = await RunGitCaptureResult(gitContextPath, GitTimeout, sourceReadOnly: false,
             "config", "--name-only", "-z", "--get-regexp", "^filter\\..*\\.(clean|smudge|process)$");
 
-        // Exit 1 is git's "no key matched" — the common case of a repo with no filters at all. Anything
-        // else means we do not KNOW what is defined, and proceeding with an empty override set would run
-        // the materialisation with every driver live.
+        // Exit 1 is git's "no key matched" — a repo with no filters, the common case. Anything else means
+        // we do not KNOW what is defined, and an empty override set would run the materialisation with
+        // every driver live.
         if (listed.ExitCode is not (0 or 1))
             throw new BranchFilterInventoryException(gitContextPath,
                 $"`git config --get-regexp` exited {listed.ExitCode}: {listed.Stderr.Trim()}");
 
-        var drivers = new SortedSet<string>(StringComparer.Ordinal);
+        var disable = new SortedSet<string>(StringComparer.Ordinal);
 
         foreach (var key in listed.Stdout.Split('\0', StringSplitOptions.RemoveEmptyEntries)) {
             var parts = key.Trim().Split('.');
             if (parts.Length < 3) continue;
 
             var driver = string.Join('.', parts[1..^1]);       // a driver name may itself contain dots
-            if (!AllowedFilterDrivers.Contains(driver, StringComparer.Ordinal)) drivers.Add(driver);
+
+            // `-c key=value` splits at the FIRST '='. A driver legally named `evil=x` would be written as
+            // key `filter.evil`, leaving `filter.evil=x.smudge` live while the override LOOKED applied.
+            // Git permits arbitrary subsection characters, so refuse rather than mis-encode: a guard that
+            // silently does nothing is worse than a launch that fails.
+            if (driver.Contains('=') || driver.Contains('\n') || driver.Contains('\0'))
+                throw new BranchFilterInventoryException(gitContextPath,
+                    $"Filter driver '{driver}' has a name that cannot be safely expressed as a command-line "
+                  + "override, so it cannot be contained.");
+
+            if (!await IsAuthenticAllowedDriverAsync(gitContextPath, driver)) disable.Add(driver);
         }
 
-        return [.. drivers.SelectMany(static driver => new[] {
+        return [.. disable.SelectMany(static driver => new[] {
             "-c", $"filter.{driver}.clean=",
             "-c", $"filter.{driver}.smudge=",
             "-c", $"filter.{driver}.process=",
@@ -80,5 +89,40 @@ public partial class WorktreeManager {
             // Clearing the command alone would turn this guard into a denial of service.
             "-c", $"filter.{driver}.required=false"
         })];
+    }
+
+    /// <summary>
+    /// Whether <paramref name="driver"/> is allowlisted AND actually bound to the expected binary.
+    ///
+    /// <para>Trusting the NAME alone is the same mistake as trusting a command string, reached from the
+    /// other side: <c>filter.lfs.smudge=./tools/f</c> is a legal config, and a branch selecting
+    /// <c>filter=lfs</c> would ride the allowlist straight to its own file. This is NOT the general command
+    /// classification that was removed — it is the far narrower question "does this invoke the one binary
+    /// we decided to trust", decided on the first token's filename. Anything unreadable or unexpected fails
+    /// closed and the driver is disabled like any other.</para>
+    /// </summary>
+    static async Task<bool> IsAuthenticAllowedDriverAsync(string gitContextPath, string driver) {
+        if (!AllowedFilterDrivers.Contains(driver, StringComparer.Ordinal)) return false;
+
+        foreach (var op in new[] { "clean", "smudge", "process" }) {
+            var value = await RunGitCaptureResult(gitContextPath, GitTimeout, sourceReadOnly: false,
+                "config", "--get", $"filter.{driver}.{op}");
+
+            if (value.ExitCode == 1) continue;                 // not defined for this operation
+            if (value.ExitCode != 0) return false;             // unreadable — do not extend trust
+
+            var first = value.Stdout.Trim()
+                .Split([' ', '\t', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries)
+                .FirstOrDefault();
+
+            if (first is null) return false;
+
+            var name = Path.GetFileName(first.Trim('"', '\''));
+            if (!name.Equals(AllowedFilterBinary, StringComparison.OrdinalIgnoreCase) &&
+                !name.Equals(AllowedFilterBinary + ".exe", StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        return true;
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
@@ -44,15 +44,25 @@ public partial class WorktreeManager {
     /// <exception cref="BranchFilterInventoryException">Enumeration failed, or a driver name cannot be
     /// safely expressed as an override.</exception>
     internal static async Task<string[]> BranchFilterOverridesAsync(string gitContextPath) {
+        // Enumerate EVERY key and match the shape here, rather than asking git to match a regex.
+        //
+        // Measured: git's `--get-regexp` runs through the platform regex in the ambient locale, where `.`
+        // does not match a byte that is not valid in that encoding. A driver named with a raw 0xff byte —
+        // `[filter "ev\xffil"]` — is therefore invisible to `^filter\..*\.(clean|smudge|process)$` while
+        // `^filter\.` still finds it, so the inventory came back EMPTY, no override was emitted, and a
+        // branch selecting `filter=ev\xffil` in .gitattributes ran the driver. That is precisely the
+        // bypass this file exists to prevent, reintroduced by trusting git to enumerate.
+        //
+        // `--list` takes no pattern, so there is no regex, no locale, and nothing to slip past.
         var listed = await RunGitCaptureResult(gitContextPath, GitTimeout, sourceReadOnly: false,
-            "config", "--name-only", "-z", "--get-regexp", "^filter\\..*\\.(clean|smudge|process)$");
+            "config", "--list", "--name-only", "-z");
 
-        // Exit 1 is git's "no key matched" — a repo with no filters, the common case. Anything else means
-        // we do not KNOW what is defined, and an empty override set would run the materialisation with
-        // every driver live.
-        if (listed.ExitCode is not (0 or 1))
+        // No "no keys" exit code to tolerate here: `--list` succeeds on an empty config. A non-zero exit
+        // means we do not KNOW what is defined, and an empty override set would run the materialisation
+        // with every driver live.
+        if (listed.ExitCode != 0)
             throw new BranchFilterInventoryException(gitContextPath,
-                $"`git config --get-regexp` exited {listed.ExitCode}: {listed.Stderr.Trim()}");
+                $"`git config --list` exited {listed.ExitCode}: {listed.Stderr.Trim()}");
 
         var drivers = new SortedSet<string>(StringComparer.Ordinal);
 
@@ -60,7 +70,22 @@ public partial class WorktreeManager {
             var parts = key.Trim().Split('.');
             if (parts.Length < 3) continue;
 
+            // The shape test git's regex used to perform. Section and variable names are canonicalized to
+            // lowercase by git on output (measured), so Ordinal is correct; only the subsection keeps case.
+            if (!parts[0].Equals("filter", StringComparison.Ordinal)) continue;
+            if (parts[^1] is not ("clean" or "smudge" or "process")) continue;
+
             var driver = string.Join('.', parts[1..^1]);       // a driver name may itself contain dots
+
+            // A name we cannot reproduce is a name we cannot disable. git config is byte-oriented, so a
+            // driver name need not be valid UTF-8; decoding one that is not yields U+FFFD, and an override
+            // built from that spelling would target a DIFFERENT driver while looking perfectly applied —
+            // the same failure as a mis-encoded `=`, and the reason this refuses rather than guesses. A
+            // genuine U+FFFD in a driver name is refused too: rare, and fail-closed is the right side.
+            if (driver.Contains('\uFFFD'))
+                throw new BranchFilterInventoryException(gitContextPath,
+                    "A filter driver name is not valid UTF-8, so an override cannot be expressed for it "
+                  + "and the driver cannot be contained.");
 
             // `-c key=value` splits at the FIRST '='. A driver legally named `evil=x` would be written as
             // key `filter.evil`, leaving `filter.evil=x.smudge` live while the override LOOKED applied.

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -212,11 +212,11 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
 
         Directory.CreateDirectory(worktreeRoot);
 
-        // Resolved once: `git config` on the SOURCE repo, whose definitions are the only ones a branch's
-        // .gitattributes can select.
-        var filterOverrides = await BranchFilterOverridesAsync(repoPath);
-        LogDisabledFilters(filterOverrides, repoPath);
-
+        // No filter inventory here on purpose. `worktree add --no-checkout` materialises nothing, so no
+        // filter can run during it, and the guarded reset re-inventories inside the TARGET — which is the
+        // context that actually decides which drivers load. A source-context inventory would add no
+        // containment and could reject a safe launch, since a source-only conditional include can define a
+        // driver the target never sees.
         if (await IsGitRepoWithCommits(repoPath)) {
             if (!string.IsNullOrEmpty(baseRef)) {
                 // Fetch into a per-worktree ref instead of the shared FETCH_HEAD
@@ -234,7 +234,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
                     "-c", "maintenance.auto=false", "-c", "gc.auto=0",
                     "fetch", "origin", $"{baseRef}:{fetchedRef}");
                 await WithWorktreeMetadataGate(repoPath, () =>
-                    RunGit(repoPath, GitTimeout, [..NoBranchHooks(), ..filterOverrides,
+                    RunGit(repoPath, GitTimeout, [..NoBranchHooks(),
                         "worktree", "add", "--no-checkout", "-B", branch, worktreePath, fetchedRef]));
                 var fetched = new WorktreeInfo(worktreePath, branch, repoPath, FetchedRef: fetchedRef);
                 await StripOrRollBackAsync(fetched);
@@ -243,7 +243,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             }
 
             await WithWorktreeMetadataGate(repoPath, () =>
-                RunGit(repoPath, GitTimeout, [..NoBranchHooks(), ..filterOverrides,
+                RunGit(repoPath, GitTimeout, [..NoBranchHooks(),
                     "worktree", "add", "--no-checkout", worktreePath, "-b", branch]));
             var linked = new WorktreeInfo(worktreePath, branch, repoPath);
             await StripOrRollBackAsync(linked);

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -212,6 +212,10 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
 
         Directory.CreateDirectory(worktreeRoot);
 
+        // Resolved once: `git config` on the SOURCE repo, whose definitions are the only ones a branch's
+        // .gitattributes can select.
+        var filterOverrides = await BranchResolvableFilterOverridesAsync(repoPath);
+
         if (await IsGitRepoWithCommits(repoPath)) {
             if (!string.IsNullOrEmpty(baseRef)) {
                 // Fetch into a per-worktree ref instead of the shared FETCH_HEAD
@@ -229,7 +233,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
                     "-c", "maintenance.auto=false", "-c", "gc.auto=0",
                     "fetch", "origin", $"{baseRef}:{fetchedRef}");
                 await WithWorktreeMetadataGate(repoPath, () =>
-                    RunGit(repoPath, GitTimeout, [..NoBranchHooks(), "worktree", "add", "-B", branch, worktreePath, fetchedRef]));
+                    RunGit(repoPath, GitTimeout, [..NoBranchHooks(), ..filterOverrides, "worktree", "add", "-B", branch, worktreePath, fetchedRef]));
                 var fetched = new WorktreeInfo(worktreePath, branch, repoPath, FetchedRef: fetchedRef);
                 await StripOrRollBackAsync(fetched);
 
@@ -237,7 +241,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             }
 
             await WithWorktreeMetadataGate(repoPath, () =>
-                RunGit(repoPath, GitTimeout, [..NoBranchHooks(), "worktree", "add", worktreePath, "-b", branch]));
+                RunGit(repoPath, GitTimeout, [..NoBranchHooks(), ..filterOverrides, "worktree", "add", worktreePath, "-b", branch]));
             var linked = new WorktreeInfo(worktreePath, branch, repoPath);
             await StripOrRollBackAsync(linked);
 
@@ -251,7 +255,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         // either — a later `git checkout` inside the tree would otherwise restore it.
         StripWorkspaceMcpConfig(worktreePath);
         await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), "init"]);
-        await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), "add", "-A"]);
+        await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), ..await BranchResolvableFilterOverridesAsync(worktreePath), "add", "-A"]);
         // Identity supplied explicitly. This is the daemon's OWN bookkeeping commit, not the user's work,
         // so it must not depend on the host having git identity configured — a machine without a global
         // user.email fails with "Author identity unknown". Found while CopyDirectory was temporarily
@@ -503,7 +507,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             // Same guard as `worktree add`: this checkout materialises branch content, so a relative
             // core.hooksPath would run the branch's post-checkout here too. Missed when the guard was
             // added — it went on the worktree paths only.
-            await RunGit(destination, GitTimeout, [..NoBranchHooks(), "checkout", "--detach", "HEAD"]);
+            await RunGit(destination, GitTimeout, [..NoBranchHooks(), ..await BranchResolvableFilterOverridesAsync(source), "checkout", "--detach", "HEAD"]);
             var clonedHead = (await RunGitCapture(destination, GitTimeout, false, "rev-parse", "HEAD")).Trim();
             if (!string.Equals(sourceHead, clonedHead, StringComparison.Ordinal)) throw new SourceChangedException();
             await RunGitBestEffort(destination, "remote", "remove", "origin");

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -271,7 +271,12 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         // either — a later `git checkout` inside the tree would otherwise restore it.
         StripWorkspaceMcpConfig(worktreePath);
         await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), "init"]);
-        await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), ..await BranchFilterOverridesAsync(worktreePath), "add", "-A"]);
+        // Inventoried and logged here, not at the source: `add -A` in this worktree is where the standalone
+        // path's filters resolve. Round 6 removed the source-level logging as dead, and this call was
+        // applying overrides inline — silently disabling LFS against a README that promises the opposite.
+        var standaloneOverrides = await BranchFilterOverridesAsync(worktreePath);
+        LogDisabledFilters(standaloneOverrides, worktreePath);
+        await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), ..standaloneOverrides, "add", "-A"]);
         // Identity supplied explicitly. This is the daemon's OWN bookkeeping commit, not the user's work,
         // so it must not depend on the host having git identity configured — a machine without a global
         // user.email fails with "Author identity unknown". Found while CopyDirectory was temporarily

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -248,8 +248,21 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             return linked;
         }
 
-        // Standalone: copy files + git init
+        // Standalone: copy files + git init.
+        // Wrapped because every step after the directory exists can throw — the MCP strip and the filter
+        // inventory are both fail-closed — and this branch returns no WorktreeInfo on the way out, so
+        // nothing downstream could clean up the partial tree. The linked paths gained rollback earlier for
+        // exactly this; review caught that the standalone one never did.
         Directory.CreateDirectory(worktreePath);
+        try {
+            return await BuildStandaloneSnapshotAsync(repoPath, worktreePath);
+        } catch {
+            try { DeleteTreeNoFollow(worktreePath); } catch { /* keep the original failure */ }
+            throw;
+        }
+    }
+
+    async Task<WorktreeInfo> BuildStandaloneSnapshotAsync(string repoPath, string worktreePath) {
         CopyDirectory(repoPath, worktreePath);
         // BEFORE the initial commit, so the snapshot's own history never carries the hostile config
         // either — a later `git checkout` inside the tree would otherwise restore it.

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -274,8 +274,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         // Inventoried and logged here, not at the source: `add -A` in this worktree is where the standalone
         // path's filters resolve. Round 6 removed the source-level logging as dead, and this call was
         // applying overrides inline — silently disabling LFS against a README that promises the opposite.
-        var standaloneOverrides = await BranchFilterOverridesAsync(worktreePath);
-        LogDisabledFilters(standaloneOverrides, worktreePath);
+        var standaloneOverrides = await FilterOverridesForAsync(worktreePath);
         await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), ..standaloneOverrides, "add", "-A"]);
         // Identity supplied explicitly. This is the daemon's OWN bookkeeping commit, not the user's work,
         // so it must not depend on the host having git identity configured — a machine without a global
@@ -364,13 +363,28 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// <c>--no-checkout</c> means nothing is materialised before that guarded step.</para>
     /// </summary>
     async Task CheckoutInTargetContextAsync(string worktreePath) {
-        var overrides = await BranchFilterOverridesAsync(worktreePath);
-        LogDisabledFilters(overrides, worktreePath);
+        var overrides = await FilterOverridesForAsync(worktreePath);
 
         // `reset --hard HEAD`, not `checkout -- .`: --no-checkout leaves the INDEX unpopulated too, so a
         // pathspec matches nothing. This is the step that materialises the tree, and therefore the step
         // the overrides have to guard.
         await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), ..overrides, "reset", "--hard", "HEAD"]);
+    }
+
+    /// <summary>
+    /// The filter overrides for a context, LOGGED as a side effect.
+    ///
+    /// <para>Single entry point on purpose. Each of the three materialising paths previously called the
+    /// inventory directly and remembered — or forgot — to log separately: standalone lost its logging when
+    /// a redundant source-level call was deleted, and the borrowed snapshot never had it, so a reviewer on
+    /// an LFS host silently got pointer files. Two rounds, one class. Computing and logging together means
+    /// a fourth path cannot repeat it.</para>
+    /// </summary>
+    async Task<string[]> FilterOverridesForAsync(string gitContextPath) {
+        var overrides = await BranchFilterOverridesAsync(gitContextPath);
+        LogDisabledFilters(overrides, gitContextPath);
+
+        return overrides;
     }
 
     /// <summary>Logs which filter drivers were disabled, so an operator whose LFS-tracked file checks out
@@ -567,7 +581,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             // Same guard as `worktree add`: this checkout materialises branch content, so a relative
             // core.hooksPath would run the branch's post-checkout here too. Missed when the guard was
             // added — it went on the worktree paths only.
-            await RunGit(destination, GitTimeout, [..NoBranchHooks(), ..await BranchFilterOverridesAsync(destination), "checkout", "--detach", "HEAD"]);
+            await RunGit(destination, GitTimeout, [..NoBranchHooks(), ..await FilterOverridesForAsync(destination), "checkout", "--detach", "HEAD"]);
             var clonedHead = (await RunGitCapture(destination, GitTimeout, false, "rev-parse", "HEAD")).Trim();
             if (!string.Equals(sourceHead, clonedHead, StringComparison.Ordinal)) throw new SourceChangedException();
             await RunGitBestEffort(destination, "remote", "remove", "origin");

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -983,8 +983,22 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         var psi = NewGitPsi(cwd, args, sourceReadOnly);
         using var proc = Process.Start(psi)!;
         using var cts = new CancellationTokenSource(timeout);
-        var stdoutTask = proc.StandardOutput.ReadToEndAsync(cts.Token);
-        var stderrTask = proc.StandardError.ReadToEndAsync(cts.Token);
+
+        // Read BYTES and decode them here. `StandardOutputEncoding` sets the encoding but does NOT turn
+        // off BOM detection: .NET builds the redirected reader with detectEncodingFromByteOrderMarks
+        // enabled, so a leading EF BB BF is swallowed before we ever see it. Measured — feeding
+        // "<BOM>A\0<BOM>B" through the reader yields "A\0<BOM>B": the FIRST BOM vanishes, later ones
+        // survive. U+FEFF is a legal character in a git path and in a config subsection, so that silently
+        // rewrites the first record of a `-z` listing — the authorised name stops being the used name,
+        // which is the whole failure class these guards exist to prevent.
+        //
+        // Measured reachability, so the claim is not broader than the evidence: for `config --list` the
+        // first records come from system/global config, which a branch does not control, so the filter
+        // inventory cannot be reached this way today. `ls-files` has no such prefix and IS reachable —
+        // that is where the regression test lives. The fix is here because the helper is shared and the
+        // property should not depend on which caller happens to be safe.
+        var stdoutTask = ReadAllDecodedAsync(proc.StandardOutput.BaseStream, cts.Token);
+        var stderrTask = ReadAllDecodedAsync(proc.StandardError.BaseStream, cts.Token);
         try {
             await proc.WaitForExitAsync(cts.Token);
         } catch (OperationCanceledException) {
@@ -1004,6 +1018,19 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         return (proc.ExitCode, await stdoutTask, await stderrTask);
     }
 
+    /// <summary>Drains a redirected stream and decodes it as UTF-8 with replacement, preserving every
+    /// byte the child wrote — including a leading BOM, which <see cref="StreamReader"/> would consume.</summary>
+    static async Task<string> ReadAllDecodedAsync(Stream stream, CancellationToken ct) {
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer, ct);
+        return GitOutputEncoding.GetString(buffer.GetBuffer().AsSpan(0, (int)buffer.Length));
+    }
+
+    /// <summary>UTF-8 with replacement fallback: an invalid sequence becomes U+FFFD, which is how a name
+    /// that cannot round-trip is detected and refused. Never emits or consumes a BOM.</summary>
+    static readonly UTF8Encoding GitOutputEncoding =
+        new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
+
     static async Task RunGitBestEffort(string cwd, params string[] args) {
         try { await RunGit(cwd, GitTimeout, args); } catch {
             /* best-effort */
@@ -1020,16 +1047,11 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             WorkingDirectory       = cwd,
             RedirectStandardOutput = true,
             RedirectStandardError  = true,
-            // EXPLICIT, because a guard depends on it. Paths and config keys are bytes to git, and the
-            // containment fails closed on names that cannot round-trip by detecting the U+FFFD a UTF-8
-            // decoder emits for an invalid sequence. Left implicit, redirected output decodes with the
-            // ambient console encoding — a Windows codepage maps 0xff to a perfectly ordinary character,
-            // no U+FFFD appears, the name looks round-trippable, and an override is emitted that names a
-            // DIFFERENT driver while looking applied. Replacement fallback is what makes the check sound.
-            StandardOutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false,
-                                                      throwOnInvalidBytes: false),
-            StandardErrorEncoding  = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false,
-                                                      throwOnInvalidBytes: false),
+            // Set for any caller that uses the StreamReader API. The capture path deliberately does NOT:
+            // it reads BaseStream and decodes with GitOutputEncoding, because this property alone does not
+            // disable the reader's BOM detection. See RunGitCaptureResult.
+            StandardOutputEncoding = GitOutputEncoding,
+            StandardErrorEncoding  = GitOutputEncoding,
             CreateNoWindow         = true,
             Environment = {
                 ["GIT_TERMINAL_PROMPT"] = "0",

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -1020,6 +1020,16 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             WorkingDirectory       = cwd,
             RedirectStandardOutput = true,
             RedirectStandardError  = true,
+            // EXPLICIT, because a guard depends on it. Paths and config keys are bytes to git, and the
+            // containment fails closed on names that cannot round-trip by detecting the U+FFFD a UTF-8
+            // decoder emits for an invalid sequence. Left implicit, redirected output decodes with the
+            // ambient console encoding — a Windows codepage maps 0xff to a perfectly ordinary character,
+            // no U+FFFD appears, the name looks round-trippable, and an override is emitted that names a
+            // DIFFERENT driver while looking applied. Replacement fallback is what makes the check sound.
+            StandardOutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false,
+                                                      throwOnInvalidBytes: false),
+            StandardErrorEncoding  = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false,
+                                                      throwOnInvalidBytes: false),
             CreateNoWindow         = true,
             Environment = {
                 ["GIT_TERMINAL_PROMPT"] = "0",

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -397,17 +397,18 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             .ToArray();
 
         if (drivers.Length > 0)
-            // Deliberately says WHAT was disabled and why, not what the file contents will look like. The
-            // outcome differs by path: an owned worktree or standalone snapshot really does leave
-            // LFS-tracked files as pointer text, but a borrowed snapshot overwrites checkout files from the
-            // source manifest and REJECTS source-side pointers outright — so it either holds real smudged
-            // bytes or fails to build. A single message claiming pointer text was true for two paths and
-            // false for the third, which is worse than saying less: this logging is the whole reason the
-            // no-exemption trade is defensible, so it has to be accurate.
+            // States WHAT was disabled and why, and stops there. Three callers materialise content three
+            // different ways — an owned worktree checks out through git, a standalone snapshot copies
+            // source bytes and re-commits with the clean filter off, a borrowed snapshot overwrites the
+            // checkout from the source manifest and refuses source-side pointers — so ANY sentence about
+            // what the resulting bytes look like is false for at least one of them. Two rounds of review
+            // were spent narrowing such a sentence before concluding it should not be here at all: this
+            // logging is the whole reason the no-exemption trade is defensible, so it has to be accurate,
+            // and per-path behaviour is documented in the README where there is room to be exact.
             logger.LogInformation(
                 "Disabled git filter drivers for agent worktree creation from {Repo}: {Drivers}. A branch's "
               + ".gitattributes selects which driver runs, so a driver with a relative command would execute "
-              + "branch-supplied code. Content those drivers would have transformed is left untransformed.",
+              + "branch-supplied code.",
                 repoPath, string.Join(", ", drivers));
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -214,7 +214,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
 
         // Resolved once: `git config` on the SOURCE repo, whose definitions are the only ones a branch's
         // .gitattributes can select.
-        var filterOverrides = await BranchResolvableFilterOverridesAsync(repoPath);
+        var filterOverrides = await BranchFilterOverridesAsync(repoPath);
 
         if (await IsGitRepoWithCommits(repoPath)) {
             if (!string.IsNullOrEmpty(baseRef)) {
@@ -255,7 +255,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         // either — a later `git checkout` inside the tree would otherwise restore it.
         StripWorkspaceMcpConfig(worktreePath);
         await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), "init"]);
-        await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), ..await BranchResolvableFilterOverridesAsync(worktreePath), "add", "-A"]);
+        await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), ..await BranchFilterOverridesAsync(worktreePath), "add", "-A"]);
         // Identity supplied explicitly. This is the daemon's OWN bookkeeping commit, not the user's work,
         // so it must not depend on the host having git identity configured — a machine without a global
         // user.email fails with "Author identity unknown". Found while CopyDirectory was temporarily
@@ -507,7 +507,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             // Same guard as `worktree add`: this checkout materialises branch content, so a relative
             // core.hooksPath would run the branch's post-checkout here too. Missed when the guard was
             // added — it went on the worktree paths only.
-            await RunGit(destination, GitTimeout, [..NoBranchHooks(), ..await BranchResolvableFilterOverridesAsync(source), "checkout", "--detach", "HEAD"]);
+            await RunGit(destination, GitTimeout, [..NoBranchHooks(), ..await BranchFilterOverridesAsync(destination), "checkout", "--detach", "HEAD"]);
             var clonedHead = (await RunGitCapture(destination, GitTimeout, false, "rev-parse", "HEAD")).Trim();
             if (!string.Equals(sourceHead, clonedHead, StringComparison.Ordinal)) throw new SourceChangedException();
             await RunGitBestEffort(destination, "remote", "remove", "origin");

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -234,7 +234,8 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
                     "-c", "maintenance.auto=false", "-c", "gc.auto=0",
                     "fetch", "origin", $"{baseRef}:{fetchedRef}");
                 await WithWorktreeMetadataGate(repoPath, () =>
-                    RunGit(repoPath, GitTimeout, [..NoBranchHooks(), ..filterOverrides, "worktree", "add", "-B", branch, worktreePath, fetchedRef]));
+                    RunGit(repoPath, GitTimeout, [..NoBranchHooks(), ..filterOverrides,
+                        "worktree", "add", "--no-checkout", "-B", branch, worktreePath, fetchedRef]));
                 var fetched = new WorktreeInfo(worktreePath, branch, repoPath, FetchedRef: fetchedRef);
                 await StripOrRollBackAsync(fetched);
 
@@ -242,7 +243,8 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             }
 
             await WithWorktreeMetadataGate(repoPath, () =>
-                RunGit(repoPath, GitTimeout, [..NoBranchHooks(), ..filterOverrides, "worktree", "add", worktreePath, "-b", branch]));
+                RunGit(repoPath, GitTimeout, [..NoBranchHooks(), ..filterOverrides,
+                    "worktree", "add", "--no-checkout", worktreePath, "-b", branch]));
             var linked = new WorktreeInfo(worktreePath, branch, repoPath);
             await StripOrRollBackAsync(linked);
 
@@ -295,13 +297,12 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// tree already executed the branch's code. Pointing <c>core.hooksPath</c> at a daemon-owned empty
     /// directory disables the whole mechanism for these commands without touching the operator's config.</para>
     ///
-    /// <para><b>This covers the hook-DIRECTORY mechanism only. Do not read it as "no branch-controlled code
-    /// runs during checkout."</b> Two sibling vectors are known and deliberately NOT closed here, tracked on
-    /// their own issue (see the branch-controlled-execution follow-up): git's config-based hooks (<c>hook.&lt;name&gt;.event</c> / <c>.command</c>), which run
-    /// independently of <c>core.hooksPath</c>; and clean/smudge filters, which a branch selects through its
-    /// own <c>.gitattributes</c> and which this flag does not affect at all. Both need a rule for "does this
-    /// command resolve to branch content" — blunt disabling would break legitimate drivers such as
-    /// <c>filter.lfs</c>, so it is real work rather than another <c>-c</c> flag.</para>
+    /// <para><b>This covers the hook-DIRECTORY mechanism only.</b> Clean/smudge filters are a separate
+    /// vector — a branch selects them through its own <c>.gitattributes</c>, and this flag does not affect
+    /// them at all — handled by <see cref="BranchFilterOverridesAsync"/>, which disables every defined
+    /// driver rather than trying to judge commands. Git's config-based hooks
+    /// (<c>hook.&lt;name&gt;.event</c> / <c>.command</c>) are not covered and need not be: measured on git
+    /// 2.49, that config is undocumented and does not run.</para>
     /// </summary>
     /// <summary>
     /// A <c>core.hooksPath</c> that cannot contain a hook, because it cannot be a directory.
@@ -337,11 +338,34 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// </summary>
     async Task StripOrRollBackAsync(WorktreeInfo created) {
         try {
+            // The add above used --no-checkout, so the tree is still empty here. Populating it inside the
+            // rollback means a filter-inventory failure cleans up like any other fail-closed step.
+            await CheckoutInTargetContextAsync(created.Path);
             StripWorkspaceMcpConfig(created.Path);
         } catch {
             try { await RemoveAsync(created); } catch { /* keep the original failure */ }
             throw;
         }
+    }
+
+    /// <summary>
+    /// Populates a worktree created with <c>--no-checkout</c>, using an override set enumerated IN that
+    /// worktree.
+    ///
+    /// <para>Inventorying the SOURCE while checking out in the TARGET is a context mismatch: git runs the
+    /// checkout in the new worktree, where <c>includeIf "onbranch:capacitor/**"</c> or a gitdir-matching
+    /// conditional include can expose a driver the source never reported. Splitting the add from the
+    /// checkout is what lets the inventory be taken where the filters actually resolve, and
+    /// <c>--no-checkout</c> means nothing is materialised before that guarded step.</para>
+    /// </summary>
+    async Task CheckoutInTargetContextAsync(string worktreePath) {
+        var overrides = await BranchFilterOverridesAsync(worktreePath);
+        LogDisabledFilters(overrides, worktreePath);
+
+        // `reset --hard HEAD`, not `checkout -- .`: --no-checkout leaves the INDEX unpopulated too, so a
+        // pathspec matches nothing. This is the step that materialises the tree, and therefore the step
+        // the overrides have to guard.
+        await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), ..overrides, "reset", "--hard", "HEAD"]);
     }
 
     /// <summary>Logs which filter drivers were disabled, so an operator whose LFS-tracked file checks out

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -215,6 +215,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         // Resolved once: `git config` on the SOURCE repo, whose definitions are the only ones a branch's
         // .gitattributes can select.
         var filterOverrides = await BranchFilterOverridesAsync(repoPath);
+        LogDisabledFilters(filterOverrides, repoPath);
 
         if (await IsGitRepoWithCommits(repoPath)) {
             if (!string.IsNullOrEmpty(baseRef)) {
@@ -341,6 +342,23 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             try { await RemoveAsync(created); } catch { /* keep the original failure */ }
             throw;
         }
+    }
+
+    /// <summary>Logs which filter drivers were disabled, so an operator whose LFS-tracked file checks out
+    /// as pointer text can see why rather than guessing. Silent containment is how a deliberate trade turns
+    /// into a bug report.</summary>
+    void LogDisabledFilters(string[] overrides, string repoPath) {
+        var drivers = overrides
+            .Where(static o => o.StartsWith("filter.", StringComparison.Ordinal) && o.EndsWith(".clean=", StringComparison.Ordinal))
+            .Select(static o => o["filter.".Length..^".clean=".Length])
+            .ToArray();
+
+        if (drivers.Length > 0)
+            logger.LogInformation(
+                "Disabled git filter drivers for agent worktree creation from {Repo}: {Drivers}. A branch's "
+              + ".gitattributes selects which driver runs, so a driver with a relative command would execute "
+              + "branch-supplied code. LFS-tracked files will appear as pointer text in the worktree.",
+                repoPath, string.Join(", ", drivers));
     }
 
     /// <summary>Removes branch-authored vendor MCP configuration and logs what went, so an operator whose

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -397,10 +397,17 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             .ToArray();
 
         if (drivers.Length > 0)
+            // Deliberately says WHAT was disabled and why, not what the file contents will look like. The
+            // outcome differs by path: an owned worktree or standalone snapshot really does leave
+            // LFS-tracked files as pointer text, but a borrowed snapshot overwrites checkout files from the
+            // source manifest and REJECTS source-side pointers outright — so it either holds real smudged
+            // bytes or fails to build. A single message claiming pointer text was true for two paths and
+            // false for the third, which is worse than saying less: this logging is the whole reason the
+            // no-exemption trade is defensible, so it has to be accurate.
             logger.LogInformation(
                 "Disabled git filter drivers for agent worktree creation from {Repo}: {Drivers}. A branch's "
               + ".gitattributes selects which driver runs, so a driver with a relative command would execute "
-              + "branch-supplied code. LFS-tracked files will appear as pointer text in the worktree.",
+              + "branch-supplied code. Content those drivers would have transformed is left untransformed.",
                 repoPath, string.Join(", ", drivers));
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
@@ -96,6 +96,51 @@ public class BranchFilterContainmentTests {
             .Contains("filter.sneaky.smudge=");
     }
 
+    /// <summary>
+    /// The name `lfs` is a CONVENTION, not an identity. Nothing stops a config binding it to a relative
+    /// command, and a branch selecting `filter=lfs` would then ride the allowlist straight to its own file.
+    /// Trusting the name alone is the same mistake as trusting a command string, reached from the other
+    /// side — so the binding is authenticated and a mis-bound `lfs` is disabled like any other driver.
+    /// </summary>
+    [Test]
+    [Arguments("./tools/f")]
+    [Arguments("sh tools/f")]
+    [Arguments("/usr/local/bin/definitely-not-lfs")]
+    public async Task An_allowlisted_name_bound_to_the_wrong_binary_is_still_disabled(string command) {
+        var repo = NewRepo();
+        Git(repo, "config", "filter.lfs.smudge", command);
+
+        await Assert.That(string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo)))
+            .Contains("filter.lfs.smudge=");
+    }
+
+    /// <summary>...and a genuine binding is still honoured, including an absolute path to the binary.</summary>
+    [Test]
+    [Arguments("git-lfs filter-process")]
+    [Arguments("/opt/homebrew/bin/git-lfs filter-process")]
+    public async Task An_allowlisted_name_bound_to_the_real_binary_is_honoured(string command) {
+        var repo = NewRepo();
+        Git(repo, "config", "filter.lfs.process", command);
+
+        await Assert.That(await WorktreeManager.BranchFilterOverridesAsync(repo)).IsEmpty();
+    }
+
+    /// <summary>
+    /// `-c key=value` splits at the FIRST '='. A driver legally named `evil=x` would be written as key
+    /// `filter.evil`, leaving `filter.evil=x.smudge` live while the override looked applied. Refused rather
+    /// than mis-encoded: a guard that silently does nothing is worse than a launch that fails.
+    /// </summary>
+    [Test]
+    public async Task A_driver_name_that_cannot_be_safely_overridden_is_refused() {
+        var repo = NewRepo();
+        Git(repo, "config", "filter.evil=x.smudge", "./tools/f");
+
+        var ex = await Assert.ThrowsAsync<BranchFilterInventoryException>(
+            async () => await WorktreeManager.BranchFilterOverridesAsync(repo));
+
+        await Assert.That(ex!.Message).Contains("evil=x");
+    }
+
     // ── end to end ──
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
@@ -11,101 +11,89 @@ namespace Capacitor.Cli.Tests.Unit;
 /// git runs it during <c>worktree add</c> — before anything has neutralised the tree.
 /// <c>core.hooksPath</c> does not affect filters, so the hook guard does nothing here.
 ///
-/// <para>The hard requirement pulling the other way is <c>git-lfs</c>: disabling filters wholesale makes it
-/// yield pointer files instead of content, silently. So the classifier has to separate branch-resolvable
-/// commands from PATH- and absolutely-resolved ones, and both directions are asserted.</para>
+/// <para>Containment is an allowlist of driver NAMES, not an analysis of command strings — a command is a
+/// shell program and a tokeniser cannot decide what one will execute. The hard requirement pulling the other
+/// way is <c>git-lfs</c>: disabling it does not fail loudly, it silently yields pointer files instead of
+/// content, so it is allowlisted.</para>
 /// </summary>
-public class BranchResolvableFilterTests {
-    // ── the classifier ──
-
-    /// <summary>Commands the BRANCH can supply. `sh -c 'cat ./tools/x'` is included deliberately: the
-    /// executable is PATH-resolved but the payload is not, and only inspecting the first token would miss
-    /// it.</summary>
-    [Test]
-    [Arguments("./tools/filter")]
-    [Arguments("../outside/filter")]
-    [Arguments("tools/filter")]
-    [Arguments("sh -c 'cat ./tools/x'")]
-    [Arguments("python scripts/clean.py")]
-    [Arguments(".\\tools\\filter.exe")]
-    public async Task A_branch_resolvable_command_is_neutralized(string command) =>
-        await Assert.That(WorktreeManager.ResolvesToBranchContent(command)).IsTrue();
-
-    /// <summary>The git-lfs case and its relatives. A bare name is PATH-resolved and an absolute path is
-    /// the operator's own — neither can be supplied by the branch, and disabling them would break real
-    /// setups.</summary>
-    [Test]
-    [Arguments("git-lfs filter-process")]
-    [Arguments("git-lfs clean -- %f")]
-    [Arguments("/usr/local/bin/filter")]
-    [Arguments("cat")]
-    public async Task A_path_or_absolutely_resolved_command_is_left_alone(string command) =>
-        await Assert.That(WorktreeManager.ResolvesToBranchContent(command)).IsFalse();
-
-    // ── the emitted overrides ──
+public class BranchFilterContainmentTests {
+    // ── the allowlist ──
 
     /// <summary>
-    /// A relative driver produces overrides, and they must include <c>required=false</c>. Measured: with
-    /// <c>filter.x.required=true</c> an empty smudge command is FATAL and `worktree add` fails outright —
-    /// so clearing the command alone would convert this guard into a launch failure for any repo using a
-    /// required filter.
+    /// Any driver the operator has defined that is NOT allowlisted gets disabled — regardless of what its
+    /// command looks like. That is the whole point of the redesign: the first version classified the command
+    /// string, and review defeated it four ways (`sh tools` and `python filter.py` execute a branch file
+    /// with no separator at all; `/bin/true;./tools/f` is one rooted token whose shell runs the relative
+    /// half; `%f` is substituted after any inspection). A command is a shell program; a name is not.
     /// </summary>
     [Test]
-    public async Task A_relative_driver_yields_overrides_including_required_false() {
+    [Arguments("./tools/f")]
+    [Arguments("sh tools")]                  // bare relative file — the old rule called this safe
+    [Arguments("python filter.py")]          // ditto
+    [Arguments("/bin/true;./tools/f")]       // rooted token, shell runs the relative half
+    [Arguments("cat %f")]                    // %f is substituted by git, after any inspection
+    [Arguments("/usr/local/bin/filter")]     // even an absolute one: not allowlisted, not trusted here
+    public async Task Any_non_allowlisted_driver_is_disabled_whatever_its_command(string command) {
         var repo = NewRepo();
-        Git(repo, "config", "filter.evil.smudge", "./tools/f");
-        Git(repo, "config", "filter.evil.required", "true");
+        Git(repo, "config", "filter.custom.smudge", command);
 
-        var overrides = await WorktreeManager.BranchResolvableFilterOverridesAsync(repo);
-        var joined = string.Join(' ', overrides);
+        var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
 
-        await Assert.That(joined).Contains("filter.evil.smudge=");
-        await Assert.That(joined).Contains("filter.evil.clean=");
-        await Assert.That(joined).Contains("filter.evil.process=");
-        await Assert.That(joined).Contains("filter.evil.required=false");
+        await Assert.That(joined).Contains("filter.custom.smudge=");
+        await Assert.That(joined).Contains("filter.custom.required=false");
     }
 
-    /// <summary>The regression that matters for real repositories: git-lfs must not be touched.</summary>
+    /// <summary>The git-lfs regression. Disabling it does not fail loudly — it silently yields pointer
+    /// files instead of content — so it is allowlisted and must stay untouched.</summary>
     [Test]
-    public async Task A_git_lfs_driver_yields_no_overrides() {
+    public async Task The_allowlisted_lfs_driver_is_left_alone() {
         var repo = NewRepo();
         Git(repo, "config", "filter.lfs.smudge", "git-lfs smudge -- %f");
-        Git(repo, "config", "filter.lfs.clean", "git-lfs clean -- %f");
         Git(repo, "config", "filter.lfs.process", "git-lfs filter-process");
         Git(repo, "config", "filter.lfs.required", "true");
 
-        await Assert.That(await WorktreeManager.BranchResolvableFilterOverridesAsync(repo)).IsEmpty();
+        await Assert.That(await WorktreeManager.BranchFilterOverridesAsync(repo)).IsEmpty();
     }
 
-    /// <summary>A repo with no filters at all — `config --get-regexp` exits non-zero, which must read as
-    /// "nothing to override" rather than as a failure.</summary>
     [Test]
     public async Task A_repo_with_no_filters_yields_no_overrides() =>
-        await Assert.That(await WorktreeManager.BranchResolvableFilterOverridesAsync(NewRepo())).IsEmpty();
+        await Assert.That(await WorktreeManager.BranchFilterOverridesAsync(NewRepo())).IsEmpty();
 
-    /// <summary>Only the offending driver is disabled; a legitimate one alongside it keeps working.</summary>
     [Test]
-    public async Task A_mixed_config_neutralizes_only_the_branch_resolvable_driver() {
+    public async Task A_mixed_config_disables_only_the_non_allowlisted_driver() {
         var repo = NewRepo();
         Git(repo, "config", "filter.lfs.process", "git-lfs filter-process");
         Git(repo, "config", "filter.evil.smudge", "./tools/f");
 
-        var joined = string.Join(' ', await WorktreeManager.BranchResolvableFilterOverridesAsync(repo));
+        var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
 
         await Assert.That(joined).Contains("filter.evil.");
         await Assert.That(joined).DoesNotContain("filter.lfs.");
     }
 
-    /// <summary>A driver name containing dots must not be truncated — `filter.my.tool.smudge` is driver
-    /// `my.tool`, and splitting naively would emit overrides for a driver that does not exist.</summary>
+    /// <summary>`filter.my.tool.smudge` is driver `my.tool`; naive splitting would emit overrides for a
+    /// driver that does not exist and leave the real one live.</summary>
     [Test]
     public async Task A_dotted_driver_name_survives_parsing() {
         var repo = NewRepo();
         Git(repo, "config", "filter.my.tool.smudge", "./tools/f");
 
-        var joined = string.Join(' ', await WorktreeManager.BranchResolvableFilterOverridesAsync(repo));
+        await Assert.That(string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo)))
+            .Contains("filter.my.tool.smudge=");
+    }
 
-        await Assert.That(joined).Contains("filter.my.tool.smudge=");
+    /// <summary>
+    /// A newline inside a config VALUE must not be able to hide a driver. A line-splitting inventory reads
+    /// `cat\n./tools/f` as a safe record plus an ignored line while git executes the whole value — which is
+    /// why enumeration is `--name-only -z` and never parses values at all.
+    /// </summary>
+    [Test]
+    public async Task A_newline_inside_a_config_value_cannot_hide_a_driver() {
+        var repo = NewRepo();
+        Git(repo, "config", "filter.sneaky.smudge", "cat\n./tools/f");
+
+        await Assert.That(string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo)))
+            .Contains("filter.sneaky.smudge=");
     }
 
     // ── end to end ──

--- a/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
@@ -90,6 +90,41 @@ public class BranchFilterContainmentTests {
         await Assert.That(emitted.Except(expected).Any()).IsFalse();
     }
 
+    /// <summary>
+    /// The enumeration regex matches lowercase <c>filter</c>/<c>clean</c>/<c>smudge</c>/<c>process</c>, but
+    /// git config SECTION and VARIABLE names are case-insensitive — so is an operator config spelled
+    /// <c>[Filter "evil"] Smudge</c> invisible to it, leaving a driver a branch could still select?
+    ///
+    /// <para>No: git canonicalizes section and variable names to lowercase when it reports keys, so
+    /// <c>--get-regexp</c> yields <c>filter.evil.smudge</c> whatever the file says, and the lowercase
+    /// override neutralizes it. Only the SUBSECTION keeps its case, which the pattern's <c>.*</c> covers.</para>
+    ///
+    /// <para>Measured end-to-end before writing this: with <c>[Filter "evil"] Smudge</c> and an absolute
+    /// command, <c>worktree add</c> really does execute the driver, and adding the lowercase overrides
+    /// stops it. This test pins the canonicalization the containment leans on — if a future git reported
+    /// keys verbatim, the guard would silently miss a live driver, and this fails instead.</para>
+    /// </summary>
+    [Test]
+    [Arguments("Filter", "evil", "Smudge", "filter.evil.smudge")]
+    [Arguments("FILTER", "shouty", "PROCESS", "filter.shouty.process")]
+    [Arguments("filter", "Mixed", "clean", "filter.Mixed.clean")]   // subsection case IS preserved
+    public async Task A_mixed_case_config_spelling_is_still_enumerated_and_overridden(
+            string section, string subsection, string variable, string canonical) {
+        var repo = NewRepo();
+        File.AppendAllText(Path.Combine(repo, ".git", "config"),
+            $"[{section} \"{subsection}\"]\n\t{variable} = ./tools/f\n");
+
+        // Precondition: git really does resolve the value under the canonical spelling.
+        await Assert.That(EffectiveDriverNames(repo)).Contains(subsection);
+
+        var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
+
+        await Assert.That(joined).Contains($"{canonical[..canonical.LastIndexOf('.')]}.clean=");
+        await Assert.That(joined).Contains($"{canonical[..canonical.LastIndexOf('.')]}.smudge=");
+        await Assert.That(joined).Contains($"{canonical[..canonical.LastIndexOf('.')]}.process=");
+        await Assert.That(joined).Contains($"{canonical[..canonical.LastIndexOf('.')]}.required=false");
+    }
+
     /// <summary>Driver names git reports for the repo's EFFECTIVE config, global scope included.</summary>
     static HashSet<string> EffectiveDriverNames(string repo) {
         var psi = new ProcessStartInfo("git") {

--- a/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
@@ -281,6 +281,42 @@ public class BranchFilterContainmentTests {
         await Assert.That(File.Exists(marker)).IsFalse();
     }
 
+    /// <summary>
+    /// The refusal alone, with no filter execution — so it runs on WINDOWS too, which the end-to-end test
+    /// above cannot (it needs a POSIX shebang). That matters specifically here: the guard detects a
+    /// non-round-trippable name by the U+FFFD a UTF-8 decoder emits, and Windows is exactly where
+    /// redirected output would otherwise decode with a console codepage that turns 0xff into an ordinary
+    /// character — no U+FFFD, no refusal, and an override naming the wrong driver. This is the coverage for
+    /// `StandardOutputEncoding` being pinned rather than inherited.
+    /// </summary>
+    [Test]
+    public async Task A_non_round_trippable_driver_name_is_refused_on_every_platform() {
+        var repo = NewRepo();
+
+        // Written as BYTES: a process argument cannot carry 0xff — .NET would encode it to valid UTF-8.
+        var config = Path.Combine(repo, ".git", "config");
+        var bytes = new List<byte>(File.ReadAllBytes(config));
+        bytes.AddRange([.. "[filter \"ev"u8, 0xff, .. "il\"]\n\tsmudge = ./tools/f\n"u8]);
+        File.WriteAllBytes(config, [.. bytes]);
+
+        // Precondition via the REGEX-FREE listing. `EffectiveDriverNames` uses `--get-regexp`, which is
+        // blind to exactly this key — that blindness is the bug the enumeration change fixed, so using it
+        // here would fail the precondition rather than test the refusal. (It did, first time round.)
+        var psi = new ProcessStartInfo("git") {
+            WorkingDirectory = repo, RedirectStandardOutput = true, RedirectStandardError = true,
+            StandardOutputEncoding = new System.Text.UTF8Encoding(false, false)
+        };
+        foreach (var a in new[] { "config", "--list", "--name-only" }) psi.ArgumentList.Add(a);
+        using var listing = Process.Start(psi)!;
+        var keys = listing.StandardOutput.ReadToEnd();
+        listing.WaitForExit();
+        await Assert.That(keys).Contains("filter.")
+            .Because("git must report the key, or there is nothing for the guard to refuse");
+
+        await Assert.ThrowsAsync<BranchFilterInventoryException>(async () =>
+            await WorktreeManager.BranchFilterOverridesAsync(repo));
+    }
+
     // ── fixture ──
 
     static string NewDir(string tag) {

--- a/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
@@ -43,16 +43,28 @@ public class BranchFilterContainmentTests {
         await Assert.That(joined).Contains("filter.custom.required=false");
     }
 
-    /// <summary>The git-lfs regression. Disabling it does not fail loudly — it silently yields pointer
-    /// files instead of content — so it is allowlisted and must stay untouched.</summary>
+    /// <summary>
+    /// The git-lfs outcome, which now depends on whether the binary resolves. Resolvable: the driver is
+    /// rebound to our canonical command so LFS keeps working. Not resolvable: there is nothing trustworthy
+    /// to substitute, so it is DISABLED rather than left running the operator's command — pointer files
+    /// instead of an unvetted execution. Both branches are asserted, because the machine running the suite
+    /// decides which one is live and a test that silently covered neither would be worthless.
+    /// </summary>
     [Test]
-    public async Task The_allowlisted_lfs_driver_is_left_alone() {
+    public async Task An_allowlisted_driver_is_rebound_when_resolvable_and_disabled_otherwise() {
         var repo = NewRepo();
         Git(repo, "config", "filter.lfs.smudge", "git-lfs smudge -- %f");
         Git(repo, "config", "filter.lfs.process", "git-lfs filter-process");
-        Git(repo, "config", "filter.lfs.required", "true");
 
-        await Assert.That(await WorktreeManager.BranchFilterOverridesAsync(repo)).IsEmpty();
+        var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
+
+        if (WorktreeManager.ResolvedAllowedFilterBinary is { } binary) {
+            await Assert.That(joined).Contains(binary);
+            await Assert.That(joined).Contains("filter.lfs.required=true");
+        } else {
+            await Assert.That(joined).Contains("filter.lfs.smudge=");
+            await Assert.That(joined).Contains("filter.lfs.required=false");
+        }
     }
 
     [Test]
@@ -67,8 +79,12 @@ public class BranchFilterContainmentTests {
 
         var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
 
-        await Assert.That(joined).Contains("filter.evil.");
-        await Assert.That(joined).DoesNotContain("filter.lfs.");
+        // The non-allowlisted driver is always neutralised...
+        await Assert.That(joined).Contains("filter.evil.smudge=");
+        await Assert.That(joined).Contains("filter.evil.required=false");
+        // ...while lfs is rebound rather than neutralised, when it can be.
+        if (WorktreeManager.ResolvedAllowedFilterBinary is { } binary)
+            await Assert.That(joined).Contains($"filter.lfs.smudge={binary}");
     }
 
     /// <summary>`filter.my.tool.smudge` is driver `my.tool`; naive splitting would emit overrides for a
@@ -97,32 +113,36 @@ public class BranchFilterContainmentTests {
     }
 
     /// <summary>
-    /// The name `lfs` is a CONVENTION, not an identity. Nothing stops a config binding it to a relative
-    /// command, and a branch selecting `filter=lfs` would then ride the allowlist straight to its own file.
-    /// Trusting the name alone is the same mistake as trusting a command string, reached from the other
-    /// side — so the binding is authenticated and a mis-bound `lfs` is disabled like any other driver.
+    /// Whatever the operator bound `lfs` to, the guarded command runs OUR command, not theirs. Vetting
+    /// their string was the previous design and is unsound: git runs the whole value through a shell, so
+    /// `git-lfs smudge -- %f; ./tools/f` passes any first-token check and then executes branch content, and
+    /// a branch-owned `/repo/tools/git-lfs` passes by basename. Substitution removes the question.
     /// </summary>
     [Test]
+    [Arguments("git-lfs smudge -- %f; ./tools/f")]   // shell chaining past a valid-looking first token
+    [Arguments("/repo/tools/git-lfs smudge")]        // branch-owned binary with the right basename
     [Arguments("./tools/f")]
-    [Arguments("sh tools/f")]
-    [Arguments("/usr/local/bin/definitely-not-lfs")]
-    public async Task An_allowlisted_name_bound_to_the_wrong_binary_is_still_disabled(string command) {
+    public async Task An_allowlisted_driver_runs_our_command_not_the_operators(string command) {
+        Skip.Unless(WorktreeManager.ResolvedAllowedFilterBinary is not null,
+            "needs git-lfs on PATH to build the canonical form");
+
         var repo = NewRepo();
         Git(repo, "config", "filter.lfs.smudge", command);
 
-        await Assert.That(string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo)))
-            .Contains("filter.lfs.smudge=");
+        var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
+
+        await Assert.That(joined).DoesNotContain("./tools/f");
+        await Assert.That(joined).Contains("filter.lfs.smudge=");
+        await Assert.That(joined).Contains(WorktreeManager.ResolvedAllowedFilterBinary!);
     }
 
-    /// <summary>...and a genuine binding is still honoured, including an absolute path to the binary.</summary>
+    /// <summary>The substituted path must be ABSOLUTE — a bare `git-lfs` can be shadowed when the
+    /// inherited PATH carries a relative component.</summary>
     [Test]
-    [Arguments("git-lfs filter-process")]
-    [Arguments("/opt/homebrew/bin/git-lfs filter-process")]
-    public async Task An_allowlisted_name_bound_to_the_real_binary_is_honoured(string command) {
-        var repo = NewRepo();
-        Git(repo, "config", "filter.lfs.process", command);
+    public async Task The_substituted_command_uses_an_absolute_path() {
+        Skip.Unless(WorktreeManager.ResolvedAllowedFilterBinary is not null, "needs git-lfs on PATH");
 
-        await Assert.That(await WorktreeManager.BranchFilterOverridesAsync(repo)).IsEmpty();
+        await Assert.That(Path.IsPathRooted(WorktreeManager.ResolvedAllowedFilterBinary!)).IsTrue();
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
@@ -11,29 +11,29 @@ namespace Capacitor.Cli.Tests.Unit;
 /// git runs it during <c>worktree add</c> — before anything has neutralised the tree.
 /// <c>core.hooksPath</c> does not affect filters, so the hook guard does nothing here.
 ///
-/// <para>Containment is an allowlist of driver NAMES, not an analysis of command strings — a command is a
-/// shell program and a tokeniser cannot decide what one will execute. The hard requirement pulling the other
-/// way is <c>git-lfs</c>: disabling it does not fail loudly, it silently yields pointer files instead of
-/// content, so it is allowlisted.</para>
+/// <para>EVERY defined driver is disabled, with no exemption. Four designs tried to keep git-lfs working —
+/// classify the command, allowlist the name, authenticate the binding, rebind to a resolved path — and
+/// review defeated each at the exemption itself. Nothing is parsed, resolved or authenticated now, so there
+/// is nothing to subvert. The cost is that LFS-tracked files appear as pointer text in agent worktrees; it
+/// is documented and logged rather than silent.</para>
 /// </summary>
 public class BranchFilterContainmentTests {
-    // ── the allowlist ──
+    // ── every defined driver is disabled ──
 
     /// <summary>
-    /// Any driver the operator has defined that is NOT allowlisted gets disabled — regardless of what its
-    /// command looks like. That is the whole point of the redesign: the first version classified the command
-    /// string, and review defeated it four ways (`sh tools` and `python filter.py` execute a branch file
-    /// with no separator at all; `/bin/true;./tools/f` is one rooted token whose shell runs the relative
-    /// half; `%f` is substituted after any inspection). A command is a shell program; a name is not.
+    /// No command is inspected, so no command can evade the guard. These are the four shapes that defeated
+    /// the classifier design plus the two that defeated its successors — all now irrelevant, which is the
+    /// point of removing the classification entirely.
     /// </summary>
     [Test]
     [Arguments("./tools/f")]
-    [Arguments("sh tools")]                  // bare relative file — the old rule called this safe
-    [Arguments("python filter.py")]          // ditto
-    [Arguments("/bin/true;./tools/f")]       // rooted token, shell runs the relative half
-    [Arguments("cat %f")]                    // %f is substituted by git, after any inspection
-    [Arguments("/usr/local/bin/filter")]     // even an absolute one: not allowlisted, not trusted here
-    public async Task Any_non_allowlisted_driver_is_disabled_whatever_its_command(string command) {
+    [Arguments("sh tools")]                            // bare relative file, no separator
+    [Arguments("python filter.py")]
+    [Arguments("/bin/true;./tools/f")]                 // rooted token, shell runs the relative half
+    [Arguments("cat %f")]                              // %f substituted after any inspection
+    [Arguments("git-lfs smudge -- %f; ./tools/f")]     // shell chaining past a trusted-looking token
+    [Arguments("/usr/local/bin/filter")]
+    public async Task Every_defined_driver_is_disabled_whatever_its_command(string command) {
         var repo = NewRepo();
         Git(repo, "config", "filter.custom.smudge", command);
 
@@ -44,48 +44,26 @@ public class BranchFilterContainmentTests {
     }
 
     /// <summary>
-    /// The git-lfs outcome, which now depends on whether the binary resolves. Resolvable: the driver is
-    /// rebound to our canonical command so LFS keeps working. Not resolvable: there is nothing trustworthy
-    /// to substitute, so it is DISABLED rather than left running the operator's command — pointer files
-    /// instead of an unvetted execution. Both branches are asserted, because the machine running the suite
-    /// decides which one is live and a test that silently covered neither would be worthless.
+    /// `lfs` has NO exemption. Four designs tried to keep it working and review defeated each one at the
+    /// exemption itself, so there is no longer a name to impersonate, a binding to authenticate, or a path
+    /// to resolve. The cost — LFS files as pointer text in agent worktrees — is documented and logged.
     /// </summary>
     [Test]
-    public async Task An_allowlisted_driver_is_rebound_when_resolvable_and_disabled_otherwise() {
+    public async Task The_lfs_driver_has_no_exemption() {
         var repo = NewRepo();
         Git(repo, "config", "filter.lfs.smudge", "git-lfs smudge -- %f");
         Git(repo, "config", "filter.lfs.process", "git-lfs filter-process");
+        Git(repo, "config", "filter.lfs.required", "true");
 
         var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
 
-        if (WorktreeManager.ResolvedAllowedFilterBinary is { } binary) {
-            await Assert.That(joined).Contains(binary);
-            await Assert.That(joined).Contains("filter.lfs.required=true");
-        } else {
-            await Assert.That(joined).Contains("filter.lfs.smudge=");
-            await Assert.That(joined).Contains("filter.lfs.required=false");
-        }
+        await Assert.That(joined).Contains("filter.lfs.smudge=");
+        await Assert.That(joined).Contains("filter.lfs.required=false");
     }
 
     [Test]
     public async Task A_repo_with_no_filters_yields_no_overrides() =>
         await Assert.That(await WorktreeManager.BranchFilterOverridesAsync(NewRepo())).IsEmpty();
-
-    [Test]
-    public async Task A_mixed_config_disables_only_the_non_allowlisted_driver() {
-        var repo = NewRepo();
-        Git(repo, "config", "filter.lfs.process", "git-lfs filter-process");
-        Git(repo, "config", "filter.evil.smudge", "./tools/f");
-
-        var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
-
-        // The non-allowlisted driver is always neutralised...
-        await Assert.That(joined).Contains("filter.evil.smudge=");
-        await Assert.That(joined).Contains("filter.evil.required=false");
-        // ...while lfs is rebound rather than neutralised, when it can be.
-        if (WorktreeManager.ResolvedAllowedFilterBinary is { } binary)
-            await Assert.That(joined).Contains($"filter.lfs.smudge={binary}");
-    }
 
     /// <summary>`filter.my.tool.smudge` is driver `my.tool`; naive splitting would emit overrides for a
     /// driver that does not exist and leave the real one live.</summary>
@@ -98,11 +76,9 @@ public class BranchFilterContainmentTests {
             .Contains("filter.my.tool.smudge=");
     }
 
-    /// <summary>
-    /// A newline inside a config VALUE must not be able to hide a driver. A line-splitting inventory reads
+    /// <summary>A newline inside a config VALUE must not hide a driver. A line-splitting inventory reads
     /// `cat\n./tools/f` as a safe record plus an ignored line while git executes the whole value — which is
-    /// why enumeration is `--name-only -z` and never parses values at all.
-    /// </summary>
+    /// why enumeration is `--name-only -z` and never parses values.</summary>
     [Test]
     public async Task A_newline_inside_a_config_value_cannot_hide_a_driver() {
         var repo = NewRepo();
@@ -113,42 +89,9 @@ public class BranchFilterContainmentTests {
     }
 
     /// <summary>
-    /// Whatever the operator bound `lfs` to, the guarded command runs OUR command, not theirs. Vetting
-    /// their string was the previous design and is unsound: git runs the whole value through a shell, so
-    /// `git-lfs smudge -- %f; ./tools/f` passes any first-token check and then executes branch content, and
-    /// a branch-owned `/repo/tools/git-lfs` passes by basename. Substitution removes the question.
-    /// </summary>
-    [Test]
-    [Arguments("git-lfs smudge -- %f; ./tools/f")]   // shell chaining past a valid-looking first token
-    [Arguments("/repo/tools/git-lfs smudge")]        // branch-owned binary with the right basename
-    [Arguments("./tools/f")]
-    public async Task An_allowlisted_driver_runs_our_command_not_the_operators(string command) {
-        Skip.Unless(WorktreeManager.ResolvedAllowedFilterBinary is not null,
-            "needs git-lfs on PATH to build the canonical form");
-
-        var repo = NewRepo();
-        Git(repo, "config", "filter.lfs.smudge", command);
-
-        var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
-
-        await Assert.That(joined).DoesNotContain("./tools/f");
-        await Assert.That(joined).Contains("filter.lfs.smudge=");
-        await Assert.That(joined).Contains(WorktreeManager.ResolvedAllowedFilterBinary!);
-    }
-
-    /// <summary>The substituted path must be ABSOLUTE — a bare `git-lfs` can be shadowed when the
-    /// inherited PATH carries a relative component.</summary>
-    [Test]
-    public async Task The_substituted_command_uses_an_absolute_path() {
-        Skip.Unless(WorktreeManager.ResolvedAllowedFilterBinary is not null, "needs git-lfs on PATH");
-
-        await Assert.That(Path.IsPathRooted(WorktreeManager.ResolvedAllowedFilterBinary!)).IsTrue();
-    }
-
-    /// <summary>
     /// `-c key=value` splits at the FIRST '='. A driver legally named `evil=x` would be written as key
     /// `filter.evil`, leaving `filter.evil=x.smudge` live while the override looked applied. Refused rather
-    /// than mis-encoded: a guard that silently does nothing is worse than a launch that fails.
+    /// than mis-encoded; the env transport that would carry it safely is tracked separately.
     /// </summary>
     [Test]
     public async Task A_driver_name_that_cannot_be_safely_overridden_is_refused() {

--- a/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
@@ -61,9 +61,53 @@ public class BranchFilterContainmentTests {
         await Assert.That(joined).Contains("filter.lfs.required=false");
     }
 
+    /// <summary>
+    /// The override set must cover EXACTLY the drivers git reports for the repository — no more, no fewer.
+    ///
+    /// <para>Computed from git rather than hard-coded, because enumeration sees EFFECTIVE config: a host
+    /// with git-lfs installed has a global <c>filter.lfs.*</c>, so "a repo with no filters of its own" is
+    /// not a repo with no filters. An earlier version asserted an empty result and passed only on machines
+    /// without git-lfs — green locally, red on CI, which is the test encoding its author's laptop.</para>
+    /// </summary>
     [Test]
-    public async Task A_repo_with_no_filters_yields_no_overrides() =>
-        await Assert.That(await WorktreeManager.BranchFilterOverridesAsync(NewRepo())).IsEmpty();
+    public async Task The_override_set_covers_exactly_the_drivers_git_reports() {
+        var repo = NewRepo();
+        Git(repo, "config", "filter.custom.smudge", "./tools/f");
+
+        var expected = EffectiveDriverNames(repo);
+        var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
+
+        await Assert.That(expected).Contains("custom");          // the fixture's own driver is in scope
+        foreach (var driver in expected)
+            await Assert.That(joined).Contains($"filter.{driver}.smudge=");
+
+        // ...and nothing outside that set is emitted.
+        var emitted = joined.Split(' ')
+            .Where(static t => t.StartsWith("filter.", StringComparison.Ordinal) && t.EndsWith(".clean=", StringComparison.Ordinal))
+            .Select(static t => t["filter.".Length..^".clean=".Length])
+            .ToHashSet(StringComparer.Ordinal);
+
+        await Assert.That(emitted.Except(expected).Any()).IsFalse();
+    }
+
+    /// <summary>Driver names git reports for the repo's EFFECTIVE config, global scope included.</summary>
+    static HashSet<string> EffectiveDriverNames(string repo) {
+        var psi = new ProcessStartInfo("git") {
+            WorkingDirectory = repo, RedirectStandardOutput = true, RedirectStandardError = true
+        };
+        foreach (var a in new[] { "config", "--name-only", "--get-regexp", "^filter\\..*\\.(clean|smudge|process)$" })
+            psi.ArgumentList.Add(a);
+
+        using var p = Process.Start(psi)!;
+        var stdout = p.StandardOutput.ReadToEnd();
+        p.WaitForExit();
+
+        return stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(static k => k.Trim().Split('.'))
+            .Where(static parts => parts.Length >= 3)
+            .Select(static parts => string.Join('.', parts[1..^1]))
+            .ToHashSet(StringComparer.Ordinal);
+    }
 
     /// <summary>`filter.my.tool.smudge` is driver `my.tool`; naive splitting would emit overrides for a
     /// driver that does not exist and leave the real one live.</summary>

--- a/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
@@ -14,8 +14,9 @@ namespace Capacitor.Cli.Tests.Unit;
 /// <para>EVERY defined driver is disabled, with no exemption. Four designs tried to keep git-lfs working —
 /// classify the command, allowlist the name, authenticate the binding, rebind to a resolved path — and
 /// review defeated each at the exemption itself. Nothing is parsed, resolved or authenticated now, so there
-/// is nothing to subvert. The cost is that LFS-tracked files appear as pointer text in agent worktrees; it
-/// is documented and logged rather than silent.</para>
+/// is nothing to subvert. The cost is documented and logged rather than silent: an OWNED worktree checks
+/// out through git and so holds LFS pointer text (standalone and borrowed snapshots carry the source's own
+/// bytes), and the overrides cover kcap's creation commands only — not git the agent later runs there.</para>
 /// </summary>
 public class BranchFilterContainmentTests {
     // ── every defined driver is disabled ──

--- a/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
@@ -47,7 +47,8 @@ public class BranchFilterContainmentTests {
     /// <summary>
     /// `lfs` has NO exemption. Four designs tried to keep it working and review defeated each one at the
     /// exemption itself, so there is no longer a name to impersonate, a binding to authenticate, or a path
-    /// to resolve. The cost — LFS files as pointer text in agent worktrees — is documented and logged.
+    /// to resolve. The cost is documented and logged: an OWNED worktree checks out through git and so
+    /// holds LFS pointer text, while standalone and borrowed snapshots carry the source's own bytes.
     /// </summary>
     [Test]
     public async Task The_lfs_driver_has_no_exemption() {

--- a/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
@@ -227,6 +227,60 @@ public class BranchFilterContainmentTests {
         await Assert.That(File.Exists(Path.Combine(info.Path, "zz.txt"))).IsTrue();
     }
 
+    /// <summary>
+    /// A driver name is BYTES, not text. git config accepts a subsection containing a raw 0xff, and this
+    /// was a live bypass of the guard's own inventory: `--get-regexp` runs the platform regex in the
+    /// ambient locale, where `.` will not span a byte that is invalid in that encoding, so
+    /// <c>^filter\..*\.(clean|smudge|process)$</c> returned NOTHING for <c>[filter "ev\xffil"]</c> while
+    /// <c>^filter\.</c> found it. Empty inventory, no overrides emitted, driver executes — the exact
+    /// failure this file exists to prevent, arriving through the enumeration rather than the command.
+    ///
+    /// <para>Enumeration no longer uses a pattern. And because such a name cannot survive a round trip
+    /// through a UTF-8 string, an override built from it would name a DIFFERENT driver while looking
+    /// applied, so this refuses instead of guessing. The control proves plain git really does run it.</para>
+    /// </summary>
+    [Test]
+    public async Task A_driver_name_that_is_not_valid_utf8_is_refused_rather_than_missed() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX filter script with a shebang");
+
+        var marker = Path.Combine(NewDir("utf8marker"), "fired");
+        var repo = NewRepo();
+        Directory.CreateDirectory(Path.Combine(repo, "tools"));
+        var script = Path.Combine(repo, "tools", "f");
+        File.WriteAllText(script, $"#!/bin/sh\nprintf fired > '{marker}'\ncat\n");
+        File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        // Raw bytes on both sides: the config subsection and the .gitattributes selector must carry the
+        // same 0xff, and neither can be written through a UTF-8 string without becoming U+FFFD.
+        static byte[] WithFF(string before, string after) =>
+            [.. System.Text.Encoding.ASCII.GetBytes(before), 0xff,
+             .. System.Text.Encoding.ASCII.GetBytes(after)];
+
+        File.WriteAllBytes(Path.Combine(repo, ".gitattributes"), WithFF("zz.txt filter=ev", "il\n"));
+        File.WriteAllText(Path.Combine(repo, "zz.txt"), "payload\n");   // sorts after tools/f — see above
+        Git(repo, "add", "-A");
+        Git(repo, "commit", "-q", "-m", "branch selects a driver named with a raw 0xff");
+
+        var config = Path.Combine(repo, ".git", "config");
+        var appended = new List<byte>(File.ReadAllBytes(config));
+        appended.AddRange(WithFF("[filter \"ev", "il\"]\n\tsmudge = ./tools/f\n"));
+        File.WriteAllBytes(config, [.. appended]);
+
+        // CONTROL — plain git honours the 0xff-named driver and runs branch code.
+        Git(repo, "worktree", "add", "-q", Path.Combine(NewDir("ctl"), "wt"),
+            "-b", "ctl-" + Guid.NewGuid().ToString("N")[..8]);
+        await Assert.That(File.Exists(marker))
+            .IsTrue()
+            .Because("the control must reproduce filter execution, or the assertion below is vacuous");
+
+        File.Delete(marker);
+
+        await Assert.ThrowsAsync<BranchFilterInventoryException>(async () =>
+            await WorktreeManager.BranchFilterOverridesAsync(repo));
+
+        await Assert.That(File.Exists(marker)).IsFalse();
+    }
+
     // ── fixture ──
 
     static string NewDir(string tag) {

--- a/test/Capacitor.Cli.Tests.Unit/BranchResolvableFilterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BranchResolvableFilterTests.cs
@@ -1,0 +1,186 @@
+using System.Diagnostics;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// <c>.gitattributes</c> is branch content and SELECTS which filter driver applies. When the operator's
+/// driver command is relative it resolves against the worktree, so the branch supplies the executable and
+/// git runs it during <c>worktree add</c> — before anything has neutralised the tree.
+/// <c>core.hooksPath</c> does not affect filters, so the hook guard does nothing here.
+///
+/// <para>The hard requirement pulling the other way is <c>git-lfs</c>: disabling filters wholesale makes it
+/// yield pointer files instead of content, silently. So the classifier has to separate branch-resolvable
+/// commands from PATH- and absolutely-resolved ones, and both directions are asserted.</para>
+/// </summary>
+public class BranchResolvableFilterTests {
+    // ── the classifier ──
+
+    /// <summary>Commands the BRANCH can supply. `sh -c 'cat ./tools/x'` is included deliberately: the
+    /// executable is PATH-resolved but the payload is not, and only inspecting the first token would miss
+    /// it.</summary>
+    [Test]
+    [Arguments("./tools/filter")]
+    [Arguments("../outside/filter")]
+    [Arguments("tools/filter")]
+    [Arguments("sh -c 'cat ./tools/x'")]
+    [Arguments("python scripts/clean.py")]
+    [Arguments(".\\tools\\filter.exe")]
+    public async Task A_branch_resolvable_command_is_neutralized(string command) =>
+        await Assert.That(WorktreeManager.ResolvesToBranchContent(command)).IsTrue();
+
+    /// <summary>The git-lfs case and its relatives. A bare name is PATH-resolved and an absolute path is
+    /// the operator's own — neither can be supplied by the branch, and disabling them would break real
+    /// setups.</summary>
+    [Test]
+    [Arguments("git-lfs filter-process")]
+    [Arguments("git-lfs clean -- %f")]
+    [Arguments("/usr/local/bin/filter")]
+    [Arguments("cat")]
+    public async Task A_path_or_absolutely_resolved_command_is_left_alone(string command) =>
+        await Assert.That(WorktreeManager.ResolvesToBranchContent(command)).IsFalse();
+
+    // ── the emitted overrides ──
+
+    /// <summary>
+    /// A relative driver produces overrides, and they must include <c>required=false</c>. Measured: with
+    /// <c>filter.x.required=true</c> an empty smudge command is FATAL and `worktree add` fails outright —
+    /// so clearing the command alone would convert this guard into a launch failure for any repo using a
+    /// required filter.
+    /// </summary>
+    [Test]
+    public async Task A_relative_driver_yields_overrides_including_required_false() {
+        var repo = NewRepo();
+        Git(repo, "config", "filter.evil.smudge", "./tools/f");
+        Git(repo, "config", "filter.evil.required", "true");
+
+        var overrides = await WorktreeManager.BranchResolvableFilterOverridesAsync(repo);
+        var joined = string.Join(' ', overrides);
+
+        await Assert.That(joined).Contains("filter.evil.smudge=");
+        await Assert.That(joined).Contains("filter.evil.clean=");
+        await Assert.That(joined).Contains("filter.evil.process=");
+        await Assert.That(joined).Contains("filter.evil.required=false");
+    }
+
+    /// <summary>The regression that matters for real repositories: git-lfs must not be touched.</summary>
+    [Test]
+    public async Task A_git_lfs_driver_yields_no_overrides() {
+        var repo = NewRepo();
+        Git(repo, "config", "filter.lfs.smudge", "git-lfs smudge -- %f");
+        Git(repo, "config", "filter.lfs.clean", "git-lfs clean -- %f");
+        Git(repo, "config", "filter.lfs.process", "git-lfs filter-process");
+        Git(repo, "config", "filter.lfs.required", "true");
+
+        await Assert.That(await WorktreeManager.BranchResolvableFilterOverridesAsync(repo)).IsEmpty();
+    }
+
+    /// <summary>A repo with no filters at all — `config --get-regexp` exits non-zero, which must read as
+    /// "nothing to override" rather than as a failure.</summary>
+    [Test]
+    public async Task A_repo_with_no_filters_yields_no_overrides() =>
+        await Assert.That(await WorktreeManager.BranchResolvableFilterOverridesAsync(NewRepo())).IsEmpty();
+
+    /// <summary>Only the offending driver is disabled; a legitimate one alongside it keeps working.</summary>
+    [Test]
+    public async Task A_mixed_config_neutralizes_only_the_branch_resolvable_driver() {
+        var repo = NewRepo();
+        Git(repo, "config", "filter.lfs.process", "git-lfs filter-process");
+        Git(repo, "config", "filter.evil.smudge", "./tools/f");
+
+        var joined = string.Join(' ', await WorktreeManager.BranchResolvableFilterOverridesAsync(repo));
+
+        await Assert.That(joined).Contains("filter.evil.");
+        await Assert.That(joined).DoesNotContain("filter.lfs.");
+    }
+
+    /// <summary>A driver name containing dots must not be truncated — `filter.my.tool.smudge` is driver
+    /// `my.tool`, and splitting naively would emit overrides for a driver that does not exist.</summary>
+    [Test]
+    public async Task A_dotted_driver_name_survives_parsing() {
+        var repo = NewRepo();
+        Git(repo, "config", "filter.my.tool.smudge", "./tools/f");
+
+        var joined = string.Join(' ', await WorktreeManager.BranchResolvableFilterOverridesAsync(repo));
+
+        await Assert.That(joined).Contains("filter.my.tool.smudge=");
+    }
+
+    // ── end to end ──
+
+    /// <summary>
+    /// The real thing: a branch that ships its own filter executable, with the operator's config pointing at
+    /// it relatively. The control runs plain git and MUST execute the filter, or the assertion below proves
+    /// nothing.
+    /// </summary>
+    [Test]
+    public async Task CreateAsync_does_not_run_a_branch_supplied_smudge_filter() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX filter script with a shebang");
+
+        var marker = Path.Combine(NewDir("filtermarker"), "fired");
+        var repo = NewRepo();
+        Directory.CreateDirectory(Path.Combine(repo, "tools"));
+        var script = Path.Combine(repo, "tools", "f");
+        File.WriteAllText(script, $"#!/bin/sh\nprintf fired > '{marker}'\ncat\n");
+        File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        // The filtered path must sort AFTER the script: git checks out in index order, so a filtered
+        // `data.txt` would smudge before `tools/f` exists and the exec would merely fail. The attack is
+        // therefore ordering-dependent, and naming it `zz.txt` is what makes the control actually fire —
+        // the first version of this test used `data.txt` and its control failed, correctly.
+        File.WriteAllText(Path.Combine(repo, "zz.txt"), "payload\n");
+        File.WriteAllText(Path.Combine(repo, ".gitattributes"), "zz.txt filter=evil\n");
+        Git(repo, "add", "-A");
+        Git(repo, "commit", "-q", "-m", "branch ships its own filter");
+        Git(repo, "config", "filter.evil.smudge", "./tools/f");
+
+        // CONTROL — plain git honours the relative command and runs branch code.
+        Git(repo, "worktree", "add", "-q", Path.Combine(NewDir("ctl"), "wt"),
+            "-b", "ctl-" + Guid.NewGuid().ToString("N")[..8]);
+        await Assert.That(File.Exists(marker))
+            .IsTrue()
+            .Because("the control must reproduce filter execution, or the assertion below is vacuous");
+
+        File.Delete(marker);
+
+        var info = await new WorktreeManager(new DaemonConfig(), NullLogger<WorktreeManager>.Instance)
+            .CreateAsync(repo);
+
+        await Assert.That(File.Exists(marker)).IsFalse();
+        // The checkout still happened — a guard that broke worktree creation would also pass the line above.
+        await Assert.That(File.Exists(Path.Combine(info.Path, "zz.txt"))).IsTrue();
+    }
+
+    // ── fixture ──
+
+    static string NewDir(string tag) {
+        var p = Path.Combine(Path.GetTempPath(), $"kcap-filt-{tag}-{Guid.NewGuid():N}"[..40]);
+        Directory.CreateDirectory(p);
+        return p;
+    }
+
+    static string NewRepo() {
+        var repo = NewDir("repo");
+        Git(repo, "init", "-q");
+        Git(repo, "config", "user.email", "t@e.com");
+        Git(repo, "config", "user.name", "T");
+        File.WriteAllText(Path.Combine(repo, "README.md"), "hi");
+        Git(repo, "add", "-A");
+        Git(repo, "commit", "-q", "-m", "init");
+        return repo;
+    }
+
+    static void Git(string cwd, params string[] args) {
+        var psi = new ProcessStartInfo("git") {
+            WorkingDirectory = cwd, RedirectStandardError = true, RedirectStandardOutput = true
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        using var p = Process.Start(psi)!;
+        var stderr = p.StandardError.ReadToEnd();
+        p.WaitForExit();
+
+        if (p.ExitCode != 0)
+            throw new InvalidOperationException($"fixture `git {string.Join(' ', args)}` failed: {stderr}");
+    }
+}


### PR DESCRIPTION
Follow-up to AI-1632. That change stopped branch-authored MCP config executing and stopped git **hooks** running during worktree creation — but hooks are only one of the mechanisms by which `git worktree add` executes branch content.

## The vector

`.gitattributes` is **branch content** and *selects* which filter driver applies to a path. The driver's command comes from the operator's config — but a **relative** command resolves against the worktree, so the branch supplies the executable. `core.hooksPath` has no effect on filters, so the existing guard does nothing here.

Measured: `filter.x.smudge=./tools/f` plus a branch-committed `tools/f` runs during `worktree add`, before anything has neutralised the tree.

## Why not just disable filters

That breaks **git-lfs**, whose `filter.lfs.smudge` is legitimate and whose absence yields pointer files instead of content — silently. The distinguishing property is whether the command resolves to branch content:

| Command | Disabled? |
|---|---|
| `./tools/filter`, `tools/filter`, `../outside/f` | yes — branch supplies it |
| `sh -c 'cat ./tools/x'` | yes — PATH-resolved executable, branch-controlled payload |
| `git-lfs filter-process`, `/usr/local/bin/filter`, `cat` | no |

Every token is examined, not just the executable. Enumerating the operator's config is sound rather than best-effort: a filter can only run if it is **defined** there, and the branch can only select from what is defined.

## `required` must be cleared too

Measured: with `filter.x.required=true`, an empty smudge command is **fatal** and `worktree add` fails outright. Suppressing the command alone would convert this guard into a launch failure for any repo using a required filter.

## The other half of the issue is not implemented, deliberately

AI-1674 also covered git's config-based hooks (`hook.<name>.event` / `.command`). **They are not a shipped git feature.** Measured on git 2.49.0: undocumented in `git help config`, and a configured `post-checkout` does not run even with `core.hooksPath` pointed away. It was an unmerged proposal. Recorded on the issue so nobody builds a guard for something that cannot fire.

## Tests

Both directions of the classifier, the git-lfs regression, a mixed config, a dotted driver name (`filter.my.tool.smudge` is driver `my.tool`), a repo with no filters, and an end-to-end case through the real `CreateAsync`.

The end-to-end control earned its keep immediately: the first version named the filtered file `data.txt`, which git checks out **before** `tools/f` exists — so the exec merely failed and the control never fired. The attack is ordering-dependent, and the test now records that. Both classifier rules mutation-proven.

README documents the behaviour under `--worktree` alongside the hook guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)