### PR TITLE
Restore config defaults the JSON source generator discards

### DIFF
--- a/src/Capacitor.Cli.Core/Config/ConfigMigration.cs
+++ b/src/Capacitor.Cli.Core/Config/ConfigMigration.cs
@@ -21,39 +21,94 @@ public static class ConfigMigration {
         if (parsed is not JsonObject node)
             return FreshDefault();
 
-        // Check if already V2
-        if (node["version"]?.GetValue<int>() is 2) {
+        // A v1 config predates versioning and so carries no "version" key at all. Anything that
+        // has one is v2 — including a value we can't read: reinterpreting that as v1 would rewrite
+        // the file from flat fields it doesn't have and drop the profiles map. An unreadable
+        // version instead surfaces as the JsonException the caller already handles.
+        if (node.ContainsKey("version")) {
             var v2 = JsonSerializer.Deserialize(json, ProfileConfigJsonContext.Default.ProfileConfig)!;
 
-            return new(v2, WasMigrated: false, ShouldPersist: false);
+            return new(ApplyDefaults(v2, node), WasMigrated: false, ShouldPersist: false);
         }
 
-        // V1 → V2: read old flat fields, build default profile
+        // V1 → V2: read old flat fields, build default profile. The v1 flat keys sit
+        // at the same paths ApplyDefaults reads ("update_check", "daemon.max_agents"),
+        // so the raw node doubles as the default profile's payload.
         var v1 = JsonSerializer.Deserialize(json, ConfigJsonContext.Default.LegacyV1Config)
          ?? new LegacyV1Config();
-
-        // STJ source-gen does not apply the record member-initializer default
-        // (`= true`) for a JSON property absent from the payload — a v1 config
-        // lacking "update_check" deserializes v1.UpdateCheck to false, even
-        // though the v1 default was true (see UpdateChannelConfigTests for the
-        // same quirk on Profile.UpdateChannel). Read the raw node instead so
-        // "absent" and "explicitly false" are distinguished correctly.
-        var updateCheck = node["update_check"]?.GetValue<bool>() ?? true;
 
         var defaultProfile = new Profile {
             ServerUrl         = v1.ServerUrl,
             Daemon            = v1.Daemon,
             DefaultVisibility = v1.DefaultVisibility,
-            UpdateCheck       = updateCheck,
             ExcludedRepos     = v1.ExcludedRepos
         };
 
         var config = new ProfileConfig {
-            ActiveProfile   = "default",
-            Profiles        = new() { ["default"] = defaultProfile },
-            ProfileBindings = []
+            ActiveProfile = "default",
+            Profiles      = new() { ["default"] = defaultProfile }
         };
 
-        return new(config, WasMigrated: true, ShouldPersist: true);
+        return new(ApplyDefaults(config, node, sharedProfilePayload: true), WasMigrated: true, ShouldPersist: true);
     }
+
+    /// <summary>
+    /// Restores the defaults these records declare but never receive from disk.
+    /// STJ source-gen builds init-only records through an object initializer that assigns
+    /// <c>default(T)</c> for every property absent from the payload, discarding the member
+    /// initializers — so a hand-written, truncated, or older-version config.json deserializes
+    /// with nulls where the record declares non-null defaults, and every command that touched
+    /// one crashed before it could dispatch (including the <c>kcap config set</c> needed to
+    /// repair the file).
+    /// <para><paramref name="raw"/> supplies the two defaults that differ from
+    /// <c>default(T)</c> — <c>update_check</c> and <c>daemon.max_agents</c> — because only the
+    /// JSON can tell "absent" from an explicit <c>false</c>/<c>0</c>.
+    /// <paramref name="sharedProfilePayload"/> marks the v1 layout, whose profile fields are
+    /// the top-level object rather than entries under <c>profiles</c>.</para>
+    /// </summary>
+    static ProfileConfig ApplyDefaults(ProfileConfig config, JsonObject raw, bool sharedProfilePayload = false) {
+        var rawProfiles = raw["profiles"] as JsonObject;
+        var profiles    = new Dictionary<string, Profile>();
+
+        foreach (var (name, profile) in config.Profiles ?? new())
+            profiles[name] = ApplyDefaults(
+                profile ?? new(),
+                sharedProfilePayload ? raw : rawProfiles?[name] as JsonObject
+            );
+
+        var bindings = new Dictionary<string, string>();
+
+        foreach (var (path, name) in config.ProfileBindings ?? new())
+            if (!string.IsNullOrEmpty(name)) bindings[path] = name;
+
+        return config with {
+            ActiveProfile   = string.IsNullOrEmpty(config.ActiveProfile) ? "default" : config.ActiveProfile,
+            Profiles        = profiles,
+            ProfileBindings = bindings,
+            CwdRemap = (config.CwdRemap ?? [])
+                .Select(r => r is null ? new CwdRemap() : r with { From = r.From ?? "", To = r.To ?? "" })
+                .ToArray()
+        };
+    }
+
+    static Profile ApplyDefaults(Profile profile, JsonObject? raw) => profile with {
+        DefaultVisibility = string.IsNullOrEmpty(profile.DefaultVisibility) ? "org_public" : profile.DefaultVisibility,
+        UpdateChannel     = string.IsNullOrEmpty(profile.UpdateChannel) ? "latest" : profile.UpdateChannel,
+        UpdateCheck       = Scalar(raw, "update_check", true),
+        ExcludedRepos     = profile.ExcludedRepos ?? [],
+        ExcludedPaths     = profile.ExcludedPaths ?? [],
+        Remotes           = profile.Remotes ?? [],
+        Daemon = profile.Daemon is null
+            ? null
+            : profile.Daemon with { MaxAgents = Scalar(raw?["daemon"] as JsonObject, "max_agents", 5) }
+    };
+
+    /// <summary>
+    /// Reads a scalar straight off the raw node, falling back to <paramref name="fallback"/> when the
+    /// key is absent or null. <c>TryGetValue</c> rather than <c>GetValue&lt;T&gt;()</c> keeps the read
+    /// total: a type mismatch already surfaces from the deserializer above as a JsonException the
+    /// caller handles, and must not be re-raised here as an uncaught InvalidOperationException.
+    /// </summary>
+    static T Scalar<T>(JsonObject? raw, string key, T fallback) =>
+        raw?[key] is JsonValue value && value.TryGetValue<T>(out var parsed) ? parsed : fallback;
 }

--- a/test/Capacitor.Cli.Tests.Unit/ConfigDefaultsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ConfigDefaultsTests.cs
@@ -1,0 +1,201 @@
+using System.Text.Json;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// A hand-written, truncated, or older-version config.json omits keys that a
+/// kcap-written one always contains. STJ source-gen builds these init-only
+/// records through an object initializer that assigns <c>default(T)</c> for every
+/// absent property, discarding the record's member initializers — so every such
+/// key used to deserialize to null/false/0 and crash the first command that
+/// touched it. These pin the declared defaults to the load boundary.
+/// </summary>
+public class ConfigDefaultsTests {
+    static ProfileConfig Load(string json) => ConfigMigration.MigrateIfNeeded(json).Config;
+
+    const string MinimalV2 = """
+        {
+            "version": 2,
+            "active_profile": "test",
+            "profiles": { "test": { "server_url": "https://example.test" } }
+        }
+        """;
+
+    [Test]
+    public async Task Absent_profile_bindings_is_an_empty_map() {
+        await Assert.That(Load(MinimalV2).ProfileBindings).IsNotNull().And.IsEmpty();
+    }
+
+    [Test]
+    public async Task Absent_profiles_is_an_empty_map() {
+        var config = Load("""{ "version": 2, "active_profile": "test" }""");
+
+        await Assert.That(config.Profiles).IsNotNull().And.IsEmpty();
+    }
+
+    [Test]
+    public async Task Absent_active_profile_falls_back_to_default() {
+        var config = Load("""{ "version": 2, "profiles": { "default": {} } }""");
+
+        await Assert.That(config.ActiveProfile).IsEqualTo("default");
+    }
+
+    [Test]
+    public async Task Absent_cwd_remap_is_an_empty_array() {
+        await Assert.That(Load(MinimalV2).CwdRemap).IsNotNull().And.IsEmpty();
+    }
+
+    [Test]
+    public async Task Absent_profile_collections_are_empty_arrays() {
+        var profile = Load(MinimalV2).Profiles["test"];
+
+        await Assert.That(profile.ExcludedRepos).IsNotNull().And.IsEmpty();
+        await Assert.That(profile.ExcludedPaths).IsNotNull().And.IsEmpty();
+        await Assert.That(profile.Remotes).IsNotNull().And.IsEmpty();
+    }
+
+    [Test]
+    public async Task Absent_profile_strings_keep_their_declared_defaults() {
+        var profile = Load(MinimalV2).Profiles["test"];
+
+        await Assert.That(profile.DefaultVisibility).IsEqualTo("org_public");
+        await Assert.That(profile.UpdateChannel).IsEqualTo("latest");
+    }
+
+    // update_check and daemon.max_agents declare defaults that differ from
+    // default(T), so only the raw JSON can tell "absent" from an explicit false/0.
+
+    [Test]
+    public async Task Absent_update_check_defaults_to_true() {
+        await Assert.That(Load(MinimalV2).Profiles["test"].UpdateCheck).IsTrue();
+    }
+
+    [Test]
+    public async Task Explicit_update_check_false_is_preserved() {
+        var config = Load("""
+            {
+                "version": 2,
+                "profiles": { "test": { "update_check": false } }
+            }
+            """);
+
+        await Assert.That(config.Profiles["test"].UpdateCheck).IsFalse();
+    }
+
+    [Test]
+    public async Task Absent_max_agents_defaults_to_five() {
+        var config = Load("""
+            {
+                "version": 2,
+                "profiles": { "test": { "daemon": { "name": "dev" } } }
+            }
+            """);
+
+        await Assert.That(config.Profiles["test"].Daemon!.MaxAgents).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task Explicit_max_agents_is_preserved() {
+        var config = Load("""
+            {
+                "version": 2,
+                "profiles": { "test": { "daemon": { "max_agents": 2 } } }
+            }
+            """);
+
+        await Assert.That(config.Profiles["test"].Daemon!.MaxAgents).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Null_valued_keys_are_treated_as_absent() {
+        var config = Load("""
+            {
+                "version": 2,
+                "active_profile": null,
+                "profiles": { "test": null },
+                "profile_bindings": null,
+                "cwd_remap": null
+            }
+            """);
+
+        await Assert.That(config.ActiveProfile).IsEqualTo("default");
+        await Assert.That(config.ProfileBindings).IsNotNull().And.IsEmpty();
+        await Assert.That(config.CwdRemap).IsNotNull().And.IsEmpty();
+        await Assert.That(config.Profiles["test"].DefaultVisibility).IsEqualTo("org_public");
+    }
+
+    [Test]
+    public async Task Binding_with_no_target_profile_is_dropped() {
+        var config = Load("""
+            {
+                "version": 2,
+                "profiles": { "test": {} },
+                "profile_bindings": { "/repos/orphan": null }
+            }
+            """);
+
+        await Assert.That(config.ProfileBindings).IsEmpty();
+    }
+
+    // An unreadable "version" must not be mistaken for a v1 config: that path rebuilds the
+    // config from flat fields a v2 file doesn't have and persists the result, dropping the
+    // profiles map. It has to stay on the v2 branch, where the failure is the JsonException
+    // AppConfig.LoadProfileConfig already reports and recovers from.
+    [Test]
+    public async Task Wrong_typed_version_reports_a_handled_error_instead_of_migrating() {
+        var json = """{ "version": "2", "profiles": { "test": {} } }""";
+
+        await Assert.That(() => ConfigMigration.MigrateIfNeeded(json)).Throws<JsonException>();
+    }
+
+    [Test]
+    public async Task Wrong_typed_scalars_report_a_handled_error() {
+        var json = """
+            {
+                "version": 2,
+                "profiles": { "test": { "update_check": "yes" } }
+            }
+            """;
+
+        await Assert.That(() => ConfigMigration.MigrateIfNeeded(json)).Throws<JsonException>();
+    }
+
+    // The reported crash: every command aborted here before dispatching, so a user
+    // in this state could not even repair the file with `kcap config set`.
+    [Test]
+    public async Task Resolver_binding_lookup_survives_a_minimal_config() {
+        var resolver = new ProfileResolver(
+            Load(MinimalV2),
+            cliServerUrl: null,
+            envUrl: null,
+            envProfile: null,
+            repoConfig: null,
+            repoRemoteUrls: [],
+            repoPath: "/repos/anything"
+        );
+
+        var result = resolver.Resolve();
+
+        await Assert.That(result.ServerUrl).IsEqualTo("https://example.test");
+        await Assert.That(result.ProfileName).IsEqualTo("test");
+    }
+
+    [Test]
+    public async Task Resolver_active_profile_fallback_survives_a_config_with_no_profiles() {
+        var resolver = new ProfileResolver(
+            Load("""{ "version": 2 }"""),
+            cliServerUrl: null,
+            envUrl: null,
+            envProfile: null,
+            repoConfig: null,
+            repoRemoteUrls: [],
+            repoPath: "/repos/anything"
+        );
+
+        var result = resolver.Resolve();
+
+        await Assert.That(result.ServerUrl).IsNull();
+        await Assert.That(result.Warning).Contains("not found");
+    }
+}


### PR DESCRIPTION
Closes #435
AI-1700

## Root cause

Not `ProfileResolver.cs:78` — that is one of several crash sites.

Every property on `ProfileConfig`/`Profile`/`DaemonSettings`/`CwdRemap` is `init`-only. The STJ source generator cannot use init-only setters, so it emits `ObjectCreator = null` and builds each record through a synthetic object initializer:

```csharp
ObjectWithParameterizedConstructorCreator = static args => new ProfileConfig() {
    Version = (int)args[0], ActiveProfile = (string)args[1], Profiles = (…)args[2],
    ProfileBindings = (…)args[3], CwdRemap = (…)args[4], MachineId = (string)args[5] }
```

For any key absent from the payload `args[i]` is `default(T)`. The member initializers (`= new()`, `= "default"`, `= true`) run in the constructor and are then overwritten with `null`/`false`/`0`. The repo already knew about this for one field — the `update_check` comment in `ConfigMigration` — and had patched it per call site (`config.CwdRemap ?? []`, `profile.ExcludedPaths ?? []`, `?? "latest"`). The general case was never fixed.

Reproduced three distinct crashes from a minimal hand-written config, not one:

| Missing key | Failure |
| --- | --- |
| `profile_bindings` | `NullReferenceException` at `ProfileResolver.cs:78` (the reported one) |
| `profiles` | `NullReferenceException` at `AppConfig.NormalizeProfileVisibilities` — before the resolver runs |
| `active_profile` | `ArgumentNullException` at `ProfileResolver.ResolveByName` |

Plus silent misbehaviour from the same quirk: absent `update_check` → `false` (update checks off), absent `daemon.max_agents` → `0`, which `DaemonRunner.cs:110` propagates into `MaxConcurrentAgents`, clamping the daemon to zero agents.

## The change

`ConfigMigration.MigrateIfNeeded` is the **only** production deserialization site for `ProfileConfig`, so the fix lands there rather than defensively in the resolver. A resolver-only fix (the shape the issue originally suggested) would have left `AppConfig`, `kcap use` and `kcap profile remove` still crashing. A new `ApplyDefaults` pass restores the declared defaults across the whole record graph, taking the raw `JsonObject` for the two defaults that differ from `default(T)` — only the JSON distinguishes "absent" from an explicit `false`/`0`.

One change beyond null handling: version routing now keys off `node.ContainsKey("version")` instead of `version is 2`. The old check called `GetValue<int>()`, which throws an *uncaught* `InvalidOperationException` on `"version": "2"`; and any non-2 value (a typo, or a future v3) fell through to the v1 branch, which rebuilds the config from flat fields a v2 file does not have **and persists it**, silently destroying the user's profiles. Unreadable versions now stay on the v2 branch, where the failure is the `JsonException` `LoadProfileConfig` already catches and reports.

The existing per-call-site `?? []` scar tissue is left in place — now redundant but harmless, and removing it is a separate cleanup.

## Verification

- 16 new tests in `ConfigDefaultsTests`; **14 failed before the fix**, all 16 pass now.
- Full unit suite: 49 failures with the change vs **48 on unmodified `main`**. The 3-test difference is entirely flaky-under-load concurrency tests (`ImportChainsAsync_dispatches_independent_chains_in_parallel`, `PermissionRequest_ConnectionDisposedWhilePending_…`, `Shutdown_with_live_children_…`) — each passes in isolation, and one of them fails on the baseline but not with this change. The 48 pre-existing failures are an unrelated setup/uninstall/MCP-TOML cluster.
- Integration suite: 192/192 pass.
- AOT publish clean — no IL2026/IL3050.
- End-to-end against the original repro: all four hand-written configs work, and `kcap config set` — the repair path that was unreachable — now succeeds and writes back a complete config with correct defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
