### PR TITLE
Refuse to stop a daemon whose PID file names this process (AI-1645)

### DIFF
--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -376,24 +376,40 @@ public static class DaemonCommands {
             }
 
             var process = Process.GetProcessById(entry.Pid);
+            var killed  = false;
 
             try {
                 process.Kill(entireProcessTree: true);
+                killed = true;
+            } catch (InvalidOperationException) when (process.HasExited) {
+                // A BENIGN race, not corruption: the daemon exited on its own between
+                // GetProcessById and Kill. .NET reports that as InvalidOperationException too, so
+                // without this arm an ordinary well-timed stop would be accused of having a
+                // malformed PID file. The outcome the caller asked for has happened — the daemon is
+                // gone — so report it like the ArgumentException path below and fall through to the
+                // marker cleanup.
+                //
+                // No test: reproducing it needs the process to exit inside that window, which cannot
+                // be scheduled deterministically. Distinguished by HasExited rather than by message.
+                Console.Out.WriteLine($"Daemon '{name}' was not running.");
             } catch (InvalidOperationException ex) {
-                // The self-PID guard above covers the case we can name. This covers the rest of the
-                // same family — chiefly the PID being an ANCESTOR of this process, which .NET also
-                // refuses and which cannot be detected portably ahead of time. Report which daemon
-                // and which PID rather than letting an unattributed exception escape.
+                // What remains is the safety rejection: .NET refuses to kill a process tree that
+                // contains the caller. The self-PID guard above handles the case we can name in
+                // advance; this covers the ANCESTOR case, which cannot be detected portably. Report
+                // which daemon and which PID rather than letting an unattributed exception escape.
                 Console.Error.WriteLine(
                     $"Daemon '{name}' (PID {entry.Pid}) could not be stopped: {ex.Message} "
                   + $"Its PID file at {DaemonLockPaths.PidPath(name)} appears not to describe a daemon.");
 
                 return 1;
             }
-            // Wait for it to actually exit so the kernel releases its flock before
-            // we try to reclaim it for cleanup below.
-            try { process.WaitForExit(5000); } catch { /* best-effort */ }
-            Console.Out.WriteLine($"Daemon '{name}' stopped (PID {entry.Pid}).");
+
+            if (killed) {
+                // Wait for it to actually exit so the kernel releases its flock before
+                // we try to reclaim it for cleanup below.
+                try { process.WaitForExit(5000); } catch { /* best-effort */ }
+                Console.Out.WriteLine($"Daemon '{name}' stopped (PID {entry.Pid}).");
+            }
         } catch (ArgumentException) {
             Console.Out.WriteLine($"Daemon '{name}' was not running.");
         }

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -357,8 +357,39 @@ public static class DaemonCommands {
                 return 0;
             }
 
+            // Refuse to kill ourselves. IsOurDaemon has already said this PID is a live process
+            // whose start token matches, so every identity check upstream has PASSED — the PID is
+            // simply not a daemon. A real daemon is never the process running `daemon stop`, so
+            // reaching here means the PID file is describing something it should not, and killing
+            // its tree would take down this process and everything above it.
+            //
+            // Without this, Process.Kill(entireProcessTree: true) throws
+            // "Cannot be used to terminate a process tree containing the calling process" — an
+            // opaque InvalidOperationException that says nothing about WHICH pid file caused it.
+            // (AI-1645: that is exactly how this surfaced, as a random kcap-cli CI failure.)
+            if (entry.Pid == Environment.ProcessId) {
+                Console.Error.WriteLine(
+                    $"Daemon '{name}' resolves to the current process (PID {entry.Pid}); refusing to stop it. "
+                  + $"Its PID file at {DaemonLockPaths.PidPath(name)} does not describe a daemon.");
+
+                return 1;
+            }
+
             var process = Process.GetProcessById(entry.Pid);
-            process.Kill(entireProcessTree: true);
+
+            try {
+                process.Kill(entireProcessTree: true);
+            } catch (InvalidOperationException ex) {
+                // The self-PID guard above covers the case we can name. This covers the rest of the
+                // same family — chiefly the PID being an ANCESTOR of this process, which .NET also
+                // refuses and which cannot be detected portably ahead of time. Report which daemon
+                // and which PID rather than letting an unattributed exception escape.
+                Console.Error.WriteLine(
+                    $"Daemon '{name}' (PID {entry.Pid}) could not be stopped: {ex.Message} "
+                  + $"Its PID file at {DaemonLockPaths.PidPath(name)} appears not to describe a daemon.");
+
+                return 1;
+            }
             // Wait for it to actually exit so the kernel releases its flock before
             // we try to reclaim it for cleanup below.
             try { process.WaitForExit(5000); } catch { /* best-effort */ }

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -366,7 +366,8 @@ public static class DaemonCommands {
             // Without this, Process.Kill(entireProcessTree: true) throws
             // "Cannot be used to terminate a process tree containing the calling process" — an
             // opaque InvalidOperationException that says nothing about WHICH pid file caused it.
-            // (AI-1645: that is exactly how this surfaced, as a random kcap-cli CI failure.)
+            // That is exactly how this surfaced: a random, always-different CI test failing
+            // with an identical stack, because the pid file named the test runner itself.
             if (entry.Pid == Environment.ProcessId) {
                 Console.Error.WriteLine(
                     $"Daemon '{name}' resolves to the current process (PID {entry.Pid}); refusing to stop it. "

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStopSelfPidTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStopSelfPidTests.cs
@@ -1,0 +1,76 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// AI-1645 — <c>daemon stop</c> must refuse to kill a PID that is this very process.
+///
+/// <para>This is a REGRESSION test for a real kcap-cli CI failure, and it reproduces it exactly
+/// rather than approximating it. A live <see cref="DaemonLock"/> writes the acquiring process's own
+/// pid and start token, so after acquiring one here, the daemons directory contains a pid file that
+/// names the test runner. Every identity check in <c>StopByName</c> then legitimately passes — the
+/// process exists, and its start token matches — and the old code proceeded to
+/// <c>Process.Kill(entireProcessTree: true)</c> on itself, which .NET refuses with
+/// <c>InvalidOperationException: Cannot be used to terminate a process tree containing the calling
+/// process</c>.</para>
+///
+/// <para>The point worth keeping: the pid was never stale or recycled, so no amount of extra
+/// validation could have caught it. A daemon simply is never the process running <c>daemon stop</c>,
+/// which is why identity is the wrong question and self-reference is the right one.</para>
+///
+/// <para>In CI this arrived as a random <c>UninstallCommandTests</c> failure — uninstall runs
+/// <c>daemon stop --yes</c>, which enumerates the daemons directory, and that directory is chosen by
+/// a process-global static that the daemon tests redirect. That parallelism hole is fixed separately
+/// by the constraint key on <c>UninstallCommandTests</c>; this test covers the production behaviour
+/// on its own, so the guard survives even if the test-isolation fix is later refactored away.</para>
+///
+/// <para><b>Mutation evidence, stated precisely.</b> Removing BOTH the self-pid guard and the
+/// <c>InvalidOperationException</c> catch fails this test with the exact CI error
+/// ("Cannot be used to terminate a process tree containing the calling process"). Removing either
+/// one ALONE does not — the other still returns a clean exit code. That is deliberate: they are two
+/// layers over the same hazard, the second covering the ancestor case that cannot be detected
+/// portably in advance. So this test pins the PROPERTY (a self-referencing pid file never escapes as
+/// an unhandled exception) rather than either individual guard, and it is worth knowing that is what
+/// it does — a future reader deleting one layer will not be told by this test.</para>
+/// </summary>
+[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+public class DaemonStopSelfPidTests {
+    [Test]
+    public async Task Stop_refuses_to_kill_a_pid_file_naming_the_current_process() {
+        var dir = Path.Combine(Path.GetTempPath(), "kcap-stop-self-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+
+        try {
+            // Write the pid file directly rather than acquiring a real DaemonLock. The first
+            // version of this test DID acquire one — and was vacuous: a held lock leaves the pid
+            // file unreadable, so StopByName returns 1 down its "PID file unreadable" branch and
+            // never reaches the kill at all. It passed with the guard removed, which is the only
+            // reason that was caught. What matters is reaching the kill, not how the file got there.
+            //
+            // The token must be the REAL one for this pid: that is what makes IsOurDaemon return
+            // true, which is the whole point. A fabricated token would be rejected earlier and the
+            // test would again pass for the wrong reason.
+            var token = ProcessStartToken.ForPid(Environment.ProcessId);
+
+            await File.WriteAllTextAsync(
+                DaemonLockPaths.PidPath("self"), $"{Environment.ProcessId}\n{token}\n");
+
+            // Before the fix this threw InvalidOperationException out of Process.Kill. The exit code
+            // matters less than the fact that it RETURNS: an unhandled exception here takes down
+            // whichever unrelated test happens to be running — which is exactly how it showed up in
+            // CI, as a random UninstallCommandTests failure.
+            var exit = await DaemonCommands.HandleAsync(["daemon", "stop", "--name", "self", "--yes"]);
+
+            await Assert.That(exit).IsEqualTo(1);
+
+            // And the process is, obviously, still here to assert it.
+            await Assert.That(Environment.HasShutdownStarted).IsFalse();
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStopSelfPidTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStopSelfPidTests.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// AI-1645 — <c>daemon stop</c> must refuse to kill a PID that is this very process.
+/// <c>daemon stop</c> must refuse to kill a PID that is this very process.
 ///
 /// <para>This is a REGRESSION test for a real kcap-cli CI failure, and it reproduces it exactly
 /// rather than approximating it. A live <see cref="DaemonLock"/> writes the acquiring process's own

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStopSelfPidTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStopSelfPidTests.cs
@@ -64,9 +64,6 @@ public class DaemonStopSelfPidTests {
             var exit = await DaemonCommands.HandleAsync(["daemon", "stop", "--name", "self", "--yes"]);
 
             await Assert.That(exit).IsEqualTo(1);
-
-            // And the process is, obviously, still here to assert it.
-            await Assert.That(Environment.HasShutdownStarted).IsFalse();
         } finally {
             DaemonLockPaths.OverrideDirectoryForTesting(null);
 

--- a/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -13,7 +13,7 @@ namespace Capacitor.Cli.Tests.Unit;
 // so we mutate it per-test to point at the test's temp dir without disturbing
 // the assembly-wide value pinned by RepoPathStoreGlobalSetup.
 //
-// DaemonLockPaths.OverrideDirectoryForTesting (AI-1645): uninstall runs
+// DaemonLockPaths.OverrideDirectoryForTesting: uninstall runs
 // `daemon stop --yes`, which ENUMERATES every name in the daemons directory and
 // kills the PID it finds. That directory is selected by a process-global static,
 // so while any daemon test holds the override, uninstall reads THAT test's temp

--- a/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -13,20 +13,13 @@ namespace Capacitor.Cli.Tests.Unit;
 // so we mutate it per-test to point at the test's temp dir without disturbing
 // the assembly-wide value pinned by RepoPathStoreGlobalSetup.
 //
-// DaemonLockPaths.OverrideDirectoryForTesting: uninstall runs
-// `daemon stop --yes`, which ENUMERATES every name in the daemons directory and
-// kills the PID it finds. That directory is selected by a process-global static,
-// so while any daemon test holds the override, uninstall reads THAT test's temp
-// dir — and DaemonLockTests puts a real DaemonLock there, whose PID file contains
-// the TEST RUNNER'S OWN pid with a matching start token. Every identity check then
-// legitimately passes and uninstall kills the tree containing itself, failing with
-// "Cannot be used to terminate a process tree containing the calling process" in
-// whichever uninstall test happened to be running.
-//
-// This is why the per-test KCAP_CONFIG_DIR isolation above did not help: the
-// daemons directory deliberately ignores KCAP_CONFIG_DIR. Sharing the constraint
-// key with the mutators is the fix — a reader of a globally-selected directory has
-// to exclude everyone who can reselect it.
+// DaemonLockPaths.OverrideDirectoryForTesting: uninstall runs `daemon stop --yes`,
+// which enumerates the daemons directory and kills the PIDs it finds. That directory
+// comes from a process-global static, so a concurrent daemon test's override sends
+// uninstall at that test's temp dir — where a real DaemonLock has written the test
+// runner's own PID. Uninstall then kills the tree containing itself. The
+// KCAP_CONFIG_DIR isolation above cannot help; that directory ignores it by design.
+// See DaemonStopSelfPidTests for the full mechanism.
 [NotInParallel([
     "HomeEnvVarMutation",
     "ConfigDirEnvVar",

--- a/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UninstallCommandTests.cs
@@ -12,7 +12,27 @@ namespace Capacitor.Cli.Tests.Unit;
 // ConfigDirEnvVar: uninstall reads KCAP_CONFIG_DIR fresh on every call,
 // so we mutate it per-test to point at the test's temp dir without disturbing
 // the assembly-wide value pinned by RepoPathStoreGlobalSetup.
-[NotInParallel(["HomeEnvVarMutation", "ConfigDirEnvVar", "CwdMutation"])]
+//
+// DaemonLockPaths.OverrideDirectoryForTesting (AI-1645): uninstall runs
+// `daemon stop --yes`, which ENUMERATES every name in the daemons directory and
+// kills the PID it finds. That directory is selected by a process-global static,
+// so while any daemon test holds the override, uninstall reads THAT test's temp
+// dir — and DaemonLockTests puts a real DaemonLock there, whose PID file contains
+// the TEST RUNNER'S OWN pid with a matching start token. Every identity check then
+// legitimately passes and uninstall kills the tree containing itself, failing with
+// "Cannot be used to terminate a process tree containing the calling process" in
+// whichever uninstall test happened to be running.
+//
+// This is why the per-test KCAP_CONFIG_DIR isolation above did not help: the
+// daemons directory deliberately ignores KCAP_CONFIG_DIR. Sharing the constraint
+// key with the mutators is the fix — a reader of a globally-selected directory has
+// to exclude everyone who can reselect it.
+[NotInParallel([
+    "HomeEnvVarMutation",
+    "ConfigDirEnvVar",
+    "CwdMutation",
+    nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting"
+])]
 public class UninstallCommandTests {
     [Test]
     public async Task User_level_uninstall_removes_kcap_entries_and_preserves_user_data() {


### PR DESCRIPTION
Fixes [AI-1645](https://linear.app/kurrent/issue/AI-1645).

## The filed diagnosis was wrong, and correcting it changes the fix

AI-1645 attributed the random `UninstallCommandTests` failures to a stale PID file or a recycled PID, and proposed *validating the PID before killing*.

That validation **already exists** — `IsOurDaemon`, since AI-839 (#147) — and it could not have helped here. The PID was neither stale nor recycled. It was **the test runner's own live PID**, carrying a start token that genuinely matched, so every identity check correctly passed. No amount of extra validation catches a PID that is legitimately valid.

## What actually happens

Verified by reading the code, not inferred from the stack:

1. `DaemonLockPaths` selects its directory through a **process-global static** (`OverrideDirectoryForTesting`).
2. `DaemonLockTests` redirects it and acquires a **real** `DaemonLock`, which writes **the acquiring process's own PID** — its own assertion at line 185 proves this.
3. `UninstallCommandTests` is in a **different** `NotInParallel` group, so it can run concurrently — and it sees the same global override.
4. Uninstall runs `daemon stop --yes`, which enumerates that redirected directory, finds a live PID with a matching token, and calls `Process.Kill(entireProcessTree: true)` — on the tree containing itself.

Hence: a random uninstall test, an identical stack every time, not reproducible on demand.

This also explains why the existing per-test `KCAP_CONFIG_DIR` isolation never helped — **the daemons directory deliberately ignores `KCAP_CONFIG_DIR`**, which its own doc comment says explicitly.

## Two changes

**1. Test isolation — the actual flake fix.** `UninstallCommandTests` joins the `DaemonLockPaths.OverrideDirectoryForTesting` constraint group. The rule worth remembering: *a reader of a globally-selected directory has to exclude everyone who can reselect it.* I swept all 12 mutator classes and every reader; uninstall was the only reader missing the key (`DaemonRestartCommandTests` only calls a pure parser).

**2. Production guard.** Refuse a PID equal to this process, and catch the `InvalidOperationException` for the **ancestor** case, which cannot be detected portably in advance. A daemon is never the process running a stop command, so reaching there means the PID file describes something it should not. Both paths now name the daemon and its PID file rather than surfacing an unattributed exception.

The production hazard is **narrower than AI-1645 claimed** — in real use the CLI and daemon are separate processes, so self-reference should not arise. I kept the guard anyway because it converts an opaque crash into a diagnosable message, which is what issue suggestion (2) asked for.

## Mutation evidence, stated precisely

Removing **both** guards fails the new test with the exact CI error:

```
InvalidOperationException: Cannot be used to terminate a process tree containing the calling process.
```

Removing **either one alone does not** — the other still returns a clean exit code. That is deliberate defence-in-depth, but it means the test pins the *property* (a self-referencing PID file never escapes as an unhandled exception), not each guard individually. That limitation is written into the test, so nobody mistakes it for per-guard coverage.

**The first version of this test was vacuous**, and mutation is the only reason I know that. It acquired a real `DaemonLock` — which leaves the PID file unreadable, so `stop` returned 1 down its "PID file unreadable" branch without ever reaching the kill. It passed with the guard removed. Rewritten to write the PID file directly with a real `ProcessStartToken.ForPid` token, so it reaches the code under test.

## Verification

`DaemonStopSelfPidTests` 1/1 · `DaemonLockTests` 17/17.

`UninstallCommandTests` is **11/16 failing locally on macOS — and identically on `origin/main`**, confirmed in a detached baseline worktree. Pre-existing and unrelated; CI (ubuntu/windows) is the gate for that class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
