### PR TITLE
[AI-1707] Make daemon shutdown crash-free: idempotent dispose + contained teardown

### DIFF
--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -521,11 +521,33 @@ public static partial class DaemonRunner {
             LogWaitForShutdownReturned(logger);
         } finally {
             LogEnteringCleanup(logger);
-            daemonLock.Dispose();
-            await orchestrator.DisposeAsync();
-            await connection.DisposeAsync();
-            await host.StopAsync();
 
+            // Each teardown step runs through RunTeardownAsync so a throw (e.g. a disposal
+            // ObjectDisposedException) is logged and contained instead of escaping this finally —
+            // under NativeAOT an escaped teardown exception aborts the process (SIGABRT) — and so
+            // every later step still runs (a skipped host-dispose would leave the DI-owned
+            // UnixSpawnerThread's foreground thread parked forever). Do NOT reorder the steps:
+            // the explicit-dispose-before-host-stop sequence is load-bearing (spawner-thread
+            // retirement, pinned by DaemonHostDisposalTests).
+            //
+            // LIMITATION: the coordinator contains a throw from each STEP, but it cannot make the
+            // DI container's own dispose walk (inside DisposeHostAsync) resilient — a tracked
+            // singleton whose Dispose/DisposeAsync throws still aborts the container's INTERNAL
+            // walk partway, silently skipping the remaining singletons. The helper prevents the
+            // process abort, not partial DI disposal; each disposable must still contain its own
+            // failures (ServerConnection and AgentOrchestrator now do).
+            //
+            // Structural double-teardown sweep (explicit dispose here + a second framework-driven
+            // dispose of the SAME instance) and why each shape is safe today:
+            //   - ServerConnection / AgentOrchestrator: run-once dispose guards (this change).
+            //   - DaemonLock: disposed explicitly here AND DI-tracked; its Dispose is
+            //     idempotent (releases the handle once, subsequent calls no-op).
+            //   - RestartCoordinator / LocalControlServer: concrete singleton + same-instance
+            //     AddHostedService registration — the host stops them once and the container
+            //     disposes the single instance once; BackgroundService.Dispose is safe to
+            //     re-enter under the current Microsoft.Extensions.Hosting behavior (it only
+            //     cancels/disposes its stopping CTS) — a framework-version assumption.
+            //
             // host.StopAsync() only STOPS IHostedServices — it does NOT dispose the
             // ServiceProvider, so a plain AddSingleton<T>() IDisposable (e.g.
             // UnixSpawnerThread, whose foreground, non-background OS thread parks
@@ -534,7 +556,20 @@ public static partial class DaemonRunner {
             // and therefore every registered IDisposable singleton — so it must run
             // after StopAsync on every shutdown path or the spawner thread's foreground
             // thread keeps the process alive past WaitForShutdownAsync forever.
-            await DisposeHostAsync(host);
+            var allStepsSucceeded = await RunTeardownAsync(logger, [
+                ("daemon-lock",       () => { daemonLock.Dispose(); return ValueTask.CompletedTask; }),
+                ("orchestrator",      () => orchestrator.DisposeAsync()),
+                ("server-connection", () => connection.DisposeAsync()),
+                ("host-stop",         async () => await host.StopAsync()),
+                ("host-dispose",      async () => await DisposeHostAsync(host))
+            ]);
+
+            // A partial teardown failure is summarized but deliberately does NOT change the exit
+            // code: the process was already exiting (normally 0), and turning a contained cleanup
+            // fault into a non-zero exit would make supervisors (systemd/launchd restart-on-
+            // failure) relaunch a daemon the user just stopped.
+            if (!allStepsSucceeded) LogTeardownPartialFailure(logger);
+
             LogCleanupCompleted(logger);
         }
 
@@ -568,6 +603,29 @@ public static partial class DaemonRunner {
         } else {
             host.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Teardown coordinator for the shutdown finally-block: runs each named step in the given
+    /// order, logging and containing any throw so every later step still runs and nothing can
+    /// escape into the NativeAOT unhandled path (which calls <c>abort()</c>). Returns whether
+    /// ALL steps succeeded so the caller can log a summary on partial failure. <c>internal</c>
+    /// so <c>DaemonHostDisposalTests</c> can pin the order/containment contract directly.
+    /// </summary>
+    internal static async Task<bool> RunTeardownAsync(
+            ILogger logger, IReadOnlyList<(string Name, Func<ValueTask> Action)> steps) {
+        var allSucceeded = true;
+
+        foreach (var (name, action) in steps) {
+            try {
+                await action();
+            } catch (Exception ex) {
+                allSucceeded = false;
+                LogTeardownStepFailed(logger, ex, name);
+            }
+        }
+
+        return allSucceeded;
     }
 
     /// <summary>
@@ -824,6 +882,12 @@ public static partial class DaemonRunner {
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Cleanup: completed, daemon exiting")]
     static partial void LogCleanupCompleted(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Teardown step '{Step}' failed; continuing shutdown")]
+    static partial void LogTeardownStepFailed(ILogger logger, Exception ex, string step);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Cleanup: one or more teardown steps failed (see warnings above); daemon exiting anyway with its normal exit code")]
+    static partial void LogTeardownPartialFailure(ILogger logger);
 
     [LoggerMessage(Level = LogLevel.Critical, Message = "AppDomain.UnhandledException (terminating={IsTerminating})")]
     static partial void LogUnhandledException(ILogger logger, Exception ex, bool isTerminating);

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -462,124 +462,72 @@ public static partial class DaemonRunner {
             lifetime.StopApplication();
         };
 
-        // Start hosted services (LocalPermissionBridge in particular) BEFORE the SignalR
-        // connection comes up. Otherwise an early LaunchAgent message can arrive while
-        // BaseUrl is still null and the spawned Claude falls back to the HTTPS path —
-        // exactly what this bridge is meant to avoid.
-        await host.StartAsync(lifetime.ApplicationStopping);
+        // Resolved INSIDE the guarded startup below (after host start); nullable so the teardown
+        // can run null-safely when SIGTERM lands before the orchestrator was ever resolved.
+        AgentOrchestrator? orchestrator = null;
 
-        // Phase B (D4 §6.4(3)): resolve the orchestrator (which wires OnLaunchAgent +
-        // GetLiveAgents in its ctor) and reap any hosted-agent children that outlived a PRIOR daemon run
-        // — all BEFORE ConnectAsync advertises this daemon and the server can dispatch launches. Doing
-        // it after connect would let new work be admitted while old capacity is still being reclaimed
-        // (those survivors aren't yet in EffectiveCount), and would leave a window where a launch races
-        // an unwired handler. Under the daemon lock; best-effort (swallows its own faults).
-        var orchestrator = host.Services.GetRequiredService<AgentOrchestrator>();
+        // EVERY exit path from host start onward — success, the nameInUse early-exit, cooperative
+        // shutdown cancelling an in-flight startup await (including host.StartAsync itself: a
+        // hosted service still starting when SIGTERM lands surfaces the cancellation as
+        // TaskCanceledException out of StartAsync — dotnet/runtime#111013 behavior), OR any
+        // startup exception — MUST run the unified teardown so DisposeHostAsync(host) fires and
+        // the process can actually exit instead of hanging or aborting: once the orchestrator is
+        // resolved, the Unix IPtyProcessFactory has pulled in UnixSpawnerThread, whose foreground
+        // (non-background) OS thread parks forever until the ServiceProvider is disposed.
+        // Structural fix; backed by DaemonHostDisposalTests.
+        var startupExit = await RunGuardedStartupAsync(
+            logger,
+            lifetime.ApplicationStopping,
+            startupAndWait: async () => {
+                // Start hosted services (LocalPermissionBridge in particular) BEFORE the SignalR
+                // connection comes up. Otherwise an early LaunchAgent message can arrive while
+                // BaseUrl is still null and the spawned Claude falls back to the HTTPS path —
+                // exactly what this bridge is meant to avoid.
+                await host.StartAsync(lifetime.ApplicationStopping);
 
-        // Once the orchestrator is resolved, the Unix IPtyProcessFactory has pulled in
-        // UnixSpawnerThread — whose foreground (non-background) OS thread is now running and
-        // parks forever until the ServiceProvider is disposed (host.StopAsync() alone does NOT
-        // retire it; see the block comment in the finally below). So EVERY exit path from here on
-        // — success, the nameInUse early-return, OR any exception out of ReapOrphansOnceAsync,
-        // ConnectAsync (non-nameInUse), CleanupOrphanedAsync, or EvalRunner resolution — MUST run
-        // the unified finally so DisposeHostAsync(host) fires and the process can actually exit
-        // instead of hanging. That is why everything below is wrapped in this single try/finally.
-        // Structural fix; backed by DaemonHostDisposalTests, which proves StopAsync-then-dispose
-        // is what retires the DI-owned UnixSpawnerThread.
-        try {
-            // Phase B (D4 §6.4(3)): reap any hosted-agent children that outlived a PRIOR daemon run
-            // BEFORE ConnectAsync advertises this daemon (see the orchestrator-resolution comment
-            // above). Under the daemon lock; best-effort (swallows its own faults).
-            await orchestrator.ReapOrphansOnceAsync();
+                // Phase B (D4 §6.4(3)): resolve the orchestrator (which wires OnLaunchAgent +
+                // GetLiveAgents in its ctor) and reap any hosted-agent children that outlived a
+                // PRIOR daemon run — all BEFORE ConnectAsync advertises this daemon and the server
+                // can dispatch launches. Doing it after connect would let new work be admitted
+                // while old capacity is still being reclaimed (those survivors aren't yet in
+                // EffectiveCount), and would leave a window where a launch races an unwired
+                // handler. Under the daemon lock; best-effort (swallows its own faults).
+                orchestrator = host.Services.GetRequiredService<AgentOrchestrator>();
+                await orchestrator.ReapOrphansOnceAsync();
 
-            try {
-                await connection.ConnectAsync(lifetime.ApplicationStopping);
-            } catch (Exception ex) when (nameInUse) {
-                // ConnectAsync's initial-connect path threw because of NameInUse. OnNameInUse
-                // already fired and set our flag; the host hasn't started its main loop yet, so
-                // just exit with code 3 — the unified finally below disposes daemonLock,
-                // orchestrator, connection, and the host (retiring the spawner thread).
-                _ = ex;
+                try {
+                    await connection.ConnectAsync(lifetime.ApplicationStopping);
+                } catch (Exception ex) when (nameInUse) {
+                    // ConnectAsync's initial-connect path threw because of NameInUse. OnNameInUse
+                    // already fired and set our flag; the host hasn't started its main loop yet,
+                    // so just exit with code 3 — the unified teardown below disposes daemonLock,
+                    // orchestrator, connection, and the host (retiring the spawner thread).
+                    _ = ex;
 
-                return 3;
-            }
+                    return 3;
+                }
 
-            var worktreeManager = host.Services.GetRequiredService<WorktreeManager>();
-            await worktreeManager.CleanupOrphanedAsync();
+                var worktreeManager = host.Services.GetRequiredService<WorktreeManager>();
+                await worktreeManager.CleanupOrphanedAsync();
 
-            // Instantiate EvalRunner so it wires the per-phase eval handlers
-            // (PrepareEval / RunQuestion / FinalizeEval / CancelEval) on the
-            // ServerConnection. It's stateless beyond the handler assignment —
-            // cached context lives in EvalContextCache — so no disposal dance.
-            _ = host.Services.GetRequiredService<EvalRunner>();
+                // Instantiate EvalRunner so it wires the per-phase eval handlers
+                // (PrepareEval / RunQuestion / FinalizeEval / CancelEval) on the
+                // ServerConnection. It's stateless beyond the handler assignment —
+                // cached context lives in EvalContextCache — so no disposal dance.
+                _ = host.Services.GetRequiredService<EvalRunner>();
 
-            // Wait without passing the lifetime token: WaitForShutdownAsync(token) treats
-            // token cancellation as a fault, so a normal Ctrl+C / lifetime.StopApplication()
-            // would surface as OperationCanceledException. The no-arg overload listens
-            // internally for ApplicationStopping and returns cleanly.
-            await host.WaitForShutdownAsync();
-            LogWaitForShutdownReturned(logger);
-        } catch (OperationCanceledException) when (lifetime.ApplicationStopping.IsCancellationRequested) {
-            // Cooperative shutdown (SIGTERM/Ctrl+C) arrived while one of the startup awaits above
-            // was still in flight — most commonly the initial ConnectAsync retry loop when the
-            // server is unreachable. The cancellation IS the requested shutdown, not a fault:
-            // swallow it so it can't escape Main and abort the NativeAOT process (SIGABRT + .ips),
-            // and fall through to the normal exit-code selection below. A cancellation with no
-            // shutdown requested still propagates (fail-loud preserved).
-            LogStartupCancelledByShutdown(logger);
-        } finally {
-            LogEnteringCleanup(logger);
+                // Wait without passing the lifetime token: WaitForShutdownAsync(token) treats
+                // token cancellation as a fault, so a normal Ctrl+C / lifetime.StopApplication()
+                // would surface as OperationCanceledException. The no-arg overload listens
+                // internally for ApplicationStopping and returns cleanly.
+                await host.WaitForShutdownAsync();
+                LogWaitForShutdownReturned(logger);
 
-            // Each teardown step runs through RunTeardownAsync so a throw (e.g. a disposal
-            // ObjectDisposedException) is logged and contained instead of escaping this finally —
-            // under NativeAOT an escaped teardown exception aborts the process (SIGABRT) — and so
-            // every later step still runs (a skipped host-dispose would leave the DI-owned
-            // UnixSpawnerThread's foreground thread parked forever). Do NOT reorder the steps:
-            // the explicit-dispose-before-host-stop sequence is load-bearing (spawner-thread
-            // retirement, pinned by DaemonHostDisposalTests).
-            //
-            // LIMITATION: the coordinator contains a throw from each STEP, but it cannot make the
-            // DI container's own dispose walk (inside DisposeHostAsync) resilient — a tracked
-            // singleton whose Dispose/DisposeAsync throws still aborts the container's INTERNAL
-            // walk partway, silently skipping the remaining singletons. The helper prevents the
-            // process abort, not partial DI disposal; each disposable must still contain its own
-            // failures (ServerConnection and AgentOrchestrator now do).
-            //
-            // Structural double-teardown sweep (explicit dispose here + a second framework-driven
-            // dispose of the SAME instance) and why each shape is safe today:
-            //   - ServerConnection / AgentOrchestrator: run-once dispose guards (this change).
-            //   - DaemonLock: disposed explicitly here AND DI-tracked; its Dispose is
-            //     idempotent (releases the handle once, subsequent calls no-op).
-            //   - RestartCoordinator / LocalControlServer: concrete singleton + same-instance
-            //     AddHostedService registration — the host stops them once and the container
-            //     disposes the single instance once; BackgroundService.Dispose is safe to
-            //     re-enter under the current Microsoft.Extensions.Hosting behavior (it only
-            //     cancels/disposes its stopping CTS) — a framework-version assumption.
-            //
-            // host.StopAsync() only STOPS IHostedServices — it does NOT dispose the
-            // ServiceProvider, so a plain AddSingleton<T>() IDisposable (e.g.
-            // UnixSpawnerThread, whose foreground, non-background OS thread parks
-            // forever on its queue until Dispose() completes it) is never released by
-            // StopAsync alone. Disposing the host is what disposes the ServiceProvider —
-            // and therefore every registered IDisposable singleton — so it must run
-            // after StopAsync on every shutdown path or the spawner thread's foreground
-            // thread keeps the process alive past WaitForShutdownAsync forever.
-            var allStepsSucceeded = await RunTeardownAsync(logger, [
-                ("daemon-lock",       () => { daemonLock.Dispose(); return ValueTask.CompletedTask; }),
-                ("orchestrator",      orchestrator.DisposeAsync),
-                ("server-connection", connection.DisposeAsync),
-                ("host-stop",         async () => await host.StopAsync()),
-                ("host-dispose",      async () => await DisposeHostAsync(host))
-            ]);
+                return null;
+            },
+            teardown: () => RunDaemonTeardownAsync(logger, daemonLock, orchestrator, connection, host));
 
-            // A partial teardown failure is summarized but deliberately does NOT change the exit
-            // code: the process was already exiting (normally 0), and turning a contained cleanup
-            // fault into a non-zero exit would make supervisors (systemd/launchd restart-on-
-            // failure) relaunch a daemon the user just stopped.
-            if (!allStepsSucceeded) LogTeardownPartialFailure(logger);
-
-            LogCleanupCompleted(logger);
-        }
+        if (startupExit is { } earlyExit) return earlyExit;
 
         // Restart-after-update (supervised): exit non-zero so the unit's
         // failure-restart policy relaunches the now-updated binary.
@@ -612,6 +560,115 @@ public static partial class DaemonRunner {
             host.Dispose();
         }
     }
+
+    /// <summary>
+    /// The guarded startup skeleton around the daemon's whole start→wait lifecycle: runs
+    /// <paramref name="startupAndWait"/>, converts a cancellation observed while cooperative
+    /// shutdown was already requested into a clean exit (SIGTERM/Ctrl+C during host start or the
+    /// initial connect-retry loop otherwise escapes <c>Main</c> and aborts the NativeAOT process
+    /// — SIGABRT + an .ips crash report), and ALWAYS runs <paramref name="teardown"/>, logging a
+    /// summary line on partial teardown failure. A cancellation with no shutdown requested still
+    /// propagates (fail-loud preserved). Returns <paramref name="startupAndWait"/>'s early-exit
+    /// code, or null to fall through to the caller's normal exit-code selection — deliberately
+    /// unchanged by teardown failures: the process was already exiting (normally 0), and turning
+    /// a contained cleanup fault into a non-zero exit would make supervisors (systemd/launchd
+    /// restart-on-failure) relaunch a daemon the user just stopped. <c>internal</c> so
+    /// <c>DaemonHostDisposalTests</c> can pin the cancellation-during-host-start contract.
+    /// </summary>
+    internal static async Task<int?> RunGuardedStartupAsync(
+            ILogger           logger,
+            CancellationToken stopping,
+            Func<Task<int?>>  startupAndWait,
+            Func<Task<bool>>  teardown) {
+        try {
+            return await startupAndWait();
+        } catch (OperationCanceledException) when (stopping.IsCancellationRequested) {
+            LogStartupCancelledByShutdown(logger);
+
+            return null;
+        } finally {
+            LogEnteringCleanup(logger);
+
+            if (!await teardown()) LogTeardownPartialFailure(logger);
+
+            LogCleanupCompleted(logger);
+        }
+    }
+
+    /// <summary>
+    /// The daemon's production teardown: the six real steps, in order, run through
+    /// <see cref="RunTeardownAsync"/>. One shared step list (see
+    /// <see cref="BuildDaemonTeardownSteps"/>) so the sequencing tests drive EXACTLY what
+    /// <c>RunAsync</c> executes — a divergence (reordered/removed step) fails the tests.
+    /// </summary>
+    internal static Task<bool> RunDaemonTeardownAsync(
+            ILogger           logger,
+            IDisposable       daemonLock,
+            IAsyncDisposable? orchestrator,
+            IAsyncDisposable  connection,
+            IHost             host)
+        => RunTeardownAsync(logger, BuildDaemonTeardownSteps(daemonLock, orchestrator, connection, host));
+
+    /// <summary>
+    /// Builds the production teardown step list. Do NOT reorder: the explicit-dispose-before-
+    /// host-stop sequence is load-bearing (spawner-thread retirement, pinned by
+    /// <c>DaemonHostDisposalTests</c>). <paramref name="orchestrator"/> is nullable because
+    /// cooperative shutdown can land before it was ever resolved (mid <c>host.StartAsync</c>);
+    /// host disposal still releases whatever WAS partially resolved.
+    ///
+    /// LIMITATION: <see cref="RunTeardownAsync"/> contains a throw from each STEP, but it cannot
+    /// make the DI container's own dispose walk (inside <see cref="DisposeHostAsync"/>) resilient
+    /// — a tracked singleton whose Dispose/DisposeAsync throws still aborts the container's
+    /// INTERNAL walk partway, silently skipping the remaining singletons. The helper prevents the
+    /// process abort, not partial DI disposal; each disposable must still contain its own
+    /// failures (ServerConnection and AgentOrchestrator now do). The one skip that could strand
+    /// the process — <see cref="UnixSpawnerThread"/>, whose Dispose retires the FOREGROUND thread
+    /// that otherwise keeps a "shut down" daemon alive forever — is closed by the dedicated
+    /// spawner-retire step below, which runs BEFORE host disposal.
+    ///
+    /// Structural double-teardown sweep (explicit dispose here + a framework-driven dispose of
+    /// the SAME instance) and why each shape is safe today:
+    ///   • ServerConnection / AgentOrchestrator / UnixSpawnerThread: run-once dispose guards.
+    ///   • DaemonLock: disposed explicitly here AND DI-tracked; its Dispose is idempotent
+    ///     (releases the handle once, subsequent calls no-op).
+    ///   • RestartCoordinator / LocalControlServer / LocalPermissionBridge: registered through
+    ///     TWO singleton descriptors each (<c>AddSingleton&lt;T&gt;()</c> + an
+    ///     <c>AddHostedService</c> factory resolving the same instance). Microsoft DI tracks
+    ///     disposables per DESCRIPTOR and does not de-duplicate by reference, so the container's
+    ///     dispose walk visits each such instance TWICE (LocalPermissionBridge's own
+    ///     <c>_disposed</c> doc documents exactly this). LocalPermissionBridge carries its own
+    ///     run-once guard; RestartCoordinator and LocalControlServer inherit
+    ///     <c>BackgroundService.Dispose</c>, which is safe to re-enter under the current
+    ///     Microsoft.Extensions.Hosting behavior (it only cancels its stopping CTS) — a
+    ///     framework-version assumption.
+    ///
+    /// host-stop/host-dispose stay split because <c>host.StopAsync()</c> only STOPS
+    /// IHostedServices — it does NOT dispose the ServiceProvider, so a plain
+    /// <c>AddSingleton&lt;T&gt;()</c> IDisposable is never released by StopAsync alone; disposing
+    /// the host is what disposes the ServiceProvider and therefore every registered singleton.
+    /// </summary>
+    internal static (string Name, Func<ValueTask> Action)[] BuildDaemonTeardownSteps(
+            IDisposable       daemonLock,
+            IAsyncDisposable? orchestrator,
+            IAsyncDisposable  connection,
+            IHost             host) => [
+        ("daemon-lock",       () => { daemonLock.Dispose(); return ValueTask.CompletedTask; }),
+        ("orchestrator",      () => orchestrator?.DisposeAsync() ?? ValueTask.CompletedTask),
+        ("server-connection", connection.DisposeAsync),
+        // Retire the spawner thread EXPLICITLY, before host disposal, so even a DI walk aborted
+        // partway by some other singleton's throwing Dispose cannot strand its foreground thread
+        // (and with it the whole process). Idempotent — the host-dispose walk disposing the same
+        // instance again is a no-op. GetService instantiates a never-yet-created singleton
+        // (thread start + immediate join — cheap and deterministic) rather than probing; returns
+        // null on Windows, where the type is not registered.
+        ("spawner-retire",    () => {
+            host.Services.GetService<UnixSpawnerThread>()?.Dispose();
+
+            return ValueTask.CompletedTask;
+        }),
+        ("host-stop",         async () => await host.StopAsync()),
+        ("host-dispose",      async () => await DisposeHostAsync(host))
+    ];
 
     /// <summary>
     /// Teardown coordinator for the shutdown finally-block: runs each named step in the given

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -519,6 +519,14 @@ public static partial class DaemonRunner {
             // internally for ApplicationStopping and returns cleanly.
             await host.WaitForShutdownAsync();
             LogWaitForShutdownReturned(logger);
+        } catch (OperationCanceledException) when (lifetime.ApplicationStopping.IsCancellationRequested) {
+            // Cooperative shutdown (SIGTERM/Ctrl+C) arrived while one of the startup awaits above
+            // was still in flight — most commonly the initial ConnectAsync retry loop when the
+            // server is unreachable. The cancellation IS the requested shutdown, not a fault:
+            // swallow it so it can't escape Main and abort the NativeAOT process (SIGABRT + .ips),
+            // and fall through to the normal exit-code selection below. A cancellation with no
+            // shutdown requested still propagates (fail-loud preserved).
+            LogStartupCancelledByShutdown(logger);
         } finally {
             LogEnteringCleanup(logger);
 
@@ -558,8 +566,8 @@ public static partial class DaemonRunner {
             // thread keeps the process alive past WaitForShutdownAsync forever.
             var allStepsSucceeded = await RunTeardownAsync(logger, [
                 ("daemon-lock",       () => { daemonLock.Dispose(); return ValueTask.CompletedTask; }),
-                ("orchestrator",      () => orchestrator.DisposeAsync()),
-                ("server-connection", () => connection.DisposeAsync()),
+                ("orchestrator",      orchestrator.DisposeAsync),
+                ("server-connection", connection.DisposeAsync),
                 ("host-stop",         async () => await host.StopAsync()),
                 ("host-dispose",      async () => await DisposeHostAsync(host))
             ]);
@@ -885,6 +893,9 @@ public static partial class DaemonRunner {
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Teardown step '{Step}' failed; continuing shutdown")]
     static partial void LogTeardownStepFailed(ILogger logger, Exception ex, string step);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Shutdown requested during startup; cancelling the in-flight startup step and exiting cleanly")]
+    static partial void LogStartupCancelledByShutdown(ILogger logger);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Cleanup: one or more teardown steps failed (see warnings above); daemon exiting anyway with its normal exit code")]
     static partial void LogTeardownPartialFailure(ILogger logger);

--- a/src/Capacitor.Cli.Daemon/Pty/Unix/UnixSpawnerThread.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Unix/UnixSpawnerThread.cs
@@ -30,6 +30,13 @@ public sealed class UnixSpawnerThread : IDisposable {
     volatile bool                             _stopping;
     volatile bool                             _testCrashRequested;
 
+    /// <summary>Guards <see cref="Dispose"/> so its body runs exactly once: the daemon's explicit
+    /// spawner-retire teardown step disposes this instance BEFORE the host-dispose DI walk visits
+    /// the same singleton again, and the second pass would otherwise call
+    /// <see cref="BlockingCollection{T}.CompleteAdding"/> on the already-disposed queue
+    /// (ObjectDisposedException).</summary>
+    int _disposeOnce;
+
     public UnixSpawnerThread() {
         _thread = new Thread(RunLoop) { IsBackground = false, Name = "kcap-unix-spawner" };
         _thread.Start();
@@ -101,6 +108,8 @@ public sealed class UnixSpawnerThread : IDisposable {
     /// deliberately do NOT dispose <c>_queue</c> (leaving it to process exit) rather than free it
     /// under a thread that may still touch it.</summary>
     public void Dispose() {
+        if (Interlocked.Exchange(ref _disposeOnce, 1) != 0) return;
+
         _stopping = true;
         _queue.CompleteAdding();
         // Bound comfortably above the native worst case (~30s handshake + kill/reap). Only

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3108,6 +3108,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 await _shutdownCts.CancelAsync();
             } catch (ObjectDisposedException) {
                 // Already torn down elsewhere — nothing left to cancel.
+            } catch (Exception ex) {
+                // A registered cancellation callback that throws faults the returned task
+                // (AggregateException per the CTS contract) even though the cancel itself
+                // succeeded. Uncontained, that fault would skip the processor drain and ALL
+                // child termination/cleanup below — and the run-once guard means the DI pass
+                // can never retry, stranding live child processes. Log and continue.
+                LogDisposeStepFailed(ex, "shutdown-cancel");
             }
 
             // Drain and settle the execution lane BEFORE the child-teardown snapshot below. The token

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -363,6 +363,23 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     readonly CancellationTokenSource _shutdownCts;
     readonly LaunchConsentGate _consentGate;
 
+    /// <summary>Guards <see cref="DisposeAsync"/> so its body runs exactly once — the DI
+    /// container tracks this singleton AND <c>DaemonRunner</c> disposes it explicitly, so
+    /// DisposeAsync runs twice by construction on every shutdown. Without the guard, disposing
+    /// <see cref="_shutdownCts"/> would make the second pass throw ObjectDisposedException into
+    /// DI teardown (NativeAOT: unhandled → abort()).</summary>
+    int _disposeOnce;
+
+    /// <summary>Counts entries into the <see cref="DisposeAsync"/> body (post-guard). Test seam:
+    /// proves durably that a second dispose did NOT re-enter the body.</summary>
+    int _disposeBodyRuns;
+
+    internal int DisposeBodyRuns => Volatile.Read(ref _disposeBodyRuns);
+
+    /// <summary>Test seam: the shutdown CTS, so tests can assert it ends cancelled AND disposed
+    /// after the first dispose pass (removal of the Dispose call fails the suite).</summary>
+    internal CancellationTokenSource ShutdownCtsForTests => _shutdownCts;
+
     public AgentOrchestrator(
             DaemonConfig                                      config,
             ServerConnection                                  server,
@@ -3070,50 +3087,94 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     }
 
     public async ValueTask DisposeAsync() {
-        // §3.3: close the execution lane to new work FIRST — before anything else, and without waiting for
-        // anything. Order matters: cancelling the shutdown token below releases whatever the in-flight item
-        // was waiting on (a consent prompt, say), and if the lane were still open at that moment it would
-        // simply move on to the queued per-agent stops and run them against children the teardown below is
-        // already killing. Closing the door first is what makes the supersession deterministic rather than a
-        // race. The drain and the terminal settlement of accepted sequenced items happen in the processor's
-        // own DisposeAsync at the very end of this method.
-        Processor?.StopAcceptingForShutdown();
+        if (Interlocked.Exchange(ref _disposeOnce, 1) != 0) return;
 
-        await _shutdownCts.CancelAsync();
+        Interlocked.Increment(ref _disposeBodyRuns);
 
-        // Drain and settle the execution lane BEFORE the child-teardown snapshot below. The token
-        // cancellation above aborts a consent-parked launch promptly, but a launch that already
-        // passed consent keeps running to registration — and if the lane settled AFTER the
-        // enumeration, that late-registered child would miss teardown and survive graceful
-        // shutdown (the next-boot PID scan is a recovery backstop, not a substitute). The
-        // supersession semantics are unaffected: _closed was set first, so every queued item
-        // still settles (sequenced) or discards (un-sequenced) in the drain arm regardless of
-        // when the drain runs.
-        if (Processor is { } lane) await lane.DisposeAsync();
+        // Faultable awaits below are each contained + logged individually so one failure can't
+        // skip its siblings or the mandatory resource release in the finally — a disposal path
+        // must never throw into DI teardown (NativeAOT: unhandled → abort()).
+        try {
+            // §3.3: close the execution lane to new work FIRST — before anything else, and without waiting for
+            // anything. Order matters: cancelling the shutdown token below releases whatever the in-flight item
+            // was waiting on (a consent prompt, say), and if the lane were still open at that moment it would
+            // simply move on to the queued per-agent stops and run them against children the teardown below is
+            // already killing. Closing the door first is what makes the supersession deterministic rather than a
+            // race. The drain and the terminal settlement of accepted sequenced items happen in the processor's
+            // own DisposeAsync at the very end of this method.
+            Processor?.StopAcceptingForShutdown();
 
-        foreach (var agent in _agents.Values.Where(a => a.Status is "Starting" or "Running")) {
             try {
-                await agent.ReadCts.CancelAsync();
-                await agent.Runtime.TerminateAsync(TimeSpan.FromSeconds(5));
-            } catch {
-                /* best-effort */
+                await _shutdownCts.CancelAsync();
+            } catch (ObjectDisposedException) {
+                // Already torn down elsewhere — nothing left to cancel.
+            }
+
+            // Drain and settle the execution lane BEFORE the child-teardown snapshot below. The token
+            // cancellation above aborts a consent-parked launch promptly, but a launch that already
+            // passed consent keeps running to registration — and if the lane settled AFTER the
+            // enumeration, that late-registered child would miss teardown and survive graceful
+            // shutdown (the next-boot PID scan is a recovery backstop, not a substitute). The
+            // supersession semantics are unaffected: _closed was set first, so every queued item
+            // still settles (sequenced) or discards (un-sequenced) in the drain arm regardless of
+            // when the drain runs.
+            try {
+                if (Processor is { } lane) await lane.DisposeAsync();
+            } catch (Exception ex) {
+                LogDisposeStepFailed(ex, "processor-drain");
+            }
+
+            foreach (var agent in _agents.Values.Where(a => a.Status is "Starting" or "Running")) {
+                try {
+                    await agent.ReadCts.CancelAsync();
+                    await agent.Runtime.TerminateAsync(TimeSpan.FromSeconds(5));
+                } catch {
+                    /* best-effort */
+                }
+            }
+
+            foreach (var agentId in _agents.Keys.ToList()) {
+                try {
+                    await CleanupAgentAsync(agentId);
+                } catch (Exception ex) {
+                    LogCleanupStepFailed(ex, "final cleanup", agentId);
+                }
+            }
+        } finally {
+            // Mandatory release — runs even if a step above threw, each step individually
+            // guarded so one failure can't skip the rest.
+            try {
+                _heartbeatTimer.Dispose();
+                _daemonHeartbeat.Dispose();
+                _tokenRefresh.Dispose();
+                _spoolDrain.Dispose();
+            } catch (Exception ex) {
+                LogDisposeStepFailed(ex, "timers");
+            }
+
+            // The execution lane was drained and settled above, before the child-teardown snapshot;
+            // this second call is a no-op (DisposeAsync is idempotent) kept as belt-and-braces for
+            // any future early-return path added between the two.
+            try {
+                if (Processor is { } proc) await proc.DisposeAsync();
+            } catch (Exception ex) {
+                LogDisposeStepFailed(ex, "processor");
+            }
+
+            // LAST: the shutdown CTS is disposed only after every token-dependent step above
+            // (the agent-teardown loop, the lane drain and the timer-driven loops all use its
+            // token). It stays readonly — the run-once guard, not a null-swap, is what makes
+            // this safe against the structural double dispose.
+            try {
+                _shutdownCts.Dispose();
+            } catch (Exception ex) {
+                LogDisposeStepFailed(ex, "shutdown-cts");
             }
         }
-
-        foreach (var agentId in _agents.Keys.ToList()) {
-            await CleanupAgentAsync(agentId);
-        }
-
-        _heartbeatTimer.Dispose();
-        _daemonHeartbeat.Dispose();
-        _tokenRefresh.Dispose();
-        _spoolDrain.Dispose();
-
-        // The execution lane was drained and settled above, before the child-teardown snapshot;
-        // this second call is a no-op (DisposeAsync is idempotent) kept as belt-and-braces for
-        // any future early-return path added between the two.
-        if (Processor is { } proc) await proc.DisposeAsync();
     }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AgentOrchestrator dispose step '{Step}' failed; continuing shutdown")]
+    partial void LogDisposeStepFailed(Exception ex, string step);
 
     /// <summary>
     /// Extracts readable text from the terminal output buffer by decoding UTF-8

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -340,6 +340,32 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     volatile bool     _disposed;
     Task?             _eventProcessorTask;
 
+    /// <summary>
+    /// Guards <see cref="DisposeAsync"/> so its body runs exactly once — the DI container tracks
+    /// this singleton AND <c>DaemonRunner</c> disposes it explicitly, so DisposeAsync runs twice
+    /// by construction on every shutdown. Distinct from <see cref="_disposed"/>, which is a
+    /// live-path flag read by <see cref="OnClosed"/>.
+    /// </summary>
+    int _disposeOnce;
+
+    /// <summary>Counts entries into the <see cref="DisposeAsync"/> body (post-guard). Test seam:
+    /// proves durably that a second dispose did NOT re-enter the body, so removal of the run-once
+    /// guard fails a suite test permanently rather than only a one-off mutation check.</summary>
+    int _disposeBodyRuns;
+
+    internal int DisposeBodyRuns => Volatile.Read(ref _disposeBodyRuns);
+
+    /// <summary>Test seam: the terminal-sender CTS, so tests can assert it ends cancelled AND
+    /// disposed after the first dispose pass (removal of the Dispose call fails the suite).</summary>
+    internal CancellationTokenSource? TerminalSenderCtsForTests => _terminalSenderCts;
+
+    /// <summary>Test seam: lets a test swap in a faulting awaited task and assert the failure is
+    /// contained + logged while the mandatory resource release still runs.</summary>
+    internal Task? EventProcessorTaskForTests {
+        get => _eventProcessorTask;
+        set => _eventProcessorTask = value;
+    }
+
     readonly TerminalOutputSender    _terminalSender;
     Task?                            _terminalSenderTask;
     CancellationTokenSource?         _terminalSenderCts;
@@ -1205,28 +1231,71 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     record PendingEvent(string AgentId, object Event);
 
     public async ValueTask DisposeAsync() {
-        _disposed = true;
-        _eventChannel.Writer.TryComplete();
-        _terminalSender.Complete();
+        if (Interlocked.Exchange(ref _disposeOnce, 1) != 0) return;
 
-        if (_eventProcessorTask is not null) {
-            await _eventProcessorTask;
+        Interlocked.Increment(ref _disposeBodyRuns);
+
+        _disposed = true; // live-path flag read by OnClosed — separate from the run-once guard
+
+        var cts = _terminalSenderCts;
+
+        try {
+            // Faultable awaits — each contained + logged individually so one faulted pipeline
+            // task can't skip its sibling or the mandatory resource release in the finally below.
+            // A disposal path must never throw into DI teardown (NativeAOT: unhandled → abort()).
+            try {
+                _eventChannel.Writer.TryComplete();
+                _terminalSender.Complete();
+
+                if (_eventProcessorTask is not null) {
+                    await _eventProcessorTask;
+                }
+            } catch (Exception ex) {
+                LogDisposeStepFailed(ex, "event-processor");
+            }
+
+            try {
+                // Cancel the sender's own token so a chunk being held through an outage
+                // can't block disposal regardless of the caller's token state.
+                if (cts is not null) {
+                    try {
+                        await cts.CancelAsync();
+                    } catch (ObjectDisposedException) {
+                        // Already torn down elsewhere — nothing left to cancel.
+                    }
+                }
+
+                if (_terminalSenderTask is not null) {
+                    await _terminalSenderTask;
+                }
+            } catch (Exception ex) {
+                LogDisposeStepFailed(ex, "terminal-sender");
+            }
+        } finally {
+            // Mandatory release — each step individually guarded so one failure can't skip the
+            // rest, and nothing here can throw into DI teardown.
+            try {
+                cts?.Dispose();
+            } catch (Exception ex) {
+                LogDisposeStepFailed(ex, "terminal-sender-cts");
+            }
+
+            try {
+                _httpClient?.Dispose();
+            } catch (Exception ex) {
+                LogDisposeStepFailed(ex, "http-client");
+            }
+
+            try {
+                await _hub.DisposeAsync();
+            } catch (Exception ex) {
+                LogDisposeStepFailed(ex, "hub");
+            }
         }
-
-        // Cancel the sender's own token so a chunk being held through an outage
-        // can't block disposal regardless of the caller's token state.
-        if (_terminalSenderCts is not null) {
-            await _terminalSenderCts.CancelAsync();
-        }
-
-        if (_terminalSenderTask is not null) {
-            await _terminalSenderTask;
-        }
-
-        _terminalSenderCts?.Dispose();
-        _httpClient?.Dispose();
-        await _hub.DisposeAsync();
     }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ServerConnection dispose step '{Step}' failed; continuing shutdown")]
+    partial void LogDisposeStepFailed(Exception ex, string step);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Daemon name '{Name}' is already in use by another live daemon on this account. Server rejected DaemonConnect: {Reason}")]
     partial void LogNameInUse(string name, string reason);

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorDisposeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorDisposeTests.cs
@@ -42,6 +42,33 @@ public partial class AgentOrchestratorVendorTests {
     }
 
     [Test]
+    public async Task A_faulting_cancellation_callback_does_not_skip_child_teardown() {
+        var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+
+        var runtime = new FakeHostedAgentRuntime("claude", emitsTerminalOutput: false);
+        orch.RegisterAgentForTest(new AgentInstance(
+            "agent-cb", null, "", null, "/tmp", "claude", runtime,
+            new WorktreeInfo("/tmp", "", "/tmp", IsStandalone: true), new CancellationTokenSource()));
+
+        // A registered cancellation callback that throws faults CancelAsync's returned task
+        // (AggregateException per the CTS contract) even though the cancel itself succeeded.
+        // Uncontained, that fault would jump straight to the dispose finally — skipping the
+        // processor drain and ALL child termination/cleanup — and the run-once guard means the
+        // DI pass can never retry, stranding live child processes.
+        orch.ShutdownCtsForTests.Token.Register(() => throw new InvalidOperationException("callback boom"));
+
+        await orch.DisposeAsync(); // must not throw
+
+        // Containment proof: teardown continued past the faulted cancel — the child was
+        // terminated, and the finally still cancelled+disposed the CTS.
+        await Assert.That(runtime.HasExited).IsTrue();
+        await Assert.That(orch.ShutdownCtsForTests.IsCancellationRequested).IsTrue();
+        await Assert.That(() => _ = orch.ShutdownCtsForTests.Token).Throws<ObjectDisposedException>();
+    }
+
+    [Test]
     public async Task Orchestrator_dispose_cancels_and_disposes_its_shutdown_cts() {
         var orch = BuildOrchestrator(
             new CaptureServerConnection(), new SpyPtyProcessFactory(),

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorDisposeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorDisposeTests.cs
@@ -1,0 +1,63 @@
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// <see cref="AgentOrchestrator.DisposeAsync"/> must be idempotent and non-throwing: the DI
+/// container tracks the singleton AND <c>DaemonRunner</c> disposes it explicitly, so it runs
+/// twice by construction on every shutdown — the same structural double-teardown that crashed
+/// <see cref="ServerConnection"/> (an ObjectDisposedException escaping into DI teardown aborts
+/// a NativeAOT process). The orchestrator's <c>_shutdownCts</c> was also never disposed; adding
+/// that Dispose without a run-once guard would recreate the crash exactly, so these contracts
+/// pin body-ran-once AND cts-ends-cancelled-and-disposed durably.
+///
+/// Partial of <see cref="AgentOrchestratorVendorTests"/> to reuse its orchestrator builder and
+/// server-connection capture.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Orchestrator_dispose_twice_does_not_throw() {
+        var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+
+        await orch.DisposeAsync();
+        // Pass 2 = the DI container's dispose walk re-entering after DaemonRunner's explicit call.
+        await orch.DisposeAsync();
+        // Reaching here without ObjectDisposedException is the assertion.
+    }
+
+    [Test]
+    public async Task Orchestrator_second_dispose_does_not_reenter_the_body() {
+        var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+
+        await orch.DisposeAsync();
+        await orch.DisposeAsync();
+
+        // Durable run-once contract: removal of the guard fails this permanently — the naive
+        // double-dispose test above passes vacuously against an unguarded-but-undisposing body.
+        await Assert.That(orch.DisposeBodyRuns).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Orchestrator_dispose_cancels_and_disposes_its_shutdown_cts() {
+        var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+
+        var cts = orch.ShutdownCtsForTests;
+
+        await orch.DisposeAsync();
+
+        // Cancelled (IsCancellationRequested is safe to read post-dispose) AND disposed (the
+        // Token property throws once the source is disposed) — removal of the Dispose call
+        // fails this permanently.
+        await Assert.That(cts.IsCancellationRequested).IsTrue();
+        await Assert.That(() => _ = cts.Token).Throws<ObjectDisposedException>();
+
+        // And a second pass over the now-disposed CTS must not throw.
+        await orch.DisposeAsync();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonHostDisposalTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonHostDisposalTests.cs
@@ -3,6 +3,8 @@ using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Pty.Unix;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
@@ -62,5 +64,79 @@ public class DaemonHostDisposalTests {
         var builder = Host.CreateApplicationBuilder();
         builder.Services.AddSingleton<UnixSpawnerThread>();
         return builder.Build();
+    }
+
+    // ---- Teardown coordinator (DaemonRunner.RunTeardownAsync) ----
+    // The daemon's finally-block teardown must never let one failing step (e.g. a disposal
+    // throwing ObjectDisposedException) skip the later steps: under NativeAOT an escaped
+    // teardown exception aborts the process (SIGABRT), and a skipped host-dispose leaves the
+    // DI-owned UnixSpawnerThread's foreground thread parked forever.
+
+    /// <summary>The production teardown step names, in the load-bearing order (explicit
+    /// dispose before host stop — spawner-thread retirement, pinned by the tests above).</summary>
+    static readonly string[] ProductionSteps =
+        ["daemon-lock", "orchestrator", "server-connection", "host-stop", "host-dispose"];
+
+    sealed class CaptureLogger : ILogger {
+        public List<string> Messages { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            => Messages.Add(formatter(state, exception));
+    }
+
+    [Test]
+    public async Task Teardown_steps_run_in_the_exact_given_order_and_report_success() {
+        var ran = new List<string>();
+
+        var steps = new List<(string Name, Func<ValueTask> Action)>();
+
+        foreach (var name in ProductionSteps) {
+            steps.Add((name, () => { ran.Add(name); return ValueTask.CompletedTask; }));
+        }
+
+        var ok = await DaemonRunner.RunTeardownAsync(NullLogger.Instance, steps);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(string.Join(",", ran)).IsEqualTo(string.Join(",", ProductionSteps));
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(3)]
+    [Arguments(4)]
+    public async Task A_throwing_step_at_any_position_does_not_prevent_later_steps(int throwAt) {
+        var ran = new List<string>();
+        var log = new CaptureLogger();
+
+        var steps = new List<(string Name, Func<ValueTask> Action)>();
+
+        for (var i = 0; i < ProductionSteps.Length; i++) {
+            var name = ProductionSteps[i];
+            var idx  = i;
+
+            steps.Add((name, () => {
+                if (idx == throwAt) throw new ObjectDisposedException(name);
+
+                ran.Add(name);
+
+                return ValueTask.CompletedTask;
+            }));
+        }
+
+        var ok = await DaemonRunner.RunTeardownAsync(log, steps);
+
+        // Every step after (and before) the throwing one still ran, in order.
+        await Assert.That(ok).IsFalse();
+        await Assert.That(string.Join(",", ran))
+            .IsEqualTo(string.Join(",", ProductionSteps.Where((_, i) => i != throwAt)));
+
+        // The failing step is named in the log so an operator can tell WHICH disposal broke.
+        await Assert.That(log.Messages.Any(m =>
+            m.Contains($"Teardown step '{ProductionSteps[throwAt]}' failed", StringComparison.Ordinal))).IsTrue();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonHostDisposalTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonHostDisposalTests.cs
@@ -66,16 +66,33 @@ public class DaemonHostDisposalTests {
         return builder.Build();
     }
 
-    // ---- Teardown coordinator (DaemonRunner.RunTeardownAsync) ----
-    // The daemon's finally-block teardown must never let one failing step (e.g. a disposal
-    // throwing ObjectDisposedException) skip the later steps: under NativeAOT an escaped
-    // teardown exception aborts the process (SIGABRT), and a skipped host-dispose leaves the
-    // DI-owned UnixSpawnerThread's foreground thread parked forever.
+    [Test]
+    public async Task Spawner_thread_dispose_is_idempotent() {
+        if (OperatingSystem.IsWindows()) return;
+
+        var spawner = new UnixSpawnerThread();
+
+        spawner.Dispose();
+        // Second pass = the host-dispose DI walk re-disposing the instance the explicit
+        // spawner-retire teardown step already retired. Without a run-once guard this hit
+        // CompleteAdding on the already-disposed BlockingCollection (ObjectDisposedException).
+        spawner.Dispose();
+
+        await Assert.That(spawner.IsThreadAlive).IsFalse();
+    }
+
+    // ---- Production teardown (DaemonRunner.RunDaemonTeardownAsync) ----
+    // The daemon's teardown must never let one failing step (e.g. a disposal throwing
+    // ObjectDisposedException) skip the later steps: under NativeAOT an escaped teardown
+    // exception aborts the process (SIGABRT), and a skipped spawner retirement leaves the
+    // DI-owned UnixSpawnerThread's foreground thread parked forever. These tests drive the SAME
+    // step list RunAsync executes (BuildDaemonTeardownSteps via RunDaemonTeardownAsync), so a
+    // production divergence — a reordered or removed step — fails them.
 
     /// <summary>The production teardown step names, in the load-bearing order (explicit
-    /// dispose before host stop — spawner-thread retirement, pinned by the tests above).</summary>
+    /// dispose + spawner retirement before host stop/dispose — pinned by the tests above).</summary>
     static readonly string[] ProductionSteps =
-        ["daemon-lock", "orchestrator", "server-connection", "host-stop", "host-dispose"];
+        ["daemon-lock", "orchestrator", "server-connection", "spawner-retire", "host-stop", "host-dispose"];
 
     sealed class CaptureLogger : ILogger {
         public List<string> Messages { get; } = [];
@@ -87,17 +104,78 @@ public class DaemonHostDisposalTests {
             => Messages.Add(formatter(state, exception));
     }
 
-    [Test]
-    public async Task Teardown_steps_run_in_the_exact_given_order_and_report_success() {
-        var ran = new List<string>();
+    sealed class SpyLock(List<string> ran, bool throws = false) : IDisposable {
+        public void Dispose() {
+            if (throws) throw new InvalidOperationException("daemon-lock boom");
 
-        var steps = new List<(string Name, Func<ValueTask> Action)>();
+            ran.Add("daemon-lock");
+        }
+    }
 
-        foreach (var name in ProductionSteps) {
-            steps.Add((name, () => { ran.Add(name); return ValueTask.CompletedTask; }));
+    sealed class SpyAsyncDisposable(List<string> ran, string name, bool throws = false) : IAsyncDisposable {
+        public ValueTask DisposeAsync() {
+            if (throws) throw new InvalidOperationException($"{name} boom");
+
+            ran.Add(name);
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>Records the spawner-retire step's UnixSpawnerThread lookup (returning null, so
+    /// the step no-ops after recording) — IServiceProvider is the only seam that step touches.</summary>
+    sealed class SpyServiceProvider(List<string> ran, bool throws = false) : IServiceProvider {
+        public object? GetService(Type serviceType) {
+            if (serviceType != typeof(UnixSpawnerThread)) return null;
+
+            if (throws) throw new InvalidOperationException("spawner-retire boom");
+
+            ran.Add("spawner-retire");
+
+            return null;
+        }
+    }
+
+    sealed class SpyHost(List<string> ran, IServiceProvider services, bool stopThrows = false, bool disposeThrows = false)
+        : IHost, IAsyncDisposable {
+        public IServiceProvider Services => services;
+
+        public Task StartAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken ct = default) {
+            if (stopThrows) throw new InvalidOperationException("host-stop boom");
+
+            ran.Add("host-stop");
+
+            return Task.CompletedTask;
         }
 
-        var ok = await DaemonRunner.RunTeardownAsync(NullLogger.Instance, steps);
+        // DisposeHostAsync prefers the IAsyncDisposable path; the sync Dispose is never hit.
+        public void Dispose() { }
+
+        public ValueTask DisposeAsync() {
+            if (disposeThrows) throw new InvalidOperationException("host-dispose boom");
+
+            ran.Add("host-dispose");
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    static Task<bool> RunProductionTeardownAsync(ILogger logger, List<string> ran, int throwAt = -1)
+        => DaemonRunner.RunDaemonTeardownAsync(
+            logger,
+            new SpyLock(ran, throws: throwAt == 0),
+            new SpyAsyncDisposable(ran, "orchestrator", throws: throwAt == 1),
+            new SpyAsyncDisposable(ran, "server-connection", throws: throwAt == 2),
+            new SpyHost(ran, new SpyServiceProvider(ran, throws: throwAt == 3),
+                stopThrows: throwAt == 4, disposeThrows: throwAt == 5));
+
+    [Test]
+    public async Task Production_teardown_runs_the_six_real_steps_in_order() {
+        var ran = new List<string>();
+
+        var ok = await RunProductionTeardownAsync(NullLogger.Instance, ran);
 
         await Assert.That(ok).IsTrue();
         await Assert.That(string.Join(",", ran)).IsEqualTo(string.Join(",", ProductionSteps));
@@ -109,26 +187,12 @@ public class DaemonHostDisposalTests {
     [Arguments(2)]
     [Arguments(3)]
     [Arguments(4)]
-    public async Task A_throwing_step_at_any_position_does_not_prevent_later_steps(int throwAt) {
+    [Arguments(5)]
+    public async Task A_throwing_production_step_at_any_position_does_not_prevent_later_steps(int throwAt) {
         var ran = new List<string>();
         var log = new CaptureLogger();
 
-        var steps = new List<(string Name, Func<ValueTask> Action)>();
-
-        for (var i = 0; i < ProductionSteps.Length; i++) {
-            var name = ProductionSteps[i];
-            var idx  = i;
-
-            steps.Add((name, () => {
-                if (idx == throwAt) throw new ObjectDisposedException(name);
-
-                ran.Add(name);
-
-                return ValueTask.CompletedTask;
-            }));
-        }
-
-        var ok = await DaemonRunner.RunTeardownAsync(log, steps);
+        var ok = await RunProductionTeardownAsync(log, ran, throwAt);
 
         // Every step after (and before) the throwing one still ran, in order.
         await Assert.That(ok).IsFalse();
@@ -138,5 +202,118 @@ public class DaemonHostDisposalTests {
         // The failing step is named in the log so an operator can tell WHICH disposal broke.
         await Assert.That(log.Messages.Any(m =>
             m.Contains($"Teardown step '{ProductionSteps[throwAt]}' failed", StringComparison.Ordinal))).IsTrue();
+    }
+
+    [Test]
+    public async Task A_never_resolved_orchestrator_is_skipped_and_every_other_step_still_runs() {
+        // The partially-started shape: SIGTERM landed inside host.StartAsync, so the
+        // orchestrator local was never assigned. Teardown must be null-safe and complete.
+        var ran = new List<string>();
+
+        var ok = await DaemonRunner.RunDaemonTeardownAsync(
+            NullLogger.Instance,
+            new SpyLock(ran),
+            orchestrator: null,
+            new SpyAsyncDisposable(ran, "server-connection"),
+            new SpyHost(ran, new SpyServiceProvider(ran)));
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(string.Join(",", ran))
+            .IsEqualTo(string.Join(",", ProductionSteps.Where(s => s != "orchestrator")));
+    }
+
+    sealed class ThrowingDisposable : IDisposable {
+        public void Dispose() => throw new InvalidOperationException("DI walk boom");
+    }
+
+    [Test]
+    public async Task A_throwing_DI_disposable_during_host_dispose_cannot_strand_the_spawner_thread() {
+        if (OperatingSystem.IsWindows()) return;
+
+        // A DI-tracked singleton whose Dispose throws mid-walk aborts the container's INTERNAL
+        // dispose walk, skipping every disposable it had not reached yet. Created AFTER the
+        // spawner (the walk runs in reverse creation order), the throwing singleton is disposed
+        // FIRST — so without the explicit spawner-retire step the UnixSpawnerThread would be
+        // skipped and its foreground thread would keep the "shut down" process alive forever.
+        var builder = Host.CreateApplicationBuilder();
+        builder.Services.AddSingleton<UnixSpawnerThread>();
+        builder.Services.AddSingleton<ThrowingDisposable>();
+        var host = builder.Build();
+
+        var spawner = host.Services.GetRequiredService<UnixSpawnerThread>();
+        _ = host.Services.GetRequiredService<ThrowingDisposable>();
+
+        await host.StartAsync();
+
+        var ran = new List<string>();
+        var log = new CaptureLogger();
+
+        var ok = await DaemonRunner.RunDaemonTeardownAsync(
+            log, new SpyLock(ran), null, new SpyAsyncDisposable(ran, "server-connection"), host);
+
+        // host-dispose reported the aborted DI walk…
+        await Assert.That(ok).IsFalse();
+        await Assert.That(log.Messages.Any(m =>
+            m.Contains("Teardown step 'host-dispose' failed", StringComparison.Ordinal))).IsTrue();
+
+        // …but the spawner thread was still retired by the explicit step.
+        await Assert.That(spawner.IsThreadAlive).IsFalse();
+    }
+
+    sealed class BlockingStartService : IHostedService {
+        public Task StartAsync(CancellationToken ct) => Task.Delay(Timeout.InfiniteTimeSpan, ct);
+        public Task StopAsync(CancellationToken  ct) => Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Cancellation_during_host_start_is_contained_and_teardown_still_runs() {
+        if (OperatingSystem.IsWindows()) return;
+
+        // SIGTERM while a hosted service is still starting surfaces as TaskCanceledException out
+        // of host.StartAsync (dotnet/runtime#111013 behavior). Guarded startup must treat that as
+        // the requested shutdown — clean exit, full teardown (daemon lock + host dispose) — not a
+        // fault that escapes Main and aborts the NativeAOT process.
+        var builder = Host.CreateApplicationBuilder();
+        builder.Services.AddSingleton<UnixSpawnerThread>();
+        builder.Services.AddHostedService<BlockingStartService>();
+        var host = builder.Build();
+
+        var spawner = host.Services.GetRequiredService<UnixSpawnerThread>();
+        var ran     = new List<string>();
+
+        using var stopping = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        var exit = await DaemonRunner.RunGuardedStartupAsync(
+            NullLogger.Instance,
+            stopping.Token,
+            startupAndWait: async () => {
+                await host.StartAsync(stopping.Token); // throws TaskCanceledException mid-start
+
+                return 0; // never reached
+            },
+            teardown: () => DaemonRunner.RunDaemonTeardownAsync(
+                NullLogger.Instance, new SpyLock(ran), orchestrator: null,
+                new SpyAsyncDisposable(ran, "server-connection"), host));
+
+        // Cooperative shutdown, not a fault — and the full teardown ran: the daemon lock was
+        // released and host disposal retired the spawner's foreground thread.
+        await Assert.That(exit).IsNull();
+        await Assert.That(ran).Contains("daemon-lock");
+        await Assert.That(spawner.IsThreadAlive).IsFalse();
+    }
+
+    [Test]
+    public async Task A_cancellation_without_a_shutdown_request_still_propagates() {
+        var teardownRan = false;
+
+        await Assert.That(async () => await DaemonRunner.RunGuardedStartupAsync(
+                NullLogger.Instance,
+                CancellationToken.None, // no shutdown was requested — fail-loud is preserved
+                startupAndWait: () => throw new OperationCanceledException(),
+                teardown: () => { teardownRan = true; return Task.FromResult(true); }))
+            .Throws<OperationCanceledException>();
+
+        // Even the fail-loud path tears down (finally).
+        await Assert.That(teardownRan).IsTrue();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ServerConnectionDisposeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ServerConnectionDisposeTests.cs
@@ -1,0 +1,134 @@
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// <see cref="ServerConnection.DisposeAsync"/> must be idempotent and non-throwing: the DI
+/// container tracks the singleton AND <c>DaemonRunner</c> disposes it explicitly, so it runs twice
+/// by construction on every shutdown. Before the run-once guard, the second pass called
+/// <c>CancelAsync</c> on the already-disposed terminal-sender CTS — an
+/// <see cref="ObjectDisposedException"/> that escaped into DI teardown and, under NativeAOT,
+/// aborted the process (SIGABRT) instead of exiting cleanly. Mirrors
+/// <see cref="ConnectWithRetryTests"/>' harness: no live SignalR transport; the internal seams are
+/// overridden so <c>ConnectAsync</c> reaches the CTS-creating line without a server.
+/// </summary>
+public class ServerConnectionDisposeTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    sealed class DisposeTestConnection(ILogger<ServerConnection>? logger = null) : ServerConnection(
+        new DaemonConfig { Name = "test", ServerUrl = "http://127.0.0.1:1" },
+        NullLoggerFactory.Instance,
+        logger ?? NullLogger<ServerConnection>.Instance
+    ) {
+        // Always "ready": ConnectAsync's retry loop returns immediately without ever touching the
+        // (never-started) real hub — but only AFTER the terminal-sender CTS has been created,
+        // which is exactly the state production disposes from.
+        internal override bool IsReady => true;
+    }
+
+    sealed class CapturingLogger : ILogger<ServerConnection> {
+        public List<string> Messages { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            => Messages.Add(formatter(state, exception));
+    }
+
+    [Test, NotInParallel(nameof(ServerConnectionDisposeTests))]
+    public async Task Dispose_twice_does_not_throw() {
+        var conn = new DisposeTestConnection();
+
+        await conn.DisposeAsync().AsTask().WaitAsync(HangGuard);
+        // Pass 2 = the DI container's dispose walk re-entering after DaemonRunner's explicit call.
+        await conn.DisposeAsync().AsTask().WaitAsync(HangGuard);
+        // Reaching here without ObjectDisposedException is the assertion.
+    }
+
+    [Test, NotInParallel(nameof(ServerConnectionDisposeTests))]
+    public async Task Dispose_twice_after_connect_does_not_throw() {
+        var conn = new DisposeTestConnection();
+
+        // Creates the linked terminal-sender CTS — the object the unguarded second pass
+        // re-cancelled after disposal (the production crash).
+        await conn.ConnectAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await conn.DisposeAsync().AsTask().WaitAsync(HangGuard);
+        await conn.DisposeAsync().AsTask().WaitAsync(HangGuard);
+    }
+
+    [Test, NotInParallel(nameof(ServerConnectionDisposeTests))]
+    public async Task Second_dispose_does_not_reenter_the_body_and_the_cts_ends_cancelled_and_disposed() {
+        var conn = new DisposeTestConnection();
+
+        await conn.ConnectAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        var cts = conn.TerminalSenderCtsForTests;
+        await Assert.That(cts).IsNotNull();
+
+        await conn.DisposeAsync().AsTask().WaitAsync(HangGuard);
+
+        await Assert.That(conn.DisposeBodyRuns).IsEqualTo(1);
+        // Cancelled (IsCancellationRequested is safe to read post-dispose) AND disposed
+        // (the Token property throws once the source is disposed).
+        await Assert.That(cts!.IsCancellationRequested).IsTrue();
+        await Assert.That(() => _ = cts.Token).Throws<ObjectDisposedException>();
+
+        await conn.DisposeAsync().AsTask().WaitAsync(HangGuard);
+
+        // Durable run-once contract: the second call must not have re-entered the body.
+        await Assert.That(conn.DisposeBodyRuns).IsEqualTo(1);
+    }
+
+    [Test, NotInParallel(nameof(ServerConnectionDisposeTests))]
+    public async Task A_faulting_awaited_task_is_logged_and_later_cleanup_still_runs() {
+        var log  = new CapturingLogger();
+        var conn = new DisposeTestConnection(log);
+
+        await conn.ConnectAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        var cts = conn.TerminalSenderCtsForTests;
+        await Assert.That(cts).IsNotNull();
+
+        // Inject a faulted pipeline task: the await must be contained + logged, never skipping
+        // the sibling awaits or the mandatory resource release.
+        conn.EventProcessorTaskForTests = Task.FromException(new InvalidOperationException("boom"));
+
+        await conn.DisposeAsync().AsTask().WaitAsync(HangGuard);
+
+        // (a) the failure is logged with the failing step's name…
+        await Assert.That(log.Messages.Any(m =>
+            m.Contains("dispose step 'event-processor' failed", StringComparison.Ordinal))).IsTrue();
+
+        // (b) …and later cleanup still ran: the CTS was cancelled AND disposed.
+        await Assert.That(cts!.IsCancellationRequested).IsTrue();
+        await Assert.That(() => _ = cts.Token).Throws<ObjectDisposedException>();
+    }
+
+    [Test, NotInParallel(nameof(ServerConnectionDisposeTests))]
+    public async Task Explicit_dispose_then_host_teardown_over_the_same_tracked_instance_does_not_throw() {
+        // The true production shape: DaemonRunner explicitly disposes the ServerConnection in its
+        // finally, THEN stops and disposes the host — whose DI container tracks the SAME instance
+        // (factory-created singleton) and walks its DisposeAsync a second time.
+        var builder = Host.CreateApplicationBuilder();
+        builder.Services.AddSingleton<ServerConnection>(_ => new DisposeTestConnection());
+        var host = builder.Build();
+
+        var conn = host.Services.GetRequiredService<ServerConnection>();
+
+        await host.StartAsync();
+        await conn.ConnectAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await conn.DisposeAsync().AsTask().WaitAsync(HangGuard); // DaemonRunner's explicit dispose
+        await host.StopAsync().WaitAsync(HangGuard);
+        await DaemonRunner.DisposeHostAsync(host).WaitAsync(HangGuard); // DI walk re-disposes
+
+        await Assert.That(((DisposeTestConnection)conn).DisposeBodyRuns).IsEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Problem

Every daemon shutdown on 0.11.10 ends in SIGABRT: `ObjectDisposedException` from `ServerConnection.DisposeAsync` surfacing through DI host teardown into the NativeAOT unhandled path. Four crash reports on 2026-08-02 alone; each abort strands every disposable ordered after `ServerConnection` in the DI walk and stretched supervisor relaunch gaps to ~2 minutes (windows of `no_daemon_available` flow failures). Same defect class as AI-1624 (#419) — this is the unswept sibling: #419 is an ancestor of v0.11.10 but was scoped to `LocalPermissionBridge` only.

## Root cause

`DaemonRunner` disposes the same `ServerConnection` singleton twice by construction — an explicit `connection.DisposeAsync()` in the `finally`, then `DisposeHostAsync(host)` walking the container's tracked disposables. `DisposeAsync` had no run-once guard, disposed `_terminalSenderCts` without nulling it, and the second pass cancelled the disposed linked CTS. Nothing on the teardown path catches, so the throw aborts the process.

## Fix (per the reviewed spec/plan on AI-1707)

- `ServerConnection.DisposeAsync`: `Interlocked` run-once guard; per-resource containment for faultable awaits; mandatory release of CTS/HttpClient/hub in `finally`, each step individually guarded; ODE-guarded cancel.
- `DaemonRunner`: teardown steps run through a new `RunTeardownAsync` coordinator — a throw in any step is logged with the step name and later steps still run, order pinned by test (`daemon-lock → orchestrator → server-connection → host-stop → host-dispose`). DI-walk limitation + the double-teardown sweep rationale documented in code.
- `AgentOrchestrator.DisposeAsync` (sweep item): same run-once + containment treatment, and its `_shutdownCts` — previously never disposed at all — is now disposed in a guaranteed `finally` after all token-dependent cleanup (stays `readonly`).
- Bonus defect found by the SIGTERM E2E: SIGTERM during the initial `ConnectAsync` retry loop let `TaskCanceledException` escape `RunAsync` → a second, pre-existing shutdown SIGABRT. Now caught when `ApplicationStopping` has fired (unrelated cancellations still propagate).

## Tests

New durable-contract suites (not just no-throw): body-ran-once counters, CTS ends cancelled+disposed, faulting-await containment with later-cleanup assertion, the exact production shape (explicit dispose → host stop → host dispose over a container-tracked instance), order-pinning + throw-at-each-position coordinator tests, and the up-front vacuous-test check on AgentOrchestrator required by the spec review. Targeted classes all green (ServerConnectionDisposeTests 5/5, DaemonHostDisposalTests 8/8, ConnectWithRetryTests 7/7, LocalPermissionBridgeTests 46/46, AgentOrchestratorVendorTests 166/166). A pre-directive full unit run showed zero new failures vs a detached-origin/main baseline (47 ⊆ 50 known pre-existing macOS failures). Full suites delegated to CI per Tony. AOT publish (Release, osx-arm64, both csprojs) clean.

E2E on published binaries with isolated config dir: SIGTERM → `Cleanup: completed, daemon exiting`, no `Unhandled exception` banner, no new `.ips`. (Note for reviewers: `kcap daemon stop` SIGKILLs the tree, so it never exercises dispose — direct SIGTERM does.)

Spec + plan + codex spec-review findings: https://linear.app/kurrent/issue/AI-1707

🤖 Generated with [Claude Code](https://claude.com/claude-code)
