### PR TITLE
[AI-1708] Allow send_flow_message for unattended flow participants on the PTY path

### DIFF
--- a/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
+++ b/src/Capacitor.Cli.Core/KcapMcpRegistry.cs
@@ -7,6 +7,18 @@ namespace Capacitor.Cli.Core;
 /// Ids are canonical lower-case; Resolve is case-insensitive so casing can't dodge the strip.</summary>
 public sealed record KcapMcpServerDescriptor(string Id, string[] Args, bool StartsFlows);
 
+/// <summary>One tool served by the reserved result channel
+/// (<see cref="KcapMcpRegistry.ReservedResultChannelId"/>). <paramref name="UnattendedSafe"/> marks
+/// it auto-approvable for ANY unattended flow participant: today's two tools only POST to the
+/// participant's own flow run on the server — they read nothing and mutate nothing else. The POST
+/// rides the daemon user's normally-authenticated HTTP client; the <c>agent_id</c> in the body is
+/// request correlation, NOT authentication — the server authorizes the authenticated principal
+/// against the exact active agent assignment and derives flow/source identity from it, rejecting
+/// closed or mismatched assignments. Participant→driver notes are an intentional
+/// prompt-injection-shaped channel across the driver↔participant trust boundary; the driver-side
+/// tooling treats them as untrusted text.</summary>
+public sealed record ReservedResultChannelTool(string Name, bool UnattendedSafe);
+
 public static class KcapMcpRegistry {
     static readonly Dictionary<string, KcapMcpServerDescriptor> Entries = new(StringComparer.OrdinalIgnoreCase) {
         ["kcap-review"]    = new("kcap-review",    ["mcp", "review"],    false),
@@ -53,6 +65,25 @@ public static class KcapMcpRegistry {
     /// (never a rejection, never re-emitted) — the server's dynamic-flow policy legitimately lists
     /// it, and every reviewer runtime must agree on that.</summary>
     public const string ReservedResultChannelId = "kcap-flow-result";
+
+    /// <summary>The ordered catalog of every tool the reserved result channel serves — the single
+    /// source of truth. <c>McpFlowResultServer</c>'s <c>tools/list</c>, Copilot's ACP
+    /// <c>--available-tools</c> argv, and <c>LocalPermissionBridge</c>'s unattended auto-approve are
+    /// all contract-tested against it, so the next tool addition can't silently regress one of the
+    /// three. Order is the advertised order (<c>submit_review_result</c> first) and is load-bearing:
+    /// the ACP argv assertions are byte-exact.</summary>
+    public static readonly IReadOnlyList<ReservedResultChannelTool> ReservedResultChannelTools = [
+        new("submit_review_result", UnattendedSafe: true),
+        new("send_flow_message",    UnattendedSafe: true),
+    ];
+
+    /// <summary>Membership view of <see cref="ReservedResultChannelTools"/>' unattended-safe names.
+    /// Ordinal (case-sensitive): this set feeds a permission auto-approve, so a case variant of a
+    /// safe name is NOT the safe name.</summary>
+    public static readonly IReadOnlySet<string> ReservedResultChannelUnattendedSafeTools =
+        ReservedResultChannelTools.Where(t => t.UnattendedSafe)
+                                  .Select(t => t.Name)
+                                  .ToHashSet(StringComparer.Ordinal);
 
     /// <summary>Explicit, reviewed classification: each auto-approvable server → the exact tool
     /// names it exposes that are unattended-safe (read / result-submit). The single source of

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -580,8 +580,12 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     static IEnumerable<string> CopilotAvailableToolIds(IReadOnlyList<AcpMcpServerSpec> servers) {
         foreach (var server in servers) {
             if (string.Equals(server.Name, KcapMcpRegistry.ReservedResultChannelId, StringComparison.Ordinal)) {
-                yield return $"{server.Name}-submit_review_result";
-                yield return $"{server.Name}-send_flow_message";
+                // Derived from the ordered catalog (the single source of truth), filtered to the
+                // unattended-safe tools — this launch is unattended, so a future non-safe catalog
+                // entry must not be advertised here. Catalog order is stable and byte-exact-tested.
+                foreach (var tool in KcapMcpRegistry.ReservedResultChannelTools) {
+                    if (tool.UnattendedSafe) yield return $"{server.Name}-{tool.Name}";
+                }
                 continue;
             }
 

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -387,17 +387,8 @@ internal sealed partial class LocalPermissionBridge(
             // would give us per-request cancellation; out of scope for this PR.
             PermissionDecision decision;
 
-            if (IsFlowResultSubmission(toolName)) {
-                // The reviewer's own result-submission tool (kcap-flow-result → submit_review_result)
-                // is unique to a server only injected for review-flow reviewers, so it's always safe.
-                // Auto-approve on ANY live token without a server round-trip — an unattended reviewer
-                // can't get a user decision otherwise.
-                LogFlowResultAutoApproved(logger, sessionId, vendor);
-                decision = new PermissionDecision("allow", null, null);
-            } else if (isReviewer) {
-                // Unattended reviewer: auto-approve its bound kcap tools; DENY an out-of-allowlist
-                // (or non-config-locked-vendor bare) call outright rather than defer to a prompt no
-                // human can answer. A well-formed tool name is required to classify.
+            if (isReviewer) {
+                // Unattended participant: a well-formed tool name is required to classify.
                 if (string.IsNullOrWhiteSpace(toolName)) {
                     context.Response.StatusCode = 400;
                     context.Response.Close();
@@ -405,14 +396,29 @@ internal sealed partial class LocalPermissionBridge(
                     return;
                 }
 
-                if (IsReviewerToolAllowed(vendor, toolName, reviewerAllowlist!)) {
+                if (IsReservedChannelTool(toolName)) {
+                    // The reserved result channel (kcap-flow-result) is injected only for flow
+                    // participants, and every tool it advertises is in the contract-tested
+                    // unattended-safe set — each only POSTs to the participant's own flow run,
+                    // authorized server-side against the caller's active agent assignment.
+                    // Auto-approve without a server round-trip: an unattended participant can't
+                    // get a user decision otherwise.
+                    LogReservedChannelToolAutoApproved(logger, toolName, sessionId, vendor);
+                    decision = new PermissionDecision("allow", null, null);
+                } else if (IsReviewerToolAllowed(vendor, toolName, reviewerAllowlist!)) {
+                    // Auto-approve its bound kcap tools; DENY an out-of-allowlist (or
+                    // non-config-locked-vendor bare) call outright rather than defer to a prompt
+                    // no human can answer.
                     decision = new PermissionDecision("allow", null, null);
                 } else {
                     LogReviewerToolDenied(logger, sessionId, toolName);
                     decision = new PermissionDecision("deny", null, null);
                 }
             } else {
-                // Shared (interactive) token → the server permission path, unchanged.
+                // Shared (interactive) token → the server permission path, unchanged. This
+                // deliberately includes the reserved channel's own tool names: an interactive
+                // session never legitimately carries that server, so an identically-named tool
+                // here is untrusted and takes the normal prompt.
                 try {
                     decision = await server.RequestPermissionAsync(sessionId, toolName, toolInput, suggestions, ct);
                 } catch (Exception ex) {
@@ -455,29 +461,46 @@ internal sealed partial class LocalPermissionBridge(
     }
 
     /// <summary>
-    /// True when the permission request is for the review-flow reviewer's result-submission tool
-    /// (the <c>kcap-flow-result</c> server's <c>submit_review_result</c>). This auto-approve bypasses
-    /// the server permission boundary, so the match is deliberately precise rather than a loose
-    /// substring: it accepts either the bare tool name (a vendor that passes the raw MCP tool name,
-    /// e.g. Codex) OR a vendor-prefixed id that both names the <c>kcap-flow-result</c> server AND ends
-    /// in the exact tool — e.g. Claude's <c>mcp__kcap_flow_result__submit_review_result</c> (Claude
-    /// sanitizes the hyphens to underscores). Requiring the server token means a coincidental
-    /// "…submit_review_result" exposed by some other MCP server on an interactive hosted agent can't
-    /// slip past the prompt.
+    /// True when the permission request is for one of the reserved result channel's
+    /// unattended-safe tools (<c>KcapMcpRegistry.ReservedResultChannelUnattendedSafeTools</c> on the
+    /// <c>kcap-flow-result</c> server). This auto-approve bypasses the server permission boundary,
+    /// so the match PARSES the canonical <c>mcp__&lt;server&gt;__&lt;tool&gt;</c> shape and compares
+    /// whole segments — never <c>Contains</c>/<c>EndsWith</c>, which are spoofable
+    /// (<c>mcp__evil_kcap_flow_result__send_flow_message</c>,
+    /// <c>mcp__kcap_flow_result__evil_send_flow_message</c>): the ENTIRE server segment must equal
+    /// the reserved channel id (hyphens normalized to underscores, since Claude sanitizes
+    /// <c>kcap-flow-result</c> to <c>kcap_flow_result</c>) and the ENTIRE tool segment must be an
+    /// exact Ordinal member of the safe set. A bare name (a vendor that passes the raw MCP tool
+    /// name, e.g. Codex) is exact set membership only. Callers additionally gate this on the
+    /// reviewer token — the channel is injected only for flow participants, so an interactive
+    /// session's identically-named tool still takes the normal prompt path.
     /// </summary>
-    static bool IsFlowResultSubmission(string? toolName) {
+    static bool IsReservedChannelTool(string? toolName) {
         if (string.IsNullOrEmpty(toolName)) return false;
 
-        // Bare tool name, no server prefix.
-        if (string.Equals(toolName, "submit_review_result", StringComparison.Ordinal)) return true;
+        const string prefix = "mcp__";
 
-        // Vendor-prefixed MCP id: require the flow-result server identity AND the exact tool suffix.
-        var namesFlowResultServer =
-            toolName.Contains("kcap_flow_result", StringComparison.Ordinal) ||
-            toolName.Contains("kcap-flow-result", StringComparison.Ordinal);
+        // Bare tool name, no server prefix: exact safe-set membership only.
+        if (!toolName.StartsWith(prefix, StringComparison.Ordinal))
+            return KcapMcpRegistry.ReservedResultChannelUnattendedSafeTools.Contains(toolName);
 
-        return namesFlowResultServer && toolName.EndsWith("submit_review_result", StringComparison.Ordinal);
+        var afterPrefix = toolName[prefix.Length..];
+        var sep         = afterPrefix.IndexOf("__", StringComparison.Ordinal);
+
+        if (sep <= 0) return false;   // malformed qualified name → not the reserved channel (fail-safe)
+
+        var server = afterPrefix[..sep].Replace('-', '_');
+        var tool   = afterPrefix[(sep + 2)..];
+
+        return string.Equals(server, ReservedChannelServerSegment, StringComparison.Ordinal)
+            && KcapMcpRegistry.ReservedResultChannelUnattendedSafeTools.Contains(tool);
     }
+
+    /// <summary>The reserved channel id in its underscore normalization (<c>kcap_flow_result</c>) —
+    /// the form a hyphenated or Claude-sanitized server segment reduces to for the exact-equality
+    /// comparison above.</summary>
+    static readonly string ReservedChannelServerSegment =
+        KcapMcpRegistry.ReservedResultChannelId.Replace('-', '_');
 
     /// <summary>
     /// Whether a tool call arriving on a reviewer token is within the reviewer's bound (read-only)
@@ -558,8 +581,8 @@ internal sealed partial class LocalPermissionBridge(
     [LoggerMessage(Level = LogLevel.Warning, Message = "RequestPermission via SignalR failed for session {SessionId}; falling back to deny")]
     static partial void LogRequestPermissionFailed(ILogger logger, Exception exception, string sessionId);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Auto-approved review-flow result submission for session {SessionId} (vendor={Vendor}) without surfacing a prompt")]
-    static partial void LogFlowResultAutoApproved(ILogger logger, string sessionId, string vendor);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Auto-approved reserved flow-channel tool {ToolName} for unattended participant session {SessionId} (vendor={Vendor}) without surfacing a prompt")]
+    static partial void LogReservedChannelToolAutoApproved(ILogger logger, string toolName, string sessionId, string vendor);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Denied out-of-allowlist tool {ToolName} for unattended reviewer session {SessionId}")]
     static partial void LogReviewerToolDenied(ILogger logger, string sessionId, string toolName);

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -461,19 +461,12 @@ internal sealed partial class LocalPermissionBridge(
     }
 
     /// <summary>
-    /// True when the permission request is for one of the reserved result channel's
-    /// unattended-safe tools (<c>KcapMcpRegistry.ReservedResultChannelUnattendedSafeTools</c> on the
-    /// <c>kcap-flow-result</c> server). This auto-approve bypasses the server permission boundary,
-    /// so the match PARSES the canonical <c>mcp__&lt;server&gt;__&lt;tool&gt;</c> shape and compares
-    /// whole segments — never <c>Contains</c>/<c>EndsWith</c>, which are spoofable
-    /// (<c>mcp__evil_kcap_flow_result__send_flow_message</c>,
-    /// <c>mcp__kcap_flow_result__evil_send_flow_message</c>): the ENTIRE server segment must equal
-    /// the reserved channel id (hyphens normalized to underscores, since Claude sanitizes
-    /// <c>kcap-flow-result</c> to <c>kcap_flow_result</c>) and the ENTIRE tool segment must be an
-    /// exact Ordinal member of the safe set. A bare name (a vendor that passes the raw MCP tool
-    /// name, e.g. Codex) is exact set membership only. Callers additionally gate this on the
-    /// reviewer token — the channel is injected only for flow participants, so an interactive
-    /// session's identically-named tool still takes the normal prompt path.
+    /// True when the permission request names one of the reserved result channel's unattended-safe
+    /// tools. The match parses the canonical <c>mcp__&lt;server&gt;__&lt;tool&gt;</c> shape and
+    /// compares whole segments (hyphens normalized to underscores) — substring matching here is
+    /// spoofable, e.g. <c>mcp__evil_kcap_flow_result__send_flow_message</c>. Bare names are exact
+    /// set membership. Callers gate this on the reviewer token, so an interactive session's
+    /// identically-named tool still takes the normal prompt path.
     /// </summary>
     static bool IsReservedChannelTool(string? toolName) {
         if (string.IsNullOrEmpty(toolName)) return false;
@@ -584,7 +577,7 @@ internal sealed partial class LocalPermissionBridge(
     [LoggerMessage(Level = LogLevel.Debug, Message = "Auto-approved reserved flow-channel tool {ToolName} for unattended participant session {SessionId} (vendor={Vendor}) without surfacing a prompt")]
     static partial void LogReservedChannelToolAutoApproved(ILogger logger, string toolName, string sessionId, string vendor);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Denied out-of-allowlist tool {ToolName} for unattended reviewer session {SessionId}")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Denied out-of-allowlist tool {ToolName} for unattended participant session {SessionId}")]
     static partial void LogReviewerToolDenied(ILogger logger, string sessionId, string toolName);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Permission bridge handler error")]

--- a/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
@@ -85,6 +85,12 @@ static class McpFlowResultServer {
                 if (toolName is null)
                     return BuildErrorResponse(callId, -32602, "Missing params.name");
 
+                // Deliberately EXHAUSTIVE explicit cases (no catalog-driven dispatch): a future tool
+                // added to KcapMcpRegistry.ReservedResultChannelTools without a case here hits the
+                // unknown-tool default rather than being routed to some existing handler. The
+                // contract test against the catalog keeps tools/list honest; this gate keeps
+                // dispatch honest. Checked BEFORE creating the authenticated client so an unknown
+                // name never triggers auth setup.
                 if (toolName is not ("submit_review_result" or "send_flow_message"))
                     return BuildToolResult(callId, $"Error: Unknown tool: {toolName}", isError: true);
 
@@ -92,7 +98,8 @@ static class McpFlowResultServer {
 
                 var (text, isError) = toolName switch {
                     "submit_review_result" => await SubmitCoreAsync(client, apiRoot, agentId, arguments, delay: Task.Delay),
-                    _                       => await SendMessageCoreAsync(client, apiRoot, agentId, arguments, delay: Task.Delay)
+                    "send_flow_message"    => await SendMessageCoreAsync(client, apiRoot, agentId, arguments, delay: Task.Delay),
+                    _                      => ($"Error: Unknown tool: {toolName}", true)
                 };
 
                 return BuildToolResult(callId, text, isError);
@@ -361,7 +368,10 @@ static class McpFlowResultServer {
         return envelope.ToJsonString();
     }
 
-    static McpTool[] BuildToolsList() => [
+    /// <summary>The advertised tool list. Contract-tested to match
+    /// <c>KcapMcpRegistry.ReservedResultChannelTools</c> name-for-name, in order — internal (not
+    /// private) solely so that test can compare it directly against the catalog.</summary>
+    internal static McpTool[] BuildToolsList() => [
         new(
             Name: "submit_review_result",
             Description: "Submit your review result for the current round. Call once. kind=\"findings\" with your findings text, or kind=\"clean\" when there are no actionable findings. round_token comes from the \"round token\" line in your prompt.",

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorReviewerTokenTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorReviewerTokenTests.cs
@@ -51,6 +51,44 @@ public partial class AgentOrchestratorVendorTests {
         }
     }
 
+    // A GENERIC flow participant (arbitrary FlowRole from start_flow, not a review-flow reviewer)
+    // launches through the same LaunchKind.ReviewFlow lane, so it gets the same reserved-channel
+    // treatment: a dedicated bridge token is minted even with no MCP allowlist at all (the reserved
+    // result channel is injected independently of the allowlist, and the bridge auto-approves its
+    // unattended-safe tools on any participant token — see
+    // LocalPermissionBridgeTests.Reviewer_token_with_empty_allowlist_still_auto_approves_reserved_channel_tools).
+    [Test, NotInParallel("LocalPermissionBridgeTests")]
+    public async Task Generic_flow_participant_codex_launch_mints_a_reviewer_token_like_a_reviewer() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new FixedPtyProcessFactory(new OneChunkThenBlockPtyProcess());
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, Launcher("codex"), allowedRepoPath: repoPath);
+            var bridge = orch.PermissionBridgeForTest;
+            await bridge.StartAsync(CancellationToken.None);
+
+            try {
+                await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                    AgentId: "part-1", Prompt: "research the topic", Model: "default", Effort: null,
+                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "codex",
+                    Kind: LaunchKind.ReviewFlow, McpAllowlist: null,
+                    FlowRunId: "flow-run-1", FlowRole: "researcher"));
+
+                var agent = orch.GetAgentForTest("part-1");
+                await Assert.That(agent).IsNotNull();
+                await Assert.That(agent!.ReviewerBridgeToken).IsNotNull();
+                await Assert.That(agent.ReviewerBridgeToken).IsNotEqualTo(bridge.BaseUrl);   // a dedicated token
+                await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(1);
+            } finally {
+                await bridge.DisposeAsync();
+            }
+        } finally {
+            cleanup();
+        }
+    }
+
     // Defense in depth: a non-Codex reviewer (Claude) is NOT minted a token, even for a ReviewFlow —
     // its config-lock doesn't apply, so a bare tool name wouldn't be provably a kcap tool.
     [Test, NotInParallel("LocalPermissionBridgeTests")]

--- a/test/Capacitor.Cli.Tests.Unit/KcapMcpRegistryReviewFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/KcapMcpRegistryReviewFlowTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core;
 
 namespace Capacitor.Cli.Tests.Unit;
@@ -89,5 +90,43 @@ public class KcapMcpRegistryReviewFlowTests {
     public async Task Classification_only_covers_auto_approvable_servers() {
         foreach (var srv in KcapMcpRegistry.ReviewFlowUnattendedSafeTools.Keys)
             await Assert.That(KcapMcpRegistry.ReviewFlowAutoApprovableServers.Contains(srv)).IsTrue();
+    }
+
+    // ── Reserved result channel tool catalog ─────────────────────────────────────────
+    //
+    // The ordered catalog on KcapMcpRegistry is the single source of truth for the reserved
+    // channel's tools. The flow-result server's tools/list is compared against it DIRECTLY
+    // (bidirectional: an advertised tool missing from the catalog fails just like a catalog
+    // entry the server no longer advertises), so the next tool addition can't silently leave
+    // the bridge auto-approve or the Copilot ACP argv behind.
+
+    [Test]
+    public async Task Flow_result_server_advertises_exactly_the_reserved_channel_catalog_in_order() {
+        var advertised = McpFlowResultServer.BuildToolsList().Select(t => t.Name).ToArray();
+        var catalog    = KcapMcpRegistry.ReservedResultChannelTools.Select(t => t.Name).ToArray();
+
+        await Assert.That(advertised.SequenceEqual(catalog, StringComparer.Ordinal)).IsTrue();
+    }
+
+    [Test]
+    public async Task Unattended_safe_set_is_exactly_the_catalogs_safe_names() {
+        var safeNames = KcapMcpRegistry.ReservedResultChannelTools
+            .Where(t => t.UnattendedSafe)
+            .Select(t => t.Name)
+            .ToArray();
+
+        await Assert.That(KcapMcpRegistry.ReservedResultChannelUnattendedSafeTools.Count)
+            .IsEqualTo(safeNames.Length);
+        foreach (var name in safeNames)
+            await Assert.That(KcapMcpRegistry.ReservedResultChannelUnattendedSafeTools.Contains(name)).IsTrue();
+    }
+
+    [Test]
+    public async Task Unattended_safe_set_membership_is_case_sensitive() {
+        // The set feeds a permission auto-approve, so membership must be exact Ordinal —
+        // a case variant of a safe tool name is NOT the safe tool.
+        await Assert.That(KcapMcpRegistry.ReservedResultChannelUnattendedSafeTools.Contains("submit_review_result")).IsTrue();
+        await Assert.That(KcapMcpRegistry.ReservedResultChannelUnattendedSafeTools.Contains("Submit_Review_Result")).IsFalse();
+        await Assert.That(KcapMcpRegistry.ReservedResultChannelUnattendedSafeTools.Contains("SEND_FLOW_MESSAGE")).IsFalse();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -512,10 +512,11 @@ public class LocalPermissionBridgeTests {
         }
     }
 
-    // Follow-up: a review-flow reviewer's own result-submission tool must be auto-approved
-    // by the bridge WITHOUT surfacing a user prompt. Codex fires a PermissionRequest for the MCP
-    // tool call even under `--ask-for-approval never`, and its hook bridges here; without this the
-    // unattended reviewer blocks on a decision it can never get.
+    // A review-flow reviewer's own result-submission tool must be auto-approved by the bridge
+    // WITHOUT surfacing a user prompt. Codex fires a PermissionRequest for the MCP tool call even
+    // under `--ask-for-approval never`, and its hook bridges here; without this the unattended
+    // reviewer blocks on a decision it can never get. The auto-approve is reviewer-token-gated:
+    // only the participant's dedicated token reaches it (see the shared-token tests below).
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
     public async Task Codex_flow_result_submission_is_auto_approved_without_a_server_round_trip() {
         var (bridge, server) = CreateBridge((_, _, _, _, _) =>
@@ -526,6 +527,7 @@ public class LocalPermissionBridgeTests {
 
         try {
             await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
 
             using var client = CreateClient();
 
@@ -534,7 +536,7 @@ public class LocalPermissionBridgeTests {
                 tool_name  = "mcp__kcap_flow_result__submit_review_result",
                 tool_input = new { kind = "clean" }
             };
-            using var response = await client.PostAsync($"{bridge.BaseUrl}/codex/permission-request", JsonContent.Create(payload));
+            using var response = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(payload));
 
             await Assert.That((int)response.StatusCode).IsEqualTo(200);
 
@@ -598,7 +600,9 @@ public class LocalPermissionBridgeTests {
     }
 
     // The bare tool name (a vendor that passes the raw MCP tool name with no server prefix) is the
-    // flow-result tool and is auto-approved without a server round-trip.
+    // flow-result tool and is auto-approved without a server round-trip — on a reviewer token, even
+    // for a non-config-locked vendor (claude): the bare names are unique to the reserved channel,
+    // which only flow participants receive. This pins the bare-name arm as intentional.
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
     public async Task Bare_flow_result_tool_name_is_auto_approved() {
         var (bridge, server) = CreateBridge((_, _, _, _, _) =>
@@ -607,11 +611,12 @@ public class LocalPermissionBridgeTests {
 
         try {
             await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
 
             using var client = CreateClient();
 
             var payload = new { session_id = "abc", tool_name = "submit_review_result" };
-            using var response = await client.PostAsync($"{bridge.BaseUrl}/codex/permission-request", JsonContent.Create(payload));
+            using var response = await client.PostAsync($"{reviewerUrl}/claude/permission-request", JsonContent.Create(payload));
 
             await Assert.That((int)response.StatusCode).IsEqualTo(200);
             await Assert.That(server.Calls.Count).IsEqualTo(0);
@@ -620,6 +625,196 @@ public class LocalPermissionBridgeTests {
             using var doc      = JsonDocument.Parse(body);
             var       decision = doc.RootElement.GetProperty("hookSpecificOutput").GetProperty("decision");
             await Assert.That(decision.GetProperty("behavior").GetString()).IsEqualTo("allow");
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    // ── Reserved-channel auto-approve: send_flow_message + adversarial shapes ────────────
+    //
+    // The production defect: an unattended Codex participant calling send_flow_message got
+    // "Denied out-of-allowlist tool mcp__kcap_flow_result__send_flow_message" — only
+    // submit_review_result was special-cased. The fix generalizes the special case to the
+    // catalog's unattended-safe set, parsed (never substring-matched) and reviewer-gated.
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_auto_approves_server_qualified_send_flow_message() {
+        var (bridge, server) = CreateBridge((_, _, _, _, _) =>
+            Task.FromResult(new PermissionDecision("deny", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+
+            var payload = new { session_id = "abc", tool_name = "mcp__kcap_flow_result__send_flow_message" };
+            using var r = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+            await Assert.That(await Behavior(r)).IsEqualTo("allow");
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Bare_send_flow_message_is_auto_approved() {
+        var (bridge, server) = CreateBridge((_, _, _, _, _) =>
+            Task.FromResult(new PermissionDecision("deny", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+
+            var payload = new { session_id = "abc", tool_name = "send_flow_message" };
+            using var r = await client.PostAsync($"{reviewerUrl}/claude/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+            await Assert.That(await Behavior(r)).IsEqualTo("allow");
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_auto_approves_hyphenated_reserved_server_qualified_tool() {
+        // Claude normalizes hyphens to underscores, but the parse accepts the raw hyphenated
+        // server id too — both normalize to the same exact server segment.
+        var (bridge, server) = CreateBridge((_, _, _, _, _) =>
+            Task.FromResult(new PermissionDecision("deny", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+
+            var payload = new { session_id = "abc", tool_name = "mcp__kcap-flow-result__send_flow_message" };
+            using var r = await client.PostAsync($"{reviewerUrl}/claude/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+            await Assert.That(await Behavior(r)).IsEqualTo("allow");
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_denies_prefixed_spoof_of_reserved_server() {
+        // "mcp__evil_kcap_flow_result__send_flow_message": a Contains-based matcher would see
+        // "kcap_flow_result" inside the server segment and auto-approve. The ENTIRE server
+        // segment must equal the reserved channel id → deny (never a prompt on a reviewer token).
+        var (bridge, server) = CreateBridge((_, _, _, _, _) =>
+            Task.FromResult(new PermissionDecision("allow", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+
+            var payload = new { session_id = "abc", tool_name = "mcp__evil_kcap_flow_result__send_flow_message" };
+            using var r = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+            await Assert.That(await Behavior(r)).IsEqualTo("deny");
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_denies_suffixed_spoof_of_reserved_tool() {
+        // "mcp__kcap_flow_result__evil_send_flow_message": an EndsWith-based matcher would see the
+        // "send_flow_message" suffix and auto-approve. The ENTIRE tool segment must be an exact
+        // safe-set member → deny.
+        var (bridge, server) = CreateBridge((_, _, _, _, _) =>
+            Task.FromResult(new PermissionDecision("allow", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+
+            var payload = new { session_id = "abc", tool_name = "mcp__kcap_flow_result__evil_send_flow_message" };
+            using var r = await client.PostAsync($"{reviewerUrl}/codex/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+            await Assert.That(await Behavior(r)).IsEqualTo("deny");
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Shared_token_reserved_channel_tool_names_consult_the_server() {
+        // The auto-approve is reviewer-gated: the reserved channel is only injected for flow
+        // participants, so on the SHARED (interactive) token an identically-named tool is
+        // untrusted — it takes the normal server prompt path, qualified or bare. (Previously the
+        // shared token also auto-approved mcp__kcap_flow_result__submit_review_result.)
+        var (bridge, server) = CreateBridge((_, _, _, _, _) =>
+            Task.FromResult(new PermissionDecision("allow", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+
+            using var client = CreateClient();
+
+            string[] toolNames = [
+                "mcp__kcap_flow_result__submit_review_result",
+                "submit_review_result",
+                "mcp__kcap_flow_result__send_flow_message",
+                "send_flow_message"
+            ];
+
+            foreach (var toolName in toolNames) {
+                var payload = new { session_id = "abc", tool_name = toolName };
+                using var r = await client.PostAsync($"{bridge.BaseUrl}/codex/permission-request", JsonContent.Create(payload));
+                await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            }
+
+            await Assert.That(server.Calls.Count).IsEqualTo(toolNames.Length);
+        } finally {
+            await bridge.DisposeAsync();
+        }
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Reviewer_token_with_empty_allowlist_still_auto_approves_reserved_channel_tools() {
+        // A generic flow participant (arbitrary role, no read allowlist) gets a token bound to an
+        // EMPTY server list — the reserved channel is injected independently of the allowlist, so
+        // its tools must still auto-approve.
+        var (bridge, server) = CreateBridge((_, _, _, _, _) =>
+            Task.FromResult(new PermissionDecision("deny", null, null))
+        );
+
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            var participantUrl = bridge.RegisterReviewerToken([]);
+
+            using var client = CreateClient();
+
+            var payload = new { session_id = "abc", tool_name = "mcp__kcap_flow_result__send_flow_message" };
+            using var r = await client.PostAsync($"{participantUrl}/codex/permission-request", JsonContent.Create(payload));
+
+            await Assert.That((int)r.StatusCode).IsEqualTo(200);
+            await Assert.That(server.Calls.Count).IsEqualTo(0);
+            await Assert.That(await Behavior(r)).IsEqualTo("allow");
         } finally {
             await bridge.DisposeAsync();
         }

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -610,8 +610,9 @@ public class AcpHostedAgentRuntimeFactoryTests {
     /// registry the review path already trusts, so the test still fails if the argv builder starts
     /// emitting an id from anywhere else.</para></summary>
     static string[] ExpectedAvailableTools(string[] allowlisted, IReadOnlyList<string> extra) => [
-        $"--available-tools={KcapMcpRegistry.ReservedResultChannelId}-submit_review_result",
-        $"--available-tools={KcapMcpRegistry.ReservedResultChannelId}-send_flow_message",
+        .. KcapMcpRegistry.ReservedResultChannelTools
+              .Where(t => t.UnattendedSafe)
+              .Select(t => $"--available-tools={KcapMcpRegistry.ReservedResultChannelId}-{t.Name}"),
         .. allowlisted.SelectMany(name => KcapMcpRegistry.ReviewFlowUnattendedSafeTools[name]
                                              .Order(StringComparer.Ordinal)
                                              .Select(t => $"--available-tools={name}-{t}")),


### PR DESCRIPTION
## Problem

The permission bridge denies `mcp__kcap_flow_result__send_flow_message` for unattended Codex flow participants (~daily in production logs since 07-29), while the flow-result MCP server advertises the tool with a description inviting its use, and the ACP path (Copilot/Gemini) explicitly grants it. Denied sidecar→driver notes vanish without a trace on either side — the deny happens before the MCP server is invoked, so no `message_id` is minted and the driver never learns a message was attempted.

## Root cause

The permission layer predates the Phase E-c tool: the flow-result special case matched only `submit_review_result` (single-tool, `Contains`+`EndsWith` shape), and the reserved channel is structurally excluded from the bound allowlist by design.

## Fix (per the reviewed spec/plan on AI-1708 — including the spec-review security amendments)

- **One ordered Core catalog** — `KcapMcpRegistry.ReservedResultChannelTools` (`(Name, UnattendedSafe)` records) is the single source of truth; the flow-result server's `tools/list`, the bridge's auto-approve set, and Copilot's ACP `--available-tools` all derive from or are contract-tested against it. Dispatch stays exhaustive (explicit cases + unknown-tool default).
- **The bridge auto-approve now parses, not pattern-matches**: full `mcp__<server>__<tool>` split, ENTIRE server segment must equal the reserved channel id (hyphen/underscore normalized, exact compare), ENTIRE tool segment must be an exact safe-set member. The spec review showed the old `Contains`/`EndsWith` shape was spoofable (`mcp__evil_kcap_flow_result__…`, `mcp__kcap_flow_result__evil_…`) — adversarial tests now pin both.
- **Reviewer-gated**: the auto-approve moved inside the `isReviewer` branch. This deliberately *tightens* existing behavior — the shared interactive token no longer auto-approves `mcp__kcap_flow_result__submit_review_result`; interactive sessions fall through to the normal prompt path (test pins all four name shapes).
- Generic `start_flow` participants (arbitrary `FlowRole`) get the same treatment as review-flow reviewers — wiring test added.

## Server-side guard (verified before shipping, per spec-review amendment 2)

`/api/flows/participant/message` requires auth (`FlowEndpoints.cs:8-10`, `:317`), enforces run ownership (`FlowOrchestratorService.cs:4136-4146`, `not_owner` 403), requires the exact ACTIVE agent assignment (`:4148-4169` + `ValidateMessageSenderRole`, `no_active_flow`/`run_closed`), and derives flow/role/session identity server-side from the index+fold — never the request body. Tests: `FlowMessagesTests.cs` (`non_owner_gets_not_owner`, `superseded_agent_gets_no_active_flow`, `terminal_run_gets_run_closed`, stopped/unknown variants).

Two informational gaps noted for upstream (not blockers): message text has no size/rate bounds server-side, and ownership is run-owner-scoped (an owner could post as any agent of their own run). Both are within the existing driver↔participant trust boundary.

## Tests

TDD throughout; targeted classes green: LocalPermissionBridgeTests 53/53 (incl. the production repro, both spoof shapes, shared-token tightening), KcapMcpRegistryReviewFlowTests 12/12 (bidirectional catalog contract), AcpHostedAgentRuntimeFactoryTests 75/75 (byte-exact argv preserved), McpFlowResultServerTests 15/15, AgentOrchestratorVendorTests 164/164. Mutation-checked: removing `send_flow_message` from the catalog fails 5 tests; relaxing the parse back to Contains/EndsWith fails both spoof tests. AOT publish clean both csprojs. Full suites delegated to CI.

Spec + plan + codex spec-review findings: https://linear.app/kurrent/issue/AI-1708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
